### PR TITLE
prefer druid.curator.compress to druid.indexer.runner.compressZnodes

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunnerFactory.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunnerFactory.java
@@ -68,7 +68,7 @@ public class RemoteTaskRunnerFactory implements TaskRunnerFactory
         curator,
         new SimplePathChildrenCacheFactory
             .Builder()
-            .withCompressed(remoteTaskRunnerConfig.isCompressZnodes())
+            .withCompressed(true)
             .build(),
         httpClient,
         strategy

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
@@ -34,9 +34,6 @@ public class RemoteTaskRunnerConfig
   private Period taskAssignmentTimeout = new Period("PT5M");
 
   @JsonProperty
-  private boolean compressZnodes = false;
-
-  @JsonProperty
   private String minWorkerVersion = "0";
 
   @JsonProperty
@@ -46,11 +43,6 @@ public class RemoteTaskRunnerConfig
   public Period getTaskAssignmentTimeout()
   {
     return taskAssignmentTimeout;
-  }
-
-  public boolean isCompressZnodes()
-  {
-    return compressZnodes;
   }
 
   public String getMinWorkerVersion()

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/TestRemoteTaskRunnerConfig.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/TestRemoteTaskRunnerConfig.java
@@ -27,12 +27,6 @@ import org.joda.time.Period;
 public class TestRemoteTaskRunnerConfig extends RemoteTaskRunnerConfig
 {
   @Override
-  public boolean isCompressZnodes()
-  {
-    return false;
-  }
-
-  @Override
   public Period getTaskAssignmentTimeout()
   {
     return new Period("PT1S");


### PR DESCRIPTION
We use `PotentiallyGzippedCompressionProvider` by default, so it should work transparently across nodes with different settings, or during ugprades
