### PR TITLE
hotfixing druid realtime breaking on bad input

### DIFF
--- a/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -187,12 +187,19 @@ public class RealtimePlumber implements Plumber
   @Override
   public int add(InputRow row) throws IndexSizeExceededException
   {
-    final Sink sink = getSink(row.getTimestampFromEpoch());
-    if (sink == null) {
+    try {
+      final Sink sink = getSink(row.getTimestampFromEpoch());
+      if (sink == null) {
+        return -1;
+      }
+
+      return sink.add(row);
+    } catch (Exception e) {
+      log.makeAlert(e, "Failed to add row[%s]", schema.getDataSource())
+           .addData("row", row)
+           .emit();
       return -1;
     }
-
-    return sink.add(row);
   }
 
   public Sink getSink(long timestamp)


### PR DESCRIPTION
One of our producers was sending empty messages. The java library returns this as null, this turns InputRow null and then intake crashes on a NullPointer exception.

To ensure intake can never crash, I wrapped the whole processing in a try-catch block. It's in production here for 2 weeks, fixes the issue.