### PR TITLE
Improve groupby by removing conversion to case insensitive row

### DIFF
--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryHelper.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryHelper.java
@@ -23,6 +23,8 @@ import com.metamx.common.ISE;
 import com.metamx.common.Pair;
 import com.metamx.common.guava.Accumulator;
 import io.druid.collections.StupidPool;
+import io.druid.data.input.MapBasedInputRow;
+import io.druid.data.input.MapBasedRow;
 import io.druid.data.input.Row;
 import io.druid.data.input.Rows;
 import io.druid.granularity.QueryGranularity;
@@ -104,10 +106,18 @@ public class GroupByQueryHelper
       public IncrementalIndex accumulate(IncrementalIndex accumulated, T in)
       {
 
-        if (in instanceof Row) {
+        if (in instanceof MapBasedRow) {
           try {
-            accumulated.add(Rows.toCaseInsensitiveInputRow((Row) in, dimensions));
-          } catch(IndexSizeExceededException e) {
+            MapBasedRow row = (MapBasedRow) in;
+            accumulated.add(
+                new MapBasedInputRow(
+                    row.getTimestamp(),
+                    dimensions,
+                    row.getEvent()
+                )
+            );
+          }
+          catch (IndexSizeExceededException e) {
             throw new ISE(e.getMessage());
           }
         } else {

--- a/server/src/main/java/io/druid/segment/realtime/firehose/EventReceiverFirehoseFactory.java
+++ b/server/src/main/java/io/druid/segment/realtime/firehose/EventReceiverFirehoseFactory.java
@@ -131,8 +131,7 @@ public class EventReceiverFirehoseFactory implements FirehoseFactory<MapInputRow
       final List<InputRow> rows = Lists.newArrayList();
       for (final Map<String, Object> event : events) {
         // Might throw an exception. We'd like that to happen now, instead of while adding to the row buffer.
-        InputRow row = parser.parse(event);
-        rows.add(Rows.toCaseInsensitiveInputRow(row, row.getDimensions()));
+        rows.add(parser.parse(event));
       }
 
       try {


### PR DESCRIPTION
conversion to a caseInsensitive row not required after death to casing in 0.7
removing this helps in perf by avoiding making the copy of a row, 
in simple testing results on TPCH 1G dataset over single segment scan it gives a performance boost for groupby queries from 7-20% depending on the cardinality of dims involved and size of result set. 

result size ,	master, 	0.7-patched, 	%improvement 
16K	       ,        2.602	 ,    2.41	    ,            7.4
100K	,      6.265         ,     5.823	 ,               7.1
120K	 ,     18.102	 ,    14.92	        ,        17.6
280K	 ,      45.43	  ,   36.47	        ,        19.7
550K	 ,      60.031	 ,    48.264	,        19.6
800K	  ,     69.176	,     58.806    	 ,        15

this should also help in improving ingestion rate when using EventReceiverFirehoseFactory as well.  
