### PR TITLE
Remove duplicate copies of servlet-api from dependency tree

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -159,7 +159,7 @@
             <version>3.2.4.Final</version>
         </dependency>
         <dependency>
-            <groupId>org.mortbay.jetty</groupId>
+            <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
         </dependency>
         <dependency>

--- a/indexer/pom.xml
+++ b/indexer/pom.xml
@@ -71,6 +71,12 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-core</artifactId>
             <version>0.20.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>servlet-api-2.5</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,12 @@
                 <groupId>org.mortbay.jetty</groupId>
                 <artifactId>jetty</artifactId>
                 <version>6.1.26</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.mortbay.jetty</groupId>
+                            <artifactId>servlet-api</artifactId>
+                        </exclusion>
+                    </exclusions>
             </dependency>
             <dependency>
                 <groupId>joda-time</groupId>
@@ -237,9 +243,9 @@
                 <version>1.2.16</version>
             </dependency>
             <dependency>
-                <groupId>org.mortbay.jetty</groupId>
+                <groupId>javax.servlet</groupId>
                 <artifactId>servlet-api</artifactId>
-                <version>2.5-20081211</version>
+                <version>2.5</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -163,7 +163,7 @@
             <artifactId>log4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mortbay.jetty</groupId>
+            <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
org.mortbay.jetty: servlet-api-2.5 (2.5 baked into artifact id) and org.mortbay.jetty:servlet-api (no 2.5 in artifact id) are both in the dependency tree right now. This patch removes the explicit dependency (and adds an exclusion for hadoop's dependency) and uses the javax.servlet:servlet-api dependency.
