### PR TITLE
correctly parse recentlyFinishedThreshold from config

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/common/config/TaskStorageConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/config/TaskStorageConfig.java
@@ -17,6 +17,7 @@
 
 package io.druid.indexing.common.config;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.joda.time.Duration;
 import org.joda.time.Period;
@@ -28,6 +29,16 @@ public class TaskStorageConfig
   @JsonProperty
   @NotNull
   public Duration recentlyFinishedThreshold = new Period("PT24H").toStandardDuration();
+
+  @JsonCreator
+  public TaskStorageConfig(
+      @JsonProperty("recentlyFinishedThreshold") Period period
+  )
+  {
+    if(period != null) {
+      this.recentlyFinishedThreshold = period.toStandardDuration();
+    }
+  }
 
   public Duration getRecentlyFinishedThreshold()
   {

--- a/indexing-service/src/test/java/io/druid/indexing/common/config/TaskStorageConfigTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/config/TaskStorageConfigTest.java
@@ -1,0 +1,53 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.indexing.common.config;
+
+import org.joda.time.Period;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.druid.jackson.DefaultObjectMapper;
+
+public class TaskStorageConfigTest
+{
+  private final ObjectMapper jsonMapper = new DefaultObjectMapper();
+
+  @Test
+  public void testDeserializationFromJson() throws Exception
+  {
+    TaskStorageConfig config = jsonMapper.readValue(
+        "{\"recentlyFinishedThreshold\": \"PT12H\" }",
+        TaskStorageConfig.class);
+    
+    Assert.assertEquals(Period.parse("PT12H").toStandardDuration(), config.getRecentlyFinishedThreshold());
+  }
+
+  @Test
+  public void testDeserializationDefault() throws Exception
+  {
+    TaskStorageConfig config = jsonMapper.readValue(
+        "{}",
+        TaskStorageConfig.class);
+    
+    Assert.assertEquals(Period.parse("PT24H").toStandardDuration(), config.getRecentlyFinishedThreshold());
+  }
+}

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLifecycleTest.java
@@ -251,7 +251,7 @@ public class TaskLifecycleTest
         TaskQueueConfig.class
     );
     ts = new HeapMemoryTaskStorage(
-        new TaskStorageConfig()
+        new TaskStorageConfig(null)
         {
         }
     );


### PR DESCRIPTION
If you have following in your runtime properties..

druid.indexer.storage.recentlyFinishedThreshold=PT12H

druid overlord startup fails with following exception...
Caused by: java.lang.IllegalArgumentException: Invalid format: "PT12H"
	at org.joda.time.convert.StringConverter.getDurationMillis(StringConverter.java:111)
	at org.joda.time.base.BaseDuration.<init>(BaseDuration.java:105)
	at org.joda.time.Duration.<init>(Duration.java:209)
	at com.fasterxml.jackson.datatype.joda.deser.DurationDeserializer.deserialize(DurationDeserializer.java:30)
	at com.fasterxml.jackson.datatype.joda.deser.DurationDeserializer.deserialize(DurationDeserializer.java:17)
	at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:464)
	at com.fasterxml.jackson.databind.deser.impl.FieldProperty.deserializeAndSet(FieldProperty.java:107)
..

because Duration deserialization can only handle strings of format "PTa.bS" . this patch fixes the issue by using Period as done for the default value already.

