### PR TITLE
Allow Smile to fall back to text

### DIFF
--- a/processing/src/main/java/io/druid/jackson/JacksonModule.java
+++ b/processing/src/main/java/io/druid/jackson/JacksonModule.java
@@ -48,7 +48,9 @@ public class JacksonModule implements Module
   @Provides @LazySingleton @Smile
   public ObjectMapper smileMapper()
   {
-    ObjectMapper retVal = new DefaultObjectMapper(new SmileFactory());
+    final SmileFactory smileFactory = new SmileFactory();
+    smileFactory.delegateToTextual(true);
+    final ObjectMapper retVal = new DefaultObjectMapper(smileFactory);
     retVal.getFactory().setCodec(retVal);
     return retVal;
   }


### PR DESCRIPTION
- Modify SmileFactory to set the delegate to text option.
  - This option only occurs when a Reader type object is passed in to the deserialization stuff
  - This is needed by the X-Druid-Response-Context header return value, which is JSON
