### PR TITLE
Remove unused payload column from sub-select that fails in postgres.  Use ...

### DIFF
--- a/server/src/main/java/io/druid/db/DatabaseRuleManager.java
+++ b/server/src/main/java/io/druid/db/DatabaseRuleManager.java
@@ -207,7 +207,7 @@ public class DatabaseRuleManager
                       String.format(
                           "SELECT r.dataSource, r.payload "
                           + "FROM %1$s r "
-                          + "INNER JOIN(SELECT dataSource, max(version) as version, payload FROM %1$s GROUP BY dataSource) ds "
+                          + "INNER JOIN(SELECT dataSource, max(version) as version FROM %1$s GROUP BY dataSource) ds "
                           + "ON r.datasource = ds.datasource and r.version = ds.version",
                           getRulesTable()
                       )

--- a/server/src/main/java/io/druid/db/DatabaseSegmentManager.java
+++ b/server/src/main/java/io/druid/db/DatabaseSegmentManager.java
@@ -213,7 +213,7 @@ public class DatabaseSegmentManager
               for (DataSegment segment : segments) {
                 batch.add(
                     String.format(
-                        "UPDATE %s SET used=1 WHERE id = '%s'",
+                        "UPDATE %s SET used=true WHERE id = '%s'",
                         getSegmentsTable(),
                         segment.getIdentifier()
                     )
@@ -244,7 +244,7 @@ public class DatabaseSegmentManager
             public Void withHandle(Handle handle) throws Exception
             {
               handle.createStatement(
-                  String.format("UPDATE %s SET used=1 WHERE id = :id", getSegmentsTable())
+                  String.format("UPDATE %s SET used=true WHERE id = :id", getSegmentsTable())
               )
                     .bind("id", segmentId)
                     .execute();
@@ -278,7 +278,7 @@ public class DatabaseSegmentManager
             public Void withHandle(Handle handle) throws Exception
             {
               handle.createStatement(
-                  String.format("UPDATE %s SET used=0 WHERE dataSource = :dataSource", getSegmentsTable())
+                  String.format("UPDATE %s SET used=false WHERE dataSource = :dataSource", getSegmentsTable())
               )
                     .bind("dataSource", ds)
                     .execute();
@@ -308,7 +308,7 @@ public class DatabaseSegmentManager
             public Void withHandle(Handle handle) throws Exception
             {
               handle.createStatement(
-                  String.format("UPDATE %s SET used=0 WHERE id = :segmentID", getSegmentsTable())
+                  String.format("UPDATE %s SET used=false WHERE id = :segmentID", getSegmentsTable())
               ).bind("segmentID", segmentID)
                     .execute();
 
@@ -408,7 +408,7 @@ public class DatabaseSegmentManager
             public List<Map<String, Object>> withHandle(Handle handle) throws Exception
             {
               return handle.createQuery(
-                  String.format("SELECT payload FROM %s WHERE used=1", getSegmentsTable())
+                  String.format("SELECT payload FROM %s WHERE used=true", getSegmentsTable())
               ).list();
             }
           }


### PR DESCRIPTION
...boolean true/false for 'used' column so that queries run in postgres.

I am using postgres instead of mysql for the druid relational store.  I found and fixed two issues:

First, in DatabaseRuleManager.java#poll, selecting the payload column in the sub-select causes an error:

druid=> SELECT dataSource, max(version) as version, payload FROM druid_rules GROUP BY dataSource;
ERROR:  column "druid_rules.payload" must appear in the GROUP BY clause or be used in an aggregate function
LINE 1: SELECT dataSource, max(version) as version, payload FROM dru...

The inner payload column doesn't seem to be used so I removed it.

Second, in DatabaseSegmentManager I changed used=0 and used=1 to used=false/used=true.  Postgres does not cast 1/0 to true/false.
