### PR TITLE
support for metadata store PasswordProvider interface

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,6 @@
 Druid - a distributed column store.
 Copyright 2012-2015 Metamarkets Group Inc.
+Copyright 2015 Yahoo! Inc.
 
 -------------------------------------------------------------------------------
 

--- a/common/src/main/java/io/druid/metadata/DefaultPasswordProvider.java
+++ b/common/src/main/java/io/druid/metadata/DefaultPasswordProvider.java
@@ -1,0 +1,53 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.metadata;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class DefaultPasswordProvider implements PasswordProvider
+{
+  private final String password;
+
+  @JsonCreator
+  public static DefaultPasswordProvider fromString(String str)
+  {
+    return new DefaultPasswordProvider(str);
+  }
+
+  @JsonCreator
+  public DefaultPasswordProvider(@JsonProperty("password") String password)
+  {
+    this.password = password;
+  }
+
+  @Override
+  @JsonProperty
+  public String getPassword()
+  {
+    return password;
+  }
+
+  @Override
+  public String toString() {
+    return this.getClass().getCanonicalName();
+  }
+}
+

--- a/common/src/main/java/io/druid/metadata/MetadataStorageConnectorConfig.java
+++ b/common/src/main/java/io/druid/metadata/MetadataStorageConnectorConfig.java
@@ -38,8 +38,8 @@ public class MetadataStorageConnectorConfig
   @JsonProperty
   private String user = null;
 
-  @JsonProperty
-  private String password = null;
+  @JsonProperty("password")
+  private PasswordProvider passwordProvider;
 
   public boolean isCreateTables()
   {
@@ -71,7 +71,7 @@ public class MetadataStorageConnectorConfig
 
   public String getPassword()
   {
-    return password;
+    return passwordProvider == null ? null : passwordProvider.getPassword();
   }
 
   @Override
@@ -81,7 +81,7 @@ public class MetadataStorageConnectorConfig
            "createTables=" + createTables +
            ", connectURI='" + getConnectURI() + '\'' +
            ", user='" + user + '\'' +
-           ", password=****" +
+           ", passwordProvider=" + passwordProvider +
            '}';
   }
 }

--- a/common/src/main/java/io/druid/metadata/PasswordProvider.java
+++ b/common/src/main/java/io/druid/metadata/PasswordProvider.java
@@ -1,0 +1,36 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.metadata;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+
+/**
+ * Implement this for different ways to (optionally securely) access db passwords.
+ */
+@JsonTypeInfo(use= JsonTypeInfo.Id.NAME, property="type", defaultImpl = DefaultPasswordProvider.class)
+@JsonSubTypes(value={
+    @JsonSubTypes.Type(name="default", value=DefaultPasswordProvider.class),
+})
+public interface PasswordProvider 
+{
+  public String getPassword();
+}

--- a/common/src/test/java/io/druid/metadata/DefaultPasswordProviderTest.java
+++ b/common/src/test/java/io/druid/metadata/DefaultPasswordProviderTest.java
@@ -1,0 +1,58 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.metadata;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class DefaultPasswordProviderTest
+{
+  private static final String pwd = "nothing";
+  private static final ObjectMapper jsonMapper = new ObjectMapper();
+
+  @Test
+  public void testExplicitConstruction() {
+    DefaultPasswordProvider pp = new DefaultPasswordProvider(pwd);
+    Assert.assertEquals(pwd, pp.getPassword());
+  }
+  
+  @Test
+  public void testFromStringConstruction() {
+    DefaultPasswordProvider pp = DefaultPasswordProvider.fromString(pwd);
+    Assert.assertEquals(pwd, pp.getPassword());
+  }
+
+  @Test
+  public void testDeserializationFromJsonString() throws Exception {
+    PasswordProvider pp = jsonMapper.readValue("\"" + pwd + "\"",
+        PasswordProvider.class);
+    Assert.assertEquals(pwd, pp.getPassword());
+  }
+
+  @Test
+  public void testDeserializationFromJson() throws Exception {
+    PasswordProvider pp = jsonMapper.readValue(
+        "{\"type\": \"default\", \"password\": \"" + pwd + "\"}",
+        PasswordProvider.class);
+    Assert.assertEquals(pwd, pp.getPassword());
+  }
+}

--- a/common/src/test/java/io/druid/metadata/MetadataStorageConnectorConfigTest.java
+++ b/common/src/test/java/io/druid/metadata/MetadataStorageConnectorConfigTest.java
@@ -1,0 +1,84 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.metadata;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class MetadataStorageConnectorConfigTest {
+
+  private static final ObjectMapper jsonMapper = new ObjectMapper();
+
+  @Test
+  public void testMetadaStorageConnectionConfigSimplePassword() throws Exception
+  {
+    testMetadataStorageConnectionConfig(
+        true,
+        "host",
+        1234,
+        "connectURI",
+        "user",
+        "\"nothing\"",
+        "nothing");
+  }
+
+  @Test
+  public void testMetadaStorageConnectionConfigWithDefaultProviderPassword() throws Exception
+  {
+    testMetadataStorageConnectionConfig(
+        true,
+        "host",
+        1234,
+        "connectURI",
+        "user",
+        "{\"type\":\"default\",\"password\":\"nothing\"}",
+        "nothing");
+  }
+
+  private void testMetadataStorageConnectionConfig(
+    boolean createTables,
+    String host,
+    int port,
+    String connectURI,
+    String user,
+    String pwdString,
+    String pwd
+    ) throws Exception
+  {
+    MetadataStorageConnectorConfig config = jsonMapper.readValue(
+          "{" +
+          "\"createTables\": \"" + createTables + "\"," +
+          "\"host\": \"" + host + "\"," +
+          "\"port\": \"" + port + "\"," +
+          "\"connectURI\": \"" + connectURI + "\"," +
+          "\"user\": \"" + user + "\"," +
+          "\"password\": " + pwdString +
+          "}",
+          MetadataStorageConnectorConfig.class);
+
+    Assert.assertEquals(host, config.getHost());
+    Assert.assertEquals(port, config.getPort());
+    Assert.assertEquals(connectURI, config.getConnectURI());
+    Assert.assertEquals(user, config.getUser());
+    Assert.assertEquals(pwd, config.getPassword());
+  }
+}

--- a/indexing-hadoop/src/main/java/io/druid/indexer/updater/MetadataStorageUpdaterJobSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/updater/MetadataStorageUpdaterJobSpec.java
@@ -20,6 +20,7 @@ package io.druid.indexer.updater;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Supplier;
 import io.druid.metadata.MetadataStorageConnectorConfig;
+import io.druid.metadata.PasswordProvider;
 
 import javax.validation.constraints.NotNull;
 
@@ -38,7 +39,7 @@ public class MetadataStorageUpdaterJobSpec implements Supplier<MetadataStorageCo
   public String user;
 
   @JsonProperty("password")
-  public String password;
+  private PasswordProvider passwordProvider;
 
   @JsonProperty("segmentTable")
   public String segmentTable;
@@ -73,7 +74,7 @@ public class MetadataStorageUpdaterJobSpec implements Supplier<MetadataStorageCo
       @Override
       public String getPassword()
       {
-        return password;
+        return passwordProvider == null ? null : passwordProvider.getPassword();
       }
     };
   }

--- a/indexing-hadoop/src/test/java/io/druid/indexer/updater/MetadataStorageUpdaterJobSpecTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/updater/MetadataStorageUpdaterJobSpecTest.java
@@ -1,0 +1,80 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.indexer.updater;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class MetadataStorageUpdaterJobSpecTest
+{
+  private static final ObjectMapper jsonMapper = new ObjectMapper();
+
+  @Test
+  public void testMetadaStorageConnectionConfigSimplePassword() throws Exception
+  {
+    testMetadataStorageUpdaterJobSpec(
+        "segments_table",
+        "db",
+        "jdbc:mysql://localhost/druid",
+        "druid",
+        "\"nothing\"",
+        "nothing");
+  }
+
+  @Test
+  public void testMetadaStorageConnectionConfigWithDefaultProviderPassword() throws Exception
+  {
+    testMetadataStorageUpdaterJobSpec(
+        "segments_table",
+        "db",
+        "jdbc:mysql://localhost/druid",
+        "druid",
+        "{\"type\":\"default\",\"password\":\"nothing\"}",
+        "nothing");
+  }
+
+  private void testMetadataStorageUpdaterJobSpec(
+    String segmentTable,
+    String type,
+    String connectURI,
+    String user,
+    String pwdString,
+    String pwd
+    ) throws Exception
+  {
+    MetadataStorageUpdaterJobSpec spec = jsonMapper.readValue(
+        "{" +
+        "\"type\": \"" + type + "\",\n" +
+        "\"connectURI\": \"" + connectURI + "\",\n" +
+        "\"user\": \"" + user + "\",\n" +
+        "\"password\": " + pwdString + ",\n" +
+        "\"segmentTable\": \"" + segmentTable + "\"\n" +
+        "}",
+        MetadataStorageUpdaterJobSpec.class);
+
+    Assert.assertEquals(segmentTable, spec.getSegmentTable());
+    Assert.assertEquals(type, spec.getType());
+    Assert.assertEquals("jdbc:mysql://localhost/druid", spec.get().getConnectURI());
+    Assert.assertEquals(user, spec.get().getUser());
+    Assert.assertEquals(pwd, spec.get().getPassword());
+  }
+}


### PR DESCRIPTION
this patch enables ppl to write druid module extension which implements the necessary logic for getting the password for metadata store. default implementation provides the necessary backward compatibility to read the password in plain text from the druid configuration file.

internally, we have an extension which gets the password from a secure mechanism instead of having password stored in the configuration file.

Here is a reference implementation --
https://github.com/himanshug/druid-pwd-provider-extn-sample