### PR TITLE
revert to using pure Java LZ4 implementation

### DIFF
--- a/processing/src/main/java/io/druid/segment/data/CompressedObjectStrategy.java
+++ b/processing/src/main/java/io/druid/segment/data/CompressedObjectStrategy.java
@@ -220,8 +220,8 @@ public class CompressedObjectStrategy<T extends Buffer> implements ObjectStrateg
 
   public static class LZ4Decompressor implements Decompressor
   {
-    private static final LZ4SafeDecompressor lz4Safe = LZ4Factory.fastestInstance().safeDecompressor();
-    private static final LZ4FastDecompressor lz4Fast = LZ4Factory.fastestInstance().fastDecompressor();
+    private static final LZ4SafeDecompressor lz4Safe = LZ4Factory.fastestJavaInstance().safeDecompressor();
+    private static final LZ4FastDecompressor lz4Fast = LZ4Factory.fastestJavaInstance().fastDecompressor();
     private static final LZ4Decompressor defaultDecompressor = new LZ4Decompressor();
 
     @Override
@@ -245,7 +245,7 @@ public class CompressedObjectStrategy<T extends Buffer> implements ObjectStrateg
   public static class LZ4Compressor implements Compressor
   {
     private static final LZ4Compressor defaultCompressor = new LZ4Compressor();
-    private static final net.jpountz.lz4.LZ4Compressor lz4High = LZ4Factory.fastestInstance().highCompressor();
+    private static final net.jpountz.lz4.LZ4Compressor lz4High = LZ4Factory.fastestJavaInstance().highCompressor();
 
     @Override
     public byte[] compress(byte[] bytes)


### PR DESCRIPTION
Native LZ4 can be faster on some platforms (up to 18% faster on Linux), and slower on other platforms (up to 15% slower on OS X). This change reverts back to using only the java only implementation for more predictable performance across all platforms.