### PR TITLE
query/wait and exec/backlog metrics

### DIFF
--- a/client/src/main/java/com/metamx/druid/http/ClientQuerySegmentWalker.java
+++ b/client/src/main/java/com/metamx/druid/http/ClientQuerySegmentWalker.java
@@ -83,7 +83,7 @@ public class ClientQuerySegmentWalker implements QuerySegmentWalker
                       }
                     },
                     toolChest.preMergeQueryDecoration(baseClient)
-                )
+                ).withWaitMeasuredFromNow()
             )
         ),
         toolChest

--- a/client/src/main/java/com/metamx/druid/query/MetricsEmittingExecutorService.java
+++ b/client/src/main/java/com/metamx/druid/query/MetricsEmittingExecutorService.java
@@ -1,0 +1,72 @@
+package com.metamx.druid.query;
+
+import com.metamx.emitter.service.ServiceEmitter;
+import com.metamx.emitter.service.ServiceMetricEvent;
+
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class MetricsEmittingExecutorService extends AbstractExecutorService
+{
+  private final ExecutorService base;
+  private final ServiceEmitter emitter;
+  private final ServiceMetricEvent.Builder metricBuilder;
+
+  public MetricsEmittingExecutorService(
+      ExecutorService base,
+      ServiceEmitter emitter,
+      ServiceMetricEvent.Builder metricBuilder
+  )
+  {
+    this.base = base;
+    this.emitter = emitter;
+    this.metricBuilder = metricBuilder;
+  }
+
+  @Override
+  public void shutdown()
+  {
+    base.shutdown();
+  }
+
+  @Override
+  public List<Runnable> shutdownNow()
+  {
+    return base.shutdownNow();
+  }
+
+  @Override
+  public boolean isShutdown()
+  {
+    return base.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated()
+  {
+    return base.isTerminated();
+  }
+
+  @Override
+  public boolean awaitTermination(long l, TimeUnit timeUnit) throws InterruptedException
+  {
+    return base.awaitTermination(l, timeUnit);
+  }
+
+  @Override
+  public void execute(Runnable runnable)
+  {
+    emitMetrics();
+    base.execute(runnable);
+  }
+
+  private void emitMetrics()
+  {
+    if (base instanceof ThreadPoolExecutor) {
+      emitter.emit(metricBuilder.build("exec/backlog", ((ThreadPoolExecutor) base).getQueue().size()));
+    }
+  }
+}

--- a/server/src/main/java/com/metamx/druid/coordination/ServerManager.java
+++ b/server/src/main/java/com/metamx/druid/coordination/ServerManager.java
@@ -336,7 +336,7 @@ public class ServerManager implements QuerySegmentWalker
                 adapter.getInterval().getStart(),
                 factory.createRunner(adapter)
             )
-        ),
+        ).withWaitMeasuredFromNow(),
         segmentSpec
     );
   }


### PR DESCRIPTION
- Add optional query/wait metric to MetricsEmittingQueryRunner
- Add MetricsEmittingExecutorService decorator, and use it on compute nodes
