### PR TITLE
Add availability zone info to autoscaling

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/overlord/scaling/EC2AutoScalingStrategy.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/scaling/EC2AutoScalingStrategy.java
@@ -24,6 +24,7 @@ import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
 import com.amazonaws.services.ec2.model.DescribeInstancesResult;
 import com.amazonaws.services.ec2.model.Filter;
 import com.amazonaws.services.ec2.model.Instance;
+import com.amazonaws.services.ec2.model.Placement;
 import com.amazonaws.services.ec2.model.Reservation;
 import com.amazonaws.services.ec2.model.RunInstancesRequest;
 import com.amazonaws.services.ec2.model.RunInstancesResult;
@@ -88,6 +89,7 @@ public class EC2AutoScalingStrategy implements AutoScalingStrategy
           )
               .withInstanceType(workerConfig.getInstanceType())
               .withSecurityGroupIds(workerConfig.getSecurityGroupIds())
+              .withPlacement(new Placement(setupData.getAvailabilityZone()))
               .withKeyName(workerConfig.getKeyName())
               .withUserData(
                   Base64.encodeBase64String(

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/setup/WorkerSetupData.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/setup/WorkerSetupData.java
@@ -31,6 +31,7 @@ public class WorkerSetupData
   private final String minVersion;
   private final int minNumWorkers;
   private final int maxNumWorkers;
+  private final String availabilityZone;
   private final EC2NodeData nodeData;
   private final GalaxyUserData userData;
 
@@ -39,6 +40,7 @@ public class WorkerSetupData
       @JsonProperty("minVersion") String minVersion,
       @JsonProperty("minNumWorkers") int minNumWorkers,
       @JsonProperty("maxNumWorkers") int maxNumWorkers,
+      @JsonProperty("availabilityZone") String availabilityZone,
       @JsonProperty("nodeData") EC2NodeData nodeData,
       @JsonProperty("userData") GalaxyUserData userData
   )
@@ -46,6 +48,7 @@ public class WorkerSetupData
     this.minVersion = minVersion;
     this.minNumWorkers = minNumWorkers;
     this.maxNumWorkers = maxNumWorkers;
+    this.availabilityZone = availabilityZone;
     this.nodeData = nodeData;
     this.userData = userData;
   }
@@ -69,6 +72,12 @@ public class WorkerSetupData
   }
 
   @JsonProperty
+  public String getAvailabilityZone()
+  {
+    return availabilityZone;
+  }
+
+  @JsonProperty
   public EC2NodeData getNodeData()
   {
     return nodeData;
@@ -87,6 +96,7 @@ public class WorkerSetupData
            "minVersion='" + minVersion + '\'' +
            ", minNumWorkers=" + minNumWorkers +
            ", maxNumWorkers=" + maxNumWorkers +
+           ", availabilityZone=" + availabilityZone +
            ", nodeData=" + nodeData +
            ", userData=" + userData +
            '}';

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTest.java
@@ -392,7 +392,7 @@ public class RemoteTaskRunnerTest
         },
         cf,
         new SimplePathChildrenCacheFactory.Builder().build(),
-        DSuppliers.of(new AtomicReference<WorkerSetupData>(new WorkerSetupData("0", 0, 1, null, null))),
+        DSuppliers.of(new AtomicReference<WorkerSetupData>(new WorkerSetupData("0", 0, 1, null, null, null))),
         null
     );
 

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/scaling/EC2AutoScalingStrategyTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/scaling/EC2AutoScalingStrategyTest.java
@@ -99,6 +99,7 @@ public class EC2AutoScalingStrategyTest
             "0",
             0,
             1,
+            "",
             new EC2NodeData(AMI_ID, INSTANCE_ID, 1, 1, Lists.<String>newArrayList(), "foo"),
             new GalaxyUserData("env", "version", "type")
         )

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/scaling/SimpleResourceManagementStrategyTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/scaling/SimpleResourceManagementStrategyTest.java
@@ -65,7 +65,7 @@ public class SimpleResourceManagementStrategyTest
     autoScalingStrategy = EasyMock.createMock(AutoScalingStrategy.class);
     workerSetupData = new AtomicReference<WorkerSetupData>(
         new WorkerSetupData(
-            "0", 0, 2, null, null
+            "0", 0, 2, null, null, null
         )
     );
 
@@ -237,7 +237,7 @@ public class SimpleResourceManagementStrategyTest
   @Test
   public void testDoSuccessfulTerminate() throws Exception
   {
-    workerSetupData.set(new WorkerSetupData("0", 0, 1, null, null));
+    workerSetupData.set(new WorkerSetupData("0", 0, 1, null, null, null));
 
     EasyMock.expect(autoScalingStrategy.ipToIdLookup(EasyMock.<List<String>>anyObject()))
             .andReturn(Lists.<String>newArrayList());
@@ -267,7 +267,7 @@ public class SimpleResourceManagementStrategyTest
   @Test
   public void testSomethingTerminating() throws Exception
   {
-    workerSetupData.set(new WorkerSetupData("0", 0, 1, null, null));
+    workerSetupData.set(new WorkerSetupData("0", 0, 1, null, null, null));
 
     EasyMock.expect(autoScalingStrategy.ipToIdLookup(EasyMock.<List<String>>anyObject()))
             .andReturn(Lists.<String>newArrayList("ip")).times(2);

--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinatorConfig.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinatorConfig.java
@@ -31,7 +31,7 @@ public abstract class DruidCoordinatorConfig
   public abstract String getHost();
 
   @Config("druid.coordinator.startDelay")
-  @Default("PT60s")
+  @Default("PT120s")
   public abstract Duration getCoordinatorStartDelay();
 
   @Config("druid.coordinator.period")


### PR DESCRIPTION
This pull request allows indexing service workers (middle managers) to spin up in a configured AZ.
