### PR TITLE
Changed downloadStartMarker in OmniSegmentLoader to simply use its .delete() method

### DIFF
--- a/server/src/main/java/io/druid/segment/loading/OmniSegmentLoader.java
+++ b/server/src/main/java/io/druid/segment/loading/OmniSegmentLoader.java
@@ -138,12 +138,10 @@ public class OmniSegmentLoader implements SegmentLoader
 
       getPuller(segment.getLoadSpec()).getSegmentFiles(segment, storageDir);
 
-      try {
-        FileUtils.deleteDirectory(downloadStartMarker);
-      }
-      catch (Exception e) {
+      if (!downloadStartMarker.delete()) {
         throw new SegmentLoadingException("Unable to remove marker file for [%s]", storageDir);
       }
+
 
       loc.addSegment(segment);
 


### PR DESCRIPTION
I was having some issues with this for some reason. So here's the fix.
