### PR TITLE
Added asNumber to OrderByColumnSpec

### DIFF
--- a/processing/src/main/java/io/druid/query/groupby/GroupByQuery.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQuery.java
@@ -380,6 +380,11 @@ public class GroupByQuery extends BaseQuery<Row>
       return addOrderByColumn(dimension, OrderByColumnSpec.determineDirection(direction));
     }
 
+    public Builder addOrderByColumn(String dimension, String direction, boolean asNumber)
+    {
+      return addOrderByColumn(new OrderByColumnSpec(asNumber, dimension, OrderByColumnSpec.determineDirection(direction)));
+    }
+
     public Builder addOrderByColumn(String dimension, OrderByColumnSpec.Direction direction)
     {
       return addOrderByColumn(new OrderByColumnSpec(dimension, direction));

--- a/processing/src/main/java/io/druid/query/groupby/orderby/OrderByColumnSpec.java
+++ b/processing/src/main/java/io/druid/query/groupby/orderby/OrderByColumnSpec.java
@@ -59,6 +59,7 @@ public class OrderByColumnSpec
     stupidEnumMap = bob.build();
   }
 
+  private final boolean asNumber;
   private final String dimension;
   private final Direction direction;
 
@@ -68,14 +69,20 @@ public class OrderByColumnSpec
     Preconditions.checkNotNull(obj, "Cannot build an OrderByColumnSpec from a null object.");
 
     if (obj instanceof String) {
-      return new OrderByColumnSpec(obj.toString(), null);
+      return new OrderByColumnSpec(false, obj.toString(), null);
     } else if (obj instanceof Map) {
       final Map map = (Map) obj;
 
+      final boolean asNumber;
+      if (map.get("asNumber") instanceof Boolean) {
+        asNumber = (Boolean) map.get("asNumber");
+      } else {
+        asNumber = false;
+      }
       final String dimension = map.get("dimension").toString();
       final Direction direction = determineDirection(map.get("direction"));
 
-      return new OrderByColumnSpec(dimension, direction);
+      return new OrderByColumnSpec(asNumber, dimension, direction);
     } else {
       throw new ISE("Cannot build an OrderByColumnSpec from a %s", obj.getClass());
     }
@@ -126,8 +133,24 @@ public class OrderByColumnSpec
       Direction direction
   )
   {
+    this(false, dimension, direction);
+  }
+
+  public OrderByColumnSpec(
+      boolean asNumber,
+      String dimension,
+      Direction direction
+  )
+  {
+    this.asNumber = asNumber;
     this.dimension = dimension;
     this.direction = direction == null ? Direction.ASCENDING : direction;
+  }
+
+  @JsonProperty
+  public boolean asNumber()
+  {
+    return asNumber;
   }
 
   @JsonProperty

--- a/processing/src/test/java/io/druid/query/QueryRunnerTestHelper.java
+++ b/processing/src/test/java/io/druid/query/QueryRunnerTestHelper.java
@@ -87,6 +87,7 @@ public class QueryRunnerTestHelper
   public static final String qualityDimension = "quality";
   public static final String placementDimension = "placement";
   public static final String placementishDimension = "placementish";
+  public static final String idDimension = "id";
   public static final String indexMetric = "index";
   public static final String uniqueMetric = "uniques";
   public static final String addRowsIndexConstantMetric = "addRowsIndexConstant";

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
@@ -26,7 +26,6 @@ import com.metamx.common.guava.Sequences;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.query.Druids;
 import io.druid.query.Query;
-import io.druid.query.QueryConfig;
 import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerFactory;
 import io.druid.query.QueryRunnerTestHelper;
@@ -42,7 +41,6 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 
 public class SegmentMetadataQueryTest
 {
@@ -82,7 +80,7 @@ public class SegmentMetadataQueryTest
     );
     SegmentAnalysis val = results.iterator().next();
     Assert.assertEquals("testSegment", val.getId());
-    Assert.assertEquals(69843, val.getSize());
+    Assert.assertEquals(79452, val.getSize());
     Assert.assertEquals(
         Arrays.asList(new Interval("2011-01-12T00:00:00.000Z/2011-04-15T00:00:00.001Z")),
         val.getIntervals()

--- a/processing/src/test/java/io/druid/query/search/SearchQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/search/SearchQueryRunnerTest.java
@@ -90,6 +90,7 @@ public class SearchQueryRunnerTest
     );
     expectedResults.put(QueryRunnerTestHelper.marketDimension, Sets.newHashSet("total_market"));
     expectedResults.put(QueryRunnerTestHelper.placementishDimension, Sets.newHashSet("a"));
+    expectedResults.put(QueryRunnerTestHelper.idDimension, Sets.newHashSet("default"));
 
     checkSearchQuery(searchQuery, expectedResults);
   }

--- a/processing/src/test/java/io/druid/segment/TestIndex.java
+++ b/processing/src/test/java/io/druid/segment/TestIndex.java
@@ -26,6 +26,7 @@ import com.google.common.io.CharStreams;
 import com.google.common.io.InputSupplier;
 import com.google.common.io.LineProcessor;
 import com.metamx.common.logger.Logger;
+import io.druid.data.input.InputRow;
 import io.druid.data.input.impl.DelimitedParseSpec;
 import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.data.input.impl.StringInputRowParser;
@@ -57,6 +58,7 @@ public class TestIndex
 {
   public static final String[] COLUMNS = new String[]{
       "ts",
+      "id",
       "market",
       "quality",
       "placement",
@@ -64,7 +66,7 @@ public class TestIndex
       "index",
       "quality_uniques"
   };
-  public static final String[] DIMENSIONS = new String[]{"market", "quality", "placement", "placementish"};
+  public static final String[] DIMENSIONS = new String[]{"id", "market", "quality", "placement", "placementish"};
   public static final String[] METRICS = new String[]{"index"};
   private static final Logger log = new Logger(TestIndex.class);
   private static final Interval DATA_INTERVAL = new Interval("2011-01-12T00:00:00.000Z/2011-05-01T00:00:00.000Z");

--- a/processing/src/test/resources/druid.sample.tsv
+++ b/processing/src/test/resources/druid.sample.tsv
@@ -1,1209 +1,1209 @@
-2011-01-12T00:00:00.000Z	spot	automotive	preferred	apreferred	100.000000
-2011-01-12T00:00:00.000Z	spot	business	preferred	bpreferred	100.000000
-2011-01-12T00:00:00.000Z	spot	entertainment	preferred	epreferred	100.000000
-2011-01-12T00:00:00.000Z	spot	health	preferred	hpreferred	100.000000
-2011-01-12T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	100.000000
-2011-01-12T00:00:00.000Z	spot	news	preferred	npreferred	100.000000
-2011-01-12T00:00:00.000Z	spot	premium	preferred	ppreferred	100.000000
-2011-01-12T00:00:00.000Z	spot	technology	preferred	tpreferred	100.000000
-2011-01-12T00:00:00.000Z	spot	travel	preferred	tpreferred	100.000000
-2011-01-12T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1000.000000
-2011-01-12T00:00:00.000Z	total_market	premium	preferred	ppreferred	1000.000000
-2011-01-12T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	800.000000
-2011-01-12T00:00:00.000Z	upfront	premium	preferred	ppreferred	800.000000
-2011-01-13T00:00:00.000Z	spot	automotive	preferred	apreferred	94.874713
-2011-01-13T00:00:00.000Z	spot	business	preferred	bpreferred	103.629399
-2011-01-13T00:00:00.000Z	spot	entertainment	preferred	epreferred	110.087299
-2011-01-13T00:00:00.000Z	spot	health	preferred	hpreferred	114.947403
-2011-01-13T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	104.465767
-2011-01-13T00:00:00.000Z	spot	news	preferred	npreferred	102.851683
-2011-01-13T00:00:00.000Z	spot	premium	preferred	ppreferred	108.863011
-2011-01-13T00:00:00.000Z	spot	technology	preferred	tpreferred	111.356672
-2011-01-13T00:00:00.000Z	spot	travel	preferred	tpreferred	106.236928
-2011-01-13T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1040.945505
-2011-01-13T00:00:00.000Z	total_market	premium	preferred	ppreferred	1689.012875
-2011-01-13T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	826.060182
-2011-01-13T00:00:00.000Z	upfront	premium	preferred	ppreferred	1564.617729
-2011-01-14T00:00:00.000Z	spot	automotive	preferred	apreferred	86.450372
-2011-01-14T00:00:00.000Z	spot	business	preferred	bpreferred	102.670409
-2011-01-14T00:00:00.000Z	spot	entertainment	preferred	epreferred	109.573474
-2011-01-14T00:00:00.000Z	spot	health	preferred	hpreferred	94.000432
-2011-01-14T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	97.903068
-2011-01-14T00:00:00.000Z	spot	news	preferred	npreferred	101.380760
-2011-01-14T00:00:00.000Z	spot	premium	preferred	ppreferred	104.611784
-2011-01-14T00:00:00.000Z	spot	technology	preferred	tpreferred	114.974216
-2011-01-14T00:00:00.000Z	spot	travel	preferred	tpreferred	112.259958
-2011-01-14T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1049.141912
-2011-01-14T00:00:00.000Z	total_market	premium	preferred	ppreferred	1073.476545
-2011-01-14T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1006.402111
-2011-01-14T00:00:00.000Z	upfront	premium	preferred	ppreferred	869.643722
-2011-01-15T00:00:00.000Z	spot	automotive	preferred	apreferred	82.840417
-2011-01-15T00:00:00.000Z	spot	business	preferred	bpreferred	99.781645
-2011-01-15T00:00:00.000Z	spot	entertainment	preferred	epreferred	100.551072
-2011-01-15T00:00:00.000Z	spot	health	preferred	hpreferred	87.954346
-2011-01-15T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	100.582654
-2011-01-15T00:00:00.000Z	spot	news	preferred	npreferred	99.383407
-2011-01-15T00:00:00.000Z	spot	premium	preferred	ppreferred	102.366798
-2011-01-15T00:00:00.000Z	spot	technology	preferred	tpreferred	111.680229
-2011-01-15T00:00:00.000Z	spot	travel	preferred	tpreferred	120.481420
-2011-01-15T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1007.365510
-2011-01-15T00:00:00.000Z	total_market	premium	preferred	ppreferred	1545.708865
-2011-01-15T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	809.041763
-2011-01-15T00:00:00.000Z	upfront	premium	preferred	ppreferred	1458.402661
-2011-01-16T00:00:00.000Z	spot	automotive	preferred	apreferred	71.315931
-2011-01-16T00:00:00.000Z	spot	business	preferred	bpreferred	100.591602
-2011-01-16T00:00:00.000Z	spot	entertainment	preferred	epreferred	99.007588
-2011-01-16T00:00:00.000Z	spot	health	preferred	hpreferred	93.085943
-2011-01-16T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	99.863171
-2011-01-16T00:00:00.000Z	spot	news	preferred	npreferred	100.192013
-2011-01-16T00:00:00.000Z	spot	premium	preferred	ppreferred	103.348007
-2011-01-16T00:00:00.000Z	spot	technology	preferred	tpreferred	87.280816
-2011-01-16T00:00:00.000Z	spot	travel	preferred	tpreferred	116.779610
-2011-01-16T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1016.965229
-2011-01-16T00:00:00.000Z	total_market	premium	preferred	ppreferred	1077.612663
-2011-01-16T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	852.437477
-2011-01-16T00:00:00.000Z	upfront	premium	preferred	ppreferred	879.988099
-2011-01-17T00:00:00.000Z	spot	automotive	preferred	apreferred	105.442374
-2011-01-17T00:00:00.000Z	spot	business	preferred	bpreferred	105.914315
-2011-01-17T00:00:00.000Z	spot	entertainment	preferred	epreferred	99.189052
-2011-01-17T00:00:00.000Z	spot	health	preferred	hpreferred	110.157325
-2011-01-17T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	103.692852
-2011-01-17T00:00:00.000Z	spot	news	preferred	npreferred	103.615039
-2011-01-17T00:00:00.000Z	spot	premium	preferred	ppreferred	106.696362
-2011-01-17T00:00:00.000Z	spot	technology	preferred	tpreferred	89.901887
-2011-01-17T00:00:00.000Z	spot	travel	preferred	tpreferred	134.415281
-2011-01-17T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1075.089574
-2011-01-17T00:00:00.000Z	total_market	premium	preferred	ppreferred	953.995422
-2011-01-17T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	950.146770
-2011-01-17T00:00:00.000Z	upfront	premium	preferred	ppreferred	712.774595
-2011-01-18T00:00:00.000Z	spot	automotive	preferred	apreferred	87.195139
-2011-01-18T00:00:00.000Z	spot	business	preferred	bpreferred	107.244699
-2011-01-18T00:00:00.000Z	spot	entertainment	preferred	epreferred	94.452739
-2011-01-18T00:00:00.000Z	spot	health	preferred	hpreferred	103.018934
-2011-01-18T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	101.087367
-2011-01-18T00:00:00.000Z	spot	news	preferred	npreferred	104.724154
-2011-01-18T00:00:00.000Z	spot	premium	preferred	ppreferred	108.979936
-2011-01-18T00:00:00.000Z	spot	technology	preferred	tpreferred	88.764512
-2011-01-18T00:00:00.000Z	spot	travel	preferred	tpreferred	113.680094
-2011-01-18T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1022.783330
-2011-01-18T00:00:00.000Z	total_market	premium	preferred	ppreferred	937.061939
-2011-01-18T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	846.267516
-2011-01-18T00:00:00.000Z	upfront	premium	preferred	ppreferred	682.885525
-2011-01-19T00:00:00.000Z	spot	automotive	preferred	apreferred	85.681683
-2011-01-19T00:00:00.000Z	spot	business	preferred	bpreferred	106.700550
-2011-01-19T00:00:00.000Z	spot	entertainment	preferred	epreferred	92.314034
-2011-01-19T00:00:00.000Z	spot	health	preferred	hpreferred	97.620315
-2011-01-19T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	105.087466
-2011-01-19T00:00:00.000Z	spot	news	preferred	npreferred	106.127830
-2011-01-19T00:00:00.000Z	spot	premium	preferred	ppreferred	104.568464
-2011-01-19T00:00:00.000Z	spot	technology	preferred	tpreferred	77.316731
-2011-01-19T00:00:00.000Z	spot	travel	preferred	tpreferred	109.772202
-2011-01-19T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1156.744712
-2011-01-19T00:00:00.000Z	total_market	premium	preferred	ppreferred	849.877513
-2011-01-19T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1109.874950
-2011-01-19T00:00:00.000Z	upfront	premium	preferred	ppreferred	594.381703
-2011-01-20T01:00:00.000Z	spot	automotive	preferred	apreferred	93.396274
-2011-01-20T01:00:00.000Z	spot	business	preferred	bpreferred	106.367723
-2011-01-20T01:00:00.000Z	spot	entertainment	preferred	epreferred	90.439020
-2011-01-20T01:00:00.000Z	spot	health	preferred	hpreferred	96.112901
-2011-01-20T01:00:00.000Z	spot	mezzanine	preferred	mpreferred	105.669498
-2011-01-20T01:00:00.000Z	spot	news	preferred	npreferred	105.225158
-2011-01-20T01:00:00.000Z	spot	premium	preferred	ppreferred	101.305541
-2011-01-20T01:00:00.000Z	spot	technology	preferred	tpreferred	77.759854
-2011-01-20T01:00:00.000Z	spot	travel	preferred	tpreferred	140.179069
-2011-01-20T01:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1066.208012
-2011-01-20T01:00:00.000Z	total_market	premium	preferred	ppreferred	904.340636
-2011-01-20T01:00:00.000Z	upfront	mezzanine	preferred	mpreferred	870.115926
-2011-01-20T01:00:00.000Z	upfront	premium	preferred	ppreferred	677.510973
-2011-01-22T00:00:00.000Z	spot	automotive	preferred	apreferred	95.235266
-2011-01-22T00:00:00.000Z	spot	business	preferred	bpreferred	105.282866
-2011-01-22T00:00:00.000Z	spot	entertainment	preferred	epreferred	93.681096
-2011-01-22T00:00:00.000Z	spot	health	preferred	hpreferred	103.527592
-2011-01-22T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	104.184494
-2011-01-22T00:00:00.000Z	spot	news	preferred	npreferred	103.399677
-2011-01-22T00:00:00.000Z	spot	premium	preferred	ppreferred	99.284525
-2011-01-22T00:00:00.000Z	spot	technology	preferred	tpreferred	107.627793
-2011-01-22T00:00:00.000Z	spot	travel	preferred	tpreferred	137.109783
-2011-01-22T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1240.525484
-2011-01-22T00:00:00.000Z	total_market	premium	preferred	ppreferred	1343.232494
-2011-01-22T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1410.278128
-2011-01-22T00:00:00.000Z	upfront	premium	preferred	ppreferred	1219.432170
-2011-01-23T00:00:00.000Z	spot	automotive	preferred	apreferred	100.432710
-2011-01-23T00:00:00.000Z	spot	business	preferred	bpreferred	107.348157
-2011-01-23T00:00:00.000Z	spot	entertainment	preferred	epreferred	92.789692
-2011-01-23T00:00:00.000Z	spot	health	preferred	hpreferred	96.826443
-2011-01-23T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	103.730730
-2011-01-23T00:00:00.000Z	spot	news	preferred	npreferred	106.418686
-2011-01-23T00:00:00.000Z	spot	premium	preferred	ppreferred	101.573522
-2011-01-23T00:00:00.000Z	spot	technology	preferred	tpreferred	110.467875
-2011-01-23T00:00:00.000Z	spot	travel	preferred	tpreferred	128.699746
-2011-01-23T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1088.943083
-2011-01-23T00:00:00.000Z	total_market	premium	preferred	ppreferred	1349.254415
-2011-01-23T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	979.306038
-2011-01-23T00:00:00.000Z	upfront	premium	preferred	ppreferred	1224.501568
-2011-01-24T00:00:00.000Z	spot	automotive	preferred	apreferred	96.671647
-2011-01-24T00:00:00.000Z	spot	business	preferred	bpreferred	104.485760
-2011-01-24T00:00:00.000Z	spot	entertainment	preferred	epreferred	88.748460
-2011-01-24T00:00:00.000Z	spot	health	preferred	hpreferred	189.385952
-2011-01-24T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	97.906256
-2011-01-24T00:00:00.000Z	spot	news	preferred	npreferred	104.167373
-2011-01-24T00:00:00.000Z	spot	premium	preferred	ppreferred	101.581339
-2011-01-24T00:00:00.000Z	spot	technology	preferred	tpreferred	105.345921
-2011-01-24T00:00:00.000Z	spot	travel	preferred	tpreferred	131.695956
-2011-01-24T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1102.866656
-2011-01-24T00:00:00.000Z	total_market	premium	preferred	ppreferred	939.244103
-2011-01-24T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1215.589859
-2011-01-24T00:00:00.000Z	upfront	premium	preferred	ppreferred	716.609179
-2011-01-25T00:00:00.000Z	spot	automotive	preferred	apreferred	90.111413
-2011-01-25T00:00:00.000Z	spot	business	preferred	bpreferred	101.624789
-2011-01-25T00:00:00.000Z	spot	entertainment	preferred	epreferred	85.974579
-2011-01-25T00:00:00.000Z	spot	health	preferred	hpreferred	180.575246
-2011-01-25T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	96.594588
-2011-01-25T00:00:00.000Z	spot	news	preferred	npreferred	102.907866
-2011-01-25T00:00:00.000Z	spot	premium	preferred	ppreferred	102.512878
-2011-01-25T00:00:00.000Z	spot	technology	preferred	tpreferred	102.044542
-2011-01-25T00:00:00.000Z	spot	travel	preferred	tpreferred	122.077247
-2011-01-25T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1109.875413
-2011-01-25T00:00:00.000Z	total_market	premium	preferred	ppreferred	997.994544
-2011-01-25T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1301.023342
-2011-01-25T00:00:00.000Z	upfront	premium	preferred	ppreferred	786.363298
-2011-01-26T00:00:00.000Z	spot	automotive	preferred	apreferred	84.906466
-2011-01-26T00:00:00.000Z	spot	business	preferred	bpreferred	105.873942
-2011-01-26T00:00:00.000Z	spot	entertainment	preferred	epreferred	84.710523
-2011-01-26T00:00:00.000Z	spot	health	preferred	hpreferred	159.988606
-2011-01-26T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	96.046584
-2011-01-26T00:00:00.000Z	spot	news	preferred	npreferred	105.266058
-2011-01-26T00:00:00.000Z	spot	premium	preferred	ppreferred	101.088903
-2011-01-26T00:00:00.000Z	spot	technology	preferred	tpreferred	105.617702
-2011-01-26T00:00:00.000Z	spot	travel	preferred	tpreferred	122.160681
-2011-01-26T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1037.449471
-2011-01-26T00:00:00.000Z	total_market	premium	preferred	ppreferred	1686.419659
-2011-01-26T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	989.931541
-2011-01-26T00:00:00.000Z	upfront	premium	preferred	ppreferred	1609.096706
-2011-01-27T00:00:00.000Z	spot	automotive	preferred	apreferred	134.127106
-2011-01-27T00:00:00.000Z	spot	business	preferred	bpreferred	104.882908
-2011-01-27T00:00:00.000Z	spot	entertainment	preferred	epreferred	90.806201
-2011-01-27T00:00:00.000Z	spot	health	preferred	hpreferred	170.735853
-2011-01-27T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	100.643435
-2011-01-27T00:00:00.000Z	spot	news	preferred	npreferred	104.609483
-2011-01-27T00:00:00.000Z	spot	premium	preferred	ppreferred	102.612747
-2011-01-27T00:00:00.000Z	spot	technology	preferred	tpreferred	116.979005
-2011-01-27T00:00:00.000Z	spot	travel	preferred	tpreferred	149.125271
-2011-01-27T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1074.006938
-2011-01-27T00:00:00.000Z	total_market	premium	preferred	ppreferred	1486.201299
-2011-01-27T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1023.295213
-2011-01-27T00:00:00.000Z	upfront	premium	preferred	ppreferred	1367.638074
-2011-01-28T00:00:00.000Z	spot	automotive	preferred	apreferred	123.006128
-2011-01-28T00:00:00.000Z	spot	business	preferred	bpreferred	111.641077
-2011-01-28T00:00:00.000Z	spot	entertainment	preferred	epreferred	99.681629
-2011-01-28T00:00:00.000Z	spot	health	preferred	hpreferred	107.788998
-2011-01-28T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	106.075672
-2011-01-28T00:00:00.000Z	spot	news	preferred	npreferred	108.106449
-2011-01-28T00:00:00.000Z	spot	premium	preferred	ppreferred	103.822842
-2011-01-28T00:00:00.000Z	spot	technology	preferred	tpreferred	93.869236
-2011-01-28T00:00:00.000Z	spot	travel	preferred	tpreferred	158.739359
-2011-01-28T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1300.302260
-2011-01-28T00:00:00.000Z	total_market	premium	preferred	ppreferred	1021.334487
-2011-01-28T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1627.598064
-2011-01-28T00:00:00.000Z	upfront	premium	preferred	ppreferred	810.889422
-2011-01-29T00:00:00.000Z	spot	automotive	preferred	apreferred	127.450345
-2011-01-29T00:00:00.000Z	spot	business	preferred	bpreferred	100.992147
-2011-01-29T00:00:00.000Z	spot	entertainment	preferred	epreferred	103.345166
-2011-01-29T00:00:00.000Z	spot	health	preferred	hpreferred	114.905745
-2011-01-29T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	106.663538
-2011-01-29T00:00:00.000Z	spot	news	preferred	npreferred	101.998823
-2011-01-29T00:00:00.000Z	spot	premium	preferred	ppreferred	104.311418
-2011-01-29T00:00:00.000Z	spot	technology	preferred	tpreferred	109.549035
-2011-01-29T00:00:00.000Z	spot	travel	preferred	tpreferred	138.865014
-2011-01-29T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1314.619452
-2011-01-29T00:00:00.000Z	total_market	premium	preferred	ppreferred	792.326066
-2011-01-29T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1685.500085
-2011-01-29T00:00:00.000Z	upfront	premium	preferred	ppreferred	545.990623
-2011-01-30T00:00:00.000Z	spot	automotive	preferred	apreferred	124.943293
-2011-01-30T00:00:00.000Z	spot	business	preferred	bpreferred	106.064111
-2011-01-30T00:00:00.000Z	spot	entertainment	preferred	epreferred	108.415967
-2011-01-30T00:00:00.000Z	spot	health	preferred	hpreferred	137.198397
-2011-01-30T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	97.023907
-2011-01-30T00:00:00.000Z	spot	news	preferred	npreferred	106.009926
-2011-01-30T00:00:00.000Z	spot	premium	preferred	ppreferred	104.298490
-2011-01-30T00:00:00.000Z	spot	technology	preferred	tpreferred	110.528451
-2011-01-30T00:00:00.000Z	spot	travel	preferred	tpreferred	137.932693
-2011-01-30T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1233.448863
-2011-01-30T00:00:00.000Z	total_market	premium	preferred	ppreferred	805.930143
-2011-01-30T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1870.061029
-2011-01-30T00:00:00.000Z	upfront	premium	preferred	ppreferred	555.476028
-2011-01-31T00:00:00.000Z	spot	automotive	preferred	apreferred	133.740047
-2011-01-31T00:00:00.000Z	spot	business	preferred	bpreferred	103.492964
-2011-01-31T00:00:00.000Z	spot	entertainment	preferred	epreferred	104.548387
-2011-01-31T00:00:00.000Z	spot	health	preferred	hpreferred	124.171944
-2011-01-31T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	97.017604
-2011-01-31T00:00:00.000Z	spot	news	preferred	npreferred	103.832040
-2011-01-31T00:00:00.000Z	spot	premium	preferred	ppreferred	103.021032
-2011-01-31T00:00:00.000Z	spot	technology	preferred	tpreferred	85.125795
-2011-01-31T00:00:00.000Z	spot	travel	preferred	tpreferred	155.744951
-2011-01-31T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1184.920651
-2011-01-31T00:00:00.000Z	total_market	premium	preferred	ppreferred	1127.231000
-2011-01-31T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1643.340851
-2011-01-31T00:00:00.000Z	upfront	premium	preferred	ppreferred	943.497198
-2011-02-01T00:00:00.000Z	spot	automotive	preferred	apreferred	132.123776
-2011-02-01T00:00:00.000Z	spot	business	preferred	bpreferred	103.890175
-2011-02-01T00:00:00.000Z	spot	entertainment	preferred	epreferred	103.652865
-2011-02-01T00:00:00.000Z	spot	health	preferred	hpreferred	113.896016
-2011-02-01T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	98.909356
-2011-02-01T00:00:00.000Z	spot	news	preferred	npreferred	104.383662
-2011-02-01T00:00:00.000Z	spot	premium	preferred	ppreferred	102.480377
-2011-02-01T00:00:00.000Z	spot	technology	preferred	tpreferred	83.931272
-2011-02-01T00:00:00.000Z	spot	travel	preferred	tpreferred	134.014606
-2011-02-01T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1203.465595
-2011-02-01T00:00:00.000Z	total_market	premium	preferred	ppreferred	1100.904846
-2011-02-01T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1667.497773
-2011-02-01T00:00:00.000Z	upfront	premium	preferred	ppreferred	913.561076
-2011-02-02T00:00:00.000Z	spot	automotive	preferred	apreferred	113.492245
-2011-02-02T00:00:00.000Z	spot	business	preferred	bpreferred	104.963233
-2011-02-02T00:00:00.000Z	spot	entertainment	preferred	epreferred	112.042996
-2011-02-02T00:00:00.000Z	spot	health	preferred	hpreferred	102.281859
-2011-02-02T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	97.711139
-2011-02-02T00:00:00.000Z	spot	news	preferred	npreferred	105.578807
-2011-02-02T00:00:00.000Z	spot	premium	preferred	ppreferred	102.152053
-2011-02-02T00:00:00.000Z	spot	technology	preferred	tpreferred	96.706279
-2011-02-02T00:00:00.000Z	spot	travel	preferred	tpreferred	123.170962
-2011-02-02T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1097.211164
-2011-02-02T00:00:00.000Z	total_market	premium	preferred	ppreferred	1410.792943
-2011-02-02T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1218.561908
-2011-02-02T00:00:00.000Z	upfront	premium	preferred	ppreferred	1273.707453
-2011-02-03T00:00:00.000Z	spot	automotive	preferred	apreferred	85.770241
-2011-02-03T00:00:00.000Z	spot	business	preferred	bpreferred	98.877952
-2011-02-03T00:00:00.000Z	spot	entertainment	preferred	epreferred	106.425780
-2011-02-03T00:00:00.000Z	spot	health	preferred	hpreferred	85.069784
-2011-02-03T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	100.559287
-2011-02-03T00:00:00.000Z	spot	news	preferred	npreferred	100.976362
-2011-02-03T00:00:00.000Z	spot	premium	preferred	ppreferred	102.349315
-2011-02-03T00:00:00.000Z	spot	technology	preferred	tpreferred	92.326431
-2011-02-03T00:00:00.000Z	spot	travel	preferred	tpreferred	134.140377
-2011-02-03T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1033.401241
-2011-02-03T00:00:00.000Z	total_market	premium	preferred	ppreferred	1283.166055
-2011-02-03T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	888.705280
-2011-02-03T00:00:00.000Z	upfront	premium	preferred	ppreferred	1113.114125
-2011-02-04T00:00:00.000Z	spot	automotive	preferred	apreferred	89.182906
-2011-02-04T00:00:00.000Z	spot	business	preferred	bpreferred	106.888769
-2011-02-04T00:00:00.000Z	spot	entertainment	preferred	epreferred	112.471918
-2011-02-04T00:00:00.000Z	spot	health	preferred	hpreferred	99.837572
-2011-02-04T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	100.918373
-2011-02-04T00:00:00.000Z	spot	news	preferred	npreferred	106.050728
-2011-02-04T00:00:00.000Z	spot	premium	preferred	ppreferred	103.103922
-2011-02-04T00:00:00.000Z	spot	technology	preferred	tpreferred	93.973465
-2011-02-04T00:00:00.000Z	spot	travel	preferred	tpreferred	113.716758
-2011-02-04T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1025.633340
-2011-02-04T00:00:00.000Z	total_market	premium	preferred	ppreferred	1331.860983
-2011-02-04T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	864.568891
-2011-02-04T00:00:00.000Z	upfront	premium	preferred	ppreferred	1308.582051
-2011-02-05T00:00:00.000Z	spot	automotive	preferred	apreferred	93.001571
-2011-02-05T00:00:00.000Z	spot	business	preferred	bpreferred	111.394244
-2011-02-05T00:00:00.000Z	spot	entertainment	preferred	epreferred	117.030289
-2011-02-05T00:00:00.000Z	spot	health	preferred	hpreferred	94.312960
-2011-02-05T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	105.660538
-2011-02-05T00:00:00.000Z	spot	news	preferred	npreferred	107.929804
-2011-02-05T00:00:00.000Z	spot	premium	preferred	ppreferred	100.646747
-2011-02-05T00:00:00.000Z	spot	technology	preferred	tpreferred	90.732978
-2011-02-05T00:00:00.000Z	spot	travel	preferred	tpreferred	114.723682
-2011-02-05T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1039.500513
-2011-02-05T00:00:00.000Z	total_market	premium	preferred	ppreferred	1332.468373
-2011-02-05T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	785.078869
-2011-02-05T00:00:00.000Z	upfront	premium	preferred	ppreferred	1363.614929
-2011-02-06T00:00:00.000Z	spot	automotive	preferred	apreferred	134.462521
-2011-02-06T00:00:00.000Z	spot	business	preferred	bpreferred	110.897359
-2011-02-06T00:00:00.000Z	spot	entertainment	preferred	epreferred	119.608310
-2011-02-06T00:00:00.000Z	spot	health	preferred	hpreferred	93.585758
-2011-02-06T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	101.847544
-2011-02-06T00:00:00.000Z	spot	news	preferred	npreferred	110.053071
-2011-02-06T00:00:00.000Z	spot	premium	preferred	ppreferred	102.770913
-2011-02-06T00:00:00.000Z	spot	technology	preferred	tpreferred	93.620739
-2011-02-06T00:00:00.000Z	spot	travel	preferred	tpreferred	121.270562
-2011-02-06T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1011.205470
-2011-02-06T00:00:00.000Z	total_market	premium	preferred	ppreferred	1029.995236
-2011-02-06T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	787.125330
-2011-02-06T00:00:00.000Z	upfront	premium	preferred	ppreferred	826.039207
-2011-02-07T00:00:00.000Z	spot	automotive	preferred	apreferred	130.194219
-2011-02-07T00:00:00.000Z	spot	business	preferred	bpreferred	98.815847
-2011-02-07T00:00:00.000Z	spot	entertainment	preferred	epreferred	112.924874
-2011-02-07T00:00:00.000Z	spot	health	preferred	hpreferred	97.480779
-2011-02-07T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	97.434318
-2011-02-07T00:00:00.000Z	spot	news	preferred	npreferred	100.706057
-2011-02-07T00:00:00.000Z	spot	premium	preferred	ppreferred	102.705243
-2011-02-07T00:00:00.000Z	spot	technology	preferred	tpreferred	83.902353
-2011-02-07T00:00:00.000Z	spot	travel	preferred	tpreferred	115.246714
-2011-02-07T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1047.212887
-2011-02-07T00:00:00.000Z	total_market	premium	preferred	ppreferred	1057.079944
-2011-02-07T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1107.243787
-2011-02-07T00:00:00.000Z	upfront	premium	preferred	ppreferred	872.625669
-2011-02-08T00:00:00.000Z	spot	automotive	preferred	apreferred	126.243536
-2011-02-08T00:00:00.000Z	spot	business	preferred	bpreferred	93.190129
-2011-02-08T00:00:00.000Z	spot	entertainment	preferred	epreferred	106.969799
-2011-02-08T00:00:00.000Z	spot	health	preferred	hpreferred	97.432302
-2011-02-08T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	96.790543
-2011-02-08T00:00:00.000Z	spot	news	preferred	npreferred	97.085047
-2011-02-08T00:00:00.000Z	spot	premium	preferred	ppreferred	103.308255
-2011-02-08T00:00:00.000Z	spot	technology	preferred	tpreferred	75.735586
-2011-02-08T00:00:00.000Z	spot	travel	preferred	tpreferred	111.040150
-2011-02-08T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1064.972638
-2011-02-08T00:00:00.000Z	total_market	premium	preferred	ppreferred	1082.727640
-2011-02-08T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1188.369265
-2011-02-08T00:00:00.000Z	upfront	premium	preferred	ppreferred	911.956790
-2011-02-09T00:00:00.000Z	spot	automotive	preferred	apreferred	129.221792
-2011-02-09T00:00:00.000Z	spot	business	preferred	bpreferred	115.548444
-2011-02-09T00:00:00.000Z	spot	entertainment	preferred	epreferred	111.729360
-2011-02-09T00:00:00.000Z	spot	health	preferred	hpreferred	97.071703
-2011-02-09T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	96.478571
-2011-02-09T00:00:00.000Z	spot	news	preferred	npreferred	113.554588
-2011-02-09T00:00:00.000Z	spot	premium	preferred	ppreferred	105.498315
-2011-02-09T00:00:00.000Z	spot	technology	preferred	tpreferred	83.742151
-2011-02-09T00:00:00.000Z	spot	travel	preferred	tpreferred	112.646238
-2011-02-09T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	971.050764
-2011-02-09T00:00:00.000Z	total_market	premium	preferred	ppreferred	1320.638308
-2011-02-09T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	794.098825
-2011-02-09T00:00:00.000Z	upfront	premium	preferred	ppreferred	1299.093262
-2011-02-10T00:00:00.000Z	spot	automotive	preferred	apreferred	115.461691
-2011-02-10T00:00:00.000Z	spot	business	preferred	bpreferred	118.062165
-2011-02-10T00:00:00.000Z	spot	entertainment	preferred	epreferred	117.629065
-2011-02-10T00:00:00.000Z	spot	health	preferred	hpreferred	97.235999
-2011-02-10T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	95.698374
-2011-02-10T00:00:00.000Z	spot	news	preferred	npreferred	115.824976
-2011-02-10T00:00:00.000Z	spot	premium	preferred	ppreferred	105.708103
-2011-02-10T00:00:00.000Z	spot	technology	preferred	tpreferred	91.750911
-2011-02-10T00:00:00.000Z	spot	travel	preferred	tpreferred	105.557241
-2011-02-10T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1070.165582
-2011-02-10T00:00:00.000Z	total_market	premium	preferred	ppreferred	1089.647884
-2011-02-10T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1212.928303
-2011-02-10T00:00:00.000Z	upfront	premium	preferred	ppreferred	901.327272
-2011-02-11T00:00:00.000Z	spot	automotive	preferred	apreferred	129.187009
-2011-02-11T00:00:00.000Z	spot	business	preferred	bpreferred	114.637486
-2011-02-11T00:00:00.000Z	spot	entertainment	preferred	epreferred	114.960877
-2011-02-11T00:00:00.000Z	spot	health	preferred	hpreferred	96.617339
-2011-02-11T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	100.111873
-2011-02-11T00:00:00.000Z	spot	news	preferred	npreferred	112.571724
-2011-02-11T00:00:00.000Z	spot	premium	preferred	ppreferred	105.672256
-2011-02-11T00:00:00.000Z	spot	technology	preferred	tpreferred	87.904114
-2011-02-11T00:00:00.000Z	spot	travel	preferred	tpreferred	102.864842
-2011-02-11T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	980.386611
-2011-02-11T00:00:00.000Z	total_market	premium	preferred	ppreferred	1179.695901
-2011-02-11T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	723.514254
-2011-02-11T00:00:00.000Z	upfront	premium	preferred	ppreferred	1061.973330
-2011-02-12T00:00:00.000Z	spot	automotive	preferred	apreferred	130.104979
-2011-02-12T00:00:00.000Z	spot	business	preferred	bpreferred	115.758445
-2011-02-12T00:00:00.000Z	spot	entertainment	preferred	epreferred	115.225386
-2011-02-12T00:00:00.000Z	spot	health	preferred	hpreferred	96.457082
-2011-02-12T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	101.515571
-2011-02-12T00:00:00.000Z	spot	news	preferred	npreferred	114.877503
-2011-02-12T00:00:00.000Z	spot	premium	preferred	ppreferred	108.637522
-2011-02-12T00:00:00.000Z	spot	technology	preferred	tpreferred	88.142774
-2011-02-12T00:00:00.000Z	spot	travel	preferred	tpreferred	102.850696
-2011-02-12T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	959.236186
-2011-02-12T00:00:00.000Z	total_market	premium	preferred	ppreferred	1092.416967
-2011-02-12T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	602.979544
-2011-02-12T00:00:00.000Z	upfront	premium	preferred	ppreferred	879.406101
-2011-02-13T00:00:00.000Z	spot	automotive	preferred	apreferred	119.490316
-2011-02-13T00:00:00.000Z	spot	business	preferred	bpreferred	118.841176
-2011-02-13T00:00:00.000Z	spot	entertainment	preferred	epreferred	119.907266
-2011-02-13T00:00:00.000Z	spot	health	preferred	hpreferred	98.607490
-2011-02-13T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	100.905238
-2011-02-13T00:00:00.000Z	spot	news	preferred	npreferred	117.965974
-2011-02-13T00:00:00.000Z	spot	premium	preferred	ppreferred	112.514409
-2011-02-13T00:00:00.000Z	spot	technology	preferred	tpreferred	87.820236
-2011-02-13T00:00:00.000Z	spot	travel	preferred	tpreferred	106.033416
-2011-02-13T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	987.067381
-2011-02-13T00:00:00.000Z	total_market	premium	preferred	ppreferred	1103.458199
-2011-02-13T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	724.262526
-2011-02-13T00:00:00.000Z	upfront	premium	preferred	ppreferred	862.931321
-2011-02-14T00:00:00.000Z	spot	automotive	preferred	apreferred	119.323168
-2011-02-14T00:00:00.000Z	spot	business	preferred	bpreferred	115.628202
-2011-02-14T00:00:00.000Z	spot	entertainment	preferred	epreferred	123.098262
-2011-02-14T00:00:00.000Z	spot	health	preferred	hpreferred	103.008650
-2011-02-14T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	101.645725
-2011-02-14T00:00:00.000Z	spot	news	preferred	npreferred	117.110451
-2011-02-14T00:00:00.000Z	spot	premium	preferred	ppreferred	121.060464
-2011-02-14T00:00:00.000Z	spot	technology	preferred	tpreferred	73.717033
-2011-02-14T00:00:00.000Z	spot	travel	preferred	tpreferred	107.663239
-2011-02-14T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1091.223197
-2011-02-14T00:00:00.000Z	total_market	premium	preferred	ppreferred	1199.607472
-2011-02-14T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1133.135123
-2011-02-14T00:00:00.000Z	upfront	premium	preferred	ppreferred	948.657939
-2011-02-15T00:00:00.000Z	spot	automotive	preferred	apreferred	123.485071
-2011-02-15T00:00:00.000Z	spot	business	preferred	bpreferred	115.527003
-2011-02-15T00:00:00.000Z	spot	entertainment	preferred	epreferred	121.563912
-2011-02-15T00:00:00.000Z	spot	health	preferred	hpreferred	103.519393
-2011-02-15T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	105.269599
-2011-02-15T00:00:00.000Z	spot	news	preferred	npreferred	117.138956
-2011-02-15T00:00:00.000Z	spot	premium	preferred	ppreferred	121.411398
-2011-02-15T00:00:00.000Z	spot	technology	preferred	tpreferred	79.700998
-2011-02-15T00:00:00.000Z	spot	travel	preferred	tpreferred	108.428302
-2011-02-15T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1044.384300
-2011-02-15T00:00:00.000Z	total_market	premium	preferred	ppreferred	1183.240825
-2011-02-15T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	807.601674
-2011-02-15T00:00:00.000Z	upfront	premium	preferred	ppreferred	914.525048
-2011-02-16T00:00:00.000Z	spot	automotive	preferred	apreferred	133.726576
-2011-02-16T00:00:00.000Z	spot	business	preferred	bpreferred	116.432276
-2011-02-16T00:00:00.000Z	spot	entertainment	preferred	epreferred	130.717934
-2011-02-16T00:00:00.000Z	spot	health	preferred	hpreferred	105.762627
-2011-02-16T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	108.338531
-2011-02-16T00:00:00.000Z	spot	news	preferred	npreferred	117.334381
-2011-02-16T00:00:00.000Z	spot	premium	preferred	ppreferred	123.270869
-2011-02-16T00:00:00.000Z	spot	technology	preferred	tpreferred	98.918664
-2011-02-16T00:00:00.000Z	spot	travel	preferred	tpreferred	113.643571
-2011-02-16T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1289.097304
-2011-02-16T00:00:00.000Z	total_market	premium	preferred	ppreferred	1360.032423
-2011-02-16T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1553.348548
-2011-02-16T00:00:00.000Z	upfront	premium	preferred	ppreferred	1208.456692
-2011-02-17T00:00:00.000Z	spot	automotive	preferred	apreferred	147.942017
-2011-02-17T00:00:00.000Z	spot	business	preferred	bpreferred	125.032692
-2011-02-17T00:00:00.000Z	spot	entertainment	preferred	epreferred	126.982673
-2011-02-17T00:00:00.000Z	spot	health	preferred	hpreferred	101.092779
-2011-02-17T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	103.940963
-2011-02-17T00:00:00.000Z	spot	news	preferred	npreferred	121.872569
-2011-02-17T00:00:00.000Z	spot	premium	preferred	ppreferred	120.050545
-2011-02-17T00:00:00.000Z	spot	technology	preferred	tpreferred	91.969195
-2011-02-17T00:00:00.000Z	spot	travel	preferred	tpreferred	112.150745
-2011-02-17T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	993.591221
-2011-02-17T00:00:00.000Z	total_market	premium	preferred	ppreferred	1021.071173
-2011-02-17T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	679.619354
-2011-02-17T00:00:00.000Z	upfront	premium	preferred	ppreferred	645.177645
-2011-02-18T00:00:00.000Z	spot	automotive	preferred	apreferred	151.053296
-2011-02-18T00:00:00.000Z	spot	business	preferred	bpreferred	127.611947
-2011-02-18T00:00:00.000Z	spot	entertainment	preferred	epreferred	128.063524
-2011-02-18T00:00:00.000Z	spot	health	preferred	hpreferred	100.849247
-2011-02-18T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	101.960196
-2011-02-18T00:00:00.000Z	spot	news	preferred	npreferred	124.513018
-2011-02-18T00:00:00.000Z	spot	premium	preferred	ppreferred	122.546253
-2011-02-18T00:00:00.000Z	spot	technology	preferred	tpreferred	92.174432
-2011-02-18T00:00:00.000Z	spot	travel	preferred	tpreferred	120.151389
-2011-02-18T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1105.383465
-2011-02-18T00:00:00.000Z	total_market	premium	preferred	ppreferred	1601.829436
-2011-02-18T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1120.088751
-2011-02-18T00:00:00.000Z	upfront	premium	preferred	ppreferred	1649.533329
-2011-02-19T00:00:00.000Z	spot	automotive	preferred	apreferred	163.351690
-2011-02-19T00:00:00.000Z	spot	business	preferred	bpreferred	123.447481
-2011-02-19T00:00:00.000Z	spot	entertainment	preferred	epreferred	133.726878
-2011-02-19T00:00:00.000Z	spot	health	preferred	hpreferred	108.822138
-2011-02-19T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	102.919452
-2011-02-19T00:00:00.000Z	spot	news	preferred	npreferred	119.371511
-2011-02-19T00:00:00.000Z	spot	premium	preferred	ppreferred	125.052129
-2011-02-19T00:00:00.000Z	spot	technology	preferred	tpreferred	91.547944
-2011-02-19T00:00:00.000Z	spot	travel	preferred	tpreferred	121.733400
-2011-02-19T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1200.527201
-2011-02-19T00:00:00.000Z	total_market	premium	preferred	ppreferred	1600.723226
-2011-02-19T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1433.398801
-2011-02-19T00:00:00.000Z	upfront	premium	preferred	ppreferred	1598.179271
-2011-02-20T00:00:00.000Z	spot	automotive	preferred	apreferred	157.483005
-2011-02-20T00:00:00.000Z	spot	business	preferred	bpreferred	129.409606
-2011-02-20T00:00:00.000Z	spot	entertainment	preferred	epreferred	176.323916
-2011-02-20T00:00:00.000Z	spot	health	preferred	hpreferred	109.790712
-2011-02-20T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	127.819268
-2011-02-20T00:00:00.000Z	spot	news	preferred	npreferred	122.082375
-2011-02-20T00:00:00.000Z	spot	premium	preferred	ppreferred	132.719065
-2011-02-20T00:00:00.000Z	spot	technology	preferred	tpreferred	105.985049
-2011-02-20T00:00:00.000Z	spot	travel	preferred	tpreferred	124.637709
-2011-02-20T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1317.458323
-2011-02-20T00:00:00.000Z	total_market	premium	preferred	ppreferred	1304.326111
-2011-02-20T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1192.563067
-2011-02-20T00:00:00.000Z	upfront	premium	preferred	ppreferred	1022.854576
-2011-02-21T00:00:00.000Z	spot	automotive	preferred	apreferred	155.632898
-2011-02-21T00:00:00.000Z	spot	business	preferred	bpreferred	132.231346
-2011-02-21T00:00:00.000Z	spot	entertainment	preferred	epreferred	193.787574
-2011-02-21T00:00:00.000Z	spot	health	preferred	hpreferred	111.386745
-2011-02-21T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	154.627912
-2011-02-21T00:00:00.000Z	spot	news	preferred	npreferred	126.995117
-2011-02-21T00:00:00.000Z	spot	premium	preferred	ppreferred	138.092468
-2011-02-21T00:00:00.000Z	spot	technology	preferred	tpreferred	119.850150
-2011-02-21T00:00:00.000Z	spot	travel	preferred	tpreferred	119.739112
-2011-02-21T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1544.108134
-2011-02-21T00:00:00.000Z	total_market	premium	preferred	ppreferred	1488.737765
-2011-02-21T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1228.502469
-2011-02-21T00:00:00.000Z	upfront	premium	preferred	ppreferred	1298.415763
-2011-02-22T00:00:00.000Z	spot	automotive	preferred	apreferred	149.171056
-2011-02-22T00:00:00.000Z	spot	business	preferred	bpreferred	124.524992
-2011-02-22T00:00:00.000Z	spot	entertainment	preferred	epreferred	139.557139
-2011-02-22T00:00:00.000Z	spot	health	preferred	hpreferred	108.370907
-2011-02-22T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	111.394542
-2011-02-22T00:00:00.000Z	spot	news	preferred	npreferred	122.510640
-2011-02-22T00:00:00.000Z	spot	premium	preferred	ppreferred	126.596847
-2011-02-22T00:00:00.000Z	spot	technology	preferred	tpreferred	86.333235
-2011-02-22T00:00:00.000Z	spot	travel	preferred	tpreferred	115.915849
-2011-02-22T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1224.827108
-2011-02-22T00:00:00.000Z	total_market	premium	preferred	ppreferred	1421.648704
-2011-02-22T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1345.964309
-2011-02-22T00:00:00.000Z	upfront	premium	preferred	ppreferred	1291.897942
-2011-02-23T00:00:00.000Z	spot	automotive	preferred	apreferred	165.273009
-2011-02-23T00:00:00.000Z	spot	business	preferred	bpreferred	127.199815
-2011-02-23T00:00:00.000Z	spot	entertainment	preferred	epreferred	145.588115
-2011-02-23T00:00:00.000Z	spot	health	preferred	hpreferred	107.896489
-2011-02-23T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	113.141185
-2011-02-23T00:00:00.000Z	spot	news	preferred	npreferred	122.404192
-2011-02-23T00:00:00.000Z	spot	premium	preferred	ppreferred	124.305608
-2011-02-23T00:00:00.000Z	spot	technology	preferred	tpreferred	91.191071
-2011-02-23T00:00:00.000Z	spot	travel	preferred	tpreferred	123.961542
-2011-02-23T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1251.906228
-2011-02-23T00:00:00.000Z	total_market	premium	preferred	ppreferred	1414.619004
-2011-02-23T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1306.495696
-2011-02-23T00:00:00.000Z	upfront	premium	preferred	ppreferred	1287.766687
-2011-02-24T00:00:00.000Z	spot	automotive	preferred	apreferred	168.988478
-2011-02-24T00:00:00.000Z	spot	business	preferred	bpreferred	123.553981
-2011-02-24T00:00:00.000Z	spot	entertainment	preferred	epreferred	139.978575
-2011-02-24T00:00:00.000Z	spot	health	preferred	hpreferred	104.951315
-2011-02-24T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	113.621184
-2011-02-24T00:00:00.000Z	spot	news	preferred	npreferred	118.862342
-2011-02-24T00:00:00.000Z	spot	premium	preferred	ppreferred	119.772575
-2011-02-24T00:00:00.000Z	spot	technology	preferred	tpreferred	91.962584
-2011-02-24T00:00:00.000Z	spot	travel	preferred	tpreferred	118.270052
-2011-02-24T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1350.175381
-2011-02-24T00:00:00.000Z	total_market	premium	preferred	ppreferred	970.728273
-2011-02-24T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1631.584352
-2011-02-24T00:00:00.000Z	upfront	premium	preferred	ppreferred	578.795979
-2011-02-25T00:00:00.000Z	spot	automotive	preferred	apreferred	172.335540
-2011-02-25T00:00:00.000Z	spot	business	preferred	bpreferred	107.539869
-2011-02-25T00:00:00.000Z	spot	entertainment	preferred	epreferred	140.941317
-2011-02-25T00:00:00.000Z	spot	health	preferred	hpreferred	99.698015
-2011-02-25T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	99.460461
-2011-02-25T00:00:00.000Z	spot	news	preferred	npreferred	106.827630
-2011-02-25T00:00:00.000Z	spot	premium	preferred	ppreferred	115.932803
-2011-02-25T00:00:00.000Z	spot	technology	preferred	tpreferred	82.350556
-2011-02-25T00:00:00.000Z	spot	travel	preferred	tpreferred	120.124862
-2011-02-25T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1057.427269
-2011-02-25T00:00:00.000Z	total_market	premium	preferred	ppreferred	1073.967314
-2011-02-25T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1017.573185
-2011-02-25T00:00:00.000Z	upfront	premium	preferred	ppreferred	782.013486
-2011-02-26T00:00:00.000Z	spot	automotive	preferred	apreferred	225.243186
-2011-02-26T00:00:00.000Z	spot	business	preferred	bpreferred	103.643952
-2011-02-26T00:00:00.000Z	spot	entertainment	preferred	epreferred	138.924835
-2011-02-26T00:00:00.000Z	spot	health	preferred	hpreferred	103.667031
-2011-02-26T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	98.314744
-2011-02-26T00:00:00.000Z	spot	news	preferred	npreferred	105.352891
-2011-02-26T00:00:00.000Z	spot	premium	preferred	ppreferred	118.896845
-2011-02-26T00:00:00.000Z	spot	technology	preferred	tpreferred	83.099365
-2011-02-26T00:00:00.000Z	spot	travel	preferred	tpreferred	131.310541
-2011-02-26T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	996.433708
-2011-02-26T00:00:00.000Z	total_market	premium	preferred	ppreferred	1743.921750
-2011-02-26T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	829.916235
-2011-02-26T00:00:00.000Z	upfront	premium	preferred	ppreferred	1862.737933
-2011-02-27T00:00:00.000Z	spot	automotive	preferred	apreferred	277.273533
-2011-02-27T00:00:00.000Z	spot	business	preferred	bpreferred	96.864384
-2011-02-27T00:00:00.000Z	spot	entertainment	preferred	epreferred	136.394846
-2011-02-27T00:00:00.000Z	spot	health	preferred	hpreferred	114.634278
-2011-02-27T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	103.226967
-2011-02-27T00:00:00.000Z	spot	news	preferred	npreferred	99.158839
-2011-02-27T00:00:00.000Z	spot	premium	preferred	ppreferred	121.929932
-2011-02-27T00:00:00.000Z	spot	technology	preferred	tpreferred	78.727950
-2011-02-27T00:00:00.000Z	spot	travel	preferred	tpreferred	136.163414
-2011-02-27T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1044.562903
-2011-02-27T00:00:00.000Z	total_market	premium	preferred	ppreferred	1474.591017
-2011-02-27T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	873.306547
-2011-02-27T00:00:00.000Z	upfront	premium	preferred	ppreferred	1427.016724
-2011-02-28T00:00:00.000Z	spot	automotive	preferred	apreferred	122.258195
-2011-02-28T00:00:00.000Z	spot	business	preferred	bpreferred	97.218943
-2011-02-28T00:00:00.000Z	spot	entertainment	preferred	epreferred	141.261324
-2011-02-28T00:00:00.000Z	spot	health	preferred	hpreferred	112.528286
-2011-02-28T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	102.185098
-2011-02-28T00:00:00.000Z	spot	news	preferred	npreferred	99.505465
-2011-02-28T00:00:00.000Z	spot	premium	preferred	ppreferred	121.786785
-2011-02-28T00:00:00.000Z	spot	technology	preferred	tpreferred	72.163651
-2011-02-28T00:00:00.000Z	spot	travel	preferred	tpreferred	114.284569
-2011-02-28T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1159.278766
-2011-02-28T00:00:00.000Z	total_market	premium	preferred	ppreferred	1292.542896
-2011-02-28T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1430.257348
-2011-02-28T00:00:00.000Z	upfront	premium	preferred	ppreferred	1101.918270
-2011-03-01T00:00:00.000Z	spot	automotive	preferred	apreferred	153.059937
-2011-03-01T00:00:00.000Z	spot	business	preferred	bpreferred	99.070796
-2011-03-01T00:00:00.000Z	spot	entertainment	preferred	epreferred	143.424672
-2011-03-01T00:00:00.000Z	spot	health	preferred	hpreferred	114.700932
-2011-03-01T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	105.453024
-2011-03-01T00:00:00.000Z	spot	news	preferred	npreferred	99.772347
-2011-03-01T00:00:00.000Z	spot	premium	preferred	ppreferred	123.251814
-2011-03-01T00:00:00.000Z	spot	technology	preferred	tpreferred	72.792970
-2011-03-01T00:00:00.000Z	spot	travel	preferred	tpreferred	116.975408
-2011-03-01T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1124.201419
-2011-03-01T00:00:00.000Z	total_market	premium	preferred	ppreferred	1243.354010
-2011-03-01T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1166.141121
-2011-03-01T00:00:00.000Z	upfront	premium	preferred	ppreferred	1004.940887
-2011-03-02T00:00:00.000Z	spot	automotive	preferred	apreferred	174.890520
-2011-03-02T00:00:00.000Z	spot	business	preferred	bpreferred	98.432014
-2011-03-02T00:00:00.000Z	spot	entertainment	preferred	epreferred	147.117434
-2011-03-02T00:00:00.000Z	spot	health	preferred	hpreferred	112.968782
-2011-03-02T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	109.239196
-2011-03-02T00:00:00.000Z	spot	news	preferred	npreferred	100.600391
-2011-03-02T00:00:00.000Z	spot	premium	preferred	ppreferred	120.212473
-2011-03-02T00:00:00.000Z	spot	technology	preferred	tpreferred	82.823988
-2011-03-02T00:00:00.000Z	spot	travel	preferred	tpreferred	116.460744
-2011-03-02T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1051.808940
-2011-03-02T00:00:00.000Z	total_market	premium	preferred	ppreferred	1143.078414
-2011-03-02T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	740.183720
-2011-03-02T00:00:00.000Z	upfront	premium	preferred	ppreferred	865.777900
-2011-03-03T00:00:00.000Z	spot	automotive	preferred	apreferred	127.994476
-2011-03-03T00:00:00.000Z	spot	business	preferred	bpreferred	92.537499
-2011-03-03T00:00:00.000Z	spot	entertainment	preferred	epreferred	140.215411
-2011-03-03T00:00:00.000Z	spot	health	preferred	hpreferred	108.914095
-2011-03-03T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	108.784646
-2011-03-03T00:00:00.000Z	spot	news	preferred	npreferred	96.031371
-2011-03-03T00:00:00.000Z	spot	premium	preferred	ppreferred	115.393493
-2011-03-03T00:00:00.000Z	spot	technology	preferred	tpreferred	75.977564
-2011-03-03T00:00:00.000Z	spot	travel	preferred	tpreferred	114.188310
-2011-03-03T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1097.490771
-2011-03-03T00:00:00.000Z	total_market	premium	preferred	ppreferred	1010.370296
-2011-03-03T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	901.307577
-2011-03-03T00:00:00.000Z	upfront	premium	preferred	ppreferred	691.958920
-2011-03-04T00:00:00.000Z	spot	automotive	preferred	apreferred	119.851231
-2011-03-04T00:00:00.000Z	spot	business	preferred	bpreferred	93.634505
-2011-03-04T00:00:00.000Z	spot	entertainment	preferred	epreferred	132.832331
-2011-03-04T00:00:00.000Z	spot	health	preferred	hpreferred	110.018472
-2011-03-04T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	107.285615
-2011-03-04T00:00:00.000Z	spot	news	preferred	npreferred	97.535226
-2011-03-04T00:00:00.000Z	spot	premium	preferred	ppreferred	113.883056
-2011-03-04T00:00:00.000Z	spot	technology	preferred	tpreferred	81.131208
-2011-03-04T00:00:00.000Z	spot	travel	preferred	tpreferred	109.607245
-2011-03-04T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1326.829155
-2011-03-04T00:00:00.000Z	total_market	premium	preferred	ppreferred	1179.803776
-2011-03-04T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1674.331703
-2011-03-04T00:00:00.000Z	upfront	premium	preferred	ppreferred	975.577927
-2011-03-05T00:00:00.000Z	spot	automotive	preferred	apreferred	136.941770
-2011-03-05T00:00:00.000Z	spot	business	preferred	bpreferred	97.942645
-2011-03-05T00:00:00.000Z	spot	entertainment	preferred	epreferred	145.393016
-2011-03-05T00:00:00.000Z	spot	health	preferred	hpreferred	108.394611
-2011-03-05T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	112.522435
-2011-03-05T00:00:00.000Z	spot	news	preferred	npreferred	102.486832
-2011-03-05T00:00:00.000Z	spot	premium	preferred	ppreferred	114.691277
-2011-03-05T00:00:00.000Z	spot	technology	preferred	tpreferred	81.105110
-2011-03-05T00:00:00.000Z	spot	travel	preferred	tpreferred	117.904527
-2011-03-05T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1281.601175
-2011-03-05T00:00:00.000Z	total_market	premium	preferred	ppreferred	994.731237
-2011-03-05T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1360.694785
-2011-03-05T00:00:00.000Z	upfront	premium	preferred	ppreferred	755.899363
-2011-03-06T00:00:00.000Z	spot	automotive	preferred	apreferred	129.531062
-2011-03-06T00:00:00.000Z	spot	business	preferred	bpreferred	99.508679
-2011-03-06T00:00:00.000Z	spot	entertainment	preferred	epreferred	144.925734
-2011-03-06T00:00:00.000Z	spot	health	preferred	hpreferred	113.069662
-2011-03-06T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	113.035167
-2011-03-06T00:00:00.000Z	spot	news	preferred	npreferred	102.536839
-2011-03-06T00:00:00.000Z	spot	premium	preferred	ppreferred	115.956859
-2011-03-06T00:00:00.000Z	spot	technology	preferred	tpreferred	81.612269
-2011-03-06T00:00:00.000Z	spot	travel	preferred	tpreferred	120.953163
-2011-03-06T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1081.650406
-2011-03-06T00:00:00.000Z	total_market	premium	preferred	ppreferred	1103.239788
-2011-03-06T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	771.348460
-2011-03-06T00:00:00.000Z	upfront	premium	preferred	ppreferred	869.308360
-2011-03-07T00:00:00.000Z	spot	automotive	preferred	apreferred	111.909348
-2011-03-07T00:00:00.000Z	spot	business	preferred	bpreferred	105.575929
-2011-03-07T00:00:00.000Z	spot	entertainment	preferred	epreferred	150.452695
-2011-03-07T00:00:00.000Z	spot	health	preferred	hpreferred	118.024245
-2011-03-07T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	111.106693
-2011-03-07T00:00:00.000Z	spot	news	preferred	npreferred	107.220218
-2011-03-07T00:00:00.000Z	spot	premium	preferred	ppreferred	121.582721
-2011-03-07T00:00:00.000Z	spot	technology	preferred	tpreferred	68.699125
-2011-03-07T00:00:00.000Z	spot	travel	preferred	tpreferred	106.884238
-2011-03-07T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1177.858403
-2011-03-07T00:00:00.000Z	total_market	premium	preferred	ppreferred	1152.547767
-2011-03-07T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1095.637520
-2011-03-07T00:00:00.000Z	upfront	premium	preferred	ppreferred	906.373797
-2011-03-08T00:00:00.000Z	spot	automotive	preferred	apreferred	109.764955
-2011-03-08T00:00:00.000Z	spot	business	preferred	bpreferred	98.972716
-2011-03-08T00:00:00.000Z	spot	entertainment	preferred	epreferred	143.214331
-2011-03-08T00:00:00.000Z	spot	health	preferred	hpreferred	119.777621
-2011-03-08T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	107.465492
-2011-03-08T00:00:00.000Z	spot	news	preferred	npreferred	101.652185
-2011-03-08T00:00:00.000Z	spot	premium	preferred	ppreferred	122.692722
-2011-03-08T00:00:00.000Z	spot	technology	preferred	tpreferred	70.866726
-2011-03-08T00:00:00.000Z	spot	travel	preferred	tpreferred	111.704071
-2011-03-08T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1117.953961
-2011-03-08T00:00:00.000Z	total_market	premium	preferred	ppreferred	1084.332554
-2011-03-08T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	988.893782
-2011-03-08T00:00:00.000Z	upfront	premium	preferred	ppreferred	835.762631
-2011-03-09T00:00:00.000Z	spot	automotive	preferred	apreferred	139.260950
-2011-03-09T00:00:00.000Z	spot	business	preferred	bpreferred	110.873407
-2011-03-09T00:00:00.000Z	spot	entertainment	preferred	epreferred	138.466933
-2011-03-09T00:00:00.000Z	spot	health	preferred	hpreferred	115.013313
-2011-03-09T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	105.613469
-2011-03-09T00:00:00.000Z	spot	news	preferred	npreferred	112.407868
-2011-03-09T00:00:00.000Z	spot	premium	preferred	ppreferred	121.220772
-2011-03-09T00:00:00.000Z	spot	technology	preferred	tpreferred	82.426362
-2011-03-09T00:00:00.000Z	spot	travel	preferred	tpreferred	107.998334
-2011-03-09T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1029.802500
-2011-03-09T00:00:00.000Z	total_market	premium	preferred	ppreferred	1121.385333
-2011-03-09T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	776.702940
-2011-03-09T00:00:00.000Z	upfront	premium	preferred	ppreferred	875.683406
-2011-03-10T00:00:00.000Z	spot	automotive	preferred	apreferred	148.809150
-2011-03-10T00:00:00.000Z	spot	business	preferred	bpreferred	105.214709
-2011-03-10T00:00:00.000Z	spot	entertainment	preferred	epreferred	134.212714
-2011-03-10T00:00:00.000Z	spot	health	preferred	hpreferred	114.717338
-2011-03-10T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	119.613508
-2011-03-10T00:00:00.000Z	spot	news	preferred	npreferred	107.127962
-2011-03-10T00:00:00.000Z	spot	premium	preferred	ppreferred	118.864028
-2011-03-10T00:00:00.000Z	spot	technology	preferred	tpreferred	79.793836
-2011-03-10T00:00:00.000Z	spot	travel	preferred	tpreferred	107.706257
-2011-03-10T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1244.849915
-2011-03-10T00:00:00.000Z	total_market	premium	preferred	ppreferred	1077.279402
-2011-03-10T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1070.836247
-2011-03-10T00:00:00.000Z	upfront	premium	preferred	ppreferred	835.461226
-2011-03-11T00:00:00.000Z	spot	automotive	preferred	apreferred	135.820968
-2011-03-11T00:00:00.000Z	spot	business	preferred	bpreferred	106.898536
-2011-03-11T00:00:00.000Z	spot	entertainment	preferred	epreferred	135.038992
-2011-03-11T00:00:00.000Z	spot	health	preferred	hpreferred	112.856230
-2011-03-11T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	120.497687
-2011-03-11T00:00:00.000Z	spot	news	preferred	npreferred	108.135811
-2011-03-11T00:00:00.000Z	spot	premium	preferred	ppreferred	118.298350
-2011-03-11T00:00:00.000Z	spot	technology	preferred	tpreferred	67.731170
-2011-03-11T00:00:00.000Z	spot	travel	preferred	tpreferred	108.186877
-2011-03-11T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1098.543170
-2011-03-11T00:00:00.000Z	total_market	premium	preferred	ppreferred	998.650727
-2011-03-11T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	715.516125
-2011-03-11T00:00:00.000Z	upfront	premium	preferred	ppreferred	755.646538
-2011-03-12T00:00:00.000Z	spot	automotive	preferred	apreferred	155.728048
-2011-03-12T00:00:00.000Z	spot	business	preferred	bpreferred	113.493460
-2011-03-12T00:00:00.000Z	spot	entertainment	preferred	epreferred	132.687079
-2011-03-12T00:00:00.000Z	spot	health	preferred	hpreferred	112.554597
-2011-03-12T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	114.681603
-2011-03-12T00:00:00.000Z	spot	news	preferred	npreferred	115.572940
-2011-03-12T00:00:00.000Z	spot	premium	preferred	ppreferred	118.574721
-2011-03-12T00:00:00.000Z	spot	technology	preferred	tpreferred	74.394926
-2011-03-12T00:00:00.000Z	spot	travel	preferred	tpreferred	109.384493
-2011-03-12T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1088.807596
-2011-03-12T00:00:00.000Z	total_market	premium	preferred	ppreferred	1008.745525
-2011-03-12T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	771.100508
-2011-03-12T00:00:00.000Z	upfront	premium	preferred	ppreferred	764.508070
-2011-03-13T00:00:00.000Z	spot	automotive	preferred	apreferred	149.637715
-2011-03-13T00:00:00.000Z	spot	business	preferred	bpreferred	113.760384
-2011-03-13T00:00:00.000Z	spot	entertainment	preferred	epreferred	120.113921
-2011-03-13T00:00:00.000Z	spot	health	preferred	hpreferred	120.760130
-2011-03-13T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	103.227522
-2011-03-13T00:00:00.000Z	spot	news	preferred	npreferred	114.814070
-2011-03-13T00:00:00.000Z	spot	premium	preferred	ppreferred	120.620862
-2011-03-13T00:00:00.000Z	spot	technology	preferred	tpreferred	70.126017
-2011-03-13T00:00:00.000Z	spot	travel	preferred	tpreferred	108.579283
-2011-03-13T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	998.753955
-2011-03-13T00:00:00.000Z	total_market	premium	preferred	ppreferred	1129.723252
-2011-03-13T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	736.409261
-2011-03-13T00:00:00.000Z	upfront	premium	preferred	ppreferred	884.837267
-2011-03-14T00:00:00.000Z	spot	automotive	preferred	apreferred	153.191744
-2011-03-14T00:00:00.000Z	spot	business	preferred	bpreferred	109.461442
-2011-03-14T00:00:00.000Z	spot	entertainment	preferred	epreferred	123.248581
-2011-03-14T00:00:00.000Z	spot	health	preferred	hpreferred	120.487244
-2011-03-14T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	104.716583
-2011-03-14T00:00:00.000Z	spot	news	preferred	npreferred	111.688901
-2011-03-14T00:00:00.000Z	spot	premium	preferred	ppreferred	122.275869
-2011-03-14T00:00:00.000Z	spot	technology	preferred	tpreferred	59.021022
-2011-03-14T00:00:00.000Z	spot	travel	preferred	tpreferred	104.724023
-2011-03-14T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1075.243024
-2011-03-14T00:00:00.000Z	total_market	premium	preferred	ppreferred	1141.588400
-2011-03-14T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	918.722840
-2011-03-14T00:00:00.000Z	upfront	premium	preferred	ppreferred	893.985017
-2011-03-15T00:00:00.000Z	spot	automotive	preferred	apreferred	145.963558
-2011-03-15T00:00:00.000Z	spot	business	preferred	bpreferred	109.382273
-2011-03-15T00:00:00.000Z	spot	entertainment	preferred	epreferred	121.386341
-2011-03-15T00:00:00.000Z	spot	health	preferred	hpreferred	119.250945
-2011-03-15T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	103.583295
-2011-03-15T00:00:00.000Z	spot	news	preferred	npreferred	112.354294
-2011-03-15T00:00:00.000Z	spot	premium	preferred	ppreferred	122.038585
-2011-03-15T00:00:00.000Z	spot	technology	preferred	tpreferred	59.266595
-2011-03-15T00:00:00.000Z	spot	travel	preferred	tpreferred	103.134338
-2011-03-15T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1037.381049
-2011-03-15T00:00:00.000Z	total_market	premium	preferred	ppreferred	1099.197263
-2011-03-15T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	832.874861
-2011-03-15T00:00:00.000Z	upfront	premium	preferred	ppreferred	850.995007
-2011-03-16T00:00:00.000Z	spot	automotive	preferred	apreferred	147.471464
-2011-03-16T00:00:00.000Z	spot	business	preferred	bpreferred	110.565004
-2011-03-16T00:00:00.000Z	spot	entertainment	preferred	epreferred	110.070846
-2011-03-16T00:00:00.000Z	spot	health	preferred	hpreferred	115.750963
-2011-03-16T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	99.137980
-2011-03-16T00:00:00.000Z	spot	news	preferred	npreferred	112.577264
-2011-03-16T00:00:00.000Z	spot	premium	preferred	ppreferred	120.455865
-2011-03-16T00:00:00.000Z	spot	technology	preferred	tpreferred	69.329723
-2011-03-16T00:00:00.000Z	spot	travel	preferred	tpreferred	107.903885
-2011-03-16T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	981.577244
-2011-03-16T00:00:00.000Z	total_market	premium	preferred	ppreferred	1092.942008
-2011-03-16T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	767.973326
-2011-03-16T00:00:00.000Z	upfront	premium	preferred	ppreferred	848.339888
-2011-03-17T00:00:00.000Z	spot	automotive	preferred	apreferred	148.905410
-2011-03-17T00:00:00.000Z	spot	business	preferred	bpreferred	113.501786
-2011-03-17T00:00:00.000Z	spot	entertainment	preferred	epreferred	109.666402
-2011-03-17T00:00:00.000Z	spot	health	preferred	hpreferred	114.540037
-2011-03-17T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	105.996125
-2011-03-17T00:00:00.000Z	spot	news	preferred	npreferred	116.816958
-2011-03-17T00:00:00.000Z	spot	premium	preferred	ppreferred	122.740143
-2011-03-17T00:00:00.000Z	spot	technology	preferred	tpreferred	69.258523
-2011-03-17T00:00:00.000Z	spot	travel	preferred	tpreferred	110.797348
-2011-03-17T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1072.239320
-2011-03-17T00:00:00.000Z	total_market	premium	preferred	ppreferred	1154.415689
-2011-03-17T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	878.683776
-2011-03-17T00:00:00.000Z	upfront	premium	preferred	ppreferred	906.101957
-2011-03-18T00:00:00.000Z	spot	automotive	preferred	apreferred	180.343171
-2011-03-18T00:00:00.000Z	spot	business	preferred	bpreferred	110.037579
-2011-03-18T00:00:00.000Z	spot	entertainment	preferred	epreferred	130.260926
-2011-03-18T00:00:00.000Z	spot	health	preferred	hpreferred	113.490115
-2011-03-18T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	111.540639
-2011-03-18T00:00:00.000Z	spot	news	preferred	npreferred	113.238556
-2011-03-18T00:00:00.000Z	spot	premium	preferred	ppreferred	119.629977
-2011-03-18T00:00:00.000Z	spot	technology	preferred	tpreferred	68.573162
-2011-03-18T00:00:00.000Z	spot	travel	preferred	tpreferred	114.564808
-2011-03-18T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1311.178603
-2011-03-18T00:00:00.000Z	total_market	premium	preferred	ppreferred	1176.605164
-2011-03-18T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1403.830217
-2011-03-18T00:00:00.000Z	upfront	premium	preferred	ppreferred	936.429632
-2011-03-19T00:00:00.000Z	spot	automotive	preferred	apreferred	177.514270
-2011-03-19T00:00:00.000Z	spot	business	preferred	bpreferred	109.788875
-2011-03-19T00:00:00.000Z	spot	entertainment	preferred	epreferred	134.147573
-2011-03-19T00:00:00.000Z	spot	health	preferred	hpreferred	117.197085
-2011-03-19T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	112.999693
-2011-03-19T00:00:00.000Z	spot	news	preferred	npreferred	112.236468
-2011-03-19T00:00:00.000Z	spot	premium	preferred	ppreferred	120.638001
-2011-03-19T00:00:00.000Z	spot	technology	preferred	tpreferred	72.369471
-2011-03-19T00:00:00.000Z	spot	travel	preferred	tpreferred	115.384807
-2011-03-19T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1107.220174
-2011-03-19T00:00:00.000Z	total_market	premium	preferred	ppreferred	1102.698977
-2011-03-19T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	846.288386
-2011-03-19T00:00:00.000Z	upfront	premium	preferred	ppreferred	856.490089
-2011-03-20T00:00:00.000Z	spot	automotive	preferred	apreferred	178.454262
-2011-03-20T00:00:00.000Z	spot	business	preferred	bpreferred	123.507497
-2011-03-20T00:00:00.000Z	spot	entertainment	preferred	epreferred	157.749330
-2011-03-20T00:00:00.000Z	spot	health	preferred	hpreferred	117.851058
-2011-03-20T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	128.274705
-2011-03-20T00:00:00.000Z	spot	news	preferred	npreferred	125.496367
-2011-03-20T00:00:00.000Z	spot	premium	preferred	ppreferred	129.519442
-2011-03-20T00:00:00.000Z	spot	technology	preferred	tpreferred	85.013155
-2011-03-20T00:00:00.000Z	spot	travel	preferred	tpreferred	128.705337
-2011-03-20T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1285.090048
-2011-03-20T00:00:00.000Z	total_market	premium	preferred	ppreferred	1217.547439
-2011-03-20T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1032.257527
-2011-03-20T00:00:00.000Z	upfront	premium	preferred	ppreferred	954.754185
-2011-03-21T00:00:00.000Z	spot	automotive	preferred	apreferred	182.035296
-2011-03-21T00:00:00.000Z	spot	business	preferred	bpreferred	124.411632
-2011-03-21T00:00:00.000Z	spot	entertainment	preferred	epreferred	157.153730
-2011-03-21T00:00:00.000Z	spot	health	preferred	hpreferred	122.462424
-2011-03-21T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	128.149976
-2011-03-21T00:00:00.000Z	spot	news	preferred	npreferred	125.243882
-2011-03-21T00:00:00.000Z	spot	premium	preferred	ppreferred	131.807919
-2011-03-21T00:00:00.000Z	spot	technology	preferred	tpreferred	75.936640
-2011-03-21T00:00:00.000Z	spot	travel	preferred	tpreferred	123.653645
-2011-03-21T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1283.957016
-2011-03-21T00:00:00.000Z	total_market	premium	preferred	ppreferred	1178.830164
-2011-03-21T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1031.990042
-2011-03-21T00:00:00.000Z	upfront	premium	preferred	ppreferred	907.021565
-2011-03-22T00:00:00.000Z	spot	automotive	preferred	apreferred	177.460613
-2011-03-22T00:00:00.000Z	spot	business	preferred	bpreferred	121.270611
-2011-03-22T00:00:00.000Z	spot	entertainment	preferred	epreferred	151.407583
-2011-03-22T00:00:00.000Z	spot	health	preferred	hpreferred	124.400780
-2011-03-22T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	126.415884
-2011-03-22T00:00:00.000Z	spot	news	preferred	npreferred	124.970533
-2011-03-22T00:00:00.000Z	spot	premium	preferred	ppreferred	133.124963
-2011-03-22T00:00:00.000Z	spot	technology	preferred	tpreferred	79.948248
-2011-03-22T00:00:00.000Z	spot	travel	preferred	tpreferred	122.357549
-2011-03-22T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1301.778098
-2011-03-22T00:00:00.000Z	total_market	premium	preferred	ppreferred	1119.247202
-2011-03-22T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1110.788895
-2011-03-22T00:00:00.000Z	upfront	premium	preferred	ppreferred	843.952139
-2011-03-23T00:00:00.000Z	spot	automotive	preferred	apreferred	154.019632
-2011-03-23T00:00:00.000Z	spot	business	preferred	bpreferred	126.764513
-2011-03-23T00:00:00.000Z	spot	entertainment	preferred	epreferred	158.592715
-2011-03-23T00:00:00.000Z	spot	health	preferred	hpreferred	118.972310
-2011-03-23T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	126.672392
-2011-03-23T00:00:00.000Z	spot	news	preferred	npreferred	129.864384
-2011-03-23T00:00:00.000Z	spot	premium	preferred	ppreferred	131.786598
-2011-03-23T00:00:00.000Z	spot	technology	preferred	tpreferred	102.603152
-2011-03-23T00:00:00.000Z	spot	travel	preferred	tpreferred	123.754240
-2011-03-23T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1403.338838
-2011-03-23T00:00:00.000Z	total_market	premium	preferred	ppreferred	1156.601892
-2011-03-23T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1362.650586
-2011-03-23T00:00:00.000Z	upfront	premium	preferred	ppreferred	884.801502
-2011-03-24T00:00:00.000Z	spot	automotive	preferred	apreferred	135.569784
-2011-03-24T00:00:00.000Z	spot	business	preferred	bpreferred	123.895027
-2011-03-24T00:00:00.000Z	spot	entertainment	preferred	epreferred	156.650862
-2011-03-24T00:00:00.000Z	spot	health	preferred	hpreferred	119.777998
-2011-03-24T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	115.945757
-2011-03-24T00:00:00.000Z	spot	news	preferred	npreferred	125.044877
-2011-03-24T00:00:00.000Z	spot	premium	preferred	ppreferred	129.023978
-2011-03-24T00:00:00.000Z	spot	technology	preferred	tpreferred	88.521042
-2011-03-24T00:00:00.000Z	spot	travel	preferred	tpreferred	124.062061
-2011-03-24T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1429.580257
-2011-03-24T00:00:00.000Z	total_market	premium	preferred	ppreferred	1137.842315
-2011-03-24T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1684.268799
-2011-03-24T00:00:00.000Z	upfront	premium	preferred	ppreferred	873.652030
-2011-03-25T00:00:00.000Z	spot	automotive	preferred	apreferred	140.577121
-2011-03-25T00:00:00.000Z	spot	business	preferred	bpreferred	125.766952
-2011-03-25T00:00:00.000Z	spot	entertainment	preferred	epreferred	157.432108
-2011-03-25T00:00:00.000Z	spot	health	preferred	hpreferred	119.400783
-2011-03-25T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	114.706960
-2011-03-25T00:00:00.000Z	spot	news	preferred	npreferred	126.057960
-2011-03-25T00:00:00.000Z	spot	premium	preferred	ppreferred	128.943094
-2011-03-25T00:00:00.000Z	spot	technology	preferred	tpreferred	89.408906
-2011-03-25T00:00:00.000Z	spot	travel	preferred	tpreferred	136.136598
-2011-03-25T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1124.935193
-2011-03-25T00:00:00.000Z	total_market	premium	preferred	ppreferred	1256.499779
-2011-03-25T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	855.717712
-2011-03-25T00:00:00.000Z	upfront	premium	preferred	ppreferred	996.564152
-2011-03-26T00:00:00.000Z	spot	automotive	preferred	apreferred	148.957194
-2011-03-26T00:00:00.000Z	spot	business	preferred	bpreferred	130.824022
-2011-03-26T00:00:00.000Z	spot	entertainment	preferred	epreferred	162.815450
-2011-03-26T00:00:00.000Z	spot	health	preferred	hpreferred	118.463523
-2011-03-26T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	117.449116
-2011-03-26T00:00:00.000Z	spot	news	preferred	npreferred	142.972964
-2011-03-26T00:00:00.000Z	spot	premium	preferred	ppreferred	139.214665
-2011-03-26T00:00:00.000Z	spot	technology	preferred	tpreferred	101.686196
-2011-03-26T00:00:00.000Z	spot	travel	preferred	tpreferred	138.663182
-2011-03-26T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1217.877395
-2011-03-26T00:00:00.000Z	total_market	premium	preferred	ppreferred	1247.890809
-2011-03-26T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1061.678577
-2011-03-26T00:00:00.000Z	upfront	premium	preferred	ppreferred	962.235801
-2011-03-27T00:00:00.000Z	spot	automotive	preferred	apreferred	144.056669
-2011-03-27T00:00:00.000Z	spot	business	preferred	bpreferred	135.183271
-2011-03-27T00:00:00.000Z	spot	entertainment	preferred	epreferred	163.161361
-2011-03-27T00:00:00.000Z	spot	health	preferred	hpreferred	130.599006
-2011-03-27T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	114.952545
-2011-03-27T00:00:00.000Z	spot	news	preferred	npreferred	139.294248
-2011-03-27T00:00:00.000Z	spot	premium	preferred	ppreferred	142.430177
-2011-03-27T00:00:00.000Z	spot	technology	preferred	tpreferred	108.489598
-2011-03-27T00:00:00.000Z	spot	travel	preferred	tpreferred	141.820068
-2011-03-27T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1185.709973
-2011-03-27T00:00:00.000Z	total_market	premium	preferred	ppreferred	1345.781728
-2011-03-27T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1019.898509
-2011-03-27T00:00:00.000Z	upfront	premium	preferred	ppreferred	1056.419292
-2011-03-28T00:00:00.000Z	spot	automotive	preferred	apreferred	156.155294
-2011-03-28T00:00:00.000Z	spot	business	preferred	bpreferred	124.336139
-2011-03-28T00:00:00.000Z	spot	entertainment	preferred	epreferred	163.100154
-2011-03-28T00:00:00.000Z	spot	health	preferred	hpreferred	131.191818
-2011-03-28T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	115.709767
-2011-03-28T00:00:00.000Z	spot	news	preferred	npreferred	127.403089
-2011-03-28T00:00:00.000Z	spot	premium	preferred	ppreferred	140.941296
-2011-03-28T00:00:00.000Z	spot	technology	preferred	tpreferred	103.578536
-2011-03-28T00:00:00.000Z	spot	travel	preferred	tpreferred	130.880788
-2011-03-28T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1250.166788
-2011-03-28T00:00:00.000Z	total_market	premium	preferred	ppreferred	1390.754050
-2011-03-28T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1198.723103
-2011-03-28T00:00:00.000Z	upfront	premium	preferred	ppreferred	1108.136072
-2011-03-29T00:00:00.000Z	spot	automotive	preferred	apreferred	134.084672
-2011-03-29T00:00:00.000Z	spot	business	preferred	bpreferred	117.626804
-2011-03-29T00:00:00.000Z	spot	entertainment	preferred	epreferred	158.073319
-2011-03-29T00:00:00.000Z	spot	health	preferred	hpreferred	128.074393
-2011-03-29T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	109.678515
-2011-03-29T00:00:00.000Z	spot	news	preferred	npreferred	122.620188
-2011-03-29T00:00:00.000Z	spot	premium	preferred	ppreferred	144.446039
-2011-03-29T00:00:00.000Z	spot	technology	preferred	tpreferred	91.604463
-2011-03-29T00:00:00.000Z	spot	travel	preferred	tpreferred	132.477651
-2011-03-29T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1224.116225
-2011-03-29T00:00:00.000Z	total_market	premium	preferred	ppreferred	1361.080245
-2011-03-29T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1289.009485
-2011-03-29T00:00:00.000Z	upfront	premium	preferred	ppreferred	1069.431801
-2011-03-30T00:00:00.000Z	spot	automotive	preferred	apreferred	135.942820
-2011-03-30T00:00:00.000Z	spot	business	preferred	bpreferred	120.283054
-2011-03-30T00:00:00.000Z	spot	entertainment	preferred	epreferred	167.960620
-2011-03-30T00:00:00.000Z	spot	health	preferred	hpreferred	121.215839
-2011-03-30T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	116.587746
-2011-03-30T00:00:00.000Z	spot	news	preferred	npreferred	122.612114
-2011-03-30T00:00:00.000Z	spot	premium	preferred	ppreferred	138.827311
-2011-03-30T00:00:00.000Z	spot	technology	preferred	tpreferred	93.331887
-2011-03-30T00:00:00.000Z	spot	travel	preferred	tpreferred	128.645571
-2011-03-30T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1190.933753
-2011-03-30T00:00:00.000Z	total_market	premium	preferred	ppreferred	1310.797070
-2011-03-30T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1001.134025
-2011-03-30T00:00:00.000Z	upfront	premium	preferred	ppreferred	1030.499562
-2011-03-31T00:00:00.000Z	spot	automotive	preferred	apreferred	151.752485
-2011-03-31T00:00:00.000Z	spot	business	preferred	bpreferred	124.414321
-2011-03-31T00:00:00.000Z	spot	entertainment	preferred	epreferred	175.778647
-2011-03-31T00:00:00.000Z	spot	health	preferred	hpreferred	120.607382
-2011-03-31T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	117.060598
-2011-03-31T00:00:00.000Z	spot	news	preferred	npreferred	125.243245
-2011-03-31T00:00:00.000Z	spot	premium	preferred	ppreferred	150.247713
-2011-03-31T00:00:00.000Z	spot	technology	preferred	tpreferred	93.390841
-2011-03-31T00:00:00.000Z	spot	travel	preferred	tpreferred	125.839686
-2011-03-31T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1466.209327
-2011-03-31T00:00:00.000Z	total_market	premium	preferred	ppreferred	1366.447617
-2011-03-31T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1734.274909
-2011-03-31T00:00:00.000Z	upfront	premium	preferred	ppreferred	1063.201156
-2011-04-01T00:00:00.000Z	spot	automotive	preferred	apreferred	135.885094
-2011-04-01T00:00:00.000Z	spot	business	preferred	bpreferred	118.570340
-2011-04-01T00:00:00.000Z	spot	entertainment	preferred	epreferred	158.747224
-2011-04-01T00:00:00.000Z	spot	health	preferred	hpreferred	120.134704
-2011-04-01T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	109.705815
-2011-04-01T00:00:00.000Z	spot	news	preferred	npreferred	121.583581
-2011-04-01T00:00:00.000Z	spot	premium	preferred	ppreferred	144.507368
-2011-04-01T00:00:00.000Z	spot	technology	preferred	tpreferred	78.622547
-2011-04-01T00:00:00.000Z	spot	travel	preferred	tpreferred	119.922742
-2011-04-01T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1314.839715
-2011-04-01T00:00:00.000Z	total_market	premium	preferred	ppreferred	1522.043733
-2011-04-01T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1447.341160
-2011-04-01T00:00:00.000Z	upfront	premium	preferred	ppreferred	1234.247546
-2011-04-02T00:00:00.000Z	spot	automotive	preferred	apreferred	147.425935
-2011-04-02T00:00:00.000Z	spot	business	preferred	bpreferred	112.987027
-2011-04-02T00:00:00.000Z	spot	entertainment	preferred	epreferred	166.016049
-2011-04-02T00:00:00.000Z	spot	health	preferred	hpreferred	113.446008
-2011-04-02T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	110.931934
-2011-04-02T00:00:00.000Z	spot	news	preferred	npreferred	114.290141
-2011-04-02T00:00:00.000Z	spot	premium	preferred	ppreferred	135.301506
-2011-04-02T00:00:00.000Z	spot	technology	preferred	tpreferred	97.387433
-2011-04-02T00:00:00.000Z	spot	travel	preferred	tpreferred	126.411364
-2011-04-02T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1193.556278
-2011-04-02T00:00:00.000Z	total_market	premium	preferred	ppreferred	1321.375057
-2011-04-02T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1144.342401
-2011-04-02T00:00:00.000Z	upfront	premium	preferred	ppreferred	1049.738585
-2011-04-03T00:00:00.000Z	spot	automotive	preferred	apreferred	122.971856
-2011-04-03T00:00:00.000Z	spot	business	preferred	bpreferred	105.735462
-2011-04-03T00:00:00.000Z	spot	entertainment	preferred	epreferred	153.927965
-2011-04-03T00:00:00.000Z	spot	health	preferred	hpreferred	103.532351
-2011-04-03T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	107.047773
-2011-04-03T00:00:00.000Z	spot	news	preferred	npreferred	107.919674
-2011-04-03T00:00:00.000Z	spot	premium	preferred	ppreferred	122.141707
-2011-04-03T00:00:00.000Z	spot	technology	preferred	tpreferred	80.861743
-2011-04-03T00:00:00.000Z	spot	travel	preferred	tpreferred	117.247070
-2011-04-03T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1055.783661
-2011-04-03T00:00:00.000Z	total_market	premium	preferred	ppreferred	1021.638673
-2011-04-03T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	811.991286
-2011-04-03T00:00:00.000Z	upfront	premium	preferred	ppreferred	768.423077
-2011-04-04T00:00:00.000Z	spot	automotive	preferred	apreferred	110.919829
-2011-04-04T00:00:00.000Z	spot	business	preferred	bpreferred	107.613577
-2011-04-04T00:00:00.000Z	spot	entertainment	preferred	epreferred	146.729242
-2011-04-04T00:00:00.000Z	spot	health	preferred	hpreferred	105.375351
-2011-04-04T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	110.573670
-2011-04-04T00:00:00.000Z	spot	news	preferred	npreferred	114.382255
-2011-04-04T00:00:00.000Z	spot	premium	preferred	ppreferred	125.285894
-2011-04-04T00:00:00.000Z	spot	technology	preferred	tpreferred	72.668430
-2011-04-04T00:00:00.000Z	spot	travel	preferred	tpreferred	117.703023
-2011-04-04T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1197.008423
-2011-04-04T00:00:00.000Z	total_market	premium	preferred	ppreferred	1131.531986
-2011-04-04T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1151.069173
-2011-04-04T00:00:00.000Z	upfront	premium	preferred	ppreferred	877.079396
-2011-04-05T00:00:00.000Z	spot	automotive	preferred	apreferred	113.318712
-2011-04-05T00:00:00.000Z	spot	business	preferred	bpreferred	105.615563
-2011-04-05T00:00:00.000Z	spot	entertainment	preferred	epreferred	141.713507
-2011-04-05T00:00:00.000Z	spot	health	preferred	hpreferred	106.207931
-2011-04-05T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	109.890586
-2011-04-05T00:00:00.000Z	spot	news	preferred	npreferred	110.012987
-2011-04-05T00:00:00.000Z	spot	premium	preferred	ppreferred	124.478408
-2011-04-05T00:00:00.000Z	spot	technology	preferred	tpreferred	86.683603
-2011-04-05T00:00:00.000Z	spot	travel	preferred	tpreferred	117.051694
-2011-04-05T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1192.144303
-2011-04-05T00:00:00.000Z	total_market	premium	preferred	ppreferred	1154.289559
-2011-04-05T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1146.423036
-2011-04-05T00:00:00.000Z	upfront	premium	preferred	ppreferred	902.615706
-2011-04-06T00:00:00.000Z	spot	automotive	preferred	apreferred	115.334018
-2011-04-06T00:00:00.000Z	spot	business	preferred	bpreferred	109.700256
-2011-04-06T00:00:00.000Z	spot	entertainment	preferred	epreferred	147.553562
-2011-04-06T00:00:00.000Z	spot	health	preferred	hpreferred	100.775597
-2011-04-06T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	108.659345
-2011-04-06T00:00:00.000Z	spot	news	preferred	npreferred	113.408308
-2011-04-06T00:00:00.000Z	spot	premium	preferred	ppreferred	121.079585
-2011-04-06T00:00:00.000Z	spot	technology	preferred	tpreferred	92.336403
-2011-04-06T00:00:00.000Z	spot	travel	preferred	tpreferred	112.921482
-2011-04-06T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1272.677122
-2011-04-06T00:00:00.000Z	total_market	premium	preferred	ppreferred	1141.514652
-2011-04-06T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1355.843374
-2011-04-06T00:00:00.000Z	upfront	premium	preferred	ppreferred	897.393445
-2011-04-07T00:00:00.000Z	spot	automotive	preferred	apreferred	117.508062
-2011-04-07T00:00:00.000Z	spot	business	preferred	bpreferred	115.418054
-2011-04-07T00:00:00.000Z	spot	entertainment	preferred	epreferred	141.565031
-2011-04-07T00:00:00.000Z	spot	health	preferred	hpreferred	95.562446
-2011-04-07T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	102.933171
-2011-04-07T00:00:00.000Z	spot	news	preferred	npreferred	122.696621
-2011-04-07T00:00:00.000Z	spot	premium	preferred	ppreferred	119.763135
-2011-04-07T00:00:00.000Z	spot	technology	preferred	tpreferred	84.357701
-2011-04-07T00:00:00.000Z	spot	travel	preferred	tpreferred	117.432760
-2011-04-07T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1190.896088
-2011-04-07T00:00:00.000Z	total_market	premium	preferred	ppreferred	1009.363132
-2011-04-07T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1260.143027
-2011-04-07T00:00:00.000Z	upfront	premium	preferred	ppreferred	762.862488
-2011-04-08T00:00:00.000Z	spot	automotive	preferred	apreferred	120.973860
-2011-04-08T00:00:00.000Z	spot	business	preferred	bpreferred	116.248860
-2011-04-08T00:00:00.000Z	spot	entertainment	preferred	epreferred	146.830618
-2011-04-08T00:00:00.000Z	spot	health	preferred	hpreferred	96.226609
-2011-04-08T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	95.447888
-2011-04-08T00:00:00.000Z	spot	news	preferred	npreferred	120.709912
-2011-04-08T00:00:00.000Z	spot	premium	preferred	ppreferred	120.309688
-2011-04-08T00:00:00.000Z	spot	technology	preferred	tpreferred	94.631354
-2011-04-08T00:00:00.000Z	spot	travel	preferred	tpreferred	122.743898
-2011-04-08T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1006.913816
-2011-04-08T00:00:00.000Z	total_market	premium	preferred	ppreferred	1032.599837
-2011-04-08T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	935.168026
-2011-04-08T00:00:00.000Z	upfront	premium	preferred	ppreferred	782.107861
-2011-04-09T00:00:00.000Z	spot	automotive	preferred	apreferred	116.080323
-2011-04-09T00:00:00.000Z	spot	business	preferred	bpreferred	116.060759
-2011-04-09T00:00:00.000Z	spot	entertainment	preferred	epreferred	158.682525
-2011-04-09T00:00:00.000Z	spot	health	preferred	hpreferred	95.509796
-2011-04-09T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	110.007248
-2011-04-09T00:00:00.000Z	spot	news	preferred	npreferred	121.905685
-2011-04-09T00:00:00.000Z	spot	premium	preferred	ppreferred	126.369367
-2011-04-09T00:00:00.000Z	spot	technology	preferred	tpreferred	92.905070
-2011-04-09T00:00:00.000Z	spot	travel	preferred	tpreferred	123.791320
-2011-04-09T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1137.385764
-2011-04-09T00:00:00.000Z	total_market	premium	preferred	ppreferred	1030.075553
-2011-04-09T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	996.205369
-2011-04-09T00:00:00.000Z	upfront	premium	preferred	ppreferred	767.692135
-2011-04-10T00:00:00.000Z	spot	automotive	preferred	apreferred	113.221448
-2011-04-10T00:00:00.000Z	spot	business	preferred	bpreferred	95.570457
-2011-04-10T00:00:00.000Z	spot	entertainment	preferred	epreferred	131.766616
-2011-04-10T00:00:00.000Z	spot	health	preferred	hpreferred	99.950855
-2011-04-10T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	91.470524
-2011-04-10T00:00:00.000Z	spot	news	preferred	npreferred	99.393076
-2011-04-10T00:00:00.000Z	spot	premium	preferred	ppreferred	123.207579
-2011-04-10T00:00:00.000Z	spot	technology	preferred	tpreferred	84.898691
-2011-04-10T00:00:00.000Z	spot	travel	preferred	tpreferred	114.353962
-2011-04-10T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1005.253077
-2011-04-10T00:00:00.000Z	total_market	premium	preferred	ppreferred	1030.094757
-2011-04-10T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1031.741509
-2011-04-10T00:00:00.000Z	upfront	premium	preferred	ppreferred	775.965555
-2011-04-11T00:00:00.000Z	spot	automotive	preferred	apreferred	130.165796
-2011-04-11T00:00:00.000Z	spot	business	preferred	bpreferred	107.765101
-2011-04-11T00:00:00.000Z	spot	entertainment	preferred	epreferred	142.751726
-2011-04-11T00:00:00.000Z	spot	health	preferred	hpreferred	104.847285
-2011-04-11T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	95.272956
-2011-04-11T00:00:00.000Z	spot	news	preferred	npreferred	106.229286
-2011-04-11T00:00:00.000Z	spot	premium	preferred	ppreferred	126.823859
-2011-04-11T00:00:00.000Z	spot	technology	preferred	tpreferred	89.250155
-2011-04-11T00:00:00.000Z	spot	travel	preferred	tpreferred	122.049678
-2011-04-11T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1112.794811
-2011-04-11T00:00:00.000Z	total_market	premium	preferred	ppreferred	1113.357530
-2011-04-11T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1374.968412
-2011-04-11T00:00:00.000Z	upfront	premium	preferred	ppreferred	853.163039
-2011-04-12T00:00:00.000Z	spot	automotive	preferred	apreferred	122.386348
-2011-04-12T00:00:00.000Z	spot	business	preferred	bpreferred	106.380995
-2011-04-12T00:00:00.000Z	spot	entertainment	preferred	epreferred	141.932300
-2011-04-12T00:00:00.000Z	spot	health	preferred	hpreferred	103.142372
-2011-04-12T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	97.340631
-2011-04-12T00:00:00.000Z	spot	news	preferred	npreferred	105.381244
-2011-04-12T00:00:00.000Z	spot	premium	preferred	ppreferred	125.189098
-2011-04-12T00:00:00.000Z	spot	technology	preferred	tpreferred	90.533391
-2011-04-12T00:00:00.000Z	spot	travel	preferred	tpreferred	122.128172
-2011-04-12T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1153.974725
-2011-04-12T00:00:00.000Z	total_market	premium	preferred	ppreferred	1069.640880
-2011-04-12T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1456.611830
-2011-04-12T00:00:00.000Z	upfront	premium	preferred	ppreferred	811.925240
-2011-04-13T00:00:00.000Z	spot	automotive	preferred	apreferred	122.688340
-2011-04-13T00:00:00.000Z	spot	business	preferred	bpreferred	105.739623
-2011-04-13T00:00:00.000Z	spot	entertainment	preferred	epreferred	136.983407
-2011-04-13T00:00:00.000Z	spot	health	preferred	hpreferred	100.860813
-2011-04-13T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	94.839191
-2011-04-13T00:00:00.000Z	spot	news	preferred	npreferred	105.261296
-2011-04-13T00:00:00.000Z	spot	premium	preferred	ppreferred	119.836611
-2011-04-13T00:00:00.000Z	spot	technology	preferred	tpreferred	91.972558
-2011-04-13T00:00:00.000Z	spot	travel	preferred	tpreferred	120.145572
-2011-04-13T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1016.137449
-2011-04-13T00:00:00.000Z	total_market	premium	preferred	ppreferred	994.902292
-2011-04-13T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	989.032799
-2011-04-13T00:00:00.000Z	upfront	premium	preferred	ppreferred	744.744657
-2011-04-14T00:00:00.000Z	spot	automotive	preferred	apreferred	111.179339
-2011-04-14T00:00:00.000Z	spot	business	preferred	bpreferred	101.984377
-2011-04-14T00:00:00.000Z	spot	entertainment	preferred	epreferred	133.606430
-2011-04-14T00:00:00.000Z	spot	health	preferred	hpreferred	99.738319
-2011-04-14T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	91.270553
-2011-04-14T00:00:00.000Z	spot	news	preferred	npreferred	101.251756
-2011-04-14T00:00:00.000Z	spot	premium	preferred	ppreferred	118.285128
-2011-04-14T00:00:00.000Z	spot	technology	preferred	tpreferred	84.951300
-2011-04-14T00:00:00.000Z	spot	travel	preferred	tpreferred	119.768525
-2011-04-14T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1032.154263
-2011-04-14T00:00:00.000Z	total_market	premium	preferred	ppreferred	999.586450
-2011-04-14T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1166.401205
-2011-04-14T00:00:00.000Z	upfront	premium	preferred	ppreferred	753.104985
-2011-04-15T00:00:00.000Z	spot	automotive	preferred	apreferred	106.793700
-2011-04-15T00:00:00.000Z	spot	business	preferred	bpreferred	94.469747
-2011-04-15T00:00:00.000Z	spot	entertainment	preferred	epreferred	135.109191
-2011-04-15T00:00:00.000Z	spot	health	preferred	hpreferred	99.596909
-2011-04-15T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	92.782760
-2011-04-15T00:00:00.000Z	spot	news	preferred	npreferred	97.859766
-2011-04-15T00:00:00.000Z	spot	premium	preferred	ppreferred	120.508160
-2011-04-15T00:00:00.000Z	spot	technology	preferred	tpreferred	89.646236
-2011-04-15T00:00:00.000Z	spot	travel	preferred	tpreferred	120.290348
-2011-04-15T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	994.752744
-2011-04-15T00:00:00.000Z	total_market	premium	preferred	ppreferred	1029.056992
-2011-04-15T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	962.731172
-2011-04-15T00:00:00.000Z	upfront	premium	preferred	ppreferred	780.271977
+2011-01-12T00:00:00.000Z	default	spot	automotive	preferred	apreferred	100.000000
+2011-01-12T00:00:00.000Z	default	spot	business	preferred	bpreferred	100.000000
+2011-01-12T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	100.000000
+2011-01-12T00:00:00.000Z	default	spot	health	preferred	hpreferred	100.000000
+2011-01-12T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	100.000000
+2011-01-12T00:00:00.000Z	default	spot	news	preferred	npreferred	100.000000
+2011-01-12T00:00:00.000Z	default	spot	premium	preferred	ppreferred	100.000000
+2011-01-12T00:00:00.000Z	default	spot	technology	preferred	tpreferred	100.000000
+2011-01-12T00:00:00.000Z	default	spot	travel	preferred	tpreferred	100.000000
+2011-01-12T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1000.000000
+2011-01-12T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1000.000000
+2011-01-12T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	800.000000
+2011-01-12T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	800.000000
+2011-01-13T00:00:00.000Z	default	spot	automotive	preferred	apreferred	94.874713
+2011-01-13T00:00:00.000Z	default	spot	business	preferred	bpreferred	103.629399
+2011-01-13T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	110.087299
+2011-01-13T00:00:00.000Z	default	spot	health	preferred	hpreferred	114.947403
+2011-01-13T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	104.465767
+2011-01-13T00:00:00.000Z	default	spot	news	preferred	npreferred	102.851683
+2011-01-13T00:00:00.000Z	default	spot	premium	preferred	ppreferred	108.863011
+2011-01-13T00:00:00.000Z	default	spot	technology	preferred	tpreferred	111.356672
+2011-01-13T00:00:00.000Z	default	spot	travel	preferred	tpreferred	106.236928
+2011-01-13T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1040.945505
+2011-01-13T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1689.012875
+2011-01-13T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	826.060182
+2011-01-13T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1564.617729
+2011-01-14T00:00:00.000Z	default	spot	automotive	preferred	apreferred	86.450372
+2011-01-14T00:00:00.000Z	default	spot	business	preferred	bpreferred	102.670409
+2011-01-14T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	109.573474
+2011-01-14T00:00:00.000Z	default	spot	health	preferred	hpreferred	94.000432
+2011-01-14T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	97.903068
+2011-01-14T00:00:00.000Z	default	spot	news	preferred	npreferred	101.380760
+2011-01-14T00:00:00.000Z	default	spot	premium	preferred	ppreferred	104.611784
+2011-01-14T00:00:00.000Z	default	spot	technology	preferred	tpreferred	114.974216
+2011-01-14T00:00:00.000Z	default	spot	travel	preferred	tpreferred	112.259958
+2011-01-14T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1049.141912
+2011-01-14T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1073.476545
+2011-01-14T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1006.402111
+2011-01-14T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	869.643722
+2011-01-15T00:00:00.000Z	default	spot	automotive	preferred	apreferred	82.840417
+2011-01-15T00:00:00.000Z	default	spot	business	preferred	bpreferred	99.781645
+2011-01-15T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	100.551072
+2011-01-15T00:00:00.000Z	default	spot	health	preferred	hpreferred	87.954346
+2011-01-15T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	100.582654
+2011-01-15T00:00:00.000Z	default	spot	news	preferred	npreferred	99.383407
+2011-01-15T00:00:00.000Z	default	spot	premium	preferred	ppreferred	102.366798
+2011-01-15T00:00:00.000Z	default	spot	technology	preferred	tpreferred	111.680229
+2011-01-15T00:00:00.000Z	default	spot	travel	preferred	tpreferred	120.481420
+2011-01-15T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1007.365510
+2011-01-15T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1545.708865
+2011-01-15T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	809.041763
+2011-01-15T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1458.402661
+2011-01-16T00:00:00.000Z	default	spot	automotive	preferred	apreferred	71.315931
+2011-01-16T00:00:00.000Z	default	spot	business	preferred	bpreferred	100.591602
+2011-01-16T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	99.007588
+2011-01-16T00:00:00.000Z	default	spot	health	preferred	hpreferred	93.085943
+2011-01-16T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	99.863171
+2011-01-16T00:00:00.000Z	default	spot	news	preferred	npreferred	100.192013
+2011-01-16T00:00:00.000Z	default	spot	premium	preferred	ppreferred	103.348007
+2011-01-16T00:00:00.000Z	default	spot	technology	preferred	tpreferred	87.280816
+2011-01-16T00:00:00.000Z	default	spot	travel	preferred	tpreferred	116.779610
+2011-01-16T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1016.965229
+2011-01-16T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1077.612663
+2011-01-16T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	852.437477
+2011-01-16T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	879.988099
+2011-01-17T00:00:00.000Z	default	spot	automotive	preferred	apreferred	105.442374
+2011-01-17T00:00:00.000Z	default	spot	business	preferred	bpreferred	105.914315
+2011-01-17T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	99.189052
+2011-01-17T00:00:00.000Z	default	spot	health	preferred	hpreferred	110.157325
+2011-01-17T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	103.692852
+2011-01-17T00:00:00.000Z	default	spot	news	preferred	npreferred	103.615039
+2011-01-17T00:00:00.000Z	default	spot	premium	preferred	ppreferred	106.696362
+2011-01-17T00:00:00.000Z	default	spot	technology	preferred	tpreferred	89.901887
+2011-01-17T00:00:00.000Z	default	spot	travel	preferred	tpreferred	134.415281
+2011-01-17T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1075.089574
+2011-01-17T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	953.995422
+2011-01-17T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	950.146770
+2011-01-17T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	712.774595
+2011-01-18T00:00:00.000Z	default	spot	automotive	preferred	apreferred	87.195139
+2011-01-18T00:00:00.000Z	default	spot	business	preferred	bpreferred	107.244699
+2011-01-18T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	94.452739
+2011-01-18T00:00:00.000Z	default	spot	health	preferred	hpreferred	103.018934
+2011-01-18T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	101.087367
+2011-01-18T00:00:00.000Z	default	spot	news	preferred	npreferred	104.724154
+2011-01-18T00:00:00.000Z	default	spot	premium	preferred	ppreferred	108.979936
+2011-01-18T00:00:00.000Z	default	spot	technology	preferred	tpreferred	88.764512
+2011-01-18T00:00:00.000Z	default	spot	travel	preferred	tpreferred	113.680094
+2011-01-18T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1022.783330
+2011-01-18T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	937.061939
+2011-01-18T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	846.267516
+2011-01-18T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	682.885525
+2011-01-19T00:00:00.000Z	default	spot	automotive	preferred	apreferred	85.681683
+2011-01-19T00:00:00.000Z	default	spot	business	preferred	bpreferred	106.700550
+2011-01-19T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	92.314034
+2011-01-19T00:00:00.000Z	default	spot	health	preferred	hpreferred	97.620315
+2011-01-19T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	105.087466
+2011-01-19T00:00:00.000Z	default	spot	news	preferred	npreferred	106.127830
+2011-01-19T00:00:00.000Z	default	spot	premium	preferred	ppreferred	104.568464
+2011-01-19T00:00:00.000Z	default	spot	technology	preferred	tpreferred	77.316731
+2011-01-19T00:00:00.000Z	default	spot	travel	preferred	tpreferred	109.772202
+2011-01-19T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1156.744712
+2011-01-19T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	849.877513
+2011-01-19T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1109.874950
+2011-01-19T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	594.381703
+2011-01-20T01:00:00.000Z	default	spot	automotive	preferred	apreferred	93.396274
+2011-01-20T01:00:00.000Z	default	spot	business	preferred	bpreferred	106.367723
+2011-01-20T01:00:00.000Z	default	spot	entertainment	preferred	epreferred	90.439020
+2011-01-20T01:00:00.000Z	default	spot	health	preferred	hpreferred	96.112901
+2011-01-20T01:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	105.669498
+2011-01-20T01:00:00.000Z	default	spot	news	preferred	npreferred	105.225158
+2011-01-20T01:00:00.000Z	default	spot	premium	preferred	ppreferred	101.305541
+2011-01-20T01:00:00.000Z	default	spot	technology	preferred	tpreferred	77.759854
+2011-01-20T01:00:00.000Z	default	spot	travel	preferred	tpreferred	140.179069
+2011-01-20T01:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1066.208012
+2011-01-20T01:00:00.000Z	default	total_market	premium	preferred	ppreferred	904.340636
+2011-01-20T01:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	870.115926
+2011-01-20T01:00:00.000Z	default	upfront	premium	preferred	ppreferred	677.510973
+2011-01-22T00:00:00.000Z	default	spot	automotive	preferred	apreferred	95.235266
+2011-01-22T00:00:00.000Z	default	spot	business	preferred	bpreferred	105.282866
+2011-01-22T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	93.681096
+2011-01-22T00:00:00.000Z	default	spot	health	preferred	hpreferred	103.527592
+2011-01-22T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	104.184494
+2011-01-22T00:00:00.000Z	default	spot	news	preferred	npreferred	103.399677
+2011-01-22T00:00:00.000Z	default	spot	premium	preferred	ppreferred	99.284525
+2011-01-22T00:00:00.000Z	default	spot	technology	preferred	tpreferred	107.627793
+2011-01-22T00:00:00.000Z	default	spot	travel	preferred	tpreferred	137.109783
+2011-01-22T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1240.525484
+2011-01-22T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1343.232494
+2011-01-22T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1410.278128
+2011-01-22T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1219.432170
+2011-01-23T00:00:00.000Z	default	spot	automotive	preferred	apreferred	100.432710
+2011-01-23T00:00:00.000Z	default	spot	business	preferred	bpreferred	107.348157
+2011-01-23T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	92.789692
+2011-01-23T00:00:00.000Z	default	spot	health	preferred	hpreferred	96.826443
+2011-01-23T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	103.730730
+2011-01-23T00:00:00.000Z	default	spot	news	preferred	npreferred	106.418686
+2011-01-23T00:00:00.000Z	default	spot	premium	preferred	ppreferred	101.573522
+2011-01-23T00:00:00.000Z	default	spot	technology	preferred	tpreferred	110.467875
+2011-01-23T00:00:00.000Z	default	spot	travel	preferred	tpreferred	128.699746
+2011-01-23T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1088.943083
+2011-01-23T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1349.254415
+2011-01-23T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	979.306038
+2011-01-23T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1224.501568
+2011-01-24T00:00:00.000Z	default	spot	automotive	preferred	apreferred	96.671647
+2011-01-24T00:00:00.000Z	default	spot	business	preferred	bpreferred	104.485760
+2011-01-24T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	88.748460
+2011-01-24T00:00:00.000Z	default	spot	health	preferred	hpreferred	189.385952
+2011-01-24T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	97.906256
+2011-01-24T00:00:00.000Z	default	spot	news	preferred	npreferred	104.167373
+2011-01-24T00:00:00.000Z	default	spot	premium	preferred	ppreferred	101.581339
+2011-01-24T00:00:00.000Z	default	spot	technology	preferred	tpreferred	105.345921
+2011-01-24T00:00:00.000Z	default	spot	travel	preferred	tpreferred	131.695956
+2011-01-24T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1102.866656
+2011-01-24T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	939.244103
+2011-01-24T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1215.589859
+2011-01-24T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	716.609179
+2011-01-25T00:00:00.000Z	default	spot	automotive	preferred	apreferred	90.111413
+2011-01-25T00:00:00.000Z	default	spot	business	preferred	bpreferred	101.624789
+2011-01-25T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	85.974579
+2011-01-25T00:00:00.000Z	default	spot	health	preferred	hpreferred	180.575246
+2011-01-25T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	96.594588
+2011-01-25T00:00:00.000Z	default	spot	news	preferred	npreferred	102.907866
+2011-01-25T00:00:00.000Z	default	spot	premium	preferred	ppreferred	102.512878
+2011-01-25T00:00:00.000Z	default	spot	technology	preferred	tpreferred	102.044542
+2011-01-25T00:00:00.000Z	default	spot	travel	preferred	tpreferred	122.077247
+2011-01-25T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1109.875413
+2011-01-25T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	997.994544
+2011-01-25T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1301.023342
+2011-01-25T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	786.363298
+2011-01-26T00:00:00.000Z	default	spot	automotive	preferred	apreferred	84.906466
+2011-01-26T00:00:00.000Z	default	spot	business	preferred	bpreferred	105.873942
+2011-01-26T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	84.710523
+2011-01-26T00:00:00.000Z	default	spot	health	preferred	hpreferred	159.988606
+2011-01-26T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	96.046584
+2011-01-26T00:00:00.000Z	default	spot	news	preferred	npreferred	105.266058
+2011-01-26T00:00:00.000Z	default	spot	premium	preferred	ppreferred	101.088903
+2011-01-26T00:00:00.000Z	default	spot	technology	preferred	tpreferred	105.617702
+2011-01-26T00:00:00.000Z	default	spot	travel	preferred	tpreferred	122.160681
+2011-01-26T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1037.449471
+2011-01-26T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1686.419659
+2011-01-26T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	989.931541
+2011-01-26T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1609.096706
+2011-01-27T00:00:00.000Z	default	spot	automotive	preferred	apreferred	134.127106
+2011-01-27T00:00:00.000Z	default	spot	business	preferred	bpreferred	104.882908
+2011-01-27T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	90.806201
+2011-01-27T00:00:00.000Z	default	spot	health	preferred	hpreferred	170.735853
+2011-01-27T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	100.643435
+2011-01-27T00:00:00.000Z	default	spot	news	preferred	npreferred	104.609483
+2011-01-27T00:00:00.000Z	default	spot	premium	preferred	ppreferred	102.612747
+2011-01-27T00:00:00.000Z	default	spot	technology	preferred	tpreferred	116.979005
+2011-01-27T00:00:00.000Z	default	spot	travel	preferred	tpreferred	149.125271
+2011-01-27T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1074.006938
+2011-01-27T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1486.201299
+2011-01-27T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1023.295213
+2011-01-27T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1367.638074
+2011-01-28T00:00:00.000Z	default	spot	automotive	preferred	apreferred	123.006128
+2011-01-28T00:00:00.000Z	default	spot	business	preferred	bpreferred	111.641077
+2011-01-28T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	99.681629
+2011-01-28T00:00:00.000Z	default	spot	health	preferred	hpreferred	107.788998
+2011-01-28T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	106.075672
+2011-01-28T00:00:00.000Z	default	spot	news	preferred	npreferred	108.106449
+2011-01-28T00:00:00.000Z	default	spot	premium	preferred	ppreferred	103.822842
+2011-01-28T00:00:00.000Z	default	spot	technology	preferred	tpreferred	93.869236
+2011-01-28T00:00:00.000Z	default	spot	travel	preferred	tpreferred	158.739359
+2011-01-28T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1300.302260
+2011-01-28T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1021.334487
+2011-01-28T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1627.598064
+2011-01-28T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	810.889422
+2011-01-29T00:00:00.000Z	default	spot	automotive	preferred	apreferred	127.450345
+2011-01-29T00:00:00.000Z	default	spot	business	preferred	bpreferred	100.992147
+2011-01-29T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	103.345166
+2011-01-29T00:00:00.000Z	default	spot	health	preferred	hpreferred	114.905745
+2011-01-29T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	106.663538
+2011-01-29T00:00:00.000Z	default	spot	news	preferred	npreferred	101.998823
+2011-01-29T00:00:00.000Z	default	spot	premium	preferred	ppreferred	104.311418
+2011-01-29T00:00:00.000Z	default	spot	technology	preferred	tpreferred	109.549035
+2011-01-29T00:00:00.000Z	default	spot	travel	preferred	tpreferred	138.865014
+2011-01-29T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1314.619452
+2011-01-29T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	792.326066
+2011-01-29T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1685.500085
+2011-01-29T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	545.990623
+2011-01-30T00:00:00.000Z	default	spot	automotive	preferred	apreferred	124.943293
+2011-01-30T00:00:00.000Z	default	spot	business	preferred	bpreferred	106.064111
+2011-01-30T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	108.415967
+2011-01-30T00:00:00.000Z	default	spot	health	preferred	hpreferred	137.198397
+2011-01-30T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	97.023907
+2011-01-30T00:00:00.000Z	default	spot	news	preferred	npreferred	106.009926
+2011-01-30T00:00:00.000Z	default	spot	premium	preferred	ppreferred	104.298490
+2011-01-30T00:00:00.000Z	default	spot	technology	preferred	tpreferred	110.528451
+2011-01-30T00:00:00.000Z	default	spot	travel	preferred	tpreferred	137.932693
+2011-01-30T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1233.448863
+2011-01-30T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	805.930143
+2011-01-30T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1870.061029
+2011-01-30T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	555.476028
+2011-01-31T00:00:00.000Z	default	spot	automotive	preferred	apreferred	133.740047
+2011-01-31T00:00:00.000Z	default	spot	business	preferred	bpreferred	103.492964
+2011-01-31T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	104.548387
+2011-01-31T00:00:00.000Z	default	spot	health	preferred	hpreferred	124.171944
+2011-01-31T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	97.017604
+2011-01-31T00:00:00.000Z	default	spot	news	preferred	npreferred	103.832040
+2011-01-31T00:00:00.000Z	default	spot	premium	preferred	ppreferred	103.021032
+2011-01-31T00:00:00.000Z	default	spot	technology	preferred	tpreferred	85.125795
+2011-01-31T00:00:00.000Z	default	spot	travel	preferred	tpreferred	155.744951
+2011-01-31T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1184.920651
+2011-01-31T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1127.231000
+2011-01-31T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1643.340851
+2011-01-31T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	943.497198
+2011-02-01T00:00:00.000Z	default	spot	automotive	preferred	apreferred	132.123776
+2011-02-01T00:00:00.000Z	default	spot	business	preferred	bpreferred	103.890175
+2011-02-01T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	103.652865
+2011-02-01T00:00:00.000Z	default	spot	health	preferred	hpreferred	113.896016
+2011-02-01T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	98.909356
+2011-02-01T00:00:00.000Z	default	spot	news	preferred	npreferred	104.383662
+2011-02-01T00:00:00.000Z	default	spot	premium	preferred	ppreferred	102.480377
+2011-02-01T00:00:00.000Z	default	spot	technology	preferred	tpreferred	83.931272
+2011-02-01T00:00:00.000Z	default	spot	travel	preferred	tpreferred	134.014606
+2011-02-01T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1203.465595
+2011-02-01T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1100.904846
+2011-02-01T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1667.497773
+2011-02-01T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	913.561076
+2011-02-02T00:00:00.000Z	default	spot	automotive	preferred	apreferred	113.492245
+2011-02-02T00:00:00.000Z	default	spot	business	preferred	bpreferred	104.963233
+2011-02-02T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	112.042996
+2011-02-02T00:00:00.000Z	default	spot	health	preferred	hpreferred	102.281859
+2011-02-02T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	97.711139
+2011-02-02T00:00:00.000Z	default	spot	news	preferred	npreferred	105.578807
+2011-02-02T00:00:00.000Z	default	spot	premium	preferred	ppreferred	102.152053
+2011-02-02T00:00:00.000Z	default	spot	technology	preferred	tpreferred	96.706279
+2011-02-02T00:00:00.000Z	default	spot	travel	preferred	tpreferred	123.170962
+2011-02-02T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1097.211164
+2011-02-02T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1410.792943
+2011-02-02T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1218.561908
+2011-02-02T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1273.707453
+2011-02-03T00:00:00.000Z	default	spot	automotive	preferred	apreferred	85.770241
+2011-02-03T00:00:00.000Z	default	spot	business	preferred	bpreferred	98.877952
+2011-02-03T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	106.425780
+2011-02-03T00:00:00.000Z	default	spot	health	preferred	hpreferred	85.069784
+2011-02-03T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	100.559287
+2011-02-03T00:00:00.000Z	default	spot	news	preferred	npreferred	100.976362
+2011-02-03T00:00:00.000Z	default	spot	premium	preferred	ppreferred	102.349315
+2011-02-03T00:00:00.000Z	default	spot	technology	preferred	tpreferred	92.326431
+2011-02-03T00:00:00.000Z	default	spot	travel	preferred	tpreferred	134.140377
+2011-02-03T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1033.401241
+2011-02-03T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1283.166055
+2011-02-03T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	888.705280
+2011-02-03T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1113.114125
+2011-02-04T00:00:00.000Z	default	spot	automotive	preferred	apreferred	89.182906
+2011-02-04T00:00:00.000Z	default	spot	business	preferred	bpreferred	106.888769
+2011-02-04T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	112.471918
+2011-02-04T00:00:00.000Z	default	spot	health	preferred	hpreferred	99.837572
+2011-02-04T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	100.918373
+2011-02-04T00:00:00.000Z	default	spot	news	preferred	npreferred	106.050728
+2011-02-04T00:00:00.000Z	default	spot	premium	preferred	ppreferred	103.103922
+2011-02-04T00:00:00.000Z	default	spot	technology	preferred	tpreferred	93.973465
+2011-02-04T00:00:00.000Z	default	spot	travel	preferred	tpreferred	113.716758
+2011-02-04T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1025.633340
+2011-02-04T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1331.860983
+2011-02-04T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	864.568891
+2011-02-04T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1308.582051
+2011-02-05T00:00:00.000Z	default	spot	automotive	preferred	apreferred	93.001571
+2011-02-05T00:00:00.000Z	default	spot	business	preferred	bpreferred	111.394244
+2011-02-05T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	117.030289
+2011-02-05T00:00:00.000Z	default	spot	health	preferred	hpreferred	94.312960
+2011-02-05T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	105.660538
+2011-02-05T00:00:00.000Z	default	spot	news	preferred	npreferred	107.929804
+2011-02-05T00:00:00.000Z	default	spot	premium	preferred	ppreferred	100.646747
+2011-02-05T00:00:00.000Z	default	spot	technology	preferred	tpreferred	90.732978
+2011-02-05T00:00:00.000Z	default	spot	travel	preferred	tpreferred	114.723682
+2011-02-05T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1039.500513
+2011-02-05T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1332.468373
+2011-02-05T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	785.078869
+2011-02-05T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1363.614929
+2011-02-06T00:00:00.000Z	default	spot	automotive	preferred	apreferred	134.462521
+2011-02-06T00:00:00.000Z	default	spot	business	preferred	bpreferred	110.897359
+2011-02-06T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	119.608310
+2011-02-06T00:00:00.000Z	default	spot	health	preferred	hpreferred	93.585758
+2011-02-06T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	101.847544
+2011-02-06T00:00:00.000Z	default	spot	news	preferred	npreferred	110.053071
+2011-02-06T00:00:00.000Z	default	spot	premium	preferred	ppreferred	102.770913
+2011-02-06T00:00:00.000Z	default	spot	technology	preferred	tpreferred	93.620739
+2011-02-06T00:00:00.000Z	default	spot	travel	preferred	tpreferred	121.270562
+2011-02-06T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1011.205470
+2011-02-06T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1029.995236
+2011-02-06T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	787.125330
+2011-02-06T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	826.039207
+2011-02-07T00:00:00.000Z	default	spot	automotive	preferred	apreferred	130.194219
+2011-02-07T00:00:00.000Z	default	spot	business	preferred	bpreferred	98.815847
+2011-02-07T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	112.924874
+2011-02-07T00:00:00.000Z	default	spot	health	preferred	hpreferred	97.480779
+2011-02-07T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	97.434318
+2011-02-07T00:00:00.000Z	default	spot	news	preferred	npreferred	100.706057
+2011-02-07T00:00:00.000Z	default	spot	premium	preferred	ppreferred	102.705243
+2011-02-07T00:00:00.000Z	default	spot	technology	preferred	tpreferred	83.902353
+2011-02-07T00:00:00.000Z	default	spot	travel	preferred	tpreferred	115.246714
+2011-02-07T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1047.212887
+2011-02-07T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1057.079944
+2011-02-07T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1107.243787
+2011-02-07T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	872.625669
+2011-02-08T00:00:00.000Z	default	spot	automotive	preferred	apreferred	126.243536
+2011-02-08T00:00:00.000Z	default	spot	business	preferred	bpreferred	93.190129
+2011-02-08T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	106.969799
+2011-02-08T00:00:00.000Z	default	spot	health	preferred	hpreferred	97.432302
+2011-02-08T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	96.790543
+2011-02-08T00:00:00.000Z	default	spot	news	preferred	npreferred	97.085047
+2011-02-08T00:00:00.000Z	default	spot	premium	preferred	ppreferred	103.308255
+2011-02-08T00:00:00.000Z	default	spot	technology	preferred	tpreferred	75.735586
+2011-02-08T00:00:00.000Z	default	spot	travel	preferred	tpreferred	111.040150
+2011-02-08T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1064.972638
+2011-02-08T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1082.727640
+2011-02-08T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1188.369265
+2011-02-08T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	911.956790
+2011-02-09T00:00:00.000Z	default	spot	automotive	preferred	apreferred	129.221792
+2011-02-09T00:00:00.000Z	default	spot	business	preferred	bpreferred	115.548444
+2011-02-09T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	111.729360
+2011-02-09T00:00:00.000Z	default	spot	health	preferred	hpreferred	97.071703
+2011-02-09T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	96.478571
+2011-02-09T00:00:00.000Z	default	spot	news	preferred	npreferred	113.554588
+2011-02-09T00:00:00.000Z	default	spot	premium	preferred	ppreferred	105.498315
+2011-02-09T00:00:00.000Z	default	spot	technology	preferred	tpreferred	83.742151
+2011-02-09T00:00:00.000Z	default	spot	travel	preferred	tpreferred	112.646238
+2011-02-09T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	971.050764
+2011-02-09T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1320.638308
+2011-02-09T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	794.098825
+2011-02-09T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1299.093262
+2011-02-10T00:00:00.000Z	default	spot	automotive	preferred	apreferred	115.461691
+2011-02-10T00:00:00.000Z	default	spot	business	preferred	bpreferred	118.062165
+2011-02-10T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	117.629065
+2011-02-10T00:00:00.000Z	default	spot	health	preferred	hpreferred	97.235999
+2011-02-10T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	95.698374
+2011-02-10T00:00:00.000Z	default	spot	news	preferred	npreferred	115.824976
+2011-02-10T00:00:00.000Z	default	spot	premium	preferred	ppreferred	105.708103
+2011-02-10T00:00:00.000Z	default	spot	technology	preferred	tpreferred	91.750911
+2011-02-10T00:00:00.000Z	default	spot	travel	preferred	tpreferred	105.557241
+2011-02-10T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1070.165582
+2011-02-10T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1089.647884
+2011-02-10T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1212.928303
+2011-02-10T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	901.327272
+2011-02-11T00:00:00.000Z	default	spot	automotive	preferred	apreferred	129.187009
+2011-02-11T00:00:00.000Z	default	spot	business	preferred	bpreferred	114.637486
+2011-02-11T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	114.960877
+2011-02-11T00:00:00.000Z	default	spot	health	preferred	hpreferred	96.617339
+2011-02-11T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	100.111873
+2011-02-11T00:00:00.000Z	default	spot	news	preferred	npreferred	112.571724
+2011-02-11T00:00:00.000Z	default	spot	premium	preferred	ppreferred	105.672256
+2011-02-11T00:00:00.000Z	default	spot	technology	preferred	tpreferred	87.904114
+2011-02-11T00:00:00.000Z	default	spot	travel	preferred	tpreferred	102.864842
+2011-02-11T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	980.386611
+2011-02-11T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1179.695901
+2011-02-11T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	723.514254
+2011-02-11T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1061.973330
+2011-02-12T00:00:00.000Z	default	spot	automotive	preferred	apreferred	130.104979
+2011-02-12T00:00:00.000Z	default	spot	business	preferred	bpreferred	115.758445
+2011-02-12T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	115.225386
+2011-02-12T00:00:00.000Z	default	spot	health	preferred	hpreferred	96.457082
+2011-02-12T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	101.515571
+2011-02-12T00:00:00.000Z	default	spot	news	preferred	npreferred	114.877503
+2011-02-12T00:00:00.000Z	default	spot	premium	preferred	ppreferred	108.637522
+2011-02-12T00:00:00.000Z	default	spot	technology	preferred	tpreferred	88.142774
+2011-02-12T00:00:00.000Z	default	spot	travel	preferred	tpreferred	102.850696
+2011-02-12T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	959.236186
+2011-02-12T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1092.416967
+2011-02-12T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	602.979544
+2011-02-12T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	879.406101
+2011-02-13T00:00:00.000Z	default	spot	automotive	preferred	apreferred	119.490316
+2011-02-13T00:00:00.000Z	default	spot	business	preferred	bpreferred	118.841176
+2011-02-13T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	119.907266
+2011-02-13T00:00:00.000Z	default	spot	health	preferred	hpreferred	98.607490
+2011-02-13T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	100.905238
+2011-02-13T00:00:00.000Z	default	spot	news	preferred	npreferred	117.965974
+2011-02-13T00:00:00.000Z	default	spot	premium	preferred	ppreferred	112.514409
+2011-02-13T00:00:00.000Z	default	spot	technology	preferred	tpreferred	87.820236
+2011-02-13T00:00:00.000Z	default	spot	travel	preferred	tpreferred	106.033416
+2011-02-13T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	987.067381
+2011-02-13T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1103.458199
+2011-02-13T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	724.262526
+2011-02-13T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	862.931321
+2011-02-14T00:00:00.000Z	default	spot	automotive	preferred	apreferred	119.323168
+2011-02-14T00:00:00.000Z	default	spot	business	preferred	bpreferred	115.628202
+2011-02-14T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	123.098262
+2011-02-14T00:00:00.000Z	default	spot	health	preferred	hpreferred	103.008650
+2011-02-14T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	101.645725
+2011-02-14T00:00:00.000Z	default	spot	news	preferred	npreferred	117.110451
+2011-02-14T00:00:00.000Z	default	spot	premium	preferred	ppreferred	121.060464
+2011-02-14T00:00:00.000Z	default	spot	technology	preferred	tpreferred	73.717033
+2011-02-14T00:00:00.000Z	default	spot	travel	preferred	tpreferred	107.663239
+2011-02-14T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1091.223197
+2011-02-14T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1199.607472
+2011-02-14T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1133.135123
+2011-02-14T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	948.657939
+2011-02-15T00:00:00.000Z	default	spot	automotive	preferred	apreferred	123.485071
+2011-02-15T00:00:00.000Z	default	spot	business	preferred	bpreferred	115.527003
+2011-02-15T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	121.563912
+2011-02-15T00:00:00.000Z	default	spot	health	preferred	hpreferred	103.519393
+2011-02-15T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	105.269599
+2011-02-15T00:00:00.000Z	default	spot	news	preferred	npreferred	117.138956
+2011-02-15T00:00:00.000Z	default	spot	premium	preferred	ppreferred	121.411398
+2011-02-15T00:00:00.000Z	default	spot	technology	preferred	tpreferred	79.700998
+2011-02-15T00:00:00.000Z	default	spot	travel	preferred	tpreferred	108.428302
+2011-02-15T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1044.384300
+2011-02-15T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1183.240825
+2011-02-15T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	807.601674
+2011-02-15T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	914.525048
+2011-02-16T00:00:00.000Z	default	spot	automotive	preferred	apreferred	133.726576
+2011-02-16T00:00:00.000Z	default	spot	business	preferred	bpreferred	116.432276
+2011-02-16T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	130.717934
+2011-02-16T00:00:00.000Z	default	spot	health	preferred	hpreferred	105.762627
+2011-02-16T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	108.338531
+2011-02-16T00:00:00.000Z	default	spot	news	preferred	npreferred	117.334381
+2011-02-16T00:00:00.000Z	default	spot	premium	preferred	ppreferred	123.270869
+2011-02-16T00:00:00.000Z	default	spot	technology	preferred	tpreferred	98.918664
+2011-02-16T00:00:00.000Z	default	spot	travel	preferred	tpreferred	113.643571
+2011-02-16T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1289.097304
+2011-02-16T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1360.032423
+2011-02-16T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1553.348548
+2011-02-16T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1208.456692
+2011-02-17T00:00:00.000Z	default	spot	automotive	preferred	apreferred	147.942017
+2011-02-17T00:00:00.000Z	default	spot	business	preferred	bpreferred	125.032692
+2011-02-17T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	126.982673
+2011-02-17T00:00:00.000Z	default	spot	health	preferred	hpreferred	101.092779
+2011-02-17T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	103.940963
+2011-02-17T00:00:00.000Z	default	spot	news	preferred	npreferred	121.872569
+2011-02-17T00:00:00.000Z	default	spot	premium	preferred	ppreferred	120.050545
+2011-02-17T00:00:00.000Z	default	spot	technology	preferred	tpreferred	91.969195
+2011-02-17T00:00:00.000Z	default	spot	travel	preferred	tpreferred	112.150745
+2011-02-17T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	993.591221
+2011-02-17T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1021.071173
+2011-02-17T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	679.619354
+2011-02-17T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	645.177645
+2011-02-18T00:00:00.000Z	default	spot	automotive	preferred	apreferred	151.053296
+2011-02-18T00:00:00.000Z	default	spot	business	preferred	bpreferred	127.611947
+2011-02-18T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	128.063524
+2011-02-18T00:00:00.000Z	default	spot	health	preferred	hpreferred	100.849247
+2011-02-18T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	101.960196
+2011-02-18T00:00:00.000Z	default	spot	news	preferred	npreferred	124.513018
+2011-02-18T00:00:00.000Z	default	spot	premium	preferred	ppreferred	122.546253
+2011-02-18T00:00:00.000Z	default	spot	technology	preferred	tpreferred	92.174432
+2011-02-18T00:00:00.000Z	default	spot	travel	preferred	tpreferred	120.151389
+2011-02-18T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1105.383465
+2011-02-18T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1601.829436
+2011-02-18T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1120.088751
+2011-02-18T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1649.533329
+2011-02-19T00:00:00.000Z	default	spot	automotive	preferred	apreferred	163.351690
+2011-02-19T00:00:00.000Z	default	spot	business	preferred	bpreferred	123.447481
+2011-02-19T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	133.726878
+2011-02-19T00:00:00.000Z	default	spot	health	preferred	hpreferred	108.822138
+2011-02-19T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	102.919452
+2011-02-19T00:00:00.000Z	default	spot	news	preferred	npreferred	119.371511
+2011-02-19T00:00:00.000Z	default	spot	premium	preferred	ppreferred	125.052129
+2011-02-19T00:00:00.000Z	default	spot	technology	preferred	tpreferred	91.547944
+2011-02-19T00:00:00.000Z	default	spot	travel	preferred	tpreferred	121.733400
+2011-02-19T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1200.527201
+2011-02-19T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1600.723226
+2011-02-19T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1433.398801
+2011-02-19T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1598.179271
+2011-02-20T00:00:00.000Z	default	spot	automotive	preferred	apreferred	157.483005
+2011-02-20T00:00:00.000Z	default	spot	business	preferred	bpreferred	129.409606
+2011-02-20T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	176.323916
+2011-02-20T00:00:00.000Z	default	spot	health	preferred	hpreferred	109.790712
+2011-02-20T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	127.819268
+2011-02-20T00:00:00.000Z	default	spot	news	preferred	npreferred	122.082375
+2011-02-20T00:00:00.000Z	default	spot	premium	preferred	ppreferred	132.719065
+2011-02-20T00:00:00.000Z	default	spot	technology	preferred	tpreferred	105.985049
+2011-02-20T00:00:00.000Z	default	spot	travel	preferred	tpreferred	124.637709
+2011-02-20T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1317.458323
+2011-02-20T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1304.326111
+2011-02-20T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1192.563067
+2011-02-20T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1022.854576
+2011-02-21T00:00:00.000Z	default	spot	automotive	preferred	apreferred	155.632898
+2011-02-21T00:00:00.000Z	default	spot	business	preferred	bpreferred	132.231346
+2011-02-21T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	193.787574
+2011-02-21T00:00:00.000Z	default	spot	health	preferred	hpreferred	111.386745
+2011-02-21T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	154.627912
+2011-02-21T00:00:00.000Z	default	spot	news	preferred	npreferred	126.995117
+2011-02-21T00:00:00.000Z	default	spot	premium	preferred	ppreferred	138.092468
+2011-02-21T00:00:00.000Z	default	spot	technology	preferred	tpreferred	119.850150
+2011-02-21T00:00:00.000Z	default	spot	travel	preferred	tpreferred	119.739112
+2011-02-21T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1544.108134
+2011-02-21T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1488.737765
+2011-02-21T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1228.502469
+2011-02-21T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1298.415763
+2011-02-22T00:00:00.000Z	default	spot	automotive	preferred	apreferred	149.171056
+2011-02-22T00:00:00.000Z	default	spot	business	preferred	bpreferred	124.524992
+2011-02-22T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	139.557139
+2011-02-22T00:00:00.000Z	default	spot	health	preferred	hpreferred	108.370907
+2011-02-22T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	111.394542
+2011-02-22T00:00:00.000Z	default	spot	news	preferred	npreferred	122.510640
+2011-02-22T00:00:00.000Z	default	spot	premium	preferred	ppreferred	126.596847
+2011-02-22T00:00:00.000Z	default	spot	technology	preferred	tpreferred	86.333235
+2011-02-22T00:00:00.000Z	default	spot	travel	preferred	tpreferred	115.915849
+2011-02-22T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1224.827108
+2011-02-22T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1421.648704
+2011-02-22T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1345.964309
+2011-02-22T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1291.897942
+2011-02-23T00:00:00.000Z	default	spot	automotive	preferred	apreferred	165.273009
+2011-02-23T00:00:00.000Z	default	spot	business	preferred	bpreferred	127.199815
+2011-02-23T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	145.588115
+2011-02-23T00:00:00.000Z	default	spot	health	preferred	hpreferred	107.896489
+2011-02-23T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	113.141185
+2011-02-23T00:00:00.000Z	default	spot	news	preferred	npreferred	122.404192
+2011-02-23T00:00:00.000Z	default	spot	premium	preferred	ppreferred	124.305608
+2011-02-23T00:00:00.000Z	default	spot	technology	preferred	tpreferred	91.191071
+2011-02-23T00:00:00.000Z	default	spot	travel	preferred	tpreferred	123.961542
+2011-02-23T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1251.906228
+2011-02-23T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1414.619004
+2011-02-23T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1306.495696
+2011-02-23T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1287.766687
+2011-02-24T00:00:00.000Z	default	spot	automotive	preferred	apreferred	168.988478
+2011-02-24T00:00:00.000Z	default	spot	business	preferred	bpreferred	123.553981
+2011-02-24T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	139.978575
+2011-02-24T00:00:00.000Z	default	spot	health	preferred	hpreferred	104.951315
+2011-02-24T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	113.621184
+2011-02-24T00:00:00.000Z	default	spot	news	preferred	npreferred	118.862342
+2011-02-24T00:00:00.000Z	default	spot	premium	preferred	ppreferred	119.772575
+2011-02-24T00:00:00.000Z	default	spot	technology	preferred	tpreferred	91.962584
+2011-02-24T00:00:00.000Z	default	spot	travel	preferred	tpreferred	118.270052
+2011-02-24T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1350.175381
+2011-02-24T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	970.728273
+2011-02-24T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1631.584352
+2011-02-24T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	578.795979
+2011-02-25T00:00:00.000Z	default	spot	automotive	preferred	apreferred	172.335540
+2011-02-25T00:00:00.000Z	default	spot	business	preferred	bpreferred	107.539869
+2011-02-25T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	140.941317
+2011-02-25T00:00:00.000Z	default	spot	health	preferred	hpreferred	99.698015
+2011-02-25T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	99.460461
+2011-02-25T00:00:00.000Z	default	spot	news	preferred	npreferred	106.827630
+2011-02-25T00:00:00.000Z	default	spot	premium	preferred	ppreferred	115.932803
+2011-02-25T00:00:00.000Z	default	spot	technology	preferred	tpreferred	82.350556
+2011-02-25T00:00:00.000Z	default	spot	travel	preferred	tpreferred	120.124862
+2011-02-25T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1057.427269
+2011-02-25T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1073.967314
+2011-02-25T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1017.573185
+2011-02-25T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	782.013486
+2011-02-26T00:00:00.000Z	default	spot	automotive	preferred	apreferred	225.243186
+2011-02-26T00:00:00.000Z	default	spot	business	preferred	bpreferred	103.643952
+2011-02-26T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	138.924835
+2011-02-26T00:00:00.000Z	default	spot	health	preferred	hpreferred	103.667031
+2011-02-26T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	98.314744
+2011-02-26T00:00:00.000Z	default	spot	news	preferred	npreferred	105.352891
+2011-02-26T00:00:00.000Z	default	spot	premium	preferred	ppreferred	118.896845
+2011-02-26T00:00:00.000Z	default	spot	technology	preferred	tpreferred	83.099365
+2011-02-26T00:00:00.000Z	default	spot	travel	preferred	tpreferred	131.310541
+2011-02-26T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	996.433708
+2011-02-26T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1743.921750
+2011-02-26T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	829.916235
+2011-02-26T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1862.737933
+2011-02-27T00:00:00.000Z	default	spot	automotive	preferred	apreferred	277.273533
+2011-02-27T00:00:00.000Z	default	spot	business	preferred	bpreferred	96.864384
+2011-02-27T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	136.394846
+2011-02-27T00:00:00.000Z	default	spot	health	preferred	hpreferred	114.634278
+2011-02-27T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	103.226967
+2011-02-27T00:00:00.000Z	default	spot	news	preferred	npreferred	99.158839
+2011-02-27T00:00:00.000Z	default	spot	premium	preferred	ppreferred	121.929932
+2011-02-27T00:00:00.000Z	default	spot	technology	preferred	tpreferred	78.727950
+2011-02-27T00:00:00.000Z	default	spot	travel	preferred	tpreferred	136.163414
+2011-02-27T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1044.562903
+2011-02-27T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1474.591017
+2011-02-27T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	873.306547
+2011-02-27T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1427.016724
+2011-02-28T00:00:00.000Z	default	spot	automotive	preferred	apreferred	122.258195
+2011-02-28T00:00:00.000Z	default	spot	business	preferred	bpreferred	97.218943
+2011-02-28T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	141.261324
+2011-02-28T00:00:00.000Z	default	spot	health	preferred	hpreferred	112.528286
+2011-02-28T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	102.185098
+2011-02-28T00:00:00.000Z	default	spot	news	preferred	npreferred	99.505465
+2011-02-28T00:00:00.000Z	default	spot	premium	preferred	ppreferred	121.786785
+2011-02-28T00:00:00.000Z	default	spot	technology	preferred	tpreferred	72.163651
+2011-02-28T00:00:00.000Z	default	spot	travel	preferred	tpreferred	114.284569
+2011-02-28T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1159.278766
+2011-02-28T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1292.542896
+2011-02-28T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1430.257348
+2011-02-28T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1101.918270
+2011-03-01T00:00:00.000Z	default	spot	automotive	preferred	apreferred	153.059937
+2011-03-01T00:00:00.000Z	default	spot	business	preferred	bpreferred	99.070796
+2011-03-01T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	143.424672
+2011-03-01T00:00:00.000Z	default	spot	health	preferred	hpreferred	114.700932
+2011-03-01T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	105.453024
+2011-03-01T00:00:00.000Z	default	spot	news	preferred	npreferred	99.772347
+2011-03-01T00:00:00.000Z	default	spot	premium	preferred	ppreferred	123.251814
+2011-03-01T00:00:00.000Z	default	spot	technology	preferred	tpreferred	72.792970
+2011-03-01T00:00:00.000Z	default	spot	travel	preferred	tpreferred	116.975408
+2011-03-01T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1124.201419
+2011-03-01T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1243.354010
+2011-03-01T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1166.141121
+2011-03-01T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1004.940887
+2011-03-02T00:00:00.000Z	default	spot	automotive	preferred	apreferred	174.890520
+2011-03-02T00:00:00.000Z	default	spot	business	preferred	bpreferred	98.432014
+2011-03-02T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	147.117434
+2011-03-02T00:00:00.000Z	default	spot	health	preferred	hpreferred	112.968782
+2011-03-02T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	109.239196
+2011-03-02T00:00:00.000Z	default	spot	news	preferred	npreferred	100.600391
+2011-03-02T00:00:00.000Z	default	spot	premium	preferred	ppreferred	120.212473
+2011-03-02T00:00:00.000Z	default	spot	technology	preferred	tpreferred	82.823988
+2011-03-02T00:00:00.000Z	default	spot	travel	preferred	tpreferred	116.460744
+2011-03-02T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1051.808940
+2011-03-02T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1143.078414
+2011-03-02T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	740.183720
+2011-03-02T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	865.777900
+2011-03-03T00:00:00.000Z	default	spot	automotive	preferred	apreferred	127.994476
+2011-03-03T00:00:00.000Z	default	spot	business	preferred	bpreferred	92.537499
+2011-03-03T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	140.215411
+2011-03-03T00:00:00.000Z	default	spot	health	preferred	hpreferred	108.914095
+2011-03-03T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	108.784646
+2011-03-03T00:00:00.000Z	default	spot	news	preferred	npreferred	96.031371
+2011-03-03T00:00:00.000Z	default	spot	premium	preferred	ppreferred	115.393493
+2011-03-03T00:00:00.000Z	default	spot	technology	preferred	tpreferred	75.977564
+2011-03-03T00:00:00.000Z	default	spot	travel	preferred	tpreferred	114.188310
+2011-03-03T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1097.490771
+2011-03-03T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1010.370296
+2011-03-03T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	901.307577
+2011-03-03T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	691.958920
+2011-03-04T00:00:00.000Z	default	spot	automotive	preferred	apreferred	119.851231
+2011-03-04T00:00:00.000Z	default	spot	business	preferred	bpreferred	93.634505
+2011-03-04T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	132.832331
+2011-03-04T00:00:00.000Z	default	spot	health	preferred	hpreferred	110.018472
+2011-03-04T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	107.285615
+2011-03-04T00:00:00.000Z	default	spot	news	preferred	npreferred	97.535226
+2011-03-04T00:00:00.000Z	default	spot	premium	preferred	ppreferred	113.883056
+2011-03-04T00:00:00.000Z	default	spot	technology	preferred	tpreferred	81.131208
+2011-03-04T00:00:00.000Z	default	spot	travel	preferred	tpreferred	109.607245
+2011-03-04T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1326.829155
+2011-03-04T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1179.803776
+2011-03-04T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1674.331703
+2011-03-04T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	975.577927
+2011-03-05T00:00:00.000Z	default	spot	automotive	preferred	apreferred	136.941770
+2011-03-05T00:00:00.000Z	default	spot	business	preferred	bpreferred	97.942645
+2011-03-05T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	145.393016
+2011-03-05T00:00:00.000Z	default	spot	health	preferred	hpreferred	108.394611
+2011-03-05T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	112.522435
+2011-03-05T00:00:00.000Z	default	spot	news	preferred	npreferred	102.486832
+2011-03-05T00:00:00.000Z	default	spot	premium	preferred	ppreferred	114.691277
+2011-03-05T00:00:00.000Z	default	spot	technology	preferred	tpreferred	81.105110
+2011-03-05T00:00:00.000Z	default	spot	travel	preferred	tpreferred	117.904527
+2011-03-05T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1281.601175
+2011-03-05T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	994.731237
+2011-03-05T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1360.694785
+2011-03-05T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	755.899363
+2011-03-06T00:00:00.000Z	default	spot	automotive	preferred	apreferred	129.531062
+2011-03-06T00:00:00.000Z	default	spot	business	preferred	bpreferred	99.508679
+2011-03-06T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	144.925734
+2011-03-06T00:00:00.000Z	default	spot	health	preferred	hpreferred	113.069662
+2011-03-06T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	113.035167
+2011-03-06T00:00:00.000Z	default	spot	news	preferred	npreferred	102.536839
+2011-03-06T00:00:00.000Z	default	spot	premium	preferred	ppreferred	115.956859
+2011-03-06T00:00:00.000Z	default	spot	technology	preferred	tpreferred	81.612269
+2011-03-06T00:00:00.000Z	default	spot	travel	preferred	tpreferred	120.953163
+2011-03-06T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1081.650406
+2011-03-06T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1103.239788
+2011-03-06T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	771.348460
+2011-03-06T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	869.308360
+2011-03-07T00:00:00.000Z	default	spot	automotive	preferred	apreferred	111.909348
+2011-03-07T00:00:00.000Z	default	spot	business	preferred	bpreferred	105.575929
+2011-03-07T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	150.452695
+2011-03-07T00:00:00.000Z	default	spot	health	preferred	hpreferred	118.024245
+2011-03-07T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	111.106693
+2011-03-07T00:00:00.000Z	default	spot	news	preferred	npreferred	107.220218
+2011-03-07T00:00:00.000Z	default	spot	premium	preferred	ppreferred	121.582721
+2011-03-07T00:00:00.000Z	default	spot	technology	preferred	tpreferred	68.699125
+2011-03-07T00:00:00.000Z	default	spot	travel	preferred	tpreferred	106.884238
+2011-03-07T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1177.858403
+2011-03-07T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1152.547767
+2011-03-07T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1095.637520
+2011-03-07T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	906.373797
+2011-03-08T00:00:00.000Z	default	spot	automotive	preferred	apreferred	109.764955
+2011-03-08T00:00:00.000Z	default	spot	business	preferred	bpreferred	98.972716
+2011-03-08T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	143.214331
+2011-03-08T00:00:00.000Z	default	spot	health	preferred	hpreferred	119.777621
+2011-03-08T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	107.465492
+2011-03-08T00:00:00.000Z	default	spot	news	preferred	npreferred	101.652185
+2011-03-08T00:00:00.000Z	default	spot	premium	preferred	ppreferred	122.692722
+2011-03-08T00:00:00.000Z	default	spot	technology	preferred	tpreferred	70.866726
+2011-03-08T00:00:00.000Z	default	spot	travel	preferred	tpreferred	111.704071
+2011-03-08T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1117.953961
+2011-03-08T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1084.332554
+2011-03-08T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	988.893782
+2011-03-08T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	835.762631
+2011-03-09T00:00:00.000Z	default	spot	automotive	preferred	apreferred	139.260950
+2011-03-09T00:00:00.000Z	default	spot	business	preferred	bpreferred	110.873407
+2011-03-09T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	138.466933
+2011-03-09T00:00:00.000Z	default	spot	health	preferred	hpreferred	115.013313
+2011-03-09T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	105.613469
+2011-03-09T00:00:00.000Z	default	spot	news	preferred	npreferred	112.407868
+2011-03-09T00:00:00.000Z	default	spot	premium	preferred	ppreferred	121.220772
+2011-03-09T00:00:00.000Z	default	spot	technology	preferred	tpreferred	82.426362
+2011-03-09T00:00:00.000Z	default	spot	travel	preferred	tpreferred	107.998334
+2011-03-09T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1029.802500
+2011-03-09T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1121.385333
+2011-03-09T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	776.702940
+2011-03-09T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	875.683406
+2011-03-10T00:00:00.000Z	default	spot	automotive	preferred	apreferred	148.809150
+2011-03-10T00:00:00.000Z	default	spot	business	preferred	bpreferred	105.214709
+2011-03-10T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	134.212714
+2011-03-10T00:00:00.000Z	default	spot	health	preferred	hpreferred	114.717338
+2011-03-10T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	119.613508
+2011-03-10T00:00:00.000Z	default	spot	news	preferred	npreferred	107.127962
+2011-03-10T00:00:00.000Z	default	spot	premium	preferred	ppreferred	118.864028
+2011-03-10T00:00:00.000Z	default	spot	technology	preferred	tpreferred	79.793836
+2011-03-10T00:00:00.000Z	default	spot	travel	preferred	tpreferred	107.706257
+2011-03-10T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1244.849915
+2011-03-10T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1077.279402
+2011-03-10T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1070.836247
+2011-03-10T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	835.461226
+2011-03-11T00:00:00.000Z	default	spot	automotive	preferred	apreferred	135.820968
+2011-03-11T00:00:00.000Z	default	spot	business	preferred	bpreferred	106.898536
+2011-03-11T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	135.038992
+2011-03-11T00:00:00.000Z	default	spot	health	preferred	hpreferred	112.856230
+2011-03-11T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	120.497687
+2011-03-11T00:00:00.000Z	default	spot	news	preferred	npreferred	108.135811
+2011-03-11T00:00:00.000Z	default	spot	premium	preferred	ppreferred	118.298350
+2011-03-11T00:00:00.000Z	default	spot	technology	preferred	tpreferred	67.731170
+2011-03-11T00:00:00.000Z	default	spot	travel	preferred	tpreferred	108.186877
+2011-03-11T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1098.543170
+2011-03-11T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	998.650727
+2011-03-11T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	715.516125
+2011-03-11T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	755.646538
+2011-03-12T00:00:00.000Z	default	spot	automotive	preferred	apreferred	155.728048
+2011-03-12T00:00:00.000Z	default	spot	business	preferred	bpreferred	113.493460
+2011-03-12T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	132.687079
+2011-03-12T00:00:00.000Z	default	spot	health	preferred	hpreferred	112.554597
+2011-03-12T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	114.681603
+2011-03-12T00:00:00.000Z	default	spot	news	preferred	npreferred	115.572940
+2011-03-12T00:00:00.000Z	default	spot	premium	preferred	ppreferred	118.574721
+2011-03-12T00:00:00.000Z	default	spot	technology	preferred	tpreferred	74.394926
+2011-03-12T00:00:00.000Z	default	spot	travel	preferred	tpreferred	109.384493
+2011-03-12T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1088.807596
+2011-03-12T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1008.745525
+2011-03-12T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	771.100508
+2011-03-12T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	764.508070
+2011-03-13T00:00:00.000Z	default	spot	automotive	preferred	apreferred	149.637715
+2011-03-13T00:00:00.000Z	default	spot	business	preferred	bpreferred	113.760384
+2011-03-13T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	120.113921
+2011-03-13T00:00:00.000Z	default	spot	health	preferred	hpreferred	120.760130
+2011-03-13T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	103.227522
+2011-03-13T00:00:00.000Z	default	spot	news	preferred	npreferred	114.814070
+2011-03-13T00:00:00.000Z	default	spot	premium	preferred	ppreferred	120.620862
+2011-03-13T00:00:00.000Z	default	spot	technology	preferred	tpreferred	70.126017
+2011-03-13T00:00:00.000Z	default	spot	travel	preferred	tpreferred	108.579283
+2011-03-13T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	998.753955
+2011-03-13T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1129.723252
+2011-03-13T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	736.409261
+2011-03-13T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	884.837267
+2011-03-14T00:00:00.000Z	default	spot	automotive	preferred	apreferred	153.191744
+2011-03-14T00:00:00.000Z	default	spot	business	preferred	bpreferred	109.461442
+2011-03-14T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	123.248581
+2011-03-14T00:00:00.000Z	default	spot	health	preferred	hpreferred	120.487244
+2011-03-14T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	104.716583
+2011-03-14T00:00:00.000Z	default	spot	news	preferred	npreferred	111.688901
+2011-03-14T00:00:00.000Z	default	spot	premium	preferred	ppreferred	122.275869
+2011-03-14T00:00:00.000Z	default	spot	technology	preferred	tpreferred	59.021022
+2011-03-14T00:00:00.000Z	default	spot	travel	preferred	tpreferred	104.724023
+2011-03-14T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1075.243024
+2011-03-14T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1141.588400
+2011-03-14T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	918.722840
+2011-03-14T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	893.985017
+2011-03-15T00:00:00.000Z	default	spot	automotive	preferred	apreferred	145.963558
+2011-03-15T00:00:00.000Z	default	spot	business	preferred	bpreferred	109.382273
+2011-03-15T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	121.386341
+2011-03-15T00:00:00.000Z	default	spot	health	preferred	hpreferred	119.250945
+2011-03-15T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	103.583295
+2011-03-15T00:00:00.000Z	default	spot	news	preferred	npreferred	112.354294
+2011-03-15T00:00:00.000Z	default	spot	premium	preferred	ppreferred	122.038585
+2011-03-15T00:00:00.000Z	default	spot	technology	preferred	tpreferred	59.266595
+2011-03-15T00:00:00.000Z	default	spot	travel	preferred	tpreferred	103.134338
+2011-03-15T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1037.381049
+2011-03-15T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1099.197263
+2011-03-15T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	832.874861
+2011-03-15T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	850.995007
+2011-03-16T00:00:00.000Z	default	spot	automotive	preferred	apreferred	147.471464
+2011-03-16T00:00:00.000Z	default	spot	business	preferred	bpreferred	110.565004
+2011-03-16T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	110.070846
+2011-03-16T00:00:00.000Z	default	spot	health	preferred	hpreferred	115.750963
+2011-03-16T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	99.137980
+2011-03-16T00:00:00.000Z	default	spot	news	preferred	npreferred	112.577264
+2011-03-16T00:00:00.000Z	default	spot	premium	preferred	ppreferred	120.455865
+2011-03-16T00:00:00.000Z	default	spot	technology	preferred	tpreferred	69.329723
+2011-03-16T00:00:00.000Z	default	spot	travel	preferred	tpreferred	107.903885
+2011-03-16T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	981.577244
+2011-03-16T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1092.942008
+2011-03-16T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	767.973326
+2011-03-16T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	848.339888
+2011-03-17T00:00:00.000Z	default	spot	automotive	preferred	apreferred	148.905410
+2011-03-17T00:00:00.000Z	default	spot	business	preferred	bpreferred	113.501786
+2011-03-17T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	109.666402
+2011-03-17T00:00:00.000Z	default	spot	health	preferred	hpreferred	114.540037
+2011-03-17T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	105.996125
+2011-03-17T00:00:00.000Z	default	spot	news	preferred	npreferred	116.816958
+2011-03-17T00:00:00.000Z	default	spot	premium	preferred	ppreferred	122.740143
+2011-03-17T00:00:00.000Z	default	spot	technology	preferred	tpreferred	69.258523
+2011-03-17T00:00:00.000Z	default	spot	travel	preferred	tpreferred	110.797348
+2011-03-17T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1072.239320
+2011-03-17T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1154.415689
+2011-03-17T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	878.683776
+2011-03-17T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	906.101957
+2011-03-18T00:00:00.000Z	default	spot	automotive	preferred	apreferred	180.343171
+2011-03-18T00:00:00.000Z	default	spot	business	preferred	bpreferred	110.037579
+2011-03-18T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	130.260926
+2011-03-18T00:00:00.000Z	default	spot	health	preferred	hpreferred	113.490115
+2011-03-18T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	111.540639
+2011-03-18T00:00:00.000Z	default	spot	news	preferred	npreferred	113.238556
+2011-03-18T00:00:00.000Z	default	spot	premium	preferred	ppreferred	119.629977
+2011-03-18T00:00:00.000Z	default	spot	technology	preferred	tpreferred	68.573162
+2011-03-18T00:00:00.000Z	default	spot	travel	preferred	tpreferred	114.564808
+2011-03-18T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1311.178603
+2011-03-18T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1176.605164
+2011-03-18T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1403.830217
+2011-03-18T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	936.429632
+2011-03-19T00:00:00.000Z	default	spot	automotive	preferred	apreferred	177.514270
+2011-03-19T00:00:00.000Z	default	spot	business	preferred	bpreferred	109.788875
+2011-03-19T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	134.147573
+2011-03-19T00:00:00.000Z	default	spot	health	preferred	hpreferred	117.197085
+2011-03-19T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	112.999693
+2011-03-19T00:00:00.000Z	default	spot	news	preferred	npreferred	112.236468
+2011-03-19T00:00:00.000Z	default	spot	premium	preferred	ppreferred	120.638001
+2011-03-19T00:00:00.000Z	default	spot	technology	preferred	tpreferred	72.369471
+2011-03-19T00:00:00.000Z	default	spot	travel	preferred	tpreferred	115.384807
+2011-03-19T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1107.220174
+2011-03-19T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1102.698977
+2011-03-19T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	846.288386
+2011-03-19T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	856.490089
+2011-03-20T00:00:00.000Z	default	spot	automotive	preferred	apreferred	178.454262
+2011-03-20T00:00:00.000Z	default	spot	business	preferred	bpreferred	123.507497
+2011-03-20T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	157.749330
+2011-03-20T00:00:00.000Z	default	spot	health	preferred	hpreferred	117.851058
+2011-03-20T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	128.274705
+2011-03-20T00:00:00.000Z	default	spot	news	preferred	npreferred	125.496367
+2011-03-20T00:00:00.000Z	default	spot	premium	preferred	ppreferred	129.519442
+2011-03-20T00:00:00.000Z	default	spot	technology	preferred	tpreferred	85.013155
+2011-03-20T00:00:00.000Z	default	spot	travel	preferred	tpreferred	128.705337
+2011-03-20T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1285.090048
+2011-03-20T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1217.547439
+2011-03-20T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1032.257527
+2011-03-20T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	954.754185
+2011-03-21T00:00:00.000Z	default	spot	automotive	preferred	apreferred	182.035296
+2011-03-21T00:00:00.000Z	default	spot	business	preferred	bpreferred	124.411632
+2011-03-21T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	157.153730
+2011-03-21T00:00:00.000Z	default	spot	health	preferred	hpreferred	122.462424
+2011-03-21T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	128.149976
+2011-03-21T00:00:00.000Z	default	spot	news	preferred	npreferred	125.243882
+2011-03-21T00:00:00.000Z	default	spot	premium	preferred	ppreferred	131.807919
+2011-03-21T00:00:00.000Z	default	spot	technology	preferred	tpreferred	75.936640
+2011-03-21T00:00:00.000Z	default	spot	travel	preferred	tpreferred	123.653645
+2011-03-21T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1283.957016
+2011-03-21T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1178.830164
+2011-03-21T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1031.990042
+2011-03-21T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	907.021565
+2011-03-22T00:00:00.000Z	default	spot	automotive	preferred	apreferred	177.460613
+2011-03-22T00:00:00.000Z	default	spot	business	preferred	bpreferred	121.270611
+2011-03-22T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	151.407583
+2011-03-22T00:00:00.000Z	default	spot	health	preferred	hpreferred	124.400780
+2011-03-22T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	126.415884
+2011-03-22T00:00:00.000Z	default	spot	news	preferred	npreferred	124.970533
+2011-03-22T00:00:00.000Z	default	spot	premium	preferred	ppreferred	133.124963
+2011-03-22T00:00:00.000Z	default	spot	technology	preferred	tpreferred	79.948248
+2011-03-22T00:00:00.000Z	default	spot	travel	preferred	tpreferred	122.357549
+2011-03-22T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1301.778098
+2011-03-22T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1119.247202
+2011-03-22T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1110.788895
+2011-03-22T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	843.952139
+2011-03-23T00:00:00.000Z	default	spot	automotive	preferred	apreferred	154.019632
+2011-03-23T00:00:00.000Z	default	spot	business	preferred	bpreferred	126.764513
+2011-03-23T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	158.592715
+2011-03-23T00:00:00.000Z	default	spot	health	preferred	hpreferred	118.972310
+2011-03-23T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	126.672392
+2011-03-23T00:00:00.000Z	default	spot	news	preferred	npreferred	129.864384
+2011-03-23T00:00:00.000Z	default	spot	premium	preferred	ppreferred	131.786598
+2011-03-23T00:00:00.000Z	default	spot	technology	preferred	tpreferred	102.603152
+2011-03-23T00:00:00.000Z	default	spot	travel	preferred	tpreferred	123.754240
+2011-03-23T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1403.338838
+2011-03-23T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1156.601892
+2011-03-23T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1362.650586
+2011-03-23T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	884.801502
+2011-03-24T00:00:00.000Z	default	spot	automotive	preferred	apreferred	135.569784
+2011-03-24T00:00:00.000Z	default	spot	business	preferred	bpreferred	123.895027
+2011-03-24T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	156.650862
+2011-03-24T00:00:00.000Z	default	spot	health	preferred	hpreferred	119.777998
+2011-03-24T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	115.945757
+2011-03-24T00:00:00.000Z	default	spot	news	preferred	npreferred	125.044877
+2011-03-24T00:00:00.000Z	default	spot	premium	preferred	ppreferred	129.023978
+2011-03-24T00:00:00.000Z	default	spot	technology	preferred	tpreferred	88.521042
+2011-03-24T00:00:00.000Z	default	spot	travel	preferred	tpreferred	124.062061
+2011-03-24T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1429.580257
+2011-03-24T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1137.842315
+2011-03-24T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1684.268799
+2011-03-24T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	873.652030
+2011-03-25T00:00:00.000Z	default	spot	automotive	preferred	apreferred	140.577121
+2011-03-25T00:00:00.000Z	default	spot	business	preferred	bpreferred	125.766952
+2011-03-25T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	157.432108
+2011-03-25T00:00:00.000Z	default	spot	health	preferred	hpreferred	119.400783
+2011-03-25T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	114.706960
+2011-03-25T00:00:00.000Z	default	spot	news	preferred	npreferred	126.057960
+2011-03-25T00:00:00.000Z	default	spot	premium	preferred	ppreferred	128.943094
+2011-03-25T00:00:00.000Z	default	spot	technology	preferred	tpreferred	89.408906
+2011-03-25T00:00:00.000Z	default	spot	travel	preferred	tpreferred	136.136598
+2011-03-25T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1124.935193
+2011-03-25T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1256.499779
+2011-03-25T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	855.717712
+2011-03-25T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	996.564152
+2011-03-26T00:00:00.000Z	default	spot	automotive	preferred	apreferred	148.957194
+2011-03-26T00:00:00.000Z	default	spot	business	preferred	bpreferred	130.824022
+2011-03-26T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	162.815450
+2011-03-26T00:00:00.000Z	default	spot	health	preferred	hpreferred	118.463523
+2011-03-26T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	117.449116
+2011-03-26T00:00:00.000Z	default	spot	news	preferred	npreferred	142.972964
+2011-03-26T00:00:00.000Z	default	spot	premium	preferred	ppreferred	139.214665
+2011-03-26T00:00:00.000Z	default	spot	technology	preferred	tpreferred	101.686196
+2011-03-26T00:00:00.000Z	default	spot	travel	preferred	tpreferred	138.663182
+2011-03-26T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1217.877395
+2011-03-26T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1247.890809
+2011-03-26T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1061.678577
+2011-03-26T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	962.235801
+2011-03-27T00:00:00.000Z	default	spot	automotive	preferred	apreferred	144.056669
+2011-03-27T00:00:00.000Z	default	spot	business	preferred	bpreferred	135.183271
+2011-03-27T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	163.161361
+2011-03-27T00:00:00.000Z	default	spot	health	preferred	hpreferred	130.599006
+2011-03-27T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	114.952545
+2011-03-27T00:00:00.000Z	default	spot	news	preferred	npreferred	139.294248
+2011-03-27T00:00:00.000Z	default	spot	premium	preferred	ppreferred	142.430177
+2011-03-27T00:00:00.000Z	default	spot	technology	preferred	tpreferred	108.489598
+2011-03-27T00:00:00.000Z	default	spot	travel	preferred	tpreferred	141.820068
+2011-03-27T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1185.709973
+2011-03-27T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1345.781728
+2011-03-27T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1019.898509
+2011-03-27T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1056.419292
+2011-03-28T00:00:00.000Z	default	spot	automotive	preferred	apreferred	156.155294
+2011-03-28T00:00:00.000Z	default	spot	business	preferred	bpreferred	124.336139
+2011-03-28T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	163.100154
+2011-03-28T00:00:00.000Z	default	spot	health	preferred	hpreferred	131.191818
+2011-03-28T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	115.709767
+2011-03-28T00:00:00.000Z	default	spot	news	preferred	npreferred	127.403089
+2011-03-28T00:00:00.000Z	default	spot	premium	preferred	ppreferred	140.941296
+2011-03-28T00:00:00.000Z	default	spot	technology	preferred	tpreferred	103.578536
+2011-03-28T00:00:00.000Z	default	spot	travel	preferred	tpreferred	130.880788
+2011-03-28T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1250.166788
+2011-03-28T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1390.754050
+2011-03-28T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1198.723103
+2011-03-28T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1108.136072
+2011-03-29T00:00:00.000Z	default	spot	automotive	preferred	apreferred	134.084672
+2011-03-29T00:00:00.000Z	default	spot	business	preferred	bpreferred	117.626804
+2011-03-29T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	158.073319
+2011-03-29T00:00:00.000Z	default	spot	health	preferred	hpreferred	128.074393
+2011-03-29T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	109.678515
+2011-03-29T00:00:00.000Z	default	spot	news	preferred	npreferred	122.620188
+2011-03-29T00:00:00.000Z	default	spot	premium	preferred	ppreferred	144.446039
+2011-03-29T00:00:00.000Z	default	spot	technology	preferred	tpreferred	91.604463
+2011-03-29T00:00:00.000Z	default	spot	travel	preferred	tpreferred	132.477651
+2011-03-29T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1224.116225
+2011-03-29T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1361.080245
+2011-03-29T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1289.009485
+2011-03-29T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1069.431801
+2011-03-30T00:00:00.000Z	default	spot	automotive	preferred	apreferred	135.942820
+2011-03-30T00:00:00.000Z	default	spot	business	preferred	bpreferred	120.283054
+2011-03-30T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	167.960620
+2011-03-30T00:00:00.000Z	default	spot	health	preferred	hpreferred	121.215839
+2011-03-30T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	116.587746
+2011-03-30T00:00:00.000Z	default	spot	news	preferred	npreferred	122.612114
+2011-03-30T00:00:00.000Z	default	spot	premium	preferred	ppreferred	138.827311
+2011-03-30T00:00:00.000Z	default	spot	technology	preferred	tpreferred	93.331887
+2011-03-30T00:00:00.000Z	default	spot	travel	preferred	tpreferred	128.645571
+2011-03-30T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1190.933753
+2011-03-30T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1310.797070
+2011-03-30T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1001.134025
+2011-03-30T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1030.499562
+2011-03-31T00:00:00.000Z	default	spot	automotive	preferred	apreferred	151.752485
+2011-03-31T00:00:00.000Z	default	spot	business	preferred	bpreferred	124.414321
+2011-03-31T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	175.778647
+2011-03-31T00:00:00.000Z	default	spot	health	preferred	hpreferred	120.607382
+2011-03-31T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	117.060598
+2011-03-31T00:00:00.000Z	default	spot	news	preferred	npreferred	125.243245
+2011-03-31T00:00:00.000Z	default	spot	premium	preferred	ppreferred	150.247713
+2011-03-31T00:00:00.000Z	default	spot	technology	preferred	tpreferred	93.390841
+2011-03-31T00:00:00.000Z	default	spot	travel	preferred	tpreferred	125.839686
+2011-03-31T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1466.209327
+2011-03-31T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1366.447617
+2011-03-31T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1734.274909
+2011-03-31T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1063.201156
+2011-04-01T00:00:00.000Z	default	spot	automotive	preferred	apreferred	135.885094
+2011-04-01T00:00:00.000Z	default	spot	business	preferred	bpreferred	118.570340
+2011-04-01T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	158.747224
+2011-04-01T00:00:00.000Z	default	spot	health	preferred	hpreferred	120.134704
+2011-04-01T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	109.705815
+2011-04-01T00:00:00.000Z	default	spot	news	preferred	npreferred	121.583581
+2011-04-01T00:00:00.000Z	default	spot	premium	preferred	ppreferred	144.507368
+2011-04-01T00:00:00.000Z	default	spot	technology	preferred	tpreferred	78.622547
+2011-04-01T00:00:00.000Z	default	spot	travel	preferred	tpreferred	119.922742
+2011-04-01T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1314.839715
+2011-04-01T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1522.043733
+2011-04-01T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1447.341160
+2011-04-01T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1234.247546
+2011-04-02T00:00:00.000Z	default	spot	automotive	preferred	apreferred	147.425935
+2011-04-02T00:00:00.000Z	default	spot	business	preferred	bpreferred	112.987027
+2011-04-02T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	166.016049
+2011-04-02T00:00:00.000Z	default	spot	health	preferred	hpreferred	113.446008
+2011-04-02T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	110.931934
+2011-04-02T00:00:00.000Z	default	spot	news	preferred	npreferred	114.290141
+2011-04-02T00:00:00.000Z	default	spot	premium	preferred	ppreferred	135.301506
+2011-04-02T00:00:00.000Z	default	spot	technology	preferred	tpreferred	97.387433
+2011-04-02T00:00:00.000Z	default	spot	travel	preferred	tpreferred	126.411364
+2011-04-02T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1193.556278
+2011-04-02T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1321.375057
+2011-04-02T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1144.342401
+2011-04-02T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1049.738585
+2011-04-03T00:00:00.000Z	default	spot	automotive	preferred	apreferred	122.971856
+2011-04-03T00:00:00.000Z	default	spot	business	preferred	bpreferred	105.735462
+2011-04-03T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	153.927965
+2011-04-03T00:00:00.000Z	default	spot	health	preferred	hpreferred	103.532351
+2011-04-03T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	107.047773
+2011-04-03T00:00:00.000Z	default	spot	news	preferred	npreferred	107.919674
+2011-04-03T00:00:00.000Z	default	spot	premium	preferred	ppreferred	122.141707
+2011-04-03T00:00:00.000Z	default	spot	technology	preferred	tpreferred	80.861743
+2011-04-03T00:00:00.000Z	default	spot	travel	preferred	tpreferred	117.247070
+2011-04-03T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1055.783661
+2011-04-03T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1021.638673
+2011-04-03T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	811.991286
+2011-04-03T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	768.423077
+2011-04-04T00:00:00.000Z	default	spot	automotive	preferred	apreferred	110.919829
+2011-04-04T00:00:00.000Z	default	spot	business	preferred	bpreferred	107.613577
+2011-04-04T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	146.729242
+2011-04-04T00:00:00.000Z	default	spot	health	preferred	hpreferred	105.375351
+2011-04-04T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	110.573670
+2011-04-04T00:00:00.000Z	default	spot	news	preferred	npreferred	114.382255
+2011-04-04T00:00:00.000Z	default	spot	premium	preferred	ppreferred	125.285894
+2011-04-04T00:00:00.000Z	default	spot	technology	preferred	tpreferred	72.668430
+2011-04-04T00:00:00.000Z	default	spot	travel	preferred	tpreferred	117.703023
+2011-04-04T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1197.008423
+2011-04-04T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1131.531986
+2011-04-04T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1151.069173
+2011-04-04T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	877.079396
+2011-04-05T00:00:00.000Z	default	spot	automotive	preferred	apreferred	113.318712
+2011-04-05T00:00:00.000Z	default	spot	business	preferred	bpreferred	105.615563
+2011-04-05T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	141.713507
+2011-04-05T00:00:00.000Z	default	spot	health	preferred	hpreferred	106.207931
+2011-04-05T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	109.890586
+2011-04-05T00:00:00.000Z	default	spot	news	preferred	npreferred	110.012987
+2011-04-05T00:00:00.000Z	default	spot	premium	preferred	ppreferred	124.478408
+2011-04-05T00:00:00.000Z	default	spot	technology	preferred	tpreferred	86.683603
+2011-04-05T00:00:00.000Z	default	spot	travel	preferred	tpreferred	117.051694
+2011-04-05T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1192.144303
+2011-04-05T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1154.289559
+2011-04-05T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1146.423036
+2011-04-05T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	902.615706
+2011-04-06T00:00:00.000Z	default	spot	automotive	preferred	apreferred	115.334018
+2011-04-06T00:00:00.000Z	default	spot	business	preferred	bpreferred	109.700256
+2011-04-06T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	147.553562
+2011-04-06T00:00:00.000Z	default	spot	health	preferred	hpreferred	100.775597
+2011-04-06T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	108.659345
+2011-04-06T00:00:00.000Z	default	spot	news	preferred	npreferred	113.408308
+2011-04-06T00:00:00.000Z	default	spot	premium	preferred	ppreferred	121.079585
+2011-04-06T00:00:00.000Z	default	spot	technology	preferred	tpreferred	92.336403
+2011-04-06T00:00:00.000Z	default	spot	travel	preferred	tpreferred	112.921482
+2011-04-06T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1272.677122
+2011-04-06T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1141.514652
+2011-04-06T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1355.843374
+2011-04-06T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	897.393445
+2011-04-07T00:00:00.000Z	default	spot	automotive	preferred	apreferred	117.508062
+2011-04-07T00:00:00.000Z	default	spot	business	preferred	bpreferred	115.418054
+2011-04-07T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	141.565031
+2011-04-07T00:00:00.000Z	default	spot	health	preferred	hpreferred	95.562446
+2011-04-07T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	102.933171
+2011-04-07T00:00:00.000Z	default	spot	news	preferred	npreferred	122.696621
+2011-04-07T00:00:00.000Z	default	spot	premium	preferred	ppreferred	119.763135
+2011-04-07T00:00:00.000Z	default	spot	technology	preferred	tpreferred	84.357701
+2011-04-07T00:00:00.000Z	default	spot	travel	preferred	tpreferred	117.432760
+2011-04-07T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1190.896088
+2011-04-07T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1009.363132
+2011-04-07T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1260.143027
+2011-04-07T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	762.862488
+2011-04-08T00:00:00.000Z	default	spot	automotive	preferred	apreferred	120.973860
+2011-04-08T00:00:00.000Z	default	spot	business	preferred	bpreferred	116.248860
+2011-04-08T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	146.830618
+2011-04-08T00:00:00.000Z	default	spot	health	preferred	hpreferred	96.226609
+2011-04-08T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	95.447888
+2011-04-08T00:00:00.000Z	default	spot	news	preferred	npreferred	120.709912
+2011-04-08T00:00:00.000Z	default	spot	premium	preferred	ppreferred	120.309688
+2011-04-08T00:00:00.000Z	default	spot	technology	preferred	tpreferred	94.631354
+2011-04-08T00:00:00.000Z	default	spot	travel	preferred	tpreferred	122.743898
+2011-04-08T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1006.913816
+2011-04-08T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1032.599837
+2011-04-08T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	935.168026
+2011-04-08T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	782.107861
+2011-04-09T00:00:00.000Z	default	spot	automotive	preferred	apreferred	116.080323
+2011-04-09T00:00:00.000Z	default	spot	business	preferred	bpreferred	116.060759
+2011-04-09T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	158.682525
+2011-04-09T00:00:00.000Z	default	spot	health	preferred	hpreferred	95.509796
+2011-04-09T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	110.007248
+2011-04-09T00:00:00.000Z	default	spot	news	preferred	npreferred	121.905685
+2011-04-09T00:00:00.000Z	default	spot	premium	preferred	ppreferred	126.369367
+2011-04-09T00:00:00.000Z	default	spot	technology	preferred	tpreferred	92.905070
+2011-04-09T00:00:00.000Z	default	spot	travel	preferred	tpreferred	123.791320
+2011-04-09T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1137.385764
+2011-04-09T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1030.075553
+2011-04-09T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	996.205369
+2011-04-09T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	767.692135
+2011-04-10T00:00:00.000Z	default	spot	automotive	preferred	apreferred	113.221448
+2011-04-10T00:00:00.000Z	default	spot	business	preferred	bpreferred	95.570457
+2011-04-10T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	131.766616
+2011-04-10T00:00:00.000Z	default	spot	health	preferred	hpreferred	99.950855
+2011-04-10T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	91.470524
+2011-04-10T00:00:00.000Z	default	spot	news	preferred	npreferred	99.393076
+2011-04-10T00:00:00.000Z	default	spot	premium	preferred	ppreferred	123.207579
+2011-04-10T00:00:00.000Z	default	spot	technology	preferred	tpreferred	84.898691
+2011-04-10T00:00:00.000Z	default	spot	travel	preferred	tpreferred	114.353962
+2011-04-10T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1005.253077
+2011-04-10T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1030.094757
+2011-04-10T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1031.741509
+2011-04-10T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	775.965555
+2011-04-11T00:00:00.000Z	default	spot	automotive	preferred	apreferred	130.165796
+2011-04-11T00:00:00.000Z	default	spot	business	preferred	bpreferred	107.765101
+2011-04-11T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	142.751726
+2011-04-11T00:00:00.000Z	default	spot	health	preferred	hpreferred	104.847285
+2011-04-11T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	95.272956
+2011-04-11T00:00:00.000Z	default	spot	news	preferred	npreferred	106.229286
+2011-04-11T00:00:00.000Z	default	spot	premium	preferred	ppreferred	126.823859
+2011-04-11T00:00:00.000Z	default	spot	technology	preferred	tpreferred	89.250155
+2011-04-11T00:00:00.000Z	default	spot	travel	preferred	tpreferred	122.049678
+2011-04-11T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1112.794811
+2011-04-11T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1113.357530
+2011-04-11T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1374.968412
+2011-04-11T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	853.163039
+2011-04-12T00:00:00.000Z	default	spot	automotive	preferred	apreferred	122.386348
+2011-04-12T00:00:00.000Z	default	spot	business	preferred	bpreferred	106.380995
+2011-04-12T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	141.932300
+2011-04-12T00:00:00.000Z	default	spot	health	preferred	hpreferred	103.142372
+2011-04-12T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	97.340631
+2011-04-12T00:00:00.000Z	default	spot	news	preferred	npreferred	105.381244
+2011-04-12T00:00:00.000Z	default	spot	premium	preferred	ppreferred	125.189098
+2011-04-12T00:00:00.000Z	default	spot	technology	preferred	tpreferred	90.533391
+2011-04-12T00:00:00.000Z	default	spot	travel	preferred	tpreferred	122.128172
+2011-04-12T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1153.974725
+2011-04-12T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1069.640880
+2011-04-12T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1456.611830
+2011-04-12T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	811.925240
+2011-04-13T00:00:00.000Z	default	spot	automotive	preferred	apreferred	122.688340
+2011-04-13T00:00:00.000Z	default	spot	business	preferred	bpreferred	105.739623
+2011-04-13T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	136.983407
+2011-04-13T00:00:00.000Z	default	spot	health	preferred	hpreferred	100.860813
+2011-04-13T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	94.839191
+2011-04-13T00:00:00.000Z	default	spot	news	preferred	npreferred	105.261296
+2011-04-13T00:00:00.000Z	default	spot	premium	preferred	ppreferred	119.836611
+2011-04-13T00:00:00.000Z	default	spot	technology	preferred	tpreferred	91.972558
+2011-04-13T00:00:00.000Z	default	spot	travel	preferred	tpreferred	120.145572
+2011-04-13T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1016.137449
+2011-04-13T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	994.902292
+2011-04-13T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	989.032799
+2011-04-13T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	744.744657
+2011-04-14T00:00:00.000Z	default	spot	automotive	preferred	apreferred	111.179339
+2011-04-14T00:00:00.000Z	default	spot	business	preferred	bpreferred	101.984377
+2011-04-14T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	133.606430
+2011-04-14T00:00:00.000Z	default	spot	health	preferred	hpreferred	99.738319
+2011-04-14T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	91.270553
+2011-04-14T00:00:00.000Z	default	spot	news	preferred	npreferred	101.251756
+2011-04-14T00:00:00.000Z	default	spot	premium	preferred	ppreferred	118.285128
+2011-04-14T00:00:00.000Z	default	spot	technology	preferred	tpreferred	84.951300
+2011-04-14T00:00:00.000Z	23b	spot	travel	preferred	tpreferred	119.768525
+2011-04-14T00:00:00.000Z	23b	total_market	mezzanine	preferred	mpreferred	1032.154263
+2011-04-14T00:00:00.000Z	23b	total_market	premium	preferred	ppreferred	999.586450
+2011-04-14T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1166.401205
+2011-04-14T00:00:00.000Z	2084	upfront	premium	preferred	ppreferred	753.104985
+2011-04-15T00:00:00.000Z	default	spot	automotive	preferred	apreferred	106.793700
+2011-04-15T00:00:00.000Z	c1	spot	business	preferred	bpreferred	94.469747
+2011-04-15T00:00:00.000Z	b8	spot	entertainment	preferred	epreferred	135.109191
+2011-04-15T00:00:00.000Z	default	spot	health	preferred	hpreferred	99.596909
+2011-04-15T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	92.782760
+2011-04-15T00:00:00.000Z	3	spot	news	preferred	npreferred	97.859766
+2011-04-15T00:00:00.000Z	3	spot	premium	preferred	ppreferred	120.508160
+2011-04-15T00:00:00.000Z	12	spot	technology	preferred	tpreferred	89.646236
+2011-04-15T00:00:00.000Z	3	spot	travel	preferred	tpreferred	120.290348
+2011-04-15T00:00:00.000Z	12	total_market	mezzanine	preferred	mpreferred	994.752744
+2011-04-15T00:00:00.000Z	100	total_market	premium	preferred	ppreferred	1029.056992
+2011-04-15T00:00:00.000Z	0	upfront	mezzanine	preferred	mpreferred	962.731172
+2011-04-15T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	780.271977

--- a/processing/src/test/resources/druid.sample.tsv.bottom
+++ b/processing/src/test/resources/druid.sample.tsv.bottom
@@ -1,732 +1,732 @@
-2011-01-12T00:00:00.000Z	spot	business	preferred	bpreferred	100.000000
-2011-01-12T00:00:00.000Z	spot	health	preferred	hpreferred	100.000000
-2011-01-12T00:00:00.000Z	spot	news	preferred	npreferred	100.000000
-2011-01-12T00:00:00.000Z	spot	technology	preferred	tpreferred	100.000000
-2011-01-12T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1000.000000
-2011-01-12T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	800.000000
-2011-01-13T00:00:00.000Z	spot	automotive	preferred	apreferred	94.874713
-2011-01-13T00:00:00.000Z	spot	entertainment	preferred	epreferred	110.087299
-2011-01-13T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	104.465767
-2011-01-13T00:00:00.000Z	spot	premium	preferred	ppreferred	108.863011
-2011-01-13T00:00:00.000Z	spot	travel	preferred	tpreferred	106.236928
-2011-01-13T00:00:00.000Z	total_market	premium	preferred	ppreferred	1689.012875
-2011-01-13T00:00:00.000Z	upfront	premium	preferred	ppreferred	1564.617729
-2011-01-14T00:00:00.000Z	spot	business	preferred	bpreferred	102.670409
-2011-01-14T00:00:00.000Z	spot	health	preferred	hpreferred	94.000432
-2011-01-14T00:00:00.000Z	spot	news	preferred	npreferred	101.380760
-2011-01-14T00:00:00.000Z	spot	technology	preferred	tpreferred	114.974216
-2011-01-14T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1049.141912
-2011-01-14T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1006.402111
-2011-01-15T00:00:00.000Z	spot	automotive	preferred	apreferred	82.840417
-2011-01-15T00:00:00.000Z	spot	entertainment	preferred	epreferred	100.551072
-2011-01-15T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	100.582654
-2011-01-15T00:00:00.000Z	spot	premium	preferred	ppreferred	102.366798
-2011-01-15T00:00:00.000Z	spot	travel	preferred	tpreferred	120.481420
-2011-01-15T00:00:00.000Z	total_market	premium	preferred	ppreferred	1545.708865
-2011-01-15T00:00:00.000Z	upfront	premium	preferred	ppreferred	1458.402661
-2011-01-16T00:00:00.000Z	spot	business	preferred	bpreferred	100.591602
-2011-01-16T00:00:00.000Z	spot	health	preferred	hpreferred	93.085943
-2011-01-16T00:00:00.000Z	spot	news	preferred	npreferred	100.192013
-2011-01-16T00:00:00.000Z	spot	technology	preferred	tpreferred	87.280816
-2011-01-16T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1016.965229
-2011-01-16T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	852.437477
-2011-01-17T00:00:00.000Z	spot	automotive	preferred	apreferred	105.442374
-2011-01-17T00:00:00.000Z	spot	entertainment	preferred	epreferred	99.189052
-2011-01-17T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	103.692852
-2011-01-17T00:00:00.000Z	spot	premium	preferred	ppreferred	106.696362
-2011-01-17T00:00:00.000Z	spot	travel	preferred	tpreferred	134.415281
-2011-01-17T00:00:00.000Z	total_market	premium	preferred	ppreferred	953.995422
-2011-01-17T00:00:00.000Z	upfront	premium	preferred	ppreferred	712.774595
-2011-01-18T00:00:00.000Z	spot	business	preferred	bpreferred	107.244699
-2011-01-18T00:00:00.000Z	spot	health	preferred	hpreferred	103.018934
-2011-01-18T00:00:00.000Z	spot	news	preferred	npreferred	104.724154
-2011-01-18T00:00:00.000Z	spot	technology	preferred	tpreferred	88.764512
-2011-01-18T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1022.783330
-2011-01-18T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	846.267516
-2011-01-19T00:00:00.000Z	spot	automotive	preferred	apreferred	85.681683
-2011-01-19T00:00:00.000Z	spot	entertainment	preferred	epreferred	92.314034
-2011-01-19T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	105.087466
-2011-01-19T00:00:00.000Z	spot	premium	preferred	ppreferred	104.568464
-2011-01-19T00:00:00.000Z	spot	travel	preferred	tpreferred	109.772202
-2011-01-19T00:00:00.000Z	total_market	premium	preferred	ppreferred	849.877513
-2011-01-19T00:00:00.000Z	upfront	premium	preferred	ppreferred	594.381703
-2011-01-20T01:00:00.000Z	spot	business	preferred	bpreferred	106.367723
-2011-01-20T01:00:00.000Z	spot	health	preferred	hpreferred	96.112901
-2011-01-20T01:00:00.000Z	spot	news	preferred	npreferred	105.225158
-2011-01-20T01:00:00.000Z	spot	technology	preferred	tpreferred	77.759854
-2011-01-20T01:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1066.208012
-2011-01-20T01:00:00.000Z	upfront	mezzanine	preferred	mpreferred	870.115926
-2011-01-22T00:00:00.000Z	spot	business	preferred	bpreferred	105.282866
-2011-01-22T00:00:00.000Z	spot	health	preferred	hpreferred	103.527592
-2011-01-22T00:00:00.000Z	spot	news	preferred	npreferred	103.399677
-2011-01-22T00:00:00.000Z	spot	technology	preferred	tpreferred	107.627793
-2011-01-22T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1240.525484
-2011-01-22T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1410.278128
-2011-01-23T00:00:00.000Z	spot	automotive	preferred	apreferred	100.432710
-2011-01-23T00:00:00.000Z	spot	entertainment	preferred	epreferred	92.789692
-2011-01-23T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	103.730730
-2011-01-23T00:00:00.000Z	spot	premium	preferred	ppreferred	101.573522
-2011-01-23T00:00:00.000Z	spot	travel	preferred	tpreferred	128.699746
-2011-01-23T00:00:00.000Z	total_market	premium	preferred	ppreferred	1349.254415
-2011-01-23T00:00:00.000Z	upfront	premium	preferred	ppreferred	1224.501568
-2011-01-24T00:00:00.000Z	spot	business	preferred	bpreferred	104.485760
-2011-01-24T00:00:00.000Z	spot	health	preferred	hpreferred	189.385952
-2011-01-24T00:00:00.000Z	spot	news	preferred	npreferred	104.167373
-2011-01-24T00:00:00.000Z	spot	technology	preferred	tpreferred	105.345921
-2011-01-24T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1102.866656
-2011-01-24T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1215.589859
-2011-01-25T00:00:00.000Z	spot	automotive	preferred	apreferred	90.111413
-2011-01-25T00:00:00.000Z	spot	entertainment	preferred	epreferred	85.974579
-2011-01-25T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	96.594588
-2011-01-25T00:00:00.000Z	spot	premium	preferred	ppreferred	102.512878
-2011-01-25T00:00:00.000Z	spot	travel	preferred	tpreferred	122.077247
-2011-01-25T00:00:00.000Z	total_market	premium	preferred	ppreferred	997.994544
-2011-01-25T00:00:00.000Z	upfront	premium	preferred	ppreferred	786.363298
-2011-01-26T00:00:00.000Z	spot	business	preferred	bpreferred	105.873942
-2011-01-26T00:00:00.000Z	spot	health	preferred	hpreferred	159.988606
-2011-01-26T00:00:00.000Z	spot	news	preferred	npreferred	105.266058
-2011-01-26T00:00:00.000Z	spot	technology	preferred	tpreferred	105.617702
-2011-01-26T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1037.449471
-2011-01-26T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	989.931541
-2011-01-27T00:00:00.000Z	spot	automotive	preferred	apreferred	134.127106
-2011-01-27T00:00:00.000Z	spot	entertainment	preferred	epreferred	90.806201
-2011-01-27T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	100.643435
-2011-01-27T00:00:00.000Z	spot	premium	preferred	ppreferred	102.612747
-2011-01-27T00:00:00.000Z	spot	travel	preferred	tpreferred	149.125271
-2011-01-27T00:00:00.000Z	total_market	premium	preferred	ppreferred	1486.201299
-2011-01-27T00:00:00.000Z	upfront	premium	preferred	ppreferred	1367.638074
-2011-01-28T00:00:00.000Z	spot	business	preferred	bpreferred	111.641077
-2011-01-28T00:00:00.000Z	spot	health	preferred	hpreferred	107.788998
-2011-01-28T00:00:00.000Z	spot	news	preferred	npreferred	108.106449
-2011-01-28T00:00:00.000Z	spot	technology	preferred	tpreferred	93.869236
-2011-01-28T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1300.302260
-2011-01-28T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1627.598064
-2011-01-29T00:00:00.000Z	spot	automotive	preferred	apreferred	127.450345
-2011-01-29T00:00:00.000Z	spot	entertainment	preferred	epreferred	103.345166
-2011-01-29T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	106.663538
-2011-01-29T00:00:00.000Z	spot	premium	preferred	ppreferred	104.311418
-2011-01-29T00:00:00.000Z	spot	travel	preferred	tpreferred	138.865014
-2011-01-29T00:00:00.000Z	total_market	premium	preferred	ppreferred	792.326066
-2011-01-29T00:00:00.000Z	upfront	premium	preferred	ppreferred	545.990623
-2011-01-30T00:00:00.000Z	spot	business	preferred	bpreferred	106.064111
-2011-01-30T00:00:00.000Z	spot	health	preferred	hpreferred	137.198397
-2011-01-30T00:00:00.000Z	spot	news	preferred	npreferred	106.009926
-2011-01-30T00:00:00.000Z	spot	technology	preferred	tpreferred	110.528451
-2011-01-30T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1233.448863
-2011-01-30T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1870.061029
-2011-01-31T00:00:00.000Z	spot	automotive	preferred	apreferred	133.740047
-2011-01-31T00:00:00.000Z	spot	entertainment	preferred	epreferred	104.548387
-2011-01-31T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	97.017604
-2011-01-31T00:00:00.000Z	spot	premium	preferred	ppreferred	103.021032
-2011-01-31T00:00:00.000Z	spot	travel	preferred	tpreferred	155.744951
-2011-01-31T00:00:00.000Z	total_market	premium	preferred	ppreferred	1127.231000
-2011-01-31T00:00:00.000Z	upfront	premium	preferred	ppreferred	943.497198
-2011-02-01T00:00:00.000Z	spot	business	preferred	bpreferred	103.890175
-2011-02-01T00:00:00.000Z	spot	health	preferred	hpreferred	113.896016
-2011-02-01T00:00:00.000Z	spot	news	preferred	npreferred	104.383662
-2011-02-01T00:00:00.000Z	spot	technology	preferred	tpreferred	83.931272
-2011-02-01T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1203.465595
-2011-02-01T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1667.497773
-2011-02-02T00:00:00.000Z	spot	automotive	preferred	apreferred	113.492245
-2011-02-02T00:00:00.000Z	spot	entertainment	preferred	epreferred	112.042996
-2011-02-02T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	97.711139
-2011-02-02T00:00:00.000Z	spot	premium	preferred	ppreferred	102.152053
-2011-02-02T00:00:00.000Z	spot	travel	preferred	tpreferred	123.170962
-2011-02-02T00:00:00.000Z	total_market	premium	preferred	ppreferred	1410.792943
-2011-02-02T00:00:00.000Z	upfront	premium	preferred	ppreferred	1273.707453
-2011-02-03T00:00:00.000Z	spot	business	preferred	bpreferred	98.877952
-2011-02-03T00:00:00.000Z	spot	health	preferred	hpreferred	85.069784
-2011-02-03T00:00:00.000Z	spot	news	preferred	npreferred	100.976362
-2011-02-03T00:00:00.000Z	spot	technology	preferred	tpreferred	92.326431
-2011-02-03T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1033.401241
-2011-02-03T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	888.705280
-2011-02-04T00:00:00.000Z	spot	automotive	preferred	apreferred	89.182906
-2011-02-04T00:00:00.000Z	spot	entertainment	preferred	epreferred	112.471918
-2011-02-04T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	100.918373
-2011-02-04T00:00:00.000Z	spot	premium	preferred	ppreferred	103.103922
-2011-02-04T00:00:00.000Z	spot	travel	preferred	tpreferred	113.716758
-2011-02-04T00:00:00.000Z	total_market	premium	preferred	ppreferred	1331.860983
-2011-02-04T00:00:00.000Z	upfront	premium	preferred	ppreferred	1308.582051
-2011-02-05T00:00:00.000Z	spot	business	preferred	bpreferred	111.394244
-2011-02-05T00:00:00.000Z	spot	health	preferred	hpreferred	94.312960
-2011-02-05T00:00:00.000Z	spot	news	preferred	npreferred	107.929804
-2011-02-05T00:00:00.000Z	spot	technology	preferred	tpreferred	90.732978
-2011-02-05T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1039.500513
-2011-02-05T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	785.078869
-2011-02-06T00:00:00.000Z	spot	automotive	preferred	apreferred	134.462521
-2011-02-06T00:00:00.000Z	spot	entertainment	preferred	epreferred	119.608310
-2011-02-06T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	101.847544
-2011-02-06T00:00:00.000Z	spot	premium	preferred	ppreferred	102.770913
-2011-02-06T00:00:00.000Z	spot	travel	preferred	tpreferred	121.270562
-2011-02-06T00:00:00.000Z	total_market	premium	preferred	ppreferred	1029.995236
-2011-02-06T00:00:00.000Z	upfront	premium	preferred	ppreferred	826.039207
-2011-02-07T00:00:00.000Z	spot	business	preferred	bpreferred	98.815847
-2011-02-07T00:00:00.000Z	spot	health	preferred	hpreferred	97.480779
-2011-02-07T00:00:00.000Z	spot	news	preferred	npreferred	100.706057
-2011-02-07T00:00:00.000Z	spot	technology	preferred	tpreferred	83.902353
-2011-02-07T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1047.212887
-2011-02-07T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1107.243787
-2011-02-08T00:00:00.000Z	spot	automotive	preferred	apreferred	126.243536
-2011-02-08T00:00:00.000Z	spot	entertainment	preferred	epreferred	106.969799
-2011-02-08T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	96.790543
-2011-02-08T00:00:00.000Z	spot	premium	preferred	ppreferred	103.308255
-2011-02-08T00:00:00.000Z	spot	travel	preferred	tpreferred	111.040150
-2011-02-08T00:00:00.000Z	total_market	premium	preferred	ppreferred	1082.727640
-2011-02-08T00:00:00.000Z	upfront	premium	preferred	ppreferred	911.956790
-2011-02-09T00:00:00.000Z	spot	business	preferred	bpreferred	115.548444
-2011-02-09T00:00:00.000Z	spot	health	preferred	hpreferred	97.071703
-2011-02-09T00:00:00.000Z	spot	news	preferred	npreferred	113.554588
-2011-02-09T00:00:00.000Z	spot	technology	preferred	tpreferred	83.742151
-2011-02-09T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	971.050764
-2011-02-09T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	794.098825
-2011-02-10T00:00:00.000Z	spot	automotive	preferred	apreferred	115.461691
-2011-02-10T00:00:00.000Z	spot	entertainment	preferred	epreferred	117.629065
-2011-02-10T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	95.698374
-2011-02-10T00:00:00.000Z	spot	premium	preferred	ppreferred	105.708103
-2011-02-10T00:00:00.000Z	spot	travel	preferred	tpreferred	105.557241
-2011-02-10T00:00:00.000Z	total_market	premium	preferred	ppreferred	1089.647884
-2011-02-10T00:00:00.000Z	upfront	premium	preferred	ppreferred	901.327272
-2011-02-11T00:00:00.000Z	spot	business	preferred	bpreferred	114.637486
-2011-02-11T00:00:00.000Z	spot	health	preferred	hpreferred	96.617339
-2011-02-11T00:00:00.000Z	spot	news	preferred	npreferred	112.571724
-2011-02-11T00:00:00.000Z	spot	technology	preferred	tpreferred	87.904114
-2011-02-11T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	980.386611
-2011-02-11T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	723.514254
-2011-02-12T00:00:00.000Z	spot	automotive	preferred	apreferred	130.104979
-2011-02-12T00:00:00.000Z	spot	entertainment	preferred	epreferred	115.225386
-2011-02-12T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	101.515571
-2011-02-12T00:00:00.000Z	spot	premium	preferred	ppreferred	108.637522
-2011-02-12T00:00:00.000Z	spot	travel	preferred	tpreferred	102.850696
-2011-02-12T00:00:00.000Z	total_market	premium	preferred	ppreferred	1092.416967
-2011-02-12T00:00:00.000Z	upfront	premium	preferred	ppreferred	879.406101
-2011-02-13T00:00:00.000Z	spot	business	preferred	bpreferred	118.841176
-2011-02-13T00:00:00.000Z	spot	health	preferred	hpreferred	98.607490
-2011-02-13T00:00:00.000Z	spot	news	preferred	npreferred	117.965974
-2011-02-13T00:00:00.000Z	spot	technology	preferred	tpreferred	87.820236
-2011-02-13T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	987.067381
-2011-02-13T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	724.262526
-2011-02-14T00:00:00.000Z	spot	automotive	preferred	apreferred	119.323168
-2011-02-14T00:00:00.000Z	spot	entertainment	preferred	epreferred	123.098262
-2011-02-14T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	101.645725
-2011-02-14T00:00:00.000Z	spot	premium	preferred	ppreferred	121.060464
-2011-02-14T00:00:00.000Z	spot	travel	preferred	tpreferred	107.663239
-2011-02-14T00:00:00.000Z	total_market	premium	preferred	ppreferred	1199.607472
-2011-02-14T00:00:00.000Z	upfront	premium	preferred	ppreferred	948.657939
-2011-02-15T00:00:00.000Z	spot	business	preferred	bpreferred	115.527003
-2011-02-15T00:00:00.000Z	spot	health	preferred	hpreferred	103.519393
-2011-02-15T00:00:00.000Z	spot	news	preferred	npreferred	117.138956
-2011-02-15T00:00:00.000Z	spot	technology	preferred	tpreferred	79.700998
-2011-02-15T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1044.384300
-2011-02-15T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	807.601674
-2011-02-16T00:00:00.000Z	spot	automotive	preferred	apreferred	133.726576
-2011-02-16T00:00:00.000Z	spot	entertainment	preferred	epreferred	130.717934
-2011-02-16T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	108.338531
-2011-02-16T00:00:00.000Z	spot	premium	preferred	ppreferred	123.270869
-2011-02-16T00:00:00.000Z	spot	travel	preferred	tpreferred	113.643571
-2011-02-16T00:00:00.000Z	total_market	premium	preferred	ppreferred	1360.032423
-2011-02-16T00:00:00.000Z	upfront	premium	preferred	ppreferred	1208.456692
-2011-02-17T00:00:00.000Z	spot	business	preferred	bpreferred	125.032692
-2011-02-17T00:00:00.000Z	spot	health	preferred	hpreferred	101.092779
-2011-02-17T00:00:00.000Z	spot	news	preferred	npreferred	121.872569
-2011-02-17T00:00:00.000Z	spot	technology	preferred	tpreferred	91.969195
-2011-02-17T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	993.591221
-2011-02-17T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	679.619354
-2011-02-18T00:00:00.000Z	spot	automotive	preferred	apreferred	151.053296
-2011-02-18T00:00:00.000Z	spot	entertainment	preferred	epreferred	128.063524
-2011-02-18T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	101.960196
-2011-02-18T00:00:00.000Z	spot	premium	preferred	ppreferred	122.546253
-2011-02-18T00:00:00.000Z	spot	travel	preferred	tpreferred	120.151389
-2011-02-18T00:00:00.000Z	total_market	premium	preferred	ppreferred	1601.829436
-2011-02-18T00:00:00.000Z	upfront	premium	preferred	ppreferred	1649.533329
-2011-02-19T00:00:00.000Z	spot	business	preferred	bpreferred	123.447481
-2011-02-19T00:00:00.000Z	spot	health	preferred	hpreferred	108.822138
-2011-02-19T00:00:00.000Z	spot	news	preferred	npreferred	119.371511
-2011-02-19T00:00:00.000Z	spot	technology	preferred	tpreferred	91.547944
-2011-02-19T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1200.527201
-2011-02-19T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1433.398801
-2011-02-20T00:00:00.000Z	spot	automotive	preferred	apreferred	157.483005
-2011-02-20T00:00:00.000Z	spot	entertainment	preferred	epreferred	176.323916
-2011-02-20T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	127.819268
-2011-02-20T00:00:00.000Z	spot	premium	preferred	ppreferred	132.719065
-2011-02-20T00:00:00.000Z	spot	travel	preferred	tpreferred	124.637709
-2011-02-20T00:00:00.000Z	total_market	premium	preferred	ppreferred	1304.326111
-2011-02-20T00:00:00.000Z	upfront	premium	preferred	ppreferred	1022.854576
-2011-02-21T00:00:00.000Z	spot	business	preferred	bpreferred	132.231346
-2011-02-21T00:00:00.000Z	spot	health	preferred	hpreferred	111.386745
-2011-02-21T00:00:00.000Z	spot	news	preferred	npreferred	126.995117
-2011-02-21T00:00:00.000Z	spot	technology	preferred	tpreferred	119.850150
-2011-02-21T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1544.108134
-2011-02-21T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1228.502469
-2011-02-22T00:00:00.000Z	spot	automotive	preferred	apreferred	149.171056
-2011-02-22T00:00:00.000Z	spot	entertainment	preferred	epreferred	139.557139
-2011-02-22T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	111.394542
-2011-02-22T00:00:00.000Z	spot	premium	preferred	ppreferred	126.596847
-2011-02-22T00:00:00.000Z	spot	travel	preferred	tpreferred	115.915849
-2011-02-22T00:00:00.000Z	total_market	premium	preferred	ppreferred	1421.648704
-2011-02-22T00:00:00.000Z	upfront	premium	preferred	ppreferred	1291.897942
-2011-02-23T00:00:00.000Z	spot	business	preferred	bpreferred	127.199815
-2011-02-23T00:00:00.000Z	spot	health	preferred	hpreferred	107.896489
-2011-02-23T00:00:00.000Z	spot	news	preferred	npreferred	122.404192
-2011-02-23T00:00:00.000Z	spot	technology	preferred	tpreferred	91.191071
-2011-02-23T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1251.906228
-2011-02-23T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1306.495696
-2011-02-24T00:00:00.000Z	spot	automotive	preferred	apreferred	168.988478
-2011-02-24T00:00:00.000Z	spot	entertainment	preferred	epreferred	139.978575
-2011-02-24T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	113.621184
-2011-02-24T00:00:00.000Z	spot	premium	preferred	ppreferred	119.772575
-2011-02-24T00:00:00.000Z	spot	travel	preferred	tpreferred	118.270052
-2011-02-24T00:00:00.000Z	total_market	premium	preferred	ppreferred	970.728273
-2011-02-24T00:00:00.000Z	upfront	premium	preferred	ppreferred	578.795979
-2011-02-25T00:00:00.000Z	spot	business	preferred	bpreferred	107.539869
-2011-02-25T00:00:00.000Z	spot	health	preferred	hpreferred	99.698015
-2011-02-25T00:00:00.000Z	spot	news	preferred	npreferred	106.827630
-2011-02-25T00:00:00.000Z	spot	technology	preferred	tpreferred	82.350556
-2011-02-25T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1057.427269
-2011-02-25T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1017.573185
-2011-02-26T00:00:00.000Z	spot	automotive	preferred	apreferred	225.243186
-2011-02-26T00:00:00.000Z	spot	entertainment	preferred	epreferred	138.924835
-2011-02-26T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	98.314744
-2011-02-26T00:00:00.000Z	spot	premium	preferred	ppreferred	118.896845
-2011-02-26T00:00:00.000Z	spot	travel	preferred	tpreferred	131.310541
-2011-02-26T00:00:00.000Z	total_market	premium	preferred	ppreferred	1743.921750
-2011-02-26T00:00:00.000Z	upfront	premium	preferred	ppreferred	1862.737933
-2011-02-27T00:00:00.000Z	spot	business	preferred	bpreferred	96.864384
-2011-02-27T00:00:00.000Z	spot	health	preferred	hpreferred	114.634278
-2011-02-27T00:00:00.000Z	spot	news	preferred	npreferred	99.158839
-2011-02-27T00:00:00.000Z	spot	technology	preferred	tpreferred	78.727950
-2011-02-27T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1044.562903
-2011-02-27T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	873.306547
-2011-02-28T00:00:00.000Z	spot	automotive	preferred	apreferred	122.258195
-2011-02-28T00:00:00.000Z	spot	entertainment	preferred	epreferred	141.261324
-2011-02-28T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	102.185098
-2011-02-28T00:00:00.000Z	spot	premium	preferred	ppreferred	121.786785
-2011-02-28T00:00:00.000Z	spot	travel	preferred	tpreferred	114.284569
-2011-02-28T00:00:00.000Z	total_market	premium	preferred	ppreferred	1292.542896
-2011-02-28T00:00:00.000Z	upfront	premium	preferred	ppreferred	1101.918270
-2011-03-01T00:00:00.000Z	spot	business	preferred	bpreferred	99.070796
-2011-03-01T00:00:00.000Z	spot	health	preferred	hpreferred	114.700932
-2011-03-01T00:00:00.000Z	spot	news	preferred	npreferred	99.772347
-2011-03-01T00:00:00.000Z	spot	technology	preferred	tpreferred	72.792970
-2011-03-01T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1124.201419
-2011-03-01T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1166.141121
-2011-03-02T00:00:00.000Z	spot	automotive	preferred	apreferred	174.890520
-2011-03-02T00:00:00.000Z	spot	entertainment	preferred	epreferred	147.117434
-2011-03-02T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	109.239196
-2011-03-02T00:00:00.000Z	spot	premium	preferred	ppreferred	120.212473
-2011-03-02T00:00:00.000Z	spot	travel	preferred	tpreferred	116.460744
-2011-03-02T00:00:00.000Z	total_market	premium	preferred	ppreferred	1143.078414
-2011-03-02T00:00:00.000Z	upfront	premium	preferred	ppreferred	865.777900
-2011-03-03T00:00:00.000Z	spot	business	preferred	bpreferred	92.537499
-2011-03-03T00:00:00.000Z	spot	health	preferred	hpreferred	108.914095
-2011-03-03T00:00:00.000Z	spot	news	preferred	npreferred	96.031371
-2011-03-03T00:00:00.000Z	spot	technology	preferred	tpreferred	75.977564
-2011-03-03T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1097.490771
-2011-03-03T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	901.307577
-2011-03-04T00:00:00.000Z	spot	automotive	preferred	apreferred	119.851231
-2011-03-04T00:00:00.000Z	spot	entertainment	preferred	epreferred	132.832331
-2011-03-04T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	107.285615
-2011-03-04T00:00:00.000Z	spot	premium	preferred	ppreferred	113.883056
-2011-03-04T00:00:00.000Z	spot	travel	preferred	tpreferred	109.607245
-2011-03-04T00:00:00.000Z	total_market	premium	preferred	ppreferred	1179.803776
-2011-03-04T00:00:00.000Z	upfront	premium	preferred	ppreferred	975.577927
-2011-03-05T00:00:00.000Z	spot	business	preferred	bpreferred	97.942645
-2011-03-05T00:00:00.000Z	spot	health	preferred	hpreferred	108.394611
-2011-03-05T00:00:00.000Z	spot	news	preferred	npreferred	102.486832
-2011-03-05T00:00:00.000Z	spot	technology	preferred	tpreferred	81.105110
-2011-03-05T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1281.601175
-2011-03-05T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1360.694785
-2011-03-06T00:00:00.000Z	spot	automotive	preferred	apreferred	129.531062
-2011-03-06T00:00:00.000Z	spot	entertainment	preferred	epreferred	144.925734
-2011-03-06T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	113.035167
-2011-03-06T00:00:00.000Z	spot	premium	preferred	ppreferred	115.956859
-2011-03-06T00:00:00.000Z	spot	travel	preferred	tpreferred	120.953163
-2011-03-06T00:00:00.000Z	total_market	premium	preferred	ppreferred	1103.239788
-2011-03-06T00:00:00.000Z	upfront	premium	preferred	ppreferred	869.308360
-2011-03-07T00:00:00.000Z	spot	business	preferred	bpreferred	105.575929
-2011-03-07T00:00:00.000Z	spot	health	preferred	hpreferred	118.024245
-2011-03-07T00:00:00.000Z	spot	news	preferred	npreferred	107.220218
-2011-03-07T00:00:00.000Z	spot	technology	preferred	tpreferred	68.699125
-2011-03-07T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1177.858403
-2011-03-07T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1095.637520
-2011-03-08T00:00:00.000Z	spot	automotive	preferred	apreferred	109.764955
-2011-03-08T00:00:00.000Z	spot	entertainment	preferred	epreferred	143.214331
-2011-03-08T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	107.465492
-2011-03-08T00:00:00.000Z	spot	premium	preferred	ppreferred	122.692722
-2011-03-08T00:00:00.000Z	spot	travel	preferred	tpreferred	111.704071
-2011-03-08T00:00:00.000Z	total_market	premium	preferred	ppreferred	1084.332554
-2011-03-08T00:00:00.000Z	upfront	premium	preferred	ppreferred	835.762631
-2011-03-09T00:00:00.000Z	spot	business	preferred	bpreferred	110.873407
-2011-03-09T00:00:00.000Z	spot	health	preferred	hpreferred	115.013313
-2011-03-09T00:00:00.000Z	spot	news	preferred	npreferred	112.407868
-2011-03-09T00:00:00.000Z	spot	technology	preferred	tpreferred	82.426362
-2011-03-09T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1029.802500
-2011-03-09T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	776.702940
-2011-03-10T00:00:00.000Z	spot	automotive	preferred	apreferred	148.809150
-2011-03-10T00:00:00.000Z	spot	entertainment	preferred	epreferred	134.212714
-2011-03-10T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	119.613508
-2011-03-10T00:00:00.000Z	spot	premium	preferred	ppreferred	118.864028
-2011-03-10T00:00:00.000Z	spot	travel	preferred	tpreferred	107.706257
-2011-03-10T00:00:00.000Z	total_market	premium	preferred	ppreferred	1077.279402
-2011-03-10T00:00:00.000Z	upfront	premium	preferred	ppreferred	835.461226
-2011-03-11T00:00:00.000Z	spot	business	preferred	bpreferred	106.898536
-2011-03-11T00:00:00.000Z	spot	health	preferred	hpreferred	112.856230
-2011-03-11T00:00:00.000Z	spot	news	preferred	npreferred	108.135811
-2011-03-11T00:00:00.000Z	spot	technology	preferred	tpreferred	67.731170
-2011-03-11T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1098.543170
-2011-03-11T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	715.516125
-2011-03-12T00:00:00.000Z	spot	automotive	preferred	apreferred	155.728048
-2011-03-12T00:00:00.000Z	spot	entertainment	preferred	epreferred	132.687079
-2011-03-12T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	114.681603
-2011-03-12T00:00:00.000Z	spot	premium	preferred	ppreferred	118.574721
-2011-03-12T00:00:00.000Z	spot	travel	preferred	tpreferred	109.384493
-2011-03-12T00:00:00.000Z	total_market	premium	preferred	ppreferred	1008.745525
-2011-03-12T00:00:00.000Z	upfront	premium	preferred	ppreferred	764.508070
-2011-03-13T00:00:00.000Z	spot	business	preferred	bpreferred	113.760384
-2011-03-13T00:00:00.000Z	spot	health	preferred	hpreferred	120.760130
-2011-03-13T00:00:00.000Z	spot	news	preferred	npreferred	114.814070
-2011-03-13T00:00:00.000Z	spot	technology	preferred	tpreferred	70.126017
-2011-03-13T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	998.753955
-2011-03-13T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	736.409261
-2011-03-14T00:00:00.000Z	spot	automotive	preferred	apreferred	153.191744
-2011-03-14T00:00:00.000Z	spot	entertainment	preferred	epreferred	123.248581
-2011-03-14T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	104.716583
-2011-03-14T00:00:00.000Z	spot	premium	preferred	ppreferred	122.275869
-2011-03-14T00:00:00.000Z	spot	travel	preferred	tpreferred	104.724023
-2011-03-14T00:00:00.000Z	total_market	premium	preferred	ppreferred	1141.588400
-2011-03-14T00:00:00.000Z	upfront	premium	preferred	ppreferred	893.985017
-2011-03-15T00:00:00.000Z	spot	business	preferred	bpreferred	109.382273
-2011-03-15T00:00:00.000Z	spot	health	preferred	hpreferred	119.250945
-2011-03-15T00:00:00.000Z	spot	news	preferred	npreferred	112.354294
-2011-03-15T00:00:00.000Z	spot	technology	preferred	tpreferred	59.266595
-2011-03-15T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1037.381049
-2011-03-15T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	832.874861
-2011-03-16T00:00:00.000Z	spot	automotive	preferred	apreferred	147.471464
-2011-03-16T00:00:00.000Z	spot	entertainment	preferred	epreferred	110.070846
-2011-03-16T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	99.137980
-2011-03-16T00:00:00.000Z	spot	premium	preferred	ppreferred	120.455865
-2011-03-16T00:00:00.000Z	spot	travel	preferred	tpreferred	107.903885
-2011-03-16T00:00:00.000Z	total_market	premium	preferred	ppreferred	1092.942008
-2011-03-16T00:00:00.000Z	upfront	premium	preferred	ppreferred	848.339888
-2011-03-17T00:00:00.000Z	spot	business	preferred	bpreferred	113.501786
-2011-03-17T00:00:00.000Z	spot	health	preferred	hpreferred	114.540037
-2011-03-17T00:00:00.000Z	spot	news	preferred	npreferred	116.816958
-2011-03-17T00:00:00.000Z	spot	technology	preferred	tpreferred	69.258523
-2011-03-17T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1072.239320
-2011-03-17T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	878.683776
-2011-03-18T00:00:00.000Z	spot	automotive	preferred	apreferred	180.343171
-2011-03-18T00:00:00.000Z	spot	entertainment	preferred	epreferred	130.260926
-2011-03-18T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	111.540639
-2011-03-18T00:00:00.000Z	spot	premium	preferred	ppreferred	119.629977
-2011-03-18T00:00:00.000Z	spot	travel	preferred	tpreferred	114.564808
-2011-03-18T00:00:00.000Z	total_market	premium	preferred	ppreferred	1176.605164
-2011-03-18T00:00:00.000Z	upfront	premium	preferred	ppreferred	936.429632
-2011-03-19T00:00:00.000Z	spot	business	preferred	bpreferred	109.788875
-2011-03-19T00:00:00.000Z	spot	health	preferred	hpreferred	117.197085
-2011-03-19T00:00:00.000Z	spot	news	preferred	npreferred	112.236468
-2011-03-19T00:00:00.000Z	spot	technology	preferred	tpreferred	72.369471
-2011-03-19T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1107.220174
-2011-03-19T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	846.288386
-2011-03-20T00:00:00.000Z	spot	automotive	preferred	apreferred	178.454262
-2011-03-20T00:00:00.000Z	spot	entertainment	preferred	epreferred	157.749330
-2011-03-20T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	128.274705
-2011-03-20T00:00:00.000Z	spot	premium	preferred	ppreferred	129.519442
-2011-03-20T00:00:00.000Z	spot	travel	preferred	tpreferred	128.705337
-2011-03-20T00:00:00.000Z	total_market	premium	preferred	ppreferred	1217.547439
-2011-03-20T00:00:00.000Z	upfront	premium	preferred	ppreferred	954.754185
-2011-03-21T00:00:00.000Z	spot	business	preferred	bpreferred	124.411632
-2011-03-21T00:00:00.000Z	spot	health	preferred	hpreferred	122.462424
-2011-03-21T00:00:00.000Z	spot	news	preferred	npreferred	125.243882
-2011-03-21T00:00:00.000Z	spot	technology	preferred	tpreferred	75.936640
-2011-03-21T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1283.957016
-2011-03-21T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1031.990042
-2011-03-22T00:00:00.000Z	spot	automotive	preferred	apreferred	177.460613
-2011-03-22T00:00:00.000Z	spot	entertainment	preferred	epreferred	151.407583
-2011-03-22T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	126.415884
-2011-03-22T00:00:00.000Z	spot	premium	preferred	ppreferred	133.124963
-2011-03-22T00:00:00.000Z	spot	travel	preferred	tpreferred	122.357549
-2011-03-22T00:00:00.000Z	total_market	premium	preferred	ppreferred	1119.247202
-2011-03-22T00:00:00.000Z	upfront	premium	preferred	ppreferred	843.952139
-2011-03-23T00:00:00.000Z	spot	business	preferred	bpreferred	126.764513
-2011-03-23T00:00:00.000Z	spot	health	preferred	hpreferred	118.972310
-2011-03-23T00:00:00.000Z	spot	news	preferred	npreferred	129.864384
-2011-03-23T00:00:00.000Z	spot	technology	preferred	tpreferred	102.603152
-2011-03-23T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1403.338838
-2011-03-23T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1362.650586
-2011-03-24T00:00:00.000Z	spot	automotive	preferred	apreferred	135.569784
-2011-03-24T00:00:00.000Z	spot	entertainment	preferred	epreferred	156.650862
-2011-03-24T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	115.945757
-2011-03-24T00:00:00.000Z	spot	premium	preferred	ppreferred	129.023978
-2011-03-24T00:00:00.000Z	spot	travel	preferred	tpreferred	124.062061
-2011-03-24T00:00:00.000Z	total_market	premium	preferred	ppreferred	1137.842315
-2011-03-24T00:00:00.000Z	upfront	premium	preferred	ppreferred	873.652030
-2011-03-25T00:00:00.000Z	spot	business	preferred	bpreferred	125.766952
-2011-03-25T00:00:00.000Z	spot	health	preferred	hpreferred	119.400783
-2011-03-25T00:00:00.000Z	spot	news	preferred	npreferred	126.057960
-2011-03-25T00:00:00.000Z	spot	technology	preferred	tpreferred	89.408906
-2011-03-25T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1124.935193
-2011-03-25T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	855.717712
-2011-03-26T00:00:00.000Z	spot	automotive	preferred	apreferred	148.957194
-2011-03-26T00:00:00.000Z	spot	entertainment	preferred	epreferred	162.815450
-2011-03-26T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	117.449116
-2011-03-26T00:00:00.000Z	spot	premium	preferred	ppreferred	139.214665
-2011-03-26T00:00:00.000Z	spot	travel	preferred	tpreferred	138.663182
-2011-03-26T00:00:00.000Z	total_market	premium	preferred	ppreferred	1247.890809
-2011-03-26T00:00:00.000Z	upfront	premium	preferred	ppreferred	962.235801
-2011-03-27T00:00:00.000Z	spot	business	preferred	bpreferred	135.183271
-2011-03-27T00:00:00.000Z	spot	health	preferred	hpreferred	130.599006
-2011-03-27T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	114.952545
-2011-03-27T00:00:00.000Z	spot	news	preferred	npreferred	139.294248
-2011-03-27T00:00:00.000Z	spot	premium	preferred	ppreferred	142.430177
-2011-03-27T00:00:00.000Z	spot	technology	preferred	tpreferred	108.489598
-2011-03-27T00:00:00.000Z	spot	travel	preferred	tpreferred	141.820068
-2011-03-27T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1185.709973
-2011-03-27T00:00:00.000Z	total_market	premium	preferred	ppreferred	1345.781728
-2011-03-27T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1019.898509
-2011-03-27T00:00:00.000Z	upfront	premium	preferred	ppreferred	1056.419292
-2011-03-28T00:00:00.000Z	spot	automotive	preferred	apreferred	156.155294
-2011-03-28T00:00:00.000Z	spot	business	preferred	bpreferred	124.336139
-2011-03-28T00:00:00.000Z	spot	entertainment	preferred	epreferred	163.100154
-2011-03-28T00:00:00.000Z	spot	health	preferred	hpreferred	131.191818
-2011-03-28T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	115.709767
-2011-03-28T00:00:00.000Z	spot	news	preferred	npreferred	127.403089
-2011-03-28T00:00:00.000Z	spot	premium	preferred	ppreferred	140.941296
-2011-03-28T00:00:00.000Z	spot	technology	preferred	tpreferred	103.578536
-2011-03-28T00:00:00.000Z	spot	travel	preferred	tpreferred	130.880788
-2011-03-28T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1250.166788
-2011-03-28T00:00:00.000Z	total_market	premium	preferred	ppreferred	1390.754050
-2011-03-28T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1198.723103
-2011-03-28T00:00:00.000Z	upfront	premium	preferred	ppreferred	1108.136072
-2011-03-29T00:00:00.000Z	spot	automotive	preferred	apreferred	134.084672
-2011-03-29T00:00:00.000Z	spot	business	preferred	bpreferred	117.626804
-2011-03-29T00:00:00.000Z	spot	entertainment	preferred	epreferred	158.073319
-2011-03-29T00:00:00.000Z	spot	health	preferred	hpreferred	128.074393
-2011-03-29T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	109.678515
-2011-03-29T00:00:00.000Z	spot	news	preferred	npreferred	122.620188
-2011-03-29T00:00:00.000Z	spot	premium	preferred	ppreferred	144.446039
-2011-03-29T00:00:00.000Z	spot	technology	preferred	tpreferred	91.604463
-2011-03-29T00:00:00.000Z	spot	travel	preferred	tpreferred	132.477651
-2011-03-29T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1224.116225
-2011-03-29T00:00:00.000Z	total_market	premium	preferred	ppreferred	1361.080245
-2011-03-29T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1289.009485
-2011-03-29T00:00:00.000Z	upfront	premium	preferred	ppreferred	1069.431801
-2011-03-30T00:00:00.000Z	spot	automotive	preferred	apreferred	135.942820
-2011-03-30T00:00:00.000Z	spot	business	preferred	bpreferred	120.283054
-2011-03-30T00:00:00.000Z	spot	entertainment	preferred	epreferred	167.960620
-2011-03-30T00:00:00.000Z	spot	health	preferred	hpreferred	121.215839
-2011-03-30T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	116.587746
-2011-03-30T00:00:00.000Z	spot	news	preferred	npreferred	122.612114
-2011-03-30T00:00:00.000Z	spot	premium	preferred	ppreferred	138.827311
-2011-03-30T00:00:00.000Z	spot	technology	preferred	tpreferred	93.331887
-2011-03-30T00:00:00.000Z	spot	travel	preferred	tpreferred	128.645571
-2011-03-30T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1190.933753
-2011-03-30T00:00:00.000Z	total_market	premium	preferred	ppreferred	1310.797070
-2011-03-30T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1001.134025
-2011-03-30T00:00:00.000Z	upfront	premium	preferred	ppreferred	1030.499562
-2011-03-31T00:00:00.000Z	spot	automotive	preferred	apreferred	151.752485
-2011-03-31T00:00:00.000Z	spot	business	preferred	bpreferred	124.414321
-2011-03-31T00:00:00.000Z	spot	entertainment	preferred	epreferred	175.778647
-2011-03-31T00:00:00.000Z	spot	health	preferred	hpreferred	120.607382
-2011-03-31T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	117.060598
-2011-03-31T00:00:00.000Z	spot	news	preferred	npreferred	125.243245
-2011-03-31T00:00:00.000Z	spot	premium	preferred	ppreferred	150.247713
-2011-03-31T00:00:00.000Z	spot	technology	preferred	tpreferred	93.390841
-2011-03-31T00:00:00.000Z	spot	travel	preferred	tpreferred	125.839686
-2011-03-31T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1466.209327
-2011-03-31T00:00:00.000Z	total_market	premium	preferred	ppreferred	1366.447617
-2011-03-31T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1734.274909
-2011-03-31T00:00:00.000Z	upfront	premium	preferred	ppreferred	1063.201156
-2011-04-01T00:00:00.000Z	spot	automotive	preferred	apreferred	135.885094
-2011-04-01T00:00:00.000Z	spot	business	preferred	bpreferred	118.570340
-2011-04-01T00:00:00.000Z	spot	entertainment	preferred	epreferred	158.747224
-2011-04-01T00:00:00.000Z	spot	health	preferred	hpreferred	120.134704
-2011-04-01T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	109.705815
-2011-04-01T00:00:00.000Z	spot	news	preferred	npreferred	121.583581
-2011-04-01T00:00:00.000Z	spot	premium	preferred	ppreferred	144.507368
-2011-04-01T00:00:00.000Z	spot	technology	preferred	tpreferred	78.622547
-2011-04-01T00:00:00.000Z	spot	travel	preferred	tpreferred	119.922742
-2011-04-01T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1314.839715
-2011-04-01T00:00:00.000Z	total_market	premium	preferred	ppreferred	1522.043733
-2011-04-01T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1447.341160
-2011-04-01T00:00:00.000Z	upfront	premium	preferred	ppreferred	1234.247546
-2011-04-02T00:00:00.000Z	spot	automotive	preferred	apreferred	147.425935
-2011-04-02T00:00:00.000Z	spot	business	preferred	bpreferred	112.987027
-2011-04-02T00:00:00.000Z	spot	entertainment	preferred	epreferred	166.016049
-2011-04-02T00:00:00.000Z	spot	health	preferred	hpreferred	113.446008
-2011-04-02T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	110.931934
-2011-04-02T00:00:00.000Z	spot	news	preferred	npreferred	114.290141
-2011-04-02T00:00:00.000Z	spot	premium	preferred	ppreferred	135.301506
-2011-04-02T00:00:00.000Z	spot	technology	preferred	tpreferred	97.387433
-2011-04-02T00:00:00.000Z	spot	travel	preferred	tpreferred	126.411364
-2011-04-02T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1193.556278
-2011-04-02T00:00:00.000Z	total_market	premium	preferred	ppreferred	1321.375057
-2011-04-02T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1144.342401
-2011-04-02T00:00:00.000Z	upfront	premium	preferred	ppreferred	1049.738585
-2011-04-03T00:00:00.000Z	spot	automotive	preferred	apreferred	122.971856
-2011-04-03T00:00:00.000Z	spot	business	preferred	bpreferred	105.735462
-2011-04-03T00:00:00.000Z	spot	entertainment	preferred	epreferred	153.927965
-2011-04-03T00:00:00.000Z	spot	health	preferred	hpreferred	103.532351
-2011-04-03T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	107.047773
-2011-04-03T00:00:00.000Z	spot	news	preferred	npreferred	107.919674
-2011-04-03T00:00:00.000Z	spot	premium	preferred	ppreferred	122.141707
-2011-04-03T00:00:00.000Z	spot	technology	preferred	tpreferred	80.861743
-2011-04-03T00:00:00.000Z	spot	travel	preferred	tpreferred	117.247070
-2011-04-03T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1055.783661
-2011-04-03T00:00:00.000Z	total_market	premium	preferred	ppreferred	1021.638673
-2011-04-03T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	811.991286
-2011-04-03T00:00:00.000Z	upfront	premium	preferred	ppreferred	768.423077
-2011-04-04T00:00:00.000Z	spot	automotive	preferred	apreferred	110.919829
-2011-04-04T00:00:00.000Z	spot	business	preferred	bpreferred	107.613577
-2011-04-04T00:00:00.000Z	spot	entertainment	preferred	epreferred	146.729242
-2011-04-04T00:00:00.000Z	spot	health	preferred	hpreferred	105.375351
-2011-04-04T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	110.573670
-2011-04-04T00:00:00.000Z	spot	news	preferred	npreferred	114.382255
-2011-04-04T00:00:00.000Z	spot	premium	preferred	ppreferred	125.285894
-2011-04-04T00:00:00.000Z	spot	technology	preferred	tpreferred	72.668430
-2011-04-04T00:00:00.000Z	spot	travel	preferred	tpreferred	117.703023
-2011-04-04T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1197.008423
-2011-04-04T00:00:00.000Z	total_market	premium	preferred	ppreferred	1131.531986
-2011-04-04T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1151.069173
-2011-04-04T00:00:00.000Z	upfront	premium	preferred	ppreferred	877.079396
-2011-04-05T00:00:00.000Z	spot	automotive	preferred	apreferred	113.318712
-2011-04-05T00:00:00.000Z	spot	business	preferred	bpreferred	105.615563
-2011-04-05T00:00:00.000Z	spot	entertainment	preferred	epreferred	141.713507
-2011-04-05T00:00:00.000Z	spot	health	preferred	hpreferred	106.207931
-2011-04-05T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	109.890586
-2011-04-05T00:00:00.000Z	spot	news	preferred	npreferred	110.012987
-2011-04-05T00:00:00.000Z	spot	premium	preferred	ppreferred	124.478408
-2011-04-05T00:00:00.000Z	spot	technology	preferred	tpreferred	86.683603
-2011-04-05T00:00:00.000Z	spot	travel	preferred	tpreferred	117.051694
-2011-04-05T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1192.144303
-2011-04-05T00:00:00.000Z	total_market	premium	preferred	ppreferred	1154.289559
-2011-04-05T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1146.423036
-2011-04-05T00:00:00.000Z	upfront	premium	preferred	ppreferred	902.615706
-2011-04-06T00:00:00.000Z	spot	automotive	preferred	apreferred	115.334018
-2011-04-06T00:00:00.000Z	spot	business	preferred	bpreferred	109.700256
-2011-04-06T00:00:00.000Z	spot	entertainment	preferred	epreferred	147.553562
-2011-04-06T00:00:00.000Z	spot	health	preferred	hpreferred	100.775597
-2011-04-06T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	108.659345
-2011-04-06T00:00:00.000Z	spot	news	preferred	npreferred	113.408308
-2011-04-06T00:00:00.000Z	spot	premium	preferred	ppreferred	121.079585
-2011-04-06T00:00:00.000Z	spot	technology	preferred	tpreferred	92.336403
-2011-04-06T00:00:00.000Z	spot	travel	preferred	tpreferred	112.921482
-2011-04-06T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1272.677122
-2011-04-06T00:00:00.000Z	total_market	premium	preferred	ppreferred	1141.514652
-2011-04-06T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1355.843374
-2011-04-06T00:00:00.000Z	upfront	premium	preferred	ppreferred	897.393445
-2011-04-07T00:00:00.000Z	spot	automotive	preferred	apreferred	117.508062
-2011-04-07T00:00:00.000Z	spot	business	preferred	bpreferred	115.418054
-2011-04-07T00:00:00.000Z	spot	entertainment	preferred	epreferred	141.565031
-2011-04-07T00:00:00.000Z	spot	health	preferred	hpreferred	95.562446
-2011-04-07T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	102.933171
-2011-04-07T00:00:00.000Z	spot	news	preferred	npreferred	122.696621
-2011-04-07T00:00:00.000Z	spot	premium	preferred	ppreferred	119.763135
-2011-04-07T00:00:00.000Z	spot	technology	preferred	tpreferred	84.357701
-2011-04-07T00:00:00.000Z	spot	travel	preferred	tpreferred	117.432760
-2011-04-07T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1190.896088
-2011-04-07T00:00:00.000Z	total_market	premium	preferred	ppreferred	1009.363132
-2011-04-07T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1260.143027
-2011-04-07T00:00:00.000Z	upfront	premium	preferred	ppreferred	762.862488
-2011-04-08T00:00:00.000Z	spot	automotive	preferred	apreferred	120.973860
-2011-04-08T00:00:00.000Z	spot	business	preferred	bpreferred	116.248860
-2011-04-08T00:00:00.000Z	spot	entertainment	preferred	epreferred	146.830618
-2011-04-08T00:00:00.000Z	spot	health	preferred	hpreferred	96.226609
-2011-04-08T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	95.447888
-2011-04-08T00:00:00.000Z	spot	news	preferred	npreferred	120.709912
-2011-04-08T00:00:00.000Z	spot	premium	preferred	ppreferred	120.309688
-2011-04-08T00:00:00.000Z	spot	technology	preferred	tpreferred	94.631354
-2011-04-08T00:00:00.000Z	spot	travel	preferred	tpreferred	122.743898
-2011-04-08T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1006.913816
-2011-04-08T00:00:00.000Z	total_market	premium	preferred	ppreferred	1032.599837
-2011-04-08T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	935.168026
-2011-04-08T00:00:00.000Z	upfront	premium	preferred	ppreferred	782.107861
-2011-04-09T00:00:00.000Z	spot	automotive	preferred	apreferred	116.080323
-2011-04-09T00:00:00.000Z	spot	business	preferred	bpreferred	116.060759
-2011-04-09T00:00:00.000Z	spot	entertainment	preferred	epreferred	158.682525
-2011-04-09T00:00:00.000Z	spot	health	preferred	hpreferred	95.509796
-2011-04-09T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	110.007248
-2011-04-09T00:00:00.000Z	spot	news	preferred	npreferred	121.905685
-2011-04-09T00:00:00.000Z	spot	premium	preferred	ppreferred	126.369367
-2011-04-09T00:00:00.000Z	spot	technology	preferred	tpreferred	92.905070
-2011-04-09T00:00:00.000Z	spot	travel	preferred	tpreferred	123.791320
-2011-04-09T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1137.385764
-2011-04-09T00:00:00.000Z	total_market	premium	preferred	ppreferred	1030.075553
-2011-04-09T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	996.205369
-2011-04-09T00:00:00.000Z	upfront	premium	preferred	ppreferred	767.692135
-2011-04-10T00:00:00.000Z	spot	automotive	preferred	apreferred	113.221448
-2011-04-10T00:00:00.000Z	spot	business	preferred	bpreferred	95.570457
-2011-04-10T00:00:00.000Z	spot	entertainment	preferred	epreferred	131.766616
-2011-04-10T00:00:00.000Z	spot	health	preferred	hpreferred	99.950855
-2011-04-10T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	91.470524
-2011-04-10T00:00:00.000Z	spot	news	preferred	npreferred	99.393076
-2011-04-10T00:00:00.000Z	spot	premium	preferred	ppreferred	123.207579
-2011-04-10T00:00:00.000Z	spot	technology	preferred	tpreferred	84.898691
-2011-04-10T00:00:00.000Z	spot	travel	preferred	tpreferred	114.353962
-2011-04-10T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1005.253077
-2011-04-10T00:00:00.000Z	total_market	premium	preferred	ppreferred	1030.094757
-2011-04-10T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1031.741509
-2011-04-10T00:00:00.000Z	upfront	premium	preferred	ppreferred	775.965555
-2011-04-11T00:00:00.000Z	spot	automotive	preferred	apreferred	130.165796
-2011-04-11T00:00:00.000Z	spot	business	preferred	bpreferred	107.765101
-2011-04-11T00:00:00.000Z	spot	entertainment	preferred	epreferred	142.751726
-2011-04-11T00:00:00.000Z	spot	health	preferred	hpreferred	104.847285
-2011-04-11T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	95.272956
-2011-04-11T00:00:00.000Z	spot	news	preferred	npreferred	106.229286
-2011-04-11T00:00:00.000Z	spot	premium	preferred	ppreferred	126.823859
-2011-04-11T00:00:00.000Z	spot	technology	preferred	tpreferred	89.250155
-2011-04-11T00:00:00.000Z	spot	travel	preferred	tpreferred	122.049678
-2011-04-11T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1112.794811
-2011-04-11T00:00:00.000Z	total_market	premium	preferred	ppreferred	1113.357530
-2011-04-11T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1374.968412
-2011-04-11T00:00:00.000Z	upfront	premium	preferred	ppreferred	853.163039
-2011-04-12T00:00:00.000Z	spot	automotive	preferred	apreferred	122.386348
-2011-04-12T00:00:00.000Z	spot	business	preferred	bpreferred	106.380995
-2011-04-12T00:00:00.000Z	spot	entertainment	preferred	epreferred	141.932300
-2011-04-12T00:00:00.000Z	spot	health	preferred	hpreferred	103.142372
-2011-04-12T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	97.340631
-2011-04-12T00:00:00.000Z	spot	news	preferred	npreferred	105.381244
-2011-04-12T00:00:00.000Z	spot	premium	preferred	ppreferred	125.189098
-2011-04-12T00:00:00.000Z	spot	technology	preferred	tpreferred	90.533391
-2011-04-12T00:00:00.000Z	spot	travel	preferred	tpreferred	122.128172
-2011-04-12T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1153.974725
-2011-04-12T00:00:00.000Z	total_market	premium	preferred	ppreferred	1069.640880
-2011-04-12T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1456.611830
-2011-04-12T00:00:00.000Z	upfront	premium	preferred	ppreferred	811.925240
-2011-04-13T00:00:00.000Z	spot	automotive	preferred	apreferred	122.688340
-2011-04-13T00:00:00.000Z	spot	business	preferred	bpreferred	105.739623
-2011-04-13T00:00:00.000Z	spot	entertainment	preferred	epreferred	136.983407
-2011-04-13T00:00:00.000Z	spot	health	preferred	hpreferred	100.860813
-2011-04-13T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	94.839191
-2011-04-13T00:00:00.000Z	spot	news	preferred	npreferred	105.261296
-2011-04-13T00:00:00.000Z	spot	premium	preferred	ppreferred	119.836611
-2011-04-13T00:00:00.000Z	spot	technology	preferred	tpreferred	91.972558
-2011-04-13T00:00:00.000Z	spot	travel	preferred	tpreferred	120.145572
-2011-04-13T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1016.137449
-2011-04-13T00:00:00.000Z	total_market	premium	preferred	ppreferred	994.902292
-2011-04-13T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	989.032799
-2011-04-13T00:00:00.000Z	upfront	premium	preferred	ppreferred	744.744657
-2011-04-14T00:00:00.000Z	spot	automotive	preferred	apreferred	111.179339
-2011-04-14T00:00:00.000Z	spot	business	preferred	bpreferred	101.984377
-2011-04-14T00:00:00.000Z	spot	entertainment	preferred	epreferred	133.606430
-2011-04-14T00:00:00.000Z	spot	health	preferred	hpreferred	99.738319
-2011-04-14T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	91.270553
-2011-04-14T00:00:00.000Z	spot	news	preferred	npreferred	101.251756
-2011-04-14T00:00:00.000Z	spot	premium	preferred	ppreferred	118.285128
-2011-04-14T00:00:00.000Z	spot	technology	preferred	tpreferred	84.951300
-2011-04-14T00:00:00.000Z	spot	travel	preferred	tpreferred	119.768525
-2011-04-14T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1032.154263
-2011-04-14T00:00:00.000Z	total_market	premium	preferred	ppreferred	999.586450
-2011-04-14T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1166.401205
-2011-04-14T00:00:00.000Z	upfront	premium	preferred	ppreferred	753.104985
-2011-04-15T00:00:00.000Z	spot	automotive	preferred	apreferred	106.793700
-2011-04-15T00:00:00.000Z	spot	business	preferred	bpreferred	94.469747
-2011-04-15T00:00:00.000Z	spot	entertainment	preferred	epreferred	135.109191
-2011-04-15T00:00:00.000Z	spot	health	preferred	hpreferred	99.596909
-2011-04-15T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	92.782760
-2011-04-15T00:00:00.000Z	spot	news	preferred	npreferred	97.859766
-2011-04-15T00:00:00.000Z	spot	premium	preferred	ppreferred	120.508160
-2011-04-15T00:00:00.000Z	spot	technology	preferred	tpreferred	89.646236
-2011-04-15T00:00:00.000Z	spot	travel	preferred	tpreferred	120.290348
-2011-04-15T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	994.752744
-2011-04-15T00:00:00.000Z	total_market	premium	preferred	ppreferred	1029.056992
-2011-04-15T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	962.731172
-2011-04-15T00:00:00.000Z	upfront	premium	preferred	ppreferred	780.271977
+2011-01-12T00:00:00.000Z	default	spot	business	preferred	bpreferred	100.000000
+2011-01-12T00:00:00.000Z	default	spot	health	preferred	hpreferred	100.000000
+2011-01-12T00:00:00.000Z	default	spot	news	preferred	npreferred	100.000000
+2011-01-12T00:00:00.000Z	default	spot	technology	preferred	tpreferred	100.000000
+2011-01-12T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1000.000000
+2011-01-12T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	800.000000
+2011-01-13T00:00:00.000Z	default	spot	automotive	preferred	apreferred	94.874713
+2011-01-13T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	110.087299
+2011-01-13T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	104.465767
+2011-01-13T00:00:00.000Z	default	spot	premium	preferred	ppreferred	108.863011
+2011-01-13T00:00:00.000Z	default	spot	travel	preferred	tpreferred	106.236928
+2011-01-13T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1689.012875
+2011-01-13T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1564.617729
+2011-01-14T00:00:00.000Z	default	spot	business	preferred	bpreferred	102.670409
+2011-01-14T00:00:00.000Z	default	spot	health	preferred	hpreferred	94.000432
+2011-01-14T00:00:00.000Z	default	spot	news	preferred	npreferred	101.380760
+2011-01-14T00:00:00.000Z	default	spot	technology	preferred	tpreferred	114.974216
+2011-01-14T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1049.141912
+2011-01-14T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1006.402111
+2011-01-15T00:00:00.000Z	default	spot	automotive	preferred	apreferred	82.840417
+2011-01-15T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	100.551072
+2011-01-15T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	100.582654
+2011-01-15T00:00:00.000Z	default	spot	premium	preferred	ppreferred	102.366798
+2011-01-15T00:00:00.000Z	default	spot	travel	preferred	tpreferred	120.481420
+2011-01-15T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1545.708865
+2011-01-15T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1458.402661
+2011-01-16T00:00:00.000Z	default	spot	business	preferred	bpreferred	100.591602
+2011-01-16T00:00:00.000Z	default	spot	health	preferred	hpreferred	93.085943
+2011-01-16T00:00:00.000Z	default	spot	news	preferred	npreferred	100.192013
+2011-01-16T00:00:00.000Z	default	spot	technology	preferred	tpreferred	87.280816
+2011-01-16T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1016.965229
+2011-01-16T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	852.437477
+2011-01-17T00:00:00.000Z	default	spot	automotive	preferred	apreferred	105.442374
+2011-01-17T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	99.189052
+2011-01-17T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	103.692852
+2011-01-17T00:00:00.000Z	default	spot	premium	preferred	ppreferred	106.696362
+2011-01-17T00:00:00.000Z	default	spot	travel	preferred	tpreferred	134.415281
+2011-01-17T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	953.995422
+2011-01-17T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	712.774595
+2011-01-18T00:00:00.000Z	default	spot	business	preferred	bpreferred	107.244699
+2011-01-18T00:00:00.000Z	default	spot	health	preferred	hpreferred	103.018934
+2011-01-18T00:00:00.000Z	default	spot	news	preferred	npreferred	104.724154
+2011-01-18T00:00:00.000Z	default	spot	technology	preferred	tpreferred	88.764512
+2011-01-18T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1022.783330
+2011-01-18T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	846.267516
+2011-01-19T00:00:00.000Z	default	spot	automotive	preferred	apreferred	85.681683
+2011-01-19T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	92.314034
+2011-01-19T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	105.087466
+2011-01-19T00:00:00.000Z	default	spot	premium	preferred	ppreferred	104.568464
+2011-01-19T00:00:00.000Z	default	spot	travel	preferred	tpreferred	109.772202
+2011-01-19T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	849.877513
+2011-01-19T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	594.381703
+2011-01-20T01:00:00.000Z	default	spot	business	preferred	bpreferred	106.367723
+2011-01-20T01:00:00.000Z	default	spot	health	preferred	hpreferred	96.112901
+2011-01-20T01:00:00.000Z	default	spot	news	preferred	npreferred	105.225158
+2011-01-20T01:00:00.000Z	default	spot	technology	preferred	tpreferred	77.759854
+2011-01-20T01:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1066.208012
+2011-01-20T01:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	870.115926
+2011-01-22T00:00:00.000Z	default	spot	business	preferred	bpreferred	105.282866
+2011-01-22T00:00:00.000Z	default	spot	health	preferred	hpreferred	103.527592
+2011-01-22T00:00:00.000Z	default	spot	news	preferred	npreferred	103.399677
+2011-01-22T00:00:00.000Z	default	spot	technology	preferred	tpreferred	107.627793
+2011-01-22T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1240.525484
+2011-01-22T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1410.278128
+2011-01-23T00:00:00.000Z	default	spot	automotive	preferred	apreferred	100.432710
+2011-01-23T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	92.789692
+2011-01-23T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	103.730730
+2011-01-23T00:00:00.000Z	default	spot	premium	preferred	ppreferred	101.573522
+2011-01-23T00:00:00.000Z	default	spot	travel	preferred	tpreferred	128.699746
+2011-01-23T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1349.254415
+2011-01-23T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1224.501568
+2011-01-24T00:00:00.000Z	default	spot	business	preferred	bpreferred	104.485760
+2011-01-24T00:00:00.000Z	default	spot	health	preferred	hpreferred	189.385952
+2011-01-24T00:00:00.000Z	default	spot	news	preferred	npreferred	104.167373
+2011-01-24T00:00:00.000Z	default	spot	technology	preferred	tpreferred	105.345921
+2011-01-24T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1102.866656
+2011-01-24T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1215.589859
+2011-01-25T00:00:00.000Z	default	spot	automotive	preferred	apreferred	90.111413
+2011-01-25T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	85.974579
+2011-01-25T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	96.594588
+2011-01-25T00:00:00.000Z	default	spot	premium	preferred	ppreferred	102.512878
+2011-01-25T00:00:00.000Z	default	spot	travel	preferred	tpreferred	122.077247
+2011-01-25T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	997.994544
+2011-01-25T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	786.363298
+2011-01-26T00:00:00.000Z	default	spot	business	preferred	bpreferred	105.873942
+2011-01-26T00:00:00.000Z	default	spot	health	preferred	hpreferred	159.988606
+2011-01-26T00:00:00.000Z	default	spot	news	preferred	npreferred	105.266058
+2011-01-26T00:00:00.000Z	default	spot	technology	preferred	tpreferred	105.617702
+2011-01-26T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1037.449471
+2011-01-26T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	989.931541
+2011-01-27T00:00:00.000Z	default	spot	automotive	preferred	apreferred	134.127106
+2011-01-27T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	90.806201
+2011-01-27T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	100.643435
+2011-01-27T00:00:00.000Z	default	spot	premium	preferred	ppreferred	102.612747
+2011-01-27T00:00:00.000Z	default	spot	travel	preferred	tpreferred	149.125271
+2011-01-27T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1486.201299
+2011-01-27T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1367.638074
+2011-01-28T00:00:00.000Z	default	spot	business	preferred	bpreferred	111.641077
+2011-01-28T00:00:00.000Z	default	spot	health	preferred	hpreferred	107.788998
+2011-01-28T00:00:00.000Z	default	spot	news	preferred	npreferred	108.106449
+2011-01-28T00:00:00.000Z	default	spot	technology	preferred	tpreferred	93.869236
+2011-01-28T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1300.302260
+2011-01-28T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1627.598064
+2011-01-29T00:00:00.000Z	default	spot	automotive	preferred	apreferred	127.450345
+2011-01-29T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	103.345166
+2011-01-29T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	106.663538
+2011-01-29T00:00:00.000Z	default	spot	premium	preferred	ppreferred	104.311418
+2011-01-29T00:00:00.000Z	default	spot	travel	preferred	tpreferred	138.865014
+2011-01-29T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	792.326066
+2011-01-29T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	545.990623
+2011-01-30T00:00:00.000Z	default	spot	business	preferred	bpreferred	106.064111
+2011-01-30T00:00:00.000Z	default	spot	health	preferred	hpreferred	137.198397
+2011-01-30T00:00:00.000Z	default	spot	news	preferred	npreferred	106.009926
+2011-01-30T00:00:00.000Z	default	spot	technology	preferred	tpreferred	110.528451
+2011-01-30T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1233.448863
+2011-01-30T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1870.061029
+2011-01-31T00:00:00.000Z	default	spot	automotive	preferred	apreferred	133.740047
+2011-01-31T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	104.548387
+2011-01-31T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	97.017604
+2011-01-31T00:00:00.000Z	default	spot	premium	preferred	ppreferred	103.021032
+2011-01-31T00:00:00.000Z	default	spot	travel	preferred	tpreferred	155.744951
+2011-01-31T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1127.231000
+2011-01-31T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	943.497198
+2011-02-01T00:00:00.000Z	default	spot	business	preferred	bpreferred	103.890175
+2011-02-01T00:00:00.000Z	default	spot	health	preferred	hpreferred	113.896016
+2011-02-01T00:00:00.000Z	default	spot	news	preferred	npreferred	104.383662
+2011-02-01T00:00:00.000Z	default	spot	technology	preferred	tpreferred	83.931272
+2011-02-01T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1203.465595
+2011-02-01T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1667.497773
+2011-02-02T00:00:00.000Z	default	spot	automotive	preferred	apreferred	113.492245
+2011-02-02T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	112.042996
+2011-02-02T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	97.711139
+2011-02-02T00:00:00.000Z	default	spot	premium	preferred	ppreferred	102.152053
+2011-02-02T00:00:00.000Z	default	spot	travel	preferred	tpreferred	123.170962
+2011-02-02T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1410.792943
+2011-02-02T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1273.707453
+2011-02-03T00:00:00.000Z	default	spot	business	preferred	bpreferred	98.877952
+2011-02-03T00:00:00.000Z	default	spot	health	preferred	hpreferred	85.069784
+2011-02-03T00:00:00.000Z	default	spot	news	preferred	npreferred	100.976362
+2011-02-03T00:00:00.000Z	default	spot	technology	preferred	tpreferred	92.326431
+2011-02-03T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1033.401241
+2011-02-03T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	888.705280
+2011-02-04T00:00:00.000Z	default	spot	automotive	preferred	apreferred	89.182906
+2011-02-04T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	112.471918
+2011-02-04T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	100.918373
+2011-02-04T00:00:00.000Z	default	spot	premium	preferred	ppreferred	103.103922
+2011-02-04T00:00:00.000Z	default	spot	travel	preferred	tpreferred	113.716758
+2011-02-04T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1331.860983
+2011-02-04T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1308.582051
+2011-02-05T00:00:00.000Z	default	spot	business	preferred	bpreferred	111.394244
+2011-02-05T00:00:00.000Z	default	spot	health	preferred	hpreferred	94.312960
+2011-02-05T00:00:00.000Z	default	spot	news	preferred	npreferred	107.929804
+2011-02-05T00:00:00.000Z	default	spot	technology	preferred	tpreferred	90.732978
+2011-02-05T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1039.500513
+2011-02-05T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	785.078869
+2011-02-06T00:00:00.000Z	default	spot	automotive	preferred	apreferred	134.462521
+2011-02-06T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	119.608310
+2011-02-06T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	101.847544
+2011-02-06T00:00:00.000Z	default	spot	premium	preferred	ppreferred	102.770913
+2011-02-06T00:00:00.000Z	default	spot	travel	preferred	tpreferred	121.270562
+2011-02-06T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1029.995236
+2011-02-06T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	826.039207
+2011-02-07T00:00:00.000Z	default	spot	business	preferred	bpreferred	98.815847
+2011-02-07T00:00:00.000Z	default	spot	health	preferred	hpreferred	97.480779
+2011-02-07T00:00:00.000Z	default	spot	news	preferred	npreferred	100.706057
+2011-02-07T00:00:00.000Z	default	spot	technology	preferred	tpreferred	83.902353
+2011-02-07T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1047.212887
+2011-02-07T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1107.243787
+2011-02-08T00:00:00.000Z	default	spot	automotive	preferred	apreferred	126.243536
+2011-02-08T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	106.969799
+2011-02-08T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	96.790543
+2011-02-08T00:00:00.000Z	default	spot	premium	preferred	ppreferred	103.308255
+2011-02-08T00:00:00.000Z	default	spot	travel	preferred	tpreferred	111.040150
+2011-02-08T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1082.727640
+2011-02-08T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	911.956790
+2011-02-09T00:00:00.000Z	default	spot	business	preferred	bpreferred	115.548444
+2011-02-09T00:00:00.000Z	default	spot	health	preferred	hpreferred	97.071703
+2011-02-09T00:00:00.000Z	default	spot	news	preferred	npreferred	113.554588
+2011-02-09T00:00:00.000Z	default	spot	technology	preferred	tpreferred	83.742151
+2011-02-09T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	971.050764
+2011-02-09T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	794.098825
+2011-02-10T00:00:00.000Z	default	spot	automotive	preferred	apreferred	115.461691
+2011-02-10T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	117.629065
+2011-02-10T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	95.698374
+2011-02-10T00:00:00.000Z	default	spot	premium	preferred	ppreferred	105.708103
+2011-02-10T00:00:00.000Z	default	spot	travel	preferred	tpreferred	105.557241
+2011-02-10T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1089.647884
+2011-02-10T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	901.327272
+2011-02-11T00:00:00.000Z	default	spot	business	preferred	bpreferred	114.637486
+2011-02-11T00:00:00.000Z	default	spot	health	preferred	hpreferred	96.617339
+2011-02-11T00:00:00.000Z	default	spot	news	preferred	npreferred	112.571724
+2011-02-11T00:00:00.000Z	default	spot	technology	preferred	tpreferred	87.904114
+2011-02-11T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	980.386611
+2011-02-11T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	723.514254
+2011-02-12T00:00:00.000Z	default	spot	automotive	preferred	apreferred	130.104979
+2011-02-12T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	115.225386
+2011-02-12T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	101.515571
+2011-02-12T00:00:00.000Z	default	spot	premium	preferred	ppreferred	108.637522
+2011-02-12T00:00:00.000Z	default	spot	travel	preferred	tpreferred	102.850696
+2011-02-12T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1092.416967
+2011-02-12T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	879.406101
+2011-02-13T00:00:00.000Z	default	spot	business	preferred	bpreferred	118.841176
+2011-02-13T00:00:00.000Z	default	spot	health	preferred	hpreferred	98.607490
+2011-02-13T00:00:00.000Z	default	spot	news	preferred	npreferred	117.965974
+2011-02-13T00:00:00.000Z	default	spot	technology	preferred	tpreferred	87.820236
+2011-02-13T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	987.067381
+2011-02-13T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	724.262526
+2011-02-14T00:00:00.000Z	default	spot	automotive	preferred	apreferred	119.323168
+2011-02-14T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	123.098262
+2011-02-14T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	101.645725
+2011-02-14T00:00:00.000Z	default	spot	premium	preferred	ppreferred	121.060464
+2011-02-14T00:00:00.000Z	default	spot	travel	preferred	tpreferred	107.663239
+2011-02-14T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1199.607472
+2011-02-14T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	948.657939
+2011-02-15T00:00:00.000Z	default	spot	business	preferred	bpreferred	115.527003
+2011-02-15T00:00:00.000Z	default	spot	health	preferred	hpreferred	103.519393
+2011-02-15T00:00:00.000Z	default	spot	news	preferred	npreferred	117.138956
+2011-02-15T00:00:00.000Z	default	spot	technology	preferred	tpreferred	79.700998
+2011-02-15T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1044.384300
+2011-02-15T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	807.601674
+2011-02-16T00:00:00.000Z	default	spot	automotive	preferred	apreferred	133.726576
+2011-02-16T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	130.717934
+2011-02-16T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	108.338531
+2011-02-16T00:00:00.000Z	default	spot	premium	preferred	ppreferred	123.270869
+2011-02-16T00:00:00.000Z	default	spot	travel	preferred	tpreferred	113.643571
+2011-02-16T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1360.032423
+2011-02-16T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1208.456692
+2011-02-17T00:00:00.000Z	default	spot	business	preferred	bpreferred	125.032692
+2011-02-17T00:00:00.000Z	default	spot	health	preferred	hpreferred	101.092779
+2011-02-17T00:00:00.000Z	default	spot	news	preferred	npreferred	121.872569
+2011-02-17T00:00:00.000Z	default	spot	technology	preferred	tpreferred	91.969195
+2011-02-17T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	993.591221
+2011-02-17T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	679.619354
+2011-02-18T00:00:00.000Z	default	spot	automotive	preferred	apreferred	151.053296
+2011-02-18T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	128.063524
+2011-02-18T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	101.960196
+2011-02-18T00:00:00.000Z	default	spot	premium	preferred	ppreferred	122.546253
+2011-02-18T00:00:00.000Z	default	spot	travel	preferred	tpreferred	120.151389
+2011-02-18T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1601.829436
+2011-02-18T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1649.533329
+2011-02-19T00:00:00.000Z	default	spot	business	preferred	bpreferred	123.447481
+2011-02-19T00:00:00.000Z	default	spot	health	preferred	hpreferred	108.822138
+2011-02-19T00:00:00.000Z	default	spot	news	preferred	npreferred	119.371511
+2011-02-19T00:00:00.000Z	default	spot	technology	preferred	tpreferred	91.547944
+2011-02-19T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1200.527201
+2011-02-19T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1433.398801
+2011-02-20T00:00:00.000Z	default	spot	automotive	preferred	apreferred	157.483005
+2011-02-20T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	176.323916
+2011-02-20T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	127.819268
+2011-02-20T00:00:00.000Z	default	spot	premium	preferred	ppreferred	132.719065
+2011-02-20T00:00:00.000Z	default	spot	travel	preferred	tpreferred	124.637709
+2011-02-20T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1304.326111
+2011-02-20T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1022.854576
+2011-02-21T00:00:00.000Z	default	spot	business	preferred	bpreferred	132.231346
+2011-02-21T00:00:00.000Z	default	spot	health	preferred	hpreferred	111.386745
+2011-02-21T00:00:00.000Z	default	spot	news	preferred	npreferred	126.995117
+2011-02-21T00:00:00.000Z	default	spot	technology	preferred	tpreferred	119.850150
+2011-02-21T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1544.108134
+2011-02-21T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1228.502469
+2011-02-22T00:00:00.000Z	default	spot	automotive	preferred	apreferred	149.171056
+2011-02-22T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	139.557139
+2011-02-22T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	111.394542
+2011-02-22T00:00:00.000Z	default	spot	premium	preferred	ppreferred	126.596847
+2011-02-22T00:00:00.000Z	default	spot	travel	preferred	tpreferred	115.915849
+2011-02-22T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1421.648704
+2011-02-22T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1291.897942
+2011-02-23T00:00:00.000Z	default	spot	business	preferred	bpreferred	127.199815
+2011-02-23T00:00:00.000Z	default	spot	health	preferred	hpreferred	107.896489
+2011-02-23T00:00:00.000Z	default	spot	news	preferred	npreferred	122.404192
+2011-02-23T00:00:00.000Z	default	spot	technology	preferred	tpreferred	91.191071
+2011-02-23T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1251.906228
+2011-02-23T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1306.495696
+2011-02-24T00:00:00.000Z	default	spot	automotive	preferred	apreferred	168.988478
+2011-02-24T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	139.978575
+2011-02-24T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	113.621184
+2011-02-24T00:00:00.000Z	default	spot	premium	preferred	ppreferred	119.772575
+2011-02-24T00:00:00.000Z	default	spot	travel	preferred	tpreferred	118.270052
+2011-02-24T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	970.728273
+2011-02-24T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	578.795979
+2011-02-25T00:00:00.000Z	default	spot	business	preferred	bpreferred	107.539869
+2011-02-25T00:00:00.000Z	default	spot	health	preferred	hpreferred	99.698015
+2011-02-25T00:00:00.000Z	default	spot	news	preferred	npreferred	106.827630
+2011-02-25T00:00:00.000Z	default	spot	technology	preferred	tpreferred	82.350556
+2011-02-25T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1057.427269
+2011-02-25T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1017.573185
+2011-02-26T00:00:00.000Z	default	spot	automotive	preferred	apreferred	225.243186
+2011-02-26T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	138.924835
+2011-02-26T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	98.314744
+2011-02-26T00:00:00.000Z	default	spot	premium	preferred	ppreferred	118.896845
+2011-02-26T00:00:00.000Z	default	spot	travel	preferred	tpreferred	131.310541
+2011-02-26T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1743.921750
+2011-02-26T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1862.737933
+2011-02-27T00:00:00.000Z	default	spot	business	preferred	bpreferred	96.864384
+2011-02-27T00:00:00.000Z	default	spot	health	preferred	hpreferred	114.634278
+2011-02-27T00:00:00.000Z	default	spot	news	preferred	npreferred	99.158839
+2011-02-27T00:00:00.000Z	default	spot	technology	preferred	tpreferred	78.727950
+2011-02-27T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1044.562903
+2011-02-27T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	873.306547
+2011-02-28T00:00:00.000Z	default	spot	automotive	preferred	apreferred	122.258195
+2011-02-28T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	141.261324
+2011-02-28T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	102.185098
+2011-02-28T00:00:00.000Z	default	spot	premium	preferred	ppreferred	121.786785
+2011-02-28T00:00:00.000Z	default	spot	travel	preferred	tpreferred	114.284569
+2011-02-28T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1292.542896
+2011-02-28T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1101.918270
+2011-03-01T00:00:00.000Z	default	spot	business	preferred	bpreferred	99.070796
+2011-03-01T00:00:00.000Z	default	spot	health	preferred	hpreferred	114.700932
+2011-03-01T00:00:00.000Z	default	spot	news	preferred	npreferred	99.772347
+2011-03-01T00:00:00.000Z	default	spot	technology	preferred	tpreferred	72.792970
+2011-03-01T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1124.201419
+2011-03-01T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1166.141121
+2011-03-02T00:00:00.000Z	default	spot	automotive	preferred	apreferred	174.890520
+2011-03-02T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	147.117434
+2011-03-02T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	109.239196
+2011-03-02T00:00:00.000Z	default	spot	premium	preferred	ppreferred	120.212473
+2011-03-02T00:00:00.000Z	default	spot	travel	preferred	tpreferred	116.460744
+2011-03-02T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1143.078414
+2011-03-02T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	865.777900
+2011-03-03T00:00:00.000Z	default	spot	business	preferred	bpreferred	92.537499
+2011-03-03T00:00:00.000Z	default	spot	health	preferred	hpreferred	108.914095
+2011-03-03T00:00:00.000Z	default	spot	news	preferred	npreferred	96.031371
+2011-03-03T00:00:00.000Z	default	spot	technology	preferred	tpreferred	75.977564
+2011-03-03T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1097.490771
+2011-03-03T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	901.307577
+2011-03-04T00:00:00.000Z	default	spot	automotive	preferred	apreferred	119.851231
+2011-03-04T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	132.832331
+2011-03-04T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	107.285615
+2011-03-04T00:00:00.000Z	default	spot	premium	preferred	ppreferred	113.883056
+2011-03-04T00:00:00.000Z	default	spot	travel	preferred	tpreferred	109.607245
+2011-03-04T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1179.803776
+2011-03-04T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	975.577927
+2011-03-05T00:00:00.000Z	default	spot	business	preferred	bpreferred	97.942645
+2011-03-05T00:00:00.000Z	default	spot	health	preferred	hpreferred	108.394611
+2011-03-05T00:00:00.000Z	default	spot	news	preferred	npreferred	102.486832
+2011-03-05T00:00:00.000Z	default	spot	technology	preferred	tpreferred	81.105110
+2011-03-05T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1281.601175
+2011-03-05T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1360.694785
+2011-03-06T00:00:00.000Z	default	spot	automotive	preferred	apreferred	129.531062
+2011-03-06T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	144.925734
+2011-03-06T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	113.035167
+2011-03-06T00:00:00.000Z	default	spot	premium	preferred	ppreferred	115.956859
+2011-03-06T00:00:00.000Z	default	spot	travel	preferred	tpreferred	120.953163
+2011-03-06T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1103.239788
+2011-03-06T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	869.308360
+2011-03-07T00:00:00.000Z	default	spot	business	preferred	bpreferred	105.575929
+2011-03-07T00:00:00.000Z	default	spot	health	preferred	hpreferred	118.024245
+2011-03-07T00:00:00.000Z	default	spot	news	preferred	npreferred	107.220218
+2011-03-07T00:00:00.000Z	default	spot	technology	preferred	tpreferred	68.699125
+2011-03-07T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1177.858403
+2011-03-07T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1095.637520
+2011-03-08T00:00:00.000Z	default	spot	automotive	preferred	apreferred	109.764955
+2011-03-08T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	143.214331
+2011-03-08T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	107.465492
+2011-03-08T00:00:00.000Z	default	spot	premium	preferred	ppreferred	122.692722
+2011-03-08T00:00:00.000Z	default	spot	travel	preferred	tpreferred	111.704071
+2011-03-08T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1084.332554
+2011-03-08T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	835.762631
+2011-03-09T00:00:00.000Z	default	spot	business	preferred	bpreferred	110.873407
+2011-03-09T00:00:00.000Z	default	spot	health	preferred	hpreferred	115.013313
+2011-03-09T00:00:00.000Z	default	spot	news	preferred	npreferred	112.407868
+2011-03-09T00:00:00.000Z	default	spot	technology	preferred	tpreferred	82.426362
+2011-03-09T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1029.802500
+2011-03-09T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	776.702940
+2011-03-10T00:00:00.000Z	default	spot	automotive	preferred	apreferred	148.809150
+2011-03-10T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	134.212714
+2011-03-10T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	119.613508
+2011-03-10T00:00:00.000Z	default	spot	premium	preferred	ppreferred	118.864028
+2011-03-10T00:00:00.000Z	default	spot	travel	preferred	tpreferred	107.706257
+2011-03-10T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1077.279402
+2011-03-10T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	835.461226
+2011-03-11T00:00:00.000Z	default	spot	business	preferred	bpreferred	106.898536
+2011-03-11T00:00:00.000Z	default	spot	health	preferred	hpreferred	112.856230
+2011-03-11T00:00:00.000Z	default	spot	news	preferred	npreferred	108.135811
+2011-03-11T00:00:00.000Z	default	spot	technology	preferred	tpreferred	67.731170
+2011-03-11T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1098.543170
+2011-03-11T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	715.516125
+2011-03-12T00:00:00.000Z	default	spot	automotive	preferred	apreferred	155.728048
+2011-03-12T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	132.687079
+2011-03-12T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	114.681603
+2011-03-12T00:00:00.000Z	default	spot	premium	preferred	ppreferred	118.574721
+2011-03-12T00:00:00.000Z	default	spot	travel	preferred	tpreferred	109.384493
+2011-03-12T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1008.745525
+2011-03-12T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	764.508070
+2011-03-13T00:00:00.000Z	default	spot	business	preferred	bpreferred	113.760384
+2011-03-13T00:00:00.000Z	default	spot	health	preferred	hpreferred	120.760130
+2011-03-13T00:00:00.000Z	default	spot	news	preferred	npreferred	114.814070
+2011-03-13T00:00:00.000Z	default	spot	technology	preferred	tpreferred	70.126017
+2011-03-13T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	998.753955
+2011-03-13T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	736.409261
+2011-03-14T00:00:00.000Z	default	spot	automotive	preferred	apreferred	153.191744
+2011-03-14T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	123.248581
+2011-03-14T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	104.716583
+2011-03-14T00:00:00.000Z	default	spot	premium	preferred	ppreferred	122.275869
+2011-03-14T00:00:00.000Z	default	spot	travel	preferred	tpreferred	104.724023
+2011-03-14T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1141.588400
+2011-03-14T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	893.985017
+2011-03-15T00:00:00.000Z	default	spot	business	preferred	bpreferred	109.382273
+2011-03-15T00:00:00.000Z	default	spot	health	preferred	hpreferred	119.250945
+2011-03-15T00:00:00.000Z	default	spot	news	preferred	npreferred	112.354294
+2011-03-15T00:00:00.000Z	default	spot	technology	preferred	tpreferred	59.266595
+2011-03-15T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1037.381049
+2011-03-15T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	832.874861
+2011-03-16T00:00:00.000Z	default	spot	automotive	preferred	apreferred	147.471464
+2011-03-16T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	110.070846
+2011-03-16T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	99.137980
+2011-03-16T00:00:00.000Z	default	spot	premium	preferred	ppreferred	120.455865
+2011-03-16T00:00:00.000Z	default	spot	travel	preferred	tpreferred	107.903885
+2011-03-16T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1092.942008
+2011-03-16T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	848.339888
+2011-03-17T00:00:00.000Z	default	spot	business	preferred	bpreferred	113.501786
+2011-03-17T00:00:00.000Z	default	spot	health	preferred	hpreferred	114.540037
+2011-03-17T00:00:00.000Z	default	spot	news	preferred	npreferred	116.816958
+2011-03-17T00:00:00.000Z	default	spot	technology	preferred	tpreferred	69.258523
+2011-03-17T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1072.239320
+2011-03-17T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	878.683776
+2011-03-18T00:00:00.000Z	default	spot	automotive	preferred	apreferred	180.343171
+2011-03-18T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	130.260926
+2011-03-18T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	111.540639
+2011-03-18T00:00:00.000Z	default	spot	premium	preferred	ppreferred	119.629977
+2011-03-18T00:00:00.000Z	default	spot	travel	preferred	tpreferred	114.564808
+2011-03-18T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1176.605164
+2011-03-18T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	936.429632
+2011-03-19T00:00:00.000Z	default	spot	business	preferred	bpreferred	109.788875
+2011-03-19T00:00:00.000Z	default	spot	health	preferred	hpreferred	117.197085
+2011-03-19T00:00:00.000Z	default	spot	news	preferred	npreferred	112.236468
+2011-03-19T00:00:00.000Z	default	spot	technology	preferred	tpreferred	72.369471
+2011-03-19T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1107.220174
+2011-03-19T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	846.288386
+2011-03-20T00:00:00.000Z	default	spot	automotive	preferred	apreferred	178.454262
+2011-03-20T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	157.749330
+2011-03-20T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	128.274705
+2011-03-20T00:00:00.000Z	default	spot	premium	preferred	ppreferred	129.519442
+2011-03-20T00:00:00.000Z	default	spot	travel	preferred	tpreferred	128.705337
+2011-03-20T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1217.547439
+2011-03-20T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	954.754185
+2011-03-21T00:00:00.000Z	default	spot	business	preferred	bpreferred	124.411632
+2011-03-21T00:00:00.000Z	default	spot	health	preferred	hpreferred	122.462424
+2011-03-21T00:00:00.000Z	default	spot	news	preferred	npreferred	125.243882
+2011-03-21T00:00:00.000Z	default	spot	technology	preferred	tpreferred	75.936640
+2011-03-21T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1283.957016
+2011-03-21T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1031.990042
+2011-03-22T00:00:00.000Z	default	spot	automotive	preferred	apreferred	177.460613
+2011-03-22T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	151.407583
+2011-03-22T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	126.415884
+2011-03-22T00:00:00.000Z	default	spot	premium	preferred	ppreferred	133.124963
+2011-03-22T00:00:00.000Z	default	spot	travel	preferred	tpreferred	122.357549
+2011-03-22T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1119.247202
+2011-03-22T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	843.952139
+2011-03-23T00:00:00.000Z	default	spot	business	preferred	bpreferred	126.764513
+2011-03-23T00:00:00.000Z	default	spot	health	preferred	hpreferred	118.972310
+2011-03-23T00:00:00.000Z	default	spot	news	preferred	npreferred	129.864384
+2011-03-23T00:00:00.000Z	default	spot	technology	preferred	tpreferred	102.603152
+2011-03-23T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1403.338838
+2011-03-23T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1362.650586
+2011-03-24T00:00:00.000Z	default	spot	automotive	preferred	apreferred	135.569784
+2011-03-24T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	156.650862
+2011-03-24T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	115.945757
+2011-03-24T00:00:00.000Z	default	spot	premium	preferred	ppreferred	129.023978
+2011-03-24T00:00:00.000Z	default	spot	travel	preferred	tpreferred	124.062061
+2011-03-24T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1137.842315
+2011-03-24T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	873.652030
+2011-03-25T00:00:00.000Z	default	spot	business	preferred	bpreferred	125.766952
+2011-03-25T00:00:00.000Z	default	spot	health	preferred	hpreferred	119.400783
+2011-03-25T00:00:00.000Z	default	spot	news	preferred	npreferred	126.057960
+2011-03-25T00:00:00.000Z	default	spot	technology	preferred	tpreferred	89.408906
+2011-03-25T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1124.935193
+2011-03-25T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	855.717712
+2011-03-26T00:00:00.000Z	default	spot	automotive	preferred	apreferred	148.957194
+2011-03-26T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	162.815450
+2011-03-26T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	117.449116
+2011-03-26T00:00:00.000Z	default	spot	premium	preferred	ppreferred	139.214665
+2011-03-26T00:00:00.000Z	default	spot	travel	preferred	tpreferred	138.663182
+2011-03-26T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1247.890809
+2011-03-26T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	962.235801
+2011-03-27T00:00:00.000Z	default	spot	business	preferred	bpreferred	135.183271
+2011-03-27T00:00:00.000Z	default	spot	health	preferred	hpreferred	130.599006
+2011-03-27T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	114.952545
+2011-03-27T00:00:00.000Z	default	spot	news	preferred	npreferred	139.294248
+2011-03-27T00:00:00.000Z	default	spot	premium	preferred	ppreferred	142.430177
+2011-03-27T00:00:00.000Z	default	spot	technology	preferred	tpreferred	108.489598
+2011-03-27T00:00:00.000Z	default	spot	travel	preferred	tpreferred	141.820068
+2011-03-27T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1185.709973
+2011-03-27T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1345.781728
+2011-03-27T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1019.898509
+2011-03-27T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1056.419292
+2011-03-28T00:00:00.000Z	default	spot	automotive	preferred	apreferred	156.155294
+2011-03-28T00:00:00.000Z	default	spot	business	preferred	bpreferred	124.336139
+2011-03-28T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	163.100154
+2011-03-28T00:00:00.000Z	default	spot	health	preferred	hpreferred	131.191818
+2011-03-28T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	115.709767
+2011-03-28T00:00:00.000Z	default	spot	news	preferred	npreferred	127.403089
+2011-03-28T00:00:00.000Z	default	spot	premium	preferred	ppreferred	140.941296
+2011-03-28T00:00:00.000Z	default	spot	technology	preferred	tpreferred	103.578536
+2011-03-28T00:00:00.000Z	default	spot	travel	preferred	tpreferred	130.880788
+2011-03-28T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1250.166788
+2011-03-28T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1390.754050
+2011-03-28T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1198.723103
+2011-03-28T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1108.136072
+2011-03-29T00:00:00.000Z	default	spot	automotive	preferred	apreferred	134.084672
+2011-03-29T00:00:00.000Z	default	spot	business	preferred	bpreferred	117.626804
+2011-03-29T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	158.073319
+2011-03-29T00:00:00.000Z	default	spot	health	preferred	hpreferred	128.074393
+2011-03-29T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	109.678515
+2011-03-29T00:00:00.000Z	default	spot	news	preferred	npreferred	122.620188
+2011-03-29T00:00:00.000Z	default	spot	premium	preferred	ppreferred	144.446039
+2011-03-29T00:00:00.000Z	default	spot	technology	preferred	tpreferred	91.604463
+2011-03-29T00:00:00.000Z	default	spot	travel	preferred	tpreferred	132.477651
+2011-03-29T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1224.116225
+2011-03-29T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1361.080245
+2011-03-29T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1289.009485
+2011-03-29T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1069.431801
+2011-03-30T00:00:00.000Z	default	spot	automotive	preferred	apreferred	135.942820
+2011-03-30T00:00:00.000Z	default	spot	business	preferred	bpreferred	120.283054
+2011-03-30T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	167.960620
+2011-03-30T00:00:00.000Z	default	spot	health	preferred	hpreferred	121.215839
+2011-03-30T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	116.587746
+2011-03-30T00:00:00.000Z	default	spot	news	preferred	npreferred	122.612114
+2011-03-30T00:00:00.000Z	default	spot	premium	preferred	ppreferred	138.827311
+2011-03-30T00:00:00.000Z	default	spot	technology	preferred	tpreferred	93.331887
+2011-03-30T00:00:00.000Z	default	spot	travel	preferred	tpreferred	128.645571
+2011-03-30T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1190.933753
+2011-03-30T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1310.797070
+2011-03-30T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1001.134025
+2011-03-30T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1030.499562
+2011-03-31T00:00:00.000Z	default	spot	automotive	preferred	apreferred	151.752485
+2011-03-31T00:00:00.000Z	default	spot	business	preferred	bpreferred	124.414321
+2011-03-31T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	175.778647
+2011-03-31T00:00:00.000Z	default	spot	health	preferred	hpreferred	120.607382
+2011-03-31T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	117.060598
+2011-03-31T00:00:00.000Z	default	spot	news	preferred	npreferred	125.243245
+2011-03-31T00:00:00.000Z	default	spot	premium	preferred	ppreferred	150.247713
+2011-03-31T00:00:00.000Z	default	spot	technology	preferred	tpreferred	93.390841
+2011-03-31T00:00:00.000Z	default	spot	travel	preferred	tpreferred	125.839686
+2011-03-31T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1466.209327
+2011-03-31T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1366.447617
+2011-03-31T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1734.274909
+2011-03-31T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1063.201156
+2011-04-01T00:00:00.000Z	default	spot	automotive	preferred	apreferred	135.885094
+2011-04-01T00:00:00.000Z	default	spot	business	preferred	bpreferred	118.570340
+2011-04-01T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	158.747224
+2011-04-01T00:00:00.000Z	default	spot	health	preferred	hpreferred	120.134704
+2011-04-01T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	109.705815
+2011-04-01T00:00:00.000Z	default	spot	news	preferred	npreferred	121.583581
+2011-04-01T00:00:00.000Z	default	spot	premium	preferred	ppreferred	144.507368
+2011-04-01T00:00:00.000Z	default	spot	technology	preferred	tpreferred	78.622547
+2011-04-01T00:00:00.000Z	default	spot	travel	preferred	tpreferred	119.922742
+2011-04-01T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1314.839715
+2011-04-01T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1522.043733
+2011-04-01T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1447.341160
+2011-04-01T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1234.247546
+2011-04-02T00:00:00.000Z	default	spot	automotive	preferred	apreferred	147.425935
+2011-04-02T00:00:00.000Z	default	spot	business	preferred	bpreferred	112.987027
+2011-04-02T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	166.016049
+2011-04-02T00:00:00.000Z	default	spot	health	preferred	hpreferred	113.446008
+2011-04-02T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	110.931934
+2011-04-02T00:00:00.000Z	default	spot	news	preferred	npreferred	114.290141
+2011-04-02T00:00:00.000Z	default	spot	premium	preferred	ppreferred	135.301506
+2011-04-02T00:00:00.000Z	default	spot	technology	preferred	tpreferred	97.387433
+2011-04-02T00:00:00.000Z	default	spot	travel	preferred	tpreferred	126.411364
+2011-04-02T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1193.556278
+2011-04-02T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1321.375057
+2011-04-02T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1144.342401
+2011-04-02T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1049.738585
+2011-04-03T00:00:00.000Z	default	spot	automotive	preferred	apreferred	122.971856
+2011-04-03T00:00:00.000Z	default	spot	business	preferred	bpreferred	105.735462
+2011-04-03T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	153.927965
+2011-04-03T00:00:00.000Z	default	spot	health	preferred	hpreferred	103.532351
+2011-04-03T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	107.047773
+2011-04-03T00:00:00.000Z	default	spot	news	preferred	npreferred	107.919674
+2011-04-03T00:00:00.000Z	default	spot	premium	preferred	ppreferred	122.141707
+2011-04-03T00:00:00.000Z	default	spot	technology	preferred	tpreferred	80.861743
+2011-04-03T00:00:00.000Z	default	spot	travel	preferred	tpreferred	117.247070
+2011-04-03T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1055.783661
+2011-04-03T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1021.638673
+2011-04-03T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	811.991286
+2011-04-03T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	768.423077
+2011-04-04T00:00:00.000Z	default	spot	automotive	preferred	apreferred	110.919829
+2011-04-04T00:00:00.000Z	default	spot	business	preferred	bpreferred	107.613577
+2011-04-04T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	146.729242
+2011-04-04T00:00:00.000Z	default	spot	health	preferred	hpreferred	105.375351
+2011-04-04T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	110.573670
+2011-04-04T00:00:00.000Z	default	spot	news	preferred	npreferred	114.382255
+2011-04-04T00:00:00.000Z	default	spot	premium	preferred	ppreferred	125.285894
+2011-04-04T00:00:00.000Z	default	spot	technology	preferred	tpreferred	72.668430
+2011-04-04T00:00:00.000Z	default	spot	travel	preferred	tpreferred	117.703023
+2011-04-04T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1197.008423
+2011-04-04T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1131.531986
+2011-04-04T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1151.069173
+2011-04-04T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	877.079396
+2011-04-05T00:00:00.000Z	default	spot	automotive	preferred	apreferred	113.318712
+2011-04-05T00:00:00.000Z	default	spot	business	preferred	bpreferred	105.615563
+2011-04-05T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	141.713507
+2011-04-05T00:00:00.000Z	default	spot	health	preferred	hpreferred	106.207931
+2011-04-05T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	109.890586
+2011-04-05T00:00:00.000Z	default	spot	news	preferred	npreferred	110.012987
+2011-04-05T00:00:00.000Z	default	spot	premium	preferred	ppreferred	124.478408
+2011-04-05T00:00:00.000Z	default	spot	technology	preferred	tpreferred	86.683603
+2011-04-05T00:00:00.000Z	default	spot	travel	preferred	tpreferred	117.051694
+2011-04-05T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1192.144303
+2011-04-05T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1154.289559
+2011-04-05T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1146.423036
+2011-04-05T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	902.615706
+2011-04-06T00:00:00.000Z	default	spot	automotive	preferred	apreferred	115.334018
+2011-04-06T00:00:00.000Z	default	spot	business	preferred	bpreferred	109.700256
+2011-04-06T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	147.553562
+2011-04-06T00:00:00.000Z	default	spot	health	preferred	hpreferred	100.775597
+2011-04-06T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	108.659345
+2011-04-06T00:00:00.000Z	default	spot	news	preferred	npreferred	113.408308
+2011-04-06T00:00:00.000Z	default	spot	premium	preferred	ppreferred	121.079585
+2011-04-06T00:00:00.000Z	default	spot	technology	preferred	tpreferred	92.336403
+2011-04-06T00:00:00.000Z	default	spot	travel	preferred	tpreferred	112.921482
+2011-04-06T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1272.677122
+2011-04-06T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1141.514652
+2011-04-06T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1355.843374
+2011-04-06T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	897.393445
+2011-04-07T00:00:00.000Z	default	spot	automotive	preferred	apreferred	117.508062
+2011-04-07T00:00:00.000Z	default	spot	business	preferred	bpreferred	115.418054
+2011-04-07T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	141.565031
+2011-04-07T00:00:00.000Z	default	spot	health	preferred	hpreferred	95.562446
+2011-04-07T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	102.933171
+2011-04-07T00:00:00.000Z	default	spot	news	preferred	npreferred	122.696621
+2011-04-07T00:00:00.000Z	default	spot	premium	preferred	ppreferred	119.763135
+2011-04-07T00:00:00.000Z	default	spot	technology	preferred	tpreferred	84.357701
+2011-04-07T00:00:00.000Z	default	spot	travel	preferred	tpreferred	117.432760
+2011-04-07T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1190.896088
+2011-04-07T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1009.363132
+2011-04-07T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1260.143027
+2011-04-07T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	762.862488
+2011-04-08T00:00:00.000Z	default	spot	automotive	preferred	apreferred	120.973860
+2011-04-08T00:00:00.000Z	default	spot	business	preferred	bpreferred	116.248860
+2011-04-08T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	146.830618
+2011-04-08T00:00:00.000Z	default	spot	health	preferred	hpreferred	96.226609
+2011-04-08T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	95.447888
+2011-04-08T00:00:00.000Z	default	spot	news	preferred	npreferred	120.709912
+2011-04-08T00:00:00.000Z	default	spot	premium	preferred	ppreferred	120.309688
+2011-04-08T00:00:00.000Z	default	spot	technology	preferred	tpreferred	94.631354
+2011-04-08T00:00:00.000Z	default	spot	travel	preferred	tpreferred	122.743898
+2011-04-08T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1006.913816
+2011-04-08T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1032.599837
+2011-04-08T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	935.168026
+2011-04-08T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	782.107861
+2011-04-09T00:00:00.000Z	default	spot	automotive	preferred	apreferred	116.080323
+2011-04-09T00:00:00.000Z	default	spot	business	preferred	bpreferred	116.060759
+2011-04-09T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	158.682525
+2011-04-09T00:00:00.000Z	default	spot	health	preferred	hpreferred	95.509796
+2011-04-09T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	110.007248
+2011-04-09T00:00:00.000Z	default	spot	news	preferred	npreferred	121.905685
+2011-04-09T00:00:00.000Z	default	spot	premium	preferred	ppreferred	126.369367
+2011-04-09T00:00:00.000Z	default	spot	technology	preferred	tpreferred	92.905070
+2011-04-09T00:00:00.000Z	default	spot	travel	preferred	tpreferred	123.791320
+2011-04-09T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1137.385764
+2011-04-09T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1030.075553
+2011-04-09T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	996.205369
+2011-04-09T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	767.692135
+2011-04-10T00:00:00.000Z	default	spot	automotive	preferred	apreferred	113.221448
+2011-04-10T00:00:00.000Z	default	spot	business	preferred	bpreferred	95.570457
+2011-04-10T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	131.766616
+2011-04-10T00:00:00.000Z	default	spot	health	preferred	hpreferred	99.950855
+2011-04-10T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	91.470524
+2011-04-10T00:00:00.000Z	default	spot	news	preferred	npreferred	99.393076
+2011-04-10T00:00:00.000Z	default	spot	premium	preferred	ppreferred	123.207579
+2011-04-10T00:00:00.000Z	default	spot	technology	preferred	tpreferred	84.898691
+2011-04-10T00:00:00.000Z	default	spot	travel	preferred	tpreferred	114.353962
+2011-04-10T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1005.253077
+2011-04-10T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1030.094757
+2011-04-10T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1031.741509
+2011-04-10T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	775.965555
+2011-04-11T00:00:00.000Z	default	spot	automotive	preferred	apreferred	130.165796
+2011-04-11T00:00:00.000Z	default	spot	business	preferred	bpreferred	107.765101
+2011-04-11T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	142.751726
+2011-04-11T00:00:00.000Z	default	spot	health	preferred	hpreferred	104.847285
+2011-04-11T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	95.272956
+2011-04-11T00:00:00.000Z	default	spot	news	preferred	npreferred	106.229286
+2011-04-11T00:00:00.000Z	default	spot	premium	preferred	ppreferred	126.823859
+2011-04-11T00:00:00.000Z	default	spot	technology	preferred	tpreferred	89.250155
+2011-04-11T00:00:00.000Z	default	spot	travel	preferred	tpreferred	122.049678
+2011-04-11T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1112.794811
+2011-04-11T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1113.357530
+2011-04-11T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1374.968412
+2011-04-11T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	853.163039
+2011-04-12T00:00:00.000Z	default	spot	automotive	preferred	apreferred	122.386348
+2011-04-12T00:00:00.000Z	default	spot	business	preferred	bpreferred	106.380995
+2011-04-12T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	141.932300
+2011-04-12T00:00:00.000Z	default	spot	health	preferred	hpreferred	103.142372
+2011-04-12T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	97.340631
+2011-04-12T00:00:00.000Z	default	spot	news	preferred	npreferred	105.381244
+2011-04-12T00:00:00.000Z	default	spot	premium	preferred	ppreferred	125.189098
+2011-04-12T00:00:00.000Z	default	spot	technology	preferred	tpreferred	90.533391
+2011-04-12T00:00:00.000Z	default	spot	travel	preferred	tpreferred	122.128172
+2011-04-12T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1153.974725
+2011-04-12T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1069.640880
+2011-04-12T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1456.611830
+2011-04-12T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	811.925240
+2011-04-13T00:00:00.000Z	default	spot	automotive	preferred	apreferred	122.688340
+2011-04-13T00:00:00.000Z	default	spot	business	preferred	bpreferred	105.739623
+2011-04-13T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	136.983407
+2011-04-13T00:00:00.000Z	default	spot	health	preferred	hpreferred	100.860813
+2011-04-13T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	94.839191
+2011-04-13T00:00:00.000Z	default	spot	news	preferred	npreferred	105.261296
+2011-04-13T00:00:00.000Z	default	spot	premium	preferred	ppreferred	119.836611
+2011-04-13T00:00:00.000Z	default	spot	technology	preferred	tpreferred	91.972558
+2011-04-13T00:00:00.000Z	default	spot	travel	preferred	tpreferred	120.145572
+2011-04-13T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1016.137449
+2011-04-13T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	994.902292
+2011-04-13T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	989.032799
+2011-04-13T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	744.744657
+2011-04-14T00:00:00.000Z	default	spot	automotive	preferred	apreferred	111.179339
+2011-04-14T00:00:00.000Z	default	spot	business	preferred	bpreferred	101.984377
+2011-04-14T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	133.606430
+2011-04-14T00:00:00.000Z	default	spot	health	preferred	hpreferred	99.738319
+2011-04-14T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	91.270553
+2011-04-14T00:00:00.000Z	default	spot	news	preferred	npreferred	101.251756
+2011-04-14T00:00:00.000Z	default	spot	premium	preferred	ppreferred	118.285128
+2011-04-14T00:00:00.000Z	default	spot	technology	preferred	tpreferred	84.951300
+2011-04-14T00:00:00.000Z	23b	spot	travel	preferred	tpreferred	119.768525
+2011-04-14T00:00:00.000Z	23b	total_market	mezzanine	preferred	mpreferred	1032.154263
+2011-04-14T00:00:00.000Z	23b	total_market	premium	preferred	ppreferred	999.586450
+2011-04-14T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1166.401205
+2011-04-14T00:00:00.000Z	2084	upfront	premium	preferred	ppreferred	753.104985
+2011-04-15T00:00:00.000Z	default	spot	automotive	preferred	apreferred	106.793700
+2011-04-15T00:00:00.000Z	c1	spot	business	preferred	bpreferred	94.469747
+2011-04-15T00:00:00.000Z	b8	spot	entertainment	preferred	epreferred	135.109191
+2011-04-15T00:00:00.000Z	default	spot	health	preferred	hpreferred	99.596909
+2011-04-15T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	92.782760
+2011-04-15T00:00:00.000Z	3	spot	news	preferred	npreferred	97.859766
+2011-04-15T00:00:00.000Z	3	spot	premium	preferred	ppreferred	120.508160
+2011-04-15T00:00:00.000Z	12	spot	technology	preferred	tpreferred	89.646236
+2011-04-15T00:00:00.000Z	3	spot	travel	preferred	tpreferred	120.290348
+2011-04-15T00:00:00.000Z	12	total_market	mezzanine	preferred	mpreferred	994.752744
+2011-04-15T00:00:00.000Z	100	total_market	premium	preferred	ppreferred	1029.056992
+2011-04-15T00:00:00.000Z	0	upfront	mezzanine	preferred	mpreferred	962.731172
+2011-04-15T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	780.271977

--- a/processing/src/test/resources/druid.sample.tsv.top
+++ b/processing/src/test/resources/druid.sample.tsv.top
@@ -1,477 +1,477 @@
-2011-01-12T00:00:00.000Z	spot	automotive	preferred	apreferred	100.000000
-2011-01-12T00:00:00.000Z	spot	entertainment	preferred	epreferred	100.000000
-2011-01-12T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	100.000000
-2011-01-12T00:00:00.000Z	spot	premium	preferred	ppreferred	100.000000
-2011-01-12T00:00:00.000Z	spot	travel	preferred	tpreferred	100.000000
-2011-01-12T00:00:00.000Z	total_market	premium	preferred	ppreferred	1000.000000
-2011-01-12T00:00:00.000Z	upfront	premium	preferred	ppreferred	800.000000
-2011-01-13T00:00:00.000Z	spot	business	preferred	bpreferred	103.629399
-2011-01-13T00:00:00.000Z	spot	health	preferred	hpreferred	114.947403
-2011-01-13T00:00:00.000Z	spot	news	preferred	npreferred	102.851683
-2011-01-13T00:00:00.000Z	spot	technology	preferred	tpreferred	111.356672
-2011-01-13T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1040.945505
-2011-01-13T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	826.060182
-2011-01-14T00:00:00.000Z	spot	automotive	preferred	apreferred	86.450372
-2011-01-14T00:00:00.000Z	spot	entertainment	preferred	epreferred	109.573474
-2011-01-14T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	97.903068
-2011-01-14T00:00:00.000Z	spot	premium	preferred	ppreferred	104.611784
-2011-01-14T00:00:00.000Z	spot	travel	preferred	tpreferred	112.259958
-2011-01-14T00:00:00.000Z	total_market	premium	preferred	ppreferred	1073.476545
-2011-01-14T00:00:00.000Z	upfront	premium	preferred	ppreferred	869.643722
-2011-01-15T00:00:00.000Z	spot	business	preferred	bpreferred	99.781645
-2011-01-15T00:00:00.000Z	spot	health	preferred	hpreferred	87.954346
-2011-01-15T00:00:00.000Z	spot	news	preferred	npreferred	99.383407
-2011-01-15T00:00:00.000Z	spot	technology	preferred	tpreferred	111.680229
-2011-01-15T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1007.365510
-2011-01-15T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	809.041763
-2011-01-16T00:00:00.000Z	spot	automotive	preferred	apreferred	71.315931
-2011-01-16T00:00:00.000Z	spot	entertainment	preferred	epreferred	99.007588
-2011-01-16T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	99.863171
-2011-01-16T00:00:00.000Z	spot	premium	preferred	ppreferred	103.348007
-2011-01-16T00:00:00.000Z	spot	travel	preferred	tpreferred	116.779610
-2011-01-16T00:00:00.000Z	total_market	premium	preferred	ppreferred	1077.612663
-2011-01-16T00:00:00.000Z	upfront	premium	preferred	ppreferred	879.988099
-2011-01-17T00:00:00.000Z	spot	business	preferred	bpreferred	105.914315
-2011-01-17T00:00:00.000Z	spot	health	preferred	hpreferred	110.157325
-2011-01-17T00:00:00.000Z	spot	news	preferred	npreferred	103.615039
-2011-01-17T00:00:00.000Z	spot	technology	preferred	tpreferred	89.901887
-2011-01-17T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1075.089574
-2011-01-17T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	950.146770
-2011-01-18T00:00:00.000Z	spot	automotive	preferred	apreferred	87.195139
-2011-01-18T00:00:00.000Z	spot	entertainment	preferred	epreferred	94.452739
-2011-01-18T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	101.087367
-2011-01-18T00:00:00.000Z	spot	premium	preferred	ppreferred	108.979936
-2011-01-18T00:00:00.000Z	spot	travel	preferred	tpreferred	113.680094
-2011-01-18T00:00:00.000Z	total_market	premium	preferred	ppreferred	937.061939
-2011-01-18T00:00:00.000Z	upfront	premium	preferred	ppreferred	682.885525
-2011-01-19T00:00:00.000Z	spot	business	preferred	bpreferred	106.700550
-2011-01-19T00:00:00.000Z	spot	health	preferred	hpreferred	97.620315
-2011-01-19T00:00:00.000Z	spot	news	preferred	npreferred	106.127830
-2011-01-19T00:00:00.000Z	spot	technology	preferred	tpreferred	77.316731
-2011-01-19T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1156.744712
-2011-01-19T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1109.874950
-2011-01-20T01:00:00.000Z	spot	automotive	preferred	apreferred	93.396274
-2011-01-20T01:00:00.000Z	spot	entertainment	preferred	epreferred	90.439020
-2011-01-20T01:00:00.000Z	spot	mezzanine	preferred	mpreferred	105.669498
-2011-01-20T01:00:00.000Z	spot	premium	preferred	ppreferred	101.305541
-2011-01-20T01:00:00.000Z	spot	travel	preferred	tpreferred	140.179069
-2011-01-20T01:00:00.000Z	total_market	premium	preferred	ppreferred	904.340636
-2011-01-20T01:00:00.000Z	upfront	premium	preferred	ppreferred	677.510973
-2011-01-22T00:00:00.000Z	spot	automotive	preferred	apreferred	95.235266
-2011-01-22T00:00:00.000Z	spot	entertainment	preferred	epreferred	93.681096
-2011-01-22T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	104.184494
-2011-01-22T00:00:00.000Z	spot	premium	preferred	ppreferred	99.284525
-2011-01-22T00:00:00.000Z	spot	travel	preferred	tpreferred	137.109783
-2011-01-22T00:00:00.000Z	total_market	premium	preferred	ppreferred	1343.232494
-2011-01-22T00:00:00.000Z	upfront	premium	preferred	ppreferred	1219.432170
-2011-01-23T00:00:00.000Z	spot	business	preferred	bpreferred	107.348157
-2011-01-23T00:00:00.000Z	spot	health	preferred	hpreferred	96.826443
-2011-01-23T00:00:00.000Z	spot	news	preferred	npreferred	106.418686
-2011-01-23T00:00:00.000Z	spot	technology	preferred	tpreferred	110.467875
-2011-01-23T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1088.943083
-2011-01-23T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	979.306038
-2011-01-24T00:00:00.000Z	spot	automotive	preferred	apreferred	96.671647
-2011-01-24T00:00:00.000Z	spot	entertainment	preferred	epreferred	88.748460
-2011-01-24T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	97.906256
-2011-01-24T00:00:00.000Z	spot	premium	preferred	ppreferred	101.581339
-2011-01-24T00:00:00.000Z	spot	travel	preferred	tpreferred	131.695956
-2011-01-24T00:00:00.000Z	total_market	premium	preferred	ppreferred	939.244103
-2011-01-24T00:00:00.000Z	upfront	premium	preferred	ppreferred	716.609179
-2011-01-25T00:00:00.000Z	spot	business	preferred	bpreferred	101.624789
-2011-01-25T00:00:00.000Z	spot	health	preferred	hpreferred	180.575246
-2011-01-25T00:00:00.000Z	spot	news	preferred	npreferred	102.907866
-2011-01-25T00:00:00.000Z	spot	technology	preferred	tpreferred	102.044542
-2011-01-25T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1109.875413
-2011-01-25T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1301.023342
-2011-01-26T00:00:00.000Z	spot	automotive	preferred	apreferred	84.906466
-2011-01-26T00:00:00.000Z	spot	entertainment	preferred	epreferred	84.710523
-2011-01-26T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	96.046584
-2011-01-26T00:00:00.000Z	spot	premium	preferred	ppreferred	101.088903
-2011-01-26T00:00:00.000Z	spot	travel	preferred	tpreferred	122.160681
-2011-01-26T00:00:00.000Z	total_market	premium	preferred	ppreferred	1686.419659
-2011-01-26T00:00:00.000Z	upfront	premium	preferred	ppreferred	1609.096706
-2011-01-27T00:00:00.000Z	spot	business	preferred	bpreferred	104.882908
-2011-01-27T00:00:00.000Z	spot	health	preferred	hpreferred	170.735853
-2011-01-27T00:00:00.000Z	spot	news	preferred	npreferred	104.609483
-2011-01-27T00:00:00.000Z	spot	technology	preferred	tpreferred	116.979005
-2011-01-27T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1074.006938
-2011-01-27T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1023.295213
-2011-01-28T00:00:00.000Z	spot	automotive	preferred	apreferred	123.006128
-2011-01-28T00:00:00.000Z	spot	entertainment	preferred	epreferred	99.681629
-2011-01-28T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	106.075672
-2011-01-28T00:00:00.000Z	spot	premium	preferred	ppreferred	103.822842
-2011-01-28T00:00:00.000Z	spot	travel	preferred	tpreferred	158.739359
-2011-01-28T00:00:00.000Z	total_market	premium	preferred	ppreferred	1021.334487
-2011-01-28T00:00:00.000Z	upfront	premium	preferred	ppreferred	810.889422
-2011-01-29T00:00:00.000Z	spot	business	preferred	bpreferred	100.992147
-2011-01-29T00:00:00.000Z	spot	health	preferred	hpreferred	114.905745
-2011-01-29T00:00:00.000Z	spot	news	preferred	npreferred	101.998823
-2011-01-29T00:00:00.000Z	spot	technology	preferred	tpreferred	109.549035
-2011-01-29T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1314.619452
-2011-01-29T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1685.500085
-2011-01-30T00:00:00.000Z	spot	automotive	preferred	apreferred	124.943293
-2011-01-30T00:00:00.000Z	spot	entertainment	preferred	epreferred	108.415967
-2011-01-30T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	97.023907
-2011-01-30T00:00:00.000Z	spot	premium	preferred	ppreferred	104.298490
-2011-01-30T00:00:00.000Z	spot	travel	preferred	tpreferred	137.932693
-2011-01-30T00:00:00.000Z	total_market	premium	preferred	ppreferred	805.930143
-2011-01-30T00:00:00.000Z	upfront	premium	preferred	ppreferred	555.476028
-2011-01-31T00:00:00.000Z	spot	business	preferred	bpreferred	103.492964
-2011-01-31T00:00:00.000Z	spot	health	preferred	hpreferred	124.171944
-2011-01-31T00:00:00.000Z	spot	news	preferred	npreferred	103.832040
-2011-01-31T00:00:00.000Z	spot	technology	preferred	tpreferred	85.125795
-2011-01-31T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1184.920651
-2011-01-31T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1643.340851
-2011-02-01T00:00:00.000Z	spot	automotive	preferred	apreferred	132.123776
-2011-02-01T00:00:00.000Z	spot	entertainment	preferred	epreferred	103.652865
-2011-02-01T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	98.909356
-2011-02-01T00:00:00.000Z	spot	premium	preferred	ppreferred	102.480377
-2011-02-01T00:00:00.000Z	spot	travel	preferred	tpreferred	134.014606
-2011-02-01T00:00:00.000Z	total_market	premium	preferred	ppreferred	1100.904846
-2011-02-01T00:00:00.000Z	upfront	premium	preferred	ppreferred	913.561076
-2011-02-02T00:00:00.000Z	spot	business	preferred	bpreferred	104.963233
-2011-02-02T00:00:00.000Z	spot	health	preferred	hpreferred	102.281859
-2011-02-02T00:00:00.000Z	spot	news	preferred	npreferred	105.578807
-2011-02-02T00:00:00.000Z	spot	technology	preferred	tpreferred	96.706279
-2011-02-02T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1097.211164
-2011-02-02T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1218.561908
-2011-02-03T00:00:00.000Z	spot	automotive	preferred	apreferred	85.770241
-2011-02-03T00:00:00.000Z	spot	entertainment	preferred	epreferred	106.425780
-2011-02-03T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	100.559287
-2011-02-03T00:00:00.000Z	spot	premium	preferred	ppreferred	102.349315
-2011-02-03T00:00:00.000Z	spot	travel	preferred	tpreferred	134.140377
-2011-02-03T00:00:00.000Z	total_market	premium	preferred	ppreferred	1283.166055
-2011-02-03T00:00:00.000Z	upfront	premium	preferred	ppreferred	1113.114125
-2011-02-04T00:00:00.000Z	spot	business	preferred	bpreferred	106.888769
-2011-02-04T00:00:00.000Z	spot	health	preferred	hpreferred	99.837572
-2011-02-04T00:00:00.000Z	spot	news	preferred	npreferred	106.050728
-2011-02-04T00:00:00.000Z	spot	technology	preferred	tpreferred	93.973465
-2011-02-04T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1025.633340
-2011-02-04T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	864.568891
-2011-02-05T00:00:00.000Z	spot	automotive	preferred	apreferred	93.001571
-2011-02-05T00:00:00.000Z	spot	entertainment	preferred	epreferred	117.030289
-2011-02-05T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	105.660538
-2011-02-05T00:00:00.000Z	spot	premium	preferred	ppreferred	100.646747
-2011-02-05T00:00:00.000Z	spot	travel	preferred	tpreferred	114.723682
-2011-02-05T00:00:00.000Z	total_market	premium	preferred	ppreferred	1332.468373
-2011-02-05T00:00:00.000Z	upfront	premium	preferred	ppreferred	1363.614929
-2011-02-06T00:00:00.000Z	spot	business	preferred	bpreferred	110.897359
-2011-02-06T00:00:00.000Z	spot	health	preferred	hpreferred	93.585758
-2011-02-06T00:00:00.000Z	spot	news	preferred	npreferred	110.053071
-2011-02-06T00:00:00.000Z	spot	technology	preferred	tpreferred	93.620739
-2011-02-06T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1011.205470
-2011-02-06T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	787.125330
-2011-02-07T00:00:00.000Z	spot	automotive	preferred	apreferred	130.194219
-2011-02-07T00:00:00.000Z	spot	entertainment	preferred	epreferred	112.924874
-2011-02-07T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	97.434318
-2011-02-07T00:00:00.000Z	spot	premium	preferred	ppreferred	102.705243
-2011-02-07T00:00:00.000Z	spot	travel	preferred	tpreferred	115.246714
-2011-02-07T00:00:00.000Z	total_market	premium	preferred	ppreferred	1057.079944
-2011-02-07T00:00:00.000Z	upfront	premium	preferred	ppreferred	872.625669
-2011-02-08T00:00:00.000Z	spot	business	preferred	bpreferred	93.190129
-2011-02-08T00:00:00.000Z	spot	health	preferred	hpreferred	97.432302
-2011-02-08T00:00:00.000Z	spot	news	preferred	npreferred	97.085047
-2011-02-08T00:00:00.000Z	spot	technology	preferred	tpreferred	75.735586
-2011-02-08T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1064.972638
-2011-02-08T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1188.369265
-2011-02-09T00:00:00.000Z	spot	automotive	preferred	apreferred	129.221792
-2011-02-09T00:00:00.000Z	spot	entertainment	preferred	epreferred	111.729360
-2011-02-09T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	96.478571
-2011-02-09T00:00:00.000Z	spot	premium	preferred	ppreferred	105.498315
-2011-02-09T00:00:00.000Z	spot	travel	preferred	tpreferred	112.646238
-2011-02-09T00:00:00.000Z	total_market	premium	preferred	ppreferred	1320.638308
-2011-02-09T00:00:00.000Z	upfront	premium	preferred	ppreferred	1299.093262
-2011-02-10T00:00:00.000Z	spot	business	preferred	bpreferred	118.062165
-2011-02-10T00:00:00.000Z	spot	health	preferred	hpreferred	97.235999
-2011-02-10T00:00:00.000Z	spot	news	preferred	npreferred	115.824976
-2011-02-10T00:00:00.000Z	spot	technology	preferred	tpreferred	91.750911
-2011-02-10T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1070.165582
-2011-02-10T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1212.928303
-2011-02-11T00:00:00.000Z	spot	automotive	preferred	apreferred	129.187009
-2011-02-11T00:00:00.000Z	spot	entertainment	preferred	epreferred	114.960877
-2011-02-11T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	100.111873
-2011-02-11T00:00:00.000Z	spot	premium	preferred	ppreferred	105.672256
-2011-02-11T00:00:00.000Z	spot	travel	preferred	tpreferred	102.864842
-2011-02-11T00:00:00.000Z	total_market	premium	preferred	ppreferred	1179.695901
-2011-02-11T00:00:00.000Z	upfront	premium	preferred	ppreferred	1061.973330
-2011-02-12T00:00:00.000Z	spot	business	preferred	bpreferred	115.758445
-2011-02-12T00:00:00.000Z	spot	health	preferred	hpreferred	96.457082
-2011-02-12T00:00:00.000Z	spot	news	preferred	npreferred	114.877503
-2011-02-12T00:00:00.000Z	spot	technology	preferred	tpreferred	88.142774
-2011-02-12T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	959.236186
-2011-02-12T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	602.979544
-2011-02-13T00:00:00.000Z	spot	automotive	preferred	apreferred	119.490316
-2011-02-13T00:00:00.000Z	spot	entertainment	preferred	epreferred	119.907266
-2011-02-13T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	100.905238
-2011-02-13T00:00:00.000Z	spot	premium	preferred	ppreferred	112.514409
-2011-02-13T00:00:00.000Z	spot	travel	preferred	tpreferred	106.033416
-2011-02-13T00:00:00.000Z	total_market	premium	preferred	ppreferred	1103.458199
-2011-02-13T00:00:00.000Z	upfront	premium	preferred	ppreferred	862.931321
-2011-02-14T00:00:00.000Z	spot	business	preferred	bpreferred	115.628202
-2011-02-14T00:00:00.000Z	spot	health	preferred	hpreferred	103.008650
-2011-02-14T00:00:00.000Z	spot	news	preferred	npreferred	117.110451
-2011-02-14T00:00:00.000Z	spot	technology	preferred	tpreferred	73.717033
-2011-02-14T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1091.223197
-2011-02-14T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1133.135123
-2011-02-15T00:00:00.000Z	spot	automotive	preferred	apreferred	123.485071
-2011-02-15T00:00:00.000Z	spot	entertainment	preferred	epreferred	121.563912
-2011-02-15T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	105.269599
-2011-02-15T00:00:00.000Z	spot	premium	preferred	ppreferred	121.411398
-2011-02-15T00:00:00.000Z	spot	travel	preferred	tpreferred	108.428302
-2011-02-15T00:00:00.000Z	total_market	premium	preferred	ppreferred	1183.240825
-2011-02-15T00:00:00.000Z	upfront	premium	preferred	ppreferred	914.525048
-2011-02-16T00:00:00.000Z	spot	business	preferred	bpreferred	116.432276
-2011-02-16T00:00:00.000Z	spot	health	preferred	hpreferred	105.762627
-2011-02-16T00:00:00.000Z	spot	news	preferred	npreferred	117.334381
-2011-02-16T00:00:00.000Z	spot	technology	preferred	tpreferred	98.918664
-2011-02-16T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1289.097304
-2011-02-16T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1553.348548
-2011-02-17T00:00:00.000Z	spot	automotive	preferred	apreferred	147.942017
-2011-02-17T00:00:00.000Z	spot	entertainment	preferred	epreferred	126.982673
-2011-02-17T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	103.940963
-2011-02-17T00:00:00.000Z	spot	premium	preferred	ppreferred	120.050545
-2011-02-17T00:00:00.000Z	spot	travel	preferred	tpreferred	112.150745
-2011-02-17T00:00:00.000Z	total_market	premium	preferred	ppreferred	1021.071173
-2011-02-17T00:00:00.000Z	upfront	premium	preferred	ppreferred	645.177645
-2011-02-18T00:00:00.000Z	spot	business	preferred	bpreferred	127.611947
-2011-02-18T00:00:00.000Z	spot	health	preferred	hpreferred	100.849247
-2011-02-18T00:00:00.000Z	spot	news	preferred	npreferred	124.513018
-2011-02-18T00:00:00.000Z	spot	technology	preferred	tpreferred	92.174432
-2011-02-18T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1105.383465
-2011-02-18T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1120.088751
-2011-02-19T00:00:00.000Z	spot	automotive	preferred	apreferred	163.351690
-2011-02-19T00:00:00.000Z	spot	entertainment	preferred	epreferred	133.726878
-2011-02-19T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	102.919452
-2011-02-19T00:00:00.000Z	spot	premium	preferred	ppreferred	125.052129
-2011-02-19T00:00:00.000Z	spot	travel	preferred	tpreferred	121.733400
-2011-02-19T00:00:00.000Z	total_market	premium	preferred	ppreferred	1600.723226
-2011-02-19T00:00:00.000Z	upfront	premium	preferred	ppreferred	1598.179271
-2011-02-20T00:00:00.000Z	spot	business	preferred	bpreferred	129.409606
-2011-02-20T00:00:00.000Z	spot	health	preferred	hpreferred	109.790712
-2011-02-20T00:00:00.000Z	spot	news	preferred	npreferred	122.082375
-2011-02-20T00:00:00.000Z	spot	technology	preferred	tpreferred	105.985049
-2011-02-20T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1317.458323
-2011-02-20T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1192.563067
-2011-02-21T00:00:00.000Z	spot	automotive	preferred	apreferred	155.632898
-2011-02-21T00:00:00.000Z	spot	entertainment	preferred	epreferred	193.787574
-2011-02-21T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	154.627912
-2011-02-21T00:00:00.000Z	spot	premium	preferred	ppreferred	138.092468
-2011-02-21T00:00:00.000Z	spot	travel	preferred	tpreferred	119.739112
-2011-02-21T00:00:00.000Z	total_market	premium	preferred	ppreferred	1488.737765
-2011-02-21T00:00:00.000Z	upfront	premium	preferred	ppreferred	1298.415763
-2011-02-22T00:00:00.000Z	spot	business	preferred	bpreferred	124.524992
-2011-02-22T00:00:00.000Z	spot	health	preferred	hpreferred	108.370907
-2011-02-22T00:00:00.000Z	spot	news	preferred	npreferred	122.510640
-2011-02-22T00:00:00.000Z	spot	technology	preferred	tpreferred	86.333235
-2011-02-22T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1224.827108
-2011-02-22T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1345.964309
-2011-02-23T00:00:00.000Z	spot	automotive	preferred	apreferred	165.273009
-2011-02-23T00:00:00.000Z	spot	entertainment	preferred	epreferred	145.588115
-2011-02-23T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	113.141185
-2011-02-23T00:00:00.000Z	spot	premium	preferred	ppreferred	124.305608
-2011-02-23T00:00:00.000Z	spot	travel	preferred	tpreferred	123.961542
-2011-02-23T00:00:00.000Z	total_market	premium	preferred	ppreferred	1414.619004
-2011-02-23T00:00:00.000Z	upfront	premium	preferred	ppreferred	1287.766687
-2011-02-24T00:00:00.000Z	spot	business	preferred	bpreferred	123.553981
-2011-02-24T00:00:00.000Z	spot	health	preferred	hpreferred	104.951315
-2011-02-24T00:00:00.000Z	spot	news	preferred	npreferred	118.862342
-2011-02-24T00:00:00.000Z	spot	technology	preferred	tpreferred	91.962584
-2011-02-24T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1350.175381
-2011-02-24T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1631.584352
-2011-02-25T00:00:00.000Z	spot	automotive	preferred	apreferred	172.335540
-2011-02-25T00:00:00.000Z	spot	entertainment	preferred	epreferred	140.941317
-2011-02-25T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	99.460461
-2011-02-25T00:00:00.000Z	spot	premium	preferred	ppreferred	115.932803
-2011-02-25T00:00:00.000Z	spot	travel	preferred	tpreferred	120.124862
-2011-02-25T00:00:00.000Z	total_market	premium	preferred	ppreferred	1073.967314
-2011-02-25T00:00:00.000Z	upfront	premium	preferred	ppreferred	782.013486
-2011-02-26T00:00:00.000Z	spot	business	preferred	bpreferred	103.643952
-2011-02-26T00:00:00.000Z	spot	health	preferred	hpreferred	103.667031
-2011-02-26T00:00:00.000Z	spot	news	preferred	npreferred	105.352891
-2011-02-26T00:00:00.000Z	spot	technology	preferred	tpreferred	83.099365
-2011-02-26T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	996.433708
-2011-02-26T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	829.916235
-2011-02-27T00:00:00.000Z	spot	automotive	preferred	apreferred	277.273533
-2011-02-27T00:00:00.000Z	spot	entertainment	preferred	epreferred	136.394846
-2011-02-27T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	103.226967
-2011-02-27T00:00:00.000Z	spot	premium	preferred	ppreferred	121.929932
-2011-02-27T00:00:00.000Z	spot	travel	preferred	tpreferred	136.163414
-2011-02-27T00:00:00.000Z	total_market	premium	preferred	ppreferred	1474.591017
-2011-02-27T00:00:00.000Z	upfront	premium	preferred	ppreferred	1427.016724
-2011-02-28T00:00:00.000Z	spot	business	preferred	bpreferred	97.218943
-2011-02-28T00:00:00.000Z	spot	health	preferred	hpreferred	112.528286
-2011-02-28T00:00:00.000Z	spot	news	preferred	npreferred	99.505465
-2011-02-28T00:00:00.000Z	spot	technology	preferred	tpreferred	72.163651
-2011-02-28T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1159.278766
-2011-02-28T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1430.257348
-2011-03-01T00:00:00.000Z	spot	automotive	preferred	apreferred	153.059937
-2011-03-01T00:00:00.000Z	spot	entertainment	preferred	epreferred	143.424672
-2011-03-01T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	105.453024
-2011-03-01T00:00:00.000Z	spot	premium	preferred	ppreferred	123.251814
-2011-03-01T00:00:00.000Z	spot	travel	preferred	tpreferred	116.975408
-2011-03-01T00:00:00.000Z	total_market	premium	preferred	ppreferred	1243.354010
-2011-03-01T00:00:00.000Z	upfront	premium	preferred	ppreferred	1004.940887
-2011-03-02T00:00:00.000Z	spot	business	preferred	bpreferred	98.432014
-2011-03-02T00:00:00.000Z	spot	health	preferred	hpreferred	112.968782
-2011-03-02T00:00:00.000Z	spot	news	preferred	npreferred	100.600391
-2011-03-02T00:00:00.000Z	spot	technology	preferred	tpreferred	82.823988
-2011-03-02T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1051.808940
-2011-03-02T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	740.183720
-2011-03-03T00:00:00.000Z	spot	automotive	preferred	apreferred	127.994476
-2011-03-03T00:00:00.000Z	spot	entertainment	preferred	epreferred	140.215411
-2011-03-03T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	108.784646
-2011-03-03T00:00:00.000Z	spot	premium	preferred	ppreferred	115.393493
-2011-03-03T00:00:00.000Z	spot	travel	preferred	tpreferred	114.188310
-2011-03-03T00:00:00.000Z	total_market	premium	preferred	ppreferred	1010.370296
-2011-03-03T00:00:00.000Z	upfront	premium	preferred	ppreferred	691.958920
-2011-03-04T00:00:00.000Z	spot	business	preferred	bpreferred	93.634505
-2011-03-04T00:00:00.000Z	spot	health	preferred	hpreferred	110.018472
-2011-03-04T00:00:00.000Z	spot	news	preferred	npreferred	97.535226
-2011-03-04T00:00:00.000Z	spot	technology	preferred	tpreferred	81.131208
-2011-03-04T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1326.829155
-2011-03-04T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1674.331703
-2011-03-05T00:00:00.000Z	spot	automotive	preferred	apreferred	136.941770
-2011-03-05T00:00:00.000Z	spot	entertainment	preferred	epreferred	145.393016
-2011-03-05T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	112.522435
-2011-03-05T00:00:00.000Z	spot	premium	preferred	ppreferred	114.691277
-2011-03-05T00:00:00.000Z	spot	travel	preferred	tpreferred	117.904527
-2011-03-05T00:00:00.000Z	total_market	premium	preferred	ppreferred	994.731237
-2011-03-05T00:00:00.000Z	upfront	premium	preferred	ppreferred	755.899363
-2011-03-06T00:00:00.000Z	spot	business	preferred	bpreferred	99.508679
-2011-03-06T00:00:00.000Z	spot	health	preferred	hpreferred	113.069662
-2011-03-06T00:00:00.000Z	spot	news	preferred	npreferred	102.536839
-2011-03-06T00:00:00.000Z	spot	technology	preferred	tpreferred	81.612269
-2011-03-06T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1081.650406
-2011-03-06T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	771.348460
-2011-03-07T00:00:00.000Z	spot	automotive	preferred	apreferred	111.909348
-2011-03-07T00:00:00.000Z	spot	entertainment	preferred	epreferred	150.452695
-2011-03-07T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	111.106693
-2011-03-07T00:00:00.000Z	spot	premium	preferred	ppreferred	121.582721
-2011-03-07T00:00:00.000Z	spot	travel	preferred	tpreferred	106.884238
-2011-03-07T00:00:00.000Z	total_market	premium	preferred	ppreferred	1152.547767
-2011-03-07T00:00:00.000Z	upfront	premium	preferred	ppreferred	906.373797
-2011-03-08T00:00:00.000Z	spot	business	preferred	bpreferred	98.972716
-2011-03-08T00:00:00.000Z	spot	health	preferred	hpreferred	119.777621
-2011-03-08T00:00:00.000Z	spot	news	preferred	npreferred	101.652185
-2011-03-08T00:00:00.000Z	spot	technology	preferred	tpreferred	70.866726
-2011-03-08T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1117.953961
-2011-03-08T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	988.893782
-2011-03-09T00:00:00.000Z	spot	automotive	preferred	apreferred	139.260950
-2011-03-09T00:00:00.000Z	spot	entertainment	preferred	epreferred	138.466933
-2011-03-09T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	105.613469
-2011-03-09T00:00:00.000Z	spot	premium	preferred	ppreferred	121.220772
-2011-03-09T00:00:00.000Z	spot	travel	preferred	tpreferred	107.998334
-2011-03-09T00:00:00.000Z	total_market	premium	preferred	ppreferred	1121.385333
-2011-03-09T00:00:00.000Z	upfront	premium	preferred	ppreferred	875.683406
-2011-03-10T00:00:00.000Z	spot	business	preferred	bpreferred	105.214709
-2011-03-10T00:00:00.000Z	spot	health	preferred	hpreferred	114.717338
-2011-03-10T00:00:00.000Z	spot	news	preferred	npreferred	107.127962
-2011-03-10T00:00:00.000Z	spot	technology	preferred	tpreferred	79.793836
-2011-03-10T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1244.849915
-2011-03-10T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1070.836247
-2011-03-11T00:00:00.000Z	spot	automotive	preferred	apreferred	135.820968
-2011-03-11T00:00:00.000Z	spot	entertainment	preferred	epreferred	135.038992
-2011-03-11T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	120.497687
-2011-03-11T00:00:00.000Z	spot	premium	preferred	ppreferred	118.298350
-2011-03-11T00:00:00.000Z	spot	travel	preferred	tpreferred	108.186877
-2011-03-11T00:00:00.000Z	total_market	premium	preferred	ppreferred	998.650727
-2011-03-11T00:00:00.000Z	upfront	premium	preferred	ppreferred	755.646538
-2011-03-12T00:00:00.000Z	spot	business	preferred	bpreferred	113.493460
-2011-03-12T00:00:00.000Z	spot	health	preferred	hpreferred	112.554597
-2011-03-12T00:00:00.000Z	spot	news	preferred	npreferred	115.572940
-2011-03-12T00:00:00.000Z	spot	technology	preferred	tpreferred	74.394926
-2011-03-12T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1088.807596
-2011-03-12T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	771.100508
-2011-03-13T00:00:00.000Z	spot	automotive	preferred	apreferred	149.637715
-2011-03-13T00:00:00.000Z	spot	entertainment	preferred	epreferred	120.113921
-2011-03-13T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	103.227522
-2011-03-13T00:00:00.000Z	spot	premium	preferred	ppreferred	120.620862
-2011-03-13T00:00:00.000Z	spot	travel	preferred	tpreferred	108.579283
-2011-03-13T00:00:00.000Z	total_market	premium	preferred	ppreferred	1129.723252
-2011-03-13T00:00:00.000Z	upfront	premium	preferred	ppreferred	884.837267
-2011-03-14T00:00:00.000Z	spot	business	preferred	bpreferred	109.461442
-2011-03-14T00:00:00.000Z	spot	health	preferred	hpreferred	120.487244
-2011-03-14T00:00:00.000Z	spot	news	preferred	npreferred	111.688901
-2011-03-14T00:00:00.000Z	spot	technology	preferred	tpreferred	59.021022
-2011-03-14T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1075.243024
-2011-03-14T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	918.722840
-2011-03-15T00:00:00.000Z	spot	automotive	preferred	apreferred	145.963558
-2011-03-15T00:00:00.000Z	spot	entertainment	preferred	epreferred	121.386341
-2011-03-15T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	103.583295
-2011-03-15T00:00:00.000Z	spot	premium	preferred	ppreferred	122.038585
-2011-03-15T00:00:00.000Z	spot	travel	preferred	tpreferred	103.134338
-2011-03-15T00:00:00.000Z	total_market	premium	preferred	ppreferred	1099.197263
-2011-03-15T00:00:00.000Z	upfront	premium	preferred	ppreferred	850.995007
-2011-03-16T00:00:00.000Z	spot	business	preferred	bpreferred	110.565004
-2011-03-16T00:00:00.000Z	spot	health	preferred	hpreferred	115.750963
-2011-03-16T00:00:00.000Z	spot	news	preferred	npreferred	112.577264
-2011-03-16T00:00:00.000Z	spot	technology	preferred	tpreferred	69.329723
-2011-03-16T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	981.577244
-2011-03-16T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	767.973326
-2011-03-17T00:00:00.000Z	spot	automotive	preferred	apreferred	148.905410
-2011-03-17T00:00:00.000Z	spot	entertainment	preferred	epreferred	109.666402
-2011-03-17T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	105.996125
-2011-03-17T00:00:00.000Z	spot	premium	preferred	ppreferred	122.740143
-2011-03-17T00:00:00.000Z	spot	travel	preferred	tpreferred	110.797348
-2011-03-17T00:00:00.000Z	total_market	premium	preferred	ppreferred	1154.415689
-2011-03-17T00:00:00.000Z	upfront	premium	preferred	ppreferred	906.101957
-2011-03-18T00:00:00.000Z	spot	business	preferred	bpreferred	110.037579
-2011-03-18T00:00:00.000Z	spot	health	preferred	hpreferred	113.490115
-2011-03-18T00:00:00.000Z	spot	news	preferred	npreferred	113.238556
-2011-03-18T00:00:00.000Z	spot	technology	preferred	tpreferred	68.573162
-2011-03-18T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1311.178603
-2011-03-18T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1403.830217
-2011-03-19T00:00:00.000Z	spot	automotive	preferred	apreferred	177.514270
-2011-03-19T00:00:00.000Z	spot	entertainment	preferred	epreferred	134.147573
-2011-03-19T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	112.999693
-2011-03-19T00:00:00.000Z	spot	premium	preferred	ppreferred	120.638001
-2011-03-19T00:00:00.000Z	spot	travel	preferred	tpreferred	115.384807
-2011-03-19T00:00:00.000Z	total_market	premium	preferred	ppreferred	1102.698977
-2011-03-19T00:00:00.000Z	upfront	premium	preferred	ppreferred	856.490089
-2011-03-20T00:00:00.000Z	spot	business	preferred	bpreferred	123.507497
-2011-03-20T00:00:00.000Z	spot	health	preferred	hpreferred	117.851058
-2011-03-20T00:00:00.000Z	spot	news	preferred	npreferred	125.496367
-2011-03-20T00:00:00.000Z	spot	technology	preferred	tpreferred	85.013155
-2011-03-20T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1285.090048
-2011-03-20T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1032.257527
-2011-03-21T00:00:00.000Z	spot	automotive	preferred	apreferred	182.035296
-2011-03-21T00:00:00.000Z	spot	entertainment	preferred	epreferred	157.153730
-2011-03-21T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	128.149976
-2011-03-21T00:00:00.000Z	spot	premium	preferred	ppreferred	131.807919
-2011-03-21T00:00:00.000Z	spot	travel	preferred	tpreferred	123.653645
-2011-03-21T00:00:00.000Z	total_market	premium	preferred	ppreferred	1178.830164
-2011-03-21T00:00:00.000Z	upfront	premium	preferred	ppreferred	907.021565
-2011-03-22T00:00:00.000Z	spot	business	preferred	bpreferred	121.270611
-2011-03-22T00:00:00.000Z	spot	health	preferred	hpreferred	124.400780
-2011-03-22T00:00:00.000Z	spot	news	preferred	npreferred	124.970533
-2011-03-22T00:00:00.000Z	spot	technology	preferred	tpreferred	79.948248
-2011-03-22T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1301.778098
-2011-03-22T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1110.788895
-2011-03-23T00:00:00.000Z	spot	automotive	preferred	apreferred	154.019632
-2011-03-23T00:00:00.000Z	spot	entertainment	preferred	epreferred	158.592715
-2011-03-23T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	126.672392
-2011-03-23T00:00:00.000Z	spot	premium	preferred	ppreferred	131.786598
-2011-03-23T00:00:00.000Z	spot	travel	preferred	tpreferred	123.754240
-2011-03-23T00:00:00.000Z	total_market	premium	preferred	ppreferred	1156.601892
-2011-03-23T00:00:00.000Z	upfront	premium	preferred	ppreferred	884.801502
-2011-03-24T00:00:00.000Z	spot	business	preferred	bpreferred	123.895027
-2011-03-24T00:00:00.000Z	spot	health	preferred	hpreferred	119.777998
-2011-03-24T00:00:00.000Z	spot	news	preferred	npreferred	125.044877
-2011-03-24T00:00:00.000Z	spot	technology	preferred	tpreferred	88.521042
-2011-03-24T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1429.580257
-2011-03-24T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1684.268799
-2011-03-25T00:00:00.000Z	spot	automotive	preferred	apreferred	140.577121
-2011-03-25T00:00:00.000Z	spot	entertainment	preferred	epreferred	157.432108
-2011-03-25T00:00:00.000Z	spot	mezzanine	preferred	mpreferred	114.706960
-2011-03-25T00:00:00.000Z	spot	premium	preferred	ppreferred	128.943094
-2011-03-25T00:00:00.000Z	spot	travel	preferred	tpreferred	136.136598
-2011-03-25T00:00:00.000Z	total_market	premium	preferred	ppreferred	1256.499779
-2011-03-25T00:00:00.000Z	upfront	premium	preferred	ppreferred	996.564152
-2011-03-26T00:00:00.000Z	spot	business	preferred	bpreferred	130.824022
-2011-03-26T00:00:00.000Z	spot	health	preferred	hpreferred	118.463523
-2011-03-26T00:00:00.000Z	spot	news	preferred	npreferred	142.972964
-2011-03-26T00:00:00.000Z	spot	technology	preferred	tpreferred	101.686196
-2011-03-26T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1217.877395
-2011-03-26T00:00:00.000Z	upfront	mezzanine	preferred	mpreferred	1061.678577
-2011-03-27T00:00:00.000Z	spot	automotive	preferred	apreferred	144.056669
-2011-03-27T00:00:00.000Z	spot	entertainment	preferred	epreferred	163.161361
+2011-01-12T00:00:00.000Z	default	spot	automotive	preferred	apreferred	100.000000
+2011-01-12T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	100.000000
+2011-01-12T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	100.000000
+2011-01-12T00:00:00.000Z	default	spot	premium	preferred	ppreferred	100.000000
+2011-01-12T00:00:00.000Z	default	spot	travel	preferred	tpreferred	100.000000
+2011-01-12T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1000.000000
+2011-01-12T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	800.000000
+2011-01-13T00:00:00.000Z	default	spot	business	preferred	bpreferred	103.629399
+2011-01-13T00:00:00.000Z	default	spot	health	preferred	hpreferred	114.947403
+2011-01-13T00:00:00.000Z	default	spot	news	preferred	npreferred	102.851683
+2011-01-13T00:00:00.000Z	default	spot	technology	preferred	tpreferred	111.356672
+2011-01-13T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1040.945505
+2011-01-13T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	826.060182
+2011-01-14T00:00:00.000Z	default	spot	automotive	preferred	apreferred	86.450372
+2011-01-14T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	109.573474
+2011-01-14T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	97.903068
+2011-01-14T00:00:00.000Z	default	spot	premium	preferred	ppreferred	104.611784
+2011-01-14T00:00:00.000Z	default	spot	travel	preferred	tpreferred	112.259958
+2011-01-14T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1073.476545
+2011-01-14T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	869.643722
+2011-01-15T00:00:00.000Z	default	spot	business	preferred	bpreferred	99.781645
+2011-01-15T00:00:00.000Z	default	spot	health	preferred	hpreferred	87.954346
+2011-01-15T00:00:00.000Z	default	spot	news	preferred	npreferred	99.383407
+2011-01-15T00:00:00.000Z	default	spot	technology	preferred	tpreferred	111.680229
+2011-01-15T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1007.365510
+2011-01-15T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	809.041763
+2011-01-16T00:00:00.000Z	default	spot	automotive	preferred	apreferred	71.315931
+2011-01-16T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	99.007588
+2011-01-16T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	99.863171
+2011-01-16T00:00:00.000Z	default	spot	premium	preferred	ppreferred	103.348007
+2011-01-16T00:00:00.000Z	default	spot	travel	preferred	tpreferred	116.779610
+2011-01-16T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1077.612663
+2011-01-16T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	879.988099
+2011-01-17T00:00:00.000Z	default	spot	business	preferred	bpreferred	105.914315
+2011-01-17T00:00:00.000Z	default	spot	health	preferred	hpreferred	110.157325
+2011-01-17T00:00:00.000Z	default	spot	news	preferred	npreferred	103.615039
+2011-01-17T00:00:00.000Z	default	spot	technology	preferred	tpreferred	89.901887
+2011-01-17T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1075.089574
+2011-01-17T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	950.146770
+2011-01-18T00:00:00.000Z	default	spot	automotive	preferred	apreferred	87.195139
+2011-01-18T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	94.452739
+2011-01-18T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	101.087367
+2011-01-18T00:00:00.000Z	default	spot	premium	preferred	ppreferred	108.979936
+2011-01-18T00:00:00.000Z	default	spot	travel	preferred	tpreferred	113.680094
+2011-01-18T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	937.061939
+2011-01-18T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	682.885525
+2011-01-19T00:00:00.000Z	default	spot	business	preferred	bpreferred	106.700550
+2011-01-19T00:00:00.000Z	default	spot	health	preferred	hpreferred	97.620315
+2011-01-19T00:00:00.000Z	default	spot	news	preferred	npreferred	106.127830
+2011-01-19T00:00:00.000Z	default	spot	technology	preferred	tpreferred	77.316731
+2011-01-19T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1156.744712
+2011-01-19T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1109.874950
+2011-01-20T01:00:00.000Z	default	spot	automotive	preferred	apreferred	93.396274
+2011-01-20T01:00:00.000Z	default	spot	entertainment	preferred	epreferred	90.439020
+2011-01-20T01:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	105.669498
+2011-01-20T01:00:00.000Z	default	spot	premium	preferred	ppreferred	101.305541
+2011-01-20T01:00:00.000Z	default	spot	travel	preferred	tpreferred	140.179069
+2011-01-20T01:00:00.000Z	default	total_market	premium	preferred	ppreferred	904.340636
+2011-01-20T01:00:00.000Z	default	upfront	premium	preferred	ppreferred	677.510973
+2011-01-22T00:00:00.000Z	default	spot	automotive	preferred	apreferred	95.235266
+2011-01-22T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	93.681096
+2011-01-22T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	104.184494
+2011-01-22T00:00:00.000Z	default	spot	premium	preferred	ppreferred	99.284525
+2011-01-22T00:00:00.000Z	default	spot	travel	preferred	tpreferred	137.109783
+2011-01-22T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1343.232494
+2011-01-22T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1219.432170
+2011-01-23T00:00:00.000Z	default	spot	business	preferred	bpreferred	107.348157
+2011-01-23T00:00:00.000Z	default	spot	health	preferred	hpreferred	96.826443
+2011-01-23T00:00:00.000Z	default	spot	news	preferred	npreferred	106.418686
+2011-01-23T00:00:00.000Z	default	spot	technology	preferred	tpreferred	110.467875
+2011-01-23T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1088.943083
+2011-01-23T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	979.306038
+2011-01-24T00:00:00.000Z	default	spot	automotive	preferred	apreferred	96.671647
+2011-01-24T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	88.748460
+2011-01-24T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	97.906256
+2011-01-24T00:00:00.000Z	default	spot	premium	preferred	ppreferred	101.581339
+2011-01-24T00:00:00.000Z	default	spot	travel	preferred	tpreferred	131.695956
+2011-01-24T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	939.244103
+2011-01-24T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	716.609179
+2011-01-25T00:00:00.000Z	default	spot	business	preferred	bpreferred	101.624789
+2011-01-25T00:00:00.000Z	default	spot	health	preferred	hpreferred	180.575246
+2011-01-25T00:00:00.000Z	default	spot	news	preferred	npreferred	102.907866
+2011-01-25T00:00:00.000Z	default	spot	technology	preferred	tpreferred	102.044542
+2011-01-25T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1109.875413
+2011-01-25T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1301.023342
+2011-01-26T00:00:00.000Z	default	spot	automotive	preferred	apreferred	84.906466
+2011-01-26T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	84.710523
+2011-01-26T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	96.046584
+2011-01-26T00:00:00.000Z	default	spot	premium	preferred	ppreferred	101.088903
+2011-01-26T00:00:00.000Z	default	spot	travel	preferred	tpreferred	122.160681
+2011-01-26T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1686.419659
+2011-01-26T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1609.096706
+2011-01-27T00:00:00.000Z	default	spot	business	preferred	bpreferred	104.882908
+2011-01-27T00:00:00.000Z	default	spot	health	preferred	hpreferred	170.735853
+2011-01-27T00:00:00.000Z	default	spot	news	preferred	npreferred	104.609483
+2011-01-27T00:00:00.000Z	default	spot	technology	preferred	tpreferred	116.979005
+2011-01-27T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1074.006938
+2011-01-27T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1023.295213
+2011-01-28T00:00:00.000Z	default	spot	automotive	preferred	apreferred	123.006128
+2011-01-28T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	99.681629
+2011-01-28T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	106.075672
+2011-01-28T00:00:00.000Z	default	spot	premium	preferred	ppreferred	103.822842
+2011-01-28T00:00:00.000Z	default	spot	travel	preferred	tpreferred	158.739359
+2011-01-28T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1021.334487
+2011-01-28T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	810.889422
+2011-01-29T00:00:00.000Z	default	spot	business	preferred	bpreferred	100.992147
+2011-01-29T00:00:00.000Z	default	spot	health	preferred	hpreferred	114.905745
+2011-01-29T00:00:00.000Z	default	spot	news	preferred	npreferred	101.998823
+2011-01-29T00:00:00.000Z	default	spot	technology	preferred	tpreferred	109.549035
+2011-01-29T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1314.619452
+2011-01-29T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1685.500085
+2011-01-30T00:00:00.000Z	default	spot	automotive	preferred	apreferred	124.943293
+2011-01-30T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	108.415967
+2011-01-30T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	97.023907
+2011-01-30T00:00:00.000Z	default	spot	premium	preferred	ppreferred	104.298490
+2011-01-30T00:00:00.000Z	default	spot	travel	preferred	tpreferred	137.932693
+2011-01-30T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	805.930143
+2011-01-30T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	555.476028
+2011-01-31T00:00:00.000Z	default	spot	business	preferred	bpreferred	103.492964
+2011-01-31T00:00:00.000Z	default	spot	health	preferred	hpreferred	124.171944
+2011-01-31T00:00:00.000Z	default	spot	news	preferred	npreferred	103.832040
+2011-01-31T00:00:00.000Z	default	spot	technology	preferred	tpreferred	85.125795
+2011-01-31T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1184.920651
+2011-01-31T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1643.340851
+2011-02-01T00:00:00.000Z	default	spot	automotive	preferred	apreferred	132.123776
+2011-02-01T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	103.652865
+2011-02-01T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	98.909356
+2011-02-01T00:00:00.000Z	default	spot	premium	preferred	ppreferred	102.480377
+2011-02-01T00:00:00.000Z	default	spot	travel	preferred	tpreferred	134.014606
+2011-02-01T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1100.904846
+2011-02-01T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	913.561076
+2011-02-02T00:00:00.000Z	default	spot	business	preferred	bpreferred	104.963233
+2011-02-02T00:00:00.000Z	default	spot	health	preferred	hpreferred	102.281859
+2011-02-02T00:00:00.000Z	default	spot	news	preferred	npreferred	105.578807
+2011-02-02T00:00:00.000Z	default	spot	technology	preferred	tpreferred	96.706279
+2011-02-02T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1097.211164
+2011-02-02T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1218.561908
+2011-02-03T00:00:00.000Z	default	spot	automotive	preferred	apreferred	85.770241
+2011-02-03T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	106.425780
+2011-02-03T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	100.559287
+2011-02-03T00:00:00.000Z	default	spot	premium	preferred	ppreferred	102.349315
+2011-02-03T00:00:00.000Z	default	spot	travel	preferred	tpreferred	134.140377
+2011-02-03T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1283.166055
+2011-02-03T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1113.114125
+2011-02-04T00:00:00.000Z	default	spot	business	preferred	bpreferred	106.888769
+2011-02-04T00:00:00.000Z	default	spot	health	preferred	hpreferred	99.837572
+2011-02-04T00:00:00.000Z	default	spot	news	preferred	npreferred	106.050728
+2011-02-04T00:00:00.000Z	default	spot	technology	preferred	tpreferred	93.973465
+2011-02-04T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1025.633340
+2011-02-04T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	864.568891
+2011-02-05T00:00:00.000Z	default	spot	automotive	preferred	apreferred	93.001571
+2011-02-05T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	117.030289
+2011-02-05T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	105.660538
+2011-02-05T00:00:00.000Z	default	spot	premium	preferred	ppreferred	100.646747
+2011-02-05T00:00:00.000Z	default	spot	travel	preferred	tpreferred	114.723682
+2011-02-05T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1332.468373
+2011-02-05T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1363.614929
+2011-02-06T00:00:00.000Z	default	spot	business	preferred	bpreferred	110.897359
+2011-02-06T00:00:00.000Z	default	spot	health	preferred	hpreferred	93.585758
+2011-02-06T00:00:00.000Z	default	spot	news	preferred	npreferred	110.053071
+2011-02-06T00:00:00.000Z	default	spot	technology	preferred	tpreferred	93.620739
+2011-02-06T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1011.205470
+2011-02-06T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	787.125330
+2011-02-07T00:00:00.000Z	default	spot	automotive	preferred	apreferred	130.194219
+2011-02-07T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	112.924874
+2011-02-07T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	97.434318
+2011-02-07T00:00:00.000Z	default	spot	premium	preferred	ppreferred	102.705243
+2011-02-07T00:00:00.000Z	default	spot	travel	preferred	tpreferred	115.246714
+2011-02-07T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1057.079944
+2011-02-07T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	872.625669
+2011-02-08T00:00:00.000Z	default	spot	business	preferred	bpreferred	93.190129
+2011-02-08T00:00:00.000Z	default	spot	health	preferred	hpreferred	97.432302
+2011-02-08T00:00:00.000Z	default	spot	news	preferred	npreferred	97.085047
+2011-02-08T00:00:00.000Z	default	spot	technology	preferred	tpreferred	75.735586
+2011-02-08T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1064.972638
+2011-02-08T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1188.369265
+2011-02-09T00:00:00.000Z	default	spot	automotive	preferred	apreferred	129.221792
+2011-02-09T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	111.729360
+2011-02-09T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	96.478571
+2011-02-09T00:00:00.000Z	default	spot	premium	preferred	ppreferred	105.498315
+2011-02-09T00:00:00.000Z	default	spot	travel	preferred	tpreferred	112.646238
+2011-02-09T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1320.638308
+2011-02-09T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1299.093262
+2011-02-10T00:00:00.000Z	default	spot	business	preferred	bpreferred	118.062165
+2011-02-10T00:00:00.000Z	default	spot	health	preferred	hpreferred	97.235999
+2011-02-10T00:00:00.000Z	default	spot	news	preferred	npreferred	115.824976
+2011-02-10T00:00:00.000Z	default	spot	technology	preferred	tpreferred	91.750911
+2011-02-10T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1070.165582
+2011-02-10T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1212.928303
+2011-02-11T00:00:00.000Z	default	spot	automotive	preferred	apreferred	129.187009
+2011-02-11T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	114.960877
+2011-02-11T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	100.111873
+2011-02-11T00:00:00.000Z	default	spot	premium	preferred	ppreferred	105.672256
+2011-02-11T00:00:00.000Z	default	spot	travel	preferred	tpreferred	102.864842
+2011-02-11T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1179.695901
+2011-02-11T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1061.973330
+2011-02-12T00:00:00.000Z	default	spot	business	preferred	bpreferred	115.758445
+2011-02-12T00:00:00.000Z	default	spot	health	preferred	hpreferred	96.457082
+2011-02-12T00:00:00.000Z	default	spot	news	preferred	npreferred	114.877503
+2011-02-12T00:00:00.000Z	default	spot	technology	preferred	tpreferred	88.142774
+2011-02-12T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	959.236186
+2011-02-12T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	602.979544
+2011-02-13T00:00:00.000Z	default	spot	automotive	preferred	apreferred	119.490316
+2011-02-13T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	119.907266
+2011-02-13T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	100.905238
+2011-02-13T00:00:00.000Z	default	spot	premium	preferred	ppreferred	112.514409
+2011-02-13T00:00:00.000Z	default	spot	travel	preferred	tpreferred	106.033416
+2011-02-13T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1103.458199
+2011-02-13T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	862.931321
+2011-02-14T00:00:00.000Z	default	spot	business	preferred	bpreferred	115.628202
+2011-02-14T00:00:00.000Z	default	spot	health	preferred	hpreferred	103.008650
+2011-02-14T00:00:00.000Z	default	spot	news	preferred	npreferred	117.110451
+2011-02-14T00:00:00.000Z	default	spot	technology	preferred	tpreferred	73.717033
+2011-02-14T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1091.223197
+2011-02-14T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1133.135123
+2011-02-15T00:00:00.000Z	default	spot	automotive	preferred	apreferred	123.485071
+2011-02-15T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	121.563912
+2011-02-15T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	105.269599
+2011-02-15T00:00:00.000Z	default	spot	premium	preferred	ppreferred	121.411398
+2011-02-15T00:00:00.000Z	default	spot	travel	preferred	tpreferred	108.428302
+2011-02-15T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1183.240825
+2011-02-15T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	914.525048
+2011-02-16T00:00:00.000Z	default	spot	business	preferred	bpreferred	116.432276
+2011-02-16T00:00:00.000Z	default	spot	health	preferred	hpreferred	105.762627
+2011-02-16T00:00:00.000Z	default	spot	news	preferred	npreferred	117.334381
+2011-02-16T00:00:00.000Z	default	spot	technology	preferred	tpreferred	98.918664
+2011-02-16T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1289.097304
+2011-02-16T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1553.348548
+2011-02-17T00:00:00.000Z	default	spot	automotive	preferred	apreferred	147.942017
+2011-02-17T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	126.982673
+2011-02-17T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	103.940963
+2011-02-17T00:00:00.000Z	default	spot	premium	preferred	ppreferred	120.050545
+2011-02-17T00:00:00.000Z	default	spot	travel	preferred	tpreferred	112.150745
+2011-02-17T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1021.071173
+2011-02-17T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	645.177645
+2011-02-18T00:00:00.000Z	default	spot	business	preferred	bpreferred	127.611947
+2011-02-18T00:00:00.000Z	default	spot	health	preferred	hpreferred	100.849247
+2011-02-18T00:00:00.000Z	default	spot	news	preferred	npreferred	124.513018
+2011-02-18T00:00:00.000Z	default	spot	technology	preferred	tpreferred	92.174432
+2011-02-18T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1105.383465
+2011-02-18T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1120.088751
+2011-02-19T00:00:00.000Z	default	spot	automotive	preferred	apreferred	163.351690
+2011-02-19T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	133.726878
+2011-02-19T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	102.919452
+2011-02-19T00:00:00.000Z	default	spot	premium	preferred	ppreferred	125.052129
+2011-02-19T00:00:00.000Z	default	spot	travel	preferred	tpreferred	121.733400
+2011-02-19T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1600.723226
+2011-02-19T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1598.179271
+2011-02-20T00:00:00.000Z	default	spot	business	preferred	bpreferred	129.409606
+2011-02-20T00:00:00.000Z	default	spot	health	preferred	hpreferred	109.790712
+2011-02-20T00:00:00.000Z	default	spot	news	preferred	npreferred	122.082375
+2011-02-20T00:00:00.000Z	default	spot	technology	preferred	tpreferred	105.985049
+2011-02-20T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1317.458323
+2011-02-20T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1192.563067
+2011-02-21T00:00:00.000Z	default	spot	automotive	preferred	apreferred	155.632898
+2011-02-21T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	193.787574
+2011-02-21T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	154.627912
+2011-02-21T00:00:00.000Z	default	spot	premium	preferred	ppreferred	138.092468
+2011-02-21T00:00:00.000Z	default	spot	travel	preferred	tpreferred	119.739112
+2011-02-21T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1488.737765
+2011-02-21T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1298.415763
+2011-02-22T00:00:00.000Z	default	spot	business	preferred	bpreferred	124.524992
+2011-02-22T00:00:00.000Z	default	spot	health	preferred	hpreferred	108.370907
+2011-02-22T00:00:00.000Z	default	spot	news	preferred	npreferred	122.510640
+2011-02-22T00:00:00.000Z	default	spot	technology	preferred	tpreferred	86.333235
+2011-02-22T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1224.827108
+2011-02-22T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1345.964309
+2011-02-23T00:00:00.000Z	default	spot	automotive	preferred	apreferred	165.273009
+2011-02-23T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	145.588115
+2011-02-23T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	113.141185
+2011-02-23T00:00:00.000Z	default	spot	premium	preferred	ppreferred	124.305608
+2011-02-23T00:00:00.000Z	default	spot	travel	preferred	tpreferred	123.961542
+2011-02-23T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1414.619004
+2011-02-23T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1287.766687
+2011-02-24T00:00:00.000Z	default	spot	business	preferred	bpreferred	123.553981
+2011-02-24T00:00:00.000Z	default	spot	health	preferred	hpreferred	104.951315
+2011-02-24T00:00:00.000Z	default	spot	news	preferred	npreferred	118.862342
+2011-02-24T00:00:00.000Z	default	spot	technology	preferred	tpreferred	91.962584
+2011-02-24T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1350.175381
+2011-02-24T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1631.584352
+2011-02-25T00:00:00.000Z	default	spot	automotive	preferred	apreferred	172.335540
+2011-02-25T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	140.941317
+2011-02-25T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	99.460461
+2011-02-25T00:00:00.000Z	default	spot	premium	preferred	ppreferred	115.932803
+2011-02-25T00:00:00.000Z	default	spot	travel	preferred	tpreferred	120.124862
+2011-02-25T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1073.967314
+2011-02-25T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	782.013486
+2011-02-26T00:00:00.000Z	default	spot	business	preferred	bpreferred	103.643952
+2011-02-26T00:00:00.000Z	default	spot	health	preferred	hpreferred	103.667031
+2011-02-26T00:00:00.000Z	default	spot	news	preferred	npreferred	105.352891
+2011-02-26T00:00:00.000Z	default	spot	technology	preferred	tpreferred	83.099365
+2011-02-26T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	996.433708
+2011-02-26T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	829.916235
+2011-02-27T00:00:00.000Z	default	spot	automotive	preferred	apreferred	277.273533
+2011-02-27T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	136.394846
+2011-02-27T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	103.226967
+2011-02-27T00:00:00.000Z	default	spot	premium	preferred	ppreferred	121.929932
+2011-02-27T00:00:00.000Z	default	spot	travel	preferred	tpreferred	136.163414
+2011-02-27T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1474.591017
+2011-02-27T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1427.016724
+2011-02-28T00:00:00.000Z	default	spot	business	preferred	bpreferred	97.218943
+2011-02-28T00:00:00.000Z	default	spot	health	preferred	hpreferred	112.528286
+2011-02-28T00:00:00.000Z	default	spot	news	preferred	npreferred	99.505465
+2011-02-28T00:00:00.000Z	default	spot	technology	preferred	tpreferred	72.163651
+2011-02-28T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1159.278766
+2011-02-28T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1430.257348
+2011-03-01T00:00:00.000Z	default	spot	automotive	preferred	apreferred	153.059937
+2011-03-01T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	143.424672
+2011-03-01T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	105.453024
+2011-03-01T00:00:00.000Z	default	spot	premium	preferred	ppreferred	123.251814
+2011-03-01T00:00:00.000Z	default	spot	travel	preferred	tpreferred	116.975408
+2011-03-01T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1243.354010
+2011-03-01T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	1004.940887
+2011-03-02T00:00:00.000Z	default	spot	business	preferred	bpreferred	98.432014
+2011-03-02T00:00:00.000Z	default	spot	health	preferred	hpreferred	112.968782
+2011-03-02T00:00:00.000Z	default	spot	news	preferred	npreferred	100.600391
+2011-03-02T00:00:00.000Z	default	spot	technology	preferred	tpreferred	82.823988
+2011-03-02T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1051.808940
+2011-03-02T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	740.183720
+2011-03-03T00:00:00.000Z	default	spot	automotive	preferred	apreferred	127.994476
+2011-03-03T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	140.215411
+2011-03-03T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	108.784646
+2011-03-03T00:00:00.000Z	default	spot	premium	preferred	ppreferred	115.393493
+2011-03-03T00:00:00.000Z	default	spot	travel	preferred	tpreferred	114.188310
+2011-03-03T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1010.370296
+2011-03-03T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	691.958920
+2011-03-04T00:00:00.000Z	default	spot	business	preferred	bpreferred	93.634505
+2011-03-04T00:00:00.000Z	default	spot	health	preferred	hpreferred	110.018472
+2011-03-04T00:00:00.000Z	default	spot	news	preferred	npreferred	97.535226
+2011-03-04T00:00:00.000Z	default	spot	technology	preferred	tpreferred	81.131208
+2011-03-04T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1326.829155
+2011-03-04T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1674.331703
+2011-03-05T00:00:00.000Z	default	spot	automotive	preferred	apreferred	136.941770
+2011-03-05T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	145.393016
+2011-03-05T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	112.522435
+2011-03-05T00:00:00.000Z	default	spot	premium	preferred	ppreferred	114.691277
+2011-03-05T00:00:00.000Z	default	spot	travel	preferred	tpreferred	117.904527
+2011-03-05T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	994.731237
+2011-03-05T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	755.899363
+2011-03-06T00:00:00.000Z	default	spot	business	preferred	bpreferred	99.508679
+2011-03-06T00:00:00.000Z	default	spot	health	preferred	hpreferred	113.069662
+2011-03-06T00:00:00.000Z	default	spot	news	preferred	npreferred	102.536839
+2011-03-06T00:00:00.000Z	default	spot	technology	preferred	tpreferred	81.612269
+2011-03-06T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1081.650406
+2011-03-06T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	771.348460
+2011-03-07T00:00:00.000Z	default	spot	automotive	preferred	apreferred	111.909348
+2011-03-07T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	150.452695
+2011-03-07T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	111.106693
+2011-03-07T00:00:00.000Z	default	spot	premium	preferred	ppreferred	121.582721
+2011-03-07T00:00:00.000Z	default	spot	travel	preferred	tpreferred	106.884238
+2011-03-07T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1152.547767
+2011-03-07T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	906.373797
+2011-03-08T00:00:00.000Z	default	spot	business	preferred	bpreferred	98.972716
+2011-03-08T00:00:00.000Z	default	spot	health	preferred	hpreferred	119.777621
+2011-03-08T00:00:00.000Z	default	spot	news	preferred	npreferred	101.652185
+2011-03-08T00:00:00.000Z	default	spot	technology	preferred	tpreferred	70.866726
+2011-03-08T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1117.953961
+2011-03-08T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	988.893782
+2011-03-09T00:00:00.000Z	default	spot	automotive	preferred	apreferred	139.260950
+2011-03-09T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	138.466933
+2011-03-09T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	105.613469
+2011-03-09T00:00:00.000Z	default	spot	premium	preferred	ppreferred	121.220772
+2011-03-09T00:00:00.000Z	default	spot	travel	preferred	tpreferred	107.998334
+2011-03-09T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1121.385333
+2011-03-09T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	875.683406
+2011-03-10T00:00:00.000Z	default	spot	business	preferred	bpreferred	105.214709
+2011-03-10T00:00:00.000Z	default	spot	health	preferred	hpreferred	114.717338
+2011-03-10T00:00:00.000Z	default	spot	news	preferred	npreferred	107.127962
+2011-03-10T00:00:00.000Z	default	spot	technology	preferred	tpreferred	79.793836
+2011-03-10T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1244.849915
+2011-03-10T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1070.836247
+2011-03-11T00:00:00.000Z	default	spot	automotive	preferred	apreferred	135.820968
+2011-03-11T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	135.038992
+2011-03-11T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	120.497687
+2011-03-11T00:00:00.000Z	default	spot	premium	preferred	ppreferred	118.298350
+2011-03-11T00:00:00.000Z	default	spot	travel	preferred	tpreferred	108.186877
+2011-03-11T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	998.650727
+2011-03-11T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	755.646538
+2011-03-12T00:00:00.000Z	default	spot	business	preferred	bpreferred	113.493460
+2011-03-12T00:00:00.000Z	default	spot	health	preferred	hpreferred	112.554597
+2011-03-12T00:00:00.000Z	default	spot	news	preferred	npreferred	115.572940
+2011-03-12T00:00:00.000Z	default	spot	technology	preferred	tpreferred	74.394926
+2011-03-12T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1088.807596
+2011-03-12T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	771.100508
+2011-03-13T00:00:00.000Z	default	spot	automotive	preferred	apreferred	149.637715
+2011-03-13T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	120.113921
+2011-03-13T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	103.227522
+2011-03-13T00:00:00.000Z	default	spot	premium	preferred	ppreferred	120.620862
+2011-03-13T00:00:00.000Z	default	spot	travel	preferred	tpreferred	108.579283
+2011-03-13T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1129.723252
+2011-03-13T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	884.837267
+2011-03-14T00:00:00.000Z	default	spot	business	preferred	bpreferred	109.461442
+2011-03-14T00:00:00.000Z	default	spot	health	preferred	hpreferred	120.487244
+2011-03-14T00:00:00.000Z	default	spot	news	preferred	npreferred	111.688901
+2011-03-14T00:00:00.000Z	default	spot	technology	preferred	tpreferred	59.021022
+2011-03-14T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1075.243024
+2011-03-14T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	918.722840
+2011-03-15T00:00:00.000Z	default	spot	automotive	preferred	apreferred	145.963558
+2011-03-15T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	121.386341
+2011-03-15T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	103.583295
+2011-03-15T00:00:00.000Z	default	spot	premium	preferred	ppreferred	122.038585
+2011-03-15T00:00:00.000Z	default	spot	travel	preferred	tpreferred	103.134338
+2011-03-15T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1099.197263
+2011-03-15T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	850.995007
+2011-03-16T00:00:00.000Z	default	spot	business	preferred	bpreferred	110.565004
+2011-03-16T00:00:00.000Z	default	spot	health	preferred	hpreferred	115.750963
+2011-03-16T00:00:00.000Z	default	spot	news	preferred	npreferred	112.577264
+2011-03-16T00:00:00.000Z	default	spot	technology	preferred	tpreferred	69.329723
+2011-03-16T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	981.577244
+2011-03-16T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	767.973326
+2011-03-17T00:00:00.000Z	default	spot	automotive	preferred	apreferred	148.905410
+2011-03-17T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	109.666402
+2011-03-17T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	105.996125
+2011-03-17T00:00:00.000Z	default	spot	premium	preferred	ppreferred	122.740143
+2011-03-17T00:00:00.000Z	default	spot	travel	preferred	tpreferred	110.797348
+2011-03-17T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1154.415689
+2011-03-17T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	906.101957
+2011-03-18T00:00:00.000Z	default	spot	business	preferred	bpreferred	110.037579
+2011-03-18T00:00:00.000Z	default	spot	health	preferred	hpreferred	113.490115
+2011-03-18T00:00:00.000Z	default	spot	news	preferred	npreferred	113.238556
+2011-03-18T00:00:00.000Z	default	spot	technology	preferred	tpreferred	68.573162
+2011-03-18T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1311.178603
+2011-03-18T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1403.830217
+2011-03-19T00:00:00.000Z	default	spot	automotive	preferred	apreferred	177.514270
+2011-03-19T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	134.147573
+2011-03-19T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	112.999693
+2011-03-19T00:00:00.000Z	default	spot	premium	preferred	ppreferred	120.638001
+2011-03-19T00:00:00.000Z	default	spot	travel	preferred	tpreferred	115.384807
+2011-03-19T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1102.698977
+2011-03-19T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	856.490089
+2011-03-20T00:00:00.000Z	default	spot	business	preferred	bpreferred	123.507497
+2011-03-20T00:00:00.000Z	default	spot	health	preferred	hpreferred	117.851058
+2011-03-20T00:00:00.000Z	default	spot	news	preferred	npreferred	125.496367
+2011-03-20T00:00:00.000Z	default	spot	technology	preferred	tpreferred	85.013155
+2011-03-20T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1285.090048
+2011-03-20T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1032.257527
+2011-03-21T00:00:00.000Z	default	spot	automotive	preferred	apreferred	182.035296
+2011-03-21T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	157.153730
+2011-03-21T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	128.149976
+2011-03-21T00:00:00.000Z	default	spot	premium	preferred	ppreferred	131.807919
+2011-03-21T00:00:00.000Z	default	spot	travel	preferred	tpreferred	123.653645
+2011-03-21T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1178.830164
+2011-03-21T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	907.021565
+2011-03-22T00:00:00.000Z	default	spot	business	preferred	bpreferred	121.270611
+2011-03-22T00:00:00.000Z	default	spot	health	preferred	hpreferred	124.400780
+2011-03-22T00:00:00.000Z	default	spot	news	preferred	npreferred	124.970533
+2011-03-22T00:00:00.000Z	default	spot	technology	preferred	tpreferred	79.948248
+2011-03-22T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1301.778098
+2011-03-22T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1110.788895
+2011-03-23T00:00:00.000Z	default	spot	automotive	preferred	apreferred	154.019632
+2011-03-23T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	158.592715
+2011-03-23T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	126.672392
+2011-03-23T00:00:00.000Z	default	spot	premium	preferred	ppreferred	131.786598
+2011-03-23T00:00:00.000Z	default	spot	travel	preferred	tpreferred	123.754240
+2011-03-23T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1156.601892
+2011-03-23T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	884.801502
+2011-03-24T00:00:00.000Z	default	spot	business	preferred	bpreferred	123.895027
+2011-03-24T00:00:00.000Z	default	spot	health	preferred	hpreferred	119.777998
+2011-03-24T00:00:00.000Z	default	spot	news	preferred	npreferred	125.044877
+2011-03-24T00:00:00.000Z	default	spot	technology	preferred	tpreferred	88.521042
+2011-03-24T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1429.580257
+2011-03-24T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1684.268799
+2011-03-25T00:00:00.000Z	default	spot	automotive	preferred	apreferred	140.577121
+2011-03-25T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	157.432108
+2011-03-25T00:00:00.000Z	default	spot	mezzanine	preferred	mpreferred	114.706960
+2011-03-25T00:00:00.000Z	default	spot	premium	preferred	ppreferred	128.943094
+2011-03-25T00:00:00.000Z	default	spot	travel	preferred	tpreferred	136.136598
+2011-03-25T00:00:00.000Z	default	total_market	premium	preferred	ppreferred	1256.499779
+2011-03-25T00:00:00.000Z	default	upfront	premium	preferred	ppreferred	996.564152
+2011-03-26T00:00:00.000Z	default	spot	business	preferred	bpreferred	130.824022
+2011-03-26T00:00:00.000Z	default	spot	health	preferred	hpreferred	118.463523
+2011-03-26T00:00:00.000Z	default	spot	news	preferred	npreferred	142.972964
+2011-03-26T00:00:00.000Z	default	spot	technology	preferred	tpreferred	101.686196
+2011-03-26T00:00:00.000Z	default	total_market	mezzanine	preferred	mpreferred	1217.877395
+2011-03-26T00:00:00.000Z	default	upfront	mezzanine	preferred	mpreferred	1061.678577
+2011-03-27T00:00:00.000Z	default	spot	automotive	preferred	apreferred	144.056669
+2011-03-27T00:00:00.000Z	default	spot	entertainment	preferred	epreferred	163.161361


### PR DESCRIPTION
This commit make dimension can be sorted numerically(only "long" here) besides lexicographically. e.g
```
query:
...
"dimensions": [
	"id",
],
"limitSpec": {
	"type": "default",
	"limit": 20,
	"columns": [
		{
			"asNumber": true,
			"dimension": "id",
			"direction": "ASCENDING"
		}
	]
},
...

result:
id	name	score
0	alias	90
1	bob		75
2	joe		60
11	flow	88
14	kevin	54
```