### PR TITLE
remove thread-locals in GenericIndexed in favor of wrapped objects

### DIFF
--- a/processing/src/main/java/io/druid/segment/column/SimpleDictionaryEncodedColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/SimpleDictionaryEncodedColumn.java
@@ -17,7 +17,7 @@
 
 package io.druid.segment.column;
 
-import io.druid.segment.data.GenericIndexed;
+import io.druid.segment.data.CachingIndexed;
 import io.druid.segment.data.IndexedInts;
 import io.druid.segment.data.VSizeIndexed;
 import io.druid.segment.data.VSizeIndexedInts;
@@ -30,17 +30,17 @@ public class SimpleDictionaryEncodedColumn implements DictionaryEncodedColumn
 {
   private final VSizeIndexedInts column;
   private final VSizeIndexed multiValueColumn;
-  private final GenericIndexed<String> lookups;
+  private final CachingIndexed<String> cachedLookups;
 
   public SimpleDictionaryEncodedColumn(
       VSizeIndexedInts singleValueColumn,
       VSizeIndexed multiValueColumn,
-      GenericIndexed<String> lookups
+      CachingIndexed<String> cachedLookups
   )
   {
     this.column = singleValueColumn;
     this.multiValueColumn = multiValueColumn;
-    this.lookups = lookups;
+    this.cachedLookups = cachedLookups;
   }
 
   @Override
@@ -70,24 +70,24 @@ public class SimpleDictionaryEncodedColumn implements DictionaryEncodedColumn
   @Override
   public String lookupName(int id)
   {
-    return lookups.get(id);
+    return cachedLookups.get(id);
   }
 
   @Override
   public int lookupId(String name)
   {
-    return lookups.indexOf(name);
+    return cachedLookups.indexOf(name);
   }
 
   @Override
   public int getCardinality()
   {
-    return lookups.size();
+    return cachedLookups.size();
   }
 
   @Override
   public void close() throws IOException
   {
-    lookups.close();
+    cachedLookups.close();
   }
 }

--- a/processing/src/main/java/io/druid/segment/data/CachingIndexed.java
+++ b/processing/src/main/java/io/druid/segment/data/CachingIndexed.java
@@ -1,0 +1,143 @@
+/*
+ * Druid - a distributed column store.
+ * Copyright 2012 - 2015 Metamarkets Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.druid.segment.data;
+
+import com.metamx.common.Pair;
+import com.metamx.common.logger.Logger;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class CachingIndexed<T> implements Indexed<T>, Closeable
+{
+  public static final int INITIAL_CACHE_CAPACITY = 16384;
+
+  private static final Logger log = new Logger(CachingIndexed.class);
+
+  private final GenericIndexed<T>.BufferIndexed delegate;
+  private final SizedLRUMap<Integer, T> cachedValues;
+
+  /**
+   * Creates a CachingIndexed wrapping the given GenericIndexed with a value lookup cache
+   *
+   * CachingIndexed objects are not thread safe and should only be used by a single thread at a time.
+   * CachingIndexed objects must be closed to release any underlying cache resources.
+   *
+   * @param delegate the GenericIndexed to wrap with a lookup cache.
+   * @param lookupCacheSize maximum size in bytes of the lookup cache if greater than zero
+   */
+  public CachingIndexed(GenericIndexed<T> delegate, final int lookupCacheSize)
+  {
+    this.delegate = delegate.singleThreaded();
+
+    if(lookupCacheSize > 0) {
+      log.debug("Allocating column cache of max size[%d]", lookupCacheSize);
+      cachedValues = new SizedLRUMap<>(INITIAL_CACHE_CAPACITY, lookupCacheSize);
+    } else {
+      cachedValues = null;
+    }
+  }
+
+  @Override
+  public Class<? extends T> getClazz()
+  {
+    return delegate.getClazz();
+  }
+
+  @Override
+  public int size()
+  {
+    return delegate.size();
+  }
+
+  @Override
+  public T get(int index)
+  {
+    if(cachedValues != null) {
+      final T cached = cachedValues.getValue(index);
+      if (cached != null) {
+        return cached;
+      }
+
+      final T value = delegate.get(index);
+      cachedValues.put(index, value, delegate.getLastValueSize());
+      return value;
+    } else {
+      return delegate.get(index);
+    }
+  }
+
+  @Override
+  public int indexOf(T value)
+  {
+    return delegate.indexOf(value);
+  }
+
+  @Override
+  public Iterator<T> iterator()
+  {
+    return delegate.iterator();
+  }
+
+  @Override
+  public void close() throws IOException
+  {
+    if (cachedValues != null) {
+      log.debug("Closing column cache");
+      cachedValues.clear();
+    }
+  }
+
+private static class SizedLRUMap<K, V> extends LinkedHashMap<K, Pair<Integer, V>>
+  {
+    private final int maxBytes;
+    private int numBytes = 0;
+
+    public SizedLRUMap(int initialCapacity, int maxBytes)
+    {
+      super(initialCapacity, 0.75f, true);
+      this.maxBytes = maxBytes;
+    }
+
+    @Override
+    protected boolean removeEldestEntry(Map.Entry<K, Pair<Integer, V>> eldest)
+    {
+      if (numBytes > maxBytes) {
+        numBytes -= eldest.getValue().lhs;
+        return true;
+      }
+      return false;
+    }
+
+    public void put(K key, V value, int size)
+    {
+      final int totalSize = size + 48; // add approximate object overhead
+      numBytes += totalSize;
+      super.put(key, new Pair<>(totalSize, value));
+    }
+
+    public V getValue(Object key)
+    {
+      final Pair<Integer, V> sizeValuePair = super.get(key);
+      return sizeValuePair == null ? null : sizeValuePair.rhs;
+    }
+  }
+}

--- a/processing/src/main/java/io/druid/segment/data/CompressedFloatsIndexedSupplier.java
+++ b/processing/src/main/java/io/druid/segment/data/CompressedFloatsIndexedSupplier.java
@@ -231,6 +231,8 @@ public class CompressedFloatsIndexedSupplier implements Supplier<IndexedFloats>
 
   private class CompressedIndexedFloats implements IndexedFloats
   {
+    final Indexed<ResourceHolder<FloatBuffer>> singleThreadedFloatBuffers = baseFloatBuffers.singleThreaded();
+
     int currIndex = -1;
     ResourceHolder<FloatBuffer> holder;
     FloatBuffer buffer;
@@ -288,7 +290,7 @@ public class CompressedFloatsIndexedSupplier implements Supplier<IndexedFloats>
     protected void loadBuffer(int bufferNum)
     {
       CloseQuietly.close(holder);
-      holder = baseFloatBuffers.get(bufferNum);
+      holder = singleThreadedFloatBuffers.get(bufferNum);
       buffer = holder.get();
       currIndex = bufferNum;
     }
@@ -299,7 +301,7 @@ public class CompressedFloatsIndexedSupplier implements Supplier<IndexedFloats>
       return "CompressedFloatsIndexedSupplier_Anonymous{" +
              "currIndex=" + currIndex +
              ", sizePer=" + sizePer +
-             ", numChunks=" + baseFloatBuffers.size() +
+             ", numChunks=" + singleThreadedFloatBuffers.size() +
              ", totalSize=" + totalSize +
              '}';
     }

--- a/processing/src/main/java/io/druid/segment/data/CompressedLongsIndexedSupplier.java
+++ b/processing/src/main/java/io/druid/segment/data/CompressedLongsIndexedSupplier.java
@@ -216,6 +216,8 @@ public class CompressedLongsIndexedSupplier implements Supplier<IndexedLongs>
 
   private class CompressedIndexedLongs implements IndexedLongs
   {
+    final Indexed<ResourceHolder<LongBuffer>> singleThreadedLongBuffers = baseLongBuffers.singleThreaded();
+
     int currIndex = -1;
     ResourceHolder<LongBuffer> holder;
     LongBuffer buffer;
@@ -273,7 +275,7 @@ public class CompressedLongsIndexedSupplier implements Supplier<IndexedLongs>
     protected void loadBuffer(int bufferNum)
     {
       CloseQuietly.close(holder);
-      holder = baseLongBuffers.get(bufferNum);
+      holder = singleThreadedLongBuffers.get(bufferNum);
       buffer = holder.get();
       currIndex = bufferNum;
     }
@@ -296,7 +298,7 @@ public class CompressedLongsIndexedSupplier implements Supplier<IndexedLongs>
       return "CompressedLongsIndexedSupplier_Anonymous{" +
              "currIndex=" + currIndex +
              ", sizePer=" + sizePer +
-             ", numChunks=" + baseLongBuffers.size() +
+             ", numChunks=" + singleThreadedLongBuffers.size() +
              ", totalSize=" + totalSize +
              '}';
     }

--- a/processing/src/main/java/io/druid/segment/serde/DictionaryEncodedColumnSupplier.java
+++ b/processing/src/main/java/io/druid/segment/serde/DictionaryEncodedColumnSupplier.java
@@ -20,6 +20,7 @@ package io.druid.segment.serde;
 import com.google.common.base.Supplier;
 import io.druid.segment.column.DictionaryEncodedColumn;
 import io.druid.segment.column.SimpleDictionaryEncodedColumn;
+import io.druid.segment.data.CachingIndexed;
 import io.druid.segment.data.GenericIndexed;
 import io.druid.segment.data.VSizeIndexed;
 import io.druid.segment.data.VSizeIndexedInts;
@@ -52,7 +53,7 @@ public class DictionaryEncodedColumnSupplier implements Supplier<DictionaryEncod
     return new SimpleDictionaryEncodedColumn(
         singleValuedColumn,
         multiValuedColumn,
-        lookupCacheSize > 0 ? dictionary.withCache(lookupCacheSize) : dictionary
+        new CachingIndexed<>(dictionary, lookupCacheSize)
     );
   }
 }


### PR DESCRIPTION
This should help reduce GC pressure form ThreadLocals on nodes with lots of indices. It may also slightly help with performance thanks to less branching.