### PR TITLE
Optional validation on ConvertSegmentTask

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/common/task/NoopTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/NoopTask.java
@@ -28,6 +28,8 @@ import io.druid.indexing.common.TaskToolbox;
 import io.druid.indexing.common.actions.TaskActionClient;
 import org.joda.time.DateTime;
 
+import java.util.UUID;
+
 /**
  */
 public class NoopTask extends AbstractTask
@@ -66,7 +68,7 @@ public class NoopTask extends AbstractTask
   )
   {
     super(
-        id == null ? String.format("noop_%s", new DateTime()) : id,
+        id == null ? String.format("noop_%s_%s", new DateTime(), UUID.randomUUID().toString()) : id,
         "none"
     );
 

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/ConvertSegmentTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/ConvertSegmentTaskTest.java
@@ -39,7 +39,7 @@ public class ConvertSegmentTaskTest
 
     DefaultObjectMapper jsonMapper = new DefaultObjectMapper();
 
-    ConvertSegmentTask task = ConvertSegmentTask.create(dataSource, interval, null, false);
+    ConvertSegmentTask task = ConvertSegmentTask.create(dataSource, interval, null, false, true);
 
     Task task2 = jsonMapper.readValue(jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(task), Task.class);
     Assert.assertEquals(task, task2);
@@ -56,7 +56,7 @@ public class ConvertSegmentTaskTest
         102937
     );
 
-    task = ConvertSegmentTask.create(segment, null, false);
+    task = ConvertSegmentTask.create(segment, null, false, true);
 
     task2 = jsonMapper.readValue(jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(task), Task.class);
     Assert.assertEquals(task, task2);

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
@@ -164,7 +164,8 @@ public class TaskSerdeTest
     final ConvertSegmentTask task = ConvertSegmentTask.create(
         DataSegment.builder().dataSource("foo").interval(new Interval("2010-01-01/P1D")).version("1234").build(),
         null,
-        false
+        false,
+        true
     );
 
     final String json = jsonMapper.writeValueAsString(task);
@@ -189,7 +190,8 @@ public class TaskSerdeTest
         "myGroupId",
         DataSegment.builder().dataSource("foo").interval(new Interval("2010-01-01/P1D")).version("1234").build(),
         indexSpec,
-        false
+        false,
+        true
     );
 
     final String json = jsonMapper.writeValueAsString(task);
@@ -370,8 +372,9 @@ public class TaskSerdeTest
             0,
             12345L
         ),
-        indexSpec
-        , false
+        indexSpec,
+        false,
+        true
     );
     final String json = jsonMapper.writeValueAsString(task);
     final ConvertSegmentTask taskFromJson = jsonMapper.readValue(json, ConvertSegmentTask.class);
@@ -394,8 +397,9 @@ public class TaskSerdeTest
     );
     final ConvertSegmentTask convertSegmentTaskOriginal = ConvertSegmentTask.create(
         segment,
-        new IndexSpec(new RoaringBitmapSerdeFactory(), "lzf", "uncompressed")
-        , false
+        new IndexSpec(new RoaringBitmapSerdeFactory(), "lzf", "uncompressed"),
+        false,
+        true
     );
     final String json = jsonMapper.writeValueAsString(convertSegmentTaskOriginal);
     final Task task = jsonMapper.readValue(json, Task.class);

--- a/processing/src/main/java/io/druid/segment/IndexIO.java
+++ b/processing/src/main/java/io/druid/segment/IndexIO.java
@@ -198,14 +198,13 @@ public class IndexIO
 
   public static boolean convertSegment(File toConvert, File converted, IndexSpec indexSpec) throws IOException
   {
-    return convertSegment(toConvert, converted, indexSpec, false);
+    return convertSegment(toConvert, converted, indexSpec, false, true);
   }
 
-  public static boolean convertSegment(File toConvert, File converted, IndexSpec indexSpec, boolean forceIfCurrent)
+  public static boolean convertSegment(File toConvert, File converted, IndexSpec indexSpec, boolean forceIfCurrent, boolean validate)
       throws IOException
   {
     final int version = SegmentUtils.getVersionFromDir(toConvert);
-
     switch (version) {
       case 1:
       case 2:
@@ -231,7 +230,9 @@ public class IndexIO
       default:
         if (forceIfCurrent) {
           IndexMaker.convert(toConvert, converted, indexSpec);
-          DefaultIndexIOHandler.validateTwoSegments(toConvert, converted);
+          if(validate){
+            DefaultIndexIOHandler.validateTwoSegments(toConvert, converted);
+          }
           return true;
         } else {
           log.info("Version[%s], skipping.", version);


### PR DESCRIPTION
The motivation behind this is to speed up the conversion task. For old segments that fall prey to issue #1309, the added time necessary to compare values in addition to indices doubles the amount of time it takes to convert a segment. When doing large amounts of batch conversions, it should be allowed to skip validation.