### PR TITLE
Query time lookup (In Code Review)

### DIFF
--- a/docs/content/Historical-Config.md
+++ b/docs/content/Historical-Config.md
@@ -100,3 +100,13 @@ You can optionally only configure caching to be enabled on the historical by set
 |`druid.cache.hosts`|Command separated list of Memcached hosts `<host:port>`.|none|
 |`druid.cache.maxObjectSize`|Maximum object size in bytes for a Memcached object.|52428800 (50 MB)|
 |`druid.cache.memcachedPrefix`|Key prefix for all keys in Memcached.|druid|
+
+
+### Namespaces
+Namespaces, or query time lookups, refers to the ability to modify a datasource with a simple mapping from one set of dimension values to another. The namespaces are a property of dimension extraction functions and can be used in any place dimension extraction functions can be used.
+The following are settings used by the historical nodes when setting namespaces
+|Property|Description|Default|
+|--------|-----------|-------|
+|`druid.query.extraction.namespace.cache.type`|Specifies the type of caching to be used by the namespaces. May be one of [`offHeap`, `onHeap`, `cache`]. `offHeap` uses a temporary file for off-heap storage of the namespace. `onHeap` stores all cache on the heap. `cache` attempts to piggyback the setup for `druid.cache`|`onHeap`|
+|`druid.query.extraction.namespace.enabled`|Specifies that processing of namespaces is to be enabled. This should only be set to `true` on historical nodes and should be absent or false everywhere else.|`false`|
+|`druid.zk.paths.namespacePath`|The path to pull namespace updates from|`${druid.zk.paths.base}/namespaces`|

--- a/docs/content/TopNQuery.md
+++ b/docs/content/TopNQuery.md
@@ -212,3 +212,6 @@ Users who can tolerate *approximate rank* topN over a dimension with greater tha
     "threshold": 2
 }
 ```
+
+### DimExtractionFn
+A TopN over a dimension which is extracted has its own code path to be able to properly capture re-bucketing data. If the query issuer knows that data does not need to be rebucketed (for example, changing a name from one unique value to another unique value), a query context of `topNFastRename` set to `true` can be specified to enable a more optimized codepath.

--- a/docs/content/ZooKeeper.md
+++ b/docs/content/ZooKeeper.md
@@ -10,6 +10,51 @@ Druid uses [ZooKeeper](http://zookeeper.apache.org/) (ZK) for management of curr
 4.  [Overlord](Indexing-Service.html) leader election
 5.  [Indexing Service](Indexing-Service.html) task management
 
+
+### Property Configuration
+
+ZooKeeper paths are set via the `runtime.properties` configuration file. Druid will automatically create paths that do not exist, so typos in config files is a very easy way to become split-brained.
+
+
+|Property|Description|Default|
+|--------|-----------|-------|
+|`druid.zk.service.host`|The ZooKeeper hosts to connect to. This is a REQUIRED property and therefore a host address must be supplied.|none|
+|`druid.zk.service.sessionTimeoutMs`|ZooKeeper session timeout, in milliseconds.|`30000`|
+|`druid.curator.compress`|Boolean flag for whether or not created Znodes should be compressed.|`false`|
+
+### Path Configuration
+Druid interacts with ZK through a set of standard path configurations. We recommend just setting the base ZK path, but all ZK paths that Druid uses can be overwritten to absolute paths.
+
+|Property|Description|Default|
+|--------|-----------|-------|
+|`druid.zk.paths.base`|Base Zookeeper path.|`/druid`|
+|`druid.zk.paths.propertiesPath`|Zookeeper properties path.|`${druid.zk.paths.base}/properties`|
+|`druid.zk.paths.announcementsPath`|Druid node announcement path.|`${druid.zk.paths.base}/announcements`|
+|`druid.zk.paths.liveSegmentsPath`|Current path for where Druid nodes announce their segments.|`${druid.zk.paths.base}/segments`|
+|`druid.zk.paths.loadQueuePath`|Entries here cause historical nodes to load and drop segments.|`${druid.zk.paths.base}/loadQueue`|
+|`druid.zk.paths.coordinatorPath`|Used by the coordinator for leader election.|`${druid.zk.paths.base}/coordinator`|
+|`druid.zk.paths.servedSegmentsPath`|@Deprecated. Legacy path for where Druid nodes announce their segments.|`${druid.zk.paths.base}/servedSegments`|
+|`druid.zk.paths.namespacePath`|The path to pull namespace updates from|`${druid.zk.paths.base}/namespaces`|
+
+The indexing service also uses its own set of paths. These configs can be included in the common configuration.
+
+|Property|Description|Default|
+|--------|-----------|-------|
+|`druid.zk.paths.indexer.base`|Base zookeeper path for |`${druid.zk.paths.base}/indexer`|
+|`druid.zk.paths.indexer.announcementsPath`|Middle managers announce themselves here.|`${druid.zk.paths.indexer.base}/announcements`|
+|`druid.zk.paths.indexer.tasksPath`|Used to assign tasks to middle managers.|`${druid.zk.paths.indexer.base}/tasks`|
+|`druid.zk.paths.indexer.statusPath`|Parent path for announcement of task statuses.|`${druid.zk.paths.indexer.base}/status`|
+|`druid.zk.paths.indexer.leaderLatchPath`|Used for Overlord leader election.|`${druid.zk.paths.indexer.base}/leaderLatchPath`|
+
+If `druid.zk.paths.base` and `druid.zk.paths.indexer.base` are both set, and none of the other `druid.zk.paths.*` or `druid.zk.paths.indexer.*` values are set, then the other properties will be evaluated relative to their respective `base`.
+For example, if `druid.zk.paths.base` is set to `/druid1` and `druid.zk.paths.indexer.base` is set to `/druid2` then `druid.zk.paths.announcementsPath` will default to `/druid1/announcements` while `druid.zk.paths.indexer.announcementsPath` will default to `/druid2/announcements`.
+
+The following path is used service discovery and are **not** affected by `druid.zk.paths.base` and **must** be specified separately.
+
+|Property|Description|Default|
+|--------|-----------|-------|
+|`druid.discovery.curator.path`|Services announce themselves under this ZooKeeper path.|`/druid/discovery`|
+
 ### Coordinator Leader Election
 
 We use the Curator LeadershipLatch recipe to do leader election at path

--- a/extensions/dim-rename-kafka8/pom.xml
+++ b/extensions/dim-rename-kafka8/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to Metamarkets Group Inc. (Metamarkets) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  Metamarkets licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.druid.extensions</groupId>
+  <artifactId>druid-dim-rename-kafka8</artifactId>
+  <name>druid-dim-rename-kafka8</name>
+  <description>Extension to rename Druid dimension values using Kafka8</description>
+
+  <parent>
+    <groupId>io.druid</groupId>
+    <artifactId>druid</artifactId>
+    <version>0.7.2-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.druid</groupId>
+      <artifactId>druid-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.druid</groupId>
+      <artifactId>druid-processing</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.druid</groupId>
+      <artifactId>druid-server</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka_2.9.2</artifactId>
+      <version>0.8.1.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- Tests -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>mx4j</groupId>
+      <artifactId>mx4j-tools</artifactId>
+      <version>3.0.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+              <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/extensions/dim-rename-kafka8/src/main/java/io/druid/query/extraction/namespace/KafkaExtractionNamespace.java
+++ b/extensions/dim-rename-kafka8/src/main/java/io/druid/query/extraction/namespace/KafkaExtractionNamespace.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.extraction.namespace;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.base.Preconditions;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ *
+ */
+@JsonTypeName("kafka")
+public class KafkaExtractionNamespace implements ExtractionNamespace
+{
+  @JsonProperty
+  private final String kafkaTopic;
+  @JsonProperty
+  private final String namespace;
+
+  @JsonCreator
+  public KafkaExtractionNamespace(
+      @NotNull @JsonProperty(value = "kafkaTopic", required = true)
+      final String kafkaTopic,
+      @NotNull @JsonProperty(value = "namespace", required = true)
+      final String namespace
+  )
+  {
+    Preconditions.checkNotNull(kafkaTopic, "kafkatTopic required");
+    Preconditions.checkNotNull(namespace, "namespace required");
+    this.kafkaTopic = kafkaTopic;
+    this.namespace = namespace;
+  }
+
+  public String getKafkaTopic()
+  {
+    return kafkaTopic;
+  }
+
+  @Override
+  public String getNamespace()
+  {
+    return namespace;
+  }
+
+  @Override
+  public String toString(){
+    return String.format("KafkaExtractionNamespace = { kafkaTopic = '%s', namespace = '%s'", kafkaTopic, namespace);
+  }
+}

--- a/extensions/dim-rename-kafka8/src/main/java/io/druid/server/namespace/KafkaExtractionManager.java
+++ b/extensions/dim-rename-kafka8/src/main/java/io/druid/server/namespace/KafkaExtractionManager.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.namespace;
+
+import com.google.common.base.Function;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import com.metamx.common.IAE;
+import com.metamx.common.ISE;
+import com.metamx.common.StringUtils;
+import com.metamx.common.lifecycle.LifecycleStart;
+import com.metamx.common.lifecycle.LifecycleStop;
+import com.metamx.common.logger.Logger;
+import io.druid.guice.ManageLifecycle;
+import io.druid.query.extraction.namespace.KafkaExtractionNamespace;
+import io.druid.server.namespace.cache.NamespaceExtractionCacheManager;
+import kafka.consumer.ConsumerConfig;
+import kafka.consumer.ConsumerIterator;
+import kafka.consumer.KafkaStream;
+import kafka.consumer.Whitelist;
+import kafka.javaapi.consumer.ConsumerConnector;
+import kafka.message.MessageAndMetadata;
+import kafka.serializer.Decoder;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Pattern;
+
+/**
+ *
+ */
+@ManageLifecycle
+public class KafkaExtractionManager
+{
+  private static final Logger log = new Logger(KafkaExtractionManager.class);
+
+  private final Properties kafkaProperties;
+  private final ConcurrentMap<String, Function<String, String>> fnCache;
+  private final Collection<ListenableFuture<?>> futures = new ConcurrentLinkedQueue<>();
+  private final ListeningExecutorService executorService = MoreExecutors.listeningDecorator(
+      Executors.newCachedThreadPool(
+          new ThreadFactoryBuilder()
+              .setNameFormat("kafka-rename-consumer-%d")
+              .setDaemon(true)
+              .setPriority(Thread.MIN_PRIORITY)
+              .build()
+      )
+  );
+  private final NamespaceExtractionCacheManager cacheManager;
+  private final AtomicInteger startedPipes = new AtomicInteger(0);
+  private final AtomicLong events = new AtomicLong(0l);
+
+  // Bindings in KafkaExtractionNamespaceModule
+  @Inject
+  public KafkaExtractionManager(
+      @Named("renameKafkaProperties") Properties kafkaProperties,
+      NamespaceExtractionCacheManager cacheManager,
+      @Named("io.druid.server.namespace.NamespacedExtractionModule")
+      ConcurrentMap<String, Function<String, String>> fnCache
+  )
+  {
+    this.kafkaProperties = new Properties();
+    this.fnCache = fnCache;
+    if (kafkaProperties != null) {
+      if (kafkaProperties.containsKey("group.id")) {
+        throw new IAE(
+            "Cannot set kafka property [group.id]. Property is randomly generated for you. Found [%s]",
+            kafkaProperties.getProperty("group.id")
+        );
+      }
+      if (kafkaProperties.containsKey("auto.offset.reset")) {
+        throw new IAE(
+            "Cannot set kafka property [auto.offset.reset]. Property will be forced to [smallest]. Found [%s]",
+            kafkaProperties.getProperty("auto.offset.reset")
+        );
+      }
+      this.kafkaProperties.putAll(kafkaProperties);
+    }
+    if (!this.kafkaProperties.containsKey("zookeeper.connect")) {
+      this.kafkaProperties.put("zookeeper.connect", "localhost:2181/kafka");
+    }
+    // Enable publish-subscribe
+    this.kafkaProperties.setProperty("auto.offset.reset", "smallest");
+    this.cacheManager = cacheManager;
+  }
+
+  public Integer getBackgroundTaskCount()
+  {
+    return startedPipes.get();
+  }
+
+  private static final Decoder<String> defaultStringDecoder = new Decoder<String>()
+  {
+    @Override
+    public String fromBytes(byte[] bytes)
+    {
+      return StringUtils.fromUtf8(bytes);
+    }
+  };
+
+  public Long getNumEvents()
+  {
+    return events.get();
+  }
+
+  private static void updateMap(final String topic, final MessageAndMetadata<String, String> messageAndMetadata, final ConcurrentMap<String, String> map){
+    final String key = messageAndMetadata.key();
+    final String message = messageAndMetadata.message();
+    if (key == null || message == null) {
+      log.error("Bad key/message from topic [%s]: [%s]", topic, messageAndMetadata);
+      return;
+    }
+    map.put(key, message);
+  }
+
+  public void addListener(final KafkaExtractionNamespace kafkaNamespace){
+    final String topic = kafkaNamespace.getKafkaTopic();
+    final String namespace = kafkaNamespace.getNamespace();
+    final ListenableFuture<?> future = executorService.submit(
+        new Runnable()
+        {
+          @Override
+          public void run()
+          {
+            final ConcurrentMap<String, String> map = cacheManager.getCacheMap(namespace);
+            final Properties privateProperties = new Properties();
+            privateProperties.putAll(kafkaProperties);
+            privateProperties.setProperty("group.id", UUID.randomUUID().toString());
+            ConsumerConnector consumerConnector = new kafka.javaapi.consumer.ZookeeperConsumerConnector(
+                new ConsumerConfig(
+                    privateProperties
+                )
+            );
+            List<KafkaStream<String, String>> streams = consumerConnector.createMessageStreamsByFilter(
+                new Whitelist(Pattern.quote(topic)), 1, defaultStringDecoder, defaultStringDecoder
+            );
+
+            if (streams == null || streams.isEmpty()) {
+              throw new IAE("Topic [%s] had no streams", topic);
+            }
+            if (streams.size() > 1) {
+              throw new ISE("Topic [%s] has %d streams! expected 1", topic, streams.size());
+            }
+            fnCache.put(
+                namespace,
+                new Function<String, String>()
+                {
+                  @Nullable
+                  @Override
+                  public String apply(@Nullable String input)
+                  {
+                    if(input == null){
+                      return null;
+                    }
+                    return map.get(input);
+                  }
+                }
+            );
+            startedPipes.incrementAndGet();
+            final KafkaStream<String, String> kafkaStream = streams.iterator().next();
+            final ConsumerIterator<String, String> it = kafkaStream.iterator();
+            log.info("Listening to topic [%s] for namespace [%s]", topic, namespace);
+            while (it.hasNext()) {
+              final MessageAndMetadata<String, String> messageAndMetadata = it.next();
+              updateMap(topic, messageAndMetadata, map);
+              events.incrementAndGet();
+            }
+          }
+        }
+    );
+    Futures.addCallback(
+        future, new FutureCallback<Object>()
+        {
+          @Override
+          public void onSuccess(Object result)
+          {
+            // Noop
+          }
+
+          @Override
+          public void onFailure(Throwable t)
+          {
+            if (t instanceof java.util.concurrent.CancellationException) {
+              log.warn("Cancelled rename task for topic [%s]", topic);
+            } else {
+              Throwables.propagate(t);
+            }
+          }
+        },
+        MoreExecutors.sameThreadExecutor()
+    );
+  }
+  @LifecycleStart
+  public void start()
+  {
+    // NO-OP
+    // all consumers are started through KafkaExtractionNamespaceFactory.getCachePopulator
+  }
+
+  @LifecycleStop
+  public void stop()
+  {
+    executorService.shutdown();
+    Futures.allAsList(futures).cancel(true);
+  }
+}

--- a/extensions/dim-rename-kafka8/src/main/java/io/druid/server/namespace/KafkaExtractionNamespaceFactory.java
+++ b/extensions/dim-rename-kafka8/src/main/java/io/druid/server/namespace/KafkaExtractionNamespaceFactory.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.namespace;
+
+import com.google.common.base.Function;
+import com.google.common.base.Strings;
+import com.google.common.util.concurrent.Runnables;
+import com.google.inject.Inject;
+import io.druid.query.extraction.namespace.ExtractionNamespaceFunctionFactory;
+import io.druid.query.extraction.namespace.KafkaExtractionNamespace;
+import io.druid.server.namespace.cache.NamespaceExtractionCacheManager;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ *
+ */
+public class KafkaExtractionNamespaceFactory implements ExtractionNamespaceFunctionFactory<KafkaExtractionNamespace>
+{
+  private final NamespaceExtractionCacheManager cacheManager;
+  private final KafkaExtractionManager kafkaExtractionManager;
+  @Inject
+  public KafkaExtractionNamespaceFactory(
+      final NamespaceExtractionCacheManager cacheManager,
+      final KafkaExtractionManager kafkaExtractionManager
+  ){
+    this.cacheManager = cacheManager;
+    this.kafkaExtractionManager = kafkaExtractionManager;
+  }
+  @Override
+  public Function<String, String> build(KafkaExtractionNamespace extractionNamespace)
+  {
+    final ConcurrentMap<String, String> cache = cacheManager.getCacheMap(extractionNamespace.getNamespace());
+    return new Function<String, String>()
+    {
+      @Nullable
+      @Override
+      public String apply(String input)
+      {
+        return cache.get(input);
+      }
+    };
+  }
+
+  @Override
+  public Runnable getCachePopulator(final KafkaExtractionNamespace extractionNamespace)
+  {
+    return new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        kafkaExtractionManager.addListener(extractionNamespace);
+      }
+    };
+  }
+}

--- a/extensions/dim-rename-kafka8/src/main/java/io/druid/server/namespace/KafkaExtractionNamespaceModule.java
+++ b/extensions/dim-rename-kafka8/src/main/java/io/druid/server/namespace/KafkaExtractionNamespaceModule.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.namespace;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import com.google.inject.Provides;
+import com.google.inject.name.Named;
+import com.google.inject.name.Names;
+import io.druid.guice.LazySingleton;
+import io.druid.guice.LifecycleModule;
+import io.druid.guice.ManageLifecycle;
+import io.druid.guice.annotations.Json;
+import io.druid.initialization.DruidModule;
+import io.druid.query.extraction.namespace.ExtractionNamespaceFunctionFactory;
+import io.druid.query.extraction.namespace.KafkaExtractionNamespace;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ *
+ */
+public class KafkaExtractionNamespaceModule implements DruidModule
+{
+  private static final String PROPERTIES_KEY = "druid.query.rename.kafka.properties";
+
+  @Override
+  public List<? extends Module> getJacksonModules()
+  {
+    return ImmutableList.<Module>of(
+        new Module()
+        {
+          @Override
+          public String getModuleName()
+          {
+            return "druid-dim-rename";
+          }
+
+          @Override
+          public Version version()
+          {
+            return Version.unknownVersion();
+          }
+
+          @Override
+          public void setupModule(SetupContext setupContext)
+          {
+            setupContext.registerSubtypes(KafkaExtractionNamespace.class);
+          }
+        }
+    );
+  }
+
+  @Provides
+  @Named("renameKafkaProperties")
+  public Properties getProperties(
+      @Json ObjectMapper mapper,
+      Properties systemProperties
+  )
+  {
+    String val = systemProperties.getProperty(PROPERTIES_KEY);
+    if (val == null) {
+      return new Properties();
+    }
+    try {
+      Properties properties = new Properties();
+      properties.putAll(
+          mapper.<Map<String, String>>readValue(
+              val, new TypeReference<Map<String, String>>()
+              {
+              }
+          )
+      );
+      return properties;
+    }
+    catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public void configure(Binder binder)
+  {
+    binder
+        .bind(ExtractionNamespaceFunctionFactory.class)
+        .annotatedWith(Names.named(KafkaExtractionNamespace.class.getCanonicalName()))
+        .to(KafkaExtractionNamespaceFactory.class)
+        .in(LazySingleton.class);
+    binder.bind(KafkaExtractionManager.class).in(ManageLifecycle.class);
+    LifecycleModule.register(binder, KafkaExtractionManager.class);
+  }
+}

--- a/extensions/dim-rename-kafka8/src/main/resources/META-INF/services/io.druid.initialization.DruidModule
+++ b/extensions/dim-rename-kafka8/src/main/resources/META-INF/services/io.druid.initialization.DruidModule
@@ -1,0 +1,19 @@
+#
+# Licensed to Metamarkets Group Inc. (Metamarkets) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Metamarkets licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+io.druid.server.namespace.KafkaExtractionNamespaceModule

--- a/extensions/dim-rename-kafka8/src/test/java/io/druid/query/extraction/namespace/TestKafkaExtractionCluster.java
+++ b/extensions/dim-rename-kafka8/src/test/java/io/druid/query/extraction/namespace/TestKafkaExtractionCluster.java
@@ -1,0 +1,309 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.extraction.namespace;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Function;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Files;
+import com.metamx.common.ISE;
+import com.metamx.common.StringUtils;
+import com.metamx.common.lifecycle.Lifecycle;
+import com.metamx.common.logger.Logger;
+import io.druid.jackson.DefaultObjectMapper;
+import io.druid.server.initialization.ZkPathsConfig;
+import io.druid.server.namespace.KafkaExtractionManager;
+import io.druid.server.namespace.KafkaExtractionNamespaceFactory;
+import io.druid.server.namespace.KafkaExtractionNamespaceModule;
+import io.druid.server.namespace.NamespacedExtractionModule;
+import io.druid.server.namespace.cache.NamespaceExtractionCacheManager;
+import io.druid.server.namespace.cache.OffHeapNamespaceExtractionCacheManager;
+import io.druid.server.namespace.cache.OnHeapNamespaceExtractionCacheManager;
+import kafka.admin.AdminUtils;
+import kafka.javaapi.producer.Producer;
+import kafka.producer.KeyedMessage;
+import kafka.producer.ProducerConfig;
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaServer;
+import kafka.utils.Time;
+import kafka.utils.ZKStringSerializer$;
+import org.I0Itec.zkclient.ZkClient;
+import org.apache.curator.test.TestingServer;
+import org.apache.log4j.BasicConfigurator;
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.Level;
+import org.apache.log4j.PatternLayout;
+import org.apache.zookeeper.CreateMode;
+import org.joda.time.DateTime;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ *
+ */
+public class TestKafkaExtractionCluster
+{
+  private static final Logger log = new Logger(TestKafkaExtractionCluster.class);
+  private static KafkaServer kafkaServer;
+  private static Properties kafkaProperties = new Properties();
+  private static KafkaConfig kafkaConfig;
+  private static final String topicName = "testTopic";
+  private static final String namespace = "testNamespace";
+  private static TestingServer zkTestServer;
+  private static KafkaExtractionManager renameManager;
+  private static final ConcurrentMap<String, Function<String, String>> fnCache = new ConcurrentHashMap<>();
+
+  private static final String[] defaultZNodes = new String[]{"kafka"};
+  private static final Lifecycle lifecycle = new Lifecycle();
+  private static final NamespaceExtractionCacheManager extractionCacheManager = new OnHeapNamespaceExtractionCacheManager(
+      lifecycle
+  );
+
+  @AfterClass
+  public static void tearDownStatic()
+  {
+    lifecycle.stop();
+  }
+
+  @BeforeClass
+  public static void setupStatic() throws Exception
+  {
+    final File tmpDir = Files.createTempDir();
+    tmpDir.deleteOnExit();
+
+    ConsoleAppender consoleAppender = new ConsoleAppender();
+    consoleAppender.setTarget("System.out");
+    consoleAppender.setFollow(true);
+    consoleAppender.activateOptions();
+    consoleAppender.setName("console");
+    consoleAppender.setThreshold(Level.INFO);
+    consoleAppender.setLayout(new PatternLayout("%d{ISO8601} %p [%t] %c - %m%n"));
+    BasicConfigurator.configure(
+        consoleAppender
+    );
+    log.info("---------------------------Set console appender---------------------------");
+    zkTestServer = new TestingServer(-1, new File(tmpDir.getAbsolutePath() + "/zk"), true);
+    {
+      ZkClient zkClient = new ZkClient(
+          zkTestServer.getConnectString(),
+          10000,
+          10000,
+          ZKStringSerializer$.MODULE$
+      );
+      for (String znode : defaultZNodes) {
+        final String zNode = String.format("/%s", znode);
+        if (zkClient.exists(zNode)) {
+          zkClient.deleteRecursive(zNode);
+        }
+        zkClient.create(zNode, null, CreateMode.PERSISTENT);
+      }
+      zkClient.close();
+    }
+
+    log.info("---------------------------Started ZK---------------------------");
+    kafkaProperties.put("broker.id", "0");
+    kafkaProperties.put("log.dir", tmpDir.getAbsolutePath() + "/log");
+    kafkaProperties.put("zookeeper.connect", zkTestServer.getConnectString() + "/kafka");
+    kafkaProperties.put("log.cleaner.enable", "true");
+    kafkaProperties.put("request.required.acks", "1");
+    kafkaProperties.put("host", "127.0.0.1");
+    kafkaProperties.put("host.name", "127.0.0.1");
+
+    kafkaProperties.put("zookeeper.session.timeout.ms", "10000");
+    kafkaProperties.put("zookeeper.sync.time.ms", "200");
+    kafkaProperties.put("auto.commit.interval.ms", "1000");
+
+    kafkaConfig = new KafkaConfig(kafkaProperties);
+
+    final long time = DateTime.parse("2015-01-01").getMillis();
+    kafkaServer = new KafkaServer(
+        kafkaConfig, new Time()
+    {
+
+      @Override
+      public long milliseconds()
+      {
+        return time;
+      }
+
+      @Override
+      public long nanoseconds()
+      {
+        return milliseconds() * 1_000_000;
+      }
+
+      @Override
+      public void sleep(long ms)
+      {
+        try {
+          Thread.sleep(ms);
+        }
+        catch (InterruptedException e) {
+          throw Throwables.propagate(e);
+        }
+      }
+    }
+    );
+    kafkaServer.startup();
+    kafkaProperties.put(
+        "metadata.broker.list",
+        String.format("127.0.0.1:%d", kafkaServer.socketServer().port())
+    );
+    int sleepCount = 0;
+    while (!kafkaServer.kafkaController().isActive()) {
+      Thread.sleep(10);
+      if (++sleepCount > 100) {
+        throw new InterruptedException("Controller took to long to awaken");
+      }
+    }
+
+    log.info("---------------------------Started Kafka Server---------------------------");
+
+    ZkClient zkClient = new ZkClient(
+        kafkaProperties.getProperty("zookeeper.connect"), 10000, 10000,
+        ZKStringSerializer$.MODULE$
+    );
+    try {
+      final Properties topicProperties = new Properties();
+      topicProperties.put("cleanup.policy", "compact");
+      if (!AdminUtils.topicExists(zkClient, topicName)) {
+        AdminUtils.createTopic(zkClient, topicName, 1, 1, topicProperties);
+      }
+
+      log.info("---------------------------Created topic---------------------------");
+
+      Assert.assertTrue(AdminUtils.topicExists(zkClient, topicName));
+    }
+    finally {
+      zkClient.close();
+    }
+    fnCache.clear();
+    renameManager = new KafkaExtractionManager(
+        kafkaProperties,
+        extractionCacheManager,
+        fnCache
+    );
+    Producer<byte[], byte[]> producer = new Producer<byte[], byte[]>(new ProducerConfig(kafkaProperties));
+    try {
+      producer.send(
+          new KeyedMessage<byte[], byte[]>(
+              topicName,
+              StringUtils.toUtf8("abcdefg"),
+              StringUtils.toUtf8("abcdefg")
+          )
+      );
+    }
+    catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+    finally {
+      producer.close();
+    }
+    log.info("--------------------------- placed default item via producer ---------------------------");
+    renameManager.start();
+    renameManager.addListener(new KafkaExtractionNamespace("testTopic", "testTopic"));
+    long start = System.currentTimeMillis();
+    while (renameManager.getBackgroundTaskCount() < 1) {
+      Thread.sleep(10); // wait for map populator to start up
+      if (System.currentTimeMillis() > start + 60_000) {
+        throw new ISE("renameManager took too long to start");
+      }
+    }
+    log.info("--------------------------- started rename manager ---------------------------");
+  }
+
+  @AfterClass
+  public static void closeStatic() throws IOException
+  {
+    if (null != renameManager) {
+      renameManager.stop();
+    }
+
+    if (null != kafkaServer) {
+      kafkaServer.shutdown();
+      kafkaServer.awaitShutdown();
+    }
+
+    if (null != zkTestServer) {
+      zkTestServer.stop();
+    }
+  }
+
+  private static void checkServer()
+  {
+    if (!kafkaServer.apis().controller().isActive()) {
+      throw new ISE("server is not active!");
+    }
+  }
+
+  @Test
+  public void testSimpleRename() throws InterruptedException
+  {
+    final Producer<byte[], byte[]> producer = new Producer<byte[], byte[]>(new ProducerConfig(kafkaProperties));
+    try {
+      checkServer();
+
+      KafkaExtractionNamespace extractionNamespace = new KafkaExtractionNamespace(namespace, topicName);
+      final KafkaExtractionNamespaceFactory factory = new KafkaExtractionNamespaceFactory(extractionCacheManager, renameManager);
+      final Function<String, String> fn = factory.build(extractionNamespace);
+      Assert.assertEquals(null, fn.apply("foo"));
+
+      long events = renameManager.getNumEvents();
+
+      producer.send(new KeyedMessage<byte[], byte[]>(topicName, StringUtils.toUtf8("foo"), StringUtils.toUtf8("bar")));
+
+      long start = System.currentTimeMillis();
+      while (fn.apply("foo") == null) {
+        Thread.sleep(10);
+        if (System.currentTimeMillis() > start + 60_000) {
+          throw new ISE("Took too long to update event");
+        }
+      }
+
+      log.info("-------------------------     Checking foo bar     -------------------------------");
+      Assert.assertEquals("bar", fn.apply("foo"));
+      Assert.assertEquals(null, fn.apply("baz"));
+
+      checkServer();
+      events = renameManager.getNumEvents();
+      producer.send(new KeyedMessage<byte[], byte[]>(topicName, StringUtils.toUtf8("baz"), StringUtils.toUtf8("bat")));
+      while (events == renameManager.getNumEvents()) {
+        Thread.sleep(10);
+        if (System.currentTimeMillis() > start + 60_000) {
+          throw new ISE("Took too long to update event");
+        }
+      }
+      Assert.assertEquals("bat", fn.apply("baz"));
+    }
+    finally {
+      producer.close();
+    }
+  }
+}

--- a/extensions/dim-rename-kafka8/src/test/java/io/druid/query/extraction/namespace/TestKafkaExtractionNamespace.java
+++ b/extensions/dim-rename-kafka8/src/test/java/io/druid/query/extraction/namespace/TestKafkaExtractionNamespace.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.extraction.namespace;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.druid.jackson.DefaultObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ *
+ */
+public class TestKafkaExtractionNamespace
+{
+  @Test
+  public void testReflectiveSerde() throws IOException
+  {
+    ObjectMapper mapper = new DefaultObjectMapper();
+    mapper.registerSubtypes(KafkaExtractionNamespace.class);
+    final String val = "{\"type\":\"kafka\",\"kafkaTopic\":\"testTopic\",\"namespace\":\"testNamespace\"}";
+    final ExtractionNamespace fn =
+        mapper.reader(ExtractionNamespace.class)
+              .readValue(
+                  val
+              );
+    Assert.assertEquals(val, mapper.writeValueAsString(fn));
+  }
+  @Test(expected = com.fasterxml.jackson.databind.JsonMappingException.class)
+  public void testMissingTopic() throws IOException
+  {
+    ObjectMapper mapper = new DefaultObjectMapper();
+    mapper.registerSubtypes(KafkaExtractionNamespace.class);
+    final String val = "{\"type\":\"kafka\",\"namespace\":\"testNamespace\"}";
+    final ExtractionNamespace fn =
+        mapper.reader(ExtractionNamespace.class)
+              .readValue(
+                  val
+              );
+    Assert.assertEquals(val, mapper.writeValueAsString(fn));
+  }
+
+  @Test(expected = com.fasterxml.jackson.databind.JsonMappingException.class)
+  public void testMissingNamespace() throws IOException
+  {
+    ObjectMapper mapper = new DefaultObjectMapper();
+    mapper.registerSubtypes(KafkaExtractionNamespace.class);
+    final String val = "{\"type\":\"kafka\",\"kafkaTopic\":\"testTopic\"}";
+    final ExtractionNamespace fn =
+        mapper.reader(ExtractionNamespace.class)
+              .readValue(
+                  val
+              );
+    Assert.assertEquals(val, mapper.writeValueAsString(fn));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
         <module>extensions/histogram</module>
         <module>extensions/mysql-metadata-storage</module>
         <module>extensions/postgresql-metadata-storage</module>
+        <module>extensions/dim-rename-kafka8</module>
     </modules>
 
     <dependencyManagement>

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -97,6 +97,22 @@
             <artifactId>caliper</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.apache.derby</groupId>
+          <artifactId>derby</artifactId>
+          <version>10.11.1.1</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.derby</groupId>
+          <artifactId>derbynet</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.derby</groupId>
+          <artifactId>derbyclient</artifactId>
+          <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/processing/src/main/java/io/druid/data/input/MapPopulator.java
+++ b/processing/src/main/java/io/druid/data/input/MapPopulator.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.data.input;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.ByteSource;
+import com.google.common.io.LineProcessor;
+import com.metamx.common.parsers.Parser;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Simple class that takes a `ByteSource` and uses a `Parser<K, V>` to populate a `Map<K, V>`
+ * The `ByteSource` must be UTF-8 encoded
+ */
+public class MapPopulator<K, V>
+{
+  private final Parser<K, V> parser;
+
+  public MapPopulator(
+      Parser<K, V> parser
+  )
+  {
+    this.parser = parser;
+  }
+
+  /**
+   * Read through the `source` line by line and populate `map` with the data returned from the `parser`
+   *
+   * @param source The ByteSource to read lines from
+   * @param map    The map to populate
+   *
+   * @return The number of entries parsed
+   *
+   * @throws IOException
+   */
+  public long populate(final ByteSource source, final Map<K, V> map) throws IOException
+  {
+    return source.asCharSource(Charsets.UTF_8).readLines(
+        new LineProcessor<Long>()
+        {
+          private long count = 0l;
+
+          @Override
+          public boolean processLine(String line) throws IOException
+          {
+            map.putAll(parser.parse(line));
+            return true;
+          }
+
+          @Override
+          public Long getResult()
+          {
+            return count;
+          }
+        }
+    );
+  }
+}

--- a/processing/src/main/java/io/druid/query/extraction/ExplicitDimRenameFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/ExplicitDimRenameFn.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.extraction;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Function;
+import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
+import io.druid.guice.annotations.Json;
+import io.druid.jackson.DefaultObjectMapper;
+
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+/**
+ *
+ */
+public class ExplicitDimRenameFn extends DimExtractionFn
+{
+  @JsonIgnore
+  private final ObjectMapper mapper;
+
+  private final Map<String, String> renames;
+  private final Function<String, String> extractionFunction;
+
+  @JsonCreator
+  public ExplicitDimRenameFn(
+      @JsonProperty("renames") final Map<String, String> renames
+  )
+  {
+    this.mapper = new DefaultObjectMapper();
+    this.renames = renames;
+    this.extractionFunction = new Function<String, String>()
+    {
+      @Nullable
+      @Override
+      public String apply(@Nullable String input)
+      {
+        final String retval = renames.get(input);
+        return Strings.isNullOrEmpty(retval) ? input : retval;
+      }
+    };
+  }
+
+  private static final byte CACHE_TYPE_ID = 0x5;
+
+  @JsonProperty("renames")
+  public Map<String, String> getRenames()
+  {
+    return renames;
+  }
+
+  @Override
+  public byte[] getCacheKey()
+  {
+    final byte[] bytes;
+    try {
+      bytes = mapper.writeValueAsBytes(renames);
+    }
+    catch (JsonProcessingException e) {
+      // Should never happen. If it can't map a Map<String, String> then there's something weird
+      throw Throwables.propagate(e);
+    }
+
+    return ByteBuffer
+        .allocate(bytes.length + 1)
+        .put(CACHE_TYPE_ID)
+        .put(bytes)
+        .array();
+  }
+
+  @Override
+  public String apply(String value)
+  {
+    return this.extractionFunction.apply(value);
+  }
+
+  @Override
+  public boolean preservesOrdering()
+  {
+    return false;
+  }
+}

--- a/processing/src/main/java/io/druid/query/extraction/ExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/ExtractionFn.java
@@ -29,7 +29,9 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @JsonSubTypes.Type(name = "partial", value = MatchingDimExtractionFn.class),
     @JsonSubTypes.Type(name = "searchQuery", value = SearchQuerySpecDimExtractionFn.class),
     @JsonSubTypes.Type(name = "javascript", value = JavascriptExtractionFn.class),
-    @JsonSubTypes.Type(name = "timeFormat", value = TimeFormatExtractionFn.class)
+    @JsonSubTypes.Type(name = "timeFormat", value = TimeFormatExtractionFn.class),
+    @JsonSubTypes.Type(name = "namespace", value = NamespacedExtraction.class),
+    @JsonSubTypes.Type(name = "explicitRename", value = ExplicitDimRenameFn.class)
 })
 /**
  * An ExtractionFn is a function that can be used to transform the values of a column (typically a dimension)

--- a/processing/src/main/java/io/druid/query/extraction/NamespacedExtraction.java
+++ b/processing/src/main/java/io/druid/query/extraction/NamespacedExtraction.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.extraction;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.inject.name.Named;
+import com.metamx.common.StringUtils;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+import java.nio.ByteBuffer;
+
+/**
+ * Namespaced extraction is a special case of DimExtractionFn where the actual extractor is pulled from a map of known implementations.
+ * In the event that an unknown namespace is passed, a simple reflective function is returned instead.
+ */
+public class NamespacedExtraction extends DimExtractionFn
+{
+  private static final byte CACHE_TYPE_ID = 0x05;
+  private static final Function<String, String> NOOP_EXTRACTOR = new Function<String, String>()
+  {
+    @Nullable
+    @Override
+    public String apply(@Nullable String input)
+    {
+      // DimExtractionFn says do not return Empty strings
+      return Strings.isNullOrEmpty(input) ? null : input;
+    }
+  };
+
+  private final String namespace;
+  private final String missingValue;
+  private final Function<String, String> extractionFunction;
+
+  @JsonCreator
+  public NamespacedExtraction(
+      @Nullable @JacksonInject @Named("dimExtractionNamespace")
+      final Function<String, Function<String, String>> namespaces,
+      @NotNull @JsonProperty(value = "namespace", required = true)
+      final String namespace,
+      @Nullable @JsonProperty(value = "missingValue", required = false)
+      final String missingValue
+  )
+  {
+    Preconditions.checkNotNull(namespace);
+    this.namespace = namespace;
+    if (namespaces == null) {
+      this.extractionFunction = NOOP_EXTRACTOR;
+    } else {
+      final Function<String, String> fn = namespaces.apply(namespace);
+      if (fn == null) {
+        this.extractionFunction = NOOP_EXTRACTOR;
+      } else {
+        // If missing value is set, have a slightly different function.
+        // This is intended to have the absolutely fastest code path possible and not have any extra logic in the function
+        if (missingValue != null) {
+          // Missing value is valid
+          final String nullableMissingValue = Strings.isNullOrEmpty(missingValue) ? null : missingValue;
+          this.extractionFunction = new Function<String, String>()
+          {
+            @Nullable
+            @Override
+            public String apply(@Nullable String dimValue)
+            {
+              final String retval = fn.apply(dimValue);
+              return Strings.isNullOrEmpty(retval) ? nullableMissingValue : retval;
+            }
+          };
+        } else {
+          // Use dimValue if missing
+          this.extractionFunction = new Function<String, String>()
+          {
+            @Nullable
+            @Override
+            public String apply(@Nullable String dimValue)
+            {
+              final String retval = fn.apply(dimValue);
+              return Strings.isNullOrEmpty(retval) ? (Strings.isNullOrEmpty(dimValue) ? null : dimValue) : retval;
+            }
+          };
+        }
+      }
+    }
+    this.missingValue = missingValue;
+  }
+
+  @JsonProperty("namespace")
+  public String getNamespace()
+  {
+    return this.namespace;
+  }
+
+  @JsonProperty("missingValue")
+  public String getMissingValue() {return this.missingValue;}
+
+  @Override
+  public byte[] getCacheKey()
+  {
+    final byte[] nsBytes = StringUtils.toUtf8(namespace);
+    return ByteBuffer.allocate(nsBytes.length + 1).put(CACHE_TYPE_ID).put(nsBytes).array();
+  }
+
+  @Override
+  public String apply(String value)
+  {
+    return extractionFunction.apply(value);
+  }
+
+  @Override
+  public boolean preservesOrdering()
+  {
+    return false;
+  }
+}

--- a/processing/src/main/java/io/druid/query/extraction/namespace/ExtractionNamespace.java
+++ b/processing/src/main/java/io/druid/query/extraction/namespace/ExtractionNamespace.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.extraction.namespace;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(value = {
+    @JsonSubTypes.Type(name = "jdbc", value = JDBCExtractionNamespace.class),
+    @JsonSubTypes.Type(name = "uri", value = URIExtractionNamespace.class)
+})
+public interface ExtractionNamespace
+{
+  public String getNamespace();
+}

--- a/processing/src/main/java/io/druid/query/extraction/namespace/ExtractionNamespaceFunctionFactory.java
+++ b/processing/src/main/java/io/druid/query/extraction/namespace/ExtractionNamespaceFunctionFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.extraction.namespace;
+
+import com.google.common.base.Function;
+
+/**
+ *
+ */
+public interface ExtractionNamespaceFunctionFactory<T extends ExtractionNamespace>
+{
+  public Function<String, String> build(T extractionNamespace);
+
+  public Runnable getCachePopulator(T extractionNamespace);
+}

--- a/processing/src/main/java/io/druid/query/extraction/namespace/ExtractionNamespaceUpdate.java
+++ b/processing/src/main/java/io/druid/query/extraction/namespace/ExtractionNamespaceUpdate.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.extraction.namespace;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+/**
+ *
+ */
+public class ExtractionNamespaceUpdate
+{
+  @JsonProperty
+  private final Long updateMs;
+  @JsonProperty
+  private final ExtractionNamespace namespace;
+  @JsonCreator
+  public ExtractionNamespaceUpdate(
+      @NotNull @JsonProperty(value = "namespace", required = true)
+      ExtractionNamespace namespace,
+      @Min(0) @Nullable @JsonProperty("updateMs")
+      Long updateMs
+  ){
+    Preconditions.checkNotNull(namespace);
+    this.updateMs = updateMs == null ? 0 : updateMs;
+    this.namespace = namespace;
+  }
+
+  public Long getUpdateMs()
+  {
+    return updateMs;
+  }
+
+  public ExtractionNamespace getNamespace()
+  {
+    return namespace;
+  }
+  @Override
+  public String toString(){
+    final StringBuilder sb = new StringBuilder();
+    sb.append("ExtractionNamespaceUpdate {");
+    sb.append("namespace = ");
+    sb.append(namespace.toString());
+    sb.append(',');
+    sb.append("updateMs = ");
+    sb.append(updateMs);
+    sb.append("}");
+    return sb.toString();
+  }
+}

--- a/processing/src/main/java/io/druid/query/extraction/namespace/JDBCExtractionNamespace.java
+++ b/processing/src/main/java/io/druid/query/extraction/namespace/JDBCExtractionNamespace.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.extraction.namespace;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.base.Preconditions;
+import io.druid.metadata.MetadataStorageConnectorConfig;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ *
+ */
+@JsonTypeName("jdbc")
+public class JDBCExtractionNamespace implements ExtractionNamespace
+{
+
+  @JsonProperty
+  private final MetadataStorageConnectorConfig connectorConfig;
+  @JsonProperty
+  private final String table;
+  @JsonProperty
+  private final String keyColumn;
+  @JsonProperty
+  private final String valueColumn;
+  @JsonProperty
+  private final String tsColumn;
+  @JsonProperty
+  private final String namespace;
+
+  @JsonCreator
+  public JDBCExtractionNamespace(
+      @NotNull @JsonProperty(value = "namespace", required = true)
+      final String namespace,
+      @NotNull @JsonProperty(value = "connectorConfig", required = true)
+      final MetadataStorageConnectorConfig connectorConfig,
+      @NotNull @JsonProperty(value = "table", required = true)
+      final String table,
+      @NotNull @JsonProperty(value = "keyColumn", required = true)
+      final String keyColumn,
+      @NotNull @JsonProperty(value = "valueColumn", required = true)
+      final String valueColumn,
+      @Nullable @JsonProperty(value = "tsColumn", required = false)
+      final String tsColumn
+  )
+  {
+    Preconditions.checkNotNull(connectorConfig);
+    Preconditions.checkNotNull(connectorConfig.getConnectURI()); // Should never be null
+    Preconditions.checkNotNull(table);
+    Preconditions.checkNotNull(keyColumn);
+    Preconditions.checkNotNull(valueColumn);
+    this.connectorConfig = connectorConfig;
+    this.table = table;
+    this.keyColumn = keyColumn;
+    this.valueColumn = valueColumn;
+    this.tsColumn = tsColumn;
+    this.namespace = namespace;
+  }
+
+  @Override
+  public String getNamespace()
+  {
+    return namespace;
+  }
+
+  public MetadataStorageConnectorConfig getConnectorConfig()
+  {
+    return connectorConfig;
+  }
+
+  public String getTable()
+  {
+    return table;
+  }
+
+  public String getKeyColumn()
+  {
+    return keyColumn;
+  }
+
+  public String getValueColumn()
+  {
+    return valueColumn;
+  }
+
+  public String getTsColumn()
+  {
+    return tsColumn;
+  }
+
+  @Override
+  public String toString(){
+    return String.format("JDBCExtractionNamespace = { namespace = %s, connectorConfig = { %s }, table = %s, keyColumn = %s, valueColumn = %s, tsColumn = %s}",
+                  namespace, connectorConfig.toString(), table, keyColumn, valueColumn, tsColumn
+    );
+  }
+}

--- a/processing/src/main/java/io/druid/query/extraction/namespace/URIExtractionNamespace.java
+++ b/processing/src/main/java/io/druid/query/extraction/namespace/URIExtractionNamespace.java
@@ -1,0 +1,410 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.extraction.namespace;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.metamx.common.UOE;
+import com.metamx.common.parsers.CSVParser;
+import com.metamx.common.parsers.DelimitedParser;
+import com.metamx.common.parsers.JSONParser;
+import com.metamx.common.parsers.Parser;
+import io.druid.guice.annotations.Json;
+
+import javax.validation.constraints.NotNull;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *
+ */
+@JsonTypeName("uri")
+public class URIExtractionNamespace implements ExtractionNamespace
+{
+  @JsonProperty
+  private final String namespace;
+  @JsonProperty
+  private final URI uri;
+
+  @JsonProperty
+  private final FlatDataParser parseSpec;
+
+  @JsonCreator
+  public URIExtractionNamespace(
+      @NotNull @JsonProperty(value = "namespace", required = true)
+      String namespace,
+      @NotNull @JsonProperty(value = "uri", required = true)
+      URI uri,
+      @JsonProperty(value = "parseSpec", required = true)
+      FlatDataParser parseSpec
+  )
+  {
+    Preconditions.checkNotNull(namespace);
+    Preconditions.checkNotNull(uri);
+    Preconditions.checkNotNull(parseSpec);
+    this.namespace = namespace;
+    this.uri = uri;
+    this.parseSpec = parseSpec;
+  }
+
+  @Override
+  public String getNamespace()
+  {
+    return namespace;
+  }
+
+  public FlatDataParser getParseSpec()
+  {
+    return this.parseSpec;
+  }
+
+  public URI getUri()
+  {
+    return uri;
+  }
+
+  @Override
+  public String toString()
+  {
+    return String.format(
+        "URIExtractionNamespace = { namespace = %s, uri = %s, parseSpec = %s }",
+        namespace,
+        uri.toString(),
+        parseSpec.toString()
+    );
+  }
+
+
+  private static class DelegateParser implements Parser<String, String>
+  {
+    private final Parser<String, Object> delegate;
+    private final String key;
+    private final String value;
+
+    private DelegateParser(
+        Parser<String, Object> delegate,
+        String key,
+        String value
+    )
+    {
+      this.delegate = delegate;
+      this.key = key;
+      this.value = value;
+    }
+
+    @Override
+    public Map<String, String> parse(String input)
+    {
+      final Map<String, Object> inner = delegate.parse(input);
+      final String k = (String) Preconditions.checkNotNull(
+          inner.get(key),
+          "Key column [%s] missing data in line [%s]",
+          key,
+          input
+      );
+      final String val = (String) Preconditions.checkNotNull(
+          inner.get(value),
+          "Value column [%s] missing data in line [%s]",
+          value,
+          input
+      );
+      return ImmutableMap.<String, String>of(k, val);
+    }
+
+    @Override
+    public void setFieldNames(Iterable<String> fieldNames)
+    {
+      delegate.setFieldNames(fieldNames);
+    }
+
+    @Override
+    public List<String> getFieldNames()
+    {
+      return delegate.getFieldNames();
+    }
+  }
+
+  @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+  @JsonSubTypes(value = {
+      @JsonSubTypes.Type(name = "csv", value = CSVFlatDataParser.class),
+      @JsonSubTypes.Type(name = "tsv", value = TSVFlatDataParser.class),
+      @JsonSubTypes.Type(name = "customJson", value = JSONFlatDataParser.class),
+      @JsonSubTypes.Type(name = "simpleJson", value = ObjectMapperFlatDataParser.class)
+  })
+  public static interface FlatDataParser
+  {
+    Parser<String, String> getParser();
+  }
+
+  @JsonTypeName("csv")
+  public static class CSVFlatDataParser implements FlatDataParser
+  {
+    private final Parser<String, String> parser;
+    private final List<String> columns;
+    private final String keyColumn;
+    private final String valueColumn;
+
+    @JsonCreator
+    public CSVFlatDataParser(
+        @JsonProperty("columns") List<String> columns,
+        @JsonProperty("keyColumn") final String keyColumn,
+        @JsonProperty("valueColumn") final String valueColumn
+    )
+    {
+      Preconditions.checkArgument(
+          Preconditions.checkNotNull(columns, "`columns` list required").size() > 1,
+          "Must specify more than one column to have a key value pair"
+      );
+      this.parser = new DelegateParser(new CSVParser(Optional.<String>absent(), columns), keyColumn, valueColumn);
+
+      Preconditions.checkArgument(
+          !(Strings.isNullOrEmpty(keyColumn) ^ Strings.isNullOrEmpty(valueColumn)),
+          "Must specify both `keyColumn` and `valueColumn` or neither `keyColumn` nor `valueColumn`"
+      );
+      this.columns = columns;
+      this.keyColumn = Strings.isNullOrEmpty(keyColumn) ? columns.get(0) : keyColumn;
+      this.valueColumn = Strings.isNullOrEmpty(valueColumn) ? columns.get(1) : valueColumn;
+      Preconditions.checkArgument(
+          columns.contains(keyColumn),
+          "Column [%s] not found int columns: %s",
+          keyColumn,
+          Arrays.toString(columns.toArray())
+      );
+      Preconditions.checkArgument(
+          columns.contains(valueColumn),
+          "Column [%s] not found int columns: %s",
+          valueColumn,
+          Arrays.toString(columns.toArray())
+      );
+    }
+
+    @JsonProperty
+    public List<String> getColumns()
+    {
+      return columns;
+    }
+
+    @JsonProperty
+    public String getKeyColumn()
+    {
+      return this.keyColumn;
+    }
+
+    @JsonProperty
+    public String getValueColumn()
+    {
+      return this.valueColumn;
+    }
+
+    @Override
+    public Parser<String, String> getParser()
+    {
+      return parser;
+    }
+  }
+
+  @JsonTypeName("tsv")
+  public static class TSVFlatDataParser implements FlatDataParser
+  {
+    private final Parser<String, String> parser;
+    private final List<String> columns;
+    private final String delimiter;
+    private final String keyColumn;
+    private final String valueColumn;
+
+    @JsonCreator
+    public TSVFlatDataParser(
+        @JsonProperty("columns") List<String> columns,
+        @JsonProperty("delimiter") String delimiter,
+        @JsonProperty("keyColumn") final String keyColumn,
+        @JsonProperty("valueColumn") final String valueColumn
+    )
+    {
+      Preconditions.checkArgument(
+          Preconditions.checkNotNull(columns, "`columns` list required").size() > 1,
+          "Must specify more than one column to have a key value pair"
+      );
+      final DelimitedParser delegate = new DelimitedParser(
+          Optional.fromNullable(Strings.isNullOrEmpty(delimiter) ? null : delimiter),
+          Optional.<String>absent()
+      );
+      Preconditions.checkArgument(
+          !(Strings.isNullOrEmpty(keyColumn) ^ Strings.isNullOrEmpty(valueColumn)),
+          "Must specify both `keyColumn` and `valueColumn` or neither `keyColumn` nor `valueColumn`"
+      );
+      delegate.setFieldNames(columns);
+      this.parser = new DelegateParser(delegate, keyColumn, valueColumn);
+      this.columns = columns;
+      this.delimiter = delimiter;
+      this.keyColumn = Strings.isNullOrEmpty(keyColumn) ? columns.get(0) : keyColumn;
+      this.valueColumn = Strings.isNullOrEmpty(valueColumn) ? columns.get(1) : valueColumn;
+      Preconditions.checkArgument(
+          columns.contains(keyColumn),
+          "Column [%s] not found int columns: %s",
+          keyColumn,
+          Arrays.toString(columns.toArray())
+      );
+      Preconditions.checkArgument(
+          columns.contains(valueColumn),
+          "Column [%s] not found int columns: %s",
+          valueColumn,
+          Arrays.toString(columns.toArray())
+      );
+    }
+
+    @JsonProperty
+    public List<String> getColumns()
+    {
+      return columns;
+    }
+
+    @JsonProperty
+    public String getKeyColumn()
+    {
+      return this.keyColumn;
+    }
+
+    @JsonProperty
+    public String getValueColumn()
+    {
+      return this.valueColumn;
+    }
+
+    @JsonProperty
+    public String getDelimiter()
+    {
+      return delimiter;
+    }
+
+    @Override
+    public Parser<String, String> getParser()
+    {
+      return parser;
+    }
+  }
+
+  @JsonTypeName("customJson")
+  public static class JSONFlatDataParser implements FlatDataParser
+  {
+    private final Parser<String, String> parser;
+    private final String keyFieldName;
+    private final String valueFieldName;
+
+    @JsonCreator
+    public JSONFlatDataParser(
+        @JacksonInject @Json ObjectMapper jsonMapper,
+        @JsonProperty("keyFieldName") final String keyFieldName,
+        @JsonProperty("valueFieldName") final String valueFieldName
+    )
+    {
+      Preconditions.checkArgument(!Strings.isNullOrEmpty(keyFieldName), "[keyFieldName] cannot be empty");
+      Preconditions.checkArgument(!Strings.isNullOrEmpty(valueFieldName), "[valueFieldName] cannot be empty");
+      this.keyFieldName = keyFieldName;
+      this.valueFieldName = valueFieldName;
+      this.parser = new DelegateParser(
+          new JSONParser(jsonMapper, ImmutableList.of(keyFieldName, valueFieldName)),
+          keyFieldName,
+          valueFieldName
+      );
+    }
+
+    @JsonProperty
+    public String getKeyFieldName()
+    {
+      return this.keyFieldName;
+    }
+
+    @JsonProperty
+    public String getValueFieldName()
+    {
+      return this.valueFieldName;
+    }
+
+    @Override
+    public Parser<String, String> getParser()
+    {
+      return this.parser;
+    }
+  }
+
+  @JsonTypeName("simpleJson")
+  public static class ObjectMapperFlatDataParser implements FlatDataParser
+  {
+
+    private final Parser<String, String> parser;
+
+    @JsonCreator
+    public ObjectMapperFlatDataParser(
+        final @JacksonInject @Json ObjectMapper jsonMapper
+    )
+    {
+      parser = new Parser<String, String>()
+      {
+        @Override
+        public Map<String, String> parse(String input)
+        {
+          try {
+            return jsonMapper.readValue(
+                input, new TypeReference<Map<String, String>>()
+                {
+                }
+            );
+          }
+          catch (IOException e) {
+            throw Throwables.propagate(e);
+          }
+        }
+
+        @Override
+        public void setFieldNames(Iterable<String> fieldNames)
+        {
+          throw new UOE("No field names available");
+        }
+
+        @Override
+        public List<String> getFieldNames()
+        {
+          throw new UOE("No field names available");
+        }
+      };
+    }
+
+    @Override
+    public Parser<String, String> getParser()
+    {
+      return parser;
+    }
+  }
+}

--- a/processing/src/main/java/io/druid/query/topn/DimExtractionTopNAlgorithm.java
+++ b/processing/src/main/java/io/druid/query/topn/DimExtractionTopNAlgorithm.java
@@ -19,7 +19,6 @@ package io.druid.query.topn;
 
 import com.google.common.collect.Maps;
 import io.druid.query.aggregation.Aggregator;
-import io.druid.query.extraction.ExtractionFn;
 import io.druid.segment.Capabilities;
 import io.druid.segment.Cursor;
 import io.druid.segment.DimensionSelector;
@@ -28,6 +27,7 @@ import io.druid.segment.data.IndexedInts;
 import java.util.Map;
 
 /**
+ * This has to be its own strategy because the pooled topn algorithm assumes each index is unique, and cannot handle multiple index numerals referencing the same dimension value.
  */
 public class DimExtractionTopNAlgorithm extends BaseTopNAlgorithm<Aggregator[][], Map<String, Aggregator[]>, TopNParams>
 {

--- a/processing/src/main/java/io/druid/query/topn/PooledTopNAlgorithm.java
+++ b/processing/src/main/java/io/druid/query/topn/PooledTopNAlgorithm.java
@@ -142,6 +142,7 @@ public class PooledTopNAlgorithm
   {
     return makeBufferAggregators(params.getCursor(), query.getAggregatorSpecs());
   }
+
   /**
    * Use aggressive loop unrolling to aggregate the data
    *
@@ -188,7 +189,7 @@ public class PooledTopNAlgorithm
 
       final int dimSize = dimValues.size();
       final int dimExtra = dimSize % AGG_UNROLL_COUNT;
-      switch(dimExtra){
+      switch (dimExtra) {
         case 7:
           aggregateDimValue(positions, theAggregators, numProcessed, resultsBuf, numBytesPerRecord, aggregatorOffsets, aggSize, aggExtra, dimValues.get(6));
         case 6:
@@ -242,7 +243,7 @@ public class PooledTopNAlgorithm
     }
     final int position = positions[dimIndex];
 
-    switch(aggExtra) {
+    switch (aggExtra) {
       case 7:
         theAggregators[6].aggregate(resultsBuf, position + aggregatorOffsets[6]);
       case 6:
@@ -260,13 +261,13 @@ public class PooledTopNAlgorithm
     }
     for (int j = aggExtra; j < aggSize; j += AGG_UNROLL_COUNT) {
       theAggregators[j].aggregate(resultsBuf, position + aggregatorOffsets[j]);
-      theAggregators[j+1].aggregate(resultsBuf, position + aggregatorOffsets[j+1]);
-      theAggregators[j+2].aggregate(resultsBuf, position + aggregatorOffsets[j+2]);
-      theAggregators[j+3].aggregate(resultsBuf, position + aggregatorOffsets[j+3]);
-      theAggregators[j+4].aggregate(resultsBuf, position + aggregatorOffsets[j+4]);
-      theAggregators[j+5].aggregate(resultsBuf, position + aggregatorOffsets[j+5]);
-      theAggregators[j+6].aggregate(resultsBuf, position + aggregatorOffsets[j+6]);
-      theAggregators[j+7].aggregate(resultsBuf, position + aggregatorOffsets[j+7]);
+      theAggregators[j + 1].aggregate(resultsBuf, position + aggregatorOffsets[j + 1]);
+      theAggregators[j + 2].aggregate(resultsBuf, position + aggregatorOffsets[j + 2]);
+      theAggregators[j + 3].aggregate(resultsBuf, position + aggregatorOffsets[j + 3]);
+      theAggregators[j + 4].aggregate(resultsBuf, position + aggregatorOffsets[j + 4]);
+      theAggregators[j + 5].aggregate(resultsBuf, position + aggregatorOffsets[j + 5]);
+      theAggregators[j + 6].aggregate(resultsBuf, position + aggregatorOffsets[j + 6]);
+      theAggregators[j + 7].aggregate(resultsBuf, position + aggregatorOffsets[j + 7]);
     }
   }
 

--- a/processing/src/test/java/io/druid/query/extraction/ExplicitRenameFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/ExplicitRenameFnTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.extraction;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import io.druid.guice.GuiceInjectors;
+import io.druid.guice.annotations.Json;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ *
+ */
+public class ExplicitRenameFnTest
+{
+  private String serialized = "";
+  private ObjectMapper mapper;
+  private static final Map<String, String> renames = ImmutableMap.of(
+      "foo", "bar",
+      "bar", "baz"
+  );
+
+  @Before
+  public void setup() throws JsonProcessingException
+  {
+    Injector defaultInjector = GuiceInjectors.makeStartupInjector();
+    mapper = defaultInjector.getInstance(Key.get(ObjectMapper.class, Json.class));
+    serialized = String.format(
+        "{\"type\":\"explicitRename\",\"renames\":%s}",
+        mapper.writeValueAsString(renames)
+    );
+  }
+
+  @Test
+  public void testDeserialization() throws IOException
+  {
+    final DimExtractionFn fn = mapper.reader(DimExtractionFn.class).readValue(serialized);
+    for (String key : renames.keySet()) {
+      Assert.assertEquals(renames.get(key), fn.apply(key));
+    }
+    final String crazyString = UUID.randomUUID().toString();
+    Assert.assertEquals(crazyString, fn.apply(crazyString));
+  }
+}

--- a/processing/src/test/java/io/druid/query/extraction/JavascriptExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/JavascriptExtractionFnTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package io.druid.query.extraction.extraction;
+package io.druid.query.extraction;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Iterators;

--- a/processing/src/test/java/io/druid/query/extraction/RegexDimExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/RegexDimExtractionFnTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package io.druid.query.extraction.extraction;
+package io.druid.query.extraction;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;

--- a/processing/src/test/java/io/druid/query/extraction/SearchQuerySpecDimExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/SearchQuerySpecDimExtractionFnTest.java
@@ -15,13 +15,13 @@
  * limitations under the License.
  */
 
-package io.druid.query.extraction.extraction;
+package io.druid.query.extraction;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
-import io.druid.jackson.DefaultObjectMapper;
 import io.druid.query.extraction.ExtractionFn;
-import io.druid.query.extraction.MatchingDimExtractionFn;
+import io.druid.query.extraction.SearchQuerySpecDimExtractionFn;
+import io.druid.query.search.search.FragmentSearchQuerySpec;
+import io.druid.query.search.search.SearchQuerySpec;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -31,26 +31,27 @@ import java.util.Set;
 
 /**
  */
-public class MatchingDimExtractionFnTest
+public class SearchQuerySpecDimExtractionFnTest
 {
   private static final String[] testStrings = {
-      "Quito",
+      "Kyoto",
       "Calgary",
       "Tokyo",
       "Stockholm",
-      "Vancouver",
+      "Toyokawa",
       "Pretoria",
-      "Wellington",
-      null,
+      "Yorktown",
       "Ontario"
   };
 
   @Test
   public void testExtraction()
   {
-    String regex = ".*[Tt][Oo].*";
-    ExtractionFn extractionFn = new MatchingDimExtractionFn(regex);
-    List<String> expected = Arrays.asList("Quito", "Tokyo", "Stockholm", "Pretoria", "Wellington");
+    SearchQuerySpec spec = new FragmentSearchQuerySpec(
+        Arrays.asList("to", "yo")
+    );
+    ExtractionFn extractionFn = new SearchQuerySpecDimExtractionFn(spec);
+    List<String> expected = Arrays.asList("Kyoto", "Tokyo", "Toyokawa", "Yorktown");
     Set<String> extracted = Sets.newHashSet();
 
     for (String str : testStrings) {
@@ -60,29 +61,10 @@ public class MatchingDimExtractionFnTest
       }
     }
 
-    Assert.assertEquals(5, extracted.size());
+    Assert.assertEquals(4, extracted.size());
 
     for (String str : extracted) {
       Assert.assertTrue(expected.contains(str));
     }
-  }
-
-  @Test
-  public void testSerde() throws Exception
-  {
-    final ObjectMapper objectMapper = new DefaultObjectMapper();
-    final String json = "{ \"type\" : \"partial\", \"expr\" : \".(...)?\" }";
-    MatchingDimExtractionFn extractionFn = (MatchingDimExtractionFn) objectMapper.readValue(json, ExtractionFn.class);
-
-    Assert.assertEquals(".(...)?", extractionFn.getExpr());
-
-    // round trip
-    Assert.assertEquals(
-        extractionFn,
-        objectMapper.readValue(
-            objectMapper.writeValueAsBytes(extractionFn),
-            ExtractionFn.class
-        )
-    );
   }
 }

--- a/processing/src/test/java/io/druid/query/extraction/TimeDimExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/TimeDimExtractionFnTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package io.druid.query.extraction.extraction;
+package io.druid.query.extraction;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;

--- a/processing/src/test/java/io/druid/query/extraction/namespace/NamespacedExtractionTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/namespace/NamespacedExtractionTest.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.extraction.namespace;
+
+import com.google.common.base.Function;
+import com.google.common.base.Strings;
+import io.druid.query.extraction.NamespacedExtraction;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ *
+ */
+public class NamespacedExtractionTest
+{
+  private static final ConcurrentMap<String, Function<String, String>> defaultMap = new ConcurrentHashMap<>();
+  private static final Function<String, String> NOOP_FN = new Function<String, String>()
+  {
+    @Nullable
+    @Override
+    public String apply(@Nullable String input)
+    {
+      return Strings.isNullOrEmpty(input) ? null : input;
+    }
+  };
+  private static final Function<String, Function<String, String>> defaultFnFinder = new Function<String, Function<String, String>>()
+  {
+    @Nullable
+    @Override
+    public Function<String, String> apply(@Nullable String input)
+    {
+      Function<String, String> fn = defaultMap.get(input);
+      return fn == null ? NOOP_FN : fn;
+    }
+  };
+  @BeforeClass
+  public static void setupStatic()
+  {
+    defaultMap.put(
+        "noop", new Function<String, String>()
+        {
+          @Nullable
+          @Override
+          public String apply(String input)
+          {
+            return input;
+          }
+        }
+    );
+    defaultMap.put(
+        "null", new Function<String, String>()
+        {
+          @Nullable
+          @Override
+          public String apply(@Nullable String input)
+          {
+            return null;
+          }
+        }
+    );
+    defaultMap.put(
+        "turtles", new Function<String, String>()
+        {
+          @Nullable
+          @Override
+          public String apply(@Nullable String input)
+          {
+            return "turtle";
+          }
+        }
+    );
+    defaultMap.put(
+        "empty", new Function<String, String>()
+        {
+          @Nullable
+          @Override
+          public String apply(@Nullable String input)
+          {
+            return "";
+          }
+        }
+    );
+  }
+
+  @Test
+  public void testSimpleNamespace()
+  {
+    NamespacedExtraction namespacedExtraction = new NamespacedExtraction(defaultFnFinder, "noop", null);
+    for (int i = 0; i < 10; ++i) {
+      final String val = UUID.randomUUID().toString();
+      Assert.assertEquals(val, namespacedExtraction.apply(val));
+    }
+    Assert.assertNull(namespacedExtraction.apply(""));
+    Assert.assertNull(namespacedExtraction.apply(null));
+  }
+
+  @Test
+  public void testUnknownNamespace()
+  {
+    NamespacedExtraction namespacedExtraction = new NamespacedExtraction(defaultFnFinder, "HFJDKSHFUINEWUINIUENFIUENFUNEWI", null);
+    for (int i = 0; i < 10; ++i) {
+      final String val = UUID.randomUUID().toString();
+      Assert.assertEquals(val, namespacedExtraction.apply(val));
+    }
+    Assert.assertNull(namespacedExtraction.apply(""));
+    Assert.assertNull(namespacedExtraction.apply(null));
+  }
+
+  @Test
+  public void testTurtles()
+  {
+    NamespacedExtraction namespacedExtraction = new NamespacedExtraction(defaultFnFinder, "turtles", null);
+    for (int i = 0; i < 10; ++i) {
+      final String val = UUID.randomUUID().toString();
+      Assert.assertEquals("turtle", namespacedExtraction.apply(val));
+    }
+    Assert.assertEquals("turtle", namespacedExtraction.apply(""));
+    Assert.assertEquals("turtle", namespacedExtraction.apply(null));
+  }
+
+  @Test
+  public void testEmpty()
+  {
+    NamespacedExtraction namespacedExtraction = new NamespacedExtraction(defaultFnFinder, "empty", null);
+    Assert.assertNull(namespacedExtraction.apply(""));
+    Assert.assertNull(namespacedExtraction.apply(null));
+  }
+
+  @Test
+  public void testNull()
+  {
+    NamespacedExtraction namespacedExtraction = new NamespacedExtraction(defaultFnFinder, "null", null);
+    Assert.assertNull(namespacedExtraction.apply(""));
+    Assert.assertNull(namespacedExtraction.apply(null));
+  }
+
+  @Test
+  public void testMissingValue(){
+    final String testval = "BANANA";
+    NamespacedExtraction namespacedExtraction = new NamespacedExtraction(defaultFnFinder, "null", testval);
+    Assert.assertEquals(testval, namespacedExtraction.apply(""));
+    Assert.assertEquals(testval, namespacedExtraction.apply(null));
+  }
+
+  @Test
+  public void testBlankMissingValueIsNull()
+  {
+    NamespacedExtraction namespacedExtraction = new NamespacedExtraction(defaultFnFinder, "null", "");
+    Assert.assertNull(namespacedExtraction.apply("fh43u1i2"));
+    Assert.assertNull(namespacedExtraction.apply(""));
+    Assert.assertNull(namespacedExtraction.apply(null));
+  }
+}

--- a/processing/src/test/java/io/druid/query/extraction/namespace/URIExtractionNamespaceTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/namespace/URIExtractionNamespaceTest.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.extraction.namespace;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
+import com.fasterxml.jackson.databind.introspect.GuiceAnnotationIntrospector;
+import com.fasterxml.jackson.databind.introspect.GuiceInjectableValues;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.Guice;
+import com.google.inject.Module;
+import io.druid.guice.annotations.Json;
+import io.druid.jackson.DefaultObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ *
+ */
+public class URIExtractionNamespaceTest
+{
+  public static ObjectMapper registerTypes(
+      final ObjectMapper mapper
+  )
+  {
+    mapper.setInjectableValues(
+        new GuiceInjectableValues(
+            Guice.createInjector(
+                ImmutableList.of(
+                    new Module()
+                    {
+                      @Override
+                      public void configure(Binder binder)
+                      {
+                        binder.bind(ObjectMapper.class).annotatedWith(Json.class).toInstance(mapper);
+                        binder.bind(ObjectMapper.class).toInstance(mapper);
+                      }
+                    }
+                )
+            )
+        )
+    ).registerSubtypes(URIExtractionNamespace.class, URIExtractionNamespace.FlatDataParser.class);
+
+    final GuiceAnnotationIntrospector guiceIntrospector = new GuiceAnnotationIntrospector();
+    mapper.setAnnotationIntrospectors(
+        new AnnotationIntrospectorPair(
+            guiceIntrospector, mapper.getSerializationConfig().getAnnotationIntrospector()
+        ),
+        new AnnotationIntrospectorPair(
+            guiceIntrospector, mapper.getDeserializationConfig().getAnnotationIntrospector()
+        )
+    );
+    return mapper;
+  }
+
+  @Test
+  public void testCSV()
+  {
+    URIExtractionNamespace.CSVFlatDataParser parser = new URIExtractionNamespace.CSVFlatDataParser(
+        ImmutableList.of(
+            "col1",
+            "col2",
+            "col3"
+        ), "col2", "col3"
+    );
+    Assert.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parse("A,B,C"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBadCSV()
+  {
+    URIExtractionNamespace.CSVFlatDataParser parser = new URIExtractionNamespace.CSVFlatDataParser(
+        ImmutableList.of(
+            "col1",
+            "col2",
+            "col3"
+        ), "col2", "col3ADFSDF"
+    );
+    Assert.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parse("A,B,C"));
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testBadCSV2()
+  {
+    URIExtractionNamespace.CSVFlatDataParser parser = new URIExtractionNamespace.CSVFlatDataParser(
+        ImmutableList.of(
+            "col1",
+            "col2",
+            "col3"
+        ), "col2", "col3"
+    );
+    Map<String, String> map = parser.getParser().parse("A");
+  }
+
+  @Test
+  public void testTSV()
+  {
+    URIExtractionNamespace.TSVFlatDataParser parser = new URIExtractionNamespace.TSVFlatDataParser(
+        ImmutableList.of("col1", "col2", "col3"),
+        "|",
+        "col2",
+        "col3"
+    );
+    Assert.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parse("A|B|C"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBadTSV()
+  {
+    URIExtractionNamespace.TSVFlatDataParser parser = new URIExtractionNamespace.TSVFlatDataParser(
+        ImmutableList.of("col1", "col2", "col3fdsfds"),
+        ",",
+        "col2",
+        "col3"
+    );
+    Map<String, String> map = parser.getParser().parse("A,B,C");
+    Assert.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parse("A,B,C"));
+  }
+
+
+  @Test(expected = NullPointerException.class)
+  public void testBadTSV2()
+  {
+    URIExtractionNamespace.TSVFlatDataParser parser = new URIExtractionNamespace.TSVFlatDataParser(
+        ImmutableList.of("col1", "col2", "col3"),
+        ",",
+        "col2",
+        "col3"
+    );
+    Map<String, String> map = parser.getParser().parse("A");
+    Assert.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parse("A,B,C"));
+  }
+
+  @Test
+  public void testJSONFlatDataParser()
+  {
+    final String keyField = "keyField";
+    final String valueField = "valueField";
+    URIExtractionNamespace.JSONFlatDataParser parser = new URIExtractionNamespace.JSONFlatDataParser(
+        new ObjectMapper(),
+        keyField,
+        valueField
+    );
+    Assert.assertEquals(
+        ImmutableMap.of("B", "C"),
+        parser.getParser()
+              .parse(
+                  String.format(
+                      "{\"%s\":\"B\", \"%s\":\"C\", \"FOO\":\"BAR\"}",
+                      keyField,
+                      valueField
+                  )
+              )
+    );
+  }
+
+
+  @Test(expected = NullPointerException.class)
+  public void testJSONFlatDataParserBad()
+  {
+    final String keyField = "keyField";
+    final String valueField = "valueField";
+    URIExtractionNamespace.JSONFlatDataParser parser = new URIExtractionNamespace.JSONFlatDataParser(
+        new ObjectMapper(),
+        keyField,
+        valueField
+    );
+    Assert.assertEquals(
+        ImmutableMap.of("B", "C"),
+        parser.getParser()
+              .parse(
+                  String.format(
+                      "{\"%sDFSDFDS\":\"B\", \"%s\":\"C\", \"FOO\":\"BAR\"}",
+                      keyField,
+                      valueField
+                  )
+              )
+    );
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testJSONFlatDataParserBad2()
+  {
+    final String keyField = "keyField";
+    final String valueField = "valueField";
+    URIExtractionNamespace.JSONFlatDataParser parser = new URIExtractionNamespace.JSONFlatDataParser(
+        registerTypes(new ObjectMapper()),
+        null,
+        valueField
+    );
+    Assert.assertEquals(
+        ImmutableMap.of("B", "C"),
+        parser.getParser()
+              .parse(
+                  String.format(
+                      "{\"%sDFSDFDS\":\"B\", \"%s\":\"C\", \"FOO\":\"BAR\"}",
+                      keyField,
+                      valueField
+                  )
+              )
+    );
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testJSONFlatDataParserBad3()
+  {
+    final String keyField = "keyField";
+    final String valueField = "valueField";
+    URIExtractionNamespace.JSONFlatDataParser parser = new URIExtractionNamespace.JSONFlatDataParser(
+        registerTypes(new ObjectMapper()),
+        keyField,
+        null
+    );
+    Assert.assertEquals(
+        ImmutableMap.of("B", "C"),
+        parser.getParser()
+              .parse(
+                  String.format(
+                      "{\"%sDFSDFDS\":\"B\", \"%s\":\"C\", \"FOO\":\"BAR\"}",
+                      keyField,
+                      valueField
+                  )
+              )
+    );
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testJSONFlatDataParserBad4()
+  {
+    final String keyField = "keyField";
+    final String valueField = "valueField";
+    URIExtractionNamespace.JSONFlatDataParser parser = new URIExtractionNamespace.JSONFlatDataParser(
+        registerTypes(new ObjectMapper()),
+        "",
+        ""
+    );
+    Assert.assertEquals(
+        ImmutableMap.of("B", "C"),
+        parser.getParser()
+              .parse(
+                  String.format(
+                      "{\"%sDFSDFDS\":\"B\", \"%s\":\"C\", \"FOO\":\"BAR\"}",
+                      keyField,
+                      valueField
+                  )
+              )
+    );
+  }
+
+  @Test
+  public void testObjectMapperFlatDataParser()
+  {
+    URIExtractionNamespace.ObjectMapperFlatDataParser parser = new URIExtractionNamespace.ObjectMapperFlatDataParser(
+        registerTypes(new ObjectMapper())
+    );
+    Assert.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parse("{\"B\":\"C\"}"));
+  }
+
+  @Test
+  public void testSimpleJSONSerDe() throws IOException
+  {
+    final ObjectMapper mapper = registerTypes(new DefaultObjectMapper());
+    for (URIExtractionNamespace.FlatDataParser parser : ImmutableList.of(
+        new URIExtractionNamespace.CSVFlatDataParser(
+            ImmutableList.of(
+                "col1",
+                "col2",
+                "col3"
+            ), "col2", "col3"
+        ),
+        new URIExtractionNamespace.ObjectMapperFlatDataParser(mapper),
+        new URIExtractionNamespace.JSONFlatDataParser(mapper, "keyField", "valueField"),
+        new URIExtractionNamespace.TSVFlatDataParser(ImmutableList.of("A", "B"), ",", "A", "B")
+    )) {
+      final String str = mapper.writeValueAsString(parser);
+      final URIExtractionNamespace.FlatDataParser parser2 = mapper.readValue(
+          str,
+          URIExtractionNamespace.FlatDataParser.class
+      );
+      Assert.assertEquals(str, mapper.writeValueAsString(parser2));
+    }
+  }
+}

--- a/server/src/main/java/io/druid/client/cache/Cache.java
+++ b/server/src/main/java/io/druid/client/cache/Cache.java
@@ -23,6 +23,7 @@ import com.metamx.common.StringUtils;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -38,6 +39,8 @@ public interface Cache
   public CacheStats getStats();
 
   public boolean isLocal();
+
+  public Collection<String> getNamespaces();
 
   public class NamedKey
   {

--- a/server/src/main/java/io/druid/client/cache/LocalCacheProvider.java
+++ b/server/src/main/java/io/druid/client/cache/LocalCacheProvider.java
@@ -17,6 +17,7 @@
 
 package io.druid.client.cache;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.validation.constraints.Min;
@@ -25,17 +26,30 @@ import javax.validation.constraints.Min;
  */
 public class LocalCacheProvider implements CacheProvider
 {
+  public LocalCacheProvider(){
+    this(null, null, null);
+  }
+  @JsonCreator
+  public LocalCacheProvider(
+      @Min(0) @JsonProperty("sizeInBytes") Long sizeInBytes,
+      @Min(0) @JsonProperty("initialSize") Integer initialSize,
+      @Min(0) @JsonProperty("logEvictionCount") Integer logEvictionCount
+  ){
+    this.sizeInBytes = sizeInBytes == null ? 0 : sizeInBytes;
+    this.initialSize = initialSize == null ? 500_000 : initialSize;
+    this.logEvictionCount = logEvictionCount == null ? 0 : logEvictionCount;
+  }
   @JsonProperty
   @Min(0)
-  private long sizeInBytes = 0;
+  private final long sizeInBytes;
 
   @JsonProperty
   @Min(0)
-  private int initialSize = 500000;
+  private final int initialSize;
 
   @JsonProperty
   @Min(0)
-  private int logEvictionCount = 0;
+  private final int logEvictionCount;
 
   @Override
   public Cache get()

--- a/server/src/main/java/io/druid/client/cache/MapCache.java
+++ b/server/src/main/java/io/druid/client/cache/MapCache.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Maps;
 import com.google.common.primitives.Ints;
 
 import java.nio.ByteBuffer;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -162,5 +163,11 @@ public class MapCache implements Cache
   public boolean isLocal()
   {
     return true;
+  }
+
+  @Override
+  public Collection<String> getNamespaces()
+  {
+    return namespaceId.keySet();
   }
 }

--- a/server/src/main/java/io/druid/client/cache/MemcachedCache.java
+++ b/server/src/main/java/io/druid/client/cache/MemcachedCache.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
 import com.google.common.primitives.Ints;
+import com.metamx.common.UOE;
 import com.metamx.common.logger.Logger;
 import net.spy.memcached.AddrUtil;
 import net.spy.memcached.ConnectionFactoryBuilder;
@@ -38,6 +39,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -279,5 +281,11 @@ public class MemcachedCache implements Cache
 
   public boolean isLocal() {
     return false;
+  }
+
+  @Override
+  public Collection<String> getNamespaces()
+  {
+    throw new UOE("Cannot get namespaces on memcache");
   }
 }

--- a/server/src/main/java/io/druid/guice/LocalDataStorageDruidModule.java
+++ b/server/src/main/java/io/druid/guice/LocalDataStorageDruidModule.java
@@ -59,6 +59,10 @@ public class LocalDataStorageDruidModule implements DruidModule
            .addBinding(SCHEME)
            .to(LocalDataSegmentPuller.class)
            .in(LazySingleton.class);
+    Binders.dataSegmentPullerBinder(binder)
+           .addBinding(LocalDataSegmentPuller.URI_SCHEMA)
+           .to(LocalDataSegmentPuller.class)
+           .in(LazySingleton.class);
 
     PolyBind.optionBinder(binder, Key.get(DataSegmentKiller.class))
             .addBinding(SCHEME)

--- a/server/src/main/java/io/druid/initialization/Initialization.java
+++ b/server/src/main/java/io/druid/initialization/Initialization.java
@@ -54,6 +54,7 @@ import io.druid.guice.annotations.Client;
 import io.druid.guice.annotations.Json;
 import io.druid.guice.annotations.Smile;
 import io.druid.guice.http.HttpClientModule;
+import io.druid.server.namespace.NamespacedExtractionModule;
 import io.druid.server.initialization.EmitterModule;
 import io.druid.server.initialization.jetty.JettyServerModule;
 import io.druid.server.metrics.MetricsModule;
@@ -352,7 +353,8 @@ public class Initialization
         new IndexingServiceDiscoveryModule(),
         new LocalDataStorageDruidModule(),
         new FirehoseModule(),
-        new ParsersModule()
+        new ParsersModule(),
+        new NamespacedExtractionModule()
     );
 
     ModuleList actualModules = new ModuleList(baseInjector);

--- a/server/src/main/java/io/druid/segment/loading/LocalDataSegmentPuller.java
+++ b/server/src/main/java/io/druid/segment/loading/LocalDataSegmentPuller.java
@@ -46,6 +46,7 @@ import java.util.Map;
  */
 public class LocalDataSegmentPuller implements DataSegmentPuller, URIDataPuller
 {
+  public static final String URI_SCHEMA = "file";
   public static FileObject buildFileObject(final URI uri)
   {
     final Path path = Paths.get(uri);

--- a/server/src/main/java/io/druid/server/QueryResource.java
+++ b/server/src/main/java/io/druid/server/QueryResource.java
@@ -17,6 +17,7 @@
 
 package io.druid.server;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.jaxrs.smile.SmileMediaTypes;
@@ -282,13 +283,16 @@ public class QueryResource
          .addData("peer", req.getRemoteAddr())
          .emit();
 
-      return Response.serverError().type(contentType).entity(
-          jsonWriter.writeValueAsBytes(
-              ImmutableMap.of(
-                  "error", e.getMessage() == null ? "null exception" : e.getMessage()
-              )
-          )
-      ).build();
+      return Response.serverError().type(contentType).entity(cleanError(e)).build();
     }
+  }
+
+  private byte[] cleanError(Exception e) throws JsonProcessingException
+  {
+    return jsonMapper.writeValueAsBytes(
+        ImmutableMap.of(
+            "error", e.getMessage() == null ? "null exception" : e.getMessage()
+        )
+    );
   }
 }

--- a/server/src/main/java/io/druid/server/http/NamespacesResource.java
+++ b/server/src/main/java/io/druid/server/http/NamespacesResource.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.http;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.jaxrs.smile.SmileMediaTypes;
+import com.google.api.client.repackaged.com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import com.metamx.common.IAE;
+import com.metamx.common.logger.Logger;
+import io.druid.guice.annotations.Json;
+import io.druid.guice.annotations.Smile;
+import io.druid.query.extraction.namespace.ExtractionNamespaceUpdate;
+import io.druid.server.namespace.NamespacedExtractionModule;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Contains information about namespaces
+ */
+@Path("/druid/coordinator/v1/namespaces")
+public class NamespacesResource
+{
+  private static final Logger log = new Logger(NamespacesResource.class);
+  final NamespacedExtractionModule.NamespacedKeeper keeper;
+  final ObjectMapper smileMapper, jsonMapper;
+
+  @Inject
+  public NamespacesResource(
+      NamespacedExtractionModule.NamespacedKeeper keeper,
+      @Json ObjectMapper jsonMapper,
+      @Smile ObjectMapper smileMapper
+  )
+  {
+    this.keeper = keeper;
+    this.jsonMapper = jsonMapper;
+    this.smileMapper = smileMapper;
+  }
+
+  @GET
+  @Produces({MediaType.APPLICATION_JSON, SmileMediaTypes.APPLICATION_JACKSON_SMILE})
+  public Response getNamespaces()
+  {
+    Response.ResponseBuilder builder = Response.ok();
+    try {
+      builder.entity(keeper.listNamespaces());
+    }catch (Exception e) {
+      log.error(e, "Error getting list of namespaces");
+      return Response.serverError().entity(
+          ImmutableMap.<String, String>of(
+              "error",
+              Strings.isNullOrEmpty(e.getMessage()) ? "null error" : e.getMessage()
+          )
+      ).build();
+    }
+    return builder.build();
+  }
+
+  @POST
+  @Produces({MediaType.APPLICATION_JSON, SmileMediaTypes.APPLICATION_JACKSON_SMILE})
+  @Consumes({MediaType.APPLICATION_JSON, SmileMediaTypes.APPLICATION_JACKSON_SMILE})
+  public Response newNamespace(
+      InputStream inputStream,
+      @Context final HttpServletRequest req // used only to get request content-type
+  )
+  {
+    final String reqContentType = req.getContentType();
+    final boolean isSmile = SmileMediaTypes.APPLICATION_JACKSON_SMILE.equals(reqContentType);
+    final ObjectMapper mapper = isSmile ? smileMapper : jsonMapper;
+
+    Response.ResponseBuilder builder = Response.status(Response.Status.ACCEPTED);
+
+
+    final ExtractionNamespaceUpdate update;
+    try {
+      update = mapper.readValue(inputStream, ExtractionNamespaceUpdate.class);
+    }
+    catch (IOException e) {
+      log.error(e, "Error parsing new namespace");
+      return Response.status(Response.Status.BAD_REQUEST).entity(
+          ImmutableMap.<String, String>of(
+              "error",
+              Strings.isNullOrEmpty(e.getMessage()) ? "null error" : e.getMessage()
+          )
+      ).build();
+    }
+
+    try {
+      keeper.newUpdate(update);
+    }catch(Exception e){
+      log.error(e, "Error creating new namespace");
+      return Response.serverError().entity(
+          ImmutableMap.<String, String>of(
+              "error",
+              Strings.isNullOrEmpty(e.getMessage()) ? "null error" : e.getMessage()
+          )
+      ).build();
+    }
+    builder.entity(update);
+    return builder.build();
+  }
+
+  @DELETE
+  @Produces({MediaType.APPLICATION_JSON, SmileMediaTypes.APPLICATION_JACKSON_SMILE})
+  @Path("/{namespace}")
+  public Response deleteNamespace(@PathParam("namespace") String namespace){
+    if(Strings.isNullOrEmpty(namespace)){
+      return Response.status(Response.Status.BAD_REQUEST).entity(ImmutableMap.of("error", "Must specify namespace")).build();
+    }
+    try{
+      keeper.deleteNamespace(namespace);
+    }catch(Exception e){
+      log.error(e, "Error deleting namespace [%s]", namespace);
+      if(e instanceof IAE){
+        // Usually because namespace doesn't exist
+        return Response.status(Response.Status.BAD_REQUEST).entity(ImmutableMap.of("error", e.getMessage())).build();
+      }
+      return Response.serverError().entity(ImmutableMap.of("error", e.getMessage() == null ? "null error" : e.getMessage())).build();
+    }
+    return Response.status(Response.Status.ACCEPTED).build();
+  }
+}

--- a/server/src/main/java/io/druid/server/initialization/ZkPathsConfig.java
+++ b/server/src/main/java/io/druid/server/initialization/ZkPathsConfig.java
@@ -46,6 +46,9 @@ public class ZkPathsConfig
   @JsonProperty
   private
   String connectorPath;
+  @JsonProperty
+  private
+  String namespacePath;
 
   public String getBase()
   {
@@ -86,6 +89,11 @@ public class ZkPathsConfig
   public String getConnectorPath()
   {
     return (null == connectorPath) ?  defaultPath("connector") : connectorPath;
+  }
+
+  public String getNamespacePath()
+  {
+    return (namespacePath == null) ? defaultPath("namespaces") : namespacePath;
   }
 
   protected String defaultPath(final String subPath)

--- a/server/src/main/java/io/druid/server/namespace/JDBCExtractionNamespaceFunctionFactory.java
+++ b/server/src/main/java/io/druid/server/namespace/JDBCExtractionNamespaceFunctionFactory.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.namespace;
+
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.inject.Inject;
+import com.metamx.common.Pair;
+import io.druid.query.extraction.namespace.ExtractionNamespaceFunctionFactory;
+import io.druid.query.extraction.namespace.JDBCExtractionNamespace;
+import io.druid.server.namespace.cache.NamespaceExtractionCacheManager;
+import org.joda.time.DateTime;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.FoldController;
+import org.skife.jdbi.v2.Folder3;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.HandleCallback;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import org.skife.jdbi.v2.util.StringMapper;
+
+import javax.annotation.Nullable;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ *
+ */
+public class JDBCExtractionNamespaceFunctionFactory
+    implements ExtractionNamespaceFunctionFactory<JDBCExtractionNamespace>
+{
+  private final ConcurrentMap<String, DBI> dbiCache = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, AtomicLong> lastUpdates = new ConcurrentHashMap<>();
+  private final NamespaceExtractionCacheManager extractionCacheManager;
+
+  @Inject
+  public JDBCExtractionNamespaceFunctionFactory(
+      NamespaceExtractionCacheManager extractionCacheManager
+  )
+  {
+    this.extractionCacheManager = extractionCacheManager;
+  }
+
+  @Override
+  public Function<String, String> build(final JDBCExtractionNamespace namespace)
+  {
+    final ConcurrentMap<String, String> cache = extractionCacheManager.getCacheMap(namespace.getNamespace());
+    final String tsColumn = namespace.getTsColumn();
+    final String table = namespace.getTable();
+    final String valueColumn = namespace.getValueColumn();
+    final String keyColumn = namespace.getKeyColumn();
+    return new Function<String, String>()
+    {
+      @Nullable
+      @Override
+      public String apply(final @Nullable String input)
+      {
+        final String retval;
+        if (cache == null) {
+          retval = ensureDBI(namespace).withHandle(
+              new HandleCallback<String>()
+              {
+                @Override
+                public String withHandle(Handle handle) throws Exception
+                {
+                  final String query;
+                  if (tsColumn == null) {
+                    query = String.format(
+                        "SELECT %s FROM %s WHERE %s='%s'",
+                        valueColumn,
+                        table,
+                        keyColumn,
+                        input
+                    );
+                  } else {
+                    query = String.format(
+                        "SELECT %s FROM %s WHERE %s='%s' ORDER BY %s DESC",
+                        valueColumn,
+                        table,
+                        keyColumn,
+                        input,
+                        tsColumn
+                    );
+                  }
+                  return handle
+                      .createQuery(query)
+                      .map(StringMapper.FIRST)
+                      .first();
+                }
+              }
+          );
+        } else {
+          retval = cache.get(input);
+        }
+        return retval;
+      }
+    };
+  }
+
+  @Override
+  public Runnable getCachePopulator(final JDBCExtractionNamespace namespace)
+  {
+    lastUpdates.putIfAbsent(namespace.getNamespace(), new AtomicLong());
+    return new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        final ConcurrentMap<String, String> cache = extractionCacheManager.getCacheMap(namespace.getNamespace());
+        Preconditions.checkNotNull(cache, "Must call setCache first");
+        final DBI dbi = ensureDBI(namespace);
+        final String tsColumn = namespace.getTsColumn();
+        final String table = namespace.getTable();
+        final String valueColumn = namespace.getValueColumn();
+        final String keyColumn = namespace.getKeyColumn();
+        final AtomicLong lastCheck = lastUpdates.get(namespace.getNamespace());
+        List<Pair<String, String>> pairs = dbi.withHandle(
+            new HandleCallback<List<Pair<String, String>>>()
+            {
+              @Override
+              public List<Pair<String, String>> withHandle(Handle handle) throws Exception
+              {
+                final String query;
+                if (tsColumn == null) {
+                  query = String.format(
+                      "SELECT %s, %s FROM %s",
+                      keyColumn,
+                      valueColumn,
+                      table
+                  );
+                } else {
+                  query = String.format(
+                      "SELECT %s, %s FROM %s WHERE %s > '%s' ORDER BY %s ASC",
+                      keyColumn, valueColumn,
+                      table,
+                      tsColumn,
+                      new DateTime(lastCheck.get()).toString("yyyy-MM-dd hh:mm:ss"),
+                      tsColumn
+                  );
+                  lastCheck.set(System.currentTimeMillis());
+                }
+                return handle
+                    .createQuery(
+                        query
+                    ).map(
+                        new ResultSetMapper<Pair<String, String>>()
+                        {
+
+                          @Override
+                          public Pair<String, String> map(
+                              final int index,
+                              final ResultSet r,
+                              final StatementContext ctx
+                          ) throws SQLException
+                          {
+                            return new Pair<String, String>(r.getString(keyColumn), r.getString(valueColumn));
+                          }
+                        }
+                    ).fold(
+                        new LinkedList<Pair<String, String>>(),
+                        new Folder3<LinkedList<Pair<String, String>>, Pair<String, String>>()
+                        {
+                          @Override
+                          public LinkedList<Pair<String, String>> fold(
+                              LinkedList<Pair<String, String>> accumulator,
+                              Pair<String, String> rs,
+                              FoldController control,
+                              StatementContext ctx
+                          ) throws SQLException
+                          {
+                            accumulator.add(rs);
+                            return accumulator;
+                          }
+                        }
+                    );
+              }
+            }
+        );
+        for (Pair<String, String> pair : pairs) {
+          cache.put(pair.lhs, pair.rhs);
+        }
+      }
+    };
+  }
+
+  private DBI ensureDBI(JDBCExtractionNamespace namespace)
+  {
+    final String key = namespace.getNamespace();
+    DBI dbi = null;
+    if (dbiCache.containsKey(key)) {
+      dbi = dbiCache.get(key);
+    }
+    if (dbi == null) {
+      final DBI newDbi = new DBI(
+          namespace.getConnectorConfig().getConnectURI(),
+          namespace.getConnectorConfig().getUser(),
+          namespace.getConnectorConfig().getPassword()
+      );
+      dbiCache.putIfAbsent(key, newDbi);
+      dbi = dbiCache.get(key);
+    }
+    return dbi;
+  }
+
+}

--- a/server/src/main/java/io/druid/server/namespace/NamespacedExtractionModule.java
+++ b/server/src/main/java/io/druid/server/namespace/NamespacedExtractionModule.java
@@ -1,0 +1,497 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.namespace;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.client.repackaged.com.google.common.base.Strings;
+import com.google.api.client.repackaged.com.google.common.base.Throwables;
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Provides;
+import com.google.inject.name.Named;
+import com.google.inject.name.Names;
+import com.metamx.common.IAE;
+import com.metamx.common.RetryUtils;
+import com.metamx.common.StringUtils;
+import com.metamx.common.lifecycle.LifecycleStart;
+import com.metamx.common.lifecycle.LifecycleStop;
+import com.metamx.common.logger.Logger;
+import io.druid.guice.JsonConfigProvider;
+import io.druid.guice.LazySingleton;
+import io.druid.guice.LifecycleModule;
+import io.druid.guice.ManageLifecycle;
+import io.druid.guice.annotations.Json;
+import io.druid.initialization.DruidModule;
+import io.druid.query.extraction.namespace.ExtractionNamespace;
+import io.druid.query.extraction.namespace.ExtractionNamespaceFunctionFactory;
+import io.druid.query.extraction.namespace.ExtractionNamespaceUpdate;
+import io.druid.query.extraction.namespace.JDBCExtractionNamespace;
+import io.druid.query.extraction.namespace.URIExtractionNamespace;
+import io.druid.server.initialization.ZkPathsConfig;
+import io.druid.server.namespace.cache.NamespaceExtractionCacheManager;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.PathChildrenCache;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
+import org.apache.curator.utils.ZKPaths;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ *
+ */
+public class NamespacedExtractionModule implements DruidModule
+{
+  private static final Logger log = new Logger(NamespacedExtractionModule.class);
+  private static final String TYPE_PREFIX = "druid.query.extraction.namespace.cache";
+  private static final String ENABLE_NAMESPACES = "druid.query.extraction.namespace";
+  private final ConcurrentMap<String, Function<String, String>> fnCache = new ConcurrentHashMap<>();
+
+  @Override
+  public List<? extends Module> getJacksonModules()
+  {
+    return ImmutableList.<Module>of(
+        new Module()
+        {
+          @Override
+          public String getModuleName()
+          {
+            return "DruidNamespacedExtractionModule";
+          }
+
+          @Override
+          public Version version()
+          {
+            return Version.unknownVersion();
+          }
+
+          @Override
+          public void setupModule(SetupContext context)
+          {
+            context.registerSubtypes(ExtractionNamespaceUpdate.class);
+            context.registerSubtypes(ExtractionNamespace.class);
+          }
+        }
+    );
+  }
+
+  public static class NamespacedExtractionModuleConfig
+  {
+    @JsonCreator
+    public NamespacedExtractionModuleConfig(
+        @JsonProperty("enabled") Boolean enabled
+    )
+    {
+      this.enabled = enabled == null ? false : enabled;
+    }
+
+    @JsonProperty
+    final Boolean enabled;
+  }
+
+  @Override
+  public void configure(Binder binder)
+  {
+    JsonConfigProvider.bind(binder, TYPE_PREFIX, NamespaceExtractionCacheManager.class);
+    JsonConfigProvider.bind(binder, ENABLE_NAMESPACES, NamespacedExtractionModuleConfig.class);
+    binder
+        .bind(ExtractionNamespaceFunctionFactory.class)
+        .annotatedWith(Names.named(JDBCExtractionNamespace.class.getCanonicalName()))
+        .to(JDBCExtractionNamespaceFunctionFactory.class)
+        .in(LazySingleton.class);
+    binder
+        .bind(ExtractionNamespaceFunctionFactory.class)
+        .annotatedWith(Names.named(URIExtractionNamespace.class.getCanonicalName()))
+        .to(URIExtractionNamespaceFunctionFactory.class)
+        .in(LazySingleton.class);
+
+    binder.bind(NamespacedKeeper.class).in(ManageLifecycle.class);
+    LifecycleModule.register(binder, NamespacedKeeper.class);
+  }
+
+  private static final Function<String, String> NOOP_FUNCTION = new Function<String, String>()
+  {
+    @Nullable
+    @Override
+    public String apply(@Nullable String input)
+    {
+      return Strings.isNullOrEmpty(input) ? null : input;
+    }
+  };
+
+  @Provides
+  @Named("io.druid.server.namespace.NamespacedExtractionModule")
+  public ConcurrentMap<String, Function<String, String>> getFnCache()
+  {
+    return fnCache;
+  }
+
+  @Provides
+  @Named("dimExtractionNamespace")
+  @LazySingleton
+  public Function<String, Function<String, String>> getFunctionMaker(
+      @Named("io.druid.server.namespace.NamespacedExtractionModule")
+      final ConcurrentMap<String, Function<String, String>> fnCache,
+      final NamespacedExtractionModuleConfig config
+  )
+  {
+    return new Function<String, Function<String, String>>()
+    {
+      @Nullable
+      @Override
+      public Function<String, String> apply(final String namespace)
+      {
+        if (config.enabled == null || !config.enabled.booleanValue()) {
+          return NOOP_FUNCTION;
+        }
+        Function<String, String> fn = fnCache.get(namespace);
+        if (fn == null) {
+          throw new IAE("Namespace [%s] not found", namespace);
+        }
+        return fn;
+      }
+    };
+  }
+
+  @ManageLifecycle
+  public static class NamespacedKeeper
+  {
+    private final CuratorFramework curator;
+    private final ZkPathsConfig zkPathsConfig;
+    private final ListeningExecutorService listeningExecutorService = MoreExecutors.listeningDecorator(
+        Executors.newSingleThreadExecutor(
+            new ThreadFactoryBuilder()
+                .setDaemon(true)
+                .setNameFormat("NamespaceKeeper-%d")
+                .setPriority(Thread.MIN_PRIORITY)
+                .build()
+        )
+    );
+    private final Injector injector;
+    private final NamespaceExtractionCacheManager namespaceExtractionCacheManager;
+    private final ObjectMapper jsonMapper;
+    private final ConcurrentMap<String, Function<String, String>> fnCache;
+    private final Boolean enableNamespaces;
+
+    @Inject
+    public NamespacedKeeper(
+        CuratorFramework curator,
+        ZkPathsConfig zkPathsConfig,
+        @Json ObjectMapper jsonMapper,
+        Injector injector,
+        NamespaceExtractionCacheManager namespaceExtractionCacheManager,
+        @Named("io.druid.server.namespace.NamespacedExtractionModule")
+        ConcurrentMap<String, Function<String, String>> fnCache,
+        NamespacedExtractionModuleConfig config
+    )
+    {
+      this.curator = curator;
+      this.zkPathsConfig = zkPathsConfig;
+      this.jsonMapper = jsonMapper;
+      this.injector = injector;
+      this.namespaceExtractionCacheManager = namespaceExtractionCacheManager;
+      this.fnCache = fnCache;
+      this.enableNamespaces = config == null ? false : config.enabled;
+    }
+
+    @LifecycleStart
+    public void start()
+    {
+      if (!enableNamespaces) {
+        log.info("Namespaces disabled. Skipping start()");
+        return;
+      }
+      try {
+        curator.newNamespaceAwareEnsurePath(zkPathsConfig.getNamespacePath()).ensure(curator.getZookeeperClient());
+      }
+      catch (Exception e) {
+        throw Throwables.propagate(e);
+      }
+      final PathChildrenCache pathChildrenCache = new PathChildrenCache(
+          curator,
+          zkPathsConfig.getNamespacePath(),
+          true,
+          true,
+          MoreExecutors.sameThreadExecutor()
+      );
+
+      log.info("Registering extraction namespace listener on path [%s]", zkPathsConfig.getNamespacePath());
+
+      pathChildrenCache.getListenable().addListener(
+          new PathChildrenCacheListener()
+          {
+            @Override
+            public void childEvent(
+                CuratorFramework curatorFramework, PathChildrenCacheEvent pathChildrenCacheEvent
+            ) throws Exception
+            {
+              if (!ImmutableSet.of(
+                  PathChildrenCacheEvent.Type.CHILD_UPDATED,
+                  PathChildrenCacheEvent.Type.CHILD_ADDED,
+                  PathChildrenCacheEvent.Type.CHILD_REMOVED
+              ).contains(pathChildrenCacheEvent.getType())) {
+                // Don't care if not above
+                return;
+              }
+              final byte[] data = pathChildrenCacheEvent.getData().getData();
+              final String sData = StringUtils.fromUtf8(data);
+              final ExtractionNamespaceUpdate update = jsonMapper.readValue(sData, ExtractionNamespaceUpdate.class);
+              final String ns = update.getNamespace().getNamespace();
+              final PathChildrenCacheEvent.Type eventType = pathChildrenCacheEvent.getType();
+              log.debug("Processing event type [%s]", eventType);
+
+              if (eventType.equals(PathChildrenCacheEvent.Type.CHILD_REMOVED) ||
+                  eventType.equals(PathChildrenCacheEvent.Type.CHILD_UPDATED)) {
+                log.debug("Removing namespace [%s]", ns);
+                namespaceExtractionCacheManager.delete(ns);
+                fnCache.remove(ns);
+              }
+
+              if (eventType.equals(PathChildrenCacheEvent.Type.CHILD_ADDED) ||
+                  eventType.equals(PathChildrenCacheEvent.Type.CHILD_UPDATED)) {
+                log.debug("Adding namespace [%s] : %s", ns, update.toString());
+                final ExtractionNamespace namespace = update.getNamespace();
+                final ExtractionNamespaceFunctionFactory factory = injector.getInstance(
+                    Key.get(
+                        ExtractionNamespaceFunctionFactory.class,
+                        Names.named(
+                            namespace
+                                .getClass()
+                                .getCanonicalName()
+                        )
+                    )
+                );
+
+                final Runnable cachePopulator = factory.getCachePopulator(namespace);
+                final Function<String, String> fn = factory.build(namespace);
+                final Object prior;
+                if (update.getUpdateMs() > 0) {
+                  log.info(
+                      "Adding repeating update for namespace [%s] at an interval of [%d] ms via [%s]",
+                      namespace.getNamespace(),
+                      update.getUpdateMs(),
+                      update.toString()
+                  );
+                  Futures.addCallback(
+                      namespaceExtractionCacheManager.scheduleRepeat(
+                          namespace.getNamespace(), cachePopulator, update.getUpdateMs(),
+                          TimeUnit.MILLISECONDS
+                      ), new FutureCallback<Object>()
+                      {
+                        @Override
+                        public void onSuccess(@Nullable Object result)
+                        {
+                          // NoOp
+                        }
+
+                        @Override
+                        public void onFailure(Throwable t)
+                        {
+                          log.error(t, "Failed to load namespace [%s]", namespace.toString());
+                        }
+                      },
+                      MoreExecutors.sameThreadExecutor()
+                  );
+                  prior = fnCache.put(ns, fn);
+                } else {
+                  log.info(
+                      "Scheduling one update of namespace [%s] via [%s]",
+                      namespace.getNamespace(),
+                      update.toString()
+                  );
+                  namespaceExtractionCacheManager.scheduleOnce(ns, cachePopulator);
+                  prior = fnCache.put(ns, fn);
+                }
+                if (prior != null) {
+                  log.warn("Function for namespace [%s] was overridden", namespace.getNamespace());
+                }
+              }
+            }
+          },
+          listeningExecutorService
+      );
+      try {
+        pathChildrenCache.start();
+      }
+      catch (Exception e) {
+        throw Throwables.propagate(e);
+      }
+    }
+
+    @LifecycleStop
+    public void stop()
+    {
+      if (!enableNamespaces) {
+        log.info("Namespaces disabled. Skipping stop()");
+        return;
+      }
+      curator.close();
+    }
+
+    public Collection<String> listNamespaces()
+    {
+      final ArrayList<Exception> innerExceptions = new ArrayList<>();
+      Set<String> retval = null;
+      try {
+         retval = ImmutableSet.copyOf(
+            Collections2.filter(
+                Collections2.transform(
+                    curator.getChildren().forPath(zkPathsConfig.getNamespacePath()),
+                    new Function<String, String>()
+                    {
+                      @Nullable
+                      @Override
+                      public String apply(@NotNull String input)
+                      {
+                        try {
+                          return jsonMapper.readValue(
+                              curator.getData()
+                                     .forPath(
+                                         ZKPaths.makePath(
+                                             zkPathsConfig.getNamespacePath(),
+                                             input
+                                         )
+                                     ), ExtractionNamespaceUpdate.class
+                          ).getNamespace().getNamespace();
+                        } catch(Exception e){
+                          innerExceptions.add(e);
+                          return null;
+                        }
+                      }
+                    }
+                ), Predicates.notNull()
+            )
+        );
+      }
+      catch (Exception e)
+      {
+        innerExceptions.add(e);
+      }
+      if(!innerExceptions.isEmpty()){
+        if(innerExceptions.size() == 1){
+          throw Throwables.propagate(innerExceptions.get(0));
+        }
+        final IAE iae = new IAE("Error in reading data from zookeeper");
+        for(Exception inEx : innerExceptions){
+          iae.addSuppressed(inEx);
+        }
+        throw iae;
+      }
+      return retval;
+    }
+
+
+    public ExtractionNamespaceUpdate newUpdate(final ExtractionNamespaceUpdate update){
+      try {
+        RetryUtils.retry(
+            new Callable<Void>()
+            {
+              @Override
+              public Void call() throws Exception
+              {
+                final String path = ZKPaths.makePath(
+                    zkPathsConfig.getNamespacePath(),
+                    update.getNamespace().getNamespace()
+                );
+                if (null != curator.checkExists().forPath(path)) {
+                  throw new IAE("Namespace [%s] already exists", update.getNamespace().getNamespace());
+                }
+                curator.inTransaction().create().forPath(path, jsonMapper.writeValueAsBytes(update)).and().commit();
+                return null;
+              }
+            },
+            new Predicate<Throwable>()
+            {
+              @Override
+              public boolean apply(@Nullable Throwable input)
+              {
+                return input instanceof IOException;
+              }
+            },
+            10
+        );
+      }
+      catch (Exception e) {
+        throw Throwables.propagate(e);
+      }
+      return update;
+    }
+
+    public void deleteNamespace(final String namespace){
+      try{
+        RetryUtils.retry(
+            new Callable<Void>()
+            {
+              @Override
+              public Void call() throws Exception
+              {
+                final String path = ZKPaths.makePath(zkPathsConfig.getNamespacePath(), namespace);
+                if (null == curator.checkExists().forPath(path)) {
+                  throw new IAE("Namespace [%s] does not exists", namespace);
+                }
+                curator.inTransaction().delete().forPath(path).and().commit();
+                return null;
+              }
+            },
+            new Predicate<Throwable>()
+            {
+              @Override
+              public boolean apply(@Nullable Throwable input)
+              {
+                return input instanceof IOException;
+              }
+            },
+            10
+        );
+      }catch(Exception e){
+        throw Throwables.propagate(e);
+      }
+    }
+  }
+}

--- a/server/src/main/java/io/druid/server/namespace/URIExtractionNamespaceFunctionFactory.java
+++ b/server/src/main/java/io/druid/server/namespace/URIExtractionNamespaceFunctionFactory.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.namespace;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.client.repackaged.com.google.common.base.Throwables;
+import com.google.common.base.Function;
+import com.google.common.io.ByteSource;
+import com.google.common.io.CharStreams;
+import com.google.inject.Inject;
+import com.metamx.common.CompressionUtils;
+import com.metamx.common.IAE;
+import com.metamx.common.RetryUtils;
+import com.metamx.common.logger.Logger;
+import io.druid.common.utils.JodaUtils;
+import io.druid.data.input.MapPopulator;
+import io.druid.guice.annotations.Json;
+import io.druid.guice.annotations.Smile;
+import io.druid.query.extraction.namespace.ExtractionNamespaceFunctionFactory;
+import io.druid.query.extraction.namespace.URIExtractionNamespace;
+import io.druid.segment.loading.DataSegmentPuller;
+import io.druid.segment.loading.URIDataPuller;
+import io.druid.server.namespace.cache.NamespaceExtractionCacheManager;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentMap;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/**
+ *
+ */
+public class URIExtractionNamespaceFunctionFactory implements ExtractionNamespaceFunctionFactory<URIExtractionNamespace>
+{
+  private static final Logger log = new Logger(URIExtractionNamespaceFunctionFactory.class);
+  private final NamespaceExtractionCacheManager extractionCacheManager;
+  private final ObjectMapper smileMapper;
+  private final ObjectMapper jsomMapper;
+  private final Map<String, DataSegmentPuller> pullers;
+
+  @Inject
+  public URIExtractionNamespaceFunctionFactory(
+      NamespaceExtractionCacheManager extractionCacheManager,
+      @Smile ObjectMapper smileMapper,
+      @Json ObjectMapper jsonMapper,
+      Map<String, DataSegmentPuller> pullers
+  )
+  {
+    this.extractionCacheManager = extractionCacheManager;
+    this.smileMapper = smileMapper;
+    this.jsomMapper = jsonMapper;
+    this.pullers = pullers;
+  }
+
+  @Override
+  public Function<String, String> build(final URIExtractionNamespace extractionNamespace)
+  {
+    final ConcurrentMap<String, String> cache = extractionCacheManager.getCacheMap(extractionNamespace.getNamespace());
+    return new Function<String, String>()
+    {
+      @Nullable
+      @Override
+      public String apply(String input)
+      {
+        if (input == null) {
+          return null;
+        }
+        return cache.get(input);
+      }
+    };
+  }
+
+  @Override
+  public Runnable getCachePopulator(final URIExtractionNamespace extractionNamespace)
+  {
+    return new Runnable()
+    {
+      private volatile long lastCached = JodaUtils.MIN_INSTANT;
+      @Override
+      public void run()
+      {
+        final URI uri = extractionNamespace.getUri();
+        final DataSegmentPuller pullerRaw = pullers.get(uri.getScheme());
+        if (pullerRaw == null) {
+          throw new IAE(
+              "Unknown loader type[%s].  Known types are %s",
+              uri.getScheme(),
+              pullers.keySet()
+          );
+        }
+        if(!(pullerRaw instanceof URIDataPuller)){
+          throw new IAE("Cannot load data from location [%s]. Data pulling from [%s] not supported", uri.toString(), uri.getScheme());
+        }
+        final URIDataPuller puller = (URIDataPuller)pullerRaw;
+        final String uriPath = uri.getPath();
+
+        // Inspired by OmniSegmentLoader
+        try {
+          RetryUtils.retry(
+              new Callable<Void>()
+              {
+                @Override
+                public Void call() throws Exception
+                {
+                  final String version = puller.getVersion(uri);
+                  Long lastModified = null;
+                  try {
+                    lastModified = Long.parseLong(version);
+                    if (lastModified <= lastCached) {
+                      final DateTimeFormatter fmt = ISODateTimeFormat.dateTime();
+                      log.info(
+                          "URI [%s] for namespace [%s] was las modified [%s] but was last cached [%s]. Skipping ",
+                          uri.toString(),
+                          extractionNamespace.getNamespace(),
+                          fmt.print(lastModified),
+                          fmt.print(lastCached)
+                      );
+                      return null;
+                    }
+                  }
+                  catch (NumberFormatException ex) {
+                    log.debug(ex, "Failed to get last modified timestamp. Assuming no timestamp");
+                  }
+                  final ByteSource source;
+                  if (CompressionUtils.isGz(uriPath)) {
+                    // Simple gzip stream
+                    log.debug("Loading gz");
+                    source = new ByteSource()
+                    {
+                      @Override
+                      public InputStream openStream() throws IOException
+                      {
+                        return CompressionUtils.gzipInputStream(puller.getInputStream(uri));
+                      }
+                    };
+                  } else {
+                    source = new ByteSource()
+                    {
+                      @Override
+                      public InputStream openStream() throws IOException
+                      {
+                        return puller.getInputStream(uri);
+                      }
+                    };
+                  }
+                  final MapPopulator<String, String> populator = new MapPopulator<>(extractionNamespace.getParseSpec().getParser());
+                  populator.populate(source, extractionCacheManager.getCacheMap(extractionNamespace.getNamespace()));
+                  log.info("Finished loading namespace [%s]", extractionNamespace.getNamespace());
+                  if (lastModified != null) {
+                    lastCached = lastModified;
+                  }
+                  return null;
+                }
+              },
+              puller.shouldRetryPredicate(),
+              10
+          );
+        }
+        catch (Exception e) {
+          throw Throwables.propagate(e);
+        }
+      }
+    };
+  }
+}

--- a/server/src/main/java/io/druid/server/namespace/cache/ClientCacheExtractionCacheManager.java
+++ b/server/src/main/java/io/druid/server/namespace/cache/ClientCacheExtractionCacheManager.java
@@ -1,0 +1,268 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.namespace.cache;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.api.client.util.Preconditions;
+import com.google.common.util.concurrent.Striped;
+import com.metamx.common.StringUtils;
+import com.metamx.common.UOE;
+import com.metamx.common.lifecycle.Lifecycle;
+import com.metamx.common.logger.Logger;
+import io.druid.client.cache.Cache;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.ReadWriteLock;
+
+/**
+ * Simple wrapper to Cache. Unfortunately Cache has a lot of missing functionality at the time being
+ * TODO: rewrite Cache
+ */
+@JsonTypeName("cache")
+public class ClientCacheExtractionCacheManager extends NamespaceExtractionCacheManager
+{
+  private static final Logger log = new Logger(ClientCacheExtractionCacheManager.class);
+  private final Cache cache;
+
+  @JsonCreator
+  public ClientCacheExtractionCacheManager(
+      @JacksonInject Cache cache,
+      @JacksonInject Lifecycle lifecycle
+  )
+  {
+    super(lifecycle);
+    this.cache = cache;
+  }
+
+  @Override
+  public void delete(String ns)
+  {
+    super.delete(ns);
+    cache.close(ns);
+  }
+
+  @Override
+  public ConcurrentMap<String, String> getCacheMap(String namespace)
+  {
+    return makeMap(namespace);
+  }
+
+  @Override
+  public Collection<String> getKnownNamespaces()
+  {
+    return cache.getNamespaces();
+  }
+
+  private static final Cache.NamedKey getKey(final String namespace, final String key)
+  {
+    return new Cache.NamedKey(namespace, StringUtils.toUtf8(key));
+  }
+
+  private static final boolean keyCheck(Object key)
+  {
+    Preconditions.checkNotNull(key);
+    if (!(key instanceof String)) {
+      log.warn("Must be String, cannot use [%s]", key.getClass().getCanonicalName());
+      return false;
+    }
+    return true;
+  }
+
+  private static final String sanitizeString(byte[] prior)
+  {
+    if (prior == null) {
+      return null;
+    }
+    final String sPrior = StringUtils.fromUtf8(prior);
+    return sPrior.isEmpty() ? null : sPrior;
+  }
+
+  private ConcurrentMap<String, String> makeMap(final String namespace)
+  {
+    // Shitty concurrentMap.
+    // Isn't actually concurrent across the cluster
+    return new ConcurrentMap<String, String>()
+    {
+      Striped<ReadWriteLock> striped = Striped.readWriteLock(64);
+
+      @Override
+      public String putIfAbsent(String key, String value)
+      {
+        final ReadWriteLock lock = striped.get(key);
+        lock.writeLock().lock();
+        try {
+          final Cache.NamedKey namedKey = getKey(namespace, key);
+          final byte[] prior = cache.get(namedKey);
+          if (prior != null) {
+            return sanitizeString(prior);
+          }
+          cache.put(getKey(namespace, key), StringUtils.toUtf8(value));
+          return null;
+        }
+        finally {
+          lock.writeLock().unlock();
+        }
+      }
+
+      @Override
+      public boolean remove(Object key, Object value)
+      {
+        throw new UOE("Cannot remove");
+      }
+
+      @Override
+      public boolean replace(String key, String oldValue, String newValue)
+      {
+        throw new UOE("Cannot atomically replace");
+      }
+
+      @Override
+      public String replace(String key, String value)
+      {
+        final Cache.NamedKey namedKey = getKey(namespace, key);
+        final ReadWriteLock lock = striped.get(key);
+        lock.writeLock().lock();
+        try {
+          final byte[] prior = cache.get(namedKey);
+          cache.put(namedKey, StringUtils.toUtf8(value));
+          return prior == null ? null : StringUtils.fromUtf8(prior);
+        }
+        finally {
+          lock.writeLock().unlock();
+        }
+      }
+
+      @Override
+      public int size()
+      {
+        throw new UOE("Cannot determine cache size");
+      }
+
+      @Override
+      public boolean isEmpty()
+      {
+        throw new UOE("Cannot determine cache size");
+      }
+
+      @Override
+      public boolean containsKey(Object key)
+      {
+        if (!keyCheck(key)) {
+          return false;
+        }
+        final String sKey = (String) key;
+        final ReadWriteLock lock = striped.get(sKey);
+        lock.readLock().lock();
+        try {
+          return cache.get(getKey(namespace, sKey)) != null;
+        }
+        finally {
+          lock.readLock().unlock();
+        }
+      }
+
+      @Override
+      public boolean containsValue(Object value)
+      {
+        throw new UOE("Cannot check for value");
+      }
+
+      @Override
+      public String get(Object key)
+      {
+        if (!keyCheck(key)) {
+          return null;
+        }
+        final String sKey = (String) key;
+        final ReadWriteLock lock = striped.get(sKey);
+        lock.readLock().lock();
+        try {
+          final byte[] bytes = cache.get(getKey(namespace, sKey));
+          if (bytes == null) {
+            return null;
+          }
+          return StringUtils.fromUtf8(bytes);
+        }
+        finally {
+          lock.readLock().unlock();
+        }
+      }
+
+      @Override
+      public String put(String key, String value)
+      {
+        final ReadWriteLock lock = striped.get(key);
+        lock.writeLock().lock();
+        try {
+          final Cache.NamedKey namedKey = getKey(namespace, key);
+          final byte[] prior = cache.get(namedKey);
+          cache.put(namedKey, StringUtils.toUtf8(value));
+          return prior == null ? null : StringUtils.fromUtf8(prior);
+        }
+        finally {
+          lock.writeLock().unlock();
+        }
+      }
+
+      @Override
+      public String remove(Object key)
+      {
+        throw new UOE("Cannot remove");
+      }
+
+      @Override
+      public void putAll(Map<? extends String, ? extends String> m)
+      {
+        for (Entry<? extends String, ? extends String> entry : m.entrySet()) {
+          put(entry.getKey(), entry.getValue());
+        }
+      }
+
+      @Override
+      public void clear()
+      {
+        cache.close(namespace);
+      }
+
+      @Override
+      public Set<String> keySet()
+      {
+        throw new UOE("Cannot get key set");
+      }
+
+      @Override
+      public Collection<String> values()
+      {
+        throw new UOE("Cannot get value set");
+      }
+
+      @Override
+      public Set<Entry<String, String>> entrySet()
+      {
+        throw new UOE("Cannot get entry set");
+      }
+    };
+  }
+}

--- a/server/src/main/java/io/druid/server/namespace/cache/NamespaceExtractionCacheManager.java
+++ b/server/src/main/java/io/druid/server/namespace/cache/NamespaceExtractionCacheManager.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.namespace.cache;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListenableScheduledFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.metamx.common.concurrent.ExecutorServices;
+import com.metamx.common.lifecycle.Lifecycle;
+import com.metamx.common.logger.Logger;
+
+import java.util.Collection;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ *
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = OnHeapNamespaceExtractionCacheManager.class)
+@JsonSubTypes(value = {
+    @JsonSubTypes.Type(name = "offHeap", value = OffHeapNamespaceExtractionCacheManager.class),
+    @JsonSubTypes.Type(name = "onHeap", value = OnHeapNamespaceExtractionCacheManager.class),
+    @JsonSubTypes.Type(name = "cache", value = ClientCacheExtractionCacheManager.class)
+})
+public abstract class NamespaceExtractionCacheManager
+{
+  private static final Logger log = new Logger(NamespaceExtractionCacheManager.class);
+  private final ListeningScheduledExecutorService listeningScheduledExecutorService;
+  private final ConcurrentMap<String, Collection<ListenableScheduledFuture<?>>> repeatFutures = new ConcurrentHashMap<>();
+
+  public NamespaceExtractionCacheManager(
+      Lifecycle lifecycle
+  )
+  {
+    this.listeningScheduledExecutorService = MoreExecutors.listeningDecorator(
+        Executors.newScheduledThreadPool(
+            1,
+            new ThreadFactoryBuilder()
+                .setDaemon(true)
+                .setNameFormat("NamespaceExtractionCacheManager-%d")
+                .setPriority(Thread.MIN_PRIORITY)
+                .build()
+        )
+    );
+    ExecutorServices.manageLifecycle(lifecycle, listeningScheduledExecutorService);
+  }
+
+  public ListenableFuture<?> scheduleOnce(final String ns, final Runnable runnable)
+  {
+    final Collection<ListenableScheduledFuture<?>> futures = repeatFutures.get(ns);
+    if (futures != null) {
+      log.warn("Namespace [%s] has repeated updates but was requested to schedule a one-off", ns);
+    }
+    return scheduleOnce(runnable);
+  }
+
+  public ListenableScheduledFuture<?> scheduleRepeat(
+      final String ns,
+      final Runnable command,
+      final long delay,
+      final TimeUnit timeUnit
+  )
+  {
+    Collection<ListenableScheduledFuture<?>> futures = repeatFutures.get(ns);
+    if (futures == null) {
+      repeatFutures.putIfAbsent(ns, new ConcurrentLinkedQueue<ListenableScheduledFuture<?>>());
+      futures = repeatFutures.get(ns);
+    } else {
+      log.warn("Namespace [%s] has repeated updates but was requested to schedule a repeated update", ns);
+    }
+    ListenableScheduledFuture<?> future = listeningScheduledExecutorService.scheduleAtFixedRate(
+        command,
+        0,
+        delay,
+        timeUnit
+    );
+    futures.add(future);
+    return future;
+  }
+
+  protected <T> ListenableFuture<T> scheduleOnce(
+      final Callable<T> command
+  )
+  {
+    return listeningScheduledExecutorService.submit(command);
+  }
+
+  protected ListenableFuture<?> scheduleOnce(
+      Runnable runnable
+  )
+  {
+    return listeningScheduledExecutorService.submit(runnable);
+  }
+
+  protected ListenableScheduledFuture<?> scheduleRepeat(
+      final Runnable command, final long delay, final TimeUnit timeUnit
+  )
+  {
+    return listeningScheduledExecutorService.scheduleAtFixedRate(command, 0, delay, timeUnit);
+  }
+
+  public abstract ConcurrentMap<String, String> getCacheMap(String namespace);
+
+  public void delete(String ns)
+  {
+    Collection<ListenableScheduledFuture<?>> futures = repeatFutures.get(ns);
+    if (futures == null) {
+      repeatFutures.putIfAbsent(ns, new ConcurrentLinkedQueue<ListenableScheduledFuture<?>>());
+      futures = repeatFutures.get(ns);
+    }
+    Futures.allAsList(futures).cancel(true);
+    repeatFutures.remove(ns);
+  }
+
+  public abstract Collection<String> getKnownNamespaces();
+}

--- a/server/src/main/java/io/druid/server/namespace/cache/OffHeapNamespaceExtractionCacheManager.java
+++ b/server/src/main/java/io/druid/server/namespace/cache/OffHeapNamespaceExtractionCacheManager.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.namespace.cache;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Collections2;
+import com.metamx.common.lifecycle.Lifecycle;
+import com.metamx.common.logger.Logger;
+import org.mapdb.DB;
+import org.mapdb.DBMaker;
+import org.mapdb.HTreeMap;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ *
+ */
+@JsonTypeName("offHeap")
+public class OffHeapNamespaceExtractionCacheManager extends NamespaceExtractionCacheManager
+{
+  private static final Logger log = new Logger(OffHeapNamespaceExtractionCacheManager.class);
+  private final DB mmapDB;
+
+  @JsonCreator
+  public OffHeapNamespaceExtractionCacheManager(
+      @JacksonInject Lifecycle lifecycle
+  )
+  {
+    super(lifecycle);
+    final File tmpFile;
+    try {
+      tmpFile = File.createTempFile("druidMapDB", getClass().getCanonicalName());
+      tmpFile.deleteOnExit();
+      log.info("Using file [%s] for mapDB off heap namespace cache", tmpFile.getAbsolutePath());
+    }
+    catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+    mmapDB = DBMaker
+        .newFileDB(tmpFile)
+        .closeOnJvmShutdown()
+        .transactionDisable()
+        .deleteFilesAfterClose()
+        .strictDBGet()
+        .asyncWriteEnable()
+        .mmapFileEnable()
+        .commitFileSyncDisable()
+        .cacheSize(100 << 20) // 100 MB
+        .make();
+  }
+
+  @Override
+  public void delete(final String ns)
+  {
+    super.delete(ns);
+    mmapDB.delete(ns);
+  }
+
+  @Override
+  public ConcurrentMap<String, String> getCacheMap(String namespace)
+  {
+    return mmapDB.createHashMap(namespace).makeOrGet();
+  }
+
+  @Override
+  public Collection<String> getKnownNamespaces()
+  {
+    return Collections2.transform(
+        Collections2.filter(
+            mmapDB.getAll().entrySet(),
+            new Predicate<Map.Entry<String, Object>>()
+            {
+              @Override
+              public boolean apply(Map.Entry<String, Object> input)
+              {
+                return input.getValue() instanceof HTreeMap;
+              }
+            }
+        ),
+        new Function<Map.Entry<String, Object>, String>()
+        {
+          @Override
+          public String apply(Map.Entry<String, Object> input)
+          {
+            return input.getKey();
+          }
+        }
+    );
+  }
+}

--- a/server/src/main/java/io/druid/server/namespace/cache/OnHeapNamespaceExtractionCacheManager.java
+++ b/server/src/main/java/io/druid/server/namespace/cache/OnHeapNamespaceExtractionCacheManager.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.namespace.cache;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.metamx.common.lifecycle.Lifecycle;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ *
+ */
+@JsonTypeName("onHeap")
+public class OnHeapNamespaceExtractionCacheManager extends NamespaceExtractionCacheManager
+{
+  private final ConcurrentMap<String, ConcurrentMap<String, String>> mapMap = new ConcurrentHashMap<>();
+
+  @JsonCreator
+  public OnHeapNamespaceExtractionCacheManager(
+      @JacksonInject Lifecycle lifecycle
+  )
+  {
+    super(lifecycle);
+  }
+
+  @Override
+  public ConcurrentMap<String, String> getCacheMap(String namespace)
+  {
+    ConcurrentMap<String, String> map = mapMap.get(namespace);
+    if (map == null) {
+      mapMap.putIfAbsent(namespace, new ConcurrentHashMap<String, String>(32));
+      map = mapMap.get(namespace);
+    }
+    return map;
+  }
+
+  @Override
+  public void delete(final String ns)
+  {
+    super.delete(ns);
+    mapMap.remove(ns);
+  }
+
+  @Override
+  public Collection<String> getKnownNamespaces()
+  {
+    return mapMap.keySet();
+  }
+}

--- a/server/src/test/java/io/druid/initialization/ZkPathsConfigTest.java
+++ b/server/src/test/java/io/druid/initialization/ZkPathsConfigTest.java
@@ -58,6 +58,7 @@ public class ZkPathsConfigTest extends JsonConfigTesterBase<ZkPathsConfig>
     propertyValues.put(String.format("%s.coordinatorPath", configPrefix), ZKPaths.makePath(base, "coordinator"));
     propertyValues.put(String.format("%s.loadQueuePath", configPrefix), ZKPaths.makePath(base, "loadQueue"));
     propertyValues.put(String.format("%s.connectorPath", configPrefix), ZKPaths.makePath(base, "connector"));
+    propertyValues.put(String.format("%s.namespacePath", configPrefix), ZKPaths.makePath(base, "namespaces"));
 
     ZkPathsConfig zkPathsConfigObj = zkPathsConfig.get().get();
     validateEntries(zkPathsConfigObj);

--- a/server/src/test/java/io/druid/server/namespace/NamespacedExtractionModuleTest.java
+++ b/server/src/test/java/io/druid/server/namespace/NamespacedExtractionModuleTest.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.namespace;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.multibindings.MapBinder;
+import com.google.inject.name.Names;
+import com.metamx.common.IAE;
+import com.metamx.common.lifecycle.Lifecycle;
+import io.druid.curator.PotentiallyGzippedCompressionProvider;
+import io.druid.guice.GuiceInjectors;
+import io.druid.guice.JsonConfigProvider;
+import io.druid.guice.LazySingleton;
+import io.druid.guice.annotations.Json;
+import io.druid.guice.annotations.Smile;
+import io.druid.initialization.Initialization;
+import io.druid.jackson.DefaultObjectMapper;
+import io.druid.metadata.MetadataStorageConnectorConfig;
+import io.druid.query.extraction.namespace.ExtractionNamespace;
+import io.druid.query.extraction.namespace.ExtractionNamespaceFunctionFactory;
+import io.druid.query.extraction.namespace.ExtractionNamespaceUpdate;
+import io.druid.query.extraction.namespace.JDBCExtractionNamespace;
+import io.druid.query.extraction.namespace.URIExtractionNamespace;
+import io.druid.query.extraction.namespace.URIExtractionNamespaceTest;
+import io.druid.segment.loading.DataSegmentPuller;
+import io.druid.segment.loading.LocalDataSegmentPuller;
+import io.druid.server.initialization.ZkPathsConfig;
+import io.druid.server.namespace.NamespacedExtractionModule;
+import io.druid.server.namespace.cache.NamespaceExtractionCacheManager;
+import io.druid.server.namespace.cache.OnHeapNamespaceExtractionCacheManager;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.GetChildrenBuilder;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.test.TestingCluster;
+import org.apache.curator.utils.ZKPaths;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.file.Files;
+import java.util.Collection;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ *
+ */
+public class NamespacedExtractionModuleTest
+{
+  private static final ObjectMapper mapper = URIExtractionNamespaceTest.registerTypes(new DefaultObjectMapper());
+  private static final ZkPathsConfig zkPathsConfig = new ZkPathsConfig();
+  private static TestingCluster testingCluster;
+  private static CuratorFramework cf;
+  private static NamespaceExtractionCacheManager cacheManager;
+  private static Lifecycle lifecycle;
+  private static NamespacedExtractionModule.NamespacedKeeper keeper;
+  private static ConcurrentMap<String, Function<String, String>> fnCache = new ConcurrentHashMap<>();
+
+  @BeforeClass
+  public static void setUpStatic() throws Exception
+  {
+    lifecycle = new Lifecycle();
+    cacheManager = new OnHeapNamespaceExtractionCacheManager(lifecycle);
+    final Injector injector = Guice.createInjector(
+        new Module()
+        {
+          @Override
+          public void configure(Binder binder)
+          {
+            binder.bind(NamespaceExtractionCacheManager.class).toInstance(cacheManager);
+            binder.bind(Key.get(ObjectMapper.class, Json.class)).toInstance(mapper);
+            binder.bind(Key.get(ObjectMapper.class, Smile.class)).toInstance(mapper);
+            binder
+                .bind(ExtractionNamespaceFunctionFactory.class)
+                .annotatedWith(Names.named(JDBCExtractionNamespace.class.getCanonicalName()))
+                .to(JDBCExtractionNamespaceFunctionFactory.class);
+            binder
+                .bind(ExtractionNamespaceFunctionFactory.class)
+                .annotatedWith(Names.named(URIExtractionNamespace.class.getCanonicalName()))
+                .to(URIExtractionNamespaceFunctionFactory.class);
+            MapBinder<String, DataSegmentPuller> mapBindings = MapBinder.newMapBinder(
+                binder,
+                String.class,
+                DataSegmentPuller.class
+            );
+            mapBindings.addBinding("file").toInstance(new LocalDataSegmentPuller());
+          }
+        }
+    );
+    testingCluster = new TestingCluster(1);
+    testingCluster.start();
+
+    cf = CuratorFrameworkFactory.builder()
+                                .connectString(testingCluster.getConnectString())
+                                .retryPolicy(new ExponentialBackoffRetry(1, 10))
+                                .compressionProvider(new PotentiallyGzippedCompressionProvider(false))
+                                .build();
+    cf.start();
+    cf.create().creatingParentsIfNeeded().forPath(zkPathsConfig.getNamespacePath());
+    fnCache.clear();
+    keeper = new NamespacedExtractionModule.NamespacedKeeper(
+        cf,
+        zkPathsConfig,
+        mapper,
+        injector,
+        cacheManager,
+        fnCache,
+        new NamespacedExtractionModule.NamespacedExtractionModuleConfig(true)
+    );
+    keeper.start();
+  }
+
+  @AfterClass
+  public static void tearDownStatic() throws Exception
+  {
+    keeper.stop();
+    lifecycle.stop();
+    cf.close();
+    testingCluster.stop();
+  }
+  
+  @Test
+  public void testNewTask() throws IOException
+  {
+    final File tmpFile =  Files.createTempFile("druidTest", "renameTmp").toFile();
+    tmpFile.deleteOnExit();
+    try(OutputStreamWriter out = new FileWriter(tmpFile)){
+      out.write(mapper.writeValueAsString(ImmutableMap.<String, String>of("foo", "bar")));
+    }
+    final URIExtractionNamespaceFunctionFactory factory = new URIExtractionNamespaceFunctionFactory(
+        cacheManager,
+        URIExtractionNamespaceTest.registerTypes(new DefaultObjectMapper()),
+        URIExtractionNamespaceTest.registerTypes(new DefaultObjectMapper()),
+        ImmutableMap.<String, DataSegmentPuller>of("file", new LocalDataSegmentPuller())
+    );
+    final URIExtractionNamespace namespace = new URIExtractionNamespace("ns", tmpFile.toURI(), new URIExtractionNamespace.ObjectMapperFlatDataParser(
+        URIExtractionNamespaceTest.registerTypes(new DefaultObjectMapper()))
+    );
+    final Function<String, String> fn = factory.build(namespace);
+    factory.getCachePopulator(namespace).run();
+    Assert.assertEquals("bar", fn.apply("foo"));
+    Assert.assertEquals(null, fn.apply("baz"));
+  }
+
+  @Before
+  public void setUp() throws Exception
+  {
+    ZKPaths.deleteChildren(cf.getZookeeperClient().getZooKeeper(), zkPathsConfig.getNamespacePath(), false);
+  }
+  @Test
+  public void testListNamespaces() throws Exception
+  {
+    final File tmpFile =  Files.createTempFile("druidTest", "renameTmp").toFile();
+    tmpFile.deleteOnExit();
+    try(OutputStreamWriter out = new FileWriter(tmpFile)){
+      out.write(mapper.writeValueAsString(ImmutableMap.<String, String>of("foo", "bar")));
+    }
+    final URIExtractionNamespace namespace = new URIExtractionNamespace("ns", tmpFile.toURI(), new URIExtractionNamespace.ObjectMapperFlatDataParser(
+        URIExtractionNamespaceTest.registerTypes(new DefaultObjectMapper()))
+    );
+    final ExtractionNamespaceUpdate update = new ExtractionNamespaceUpdate(namespace, 0l);
+    cf.inTransaction().create().forPath(ZKPaths.makePath(zkPathsConfig.getNamespacePath(),"ns"), mapper.writeValueAsString(update).getBytes("utf8")).and().commit();
+    Collection<String> strings = keeper.listNamespaces();
+    Assert.assertArrayEquals(new String[]{"ns"},strings.toArray(new String[strings.size()]));
+    cf.inTransaction().delete().forPath(ZKPaths.makePath(zkPathsConfig.getNamespacePath(), "ns")).and().commit();
+    Assert.assertTrue(keeper.listNamespaces().isEmpty());
+    tmpFile.delete();
+  }
+
+  @Test
+  public void testDeleteNamespaces() throws Exception
+  {
+    final File tmpFile =  Files.createTempFile("druidTest", "renameTmp").toFile();
+    tmpFile.deleteOnExit();
+    try(OutputStreamWriter out = new FileWriter(tmpFile)){
+      out.write(mapper.writeValueAsString(ImmutableMap.<String, String>of("foo", "bar")));
+    }
+    final URIExtractionNamespace namespace = new URIExtractionNamespace("ns", tmpFile.toURI(), new URIExtractionNamespace.ObjectMapperFlatDataParser(
+        URIExtractionNamespaceTest.registerTypes(new DefaultObjectMapper()))
+    );
+    final ExtractionNamespaceUpdate update = new ExtractionNamespaceUpdate(namespace, 0l);
+    cf.inTransaction().create().forPath(ZKPaths.makePath(zkPathsConfig.getNamespacePath(),"ns"), mapper.writeValueAsString(update).getBytes("utf8")).and().commit();
+    keeper.deleteNamespace("ns");
+    Assert.assertTrue(keeper.listNamespaces().isEmpty());
+    tmpFile.delete();
+  }
+
+  @Test(expected = IAE.class)
+  public void testBadNamespaces() throws Exception
+  {
+    keeper.deleteNamespace("ns");
+  }
+
+  @Test
+  public void testNewUpdate() throws Exception
+  {
+    final File tmpFile =  Files.createTempFile("druidTest", "renameTmp").toFile();
+    tmpFile.deleteOnExit();
+    try(OutputStreamWriter out = new FileWriter(tmpFile)){
+      out.write(mapper.writeValueAsString(ImmutableMap.<String, String>of("foo", "bar")));
+    }
+    final URIExtractionNamespace namespace = new URIExtractionNamespace("ns", tmpFile.toURI(), new URIExtractionNamespace.ObjectMapperFlatDataParser(
+        URIExtractionNamespaceTest.registerTypes(new DefaultObjectMapper()))
+    );
+    final ExtractionNamespaceUpdate update = new ExtractionNamespaceUpdate(namespace, 0l);
+    Assert.assertTrue(keeper.listNamespaces().isEmpty());
+    keeper.newUpdate(update);
+    Assert.assertArrayEquals(keeper.listNamespaces().toArray(), new Object[]{"ns"});
+    tmpFile.delete();
+  }
+
+  @Test(expected = IAE.class)
+  public void testBadNewUpdate() throws Exception
+  {
+    final File tmpFile =  Files.createTempFile("druidTest", "renameTmp").toFile();
+    tmpFile.deleteOnExit();
+    try(OutputStreamWriter out = new FileWriter(tmpFile)){
+      out.write(mapper.writeValueAsString(ImmutableMap.<String, String>of("foo", "bar")));
+    }
+    final URIExtractionNamespace namespace = new URIExtractionNamespace("ns", tmpFile.toURI(), new URIExtractionNamespace.ObjectMapperFlatDataParser(
+        URIExtractionNamespaceTest.registerTypes(new DefaultObjectMapper()))
+    );
+    final ExtractionNamespaceUpdate update = new ExtractionNamespaceUpdate(namespace, 0l);
+    Assert.assertTrue(keeper.listNamespaces().isEmpty());
+    keeper.newUpdate(update);
+    Assert.assertFalse(keeper.listNamespaces().isEmpty());
+    keeper.newUpdate(update);
+    tmpFile.delete();
+  }
+}

--- a/server/src/test/java/io/druid/server/namespace/URIExtractionNamespaceFunctionFactoryTest.java
+++ b/server/src/test/java/io/druid/server/namespace/URIExtractionNamespaceFunctionFactoryTest.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.namespace;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Function;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.metamx.common.lifecycle.Lifecycle;
+import io.druid.jackson.DefaultObjectMapper;
+import io.druid.query.extraction.namespace.URIExtractionNamespace;
+import io.druid.query.extraction.namespace.URIExtractionNamespaceTest;
+import io.druid.segment.loading.DataSegmentPuller;
+import io.druid.segment.loading.LocalDataSegmentPuller;
+import io.druid.server.namespace.cache.NamespaceExtractionCacheManager;
+import io.druid.server.namespace.cache.OnHeapNamespaceExtractionCacheManager;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.util.Collection;
+import java.util.zip.GZIPOutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+/**
+ *
+ */
+@RunWith(Parameterized.class)
+public class URIExtractionNamespaceFunctionFactoryTest
+{
+  @Parameterized.Parameters
+  public static Collection<Object[]> getParameters()
+  {
+    return ImmutableList.<Object[]>of(
+        new Object[]{
+            ".gz",
+            new Function<File, OutputStream>()
+            {
+
+              @Nullable
+              @Override
+              public OutputStream apply(@Nullable File outFile)
+              {
+                try {
+                  final FileOutputStream fos = new FileOutputStream(outFile);
+                  return new GZIPOutputStream(fos)
+                  {
+                    @Override
+                    public void close() throws IOException
+                    {
+                      try {
+                        super.close();
+                      }
+                      finally {
+                        fos.close();
+                      }
+                    }
+                  };
+                }
+                catch (IOException ex) {
+                  throw Throwables.propagate(ex);
+                }
+              }
+            }
+        },
+        new Object[]{
+            "",
+            new Function<File, OutputStream>()
+            {
+
+              @Nullable
+              @Override
+              public OutputStream apply(@Nullable File outFile)
+              {
+                try {
+                  return new FileOutputStream(outFile);
+                }
+                catch (IOException ex) {
+                  throw Throwables.propagate(ex);
+                }
+              }
+            }
+        }
+    );
+  }
+
+  public URIExtractionNamespaceFunctionFactoryTest(
+      String suffix,
+      Function<File, OutputStream> outStreamSupplier
+  )
+  {
+    this.suffix = suffix;
+    this.outStreamSupplier = outStreamSupplier;
+  }
+
+  private final String suffix;
+  private final Function<File, OutputStream> outStreamSupplier;
+  private Lifecycle lifecycle;
+  private NamespaceExtractionCacheManager manager;
+  private File tmpFile;
+  private URIExtractionNamespaceFunctionFactory factory;
+  private URIExtractionNamespace namespace;
+
+  @Before
+  public void setUp() throws IOException
+  {
+    lifecycle = new Lifecycle();
+    manager = new OnHeapNamespaceExtractionCacheManager(lifecycle);
+    tmpFile = Files.createTempFile("druidTestURIExtractionNS", suffix).toFile();
+    tmpFile.deleteOnExit();
+    final ObjectMapper mapper = new DefaultObjectMapper();
+    try (OutputStream ostream = outStreamSupplier.apply(tmpFile)) {
+      try (OutputStreamWriter out = new OutputStreamWriter(ostream)) {
+        out.write(mapper.writeValueAsString(ImmutableMap.<String, String>of("foo", "bar")));
+      }
+    }
+    factory = new URIExtractionNamespaceFunctionFactory(
+        manager,
+        new DefaultObjectMapper(),
+        new DefaultObjectMapper(),
+        ImmutableMap.<String, DataSegmentPuller>of("file", new LocalDataSegmentPuller())
+    );
+    namespace = new URIExtractionNamespace(
+        "ns",
+        tmpFile.toURI(),
+        new URIExtractionNamespace.ObjectMapperFlatDataParser(
+            URIExtractionNamespaceTest.registerTypes(new ObjectMapper())
+        )
+    );
+  }
+
+  @After
+  public void tearDown()
+  {
+    lifecycle.stop();
+    tmpFile.delete();
+  }
+
+  @Test
+  public void simpleTest() throws IOException
+  {
+    final Function<String, String> fn = factory.build(namespace);
+    Assert.assertEquals(null, fn.apply("foo"));
+    Assert.assertEquals(null, fn.apply("baz"));
+    factory.getCachePopulator(namespace).run();
+    Assert.assertEquals("bar", fn.apply("foo"));
+    Assert.assertEquals(null, fn.apply("baz"));
+  }
+
+  @Test
+  public void testLoadOnlyOnce() throws NoSuchFieldException, IllegalAccessException
+  {
+
+    final Function<String, String> fn = factory.build(namespace);
+    Assert.assertEquals(null, fn.apply("foo"));
+    Assert.assertEquals(null, fn.apply("baz"));
+
+    Runnable populator = factory.getCachePopulator(namespace);
+
+    final Field field = populator.getClass().getDeclaredField("lastCached");
+    field.setAccessible(true);
+
+    final long lastChecked = field.getLong(populator);
+
+    populator.run();
+    Assert.assertEquals("bar", fn.apply("foo"));
+    Assert.assertEquals(null, fn.apply("baz"));
+    final long postFirst = field.getLong(populator);
+    Assert.assertNotEquals(lastChecked, postFirst);
+
+    populator.run();
+    Assert.assertEquals("bar", fn.apply("foo"));
+    Assert.assertEquals(null, fn.apply("baz"));
+    final long postSecond = field.getLong(populator);
+    Assert.assertNotEquals(lastChecked, postSecond);
+    Assert.assertEquals(postFirst, postSecond);
+  }
+}

--- a/server/src/test/java/io/druid/server/namespace/cache/JDBCExtractionNamespaceTest.java
+++ b/server/src/test/java/io/druid/server/namespace/cache/JDBCExtractionNamespaceTest.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.namespace.cache;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.metamx.common.ISE;
+import com.metamx.common.lifecycle.Lifecycle;
+import io.druid.metadata.MetadataStorageConnectorConfig;
+import io.druid.query.extraction.namespace.JDBCExtractionNamespace;
+import io.druid.server.namespace.JDBCExtractionNamespaceFunctionFactory;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.tweak.HandleCallback;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ *
+ */
+@RunWith(Parameterized.class)
+public class JDBCExtractionNamespaceTest
+{
+  private static final String namespace = "testNamespace";
+  private static final String tableName = "abstractDbRenameTest";
+  private static final String keyName = "keyName";
+  private static final String valName = "valName";
+  private static final String tsColumn_ = "tsColumn";
+  private static final Map<String, String> renames = ImmutableMap.of(
+      "foo", "bar",
+      "bad", "bar",
+      "how about that", "foo"
+  );
+  private static final String connectionURI = "jdbc:derby:memory:druid;create=true";
+  private static DBI dbi;
+
+  @BeforeClass
+  public static final void createTables()
+  {
+    final BasicDataSource datasource = new BasicDataSource();
+    datasource.setUrl(connectionURI);
+    datasource.setDriverClassLoader(JDBCExtractionNamespaceTest.class.getClassLoader());
+    datasource.setDriverClassName("org.apache.derby.jdbc.EmbeddedDriver");
+    dbi = new DBI(datasource);
+    dbi.withHandle(
+        new HandleCallback<Void>()
+        {
+          @Override
+          public Void withHandle(Handle handle) throws Exception
+          {
+            handle
+                .createStatement(
+                    String.format(
+                        "CREATE TABLE %s (%s TIMESTAMP, %s VARCHAR(64), %s VARCHAR(64))",
+                        tableName,
+                        tsColumn_,
+                        keyName,
+                        valName
+                    )
+                )
+                .execute();
+            return null;
+          }
+        }
+    );
+  }
+
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> getParameters()
+  {
+    return ImmutableList.<Object[]>of(
+        new Object[]{null, "tsColumn"},
+        new Object[]{new ConcurrentHashMap<String, String>(), "tsColumn"},
+        new Object[]{new ConcurrentHashMap<String, String>(), null},
+        new Object[]{null, null}
+    );
+  }
+
+  public JDBCExtractionNamespaceTest(
+      ConcurrentMap<String, String> cache,
+      String tsColumn
+  )
+  {
+    this.cache = cache;
+    this.tsColumn = tsColumn;
+  }
+
+  private final ConcurrentMap<String, String> cache;
+  private final String tsColumn;
+  private NamespaceExtractionCacheManager extractionCacheManager;
+  private final Lifecycle lifecycle = new Lifecycle();
+  @Before
+  public void setup()
+  {
+    dbi.withHandle(
+        new HandleCallback<Void>()
+        {
+          @Override
+          public Void withHandle(Handle handle) throws Exception
+          {
+            handle.createStatement(String.format("TRUNCATE TABLE %s", tableName)).execute();
+            handle.commit();
+            return null;
+          }
+        }
+    );
+    for (Map.Entry<String, String> entry : renames.entrySet()) {
+      insertValues(entry.getKey(), entry.getValue(), "2015-01-01 00:00:00");
+    }
+    if (cache != null) {
+      cache.clear();
+    }
+    extractionCacheManager = new NamespaceExtractionCacheManager(lifecycle)
+    {
+      @Override
+      public ConcurrentMap<String, String> getCacheMap(String namespace)
+      {
+        return cache;
+      }
+
+      @Override
+      public Collection<String> getKnownNamespaces()
+      {
+        return ImmutableList.of();
+      }
+    };
+  }
+  @After
+  public void tearDown(){
+    lifecycle.stop();
+  }
+
+  private void insertValues(final String key, final String val, final String updateTs)
+  {
+    dbi.withHandle(
+        new HandleCallback<Void>()
+        {
+          @Override
+          public Void withHandle(Handle handle) throws Exception
+          {
+            final String query;
+            if (tsColumn == null) {
+              handle.createStatement(
+                  String.format("DELETE FROM %s WHERE %s='%s'", tableName, keyName, key)
+              ).execute();
+              handle.commit();
+              query = String.format(
+                  "INSERT INTO %s (%s, %s) VALUES ('%s', '%s')",
+                  tableName,
+                  keyName, valName,
+                  key, val
+              );
+            } else {
+              query = String.format(
+                  "INSERT INTO %s (%s, %s, %s) VALUES ('%s', '%s', '%s')",
+                  tableName,
+                  tsColumn, keyName, valName,
+                  updateTs, key, val
+              );
+            }
+            if (1 != handle.createStatement(query).execute()) {
+              throw new ISE("Did not return the correct number of rows");
+            }
+            handle.commit();
+            return null;
+          }
+        }
+    );
+  }
+
+  @Test
+  public void testMapping() throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException
+  {
+    MetadataStorageConnectorConfig config = new MetadataStorageConnectorConfig();
+    Field uriField = MetadataStorageConnectorConfig.class.getDeclaredField("connectURI");
+    uriField.setAccessible(true);
+    uriField.set(config, connectionURI);
+
+    final JDBCExtractionNamespace extractionNamespace = new JDBCExtractionNamespace(
+        namespace,
+        config,
+        tableName,
+        keyName,
+        valName,
+        tsColumn
+    );
+    JDBCExtractionNamespaceFunctionFactory factory = new JDBCExtractionNamespaceFunctionFactory(extractionCacheManager);
+    Runnable populateCache = factory.getCachePopulator(extractionNamespace);
+    Function<String, String> extractionFn = factory.build(extractionNamespace);
+    if (cache != null) {
+      populateCache.run();
+    }
+    for (Map.Entry<String, String> entry : renames.entrySet()) {
+      String key = entry.getKey();
+      String val = entry.getValue();
+      Assert.assertEquals(
+          String.format("Failed on key [%s] with cache [%s] ts [%s]", key, cache, tsColumn),
+          val,
+          String.format(val, extractionFn.apply(key))
+      );
+    }
+    Assert.assertEquals(
+        String.format("Failed with cache [%s] ts [%s]", cache, tsColumn),
+        null,
+        extractionFn.apply("baz")
+    );
+  }
+
+
+  @Test
+  public void testSkipOld() throws NoSuchFieldException, IllegalAccessException
+  {
+    MetadataStorageConnectorConfig config = new MetadataStorageConnectorConfig();
+    Field uriField = MetadataStorageConnectorConfig.class.getDeclaredField("connectURI");
+    uriField.setAccessible(true);
+    uriField.set(config, connectionURI);
+    final JDBCExtractionNamespace extractionNamespace = new JDBCExtractionNamespace(
+        namespace,
+        config,
+        tableName,
+        keyName,
+        valName,
+        tsColumn
+    );
+    final JDBCExtractionNamespaceFunctionFactory factory = new JDBCExtractionNamespaceFunctionFactory(extractionCacheManager);
+    final Runnable populateCache = factory.getCachePopulator(extractionNamespace);
+    final Function<String, String> extractionFn = factory.build(extractionNamespace);
+    if (cache != null) {
+      populateCache.run();
+    }
+    if (tsColumn != null) {
+      insertValues("foo", "baz", "1900-01-01 00:00:00");
+    }
+    if (cache != null) {
+      populateCache.run();
+    }
+    Assert.assertEquals(
+        String.format("Failed with cache [%s] ts [%s]", cache, tsColumn),
+        "bar",
+        extractionFn.apply("foo")
+    );
+  }
+
+  @Test
+  public void testFindNew() throws NoSuchFieldException, IllegalAccessException
+  {
+    MetadataStorageConnectorConfig config = new MetadataStorageConnectorConfig();
+    Field uriField = MetadataStorageConnectorConfig.class.getDeclaredField("connectURI");
+    uriField.setAccessible(true);
+    uriField.set(config, connectionURI);
+    final JDBCExtractionNamespace extractionNamespace = new JDBCExtractionNamespace(
+        namespace,
+        config,
+        tableName,
+        keyName,
+        valName,
+        tsColumn
+    );
+    final JDBCExtractionNamespaceFunctionFactory factory = new JDBCExtractionNamespaceFunctionFactory(extractionCacheManager);
+    final Runnable populateCache = factory.getCachePopulator(extractionNamespace);
+    final Function<String, String> extractionFn = factory.build(extractionNamespace);
+    if (cache != null) {
+      populateCache.run();
+    }
+    insertValues("foo", "baz", "2900-01-01 00:00:00");
+    if (cache != null) {
+      populateCache.run();
+    }
+    Assert.assertEquals(
+        String.format("Failed with cache [%s] ts [%s]", cache, tsColumn),
+        "baz",
+        extractionFn.apply("foo")
+    );
+  }
+}

--- a/server/src/test/java/io/druid/server/namespace/cache/TestNamespaceExtractionCacheManagerExecutors.java
+++ b/server/src/test/java/io/druid/server/namespace/cache/TestNamespaceExtractionCacheManagerExecutors.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.namespace.cache;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableScheduledFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.metamx.common.lifecycle.Lifecycle;
+import io.druid.jackson.DefaultObjectMapper;
+import net.spy.memcached.internal.ListenableFuture;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ *
+ */
+public class TestNamespaceExtractionCacheManagerExecutors
+{
+  @Test
+  public void testSimpleSubmission() throws ExecutionException, InterruptedException
+  {
+    final Lifecycle lifecycle = new Lifecycle();
+    final AtomicBoolean ran = new AtomicBoolean(false);
+    try {
+      NamespaceExtractionCacheManager onHeap = new OnHeapNamespaceExtractionCacheManager(lifecycle);
+      onHeap.scheduleOnce(
+          new Runnable()
+          {
+            @Override
+            public void run()
+            {
+              ran.set(true);
+            }
+          }
+      ).get();
+    }
+    finally {
+      lifecycle.stop();
+    }
+    Assert.assertTrue(ran.get());
+  }
+
+  @Test
+  public void testRepeatSubmission() throws ExecutionException, InterruptedException
+  {
+    final Lifecycle lifecycle = new Lifecycle();
+    final int repeatCount = 5;
+    final int delay = 5;
+    final CountDownLatch latch = new CountDownLatch(repeatCount);
+    final AtomicLong ranCount = new AtomicLong(0l);
+    final long totalRunCount;
+    final long start;
+    try {
+      NamespaceExtractionCacheManager onHeap = new OnHeapNamespaceExtractionCacheManager(lifecycle);
+      start = System.currentTimeMillis();
+      onHeap.scheduleRepeat(
+          "testNamespace",
+          new Runnable()
+          {
+            @Override
+            public void run()
+            {
+              latch.countDown();
+              ranCount.incrementAndGet();
+            }
+          }, delay, TimeUnit.MILLISECONDS
+      );
+      latch.await();
+      long minEnd = start + ((repeatCount - 1) * delay);
+      long end = System.currentTimeMillis();
+      Assert.assertTrue(String.format("Didn't wait long enough between runs. Expected more than %d was %d", minEnd - start, end - start), minEnd < end);
+    }
+    finally {
+      lifecycle.stop();
+    }
+    totalRunCount = ranCount.get();
+    Thread.sleep(50);
+    Assert.assertEquals(totalRunCount, ranCount.get(), 1);
+  }
+
+
+  @Test(timeout = 500)
+  public void testDelete()
+      throws NoSuchFieldException, IllegalAccessException, InterruptedException, ExecutionException
+  {
+    final CountDownLatch latch = new CountDownLatch(1);
+    final Lifecycle lifecycle = new Lifecycle();
+    final NamespaceExtractionCacheManager onHeap;
+    final ListenableScheduledFuture future;
+    final AtomicLong runs = new AtomicLong(0);
+    long prior = 0;
+    try {
+      onHeap = new OnHeapNamespaceExtractionCacheManager(lifecycle);
+      future = onHeap.scheduleRepeat(
+          "testNamespace",
+          new Runnable()
+          {
+            @Override
+            public void run()
+            {
+              runs.incrementAndGet();
+              latch.countDown();
+            }
+          }, 1, TimeUnit.MILLISECONDS
+      );
+
+      latch.await();
+      Assert.assertFalse(future.isCancelled());
+      Assert.assertFalse(future.isDone());
+      prior = runs.get();
+      Thread.sleep(10);
+      Assert.assertTrue(runs.get() > prior);
+
+      onHeap.delete("testNamespace");
+
+      prior = runs.get();
+      Thread.sleep(10);
+      Assert.assertEquals(prior, runs.get());
+    }
+    finally {
+      lifecycle.stop();
+    }
+  }
+
+  @Test(timeout = 500)
+  public void testShutdown()
+      throws NoSuchFieldException, IllegalAccessException, InterruptedException, ExecutionException
+  {
+    final CountDownLatch latch = new CountDownLatch(1);
+    final Lifecycle lifecycle = new Lifecycle();
+    final NamespaceExtractionCacheManager onHeap;
+    final ListenableScheduledFuture future;
+    final AtomicLong runs = new AtomicLong(0);
+    long prior = 0;
+    try {
+      onHeap = new OnHeapNamespaceExtractionCacheManager(lifecycle);
+      future = onHeap.scheduleRepeat(
+          "testNamespace",
+          new Runnable()
+          {
+            @Override
+            public void run()
+            {
+              runs.incrementAndGet();
+              latch.countDown();
+            }
+          }, 1, TimeUnit.MILLISECONDS
+      );
+
+      latch.await();
+      Assert.assertFalse(future.isCancelled());
+      Assert.assertFalse(future.isDone());
+      prior = runs.get();
+      Thread.sleep(10);
+      Assert.assertTrue(runs.get() > prior);
+    }
+    finally {
+      lifecycle.stop();
+    }
+
+    prior = runs.get();
+    Thread.sleep(10);
+    Assert.assertEquals(prior, runs.get());
+
+    Field execField = NamespaceExtractionCacheManager.class.getDeclaredField("listeningScheduledExecutorService");
+    execField.setAccessible(true);
+    Assert.assertTrue(((ListeningScheduledExecutorService) execField.get(onHeap)).isShutdown());
+    Assert.assertTrue(((ListeningScheduledExecutorService) execField.get(onHeap)).isTerminated());
+  }
+
+  @Test(timeout = 500)
+  public void testRunCount()
+      throws InterruptedException, ExecutionException
+  {
+    final Lifecycle lifecycle = new Lifecycle();
+    final NamespaceExtractionCacheManager onHeap;
+    final AtomicLong runCount = new AtomicLong(0);
+    final CountDownLatch latch = new CountDownLatch(1);
+    try {
+      onHeap = new OnHeapNamespaceExtractionCacheManager(lifecycle);
+      onHeap.scheduleRepeat(
+          new Runnable()
+          {
+            @Override
+            public void run()
+            {
+              latch.countDown();
+              runCount.incrementAndGet();
+            }
+          }, 1, TimeUnit.MILLISECONDS
+      );
+      latch.countDown();
+      Thread.sleep(20);
+    }
+    finally {
+      lifecycle.stop();
+    }
+    Assert.assertTrue(runCount.get() > 5);
+  }
+}

--- a/server/src/test/java/io/druid/server/namespace/cache/TestNamespaceExtractionCacheManagers.java
+++ b/server/src/test/java/io/druid/server/namespace/cache/TestNamespaceExtractionCacheManagers.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.namespace.cache;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.metamx.common.lifecycle.Lifecycle;
+import io.druid.client.cache.LocalCacheProvider;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ *
+ */
+@RunWith(Parameterized.class)
+public class TestNamespaceExtractionCacheManagers
+{
+  private static final Lifecycle lifecycle = new Lifecycle();
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> getParameters()
+  {
+    return ImmutableList.<Object[]>of(
+        new Object[]{new OffHeapNamespaceExtractionCacheManager(lifecycle)},
+        new Object[]{new OnHeapNamespaceExtractionCacheManager(lifecycle)},
+        new Object[]{new ClientCacheExtractionCacheManager(new LocalCacheProvider(500_000l, 500_000, 0).get(), lifecycle)}
+    );
+  }
+
+  private final NamespaceExtractionCacheManager extractionCacheManager;
+
+  public TestNamespaceExtractionCacheManagers(NamespaceExtractionCacheManager extractionCacheManager)
+  {
+    this.extractionCacheManager = extractionCacheManager;
+  }
+
+  private static final List<String> nsList = ImmutableList.<String>of("testNs", "test.ns", "//tes-tn!s");
+
+  @Before
+  public void setup()
+  {
+    // prepopulate caches
+    for (String ns : nsList) {
+      final ConcurrentMap<String, String> map = extractionCacheManager.getCacheMap(ns);
+      map.put("oldNameSeed1", "oldNameSeed2");
+    }
+  }
+
+  @Test
+  public void testSimpleCacheCreate()
+  {
+    for (String ns : nsList) {
+      ConcurrentMap<String, String> map = extractionCacheManager.getCacheMap(ns);
+      map.put("key", "val");
+      Assert.assertEquals("val", map.get("key"));
+      Assert.assertEquals("val", extractionCacheManager.getCacheMap(ns).get("key"));
+    }
+  }
+
+  @Test
+  public void testCacheList()
+  {
+    List<String> nsList = new ArrayList<String>(TestNamespaceExtractionCacheManagers.nsList);
+    List<String> retvalList = Lists.newArrayList(extractionCacheManager.getKnownNamespaces());
+    Collections.sort(nsList);
+    Collections.sort(retvalList);
+    Assert.assertArrayEquals(nsList.toArray(), retvalList.toArray());
+  }
+}

--- a/services/src/main/java/io/druid/cli/CliCoordinator.java
+++ b/services/src/main/java/io/druid/cli/CliCoordinator.java
@@ -51,6 +51,7 @@ import io.druid.server.http.CoordinatorRedirectInfo;
 import io.druid.server.http.CoordinatorResource;
 import io.druid.server.http.DatasourcesResource;
 import io.druid.server.http.MetadataResource;
+import io.druid.server.http.NamespacesResource;
 import io.druid.server.http.RedirectFilter;
 import io.druid.server.http.RedirectInfo;
 import io.druid.server.http.RulesResource;
@@ -132,6 +133,7 @@ public class CliCoordinator extends ServerRunnable
             Jerseys.addResource(binder, ServersResource.class);
             Jerseys.addResource(binder, DatasourcesResource.class);
             Jerseys.addResource(binder, MetadataResource.class);
+            Jerseys.addResource(binder, NamespacesResource.class);
 
             LifecycleModule.register(binder, Server.class);
           }


### PR DESCRIPTION
This PR is at the code review stage. Comments on either the high-level overview or the low-level implementations are welcome. This master comment will be updated with pertinent discussion points if they become major topics in the track below.

Add query time lookups for renames via query "namespace" (may end up renaming this to something with a more natural description)
    * Add a new factory type `io.druid.query.extraction.namespace.ExtractionNamespaceFunctionFactory` which is used for runtime wiring of `io.druid.query.extraction.namespace.ExtractionNamespace` to their caching and functionality. The wiring of a namespace to its factory is accomplished at guice binding via `@Named` implementations of the `ExtractionNamespace`'s canonical class name.
    * Add ability to explicitly rename with a map passed at query time
    * Add ability to rename using a key/value lookup in a database
    * Add extension which caches renames from a kafka stream
    * Added README.md for the dim-rename extension
    * Changed DimExtractionFn to be more of a factory rather than an implementation
    * Updates are pushed via a zookeeper path (defaults to `${base}/namespaces`) and take the form of `io.druid.query.extraction.namespace.ExtractionNamespaceUpdate`. They can be one-off (`updateMs` to 0 or null) or regularly scheduled. Regularly scheduled makes an attempt to only update if the source has been modified since the cache refresh.
    * Added coordinator endpiont `/druid/coordinator/v1/namespaces` for items that need "load everything everywhere" kind of logic.


I'll do a rebase/squash before real merge

What currently works:
* Lookup up stuff at query time (renames and rebucket)
* Choosing optimization path
* Kafka powered cluster-wide instant renames
* Pulling configurations from zookeeper
* Pulling from a DB table via JDBC
* Pulling rename information from a file location on: S3, HDFS, Cassandra, or locally
* Refreshing rename information

TODO:
 * ~~Better cluster-level data distribution capacity (ex: piggy-backing omniLoader)~~ Done
 * ~~Have Rename Query Results and a Rebucket Query Results be two separate use cases.~~ This one largely affects topN, and is not unique to this PR. See https://github.com/druid-io/druid/issues/1134 and https://github.com/druid-io/druid/pull/1135
 * Add Coordinator configuration web page. (API  get - add - delete available, need help from @tarekrached for console)
 * ~~Better polymorphism on loadSpec (see https://github.com/druid-io/druid/pull/1132  waiting on code review)~~ Merged

Current performance comparison for TopN:
![namespaces](https://cloud.githubusercontent.com/assets/8213081/6259444/87bed7c6-b787-11e4-8169-8342622f2133.png)