### PR TITLE
Fix some of the Task json examples to have the correct description

### DIFF
--- a/docs/content/Tasks.md
+++ b/docs/content/Tasks.md
@@ -191,7 +191,7 @@ Merge tasks merge a list of segments together. Any common timestamps are merged.
     "type": "merge",
     "id": <task_id>,
     "dataSource": <task_datasource>,
-    "segments": <JSON list of DataSegment objects to append>
+    "segments": <JSON list of DataSegment objects to merge>
 }
 ```
 
@@ -207,7 +207,7 @@ Delete tasks create empty segments with no data. The grammar is:
     "type": "delete",
     "id": <task_id>,
     "dataSource": <task_datasource>,
-    "segments": <JSON list of DataSegment objects to append>
+    "segments": <JSON list of DataSegment objects to delete>
 }
 ```
 


### PR DESCRIPTION
Two of the task example JSON's had the wrong description in the 'segments' field.