### PR TITLE
Fix Hadoop CLI jobs

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerConfig.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerConfig.java
@@ -48,6 +48,10 @@ import io.druid.guice.annotations.Self;
 import io.druid.indexer.partitions.PartitionsSpec;
 import io.druid.indexer.path.PathSpec;
 import io.druid.initialization.Initialization;
+import io.druid.segment.indexing.DataSchema;
+import io.druid.segment.indexing.IOConfig;
+import io.druid.segment.indexing.IngestionSpec;
+import io.druid.segment.indexing.TuningConfig;
 import io.druid.segment.indexing.granularity.GranularitySpec;
 import io.druid.server.DruidNode;
 import io.druid.timeline.DataSegment;
@@ -143,13 +147,7 @@ public class HadoopDruidIndexerConfig
   public static HadoopDruidIndexerConfig fromString(String str)
   {
     try {
-      return fromMap(
-          (Map<String, Object>) HadoopDruidIndexerConfig.jsonMapper.readValue(
-              str, new TypeReference<Map<String, Object>>()
-          {
-          }
-          )
-      );
+      return HadoopDruidIndexerConfig.jsonMapper.readValue(str, HadoopDruidIndexerConfig.class);
     }
     catch (IOException e) {
       throw Throwables.propagate(e);
@@ -171,11 +169,11 @@ public class HadoopDruidIndexerConfig
 
   @JsonCreator
   public HadoopDruidIndexerConfig(
-      final @JsonProperty("schema") HadoopIngestionSpec schema
+      final @JsonProperty("spec") HadoopIngestionSpec schema
   )
   {
     this.schema = schema;
-    this.pathSpec = jsonMapper.convertValue(schema.getIOConfig().getPathSpec(), PathSpec.class);
+    this.pathSpec = schema.getIOConfig().getPathSpec();
     for (Map.Entry<DateTime, List<HadoopyShardSpec>> entry : schema.getTuningConfig().getShardSpecs().entrySet()) {
       if (entry.getValue() == null || entry.getValue().isEmpty()) {
         continue;
@@ -202,7 +200,7 @@ public class HadoopDruidIndexerConfig
     this.rollupGran = schema.getDataSchema().getGranularitySpec().getQueryGranularity();
   }
 
-  @JsonProperty
+  @JsonProperty(value="spec")
   public HadoopIngestionSpec getSchema()
   {
     return schema;

--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopIOConfig.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopIOConfig.java
@@ -19,8 +19,10 @@
 
 package io.druid.indexer;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.druid.indexer.path.PathSpec;
 import io.druid.indexer.updater.MetadataStorageUpdaterJobSpec;
 import io.druid.segment.indexing.IOConfig;
 
@@ -31,12 +33,13 @@ import java.util.Map;
 @JsonTypeName("hadoop")
 public class HadoopIOConfig implements IOConfig
 {
-  private final Map<String, Object> pathSpec;
+  private final PathSpec pathSpec;
   private final MetadataStorageUpdaterJobSpec metadataUpdateSpec;
   private final String segmentOutputPath;
 
+  @JsonCreator
   public HadoopIOConfig(
-      final @JsonProperty("inputSpec") Map<String, Object> pathSpec,
+      final @JsonProperty("inputSpec") PathSpec pathSpec,
       final @JsonProperty("metadataUpdateSpec") MetadataStorageUpdaterJobSpec metadataUpdateSpec,
       final @JsonProperty("segmentOutputPath") String segmentOutputPath
   )
@@ -47,7 +50,7 @@ public class HadoopIOConfig implements IOConfig
   }
 
   @JsonProperty("inputSpec")
-  public Map<String, Object> getPathSpec()
+  public PathSpec getPathSpec()
   {
     return pathSpec;
   }

--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopIngestionSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopIngestionSpec.java
@@ -21,6 +21,7 @@ package io.druid.indexer;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import io.druid.segment.indexing.DataSchema;
 import io.druid.segment.indexing.IngestionSpec;
 

--- a/indexing-hadoop/src/test/java/io/druid/indexer/HadoopDruidIndexerConfigTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/HadoopDruidIndexerConfigTest.java
@@ -27,6 +27,8 @@ import com.google.common.collect.ImmutableMap;
 import com.metamx.common.Granularity;
 import io.druid.data.input.MapBasedInputRow;
 import io.druid.granularity.QueryGranularity;
+import io.druid.indexer.path.PathSpec;
+import io.druid.indexer.path.StaticPathSpec;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.segment.indexing.DataSchema;
@@ -160,6 +162,8 @@ public class HadoopDruidIndexerConfigTest
     for (int i = 0; i < partitionCount; i++) {
       specs.add(new HadoopyShardSpec(new HashBasedNumberedShardSpec(i, partitionCount, new DefaultObjectMapper()), i));
     }
+    final StaticPathSpec pathSpec = new StaticPathSpec();
+    pathSpec.paths = "bar";
 
     HadoopIngestionSpec spec = new HadoopIngestionSpec(
         new DataSchema(
@@ -168,7 +172,7 @@ public class HadoopDruidIndexerConfigTest
             QueryGranularity.MINUTE,
             ImmutableList.of(new Interval("2010-01-01/P1D"))
         )
-        ), new HadoopIOConfig(ImmutableMap.<String, Object>of("paths", "bar", "type", "static"), null, null),
+        ), new HadoopIOConfig(pathSpec, null, null),
         new HadoopTuningConfig(
             null,
             null,

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
@@ -29,6 +29,7 @@ import io.druid.granularity.QueryGranularity;
 import io.druid.guice.FirehoseModule;
 import io.druid.indexer.HadoopIOConfig;
 import io.druid.indexer.HadoopIngestionSpec;
+import io.druid.indexer.path.StaticPathSpec;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
@@ -372,6 +373,8 @@ public class TaskSerdeTest
   @Test
   public void testHadoopIndexTaskSerde() throws Exception
   {
+    final StaticPathSpec pathSpec = new StaticPathSpec();
+    pathSpec.paths = "bar";
     final HadoopIndexTask task = new HadoopIndexTask(
         null,
         new HadoopIngestionSpec(
@@ -381,7 +384,7 @@ public class TaskSerdeTest
                 null,
                 ImmutableList.of(new Interval("2010-01-01/P1D"))
             )
-            ), new HadoopIOConfig(ImmutableMap.<String, Object>of("paths", "bar"), null, null), null
+            ), new HadoopIOConfig(pathSpec, null, null), null
         ),
         null,
         null,


### PR DESCRIPTION
- Change "schema" --> "spec" for cli hadoop to keep up with internal hadoop
- Change PathSpec to use PathSpec instead of Map<>
- Change Config ingestion to go straight from String to object rather than using a Map<> intermediary
