### PR TITLE
Fix NPE for union queries

### DIFF
--- a/common/src/main/java/io/druid/timeline/UnionTimeLineLookup.java
+++ b/common/src/main/java/io/druid/timeline/UnionTimeLineLookup.java
@@ -18,6 +18,7 @@
 package io.druid.timeline;
 
 import com.google.common.base.Function;
+import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
 import io.druid.timeline.partition.PartitionHolder;
 import org.joda.time.Interval;
@@ -29,7 +30,8 @@ public class UnionTimeLineLookup<VersionType, ObjectType> implements TimelineLoo
 
   public UnionTimeLineLookup(Iterable<TimelineLookup<VersionType, ObjectType>> delegates)
   {
-    this.delegates = delegates;
+    // delegate can be null in case there is no segment loaded for the dataSource on this node
+    this.delegates = Iterables.filter(delegates, Predicates.notNull());
   }
 
   @Override

--- a/common/src/test/java/io/druid/timeline/VersionedIntervalTimelineTest.java
+++ b/common/src/test/java/io/druid/timeline/VersionedIntervalTimelineTest.java
@@ -21,6 +21,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 import com.metamx.common.Pair;
@@ -1593,5 +1594,50 @@ public class VersionedIntervalTimelineTest
   private VersionedIntervalTimeline<String, Integer> makeStringIntegerTimeline()
   {
     return new VersionedIntervalTimeline<String, Integer>(Ordering.<String>natural());
+  }
+
+  @Test
+  public void testUnionTimeLineLookup()
+  {
+    TimelineLookup<String, Integer> lookup = new UnionTimeLineLookup<String, Integer>(
+        Arrays.<TimelineLookup<String, Integer>>asList(
+            timeline,
+            timeline
+        )
+    );
+    assertValues(
+        Arrays.asList(
+            createExpected("2011-04-01/2011-04-02", "3", 5),
+            createExpected("2011-04-02/2011-04-06", "2", 1),
+            createExpected("2011-04-06/2011-04-09", "3", 4),
+            createExpected("2011-04-01/2011-04-02", "3", 5),
+            createExpected("2011-04-02/2011-04-06", "2", 1),
+            createExpected("2011-04-06/2011-04-09", "3", 4)
+        ),
+        (List)Lists.newArrayList(lookup.lookup(new Interval("2011-04-01/2011-04-09")))
+    );
+  }
+
+  @Test
+  public void testUnionTimeLineLookupNonExistentDelegates()
+  {
+    TimelineLookup<String, Integer> lookup = new UnionTimeLineLookup<String, Integer>(
+        Arrays.<TimelineLookup<String, Integer>>asList(
+            timeline,
+            null,
+            timeline,
+            null
+        )
+    );
+    assertValues(
+        Arrays.asList(
+            createExpected("2011-04-01/2011-04-02", "3", 5),
+            createExpected("2011-04-02/2011-04-06", "2", 1),
+            createExpected("2011-04-06/2011-04-09", "3", 4),
+            createExpected("2011-04-01/2011-04-02", "3", 5),
+            createExpected("2011-04-02/2011-04-06", "2", 1),
+            createExpected("2011-04-06/2011-04-09", "3", 4)
+        ),
+        (List)Lists.newArrayList(lookup.lookup(new Interval("2011-04-01/2011-04-09")))    );
   }
 }


### PR DESCRIPTION
fix union queries- 
filter non-existing datasources for union queries.
