### PR TITLE
Changed indexGranularity on webstream example from minute to second

### DIFF
--- a/examples/bin/examples/webstream/webstream_realtime.spec
+++ b/examples/bin/examples/webstream/webstream_realtime.spec
@@ -5,7 +5,7 @@
             {"type": "count", "name": "rows"},
             {"type": "doubleSum", "fieldName": "known_users", "name": "known_users"}
         ],
-        "indexGranularity": "minute",
+        "indexGranularity": "second",
         "shardSpec": {"type": "none"}
 	    },
 


### PR DESCRIPTION
This is needed for a realtime demo I am doing.
