### PR TITLE
add test for exception during timeboundary

### DIFF
--- a/server/src/test/java/io/druid/client/CachingClusteredClientTest.java
+++ b/server/src/test/java/io/druid/client/CachingClusteredClientTest.java
@@ -2295,4 +2295,70 @@ public class CachingClusteredClientTest
       return expectations.iterator();
     }
   }
+
+  @Test
+  public void testTimeBoundaryCachingWhenTimeIsInteger() throws Exception
+  {
+    testQueryCaching(
+        client,
+        Druids.newTimeBoundaryQueryBuilder()
+              .dataSource(CachingClusteredClientTest.DATA_SOURCE)
+              .intervals(CachingClusteredClientTest.SEG_SPEC)
+              .context(CachingClusteredClientTest.CONTEXT)
+              .build(),
+        new Interval("1970-01-01/1970-01-02"),
+        makeTimeBoundaryResult(new DateTime("1970-01-01"), new DateTime("1970-01-01"), new DateTime("1970-01-02")),
+
+        new Interval("1970-01-01/2011-01-03"),
+        makeTimeBoundaryResult(new DateTime("1970-01-02"), new DateTime("1970-01-02"), new DateTime("1970-01-03")),
+
+        new Interval("1970-01-01/2011-01-10"),
+        makeTimeBoundaryResult(new DateTime("1970-01-05"), new DateTime("1970-01-05"), new DateTime("1970-01-10")),
+
+        new Interval("1970-01-01/2011-01-10"),
+        makeTimeBoundaryResult(new DateTime("1970-01-05T01"), new DateTime("1970-01-05T01"), new DateTime("1970-01-10"))
+    );
+
+    testQueryCaching(
+        client,
+        Druids.newTimeBoundaryQueryBuilder()
+              .dataSource(CachingClusteredClientTest.DATA_SOURCE)
+              .intervals(CachingClusteredClientTest.SEG_SPEC)
+              .context(CachingClusteredClientTest.CONTEXT)
+              .bound(TimeBoundaryQuery.MAX_TIME)
+              .build(),
+        new Interval("1970-01-01/2011-01-02"),
+        makeTimeBoundaryResult(new DateTime("1970-01-01"), null, new DateTime("1970-01-02")),
+
+        new Interval("1970-01-01/2011-01-03"),
+        makeTimeBoundaryResult(new DateTime("1970-01-02"), null, new DateTime("1970-01-03")),
+
+        new Interval("1970-01-01/2011-01-10"),
+        makeTimeBoundaryResult(new DateTime("1970-01-05"), null, new DateTime("1970-01-10")),
+
+        new Interval("1970-01-01/2011-01-10"),
+        makeTimeBoundaryResult(new DateTime("1970-01-05T01"), null, new DateTime("1970-01-10"))
+    );
+
+    testQueryCaching(
+        client,
+        Druids.newTimeBoundaryQueryBuilder()
+              .dataSource(CachingClusteredClientTest.DATA_SOURCE)
+              .intervals(CachingClusteredClientTest.SEG_SPEC)
+              .context(CachingClusteredClientTest.CONTEXT)
+              .bound(TimeBoundaryQuery.MIN_TIME)
+              .build(),
+        new Interval("1970-01-01/2011-01-02"),
+        makeTimeBoundaryResult(new DateTime("1970-01-01"), new DateTime("1970-01-01"), null),
+
+        new Interval("1970-01-01/2011-01-03"),
+        makeTimeBoundaryResult(new DateTime("1970-01-02"), new DateTime("1970-01-02"), null),
+
+        new Interval("1970-01-01/1970-01-10"),
+        makeTimeBoundaryResult(new DateTime("1970-01-05"), new DateTime("1970-01-05"), null),
+
+        new Interval("1970-01-01/2011-01-10"),
+        makeTimeBoundaryResult(new DateTime("1970-01-05T01"), new DateTime("1970-01-05T01"), null)
+    );
+  }
 }


### PR DESCRIPTION
Add Test for exception during time boundary query where results can be
represented as integers
Stack trace of exception - 
java.lang.IllegalArgumentException: No instant converter found for type: java.lang.Integer
        at org.joda.time.convert.ConverterManager.getInstantConverter(ConverterManager.java:165) ~[druid-selfcontained-0c734c6.jar:0c734c6]
        at org.joda.time.base.BaseDateTime.<init>(BaseDateTime.java:173) ~[druid-selfcontained-0c734c6.jar:0c734c6]
        at org.joda.time.DateTime.<init>(DateTime.java:257) ~[druid-selfcontained-0c734c6.jar:0c734c6]
        at io.druid.query.timeboundary.TimeBoundaryQueryQueryToolChest$5$2.apply(TimeBoundaryQueryQueryToolChest.java:189) ~[druid-selfcontained-0c734c6.jar:0c734c6]

