### PR TITLE
fix IndexTaskTest temp dir

### DIFF
--- a/indexing-service/src/test/java/io/druid/indexing/common/task/IndexTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/IndexTaskTest.java
@@ -20,6 +20,7 @@
 package io.druid.indexing.common.task;
 
 import com.google.common.collect.Lists;
+import com.google.common.io.Files;
 import com.metamx.common.Granularity;
 import io.druid.data.input.impl.CSVParseSpec;
 import io.druid.data.input.impl.DimensionsSpec;
@@ -57,7 +58,10 @@ public class IndexTaskTest
   @Test
   public void testDeterminePartitions() throws Exception
   {
-    File tmpFile = File.createTempFile("druid", "index");
+    File tmpDir = Files.createTempDir();
+    tmpDir.deleteOnExit();
+
+    File tmpFile = File.createTempFile("druid", "index", tmpDir);
     tmpFile.deleteOnExit();
 
     PrintWriter writer = new PrintWriter(tmpFile);
@@ -97,7 +101,7 @@ public class IndexTaskTest
             ),
             new IndexTask.IndexIOConfig(
                 new LocalFirehoseFactory(
-                    tmpFile.getParentFile(),
+                    tmpDir,
                     "druid*",
                     null
                 )


### PR DESCRIPTION
- Create local firehose files in a clean temp directory to avoid
  firehose reading other random temp files that start with 'druid'
