### PR TITLE
make ServerTimeRejectionPolicy also reject timestamps AHEAD of server time

### DIFF
--- a/server/src/main/java/io/druid/segment/realtime/plumber/ServerTimeRejectionPolicyFactory.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/ServerTimeRejectionPolicyFactory.java
@@ -40,7 +40,12 @@ public class ServerTimeRejectionPolicyFactory implements RejectionPolicyFactory
       @Override
       public boolean accept(long timestamp)
       {
-        return timestamp >= (System.currentTimeMillis() - windowMillis);
+        long now = System.currentTimeMillis();
+
+        boolean notTooOld = timestamp >= (now - windowMillis);
+        boolean notTooYoung = timestamp <= (now + windowMillis);
+
+        return notTooOld && notTooYoung;
       }
 
       @Override

--- a/server/src/test/java/io/druid/segment/realtime/plumber/ServerTimeRejectionPolicyFactoryTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/plumber/ServerTimeRejectionPolicyFactoryTest.java
@@ -37,8 +37,10 @@ public class ServerTimeRejectionPolicyFactoryTest
 
     DateTime now = new DateTime();
     DateTime past = now.minus(period).minus(1);
+    DateTime future = now.plus(period).plus(1);
 
     Assert.assertTrue(rejectionPolicy.accept(now.getMillis()));
     Assert.assertFalse(rejectionPolicy.accept(past.getMillis()));
+    Assert.assertFalse(rejectionPolicy.accept(future.getMillis()));
   }
 }


### PR DESCRIPTION
Tries to fix https://github.com/metamx/druid/issues/359
