### PR TITLE
Rejigger exception handling in standalone realtime

### DIFF
--- a/indexing-common/src/main/java/com/metamx/druid/indexer/data/InputRowParser.java
+++ b/indexing-common/src/main/java/com/metamx/druid/indexer/data/InputRowParser.java
@@ -1,9 +1,10 @@
 package com.metamx.druid.indexer.data;
 
+import com.metamx.common.exception.FormattedException;
 import com.metamx.druid.input.InputRow;
 
 public interface InputRowParser<T>
 {
-  public InputRow parse(T input);
+  public InputRow parse(T input) throws FormattedException;
   public void addDimensionExclusion(String dimension);
 }

--- a/realtime/src/main/java/com/metamx/druid/realtime/RealtimeManager.java
+++ b/realtime/src/main/java/com/metamx/druid/realtime/RealtimeManager.java
@@ -164,31 +164,36 @@ public class RealtimeManager implements QuerySegmentWalker
           final InputRow inputRow;
           try {
             inputRow = firehose.nextRow();
-
-            final Sink sink = plumber.getSink(inputRow.getTimestampFromEpoch());
-            if (sink == null) {
-              metrics.incrementThrownAway();
-              log.debug("Throwing away event[%s]", inputRow);
-
-              if (System.currentTimeMillis() > nextFlush) {
-                plumber.persist(firehose.commit());
-                nextFlush = new DateTime().plus(intermediatePersistPeriod).getMillis();
-              }
-
-              continue;
-            }
-
-            int currCount = sink.add(inputRow);
-            metrics.incrementProcessed();
-            if (currCount >= config.getMaxRowsInMemory() || System.currentTimeMillis() > nextFlush) {
-              plumber.persist(firehose.commit());
-              nextFlush = new DateTime().plus(intermediatePersistPeriod).getMillis();
-            }
           }
           catch (FormattedException e) {
             log.info(e, "unparseable line: %s", e.getDetails());
             metrics.incrementUnparseable();
             continue;
+          }
+          catch (Exception e) {
+            log.info(e, "thrown away line due to exception");
+            metrics.incrementThrownAway();
+            continue;
+          }
+
+          final Sink sink = plumber.getSink(inputRow.getTimestampFromEpoch());
+          if (sink == null) {
+            metrics.incrementThrownAway();
+            log.debug("Throwing away event[%s]", inputRow);
+
+            if (System.currentTimeMillis() > nextFlush) {
+              plumber.persist(firehose.commit());
+              nextFlush = new DateTime().plus(intermediatePersistPeriod).getMillis();
+            }
+
+            continue;
+          }
+
+          int currCount = sink.add(inputRow);
+          metrics.incrementProcessed();
+          if (currCount >= config.getMaxRowsInMemory() || System.currentTimeMillis() > nextFlush) {
+            plumber.persist(firehose.commit());
+            nextFlush = new DateTime().plus(intermediatePersistPeriod).getMillis();
           }
         }
       } catch (RuntimeException e) {


### PR DESCRIPTION
- Throw FormattedExceptions on null or unparseable timestamps
- Throw away events (and increment thrownAway) on non-FormattedExceptions in the fire chief

Fixes #99 
