### PR TITLE
Fix deadlock in DirectDruidClient

### DIFF
--- a/server/src/main/java/io/druid/client/DirectDruidClient.java
+++ b/server/src/main/java/io/druid/client/DirectDruidClient.java
@@ -214,15 +214,12 @@ public class DirectDruidClient<T> implements QueryRunner<T>
                     @Override
                     public InputStream nextElement()
                     {
-                      synchronized (done) {
-                        try {
-                          // Ensures more elements are expected via `done`
-                          return queue.take();
-                        }
-                        catch (InterruptedException e) {
-                          Thread.currentThread().interrupt();
-                          throw Throwables.propagate(e);
-                        }
+                      try {
+                        return queue.take();
+                      }
+                      catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw Throwables.propagate(e);
                       }
                     }
                   }


### PR DESCRIPTION
Bug seems to show up when there are active queries and a large amount of shuffling of nodes
