### PR TITLE
bug fix: hdfs task log and indexing task not work properly with Hadoop HA

### DIFF
--- a/extensions/hdfs-storage/src/main/java/io/druid/storage/hdfs/tasklog/HdfsTaskLogs.java
+++ b/extensions/hdfs-storage/src/main/java/io/druid/storage/hdfs/tasklog/HdfsTaskLogs.java
@@ -40,11 +40,13 @@ public class HdfsTaskLogs implements TaskLogs
   private static final Logger log = new Logger(HdfsTaskLogs.class);
 
   private final HdfsTaskLogsConfig config;
+  private final Configuration hadoopConfig;
 
   @Inject
-  public HdfsTaskLogs(HdfsTaskLogsConfig config)
+  public HdfsTaskLogs(HdfsTaskLogsConfig config, Configuration hadoopConfig)
   {
     this.config = config;
+    this.hadoopConfig = hadoopConfig;
   }
 
   @Override
@@ -52,9 +54,8 @@ public class HdfsTaskLogs implements TaskLogs
   {
     final Path path = getTaskLogFileFromId(taskId);
     log.info("Writing task log to: %s", path);
-    Configuration conf = new Configuration();
-    final FileSystem fs = path.getFileSystem(conf);
-    FileUtil.copy(logFile, fs, path, false, conf);
+    final FileSystem fs = path.getFileSystem(hadoopConfig);
+    FileUtil.copy(logFile, fs, path, false, hadoopConfig);
     log.info("Wrote task log to: %s", path);
   }
 
@@ -62,7 +63,7 @@ public class HdfsTaskLogs implements TaskLogs
   public Optional<ByteSource> streamTaskLog(final String taskId, final long offset) throws IOException
   {
     final Path path = getTaskLogFileFromId(taskId);
-    final FileSystem fs = path.getFileSystem(new Configuration());
+    final FileSystem fs = path.getFileSystem(hadoopConfig);
     if (fs.exists(path)) {
       return Optional.<ByteSource>of(
           new ByteSource()

--- a/extensions/hdfs-storage/src/test/java/io/druid/indexing/common/tasklogs/HdfsTaskLogsTest.java
+++ b/extensions/hdfs-storage/src/test/java/io/druid/indexing/common/tasklogs/HdfsTaskLogsTest.java
@@ -25,6 +25,7 @@ import io.druid.storage.hdfs.tasklog.HdfsTaskLogs;
 import io.druid.storage.hdfs.tasklog.HdfsTaskLogsConfig;
 import io.druid.tasklogs.TaskLogs;
 import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -41,7 +42,7 @@ public class HdfsTaskLogsTest
       final File logDir = new File(tmpDir, "logs");
       final File logFile = new File(tmpDir, "log");
       Files.write("blah", logFile, Charsets.UTF_8);
-      final TaskLogs taskLogs = new HdfsTaskLogs(new HdfsTaskLogsConfig(logDir.toString()));
+      final TaskLogs taskLogs = new HdfsTaskLogs(new HdfsTaskLogsConfig(logDir.toString()), new Configuration());
       taskLogs.pushTaskLog("foo", logFile);
 
       final Map<Long, String> expected = ImmutableMap.of(0L, "blah", 1L, "lah", -2L, "ah", -5L, "blah");

--- a/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
@@ -95,16 +95,10 @@ public class IndexGeneratorJob implements Jobby
 
   public static List<DataSegment> getPublishedSegments(HadoopDruidIndexerConfig config)
   {
-    final Configuration conf = new Configuration();
+    final Configuration conf = JobHelper.injectSystemProperties(new Configuration());
     final ObjectMapper jsonMapper = HadoopDruidIndexerConfig.jsonMapper;
 
     ImmutableList.Builder<DataSegment> publishedSegmentsBuilder = ImmutableList.builder();
-
-    for (String propName : System.getProperties().stringPropertyNames()) {
-      if (propName.startsWith("hadoop.")) {
-        conf.set(propName.substring("hadoop.".length()), System.getProperty(propName));
-      }
-    }
 
     final Path descriptorInfoDir = config.makeDescriptorInfoDir();
 

--- a/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
@@ -100,12 +100,16 @@ public class JobHelper
 
   public static void injectSystemProperties(Job job)
   {
-    final Configuration conf = job.getConfiguration();
+    injectSystemProperties(job.getConfiguration());
+  }
+
+  public static Configuration injectSystemProperties(Configuration conf) {
     for (String propName : System.getProperties().stringPropertyNames()) {
       if (propName.startsWith("hadoop.")) {
         conf.set(propName.substring("hadoop.".length()), System.getProperty(propName));
       }
     }
+    return conf;
   }
 
   public static void ensurePaths(HadoopDruidIndexerConfig config)
@@ -143,7 +147,7 @@ public class JobHelper
         Path workingPath = config.makeIntermediatePath();
         log.info("Deleting path[%s]", workingPath);
         try {
-          workingPath.getFileSystem(new Configuration()).delete(workingPath, true);
+          workingPath.getFileSystem(injectSystemProperties(new Configuration())).delete(workingPath, true);
         }
         catch (IOException e) {
           log.error(e, "Failed to cleanup path[%s]", workingPath);

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/config/ForkingTaskRunnerConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/config/ForkingTaskRunnerConfig.java
@@ -57,7 +57,8 @@ public class ForkingTaskRunnerConfig
       "io.druid",
       "user.timezone",
       "file.encoding",
-      "java.io.tmpdir"
+      "java.io.tmpdir",
+      "hadoop"
   );
 
   public String getJavaCommand()


### PR DESCRIPTION
Fix:

* While using HDFS with Hadoop HA to store task logs,  exception could be thrown while fetching or pushing task log:

```
2015-05-22T11:05:44,987 [WARN ] [qtp164455471-95] io.druid.indexing.overlord.http.OverlordResource - Failed to stream log for task index_hadoop_dsp_campaign_only_2015-05-21T12:44:10.075Z
java.lang.IllegalArgumentException: java.net.UnknownHostException: mycluster
	at org.apache.hadoop.security.SecurityUtil.buildTokenService(SecurityUtil.java:373) ~[hadoop-common-2.5.1.jar:?]
	at org.apache.hadoop.hdfs.NameNodeProxies.createNonHAProxy(NameNodeProxies.java:258) ~[hadoop-hdfs-2.5.1.jar:?]
	at org.apache.hadoop.hdfs.NameNodeProxies.createProxy(NameNodeProxies.java:153) ~[hadoop-hdfs-2.5.1.jar:?]
	at org.apache.hadoop.hdfs.DFSClient.<init>(DFSClient.java:602) ~[hadoop-hdfs-2.5.1.jar:?]
	at org.apache.hadoop.hdfs.DFSClient.<init>(DFSClient.java:547) ~[hadoop-hdfs-2.5.1.jar:?]
	at org.apache.hadoop.hdfs.DistributedFileSystem.initialize(DistributedFileSystem.java:139) ~[hadoop-hdfs-2.5.1.jar:?]
	at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:2591) ~[hadoop-common-2.5.1.jar:?]
	at org.apache.hadoop.fs.FileSystem.access$200(FileSystem.java:89) ~[hadoop-common-2.5.1.jar:?]
	at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:2625) ~[hadoop-common-2.5.1.jar:?]
	at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:2607) ~[hadoop-common-2.5.1.jar:?]
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:368) ~[hadoop-common-2.5.1.jar:?]
	at org.apache.hadoop.fs.Path.getFileSystem(Path.java:296) ~[hadoop-common-2.5.1.jar:?]
	at io.druid.storage.hdfs.tasklog.HdfsTaskLogs.streamTaskLog(HdfsTaskLogs.java:65) ~[?:?]
	at io.druid.indexing.common.tasklogs.SwitchingTaskLogStreamer.streamTaskLog(SwitchingTaskLogStreamer.java:46) ~[druid-services-0.7.0-selfcontained.jar:0.7.0]
	at io.druid.indexing.overlord.http.OverlordResource.doGetLog(OverlordResource.java:382) [druid-services-0.7.0-selfcontained.jar:0.7.0]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.7.0_67]
```

and

```
2015-05-22T11:19:00,804 [INFO ] [pool-10-thread-2] io.druid.indexing.overlord.ForkingTaskRunner - Process exited with status[0] for task: index_hadoop_dsp_campaign_only_2015-05-22T03:18:46.860Z
2015-05-22T11:19:00,804 [INFO ] [pool-10-thread-2] io.druid.storage.hdfs.tasklog.HdfsTaskLogs - Writing task log to: hdfs://mycluster/druid/tasklogs/index_hadoop_dsp_campaign_only_2015-05-22T03_18_46.860Z
2015-05-22T11:19:00,882 [INFO ] [pool-10-thread-2] io.druid.indexing.overlord.ForkingTaskRunner - Exception caught during execution
java.lang.IllegalArgumentException: java.net.UnknownHostException: mycluster
	at org.apache.hadoop.security.SecurityUtil.buildTokenService(SecurityUtil.java:373) ~[hadoop-common-2.5.1.jar:?]
	at org.apache.hadoop.hdfs.NameNodeProxies.createNonHAProxy(NameNodeProxies.java:258) ~[hadoop-hdfs-2.5.1.jar:?]
	at org.apache.hadoop.hdfs.NameNodeProxies.createProxy(NameNodeProxies.java:153) ~[hadoop-hdfs-2.5.1.jar:?]
	at org.apache.hadoop.hdfs.DFSClient.<init>(DFSClient.java:602) ~[hadoop-hdfs-2.5.1.jar:?]
	at org.apache.hadoop.hdfs.DFSClient.<init>(DFSClient.java:547) ~[hadoop-hdfs-2.5.1.jar:?]
	at org.apache.hadoop.hdfs.DistributedFileSystem.initialize(DistributedFileSystem.java:139) ~[hadoop-hdfs-2.5.1.jar:?]
	at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:2591) ~[hadoop-common-2.5.1.jar:?]
	at org.apache.hadoop.fs.FileSystem.access$200(FileSystem.java:89) ~[hadoop-common-2.5.1.jar:?]
	at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:2625) ~[hadoop-common-2.5.1.jar:?]
	at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:2607) ~[hadoop-common-2.5.1.jar:?]
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:368) ~[hadoop-common-2.5.1.jar:?]
	at org.apache.hadoop.fs.Path.getFileSystem(Path.java:296) ~[hadoop-common-2.5.1.jar:?]
	at io.druid.storage.hdfs.tasklog.HdfsTaskLogs.pushTaskLog(HdfsTaskLogs.java:56) ~[?:?]
	at io.druid.indexing.overlord.ForkingTaskRunner$1.call(ForkingTaskRunner.java:244) [druid-services-0.7.0-selfcontained.jar:0.7.0]
	at io.druid.indexing.overlord.ForkingTaskRunner$1.call(ForkingTaskRunner.java:118) [druid-services-0.7.0-selfcontained.jar:0.7.0]
	at java.util.concurrent.FutureTask.run(FutureTask.java:262) [?:1.7.0_67]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [?:1.7.0_67]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [?:1.7.0_67]
	at java.lang.Thread.run(Thread.java:745) [?:1.7.0_67]
Caused by: java.net.UnknownHostException: mycluster
	... 19 more
```

* While using HDFS with Hadoop HA as deep storage, could throw exceptions while running indexing job:

```
Caused by: java.net.UnknownHostException: mycluster
	at org.apache.hadoop.security.SecurityUtil.buildTokenService(SecurityUtil.java:373) ~[hadoop-common-2.5.1.jar:?]
	at org.apache.hadoop.hdfs.NameNodeProxies.createNonHAProxy(NameNodeProxies.java:258) ~[hadoop-hdfs-2.5.1.jar:?]
	at org.apache.hadoop.hdfs.NameNodeProxies.createProxy(NameNodeProxies.java:153) ~[hadoop-hdfs-2.5.1.jar:?]
	at org.apache.hadoop.hdfs.DFSClient.<init>(DFSClient.java:602) ~[hadoop-hdfs-2.5.1.jar:?]
	at org.apache.hadoop.hdfs.DFSClient.<init>(DFSClient.java:547) ~[hadoop-hdfs-2.5.1.jar:?]
	at org.apache.hadoop.hdfs.DistributedFileSystem.initialize(DistributedFileSystem.java:139) ~[hadoop-hdfs-2.5.1.jar:?]
	at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:2591) ~[hadoop-common-2.5.1.jar:?]
	at org.apache.hadoop.fs.FileSystem.access$200(FileSystem.java:89) ~[hadoop-common-2.5.1.jar:?]
	at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:2625) ~[hadoop-common-2.5.1.jar:?]
	at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:2607) ~[hadoop-common-2.5.1.jar:?]
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:368) ~[hadoop-common-2.5.1.jar:?]
	at org.apache.hadoop.fs.Path.getFileSystem(Path.java:296) ~[hadoop-common-2.5.1.jar:?]
	at org.apache.hadoop.mapreduce.lib.input.FileInputFormat.addInputPath(FileInputFormat.java:518) ~[hadoop-mapreduce-client-core-2.5.1.jar:?]
	at org.apache.hadoop.mapreduce.lib.input.FileInputFormat.addInputPaths(FileInputFormat.java:483) ~[hadoop-mapreduce-client-core-2.5.1.jar:?]
	at io.druid.indexer.path.StaticPathSpec.addInputPaths(StaticPathSpec.java:56) ~[druid-services-0.7.0-selfcontained.jar:0.7.0]
	at io.druid.indexer.HadoopDruidIndexerConfig.addInputPaths(HadoopDruidIndexerConfig.java:316) ~[druid-services-0.7.0-selfcontained.jar:0.7.0]
	at io.druid.indexer.JobHelper.ensurePaths(JobHelper.java:121) ~[druid-services-0.7.0-selfcontained.jar:0.7.0]
	at io.druid.indexer.HadoopDruidDetermineConfigurationJob.run(HadoopDruidDetermineConfigurationJob.java:53) ~[druid-services-0.7.0-selfcontained.jar:0.7.0]
	at io.druid.indexing.common.task.HadoopIndexTask$HadoopDetermineConfigInnerProcessing.runTask(HadoopIndexTask.java:334) ~[druid-services-0.7.0-selfcontained.jar:0.7.0]
	... 11 more
``` 

* Make indexing worker, i.e. Peon process also inherit middleManager's  Java args with `hadoop` prefix.

Args like this:
```
-Dhadoop.fs.defaultFS=hdfs://mycluster \
-Dhadoop.dfs.nameservices=mycluster \
-Dhadoop.dfs.ha.namenodes.mycluster=nn1,nn2 \
-Dhadoop.dfs.namenode.rpc-address.mycluster.nn1=hadoop.namenode1:9000 \
-Dhadoop.dfs.namenode.rpc-address.mycluster.nn2=hadoop.namenode2:9000 \
-Dhadoop.dfs.client.failover.proxy.provider.mycluster=org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider