### PR TITLE
Bug fix @DruidSecondaryModule plus unit test

### DIFF
--- a/common/src/main/java/io/druid/guice/DruidSecondaryModule.java
+++ b/common/src/main/java/io/druid/guice/DruidSecondaryModule.java
@@ -43,7 +43,6 @@ public class DruidSecondaryModule implements Module
   private final ObjectMapper jsonMapper;
   private final ObjectMapper smileMapper;
   private final Validator validator;
-  private final JsonConfigurator jsonConfigurator;
 
   @Inject
   public DruidSecondaryModule(
@@ -51,8 +50,7 @@ public class DruidSecondaryModule implements Module
       ConfigurationObjectFactory factory,
       @Json ObjectMapper jsonMapper,
       @Smile ObjectMapper smileMapper,
-      Validator validator,
-      JsonConfigurator jsonConfigurator
+      Validator validator
   )
   {
     this.properties = properties;
@@ -60,7 +58,6 @@ public class DruidSecondaryModule implements Module
     this.jsonMapper = jsonMapper;
     this.smileMapper = smileMapper;
     this.validator = validator;
-    this.jsonConfigurator = jsonConfigurator;
   }
 
   @Override
@@ -69,10 +66,9 @@ public class DruidSecondaryModule implements Module
     binder.install(new DruidGuiceExtensions());
     binder.bind(Properties.class).toInstance(properties);
     binder.bind(ConfigurationObjectFactory.class).toInstance(factory);
-    // make objectMapper eager to ensure jackson gets setup with guice injection for JsonConfigurator
-    binder.bind(ObjectMapper.class).to(Key.get(ObjectMapper.class, Json.class)).asEagerSingleton();
+    binder.bind(ObjectMapper.class).to(Key.get(ObjectMapper.class, Json.class));
     binder.bind(Validator.class).toInstance(validator);
-    binder.bind(JsonConfigurator.class).toInstance(jsonConfigurator);
+    binder.bind(JsonConfigurator.class);
   }
 
   @Provides @LazySingleton @Json

--- a/processing/src/test/java/io/druid/guice/GuiceInjectorsTest.java
+++ b/processing/src/test/java/io/druid/guice/GuiceInjectorsTest.java
@@ -1,0 +1,77 @@
+package io.druid.guice;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.google.inject.Binder;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Provider;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class GuiceInjectorsTest
+{
+  @Test public void testSanity()
+  {
+    Injector stageOne = GuiceInjectors.makeStartupInjector();
+
+    Module module = stageOne.getInstance(DruidSecondaryModule.class);
+
+    Injector stageTwo = Guice.createInjector(module, new Module()
+    {
+      @Override public void configure(Binder binder)
+      {
+        binder.bind(String.class).toInstance("Expected String");
+        JsonConfigProvider.bind(binder, "druid.emitter.", Emitter.class);
+        binder.bind(CustomEmitter.class).toProvider(new CustomEmitterFactory());
+      }
+    });
+
+
+    CustomEmitter customEmitter = stageTwo.getInstance(CustomEmitter.class);
+
+    Assert.assertEquals("Expected String", customEmitter.getOtherValue());
+  }
+
+  private static class Emitter {
+
+    @JacksonInject
+    private String value;
+
+    public String getValue()
+    {
+      return value;
+    }
+  }
+
+  private class CustomEmitterFactory implements Provider<CustomEmitter> {
+
+    private Emitter emitter;
+    private Injector injector;
+
+    @com.google.inject.Inject
+    public void configure(Injector injector) {
+      this.injector = injector;
+      emitter = injector.getInstance(Emitter.class);
+    }
+
+    @Override public CustomEmitter get()
+    {
+      return new CustomEmitter(emitter);
+    }
+  }
+
+  private static class CustomEmitter
+  {
+    public String getOtherValue()
+    {
+      return emitter.getValue();
+    }
+
+    private Emitter emitter;
+
+    public CustomEmitter(Emitter emitter){
+      this.emitter = emitter;
+    }
+  }
+}


### PR DESCRIPTION
This PR has a fix and unit test to catch the bug.
The bug will raise when a module use the `JsonConfigurator` while the Guice built in `.asEagerSingleton()` start for `ObjectMapper` did not initialize it yet.

```java
Caused by: java.lang.IllegalStateException: No 'injectableValues' configured, can not inject value with id [java.lang.String]
	at com.fasterxml.jackson.databind.DeserializationContext.findInjectableValue(DeserializationContext.java:291)
	at com.fasterxml.jackson.databind.deser.impl.ValueInjector.findValue(ValueInjector.java:46)
	at com.fasterxml.jackson.databind.deser.impl.ValueInjector.inject(ValueInjector.java:52)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.injectValues(BeanDeserializerBase.java:1237)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:290)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:124)
	at com.fasterxml.jackson.databind.ObjectMapper._convert(ObjectMapper.java:2769)
	at com.fasterxml.jackson.databind.ObjectMapper.convertValue(ObjectMapper.java:2700)
	at io.druid.guice.JsonConfigurator.configurate(JsonConfigurator.java:81)
	at io.druid.guice.JsonConfigProvider.get(JsonConfigProvider.java:181)
	at io.druid.guice.JsonConfigProvider.get(JsonConfigProvider.java:60)
	at com.google.inject.internal.ProviderInternalFactory.provision(ProviderInternalFactory.java:86)
	at com.google.inject.internal.InternalFactoryToInitializableAdapter.provision(InternalFactoryToInitializableAdapter.java:55)
	at com.google.inject.internal.ProviderInternalFactory.circularGet(ProviderInternalFactory.java:66)
	at com.google.inject.internal.InternalFactoryToInitializableAdapter.get(InternalFactoryToInitializableAdapter.java:47)
	at 

```