### PR TITLE
Use the proper FileSystems for writing segments and caching jars. (for issue #1116)

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
@@ -48,7 +48,7 @@ public class JobHelper
 
   public static void setupClasspath(
       HadoopDruidIndexerConfig config,
-      Job groupByJob
+      Job job
   )
       throws IOException
   {
@@ -59,9 +59,9 @@ public class JobHelper
 
     String[] jarFiles = classpathProperty.split(File.pathSeparator);
 
-    final Configuration conf = groupByJob.getConfiguration();
-    final FileSystem fs = FileSystem.get(conf);
-    Path distributedClassPath = new Path(config.getWorkingPath(), "classpath");
+    final Configuration conf = job.getConfiguration();
+    final Path distributedClassPath = new Path(config.getWorkingPath(), "classpath");
+    final FileSystem fs = distributedClassPath.getFileSystem(conf);
 
     if (fs instanceof LocalFileSystem) {
       return;


### PR DESCRIPTION
This changes all usages of ```FileSystem.get(Configuration)``` (getting the default fs) with something that gets the right fs for the paths we're interacting with. Ideally that means fs.defaultFS, segmentOutputPath, and the workingPath could all be on different fses and things should still work. I haven't actually tested it yet, though…