### PR TITLE
Update mysql-connector-java to 5.1.34

### DIFF
--- a/extensions/mysql-metadata-storage/pom.xml
+++ b/extensions/mysql-metadata-storage/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.33</version>
+            <version>5.1.34</version>
         </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>


### PR DESCRIPTION
This fixes errors such as `com.mysql.jdbc.exceptions.jdbc4.MySQLSyntaxErrorException: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'OPTION SQL_SELECT_LIMIT=DEFAULT'` that can occur for recent MySQL versions.

See https://groups.google.com/forum/#!topic/druid-user/FEy_46r_yEI