### PR TITLE
Added task strategy with priority on workers with more task capacity.

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
@@ -40,6 +40,13 @@ public class RemoteTaskRunnerConfig
   @Min(10 * 1024)
   private long maxZnodeBytes = 512 * 1024;
 
+  @JsonProperty
+  private boolean strategyTaskAscOrder = true;
+
+  public boolean isStrategyTaskAscOrder() {
+    return strategyTaskAscOrder;
+  }
+
   public Period getTaskAssignmentTimeout()
   {
     return taskAssignmentTimeout;

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/setup/FillCapacityWorkerSelectStrategy.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/setup/FillCapacityWorkerSelectStrategy.java
@@ -54,7 +54,7 @@ public class FillCapacityWorkerSelectStrategy implements WorkerSelectStrategy
               retVal = zkWorker.getWorker().getHost().compareTo(zkWorker2.getWorker().getHost());
             }
 
-            return retVal;
+            return config.isStrategyTaskAscOrder() ? retVal : -retVal;
           }
         }
     );


### PR DESCRIPTION
This pull request adds new feature on the way how the tasks are distributed through the middleManagers. By default the task are distributed on the middleManagers which have less capacity, this causes a problem if you haven't autoscaling, as in this example:

If you have 3 middleManagers with 4 of capacity, you can have 12 simultaneous task. If my task has 3 partitions and 1 replica, and I have a windowPeriod the 20MINUTE, and 1 HOUR of granularity, then the first hour, I will have this task:

Task: 1H-00 1H-01 1H-10 1H-11 1H-20 1H-21 

If you use the default strategy order to assign the task, you will have this distribution:
<pre>
        MiddleManager 1                   MiddleManager 2            MiddleManager 3
             1H-00                            1H-01
             1H-10                            1H-11
             1H-20                            1H-21

<b> Pending task: None </b>
</pre>

This works fine .. but the middleManager 3 doesn't do anything, and when the next hour comes, You will find this problem:

new task: 2H-00 2H-01 2H-10 2H-11 2H-20 2H-21

<pre>
        MiddleManager 1                   MiddleManager 2            MiddleManager 3
             1H-00                            1H-01
             1H-10                            1H-11
             1H-20                            1H-21
             2H-00                            2H-01

<b> Pending task: 2H-10 2H-11 2H-20 2H-21 </b>
</pre>

You have 4 pending task, when you have a middleManager with 4 of capacity... but you can't assign the task because have the same group.

Now I explain the same example using the other strategy:

task: 1H-00 1H-01 1H-10 1H-11 1H-20 1H-21

If you use the default strategy order to assign the task, you will have this distribution:
<pre>
        MiddleManager 1                   MiddleManager 2            MiddleManager 3
             1H-00                            1H-01                      1H-10
             1H-11                            1H-20                      1H-21    

<b> Pending task: None </b>                    
</pre>
This works fine too, but now the middleManager 3 do something, and when the next hour comes, it looks like this:

new task: 2H-00 2H-01 2H-10 2H-11 2H-20 2H-21

<pre>
        MiddleManager 1                   MiddleManager 2            MiddleManager 3
             1H-00                            1H-01                      1H-10
             1H-11                            1H-20                      1H-21   
             2H-00                            2H-01                      2H-10
             2H-11                            2H-20                      2H-21

<b> Pending task: None!!! </b>
</pre>

Now you can assign all task, and all middleManager work more distributed.


<b> ------ Config file: overlord.runtime ------ </b>
To enable o disable this feature you only have to write this property on <b> overlord.runtime </b>

<pre>
<b>Enable:</b> druid.indexer.runner.strategyTaskAscOrder=false
<b>Disable:</b> druid.indexer.runner.strategyTaskAscOrder=true
<b>Default:</b> druid.indexer.runner.strategyTaskAscOrder=true
</pre>

<b> Example: If I want use the new strategy, I must use: druid.indexer.runner.strategyTaskAscOrder=false </b>