### PR TITLE
Add URISupplier to LoadSpec for certain classes

### DIFF
--- a/extensions/s3-extensions/src/test/java/io/druid/storage/s3/TestS3LoadSpec.java
+++ b/extensions/s3-extensions/src/test/java/io/druid/storage/s3/TestS3LoadSpec.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.storage.s3;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class TestS3LoadSpec
+{
+  private S3DataSegmentPuller puller = null;
+  @Before
+  public void setUp(){
+    puller = new S3DataSegmentPuller(null);
+  }
+  @Test
+  public void testToURI() throws URISyntaxException
+  {
+    S3LoadSpec loadSpec = new S3LoadSpec(puller,"bucket","key");
+    Assert.assertEquals(new URI("s3://bucket/key"), loadSpec.getURI());
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <metamx.java-util.version>0.27.0</metamx.java-util.version>
         <apache.curator.version>2.7.0</apache.curator.version>
         <jetty.version>9.2.5.v20141112</jetty.version>
-        <druid.api.version>0.3.8</druid.api.version>
+        <druid.api.version>0.3.9-SNAPSHOT</druid.api.version>
         <jackson.version>2.4.4</jackson.version>
         <log4j.version>2.2</log4j.version>
         <slf4j.version>1.7.10</slf4j.version>

--- a/server/src/main/java/io/druid/segment/loading/LocalLoadSpec.java
+++ b/server/src/main/java/io/druid/segment/loading/LocalLoadSpec.java
@@ -25,6 +25,7 @@ import com.google.api.client.util.Preconditions;
 import io.druid.guice.LocalDataStorageDruidModule;
 
 import java.io.File;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -33,7 +34,7 @@ import java.nio.file.Paths;
  *
  */
 @JsonTypeName(LocalDataStorageDruidModule.SCHEME)
-public class LocalLoadSpec implements LoadSpec
+public class LocalLoadSpec implements LoadSpec, URISupplier
 {
   private final Path path;
   private final LocalDataSegmentPuller puller;
@@ -60,5 +61,11 @@ public class LocalLoadSpec implements LoadSpec
   public LoadSpecResult loadSegment(final File outDir) throws SegmentLoadingException
   {
     return new LoadSpecResult(puller.getSegmentFiles(path.toFile(), outDir).size());
+  }
+
+  @Override
+  public URI getURI()
+  {
+    return path.toUri();
   }
 }

--- a/server/src/test/java/io/druid/segment/loading/LoadSpecTest.java
+++ b/server/src/test/java/io/druid/segment/loading/LoadSpecTest.java
@@ -18,6 +18,7 @@
 package io.druid.segment.loading;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -36,12 +37,15 @@ import com.metamx.common.IAE;
 import io.druid.guice.GuiceInjectors;
 import io.druid.jackson.DefaultObjectMapper;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collection;
 
 /**
@@ -104,5 +108,14 @@ public class LoadSpecTest
   {
     LoadSpec loadSpec = mapper.readValue(value, LoadSpec.class);
     Assert.assertEquals(expectedId, loadSpec.getClass().getAnnotation(JsonTypeName.class).value());
+  }
+
+  @Test
+  public void testURISupplier() throws IOException, URISyntaxException
+  {
+    LoadSpec loadSpec = mapper.readValue(value, LoadSpec.class);
+    Assume.assumeTrue(loadSpec instanceof URISupplier);
+    URISupplier uriSupplier = (URISupplier)loadSpec;
+    Assert.assertEquals(new URI("file:/"),uriSupplier.getURI());
   }
 }


### PR DESCRIPTION
Requires https://github.com/druid-io/druid-api/pull/42

I realized there are no ways to get URI data from a LoadSpec. For example, if you want to pull segment files into Hadoop.