### PR TITLE
fix NPE

### DIFF
--- a/processing/src/main/java/io/druid/query/topn/AggregateTopNMetricFirstAlgorithm.java
+++ b/processing/src/main/java/io/druid/query/topn/AggregateTopNMetricFirstAlgorithm.java
@@ -101,9 +101,7 @@ public class AggregateTopNMetricFirstAlgorithm implements TopNAlgorithm<int[], T
       dimValSelector = getDimValSelectorForTopNMetric(singleMetricParam, singleMetricResultBuilder);
     }
     finally {
-      if (singleMetricParam != null) {
-        singleMetricAlgo.cleanup(singleMetricParam);
-      }
+      singleMetricAlgo.cleanup(singleMetricParam);
     }
 
     PooledTopNAlgorithm allMetricAlgo = new PooledTopNAlgorithm(capabilities, query, bufferPool);
@@ -118,9 +116,7 @@ public class AggregateTopNMetricFirstAlgorithm implements TopNAlgorithm<int[], T
       );
     }
     finally {
-      if (allMetricsParam != null) {
-        allMetricAlgo.cleanup(allMetricsParam);
-      }
+      allMetricAlgo.cleanup(allMetricsParam);
     }
   }
 

--- a/processing/src/main/java/io/druid/query/topn/PooledTopNAlgorithm.java
+++ b/processing/src/main/java/io/druid/query/topn/PooledTopNAlgorithm.java
@@ -311,12 +311,14 @@ public class PooledTopNAlgorithm
   @Override
   public void cleanup(PooledTopNParams params)
   {
-    ResourceHolder<ByteBuffer> resultsBufHolder = params.getResultsBufHolder();
+    if (params != null) {
+      ResourceHolder<ByteBuffer> resultsBufHolder = params.getResultsBufHolder();
 
-    if (resultsBufHolder != null) {
-      resultsBufHolder.get().clear();
+      if (resultsBufHolder != null) {
+        resultsBufHolder.get().clear();
+      }
+      CloseQuietly.close(resultsBufHolder);
     }
-    CloseQuietly.close(resultsBufHolder);
   }
 
   public static class PooledTopNParams extends TopNParams

--- a/processing/src/test/java/io/druid/query/topn/PooledTopNAlgorithmTest.java
+++ b/processing/src/test/java/io/druid/query/topn/PooledTopNAlgorithmTest.java
@@ -1,0 +1,56 @@
+/*
+ * Druid - a distributed column store.
+ * Copyright 2012 - 2015 Metamarkets Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.druid.query.topn;
+
+import io.druid.collections.ResourceHolder;
+import io.druid.segment.Capabilities;
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class PooledTopNAlgorithmTest
+{
+  @Test
+  public void testCleanupWithNullParams()
+  {
+    PooledTopNAlgorithm pooledTopNAlgorithm = new PooledTopNAlgorithm(Capabilities.builder().build(), null, null);
+    pooledTopNAlgorithm.cleanup(null);
+  }
+
+  @Test
+  public void cleanup() throws IOException
+  {
+    PooledTopNAlgorithm pooledTopNAlgorithm = new PooledTopNAlgorithm(Capabilities.builder().build(), null, null);
+    PooledTopNAlgorithm.PooledTopNParams params = EasyMock.createMock(PooledTopNAlgorithm.PooledTopNParams.class);
+    ResourceHolder<ByteBuffer> resourceHolder = EasyMock.createMock(ResourceHolder.class);
+    ByteBuffer buffer = EasyMock.createMock(ByteBuffer.class);
+    EasyMock.expect(params.getResultsBufHolder()).andReturn(resourceHolder).times(1);
+    EasyMock.expect(resourceHolder.get()).andReturn(buffer).times(1);
+    resourceHolder.close();
+    EasyMock.expectLastCall().once();
+    EasyMock.replay(params);
+    EasyMock.replay(resourceHolder);
+    EasyMock.replay(buffer);
+    pooledTopNAlgorithm.cleanup(params);
+    EasyMock.verify(params);
+    EasyMock.verify(resourceHolder);
+    EasyMock.verify(buffer);
+  }
+}


### PR DESCRIPTION
Fix NPE 
Stack trace for NPE - 
java.lang.NullPointerException
        at io.druid.query.topn.PooledTopNAlgorithm.cleanup(PooledTopNAlgorithm.java:314) ~[druid-selfcontained-0f7946b.jar:0f7946b]
        at io.druid.query.topn.PooledTopNAlgorithm.cleanup(PooledTopNAlgorithm.java:35) ~[druid-selfcontained-0f7946b.jar:0f7946b]
        at io.druid.query.topn.TopNMapFn.apply(TopNMapFn.java:63) ~[druid-selfcontained-0f7946b.jar:0f7946b]
        at io.druid.query.topn.TopNMapFn.apply(TopNMapFn.java:25) ~[druid-selfcontained-0f7946b.jar:0f7946b]
        at io.druid.query.topn.TopNQueryEngine$1.apply(TopNQueryEngine.java:81) ~[druid-selfcontained-0f7946b.jar:0f7946b]
        at io.druid.query.topn.TopNQueryEngine$1.apply(TopNQueryEngine.java:76) ~[druid-selfcontained-0f7946b.jar:0f7946b]
        at com.metamx.common.guava.MappingAccumulator.accumulate(MappingAccumulator.java:39) ~[druid-selfcontained-0f7946b.jar:0f7946b]
        at com.metamx.common.guava.FilteringAccumulator.accumulate(FilteringAccumulator.java:40) ~[druid-selfcontained-0f7946b.jar:0f7946b]
        at com.metamx.common.guava.YieldingAccumulators$1.accumulate(YieldingAccumulators.java:32) ~[druid-selfcontained-0f7946b.jar:0f7946b]
        at com.metamx.common.guava.MappingYieldingAccumulator.accumulate(MappingYieldingAccumulator.java:57) ~[druid-selfcontained-0f7946b.jar:0f7946b]
        at com.metamx.common.guava.BaseSequence.makeYielder(BaseSequence.java:104) ~[druid-selfcontained-0f7946b.jar:0f7946b]
        at com.metamx.common.guava.BaseSequence.toYielder(BaseSequence.java:81) ~[druid-selfcontained-0f7946b.jar:0f7946b]
        at com.metamx.common.guava.MappedSequence.toYielder(MappedSequence.java:46) ~[druid-selfcontained-0f7946b.jar:0f7946b]
        at com.metamx.common.guava.ResourceClosingSequence.toYielder(ResourceClosingSequence.java:41) ~[druid-selfcontained-0f7946b.jar:0f7946b]