### PR TITLE
Fixing the regression caused by #1172

### DIFF
--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
@@ -216,7 +216,7 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
     };
   }
 
-  public Ordering<SegmentAnalysis> getOrdering()
+  private Ordering<SegmentAnalysis> getOrdering()
   {
     return new Ordering<SegmentAnalysis>()
     {

--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
@@ -17,13 +17,20 @@
 
 package io.druid.query.metadata;
 
+import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
 import com.metamx.common.guava.Sequence;
 import com.metamx.common.guava.Sequences;
 import com.metamx.common.logger.Logger;
-import io.druid.query.ChainedExecutionQueryRunner;
+import io.druid.query.AbstractPrioritizedCallable;
+import io.druid.query.ConcatQueryRunner;
 import io.druid.query.Query;
+import io.druid.query.QueryInterruptedException;
 import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerFactory;
 import io.druid.query.QueryToolChest;
@@ -37,7 +44,11 @@ import io.druid.segment.Segment;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class SegmentMetadataQueryRunnerFactory implements QueryRunnerFactory<SegmentAnalysis, SegmentMetadataQuery>
 {
@@ -111,8 +122,60 @@ public class SegmentMetadataQueryRunnerFactory implements QueryRunnerFactory<Seg
       ExecutorService exec, Iterable<QueryRunner<SegmentAnalysis>> queryRunners
   )
   {
-    return new ChainedExecutionQueryRunner<>(
-        exec, toolChest.getOrdering(), queryWatcher, queryRunners
+    final ListeningExecutorService queryExecutor = MoreExecutors.listeningDecorator(exec);
+    return new ConcatQueryRunner<SegmentAnalysis>(
+        Sequences.map(
+            Sequences.simple(queryRunners),
+            new Function<QueryRunner<SegmentAnalysis>, QueryRunner<SegmentAnalysis>>()
+            {
+              @Override
+              public QueryRunner<SegmentAnalysis> apply(final QueryRunner<SegmentAnalysis> input)
+              {
+                return new QueryRunner<SegmentAnalysis>()
+                {
+                  @Override
+                  public Sequence<SegmentAnalysis> run(
+                      final Query<SegmentAnalysis> query,
+                      final Map<String, Object> responseContext
+                  )
+                  {
+                    final int priority = query.getContextPriority(0);
+                    ListenableFuture<Sequence<SegmentAnalysis>> future = queryExecutor.submit(
+                        new AbstractPrioritizedCallable<Sequence<SegmentAnalysis>>(priority)
+                        {
+                          @Override
+                          public Sequence<SegmentAnalysis> call() throws Exception
+                          {
+                            return input.run(query, responseContext);
+                          }
+                        }
+                    );
+                    try {
+                      queryWatcher.registerQuery(query, future);
+                      final Number timeout = query.getContextValue("timeout", (Number) null);
+                      return timeout == null ? future.get() : future.get(timeout.longValue(), TimeUnit.MILLISECONDS);
+                    }
+                    catch (InterruptedException e) {
+                      log.warn(e, "Query interrupted, cancelling pending results, query id [%s]", query.getId());
+                      future.cancel(true);
+                      throw new QueryInterruptedException("Query interrupted");
+                    }
+                    catch(CancellationException e) {
+                      throw new QueryInterruptedException("Query cancelled");
+                    }
+                    catch(TimeoutException e) {
+                      log.info("Query timeout, cancelling pending results for query id [%s]", query.getId());
+                      future.cancel(true);
+                      throw new QueryInterruptedException("Query timeout");
+                    }
+                    catch (ExecutionException e) {
+                      throw Throwables.propagate(e.getCause());
+                    }
+                  }
+                };
+              }
+            }
+        )
     );
   }
 

--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
@@ -42,6 +42,7 @@ import io.druid.query.metadata.metadata.SegmentMetadataQuery;
 import io.druid.segment.QueryableIndex;
 import io.druid.segment.Segment;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
@@ -146,7 +147,9 @@ public class SegmentMetadataQueryRunnerFactory implements QueryRunnerFactory<Seg
                           @Override
                           public Sequence<SegmentAnalysis> call() throws Exception
                           {
-                            return input.run(query, responseContext);
+                            return Sequences.simple(
+                                Sequences.toList(input.run(query, responseContext), new ArrayList<SegmentAnalysis>())
+                            );
                           }
                         }
                     );

--- a/processing/src/main/java/io/druid/query/metadata/metadata/ColumnAnalysis.java
+++ b/processing/src/main/java/io/druid/query/metadata/metadata/ColumnAnalysis.java
@@ -92,6 +92,7 @@ public class ColumnAnalysis
     Integer cardinality = getCardinality();
     final Integer rhsCardinality = rhs.getCardinality();
     if (cardinality == null) {
+
       cardinality = rhsCardinality;
     }
     else {
@@ -112,5 +113,40 @@ public class ColumnAnalysis
            ", cardinality=" + cardinality +
            ", errorMessage='" + errorMessage + '\'' +
            '}';
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ColumnAnalysis that = (ColumnAnalysis) o;
+
+    if (size != that.size) {
+      return false;
+    }
+    if (type != null ? !type.equals(that.type) : that.type != null) {
+      return false;
+    }
+    if (cardinality != null ? !cardinality.equals(that.cardinality) : that.cardinality != null) {
+      return false;
+    }
+    return !(errorMessage != null ? !errorMessage.equals(that.errorMessage) : that.errorMessage != null);
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = type != null ? type.hashCode() : 0;
+    result = 31 * result + (int) (size ^ (size >>> 32));
+    result = 31 * result + (cardinality != null ? cardinality.hashCode() : 0);
+    result = 31 * result + (errorMessage != null ? errorMessage.hashCode() : 0);
+    return result;
   }
 }

--- a/processing/src/main/java/io/druid/query/metadata/metadata/SegmentAnalysis.java
+++ b/processing/src/main/java/io/druid/query/metadata/metadata/SegmentAnalysis.java
@@ -89,4 +89,39 @@ public class SegmentAnalysis
            ", size=" + size +
            '}';
   }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SegmentAnalysis that = (SegmentAnalysis) o;
+
+    if (size != that.size) {
+      return false;
+    }
+    if (id != null ? !id.equals(that.id) : that.id != null) {
+      return false;
+    }
+    if (interval != null ? !interval.equals(that.interval) : that.interval != null) {
+      return false;
+    }
+    return !(columns != null ? !columns.equals(that.columns) : that.columns != null);
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = id != null ? id.hashCode() : 0;
+    result = 31 * result + (interval != null ? interval.hashCode() : 0);
+    result = 31 * result + (columns != null ? columns.hashCode() : 0);
+    result = 31 * result + (int) (size ^ (size >>> 32));
+    return result;
+  }
 }

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
@@ -18,37 +18,51 @@
 package io.druid.query.metadata;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.metamx.common.guava.Sequences;
 import io.druid.jackson.DefaultObjectMapper;
+import io.druid.query.BySegmentResultValue;
+import io.druid.query.BySegmentResultValueClass;
 import io.druid.query.Druids;
+import io.druid.query.FinalizeResultsQueryRunner;
 import io.druid.query.Query;
 import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerFactory;
 import io.druid.query.QueryRunnerTestHelper;
+import io.druid.query.QueryToolChest;
+import io.druid.query.Result;
 import io.druid.query.metadata.metadata.ColumnAnalysis;
 import io.druid.query.metadata.metadata.ListColumnIncluderator;
 import io.druid.query.metadata.metadata.SegmentAnalysis;
 import io.druid.query.metadata.metadata.SegmentMetadataQuery;
 import io.druid.segment.QueryableIndexSegment;
+import io.druid.segment.TestHelper;
 import io.druid.segment.TestIndex;
+import io.druid.segment.column.ValueType;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class SegmentMetadataQueryTest
 {
-  @SuppressWarnings("unchecked")
-  private final QueryRunner runner = makeQueryRunner(
-      new SegmentMetadataQueryRunnerFactory(
-          new SegmentMetadataQueryQueryToolChest(),
-          QueryRunnerTestHelper.NOOP_QUERYWATCHER)
+  private final SegmentMetadataQueryRunnerFactory factory = new SegmentMetadataQueryRunnerFactory(
+      new SegmentMetadataQueryQueryToolChest(),
+      QueryRunnerTestHelper.NOOP_QUERYWATCHER
   );
-  private ObjectMapper mapper = new DefaultObjectMapper();
+
+  @SuppressWarnings("unchecked")
+  private final QueryRunner runner = makeQueryRunner(factory);
+
+  private final ObjectMapper mapper = new DefaultObjectMapper();
 
   @SuppressWarnings("unchecked")
   public static QueryRunner makeQueryRunner(
@@ -61,35 +75,81 @@ public class SegmentMetadataQueryTest
     );
   }
 
+  private final SegmentMetadataQuery testQuery;
+  private final SegmentAnalysis expectedSegmentAnalysis;
+
+  public SegmentMetadataQueryTest()
+  {
+    testQuery = Druids.newSegmentMetadataQueryBuilder()
+                      .dataSource("testing")
+                      .intervals("2013/2014")
+                      .toInclude(new ListColumnIncluderator(Arrays.asList("placement")))
+                      .merge(true)
+                      .build();
+
+    expectedSegmentAnalysis = new SegmentAnalysis(
+        "testSegment",
+        ImmutableList.of(
+            new Interval("2011-01-12T00:00:00.000Z/2011-04-15T00:00:00.001Z")
+        ),
+        ImmutableMap.of(
+            "placement",
+            new ColumnAnalysis(
+                ValueType.STRING.toString(),
+                10881,
+                1,
+                null
+            )
+        ), 71982
+    );
+  }
   @Test
   @SuppressWarnings("unchecked")
   public void testSegmentMetadataQuery()
   {
-    SegmentMetadataQuery query = Druids.newSegmentMetadataQueryBuilder()
-                                       .dataSource("testing")
-                                       .intervals("2013/2014")
-                                       .toInclude(new ListColumnIncluderator(Arrays.asList("placement")))
-                                       .merge(true)
-                                       .build();
-    HashMap<String,Object> context = new HashMap<String, Object>();
-    Iterable<SegmentAnalysis> results = Sequences.toList(
-        runner.run(query, context),
+    List<SegmentAnalysis> results = Sequences.toList(
+        runner.run(testQuery, Maps.newHashMap()),
         Lists.<SegmentAnalysis>newArrayList()
     );
-    SegmentAnalysis val = results.iterator().next();
-    Assert.assertEquals("testSegment", val.getId());
-    Assert.assertEquals(71982, val.getSize());
-    Assert.assertEquals(
-        Arrays.asList(new Interval("2011-01-12T00:00:00.000Z/2011-04-15T00:00:00.001Z")),
-        val.getIntervals()
-    );
-    Assert.assertEquals(1, val.getColumns().size());
-    final ColumnAnalysis columnAnalysis = val.getColumns().get("placement");
-    Assert.assertEquals("STRING", columnAnalysis.getType());
-    Assert.assertEquals(10881, columnAnalysis.getSize());
-    Assert.assertEquals(new Integer(1), columnAnalysis.getCardinality());
-    Assert.assertNull(columnAnalysis.getErrorMessage());
 
+    Assert.assertEquals(Arrays.asList(expectedSegmentAnalysis), results);
+  }
+
+  @Test
+  public void testBySegmentResults()
+  {
+    Result<BySegmentResultValue> bySegmentResult = new Result<BySegmentResultValue>(
+        expectedSegmentAnalysis.getIntervals().get(0).getStart(),
+        new BySegmentResultValueClass(
+            Arrays.asList(
+                expectedSegmentAnalysis
+            ), expectedSegmentAnalysis.getId(), testQuery.getIntervals().get(0)
+        )
+    );
+
+    QueryToolChest toolChest = factory.getToolchest();
+
+    QueryRunner singleSegmentQueryRunner = toolChest.preMergeQueryDecoration(runner);
+    ExecutorService exec = Executors.newCachedThreadPool();
+    QueryRunner myRunner = new FinalizeResultsQueryRunner<>(
+        toolChest.mergeResults(
+            factory.mergeRunners(
+                Executors.newCachedThreadPool(),
+                //Note: It is essential to have atleast 2 query runners merged to reproduce the regression bug described in
+                //https://github.com/druid-io/druid/pull/1172
+                //the bug surfaces only when ordering is used which happens only when you have 2 things to compare
+                Lists.<QueryRunner<SegmentAnalysis>>newArrayList(singleSegmentQueryRunner, singleSegmentQueryRunner))),
+        toolChest
+    );
+
+    TestHelper.assertExpectedObjects(
+        ImmutableList.of(bySegmentResult, bySegmentResult),
+        myRunner.run(
+            testQuery.withOverriddenContext(ImmutableMap.<String, Object>of("bySegment", true)),
+            Maps.newHashMap()
+        ),
+        "failed SegmentMetadata bySegment query");
+    exec.shutdownNow();
   }
 
   @Test
@@ -107,6 +167,5 @@ public class SegmentMetadataQueryTest
 
     // test serialize and deserialize
     Assert.assertEquals(query, mapper.readValue(mapper.writeValueAsString(query), Query.class));
-
   }
 }


### PR DESCRIPTION
Fixing the regression caused by #1172

Reverted the use of ChainedExecutionQueryRunner and used simple approach to enforce eagerness.