### PR TITLE
Fix filtered agg 0.7

### DIFF
--- a/docs/content/Aggregations.md
+++ b/docs/content/Aggregations.md
@@ -169,14 +169,13 @@ A filtered aggregator wraps any given aggregator, but only aggregates the values
 
 This makes it possible to compute the results of a filtered and an unfiltered aggregation simultaneously, without having to issue multiple queries, and use both results as part of post-aggregations.
 
-*Limitations:* The filtered aggregator currently only supports selector and not filter with a single selector, i.e. matching a dimension against a single value.
+*Limitations:* The filtered aggregator currently only supports 'or', 'and', 'selector' and 'not' filters, i.e. matching one or multiple dimensions against a single value.
 
 *Note:* If only the filtered results are required, consider putting the filter on the query itself, which will be much faster since it does not require scanning all the data.
 
 ```json
 {
   "type" : "filtered",
-  "name" : "aggMatching",
   "filter" : {
     "type" : "selector",
     "dimension" : <dimension>,

--- a/processing/src/main/java/io/druid/query/aggregation/FilteredAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/FilteredAggregator.java
@@ -19,38 +19,24 @@
 
 package io.druid.query.aggregation;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-import io.druid.segment.DimensionSelector;
-import io.druid.segment.data.IndexedInts;
-
-import javax.annotation.Nullable;
+import io.druid.query.filter.ValueMatcher;
 
 public class FilteredAggregator implements Aggregator
 {
-  private final String name;
-  private final DimensionSelector dimSelector;
+  private final ValueMatcher matcher;
   private final Aggregator delegate;
-  private final IntPredicate predicate;
 
-  public FilteredAggregator(String name, DimensionSelector dimSelector, IntPredicate predicate, Aggregator delegate)
+  public FilteredAggregator(ValueMatcher matcher, Aggregator delegate)
   {
-    this.name = name;
-    this.dimSelector = dimSelector;
+    this.matcher = matcher;
     this.delegate = delegate;
-    this.predicate = predicate;
   }
 
   @Override
   public void aggregate()
   {
-    final IndexedInts row = dimSelector.getRow();
-    final int size = row.size();
-    for (int i = 0; i < size; ++i) {
-      if (predicate.apply(row.get(i))) {
-        delegate.aggregate();
-        break;
-      }
+    if (matcher.matches()) {
+      delegate.aggregate();
     }
   }
 
@@ -75,7 +61,7 @@ public class FilteredAggregator implements Aggregator
   @Override
   public String getName()
   {
-    return name;
+    return delegate.getName();
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/FilteredBufferAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/FilteredBufferAggregator.java
@@ -19,6 +19,7 @@
 
 package io.druid.query.aggregation;
 
+import io.druid.query.filter.ValueMatcher;
 import io.druid.segment.DimensionSelector;
 import io.druid.segment.data.IndexedInts;
 
@@ -26,14 +27,12 @@ import java.nio.ByteBuffer;
 
 public class FilteredBufferAggregator implements BufferAggregator
 {
-  private final DimensionSelector dimSelector;
-  private final IntPredicate predicate;
+  private final ValueMatcher matcher;
   private final BufferAggregator delegate;
 
-  public FilteredBufferAggregator(DimensionSelector dimSelector, IntPredicate predicate, BufferAggregator delegate)
+  public FilteredBufferAggregator(ValueMatcher matcher, BufferAggregator delegate)
   {
-    this.dimSelector = dimSelector;
-    this.predicate = predicate;
+    this.matcher = matcher;
     this.delegate = delegate;
   }
 
@@ -46,13 +45,8 @@ public class FilteredBufferAggregator implements BufferAggregator
   @Override
   public void aggregate(ByteBuffer buf, int position)
   {
-    final IndexedInts row = dimSelector.getRow();
-    final int size = row.size();
-    for (int i = 0; i < size; ++i) {
-      if (predicate.apply(row.get(i))) {
-        delegate.aggregate(buf, position);
-        break;
-      }
+    if (matcher.matches()) {
+      delegate.aggregate(buf, position);
     }
   }
 

--- a/processing/src/main/java/io/druid/query/filter/Filter.java
+++ b/processing/src/main/java/io/druid/query/filter/Filter.java
@@ -20,6 +20,7 @@
 package io.druid.query.filter;
 
 import com.metamx.collections.bitmap.ImmutableBitmap;
+import io.druid.segment.ColumnSelectorFactory;
 
 /**
  */
@@ -27,4 +28,5 @@ public interface Filter
 {
   public ImmutableBitmap getBitmapIndex(BitmapIndexSelector selector);
   public ValueMatcher makeMatcher(ValueMatcherFactory factory);
+  public ValueMatcher makeMatcher(ColumnSelectorFactory columnSelectorFactory);
 }

--- a/processing/src/main/java/io/druid/segment/filter/AndFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/AndFilter.java
@@ -25,6 +25,7 @@ import io.druid.query.filter.BitmapIndexSelector;
 import io.druid.query.filter.Filter;
 import io.druid.query.filter.ValueMatcher;
 import io.druid.query.filter.ValueMatcherFactory;
+import io.druid.segment.ColumnSelectorFactory;
 
 import java.util.List;
 
@@ -68,9 +69,23 @@ public class AndFilter implements Filter
     for (int i = 0; i < filters.size(); i++) {
       matchers[i] = filters.get(i).makeMatcher(factory);
     }
+    return makeMatcher(matchers);
+  }
 
-    if (matchers.length == 1) {
-      return matchers[0];
+  public ValueMatcher makeMatcher(ColumnSelectorFactory factory)
+  {
+    final ValueMatcher[] matchers = new ValueMatcher[filters.size()];
+
+    for (int i = 0; i < filters.size(); i++) {
+      matchers[i] = filters.get(i).makeMatcher(factory);
+    }
+    return makeMatcher(matchers);
+  }
+
+  private ValueMatcher makeMatcher(final ValueMatcher[] baseMatchers)
+  {
+    if (baseMatchers.length == 1) {
+      return baseMatchers[0];
     }
 
     return new ValueMatcher()
@@ -78,7 +93,7 @@ public class AndFilter implements Filter
       @Override
       public boolean matches()
       {
-        for (ValueMatcher matcher : matchers) {
+        for (ValueMatcher matcher : baseMatchers) {
           if (!matcher.matches()) {
             return false;
           }
@@ -87,5 +102,4 @@ public class AndFilter implements Filter
       }
     };
   }
-
 }

--- a/processing/src/main/java/io/druid/segment/filter/DimensionPredicateFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/DimensionPredicateFilter.java
@@ -27,6 +27,7 @@ import io.druid.query.filter.BitmapIndexSelector;
 import io.druid.query.filter.Filter;
 import io.druid.query.filter.ValueMatcher;
 import io.druid.query.filter.ValueMatcherFactory;
+import io.druid.segment.ColumnSelectorFactory;
 import io.druid.segment.data.Indexed;
 
 import javax.annotation.Nullable;
@@ -75,5 +76,11 @@ class DimensionPredicateFilter implements Filter
   public ValueMatcher makeMatcher(ValueMatcherFactory factory)
   {
     return factory.makeValueMatcher(dimension, predicate);
+  }
+
+  @Override
+  public ValueMatcher makeMatcher(ColumnSelectorFactory factory)
+  {
+    throw new UnsupportedOperationException();
   }
 }

--- a/processing/src/main/java/io/druid/segment/filter/ExtractionFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/ExtractionFilter.java
@@ -26,6 +26,7 @@ import io.druid.query.filter.BitmapIndexSelector;
 import io.druid.query.filter.Filter;
 import io.druid.query.filter.ValueMatcher;
 import io.druid.query.filter.ValueMatcherFactory;
+import io.druid.segment.ColumnSelectorFactory;
 import io.druid.segment.data.Indexed;
 
 import java.util.List;
@@ -75,4 +76,11 @@ public class ExtractionFilter implements Filter
   {
     throw new UnsupportedOperationException();
   }
+
+  @Override
+  public ValueMatcher makeMatcher(ColumnSelectorFactory factory)
+  {
+    throw new UnsupportedOperationException();
+  }
+
 }

--- a/processing/src/main/java/io/druid/segment/filter/JavaScriptFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/JavaScriptFilter.java
@@ -27,6 +27,7 @@ import io.druid.query.filter.BitmapIndexSelector;
 import io.druid.query.filter.Filter;
 import io.druid.query.filter.ValueMatcher;
 import io.druid.query.filter.ValueMatcherFactory;
+import io.druid.segment.ColumnSelectorFactory;
 import io.druid.segment.data.Indexed;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Function;
@@ -160,4 +161,11 @@ public class JavaScriptFilter implements Filter
       return script.hashCode();
     }
   }
+
+  @Override
+  public ValueMatcher makeMatcher(ColumnSelectorFactory factory)
+  {
+    throw new UnsupportedOperationException();
+  }
+
 }

--- a/processing/src/main/java/io/druid/segment/filter/NotFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/NotFilter.java
@@ -24,6 +24,7 @@ import io.druid.query.filter.BitmapIndexSelector;
 import io.druid.query.filter.Filter;
 import io.druid.query.filter.ValueMatcher;
 import io.druid.query.filter.ValueMatcherFactory;
+import io.druid.segment.ColumnSelectorFactory;
 
 /**
  */
@@ -49,6 +50,21 @@ public class NotFilter implements Filter
 
   @Override
   public ValueMatcher makeMatcher(ValueMatcherFactory factory)
+  {
+    final ValueMatcher baseMatcher = baseFilter.makeMatcher(factory);
+
+    return new ValueMatcher()
+    {
+      @Override
+      public boolean matches()
+      {
+        return !baseMatcher.matches();
+      }
+    };
+  }
+
+  @Override
+  public ValueMatcher makeMatcher(ColumnSelectorFactory factory)
   {
     final ValueMatcher baseMatcher = baseFilter.makeMatcher(factory);
 

--- a/processing/src/main/java/io/druid/segment/filter/OrFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/OrFilter.java
@@ -25,6 +25,7 @@ import io.druid.query.filter.BitmapIndexSelector;
 import io.druid.query.filter.Filter;
 import io.druid.query.filter.ValueMatcher;
 import io.druid.query.filter.ValueMatcherFactory;
+import io.druid.segment.ColumnSelectorFactory;
 
 import java.util.List;
 
@@ -68,9 +69,22 @@ public class OrFilter implements Filter
     for (int i = 0; i < filters.size(); i++) {
       matchers[i] = filters.get(i).makeMatcher(factory);
     }
+    return makeMatcher(matchers);
+  }
 
-    if (matchers.length == 1) {
-      return matchers[0];
+  public ValueMatcher makeMatcher(ColumnSelectorFactory factory)
+  {
+    final ValueMatcher[] matchers = new ValueMatcher[filters.size()];
+
+    for (int i = 0; i < filters.size(); i++) {
+      matchers[i] = filters.get(i).makeMatcher(factory);
+    }
+    return makeMatcher(matchers);
+  }
+
+  private ValueMatcher makeMatcher(final ValueMatcher[] baseMatchers){
+    if (baseMatchers.length == 1) {
+      return baseMatchers[0];
     }
 
     return new ValueMatcher()
@@ -78,7 +92,7 @@ public class OrFilter implements Filter
       @Override
       public boolean matches()
       {
-        for (ValueMatcher matcher : matchers) {
+        for (ValueMatcher matcher : baseMatchers) {
           if (matcher.matches()) {
             return true;
           }
@@ -87,4 +101,5 @@ public class OrFilter implements Filter
       }
     };
   }
+
 }

--- a/processing/src/main/java/io/druid/segment/filter/SelectorFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/SelectorFilter.java
@@ -20,10 +20,14 @@
 package io.druid.segment.filter;
 
 import com.metamx.collections.bitmap.ImmutableBitmap;
+import io.druid.query.aggregation.Aggregators;
 import io.druid.query.filter.BitmapIndexSelector;
 import io.druid.query.filter.Filter;
 import io.druid.query.filter.ValueMatcher;
 import io.druid.query.filter.ValueMatcherFactory;
+import io.druid.segment.ColumnSelectorFactory;
+import io.druid.segment.DimensionSelector;
+import io.druid.segment.data.IndexedInts;
 
 /**
  */
@@ -52,4 +56,34 @@ public class SelectorFilter implements Filter
   {
     return factory.makeValueMatcher(dimension, value);
   }
+
+  @Override
+  public ValueMatcher makeMatcher(ColumnSelectorFactory columnSelectorFactory)
+  {
+    final DimensionSelector dimensionSelector = columnSelectorFactory.makeDimensionSelector(dimension);
+
+    // Missing columns are treated the same way as selector.getBitmapIndex, always returning false
+    if (dimensionSelector == null) {
+      return new BooleanValueMatcher(false);
+    } else {
+      final int valueId = dimensionSelector.lookupId(value);
+      return new ValueMatcher()
+      {
+        @Override
+        public boolean matches()
+        {
+          final IndexedInts row = dimensionSelector.getRow();
+          final int size = row.size();
+          for (int i = 0; i < size; ++i) {
+            if (row.get(i) == valueId) {
+              return true;
+            }
+          }
+          return false;
+        }
+      };
+    }
+  }
+
+
 }

--- a/processing/src/main/java/io/druid/segment/filter/SpatialFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/SpatialFilter.java
@@ -24,6 +24,7 @@ import io.druid.query.filter.BitmapIndexSelector;
 import io.druid.query.filter.Filter;
 import io.druid.query.filter.ValueMatcher;
 import io.druid.query.filter.ValueMatcherFactory;
+import io.druid.segment.ColumnSelectorFactory;
 
 /**
  */
@@ -59,4 +60,11 @@ public class SpatialFilter implements Filter
         bound
     );
   }
+
+  @Override
+  public ValueMatcher makeMatcher(ColumnSelectorFactory factory)
+  {
+    throw new UnsupportedOperationException();
+  }
+
 }

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -837,7 +837,11 @@ public class IncrementalIndex implements Iterable<Row>, Closeable
 
     public int getId(String value)
     {
-      return falseIds.get(value);
+      if (value == null) {
+        value = "";
+      }
+      final Integer id = falseIds.get(value);
+      return id == null ? -1 : id;
     }
 
     public String getValue(int id)

--- a/processing/src/test/java/io/druid/query/aggregation/FilteredAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/FilteredAggregatorTest.java
@@ -19,7 +19,11 @@
 
 package io.druid.query.aggregation;
 
+import com.google.common.collect.Lists;
+import io.druid.query.filter.AndDimFilter;
+import io.druid.query.filter.DimFilter;
 import io.druid.query.filter.NotDimFilter;
+import io.druid.query.filter.OrDimFilter;
 import io.druid.query.filter.SelectorDimFilter;
 import io.druid.segment.ColumnSelectorFactory;
 import io.druid.segment.DimensionSelector;
@@ -46,7 +50,6 @@ public class FilteredAggregatorTest
     final TestFloatColumnSelector selector = new TestFloatColumnSelector(values);
 
     FilteredAggregatorFactory factory = new FilteredAggregatorFactory(
-        "test",
         new DoubleSumAggregatorFactory("billy", "value"),
         new SelectorDimFilter("dim", "a")
     );
@@ -55,7 +58,7 @@ public class FilteredAggregatorTest
      makeColumnSelector(selector)
     );
 
-    Assert.assertEquals("test", agg.getName());
+    Assert.assertEquals("billy", agg.getName());
 
     double expectedFirst = new Float(values[0]).doubleValue();
     double expectedSecond = new Float(values[1]).doubleValue() + expectedFirst;
@@ -164,7 +167,6 @@ public class FilteredAggregatorTest
     final TestFloatColumnSelector selector = new TestFloatColumnSelector(values);
 
     FilteredAggregatorFactory factory = new FilteredAggregatorFactory(
-        "test",
         new DoubleSumAggregatorFactory("billy", "value"),
         new NotDimFilter(new SelectorDimFilter("dim", "b"))
     );
@@ -173,7 +175,52 @@ public class FilteredAggregatorTest
         makeColumnSelector(selector)
     );
 
-    Assert.assertEquals("test", agg.getName());
+    Assert.assertEquals("billy", agg.getName());
+
+    double expectedFirst = new Float(values[0]).doubleValue();
+    double expectedSecond = new Float(values[1]).doubleValue() + expectedFirst;
+    double expectedThird = expectedSecond;
+    assertValues(agg, selector, expectedFirst, expectedSecond, expectedThird);
+  }
+
+  @Test
+  public void testAggregateWithOrFilter()
+  {
+    final float[] values = {0.15f, 0.27f, 0.14f};
+    final TestFloatColumnSelector selector = new TestFloatColumnSelector(values);
+
+    FilteredAggregatorFactory factory = new FilteredAggregatorFactory(
+        new DoubleSumAggregatorFactory("billy", "value"),
+        new OrDimFilter(Lists.<DimFilter>newArrayList(new SelectorDimFilter("dim", "a"), new SelectorDimFilter("dim", "b")))
+    );
+
+    FilteredAggregator agg = (FilteredAggregator) factory.factorize(
+        makeColumnSelector(selector)
+    );
+
+    Assert.assertEquals("billy", agg.getName());
+
+    double expectedFirst = new Float(values[0]).doubleValue();
+    double expectedSecond = new Float(values[1]).doubleValue() + expectedFirst;
+    double expectedThird = expectedSecond + new Float(values[2]).doubleValue();
+    assertValues(agg, selector, expectedFirst, expectedSecond, expectedThird);
+  }
+
+  @Test
+  public void testAggregateWithAndFilter()
+  {
+    final float[] values = {0.15f, 0.27f};
+    final TestFloatColumnSelector selector = new TestFloatColumnSelector(values);
+
+    FilteredAggregatorFactory factory = new FilteredAggregatorFactory(
+        new DoubleSumAggregatorFactory("billy", "value"),
+        new AndDimFilter(Lists.<DimFilter>newArrayList(new NotDimFilter(new SelectorDimFilter("dim", "b")), new SelectorDimFilter("dim", "a"))));
+
+    FilteredAggregator agg = (FilteredAggregator) factory.factorize(
+        makeColumnSelector(selector)
+    );
+
+    Assert.assertEquals("billy", agg.getName());
 
     double expectedFirst = new Float(values[0]).doubleValue();
     double expectedSecond = new Float(values[1]).doubleValue() + expectedFirst;

--- a/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerTest.java
@@ -32,12 +32,15 @@ import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerTestHelper;
 import io.druid.query.Result;
 import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.query.aggregation.CountAggregatorFactory;
+import io.druid.query.aggregation.FilteredAggregatorFactory;
 import io.druid.query.aggregation.LongSumAggregatorFactory;
 import io.druid.query.aggregation.MaxAggregatorFactory;
 import io.druid.query.aggregation.MinAggregatorFactory;
 import io.druid.query.aggregation.PostAggregator;
 import io.druid.query.filter.AndDimFilter;
 import io.druid.query.filter.DimFilter;
+import io.druid.query.filter.NotDimFilter;
 import io.druid.query.filter.RegexDimFilter;
 import io.druid.query.spec.MultipleIntervalSegmentSpec;
 import io.druid.segment.TestHelper;
@@ -53,8 +56,8 @@ import org.junit.runners.Parameterized;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 
 /**
  */
@@ -1656,6 +1659,252 @@ public class TimeseriesQueryRunnerTest
         runner.run(query, CONTEXT),
         Lists.<Result<TimeseriesResultValue>>newArrayList()
     );
+    TestHelper.assertExpectedResults(expectedResults, actualResults);
+  }
+
+  @Test
+  public void testTimeSeriesWithFilteredAgg()
+  {
+    TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
+                                  .dataSource(QueryRunnerTestHelper.dataSource)
+                                  .granularity(QueryRunnerTestHelper.allGran)
+                                  .intervals(QueryRunnerTestHelper.firstToThird)
+                                  .aggregators(
+                                      Lists.newArrayList(
+                                          Iterables.concat(
+                                              QueryRunnerTestHelper.commonAggregators,
+                                              Lists.newArrayList(
+                                                  new FilteredAggregatorFactory(
+                                                      new CountAggregatorFactory("filteredAgg"),
+                                                      Druids.newSelectorDimFilterBuilder()
+                                                            .dimension(QueryRunnerTestHelper.marketDimension)
+                                                            .value("spot")
+                                                            .build()
+                                                  )
+                                              )
+                                          )
+                                      )
+                                  )
+                                  .postAggregators(Arrays.<PostAggregator>asList(QueryRunnerTestHelper.addRowsIndexConstant))
+                                  .build();
+
+    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
+        runner.run(query, CONTEXT),
+        Lists.<Result<TimeseriesResultValue>>newArrayList()
+    );
+    List<Result<TimeseriesResultValue>> expectedResults = Arrays.asList(
+        new Result<TimeseriesResultValue>(
+            new DateTime("2011-04-01"),
+            new TimeseriesResultValue(
+                ImmutableMap.<String, Object>of(
+                    "filteredAgg", 18L,
+                    "addRowsIndexConstant", 12486.361190795898d,
+                    "index", 12459.361190795898d,
+                    "uniques", 9.019833517963864d,
+                    "rows", 26L
+                )
+            )
+        )
+    );
+
+    TestHelper.assertExpectedResults(expectedResults, actualResults);
+  }
+
+  @Test
+  public void testTimeSeriesWithFilteredAggDimensionNotPresentNotNullValue()
+  {
+    TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
+                                  .dataSource(QueryRunnerTestHelper.dataSource)
+                                  .granularity(QueryRunnerTestHelper.allGran)
+                                  .intervals(QueryRunnerTestHelper.firstToThird)
+                                  .aggregators(
+                                      Lists.newArrayList(
+                                          Iterables.concat(
+                                              QueryRunnerTestHelper.commonAggregators,
+                                              Lists.newArrayList(
+                                                  new FilteredAggregatorFactory(
+                                                      new CountAggregatorFactory("filteredAgg"),
+                                                      Druids.newSelectorDimFilterBuilder()
+                                                            .dimension("abraKaDabra")
+                                                            .value("Lol")
+                                                            .build()
+                                                  )
+                                              )
+                                          )
+                                      )
+                                  )
+                                  .postAggregators(Arrays.<PostAggregator>asList(QueryRunnerTestHelper.addRowsIndexConstant))
+                                  .build();
+
+    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
+        runner.run(query, CONTEXT),
+        Lists.<Result<TimeseriesResultValue>>newArrayList()
+    );
+
+    List<Result<TimeseriesResultValue>> expectedResults = Arrays.asList(
+        new Result<TimeseriesResultValue>(
+            new DateTime("2011-04-01"),
+            new TimeseriesResultValue(
+                ImmutableMap.<String, Object>of(
+                    "filteredAgg", 0L,
+                    "addRowsIndexConstant", 12486.361190795898d,
+                    "index", 12459.361190795898d,
+                    "uniques", 9.019833517963864d,
+                    "rows", 26L
+                )
+            )
+        )
+    );
+
+    TestHelper.assertExpectedResults(expectedResults, actualResults);
+  }
+
+  @Test
+  public void testTimeSeriesWithFilteredAggDimensionNotPresentNullValue()
+  {
+    TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
+                                  .dataSource(QueryRunnerTestHelper.dataSource)
+                                  .granularity(QueryRunnerTestHelper.allGran)
+                                  .intervals(QueryRunnerTestHelper.firstToThird)
+                                  .aggregators(
+                                      Lists.newArrayList(
+                                          Iterables.concat(
+                                              QueryRunnerTestHelper.commonAggregators,
+                                              Lists.newArrayList(
+                                                  new FilteredAggregatorFactory(
+                                                      new CountAggregatorFactory("filteredAgg"),
+                                                      Druids.newSelectorDimFilterBuilder()
+                                                            .dimension("abraKaDabra")
+                                                            .value(null)
+                                                            .build()
+                                                  )
+                                              )
+                                          )
+                                      )
+                                  )
+                                  .postAggregators(Arrays.<PostAggregator>asList(QueryRunnerTestHelper.addRowsIndexConstant))
+                                  .build();
+
+    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
+        runner.run(query, CONTEXT),
+        Lists.<Result<TimeseriesResultValue>>newArrayList()
+    );
+
+    List<Result<TimeseriesResultValue>> expectedResults = Arrays.asList(
+        new Result<TimeseriesResultValue>(
+            new DateTime("2011-04-01"),
+            new TimeseriesResultValue(
+                ImmutableMap.<String, Object>of(
+                    "filteredAgg", 0L,
+                    "addRowsIndexConstant", 12486.361190795898d,
+                    "index", 12459.361190795898d,
+                    "uniques", 9.019833517963864d,
+                    "rows", 26L
+                )
+            )
+        )
+    );
+
+    TestHelper.assertExpectedResults(expectedResults, actualResults);
+  }
+
+  @Test
+  public void testTimeSeriesWithFilteredAggValueNotPresent()
+  {
+    TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
+                                  .dataSource(QueryRunnerTestHelper.dataSource)
+                                  .granularity(QueryRunnerTestHelper.allGran)
+                                  .intervals(QueryRunnerTestHelper.firstToThird)
+                                  .aggregators(
+                                      Lists.newArrayList(
+                                          Iterables.concat(
+                                              QueryRunnerTestHelper.commonAggregators,
+                                              Lists.newArrayList(
+                                                  new FilteredAggregatorFactory(
+                                                      new CountAggregatorFactory("filteredAgg"),
+                                                      new NotDimFilter(
+                                                          Druids.newSelectorDimFilterBuilder()
+                                                                .dimension(QueryRunnerTestHelper.marketDimension)
+                                                                .value("LolLol")
+                                                                .build()
+                                                      )
+                                                  )
+                                              )
+                                          )
+                                      )
+                                  )
+                                  .postAggregators(Arrays.<PostAggregator>asList(QueryRunnerTestHelper.addRowsIndexConstant))
+                                  .build();
+
+    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
+        runner.run(query, CONTEXT),
+        Lists.<Result<TimeseriesResultValue>>newArrayList()
+    );
+    List<Result<TimeseriesResultValue>> expectedResults = Arrays.asList(
+        new Result<TimeseriesResultValue>(
+            new DateTime("2011-04-01"),
+            new TimeseriesResultValue(
+                ImmutableMap.<String, Object>of(
+                    "filteredAgg", 26L,
+                    "addRowsIndexConstant", 12486.361190795898d,
+                    "index", 12459.361190795898d,
+                    "uniques", 9.019833517963864d,
+                    "rows", 26L
+                )
+            )
+        )
+    );
+
+    TestHelper.assertExpectedResults(expectedResults, actualResults);
+  }
+
+  @Test
+  public void testTimeSeriesWithFilteredAggNullValue()
+  {
+    TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
+                                  .dataSource(QueryRunnerTestHelper.dataSource)
+                                  .granularity(QueryRunnerTestHelper.allGran)
+                                  .intervals(QueryRunnerTestHelper.firstToThird)
+                                  .aggregators(
+                                      Lists.newArrayList(
+                                          Iterables.concat(
+                                              QueryRunnerTestHelper.commonAggregators,
+                                              Lists.newArrayList(
+                                                  new FilteredAggregatorFactory(
+                                                      new CountAggregatorFactory("filteredAgg"),
+                                                      new NotDimFilter(
+                                                          Druids.newSelectorDimFilterBuilder()
+                                                                .dimension(QueryRunnerTestHelper.marketDimension)
+                                                                .value(null)
+                                                                .build()
+                                                      )
+                                                  )
+                                              )
+                                          )
+                                      )
+                                  )
+                                  .postAggregators(Arrays.<PostAggregator>asList(QueryRunnerTestHelper.addRowsIndexConstant))
+                                  .build();
+
+    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
+        runner.run(query, CONTEXT),
+        Lists.<Result<TimeseriesResultValue>>newArrayList()
+    );
+    List<Result<TimeseriesResultValue>> expectedResults = Arrays.asList(
+        new Result<TimeseriesResultValue>(
+            new DateTime("2011-04-01"),
+            new TimeseriesResultValue(
+                ImmutableMap.<String, Object>of(
+                    "filteredAgg", 26L,
+                    "addRowsIndexConstant", 12486.361190795898d,
+                    "index", 12459.361190795898d,
+                    "uniques", 9.019833517963864d,
+                    "rows", 26L
+                )
+            )
+        )
+    );
+
     TestHelper.assertExpectedResults(expectedResults, actualResults);
   }
 }


### PR DESCRIPTION
1) fix NPE when value or dimension is not presnet
2) fix #872 
3) Add more tests for boundary cases
4) Add support for AND & OR filter, allowing filtering on multiple dimensions 
5) code cleanup
6) behavior of empty columns - they are treated equivalent to all rows having null/empty values
