### PR TITLE
Modify SocketUtil to have better checks on free ports

### DIFF
--- a/common/src/main/java/io/druid/common/utils/SocketUtil.java
+++ b/common/src/main/java/io/druid/common/utils/SocketUtil.java
@@ -17,10 +17,25 @@
 
 package io.druid.common.utils;
 
+import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.metamx.common.ISE;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  */
@@ -29,25 +44,68 @@ public class SocketUtil
   public static int findOpenPort(int startPort)
   {
     int currPort = startPort;
+    final byte[] key = new byte[1<<10];
+    final Random rnd = new Random(473819178L);
+    rnd.nextBytes(key);
 
     while (currPort < 0xffff) {
-      ServerSocket socket = null;
-      try {
-        socket = new ServerSocket(currPort);
+      final ListeningExecutorService executorService = MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor());
+      try(final ServerSocket serverSocket =  new ServerSocket(currPort)){
+        final ListenableFuture<?> future = executorService
+            .submit(
+                new Runnable()
+                {
+                  @Override
+                  public void run()
+                  {
+                    try (Socket socket = serverSocket.accept()) {
+                      try (InputStream inputStream = socket.getInputStream()) {
+                        final byte[] check = new byte[key.length];
+                        try {
+                          int off = 0;
+                          while (off < check.length) {
+                            int i = inputStream.read(check, off, check.length - off);
+                            if(i < 0){
+                              throw new IOException("EOS");
+                            }
+                            off += i;
+                          }
+                        }
+                        catch (IOException e) {
+                          throw Throwables.propagate(e);
+                        }
+                        if (!Arrays.equals(key, check)) {
+                          throw new RuntimeException("Key Mismatch");
+                        }
+                      }
+                    }
+                    catch (IOException e) {
+                      throw Throwables.propagate(e);
+                    }
+                  }
+                }
+            );
+        try (SocketChannel sendSocket = SocketChannel.open(new InetSocketAddress("localhost", currPort))) {
+          sendSocket.write(ByteBuffer.wrap(key));
+          future.get(10, TimeUnit.MILLISECONDS);
+        }
+        catch (TimeoutException ex) {
+          throw new IOException("Send took too long", ex);
+        }
+        catch (ExecutionException ex) {
+          throw new IOException("Error in thread", ex);
+        }
+        catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw Throwables.propagate(e);
+        }
         return currPort;
       }
       catch (IOException e) {
         ++currPort;
       }
       finally {
-        if (socket != null) {
-          try {
-            socket.close();
-          }
-          catch (IOException e) {
-
-          }
-        }
+        executorService.shutdownNow();
       }
     }
 


### PR DESCRIPTION
* Now checks if the port is addressable instead of just bindable

I ran into this while running a VirtualBox VM that had port forwards defined on 8080. Turns out the existing SocketUtil won't fail the binding, but isn't addressable!

This patch also checks that the port is addressable through localhost:port