### PR TITLE
Fix DruidNodeTest for ipv6 only hosts

### DIFF
--- a/server/src/test/java/io/druid/server/DruidNodeTest.java
+++ b/server/src/test/java/io/druid/server/DruidNodeTest.java
@@ -17,6 +17,7 @@
 
 package io.druid.server;
 
+import com.google.common.net.HostAndPort;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -32,7 +33,9 @@ public class DruidNodeTest
     node = new DruidNode(service, null, null);
     Assert.assertEquals(DruidNode.getDefaultHost(), node.getHost());
     Assert.assertEquals(-1, node.getPort());
-    Assert.assertEquals(DruidNode.getDefaultHost(), node.getHostAndPort());
+    // Hosts which report only ipv6 will have getDefaultHost() report something like fe80::6e40:8ff:fe93:9230
+    // but getHostAndPort() reports [fe80::6e40:8ff:fe93:9230]
+    Assert.assertEquals(HostAndPort.fromString(DruidNode.getDefaultHost()).toString(), node.getHostAndPort());
 
     node = new DruidNode(service, "2001:db8:85a3::8a2e:370:7334", -1);
     Assert.assertEquals("2001:db8:85a3::8a2e:370:7334", node.getHost());


### PR DESCRIPTION
This unit test was failing on the BART for me this morning.