### PR TITLE
Add support for querying latest ingested event timestamp

### DIFF
--- a/processing/src/main/java/io/druid/query/TimewarpOperator.java
+++ b/processing/src/main/java/io/druid/query/TimewarpOperator.java
@@ -116,7 +116,8 @@ public class TimewarpOperator<T> implements PostProcessingOperator<T>
                     return (T) ((TimeBoundaryQuery) query).buildResult(
                         new DateTime(Math.min(res.getTimestamp().getMillis() - offset, now)),
                         minTime != null ? minTime.minus(offset) : null,
-                        maxTime != null ? new DateTime(Math.min(maxTime.getMillis() - offset, now)) : null
+                        maxTime != null ? new DateTime(Math.min(maxTime.getMillis() - offset, now)) : null,
+                        null
                     ).iterator().next();
                   }
                   return (T) new Result(res.getTimestamp().minus(offset), value);

--- a/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQueryRunnerFactory.java
+++ b/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQueryRunnerFactory.java
@@ -108,18 +108,32 @@ public class TimeBoundaryQueryRunnerFactory
                 );
               }
 
-              final DateTime minTime = legacyQuery.getBound().equalsIgnoreCase(TimeBoundaryQuery.MAX_TIME)
-                                       ? null
-                                       : adapter.getMinTime();
-              final DateTime maxTime = legacyQuery.getBound().equalsIgnoreCase(TimeBoundaryQuery.MIN_TIME)
-                                       ? null
-                                       : adapter.getMaxTime();
-
+              final DateTime minTime;
+              final DateTime maxTime;
+              final DateTime lastIngestedEventTime;
+              if (legacyQuery.getBound().equalsIgnoreCase(TimeBoundaryQuery.MIN_TIME)) {
+                minTime = adapter.getMinTime();
+                maxTime = null;
+                lastIngestedEventTime = null;
+              } else  if (legacyQuery.getBound().equalsIgnoreCase(TimeBoundaryQuery.MAX_TIME)) {
+              minTime = null;
+              maxTime = adapter.getMaxTime();
+              lastIngestedEventTime = null;
+            } else  if (legacyQuery.getBound().equalsIgnoreCase(TimeBoundaryQuery.LAST_INGESTED_EVENT_TIME)) {
+                minTime = null;
+                maxTime = null;
+                lastIngestedEventTime = adapter.getLastIngestedEventTime();
+              } else {
+                minTime = adapter.getMinTime();
+                maxTime = adapter.getMaxTime();
+                lastIngestedEventTime = null;
+              }
 
               return legacyQuery.buildResult(
                   adapter.getInterval().getStart(),
                   minTime,
-                  maxTime
+                  maxTime,
+                  lastIngestedEventTime
               ).iterator();
             }
 

--- a/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryResultValue.java
+++ b/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryResultValue.java
@@ -55,6 +55,15 @@ public class TimeBoundaryResultValue
     }
   }
 
+  public DateTime getLastIngestedEventTime()
+  {
+    if (value instanceof Map) {
+      return getDateTimeValue(((Map) value).get(TimeBoundaryQuery.LAST_INGESTED_EVENT_TIME));
+    } else {
+      return getDateTimeValue(value);
+    }
+  }
+
   public DateTime getMinTime()
   {
     if (value instanceof Map) {

--- a/processing/src/main/java/io/druid/segment/QueryableIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/QueryableIndexStorageAdapter.java
@@ -128,6 +128,13 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
   }
 
   @Override
+  public DateTime getLastIngestedEventTime()
+  {
+    // for Immutable indexes lastIngestedEventTimestamp is equal to maxTime
+    return getMaxTime();
+  }
+
+  @Override
   public Capabilities getCapabilities()
   {
     return Capabilities.builder().dimensionValuesSorted(true).build();

--- a/processing/src/main/java/io/druid/segment/StorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/StorageAdapter.java
@@ -34,5 +34,6 @@ public interface StorageAdapter extends CursorFactory
   public int getDimensionCardinality(String dimension);
   public DateTime getMinTime();
   public DateTime getMaxTime();
+  public DateTime getLastIngestedEventTime();
   public Capabilities getCapabilities();
 }

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
@@ -119,6 +119,12 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
   }
 
   @Override
+  public DateTime getLastIngestedEventTime()
+  {
+    return index.getLastIngestedEventTime();
+  }
+
+  @Override
   public Capabilities getCapabilities()
   {
     return Capabilities.builder().dimensionValuesSorted(false).build();


### PR DESCRIPTION
Add support for querying latest ingested event raw timestamp.
Useful for the knowing how much updated information realtime pipeline has specifically with high rollup granularity.
