### PR TITLE
Blocking Executors and maxPendingPersists, oh my!

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/common/task/RealtimeIndexTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/RealtimeIndexTask.java
@@ -109,7 +109,7 @@ public class RealtimeIndexTask extends AbstractTask
       @JsonProperty("firehose") FirehoseFactory firehoseFactory,
       @JsonProperty("fireDepartmentConfig") FireDepartmentConfig fireDepartmentConfig,
       @JsonProperty("windowPeriod") Period windowPeriod,
-      @JsonProperty("maxPendingPersists") int maxPendingPersists,
+      @JsonProperty("maxPendingPersists") Integer maxPendingPersists,
       @JsonProperty("segmentGranularity") IndexGranularity segmentGranularity,
       @JsonProperty("rejectionPolicy") RejectionPolicyFactory rejectionPolicyFactory
   )
@@ -139,7 +139,7 @@ public class RealtimeIndexTask extends AbstractTask
     this.firehoseFactory = firehoseFactory;
     this.fireDepartmentConfig = fireDepartmentConfig;
     this.windowPeriod = windowPeriod;
-    this.maxPendingPersists = (maxPendingPersists == 0)
+    this.maxPendingPersists = (maxPendingPersists == null)
                               ? RealtimePlumberSchool.DEFAULT_MAX_PENDING_PERSISTS
                               : maxPendingPersists;
     this.segmentGranularity = segmentGranularity;
@@ -396,6 +396,12 @@ public class RealtimeIndexTask extends AbstractTask
   public Period getWindowPeriod()
   {
     return windowPeriod;
+  }
+
+  @JsonProperty
+  public int getMaxPendingPersists()
+  {
+    return maxPendingPersists;
   }
 
   @JsonProperty

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
@@ -198,7 +198,7 @@ public class TaskSerdeTest
         null,
         null,
         new Period("PT10M"),
-        1,
+        5,
         IndexGranularity.HOUR,
         null
     );
@@ -214,6 +214,7 @@ public class TaskSerdeTest
     Assert.assertEquals("rofl", task.getTaskResource().getAvailabilityGroup());
     Assert.assertEquals(new Period("PT10M"), task.getWindowPeriod());
     Assert.assertEquals(IndexGranularity.HOUR, task.getSegmentGranularity());
+    Assert.assertEquals(5, task.getMaxPendingPersists());
 
     Assert.assertEquals(task.getId(), task2.getId());
     Assert.assertEquals(task.getGroupId(), task2.getGroupId());
@@ -222,6 +223,7 @@ public class TaskSerdeTest
     Assert.assertEquals(task.getTaskResource().getAvailabilityGroup(), task2.getTaskResource().getAvailabilityGroup());
     Assert.assertEquals(task.getWindowPeriod(), task2.getWindowPeriod());
     Assert.assertEquals(task.getSegmentGranularity(), task2.getSegmentGranularity());
+    Assert.assertEquals(task.getMaxPendingPersists(), task2.getMaxPendingPersists());
   }
 
   @Test

--- a/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumberSchool.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumberSchool.java
@@ -44,7 +44,7 @@ import java.util.concurrent.ExecutorService;
  */
 public class RealtimePlumberSchool implements PlumberSchool
 {
-  public static final int DEFAULT_MAX_PENDING_PERSISTS = 2;
+  public static final int DEFAULT_MAX_PENDING_PERSISTS = 0;
 
   private static final EmittingLogger log = new EmittingLogger(RealtimePlumberSchool.class);
 


### PR DESCRIPTION
- Execs.newBlockingSingleThreaded can now accept capacity = 0.
- Changed default maxPendingPersists from 2 to 0.
- Fixed serde of maxPendingPersists in RealtimeIndexTasks.
