### PR TITLE
in segment metadata query return actual complex data type name 

### DIFF
--- a/docs/content/SegmentMetadataQuery.md
+++ b/docs/content/SegmentMetadataQuery.md
@@ -47,7 +47,7 @@ The format of the result is:
 ```
 
 Dimension columns will have type `STRING`.  
-Metric columns will have type `FLOAT`.  
+Metric columns will have type `FLOAT` or `LONG` or name of the underlying complex type such as `hyperUnique` in case of COMPLEX metric.
 Timestamp column will have type `LONG`.
 
 Only columns which are dimensions (ie, have type `STRING`) will have any cardinality. Rest of the columns (timestamp and metric columns) will show cardinality as `null`.

--- a/processing/src/main/java/io/druid/query/metadata/SegmentAnalyzer.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentAnalyzer.java
@@ -143,7 +143,7 @@ public class SegmentAnalyzer
 
     final Function<Object, Long> inputSizeFn = serde.inputSizeFn();
     if (inputSizeFn == null) {
-      return ColumnAnalysis.error("noSizeFn");
+      return new ColumnAnalysis(typeName, 0, null, null);
     }
 
     final int length = column.getLength();
@@ -152,6 +152,6 @@ public class SegmentAnalyzer
       size += inputSizeFn.apply(complexColumn.getRowValue(i));
     }
 
-    return new ColumnAnalysis(capabilities.getType().name(), size, null, null);
+    return new ColumnAnalysis(typeName, size, null, null);
   }
 }


### PR DESCRIPTION
and dont fail if size information is not available (do best effort to return whatever information is available)

Fixes #1365