### PR TITLE
Fix for breaking Dimension Extraction Filter on empty filter

### DIFF
--- a/processing/src/main/java/io/druid/segment/filter/ExtractionFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/ExtractionFilter.java
@@ -19,7 +19,7 @@ package io.druid.segment.filter;
 
 import com.google.common.collect.Lists;
 import com.metamx.collections.bitmap.ImmutableBitmap;
-import com.metamx.collections.bitmap.WrappedConciseBitmap;
+import com.metamx.collections.bitmap.WrappedImmutableConciseBitmap;
 import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.filter.BitmapIndexSelector;
 import io.druid.query.filter.Filter;
@@ -27,6 +27,7 @@ import io.druid.query.filter.ValueMatcher;
 import io.druid.query.filter.ValueMatcherFactory;
 import io.druid.segment.ColumnSelectorFactory;
 import io.druid.segment.data.Indexed;
+import it.uniroma3.mat.extendedset.intset.ImmutableConciseSet;
 
 import java.util.List;
 
@@ -65,12 +66,14 @@ public class ExtractionFilter implements Filter
     return filters;
   }
 
+  private static final WrappedImmutableConciseBitmap ZERO_LENGTH_SET = new WrappedImmutableConciseBitmap(new ImmutableConciseSet());
+
   @Override
   public ImmutableBitmap getBitmapIndex(BitmapIndexSelector selector)
   {
     final List<Filter> filters = makeFilters(selector);
     if (filters.isEmpty()) {
-      return new WrappedConciseBitmap();
+      return ZERO_LENGTH_SET;
     }
     return new OrFilter(makeFilters(selector)).getBitmapIndex(selector);
   }

--- a/processing/src/test/java/io/druid/segment/filter/ExtractionDimFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/ExtractionDimFilterTest.java
@@ -26,6 +26,8 @@ import com.metamx.collections.spatial.ImmutableRTree;
 import io.druid.query.extraction.DimExtractionFn;
 import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.filter.BitmapIndexSelector;
+import io.druid.query.filter.DimFilters;
+import io.druid.query.filter.ExtractionDimFilter;
 import io.druid.segment.data.ArrayIndexed;
 import io.druid.segment.data.Indexed;
 import it.uniroma3.mat.extendedset.intset.ConciseSet;
@@ -47,16 +49,19 @@ public class ExtractionDimFilterTest
   );
 
   private static final Map<String, String> EXTRACTION_VALUES = ImmutableMap.of(
-      "foo1","extractDimVal"
+      "foo1", "extractDimVal"
   );
 
   private static ImmutableBitmap foo1BitMap;
+
   @BeforeClass
-  public static void setupStatic(){
+  public static void setupStatic()
+  {
     final ConciseSet conciseSet = new ConciseSet();
     conciseSet.add(1);
     foo1BitMap = new WrappedConciseBitmap(conciseSet);
   }
+
   private static final BitmapIndexSelector BITMAP_INDEX_SELECTOR = new BitmapIndexSelector()
   {
     @Override
@@ -113,7 +118,8 @@ public class ExtractionDimFilterTest
   };
 
   @Test
-  public void testEmpty(){
+  public void testEmpty()
+  {
     ExtractionFilter extractionFilter = new ExtractionFilter(
         "foo", "NFDJUKFNDSJFNS", DIM_EXTRACTION_FN
     );
@@ -122,7 +128,8 @@ public class ExtractionDimFilterTest
   }
 
   @Test
-  public void testNull(){
+  public void testNull()
+  {
     ExtractionFilter extractionFilter = new ExtractionFilter(
         "FDHJSFFHDS", "extractDimVal", DIM_EXTRACTION_FN
     );
@@ -131,11 +138,49 @@ public class ExtractionDimFilterTest
   }
 
   @Test
-  public void testNormal(){
+  public void testNormal()
+  {
     ExtractionFilter extractionFilter = new ExtractionFilter(
         "foo", "extractDimVal", DIM_EXTRACTION_FN
     );
     ImmutableBitmap immutableBitmap = extractionFilter.getBitmapIndex(BITMAP_INDEX_SELECTOR);
     Assert.assertEquals(1, immutableBitmap.size());
+  }
+
+  @Test
+  public void testOr()
+  {
+    Assert.assertEquals(
+        1, Filters.convertDimensionFilters(
+            DimFilters.or(
+                new ExtractionDimFilter(
+                    "foo",
+                    "extractDimVal",
+                    DIM_EXTRACTION_FN,
+                    null
+                )
+            )
+        ).getBitmapIndex(BITMAP_INDEX_SELECTOR).size()
+    );
+
+    Assert.assertEquals(
+        1,
+        Filters.convertDimensionFilters(
+            DimFilters.or(
+                new ExtractionDimFilter(
+                    "foo",
+                    "extractDimVal",
+                    DIM_EXTRACTION_FN,
+                    null
+                ),
+                new ExtractionDimFilter(
+                    "foo",
+                    "DOES NOT EXIST",
+                    DIM_EXTRACTION_FN,
+                    null
+                )
+            )
+        ).getBitmapIndex(BITMAP_INDEX_SELECTOR).size()
+    );
   }
 }


### PR DESCRIPTION
Extraction filters can break with 
```
java.lang.ClassCastException: com.metamx.collections.bitmap.WrappedConciseBitmap cannot be cast to com.metamx.collections.bitmap.WrappedImmutableConciseBitmap
	at com.metamx.collections.bitmap.ConciseBitmapFactory$1$1.next(ConciseBitmapFactory.java:121)
	at com.metamx.collections.bitmap.ConciseBitmapFactory$1$1.next(ConciseBitmapFactory.java:105)
	at com.google.common.collect.Iterators$9.next(Iterators.java:939)
	at it.uniroma3.mat.extendedset.intset.ImmutableConciseSet.doUnion(ImmutableConciseSet.java:285)
	at it.uniroma3.mat.extendedset.intset.ImmutableConciseSet.union(ImmutableConciseSet.java:64)
	at it.uniroma3.mat.extendedset.intset.ImmutableConciseSet.union(ImmutableConciseSet.java:59)
	at com.metamx.collections.bitmap.ConciseBitmapFactory.union(ConciseBitmapFactory.java:67)
	at io.druid.segment.filter.OrFilter.getBitmapIndex(OrFilter.java:59)
```

As per the UT in this PR