### PR TITLE
Fix compile error in Eclipse 4.3.

### DIFF
--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
@@ -166,7 +166,7 @@ public class IncrementalIndexStorageAdapterTest
                      .addDimension("billy")
                      .addDimension("sally")
                      .addAggregator(new LongSumAggregatorFactory("cnt", "cnt"))
-                     .setDimFilter(DimFilters.dimEquals("sally", null))
+                     .setDimFilter(DimFilters.dimEquals("sally", (String) null))
                      .build(),
          new IncrementalIndexStorageAdapter(index)
      );


### PR DESCRIPTION
The method dimEquals(String, String) is ambiguous for the type DimFilters.
