### PR TITLE
Fixed the issue about the path's prefix after batch ingestion with indexing service to hdfs

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
@@ -448,7 +448,7 @@ public class IndexGeneratorJob implements Jobby
       } else if (outputFS instanceof DistributedFileSystem) {
         loadSpec = ImmutableMap.<String, Object>of(
             "type", "hdfs",
-            "path", indexOutURI.getPath()
+            "path", indexOutURI.toString()
         );
       } else {
         throw new ISE("Unknown file system[%s]", outputFS.getClass());


### PR DESCRIPTION
Fixed the issue of batch ingestion with indexing service to hdfs end up with the path of metadata in mysql missing "hdfs://host" prefix. 
The detail describe can be found here: https://groups.google.com/forum/#!topic/druid-development/ofvSxiPpCxI
