### PR TITLE
Improve filtering of segments for dataSourceMetadataQuery

### DIFF
--- a/processing/src/main/java/io/druid/query/datasourcemetadata/DataSourceQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/datasourcemetadata/DataSourceQueryQueryToolChest.java
@@ -58,7 +58,6 @@ public class DataSourceQueryQueryToolChest
       return segments;
     }
 
-    final T min = segments.get(0);
     final T max = segments.get(segments.size() - 1);
 
     return Lists.newArrayList(
@@ -69,8 +68,7 @@ public class DataSourceQueryQueryToolChest
               @Override
               public boolean apply(T input)
               {
-                return (min != null && input.getInterval().overlaps(min.getInterval())) ||
-                       (max != null && input.getInterval().overlaps(max.getInterval()));
+                return max != null && input.getInterval().overlaps(max.getInterval());
               }
             }
         )

--- a/processing/src/test/java/io/druid/query/datasourcemetadata/DataSourceMetadataQueryTest.java
+++ b/processing/src/test/java/io/druid/query/datasourcemetadata/DataSourceMetadataQueryTest.java
@@ -35,7 +35,6 @@ import io.druid.query.QueryRunnerTestHelper;
 import io.druid.query.Result;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
-import io.druid.query.timeboundary.TimeBoundaryQueryQueryToolChest;
 import io.druid.segment.IncrementalIndexSegment;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
@@ -142,9 +141,25 @@ public class DataSourceMetadataQueryTest
   @Test
   public void testFilterSegments()
   {
-    List<LogicalSegment> segments = new TimeBoundaryQueryQueryToolChest().filterSegments(
+    List<LogicalSegment> segments = new DataSourceQueryQueryToolChest().filterSegments(
         null,
         Arrays.asList(
+            new LogicalSegment()
+            {
+              @Override
+              public Interval getInterval()
+              {
+                return new Interval("2012-01-01/P1D");
+              }
+            },
+            new LogicalSegment()
+            {
+              @Override
+              public Interval getInterval()
+              {
+                return new Interval("2012-01-01T01/PT1H");
+              }
+            },
             new LogicalSegment()
             {
               @Override
@@ -172,8 +187,8 @@ public class DataSourceMetadataQueryTest
         )
     );
 
-    Assert.assertEquals(segments.size(), 3);
-
+    Assert.assertEquals(segments.size(), 2);
+    // should only have the latest segments. 
     List<LogicalSegment> expected = Arrays.asList(
         new LogicalSegment()
         {
@@ -188,21 +203,13 @@ public class DataSourceMetadataQueryTest
           @Override
           public Interval getInterval()
           {
-            return new Interval("2013-01-01T01/PT1H");
-          }
-        },
-        new LogicalSegment()
-        {
-          @Override
-          public Interval getInterval()
-          {
             return new Interval("2013-01-01T02/PT1H");
           }
         }
     );
 
     for (int i = 0; i < segments.size(); i++) {
-      Assert.assertEquals(segments.get(i).getInterval(), expected.get(i).getInterval());
+      Assert.assertEquals(expected.get(i).getInterval(),segments.get(i).getInterval());
     }
   }
 


### PR DESCRIPTION
dataSourceMetadataQuery only needs to be executed on latest segments at
present, modify filterSegments and add test.