### PR TITLE
Pull the servicePort from environment variable if unavailable from command line

### DIFF
--- a/server/src/main/java/io/druid/server/DruidNode.java
+++ b/server/src/main/java/io/druid/server/DruidNode.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.net.HostAndPort;
 import com.google.inject.name.Named;
 import com.metamx.common.IAE;
@@ -35,6 +36,7 @@ import javax.validation.constraints.NotNull;
 public class DruidNode
 {
   public static final String DEFAULT_HOST = "localhost";
+  public static final String DEFAULT_ENV_KEY_PORT = "PORT"; // pulls from Env variable
 
   @JsonProperty("service")
   @NotNull
@@ -79,6 +81,17 @@ public class DruidNode
   {
     Preconditions.checkNotNull(serviceName);
     this.serviceName = serviceName;
+
+    if(port == null){
+      String sPort = System.getenv(DEFAULT_ENV_KEY_PORT);
+      if(!Strings.isNullOrEmpty(sPort)){
+        try{
+          port = Integer.parseInt(sPort);
+        } catch(NumberFormatException e){
+          throw new IAE("Unparsable port found in PORT environment variable, cannot parse [%s]", sPort);
+        }
+      }
+    }
 
     if(host == null && port == null) {
       host = DEFAULT_HOST;

--- a/server/src/test/java/io/druid/server/DruidNodeTest.java
+++ b/server/src/test/java/io/druid/server/DruidNodeTest.java
@@ -17,7 +17,9 @@
 
 package io.druid.server;
 
+import com.google.common.base.Strings;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class DruidNodeTest
@@ -108,5 +110,23 @@ public class DruidNodeTest
   public void testConflictingPortsNonsense() throws Exception
   {
     new DruidNode("test/service", "[2001:db8:85a3::8a2e:370:7334]:123", 456);
+  }
+
+  @Test
+  public void testEnvPort(){
+    final Integer port;
+    String prior = System.getenv(DruidNode.DEFAULT_ENV_KEY_PORT);
+    if(Strings.isNullOrEmpty(prior)){
+      Assume.assumeTrue(false); // force skip
+      return;
+    }
+
+    try{
+      port = Integer.parseInt(prior);
+    } catch (NumberFormatException e){
+      Assume.assumeTrue(false); // Force skip
+      return;
+    }
+    Assert.assertEquals(port.intValue(), new DruidNode("fooServer", "fooHost", null).getPort());
   }
 }


### PR DESCRIPTION
Pulls from `PORT`
Fixes https://github.com/druid-io/druid/issues/1124