### PR TITLE
Common Configs in Tutorial

### DIFF
--- a/docs/content/Tutorial:-All-About-Queries.md
+++ b/docs/content/Tutorial:-All-About-Queries.md
@@ -19,19 +19,19 @@ Note: If Zookeeper and metadata storage aren't running, you'll have to start the
 To start a Coordinator node:
 
 ```bash
-java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath lib/*:config/coordinator io.druid.cli.Main server coordinator
+java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath lib/*:config/_common:config/coordinator io.druid.cli.Main server coordinator
 ```
 
 To start a Historical node:
 
 ```bash
-java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath lib/*:config/historical io.druid.cli.Main server historical
+java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath lib/*:config/_common:config/historical io.druid.cli.Main server historical
 ```
 
 To start a Broker node:
 
 ```bash
-java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath lib/*:config/broker io.druid.cli.Main server broker
+java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath lib/*:config/_common:config/broker io.druid.cli.Main server broker
 ```
 
 Querying Your Data

--- a/docs/content/Tutorial:-Loading-Batch-Data.md
+++ b/docs/content/Tutorial:-Loading-Batch-Data.md
@@ -69,19 +69,19 @@ Note: If Zookeeper and MySQL aren't running, you'll have to start them again as 
 To start the Indexing Service:
 
 ```bash
-java -Xmx2g -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath lib/*:<hadoop_config_path>:config/overlord io.druid.cli.Main server overlord
+java -Xmx2g -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath lib/*:<hadoop_config_path>:config/_common:config/overlord io.druid.cli.Main server overlord
 ```
 
 To start the Coordinator Node:
 
 ```bash
-java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath lib/*:config/coordinator io.druid.cli.Main server coordinator
+java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath lib/*:config/_common:config/coordinator io.druid.cli.Main server coordinator
 ```
 
 To start the Historical Node:
 
 ```bash
-java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath lib/*:config/historical io.druid.cli.Main server historical
+java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath lib/*:config/_common:config/historical io.druid.cli.Main server historical
 ```
 
 #### Index the Data

--- a/docs/content/Tutorial:-Loading-Streaming-Data.md
+++ b/docs/content/Tutorial:-Loading-Streaming-Data.md
@@ -93,7 +93,7 @@ You should be comfortable starting Druid nodes at this point. If not, it may be 
 1. Real-time nodes can be started with:
 
   ```bash
-  java -Xmx512m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -Ddruid.realtime.specFile=examples/indexing/wikipedia.spec -classpath lib/*:config/realtime io.druid.cli.Main server realtime
+  java -Xmx512m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -Ddruid.realtime.specFile=examples/indexing/wikipedia.spec -classpath lib/*:config/_common:config/realtime io.druid.cli.Main server realtime
   ```
 
 2. A realtime.spec should already exist for the data source in the Druid tarball. You should be able to find it at:


### PR DESCRIPTION
The tutorial does not include the common configs in the classpath, so they aren't picked up. 

I also added a "Query" section to the cluster tutorial as it was a bit jarring to get to the end and then essentially left to figure out how to query on my own :)