### PR TITLE
Fix breaking while exceeding max intermediate rows.

### DIFF
--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryEngine.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryEngine.java
@@ -366,11 +366,11 @@ public class GroupByQueryEngine
         }
         cursor.advance();
       }
-      while (!cursor.isDone()) {
+      while (!cursor.isDone() && rowUpdater.getNumRows() < config.getMaxIntermediateRows()) {
         ByteBuffer key = ByteBuffer.allocate(dimensions.size() * Ints.BYTES);
 
         unprocessedKeys = rowUpdater.updateValues(key, dimensions);
-        if (unprocessedKeys != null || rowUpdater.getNumRows() > config.getMaxIntermediateRows()) {
+        if (unprocessedKeys != null) {
           break;
         }
 


### PR DESCRIPTION
If **rowUpdater.getNumRows() > config.getMaxIntermediateRows()**, then the current row will be processed twice, so just move **cursor.advance()**; before the breaking.