### PR TITLE
GroupBy Query with Having/Limit/Orderingspec inconsistencies (UnitTest)

### DIFF
--- a/processing/src/main/java/io/druid/query/groupby/GroupByQuery.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQuery.java
@@ -104,6 +104,7 @@ public class GroupByQuery extends BaseQuery<Row>
 
     if (havingSpec != null) {
       postProcFn = Functions.compose(
+          postProcFn,
           new Function<Sequence<Row>, Sequence<Row>>()
           {
             @Override
@@ -121,8 +122,7 @@ public class GroupByQuery extends BaseQuery<Row>
                   }
               );
             }
-          },
-          postProcFn
+          }
       );
     }
 

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryQueryToolChest.java
@@ -189,7 +189,7 @@ public class GroupByQueryQueryToolChest extends QueryToolChest<Row, GroupByQuery
                   ImmutableList.<PostAggregator>of(),
                   // Don't do "having" clause until the end of this method.
                   null,
-                  query.getLimitSpec(),
+                  null,
                   query.getContext()
               ).withOverriddenContext(
                   ImmutableMap.<String, Object>of(

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -1407,6 +1407,91 @@ public class GroupByQueryRunnerTest
   }
 
   @Test
+  public void testGroupByWithOrderLimitHavingSpec()
+  {
+    GroupByQuery.Builder builder = GroupByQuery
+        .builder()
+        .setDataSource(QueryRunnerTestHelper.dataSource)
+        .setInterval("2011-01-25/2011-01-28")
+        .setDimensions(Lists.<DimensionSpec>newArrayList(new DefaultDimensionSpec("quality", "alias")))
+        .setAggregatorSpecs(
+            Arrays.asList(
+                QueryRunnerTestHelper.rowsCount,
+                new DoubleSumAggregatorFactory("index", "index")
+            )
+        )
+        .setGranularity(QueryGranularity.ALL)
+        .setHavingSpec(new GreaterThanHavingSpec("index", 310L))
+        .setLimitSpec(
+            new DefaultLimitSpec(
+                Lists.newArrayList(
+                    new OrderByColumnSpec(
+                        "index",
+                        OrderByColumnSpec.Direction.ASCENDING
+                    )
+                ),
+                5
+            )
+        );
+
+    List<Row> expectedResults = Arrays.asList(
+        GroupByQueryRunnerTestHelper.createExpectedRow(
+            "2011-01-25",
+            "alias",
+            "business",
+            "rows",
+            3L,
+            "index",
+            312.38165283203125
+        ),
+        GroupByQueryRunnerTestHelper.createExpectedRow(
+            "2011-01-25",
+            "alias",
+            "news",
+            "rows",
+            3L,
+            "index",
+            312.7834167480469
+        ),
+        GroupByQueryRunnerTestHelper.createExpectedRow(
+            "2011-01-25",
+            "alias",
+            "technology",
+            "rows",
+            3L,
+            "index",
+            324.6412353515625
+        ),
+        GroupByQueryRunnerTestHelper.createExpectedRow(
+            "2011-01-25",
+            "alias",
+            "travel",
+            "rows",
+            3L,
+            "index",
+            393.36322021484375
+        ),
+        GroupByQueryRunnerTestHelper.createExpectedRow(
+            "2011-01-25",
+            "alias",
+            "health",
+            "rows",
+            3L,
+            "index",
+            511.2996826171875
+        )
+    );
+
+    GroupByQuery fullQuery = builder.build();
+    Iterable<Row> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, fullQuery);
+    TestHelper.assertExpectedObjects(
+        expectedResults,
+        results,
+        ""
+    );
+  }
+
+  @Test
   public void testPostAggHavingSpec()
   {
     List<Row> expectedResults = Arrays.asList(


### PR DESCRIPTION
As discussed on IRC with @fjy the query that I originally intended to do was the following:

```java
GroupByQuery.Builder queryBuilder = new GroupByQuery.Builder()
                .setDataSource("datasource")
                .setInterval(this.interval.getIntervalAsString())
                .addAggregator(new DoubleSumAggregatorFactory(this.metric, this.metric))
                .setGranularity(QueryGranularity.ALL)
                .addDimension("dimension1")
                .addDimension("dimension2")
                .setDimFilter(new SelectorDimFilter("dimension3", "data"))
                .setHavingSpec(new GreaterThanHavingSpec(this.metric, 0))
                .setLimitSpec(
                        new DefaultLimitSpec(
                                Lists.newArrayList(
                                        new OrderByColumnSpec(this.metric, OrderByColumnSpec.Direction.ASCENDING)),
                                this.limit)
                )
```

Basically, I wanted to do a LeastN query with more than 1 dimension and only take into account the rows that have metric > 0.
But when executing the query, I got an empty resultset. My thought was that the limit must have been applied before the having, which resulted in an empty resultset because the number of rows for which metric = 0 was greater than the limit.

Per the suggestion of @fjy I have created a Unittest that replicates this behavior. 

The full query is:

```java
 GroupByQuery.Builder builder = GroupByQuery
        .builder()
        .setDataSource(QueryRunnerTestHelper.dataSource)
        .setInterval("2011-01-25/2011-01-28")
        .setDimensions(Lists.<DimensionSpec>newArrayList(new DefaultDimensionSpec("quality", "alias")))
        .setAggregatorSpecs(
            Arrays.asList(
                QueryRunnerTestHelper.rowsCount,
                new DoubleSumAggregatorFactory("index", "index")
            )
        )
        .setGranularity(QueryGranularity.ALL)
        .setHavingSpec(new GreaterThanHavingSpec("index", 310L))
        .setLimitSpec(
            new DefaultLimitSpec(
                Lists.newArrayList(
                    new OrderByColumnSpec(
                        "index",
                        OrderByColumnSpec.Direction.ASCENDING
                    )
                ),
                5
            )
        );
```

I ran different mutations of this query (with or without the limit and havingspec) to get these results:

### With only orderingspec:
```
0 = {MapBasedRow@3755} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=261.4913024902344, alias=entertainment, rows=3}}"
1 = {MapBasedRow@3756} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=309.1449890136719, alias=automotive, rows=3}}"
2 = {MapBasedRow@3757} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=312.38165283203125, alias=business, rows=3}}"
3 = {MapBasedRow@3758} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=312.7834167480469, alias=news, rows=3}}"
4 = {MapBasedRow@3759} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=324.6412353515625, alias=technology, rows=3}}"
5 = {MapBasedRow@3760} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=393.36322021484375, alias=travel, rows=3}}"
6 = {MapBasedRow@3761} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=511.2996826171875, alias=health, rows=3}}"
7 = {MapBasedRow@3762} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=6828.8662109375, alias=mezzanine, rows=9}}"
8 = {MapBasedRow@3763} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=8239.927734375, alias=premium, rows=9}}"
```

### With only havingspec + orderingspec and without limit:
```
0 = {MapBasedRow@3754} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=312.38165283203125, alias=business, rows=3}}"
1 = {MapBasedRow@3755} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=312.7834167480469, alias=news, rows=3}}"
2 = {MapBasedRow@3756} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=324.6412353515625, alias=technology, rows=3}}"
3 = {MapBasedRow@3757} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=393.36322021484375, alias=travel, rows=3}}"
4 = {MapBasedRow@3758} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=511.2996826171875, alias=health, rows=3}}"
5 = {MapBasedRow@3759} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=6828.8662109375, alias=mezzanine, rows=9}}"
6 = {MapBasedRow@3760} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=8239.927734375, alias=premium, rows=9}}"
```

### With havingspec + orderingspec + limitspec:
```
0 = {MapBasedRow@3756} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=312.38165283203125, alias=business, rows=3}}"
1 = {MapBasedRow@3757} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=312.7834167480469, alias=news, rows=3}}"
2 = {MapBasedRow@3758} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=324.6412353515625, alias=technology, rows=3}}"
```

### Expected results:
```
0 = {MapBasedRow@3756} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=312.38165283203125, alias=business, rows=3}}"
1 = {MapBasedRow@3757} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=312.7834167480469, alias=news, rows=3}}"
2 = {MapBasedRow@3758} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=324.6412353515625, alias=technology, rows=3}}"
3 = {MapBasedRow@3757} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=393.36322021484375, alias=travel, rows=3}}"
4 = {MapBasedRow@3758} "MapBasedRow{timestamp=2011-01-25T00:00:00.000Z, event={index=511.2996826171875, alias=health, rows=3}}"
```

Am I correct in assuming that the expected results should be the correct result? Or am I misinterpreting something else?
I hope this unit test is sufficient, first time writing a Druid unit test :smile: