### PR TITLE
Overall improvement on Azure Deep Storage extension.

### DIFF
--- a/extensions/azure-extensions/src/main/java/io/druid/storage/azure/AzureByteSource.java
+++ b/extensions/azure-extensions/src/main/java/io/druid/storage/azure/AzureByteSource.java
@@ -28,23 +28,26 @@ import java.net.URISyntaxException;
 public class AzureByteSource extends ByteSource
 {
 
-  final private AzureStorageContainer azureStorageContainer;
-  final private String filePath;
+  final private AzureStorage azureStorage;
+  final private String containerName;
+  final private String blobPath;
 
   public AzureByteSource(
-      AzureStorageContainer azureStorageContainer,
-      String filePath
+      AzureStorage azureStorage,
+      String containerName,
+      String blobPath
   )
   {
-    this.azureStorageContainer = azureStorageContainer;
-    this.filePath = filePath;
+    this.azureStorage = azureStorage;
+    this.containerName = containerName;
+    this.blobPath = blobPath;
   }
 
   @Override
   public InputStream openStream() throws IOException
   {
     try {
-      return azureStorageContainer.getBlobInputStream(filePath);
+      return azureStorage.getBlobInputStream(containerName, blobPath);
     }
     catch (StorageException | URISyntaxException e) {
       if (AzureUtils.AZURE_RETRY.apply(e)) {

--- a/extensions/azure-extensions/src/main/java/io/druid/storage/azure/AzureLoadSpec.java
+++ b/extensions/azure-extensions/src/main/java/io/druid/storage/azure/AzureLoadSpec.java
@@ -30,25 +30,32 @@ import java.io.File;
 @JsonTypeName(AzureStorageDruidModule.SCHEME)
 public class AzureLoadSpec implements LoadSpec
 {
+
   @JsonProperty
-  private final String storageDir;
+  private final String containerName;
+
+  @JsonProperty
+  private final String blobPath;
 
   private final AzureDataSegmentPuller puller;
 
   @JsonCreator
   public AzureLoadSpec(
-      @JacksonInject AzureDataSegmentPuller puller,
-      @JsonProperty("storageDir") String storageDir
+      @JsonProperty("containerName") String containerName,
+      @JsonProperty("blobPath") String blobPath,
+      @JacksonInject AzureDataSegmentPuller puller
   )
   {
-    Preconditions.checkNotNull(storageDir);
-    this.storageDir = storageDir;
+    Preconditions.checkNotNull(blobPath);
+    Preconditions.checkNotNull(containerName);
+    this.containerName = containerName;
+    this.blobPath = blobPath;
     this.puller = puller;
   }
 
   @Override
   public LoadSpecResult loadSegment(File file) throws SegmentLoadingException
   {
-    return new LoadSpecResult(puller.getSegmentFiles(storageDir, file).size());
+    return new LoadSpecResult(puller.getSegmentFiles(containerName, blobPath, file).size());
   }
 }

--- a/extensions/azure-extensions/src/test/java/io/druid/storage/azure/AzureByteSourceTest.java
+++ b/extensions/azure-extensions/src/test/java/io/druid/storage/azure/AzureByteSourceTest.java
@@ -29,18 +29,20 @@ import static org.easymock.EasyMock.*;
 
 public class AzureByteSourceTest extends EasyMockSupport
 {
+
   @Test
   public void openStreamTest() throws IOException, URISyntaxException, StorageException
   {
-    final String filePath = "/path/to/file";
-    AzureStorageContainer azureStorageContainer = createMock(AzureStorageContainer.class);
+    final String containerName = "container";
+    final String blobPath = "/path/to/file";
+    AzureStorage azureStorage = createMock(AzureStorage.class);
     InputStream stream = createMock(InputStream.class);
 
-    expect(azureStorageContainer.getBlobInputStream(filePath)).andReturn(stream);
+    expect(azureStorage.getBlobInputStream(containerName, blobPath)).andReturn(stream);
 
     replayAll();
 
-    AzureByteSource byteSource = new AzureByteSource(azureStorageContainer, filePath);
+    AzureByteSource byteSource = new AzureByteSource(azureStorage, containerName, blobPath);
 
     byteSource.openStream();
 
@@ -50,14 +52,23 @@ public class AzureByteSourceTest extends EasyMockSupport
   @Test(expected = IOException.class)
   public void openStreamWithRecoverableErrorTest() throws URISyntaxException, StorageException, IOException
   {
-    final String filePath = "/path/to/file";
-    AzureStorageContainer azureStorageContainer = createMock(AzureStorageContainer.class);
+    final String containerName = "container";
+    final String blobPath = "/path/to/file";
+    AzureStorage azureStorage = createMock(AzureStorage.class);
 
-    expect(azureStorageContainer.getBlobInputStream(filePath)).andThrow(new StorageException("", "", 500, null, null));
+    expect(azureStorage.getBlobInputStream(containerName, blobPath)).andThrow(
+        new StorageException(
+            "",
+            "",
+            500,
+            null,
+            null
+        )
+    );
 
     replayAll();
 
-    AzureByteSource byteSource = new AzureByteSource(azureStorageContainer, filePath);
+    AzureByteSource byteSource = new AzureByteSource(azureStorage, containerName, blobPath);
 
     byteSource.openStream();
 


### PR DESCRIPTION
* Remove hard-coded azure path manipulation from the puller.
* Fix segment size not being zero after uploading it do Azure.
* Remove both index and desc files only on a success upload to Azure.
* Add Azure container name to load spec.