### PR TITLE
Modify CompressedPools buffer size to match LZF max chunk size

### DIFF
--- a/processing/src/main/java/io/druid/segment/CompressedPools.java
+++ b/processing/src/main/java/io/druid/segment/CompressedPools.java
@@ -22,6 +22,7 @@ package io.druid.segment;
 import com.google.common.base.Supplier;
 import com.metamx.common.logger.Logger;
 import com.ning.compress.lzf.ChunkEncoder;
+import com.ning.compress.lzf.LZFChunk;
 import io.druid.collections.ResourceHolder;
 import io.druid.collections.StupidPool;
 
@@ -35,7 +36,7 @@ public class CompressedPools
 {
   private static final Logger log = new Logger(CompressedPools.class);
 
-  public static final int BUFFER_SIZE = 0x10000;
+  public static final int BUFFER_SIZE = LZFChunk.MAX_CHUNK_LEN;
   private static final StupidPool<ChunkEncoder> chunkEncoderPool = new StupidPool<ChunkEncoder>(
       new Supplier<ChunkEncoder>()
       {

--- a/processing/src/test/java/io/druid/segment/IndexMergerTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerTest.java
@@ -31,8 +31,8 @@ import io.druid.segment.column.Column;
 import io.druid.segment.data.IncrementalIndexTest;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
-import junit.framework.Assert;
 import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.File;


### PR DESCRIPTION
This fixes encoding problems that cause unit tests to fail if the default CompressionStrategy is set to LZF