### PR TITLE
Add a microcluster CLI option that launches a local Druid cluster with mostly default settings

### DIFF
--- a/extensions/microcluster/README.md
+++ b/extensions/microcluster/README.md
@@ -1,0 +1,94 @@
+A micro cluster consisting of a historical, coordinator, broker, overlord, and middle-manager node. Also tries to run zookeeper and a derby instance for metadata.
+
+Each of the Druid services runs in its own JVM but the IO is inherited from the master JVM.
+
+This microcluster is completely transient, and intended to have all data lost upon termination. As such, it is for example purposes only.
+
+To run, call the `microcluster all` command with the following JVM options:
+`java -server -Duser.timezone=UTC -Dfile.encoding=UTF-8 -cp 'druid_lib_path/*' io.druid.cli.Main microcluster all`
+
+To add a mysql database (instead of the embedded Derby), use something like the following:
+```
+-Ddruid.metadata.storage.type=mysql
+-Ddruid.metadata.storage.connector.connectURI="jdbc:mysql://localhost:3306/druid"
+-Ddruid.metadata.storage.connector.user=druid
+-Ddruid.metadata.storage.connector.password=diurd
+```
+
+The realtime indexer can be started against the twitter spritzer as follows
+```
+curl -i -X POST 'http://localhost:8090/druid/indexer/v1/task' -H 'Content-Type: application/json' -d '{
+  "spec": {
+    "dataSchema": {
+      "dataSource": "twitterstream",
+      "granularitySpec": {
+        "queryGranularity": "all",
+        "type": "uniform",
+        "segmentGranularity": "hour"
+      },
+      "metricsSpec": [
+        {"type": "count", "name": "tweets"},
+        {"type": "doubleSum", "fieldName": "follower_count", "name": "total_follower_count"},
+        {"type": "doubleSum", "fieldName": "retweet_count",  "name": "total_retweet_count" },
+        {"type": "doubleSum", "fieldName": "friends_count",  "name": "total_friends_count" },
+        {"type": "doubleSum", "fieldName": "statuses_count", "name": "total_statuses_count"},
+        {"type": "hyperUnique", "fieldName": "text", "name": "text_hll"},
+        {"type": "hyperUnique", "fieldName": "user_id", "name": "user_id_hll"},
+        {"type": "hyperUnique", "fieldName": "contributors", "name": "contributors_hll"},
+        {"type": "hyperUnique", "fieldName": "htags", "name": "htags_hll"},
+        {"type": "min", "fieldName": "follower_count", "name": "min_follower_count"},
+        {"type": "max", "fieldName": "follower_count", "name": "max_follower_count"},
+        {"type": "min", "fieldName": "friends_count", "name": "min_friends_count"},
+        {"type": "max", "fieldName": "friends_count", "name": "max_friends_count"},
+        {"type": "min", "fieldName": "statuses_count", "name": "min_statuses_count"},
+        {"type": "max", "fieldName": "statuses_count", "name": "max_statuses_count"},
+        {"type": "min", "fieldName": "retweet_count", "name": "min_retweet_count"},
+        {"type": "max", "fieldName": "retweet_count", "name": "max_retweet_count"}
+      ],
+      "parser":{
+        "parseSpec":{
+          "format":"json",
+          "timestampSpec":{"column":"ts", "format":"millis"},
+          "dimensionsSpec":{
+            "dimensions":["text","htags","contributors","lat","lon","retweet_count","follower_count","friendscount","lang","utc_offset","statuses_count","user_id","ts"],
+            "spatialDimensions":[{"dimName":"geo","dims":["lat","lon"]}]
+          }
+        }
+      }
+    },
+      "ioConfig": {
+        "type":"realtime",
+        "firehose": {
+          "type": "twitzer",
+          "maxEventCount": 500000,
+          "maxRunMinutes": 120
+        }
+      },
+      "tuningConfig": {
+        "type":"realtime",
+        "intermediatePersistPeriod": "PT10m",
+        "maxRowsInMemory": 500000,
+        "windowPeriod": "PT10m"
+      }
+  },
+  "type": "index_realtime"
+}'
+
+```
+
+After a short pause you should be able to query data as follows:
+
+```
+curl -i -X POST "http://localhost:8082/druid/v2/?pretty" -H 'content-type: application/json' -d '{
+  "queryType"  : "timeseries",
+  "dataSource" : "twitterstream",
+  "granularity" : "hour",
+  "intervals": [ "1970-01-01T00:00:00.000/2019-01-03T00:00:00.000" ],
+  "aggregations": [
+    { "type": "count", "name": "count" },
+    { "type": "hyperUnique", "name":"text_hll", "fieldName":"text_hll" },
+    { "type": "hyperUnique", "name":"htag_hll", "fieldName":"htags_hll" },
+    { "type": "hyperUnique", "name":"user_id_hll", "fieldName":"user_id_hll" }
+  ]
+}'
+```

--- a/extensions/microcluster/pom.xml
+++ b/extensions/microcluster/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Druid - a distributed column store.
+  ~ Copyright (C) 2012, 2013  Metamarkets Group Inc.
+  ~
+  ~ This program is free software; you can redistribute it and/or
+  ~ modify it under the terms of the GNU General Public License
+  ~ as published by the Free Software Foundation; either version 2
+  ~ of the License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.druid.extensions</groupId>
+  <artifactId>druid-microcluster</artifactId>
+  <name>druid-microcluster</name>
+  <description>A small microcluster consisting of a broker, coordinator, and historical node. All in the same JVM</description>
+
+  <parent>
+    <groupId>io.druid</groupId>
+    <artifactId>druid</artifactId>
+    <version>0.7.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.druid</groupId>
+      <artifactId>druid-processing</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.druid</groupId>
+      <artifactId>druid-services</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper</artifactId>
+      <version>3.4.6</version>
+    </dependency>
+
+    <!-- Tests -->
+    <dependency>
+      <groupId>io.druid</groupId>
+      <artifactId>druid-processing</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+              <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/extensions/microcluster/src/main/java/io/druid/cli/CliMicrocluster.java
+++ b/extensions/microcluster/src/main/java/io/druid/cli/CliMicrocluster.java
@@ -1,0 +1,332 @@
+/*
+ * Druid - a distributed column store.
+ * Copyright (C) 2012, 2013, 2014  Metamarkets Group Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.druid.cli;
+
+import com.google.api.client.repackaged.com.google.common.base.Joiner;
+import com.google.common.base.Throwables;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.name.Names;
+import com.metamx.common.lifecycle.LifecycleStart;
+import com.metamx.common.lifecycle.LifecycleStop;
+import com.metamx.common.logger.Logger;
+import io.airlift.command.Command;
+import io.druid.guice.GuiceInjectors;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.druid.guice.LifecycleModule;
+import io.druid.guice.ManageLifecycle;
+import org.apache.derby.drda.NetworkServerControl;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.apache.zookeeper.server.ZooKeeperServer;
+
+import javax.annotation.Nullable;
+
+/**
+ *
+ */
+
+@Command(
+    name = "all",
+    description = "Runs a microcluster of a historical, broker, overlord, and coordinator thread"
+)
+public class CliMicrocluster extends ServerRunnable
+{
+  private static final Logger log = new Logger(CliMicrocluster.class);
+
+  @Inject
+  final Injector baseInjector = null;
+
+  public CliMicrocluster()
+  {
+    super(log);
+  }
+
+  @ManageLifecycle
+  public static class Microcluster
+  {
+    final ListeningExecutorService executorService = MoreExecutors.listeningDecorator(
+        Executors.newFixedThreadPool(
+            10,
+            new ThreadFactoryBuilder()
+                .setDaemon(true)
+                .setNameFormat("microcluster-%d")
+                .build()
+        )
+    );
+    final ConcurrentHashMap<String, Process> cmdProcesses = new ConcurrentHashMap<>();
+    final ConcurrentHashMap<String, ListenableFuture<?>> cmdFutures = new ConcurrentHashMap<>();
+    static final List<List<String>> commands = ImmutableList.<List<String>>of(
+        ImmutableList.<String>of("server", "historical"),
+        ImmutableList.<String>of("server", "broker"),
+        ImmutableList.<String>of("server", "coordinator"),
+        ImmutableList.<String>of("server", "overlord"),
+        ImmutableList.<String>of("server", "middleManager")
+    );
+    final Thread dbThread = new Thread(
+        new Runnable()
+        {
+          @Override
+          public void run()
+          {
+            io.druid.cli.Main.main(new String[]{"microcluster","DB"});
+          }
+        }
+    );
+
+    final Thread zkThread = new Thread(
+        new Runnable()
+        {
+          @Override
+          public void run()
+          {
+            io.druid.cli.Main.main(new String[]{"microcluster","ZK"});
+          }
+        }
+    );
+    @LifecycleStart
+    public void start()
+    {
+      final Path tmpDBPath;
+      try {
+        tmpDBPath = Files.createTempDirectory("microclusterMetaDB");
+      }
+      catch (IOException e) {
+        throw Throwables.propagate(e);
+      }
+      File tmpDB = tmpDBPath.toFile();
+      tmpDB.deleteOnExit();
+      final String connectionURI = String.format(
+          "jdbc:derby://127.0.0.1:%d%s/metaDB;create=true",
+          CliMicroclusterDB.dbPort,
+          tmpDB.getAbsolutePath()
+      );
+      System.getProperties().setProperty("druid.metadata.storage.connector.connectURI", connectionURI);
+
+      Properties properties = new Properties();
+      try (InputStream inStream = this.getClass().getResourceAsStream("/microcluster.runtime.properties")) {
+        properties.load(inStream);
+      }
+      catch (IOException e) {
+        throw Throwables.propagate(e);
+      }
+      // Override with environment properties
+      System.getProperties().putAll(properties);
+
+      try {
+        Class<?> driver = Class.forName("org.apache.derby.jdbc.ClientDriver");
+      }
+      catch (ClassNotFoundException e) {
+        throw Throwables.propagate(e);
+      }
+
+      try {
+        final Path tempPath = Files.createTempDirectory("microserver-localstorage");
+        final File tempDir = tempPath.toFile();
+        tempDir.deleteOnExit();
+        System.getProperties().setProperty("druid.storage.storage.storageDirectory", tempDir.getAbsolutePath());
+
+      }
+      catch (IOException e) {
+        e.printStackTrace();
+      }
+
+      try {
+        final Path tempPath = Files.createTempDirectory("microserver-historical");
+        final File tempDir = tempPath.toFile();
+        tempDir.deleteOnExit();
+        System.getProperties()
+              .setProperty(
+                  "druid.segmentCache.locations",
+                  "[{\"path\": \"" + tempDir.getAbsolutePath() + "\", \"maxSize\": " + String.format(
+                      "%d",
+                      tempDir.getFreeSpace()
+                  ) + " }]"
+              );
+      }
+      catch (IOException e) {
+        throw Throwables.propagate(e);
+      }
+
+      // Start up general cluster resources first
+      try {
+        dbThread.setName("microcluster-db");
+        dbThread.start();
+        synchronized (dbThread) {
+          dbThread.wait();
+        }
+        zkThread.setName("microcluster-zk");
+        zkThread.start();
+        synchronized (zkThread) {
+          zkThread.wait();
+        }
+      }
+      catch (InterruptedException e) {
+        throw Throwables.propagate(e);
+      }
+      for (final List<String> cmd : commands) {
+        log.info("Submitting cmd %s", cmd);
+        final String cmdKey = cmd.get(1);
+        ListenableFuture future = executorService.submit(
+            new Runnable()
+            {
+              @Override
+              public void run()
+              {
+                log.info("Starting cmd %s", cmd);
+                List<String> sb = new LinkedList<String>();
+                sb.add("java");
+                sb.add("-server");
+                sb.add("-Duser.timezone=UTC");
+                sb.add("-Dfile.encoding=UTF-8");
+                for (Map.Entry<Object, Object> entry : System.getProperties().entrySet()) {
+                  if (entry.getKey().equals("java.class.path")) {
+                    sb.add("-cp");
+                    sb.add(entry.getValue().toString().replace("\"", "\\\""));
+                  } else if (((String) entry.getKey()).startsWith("druid.")) {
+                    sb.add(String.format("-D%s=%s", entry.getKey(), entry.getValue().toString()));
+                  }
+                }
+                Thread.currentThread().setName("microcluster-" + cmdKey);
+                sb.add("io.druid.cli.Main");
+                sb.addAll(cmd);
+                ProcessBuilder processBuilder = new ProcessBuilder();
+                log.info("Launching command %s with line: %s", cmd, Joiner.on(' ').join(sb));
+                processBuilder.inheritIO().command(sb);
+                try {
+                  Process process = processBuilder.start();
+                  cmdProcesses.put(cmdKey, process);
+                  // waitFor is running in executor thread
+                  int result = process.waitFor();
+                  // 143 = java SIGTERM
+                  if (0 != result && result != 143) {
+                    throw new RuntimeException(
+                        String.format(
+                            "Process failed for command %s with code %d",
+                            cmd,
+                            result
+                        )
+                    );
+                  }
+                }
+                catch (IOException | InterruptedException e) {
+                  throw Throwables.propagate(e);
+                }
+              }
+            }
+        );
+        cmdFutures.put(cmdKey, future);
+        future.addListener(
+            new Runnable()
+            {
+              @Override
+              public void run()
+              {
+                printAttentionLine(String.format("Finished %s", cmd));
+              }
+            }, MoreExecutors.sameThreadExecutor()
+        );
+      }
+    }
+
+    @LifecycleStop
+    public void stop()
+    {
+      log.info("Destroying %d processes", cmdProcesses.size());
+      for(List<String> cmd : commands){
+        final String cmdKey = cmd.get(1);
+        Process process = cmdProcesses.get(cmdKey);
+        log.info("Destroying %s", cmdKey);
+        process.destroy();
+        try {
+          cmdFutures.get(cmdKey).get();
+        }
+        catch (InterruptedException e1) {
+          // Interrupted, just continue with shutdown
+        }
+        catch (ExecutionException e1) {
+          log.error(e1, "Error in execution of subtask");
+
+        }
+      }
+      // Don't stop the zk or db thread... let it die with the JVM
+      executorService.shutdownNow();
+    }
+  }
+
+  @Override
+  public List<Module> getModules()
+  {
+    return ImmutableList.<Module>of(
+        new Module()
+        {
+          @Override
+          public void configure(Binder binder)
+          {
+            binder.bindConstant().annotatedWith(Names.named("serviceName")).to("druid/microcluster");
+            binder.bindConstant().annotatedWith(Names.named("servicePort")).to(0);// Don't actually need a port
+            binder.bind(Microcluster.class).in(ManageLifecycle.class);
+            LifecycleModule.register(binder, Microcluster.class);
+
+          }
+        }
+    );
+  }
+
+  private static final void printAttentionLine(String string)
+  {
+    log.info(
+        "\n***********************************************\n**\n** %s\n**\n***********************************************",
+        string
+    );
+  }
+}

--- a/extensions/microcluster/src/main/java/io/druid/cli/CliMicroclusterDB.java
+++ b/extensions/microcluster/src/main/java/io/druid/cli/CliMicroclusterDB.java
@@ -1,0 +1,156 @@
+/*
+ * Druid - a distributed column store.
+ * Copyright (C) 2012, 2013, 2014  Metamarkets Group Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package io.druid.cli;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.net.InetAddresses;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.name.Names;
+import com.metamx.common.lifecycle.LifecycleStart;
+import com.metamx.common.lifecycle.LifecycleStop;
+import com.metamx.common.logger.Logger;
+import io.airlift.command.Command;
+import io.druid.guice.LazySingleton;
+import io.druid.guice.LifecycleModule;
+import io.druid.guice.ManageLifecycle;
+import org.apache.derby.drda.NetworkServerControl;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *
+ */
+@Command(
+    name = "DB",
+    description = "Runs a microcluster DB"
+)
+public class CliMicroclusterDB extends ServerRunnable
+{
+  private static final Logger log = new Logger(CliMicroclusterDB.class);
+  public static final int dbPort = 1527;
+
+  public CliMicroclusterDB()
+  {
+    super(log);
+  }
+
+  @ManageLifecycle
+  public static class DerbyDB
+  {
+    NetworkServerControl server;
+
+    @LifecycleStart
+    public void start()
+    {
+      try {
+        server = new NetworkServerControl
+            (InetAddresses.forString("127.0.0.1"), dbPort);
+        server.start(
+            new PrintWriter(
+                new OutputStream()
+                {
+                  ArrayList<Byte> buff = new ArrayList<>(1024);
+
+                  @Override
+                  public void write(int b) throws IOException
+                  {
+                    if (System.lineSeparator().getBytes()[0] == (byte) b) {
+                      flush();
+                    } else {
+                      buff.add((byte) b);
+                    }
+                  }
+
+                  @Override
+                  public void flush()
+                  {
+                    final byte[] bytes = new byte[buff.size()];
+                    for (int i = 0; i < bytes.length; ++i) {
+                      bytes[i] = buff.get(i);
+                    }
+                    try {
+                      log.info("DB: %s", new String(bytes, "UTF-8"));
+                    }
+                    catch (UnsupportedEncodingException e) {
+                      throw Throwables.propagate(e);
+                    }
+                    buff.clear();
+                    buff.ensureCapacity(1024);
+                  }
+                }
+            )
+        );
+        // Give the server some time to attach to the port
+        Thread.sleep(1000);
+        server.ping();
+        log.info(System.lineSeparator() + "Started DB: " + server.getRuntimeInfo());
+      }
+      catch (Exception e) {
+        log.error(e, "Error in setting up DB");
+        System.exit(-1);
+      }
+      final Thread currentThread = Thread.currentThread();
+      synchronized (currentThread) {
+        currentThread.notifyAll();
+      }
+    }
+
+    @LifecycleStop
+    public void stop()
+    {
+      // Let the server die with the JVM
+    }
+  }
+
+  @Override
+  protected List<Module> getModules()
+  {
+    return ImmutableList.<Module>of(
+        new Module()
+        {
+          @Override
+          public void configure(Binder binder)
+          {
+            binder.bindConstant().annotatedWith(Names.named("serviceName")).to("druid/microcluster/db");
+            binder.bindConstant().annotatedWith(Names.named("servicePort")).to(dbPort);
+            binder.bind(DerbyDB.class).in(ManageLifecycle.class);
+            LifecycleModule.register(binder, DerbyDB.class);
+          }
+        }
+    );
+  }
+}

--- a/extensions/microcluster/src/main/java/io/druid/cli/CliMicroclusterZk.java
+++ b/extensions/microcluster/src/main/java/io/druid/cli/CliMicroclusterZk.java
@@ -1,0 +1,117 @@
+/*
+ * Druid - a distributed column store.
+ * Copyright (C) 2012, 2013, 2014  Metamarkets Group Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package io.druid.cli;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.name.Names;
+import com.metamx.common.lifecycle.LifecycleStart;
+import com.metamx.common.lifecycle.LifecycleStop;
+import com.metamx.common.logger.Logger;
+import io.airlift.command.Command;
+import io.druid.guice.LifecycleModule;
+import io.druid.guice.ManageLifecycle;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.apache.zookeeper.server.ZooKeeperServer;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+
+@Command(
+    name = "ZK",
+    description = "Runs a microcluster zookeeper"
+)
+public class CliMicroclusterZk extends ServerRunnable
+{
+  private static final Logger log = new Logger(CliMicroclusterZk.class);
+  public static final int zkPort = 2181;
+
+  public CliMicroclusterZk()
+  {
+    super(log);
+  }
+
+  @ManageLifecycle
+  public static class ZkServer
+  {
+    ZooKeeperServer zkServer;
+    ServerCnxnFactory serverCnxnFactory;
+
+    @LifecycleStart
+    public void start()
+    {
+
+      final Thread currentThread = Thread.currentThread();
+      try {
+        File tempDir = File.createTempFile("microserver", "zk");
+        tempDir.delete();
+        tempDir.mkdir();
+        tempDir.deleteOnExit();
+        zkServer = new ZooKeeperServer(tempDir, tempDir, 2000);
+        serverCnxnFactory = ServerCnxnFactory.createFactory(zkPort, 1000);
+        serverCnxnFactory.startup(zkServer);
+        System.getProperties().setProperty("druid.zk.service.host", String.format("localhost:%d", zkPort));
+        log.info("Started zookeeper on localhost:%d", zkPort);
+        synchronized (currentThread){
+          currentThread.notifyAll();
+        }
+      }
+      catch (java.net.BindException e) {
+        log.warn("Port %d is already in use, politely skipping local ZK setup");
+        stop();
+        synchronized (currentThread){
+          currentThread.notifyAll();
+        }
+      }
+      catch (IOException | InterruptedException e) {
+        log.error(e, "Error starting Zk");
+        System.exit(-1);
+      }
+    }
+
+    @LifecycleStop
+    public void stop()
+    {
+      // Do not actually stop the zk service, let it die with the JVM
+    }
+  }
+
+  @Override
+  protected List<Module> getModules()
+  {
+    return ImmutableList.<Module>of(
+        new Module()
+        {
+          @Override
+          public void configure(Binder binder)
+          {
+            binder.bindConstant().annotatedWith(Names.named("serviceName")).to("druid/microcluster/zk");
+            binder.bindConstant().annotatedWith(Names.named("servicePort")).to(zkPort);
+            binder.bind(ZkServer.class).in(ManageLifecycle.class);
+            LifecycleModule.register(binder, ZkServer.class);
+          }
+        }
+    );
+  }
+}

--- a/extensions/microcluster/src/main/java/io/druid/cli/MicroclusterCommandCreator.java
+++ b/extensions/microcluster/src/main/java/io/druid/cli/MicroclusterCommandCreator.java
@@ -1,0 +1,37 @@
+/*
+ * Druid - a distributed column store.
+ * Copyright (C) 2012, 2013, 2014  Metamarkets Group Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.druid.cli;
+
+import io.airlift.command.Cli;
+import io.airlift.command.Help;
+
+/**
+ *
+ */
+public class MicroclusterCommandCreator implements CliCommandCreator
+{
+  @Override
+  public void addCommands(Cli.CliBuilder cliBuilder)
+  {
+    cliBuilder.withGroup("microcluster")
+              .withDescription("Run a micro server suite of a historical, broker, and coordinator")
+              .withDefaultCommand(Help.class)
+              .withCommands(CliMicrocluster.class, CliMicroclusterZk.class, CliMicroclusterDB.class);
+  }
+}

--- a/extensions/microcluster/src/main/resources/META-INF/services/io.druid.cli.CliCommandCreator
+++ b/extensions/microcluster/src/main/resources/META-INF/services/io.druid.cli.CliCommandCreator
@@ -1,0 +1,1 @@
+io.druid.cli.MicroclusterCommandCreator

--- a/extensions/microcluster/src/main/resources/microcluster.runtime.properties
+++ b/extensions/microcluster/src/main/resources/microcluster.runtime.properties
@@ -1,0 +1,30 @@
+# Deep storage
+druid.storage.type=local
+
+# Indexing service discovery
+druid.selectors.indexing.serviceName=overlord
+
+# Metrics logging (disabled for examples)
+druid.emitter=noop
+
+druid.zk.service.host=127.0.0.1
+
+druid.coordinator.startDelay=PT7s
+
+druid.server.maxSize=10000000000
+
+# Change these to make Druid faster
+druid.processing.buffer.sizeBytes=100000000
+druid.processing.numThreads=1
+druid.s3.accessKey=none
+druid.s3.secretKey=none
+
+druid.broker.balancer.type=random
+druid.broker.select.tier=highestPriority
+druid.peon.mode=local
+
+druid.processing.columnCache.sizeBytes=100000000
+druid.cache.type=local
+druid.cache.sizeInBytes=100000000
+
+druid.indexer.runner.type=remote

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
         <module>extensions/kafka-eight</module>
         <module>extensions/rabbitmq</module>
         <module>extensions/histogram</module>
+        <module>extensions/microcluster</module>
         <module>extensions/mysql-metadata-storage</module>
         <module>extensions/postgresql-metadata-storage</module>
     </modules>

--- a/server/src/main/java/io/druid/metadata/storage/derby/DerbyConnector.java
+++ b/server/src/main/java/io/druid/metadata/storage/derby/DerbyConnector.java
@@ -58,8 +58,9 @@ public class DerbyConnector extends SQLMetadataConnector
   @Override
   public boolean tableExists(Handle handle, String tableName)
   {
-    return !handle.createQuery("select * from SYS.SYSTABLES where tablename = :tableName")
-                  .bind("tableName", tableName.toUpperCase())
+    return !handle.createQuery(
+        String.format("select * from SYS.SYSTABLES where tablename = '%s'", tableName.toUpperCase())
+    )
                   .list()
                   .isEmpty();
   }


### PR DESCRIPTION
* Makes heavy use of temporary dictories
* Checks localhost:2181 for already launched zk instances, and launches a local zk server if nothing is bound to port 2181
* Launches a new JVM with really standard settings for each subtask
* Launches a temporary Derby DB to hold data.
* All things in this cluster are temporary and intended to die when the master JVM is shutdown.

Re-open of #980 