### PR TITLE
Autoscaling: Fix case where target < current, but target is too low.

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/overlord/scaling/SimpleResourceManagementStrategy.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/scaling/SimpleResourceManagementStrategy.java
@@ -323,14 +323,15 @@ public class SimpleResourceManagementStrategy implements ResourceManagementStrat
         );
       }
 
-      final boolean atSteadyState = currentlyProvisioning.isEmpty()
-                                    && currentlyTerminating.isEmpty()
-                                    && validWorkers.size() == targetWorkerCount;
-      final boolean shouldScaleUp = atSteadyState
+      final boolean notTakingActions = currentlyProvisioning.isEmpty()
+                                    && currentlyTerminating.isEmpty();
+      final boolean shouldScaleUp = notTakingActions
+                                    && validWorkers.size() >= targetWorkerCount
                                     && targetWorkerCount < maxWorkerCount
                                     && (hasTaskPendingBeyondThreshold(pendingTasks)
                                         || targetWorkerCount < minWorkerCount);
-      final boolean shouldScaleDown = atSteadyState
+      final boolean shouldScaleDown = notTakingActions
+                                      && validWorkers.size() == targetWorkerCount
                                       && targetWorkerCount > minWorkerCount
                                       && Iterables.any(validWorkers, isLazyWorker);
       if (shouldScaleUp) {


### PR DESCRIPTION
This can happen when workers are provisioned manually.
