### PR TITLE
Update docs and examples for log4j2 usage.

### DIFF
--- a/docs/content/Logging.md
+++ b/docs/content/Logging.md
@@ -6,34 +6,31 @@ Logging
 
 Druid nodes will emit logs that are useful for debugging to the console. Druid nodes also emit periodic metrics about their state. For more about metrics, see [Configuration](Configuration.html). Metric logs are printed to the console by default, and can be disabled with `-Ddruid.emitter.logging.logLevel=debug`.
 
-Druid uses [log4j](http://logging.apache.org/log4j/2.x/) for logging, and console logs can be configured by adding a log4j.xml file. Add this xml file to your classpath if you want to override default Druid log configuration.
+Druid uses [log4j2](http://logging.apache.org/log4j/2.x/) for logging. Logging can be configured with a log4j2.xml file. Add the path to the directory containing the log4j2.xml file (eg a config dir) to your classpath if you want to override default Druid log configuration. Note that this directory should be earlier in the classpath than the druid jars. The easiest way to do this is to prefix the classpath with the config dir. For example, if the log4j2.xml file is in config/_common:
 
-An example log4j.xml file is shown below:
+```bash
+java -Xmx512m -Duser.timezone=UTC -Dfile.encoding=UTF-8         \
+     -Ddruid.realtime.specFile=examples/indexing/wikipedia.spec \
+     -classpath "config/_common:config/realtime:lib/*"          \
+     io.druid.cli.Main server realtime
+```
+
+Note the "-classpath" in this example has the config dir before the jars under lib/*.
+
+An example log4j2.xml ships with Druid under config/_common/log4j2.xml, and a sample file is also shown below:
 
 ```
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
-
-<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
-
-  <appender name="ConsoleAppender" class="org.apache.log4j.ConsoleAppender">
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="%d{ISO8601} %-5p [%t] %c - %m%n"/>
-    </layout>
-  </appender>
-
-  <!-- ServerView-related stuff is way too chatty -->
-  <logger name="io.druid.client.BatchServerInventoryView">
-    <level value="warn"/>
-  </logger>
-  <logger name="io.druid.curator.inventory.CuratorInventoryManager">
-    <level value="warn"/>
-  </logger>
-
-  <root>
-    <priority value="info" />
-    <appender-ref ref="ConsoleAppender"/>
-  </root>
-
-</log4j:configuration>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{ISO8601} %p [%t] %c - %m%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>
 ```

--- a/docs/content/Tutorial:-All-About-Queries.md
+++ b/docs/content/Tutorial:-All-About-Queries.md
@@ -19,19 +19,19 @@ Note: If Zookeeper and metadata storage aren't running, you'll have to start the
 To start a Coordinator node:
 
 ```bash
-java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath lib/*:config/_common:config/coordinator io.druid.cli.Main server coordinator
+java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath config/_common:config/coordinator:lib/* io.druid.cli.Main server coordinator
 ```
 
 To start a Historical node:
 
 ```bash
-java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath lib/*:config/_common:config/historical io.druid.cli.Main server historical
+java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath config/_common:config/historical:lib/* io.druid.cli.Main server historical
 ```
 
 To start a Broker node:
 
 ```bash
-java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath lib/*:config/_common:config/broker io.druid.cli.Main server broker
+java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath config/_common:config/broker:lib/* io.druid.cli.Main server broker
 ```
 
 Querying Your Data

--- a/docs/content/Tutorial:-Loading-Batch-Data.md
+++ b/docs/content/Tutorial:-Loading-Batch-Data.md
@@ -66,19 +66,19 @@ Note: If Zookeeper and MySQL aren't running, you'll have to start them again as 
 To start the Indexing Service:
 
 ```bash
-java -Xmx2g -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath lib/*:<hadoop_config_path>:config/_common:config/overlord io.druid.cli.Main server overlord
+java -Xmx2g -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath config/_common:config/overlord:lib/*:<hadoop_config_path> io.druid.cli.Main server overlord
 ```
 
 To start the Coordinator Node:
 
 ```bash
-java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath lib/*:config/_common:config/coordinator io.druid.cli.Main server coordinator
+java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath config/_common:config/coordinator:lib/* io.druid.cli.Main server coordinator
 ```
 
 To start the Historical Node:
 
 ```bash
-java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath lib/*:config/_common:config/historical io.druid.cli.Main server historical
+java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath config/_common:config/historical:lib/* io.druid.cli.Main server historical
 ```
 
 #### Index the Data

--- a/docs/content/Tutorial:-The-Druid-Cluster.md
+++ b/docs/content/Tutorial:-The-Druid-Cluster.md
@@ -169,7 +169,7 @@ druid.coordinator.startDelay=PT70s
 To start the coordinator node:
 
 ```bash
-java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath lib/*:config/_common:config/coordinator io.druid.cli.Main server coordinator
+java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath config/_common:config/coordinator:lib/* io.druid.cli.Main server coordinator
 ```
 
 Note: we will be running a single historical node in these examples, so you may see some warnings about not being able to replicate segments. These can be safely ignored, but in production, you should always replicate segments across multiple historical nodes.
@@ -204,7 +204,7 @@ druid.server.maxSize=10000000000
 To start the historical node:
 
 ```bash
-java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath lib/*:config/_common:config/historical io.druid.cli.Main server historical
+java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath config/_common:config/historical:lib/* io.druid.cli.Main server historical
 ```
 
 #### Start a Broker Node
@@ -236,7 +236,7 @@ druid.processing.numThreads=1
 To start the broker node:
 
 ```bash
-java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath lib/*:config/_common:config/broker io.druid.cli.Main server broker
+java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -classpath config/_common:config/broker:lib/* io.druid.cli.Main server broker
 ```
 
 #### Start a Realtime Node
@@ -282,7 +282,7 @@ Now we should be handing off segments every 6 minutes or so.
 To start the realtime node that was used in our first tutorial, you simply have to issue:
 
 ```
-java -Xmx512m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -Ddruid.realtime.specFile=examples/wikipedia/wikipedia_realtime.spec -classpath lib/*:config/_common:config/realtime io.druid.cli.Main server realtime
+java -Xmx512m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -Ddruid.realtime.specFile=examples/wikipedia/wikipedia_realtime.spec -classpath config/_common:config/realtime:lib/* io.druid.cli.Main server realtime
 ```
 
 The configurations are located in `config/realtime/runtime.properties` and should contain the following:

--- a/examples/bin/run_example_server.sh
+++ b/examples/bin/run_example_server.sh
@@ -55,11 +55,11 @@ JAVA_ARGS="${JAVA_ARGS} -Ddruid.realtime.specFile=${SPEC_FILE}"
 
 DRUID_CP=${EXAMPLE_LOC}
 #For a pull
-DRUID_CP=${DRUID_CP}:${SCRIPT_DIR}/../config/realtime
+DRUID_CP=${SCRIPT_DIR}/../config/realtime:${DRUID_CP}
 #For the kit
-DRUID_CP=${DRUID_CP}:${SCRIPT_DIR}/lib/*
 DRUID_CP=${DRUID_CP}:${SCRIPT_DIR}/config/_common
 DRUID_CP=${DRUID_CP}:${SCRIPT_DIR}/config/realtime
+DRUID_CP=${DRUID_CP}:${SCRIPT_DIR}/lib/*
 
 echo "Running command:"
 

--- a/examples/config/_common/log4j2.xml
+++ b/examples/config/_common/log4j2.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Druid - a distributed column store.
+  ~ Copyright 2012 - 2015 Metamarkets Group Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ISO8601} %p [%t] %c - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/processing/src/main/java/io/druid/guice/PropertiesModule.java
+++ b/processing/src/main/java/io/druid/guice/PropertiesModule.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package io.druid.guice;;
+package io.druid.guice;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;


### PR DESCRIPTION
Druid no longer works with just log4j.xml as described in the docs (since it recently bumped up to using log4j2). Even if log4j.xml IS on the classpath (first even), it will be ignored, in favor of the log4j2.xml found in the druid jars. This should probably be spelled out as a difference for upgrading to Druid 0.7. 

This PR updates docs and examples to clarify log4j2.xml as well as clarify how the classpath should be set (ie the dir with the log4j2.xml should be before the jars). 

In this PR:
- Put configs early in classpath in examples so log4j2.xml will get picked up properly
- Add an example log4j2.xml file.
- Update Logging doc.

This PR does NOT address jdk logging. Any jdk logging does not respect the log4j configs. For example, if you set up logging to go only to file and not console, you will see jdk logging still go to console (mostly from jersey code). This can be addressed as well by:

- adding a dependency on log4j-jul to the parent and common poms:

```
<dependency>
	<groupId>org.apache.logging.log4j</groupId>
	<artifactId>log4j-jul</artifactId>
	<version>${log4j.version}</version>
</dependency>
```

- then add the following to the command line

```
-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
```

Alternatively, the system prop could be set in io.druid.cli.Main, but that didn't seem right. See http://logging.apache.org/log4j/2.0/log4j-jul/index.html for more info.