### PR TITLE
Fix for concurrent jobs causing lease mismatches on resources in classpath

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
@@ -62,7 +62,7 @@ public class JobHelper
     String[] jarFiles = classpathProperty.split(File.pathSeparator);
 
     final Configuration conf = job.getConfiguration();
-    final Path distributedClassPath = new Path(config.getWorkingPath(), "classpath");
+    final Path distributedClassPath = new Path(config.makeIntermediatePath(), "classpath");
     final FileSystem fs = distributedClassPath.getFileSystem(conf);
 
     if (fs instanceof LocalFileSystem) {


### PR DESCRIPTION
Running simultaneous hadoop-index jobs was resulting in frequent lease mismatch exceptions on resources stored in the classpath. The classpath was being saved in the `hadoopWorkingPath` to be distributed among jobs but it causes too many issues with concurrent jobs. Moving the the intermediate path that takes into account `datasource` and `interval` alleviates this issue, although we lose the optimization of a distributed classpath. The classpaths are cleaned up after job runs however.