### PR TITLE
Exclude log4j from curator dependencies in favor of log4j-1.2-api

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -133,6 +133,10 @@
             <artifactId>log4j-jul</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
         </dependency>

--- a/docs/content/Production-Cluster-Configuration.md
+++ b/docs/content/Production-Cluster-Configuration.md
@@ -92,6 +92,7 @@ JVM Configuration:
 -XX:+PrintGCTimeStamps
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
+-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
 -Djava.io.tmpdir=/mnt/tmp
 ```
 
@@ -147,6 +148,7 @@ JVM Configuration:
 -XX:+PrintGCTimeStamps
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
+-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
 -Djava.io.tmpdir=/mnt/tmp
 ```
 
@@ -210,6 +212,7 @@ JVM Configuration:
 -XX:+PrintGCTimeStamps
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
+-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
 -Djava.io.tmpdir=/mnt/tmp
 ```
 
@@ -249,6 +252,7 @@ JVM Configuration:
 -XX:+PrintGCTimeStamps
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
+-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
 -Djava.io.tmpdir=/mnt/tmp
 ```
 
@@ -301,6 +305,7 @@ JVM Configuration:
 -XX:+PrintGCTimeStamps
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
+-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
 -Djava.io.tmpdir=/mnt/tmp
 
 -Dcom.sun.management.jmxremote.port=17071

--- a/docs/content/Simple-Cluster-Configuration.md
+++ b/docs/content/Simple-Cluster-Configuration.md
@@ -32,6 +32,7 @@ Configuration:
 -Xmx256m
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
+-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
 
 -Ddruid.indexer.queue.startDelay=PT0M
 -Ddruid.indexer.runner.javaOpts="-server -Xmx1g"
@@ -56,6 +57,7 @@ Configuration:
 -Xmx256m
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
+-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
 
 druid.coordinator.startDelay=PT70s
 ```
@@ -77,6 +79,7 @@ Configuration:
 -Xmx256m
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
+-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
 
 druid.server.maxSize=10000000000
 
@@ -103,6 +106,7 @@ Configuration:
 -Xmx256m
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
+-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
 
 druid.processing.buffer.sizeBytes=100000000
 druid.processing.numThreads=1

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <jetty.version>9.2.5.v20141112</jetty.version>
         <druid.api.version>0.3.5</druid.api.version>
         <jackson.version>2.4.4</jackson.version>
-        <log4j.version>2.1</log4j.version>
+        <log4j.version>2.2</log4j.version>
         <slf4j.version>1.7.10</slf4j.version>
     </properties>
 
@@ -611,7 +611,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
                         <!-- locale settings must be set on the command line before startup -->
-                        <argLine>-Duser.language=en -Duser.country=US</argLine>
+                        <argLine>-Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8 -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager</argLine>
                         <!-- our tests are very verbose, let's keep the volume down -->
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     </configuration>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -67,6 +67,13 @@
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-framework</artifactId>
+            <!-- We use log4j2 and log4j-1.2-api as a bridge -->
+            <exclusions>
+              <exclusion>
+                <artifactId>log4j</artifactId>
+                <groupId>log4j</groupId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>


### PR DESCRIPTION
Ran into this one while working with some Mesos deployments. Curator draws in Zookeeper, which draws in log4j 1.2.16, this prevents said dependency from being pulled into Druid.