### PR TITLE
Fix BUG "No FileSystem for scheme: hdfs" for hdfs-srorage-extension

### DIFF
--- a/extensions/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsStorageDruidModule.java
+++ b/extensions/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsStorageDruidModule.java
@@ -30,6 +30,7 @@ import io.druid.initialization.DruidModule;
 import io.druid.storage.hdfs.tasklog.HdfsTaskLogs;
 import io.druid.storage.hdfs.tasklog.HdfsTaskLogsConfig;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
 
 import java.util.List;
 import java.util.Properties;
@@ -60,6 +61,10 @@ public class HdfsStorageDruidModule implements DruidModule
     Binders.dataSegmentKillerBinder(binder).addBinding("hdfs").to(HdfsDataSegmentKiller.class).in(LazySingleton.class);
 
     final Configuration conf = new Configuration();
+
+    // Walk around a typical case that "maven-assembly" causes bug about "No FileSystem for scheme: hdfs" while loading hadoop-hdfs dependency
+    conf.set("fs.hdfs.impl", DistributedFileSystem.class.getName());
+
     if (props != null) {
       for (String propName : System.getProperties().stringPropertyNames()) {
         if (propName.startsWith("hadoop.")) {

--- a/extensions/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsStorageDruidModule.java
+++ b/extensions/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsStorageDruidModule.java
@@ -30,6 +30,7 @@ import io.druid.initialization.DruidModule;
 import io.druid.storage.hdfs.tasklog.HdfsTaskLogs;
 import io.druid.storage.hdfs.tasklog.HdfsTaskLogsConfig;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 
 import java.util.List;
@@ -64,6 +65,7 @@ public class HdfsStorageDruidModule implements DruidModule
 
     // Walk around a typical case that "maven-assembly" causes bug about "No FileSystem for scheme: hdfs" while loading hadoop-hdfs dependency
     conf.set("fs.hdfs.impl", DistributedFileSystem.class.getName());
+    conf.set("fs.file.impl", LocalFileSystem.class.getName());
 
     if (props != null) {
       for (String propName : System.getProperties().stringPropertyNames()) {


### PR DESCRIPTION
Problem
----------

While starting realtime node with hdfs as deep storage (i.e. hdfs-storage-extenstion), log as following shows that it should already loaded hadoop-hdfs correctly

    INFO [main] io.druid.initialization.Initialization - Added URL[file:/home/druid/.m2/repository/org/apache/hadoop/hadoop-hdfs/2.3.0/hadoop-hdfs-2.3.0.jar]

But we got __IOException about "No FileSystem for scheme: hdfs"__  while it tried to persist segments  onto hdfs which means `hadoop-hdfs` ( class `org.apache.hadoop.hdfs.DistributedFileSystem` in fact) should not been loaded correctly.

    No FileSystem for scheme: hdfs","exceptionStackTrace":"java.io.IOException: No FileSystem for scheme: hdfs
         at org.apache.hadoop.fs.FileSystem.getFileSystemClass(FileSystem.java:2304)
         at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:2311)
         at org.apache.hadoop.fs.FileSystem.access$200(FileSystem.java:90)
         at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:2350)
         at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:2332)
         at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:369)
         at org.apache.hadoop.fs.Path.getFileSystem(Path.java:296)
         at io.druid.storage.hdfs.HdfsDataSegmentPusher.push(HdfsDataSegmentPusher.java:75)
         at io.druid.segment.realtime.plumber.RealtimePlumber$4.doRun(RealtimePlumber.java:356)
         at io.druid.common.guava.ThreadRenamingRunnable.run(ThreadRenamingRunnable.java:42)
         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
         at java.lang.Thread.run(Thread.java:745)\n","interval":"2015-01-08T08:00:00.000Z/2015-01-08T09:00:00.000Z"}}

In fact, lots of other Druid users rather than us are also being confused by the same bug
* https://groups.google.com/forum/#!topic/druid-development/QpYq0eGDHa8
* https://groups.google.com/forum/#!topic/druid-development/U-X8A5vsmog

Root Cause
---------------
In fact, this is a typical case of the `maven-assembly` plugin breaking things in hadoop hdfs.

The root cause is because differents JARs (`hadoop-commons` for `LocalFileSystem`, `hadoop-hdfs` for `DistributedFileSystem`) each contain a different file called `org.apache.hadoop.fs.FileSystem` in their `META-INFO/services` directory. This file lists the canonical classnames of the filesystem implementations they want to declare (This is called a __`Service Provider Interface`__, see [org.apache.hadoop.FileSystem line L2591](https://github.com/apache/hadoop/blob/trunk/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java#L2591)). Druid module management system seems to rely on customized ServiceProviderInterface too, right ? When we use maven-assembly, all META-INFO/services/org.apache.hadoop.fs.FileSystem overwrite each-other. Only one of these files remains (the last one that was added). In this case, the Filesystem list from hadoop-commons overwrites the list from hadoop-hdfs, so DistributedFileSystem was no longer declared.

Solution
----------
1. As a quick solution, the druid users caught with the same problems may start druid nodes with `hadoop classpath` or copy all hadoop-hdfs related jars' path to the end of classpath  like: 

        java -Ddruid.realtime.specFile=config/realtime/metrics.spec -classpath lib/*:config/realtime:`hadoop classpath` io.druid.cli.Main server realtime

2. To completely fixed the bug, we can explicitly refer to `DistributedFileSystem` in `hdfs-storage-extension` code

