### PR TITLE
Ensure unique names for aggregators / post-aggregators + optimize groupBy post-aggregators

### DIFF
--- a/extensions/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
+++ b/extensions/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
@@ -214,4 +214,64 @@ public class ApproximateHistogramGroupByQueryTest
     Iterable<Row> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);
     TestHelper.assertExpectedObjects(expectedResults, results, "approx-histo");
   }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGroupByWithSameNameComplexPostAgg()
+  {
+    ApproximateHistogramAggregatorFactory aggFactory = new ApproximateHistogramAggregatorFactory(
+        "quantile",
+        "index",
+        10,
+        5,
+        Float.NEGATIVE_INFINITY,
+        Float.POSITIVE_INFINITY
+    );
+
+    GroupByQuery query = new GroupByQuery.Builder()
+        .setDataSource(QueryRunnerTestHelper.dataSource)
+        .setGranularity(QueryRunnerTestHelper.allGran)
+        .setDimensions(
+            Arrays.<DimensionSpec>asList(
+                new DefaultDimensionSpec(
+                    QueryRunnerTestHelper.marketDimension,
+                    "marketalias"
+                )
+            )
+        )
+        .setInterval(QueryRunnerTestHelper.fullOnInterval)
+        .setLimitSpec(
+            new DefaultLimitSpec(
+                Lists.newArrayList(
+                    new OrderByColumnSpec(
+                        "marketalias",
+                        OrderByColumnSpec.Direction.DESCENDING
+                    )
+                ), 1
+            )
+        )
+        .setAggregatorSpecs(
+            Lists.newArrayList(
+                QueryRunnerTestHelper.rowsCount,
+                aggFactory
+            )
+        )
+        .setPostAggregatorSpecs(
+            Arrays.<PostAggregator>asList(
+                new QuantilePostAggregator("quantile", "quantile", 0.5f)
+            )
+        )
+        .build();
+
+    List<Row> expectedResults = Arrays.asList(
+        GroupByQueryRunnerTestHelper.createExpectedRow(
+            "1970-01-01T00:00:00.000Z",
+            "marketalias", "upfront",
+            "rows", 186L,
+            "quantile", 880.9881f
+        )
+    );
+
+    Iterable<Row> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);
+    TestHelper.assertExpectedObjects(expectedResults, results, "approx-histo");
+  }
 }


### PR DESCRIPTION
- Ensure names for aggregators and post-aggregators are unique
- Fixes #1045 by not allowing the same name for both post-aggregators and aggregators
- Optimizes post-aggregator calculation for groupBy