### PR TITLE
adding router numMaxThread configuration for ProxyServlet HttpClient executor

### DIFF
--- a/docs/content/Router.md
+++ b/docs/content/Router.md
@@ -56,6 +56,9 @@ druid.router.tierToBrokerMap={"hot":"druid:prod:broker-hot","_default_tier":"dru
 druid.router.http.numConnections=50
 druid.router.http.readTimeout=PT5M
 
+# Number of threads used by the router proxy http client
+druid.router.http.numMaxThreads=100
+
 druid.server.http.numThreads=100
 ```
 

--- a/server/src/main/java/io/druid/guice/http/DruidHttpClientConfig.java
+++ b/server/src/main/java/io/druid/guice/http/DruidHttpClientConfig.java
@@ -35,6 +35,10 @@ public class DruidHttpClientConfig
   @JsonProperty
   private Period readTimeout = new Period("PT15M");
 
+  @JsonProperty
+  @Min(1)
+  private int numMaxThreads = Math.max(10, (Runtime.getRuntime().availableProcessors() * 17) / 16 + 2) + 30;
+
   public int getNumConnections()
   {
     return numConnections;
@@ -43,5 +47,10 @@ public class DruidHttpClientConfig
   public Duration getReadTimeout()
   {
     return readTimeout == null ? null : readTimeout.toStandardDuration();
+  }
+
+  public int getNumMaxThreads()
+  {
+    return numMaxThreads;
   }
 }

--- a/services/src/main/java/io/druid/cli/RouterJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/RouterJettyServerInitializer.java
@@ -89,7 +89,11 @@ public class RouterJettyServerInitializer implements JettyServerInitializer
         requestLogger
     );
     asyncQueryForwardingServlet.setTimeout(httpClientConfig.getReadTimeout().getMillis());
-    root.addServlet(new ServletHolder(asyncQueryForwardingServlet), "/druid/v2/*");
+    ServletHolder sh = new ServletHolder(asyncQueryForwardingServlet);
+    //NOTE: explicit maxThreads to workaround https://tickets.puppetlabs.com/browse/TK-152
+    sh.setInitParameter("maxThreads", Integer.toString(httpClientConfig.getNumMaxThreads()));
+
+    root.addServlet(sh, "/druid/v2/*");
     JettyServerInitUtils.addExtensionFilters(root, injector);
     root.addFilter(JettyServerInitUtils.defaultAsyncGzipFilterHolder(), "/*", null);
     // Can't use '/*' here because of Guice conflicts with AsyncQueryForwardingServlet path


### PR DESCRIPTION
workaround for https://tickets.puppetlabs.com/browse/TK-152

I'm not really sure if we need to merge this one. one workaround without code change is to just increase number of jetty threads at the router in case it is getting blocked for someone.
