### PR TITLE
Default to UTF-8 columns on MySQL

### DIFF
--- a/common/src/main/java/io/druid/db/DbConnector.java
+++ b/common/src/main/java/io/druid/db/DbConnector.java
@@ -53,7 +53,7 @@ public class DbConnector
                 "CREATE TABLE %1$s (id VARCHAR(255) NOT NULL, dataSource VARCHAR(255) NOT NULL, created_date TEXT NOT NULL, start TEXT NOT NULL, \"end\" TEXT NOT NULL, partitioned SMALLINT NOT NULL, version TEXT NOT NULL, used BOOLEAN NOT NULL, payload bytea NOT NULL, PRIMARY KEY (id));" +
                 "CREATE INDEX ON %1$s(dataSource);"+
                 "CREATE INDEX ON %1$s(used);":
-                "CREATE table %s (id VARCHAR(255) NOT NULL, dataSource VARCHAR(255) NOT NULL, created_date TINYTEXT NOT NULL, start TINYTEXT NOT NULL, end TINYTEXT NOT NULL, partitioned BOOLEAN NOT NULL, version TINYTEXT NOT NULL, used BOOLEAN NOT NULL, payload LONGTEXT NOT NULL, INDEX(dataSource), INDEX(used), PRIMARY KEY (id))",
+                "CREATE table %s (id VARCHAR(255) NOT NULL, dataSource VARCHAR(255) NOT NULL, created_date TINYTEXT NOT NULL, start TINYTEXT NOT NULL, end TINYTEXT NOT NULL, partitioned BOOLEAN NOT NULL, version TINYTEXT NOT NULL, used BOOLEAN NOT NULL, payload LONGTEXT NOT NULL, INDEX(dataSource), INDEX(used), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8",
             segmentTableName
         ),
         isPostgreSQL
@@ -69,7 +69,7 @@ public class DbConnector
             isPostgreSQL ?
                 "CREATE TABLE %1$s (id VARCHAR(255) NOT NULL, dataSource VARCHAR(255) NOT NULL, version TEXT NOT NULL, payload bytea NOT NULL, PRIMARY KEY (id));"+
                 "CREATE INDEX ON %1$s(dataSource);":
-                "CREATE table %s (id VARCHAR(255) NOT NULL, dataSource VARCHAR(255) NOT NULL, version TINYTEXT NOT NULL, payload LONGTEXT NOT NULL, INDEX(dataSource), PRIMARY KEY (id))",
+                "CREATE table %s (id VARCHAR(255) NOT NULL, dataSource VARCHAR(255) NOT NULL, version TINYTEXT NOT NULL, payload LONGTEXT NOT NULL, INDEX(dataSource), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8",
             ruleTableName
         ),
         isPostgreSQL
@@ -84,7 +84,7 @@ public class DbConnector
         String.format(
             isPostgreSQL ?
                 "CREATE TABLE %s (name VARCHAR(255) NOT NULL, payload bytea NOT NULL, PRIMARY KEY(name))":
-                "CREATE table %s (name VARCHAR(255) NOT NULL, payload BLOB NOT NULL, PRIMARY KEY(name))",
+                "CREATE table %s (name VARCHAR(255) NOT NULL, payload BLOB NOT NULL, PRIMARY KEY(name)) DEFAULT CHARACTER SET utf8",
             configTableName
         ),
         isPostgreSQL
@@ -117,7 +117,7 @@ public class DbConnector
                 + "  `active` tinyint(1) NOT NULL DEFAULT '0',\n"
                 + "  PRIMARY KEY (`id`),\n"
                 + "  KEY (active, created_date(100))\n"
-                + ")",
+                + ") DEFAULT CHARACTER SET utf8",
             taskTableName
         ),
         isPostgreSQL
@@ -144,7 +144,7 @@ public class DbConnector
                 + "  `log_payload` longblob,\n"
                 + "  PRIMARY KEY (`id`),\n"
                 + "  KEY `task_id` (`task_id`)\n"
-                + ")",
+                + ") DEFAULT CHARACTER SET utf8",
             taskLogsTableName
         ),
         isPostgreSQL
@@ -171,7 +171,7 @@ public class DbConnector
                 + "  `lock_payload` longblob,\n"
                 + "  PRIMARY KEY (`id`),\n"
                 + "  KEY `task_id` (`task_id`)\n"
-                + ")",
+                + ") DEFAULT CHARACTER SET utf8",
             taskLocksTableName
         ),
         isPostgreSQL


### PR DESCRIPTION
Changes introduced by #975 require column encoding to be UTF-8.
This ensures columns are setup properly regardless of MySQL configuration.
NOTE: existing clusters will need to convert their tables to UTF-8 prior to updating to the next stable release