### PR TITLE
Add time extraction functions to project time as a dimension

### DIFF
--- a/docs/content/DimensionSpecs.md
+++ b/docs/content/DimensionSpecs.md
@@ -1,14 +1,16 @@
 ---
 layout: doc_page
 ---
+
 # Transforming Dimension Values
-The following JSON fields can be used in a query to operate on dimension values. 
+
+The following JSON fields can be used in a query to operate on dimension values.
 
 ## DimensionSpec
 
 `DimensionSpec`s define how dimension values get transformed prior to aggregation.
 
-### DefaultDimensionSpec
+### Default DimensionSpec
 
 Returns dimension values as is and optionally renames the dimension.
 
@@ -16,63 +18,139 @@ Returns dimension values as is and optionally renames the dimension.
 { "type" : "default", "dimension" : <dimension>, "outputName": <output_name> }
 ```
 
-### ExtractionDimensionSpec
+### Extraction DimensionSpec
 
-Returns dimension values transformed using the given [DimExtractionFn](#toc_3)
+Returns dimension values transformed using the given [extraction function](#extraction-functions).
 
 ```json
 {
   "type" : "extraction",
   "dimension" : <dimension>,
   "outputName" :  <output_name>,
-  "dimExtractionFn" : <dim_extraction_fn>
+  "extractionFn" : <extraction_function>
 }
 ```
 
-## <a id="toc_3"></a>DimExtractionFn
+## Extraction Functions
 
-`DimExtractionFn`s define the transformation applied to each dimension value
+Extraction functions define the transformation applied to each dimension value.
 
-### RegexDimExtractionFn
+Transformations can be applied to both regular (string) dimensions, as well
+as the special `__time` dimension, which represents the current time bucket
+according to the query [aggregation granularity](Granularities.html).
 
-Returns the first group matched by the given regular expression. If there is no match it returns the dimension value as is.
+**Note**: for functions taking string values (such as regular expressions),
+`__time` dimension values will be formatted in [ISO-8601 format](https://en.wikipedia.org/wiki/ISO_8601)
+before getting passed to the extraction function.
+
+### Regular Expression Extraction Function
+
+Returns the first matching group for the given regular expression.
+If there is no match, it returns the dimension value as is.
 
 ```json
-{ "type" : "regex", "expr", <regular_expression> }
+{ "type" : "regex", "expr" : <regular_expression> }
 ```
 
-### PartialDimExtractionFn
+For example, using `"expr" : "(\\w\\w\\w).*"` will transform
+`'Monday'`, `'Tuesday'`, `'Wednesday'` into `'Mon'`, `'Tue'`, `'Wed'`.
 
-Returns the dimension value as is if there is a match, otherwise returns null.
+### Partial Extraction Function
+
+Returns the dimension value unchanged if the regular expression matches, otherwise returns null.
 
 ```json
-{ "type" : "partial", "expr", <regular_expression> }
+{ "type" : "partial", "expr" : <regular_expression> }
 ```
 
-### SearchQuerySpecDimExtractionFn
+### Search Query Extraction Function
 
-Returns the dimension value as is if the given [SearchQuerySpec](SearchQuerySpec.html) matches, otherwise returns null.
+Returns the dimension value unchanged if the given [`SearchQuerySpec`](SearchQuerySpec.html)
+matches, otherwise returns null.
 
 ```json
 { "type" : "searchQuery", "query" : <search_query_spec> }
 ```
 
-### TimeDimExtractionFn
+### Time Format Extraction Function
 
-Parses dimension values as timestamps using the given input format, and returns them formatted using the given output format. Time formats follow the [com.ibm.icu.text.SimpleDateFormat](http://icu-project.org/apiref/icu4j/com/ibm/icu/text/SimpleDateFormat.html) format
+Returns the dimension value formatted according to the given format string, time zone, and locale.
+
+For `__time` dimension values, this formats the time value bucketed by the
+[aggregation granularity](Granularities.html)
+
+For a regular dimension, it assumes the string is formatted in
+[ISO-8601 date and time format](https://en.wikipedia.org/wiki/ISO_8601).
+
+* `format` : date time format for the resulting dimension value, in [Joda Time DateTimeFormat](http://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html).
+* `locale` : locale (language and country) to use, given as a [IETF BCP 47 language tag](http://www.oracle.com/technetwork/java/javase/java8locales-2095355.html#util-text), e.g. `en-US`, `en-GB`, `fr-FR`, `fr-CA`, etc.
+* `timeZone` : time zone to use in [IANA tz database format](http://en.wikipedia.org/wiki/List_of_tz_database_time_zones), e.g. `Europe/Berlin` (this can possibly be different than the aggregation time-zone)
 
 ```json
-{ "type" : "time", "timeFormat" : <input_format>, "resultFormat" : <output_format> }
+{ "type" : "timeFormat",
+  "format" : <output_format>,
+  "timeZone" : <time_zone> (optional),
+  "locale" : <locale> (optional) }
 ```
 
-### JavascriptDimExtractionFn
+For example, the following dimension spec returns the day of the week for Montréal in French:
 
-Returns the dimension value as transformed by the given JavaScript function.
+```json
+{
+  "type" : "extraction",
+  "dimension" : "__time",
+  "outputName" :  "dayOfWeek",
+  "extractionFn" : {
+    "type" : "timeFormat",
+    "format" : "EEEE",
+    "timeZone" : "America/Montreal",
+    "locale" : "fr"
+  }
+}
+```
 
-Example
+### Time Parsing Extraction Function
+
+Parses dimension values as timestamps using the given input format,
+and returns them formatted using the given output format.
+
+Note, if you are working with the `__time` dimension, you should consider using the
+[time extraction function instead](#time-format-extraction-function) instead,
+which works on time value directly as opposed to string values.
+
+Time formats are described in the
+[SimpleDateFormat documentation](http://icu-project.org/apiref/icu4j/com/ibm/icu/text/SimpleDateFormat.html)
+
+```json
+{ "type" : "time",
+  "timeFormat" : <input_format>,
+  "resultFormat" : <output_format> }
+```
+
+
+### Javascript Extraction Function
+
+Returns the dimension value, as transformed by the given JavaScript function.
+
+For regular dimensions, the input value is passed as a string.
+
+For the `__time` dimension, the input value is passed as a number
+representing the number of milliseconds since January 1, 1970 UTC.
+
+Example for a regular dimension
 
 ```json
 {
   "type" : "javascript",
   "function" : "function(str) { return str.substr(0, 3); }"
 }
+```
+
+Example for the `__time` dimension:
+
+```json
+{
+  "type" : "javascript",
+  "function" : "function(t) { return 'Second ' + Math.floor((t % 60000) / 1000); }"
+}
+```

--- a/docs/content/Granularities.md
+++ b/docs/content/Granularities.md
@@ -1,6 +1,7 @@
 ---
 layout: doc_page
 ---
+
 # Aggregation Granularity
 The granularity field determines how data gets bucketed across the time dimension, or how it gets aggregated by hour, day, minute, etc.
 

--- a/indexing-service/src/main/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactory.java
+++ b/indexing-service/src/main/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactory.java
@@ -256,7 +256,7 @@ public class IngestSegmentFirehoseFactory implements FirehoseFactory<InputRowPar
 
                       final Map<String, DimensionSelector> dimSelectors = Maps.newHashMap();
                       for (String dim : dims) {
-                        final DimensionSelector dimSelector = cursor.makeDimensionSelector(dim);
+                        final DimensionSelector dimSelector = cursor.makeDimensionSelector(dim, null);
                         // dimSelector is null if the dimension is not present
                         if (dimSelector != null) {
                           dimSelectors.put(dim, dimSelector);

--- a/processing/src/main/java/io/druid/query/aggregation/cardinality/CardinalityAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/cardinality/CardinalityAggregatorFactory.java
@@ -105,7 +105,7 @@ public class CardinalityAggregatorFactory implements AggregatorFactory
               @Override
               public DimensionSelector apply(@Nullable String input)
               {
-                return columnFactory.makeDimensionSelector(input);
+                return columnFactory.makeDimensionSelector(input, null);
               }
             }
             ), Predicates.notNull()

--- a/processing/src/main/java/io/druid/query/dimension/DefaultDimensionSpec.java
+++ b/processing/src/main/java/io/druid/query/dimension/DefaultDimensionSpec.java
@@ -20,7 +20,7 @@ package io.druid.query.dimension;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.metamx.common.StringUtils;
-import io.druid.query.extraction.DimExtractionFn;
+import io.druid.query.extraction.ExtractionFn;
 
 import java.nio.ByteBuffer;
 
@@ -59,7 +59,7 @@ public class DefaultDimensionSpec implements DimensionSpec
   }
 
   @Override
-  public DimExtractionFn getDimExtractionFn()
+  public ExtractionFn getExtractionFn()
   {
     return null;
   }

--- a/processing/src/main/java/io/druid/query/dimension/DimensionSpec.java
+++ b/processing/src/main/java/io/druid/query/dimension/DimensionSpec.java
@@ -19,7 +19,7 @@ package io.druid.query.dimension;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import io.druid.query.extraction.DimExtractionFn;
+import io.druid.query.extraction.ExtractionFn;
 
 /**
  */
@@ -34,7 +34,7 @@ public interface DimensionSpec
 
   public String getOutputName();
 
-  public DimExtractionFn getDimExtractionFn();
+  public ExtractionFn getExtractionFn();
 
   public byte[] getCacheKey();
 

--- a/processing/src/main/java/io/druid/query/extraction/DimExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/DimExtractionFn.java
@@ -1,73 +1,35 @@
 /*
- * Druid - a distributed column store.
- * Copyright 2012 - 2015 Metamarkets Group Inc.
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package io.druid.query.extraction;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-
-/**
- */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes(value = {
-    @JsonSubTypes.Type(name = "time", value = TimeDimExtractionFn.class),
-    @JsonSubTypes.Type(name = "regex", value = RegexDimExtractionFn.class),
-    @JsonSubTypes.Type(name = "partial", value = MatchingDimExtractionFn.class),
-    @JsonSubTypes.Type(name = "searchQuery", value = SearchQuerySpecDimExtractionFn.class),
-    @JsonSubTypes.Type(name = "javascript", value = JavascriptDimExtractionFn.class)
-})
-/**
- * A DimExtractionFn is a function that can be used to modify the values of a dimension column.
- *
- * A simple example of the type of operation this enables is the RegexDimExtractionFn which applies a
- * regular expression with a capture group.  When the regular expression matches the value of a dimension,
- * the value captured by the group is used for grouping operations instead of the dimension value.
- */
-public interface DimExtractionFn
+public abstract class DimExtractionFn implements ExtractionFn
 {
-  /**
-   * Returns a byte[] unique to all concrete implementations of DimExtractionFn.  This byte[] is used to
-   * generate a cache key for the specific query.
-   *
-   * @return a byte[] unit to all concrete implements of DimExtractionFn
-   */
-  public byte[] getCacheKey();
+  @Override
+  public String apply(Object value)
+  {
+    return apply(value.toString());
+  }
 
-  /**
-   * The "extraction" function.  This should map a dimension value into some other value.
-   *
-   * In order to maintain the "null and empty string are equivalent" semantics that Druid provides, the
-   * empty string is considered invalid output for this method and should instead return null.  This is
-   * a contract on the method rather than enforced at a lower level in order to eliminate a global check
-   * for extraction functions that do not already need one.
-   *
-   *
-   * @param dimValue the original value of the dimension
-   * @return a value that should be used instead of the original
-   */
-  public String apply(String dimValue);
-
-  /**
-   * Offers information on whether the extraction will preserve the original ordering of the values.
-   *
-   * Some optimizations of queries is possible if ordering is preserved.  Null values *do* count towards
-   * ordering.
-   *
-   * @return true if ordering is preserved, false otherwise
-   */
-  public boolean preservesOrdering();
+  @Override
+  public String apply(long value)
+  {
+    return apply(Long.toString(value));
+  }
 }

--- a/processing/src/main/java/io/druid/query/extraction/ExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/ExtractionFn.java
@@ -1,0 +1,78 @@
+/*
+ * Druid - a distributed column store.
+ * Copyright 2012 - 2015 Metamarkets Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.druid.query.extraction;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(value = {
+    @JsonSubTypes.Type(name = "time", value = TimeDimExtractionFn.class),
+    @JsonSubTypes.Type(name = "regex", value = RegexDimExtractionFn.class),
+    @JsonSubTypes.Type(name = "partial", value = MatchingDimExtractionFn.class),
+    @JsonSubTypes.Type(name = "searchQuery", value = SearchQuerySpecDimExtractionFn.class),
+    @JsonSubTypes.Type(name = "javascript", value = JavascriptExtractionFn.class),
+    @JsonSubTypes.Type(name = "timeFormat", value = TimeFormatExtractionFn.class)
+})
+/**
+ * An ExtractionFn is a function that can be used to transform the values of a column (typically a dimension)
+ *
+ * A simple example of the type of operation this enables is the RegexDimExtractionFn which applies a
+ * regular expression with a capture group.  When the regular expression matches the value of a dimension,
+ * the value captured by the group is used for grouping operations instead of the dimension value.
+ */
+public interface ExtractionFn
+{
+  /**
+   * Returns a byte[] unique to all concrete implementations of DimExtractionFn.  This byte[] is used to
+   * generate a cache key for the specific query.
+   *
+   * @return a byte[] unit to all concrete implements of DimExtractionFn
+   */
+  public byte[] getCacheKey();
+
+  /**
+   * The "extraction" function.  This should map a value into some other String value.
+   *
+   * In order to maintain the "null and empty string are equivalent" semantics that Druid provides, the
+   * empty string is considered invalid output for this method and should instead return null.  This is
+   * a contract on the method rather than enforced at a lower level in order to eliminate a global check
+   * for extraction functions that do not already need one.
+   *
+   *
+   * @param value the original value of the dimension
+   * @return a value that should be used instead of the original
+   */
+  public String apply(Object value);
+
+  public String apply(String value);
+
+  public String apply(long value);
+
+  /**
+   * Offers information on whether the extraction will preserve the original ordering of the values.
+   *
+   * Some optimizations of queries is possible if ordering is preserved.  Null values *do* count towards
+   * ordering.
+   *
+   * @return true if ordering is preserved, false otherwise
+   */
+  public boolean preservesOrdering();
+}

--- a/processing/src/main/java/io/druid/query/extraction/JavascriptExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/JavascriptExtractionFn.java
@@ -20,6 +20,7 @@ package io.druid.query.extraction;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.metamx.common.StringUtils;
 import org.mozilla.javascript.Context;
@@ -67,6 +68,8 @@ public class JavascriptExtractionFn implements ExtractionFn
       @JsonProperty("function") String function
   )
   {
+    Preconditions.checkNotNull(function, "function must not be null");
+
     this.function = function;
     this.fn = compile(function);
   }
@@ -117,5 +120,30 @@ public class JavascriptExtractionFn implements ExtractionFn
     return "JavascriptDimExtractionFn{" +
            "function='" + function + '\'' +
            '}';
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    JavascriptExtractionFn that = (JavascriptExtractionFn) o;
+
+    if (!function.equals(that.function)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return function.hashCode();
   }
 }

--- a/processing/src/main/java/io/druid/query/extraction/JavascriptExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/JavascriptExtractionFn.java
@@ -22,17 +22,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Function;
 import com.google.common.base.Strings;
 import com.metamx.common.StringUtils;
-import com.google.common.base.Strings;
-import com.metamx.common.StringUtils;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.ScriptableObject;
 
 import java.nio.ByteBuffer;
 
-public class JavascriptDimExtractionFn implements DimExtractionFn
+public class JavascriptExtractionFn implements ExtractionFn
 {
-  private static Function<String, String> compile(String function) {
+  private static Function<Object, String> compile(String function) {
     final ContextFactory contextFactory = ContextFactory.getGlobal();
     final Context context = contextFactory.enterContext();
     context.setOptimizationLevel(9);
@@ -43,9 +41,9 @@ public class JavascriptDimExtractionFn implements DimExtractionFn
     Context.exit();
 
 
-    return new Function<String, String>()
+    return new Function<Object, String>()
     {
-      public String apply(String input)
+      public String apply(Object input)
       {
         // ideally we need a close() function to discard the context once it is not used anymore
         Context cx = Context.getCurrentContext();
@@ -53,7 +51,7 @@ public class JavascriptDimExtractionFn implements DimExtractionFn
           cx = contextFactory.enterContext();
         }
 
-        final Object res = fn.call(cx, scope, scope, new String[]{input});
+        final Object res = fn.call(cx, scope, scope, new Object[]{input});
         return res != null ? Context.toString(res) : null;
       }
     };
@@ -62,10 +60,10 @@ public class JavascriptDimExtractionFn implements DimExtractionFn
   private static final byte CACHE_TYPE_ID = 0x4;
 
   private final String function;
-  private final Function<String, String> fn;
+  private final Function<Object, String> fn;
 
   @JsonCreator
-  public JavascriptDimExtractionFn(
+  public JavascriptExtractionFn(
       @JsonProperty("function") String function
   )
   {
@@ -90,10 +88,21 @@ public class JavascriptDimExtractionFn implements DimExtractionFn
   }
 
   @Override
-  public String apply(String dimValue)
+  public String apply(Object value)
   {
-    String retVal = fn.apply(dimValue);
-    return Strings.isNullOrEmpty(retVal) ? null : retVal;
+    return Strings.emptyToNull(fn.apply(value));
+  }
+
+  @Override
+  public String apply(String value)
+  {
+    return this.apply((Object)value);
+  }
+
+  @Override
+  public String apply(long value)
+  {
+    return this.apply((Long)value);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/extraction/MatchingDimExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/MatchingDimExtractionFn.java
@@ -19,6 +19,7 @@ package io.druid.query.extraction;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import com.metamx.common.StringUtils;
 
 import java.nio.ByteBuffer;
@@ -39,6 +40,8 @@ public class MatchingDimExtractionFn extends DimExtractionFn
       @JsonProperty("expr") String expr
   )
   {
+    Preconditions.checkNotNull(expr, "expr must not be null");
+
     this.expr = expr;
     this.pattern = Pattern.compile(expr);
   }
@@ -77,5 +80,30 @@ public class MatchingDimExtractionFn extends DimExtractionFn
   public String toString()
   {
     return String.format("regex_matches(%s)", expr);
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    MatchingDimExtractionFn that = (MatchingDimExtractionFn) o;
+
+    if (!expr.equals(that.expr)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return expr.hashCode();
   }
 }

--- a/processing/src/main/java/io/druid/query/extraction/MatchingDimExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/MatchingDimExtractionFn.java
@@ -27,7 +27,7 @@ import java.util.regex.Pattern;
 
 /**
  */
-public class MatchingDimExtractionFn implements DimExtractionFn
+public class MatchingDimExtractionFn extends DimExtractionFn
 {
   private static final byte CACHE_TYPE_ID = 0x2;
 

--- a/processing/src/main/java/io/druid/query/extraction/RegexDimExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/RegexDimExtractionFn.java
@@ -27,7 +27,7 @@ import java.util.regex.Pattern;
 
 /**
  */
-public class RegexDimExtractionFn implements DimExtractionFn
+public class RegexDimExtractionFn extends DimExtractionFn
 {
   private static final byte CACHE_TYPE_ID = 0x1;
 

--- a/processing/src/main/java/io/druid/query/extraction/RegexDimExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/RegexDimExtractionFn.java
@@ -19,6 +19,7 @@ package io.druid.query.extraction;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import com.metamx.common.StringUtils;
 
 import java.nio.ByteBuffer;
@@ -39,6 +40,8 @@ public class RegexDimExtractionFn extends DimExtractionFn
       @JsonProperty("expr") String expr
   )
   {
+    Preconditions.checkNotNull(expr, "expr must not be null");
+
     this.expr = expr;
     this.pattern = Pattern.compile(expr);
   }
@@ -76,5 +79,30 @@ public class RegexDimExtractionFn extends DimExtractionFn
   public String toString()
   {
     return String.format("regex(%s)", expr);
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    RegexDimExtractionFn that = (RegexDimExtractionFn) o;
+
+    if (!expr.equals(that.expr)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return expr.hashCode();
   }
 }

--- a/processing/src/main/java/io/druid/query/extraction/SearchQuerySpecDimExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/SearchQuerySpecDimExtractionFn.java
@@ -25,7 +25,7 @@ import java.nio.ByteBuffer;
 
 /**
  */
-public class SearchQuerySpecDimExtractionFn implements DimExtractionFn
+public class SearchQuerySpecDimExtractionFn extends DimExtractionFn
 {
   private static final byte CACHE_TYPE_ID = 0x3;
 

--- a/processing/src/main/java/io/druid/query/extraction/SearchQuerySpecDimExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/SearchQuerySpecDimExtractionFn.java
@@ -19,6 +19,7 @@ package io.druid.query.extraction;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import io.druid.query.search.search.SearchQuerySpec;
 
 import java.nio.ByteBuffer;
@@ -36,6 +37,8 @@ public class SearchQuerySpecDimExtractionFn extends DimExtractionFn
       @JsonProperty("query") SearchQuerySpec searchQuerySpec
   )
   {
+    Preconditions.checkNotNull(searchQuerySpec, "search query must not be null");
+
     this.searchQuerySpec = searchQuerySpec;
   }
 
@@ -73,5 +76,30 @@ public class SearchQuerySpecDimExtractionFn extends DimExtractionFn
     return "SearchQuerySpecDimExtractionFn{" +
            "searchQuerySpec=" + searchQuerySpec +
            '}';
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SearchQuerySpecDimExtractionFn that = (SearchQuerySpecDimExtractionFn) o;
+
+    if (!searchQuerySpec.equals(that.searchQuerySpec)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return searchQuerySpec.hashCode();
   }
 }

--- a/processing/src/main/java/io/druid/query/extraction/TimeDimExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/TimeDimExtractionFn.java
@@ -28,7 +28,7 @@ import java.util.Date;
 
 /**
  */
-public class TimeDimExtractionFn implements DimExtractionFn
+public class TimeDimExtractionFn extends DimExtractionFn
 {
   private static final byte CACHE_TYPE_ID = 0x0;
 

--- a/processing/src/main/java/io/druid/query/extraction/TimeDimExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/TimeDimExtractionFn.java
@@ -19,6 +19,7 @@ package io.druid.query.extraction;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import com.ibm.icu.text.SimpleDateFormat;
 import com.metamx.common.StringUtils;
 
@@ -43,6 +44,9 @@ public class TimeDimExtractionFn extends DimExtractionFn
       @JsonProperty("resultFormat") String resultFormat
   )
   {
+    Preconditions.checkNotNull(timeFormat, "timeFormat must not be null");
+    Preconditions.checkNotNull(resultFormat, "resultFormat must not be null");
+
     this.timeFormat = timeFormat;
     this.timeFormatter = new SimpleDateFormat(timeFormat);
     this.timeFormatter.setLenient(true);
@@ -99,5 +103,35 @@ public class TimeDimExtractionFn extends DimExtractionFn
            "timeFormat='" + timeFormat + '\'' +
            ", resultFormat='" + resultFormat + '\'' +
            '}';
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    TimeDimExtractionFn that = (TimeDimExtractionFn) o;
+
+    if (!resultFormat.equals(that.resultFormat)) {
+      return false;
+    }
+    if (!timeFormat.equals(that.timeFormat)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = timeFormat.hashCode();
+    result = 31 * result + resultFormat.hashCode();
+    return result;
   }
 }

--- a/processing/src/main/java/io/druid/query/extraction/TimeFormatExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/TimeFormatExtractionFn.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.extraction;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import com.metamx.common.StringUtils;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+import java.nio.ByteBuffer;
+import java.util.Locale;
+
+public class TimeFormatExtractionFn implements ExtractionFn
+{
+  private static final byte CACHE_TYPE_ID = 0x5;
+
+  private final DateTimeZone tz;
+  private final String pattern;
+  private final Locale locale;
+  private final DateTimeFormatter formatter;
+
+  public TimeFormatExtractionFn(
+      @JsonProperty("format") String pattern,
+      @JsonProperty("timeZone") DateTimeZone tz,
+      @JsonProperty("locale") String localeString
+  )
+  {
+    Preconditions.checkArgument(pattern != null, "format cannot be null");
+
+    this.pattern = pattern;
+    this.tz = tz;
+    this.locale = localeString == null ? null : Locale.forLanguageTag(localeString);
+    this.formatter = DateTimeFormat.forPattern(pattern)
+                                   .withZone(tz == null ? DateTimeZone.UTC : tz)
+                                   .withLocale(locale);
+  }
+
+  @JsonProperty
+  public DateTimeZone getTimeZone()
+  {
+    return tz;
+  }
+
+  @JsonProperty
+  public String getFormat()
+  {
+    return pattern;
+  }
+
+  @JsonProperty
+  public String getLocale()
+  {
+    if (locale != null) {
+      return locale.toLanguageTag();
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public byte[] getCacheKey()
+  {
+    byte[] exprBytes = StringUtils.toUtf8(pattern + "\u0001" + tz.getID() + "\u0001" + locale.toLanguageTag());
+    return ByteBuffer.allocate(1 + exprBytes.length)
+                     .put(CACHE_TYPE_ID)
+                     .put(exprBytes)
+                     .array();
+  }
+
+  @Override
+  public String apply(long value)
+  {
+    return formatter.print(value);
+  }
+
+  @Override
+  public String apply(Object value)
+  {
+    return formatter.print(new DateTime(value));
+  }
+
+  @Override
+  public String apply(String value)
+  {
+    return apply((Object)value);
+  }
+
+  @Override
+  public boolean preservesOrdering()
+  {
+    return false;
+  }
+}

--- a/processing/src/main/java/io/druid/query/extraction/TimeFormatExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/TimeFormatExtractionFn.java
@@ -110,4 +110,38 @@ public class TimeFormatExtractionFn implements ExtractionFn
   {
     return false;
   }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    TimeFormatExtractionFn that = (TimeFormatExtractionFn) o;
+
+    if (locale != null ? !locale.equals(that.locale) : that.locale != null) {
+      return false;
+    }
+    if (!pattern.equals(that.pattern)) {
+      return false;
+    }
+    if (tz != null ? !tz.equals(that.tz) : that.tz != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = tz != null ? tz.hashCode() : 0;
+    result = 31 * result + pattern.hashCode();
+    result = 31 * result + (locale != null ? locale.hashCode() : 0);
+    return result;
+  }
 }

--- a/processing/src/main/java/io/druid/query/filter/ExtractionDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/ExtractionDimFilter.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.metamx.common.StringUtils;
-import io.druid.query.extraction.DimExtractionFn;
+import io.druid.query.extraction.ExtractionFn;
 
 import java.nio.ByteBuffer;
 
@@ -31,22 +31,24 @@ public class ExtractionDimFilter implements DimFilter
 {
   private final String dimension;
   private final String value;
-  private final DimExtractionFn dimExtractionFn;
+  private final ExtractionFn extractionFn;
 
   @JsonCreator
   public ExtractionDimFilter(
       @JsonProperty("dimension") String dimension,
       @JsonProperty("value") String value,
-      @JsonProperty("dimExtractionFn") DimExtractionFn dimExtractionFn
+      @JsonProperty("extractionFn") ExtractionFn extractionFn,
+      // for backwards compatibility
+      @Deprecated @JsonProperty("dimExtractionFn") ExtractionFn dimExtractionFn
   )
   {
     Preconditions.checkArgument(dimension != null, "dimension must not be null");
     Preconditions.checkArgument(value != null, "value must not be null");
-    Preconditions.checkArgument(dimExtractionFn != null, "extraction function must not be null");
+    Preconditions.checkArgument(extractionFn != null || dimExtractionFn != null, "extraction function must not be null");
 
     this.dimension = dimension;
     this.value = value;
-    this.dimExtractionFn = dimExtractionFn;
+    this.extractionFn = extractionFn != null ? extractionFn : dimExtractionFn;
   }
 
   @JsonProperty
@@ -62,9 +64,9 @@ public class ExtractionDimFilter implements DimFilter
   }
 
   @JsonProperty
-  public DimExtractionFn getDimExtractionFn()
+  public ExtractionFn getExtractionFn()
   {
-    return dimExtractionFn;
+    return extractionFn;
   }
 
   @Override
@@ -83,6 +85,6 @@ public class ExtractionDimFilter implements DimFilter
   @Override
   public String toString()
   {
-    return String.format("%s(%s) = %s", dimExtractionFn, dimension, value);
+    return String.format("%s(%s) = %s", extractionFn, dimension, value);
   }
 }

--- a/processing/src/main/java/io/druid/query/search/SearchQueryRunner.java
+++ b/processing/src/main/java/io/druid/query/search/SearchQueryRunner.java
@@ -161,7 +161,8 @@ public class SearchQueryRunner implements QueryRunner<Result<SearchResultValue>>
 
             Map<String, DimensionSelector> dimSelectors = Maps.newHashMap();
             for (String dim : dimsToSearch) {
-              dimSelectors.put(dim, cursor.makeDimensionSelector(dim));
+              // switching to using DimensionSpec for search would allow the use of extractionFn here.
+              dimSelectors.put(dim, cursor.makeDimensionSelector(dim, null));
             }
 
             while (!cursor.isDone()) {

--- a/processing/src/main/java/io/druid/query/select/SelectQueryEngine.java
+++ b/processing/src/main/java/io/druid/query/select/SelectQueryEngine.java
@@ -86,7 +86,8 @@ public class SelectQueryEngine
 
             final Map<String, DimensionSelector> dimSelectors = Maps.newHashMap();
             for (String dim : dims) {
-              final DimensionSelector dimSelector = cursor.makeDimensionSelector(dim);
+              // switching to using DimensionSpec for select would allow the use of extractionFn here.
+              final DimensionSelector dimSelector = cursor.makeDimensionSelector(dim, null);
               dimSelectors.put(dim, dimSelector);
             }
 

--- a/processing/src/main/java/io/druid/query/topn/TimeExtractionTopNAlgorithm.java
+++ b/processing/src/main/java/io/druid/query/topn/TimeExtractionTopNAlgorithm.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.topn;
+
+import com.google.common.collect.Maps;
+import io.druid.query.aggregation.Aggregator;
+import io.druid.query.extraction.ExtractionFn;
+import io.druid.segment.Capabilities;
+import io.druid.segment.Cursor;
+import io.druid.segment.DimensionSelector;
+import io.druid.segment.LongColumnSelector;
+import io.druid.segment.column.Column;
+
+import java.util.Map;
+
+public class TimeExtractionTopNAlgorithm extends BaseTopNAlgorithm<int[], Map<String, Aggregator[]>, TopNParams>
+{
+  public static final int[] EMPTY_INTS = new int[]{};
+  private final TopNQuery query;
+
+  public TimeExtractionTopNAlgorithm(Capabilities capabilities, TopNQuery query)
+  {
+    super(capabilities);
+    this.query = query;
+  }
+
+
+  @Override
+  public TopNParams makeInitParams(DimensionSelector dimSelector, Cursor cursor)
+  {
+    return new TopNParams(
+        dimSelector,
+        cursor,
+        dimSelector.getValueCardinality(),
+        Integer.MAX_VALUE
+    );
+  }
+
+  @Override
+  protected int[] makeDimValSelector(TopNParams params, int numProcessed, int numToProcess)
+  {
+    return EMPTY_INTS;
+  }
+
+  @Override
+  protected int[] updateDimValSelector(int[] dimValSelector, int numProcessed, int numToProcess)
+  {
+    return dimValSelector;
+  }
+
+  @Override
+  protected Map<String, Aggregator[]> makeDimValAggregateStore(TopNParams params)
+  {
+    return Maps.newHashMap();
+  }
+
+  @Override
+  protected void scanAndAggregate(
+      TopNParams params, int[] dimValSelector, Map<String, Aggregator[]> aggregatesStore, int numProcessed
+  )
+  {
+    final Cursor cursor = params.getCursor();
+    final DimensionSelector dimSelector = params.getDimSelector();
+
+    while (!cursor.isDone()) {
+      final String key = dimSelector.lookupName(dimSelector.getRow().get(0));
+
+      Aggregator[] theAggregators = aggregatesStore.get(key);
+      if (theAggregators == null) {
+        theAggregators = makeAggregators(cursor, query.getAggregatorSpecs());
+        aggregatesStore.put(key, theAggregators);
+      }
+
+      for (Aggregator aggregator : theAggregators) {
+        aggregator.aggregate();
+      }
+
+      cursor.advance();
+    }
+  }
+
+  @Override
+  protected void updateResults(
+      TopNParams params,
+      int[] dimValSelector,
+      Map<String, Aggregator[]> aggregatesStore,
+      TopNResultBuilder resultBuilder
+  )
+  {
+    for (Map.Entry<String, Aggregator[]> entry : aggregatesStore.entrySet()) {
+      Aggregator[] aggs = entry.getValue();
+      if (aggs != null && aggs.length > 0) {
+        Object[] vals = new Object[aggs.length];
+        for (int i = 0; i < aggs.length; i++) {
+          vals[i] = aggs[i].get();
+        }
+
+        resultBuilder.addEntry(
+            entry.getKey(),
+            entry.getKey(),
+            vals
+        );
+      }
+    }
+  }
+
+  @Override
+  protected void closeAggregators(Map<String, Aggregator[]> stringMap)
+  {
+    for (Aggregator[] aggregators : stringMap.values()) {
+      for (Aggregator agg : aggregators) {
+        agg.close();
+      }
+    }
+  }
+
+  @Override
+  public void cleanup(TopNParams params)
+  {
+
+  }
+}

--- a/processing/src/main/java/io/druid/query/topn/TopNAlgorithmSelector.java
+++ b/processing/src/main/java/io/druid/query/topn/TopNAlgorithmSelector.java
@@ -24,7 +24,7 @@ public class TopNAlgorithmSelector
   private final int cardinality;
   private final int numBytesPerRecord;
 
-  private volatile boolean hasDimExtractionFn;
+  private volatile boolean hasExtractionFn;
   private volatile boolean aggregateAllMetrics;
   private volatile boolean aggregateTopNMetricFirst;
 
@@ -34,9 +34,9 @@ public class TopNAlgorithmSelector
     this.numBytesPerRecord = numBytesPerRecord;
   }
 
-  public void setHasDimExtractionFn(boolean hasDimExtractionFn)
+  public void setHasExtractionFn(boolean hasExtractionFn)
   {
-    this.hasDimExtractionFn = hasDimExtractionFn;
+    this.hasExtractionFn = hasExtractionFn;
   }
 
   public void setAggregateAllMetrics(boolean aggregateAllMetrics)
@@ -53,9 +53,9 @@ public class TopNAlgorithmSelector
     }
   }
 
-  public boolean isHasDimExtractionFn()
+  public boolean isHasExtractionFn()
   {
-    return hasDimExtractionFn;
+    return hasExtractionFn;
   }
 
   public boolean isAggregateAllMetrics()

--- a/processing/src/main/java/io/druid/query/topn/TopNMapFn.java
+++ b/processing/src/main/java/io/druid/query/topn/TopNMapFn.java
@@ -41,7 +41,10 @@ public class TopNMapFn implements Function<Cursor, Result<TopNResultValue>>
   @SuppressWarnings("unchecked")
   public Result<TopNResultValue> apply(Cursor cursor)
   {
-    final DimensionSelector dimSelector = cursor.makeDimensionSelector(query.getDimensionSpec().getDimension());
+    final DimensionSelector dimSelector = cursor.makeDimensionSelector(
+        query.getDimensionSpec().getDimension(),
+        query.getDimensionSpec().getExtractionFn()
+    );
     if (dimSelector == null) {
       return null;
     }

--- a/processing/src/main/java/io/druid/query/topn/TopNQuery.java
+++ b/processing/src/main/java/io/druid/query/topn/TopNQuery.java
@@ -139,8 +139,8 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
 
   public void initTopNAlgorithmSelector(TopNAlgorithmSelector selector)
   {
-    if (dimensionSpec.getDimExtractionFn() != null) {
-      selector.setHasDimExtractionFn(true);
+    if (dimensionSpec.getExtractionFn() != null) {
+      selector.setHasExtractionFn(true);
     }
     topNMetricSpec.initTopNAlgorithmSelector(selector);
   }

--- a/processing/src/main/java/io/druid/query/topn/TopNQueryEngine.java
+++ b/processing/src/main/java/io/druid/query/topn/TopNQueryEngine.java
@@ -32,6 +32,7 @@ import io.druid.segment.Capabilities;
 import io.druid.segment.Cursor;
 import io.druid.segment.SegmentMissingException;
 import io.druid.segment.StorageAdapter;
+import io.druid.segment.column.Column;
 import io.druid.segment.filter.Filters;
 import org.joda.time.Interval;
 
@@ -88,7 +89,10 @@ public class TopNQueryEngine
   private Function<Cursor, Result<TopNResultValue>> getMapFn(TopNQuery query, final StorageAdapter adapter)
   {
     final Capabilities capabilities = adapter.getCapabilities();
-    final int cardinality = adapter.getDimensionCardinality(query.getDimensionSpec().getDimension());
+    final String dimension = query.getDimensionSpec().getDimension();
+
+    final int cardinality = adapter.getDimensionCardinality(dimension);
+
     int numBytesPerRecord = 0;
     for (AggregatorFactory aggregatorFactory : query.getAggregatorSpecs()) {
       numBytesPerRecord += aggregatorFactory.getMaxIntermediateSize();
@@ -97,8 +101,18 @@ public class TopNQueryEngine
     final TopNAlgorithmSelector selector = new TopNAlgorithmSelector(cardinality, numBytesPerRecord);
     query.initTopNAlgorithmSelector(selector);
 
-    TopNAlgorithm topNAlgorithm = null;
-    if (selector.isHasDimExtractionFn()) {
+    final TopNAlgorithm topNAlgorithm;
+    if (
+        selector.isHasExtractionFn() &&
+        // TimeExtractionTopNAlgorithm can work on any single-value dimension of type long.
+        // Once we have arbitrary dimension types following check should be replaced by checking
+        // that the column is of type long and single-value.
+        dimension.equals(Column.TIME_COLUMN_NAME)
+        ) {
+      // A special TimeExtractionTopNAlgorithm is required, since DimExtractionTopNAlgorithm
+      // currently relies on the dimension cardinality to support lexicographic sorting
+      topNAlgorithm = new TimeExtractionTopNAlgorithm(capabilities, query);
+    } else if(selector.isHasExtractionFn()) {
       topNAlgorithm = new DimExtractionTopNAlgorithm(capabilities, query);
     } else if (selector.isAggregateAllMetrics()) {
       topNAlgorithm = new PooledTopNAlgorithm(capabilities, query, bufferPool);

--- a/processing/src/main/java/io/druid/segment/ColumnSelectorFactory.java
+++ b/processing/src/main/java/io/druid/segment/ColumnSelectorFactory.java
@@ -17,12 +17,16 @@
 
 package io.druid.segment;
 
+import io.druid.query.extraction.ExtractionFn;
+
+import javax.annotation.Nullable;
+
 /**
  * Factory class for MetricSelectors
  */
 public interface ColumnSelectorFactory
 {
-  public DimensionSelector makeDimensionSelector(String dimensionName);
+  public DimensionSelector makeDimensionSelector(String dimensionName, @Nullable ExtractionFn extractionFn);
   public FloatColumnSelector makeFloatColumnSelector(String columnName);
   public LongColumnSelector makeLongColumnSelector(String columnName);
   public ObjectColumnSelector makeObjectColumnSelector(String columnName);

--- a/processing/src/main/java/io/druid/segment/StorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/StorageAdapter.java
@@ -29,7 +29,16 @@ public interface StorageAdapter extends CursorFactory
   public Interval getInterval();
   public Indexed<String> getAvailableDimensions();
   public Iterable<String> getAvailableMetrics();
-  public int getDimensionCardinality(String dimension);
+
+  /**
+   * Returns the number of distinct values for the given dimension column
+   * For dimensions of unknown cardinality, e.g. __time this currently returns
+   * Integer.MAX_VALUE
+   *
+   * @param column
+   * @return
+   */
+  public int getDimensionCardinality(String column);
   public DateTime getMinTime();
   public DateTime getMaxTime();
   public Capabilities getCapabilities();

--- a/processing/src/main/java/io/druid/segment/filter/ExtractionFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/ExtractionFilter.java
@@ -20,7 +20,7 @@ package io.druid.segment.filter;
 import com.google.common.collect.Lists;
 import com.metamx.collections.bitmap.ImmutableBitmap;
 import com.metamx.collections.bitmap.WrappedConciseBitmap;
-import io.druid.query.extraction.DimExtractionFn;
+import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.filter.BitmapIndexSelector;
 import io.druid.query.filter.Filter;
 import io.druid.query.filter.ValueMatcher;
@@ -36,12 +36,12 @@ public class ExtractionFilter implements Filter
 {
   private final String dimension;
   private final String value;
-  private final DimExtractionFn fn;
+  private final ExtractionFn fn;
 
   public ExtractionFilter(
       String dimension,
       String value,
-      DimExtractionFn fn
+      ExtractionFn fn
   )
   {
     this.dimension = dimension;

--- a/processing/src/main/java/io/druid/segment/filter/Filters.java
+++ b/processing/src/main/java/io/druid/segment/filter/Filters.java
@@ -75,7 +75,7 @@ public class Filters
       filter = new ExtractionFilter(
           extractionDimFilter.getDimension(),
           extractionDimFilter.getValue(),
-          extractionDimFilter.getDimExtractionFn()
+          extractionDimFilter.getExtractionFn()
       );
     } else if (dimFilter instanceof RegexDimFilter) {
       final RegexDimFilter regexDimFilter = (RegexDimFilter) dimFilter;

--- a/processing/src/main/java/io/druid/segment/filter/SelectorFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/SelectorFilter.java
@@ -58,7 +58,7 @@ public class SelectorFilter implements Filter
   @Override
   public ValueMatcher makeMatcher(ColumnSelectorFactory columnSelectorFactory)
   {
-    final DimensionSelector dimensionSelector = columnSelectorFactory.makeDimensionSelector(dimension);
+    final DimensionSelector dimensionSelector = columnSelectorFactory.makeDimensionSelector(dimension, null);
 
     // Missing columns match a null or empty string value and don't match anything else
     if (dimensionSelector == null) {

--- a/processing/src/test/java/io/druid/query/aggregation/FilteredAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/FilteredAggregatorTest.java
@@ -18,6 +18,7 @@
 package io.druid.query.aggregation;
 
 import com.google.common.collect.Lists;
+import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.filter.AndDimFilter;
 import io.druid.query.filter.DimFilter;
 import io.druid.query.filter.NotDimFilter;
@@ -70,7 +71,7 @@ public class FilteredAggregatorTest
     return new ColumnSelectorFactory()
     {
       @Override
-      public DimensionSelector makeDimensionSelector(String dimensionName)
+      public DimensionSelector makeDimensionSelector(String dimensionName, ExtractionFn extractionFn)
       {
         if (dimensionName.equals("dim")) {
           return new DimensionSelector()

--- a/processing/src/test/java/io/druid/query/dimension/ExtractionDimensionSpecTest.java
+++ b/processing/src/test/java/io/druid/query/dimension/ExtractionDimensionSpecTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.dimension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.druid.jackson.DefaultObjectMapper;
+import io.druid.query.extraction.MatchingDimExtractionFn;
+import io.druid.query.extraction.RegexDimExtractionFn;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ExtractionDimensionSpecTest
+{
+  @Test
+  public void testSerde() throws Exception
+  {
+    final ObjectMapper objectMapper = new DefaultObjectMapper();
+
+    final String oldJson = "{\n"
+                           + "    \"type\": \"extraction\",\n"
+                           + "    \"outputName\": \"first3Letters\",\n"
+                           + "    \"dimension\": \"myDim\","
+                           + "    \"extractionFn\": {\n"
+                           + "        \"type\": \"regex\",\n"
+                           + "        \"expr\": \"(...).*\"\n"
+                           + "    }\n"
+                           + "}";
+
+    final ExtractionDimensionSpec extractionDimensionSpec = (ExtractionDimensionSpec) objectMapper.readValue(oldJson, DimensionSpec.class);
+
+    Assert.assertEquals("first3Letters", extractionDimensionSpec.getOutputName());
+    Assert.assertEquals("myDim", extractionDimensionSpec.getDimension());
+    Assert.assertNotNull(extractionDimensionSpec.getExtractionFn());
+    Assert.assertTrue(extractionDimensionSpec.getExtractionFn() instanceof RegexDimExtractionFn);
+
+    Assert.assertEquals(
+        extractionDimensionSpec,
+        objectMapper.readValue(
+            objectMapper.writeValueAsBytes(extractionDimensionSpec),
+            DimensionSpec.class
+        )
+    );
+  }
+
+  @Test
+  public void testSerdeBackwardsCompatibility() throws Exception
+  {
+    final ObjectMapper objectMapper = new DefaultObjectMapper();
+
+    final String oldJson = "{\n"
+                        + "    \"type\": \"extraction\",\n"
+                        + "    \"outputName\": \"first3Letters\",\n"
+                        + "    \"dimension\": \"myDim\","
+                        + "    \"dimExtractionFn\": {\n"
+                        + "        \"type\": \"regex\",\n"
+                        + "        \"expr\": \"(...).*\"\n"
+                        + "    }\n"
+                        + "}";
+
+    final ExtractionDimensionSpec extractionDimensionSpec = (ExtractionDimensionSpec) objectMapper.readValue(oldJson, DimensionSpec.class);
+
+    Assert.assertEquals("first3Letters", extractionDimensionSpec.getOutputName());
+    Assert.assertEquals("myDim", extractionDimensionSpec.getDimension());
+    Assert.assertNotNull(extractionDimensionSpec.getExtractionFn());
+    Assert.assertTrue(extractionDimensionSpec.getExtractionFn() instanceof RegexDimExtractionFn);
+
+    Assert.assertEquals(
+        extractionDimensionSpec,
+        objectMapper.readValue(
+            objectMapper.writeValueAsBytes(extractionDimensionSpec),
+            DimensionSpec.class
+        )
+    );
+
+    // new trumps old
+    final String oldAndNewJson = "{\n"
+                           + "    \"type\": \"extraction\",\n"
+                           + "    \"outputName\": \"first3Letters\",\n"
+                           + "    \"dimension\": \"myDim\","
+                           + "    \"extractionFn\": {\n"
+                           + "        \"type\": \"partial\",\n"
+                           + "        \"expr\": \"(...).*\"\n"
+                           + "    },\n"
+                           + "    \"dimExtractionFn\": {\n"
+                           + "        \"type\": \"regex\",\n"
+                           + "        \"expr\": \"(...).*\"\n"
+                           + "    }\n"
+                           + "}";
+
+    Assert.assertTrue(
+        objectMapper.readValue(oldAndNewJson, DimensionSpec.class)
+                    .getExtractionFn() instanceof MatchingDimExtractionFn
+    );
+  }
+}

--- a/processing/src/test/java/io/druid/query/extraction/TimeFormatExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/TimeFormatExtractionFnTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.extraction;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.druid.jackson.DefaultObjectMapper;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TimeFormatExtractionFnTest
+{
+
+  private static final long[] timestamps = {
+      new DateTime("2015-01-01T23:00:00Z").getMillis(),
+      new DateTime("2015-01-02T23:00:00Z").getMillis(),
+      new DateTime("2015-03-03T23:00:00Z").getMillis(),
+      new DateTime("2015-03-04T23:00:00Z").getMillis(),
+      new DateTime("2015-05-02T23:00:00Z").getMillis(),
+      new DateTime("2015-12-21T23:00:00Z").getMillis()
+  };
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testIAEForNullPattern() throws Exception
+  {
+    new TimeFormatExtractionFn(null, null, null);
+  }
+
+  @Test
+  public void testDayOfWeekExtraction() throws Exception
+  {
+    TimeFormatExtractionFn fn = new TimeFormatExtractionFn("EEEE", null, null);
+    Assert.assertEquals("Thursday",  fn.apply(timestamps[0]));
+    Assert.assertEquals("Friday",    fn.apply(timestamps[1]));
+    Assert.assertEquals("Tuesday",   fn.apply(timestamps[2]));
+    Assert.assertEquals("Wednesday", fn.apply(timestamps[3]));
+    Assert.assertEquals("Saturday",  fn.apply(timestamps[4]));
+    Assert.assertEquals("Monday",    fn.apply(timestamps[5]));
+
+    testSerde(fn, "EEEE", null, null);
+  }
+
+  @Test
+  public void testLocalizedExtraction() throws Exception
+  {
+    TimeFormatExtractionFn fn = new TimeFormatExtractionFn("EEEE", null, "is");
+    Assert.assertEquals("fimmtudagur",  fn.apply(timestamps[0]));
+    Assert.assertEquals("föstudagur",   fn.apply(timestamps[1]));
+    Assert.assertEquals("þriðjudagur",  fn.apply(timestamps[2]));
+    Assert.assertEquals("miðvikudagur", fn.apply(timestamps[3]));
+    Assert.assertEquals("laugardagur",  fn.apply(timestamps[4]));
+    Assert.assertEquals("mánudagur",    fn.apply(timestamps[5]));
+
+    testSerde(fn, "EEEE", null, "is");
+  }
+
+  @Test
+  public void testTimeZoneExtraction() throws Exception
+  {
+    TimeFormatExtractionFn fn = new TimeFormatExtractionFn("'In Berlin ist es schon 'EEEE", DateTimeZone.forID("Europe/Berlin"), "de");
+    Assert.assertEquals("In Berlin ist es schon Freitag",    fn.apply(timestamps[0]));
+    Assert.assertEquals("In Berlin ist es schon Samstag",    fn.apply(timestamps[1]));
+    Assert.assertEquals("In Berlin ist es schon Mittwoch",   fn.apply(timestamps[2]));
+    Assert.assertEquals("In Berlin ist es schon Donnerstag", fn.apply(timestamps[3]));
+    Assert.assertEquals("In Berlin ist es schon Sonntag",    fn.apply(timestamps[4]));
+    Assert.assertEquals("In Berlin ist es schon Dienstag",   fn.apply(timestamps[5]));
+
+    testSerde(fn, "'In Berlin ist es schon 'EEEE", DateTimeZone.forID("Europe/Berlin"), "de");
+  }
+
+  public void testSerde(TimeFormatExtractionFn fn, String format, DateTimeZone tz, String locale) throws Exception {
+    ObjectMapper objectMapper = new DefaultObjectMapper();
+    String json = objectMapper.writeValueAsString(fn);
+    TimeFormatExtractionFn deserialized = objectMapper.readValue(json, TimeFormatExtractionFn.class);
+
+    Assert.assertEquals(format, deserialized.getFormat());
+    Assert.assertEquals(tz, deserialized.getTimeZone());
+    Assert.assertEquals(locale, deserialized.getLocale());
+  }
+}

--- a/processing/src/test/java/io/druid/query/extraction/TimeFormatExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/TimeFormatExtractionFnTest.java
@@ -87,12 +87,35 @@ public class TimeFormatExtractionFnTest
   }
 
   public void testSerde(TimeFormatExtractionFn fn, String format, DateTimeZone tz, String locale) throws Exception {
-    ObjectMapper objectMapper = new DefaultObjectMapper();
-    String json = objectMapper.writeValueAsString(fn);
+    final ObjectMapper objectMapper = new DefaultObjectMapper();
+    final  String json = objectMapper.writeValueAsString(fn);
     TimeFormatExtractionFn deserialized = objectMapper.readValue(json, TimeFormatExtractionFn.class);
 
     Assert.assertEquals(format, deserialized.getFormat());
     Assert.assertEquals(tz, deserialized.getTimeZone());
     Assert.assertEquals(locale, deserialized.getLocale());
+
+    Assert.assertEquals(fn, deserialized);
+  }
+
+  @Test
+  public void testSerdeFromJson() throws Exception
+  {
+    final ObjectMapper objectMapper = new DefaultObjectMapper();
+    final String json = "{ \"type\" : \"timeFormat\", \"format\" : \"HH\" }";
+    TimeFormatExtractionFn extractionFn = (TimeFormatExtractionFn) objectMapper.readValue(json, ExtractionFn.class);
+
+    Assert.assertEquals("HH", extractionFn.getFormat());
+    Assert.assertEquals(null, extractionFn.getLocale());
+    Assert.assertEquals(null, extractionFn.getTimeZone());
+
+    // round trip
+    Assert.assertEquals(
+        extractionFn,
+        objectMapper.readValue(
+            objectMapper.writeValueAsBytes(extractionFn),
+            ExtractionFn.class
+        )
+    );
   }
 }

--- a/processing/src/test/java/io/druid/query/extraction/extraction/JavascriptExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/extraction/JavascriptExtractionFnTest.java
@@ -17,8 +17,10 @@
 
 package io.druid.query.extraction.extraction;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
+import io.druid.jackson.DefaultObjectMapper;
 import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.extraction.JavascriptExtractionFn;
 import org.joda.time.DateTime;
@@ -306,5 +308,24 @@ public class JavascriptExtractionFnTest
       String res = extractionFn.apply(inputs.next());
       Assert.assertEquals(it.next(), res);
     }
+  }
+
+  @Test
+  public void testSerde() throws Exception
+  {
+    final ObjectMapper objectMapper = new DefaultObjectMapper();
+    final String json = "{ \"type\" : \"javascript\", \"function\" : \"function(str) { return str.substring(0,3); }\" }";
+    JavascriptExtractionFn extractionFn = (JavascriptExtractionFn) objectMapper.readValue(json, ExtractionFn.class);
+
+    Assert.assertEquals("function(str) { return str.substring(0,3); }", extractionFn.getFunction());
+
+    // round trip
+    Assert.assertEquals(
+        extractionFn,
+        objectMapper.readValue(
+            objectMapper.writeValueAsBytes(extractionFn),
+            ExtractionFn.class
+        )
+    );
   }
 }

--- a/processing/src/test/java/io/druid/query/extraction/extraction/JavascriptExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/extraction/JavascriptExtractionFnTest.java
@@ -19,14 +19,15 @@ package io.druid.query.extraction.extraction;
 
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
-import io.druid.query.extraction.DimExtractionFn;
-import io.druid.query.extraction.JavascriptDimExtractionFn;
+import io.druid.query.extraction.ExtractionFn;
+import io.druid.query.extraction.JavascriptExtractionFn;
+import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Iterator;
 
-public class JavascriptDimExtractionFnTest
+public class JavascriptExtractionFnTest
 {
   private static final String[] testStrings = {
       "Quito",
@@ -43,24 +44,46 @@ public class JavascriptDimExtractionFnTest
   public void testJavascriptSubstring()
   {
     String function = "function(str) { return str.substring(0,3); }";
-    DimExtractionFn dimExtractionFn = new JavascriptDimExtractionFn(function);
+    ExtractionFn extractionFn = new JavascriptExtractionFn(function);
 
     for (String str : testStrings) {
-      String res = dimExtractionFn.apply(str);
+      String res = extractionFn.apply(str);
       Assert.assertEquals(str.substring(0, 3), res);
     }
+  }
+
+  @Test
+  public void testTimeExample() throws Exception
+  {
+    String utcHour = "function(t) {\nreturn 'Second ' + Math.floor((t % 60000) / 1000);\n}";
+    final long millis = new DateTime("2015-01-02T13:00:59.999Z").getMillis();
+    Assert.assertEquals("Second 59" , new JavascriptExtractionFn(utcHour).apply(millis));
+  }
+
+  @Test
+  public void testLongs() throws Exception
+  {
+    String typeOf = "function(x) {\nreturn typeof x\n}";
+    Assert.assertEquals("number", new JavascriptExtractionFn(typeOf).apply(1234L));
+  }
+
+  @Test
+  public void testFloats() throws Exception
+  {
+    String typeOf = "function(x) {\nreturn typeof x\n}";
+    Assert.assertEquals("number", new JavascriptExtractionFn(typeOf).apply(1234.0));
   }
 
   @Test
   public void testCastingAndNull()
   {
     String function = "function(x) {\n  x = Number(x);\n  if(isNaN(x)) return null;\n  return Math.floor(x / 5) * 5;\n}";
-    DimExtractionFn dimExtractionFn = new JavascriptDimExtractionFn(function);
+    ExtractionFn extractionFn = new JavascriptExtractionFn(function);
 
     Iterator<String> it = Iterators.forArray("0", "5", "5", "10", null);
 
     for(String str : Lists.newArrayList("1", "5", "6", "10", "CA")) {
-      String res = dimExtractionFn.apply(str);
+      String res = extractionFn.apply(str);
       String expected = it.next();
       Assert.assertEquals(expected, res);
     }
@@ -70,11 +93,11 @@ public class JavascriptDimExtractionFnTest
   public void testJavascriptRegex()
   {
     String function = "function(str) { return str.replace(/[aeiou]/g, ''); }";
-    DimExtractionFn dimExtractionFn = new JavascriptDimExtractionFn(function);
+    ExtractionFn extractionFn = new JavascriptExtractionFn(function);
 
     Iterator it = Iterators.forArray("Qt", "Clgry", "Tky", "Stckhlm", "Vncvr", "Prtr", "Wllngtn", "Ontr");
     for (String str : testStrings) {
-      String res = dimExtractionFn.apply(str);
+      String res = extractionFn.apply(str);
       Assert.assertEquals(it.next(), res);
     }
   }
@@ -274,13 +297,13 @@ public class JavascriptDimExtractionFnTest
                       + ""
                       + "}";
 
-    DimExtractionFn dimExtractionFn = new JavascriptDimExtractionFn(function);
+    ExtractionFn extractionFn = new JavascriptExtractionFn(function);
 
     Iterator<String> inputs = Iterators.forArray("introducing", "exploratory", "analytics", "on", "large", "datasets");
     Iterator<String> it = Iterators.forArray("introduc", "exploratori", "analyt", "on", "larg", "dataset");
 
     while(inputs.hasNext()) {
-      String res = dimExtractionFn.apply(inputs.next());
+      String res = extractionFn.apply(inputs.next());
       Assert.assertEquals(it.next(), res);
     }
   }

--- a/processing/src/test/java/io/druid/query/extraction/extraction/MatchingDimExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/extraction/MatchingDimExtractionFnTest.java
@@ -17,7 +17,9 @@
 
 package io.druid.query.extraction.extraction;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
+import io.druid.jackson.DefaultObjectMapper;
 import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.extraction.MatchingDimExtractionFn;
 import org.junit.Assert;
@@ -63,5 +65,24 @@ public class MatchingDimExtractionFnTest
     for (String str : extracted) {
       Assert.assertTrue(expected.contains(str));
     }
+  }
+
+  @Test
+  public void testSerde() throws Exception
+  {
+    final ObjectMapper objectMapper = new DefaultObjectMapper();
+    final String json = "{ \"type\" : \"partial\", \"expr\" : \".(...)?\" }";
+    MatchingDimExtractionFn extractionFn = (MatchingDimExtractionFn) objectMapper.readValue(json, ExtractionFn.class);
+
+    Assert.assertEquals(".(...)?", extractionFn.getExpr());
+
+    // round trip
+    Assert.assertEquals(
+        extractionFn,
+        objectMapper.readValue(
+            objectMapper.writeValueAsBytes(extractionFn),
+            ExtractionFn.class
+        )
+    );
   }
 }

--- a/processing/src/test/java/io/druid/query/extraction/extraction/MatchingDimExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/extraction/MatchingDimExtractionFnTest.java
@@ -18,7 +18,7 @@
 package io.druid.query.extraction.extraction;
 
 import com.google.common.collect.Sets;
-import io.druid.query.extraction.DimExtractionFn;
+import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.extraction.MatchingDimExtractionFn;
 import org.junit.Assert;
 import org.junit.Test;
@@ -47,12 +47,12 @@ public class MatchingDimExtractionFnTest
   public void testExtraction()
   {
     String regex = ".*[Tt][Oo].*";
-    DimExtractionFn dimExtractionFn = new MatchingDimExtractionFn(regex);
+    ExtractionFn extractionFn = new MatchingDimExtractionFn(regex);
     List<String> expected = Arrays.asList("Quito", "Tokyo", "Stockholm", "Pretoria", "Wellington");
     Set<String> extracted = Sets.newHashSet();
 
     for (String str : testStrings) {
-      String res = dimExtractionFn.apply(str);
+      String res = extractionFn.apply(str);
       if (res != null) {
         extracted.add(res);
       }

--- a/processing/src/test/java/io/druid/query/extraction/extraction/RegexDimExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/extraction/RegexDimExtractionFnTest.java
@@ -18,7 +18,7 @@
 package io.druid.query.extraction.extraction;
 
 import com.google.common.collect.Sets;
-import io.druid.query.extraction.DimExtractionFn;
+import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.extraction.RegexDimExtractionFn;
 import org.junit.Assert;
 import org.junit.Test;
@@ -53,11 +53,11 @@ public class RegexDimExtractionFnTest
   public void testPathExtraction()
   {
     String regex = "/([^/]+)/";
-    DimExtractionFn dimExtractionFn = new RegexDimExtractionFn(regex);
+    ExtractionFn extractionFn = new RegexDimExtractionFn(regex);
     Set<String> extracted = Sets.newHashSet();
 
     for (String path : paths) {
-      extracted.add(dimExtractionFn.apply(path));
+      extracted.add(extractionFn.apply(path));
     }
 
     Assert.assertEquals(2, extracted.size());
@@ -69,11 +69,11 @@ public class RegexDimExtractionFnTest
   public void testDeeperPathExtraction()
   {
     String regex = "^/([^/]+/[^/]+)(/|$)";
-    DimExtractionFn dimExtractionFn = new RegexDimExtractionFn(regex);
+    ExtractionFn extractionFn = new RegexDimExtractionFn(regex);
     Set<String> extracted = Sets.newHashSet();
 
     for (String path : paths) {
-      extracted.add(dimExtractionFn.apply(path));
+      extracted.add(extractionFn.apply(path));
     }
 
     Assert.assertEquals(4, extracted.size());
@@ -87,11 +87,11 @@ public class RegexDimExtractionFnTest
   public void testStringExtraction()
   {
     String regex = "(.)";
-    DimExtractionFn dimExtractionFn = new RegexDimExtractionFn(regex);
+    ExtractionFn extractionFn = new RegexDimExtractionFn(regex);
     Set<String> extracted = Sets.newHashSet();
 
     for (String testString : testStrings) {
-      extracted.add(dimExtractionFn.apply(testString));
+      extracted.add(extractionFn.apply(testString));
     }
 
     Assert.assertEquals(3, extracted.size());

--- a/processing/src/test/java/io/druid/query/extraction/extraction/RegexDimExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/extraction/RegexDimExtractionFnTest.java
@@ -17,7 +17,9 @@
 
 package io.druid.query.extraction.extraction;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
+import io.druid.jackson.DefaultObjectMapper;
 import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.extraction.RegexDimExtractionFn;
 import org.junit.Assert;
@@ -98,5 +100,24 @@ public class RegexDimExtractionFnTest
     Assert.assertTrue(extracted.contains("a"));
     Assert.assertTrue(extracted.contains("b"));
     Assert.assertTrue(extracted.contains("c"));
+  }
+
+  @Test
+  public void testSerde() throws Exception
+  {
+    final ObjectMapper objectMapper = new DefaultObjectMapper();
+    final String json = "{ \"type\" : \"regex\", \"expr\" : \".(...)?\" }";
+    RegexDimExtractionFn extractionFn = (RegexDimExtractionFn) objectMapper.readValue(json, ExtractionFn.class);
+
+    Assert.assertEquals(".(...)?", extractionFn.getExpr());
+
+    // round trip
+    Assert.assertEquals(
+        extractionFn,
+        objectMapper.readValue(
+            objectMapper.writeValueAsBytes(extractionFn),
+            ExtractionFn.class
+        )
+    );
   }
 }

--- a/processing/src/test/java/io/druid/query/extraction/extraction/SearchQuerySpecDimExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/extraction/SearchQuerySpecDimExtractionFnTest.java
@@ -18,7 +18,7 @@
 package io.druid.query.extraction.extraction;
 
 import com.google.common.collect.Sets;
-import io.druid.query.extraction.DimExtractionFn;
+import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.extraction.SearchQuerySpecDimExtractionFn;
 import io.druid.query.search.search.FragmentSearchQuerySpec;
 import io.druid.query.search.search.SearchQuerySpec;
@@ -50,12 +50,12 @@ public class SearchQuerySpecDimExtractionFnTest
     SearchQuerySpec spec = new FragmentSearchQuerySpec(
         Arrays.asList("to", "yo")
     );
-    DimExtractionFn dimExtractionFn = new SearchQuerySpecDimExtractionFn(spec);
+    ExtractionFn extractionFn = new SearchQuerySpecDimExtractionFn(spec);
     List<String> expected = Arrays.asList("Kyoto", "Tokyo", "Toyokawa", "Yorktown");
     Set<String> extracted = Sets.newHashSet();
 
     for (String str : testStrings) {
-      String res = dimExtractionFn.apply(str);
+      String res = extractionFn.apply(str);
       if (res != null) {
         extracted.add(res);
       }

--- a/processing/src/test/java/io/druid/query/extraction/extraction/TimeDimExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/extraction/TimeDimExtractionFnTest.java
@@ -18,7 +18,7 @@
 package io.druid.query.extraction.extraction;
 
 import com.google.common.collect.Sets;
-import io.druid.query.extraction.DimExtractionFn;
+import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.extraction.TimeDimExtractionFn;
 import org.junit.Assert;
 import org.junit.Test;
@@ -42,10 +42,10 @@ public class TimeDimExtractionFnTest
   public void testMonthExtraction()
   {
     Set<String> months = Sets.newHashSet();
-    DimExtractionFn dimExtractionFn = new TimeDimExtractionFn("MM/dd/yyyy", "MM/yyyy");
+    ExtractionFn extractionFn = new TimeDimExtractionFn("MM/dd/yyyy", "MM/yyyy");
 
     for (String dim : dims) {
-      months.add(dimExtractionFn.apply(dim));
+      months.add(extractionFn.apply(dim));
     }
 
     Assert.assertEquals(months.size(), 4);
@@ -59,10 +59,10 @@ public class TimeDimExtractionFnTest
   public void testQuarterExtraction()
   {
     Set<String> quarters = Sets.newHashSet();
-    DimExtractionFn dimExtractionFn = new TimeDimExtractionFn("MM/dd/yyyy", "QQQ/yyyy");
+    ExtractionFn extractionFn = new TimeDimExtractionFn("MM/dd/yyyy", "QQQ/yyyy");
 
     for (String dim : dims) {
-      quarters.add(dimExtractionFn.apply(dim));
+      quarters.add(extractionFn.apply(dim));
     }
 
     Assert.assertEquals(quarters.size(), 3);

--- a/processing/src/test/java/io/druid/query/extraction/extraction/TimeDimExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/extraction/TimeDimExtractionFnTest.java
@@ -17,8 +17,11 @@
 
 package io.druid.query.extraction.extraction;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
+import io.druid.jackson.DefaultObjectMapper;
 import io.druid.query.extraction.ExtractionFn;
+import io.druid.query.extraction.MatchingDimExtractionFn;
 import io.druid.query.extraction.TimeDimExtractionFn;
 import org.junit.Assert;
 import org.junit.Test;
@@ -69,5 +72,25 @@ public class TimeDimExtractionFnTest
     Assert.assertTrue(quarters.contains("Q1/2012"));
     Assert.assertTrue(quarters.contains("Q2/2012"));
     Assert.assertTrue(quarters.contains("Q4/2012"));
+  }
+
+  @Test
+  public void testSerde() throws Exception
+  {
+    final ObjectMapper objectMapper = new DefaultObjectMapper();
+    final String json = "{ \"type\" : \"time\", \"timeFormat\" : \"MM/dd/yyyy\", \"resultFormat\" : \"QQQ/yyyy\" }";
+    TimeDimExtractionFn extractionFn = (TimeDimExtractionFn) objectMapper.readValue(json, ExtractionFn.class);
+
+    Assert.assertEquals("MM/dd/yyyy", extractionFn.getTimeFormat());
+    Assert.assertEquals("QQQ/yyyy", extractionFn.getResultFormat());
+
+    // round trip
+    Assert.assertEquals(
+        extractionFn,
+        objectMapper.readValue(
+            objectMapper.writeValueAsBytes(extractionFn),
+            ExtractionFn.class
+        )
+    );
   }
 }

--- a/processing/src/test/java/io/druid/segment/filter/ExtractionDimFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/ExtractionDimFilterTest.java
@@ -17,7 +17,6 @@
 
 package io.druid.segment.filter;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.metamx.collections.bitmap.BitmapFactory;
 import com.metamx.collections.bitmap.ConciseBitmapFactory;
@@ -25,18 +24,15 @@ import com.metamx.collections.bitmap.ImmutableBitmap;
 import com.metamx.collections.bitmap.WrappedConciseBitmap;
 import com.metamx.collections.spatial.ImmutableRTree;
 import io.druid.query.extraction.DimExtractionFn;
+import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.filter.BitmapIndexSelector;
-import io.druid.query.filter.Filter;
 import io.druid.segment.data.ArrayIndexed;
 import io.druid.segment.data.Indexed;
 import it.uniroma3.mat.extendedset.intset.ConciseSet;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
-import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -94,7 +90,7 @@ public class ExtractionDimFilterTest
       return null;
     }
   };
-  private static final DimExtractionFn DIM_EXTRACTION_FN = new DimExtractionFn()
+  private static final ExtractionFn DIM_EXTRACTION_FN = new DimExtractionFn()
   {
     @Override
     public byte[] getCacheKey()

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
@@ -273,7 +273,7 @@ public class IncrementalIndexStorageAdapterTest
     Cursor cursor = Sequences.toList(Sequences.limit(cursorSequence, 1), Lists.<Cursor>newArrayList()).get(0);
     DimensionSelector dimSelector;
 
-    dimSelector = cursor.makeDimensionSelector("sally");
+    dimSelector = cursor.makeDimensionSelector("sally", null);
     Assert.assertEquals("bo", dimSelector.lookupName(dimSelector.getRow().get(0)));
 
     index.add(
@@ -287,7 +287,7 @@ public class IncrementalIndexStorageAdapterTest
     // Cursor reset should not be affected by out of order values
     cursor.reset();
 
-    dimSelector = cursor.makeDimensionSelector("sally");
+    dimSelector = cursor.makeDimensionSelector("sally", null);
     Assert.assertEquals("bo", dimSelector.lookupName(dimSelector.getRow().get(0)));
   }
 


### PR DESCRIPTION
Time extraction functions are similar to dimension extraction functions in that they allow mapping the time column to arbitrary Strings. Unlike granularities, they allow for non-linear mapping and aggregation across the resulting values. For example, this allows aggregating by day of the week or hour of the day and return the results either as part of a topN or groupBy similar to any other dimension.

This pull request proposes the addition of TimeExtractionDimensionSpec as a new type of DimensionSpec, as well as a the TimeExtractionFn type.

Time is not yet currently available as a true dimension, and this is not the objective of this pull request.
Current topN and groupBy queries still heavily rely on having dimension value indices, which makes it difficult to operate on an arbitrary column. For the sake of cleaner code, it therefore felt more natural to leave the concept of time extraction separate from the existing dimension extraction. This also allows for specific optimizations in for topN and groupBy, given the properties of the time dimension.

Hopefully this can help shape future work towards supporting arbitrary columns as dimensions.   