### PR TITLE
Add benchmarking for bitmaps

### DIFF
--- a/processing/src/test/java/io/druid/segment/data/BitmapCreationBenchmark.java
+++ b/processing/src/test/java/io/druid/segment/data/BitmapCreationBenchmark.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -104,6 +105,7 @@ public class BitmapCreationBenchmark extends AbstractBenchmark
   ImmutableBitmap baseImmutableBitmap;
   MutableBitmap baseMutableBitmap;
   byte[] baseBytes;
+  ByteBuffer baseByteBuffer;
 
   @Before
   public void setup()
@@ -114,6 +116,7 @@ public class BitmapCreationBenchmark extends AbstractBenchmark
     }
     baseImmutableBitmap = factory.makeImmutableBitmap(baseMutableBitmap);
     baseBytes = baseImmutableBitmap.toBytes();
+    baseByteBuffer = ByteBuffer.wrap(baseBytes);
   }
 
 
@@ -157,6 +160,15 @@ public class BitmapCreationBenchmark extends AbstractBenchmark
   {
     ImmutableBitmap immutableBitmap = factory.makeImmutableBitmap(baseMutableBitmap);
     Assert.assertArrayEquals(baseBytes, immutableBitmap.toBytes());
+  }
+
+
+  @BenchmarkOptions(warmupRounds = 10, benchmarkRounds = 1000)
+  @Test
+  public void testFromImmutableByteArray()
+  {
+    ImmutableBitmap immutableBitmap = factory.mapImmutableBitmap(baseByteBuffer);
+    Assert.assertEquals(numBits, immutableBitmap.size());
   }
 
 }


### PR DESCRIPTION
Here are the results on my laptop:

```
BitmapCreationBenchmark.testRandomAddition[0]: [measured 10 out of 20 rounds, threads: 1 (sequential)]
 round: 0.49 [+- 0.07], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 16, GC.time: 0.01, time.total: 9.91, time.warmup: 5.06, time.bench: 4.86
BitmapCreationBenchmark.testLinearAdditionDescending[0]: [measured 1000 out of 1010 rounds, threads: 1 (sequential)]
 round: 0.01 [+- 0.00], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 74, GC.time: 0.03, time.total: 5.82, time.warmup: 0.06, time.bench: 5.76
BitmapCreationBenchmark.testToImmutableByteArray[0]: [measured 1000 out of 1010 rounds, threads: 1 (sequential)]
 round: 0.00 [+- 0.00], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 0, GC.time: 0.00, time.total: 1.80, time.warmup: 0.02, time.bench: 1.78
BitmapCreationBenchmark.testRandomAddition[1]: [measured 10 out of 20 rounds, threads: 1 (sequential)]
 round: 0.00 [+- 0.00], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 0, GC.time: 0.00, time.total: 0.12, time.warmup: 0.08, time.bench: 0.04
BitmapCreationBenchmark.testLinearAdditionDescending[1]: [measured 1000 out of 1010 rounds, threads: 1 (sequential)]
 round: 0.00 [+- 0.00], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 10, GC.time: 0.01, time.total: 4.26, time.warmup: 0.04, time.bench: 4.22
BitmapCreationBenchmark.testToImmutableByteArray[1]: [measured 1000 out of 1010 rounds, threads: 1 (sequential)]
 round: 0.01 [+- 0.00], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 27, GC.time: 0.01, time.total: 5.11, time.warmup: 0.05, time.bench: 5.06
BitmapCreationBenchmark.testLinearAddition[0]: [measured 1000 out of 1010 rounds, threads: 1 (sequential)]
 round: 0.00 [+- 0.00], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 0, GC.time: 0.00, time.total: 3.48, time.warmup: 0.04, time.bench: 3.45
BitmapCreationBenchmark.testLinearAddition[1]: [measured 1000 out of 1010 rounds, threads: 1 (sequential)]
 round: 0.00 [+- 0.00], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 9, GC.time: 0.00, time.total: 2.95, time.warmup: 0.03, time.bench: 2.92
2014-11-13 12:47:23,995 INFO [main] io.druid.segment.data.BitmapCreationBenchmark - Entry [0] is io.druid.segment.data.ConciseBitmapSerdeFactory
2014-11-13 12:47:23,995 INFO [main] io.druid.segment.data.BitmapCreationBenchmark - Entry [1] is io.druid.segment.data.RoaringBitmapSerdeFactory
```
