### PR TITLE
Fix type of values in sql update.

### DIFF
--- a/server/src/main/java/io/druid/indexer/SQLMetadataStorageUpdaterJobHandler.java
+++ b/server/src/main/java/io/druid/indexer/SQLMetadataStorageUpdaterJobHandler.java
@@ -67,10 +67,10 @@ public class SQLMetadataStorageUpdaterJobHandler implements MetadataStorageUpdat
                       .put("created_date", new DateTime().toString())
                       .put("start", segment.getInterval().getStart().toString())
                       .put("end", segment.getInterval().getEnd().toString())
-                      .put("partitioned", (segment.getShardSpec() instanceof NoneShardSpec) ? 0 : 1)
+                      .put("partitioned", (segment.getShardSpec() instanceof NoneShardSpec) ? false : true)
                       .put("version", segment.getVersion())
                       .put("used", true)
-                      .put("payload", mapper.writeValueAsString(segment))
+                      .put("payload", mapper.writeValueAsBytes(segment))
                       .build()
               );
 


### PR DESCRIPTION
While running hadoop indexer with postgres, postgres update fails due to type mismatch between the update and the segments table. This CL fixes it.