### PR TITLE
Update VersionConverterTask for IndexSepc and allowing Forced updates (DO NOT MERGE YET)

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/common/task/IndexReprocessTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/IndexReprocessTask.java
@@ -45,29 +45,30 @@ import java.util.Map;
 
 /**
  */
-public class VersionConverterTask extends AbstractFixedIntervalTask
+public class IndexReprocessTask extends AbstractFixedIntervalTask
 {
-  private static final String TYPE = "version_converter";
+  private static final String TYPE = "index_reprocess";
   private static final Integer CURR_VERSION_INTEGER = IndexIO.CURRENT_VERSION_ID;
 
-  private static final Logger log = new Logger(VersionConverterTask.class);
+  private static final Logger log = new Logger(IndexReprocessTask.class);
 
   @JsonIgnore
   private final DataSegment segment;
   private final IndexSpec indexSpec;
+  private final boolean force;
 
-  public static VersionConverterTask create(String dataSource, Interval interval)
+  public static IndexReprocessTask create(String dataSource, Interval interval, IndexSpec indexSpec, boolean force)
   {
     final String id = makeId(dataSource, interval);
-    return new VersionConverterTask(id, id, dataSource, interval, null, null);
+    return new IndexReprocessTask(id, id, dataSource, interval, null, indexSpec, force);
   }
 
-  public static VersionConverterTask create(DataSegment segment)
+  public static IndexReprocessTask create(DataSegment segment, IndexSpec indexSpec, boolean force)
   {
     final Interval interval = segment.getInterval();
     final String dataSource = segment.getDataSource();
     final String id = makeId(dataSource, interval);
-    return new VersionConverterTask(id, id, dataSource, interval, segment, null);
+    return new IndexReprocessTask(id, id, dataSource, interval, segment, indexSpec, force);
   }
 
   private static String makeId(String dataSource, Interval interval)
@@ -78,37 +79,46 @@ public class VersionConverterTask extends AbstractFixedIntervalTask
   }
 
   @JsonCreator
-  private static VersionConverterTask createFromJson(
+  private static IndexReprocessTask createFromJson(
       @JsonProperty("id") String id,
       @JsonProperty("groupId") String groupId,
       @JsonProperty("dataSource") String dataSource,
       @JsonProperty("interval") Interval interval,
       @JsonProperty("segment") DataSegment segment,
-      @JsonProperty("indexSpec") IndexSpec indexSpec
+      @JsonProperty("indexSpec") IndexSpec indexSpec,
+      @JsonProperty("force") Boolean force
   )
   {
+    final boolean isForce = force == null ? false : force;
     if (id == null) {
       if (segment == null) {
-        return create(dataSource, interval);
+        return create(dataSource, interval, indexSpec, isForce);
       } else {
-        return create(segment);
+        return create(segment, indexSpec, isForce);
       }
     }
-    return new VersionConverterTask(id, groupId, dataSource, interval, segment, indexSpec);
+    return new IndexReprocessTask(id, groupId, dataSource, interval, segment, indexSpec, isForce);
   }
 
-  private VersionConverterTask(
+  private IndexReprocessTask(
       String id,
       String groupId,
       String dataSource,
       Interval interval,
       DataSegment segment,
-      IndexSpec indexSpec
+      IndexSpec indexSpec,
+      boolean force
   )
   {
     super(id, groupId, dataSource, interval);
     this.segment = segment;
     this.indexSpec = indexSpec == null ? new IndexSpec() : indexSpec;
+    this.force = force;
+  }
+
+  @JsonProperty
+  public boolean getForce(){
+    return this.force;
   }
 
   @Override
@@ -143,11 +153,14 @@ public class VersionConverterTask extends AbstractFixedIntervalTask
                 {
                   final Integer segmentVersion = segment.getBinaryVersion();
                   if (!CURR_VERSION_INTEGER.equals(segmentVersion)) {
-                    return new SubTask(getGroupId(), segment, indexSpec);
+                    return new SubTask(getGroupId(), segment, indexSpec, force);
+                  } else if(force){
+                    log.info("Segment[%s] already at version[%s], forcing conversion", segment.getIdentifier(), segmentVersion);
+                    return new SubTask(getGroupId(), segment, indexSpec, force);
+                  } else {
+                    log.info("Skipping[%s], already version[%s]", segment.getIdentifier(), segmentVersion);
+                    return null;
                   }
-
-                  log.info("Skipping[%s], already version[%s]", segment.getIdentifier(), segmentVersion);
-                  return null;
                 }
               }
           );
@@ -161,7 +174,7 @@ public class VersionConverterTask extends AbstractFixedIntervalTask
       }
     } else {
       log.info("I'm in a subless mood.");
-      convertSegment(toolbox, segment, indexSpec);
+      convertSegment(toolbox, segment, indexSpec, force);
     }
     return success();
   }
@@ -176,7 +189,7 @@ public class VersionConverterTask extends AbstractFixedIntervalTask
       return false;
     }
 
-    VersionConverterTask that = (VersionConverterTask) o;
+    IndexReprocessTask that = (IndexReprocessTask) o;
 
     if (segment != null ? !segment.equals(that.segment) : that.segment != null) {
       return false;
@@ -190,12 +203,14 @@ public class VersionConverterTask extends AbstractFixedIntervalTask
     @JsonIgnore
     private final DataSegment segment;
     private final IndexSpec indexSpec;
+    private final boolean force;
 
     @JsonCreator
     public SubTask(
         @JsonProperty("groupId") String groupId,
         @JsonProperty("segment") DataSegment segment,
-        @JsonProperty("indexSpec") IndexSpec indexSpec
+        @JsonProperty("indexSpec") IndexSpec indexSpec,
+        @JsonProperty("force") Boolean force
     )
     {
       super(
@@ -212,6 +227,12 @@ public class VersionConverterTask extends AbstractFixedIntervalTask
       );
       this.segment = segment;
       this.indexSpec = indexSpec == null ? new IndexSpec() : indexSpec;
+      this.force = force == null ? false : force;
+    }
+
+    @JsonProperty
+    public boolean getForce(){
+      return force;
     }
 
     @JsonProperty
@@ -230,12 +251,12 @@ public class VersionConverterTask extends AbstractFixedIntervalTask
     public TaskStatus run(TaskToolbox toolbox) throws Exception
     {
       log.info("Subs are good!  Italian BMT and Meatball are probably my favorite.");
-      convertSegment(toolbox, segment, indexSpec);
+      convertSegment(toolbox, segment, indexSpec, force);
       return success();
     }
   }
 
-  private static void convertSegment(TaskToolbox toolbox, final DataSegment segment, IndexSpec indexSpec)
+  private static void convertSegment(TaskToolbox toolbox, final DataSegment segment, IndexSpec indexSpec, boolean force)
       throws SegmentLoadingException, IOException
   {
     log.info("Converting segment[%s]", segment);
@@ -248,7 +269,7 @@ public class VersionConverterTask extends AbstractFixedIntervalTask
       final String version = currentSegment.getVersion();
       final Integer binaryVersion = currentSegment.getBinaryVersion();
 
-      if (version.startsWith(segment.getVersion()) && CURR_VERSION_INTEGER.equals(binaryVersion)) {
+      if (!force && (version.startsWith(segment.getVersion()) && CURR_VERSION_INTEGER.equals(binaryVersion))) {
         log.info("Skipping already updated segment[%s].", segment);
         return;
       }
@@ -258,7 +279,7 @@ public class VersionConverterTask extends AbstractFixedIntervalTask
 
     final File location = localSegments.get(segment);
     final File outLocation = new File(location, "v9_out");
-    if (IndexIO.convertSegment(location, outLocation, indexSpec)) {
+    if (IndexIO.convertSegment(location, outLocation, indexSpec, force)) {
       final int outVersion = IndexIO.getVersionFromDir(outLocation);
 
       // Appending to the version makes a new version that inherits most comparability parameters of the original

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/Task.java
@@ -49,8 +49,9 @@ import io.druid.query.QueryRunner;
     @JsonSubTypes.Type(name = "index_hadoop", value = HadoopIndexTask.class),
     @JsonSubTypes.Type(name = "index_realtime", value = RealtimeIndexTask.class),
     @JsonSubTypes.Type(name = "noop", value = NoopTask.class),
-    @JsonSubTypes.Type(name = "version_converter", value = VersionConverterTask.class),
-    @JsonSubTypes.Type(name = "version_converter_sub", value = VersionConverterTask.SubTask.class)
+    @JsonSubTypes.Type(name = "version_converter", value = IndexReprocessTask.class), // Backwards compat
+    @JsonSubTypes.Type(name = "index_reprocess", value = IndexReprocessTask.class),
+    @JsonSubTypes.Type(name = "version_converter_sub", value = IndexReprocessTask.SubTask.class)
 })
 public interface Task
 {

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/IndexReprocessTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/IndexReprocessTaskTest.java
@@ -22,14 +22,14 @@ import com.google.common.collect.ImmutableMap;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.timeline.DataSegment;
 import io.druid.timeline.partition.NoneShardSpec;
-import junit.framework.Assert;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
  */
-public class VersionConverterTaskTest
+public class IndexReprocessTaskTest
 {
   @Test
   public void testSerializationSimple() throws Exception
@@ -39,7 +39,7 @@ public class VersionConverterTaskTest
 
     DefaultObjectMapper jsonMapper = new DefaultObjectMapper();
 
-    VersionConverterTask task = VersionConverterTask.create(dataSource, interval);
+    IndexReprocessTask task = IndexReprocessTask.create(dataSource, interval, null, false);
 
     Task task2 = jsonMapper.readValue(jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(task), Task.class);
     Assert.assertEquals(task, task2);
@@ -56,7 +56,7 @@ public class VersionConverterTaskTest
         102937
     );
 
-    task = VersionConverterTask.create(segment);
+    task = IndexReprocessTask.create(segment, null, false);
 
     task2 = jsonMapper.readValue(jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(task), Task.class);
     Assert.assertEquals(task, task2);

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
@@ -159,14 +159,16 @@ public class TaskSerdeTest
   @Test
   public void testVersionConverterTaskSerde() throws Exception
   {
-    final VersionConverterTask task = VersionConverterTask.create(
-        DataSegment.builder().dataSource("foo").interval(new Interval("2010-01-01/P1D")).version("1234").build()
+    final IndexReprocessTask task = IndexReprocessTask.create(
+        DataSegment.builder().dataSource("foo").interval(new Interval("2010-01-01/P1D")).version("1234").build(),
+        null,
+        false
     );
 
     final String json = jsonMapper.writeValueAsString(task);
 
     Thread.sleep(100); // Just want to run the clock a bit to make sure the task id doesn't change
-    final VersionConverterTask task2 = (VersionConverterTask) jsonMapper.readValue(json, Task.class);
+    final IndexReprocessTask task2 = (IndexReprocessTask) jsonMapper.readValue(json, Task.class);
 
     Assert.assertEquals("foo", task.getDataSource());
     Assert.assertEquals(new Interval("2010-01-01/P1D"), task.getInterval());
@@ -181,16 +183,17 @@ public class TaskSerdeTest
   @Test
   public void testVersionConverterSubTaskSerde() throws Exception
   {
-    final VersionConverterTask.SubTask task = new VersionConverterTask.SubTask(
+    final IndexReprocessTask.SubTask task = new IndexReprocessTask.SubTask(
         "myGroupId",
         DataSegment.builder().dataSource("foo").interval(new Interval("2010-01-01/P1D")).version("1234").build(),
-        indexSpec
+        indexSpec,
+        false
     );
 
     final String json = jsonMapper.writeValueAsString(task);
 
     Thread.sleep(100); // Just want to run the clock a bit to make sure the task id doesn't change
-    final VersionConverterTask.SubTask task2 = (VersionConverterTask.SubTask) jsonMapper.readValue(json, Task.class);
+    final IndexReprocessTask.SubTask task2 = (IndexReprocessTask.SubTask) jsonMapper.readValue(json, Task.class);
 
     Assert.assertEquals("foo", task.getDataSource());
     Assert.assertEquals("myGroupId", task.getGroupId());


### PR DESCRIPTION
In a really basic test with 1 thread vs 1 thread locally, this seems to run about 70% faster than re-indexing the raw data with hadoop.