### PR TITLE
Fix for loadByPeriod rule

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/rules/PeriodLoadRule.java
+++ b/server/src/main/java/io/druid/server/coordinator/rules/PeriodLoadRule.java
@@ -83,6 +83,6 @@ public class PeriodLoadRule extends LoadRule
   public boolean appliesTo(Interval interval, DateTime referenceTimestamp)
   {
     final Interval currInterval = new Interval(period, referenceTimestamp);
-    return currInterval.overlaps(interval) && interval.getStartMillis() >= currInterval.getStartMillis();
+    return currInterval.overlaps(interval);
   }
 }

--- a/server/src/test/java/io/druid/server/coordinator/rules/PeriodLoadRuleTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/rules/PeriodLoadRuleTest.java
@@ -60,16 +60,21 @@ public class PeriodLoadRuleTest
 
     Assert.assertTrue(rule.appliesTo(builder.interval(new Interval(now.minusWeeks(1), now)).build(), now));
     Assert.assertTrue(
+        rule.appliesTo(builder.interval(new Interval(now.minusDays(1), now.plusDays(1))).build(),
+            now)
+    );
+    Assert.assertTrue(
         rule.appliesTo(
-            builder.interval(new Interval(now.minusDays(1), now.plusDays(1)))
-                   .build(),
-            now
-        )
+            builder.interval(new Interval(now.minusWeeks(7), now.minusWeeks(1))).build(),
+            now)
     );
     Assert.assertFalse(
         rule.appliesTo(
-            builder.interval(new Interval(now.plusDays(1), now.plusDays(2)))
-                       .build(),
+            builder.interval(new Interval(now.minusWeeks(7), now.minusWeeks(6))).build(),
+            now)
+    );
+    Assert.assertFalse(
+        rule.appliesTo(builder.interval(new Interval(now.plusDays(1), now.plusDays(2))).build(),
             now
         )
     );


### PR DESCRIPTION
If a segment (say created by merge from multiple smaller segments), has a start time less than the loadByPeriod start time, it is currently dropped by the coordinator even if it overlaps the load period. This CL fixes that.