### PR TITLE
force eager the processing of segment metadata query on the processing executor

### DIFF
--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
@@ -216,7 +216,7 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
     };
   }
 
-  private Ordering<SegmentAnalysis> getOrdering()
+  public Ordering<SegmentAnalysis> getOrdering()
   {
     return new Ordering<SegmentAnalysis>()
     {


### PR DESCRIPTION
This makes sure that, irrespective of the behavior of input query runners, query runner returned by mergeRunners returns a query runner which ensures that processing really happens inside the threadpool of processor executor service instead of jetty threads which is what was intended probably.