### PR TITLE
Update MapDB to version 1.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -501,7 +501,7 @@
             <dependency>
                 <groupId>org.mapdb</groupId>
                 <artifactId>mapdb</artifactId>
-                <version>1.0.6</version>
+                <version>1.0.7</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.derby</groupId>


### PR DESCRIPTION
The update fixes a bunch of HTree issues which we have not encountered yet, but we use HTRee in many of our MapDB usages
http://www.mapdb.org/changelog.html#Version_107_2015-02-19