### PR TITLE
consider errors in reading from firehose as unparsable

### DIFF
--- a/server/src/main/java/io/druid/segment/realtime/RealtimeManager.java
+++ b/server/src/main/java/io/druid/segment/realtime/RealtimeManager.java
@@ -182,8 +182,8 @@ public class RealtimeManager implements QuerySegmentWalker
               inputRow = firehose.nextRow();
             }
             catch (Exception e) {
-              log.info(e, "thrown away line due to exception");
-              metrics.incrementThrownAway();
+              log.debug(e, "thrown away line due to exception, considering unparseable");
+              metrics.incrementUnparseable();
               continue;
             }
 


### PR DESCRIPTION
I noticed exceptions in reading an event are considered thrownAway, but unparseable makes much more sense.

Silenced the log at the same time.
