### PR TITLE
Improvements around resource handling in IndexMerger / IndexIO / QueryableIndex

### DIFF
--- a/processing/src/main/java/io/druid/segment/IndexIO.java
+++ b/processing/src/main/java/io/druid/segment/IndexIO.java
@@ -466,10 +466,14 @@ public class IndexIO
 
     public static void validateTwoSegments(File dir1, File dir2) throws IOException
     {
-      validateTwoSegments(
-          new QueryableIndexIndexableAdapter(loadIndex(dir1)),
-          new QueryableIndexIndexableAdapter(loadIndex(dir2))
-      );
+      try(QueryableIndex queryableIndex1 = loadIndex(dir1)) {
+        try(QueryableIndex queryableIndex2 = loadIndex(dir2)) {
+          validateTwoSegments(
+              new QueryableIndexIndexableAdapter(queryableIndex1),
+              new QueryableIndexIndexableAdapter(queryableIndex2)
+          );
+        }
+      }
     }
 
     public static void validateTwoSegments(final IndexableAdapter adapter1, final IndexableAdapter adapter2)

--- a/processing/src/main/java/io/druid/segment/IndexMerger.java
+++ b/processing/src/main/java/io/druid/segment/IndexMerger.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.base.Objects;
 import com.google.common.base.Splitter;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
@@ -335,6 +334,38 @@ public class IndexMerger
     };
 
     return makeIndexFiles(indexes, outDir, progress, mergedDimensions, mergedMetrics, rowMergerFn, indexSpec);
+  }
+
+  // Faster than IndexMaker
+  public static File convert(final File inDir, final File outDir, final IndexSpec indexSpec) throws IOException
+  {
+    return convert(inDir, outDir, indexSpec, new BaseProgressIndicator());
+  }
+
+  public static File convert(
+      final File inDir, final File outDir, final IndexSpec indexSpec, final ProgressIndicator progress
+  ) throws IOException
+  {
+    try (QueryableIndex index = IndexIO.loadIndex(inDir)) {
+      final IndexableAdapter adapter = new QueryableIndexIndexableAdapter(index);
+      return makeIndexFiles(
+          ImmutableList.of(adapter),
+          outDir,
+          progress,
+          Lists.newArrayList(adapter.getDimensionNames()),
+          Lists.newArrayList(adapter.getMetricNames()),
+          new Function<ArrayList<Iterable<Rowboat>>, Iterable<Rowboat>>()
+          {
+            @Nullable
+            @Override
+            public Iterable<Rowboat> apply(ArrayList<Iterable<Rowboat>> input)
+            {
+              return input.get(0);
+            }
+          },
+          indexSpec
+      );
+    }
   }
 
   public static File append(

--- a/processing/src/main/java/io/druid/segment/QueryableIndex.java
+++ b/processing/src/main/java/io/druid/segment/QueryableIndex.java
@@ -21,11 +21,12 @@ import com.metamx.collections.bitmap.BitmapFactory;
 import io.druid.segment.data.Indexed;
 import org.joda.time.Interval;
 
+import java.io.Closeable;
 import java.io.IOException;
 
 /**
  */
-public interface QueryableIndex extends ColumnSelector
+public interface QueryableIndex extends ColumnSelector, Closeable
 {
   public Interval getDataInterval();
   public int getNumRows();
@@ -37,6 +38,6 @@ public interface QueryableIndex extends ColumnSelector
    * The close method shouldn't actually be here as this is nasty. We will adjust it in the future.
    * @throws java.io.IOException if an exception was thrown closing the index
    */
-  @Deprecated
+  //@Deprecated // This is still required for SimpleQueryableIndex. It should not go away unitl SimpleQueryableIndex is fixed
   public void close() throws IOException;
 }

--- a/processing/src/test/java/io/druid/segment/CloserRule.java
+++ b/processing/src/test/java/io/druid/segment/CloserRule.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment;
+
+import com.metamx.common.logger.Logger;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+
+public class CloserRule implements TestRule
+{
+  private final boolean throwException;
+
+  public CloserRule(boolean throwException)
+  {
+    this.throwException = throwException;
+  }
+
+  private static final Logger log = new Logger(CloserRule.class);
+  private final List<AutoCloseable> autoCloseables = new LinkedList<>();
+
+  @Override
+  public Statement apply(
+      final Statement base, Description description
+  )
+  {
+    return new Statement()
+    {
+      @Override
+      public void evaluate() throws Throwable
+      {
+        Throwable baseThrown = null;
+        try {
+          base.evaluate();
+        }
+        catch (Throwable e) {
+          baseThrown = e;
+        }
+        finally {
+          Throwable exception = null;
+          for (AutoCloseable autoCloseable : autoCloseables) {
+            try {
+              autoCloseable.close();
+            }
+            catch (Exception e) {
+              exception = suppressOrSet(exception, e);
+            }
+          }
+          autoCloseables.clear();
+          if (exception != null) {
+            if (throwException && baseThrown == null) {
+              throw exception;
+            } else if (baseThrown != null) {
+              baseThrown.addSuppressed(exception);
+            } else {
+              log.error(exception, "Exception closing resources");
+            }
+          }
+          if (baseThrown != null) {
+            throw baseThrown;
+          }
+        }
+      }
+    };
+  }
+
+  private static Throwable suppressOrSet(Throwable prior, Throwable other)
+  {
+    if (prior == null) {
+      prior = new IOException("Error closing resources");
+    }
+    prior.addSuppressed(other);
+    return prior;
+  }
+
+  public <T extends AutoCloseable> T closeLater(T autoCloseable)
+  {
+    autoCloseables.add(autoCloseable);
+    return autoCloseable;
+  }
+}

--- a/processing/src/test/java/io/druid/segment/CloserRuleTest.java
+++ b/processing/src/test/java/io/druid/segment/CloserRuleTest.java
@@ -1,0 +1,364 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Runnables;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import javax.annotation.Nullable;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class CloserRuleTest
+{
+  @Rule
+  public final CloserRule closer = new CloserRule(true);
+  @Test
+  public void testCloses() throws Throwable
+  {
+    final CloserRule closer = new CloserRule(false);
+    final AtomicBoolean closed = new AtomicBoolean(false);
+    closer.closeLater(
+        new Closeable()
+        {
+          @Override
+          public void close() throws IOException
+          {
+            closed.set(true);
+          }
+        }
+    );
+    run(closer, Runnables.doNothing());
+    Assert.assertTrue(closed.get());
+  }
+
+  @Test
+  public void testAutoCloses() throws Throwable
+  {
+    final CloserRule closer = new CloserRule(false);
+    final AtomicBoolean closed = new AtomicBoolean(false);
+    closer.closeLater(
+        new AutoCloseable()
+        {
+          @Override
+          public void close() throws Exception
+          {
+            closed.set(true);
+          }
+        }
+    );
+    run(closer, Runnables.doNothing());
+    Assert.assertTrue(closed.get());
+  }
+
+  @Test
+  public void testPreservesException() throws Throwable
+  {
+    final CloserRule closer = new CloserRule(false);
+    final AtomicBoolean closed = new AtomicBoolean(false);
+    closer.closeLater(
+        new Closeable()
+        {
+          @Override
+          public void close() throws IOException
+          {
+            closed.set(true);
+          }
+        }
+    );
+
+    final String msg = "You can't divide by zero, you can only take the limit of such!";
+    Exception ex = null;
+    try {
+      run(
+          closer, new Runnable()
+          {
+            @Override
+            public void run()
+            {
+              throw new ArithmeticException(msg);
+            }
+          }
+      );
+    }
+    catch (Exception e) {
+      ex = e;
+    }
+    Assert.assertTrue(closed.get());
+    Assert.assertNotNull(ex);
+    Assert.assertTrue(ex instanceof ArithmeticException);
+    Assert.assertEquals(msg, ex.getMessage());
+  }
+
+
+  @Test
+  public void testAddsSuppressed() throws Throwable
+  {
+    final CloserRule closer = new CloserRule(false);
+    final AtomicBoolean closed = new AtomicBoolean(false);
+    final String ioExceptionMsg = "You can't triple stamp a double stamp!";
+    closer.closeLater(
+        new Closeable()
+        {
+          @Override
+          public void close() throws IOException
+          {
+            throw new IOException(ioExceptionMsg);
+          }
+        }
+    );
+    closer.closeLater(
+        new Closeable()
+        {
+          @Override
+          public void close() throws IOException
+          {
+            closed.set(true);
+          }
+        }
+    );
+
+    final String msg = "You can't divide by zero, you can only take the limit of such!";
+    Throwable ex = null;
+    try {
+      run(
+          closer, new Runnable()
+          {
+            @Override
+            public void run()
+            {
+              throw new ArithmeticException(msg);
+            }
+          }
+      );
+    }
+    catch (Throwable e) {
+      ex = e;
+    }
+    Assert.assertTrue(closed.get());
+    Assert.assertNotNull(ex);
+    Assert.assertTrue(ex instanceof ArithmeticException);
+    Assert.assertEquals(msg, ex.getMessage());
+    Assert.assertEquals(
+        ImmutableList.of(ioExceptionMsg),
+        Lists.transform(
+            Arrays.asList(ex.getSuppressed()),
+            new Function<Throwable, String>()
+            {
+              @Nullable
+              @Override
+              public String apply(@Nullable Throwable input)
+              {
+                if (input == null) {
+                  return null;
+                }
+                return input.getSuppressed()[0].getMessage();
+              }
+            }
+        )
+    );
+  }
+
+  @Test
+  public void testThrowsCloseException()
+  {
+    final CloserRule closer = new CloserRule(true);
+    final String ioExceptionMsg = "You can't triple stamp a double stamp!";
+    closer.closeLater(
+        new Closeable()
+        {
+          @Override
+          public void close() throws IOException
+          {
+            throw new IOException(ioExceptionMsg);
+          }
+        }
+    );
+    Throwable ex = null;
+    try {
+      run(closer, Runnables.doNothing());
+    }
+    catch (Throwable throwable) {
+      ex = throwable;
+    }
+    Assert.assertNotNull(ex);
+    ex = ex.getSuppressed()[0];
+    Assert.assertNotNull(ex);
+    Assert.assertTrue(ex instanceof IOException);
+    Assert.assertEquals(ioExceptionMsg, ex.getMessage());
+  }
+
+
+  @Test
+  public void testJustLogs() throws Throwable
+  {
+    final CloserRule closer = new CloserRule(false);
+    final String ioExceptionMsg = "You can't triple stamp a double stamp!";
+    closer.closeLater(
+        new Closeable()
+        {
+          @Override
+          public void close() throws IOException
+          {
+            throw new IOException(ioExceptionMsg);
+          }
+        }
+    );
+    run(closer, Runnables.doNothing());
+  }
+
+  @Test
+  public void testJustLogsAnything() throws Throwable
+  {
+    final CloserRule closer = new CloserRule(false);
+    final String ioExceptionMsg = "You can't triple stamp a double stamp!";
+    closer.closeLater(
+        new Closeable()
+        {
+          @Override
+          public void close() throws IOException
+          {
+            throw new IOException(ioExceptionMsg);
+          }
+        }
+    );
+    closer.closeLater(
+        new Closeable()
+        {
+          @Override
+          public void close() throws IOException
+          {
+            throw new IOException(ioExceptionMsg);
+          }
+        }
+    );
+    closer.closeLater(
+        new AutoCloseable()
+        {
+          @Override
+          public void close() throws Exception
+          {
+            throw new IOException(ioExceptionMsg);
+          }
+        }
+    );
+    run(closer, Runnables.doNothing());
+  }
+
+  @Test
+  public void testClosesEverything()
+  {
+    final AtomicLong counter = new AtomicLong(0L);
+    final CloserRule closer = new CloserRule(true);
+    final String ioExceptionMsg = "You can't triple stamp a double stamp!";
+    final List<IOException> ioExceptions = Arrays.<IOException>asList(
+        new IOException(ioExceptionMsg),
+        null,
+        new IOException(ioExceptionMsg),
+        null,
+        new IOException(ioExceptionMsg),
+        null
+    );
+    for(final IOException throwable : ioExceptions){
+      closer.closeLater(
+          new Closeable()
+          {
+            @Override
+            public void close() throws IOException
+            {
+              counter.incrementAndGet();
+              if(throwable != null){
+                throw throwable;
+              }
+            }
+          }
+      );
+    }
+    for(final IOException throwable : ioExceptions){
+      closer.closeLater(
+          new AutoCloseable()
+          {
+            @Override
+            public void close() throws Exception
+            {
+              counter.incrementAndGet();
+              if(throwable != null){
+                throw throwable;
+              }
+            }
+          }
+      );
+    }
+    Throwable ex = null;
+    try {
+      run(closer, Runnables.doNothing());
+    }catch (Throwable throwable) {
+      ex = throwable;
+    }
+    Assert.assertNotNull(ex);
+    Assert.assertEquals(ioExceptions.size() * 2, counter.get());
+    Assert.assertEquals(ioExceptions.size(), ex.getSuppressed().length);
+  }
+
+  @Ignore // This one doesn't quite work right, it will throw the IOException, but JUnit doesn't detect it properly and treats it as suppressed instead
+  @Test(expected = IOException.class)
+  public void testCloserException()
+  {
+    closer.closeLater(
+        new Closeable()
+        {
+          @Override
+          public void close() throws IOException
+          {
+            throw new IOException("This is a test");
+          }
+        }
+    );
+  }
+
+  private void run(CloserRule closer, final Runnable runnable) throws Throwable
+  {
+    closer.apply(
+        new Statement()
+        {
+          @Override
+          public void evaluate() throws Throwable
+          {
+            runnable.run();
+          }
+        }, Description.createTestDescription(
+            CloserRuleTest.class.getCanonicalName(), "baseRunner", UUID.randomUUID()
+        )
+    ).evaluate();
+  }
+}

--- a/processing/src/test/java/io/druid/segment/IndexMakerTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMakerTest.java
@@ -40,6 +40,7 @@ import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -58,6 +59,8 @@ import java.util.Map;
 @RunWith(Parameterized.class)
 public class IndexMakerTest
 {
+  @Rule
+  public final CloserRule closer = new CloserRule(false);
   private static final long TIMESTAMP = DateTime.parse("2014-01-01").getMillis();
   private static final AggregatorFactory[] DEFAULT_AGG_FACTORIES = new AggregatorFactory[]{
       new CountAggregatorFactory(
@@ -179,7 +182,7 @@ public class IndexMakerTest
   @Test
   public void testSimpleReprocess() throws IOException
   {
-    final IndexableAdapter adapter = new QueryableIndexIndexableAdapter(IndexIO.loadIndex(persistTmpDir));
+    final IndexableAdapter adapter = new QueryableIndexIndexableAdapter(closer.closeLater(IndexIO.loadIndex(persistTmpDir)));
     Assert.assertEquals(events.size(), adapter.getNumRows());
     reprocessAndValidate(persistTmpDir, new File(tmpDir, "reprocessed"));
   }
@@ -198,7 +201,7 @@ public class IndexMakerTest
   private File appendAndValidate(File inDir, File tmpDir) throws IOException
   {
     final File outDir = IndexMerger.append(
-        ImmutableList.<IndexableAdapter>of(new QueryableIndexIndexableAdapter(IndexIO.loadIndex(inDir))),
+        ImmutableList.<IndexableAdapter>of(new QueryableIndexIndexableAdapter(closer.closeLater(IndexIO.loadIndex(inDir)))),
         tmpDir,
         INDEX_SPEC
     );
@@ -209,18 +212,18 @@ public class IndexMakerTest
   @Test
   public void testIdempotentReprocess() throws IOException
   {
-    final IndexableAdapter adapter = new QueryableIndexIndexableAdapter(IndexIO.loadIndex(persistTmpDir));
+    final IndexableAdapter adapter = new QueryableIndexIndexableAdapter(closer.closeLater(IndexIO.loadIndex(persistTmpDir)));
     Assert.assertEquals(events.size(), adapter.getNumRows());
     final File tmpDir1 = new File(tmpDir, "reprocessed1");
     reprocessAndValidate(persistTmpDir, tmpDir1);
 
     final File tmpDir2 = new File(tmpDir, "reprocessed2");
-    final IndexableAdapter adapter2 = new QueryableIndexIndexableAdapter(IndexIO.loadIndex(tmpDir1));
+    final IndexableAdapter adapter2 = new QueryableIndexIndexableAdapter(closer.closeLater(IndexIO.loadIndex(tmpDir1)));
     Assert.assertEquals(events.size(), adapter2.getNumRows());
     reprocessAndValidate(tmpDir1, tmpDir2);
 
     final File tmpDir3 = new File(tmpDir, "reprocessed3");
-    final IndexableAdapter adapter3 = new QueryableIndexIndexableAdapter(IndexIO.loadIndex(tmpDir2));
+    final IndexableAdapter adapter3 = new QueryableIndexIndexableAdapter(closer.closeLater(IndexIO.loadIndex(tmpDir2)));
     Assert.assertEquals(events.size(), adapter3.getNumRows());
     reprocessAndValidate(tmpDir2, tmpDir3);
   }
@@ -228,7 +231,7 @@ public class IndexMakerTest
   @Test
   public void testSimpleAppend() throws IOException
   {
-    final IndexableAdapter adapter = new QueryableIndexIndexableAdapter(IndexIO.loadIndex(persistTmpDir));
+    final IndexableAdapter adapter = new QueryableIndexIndexableAdapter(closer.closeLater(IndexIO.loadIndex(persistTmpDir)));
     Assert.assertEquals(events.size(), adapter.getNumRows());
     appendAndValidate(persistTmpDir, new File(tmpDir, "reprocessed"));
   }
@@ -236,18 +239,18 @@ public class IndexMakerTest
   @Test
   public void testIdempotentAppend() throws IOException
   {
-    final IndexableAdapter adapter = new QueryableIndexIndexableAdapter(IndexIO.loadIndex(persistTmpDir));
+    final IndexableAdapter adapter = new QueryableIndexIndexableAdapter(closer.closeLater(IndexIO.loadIndex(persistTmpDir)));
     Assert.assertEquals(events.size(), adapter.getNumRows());
     final File tmpDir1 = new File(tmpDir, "reprocessed1");
     appendAndValidate(persistTmpDir, tmpDir1);
 
     final File tmpDir2 = new File(tmpDir, "reprocessed2");
-    final IndexableAdapter adapter2 = new QueryableIndexIndexableAdapter(IndexIO.loadIndex(tmpDir1));
+    final IndexableAdapter adapter2 = new QueryableIndexIndexableAdapter(closer.closeLater(IndexIO.loadIndex(tmpDir1)));
     Assert.assertEquals(events.size(), adapter2.getNumRows());
     appendAndValidate(tmpDir1, tmpDir2);
 
     final File tmpDir3 = new File(tmpDir, "reprocessed3");
-    final IndexableAdapter adapter3 = new QueryableIndexIndexableAdapter(IndexIO.loadIndex(tmpDir2));
+    final IndexableAdapter adapter3 = new QueryableIndexIndexableAdapter(closer.closeLater(IndexIO.loadIndex(tmpDir2)));
     Assert.assertEquals(events.size(), adapter3.getNumRows());
     appendAndValidate(tmpDir2, tmpDir3);
   }


### PR DESCRIPTION
* Fix resource leak in `io.druid.segment.IndexIO.DefaultIndexIOHandler#validateTwoSegments(java.io.File, java.io.File)`
* Un-deprecate `close()` in `QueryableIndex` and make it inherit `Closeable`
* Fix resource leaks in various unit tests
* Add `CloserRule` for closing out resources in unit tests
* Add `convert` to `IndexMerger` and tests