### PR TITLE
[fix typo] header formatting in tutorial doc

### DIFF
--- a/docs/content/Tutorial:-A-First-Look-at-Druid.md
+++ b/docs/content/Tutorial:-A-First-Look-at-Druid.md
@@ -140,7 +140,8 @@ The result looks something like this:
 
 This groupBy query is a bit complicated and we'll return to it later. For the time being, just make sure you are getting some blocks of data back. If you are having problems, make sure you have [curl](http://curl.haxx.se/) installed. Control+C to break out of the client script.
 
-h2. Querying Druid
+Querying Druid
+--------------
 
 In your favorite editor, create the file:
 


### PR DESCRIPTION
Hi, I found that the "Querying Druid" section header wasn't being formatted correctly here (http://druid.io/docs/0.6.10/Tutorial:-A-First-Look-at-Druid.html) so I'm submitting this pull request to fix it :)

Thx!
Haj
