### PR TITLE
Move OmniSegmentLoader to use Guice named instances instead of keeping a local custom mapping

### DIFF
--- a/extensions/cassandra-storage/src/main/java/io/druid/storage/cassandra/CassandraDruidModule.java
+++ b/extensions/cassandra-storage/src/main/java/io/druid/storage/cassandra/CassandraDruidModule.java
@@ -21,11 +21,13 @@ import com.fasterxml.jackson.databind.Module;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Key;
+import com.google.inject.name.Names;
 import io.druid.guice.Binders;
 import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.LazySingleton;
 import io.druid.guice.PolyBind;
 import io.druid.initialization.DruidModule;
+import io.druid.segment.loading.DataSegmentPuller;
 import io.druid.segment.loading.DataSegmentPusher;
 
 import java.util.List;
@@ -43,10 +45,9 @@ public class CassandraDruidModule implements DruidModule
   @Override
   public void configure(Binder binder)
   {
-    Binders.dataSegmentPullerBinder(binder)
-                .addBinding("c*")
-                .to(CassandraDataSegmentPuller.class)
-                .in(LazySingleton.class);
+    binder.bind(Key.get(DataSegmentPuller.class, Names.named("c*")))
+          .to(CassandraDataSegmentPuller.class)
+          .in(LazySingleton.class);
 
     PolyBind.optionBinder(binder, Key.get(DataSegmentPusher.class))
             .addBinding("c*")

--- a/extensions/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsStorageDruidModule.java
+++ b/extensions/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsStorageDruidModule.java
@@ -21,10 +21,14 @@ import com.fasterxml.jackson.databind.Module;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Inject;
+import com.google.inject.Key;
+import com.google.inject.name.Names;
 import io.druid.guice.Binders;
 import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.LazySingleton;
 import io.druid.initialization.DruidModule;
+import io.druid.segment.loading.DataSegmentPuller;
+import io.druid.segment.loading.DataSegmentPusher;
 import io.druid.storage.hdfs.tasklog.HdfsTaskLogs;
 import io.druid.storage.hdfs.tasklog.HdfsTaskLogsConfig;
 import org.apache.hadoop.conf.Configuration;
@@ -53,7 +57,10 @@ public class HdfsStorageDruidModule implements DruidModule
   @Override
   public void configure(Binder binder)
   {
-    Binders.dataSegmentPullerBinder(binder).addBinding("hdfs").to(HdfsDataSegmentPuller.class).in(LazySingleton.class);
+    binder.bind(Key.get(DataSegmentPuller.class, Names.named("hdfs")))
+          .to(HdfsDataSegmentPuller.class)
+          .in(LazySingleton.class);
+
     Binders.dataSegmentPusherBinder(binder).addBinding("hdfs").to(HdfsDataSegmentPusher.class).in(LazySingleton.class);
     Binders.dataSegmentKillerBinder(binder).addBinding("hdfs").to(HdfsDataSegmentKiller.class).in(LazySingleton.class);
 

--- a/extensions/s3-extensions/src/main/java/io/druid/storage/s3/S3StorageDruidModule.java
+++ b/extensions/s3-extensions/src/main/java/io/druid/storage/s3/S3StorageDruidModule.java
@@ -21,13 +21,16 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.fasterxml.jackson.databind.Module;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
+import com.google.inject.Key;
 import com.google.inject.Provides;
+import com.google.inject.name.Names;
 import io.druid.common.aws.AWSCredentialsConfig;
 import io.druid.common.aws.AWSCredentialsUtils;
 import io.druid.guice.Binders;
 import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.LazySingleton;
 import io.druid.initialization.DruidModule;
+import io.druid.segment.loading.DataSegmentPuller;
 import org.jets3t.service.impl.rest.httpclient.RestS3Service;
 import org.jets3t.service.security.AWSCredentials;
 
@@ -48,7 +51,9 @@ public class S3StorageDruidModule implements DruidModule
   {
     JsonConfigProvider.bind(binder, "druid.s3", AWSCredentialsConfig.class);
 
-    Binders.dataSegmentPullerBinder(binder).addBinding("s3_zip").to(S3DataSegmentPuller.class).in(LazySingleton.class);
+    binder.bind(Key.get(DataSegmentPuller.class, Names.named("s3_zip")))
+          .to(S3DataSegmentPuller.class)
+          .in(LazySingleton.class);
     Binders.dataSegmentKillerBinder(binder).addBinding("s3_zip").to(S3DataSegmentKiller.class).in(LazySingleton.class);
     Binders.dataSegmentMoverBinder(binder).addBinding("s3_zip").to(S3DataSegmentMover.class).in(LazySingleton.class);
     Binders.dataSegmentArchiverBinder(binder).addBinding("s3_zip").to(S3DataSegmentArchiver.class).in(LazySingleton.class);

--- a/indexing-service/src/test/java/io/druid/indexing/worker/WorkerTaskMonitorTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/worker/WorkerTaskMonitorTest.java
@@ -23,12 +23,13 @@ import com.fasterxml.jackson.databind.introspect.GuiceAnnotationIntrospector;
 import com.fasterxml.jackson.databind.introspect.GuiceInjectableValues;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import com.google.inject.Binder;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.name.Names;
 import io.druid.curator.PotentiallyGzippedCompressionProvider;
 import io.druid.indexing.common.IndexingServiceCondition;
 import io.druid.indexing.common.SegmentLoaderFactory;
@@ -83,6 +84,9 @@ public class WorkerTaskMonitorTest
                 }
               }
           );
+          binder.bind(Key.get(DataSegmentPuller.class, Names.named("local")))
+              .to(LocalDataSegmentPuller.class)
+              .asEagerSingleton();
         }
       }
   );
@@ -165,10 +169,7 @@ public class WorkerTaskMonitorTest
                 new TaskConfig(tmp.toString(), null, null, 0, null),
                 null, null, null, null, null, null, null, null, null, null, null, new SegmentLoaderFactory(
                 new OmniSegmentLoader(
-                    ImmutableMap.<String, DataSegmentPuller>of(
-                        "local",
-                        new LocalDataSegmentPuller()
-                    ),
+                    injector,
                     null,
                     new SegmentLoaderConfig()
                     {

--- a/server/src/main/java/io/druid/guice/LocalDataStorageDruidModule.java
+++ b/server/src/main/java/io/druid/guice/LocalDataStorageDruidModule.java
@@ -20,7 +20,9 @@ package io.druid.guice;
 import com.google.inject.Binder;
 import com.google.inject.Key;
 import com.google.inject.Module;
+import com.google.inject.name.Names;
 import io.druid.segment.loading.DataSegmentKiller;
+import io.druid.segment.loading.DataSegmentPuller;
 import io.druid.segment.loading.DataSegmentPusher;
 import io.druid.segment.loading.LocalDataSegmentKiller;
 import io.druid.segment.loading.LocalDataSegmentPuller;
@@ -47,10 +49,9 @@ public class LocalDataStorageDruidModule implements Module
 
   private static void bindDeepStorageLocal(Binder binder)
   {
-    Binders.dataSegmentPullerBinder(binder)
-                .addBinding("local")
-                .to(LocalDataSegmentPuller.class)
-                .in(LazySingleton.class);
+    binder.bind(Key.get(DataSegmentPuller.class, Names.named("local")))
+          .to(LocalDataSegmentPuller.class)
+          .in(LazySingleton.class);
 
     PolyBind.optionBinder(binder, Key.get(DataSegmentKiller.class))
         .addBinding("local")

--- a/server/src/main/java/io/druid/segment/loading/OmniSegmentLoader.java
+++ b/server/src/main/java/io/druid/segment/loading/OmniSegmentLoader.java
@@ -19,6 +19,9 @@ package io.druid.segment.loading;
 
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.name.Names;
 import com.metamx.common.ISE;
 import com.metamx.common.MapUtils;
 import com.metamx.common.logger.Logger;
@@ -40,7 +43,7 @@ public class OmniSegmentLoader implements SegmentLoader
 {
   private static final Logger log = new Logger(OmniSegmentLoader.class);
 
-  private final Map<String, DataSegmentPuller> pullers;
+  private final Injector injector;
   private final QueryableIndexFactory factory;
   private final SegmentLoaderConfig config;
 
@@ -50,12 +53,12 @@ public class OmniSegmentLoader implements SegmentLoader
 
   @Inject
   public OmniSegmentLoader(
-      Map<String, DataSegmentPuller> pullers,
+      Injector injector,
       QueryableIndexFactory factory,
       SegmentLoaderConfig config
   )
   {
-    this.pullers = pullers;
+    this.injector = injector;
     this.factory = factory;
     this.config = config;
 
@@ -67,7 +70,7 @@ public class OmniSegmentLoader implements SegmentLoader
 
   public OmniSegmentLoader withConfig(SegmentLoaderConfig config)
   {
-    return new OmniSegmentLoader(pullers, factory, config);
+    return new OmniSegmentLoader(injector, factory, config);
   }
 
   @Override
@@ -182,10 +185,10 @@ public class OmniSegmentLoader implements SegmentLoader
   private DataSegmentPuller getPuller(Map<String, Object> loadSpec) throws SegmentLoadingException
   {
     String type = MapUtils.getString(loadSpec, "type");
-    DataSegmentPuller loader = pullers.get(type);
+    DataSegmentPuller loader = injector.getInstance(Key.get(DataSegmentPuller.class, Names.named(type)));
 
     if (loader == null) {
-      throw new SegmentLoadingException("Unknown loader type[%s].  Known types are %s", type, pullers.keySet());
+      throw new SegmentLoadingException("Unknown loader type[%s].", type);
     }
 
     return loader;


### PR DESCRIPTION
It seemed silly to me that we are effectively keeping a local binding map per Omni... impl instead of just using Guice named bindings. This is an example of using Guice named bindings for the Loader. If this looks like a reasonable way to go, I suggest this also be applied to the killer / archiver / mover.