### PR TITLE
Update jets3t version to support aws v4 auth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -473,7 +473,7 @@
             <dependency>
                 <groupId>net.java.dev.jets3t</groupId>
                 <artifactId>jets3t</artifactId>
-                <version>0.9.1</version>
+                <version>0.9.3</version>
                 <exclusions>
                     <exclusion>
                         <!-- exclude artifact not available in maven central -->


### PR DESCRIPTION
To address https://groups.google.com/forum/#!topic/druid-development/qADVfPyFn6U

The original message is as follows:

Hello,

i have just created a new S3 bucket.

And i ran into this error:

- http://pastebin.com/5gRS2i9S  (expires in a month, sowwie)

Authentication via "AWS4-HMAC-SHA256" is required for newer buckets.

This is supported beginning with jets3t 0.9.3

- http://www.jets3t.org/RELEASE_NOTES.html

Druid 0.7.0 currently uses jets3t 0.9.1

Thanks.