### PR TITLE
Cleanup router servlet + tests for gzip proxying

### DIFF
--- a/server/src/main/java/io/druid/guice/http/JettyHttpClientModule.java
+++ b/server/src/main/java/io/druid/guice/http/JettyHttpClientModule.java
@@ -124,11 +124,6 @@ public class JettyHttpClientModule implements Module
               @Override
               public void start() throws Exception
               {
-                httpClient.start();
-
-                // forwards raw bytes, don't decode gzip
-                // decoders are populated on start, so this has to be done after start() is called
-                httpClient.getContentDecoderFactories().clear();
               }
 
               @Override

--- a/server/src/test/java/io/druid/server/AsyncQueryForwardingServletTest.java
+++ b/server/src/test/java/io/druid/server/AsyncQueryForwardingServletTest.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.servlet.GuiceFilter;
+import com.metamx.common.lifecycle.Lifecycle;
+import io.druid.guice.GuiceInjectors;
+import io.druid.guice.Jerseys;
+import io.druid.guice.JsonConfigProvider;
+import io.druid.guice.LazySingleton;
+import io.druid.guice.LifecycleModule;
+import io.druid.guice.annotations.Self;
+import io.druid.guice.annotations.Smile;
+import io.druid.guice.http.DruidHttpClientConfig;
+import io.druid.initialization.Initialization;
+import io.druid.query.Query;
+import io.druid.server.initialization.BaseJettyServerInitializer;
+import io.druid.server.initialization.JettyServerInitializer;
+import io.druid.server.initialization.BaseJettyTest;
+import io.druid.server.log.RequestLogger;
+import io.druid.server.metrics.NoopServiceEmitter;
+import io.druid.server.router.QueryHostFinder;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.HandlerList;
+import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+
+public class AsyncQueryForwardingServletTest extends BaseJettyTest
+{
+  @Before
+  public void setup() throws Exception
+  {
+    setProperties();
+    Injector injector = setupInjector();
+    final DruidNode node = injector.getInstance(Key.get(DruidNode.class, Self.class));
+    port = node.getPort();
+
+    lifecycle = injector.getInstance(Lifecycle.class);
+    lifecycle.start();
+    ClientHolder holder = injector.getInstance(ClientHolder.class);
+    client = holder.getClient();
+  }
+
+  @Override
+  protected Injector setupInjector()
+  {
+    return Initialization.makeInjectorWithModules(
+        GuiceInjectors.makeStartupInjector(), ImmutableList.<Module>of(
+            new Module()
+            {
+              @Override
+              public void configure(Binder binder)
+              {
+                JsonConfigProvider.bindInstance(
+                    binder, Key.get(DruidNode.class, Self.class), new DruidNode("test", "localhost", null)
+                );
+                binder.bind(JettyServerInitializer.class).to(ProxyJettyServerInit.class).in(LazySingleton.class);
+                Jerseys.addResource(binder, SlowResource.class);
+                Jerseys.addResource(binder, ExceptionResource.class);
+                Jerseys.addResource(binder, DefaultResource.class);
+                LifecycleModule.register(binder, Server.class);
+              }
+            }
+        )
+    );
+  }
+
+  @Test
+  public void testProxyGzipCompression() throws Exception
+  {
+    final URL url = new URL("http://localhost:" + port + "/proxy/default");
+
+    final HttpURLConnection get = (HttpURLConnection) url.openConnection();
+    get.setRequestProperty("Accept-Encoding", "gzip");
+    Assert.assertEquals("gzip", get.getContentEncoding());
+
+    final HttpURLConnection post = (HttpURLConnection) url.openConnection();
+    post.setRequestProperty("Accept-Encoding", "gzip");
+    post.setRequestMethod("POST");
+    Assert.assertEquals("gzip", post.getContentEncoding());
+
+    final HttpURLConnection getNoGzip = (HttpURLConnection) url.openConnection();
+    Assert.assertNotEquals("gzip", getNoGzip.getContentEncoding());
+
+    final HttpURLConnection postNoGzip = (HttpURLConnection) url.openConnection();
+    postNoGzip.setRequestMethod("POST");
+    Assert.assertNotEquals("gzip", postNoGzip.getContentEncoding());
+  }
+
+  public static class ProxyJettyServerInit extends BaseJettyServerInitializer
+  {
+
+    private final DruidNode node;
+
+    @Inject
+    public ProxyJettyServerInit(@Self DruidNode node)
+    {
+      this.node = node;
+    }
+
+    @Override
+    public void initialize(Server server, Injector injector)
+    {
+      final ServletContextHandler root = new ServletContextHandler(ServletContextHandler.SESSIONS);
+      root.addServlet(new ServletHolder(new DefaultServlet()), "/*");
+
+      final QueryHostFinder hostFinder = new QueryHostFinder(null)
+      {
+        @Override
+        public String getHost(Query query)
+        {
+          return "localhost:" + node.getPort();
+        }
+
+        @Override
+        public String getDefaultHost()
+        {
+          return "localhost:" + node.getPort();
+        }
+      };
+
+      root.addServlet(
+          new ServletHolder(
+              new AsyncQueryForwardingServlet(
+                  injector.getInstance(ObjectMapper.class),
+                  injector.getInstance(Key.get(ObjectMapper.class, Smile.class)),
+                  hostFinder,
+                  injector.getProvider(org.eclipse.jetty.client.HttpClient.class),
+                  injector.getInstance(DruidHttpClientConfig.class),
+                  new NoopServiceEmitter(),
+                  new RequestLogger()
+                  {
+                    @Override
+                    public void log(RequestLogLine requestLogLine) throws IOException
+                    {
+                      // noop
+                    }
+                  }
+              ) {
+                @Override
+                protected URI rewriteURI(HttpServletRequest request)
+                {
+                  URI uri = super.rewriteURI(request);
+                  return URI.create(uri.toString().replace("/proxy", ""));
+                }
+              }
+          ), "/proxy/*"
+      );
+
+      root.addFilter(defaultAsyncGzipFilterHolder(), "/*", null);
+      root.addFilter(GuiceFilter.class, "/slow/*", null);
+      root.addFilter(GuiceFilter.class, "/default/*", null);
+      root.addFilter(GuiceFilter.class, "/exception/*", null);
+
+      final HandlerList handlerList = new HandlerList();
+      handlerList.setHandlers(new Handler[]{root});
+      server.setHandler(handlerList);
+    }
+  }
+}

--- a/server/src/test/java/io/druid/server/initialization/BaseJettyTest.java
+++ b/server/src/test/java/io/druid/server/initialization/BaseJettyTest.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.initialization;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.servlet.GuiceFilter;
+import com.metamx.common.lifecycle.Lifecycle;
+import com.metamx.http.client.HttpClient;
+import com.metamx.http.client.HttpClientConfig;
+import com.metamx.http.client.HttpClientInit;
+import io.druid.guice.GuiceInjectors;
+import io.druid.guice.Jerseys;
+import io.druid.guice.JsonConfigProvider;
+import io.druid.guice.LazySingleton;
+import io.druid.guice.LifecycleModule;
+import io.druid.guice.annotations.Self;
+import io.druid.initialization.Initialization;
+import io.druid.server.DruidNode;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.HandlerList;
+import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.joda.time.Duration;
+import org.junit.After;
+import org.junit.Before;
+
+import javax.net.ssl.SSLContext;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+public class BaseJettyTest
+{
+  protected Lifecycle lifecycle;
+  protected HttpClient client;
+  protected int port = -1;
+
+  public static void setProperties()
+  {
+    System.setProperty("druid.server.http.numThreads", "20");
+    System.setProperty("druid.server.http.maxIdleTime", "PT1S");
+    System.setProperty("druid.global.http.readTimeout", "PT1S");
+  }
+
+  @Before
+  public void setup() throws Exception
+  {
+    setProperties();
+    Injector injector = setupInjector();
+    final DruidNode node = injector.getInstance(Key.get(DruidNode.class, Self.class));
+    port = node.getPort();
+    lifecycle = injector.getInstance(Lifecycle.class);
+    lifecycle.start();
+    ClientHolder holder = injector.getInstance(ClientHolder.class);
+    client = holder.getClient();
+  }
+
+  protected Injector setupInjector()
+  {
+    return Initialization.makeInjectorWithModules(
+        GuiceInjectors.makeStartupInjector(), ImmutableList.<Module>of(
+            new Module()
+            {
+              @Override
+              public void configure(Binder binder)
+              {
+                JsonConfigProvider.bindInstance(
+                    binder, Key.get(DruidNode.class, Self.class), new DruidNode("test", "localhost", null)
+                );
+                binder.bind(JettyServerInitializer.class).to(JettyServerInit.class).in(LazySingleton.class);
+                Jerseys.addResource(binder, SlowResource.class);
+                Jerseys.addResource(binder, ExceptionResource.class);
+                Jerseys.addResource(binder, DefaultResource.class);
+                LifecycleModule.register(binder, Server.class);
+              }
+            }
+        )
+    );
+  }
+
+  @After
+  public void teardown()
+  {
+    lifecycle.stop();
+  }
+
+  public static class ClientHolder
+  {
+    HttpClient client;
+
+    ClientHolder()
+    {
+      try {
+        this.client = HttpClientInit.createClient(
+            new HttpClientConfig(1, SSLContext.getDefault(), Duration.ZERO),
+            new Lifecycle()
+        );
+      }
+      catch (Exception e) {
+        throw Throwables.propagate(e);
+      }
+    }
+
+    public HttpClient getClient()
+    {
+      return client;
+    }
+  }
+
+  public static class JettyServerInit extends BaseJettyServerInitializer
+  {
+
+    @Override
+    public void initialize(Server server, Injector injector)
+    {
+      final ServletContextHandler root = new ServletContextHandler(ServletContextHandler.SESSIONS);
+      root.addServlet(new ServletHolder(new DefaultServlet()), "/*");
+      root.addFilter(defaultGzipFilterHolder(), "/*", null);
+      root.addFilter(GuiceFilter.class, "/*", null);
+
+      final HandlerList handlerList = new HandlerList();
+      handlerList.setHandlers(new Handler[]{root});
+      server.setHandler(handlerList);
+    }
+
+  }
+
+  @Path("/slow")
+  public static class SlowResource
+  {
+
+    public static Random random = new Random();
+
+    @GET
+    @Path("/hello")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response hello()
+    {
+      try {
+        TimeUnit.MILLISECONDS.sleep(100 + random.nextInt(2000));
+      }
+      catch (InterruptedException e) {
+        //
+      }
+      return Response.ok("hello").build();
+    }
+  }
+
+  @Path("/default")
+  public static class DefaultResource
+  {
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response get()
+    {
+      return Response.ok("hello").build();
+    }
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response post()
+    {
+      return Response.ok("hello").build();
+    }
+  }
+
+  @Path("/exception")
+  public static class ExceptionResource
+  {
+    @GET
+    @Path("/exception")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response exception(
+        @Context HttpServletResponse resp
+    ) throws IOException
+    {
+      final ServletOutputStream outputStream = resp.getOutputStream();
+      outputStream.println("hello");
+      outputStream.flush();
+      try {
+        TimeUnit.MILLISECONDS.sleep(200);
+      }
+      catch (InterruptedException e) {
+        //
+      }
+      throw new IOException();
+    }
+  }
+}

--- a/server/src/test/java/io/druid/server/initialization/JettyTest.java
+++ b/server/src/test/java/io/druid/server/initialization/JettyTest.java
@@ -1,128 +1,50 @@
 /*
- * Druid - a distributed column store.
- * Copyright 2012 - 2015 Metamarkets Group Inc.
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package io.druid.server.initialization;
 
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.inject.Binder;
-import com.google.inject.Injector;
-import com.google.inject.Key;
-import com.google.inject.Module;
-import com.google.inject.servlet.GuiceFilter;
-import com.metamx.common.lifecycle.Lifecycle;
-import com.metamx.http.client.HttpClient;
-import com.metamx.http.client.HttpClientConfig;
-import com.metamx.http.client.HttpClientInit;
 import com.metamx.http.client.Request;
 import com.metamx.http.client.response.InputStreamResponseHandler;
 import com.metamx.http.client.response.StatusResponseHandler;
 import com.metamx.http.client.response.StatusResponseHolder;
-import io.druid.guice.GuiceInjectors;
-import io.druid.guice.Jerseys;
-import io.druid.guice.JsonConfigProvider;
-import io.druid.guice.LazySingleton;
-import io.druid.guice.LifecycleModule;
-import io.druid.guice.annotations.Self;
-import io.druid.initialization.Initialization;
-import io.druid.server.DruidNode;
 import org.apache.commons.io.IOUtils;
-import org.eclipse.jetty.server.Handler;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.HandlerList;
-import org.eclipse.jetty.servlet.DefaultServlet;
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
 import org.jboss.netty.handler.codec.http.HttpMethod;
-import org.joda.time.Duration;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import javax.net.ssl.SSLContext;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.Charset;
-import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-public class JettyTest
+public class JettyTest extends BaseJettyTest
 {
-  private Lifecycle lifecycle;
-  private HttpClient client;
-  private int port = -1;
-
-  public static void setProperties()
-  {
-    System.setProperty("druid.server.http.numThreads", "20");
-    System.setProperty("druid.server.http.maxIdleTime", "PT1S");
-    System.setProperty("druid.global.http.readTimeout", "PT1S");
-  }
-
-  @Before
-  public void setup() throws Exception
-  {
-    setProperties();
-    Injector injector = Initialization.makeInjectorWithModules(
-        GuiceInjectors.makeStartupInjector(), ImmutableList.<Module>of(
-            new Module()
-            {
-              @Override
-              public void configure(Binder binder)
-              {
-                JsonConfigProvider.bindInstance(
-                    binder, Key.get(DruidNode.class, Self.class), new DruidNode("test", "localhost", null)
-                );
-                binder.bind(JettyServerInitializer.class).to(JettyServerInit.class).in(LazySingleton.class);
-                Jerseys.addResource(binder, SlowResource.class);
-                Jerseys.addResource(binder, ExceptionResource.class);
-                Jerseys.addResource(binder, DefaultResource.class);
-                LifecycleModule.register(binder, Server.class);
-              }
-            }
-        )
-    );
-    final DruidNode node = injector.getInstance(Key.get(DruidNode.class, Self.class));
-    port = node.getPort();
-
-    lifecycle = injector.getInstance(Lifecycle.class);
-    lifecycle.start();
-    ClientHolder holder = injector.getInstance(ClientHolder.class);
-    client = holder.getClient();
-  }
 
   @Test
   @Ignore // this test will deadlock if it hits an issue, so ignored by default
@@ -193,8 +115,14 @@ public class JettyTest
     final HttpURLConnection post = (HttpURLConnection) url.openConnection();
     post.setRequestProperty("Accept-Encoding", "gzip");
     post.setRequestMethod("POST");
-
     Assert.assertEquals("gzip", post.getContentEncoding());
+
+    final HttpURLConnection getNoGzip = (HttpURLConnection) url.openConnection();
+    Assert.assertNotEquals("gzip", getNoGzip.getContentEncoding());
+
+    final HttpURLConnection postNoGzip = (HttpURLConnection) url.openConnection();
+    postNoGzip.setRequestMethod("POST");
+    Assert.assertNotEquals("gzip", postNoGzip.getContentEncoding());
   }
 
   // Tests that threads are not stuck when partial chunk is not finalized
@@ -250,114 +178,5 @@ public class JettyTest
     );
 
     latch.await(5, TimeUnit.SECONDS);
-  }
-
-  @After
-  public void teardown()
-  {
-    lifecycle.stop();
-  }
-
-  public static class ClientHolder
-  {
-    HttpClient client;
-
-    ClientHolder()
-    {
-      try {
-        this.client = HttpClientInit.createClient(
-            new HttpClientConfig(1, SSLContext.getDefault(), Duration.ZERO),
-            new Lifecycle()
-        );
-      }
-      catch (Exception e) {
-        throw Throwables.propagate(e);
-      }
-    }
-
-    public HttpClient getClient()
-    {
-      return client;
-    }
-  }
-
-  public static class JettyServerInit extends BaseJettyServerInitializer
-  {
-
-    @Override
-    public void initialize(Server server, Injector injector)
-    {
-      final ServletContextHandler root = new ServletContextHandler(ServletContextHandler.SESSIONS);
-      root.addServlet(new ServletHolder(new DefaultServlet()), "/*");
-      root.addFilter(defaultGzipFilterHolder(), "/*", null);
-      root.addFilter(GuiceFilter.class, "/*", null);
-
-      final HandlerList handlerList = new HandlerList();
-      handlerList.setHandlers(new Handler[]{root});
-      server.setHandler(handlerList);
-    }
-  }
-
-  @Path("/slow")
-  public static class SlowResource
-  {
-
-    public static Random random = new Random();
-
-    @GET
-    @Path("/hello")
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response hello()
-    {
-      try {
-        TimeUnit.MILLISECONDS.sleep(100 + random.nextInt(2000));
-      }
-      catch (InterruptedException e) {
-        //
-      }
-      return Response.ok("hello").build();
-    }
-  }
-
-  @Path("/default")
-  public static class DefaultResource
-  {
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response get()
-    {
-      return Response.ok("hello").build();
-    }
-
-    @POST
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response post()
-    {
-      return Response.ok("hello").build();
-    }
-
-  }
-
-  @Path("/exception")
-  public static class ExceptionResource
-  {
-    @GET
-    @Path("/exception")
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response exception(
-        @Context HttpServletResponse resp
-    ) throws IOException
-    {
-      final ServletOutputStream outputStream = resp.getOutputStream();
-      outputStream.println("hello");
-      outputStream.flush();
-      try {
-        TimeUnit.MILLISECONDS.sleep(200);
-      }
-      catch (InterruptedException e) {
-        //
-      }
-      throw new IOException();
-    }
   }
 }


### PR DESCRIPTION
- Uses method overrides instead of modified Jetty code, now that
  ProxyServlet provides enough method hooks for proper overrides.
  This means we may also benefit from any Jetty ProxyServlet fixes
- Adds test for async proxy servlet to make sure gzip encoding is
  properly proxied.
- Router now proxies POST requests for requests that are not Druid
  queries, by only treating `/druid/v2/*` endpoints as queries.