### PR TITLE
Added null check for the pagingSpec on a Select Query.

### DIFF
--- a/processing/src/main/java/io/druid/query/select/SelectQuery.java
+++ b/processing/src/main/java/io/druid/query/select/SelectQuery.java
@@ -17,6 +17,7 @@
 
 package io.druid.query.select;
 
+import com.google.common.base.Preconditions;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -60,6 +61,8 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
     this.dimensions = dimensions;
     this.metrics = metrics;
     this.pagingSpec = pagingSpec;
+
+    Preconditions.checkNotNull(pagingSpec, "must specify a pagingSpec");
   }
 
   @Override


### PR DESCRIPTION
Added a Precondition check to the constructor for the Select Query so that the error message thrown for a missing pageingSpec will be more meaningful instead of 'null exception'.