### PR TITLE
DataSourceMetadataResultValue fixes and JodaUtils adjustments.

### DIFF
--- a/common/src/main/java/io/druid/common/utils/JodaUtils.java
+++ b/common/src/main/java/io/druid/common/utils/JodaUtils.java
@@ -27,7 +27,6 @@ import com.metamx.common.guava.Comparators;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.TreeSet;
@@ -36,9 +35,9 @@ import java.util.TreeSet;
  */
 public class JodaUtils
 {
-  // joda limits years to [-292275054,292278993] that should be reasonable
-  public static final long MAX_INSTANT = new DateTime("292278993").getMillis();
-  public static final long MIN_INSTANT = new DateTime("-292275054").getMillis();
+  // limit intervals such that duration millis fits in a long
+  public static final long MAX_INSTANT = Long.MAX_VALUE / 2;
+  public static final long MIN_INSTANT = Long.MIN_VALUE / 2;
 
   public static ArrayList<Interval> condenseIntervals(Iterable<Interval> intervals)
   {

--- a/common/src/test/java/io/druid/common/utils/JodaUtilsTest.java
+++ b/common/src/test/java/io/druid/common/utils/JodaUtilsTest.java
@@ -119,4 +119,11 @@ public class JodaUtilsTest
       );
     }
   }
+
+  @Test
+  public void testMinMaxInterval()
+  {
+    final Interval interval = new Interval(JodaUtils.MIN_INSTANT, JodaUtils.MAX_INSTANT);
+    Assert.assertEquals(Long.MAX_VALUE, interval.toDuration().getMillis());
+  }
 }

--- a/processing/src/main/java/io/druid/query/datasourcemetadata/DataSourceMetadataQuery.java
+++ b/processing/src/main/java/io/druid/query/datasourcemetadata/DataSourceMetadataQuery.java
@@ -22,7 +22,6 @@ package io.druid.query.datasourcemetadata;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import io.druid.common.utils.JodaUtils;
 import io.druid.query.BaseQuery;
 import io.druid.query.DataSource;
@@ -44,9 +43,6 @@ public class DataSourceMetadataQuery extends BaseQuery<Result<DataSourceMetadata
   public static final Interval MY_Y2K_INTERVAL = new Interval(
       JodaUtils.MIN_INSTANT, JodaUtils.MAX_INSTANT
   );
-
-  public static String MAX_INGESTED_EVENT_TIME = "maxIngestedEventTime";
-
 
   @JsonCreator
   public DataSourceMetadataQuery(

--- a/processing/src/main/java/io/druid/query/datasourcemetadata/DataSourceMetadataResultValue.java
+++ b/processing/src/main/java/io/druid/query/datasourcemetadata/DataSourceMetadataResultValue.java
@@ -20,7 +20,7 @@
 package io.druid.query.datasourcemetadata;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.joda.time.DateTime;
 
 /**
@@ -31,13 +31,13 @@ public class DataSourceMetadataResultValue
 
   @JsonCreator
   public DataSourceMetadataResultValue(
-      DateTime maxIngestedEventTime
+      @JsonProperty("maxIngestedEventTime") DateTime maxIngestedEventTime
   )
   {
     this.maxIngestedEventTime = maxIngestedEventTime;
   }
 
-  @JsonValue
+  @JsonProperty
   public DateTime getMaxIngestedEventTime()
   {
     return maxIngestedEventTime;


### PR DESCRIPTION
- Fix DataSourceMetadataResultValue serde.
- Bring in MIN/MAX instants a bit on JodaUtils to prevent the difference from overflowing a long.