### PR TITLE
Honor ignoreInvalidRows in reducer of Hadoop indexer 

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerMapper.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerMapper.java
@@ -17,6 +17,7 @@
 
 package io.druid.indexer;
 
+import com.metamx.common.logger.Logger;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.impl.InputRowParser;
 import io.druid.data.input.impl.MapInputRowParser;
@@ -42,6 +43,8 @@ import com.metamx.common.RE;
 
 public abstract class HadoopDruidIndexerMapper<KEYOUT, VALUEOUT> extends Mapper<Writable, Writable, KEYOUT, VALUEOUT>
 {
+  private static final Logger log = new Logger(HadoopDruidIndexerMapper.class);
+
   private HadoopDruidIndexerConfig config;
   private InputRowParser parser;
   protected GranularitySpec granularitySpec;
@@ -77,6 +80,7 @@ public abstract class HadoopDruidIndexerMapper<KEYOUT, VALUEOUT> extends Mapper<
       }
       catch (Exception e) {
         if (config.isIgnoreInvalidRows()) {
+          log.debug(e, "Ignoring invalid row [%s] due to parsing error", value.toString());
           context.getCounter(HadoopDruidIndexerConfig.IndexJobCounters.INVALID_ROW_COUNTER).increment(1);
           return; // we're ignoring this invalid row
         } else {


### PR DESCRIPTION
In the reducer of the Hadoop indexer, exceptions are sometimes thrown for invalid column values. This change ignores those lines if 'ignoreInvalidRows' flag is enabled, similar to the mapper.

Without this change, the Hadoop Indexer job failed due to 1 line that was corrupt.