### PR TITLE
CliHadoopIndexer: fixing comma separated list of coordinates addition to allCoordinates

### DIFF
--- a/services/src/main/java/io/druid/cli/CliHadoopIndexer.java
+++ b/services/src/main/java/io/druid/cli/CliHadoopIndexer.java
@@ -54,8 +54,8 @@ public class CliHadoopIndexer implements Runnable
   private String argumentSpec;
 
   @Option(name = {"-c", "--coordinate", "hadoopDependencies"},
-          description = "extra dependencies to pull down (e.g. non-default hadoop coordinates or extra hadoop jars)")
-  private List<String> coordinates;
+          description = "comma separated list of extra dependencies to pull down (e.g. non-default hadoop coordinates or extra hadoop jars)")
+  private String coordinates;
 
   @Option(name = "--no-default-hadoop",
           description = "don't pull down the default hadoop version (currently " + DEFAULT_HADOOP_COORDINATES + ")",
@@ -72,7 +72,7 @@ public class CliHadoopIndexer implements Runnable
     try {
       final List<String> allCoordinates = Lists.newArrayList();
       if (coordinates != null) {
-        allCoordinates.addAll(coordinates);
+        allCoordinates.addAll(Arrays.asList(coordinates.replaceAll("\\s+", "").split(",")));
       }
       if (!noDefaultHadoop) {
         allCoordinates.add(DEFAULT_HADOOP_COORDINATES);


### PR DESCRIPTION
airlift/airline does not seem to parse comma separated list correctly, so you couldn't specify more than one mvn coordinate inside the option "-c/--coordinate/hadoopDependencies". This change fixes that. It can now support comma separated list of mvn coordinates.
