### PR TITLE
upgrade to jetty 9.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,17 +324,17 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-server</artifactId>
-                <version>9.1.5.v20140505</version>
+                <version>9.2.1.v20140609</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-servlet</artifactId>
-                <version>9.1.5.v20140505</version>
+                <version>9.2.1.v20140609</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-servlets</artifactId>
-                <version>9.1.5.v20140505</version>
+                <version>9.2.1.v20140609</version>
             </dependency>
             <dependency>
                 <groupId>joda-time</groupId>


### PR DESCRIPTION
Upgrade jetty version
- supports Java8
- Async I/O Proxying
- other jetty bug fixes
  http://dev.eclipse.org/mhonarc/lists/jetty-announce/msg00065.html
  http://dev.eclipse.org/mhonarc/lists/jetty-announce/msg00066.html
