### PR TITLE
Fixing bug where twitter example does not run.

### DIFF
--- a/examples/bin/run_example_server.sh
+++ b/examples/bin/run_example_server.sh
@@ -56,10 +56,10 @@ JAVA_ARGS="${JAVA_ARGS} -Ddruid.realtime.specFile=${SPEC_FILE}"
 DRUID_CP=${EXAMPLE_LOC}
 #For a pull
 DRUID_CP=${DRUID_CP}:`ls ${SCRIPT_DIR}/../target/druid-examples-*-selfcontained.jar`
-DRUID_CP=${DRUID_CP}:${SCRIPT_DIR}/../config
+DRUID_CP=${DRUID_CP}:${SCRIPT_DIR}/../config/realtime
 #For the kit
 DRUID_CP=${DRUID_CP}:`ls ${SCRIPT_DIR}/lib/druid-examples-*-selfcontained.jar`
-DRUID_CP=${DRUID_CP}:${SCRIPT_DIR}/config
+DRUID_CP=${DRUID_CP}:${SCRIPT_DIR}/config/realtime
 
 echo "Running command:"
 


### PR DESCRIPTION
Edited path in the assembly tarball to point at config/realtime instead of just config (which is no longer there), fixing the bug that made the twitter example server not run.
