### PR TITLE
Using new release of the http-client.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
             <dependency>
                 <groupId>com.metamx</groupId>
                 <artifactId>http-client</artifactId>
-                <version>1.0.0</version>
+                <version>1.0.1</version>
             </dependency>
             <dependency>
                 <groupId>com.metamx</groupId>


### PR DESCRIPTION
This new version 1.0.1 has a bug fix. Bug was  causing can not add a handler exceptions.
```
Caused by: com.metamx.common.ISE: Cannot add a handler after the Lifecycle has started, it doesn't work that way.
at com.metamx.common.lifecycle.Lifecycle.addHandler(Lifecycle.java:153)
at com.metamx.common.lifecycle.Lifecycle.addHandler(Lifecycle.java:139)
```
Bug description can be found [here](https://github.com/metamx/http-client/pull/16)