### PR TITLE
curator 2.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <metamx.java-util.version>0.25.1</metamx.java-util.version>
-        <apache.curator.version>2.1.0-incubating</apache.curator.version>
+        <apache.curator.version>2.3.0</apache.curator.version>
         <druid.api.version>0.1.7</druid.api.version>
     </properties>
 

--- a/server/src/main/java/io/druid/curator/discovery/DiscoveryModule.java
+++ b/server/src/main/java/io/druid/curator/discovery/DiscoveryModule.java
@@ -40,14 +40,7 @@ import io.druid.guice.annotations.Self;
 import io.druid.server.DruidNode;
 import io.druid.server.initialization.CuratorDiscoveryConfig;
 import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.x.discovery.ProviderStrategy;
-import org.apache.curator.x.discovery.ServiceCache;
-import org.apache.curator.x.discovery.ServiceCacheBuilder;
-import org.apache.curator.x.discovery.ServiceDiscovery;
-import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
-import org.apache.curator.x.discovery.ServiceInstance;
-import org.apache.curator.x.discovery.ServiceProvider;
-import org.apache.curator.x.discovery.ServiceProviderBuilder;
+import org.apache.curator.x.discovery.*;
 import org.apache.curator.x.discovery.details.ServiceCacheListener;
 
 import java.io.IOException;
@@ -389,8 +382,12 @@ public class DiscoveryModule implements Module
     }
 
     @Override
-    public ServiceProviderBuilder<T> refreshPaddingMs(int refreshPaddingMs)
-    {
+    public ServiceProviderBuilder<T> downInstancePolicy(DownInstancePolicy downInstancePolicy) {
+      return this;
+    }
+
+    @Override
+    public ServiceProviderBuilder<T> additionalFilter(InstanceFilter<T> tInstanceFilter) {
       return this;
     }
   }
@@ -407,6 +404,11 @@ public class DiscoveryModule implements Module
     public ServiceInstance<T> getInstance() throws Exception
     {
       return null;
+    }
+
+    @Override
+    public void noteError(ServiceInstance<T> tServiceInstance) {
+
     }
 
     @Override

--- a/server/src/main/java/io/druid/curator/discovery/ServerDiscoveryFactory.java
+++ b/server/src/main/java/io/druid/curator/discovery/ServerDiscoveryFactory.java
@@ -63,6 +63,11 @@ public class ServerDiscoveryFactory
     }
 
     @Override
+    public void noteError(ServiceInstance<T> tServiceInstance) {
+      // do nothing
+    }
+
+    @Override
     public void close() throws IOException
     {
       // do nothing


### PR DESCRIPTION
In Netflix, we're not using curator incubating version anymore. Our platform based zookeeper client's dependency resolution is always overriding curator version and it's not easy to override with 2.1.0-incubating version. If you don't have any specific reason to stay with 2.1.0-incubating, please accept this pull request and release the new one for Netflix to enjoy Druid 0.6.

Thank you
Best, Jae
