### PR TITLE
kafka-eight: bump kafka dependency to 0.8 release

### DIFF
--- a/kafka-eight/pom.xml
+++ b/kafka-eight/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.9.2</artifactId>
-            <version>0.8.0-beta1</version>
+            <version>0.8.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>log4j</groupId>


### PR DESCRIPTION
I think there are binary the same, but just to be correct
