### PR TITLE
upgrade jetty and workaround for half open connection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,22 +324,22 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-server</artifactId>
-                <version>9.2.2.v20140723</version>
+                <version>9.2.3.v20140905</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-servlet</artifactId>
-                <version>9.2.2.v20140723</version>
+                <version>9.2.3.v20140905</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-servlets</artifactId>
-                <version>9.2.2.v20140723</version>
+                <version>9.2.3.v20140905</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-proxy</artifactId>
-                <version>9.2.2.v20140723</version>
+                <version>9.2.3.v20140905</version>
             </dependency>
             <dependency>
                 <groupId>joda-time</groupId>

--- a/server/src/main/java/io/druid/server/initialization/JettyServerModule.java
+++ b/server/src/main/java/io/druid/server/initialization/JettyServerModule.java
@@ -158,6 +158,9 @@ public class JettyServerModule extends JerseyServletModule
     ServerConnector connector = new ServerConnector(server);
     connector.setPort(node.getPort());
     connector.setIdleTimeout(Ints.checkedCast(config.getMaxIdleTime().toStandardDuration().getMillis()));
+    // workaround suggested in -
+    // https://bugs.eclipse.org/bugs/show_bug.cgi?id=435322#c66 for jetty half open connection issues during failovers
+    connector.setAcceptorPriorityDelta(-1);
 
     server.setConnectors(new Connector[]{connector});
 


### PR DESCRIPTION
Upgrade jetty and set acceptor priority delta to -1 to give priority to servicing connections already accepted rather than opening new connections.
workaround suggested in - https://bugs.eclipse.org/bugs/show_bug.cgi?id=435322#c66
