### PR TITLE
YeOldePlumberSchool: Populate dimension metadata in segment descriptor

### DIFF
--- a/merger/src/main/java/com/metamx/druid/merger/common/index/YeOldePlumberSchool.java
+++ b/merger/src/main/java/com/metamx/druid/merger/common/index/YeOldePlumberSchool.java
@@ -140,7 +140,7 @@ public class YeOldePlumberSchool implements PlumberSchool
           }
 
           // Map merged segment so we can extract dimensions
-          final MMappedIndex mappedSegment = IndexIO.mapDir(fileToUpload);
+          final QueryableIndex mappedSegment = IndexIO.loadIndex(fileToUpload);
 
           final DataSegment segmentToUpload = theSink.getSegment()
                                                      .withDimensions(ImmutableList.copyOf(mappedSegment.getAvailableDimensions()))


### PR DESCRIPTION
Fixes empty dimension metadata from indexing-service-created segments.
