### PR TITLE
Edited assembly.xml to exclude the selfcontained jars, and edited path o...

### DIFF
--- a/examples/bin/run_example_server.sh
+++ b/examples/bin/run_example_server.sh
@@ -58,7 +58,7 @@ DRUID_CP=${EXAMPLE_LOC}
 DRUID_CP=${DRUID_CP}:`ls ${SCRIPT_DIR}/../target/druid-examples-*-selfcontained.jar`
 DRUID_CP=${DRUID_CP}:${SCRIPT_DIR}/../config/realtime
 #For the kit
-DRUID_CP=${DRUID_CP}:`ls ${SCRIPT_DIR}/lib/druid-examples-*-selfcontained.jar`
+DRUID_CP=${DRUID_CP}:${SCRIPT_DIR}/lib/*
 DRUID_CP=${DRUID_CP}:${SCRIPT_DIR}/config/realtime
 
 echo "Running command:"

--- a/services/src/assembly/assembly.xml
+++ b/services/src/assembly/assembly.xml
@@ -51,14 +51,14 @@
         <fileSet>
             <directory>../examples/target</directory>
             <includes>
-                <include>druid-examples-*-selfcontained.jar</include>
+                <include>druid-examples-${project.version}.jar</include>
             </includes>
             <outputDirectory>lib</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>../services/target</directory>
             <includes>
-                <include>druid-services-*-selfcontained.jar</include>
+                <include>druid-services-${project.version}.jar</include>
             </includes>
             <outputDirectory>lib</outputDirectory>
         </fileSet>


### PR DESCRIPTION
...f run_example_server to use the lib/ directory instead of selfcontained jars, thus reducing the size of the assembly tarball from 150MB to 50MB.

Also need to tag/release 0.5.51 to get this into the tarball download.
