### PR TITLE
DeterminePartitionsJob: Only create as many reducers as needed

### DIFF
--- a/indexer/src/main/java/com/metamx/druid/indexer/IndexGeneratorJob.java
+++ b/indexer/src/main/java/com/metamx/druid/indexer/IndexGeneratorJob.java
@@ -220,7 +220,7 @@ public class IndexGeneratorJob implements Jobby
     public int getPartition(BytesWritable bytesWritable, Text text, int numPartitions)
     {
       final ByteBuffer bytes = ByteBuffer.wrap(bytesWritable.getBytes());
-      bytes.position(4); // Skip length added by BytesWritable
+      bytes.position(4); // Skip length added by SortableBytes
       int shardNum = bytes.getInt();
 
       if (shardNum >= numPartitions) {


### PR DESCRIPTION
Uses the same technique as IndexGeneratorJob
