### PR TITLE
Use thread priorities. (aka set `nice` values for background-like tasks)

### DIFF
--- a/common/src/main/java/io/druid/concurrent/Execs.java
+++ b/common/src/main/java/io/druid/concurrent/Execs.java
@@ -42,9 +42,19 @@ public class Execs
     return Executors.newSingleThreadExecutor(makeThreadFactory(nameFormat));
   }
 
+  public static ExecutorService singleThreaded(String nameFormat, Integer priority)
+  {
+    return Executors.newSingleThreadExecutor(makeThreadFactory(nameFormat, priority));
+  }
+
   public static ExecutorService multiThreaded(int threads, String nameFormat)
   {
     return Executors.newFixedThreadPool(threads, makeThreadFactory(nameFormat));
+  }
+
+  public static ExecutorService multiThreaded(int threads, String nameFormat, Integer priority)
+  {
+    return Executors.newFixedThreadPool(threads, makeThreadFactory(nameFormat, priority));
   }
 
   public static ScheduledExecutorService scheduledSingleThreaded(String nameFormat)
@@ -52,17 +62,37 @@ public class Execs
     return Executors.newSingleThreadScheduledExecutor(makeThreadFactory(nameFormat));
   }
 
+  public static ScheduledExecutorService scheduledSingleThreaded(String nameFormat, Integer priority)
+  {
+    return Executors.newSingleThreadScheduledExecutor(makeThreadFactory(nameFormat, priority));
+  }
+
   public static ThreadFactory makeThreadFactory(String nameFormat)
   {
     return new ThreadFactoryBuilder().setDaemon(true).setNameFormat(nameFormat).build();
   }
 
+  public static ThreadFactory makeThreadFactory(String nameFormat, Integer priority)
+  {
+    return new ThreadFactoryBuilder().setDaemon(true).setPriority(priority).setNameFormat(nameFormat).build();
+  }
+
   /**
    * @param nameFormat nameformat for threadFactory
-   * @param capacity maximum capacity after which the executorService will block on accepting new tasks
+   * @param capacity   maximum capacity after which the executorService will block on accepting new tasks
+   *
    * @return ExecutorService which blocks accepting new tasks when the capacity reached
    */
   public static ExecutorService newBlockingSingleThreaded(final String nameFormat, final int capacity)
+  {
+    return newBlockingSingleThreaded(nameFormat, capacity, Thread.NORM_PRIORITY);
+  }
+
+  public static ExecutorService newBlockingSingleThreaded(
+      final String nameFormat,
+      final int capacity,
+      final Integer priority
+  )
   {
     final BlockingQueue<Runnable> queue;
     if (capacity > 0) {

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/AbstractTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/AbstractTask.java
@@ -120,13 +120,24 @@ public abstract class AbstractTask implements Task
                   .add("id", id)
                   .add("type", getType())
                   .add("dataSource", dataSource)
+                  .add("priority", priority)
                   .toString();
+  }
+
+  Priority priority = Priority.NORMAL;
+
+  @JsonProperty
+  @Override
+  public Priority getPriority()
+  {
+    return this.priority;
   }
 
   /**
    * Start helper methods
    *
    * @param objects objects to join
+   *
    * @return string of joined objects
    */
   public static String joinId(Object... objects)

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/ArchiveTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/ArchiveTask.java
@@ -50,6 +50,7 @@ public class ArchiveTask extends AbstractFixedIntervalTask
         dataSource,
         interval
     );
+    this.priority = Priority.LOW;
   }
 
   @Override

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/HadoopIndexTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/HadoopIndexTask.java
@@ -66,13 +66,14 @@ public class HadoopIndexTask extends AbstractTask
   private static final ExtensionsConfig extensionsConfig;
 
   final static Injector injector = GuiceInjectors.makeStartupInjector();
+
   static {
     extensionsConfig = injector.getInstance(ExtensionsConfig.class);
   }
 
   private static String getTheDataSource(HadoopIngestionSpec spec)
   {
-      return spec.getDataSchema().getDataSource();
+    return spec.getDataSchema().getDataSource();
   }
 
   @JsonIgnore
@@ -85,7 +86,7 @@ public class HadoopIndexTask extends AbstractTask
   /**
    * @param spec is used by the HadoopDruidIndexerJob to set up the appropriate parameters
    *             for creating Druid index segments. It may be modified.
-   *             
+   *             <p/>
    *             Here, we will ensure that the DbConnectorConfig field of the spec is set to null, such that the
    *             job does not push a list of published segments the database. Instead, we will use the method
    *             IndexGeneratorJob.getPublishedSegments() to simply return a list of the published
@@ -106,6 +107,7 @@ public class HadoopIndexTask extends AbstractTask
         getTheDataSource(spec)
     );
 
+    this.priority = Priority.LOW;
 
     this.spec = spec;
 

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/MergeTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/MergeTask.java
@@ -53,6 +53,7 @@ public class MergeTask extends MergeTaskBase
   )
   {
     super(id, dataSource, segments);
+    this.priority = Priority.LOW;
     this.aggregators = aggregators;
   }
 

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/MergeTaskBase.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/MergeTaskBase.java
@@ -75,6 +75,8 @@ public abstract class MergeTaskBase extends AbstractFixedIntervalTask
         computeMergedInterval(segments)
     );
 
+    this.priority = Priority.LOW;
+
     // Verify segment list is nonempty
     Preconditions.checkArgument(segments.size() > 0, "segments nonempty");
     // Verify segments are all in the correct datasource
@@ -251,19 +253,19 @@ public abstract class MergeTaskBase extends AbstractFixedIntervalTask
     final String segmentIDs = Joiner.on("_").join(
         Iterables.transform(
             Ordering.natural().sortedCopy(segments), new Function<DataSegment, String>()
-        {
-          @Override
-          public String apply(DataSegment x)
-          {
-            return String.format(
-                "%s_%s_%s_%s",
-                x.getInterval().getStart(),
-                x.getInterval().getEnd(),
-                x.getVersion(),
-                x.getShardSpec().getPartitionNum()
-            );
-          }
-        }
+            {
+              @Override
+              public String apply(DataSegment x)
+              {
+                return String.format(
+                    "%s_%s_%s_%s",
+                    x.getInterval().getStart(),
+                    x.getInterval().getEnd(),
+                    x.getVersion(),
+                    x.getShardSpec().getPartitionNum()
+                );
+              }
+            }
         )
     );
 

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/ForkingTaskRunner.java
@@ -207,6 +207,9 @@ public class ForkingTaskRunner implements TaskRunner, TaskLogStreamer
                               command.add(String.format("-Ddruid.host=%s", childHost));
                               command.add(String.format("-Ddruid.port=%d", childPort));
 
+                              command.add("-XX:+UseThreadPriorities");
+                              command.add("-XX:ThreadPriorityPolicy=42");
+
                               command.add("io.druid.cli.Main");
                               command.add("internal");
                               command.add("peon");
@@ -254,9 +257,11 @@ public class ForkingTaskRunner implements TaskRunner, TaskLogStreamer
                               // Process exited unsuccessfully
                               return TaskStatus.failure(task.getId());
                             }
-                          } catch (Throwable t) {
+                          }
+                          catch (Throwable t) {
                             throw closer.rethrow(t);
-                          } finally {
+                          }
+                          finally {
                             closer.close();
                           }
                         }

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/ThreadPoolTaskRunner.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/ThreadPoolTaskRunner.java
@@ -24,6 +24,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -47,6 +48,8 @@ import org.joda.time.Interval;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentSkipListSet;
@@ -57,7 +60,7 @@ import java.util.concurrent.ConcurrentSkipListSet;
 public class ThreadPoolTaskRunner implements TaskRunner, QuerySegmentWalker
 {
   private final TaskToolboxFactory toolboxFactory;
-  private final ListeningExecutorService exec;
+  private final Map<Task.Priority, ListeningExecutorService> exec = Maps.newHashMap();
   private final Set<ThreadPoolTaskRunnerWorkItem> runningItems = new ConcurrentSkipListSet<>();
 
   private static final EmittingLogger log = new EmittingLogger(ThreadPoolTaskRunner.class);
@@ -68,37 +71,51 @@ public class ThreadPoolTaskRunner implements TaskRunner, QuerySegmentWalker
   )
   {
     this.toolboxFactory = Preconditions.checkNotNull(toolboxFactory, "toolboxFactory");
-    this.exec = MoreExecutors.listeningDecorator(Execs.singleThreaded("task-runner-%d"));
+    for (Task.Priority priority : Task.Priority.values()) {
+      this.exec.put(
+          priority,
+          MoreExecutors.listeningDecorator(
+              Execs.singleThreaded(
+                  "task-runner-%d-priority-" + priority.toString(),
+                  priority.getPriority()
+              )
+          )
+      );
+    }
+
   }
 
   @LifecycleStop
   public void stop()
   {
-    exec.shutdownNow();
+    for (Map.Entry<Task.Priority, ListeningExecutorService> entry : exec.entrySet()) {
+      entry.getValue().shutdownNow();
+    }
   }
 
   @Override
   public ListenableFuture<TaskStatus> run(final Task task)
   {
     final TaskToolbox toolbox = toolboxFactory.build(task);
-    final ListenableFuture<TaskStatus> statusFuture = exec.submit(new ThreadPoolTaskRunnerCallable(task, toolbox));
+    final ListenableFuture<TaskStatus> statusFuture = exec.get(task.getPriority())
+                                                          .submit(new ThreadPoolTaskRunnerCallable(task, toolbox));
     final ThreadPoolTaskRunnerWorkItem taskRunnerWorkItem = new ThreadPoolTaskRunnerWorkItem(task, statusFuture);
     runningItems.add(taskRunnerWorkItem);
     Futures.addCallback(
         statusFuture, new FutureCallback<TaskStatus>()
-    {
-      @Override
-      public void onSuccess(TaskStatus result)
-      {
-        runningItems.remove(taskRunnerWorkItem);
-      }
+        {
+          @Override
+          public void onSuccess(TaskStatus result)
+          {
+            runningItems.remove(taskRunnerWorkItem);
+          }
 
-      @Override
-      public void onFailure(Throwable t)
-      {
-        runningItems.remove(taskRunnerWorkItem);
-      }
-    }
+          @Override
+          public void onFailure(Throwable t)
+          {
+            runningItems.remove(taskRunnerWorkItem);
+          }
+        }
     );
 
     return statusFuture;


### PR DESCRIPTION
There are some items which seem to cause resource contesting when they are running. This is an attempt to allow the OS / JVM to help figure out which tasks should be run realtime, and which can be interrupted.
- Defaults the thread priority to java.util.Thread.NORM_PRIORITY in io.druid.indexing.common.task.AbstractTask
- Each exec service has its own Task Factory which is assigned a priority for spawned task. Therefore each priority class has a unique exec service
- Added Task.Priority enum
  - Can be either NORMAL or LOW
- Add options to ForkingTaskRunner
  - Add "-XX:+UseThreadPriorities" default option
  - Add "-XX:ThreadPriorityPolicy=42" default option
- AbstractTask - Removed unneded @JsonIgnore on priority
- Added priority to RealtimePlumber executors. All sub-executors (non query runners) get Thread.MIN_PRIORITY
