### PR TITLE
Add metric for cpu user time usage of threads in the processing pool

### DIFF
--- a/processing/src/main/java/io/druid/query/MetricsEmittingExecutorService.java
+++ b/processing/src/main/java/io/druid/query/MetricsEmittingExecutorService.java
@@ -20,16 +20,49 @@ package io.druid.query;
 import com.google.common.util.concurrent.ForwardingListeningExecutorService;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.Runnables;
 import com.metamx.emitter.service.ServiceEmitter;
 import com.metamx.emitter.service.ServiceMetricEvent;
 
+import javax.validation.constraints.NotNull;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
 import java.util.concurrent.Callable;
 
 public class MetricsEmittingExecutorService extends ForwardingListeningExecutorService
 {
+  private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
+  private static final ThreadLocal<Long> THREAD_USER_START = new ThreadLocal<Long>()
+  {
+    @Override
+    public Long initialValue()
+    {
+      return 0L;
+    }
+  };
+  private static final Runnable PRE = THREAD_MX_BEAN.isCurrentThreadCpuTimeSupported() ? new Runnable()
+  {
+    @Override
+    public void run()
+    {
+      THREAD_USER_START.set(THREAD_MX_BEAN.getCurrentThreadUserTime());
+    }
+  } : Runnables.doNothing();
+
   private final ListeningExecutorService delegate;
   private final ServiceEmitter emitter;
   private final ServiceMetricEvent.Builder metricBuilder;
+
+  private final Runnable post = THREAD_MX_BEAN.isCurrentThreadCpuTimeSupported() ? new Runnable()
+  {
+    @Override
+    public void run()
+    {
+      emitter.emit(
+          metricBuilder.build("exec/cpu", THREAD_MX_BEAN.getCurrentThreadUserTime() - THREAD_USER_START.get())
+      );
+    }
+  } : Runnables.doNothing();
 
   public MetricsEmittingExecutorService(
       ListeningExecutorService delegate,
@@ -38,7 +71,6 @@ public class MetricsEmittingExecutorService extends ForwardingListeningExecutorS
   )
   {
     super();
-
     this.delegate = delegate;
     this.emitter = emitter;
     this.metricBuilder = metricBuilder;
@@ -51,17 +83,37 @@ public class MetricsEmittingExecutorService extends ForwardingListeningExecutorS
   }
 
   @Override
-  public <T> ListenableFuture<T> submit(Callable<T> tCallable)
+  public <T> ListenableFuture<T> submit(final Callable<T> tCallable)
   {
+    final Callable<T> wrappedPrioritizedCallable =
+        (tCallable instanceof PrioritizedCallable)
+        ? PrioritizedExecutorService.wrapCallable((PrioritizedCallable<T>) tCallable, PRE, post)
+        : wrapCallable(tCallable, PRE, post);
     emitMetrics();
-    return delegate.submit(tCallable);
+    return super.submit(wrappedPrioritizedCallable);
+  }
+
+  @Override
+  public ListenableFuture<?> submit(final Runnable runnable)
+  {
+    return submit(runnable, (Object) null);
+  }
+
+  @Override
+  public <T> ListenableFuture<T> submit(final Runnable runnable, T result)
+  {
+    final Runnable wrappedPrioritizedRunnable =
+        (runnable instanceof PrioritizedRunnable)
+        ? PrioritizedExecutorService.wrapRunnable((PrioritizedRunnable) runnable, PRE, post)
+        : wrapRunnable(runnable, PRE, post);
+    emitMetrics();
+    return super.submit(wrappedPrioritizedRunnable, result);
   }
 
   @Override
   public void execute(Runnable runnable)
   {
-    emitMetrics();
-    delegate.execute(runnable);
+    submit(runnable);
   }
 
   private void emitMetrics()
@@ -69,5 +121,42 @@ public class MetricsEmittingExecutorService extends ForwardingListeningExecutorS
     if (delegate instanceof PrioritizedExecutorService) {
       emitter.emit(metricBuilder.build("exec/backlog", ((PrioritizedExecutorService) delegate).getQueueSize()));
     }
+  }
+
+  public static Runnable wrapRunnable(
+      @NotNull final Runnable runnable,
+      @NotNull final Runnable pre,
+      @NotNull final Runnable post
+  )
+  {
+    return new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        pre.run();
+        runnable.run();
+        post.run();
+      }
+    };
+  }
+
+  public static <V> Callable<V> wrapCallable(
+      @NotNull final Callable<V> callable,
+      @NotNull final Runnable pre,
+      @NotNull final Runnable post
+  )
+  {
+    return new Callable<V>()
+    {
+      @Override
+      public V call() throws Exception
+      {
+        pre.run();
+        final V retVal = callable.call();
+        post.run();
+        return retVal;
+      }
+    };
   }
 }

--- a/processing/src/main/java/io/druid/query/PrioritizedExecutorService.java
+++ b/processing/src/main/java/io/druid/query/PrioritizedExecutorService.java
@@ -98,17 +98,28 @@ public class PrioritizedExecutorService extends AbstractExecutorService implemen
     this.defaultPriority = defaultPriority;
   }
 
-  @Override protected <T> PrioritizedListenableFutureTask<T> newTaskFor(Runnable runnable, T value) {
-    Preconditions.checkArgument(allowRegularTasks || runnable instanceof PrioritizedRunnable, "task does not implement PrioritizedRunnable");
-    return PrioritizedListenableFutureTask.create(ListenableFutureTask.create(runnable, value),
-                                                  runnable instanceof PrioritizedRunnable
-                                                  ? ((PrioritizedRunnable) runnable).getPriority()
-                                                  : defaultPriority
+  @Override
+  protected <T> PrioritizedListenableFutureTask<T> newTaskFor(Runnable runnable, T value)
+  {
+    Preconditions.checkArgument(
+        allowRegularTasks || runnable instanceof PrioritizedRunnable,
+        "task does not implement PrioritizedRunnable"
+    );
+    return PrioritizedListenableFutureTask.create(
+        ListenableFutureTask.create(runnable, value),
+        runnable instanceof PrioritizedRunnable
+        ? ((PrioritizedRunnable) runnable).getPriority()
+        : defaultPriority
     );
   }
 
-  @Override protected <T> PrioritizedListenableFutureTask<T> newTaskFor(Callable<T> callable) {
-    Preconditions.checkArgument(allowRegularTasks || callable instanceof PrioritizedCallable, "task does not implement PrioritizedCallable");
+  @Override
+  protected <T> PrioritizedListenableFutureTask<T> newTaskFor(Callable<T> callable)
+  {
+    Preconditions.checkArgument(
+        allowRegularTasks || callable instanceof PrioritizedCallable,
+        "task does not implement PrioritizedCallable"
+    );
     return PrioritizedListenableFutureTask.create(
         ListenableFutureTask.create(callable), callable instanceof PrioritizedCallable
                                                ? ((PrioritizedCallable) callable).getPriority()
@@ -116,15 +127,21 @@ public class PrioritizedExecutorService extends AbstractExecutorService implemen
     );
   }
 
-  @Override public ListenableFuture<?> submit(Runnable task) {
+  @Override
+  public ListenableFuture<?> submit(Runnable task)
+  {
     return (ListenableFuture<?>) super.submit(task);
   }
 
-  @Override public <T> ListenableFuture<T> submit(Runnable task, @Nullable T result) {
+  @Override
+  public <T> ListenableFuture<T> submit(Runnable task, @Nullable T result)
+  {
     return (ListenableFuture<T>) super.submit(task, result);
   }
 
-  @Override public <T> ListenableFuture<T> submit(Callable<T> task) {
+  @Override
+  public <T> ListenableFuture<T> submit(Callable<T> task)
+  {
     return (ListenableFuture<T>) super.submit(task);
   }
 
@@ -169,8 +186,15 @@ public class PrioritizedExecutorService extends AbstractExecutorService implemen
     return delegateQueue.size();
   }
 
+  public int getDefaultPriority()
+  {
+    return defaultPriority;
+  }
 
-  public static class PrioritizedListenableFutureTask<V> implements RunnableFuture<V>, ListenableFuture<V>, PrioritizedRunnable, Comparable<PrioritizedListenableFutureTask>
+  public static class PrioritizedListenableFutureTask<V> implements RunnableFuture<V>,
+      ListenableFuture<V>,
+      PrioritizedRunnable,
+      Comparable<PrioritizedListenableFutureTask>
   {
     public static <V> PrioritizedListenableFutureTask<V> create(PrioritizedRunnable task, @Nullable V result)
     {
@@ -249,5 +273,63 @@ public class PrioritizedExecutorService extends AbstractExecutorService implemen
     {
       return Ints.compare(otherTask.getPriority(), getPriority());
     }
+  }
+
+  public static <V> PrioritizedCallable<V> wrapCallable(
+      final PrioritizedCallable<V> callable,
+      final Runnable pre,
+      final Runnable post
+  )
+  {
+    return new PrioritizedCallable<V>()
+    {
+      @Override
+      public int getPriority()
+      {
+        return callable.getPriority();
+      }
+
+      @Override
+      public V call() throws Exception
+      {
+        if (pre != null) {
+          pre.run();
+        }
+        final V retVal = callable.call();
+        if (post != null) {
+          post.run();
+        }
+        return retVal;
+      }
+    };
+  }
+
+  public static PrioritizedRunnable wrapRunnable(
+      final PrioritizedRunnable runnable,
+      final Runnable pre,
+      final Runnable post
+  )
+  {
+    return new PrioritizedRunnable()
+    {
+
+      @Override
+      public void run()
+      {
+        if (pre != null) {
+          pre.run();
+        }
+        runnable.run();
+        if (post != null) {
+          post.run();
+        }
+      }
+
+      @Override
+      public int getPriority()
+      {
+        return runnable.getPriority();
+      }
+    };
   }
 }


### PR DESCRIPTION
This is a small proposed patch to allow emitting of a user-cpu time statistic on metrics emitting thread pools (the processing pool).

The down side is that it no longer directly passes through the runnable or callable to the service, but instead wraps it in order to capture the actual cpu run time of the task.