### PR TITLE
Conjure firehose + Event ingestion metrics

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -58,6 +58,11 @@
             <artifactId>twitter4j-stream</artifactId>
             <version>3.0.3</version>
         </dependency>
+        <dependency>
+            <groupId>io.d8a</groupId>
+            <artifactId>d8a-conjure</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
 
         <!-- For tests! -->
         <dependency>

--- a/examples/src/main/java/io/druid/examples/ExamplesDruidModule.java
+++ b/examples/src/main/java/io/druid/examples/ExamplesDruidModule.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.inject.Binder;
+import io.druid.examples.conjure.ConjureFirehoseFactory;
 import io.druid.examples.flights.FlightsFirehoseFactory;
 import io.druid.examples.rand.RandomFirehoseFactory;
 import io.druid.examples.twitter.TwitterSpritzerFirehoseFactory;
@@ -45,7 +46,8 @@ public class ExamplesDruidModule implements DruidModule
                 new NamedType(TwitterSpritzerFirehoseFactory.class, "twitzer"),
                 new NamedType(FlightsFirehoseFactory.class, "flights"),
                 new NamedType(RandomFirehoseFactory.class, "rand"),
-                new NamedType(WebFirehoseFactory.class, "webstream")
+                new NamedType(WebFirehoseFactory.class, "webstream"),
+                new NamedType(ConjureFirehoseFactory.class, "conjure")
             )
     );
   }

--- a/examples/src/main/java/io/druid/examples/conjure/ConjureFirehoseFactory.java
+++ b/examples/src/main/java/io/druid/examples/conjure/ConjureFirehoseFactory.java
@@ -1,0 +1,146 @@
+/*
+ * Druid - a distributed column store.
+ * Copyright (C) 2012, 2013  Metamarkets Group Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package io.druid.examples.conjure;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.collect.Lists;
+import com.metamx.common.logger.Logger;
+import io.d8a.conjure.Clock;
+import io.d8a.conjure.ConjureTemplate;
+import io.d8a.conjure.ConjureTemplateParser;
+import io.druid.data.input.Firehose;
+import io.druid.data.input.FirehoseFactory;
+import io.druid.data.input.InputRow;
+import io.druid.data.input.MapBasedInputRow;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+
+@JsonTypeName("conjure")
+public class ConjureFirehoseFactory implements FirehoseFactory
+{
+
+  private static final Logger log = new Logger(ConjureFirehoseFactory.class);
+
+  private final Long sleepMs;
+  private final Long eventsPerSleep;
+  private final Long maxGeneratedRows;
+  private final String conjurePatternFile;
+
+  public ConjureFirehoseFactory(
+      @JsonProperty("conjurePatternFile") String conjurePatternFile,
+      @JsonProperty("maxGeneratedRows") Long maxGeneratedRows,
+      @JsonProperty("eventsPerSleep") Long eventsPerSleep,
+      @JsonProperty("sleepMs") Long sleepMs
+  )
+  {
+    this.sleepMs = sleepMs;
+    this.maxGeneratedRows = maxGeneratedRows;
+    this.eventsPerSleep = eventsPerSleep;
+    this.conjurePatternFile = conjurePatternFile;
+  }
+
+  @Override
+  public Firehose connect() throws IOException
+  {
+    log.info("Using conjure file: %s", conjurePatternFile);
+    ConjureTemplateParser parser = new ConjureTemplateParser(Clock.SYSTEM_CLOCK);
+    final ConjureTemplate template = parser.jsonParse(conjurePatternFile);
+    log.info("Generating event at approximate rate of %.2f events/sec.", (eventsPerSleep * 1000.0 / sleepMs));
+
+    return new Firehose()
+    {
+      private long rowCount = 0;
+
+      @Override
+      public boolean hasMore()
+      {
+        return maxGeneratedRows < 0 || rowCount < maxGeneratedRows;
+      }
+
+      @Override
+      public InputRow nextRow()
+      {
+        if (rowCount % eventsPerSleep == 0) {
+          try {
+            Thread.sleep(sleepMs);
+          }
+          catch (InterruptedException e) {
+            e.printStackTrace();
+          }
+        }
+        if (++rowCount % 20000 == 0) {
+          log.info("Generated %d events.", rowCount);
+        }
+
+        Map<String, Object> event = template.conjureMapData();
+        return new MapBasedInputRow((Long) event.get("timestamp"), Lists.newArrayList(event.keySet()), event);
+      }
+
+      @Override
+      public Runnable commit()
+      {
+        return new Runnable()
+        {
+          @Override
+          public void run()
+          {
+          }
+        };
+
+      }
+
+      @Override
+      public void close() throws IOException
+      {
+      }
+    };
+  }
+
+  @JsonProperty
+  public Long getSleepMs()
+  {
+    return sleepMs;
+  }
+
+  @JsonProperty
+  public Long getMaxGeneratedRows()
+  {
+    return maxGeneratedRows;
+  }
+
+  @JsonProperty
+  public String getConjurePatternFile()
+  {
+    return conjurePatternFile;
+  }
+
+  @JsonProperty
+  public Long getEventsPerSleep()
+  {
+    return eventsPerSleep;
+  }
+
+}

--- a/examples/src/test/java/io/druid/examples/conjure/ConjureFirehoseFactoryTest.java
+++ b/examples/src/test/java/io/druid/examples/conjure/ConjureFirehoseFactoryTest.java
@@ -1,0 +1,91 @@
+/*
+ * Druid - a distributed column store.
+ * Copyright (C) 2012, 2013  Metamarkets Group Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package io.druid.examples.conjure;
+
+import io.druid.data.input.Firehose;
+import io.druid.data.input.InputRow;
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+public class ConjureFirehoseFactoryTest
+{
+  private ConjureFirehoseFactory conjureFirehoseFactory;
+
+  @Before
+  public void setUp()
+  {
+    String file = ConjureFirehoseFactory.class.getResource("/conjure.json").getFile();
+    conjureFirehoseFactory = new ConjureFirehoseFactory(file, 5000L, 50L, 2L);
+  }
+
+  @Test
+  public void testDimensions() throws IOException
+  {
+    Set<Integer> intDim = new LinkedHashSet<>();
+    Set<Double> doubleDim = new LinkedHashSet<>();
+    Set<String> stringDim = new LinkedHashSet<>();
+    Set<Long> longDim = new LinkedHashSet<>();
+
+    Firehose firehose = conjureFirehoseFactory.connect();
+    InputRow row;
+    if (firehose.hasMore()) {
+      row = firehose.nextRow();
+    } else {
+      throw new RuntimeException("No events to supply?");
+    }
+
+    List<String> dimensions = row.getDimensions();
+    Assert.assertEquals("Total number of dims should be 5", 5, dimensions.size());
+
+    List<String> sorted = Arrays.asList("Double150Card0", "Int10Card0", "Long200Card0", "String100Card0", "timestamp");
+
+    Collections.sort(dimensions);
+    Assert.assertEquals("Dimensions should be same.", dimensions, sorted);
+
+    Assert.assertEquals("Double dimension.", row.getRaw("Double150Card0").getClass(), Double.class);
+    Assert.assertEquals("String dimension.", row.getRaw("String100Card0").getClass(), String.class);
+    Assert.assertEquals("Int dimension.", row.getRaw("Int10Card0").getClass(), Integer.class);
+    Assert.assertEquals("Long dimension.", row.getRaw("Long200Card0").getClass(), Long.class);
+
+    int count = 1;
+    while (firehose.hasMore()) {
+      row = firehose.nextRow();
+      doubleDim.add((Double) row.getRaw("Double150Card0"));
+      stringDim.add((String) row.getRaw("String100Card0"));
+      longDim.add((Long) row.getRaw("Long200Card0"));
+      intDim.add((Integer) row.getRaw("Int10Card0"));
+      count++;
+    }
+
+    Assert.assertEquals("Double dim cardinality.", 150, doubleDim.size());
+    Assert.assertEquals("Integer dim cardinality.", 10, intDim.size());
+    Assert.assertEquals("Long dim cardinality.", 200, longDim.size());
+    Assert.assertEquals("String dim cardinality.", 100, stringDim.size());
+    Assert.assertEquals("Total events.", 5000, count);
+  }
+}

--- a/examples/src/test/resources/conjure.json
+++ b/examples/src/test/resources/conjure.json
@@ -1,0 +1,29 @@
+{
+    "specs":
+    [
+        {
+            "cardinality":10,
+            "type":"int",
+            "count":1,
+            "name":"Int10Card"
+        },
+        {
+            "cardinality":100,
+            "type":"string",
+            "count":1,
+            "name":"String100Card"
+        },
+        {
+            "cardinality":150,
+            "type":"double",
+            "count":1,
+            "name":"Double150Card"
+        },
+        {
+            "cardinality":200,
+            "type":"long",
+            "count":1,
+            "name":"Long200Card"
+        }
+    ]
+}

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/RealtimeIndexTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/RealtimeIndexTask.java
@@ -303,6 +303,7 @@ public class RealtimeIndexTask extends AbstractTask
         final InputRow inputRow;
         try {
           inputRow = firehose.nextRow();
+          long start = System.currentTimeMillis();
           if (inputRow == null) {
             continue;
           }
@@ -330,6 +331,8 @@ public class RealtimeIndexTask extends AbstractTask
             plumber.persist(firehose.commit());
             nextFlush = new DateTime().plus(intermediatePersistPeriod).getMillis();
           }
+          long end = System.currentTimeMillis();
+          fireDepartment.getMetrics().incrementIngestionTime(end - start);
         }
         catch (FormattedException e) {
           log.warn(e, "unparseable line");

--- a/server/src/main/java/io/druid/segment/realtime/FireDepartmentMetrics.java
+++ b/server/src/main/java/io/druid/segment/realtime/FireDepartmentMetrics.java
@@ -29,6 +29,7 @@ public class FireDepartmentMetrics
   private final AtomicLong thrownAwayCount = new AtomicLong(0);
   private final AtomicLong unparseableCount = new AtomicLong(0);
   private final AtomicLong rowOutputCount = new AtomicLong(0);
+  private final AtomicLong ingestionTime = new AtomicLong(0);
 
   public void incrementProcessed()
   {
@@ -48,6 +49,11 @@ public class FireDepartmentMetrics
   public void incrementRowOutputCount(long numRows)
   {
     rowOutputCount.addAndGet(numRows);
+  }
+
+  public void incrementIngestionTime(long inMillis)
+  {
+    ingestionTime.addAndGet(inMillis);
   }
 
   public long processed()
@@ -70,6 +76,11 @@ public class FireDepartmentMetrics
     return rowOutputCount.get();
   }
 
+  public long ingestionTime()
+  {
+    return ingestionTime.get();
+  }
+
   public FireDepartmentMetrics snapshot()
   {
     final FireDepartmentMetrics retVal = new FireDepartmentMetrics();
@@ -77,6 +88,7 @@ public class FireDepartmentMetrics
     retVal.thrownAwayCount.set(thrownAwayCount.get());
     retVal.unparseableCount.set(unparseableCount.get());
     retVal.rowOutputCount.set(rowOutputCount.get());
+    retVal.ingestionTime.set(ingestionTime.get());
     return retVal;
   }
 }

--- a/server/src/main/java/io/druid/segment/realtime/RealtimeMetricsMonitor.java
+++ b/server/src/main/java/io/druid/segment/realtime/RealtimeMetricsMonitor.java
@@ -54,9 +54,18 @@ public class RealtimeMetricsMonitor extends AbstractMonitor
       final ServiceMetricEvent.Builder builder = new ServiceMetricEvent.Builder()
           .setUser2(fireDepartment.getSchema().getDataSource());
 
+      long processed = metrics.processed() - previous.processed();
       emitter.emit(builder.build("events/thrownAway", metrics.thrownAway() - previous.thrownAway()));
       emitter.emit(builder.build("events/unparseable", metrics.unparseable() - previous.unparseable()));
-      emitter.emit(builder.build("events/processed", metrics.processed() - previous.processed()));
+      emitter.emit(builder.build("events/processed", processed));
+      emitter.emit(
+          builder.build(
+              "events/delta/avgIngestionTime", 1.0 * (metrics.ingestionTime() - previous.ingestionTime()) / processed
+          )
+      );
+      emitter.emit(
+          builder.build("events/total/avgIngestionTime", 1.0 * metrics.ingestionTime() / metrics.processed())
+      );
       emitter.emit(builder.build("rows/output", metrics.rowOutput() - previous.rowOutput()));
 
       previousValues.put(fireDepartment, metrics);


### PR DESCRIPTION
Impl of Conjure Firehose factory. 

This requires a conjure pattern file. Instead of using a queue, its better to template. 
Test added for Conjure firehose factory.

Added some latency metrics for event ingestion to find the maximum throughput supported by druid realtime server.