### PR TITLE
Update VersionConverterTask for IndexSpec and allowing Forced updates

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/Task.java
@@ -49,8 +49,10 @@ import io.druid.query.QueryRunner;
     @JsonSubTypes.Type(name = "index_hadoop", value = HadoopIndexTask.class),
     @JsonSubTypes.Type(name = "index_realtime", value = RealtimeIndexTask.class),
     @JsonSubTypes.Type(name = "noop", value = NoopTask.class),
-    @JsonSubTypes.Type(name = "version_converter", value = VersionConverterTask.class),
-    @JsonSubTypes.Type(name = "version_converter_sub", value = VersionConverterTask.SubTask.class)
+    @JsonSubTypes.Type(name = "version_converter", value = ConvertSegmentTask.class), // Backwards compat - Deprecated
+    @JsonSubTypes.Type(name = "version_converter_sub", value = ConvertSegmentTask.SubTask.class), // backwards compat - Deprecated
+    @JsonSubTypes.Type(name = "convert_segment", value = ConvertSegmentTask.class),
+    @JsonSubTypes.Type(name = "convert_segment_sub", value = ConvertSegmentTask.SubTask.class)
 })
 public interface Task
 {

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/ConvertSegmentTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/ConvertSegmentTaskTest.java
@@ -22,14 +22,14 @@ import com.google.common.collect.ImmutableMap;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.timeline.DataSegment;
 import io.druid.timeline.partition.NoneShardSpec;
-import junit.framework.Assert;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
  */
-public class VersionConverterTaskTest
+public class ConvertSegmentTaskTest
 {
   @Test
   public void testSerializationSimple() throws Exception
@@ -39,7 +39,7 @@ public class VersionConverterTaskTest
 
     DefaultObjectMapper jsonMapper = new DefaultObjectMapper();
 
-    VersionConverterTask task = VersionConverterTask.create(dataSource, interval);
+    ConvertSegmentTask task = ConvertSegmentTask.create(dataSource, interval, null, false);
 
     Task task2 = jsonMapper.readValue(jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(task), Task.class);
     Assert.assertEquals(task, task2);
@@ -56,7 +56,7 @@ public class VersionConverterTaskTest
         102937
     );
 
-    task = VersionConverterTask.create(segment);
+    task = ConvertSegmentTask.create(segment, null, false);
 
     task2 = jsonMapper.readValue(jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(task), Task.class);
     Assert.assertEquals(task, task2);


### PR DESCRIPTION
Other PR got swallowed by a rebase. https://github.com/druid-io/druid/pull/1293

In a really basic test with 1 thread vs 1 thread locally, this seems to run about 70% faster than re-indexing the raw data with hadoop.

This does not try to get the most "optimal" way of doing it, but rather simply tries to get a "pretty good" way that has validation.