### PR TITLE
explicitly pass in parent pom

### DIFF
--- a/extensions/cassandra-storage/pom.xml
+++ b/extensions/cassandra-storage/pom.xml
@@ -30,6 +30,7 @@
     <groupId>io.druid</groupId>
     <artifactId>druid</artifactId>
     <version>0.7.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <dependencies>

--- a/extensions/hdfs-storage/pom.xml
+++ b/extensions/hdfs-storage/pom.xml
@@ -30,6 +30,7 @@
     <groupId>io.druid</groupId>
     <artifactId>druid</artifactId>
     <version>0.7.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <dependencies>

--- a/extensions/histogram/pom.xml
+++ b/extensions/histogram/pom.xml
@@ -29,6 +29,7 @@
     <groupId>io.druid</groupId>
     <artifactId>druid</artifactId>
     <version>0.7.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <dependencies>

--- a/extensions/kafka-eight/pom.xml
+++ b/extensions/kafka-eight/pom.xml
@@ -30,6 +30,7 @@
     <groupId>io.druid</groupId>
     <artifactId>druid</artifactId>
     <version>0.7.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <dependencies>

--- a/extensions/kafka-seven/pom.xml
+++ b/extensions/kafka-seven/pom.xml
@@ -30,6 +30,7 @@
     <groupId>io.druid</groupId>
     <artifactId>druid</artifactId>
     <version>0.7.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <dependencies>

--- a/extensions/mysql-metadata-storage/pom.xml
+++ b/extensions/mysql-metadata-storage/pom.xml
@@ -32,6 +32,7 @@
     <groupId>io.druid</groupId>
     <artifactId>druid</artifactId>
     <version>0.7.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <dependencies>

--- a/extensions/postgresql-metadata-storage/pom.xml
+++ b/extensions/postgresql-metadata-storage/pom.xml
@@ -32,6 +32,7 @@
     <groupId>io.druid</groupId>
     <artifactId>druid</artifactId>
     <version>0.7.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <dependencies>

--- a/extensions/rabbitmq/pom.xml
+++ b/extensions/rabbitmq/pom.xml
@@ -11,6 +11,7 @@
     <groupId>io.druid</groupId>
     <artifactId>druid</artifactId>
     <version>0.7.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <dependencies>

--- a/extensions/s3-extensions/pom.xml
+++ b/extensions/s3-extensions/pom.xml
@@ -30,6 +30,7 @@
     <groupId>io.druid</groupId>
     <artifactId>druid</artifactId>
     <version>0.7.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <dependencies>


### PR DESCRIPTION
This makes the 0.7 build pass for me locally. This will probably fix the Jenkins build too. It seems to prevent maven from trying to download the parent pom. 
