### PR TITLE
Converter to use TaskMerger not TaskMaker

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/updater/HadoopConverterJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/updater/HadoopConverterJob.java
@@ -33,7 +33,7 @@ import com.metamx.common.ISE;
 import com.metamx.common.logger.Logger;
 import io.druid.indexer.JobHelper;
 import io.druid.segment.IndexIO;
-import io.druid.segment.IndexMaker;
+import io.druid.segment.IndexMerger;
 import io.druid.timeline.DataSegment;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -508,7 +508,7 @@ public class HadoopConverterJob
       if (!outDir.mkdir() && (!outDir.exists() || !outDir.isDirectory())) {
         throw new IOException(String.format("Could not create output directory [%s]", outDir));
       }
-      IndexMaker.convert(
+      IndexMerger.convert(
           inDir,
           outDir,
           config.getIndexSpec(),

--- a/processing/src/main/java/io/druid/segment/IndexIO.java
+++ b/processing/src/main/java/io/druid/segment/IndexIO.java
@@ -229,7 +229,7 @@ public class IndexIO
         return true;
       default:
         if (forceIfCurrent) {
-          IndexMaker.convert(toConvert, converted, indexSpec);
+          IndexMerger.convert(toConvert, converted, indexSpec);
           if(validate){
             DefaultIndexIOHandler.validateTwoSegments(toConvert, converted);
           }


### PR DESCRIPTION
Finally was able to do some validation to make sure of some unknowns:

* Both Merger and Maker pass validation for data integrity
* The Maker version also takes 6 times as long to run compared to Merger.
* Resultant segment sizes were comparable but not equal.

So this reduces the execution time by ~80%

This depends on PRs

* ~~https://github.com/druid-io/druid/pull/1351~~
* ~~https://github.com/druid-io/druid/pull/1403~~