### PR TITLE
fixes TimeboundaryQuery and DataSourceMetadata queries returning wrong values for union queries 

### DIFF
--- a/common/src/main/java/io/druid/timeline/TimelineLookup.java
+++ b/common/src/main/java/io/druid/timeline/TimelineLookup.java
@@ -31,7 +31,7 @@ public interface TimelineLookup<VersionType, ObjectType>
    * @param interval interval to find objects for
    *
    * @return Holders representing the interval that the objects exist for, PartitionHolders
-   *         are guaranteed to be complete
+   *         are guaranteed to be complete. Holders returned sorted by the interval.
    */
   public Iterable<TimelineObjectHolder<VersionType, ObjectType>> lookup(Interval interval);
 

--- a/common/src/test/java/io/druid/timeline/VersionedIntervalTimelineTest.java
+++ b/common/src/test/java/io/druid/timeline/VersionedIntervalTimelineTest.java
@@ -1608,10 +1608,10 @@ public class VersionedIntervalTimelineTest
     assertValues(
         Arrays.asList(
             createExpected("2011-04-01/2011-04-02", "3", 5),
-            createExpected("2011-04-02/2011-04-06", "2", 1),
-            createExpected("2011-04-06/2011-04-09", "3", 4),
             createExpected("2011-04-01/2011-04-02", "3", 5),
             createExpected("2011-04-02/2011-04-06", "2", 1),
+            createExpected("2011-04-02/2011-04-06", "2", 1),
+            createExpected("2011-04-06/2011-04-09", "3", 4),
             createExpected("2011-04-06/2011-04-09", "3", 4)
         ),
         (List)Lists.newArrayList(lookup.lookup(new Interval("2011-04-01/2011-04-09")))
@@ -1632,12 +1632,43 @@ public class VersionedIntervalTimelineTest
     assertValues(
         Arrays.asList(
             createExpected("2011-04-01/2011-04-02", "3", 5),
-            createExpected("2011-04-02/2011-04-06", "2", 1),
-            createExpected("2011-04-06/2011-04-09", "3", 4),
             createExpected("2011-04-01/2011-04-02", "3", 5),
             createExpected("2011-04-02/2011-04-06", "2", 1),
+            createExpected("2011-04-02/2011-04-06", "2", 1),
+            createExpected("2011-04-06/2011-04-09", "3", 4),
             createExpected("2011-04-06/2011-04-09", "3", 4)
         ),
         (List)Lists.newArrayList(lookup.lookup(new Interval("2011-04-01/2011-04-09")))    );
   }
+
+  @Test
+  public void testUnionTimeLineLookupReturnsSortedValues()
+  {
+    timeline = makeStringIntegerTimeline();
+    add("2011-04-02/2011-04-06", "1", 1);
+    add("2011-04-03/2011-04-09", "9", 2);
+    VersionedIntervalTimeline t1 = timeline;
+    timeline = makeStringIntegerTimeline();
+    add("2011-04-01/2011-04-03", "2", 1);
+    add("2011-04-03/2011-04-10", "8", 2);
+    VersionedIntervalTimeline t2 = timeline;
+    TimelineLookup<String, Integer> lookup = new UnionTimeLineLookup<String, Integer>(
+        Arrays.<TimelineLookup<String, Integer>>asList(
+            t1, t2
+        )
+    );
+    assertValues(
+        Arrays.asList(
+            createExpected("2011-04-01/2011-04-03", "2", 1),
+            createExpected("2011-04-02/2011-04-03", "1", 1),
+            createExpected("2011-04-03/2011-04-09", "9", 2),
+            createExpected("2011-04-03/2011-04-10", "8", 2)
+
+        ),
+        (List) Lists.newArrayList(lookup.lookup(new Interval("2011-04-01/2011-04-11")))
+    );
+  }
+
+
+
 }

--- a/processing/src/main/java/io/druid/query/QueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/QueryToolChest.java
@@ -76,6 +76,11 @@ public abstract class QueryToolChest<ResultType, QueryType extends Query<ResultT
     return runner;
   }
 
+  /**
+   * @param query
+   * @param segments list of segments sorted by segment intervals.
+   * @return list of segments to be queried in order to determine query results.
+   */
   public <T extends LogicalSegment> List<T> filterSegments(QueryType query, List<T> segments)
   {
     return segments;


### PR DESCRIPTION
fixes TimeboundaryQuery and DataSourceMetadata queries returning wrong values for union queries due to filtering based on unordered segments. 