### PR TITLE
fix race described in 1360

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/ResourceManagementScheduler.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/ResourceManagementScheduler.java
@@ -32,8 +32,6 @@ import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * The ResourceManagementScheduler schedules a check for when worker nodes should potentially be created or destroyed.
- * It uses a {@link TaskRunner} to return all pending tasks in the system and the status of the worker nodes in
- * the system.
  * The ResourceManagementScheduler does not contain the logic to decide whether provision or termination should actually
  * occur. That decision is made in the {@link ResourceManagementStrategy}.
  */
@@ -80,7 +78,7 @@ public class ResourceManagementScheduler
             @Override
             public void run()
             {
-              resourceManagementStrategy.doProvision(taskRunner.getPendingTasks(), taskRunner.getWorkers());
+              resourceManagementStrategy.doProvision(taskRunner);
             }
           }
       );
@@ -99,7 +97,7 @@ public class ResourceManagementScheduler
             @Override
             public void run()
             {
-              resourceManagementStrategy.doTerminate(taskRunner.getPendingTasks(), taskRunner.getWorkers());
+              resourceManagementStrategy.doTerminate(taskRunner);
             }
           }
       );

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/ResourceManagementStrategy.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/ResourceManagementStrategy.java
@@ -17,6 +17,7 @@
 
 package io.druid.indexing.overlord.autoscaling;
 
+import io.druid.indexing.overlord.RemoteTaskRunner;
 import io.druid.indexing.overlord.RemoteTaskRunnerWorkItem;
 import io.druid.indexing.overlord.ZkWorker;
 
@@ -28,9 +29,9 @@ import java.util.Collection;
  */
 public interface ResourceManagementStrategy
 {
-  public boolean doProvision(Collection<RemoteTaskRunnerWorkItem> runningTasks, Collection<ZkWorker> zkWorkers);
+  public boolean doProvision(RemoteTaskRunner runner);
 
-  public boolean doTerminate(Collection<RemoteTaskRunnerWorkItem> runningTasks, Collection<ZkWorker> zkWorkers);
+  public boolean doTerminate(RemoteTaskRunner runner);
 
   public ScalingStats getStats();
 }

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/SimpleResourceManagementStrategy.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/SimpleResourceManagementStrategy.java
@@ -22,13 +22,13 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Collections2;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.metamx.common.ISE;
 import com.metamx.emitter.EmittingLogger;
+import io.druid.indexing.overlord.RemoteTaskRunner;
 import io.druid.indexing.overlord.RemoteTaskRunnerWorkItem;
 import io.druid.indexing.overlord.TaskRunnerWorkItem;
 import io.druid.indexing.overlord.ZkWorker;
@@ -70,8 +70,10 @@ public class SimpleResourceManagementStrategy implements ResourceManagementStrat
   }
 
   @Override
-  public boolean doProvision(Collection<RemoteTaskRunnerWorkItem> pendingTasks, Collection<ZkWorker> zkWorkers)
+  public boolean doProvision(RemoteTaskRunner runner)
   {
+    Collection<RemoteTaskRunnerWorkItem> pendingTasks = runner.getPendingTasks();
+    Collection<ZkWorker> zkWorkers = runner.getWorkers();
     synchronized (lock) {
       boolean didProvision = false;
       final WorkerBehaviorConfig workerConfig = workerConfigRef.get();
@@ -137,8 +139,9 @@ public class SimpleResourceManagementStrategy implements ResourceManagementStrat
   }
 
   @Override
-  public boolean doTerminate(Collection<RemoteTaskRunnerWorkItem> pendingTasks, Collection<ZkWorker> zkWorkers)
+  public boolean doTerminate(RemoteTaskRunner runner)
   {
+    Collection<RemoteTaskRunnerWorkItem> pendingTasks = runner.getPendingTasks();
     synchronized (lock) {
       final WorkerBehaviorConfig workerConfig = workerConfigRef.get();
       if (workerConfig == null) {
@@ -151,7 +154,7 @@ public class SimpleResourceManagementStrategy implements ResourceManagementStrat
           workerConfig.getAutoScaler().ipToIdLookup(
               Lists.newArrayList(
                   Iterables.transform(
-                      zkWorkers,
+                      runner.getLazyWorkers(),
                       new Function<ZkWorker, String>()
                       {
                         @Override
@@ -174,28 +177,26 @@ public class SimpleResourceManagementStrategy implements ResourceManagementStrat
       currentlyTerminating.clear();
       currentlyTerminating.addAll(stillExisting);
 
-      updateTargetWorkerCount(workerConfig, pendingTasks, zkWorkers);
+      Collection<ZkWorker> workers = runner.getWorkers();
+      updateTargetWorkerCount(workerConfig, pendingTasks, workers);
 
-      final Predicate<ZkWorker> isLazyWorker = createLazyWorkerPredicate(config);
       if (currentlyTerminating.isEmpty()) {
-        final int excessWorkers = (zkWorkers.size() + currentlyProvisioning.size()) - targetWorkerCount;
-        if (excessWorkers > 0) {
-          final List<String> laziestWorkerIps =
-              FluentIterable.from(zkWorkers)
-                            .filter(isLazyWorker)
-                            .limit(excessWorkers)
-                            .transform(
-                                new Function<ZkWorker, String>()
-                                {
-                                  @Override
-                                  public String apply(ZkWorker zkWorker)
-                                  {
-                                    return zkWorker.getWorker().getIp();
-                                  }
-                                }
-                            )
-                            .toList();
 
+        final int excessWorkers = (workers.size() + currentlyProvisioning.size()) - targetWorkerCount;
+        if (excessWorkers > 0) {
+          final Predicate<ZkWorker> isLazyWorker = createLazyWorkerPredicate(config);
+          final List<String> laziestWorkerIps =
+              Lists.transform(
+                  runner.markWokersLazy(isLazyWorker, excessWorkers),
+                  new Function<ZkWorker, String>()
+                  {
+                    @Override
+                    public String apply(ZkWorker zkWorker)
+                    {
+                      return zkWorker.getWorker().getIp();
+                    }
+                  }
+              );
           if (laziestWorkerIps.isEmpty()) {
             log.info("Wanted to terminate %,d workers, but couldn't find any lazy ones!", excessWorkers);
           } else {
@@ -253,7 +254,7 @@ public class SimpleResourceManagementStrategy implements ResourceManagementStrat
       {
         final boolean itHasBeenAWhile = System.currentTimeMillis() - worker.getLastCompletedTaskTime().getMillis()
                                         >= config.getWorkerIdleTimeout().toStandardDuration().getMillis();
-        return worker.getRunningTasks().isEmpty() && (itHasBeenAWhile || !isValidWorker.apply(worker));
+        return itHasBeenAWhile || !isValidWorker.apply(worker);
       }
     };
   }

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/SimpleResourceManagementStrategyTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/SimpleResourceManagementStrategyTest.java
@@ -17,6 +17,7 @@
 
 package io.druid.indexing.overlord.autoscaling;
 
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -28,6 +29,7 @@ import io.druid.indexing.common.TaskStatus;
 import io.druid.indexing.common.TestMergeTask;
 import io.druid.indexing.common.task.NoopTask;
 import io.druid.indexing.common.task.Task;
+import io.druid.indexing.overlord.RemoteTaskRunner;
 import io.druid.indexing.overlord.RemoteTaskRunnerWorkItem;
 import io.druid.indexing.overlord.ZkWorker;
 import io.druid.indexing.overlord.setup.WorkerBehaviorConfig;
@@ -46,6 +48,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -117,16 +120,21 @@ public class SimpleResourceManagementStrategyTest
     EasyMock.expect(autoScaler.provision()).andReturn(
         new AutoScalingData(Lists.<String>newArrayList("aNode"))
     );
-    EasyMock.replay(autoScaler);
-
-    boolean provisionedSomething = simpleResourceManagementStrategy.doProvision(
-        Arrays.<RemoteTaskRunnerWorkItem>asList(
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    EasyMock.expect(runner.getPendingTasks()).andReturn(
+        Arrays.asList(
             new RemoteTaskRunnerWorkItem(testTask.getId(), null).withQueueInsertionTime(new DateTime())
-        ),
+        )
+    );
+    EasyMock.expect(runner.getWorkers()).andReturn(
         Arrays.<ZkWorker>asList(
             new TestZkWorker(testTask)
         )
     );
+    EasyMock.replay(runner);
+    EasyMock.replay(autoScaler);
+
+    boolean provisionedSomething = simpleResourceManagementStrategy.doProvision(runner);
 
     Assert.assertTrue(provisionedSomething);
     Assert.assertTrue(simpleResourceManagementStrategy.getStats().toList().size() == 1);
@@ -135,6 +143,7 @@ public class SimpleResourceManagementStrategyTest
     );
 
     EasyMock.verify(autoScaler);
+    EasyMock.verify(runner);
   }
 
   @Test
@@ -147,16 +156,21 @@ public class SimpleResourceManagementStrategyTest
     EasyMock.expect(autoScaler.provision()).andReturn(
         new AutoScalingData(Lists.<String>newArrayList("fake"))
     );
-    EasyMock.replay(autoScaler);
-
-    boolean provisionedSomething = simpleResourceManagementStrategy.doProvision(
-        Arrays.<RemoteTaskRunnerWorkItem>asList(
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    EasyMock.expect(runner.getPendingTasks()).andReturn(
+        Arrays.asList(
             new RemoteTaskRunnerWorkItem(testTask.getId(), null).withQueueInsertionTime(new DateTime())
-        ),
+        )
+    ).times(2);
+    EasyMock.expect(runner.getWorkers()).andReturn(
         Arrays.<ZkWorker>asList(
             new TestZkWorker(testTask)
         )
-    );
+    ).times(2);
+    EasyMock.replay(runner);
+    EasyMock.replay(autoScaler);
+
+    boolean provisionedSomething = simpleResourceManagementStrategy.doProvision(runner);
 
     Assert.assertTrue(provisionedSomething);
     Assert.assertTrue(simpleResourceManagementStrategy.getStats().toList().size() == 1);
@@ -165,14 +179,7 @@ public class SimpleResourceManagementStrategyTest
         simpleResourceManagementStrategy.getStats().toList().get(0).getEvent() == ScalingStats.EVENT.PROVISION
     );
 
-    provisionedSomething = simpleResourceManagementStrategy.doProvision(
-        Arrays.<RemoteTaskRunnerWorkItem>asList(
-            new RemoteTaskRunnerWorkItem(testTask.getId(), null).withQueueInsertionTime(new DateTime())
-        ),
-        Arrays.<ZkWorker>asList(
-            new TestZkWorker(testTask)
-        )
-    );
+    provisionedSomething = simpleResourceManagementStrategy.doProvision(runner);
 
     Assert.assertFalse(provisionedSomething);
     Assert.assertTrue(
@@ -184,6 +191,7 @@ public class SimpleResourceManagementStrategyTest
     );
 
     EasyMock.verify(autoScaler);
+    EasyMock.verify(runner);
   }
 
   @Test
@@ -205,15 +213,20 @@ public class SimpleResourceManagementStrategyTest
         new AutoScalingData(Lists.<String>newArrayList("fake"))
     );
     EasyMock.replay(autoScaler);
-
-    boolean provisionedSomething = simpleResourceManagementStrategy.doProvision(
-        Arrays.<RemoteTaskRunnerWorkItem>asList(
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    EasyMock.expect(runner.getPendingTasks()).andReturn(
+        Arrays.asList(
             new RemoteTaskRunnerWorkItem(testTask.getId(), null).withQueueInsertionTime(new DateTime())
-        ),
+        )
+    ).times(2);
+    EasyMock.expect(runner.getWorkers()).andReturn(
         Arrays.<ZkWorker>asList(
             new TestZkWorker(testTask)
         )
-    );
+    ).times(2);
+    EasyMock.replay(runner);
+
+    boolean provisionedSomething = simpleResourceManagementStrategy.doProvision(runner);
 
     Assert.assertTrue(provisionedSomething);
     Assert.assertTrue(simpleResourceManagementStrategy.getStats().toList().size() == 1);
@@ -224,14 +237,7 @@ public class SimpleResourceManagementStrategyTest
 
     Thread.sleep(2000);
 
-    provisionedSomething = simpleResourceManagementStrategy.doProvision(
-        Arrays.<RemoteTaskRunnerWorkItem>asList(
-            new RemoteTaskRunnerWorkItem(testTask.getId(), null).withQueueInsertionTime(new DateTime())
-        ),
-        Arrays.<ZkWorker>asList(
-            new TestZkWorker(testTask)
-        )
-    );
+    provisionedSomething = simpleResourceManagementStrategy.doProvision(runner);
 
     Assert.assertFalse(provisionedSomething);
     Assert.assertTrue(
@@ -244,6 +250,7 @@ public class SimpleResourceManagementStrategyTest
 
     EasyMock.verify(autoScaler);
     EasyMock.verify(emitter);
+    EasyMock.verify(runner);
   }
 
   @Test
@@ -257,15 +264,26 @@ public class SimpleResourceManagementStrategyTest
         new AutoScalingData(Lists.<String>newArrayList())
     );
     EasyMock.replay(autoScaler);
-
-    boolean terminatedSomething = simpleResourceManagementStrategy.doTerminate(
-        Arrays.<RemoteTaskRunnerWorkItem>asList(
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    EasyMock.expect(runner.getPendingTasks()).andReturn(
+        Arrays.asList(
             new RemoteTaskRunnerWorkItem(testTask.getId(), null).withQueueInsertionTime(new DateTime())
-        ),
+        )
+    ).times(2);
+    EasyMock.expect(runner.getWorkers()).andReturn(
         Arrays.<ZkWorker>asList(
-            new TestZkWorker(null)
+            new TestZkWorker(testTask)
+        )
+    ).times(2);
+    EasyMock.expect(runner.markWokersLazy((Predicate<ZkWorker>) EasyMock.anyObject(), EasyMock.anyInt())).andReturn(
+        Arrays.<ZkWorker>asList(
+            new TestZkWorker(testTask)
         )
     );
+    EasyMock.expect(runner.getLazyWorkers()).andReturn(Lists.<ZkWorker>newArrayList());
+    EasyMock.replay(runner);
+
+    boolean terminatedSomething = simpleResourceManagementStrategy.doTerminate(runner);
 
     Assert.assertTrue(terminatedSomething);
     Assert.assertTrue(simpleResourceManagementStrategy.getStats().toList().size() == 1);
@@ -288,14 +306,26 @@ public class SimpleResourceManagementStrategyTest
     );
     EasyMock.replay(autoScaler);
 
-    boolean terminatedSomething = simpleResourceManagementStrategy.doTerminate(
-        Arrays.<RemoteTaskRunnerWorkItem>asList(
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    EasyMock.expect(runner.getPendingTasks()).andReturn(
+        Arrays.asList(
             new RemoteTaskRunnerWorkItem(testTask.getId(), null).withQueueInsertionTime(new DateTime())
-        ),
+        )
+    ).times(2);
+    EasyMock.expect(runner.getWorkers()).andReturn(
         Arrays.<ZkWorker>asList(
-            new TestZkWorker(null)
+            new TestZkWorker(testTask)
+        )
+    ).times(2);
+    EasyMock.expect(runner.getLazyWorkers()).andReturn(Lists.<ZkWorker>newArrayList()).times(2);
+    EasyMock.expect(runner.markWokersLazy((Predicate<ZkWorker>) EasyMock.anyObject(), EasyMock.anyInt())).andReturn(
+        Arrays.<ZkWorker>asList(
+            new TestZkWorker(testTask)
         )
     );
+    EasyMock.replay(runner);
+
+    boolean terminatedSomething = simpleResourceManagementStrategy.doTerminate(runner);
 
     Assert.assertTrue(terminatedSomething);
     Assert.assertTrue(simpleResourceManagementStrategy.getStats().toList().size() == 1);
@@ -303,14 +333,7 @@ public class SimpleResourceManagementStrategyTest
         simpleResourceManagementStrategy.getStats().toList().get(0).getEvent() == ScalingStats.EVENT.TERMINATE
     );
 
-    terminatedSomething = simpleResourceManagementStrategy.doTerminate(
-        Arrays.<RemoteTaskRunnerWorkItem>asList(
-            new RemoteTaskRunnerWorkItem(testTask.getId(), null).withQueueInsertionTime(new DateTime())
-        ),
-        Arrays.<ZkWorker>asList(
-            new TestZkWorker(null)
-        )
-    );
+    terminatedSomething = simpleResourceManagementStrategy.doTerminate(runner);
 
     Assert.assertFalse(terminatedSomething);
     Assert.assertTrue(simpleResourceManagementStrategy.getStats().toList().size() == 1);
@@ -319,6 +342,7 @@ public class SimpleResourceManagementStrategyTest
     );
 
     EasyMock.verify(autoScaler);
+    EasyMock.verify(runner);
   }
 
   @Test
@@ -331,15 +355,25 @@ public class SimpleResourceManagementStrategyTest
             .andReturn(Lists.<String>newArrayList("ip"));
     EasyMock.replay(autoScaler);
 
-    boolean terminatedSomething = simpleResourceManagementStrategy.doTerminate(
-        Arrays.<RemoteTaskRunnerWorkItem>asList(
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    EasyMock.expect(runner.getPendingTasks()).andReturn(
+        Arrays.asList(
             new RemoteTaskRunnerWorkItem(testTask.getId(), null).withQueueInsertionTime(new DateTime())
-        ),
+        )
+    ).times(2);
+    EasyMock.expect(runner.getWorkers()).andReturn(
         Arrays.<ZkWorker>asList(
             new TestZkWorker(NoopTask.create()),
             new TestZkWorker(NoopTask.create())
         )
+    ).times(2);
+    EasyMock.expect(runner.getLazyWorkers()).andReturn(Lists.<ZkWorker>newArrayList());
+    EasyMock.expect(runner.markWokersLazy((Predicate<ZkWorker>) EasyMock.anyObject(), EasyMock.anyInt())).andReturn(
+        Collections.<ZkWorker>emptyList()
     );
+    EasyMock.replay(runner);
+
+    boolean terminatedSomething = simpleResourceManagementStrategy.doTerminate(runner);
 
     Assert.assertFalse(terminatedSomething);
     EasyMock.verify(autoScaler);
@@ -351,18 +385,11 @@ public class SimpleResourceManagementStrategyTest
             .andReturn(Lists.<String>newArrayList("ip"));
     EasyMock.replay(autoScaler);
 
-    boolean provisionedSomething = simpleResourceManagementStrategy.doProvision(
-        Arrays.<RemoteTaskRunnerWorkItem>asList(
-            new RemoteTaskRunnerWorkItem(testTask.getId(), null).withQueueInsertionTime(new DateTime())
-        ),
-        Arrays.<ZkWorker>asList(
-            new TestZkWorker(NoopTask.create()),
-            new TestZkWorker(NoopTask.create())
-        )
-    );
+    boolean provisionedSomething = simpleResourceManagementStrategy.doProvision(runner);
 
     Assert.assertFalse(provisionedSomething);
     EasyMock.verify(autoScaler);
+    EasyMock.verify(runner);
   }
 
   @Test
@@ -375,11 +402,23 @@ public class SimpleResourceManagementStrategyTest
     EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.<List<String>>anyObject()))
             .andReturn(Lists.<String>newArrayList("ip"));
     EasyMock.replay(autoScaler);
-    boolean terminatedSomething = simpleResourceManagementStrategy.doTerminate(
-        Arrays.<RemoteTaskRunnerWorkItem>asList(),
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    EasyMock.expect(runner.getPendingTasks()).andReturn(
+        Arrays.<RemoteTaskRunnerWorkItem>asList()
+    ).times(3);
+    EasyMock.expect(runner.getWorkers()).andReturn(
         Arrays.<ZkWorker>asList(
             new TestZkWorker(NoopTask.create(), "h1", "i1", "0")
         )
+    ).times(3);
+    EasyMock.expect(runner.getLazyWorkers()).andReturn(Lists.<ZkWorker>newArrayList());
+    EasyMock.expect(runner.markWokersLazy((Predicate<ZkWorker>) EasyMock.anyObject(), EasyMock.anyInt())).andReturn(
+        Collections.<ZkWorker>emptyList()
+    );
+    EasyMock.replay(runner);
+
+    boolean terminatedSomething = simpleResourceManagementStrategy.doTerminate(
+      runner
     );
     Assert.assertFalse(terminatedSomething);
     EasyMock.verify(autoScaler);
@@ -392,10 +431,7 @@ public class SimpleResourceManagementStrategyTest
             .andReturn(Lists.<String>newArrayList("ip"));
     EasyMock.replay(autoScaler);
     boolean provisionedSomething = simpleResourceManagementStrategy.doProvision(
-        Arrays.<RemoteTaskRunnerWorkItem>asList(),
-        Arrays.<ZkWorker>asList(
-            new TestZkWorker(NoopTask.create())
-        )
+        runner
     );
     Assert.assertFalse(provisionedSomething);
     EasyMock.verify(autoScaler);
@@ -415,13 +451,11 @@ public class SimpleResourceManagementStrategyTest
     );
     EasyMock.replay(autoScaler);
     provisionedSomething = simpleResourceManagementStrategy.doProvision(
-        Arrays.<RemoteTaskRunnerWorkItem>asList(),
-        Arrays.<ZkWorker>asList(
-            new TestZkWorker(NoopTask.create(), "h1", "i1", "0")
-        )
+      runner
     );
     Assert.assertTrue(provisionedSomething);
     EasyMock.verify(autoScaler);
+    EasyMock.verify(runner);
   }
 
   @Test
@@ -430,28 +464,32 @@ public class SimpleResourceManagementStrategyTest
     workerConfig.set(null);
     EasyMock.replay(autoScaler);
 
-    boolean terminatedSomething = simpleResourceManagementStrategy.doTerminate(
-        Arrays.<RemoteTaskRunnerWorkItem>asList(
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    EasyMock.expect(runner.getPendingTasks()).andReturn(
+        Arrays.asList(
             new RemoteTaskRunnerWorkItem(testTask.getId(), null).withQueueInsertionTime(new DateTime())
-        ),
+        )
+    ).times(2);
+    EasyMock.expect(runner.getWorkers()).andReturn(
         Arrays.<ZkWorker>asList(
             new TestZkWorker(null)
         )
+    ).times(1);
+    EasyMock.replay(runner);
+
+    boolean terminatedSomething = simpleResourceManagementStrategy.doTerminate(
+        runner
     );
 
     boolean provisionedSomething = simpleResourceManagementStrategy.doProvision(
-        Arrays.<RemoteTaskRunnerWorkItem>asList(
-            new RemoteTaskRunnerWorkItem(testTask.getId(), null).withQueueInsertionTime(new DateTime())
-        ),
-        Arrays.<ZkWorker>asList(
-            new TestZkWorker(null)
-        )
+       runner
     );
 
     Assert.assertFalse(terminatedSomething);
     Assert.assertFalse(provisionedSomething);
 
     EasyMock.verify(autoScaler);
+    EasyMock.verify(runner);
   }
 
   private static class TestZkWorker extends ZkWorker


### PR DESCRIPTION
moves marking of lazy workers to remote task runner, 
prevents race described in #1360, #784 by removing workers from available zkWorkers when marking them as lazy before resource management strategy can terminate them.  