### PR TITLE
minor fixes in the Endpoints section of Coordinator.md

### DIFF
--- a/docs/content/Coordinator.md
+++ b/docs/content/Coordinator.md
@@ -52,7 +52,7 @@ Returns the Druid version, loaded extensions, memory used, total memory and othe
 
 * `/druid/coordinator/v1/leader`
 
-Returns the current leader coordinator of the cluster as a JSON object.
+Returns the current leader coordinator of the cluster.
 
 * `/druid/coordinator/v1/loadstatus`
 
@@ -84,7 +84,7 @@ Returns a list of the names of enabled datasources in the cluster.
 
 * `/druid/coordinator/v1/metadata/datasources?includeDisabled`
 
-Returns a list of the names of enabled and enabled datasources in the cluster.
+Returns a list of the names of enabled and disabled datasources in the cluster.
 
 * `/druid/coordinator/v1/metadata/datasources?full`
 


### PR DESCRIPTION
Under /leader, it says that the return value is a JSON object, but it's a string.  I changed it to just not say exactly what format it is.  This is in line with most of the other descriptions.

Under /datasource?includeDisabled, I changed "enabled and enabled" to "enabled and disabled".