### PR TITLE
fixing the typo for audit table (type, created_date) index creation

### DIFF
--- a/server/src/main/java/io/druid/metadata/SQLMetadataConnector.java
+++ b/server/src/main/java/io/druid/metadata/SQLMetadataConnector.java
@@ -397,7 +397,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
                 tableName, getSerialType(), getPayloadType()
             ),
             String.format("CREATE INDEX idx_%1$s_key_time ON %1$s(audit_key, created_date)", tableName),
-            String.format("CREATE INDEX idx_%1$s_type_time ON %1$s(audit_key, created_date)", tableName),
+            String.format("CREATE INDEX idx_%1$s_type_time ON %1$s(type, created_date)", tableName),
             String.format("CREATE INDEX idx_%1$s_audit_time ON %1$s(created_date)", tableName)
         )
     );


### PR DESCRIPTION
This PR fixes keys of an index in the audit table. Anyone migrating from previous versions of druid-0.7.x would need to execute following sql on their database.

&lt;table_name&gt; = "druid_audit" (by default) or value of property "druid.metadata.storage.tables.audit" from your druid configuration

mysql:
```
ALTER TABLE <table_name> DROP INDEX idx_<table_name>_type_time;
CREATE INDEX idx_<table_name>_type_time ON <table_name>(type, created_date);
```

postgres:
```
DROP INDEX idx_<table_name>_type_time;
CREATE INDEX idx_<table_name>_type_time ON <table_name>(type, created_date);
```
