### PR TITLE
fixes #1330

### DIFF
--- a/common/src/test/java/io/druid/common/utils/JodaUtilsTest.java
+++ b/common/src/test/java/io/druid/common/utils/JodaUtilsTest.java
@@ -17,12 +17,16 @@
 
 package io.druid.common.utils;
 
+import org.joda.time.DateTimeConstants;
+import org.joda.time.Duration;
 import org.joda.time.Interval;
+import org.joda.time.Period;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -124,4 +128,23 @@ public class JodaUtilsTest
     final Interval interval = new Interval(JodaUtils.MIN_INSTANT, JodaUtils.MAX_INSTANT);
     Assert.assertEquals(Long.MAX_VALUE, interval.toDuration().getMillis());
   }
+
+  @Test
+  public void testMinMaxDuration()
+  {
+    final Interval interval = new Interval(JodaUtils.MIN_INSTANT, JodaUtils.MAX_INSTANT);
+    final Duration duration = interval.toDuration();
+    Assert.assertEquals(Long.MAX_VALUE, duration.getMillis());
+    Assert.assertEquals("PT9223372036854775.807S", duration.toString());
+  }
+
+  // new Period(Long.MAX_VALUE) throws ArithmeticException
+  @Test(expected = ArithmeticException.class)
+  public void testMinMaxPeriod()
+  {
+    final Interval interval = new Interval(JodaUtils.MIN_INSTANT, JodaUtils.MAX_INSTANT);
+    final Period period = interval.toDuration().toPeriod();
+    Assert.assertEquals(Long.MAX_VALUE, period.getMinutes());
+  }
+
 }

--- a/processing/src/main/java/io/druid/query/DruidMetrics.java
+++ b/processing/src/main/java/io/druid/query/DruidMetrics.java
@@ -76,7 +76,7 @@ public class DruidMetrics
             ).toArray(new String[query.getIntervals().size()])
         )
         .setDimension("hasFilters", String.valueOf(query.hasFilters()))
-        .setDimension("duration", query.getDuration().toPeriod().toStandardMinutes().toString());
+        .setDimension("duration", query.getDuration().toString());
   }
 
   public static <T> ServiceMetricEvent.Builder makeQueryTimeMetric(


### PR DESCRIPTION
fixes #1330,
Avoid creating Period instance as creating a Period from Long.MAX_VALUE
throws arithmetic exception.
After this query metric will emit duration in seconds instead of
minutes.