### PR TITLE
Upgrade to log4j2

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -116,8 +116,27 @@
             <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+        </dependency>
+        <!-- com.lmax.disruptor is optional in log4j-core, so we explicitly include it here -->
+        <dependency>
+            <groupId>com.lmax</groupId>
+            <artifactId>disruptor</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j.adapters</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <version>2.0-beta4</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- Tests -->

--- a/common/src/main/resources/log4j2.xml
+++ b/common/src/main/resources/log4j2.xml
@@ -18,18 +18,15 @@
   ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   -->
 
-<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
-
-<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
-
-  <appender name="ConsoleAppender" class="org.apache.log4j.ConsoleAppender">
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="%d{ISO8601} %p [%t] %c - %m%n"/>
-    </layout>
-  </appender>
-
-  <root>
-    <priority value ="info" />
-    <appender-ref ref="ConsoleAppender"/>
-  </root>
-</log4j:configuration>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{ISO8601} %p [%t] %c - %m%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <AsyncRoot level="info">
+      <AppenderRef ref="Console"/>
+    </AsyncRoot>
+  </Loggers>
+</Configuration>

--- a/extensions/s3-extensions/pom.xml
+++ b/extensions/s3-extensions/pom.xml
@@ -43,6 +43,11 @@
             <groupId>net.java.dev.jets3t</groupId>
             <artifactId>jets3t</artifactId>
         </dependency>
+        <!-- jets3t requires log4j 1.2 compatability -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
@@ -76,11 +81,6 @@
             <artifactId>easymock</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -95,6 +95,17 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <!-- Must set timezone to UTC to run unit tests for this module independently -->
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- locale settings must be set on the command line before startup -->
+                    <argLine>-Duser.language=en -Duser.country=US</argLine>
+                    <systemPropertyVariables>
+                        <user.timezone>UTC</user.timezone>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <jetty.version>9.2.5.v20141112</jetty.version>
         <druid.api.version>0.3.1</druid.api.version>
         <jackson.version>2.4.4</jackson.version>
+        <log4j.version>2.1</log4j.version>
     </properties>
 
     <modules>
@@ -347,14 +348,29 @@
                 <version>2.0.1</version>
             </dependency>
             <dependency>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
-                <version>1.2.16</version>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${log4j.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
-                <version>1.6.2</version>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-1.2-api</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.lmax</groupId>
+                <artifactId>disruptor</artifactId>
+                <version>3.3.0</version>
             </dependency>
             <dependency>
                 <groupId>net.spy</groupId>

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -55,10 +55,6 @@
       <artifactId>config-magic</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
     </dependency>


### PR DESCRIPTION
Default `log4j2.xml` has been updated to use AsyncRoot, which should mean the system setting is no longer needed

Difference in performance:

No Async:

|Quartile|Latency (ms)|
|--------|----------|
|min|828|
|25%|966.25|
|50%|1032|
|75%|1165|
|max|93287|

With Async:

|Quartile|Latency (ms)|
|-------|-------|
|min|843|
|25%|931.5|
|50%|1017|
|75%|1129|
|max|2194|

It is worth noting that there is still a nasty performance lag when new RealTime segments are rolled over to historicals if the segment is queried during that transition time. This seems to have eliminated the intermittent bad query times though.