### PR TITLE
Change announcement ID to a UUID instead of Timestamp

### DIFF
--- a/common/src/main/java/io/druid/common/utils/UUIDUtils.java
+++ b/common/src/main/java/io/druid/common/utils/UUIDUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Druid - a distributed column store.
+ * Copyright 2012 - 2015 Metamarkets Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.druid.common.utils;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+
+import java.util.ArrayList;
+import java.util.UUID;
+
+/**
+ *
+ */
+public class UUIDUtils
+{
+  public static final String UUID_DELIM = "-";
+
+  /**
+   * Generates a universally unique identifier.
+   *
+   * @param extraData Extra data which often takes the form of debugging information
+   *
+   * @return A string which is a universally unique id (as determined by java.util.UUID) with extra data. It does not conform to a UUID variant standard.
+   */
+  public static String generateUuid(String... extraData)
+  {
+    String extra = null;
+    if (extraData != null && extraData.length > 0) {
+      final ArrayList<String> extraStrings = new ArrayList<>(extraData.length);
+      for (String extraString : extraData) {
+        if (!Strings.isNullOrEmpty(extraString)) {
+          extraStrings.add(extraString);
+        }
+      }
+      if (!extraStrings.isEmpty()) {
+        extra = Joiner.on(UUID_DELIM).join(extraStrings);
+      }
+    }
+    final String uuid = UUID.randomUUID().toString();
+    return extra == null ? uuid : (extra + UUID_DELIM + uuid);
+  }
+}

--- a/common/src/test/java/io/druid/common/utils/UUIDUtilsTest.java
+++ b/common/src/test/java/io/druid/common/utils/UUIDUtilsTest.java
@@ -1,0 +1,104 @@
+/*
+ * Druid - a distributed column store.
+ * Copyright 2012 - 2015 Metamarkets Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.druid.common.utils;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Lists;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ *
+ */
+@RunWith(Parameterized.class)
+public class UUIDUtilsTest
+{
+  @Parameterized.Parameters
+  public static Collection<Object[]> constructorFeeder()
+  {
+    final ArrayList<String[]> args = new ArrayList<>();
+    final List<String> possibleArgs = Lists.newArrayList("one", "two", null, "");
+    for (int i = 0; i < possibleArgs.size(); ++i) {
+      args.add(new String[]{possibleArgs.get(i)});
+      for (int j = 0; j < possibleArgs.size(); ++j) {
+        for (int k = 0; k < possibleArgs.size(); ++k) {
+          args.add(new String[]{possibleArgs.get(i), possibleArgs.get(j), possibleArgs.get(k)});
+        }
+      }
+    }
+    for(String possibleArg : possibleArgs){
+      args.add(new String[]{possibleArg});
+    }
+    return Collections2.transform(
+        args, new Function<String[], Object[]>()
+        {
+          @Override
+          public Object[] apply(String[] input)
+          {
+            final ArrayList<String> strings = new ArrayList<>(input.length);
+            for (String str : input) {
+              if (!Strings.isNullOrEmpty(str)) {
+                strings.add(str);
+              }
+            }
+            final String expected;
+            if (!strings.isEmpty()) {
+              expected = Joiner.on(UUIDUtils.UUID_DELIM).join(strings) + UUIDUtils.UUID_DELIM;
+            } else {
+              expected = "";
+            }
+            return new Object[]{input, expected};
+          }
+        }
+    );
+  }
+
+  private final String[] args;
+  private final String expectedBase;
+
+  public UUIDUtilsTest(String[] args, String expectedBase)
+  {
+    this.args = args;
+    this.expectedBase = expectedBase;
+  }
+
+  public static void validateIsStandardUUID(
+      String uuidString
+  )
+  {
+    UUID uuid = UUID.fromString(uuidString);
+    Assert.assertEquals(uuid.toString(), uuidString);
+  }
+
+  @Test
+  public void testUuid()
+  {
+    final String uuid = UUIDUtils.generateUuid(args);
+    validateIsStandardUUID(uuid.substring(expectedBase.length()));
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/druid-io/druid/issues/1217

Added unit test fails under master with 
```
Caused by: com.metamx.common.IAE: Cannot reannounce different values under the same path
at io.druid.curator.announcement.Announcer.announce(Announcer.java:267)
at io.druid.server.coordination.BatchDataSegmentAnnouncer.announceSegment(BatchDataSegmentAnnouncer.java:92)
at io.druid.client.client.BatchServerInventoryViewTest$9.run(BatchServerInventoryViewTest.java:433)
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
at java.util.concurrent.FutureTask.run(FutureTask.java:262)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
at java.lang.Thread.run(Thread.java:745)

```

But works under this branch.