### PR TITLE
Allow blank mysql passwords

### DIFF
--- a/server/src/main/java/com/metamx/druid/utils/ZkSetup.java
+++ b/server/src/main/java/com/metamx/druid/utils/ZkSetup.java
@@ -64,8 +64,13 @@ public class ZkSetup
       private final String password;
 
       {
-        username = args[3].split(":")[0];
-        password = args[3].split(":")[1];
+        String[] splitArgs = args[3].split(":");
+        username = splitArgs[0];
+        if (splitArgs.length > 1) {
+          password = splitArgs[1];
+        } else {
+          password = "";
+        }
       }
 
       @Override


### PR DESCRIPTION
ZkSetup wasn't allowing a blank password for mysql. I changed it to have "root:" correctly login as root without a password.
