### PR TITLE
Fix roaring extraction filter on empty values

### DIFF
--- a/processing/src/main/java/io/druid/segment/filter/ExtractionFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/ExtractionFilter.java
@@ -66,14 +66,12 @@ public class ExtractionFilter implements Filter
     return filters;
   }
 
-  private static final WrappedImmutableConciseBitmap ZERO_LENGTH_SET = new WrappedImmutableConciseBitmap(new ImmutableConciseSet());
-
   @Override
   public ImmutableBitmap getBitmapIndex(BitmapIndexSelector selector)
   {
     final List<Filter> filters = makeFilters(selector);
     if (filters.isEmpty()) {
-      return ZERO_LENGTH_SET;
+      return selector.getBitmapFactory().makeEmptyImmutableBitmap();
     }
     return new OrFilter(makeFilters(selector)).getBitmapIndex(selector);
   }


### PR DESCRIPTION
Prior patch ( https://github.com/druid-io/druid/pull/1385 ) only fixed things for Concise. This one should work for Concise and Roaring, and puts in some more unit tests.