### PR TITLE
Remove ObjectMapper::copy() from QueryResource

### DIFF
--- a/server/src/main/java/io/druid/server/QueryResource.java
+++ b/server/src/main/java/io/druid/server/QueryResource.java
@@ -17,7 +17,6 @@
 
 package io.druid.server;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.jaxrs.smile.SmileMediaTypes;
@@ -89,12 +88,8 @@ public class QueryResource
   )
   {
     this.config = config;
-    this.jsonMapper = jsonMapper.copy();
-    this.jsonMapper.getFactory().configure(JsonGenerator.Feature.AUTO_CLOSE_TARGET, false);
-
-    this.smileMapper = smileMapper.copy();
-    this.smileMapper.getFactory().configure(JsonGenerator.Feature.AUTO_CLOSE_TARGET, false);
-
+    this.jsonMapper = jsonMapper;
+    this.smileMapper = smileMapper;
     this.texasRanger = texasRanger;
     this.emitter = emitter;
     this.requestLogger = requestLogger;
@@ -125,7 +120,8 @@ public class QueryResource
     String queryId = null;
 
     final String reqContentType = req.getContentType();
-    final boolean isSmile = SmileMediaTypes.APPLICATION_JACKSON_SMILE.equals(reqContentType) || APPLICATION_SMILE.equals(reqContentType);
+    final boolean isSmile = SmileMediaTypes.APPLICATION_JACKSON_SMILE.equals(reqContentType)
+                            || APPLICATION_SMILE.equals(reqContentType);
     final String contentType = isSmile ? SmileMediaTypes.APPLICATION_JACKSON_SMILE : MediaType.APPLICATION_JSON;
 
     ObjectMapper objectMapper = isSmile ? smileMapper : jsonMapper;
@@ -210,7 +206,7 @@ public class QueryResource
                   }
                 },
                 contentType
-        )
+            )
             .header("X-Druid-Query-Id", queryId)
             .header("X-Druid-Response-Context", jsonMapper.writeValueAsString(responseContext))
             .build();

--- a/server/src/test/java/io/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/io/druid/server/QueryResourceTest.java
@@ -50,13 +50,17 @@ import java.util.Map;
 public class QueryResourceTest
 {
   private static final ObjectMapper jsonMapper = new DefaultObjectMapper();
-  public static final ServerConfig serverConfig = new ServerConfig(){
+  public static final ServerConfig serverConfig = new ServerConfig()
+  {
     @Override
-    public int getNumThreads(){
+    public int getNumThreads()
+    {
       return 1;
     }
+
     @Override
-    public Period getMaxIdleTime(){
+    public Period getMaxIdleTime()
+    {
       return Period.seconds(1);
     }
   };
@@ -90,10 +94,13 @@ public class QueryResourceTest
   };
 
   private static final ServiceEmitter noopServiceEmitter = new NoopServiceEmitter();
+
   @BeforeClass
-  public static void staticSetup(){
+  public static void staticSetup()
+  {
     com.metamx.emitter.EmittingLogger.registerEmitter(noopServiceEmitter);
   }
+
   @Before
   public void setup()
   {
@@ -101,6 +108,7 @@ public class QueryResourceTest
     EasyMock.expect(testServletRequest.getRemoteAddr()).andReturn("localhost").anyTimes();
     EasyMock.replay(testServletRequest);
   }
+
   private static final String simpleTimeSeriesQuery = "{\n"
                                                       + "    \"queryType\": \"timeseries\",\n"
                                                       + "    \"dataSource\": \"mmx_metrics\",\n"
@@ -115,6 +123,7 @@ public class QueryResourceTest
                                                       + "      }\n"
                                                       + "    ]\n"
                                                       + "}";
+
   @Test
   public void testGoodQuery() throws IOException
   {
@@ -126,10 +135,15 @@ public class QueryResourceTest
         new NoopServiceEmitter(),
         new NoopRequestLogger(),
         new QueryManager()
-        );
-    Response respone = queryResource.doPost(new ByteArrayInputStream(simpleTimeSeriesQuery.getBytes("UTF-8")), null /*pretty*/, testServletRequest);
+    );
+    Response respone = queryResource.doPost(
+        new ByteArrayInputStream(simpleTimeSeriesQuery.getBytes("UTF-8")),
+        null /*pretty*/,
+        testServletRequest
+    );
     Assert.assertNotNull(respone);
   }
+
   @Test
   public void testBadQuery() throws IOException
   {
@@ -143,7 +157,11 @@ public class QueryResourceTest
         new NoopRequestLogger(),
         new QueryManager()
     );
-    Response respone = queryResource.doPost(new ByteArrayInputStream("Meka Leka Hi Meka Hiney Ho".getBytes("UTF-8")), null /*pretty*/, testServletRequest);
+    Response respone = queryResource.doPost(
+        new ByteArrayInputStream("Meka Leka Hi Meka Hiney Ho".getBytes("UTF-8")),
+        null /*pretty*/,
+        testServletRequest
+    );
     Assert.assertNotNull(respone);
     Assert.assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), respone.getStatus());
   }


### PR DESCRIPTION
Ran into this one while working on Query-time Lookups.

Essentially anything annotated with `@JacksonInject` that's in the *query* codepath does not inject at all currently.

The configuration codepath still works as intended as far as I know.

This now uses the default configuration for `ObjectMapper` (`@Json` and `@Smile`)  which *may* auto-close the input/outputs.