### PR TITLE
Changed wikipedia example to second indexGranularity.

### DIFF
--- a/examples/bin/examples/wikipedia/wikipedia_realtime.spec
+++ b/examples/bin/examples/wikipedia/wikipedia_realtime.spec
@@ -7,7 +7,7 @@
             {"type": "longSum", "fieldName": "deleted", "name": "deleted"},
             {"type": "longSum", "fieldName": "delta", "name": "delta"}
         ],
-        "indexGranularity": "minute",
+        "indexGranularity": "second",
         "shardSpec": {"type": "none"}
 	    },
 


### PR DESCRIPTION
I am creating a one-second updating sliding window example, and need the wikipedia example to be second indexGranularity.
