### PR TITLE
fix deadlock condition that can exist in the coordinator

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/LoadQueueTaskMaster.java
+++ b/server/src/main/java/io/druid/server/coordinator/LoadQueueTaskMaster.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import org.apache.curator.framework.CuratorFramework;
 
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
@@ -33,6 +34,7 @@ public class LoadQueueTaskMaster
   private final CuratorFramework curator;
   private final ObjectMapper jsonMapper;
   private final ScheduledExecutorService peonExec;
+  private final ExecutorService callbackExec;
   private final DruidCoordinatorConfig config;
 
   @Inject
@@ -40,17 +42,19 @@ public class LoadQueueTaskMaster
       CuratorFramework curator,
       ObjectMapper jsonMapper,
       ScheduledExecutorService peonExec,
+      ExecutorService callbackExec,
       DruidCoordinatorConfig config
   )
   {
     this.curator = curator;
     this.jsonMapper = jsonMapper;
     this.peonExec = peonExec;
+    this.callbackExec = callbackExec;
     this.config = config;
   }
 
   public LoadQueuePeon giveMePeon(String basePath)
   {
-    return new LoadQueuePeon(curator, basePath, jsonMapper, peonExec, config);
+    return new LoadQueuePeon(curator, basePath, jsonMapper, peonExec, callbackExec, config);
   }
 }

--- a/server/src/test/java/io/druid/server/coordinator/LoadQueuePeonTester.java
+++ b/server/src/test/java/io/druid/server/coordinator/LoadQueuePeonTester.java
@@ -29,7 +29,7 @@ public class LoadQueuePeonTester extends LoadQueuePeon
 
   public LoadQueuePeonTester()
   {
-    super(null, null, null, null, null);
+    super(null, null, null, null, null, null);
   }
 
   @Override

--- a/services/src/main/java/io/druid/cli/CliCoordinator.java
+++ b/services/src/main/java/io/druid/cli/CliCoordinator.java
@@ -61,6 +61,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.eclipse.jetty.server.Server;
 
 import java.util.List;
+import java.util.concurrent.Executors;
 
 /**
  */
@@ -128,10 +129,16 @@ public class CliCoordinator extends ServerRunnable
           @Provides
           @LazySingleton
           public LoadQueueTaskMaster getLoadQueueTaskMaster(
-              CuratorFramework curator, ObjectMapper jsonMapper, ScheduledExecutorFactory factory, DruidCoordinatorConfig config
+              CuratorFramework curator,
+              ObjectMapper jsonMapper,
+              ScheduledExecutorFactory factory,
+              DruidCoordinatorConfig config
           )
           {
-            return new LoadQueueTaskMaster(curator, jsonMapper, factory.create(1, "Master-PeonExec--%d"), config);
+            return new LoadQueueTaskMaster(
+                curator, jsonMapper, factory.create(1, "Master-PeonExec--%d"),
+                Executors.newSingleThreadExecutor(), config
+            );
           }
         }
     );


### PR DESCRIPTION
2 LoadQueuePeons refer to each other via executeCallbacks(), when this happens at the same time, coordinator deadlocks.

```
"Master-PeonExec--0" daemon prio=10 tid=0x0000000000f68c70 nid=0x4aac waiting for monitor entry [0x0000000040e0a000]
   java.lang.Thread.State: BLOCKED (on object monitor)
    at io.druid.server.coordinator.LoadQueuePeon.dropSegment(LoadQueuePeon.java:188)
    - waiting to lock <____0x00000007c647fbb8____> (a java.lang.Object)
    at io.druid.server.coordinator.DruidCoordinator$1.execute(DruidCoordinator.java:333)
    at io.druid.server.coordinator.LoadQueuePeon$SegmentHolder.executeCallbacks(LoadQueuePeon.java:455)
    - locked <0x0000000799747ce0> (a java.util.ArrayList)
    at io.druid.server.coordinator.LoadQueuePeon.actionCompleted(LoadQueuePeon.java:331)
    at io.druid.server.coordinator.LoadQueuePeon.entryRemoved(LoadQueuePeon.java:377)
    - locked <0x00000007c4570f18> (a java.lang.Object)
    at io.druid.server.coordinator.LoadQueuePeon.access$1200(LoadQueuePeon.java:54)
    at io.druid.server.coordinator.LoadQueuePeon$4.run(LoadQueuePeon.java:299)
    - locked <____0x00000007c4570f18____> (a java.lang.Object)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
    at java.util.concurrent.FutureTask.run(FutureTask.java:262)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:178)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:292)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:744)

"main-EventThread" daemon prio=10 tid=0x0000000000b82b80 nid=0x4ca9 waiting for monitor entry [0x000000004154a000]
   java.lang.Thread.State: BLOCKED (on object monitor)
    at io.druid.server.coordinator.LoadQueuePeon.dropSegment(LoadQueuePeon.java:188)
    - waiting to lock <____0x00000007c4570f18____> (a java.lang.Object)
    at io.druid.server.coordinator.DruidCoordinator$1.execute(DruidCoordinator.java:333)
    at io.druid.server.coordinator.LoadQueuePeon$SegmentHolder.executeCallbacks(LoadQueuePeon.java:455)
    - locked <0x000000079974d2f0> (a java.util.ArrayList)
    at io.druid.server.coordinator.LoadQueuePeon.actionCompleted(LoadQueuePeon.java:331)
    at io.druid.server.coordinator.LoadQueuePeon.entryRemoved(LoadQueuePeon.java:377)
    - locked <____0x00000007c647fbb8____> (a java.lang.Object)
    at io.druid.server.coordinator.LoadQueuePeon.access$1200(LoadQueuePeon.java:54)
    at io.druid.server.coordinator.LoadQueuePeon$4$2.process(LoadQueuePeon.java:275)
    at org.apache.curator.framework.imps.NamespaceWatcher.process(NamespaceWatcher.java:56)
    at org.apache.zookeeper.ClientCnxn$EventThread.processEvent(ClientCnxn.java:519)
    at org.apache.zookeeper.ClientCnxn$EventThread.run(ClientCnxn.java:495)
```
