### PR TITLE
fail early if there is no input data found for batch hadoop indexing

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
@@ -169,7 +169,11 @@ public class IndexGeneratorJob implements Jobby
 
       SortableBytes.useSortableBytesAsMapOutputKey(job);
 
-      job.setNumReduceTasks(Iterables.size(config.getAllBuckets().get()));
+      int numReducers = Iterables.size(config.getAllBuckets().get());
+      if(numReducers == 0) {
+        throw new RuntimeException("No buckets?? seems there is no data to index.");
+      }
+      job.setNumReduceTasks(numReducers);
       job.setPartitionerClass(IndexGeneratorPartitioner.class);
 
       setReducerClass(job);


### PR DESCRIPTION
this patch fails the IndexGeneratorJob early if there is no data to ingest. 
It happened in one case that batch pipeline produced no data (but one file per reducer of size 0 bytes each) and druid indexing got triggered and failed with following message.

"Caused by: java.io.FileNotFoundException: File hdfs:/path/to/my/datasource//2015-02-25T085127.338Z/segmentDescriptorInfo does not exist."

It took us a while to figure out the root cause that the problem is not in druid but there was no data to index.

this patch will fail the job early with a more appropriate error message.