### PR TITLE
Tackle "merged" dir. issue after restarting realtime node

### DIFF
--- a/realtime/src/main/java/com/metamx/druid/realtime/plumber/RealtimePlumberSchool.java
+++ b/realtime/src/main/java/com/metamx/druid/realtime/plumber/RealtimePlumberSchool.java
@@ -383,7 +383,7 @@ public class RealtimePlumberSchool implements PlumberSchool
           final File[] sinkFiles = sinkDir.listFiles(new FilenameFilter() {  		
         			@Override
         			public boolean accept(File dir, String fileName) {				
-        				return !fileName.equalsIgnoreCase("merged");
+        				return !(Ints.tryParse(fileName) == null);
         			}
         		});
           Arrays.sort(
@@ -409,12 +409,14 @@ public class RealtimePlumberSchool implements PlumberSchool
             for (File segmentDir : sinkFiles) {
               log.info("Loading previously persisted segment at [%s]", segmentDir);
               
-              // Although this is has been tackled at start of this method.
+              // Although this has been tackled at start of this method.
               // Just a doubly-check added to skip "merged" dir. from being added to hydrants 
               // If 100% sure that this is not needed, this check can be removed.
-              if(segmentDir.getName().equalsIgnoreCase("merged"))
+              if(Ints.tryParse(segmentDir.getName()) == null)
+              {
                 continue;
-                
+              }
+              
               hydrants.add(
                   new FireHydrant(
                       new QueryableIndexSegment(null, IndexIO.loadIndex(segmentDir)),


### PR DESCRIPTION
There was an issue if you restart realtime node and merged dir is still there it will throw exceptions. To tackle this issue a check has been added. So now only persisted dir/files will be read and anything from "merged" will be avoided.
