### PR TITLE
Azure Deep Storage extension

### DIFF
--- a/docs/content/Deep-Storage.md
+++ b/docs/content/Deep-Storage.md
@@ -54,3 +54,17 @@ If you are using the Hadoop indexer, set your output directory to be a location 
 
 Please note that this is a community contributed module and does not support Cassandra 2.x or hadoop-based batch indexing. For more information on using Cassandra as deep storage, see [Cassandra Deep Storage](Cassandra-Deep-Storage.html).
 
+## Azure
+
+[Microsoft Azure Storage](http://azure.microsoft.com/en-us/services/storage/) is another option for deep storage. This requires some additional druid configuration.
+
+```
+druid.storage.type=azure
+druid.azure.account=<azure storage account>
+druid.azure.key=<azure storage account key>
+druid.azure.container=<azure storage container>
+druid.azure.protocol=<optional; valid options: https or http; default: https>
+druid.azure.maxTries=<optional; number of tries before give up an Azure operation; default: 3; min: 1>
+```
+
+Please note that this is a community contributed module. See [Azure Services](http://azure.microsoft.com/en-us/pricing/free-trial/) for more information.

--- a/extensions/azure-extensions/pom.xml
+++ b/extensions/azure-extensions/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Druid - a distributed column store.
+  ~ Copyright 2012 - 2015 Metamarkets Group Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.druid.extensions</groupId>
+    <artifactId>druid-azure-extensions</artifactId>
+    <name>druid-azure-extensions</name>
+    <description>druid-azure-extensions</description>
+
+    <parent>
+        <groupId>io.druid</groupId>
+        <artifactId>druid</artifactId>
+        <version>0.7.2-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.druid</groupId>
+            <artifactId>druid-api</artifactId>
+        </dependency>
+
+      <dependency>
+          <groupId>com.microsoft.azure</groupId>
+          <artifactId>azure-storage</artifactId>
+          <version>2.1.0</version>
+      </dependency>
+
+        <!-- Tests -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/extensions/azure-extensions/src/main/java/io/druid/storage/azure/AzureAccountConfig.java
+++ b/extensions/azure-extensions/src/main/java/io/druid/storage/azure/AzureAccountConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Druid - a distributed column store.
+ * Copyright 2012 - 2015 Metamarkets Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.druid.storage.azure;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+public class AzureAccountConfig
+{
+  @JsonProperty
+  private String protocol = "https";
+
+  @JsonProperty
+  @Min(1)
+  private int maxTries = 3;
+
+  @JsonProperty
+  @NotNull
+  private String account;
+
+  @JsonProperty
+  @NotNull
+  private String key;
+
+  @JsonProperty
+  @NotNull
+  private String container;
+
+  public String getProtocol() { return protocol; }
+
+  public int getMaxTries() { return maxTries; }
+
+  public String getAccount() { return account; }
+
+  public String getKey() { return key;}
+
+  public String getContainer() { return container; }
+}

--- a/extensions/azure-extensions/src/main/java/io/druid/storage/azure/AzureByteSource.java
+++ b/extensions/azure-extensions/src/main/java/io/druid/storage/azure/AzureByteSource.java
@@ -1,0 +1,56 @@
+/*
+ * Druid - a distributed column store.
+ *  Copyright 2012 - 2015 Metamarkets Group Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.druid.storage.azure;
+
+import com.google.common.base.Throwables;
+import com.google.common.io.ByteSource;
+import com.microsoft.azure.storage.StorageException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+
+public class AzureByteSource extends ByteSource
+{
+
+  final private AzureStorageContainer azureStorageContainer;
+  final private String filePath;
+
+  public AzureByteSource(
+      AzureStorageContainer azureStorageContainer,
+      String filePath
+  )
+  {
+    this.azureStorageContainer = azureStorageContainer;
+    this.filePath = filePath;
+  }
+
+  @Override
+  public InputStream openStream() throws IOException
+  {
+    try {
+      return azureStorageContainer.getBlobInputStream(filePath);
+    }
+    catch (StorageException | URISyntaxException e) {
+      if (AzureUtils.AZURE_RETRY.apply(e)) {
+        throw new IOException("Recoverable exception", e);
+      }
+      throw Throwables.propagate(e);
+    }
+  }
+}

--- a/extensions/azure-extensions/src/main/java/io/druid/storage/azure/AzureDataSegmentKiller.java
+++ b/extensions/azure-extensions/src/main/java/io/druid/storage/azure/AzureDataSegmentKiller.java
@@ -1,0 +1,61 @@
+/*
+ * Druid - a distributed column store.
+ * Copyright 2012 - 2015 Metamarkets Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.druid.storage.azure;
+
+import com.google.inject.Inject;
+import com.metamx.common.MapUtils;
+import com.metamx.common.logger.Logger;
+import com.microsoft.azure.storage.StorageException;
+import io.druid.segment.loading.DataSegmentKiller;
+import io.druid.segment.loading.SegmentLoadingException;
+import io.druid.timeline.DataSegment;
+
+import java.net.URISyntaxException;
+import java.util.Map;
+
+public class AzureDataSegmentKiller implements DataSegmentKiller
+{
+  private static final Logger log = new Logger(AzureDataSegmentKiller.class);
+
+  private final AzureStorageContainer azureStorageContainer;
+
+  @Inject
+  public AzureDataSegmentKiller(
+      final AzureStorageContainer azureStorageContainer
+  )
+  {
+    this.azureStorageContainer = azureStorageContainer;
+  }
+
+  @Override
+  public void kill(DataSegment segment) throws SegmentLoadingException
+  {
+    log.info("Killing segment [%s]", segment);
+
+    Map<String, Object> loadSpec = segment.getLoadSpec();
+    String storageDir = MapUtils.getString(loadSpec, "storageDir");
+
+    try {
+      azureStorageContainer.emptyCloudBlobDirectory(storageDir);
+    }
+    catch (StorageException | URISyntaxException e) {
+      throw new SegmentLoadingException(e, "Couldn't kill segment[%s]", segment.getIdentifier());
+    }
+  }
+
+}

--- a/extensions/azure-extensions/src/main/java/io/druid/storage/azure/AzureDataSegmentPuller.java
+++ b/extensions/azure-extensions/src/main/java/io/druid/storage/azure/AzureDataSegmentPuller.java
@@ -1,0 +1,106 @@
+/*
+ * Druid - a distributed column store.
+ * Copyright 2012 - 2015 Metamarkets Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.druid.storage.azure;
+
+import com.google.common.io.ByteSource;
+import com.google.inject.Inject;
+import com.metamx.common.ISE;
+import com.metamx.common.MapUtils;
+import com.metamx.common.logger.Logger;
+import io.druid.segment.loading.DataSegmentPuller;
+import io.druid.segment.loading.SegmentLoadingException;
+import io.druid.timeline.DataSegment;
+import com.metamx.common.CompressionUtils;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+public class AzureDataSegmentPuller implements DataSegmentPuller
+{
+  private static final Logger log = new Logger(AzureDataSegmentPuller.class);
+
+  private final AzureStorageContainer azureStorageContainer;
+
+  @Inject
+  public AzureDataSegmentPuller(
+      AzureStorageContainer azureStorageContainer
+  )
+  {
+    this.azureStorageContainer = azureStorageContainer;
+  }
+
+  public com.metamx.common.FileUtils.FileCopyResult getSegmentFiles(final String storageDir, final File outDir)
+      throws SegmentLoadingException
+  {
+    prepareOutDir(outDir);
+
+    try {
+
+      final String filePath = String.format("%s/%s", storageDir, AzureStorageDruidModule.INDEX_ZIP_FILE_NAME);
+      final ByteSource byteSource = new AzureByteSource(azureStorageContainer, filePath);
+      final com.metamx.common.FileUtils.FileCopyResult result = CompressionUtils.unzip(
+          byteSource,
+          outDir,
+          AzureUtils.AZURE_RETRY,
+          true
+      );
+
+      log.info("Loaded %d bytes from [%s] to [%s]", result.size(), filePath, outDir.getAbsolutePath());
+      return result;
+    }
+    catch (IOException e) {
+      try {
+        FileUtils.deleteDirectory(outDir);
+      }
+      catch (IOException ioe) {
+        log.warn(
+            ioe,
+            "Failed to remove output directory [%s] for segment pulled from [%s]",
+            outDir.getAbsolutePath(),
+            storageDir
+        );
+      }
+      throw new SegmentLoadingException(e, e.getMessage());
+    }
+
+  }
+
+  @Override
+  public void getSegmentFiles(DataSegment segment, File outDir) throws SegmentLoadingException
+  {
+
+    final Map<String, Object> loadSpec = segment.getLoadSpec();
+    final String storageDir = MapUtils.getString(loadSpec, "storageDir");
+
+    getSegmentFiles(storageDir, outDir);
+  }
+
+  public void prepareOutDir(final File outDir) throws ISE
+  {
+    if (!outDir.exists()) {
+      outDir.mkdirs();
+    }
+
+    if (!outDir.isDirectory()) {
+      throw new ISE("[%s] must be a directory.", outDir);
+    }
+
+  }
+}

--- a/extensions/azure-extensions/src/main/java/io/druid/storage/azure/AzureDataSegmentPusher.java
+++ b/extensions/azure-extensions/src/main/java/io/druid/storage/azure/AzureDataSegmentPusher.java
@@ -1,0 +1,164 @@
+/*
+ * Druid - a distributed column store.
+ * Copyright 2012 - 2015 Metamarkets Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.druid.storage.azure;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import com.metamx.common.CompressionUtils;
+import com.metamx.common.RetryUtils;
+import com.metamx.common.logger.Logger;
+import com.microsoft.azure.storage.StorageException;
+import io.druid.segment.SegmentUtils;
+import io.druid.segment.loading.DataSegmentPusher;
+import io.druid.segment.loading.DataSegmentPusherUtil;
+import io.druid.timeline.DataSegment;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+public class AzureDataSegmentPusher implements DataSegmentPusher
+{
+
+  private static final Logger log = new Logger(AzureDataSegmentPusher.class);
+  private final AzureStorageContainer azureStorageContainer;
+  private final AzureAccountConfig azureAccountConfig;
+  private final ObjectMapper jsonMapper;
+
+  @Inject
+  public AzureDataSegmentPusher(
+      AzureStorageContainer azureStorageContainer,
+      AzureAccountConfig azureAccountConfig,
+      ObjectMapper jsonMapper
+  )
+  {
+    this.azureStorageContainer = azureStorageContainer;
+    this.azureAccountConfig = azureAccountConfig;
+    this.jsonMapper = jsonMapper;
+  }
+
+  @Override
+  public String getPathForHadoop(String dataSource)
+  {
+    return null;
+  }
+
+  public File createCompressedSegmentDataFile(final File indexFilesDir) throws IOException
+  {
+    final File zipOutFile = File.createTempFile("index", ".zip");
+    CompressionUtils.zip(indexFilesDir, zipOutFile);
+
+    return zipOutFile;
+
+  }
+
+  public File createSegmentDescriptorFile(final ObjectMapper jsonMapper, final DataSegment segment) throws
+                                                                                                    IOException
+  {
+    File descriptorFile = File.createTempFile("descriptor", ".json");
+    try (FileOutputStream stream = new FileOutputStream(descriptorFile)) {
+      stream.write(jsonMapper.writeValueAsBytes(segment));
+    }
+
+    return descriptorFile;
+  }
+
+  public Map<String, String> getAzurePaths(final DataSegment segment)
+  {
+    final String storageDir = DataSegmentPusherUtil.getStorageDir(segment);
+
+    return ImmutableMap.of(
+        "storage", storageDir,
+        "index", String.format("%s/%s", storageDir, AzureStorageDruidModule.INDEX_ZIP_FILE_NAME),
+        "descriptor", String.format("%s/%s", storageDir, AzureStorageDruidModule.DESCRIPTOR_FILE_NAME)
+    );
+
+  }
+
+  public <T> T retryAzureOperation(Callable<T> f, int maxTries) throws Exception
+  {
+    return RetryUtils.retry(f, AzureUtils.AZURE_RETRY, maxTries);
+  }
+
+  public void uploadThenDelete(final File file, final String azurePath)
+      throws StorageException, IOException, URISyntaxException
+  {
+    azureStorageContainer.uploadBlob(file, azurePath);
+    log.info("Deleting file [%s]", file);
+    file.delete();
+  }
+
+  public DataSegment uploadDataSegment(
+      DataSegment segment,
+      final int version,
+      final File compressedSegmentData,
+      final File descriptorFile,
+      final Map<String, String> azurePaths
+  )
+      throws StorageException, IOException, URISyntaxException
+  {
+    uploadThenDelete(compressedSegmentData, azurePaths.get("index"));
+    uploadThenDelete(descriptorFile, azurePaths.get("descriptor"));
+
+    return segment
+        .withSize(compressedSegmentData.length())
+        .withLoadSpec(
+            ImmutableMap.<String, Object>of(
+                "type",
+                AzureStorageDruidModule.SCHEME,
+                "storageDir",
+                azurePaths.get("storage")
+            )
+        )
+        .withBinaryVersion(version);
+  }
+
+  @Override
+  public DataSegment push(final File indexFilesDir, final DataSegment segment) throws IOException
+  {
+
+    log.info("Uploading [%s] to Azure.", indexFilesDir);
+
+    final int version = SegmentUtils.getVersionFromDir(indexFilesDir);
+    final File compressedSegmentData = createCompressedSegmentDataFile(indexFilesDir);
+    final File descriptorFile = createSegmentDescriptorFile(jsonMapper, segment);
+    final Map<String, String> azurePaths = getAzurePaths(segment);
+
+    try {
+      return retryAzureOperation(
+          new Callable<DataSegment>()
+          {
+            @Override
+            public DataSegment call() throws Exception
+            {
+              return uploadDataSegment(segment, version, compressedSegmentData, descriptorFile, azurePaths);
+            }
+          },
+          azureAccountConfig.getMaxTries()
+      );
+    }
+    catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+}

--- a/extensions/azure-extensions/src/main/java/io/druid/storage/azure/AzureLoadSpec.java
+++ b/extensions/azure-extensions/src/main/java/io/druid/storage/azure/AzureLoadSpec.java
@@ -1,0 +1,54 @@
+/*
+ * Druid - a distributed column store.
+ *  Copyright 2012 - 2015 Metamarkets Group Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.druid.storage.azure;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.base.Preconditions;
+import io.druid.segment.loading.LoadSpec;
+import io.druid.segment.loading.SegmentLoadingException;
+
+import java.io.File;
+
+@JsonTypeName(AzureStorageDruidModule.SCHEME)
+public class AzureLoadSpec implements LoadSpec
+{
+  @JsonProperty
+  private final String storageDir;
+
+  private final AzureDataSegmentPuller puller;
+
+  @JsonCreator
+  public AzureLoadSpec(
+      @JacksonInject AzureDataSegmentPuller puller,
+      @JsonProperty("storageDir") String storageDir
+  )
+  {
+    Preconditions.checkNotNull(storageDir);
+    this.storageDir = storageDir;
+    this.puller = puller;
+  }
+
+  @Override
+  public LoadSpecResult loadSegment(File file) throws SegmentLoadingException
+  {
+    return new LoadSpecResult(puller.getSegmentFiles(storageDir, file).size());
+  }
+}

--- a/extensions/azure-extensions/src/main/java/io/druid/storage/azure/AzureStorageContainer.java
+++ b/extensions/azure-extensions/src/main/java/io/druid/storage/azure/AzureStorageContainer.java
@@ -1,0 +1,87 @@
+/*
+ * Druid - a distributed column store.
+ *  Copyright 2012 - 2015 Metamarkets Group Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.druid.storage.azure;
+
+import com.metamx.common.logger.Logger;
+import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.blob.CloudBlob;
+import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import com.microsoft.azure.storage.blob.CloudBlobDirectory;
+import com.microsoft.azure.storage.blob.CloudBlockBlob;
+import com.microsoft.azure.storage.blob.ListBlobItem;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AzureStorageContainer
+{
+
+  private final Logger log = new Logger(AzureStorageContainer.class);
+
+  private final CloudBlobContainer cloudBlobContainer;
+
+  public AzureStorageContainer(
+      CloudBlobContainer cloudBlobContainer
+  )
+  {
+    this.cloudBlobContainer = cloudBlobContainer;
+  }
+
+  public List<String> emptyCloudBlobDirectory(final String path)
+      throws StorageException, URISyntaxException
+  {
+    List<String> deletedFiles = new ArrayList<>();
+
+    for (ListBlobItem blobItem : cloudBlobContainer.listBlobs(path, true, null, null, null))
+    {
+      CloudBlob cloudBlob = (CloudBlob) blobItem;
+      log.info("Removing file[%s] from Azure.", cloudBlob.getName());
+      if (cloudBlob.deleteIfExists()) {
+        deletedFiles.add(cloudBlob.getName());
+      }
+    }
+
+    if (deletedFiles.isEmpty())
+    {
+      log.warn("No files were deleted on the following Azure path: [%s]", path);
+    }
+
+    return deletedFiles;
+
+  }
+
+  public void uploadBlob(final File file, final String destination)
+      throws IOException, StorageException, URISyntaxException
+
+  {
+    try (FileInputStream stream = new FileInputStream(file)) {
+      CloudBlockBlob blob = cloudBlobContainer.getBlockBlobReference(destination);
+      blob.upload(stream, file.length());
+    }
+  }
+
+  public InputStream getBlobInputStream(final String filePath) throws URISyntaxException, StorageException
+  {
+    return cloudBlobContainer.getBlockBlobReference(filePath).openInputStream();
+  }
+}

--- a/extensions/azure-extensions/src/main/java/io/druid/storage/azure/AzureStorageDruidModule.java
+++ b/extensions/azure-extensions/src/main/java/io/druid/storage/azure/AzureStorageDruidModule.java
@@ -1,0 +1,130 @@
+/*
+ * Druid - a distributed column store.
+ * Copyright 2012 - 2015 Metamarkets Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.druid.storage.azure;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.Module;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import com.google.inject.Provides;
+import com.microsoft.azure.storage.CloudStorageAccount;
+import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.blob.CloudBlobClient;
+import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import io.druid.guice.Binders;
+import io.druid.guice.JsonConfigProvider;
+import io.druid.guice.LazySingleton;
+import io.druid.initialization.DruidModule;
+
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import java.util.List;
+
+public class AzureStorageDruidModule implements DruidModule
+{
+
+  public static final String SCHEME = "azure";
+  public static final String STORAGE_CONNECTION_STRING = "DefaultEndpointsProtocol=%s;AccountName=%s;AccountKey=%s";
+  public static final String DESCRIPTOR_FILE_NAME = "descriptor.json";
+  public static final String INDEX_ZIP_FILE_NAME = "index.zip";
+
+  @Override
+  public List<? extends Module> getJacksonModules()
+  {
+    return ImmutableList.of(
+        new Module()
+        {
+          @Override
+          public String getModuleName()
+          {
+            return "DruidAzure-" + System.identityHashCode(this);
+          }
+
+          @Override
+          public Version version()
+          {
+            return Version.unknownVersion();
+          }
+
+          @Override
+          public void setupModule(SetupContext context)
+          {
+            context.registerSubtypes(AzureLoadSpec.class);
+          }
+        }
+    );
+  }
+
+  @Override
+  public void configure(Binder binder)
+  {
+    JsonConfigProvider.bind(binder, "druid.azure", AzureAccountConfig.class);
+
+    Binders.dataSegmentPullerBinder(binder)
+           .addBinding(SCHEME)
+           .to(AzureDataSegmentPuller.class).in(LazySingleton.class);
+
+    Binders.dataSegmentPusherBinder(binder)
+           .addBinding(SCHEME)
+           .to(AzureDataSegmentPusher.class).in(LazySingleton.class);
+
+    Binders.dataSegmentKillerBinder(binder)
+           .addBinding(SCHEME)
+           .to(AzureDataSegmentKiller.class).in(LazySingleton.class);
+  }
+
+  @Provides
+  @LazySingleton
+  public CloudStorageAccount getCloudStorageAccount(final AzureAccountConfig config)
+      throws URISyntaxException, InvalidKeyException
+  {
+    return CloudStorageAccount.parse(
+        String.format(
+            STORAGE_CONNECTION_STRING,
+            config.getProtocol(),
+            config.getAccount(),
+            config.getKey()
+        )
+    );
+  }
+
+  @Provides
+  @LazySingleton
+  public CloudBlobContainer getCloudBlobContainer(
+      final AzureAccountConfig config,
+      final CloudStorageAccount cloudStorageAccount
+  )
+      throws URISyntaxException, StorageException
+  {
+    CloudBlobClient blobClient = cloudStorageAccount.createCloudBlobClient();
+    CloudBlobContainer cloudBlobContainer = blobClient.getContainerReference(config.getContainer());
+
+    cloudBlobContainer.createIfNotExists();
+
+    return cloudBlobContainer;
+  }
+
+  @Provides
+  @LazySingleton
+  public AzureStorageContainer getAzureStorageContainer(
+      final CloudBlobContainer cloudBlobContainer
+  )
+  {
+    return new AzureStorageContainer(cloudBlobContainer);
+  }
+}

--- a/extensions/azure-extensions/src/main/java/io/druid/storage/azure/AzureUtils.java
+++ b/extensions/azure-extensions/src/main/java/io/druid/storage/azure/AzureUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Druid - a distributed column store.
+ * Copyright 2012 - 2015 Metamarkets Group Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.druid.storage.azure;
+
+import com.google.common.base.Predicate;
+import com.microsoft.azure.storage.StorageException;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+public class AzureUtils
+{
+
+
+  public static final Predicate<Throwable> AZURE_RETRY = new Predicate<Throwable>()
+  {
+    @Override
+    public boolean apply(Throwable e)
+    {
+      if (e instanceof URISyntaxException) {
+        return false;
+      }
+
+      if (e instanceof IOException) {
+        return false;
+      }
+
+      if (e instanceof StorageException) {
+        return true;
+      }
+
+      return false;
+    }
+  };
+
+
+}

--- a/extensions/azure-extensions/src/main/resources/META-INF/services/io.druid.initialization.DruidModule
+++ b/extensions/azure-extensions/src/main/resources/META-INF/services/io.druid.initialization.DruidModule
@@ -1,0 +1,1 @@
+io.druid.storage.azure.AzureStorageDruidModule

--- a/extensions/azure-extensions/src/test/java/io/druid/storage/azure/AzureByteSourceTest.java
+++ b/extensions/azure-extensions/src/test/java/io/druid/storage/azure/AzureByteSourceTest.java
@@ -1,0 +1,66 @@
+/*
+ * Druid - a distributed column store.
+ *  Copyright 2012 - 2015 Metamarkets Group Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.druid.storage.azure;
+
+import com.microsoft.azure.storage.StorageException;
+import org.easymock.EasyMockSupport;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+
+import static org.easymock.EasyMock.*;
+
+public class AzureByteSourceTest extends EasyMockSupport
+{
+  @Test
+  public void openStreamTest() throws IOException, URISyntaxException, StorageException
+  {
+    final String filePath = "/path/to/file";
+    AzureStorageContainer azureStorageContainer = createMock(AzureStorageContainer.class);
+    InputStream stream = createMock(InputStream.class);
+
+    expect(azureStorageContainer.getBlobInputStream(filePath)).andReturn(stream);
+
+    replayAll();
+
+    AzureByteSource byteSource = new AzureByteSource(azureStorageContainer, filePath);
+
+    byteSource.openStream();
+
+    verifyAll();
+  }
+
+  @Test(expected = IOException.class)
+  public void openStreamWithRecoverableErrorTest() throws URISyntaxException, StorageException, IOException
+  {
+    final String filePath = "/path/to/file";
+    AzureStorageContainer azureStorageContainer = createMock(AzureStorageContainer.class);
+
+    expect(azureStorageContainer.getBlobInputStream(filePath)).andThrow(new StorageException("", "", 500, null, null));
+
+    replayAll();
+
+    AzureByteSource byteSource = new AzureByteSource(azureStorageContainer, filePath);
+
+    byteSource.openStream();
+
+    verifyAll();
+  }
+}

--- a/extensions/azure-extensions/src/test/java/io/druid/storage/azure/AzureDataSegmentKillerTest.java
+++ b/extensions/azure-extensions/src/test/java/io/druid/storage/azure/AzureDataSegmentKillerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Druid - a distributed column store.
+ *  Copyright 2012 - 2015 Metamarkets Group Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.druid.storage.azure;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.azure.storage.StorageException;
+import io.druid.segment.loading.SegmentLoadingException;
+import io.druid.timeline.DataSegment;
+import io.druid.timeline.partition.NoneShardSpec;
+import org.easymock.EasyMockSupport;
+import org.joda.time.Interval;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.easymock.EasyMock.*;
+
+public class AzureDataSegmentKillerTest extends EasyMockSupport
+{
+
+  private static final DataSegment dataSegment = new DataSegment(
+      "test",
+      new Interval("2015-04-12/2015-04-13"),
+      "1",
+      ImmutableMap.<String, Object>of("storageDir", "/path/to/storage/"),
+      null,
+      null,
+      new NoneShardSpec(),
+      0,
+      1
+  );
+
+  private AzureStorageContainer azureStorageContainer;
+
+  @Before
+  public void before()
+  {
+    azureStorageContainer = createMock(AzureStorageContainer.class);
+  }
+
+  @Test
+  public void killTest() throws SegmentLoadingException, URISyntaxException, StorageException
+  {
+
+    List<String> deletedFiles = new ArrayList<>();
+
+    expect(azureStorageContainer.emptyCloudBlobDirectory("/path/to/storage/")).andReturn(deletedFiles);
+
+    replayAll();
+
+    AzureDataSegmentKiller killer = new AzureDataSegmentKiller(azureStorageContainer);
+
+    killer.kill(dataSegment);
+
+    verifyAll();
+  }
+
+  @Test(expected = SegmentLoadingException.class)
+  public void killWithErrorTest() throws SegmentLoadingException, URISyntaxException, StorageException
+  {
+
+    expect(azureStorageContainer.emptyCloudBlobDirectory("/path/to/storage/")).andThrow(
+        new StorageException(
+            "",
+            "",
+            400,
+            null,
+            null
+        )
+    );
+
+    replayAll();
+
+    AzureDataSegmentKiller killer = new AzureDataSegmentKiller(azureStorageContainer);
+
+    killer.kill(dataSegment);
+
+    verifyAll();
+  }
+}

--- a/extensions/azure-extensions/src/test/java/io/druid/storage/azure/AzureDataSegmentPullerTest.java
+++ b/extensions/azure-extensions/src/test/java/io/druid/storage/azure/AzureDataSegmentPullerTest.java
@@ -1,0 +1,165 @@
+/*
+ * Druid - a distributed column store.
+ *  Copyright 2012 - 2015 Metamarkets Group Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.druid.storage.azure;
+
+import com.google.common.collect.ImmutableMap;
+import com.metamx.common.FileUtils;
+import com.metamx.common.MapUtils;
+import com.microsoft.azure.storage.StorageException;
+import io.druid.segment.loading.SegmentLoadingException;
+import io.druid.timeline.DataSegment;
+import io.druid.timeline.partition.NoneShardSpec;
+import org.easymock.EasyMockSupport;
+import org.joda.time.Interval;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.util.Map;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class AzureDataSegmentPullerTest extends EasyMockSupport
+{
+
+  private AzureStorageContainer azureStorageContainer;
+  private static final String SEGMENT_FILE_NAME = "segment";
+  private static final DataSegment dataSegment = new DataSegment(
+      "test",
+      new Interval("2015-04-12/2015-04-13"),
+      "1",
+      ImmutableMap.<String, Object>of("storageDir", "/path/to/storage/"),
+      null,
+      null,
+      new NoneShardSpec(),
+      0,
+      1
+  );
+
+  @Before
+  public void before()
+  {
+    azureStorageContainer = createMock(AzureStorageContainer.class);
+  }
+
+  @Test
+  public void testZIPUncompress() throws SegmentLoadingException, URISyntaxException, StorageException, IOException
+  {
+    final String value = "bucket";
+    final File pulledFile = AzureTestUtils.createZipTempFile(SEGMENT_FILE_NAME, value);
+    pulledFile.deleteOnExit();
+    final File toDir = Files.createTempDirectory("druid").toFile();
+    toDir.deleteOnExit();
+    final File zipFilePath = new File(pulledFile.getParent(), AzureStorageDruidModule.INDEX_ZIP_FILE_NAME);
+    final InputStream zipStream = new FileInputStream(pulledFile);
+
+    expect(azureStorageContainer.getBlobInputStream(zipFilePath.getAbsolutePath())).andReturn(zipStream);
+
+    replayAll();
+
+    AzureDataSegmentPuller puller = new AzureDataSegmentPuller(azureStorageContainer);
+
+    FileUtils.FileCopyResult result = puller.getSegmentFiles(pulledFile.getParent(), toDir);
+
+    File expected = new File(toDir, SEGMENT_FILE_NAME);
+    assertEquals(value.length(), result.size());
+    assertTrue(expected.exists());
+    assertEquals(value.length(), expected.length());
+
+    verifyAll();
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testDeleteOutputDirectoryWhenErrorIsRaisedPullingSegmentFiles()
+      throws IOException, URISyntaxException, StorageException, SegmentLoadingException
+  {
+
+    final File fromDir = Files.createTempDirectory("druidA").toFile();
+    fromDir.deleteOnExit();
+    final File outDir = Files.createTempDirectory("druid").toFile();
+    outDir.deleteOnExit();
+
+    final File zipFilePath = new File(fromDir.getAbsolutePath(), AzureStorageDruidModule.INDEX_ZIP_FILE_NAME);
+
+    expect(azureStorageContainer.getBlobInputStream(zipFilePath.getAbsolutePath())).andThrow(
+        new StorageException(
+            "error",
+            "error",
+            404,
+            null,
+            null
+        )
+    );
+
+    replayAll();
+
+    AzureDataSegmentPuller puller = new AzureDataSegmentPuller(azureStorageContainer);
+
+    puller.getSegmentFiles(fromDir.getAbsolutePath(), outDir);
+
+    assertFalse(outDir.exists());
+
+    verifyAll();
+
+  }
+
+  @Test
+  public void getSegmentFilesTest() throws SegmentLoadingException
+  {
+    final File outDir = new File("");
+    final Map<String, Object> loadSpec = dataSegment.getLoadSpec();
+    final String storageDir = MapUtils.getString(loadSpec, "storageDir");
+    final FileUtils.FileCopyResult result = createMock(FileUtils.FileCopyResult.class);
+    final AzureDataSegmentPuller puller = createMockBuilder(AzureDataSegmentPuller.class).withConstructor(
+        azureStorageContainer
+    ).addMockedMethod("getSegmentFiles", String.class, File.class).createMock();
+
+    expect(puller.getSegmentFiles(storageDir, outDir)).andReturn(result);
+
+    replayAll();
+
+    puller.getSegmentFiles(dataSegment, outDir);
+
+    verifyAll();
+
+  }
+
+  @Test
+  public void prepareOutDirTest() throws IOException
+  {
+    File outDir = Files.createTempDirectory("druid").toFile();
+
+    try {
+      AzureDataSegmentPuller puller = new AzureDataSegmentPuller(azureStorageContainer);
+      puller.prepareOutDir(outDir);
+
+      assertTrue(outDir.exists());
+    }
+    finally {
+      outDir.delete();
+    }
+  }
+}

--- a/extensions/azure-extensions/src/test/java/io/druid/storage/azure/AzureDataSegmentPusherTest.java
+++ b/extensions/azure-extensions/src/test/java/io/druid/storage/azure/AzureDataSegmentPusherTest.java
@@ -1,0 +1,161 @@
+/*
+ * Druid - a distributed column store.
+ *  Copyright 2012 - 2015 Metamarkets Group Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.druid.storage.azure;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.metamx.common.MapUtils;
+import com.microsoft.azure.storage.StorageException;
+import io.druid.segment.loading.DataSegmentPusherUtil;
+import io.druid.timeline.DataSegment;
+import io.druid.timeline.partition.NoneShardSpec;
+import org.easymock.EasyMockSupport;
+import org.joda.time.Interval;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.easymock.EasyMock.*;
+
+public class AzureDataSegmentPusherTest extends EasyMockSupport
+{
+  private static final DataSegment dataSegment = new DataSegment(
+      "test",
+      new Interval("2015-04-12/2015-04-13"),
+      "1",
+      ImmutableMap.<String, Object>of("storageDir", "/path/to/storage/"),
+      null,
+      null,
+      new NoneShardSpec(),
+      0,
+      1
+  );
+
+  private AzureStorageContainer azureStorageContainer;
+  private AzureAccountConfig azureAccountConfig;
+  private ObjectMapper jsonMapper;
+
+  @Before
+  public void before()
+  {
+    azureStorageContainer = createMock(AzureStorageContainer.class);
+    azureAccountConfig = createMock(AzureAccountConfig.class);
+    jsonMapper = createMock(ObjectMapper.class);
+
+  }
+
+  @Test
+  public void getAzurePathsTest()
+  {
+    final String storageDir = DataSegmentPusherUtil.getStorageDir(dataSegment);
+    AzureDataSegmentPusher pusher = new AzureDataSegmentPusher(azureStorageContainer, azureAccountConfig, jsonMapper);
+
+    Map<String, String> paths = pusher.getAzurePaths(dataSegment);
+
+    assertEquals(storageDir, paths.get("storage"));
+    assertEquals(String.format("%s/%s", storageDir, AzureStorageDruidModule.INDEX_ZIP_FILE_NAME), paths.get("index"));
+    assertEquals(
+        String.format("%s/%s", storageDir, AzureStorageDruidModule.DESCRIPTOR_FILE_NAME),
+        paths.get("descriptor")
+    );
+  }
+
+  @Test
+  public void uploadThenDeleteTest() throws StorageException, IOException, URISyntaxException
+  {
+    final File file = AzureTestUtils.createZipTempFile("segment", "bucket");
+    file.deleteOnExit();
+    final String azureDestPath = "/azure/path/";
+    azureStorageContainer.uploadBlob(file, azureDestPath);
+    expectLastCall();
+
+    replayAll();
+
+    AzureDataSegmentPusher pusher = new AzureDataSegmentPusher(azureStorageContainer, azureAccountConfig, jsonMapper);
+
+    pusher.uploadThenDelete(file, azureDestPath);
+
+    verifyAll();
+  }
+
+  @Test
+  public void uploadDataSegmentTest() throws StorageException, IOException, URISyntaxException
+  {
+    final int version = 9;
+    final File compressedSegmentData = AzureTestUtils.createZipTempFile("segment", "bucket");
+    compressedSegmentData.deleteOnExit();
+    final File descriptorFile = Files.createTempFile("descriptor", ".json").toFile();
+    descriptorFile.deleteOnExit();
+    final Map<String, String> azurePaths = ImmutableMap.of(
+        "index",
+        "/path/to/azure/storage",
+        "descriptor",
+        "/path/to/azure/storage",
+        "storage",
+        "/path/to/azure/storage"
+    );
+
+    azureStorageContainer.uploadBlob(compressedSegmentData, azurePaths.get("index"));
+    expectLastCall();
+    azureStorageContainer.uploadBlob(descriptorFile, azurePaths.get("descriptor"));
+    expectLastCall();
+
+    replayAll();
+
+    AzureDataSegmentPusher pusher = new AzureDataSegmentPusher(azureStorageContainer, azureAccountConfig, jsonMapper);
+
+    DataSegment pushedDataSegment = pusher.uploadDataSegment(
+        dataSegment,
+        version,
+        compressedSegmentData,
+        descriptorFile,
+        azurePaths
+    );
+
+    assertEquals(compressedSegmentData.length(), pushedDataSegment.getSize());
+    assertEquals(version, (int) pushedDataSegment.getBinaryVersion());
+    Map<String, Object> loadSpec = pushedDataSegment.getLoadSpec();
+    assertEquals(AzureStorageDruidModule.SCHEME, MapUtils.getString(loadSpec, "type"));
+    assertEquals(azurePaths.get("storage"), MapUtils.getString(loadSpec, "storageDir"));
+
+    verifyAll();
+
+  }
+
+  @Test
+  public void t() throws IOException
+  {
+    AzureDataSegmentPusher pusher = new AzureDataSegmentPusher(azureStorageContainer, azureAccountConfig, jsonMapper);
+
+    File dir = Files.createTempDirectory("druid").toFile();
+    dir.deleteOnExit();
+
+    File x = pusher.createCompressedSegmentDataFile(dir);
+
+    System.out.println(x);
+  }
+
+}

--- a/extensions/azure-extensions/src/test/java/io/druid/storage/azure/AzureTestUtils.java
+++ b/extensions/azure-extensions/src/test/java/io/druid/storage/azure/AzureTestUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Druid - a distributed column store.
+ *  Copyright 2012 - 2015 Metamarkets Group Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.druid.storage.azure;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+public class AzureTestUtils
+{
+  public static File createZipTempFile(final String segmentFileName, final String content) throws IOException
+  {
+    final File zipFile = Files.createTempFile("index", ".zip").toFile();
+    final byte[] value = content.getBytes("utf8");
+
+    try (ZipOutputStream zipStream = new ZipOutputStream(new FileOutputStream(zipFile))) {
+      zipStream.putNextEntry(new ZipEntry(segmentFileName));
+      zipStream.write(value);
+    }
+
+    return zipFile;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
         <module>extensions/histogram</module>
         <module>extensions/mysql-metadata-storage</module>
         <module>extensions/postgresql-metadata-storage</module>
+        <module>extensions/azure-extensions</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
Adding a new Deep Storage implementation using [Microsoft Azure Storage](http://azure.microsoft.com/en-us/services/storage/).

Common configuration options:

```
druid.storage.type=azure
druid.azure.account=<azure storage account>
druid.azure.key=<azure storage account key>
druid.azure.container=<azure storage container>
druid.azure.protocol=<optional; valid options: https or http; default: https>
druid.azure.maxTries=<optional; number of tries before give up an Azure operation; default: 3; min: 1>
```
