### PR TITLE
upgrade LZ4 to operate directly on ByteBuffers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -393,7 +393,7 @@
             <dependency>
                 <groupId>net.jpountz.lz4</groupId>
                 <artifactId>lz4</artifactId>
-                <version>1.2.0</version>
+                <version>1.3.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
- reduces overhead of copying from byte buffers to byte arrays and back to buffers 
- removes the need for CompressedPools outputBytes resources
