### PR TITLE
Add schema check for overlap between dimension and metric names

### DIFF
--- a/docs/content/Ingestion.md
+++ b/docs/content/Ingestion.md
@@ -184,3 +184,12 @@ Batch Ingestion: See [Batch ingestion](Batch-ingestion.html)
 
 Real-time Ingestion: See [Real-time ingestion](Realtime-ingestion.html).
 Batch Ingestion: See [Batch ingestion](Batch-ingestion.html)
+
+# Evaluating Timestamp, Dimensions and Metrics
+
+Druid will interpret dimensions, dimension exclusions, and metrics in the following order:
+
+* Any column listed in the list of dimensions is treated as a dimension.
+* Any column listed in the list of dimension exclusions is excluded as a dimension.
+* The timestamp column and columns/fieldNames required by metrics are excluded by default.
+* If a metric is also listed as a dimension, the metric must have a different name than the dimension name.

--- a/server/src/test/java/io/druid/segment/indexing/DataSchemaTest.java
+++ b/server/src/test/java/io/druid/segment/indexing/DataSchemaTest.java
@@ -19,6 +19,7 @@ package io.druid.segment.indexing;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.metamx.common.IAE;
 import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.data.input.impl.JSONParseSpec;
 import io.druid.data.input.impl.StringInputRowParser;
@@ -78,6 +79,25 @@ public class DataSchemaTest
     Assert.assertEquals(
         ImmutableSet.of("dimC", "col1"),
         schema.getParser().getParseSpec().getDimensionsSpec().getDimensionExclusions()
+    );
+  }
+
+  @Test(expected = IAE.class)
+  public void testOverlapMetricNameAndDim() throws Exception
+  {
+    DataSchema schema = new DataSchema(
+        "test",
+        new StringInputRowParser(
+            new JSONParseSpec(
+                new TimestampSpec("time", "auto", null),
+                new DimensionsSpec(ImmutableList.of("time", "dimA", "dimB", "metric1"), ImmutableList.of("dimC"), null)
+            )
+        ),
+        new AggregatorFactory[]{
+            new DoubleSumAggregatorFactory("metric1", "col1"),
+            new DoubleSumAggregatorFactory("metric2", "col2"),
+        },
+        new ArbitraryGranularitySpec(QueryGranularity.DAY, ImmutableList.of(Interval.parse("2014/2015")))
     );
   }
 }


### PR DESCRIPTION
Druid will evaluate the schema in the following order:

1) Any column listed in the list of dimensions is treated as a dimension
2) Any column listed in the list of dimension exclusions is excluded as a dimension
3) Timestamp and required fields by metrics are excluded by default
4) If a metric is also listed as a dimension, the metric must have a different name than the dimension name.
