### PR TITLE
Fixed segments SQL queries for PostgreSQL compatibility

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/overlord/IndexerDBCoordinator.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/IndexerDBCoordinator.java
@@ -90,7 +90,7 @@ public class IndexerDBCoordinator
             final ResultIterator<Map<String, Object>> dbSegments =
                 handle.createQuery(
                     String.format(
-                        "SELECT payload FROM %s WHERE used = 1 AND dataSource = :dataSource",
+                        "SELECT payload FROM %s WHERE used = true AND dataSource = :dataSource",
                         dbTables.getSegmentsTable()
                     )
                 )
@@ -304,8 +304,8 @@ public class IndexerDBCoordinator
             return handle.createQuery(
                 String.format(
                     DbConnector.isPostgreSQL(handle)?
-                        "SELECT payload FROM %s WHERE dataSource = :dataSource and start >= :start and \"end\" <= :end and used = 0":
-                        "SELECT payload FROM %s WHERE dataSource = :dataSource and start >= :start and end <= :end and used = 0",
+                        "SELECT payload FROM %s WHERE dataSource = :dataSource and start >= :start and \"end\" <= :end and used = false":
+                        "SELECT payload FROM %s WHERE dataSource = :dataSource and start >= :start and end <= :end and used = false",
                     dbTables.getSegmentsTable()
                 )
             )


### PR DESCRIPTION
PostgreSQL doesn't cast int to boolean.
Without that, many tasks are not possible (tried with index and kill but may be more tasks affected).
