### PR TITLE
path should already be a proper uri

### DIFF
--- a/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsDataSegmentPusher.java
+++ b/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsDataSegmentPusher.java
@@ -66,12 +66,7 @@ public class HdfsDataSegmentPusher implements DataSegmentPusher
   @Override
   public String getPathForHadoop(String dataSource)
   {
-    try {
-      return new Path(config.getStorageDirectory(), dataSource).makeQualified(FileSystem.get(hadoopConfig)).toString();
-    }
-    catch (IOException e) {
-      throw Throwables.propagate(e);
-    }
+    return new Path(config.getStorageDirectory(), dataSource).toUri().toString();
   }
 
   @Override


### PR DESCRIPTION
works around issues when config cannot properly initialize early
in the indexing process
