### PR TITLE
Robustness fixes for properly keeping track of when Segments are accessible

### DIFF
--- a/server/src/main/java/com/metamx/druid/query/ReferenceCountingSegmentQueryRunner.java
+++ b/server/src/main/java/com/metamx/druid/query/ReferenceCountingSegmentQueryRunner.java
@@ -12,7 +12,7 @@ import java.io.Closeable;
 */
 public class ReferenceCountingSegmentQueryRunner<T> implements QueryRunner<T>
 {
-  private final QueryRunner<T> runner;
+  private final QueryRunnerFactory<T, Query<T>> factory;
   private final ReferenceCountingSegment adapter;
 
   public ReferenceCountingSegmentQueryRunner(
@@ -20,9 +20,8 @@ public class ReferenceCountingSegmentQueryRunner<T> implements QueryRunner<T>
       ReferenceCountingSegment adapter
   )
   {
+    this.factory = factory;
     this.adapter = adapter;
-
-    this.runner = factory.createRunner(adapter);
   }
 
   @Override
@@ -30,7 +29,7 @@ public class ReferenceCountingSegmentQueryRunner<T> implements QueryRunner<T>
   {
     final Closeable closeable = adapter.increment();
     try {
-      final Sequence<T> baseSequence = runner.run(query);
+      final Sequence<T> baseSequence = factory.createRunner(adapter).run(query);
 
       return new ResourceClosingSequence<T>(baseSequence, closeable);
     }


### PR DESCRIPTION
1) Add check in ServerManagerTest to make sure that the Segment has been "checked out" before the factory ever sees it.

2) Some code readability changes to ReferenceCountingSegment
