### PR TITLE
Replace "timeout" with QueryContextKeys.TIMEOUT

### DIFF
--- a/processing/src/main/java/io/druid/query/ChainedExecutionQueryRunner.java
+++ b/processing/src/main/java/io/druid/query/ChainedExecutionQueryRunner.java
@@ -153,7 +153,7 @@ public class ChainedExecutionQueryRunner<T> implements QueryRunner<T>
             queryWatcher.registerQuery(query, futures);
 
             try {
-              final Number timeout = query.getContextValue("timeout", (Number) null);
+              final Number timeout = query.getContextValue(QueryContextKeys.TIMEOUT, (Number) null);
               return new MergeIterable<>(
                   ordering.nullsFirst(),
                   timeout == null ?

--- a/processing/src/main/java/io/druid/query/GroupByParallelQueryRunner.java
+++ b/processing/src/main/java/io/druid/query/GroupByParallelQueryRunner.java
@@ -138,7 +138,7 @@ public class GroupByParallelQueryRunner<T> implements QueryRunner<T>
     // Let the runners complete
     try {
       queryWatcher.registerQuery(query, futures);
-      final Number timeout = query.getContextValue("timeout", (Number) null);
+      final Number timeout = query.getContextValue(QueryContextKeys.TIMEOUT, (Number) null);
       if (timeout == null) {
         futures.get();
       } else {

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryRunnerFactory.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryRunnerFactory.java
@@ -37,6 +37,7 @@ import io.druid.query.AbstractPrioritizedCallable;
 import io.druid.query.ConcatQueryRunner;
 import io.druid.query.GroupByParallelQueryRunner;
 import io.druid.query.Query;
+import io.druid.query.QueryContextKeys;
 import io.druid.query.QueryInterruptedException;
 import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerFactory;
@@ -143,7 +144,7 @@ public class GroupByQueryRunnerFactory implements QueryRunnerFactory<Row, GroupB
                       );
                       try {
                         queryWatcher.registerQuery(query, future);
-                        final Number timeout = query.getContextValue("timeout", (Number) null);
+                        final Number timeout = query.getContextValue(QueryContextKeys.TIMEOUT, (Number) null);
                         if (timeout == null) {
                           future.get();
                         } else {

--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
@@ -30,6 +30,7 @@ import com.metamx.common.logger.Logger;
 import io.druid.query.AbstractPrioritizedCallable;
 import io.druid.query.ConcatQueryRunner;
 import io.druid.query.Query;
+import io.druid.query.QueryContextKeys;
 import io.druid.query.QueryInterruptedException;
 import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerFactory;
@@ -155,7 +156,7 @@ public class SegmentMetadataQueryRunnerFactory implements QueryRunnerFactory<Seg
                     );
                     try {
                       queryWatcher.registerQuery(query, future);
-                      final Number timeout = query.getContextValue("timeout", (Number) null);
+                      final Number timeout = query.getContextValue(QueryContextKeys.TIMEOUT, (Number) null);
                       return timeout == null ? future.get() : future.get(timeout.longValue(), TimeUnit.MILLISECONDS);
                     }
                     catch (InterruptedException e) {

--- a/processing/src/test/java/io/druid/query/AsyncQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/AsyncQueryRunnerTest.java
@@ -102,7 +102,7 @@ public class AsyncQueryRunnerTest
         QueryRunnerTestHelper.NOOP_QUERYWATCHER);
 
     Sequence lazy = asyncRunner.run(
-        query.withOverriddenContext(ImmutableMap.<String,Object>of("timeout", 1)),
+        query.withOverriddenContext(ImmutableMap.<String,Object>of(QueryContextKeys.TIMEOUT, 1)),
         Collections.EMPTY_MAP);
 
     try {

--- a/processing/src/test/java/io/druid/query/ChainedExecutionQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/ChainedExecutionQueryRunnerTest.java
@@ -253,7 +253,7 @@ public class ChainedExecutionQueryRunnerTest
               .dataSource("test")
               .intervals("2014/2015")
               .aggregators(Lists.<AggregatorFactory>newArrayList(new CountAggregatorFactory("count")))
-              .context(ImmutableMap.<String, Object>of("timeout", 100, "queryId", "test"))
+              .context(ImmutableMap.<String, Object>of(QueryContextKeys.TIMEOUT, 100, "queryId", "test"))
               .build(),
         context
     );

--- a/server/src/main/java/io/druid/server/QueryResource.java
+++ b/server/src/main/java/io/druid/server/QueryResource.java
@@ -33,6 +33,7 @@ import com.metamx.emitter.service.ServiceEmitter;
 import io.druid.guice.annotations.Json;
 import io.druid.guice.annotations.Smile;
 import io.druid.query.Query;
+import io.druid.query.QueryContextKeys;
 import io.druid.query.QueryInterruptedException;
 import io.druid.query.DruidMetrics;
 import io.druid.query.QuerySegmentWalker;
@@ -136,10 +137,10 @@ public class QueryResource
         queryId = UUID.randomUUID().toString();
         query = query.withId(queryId);
       }
-      if (query.getContextValue("timeout") == null) {
+      if (query.getContextValue(QueryContextKeys.TIMEOUT) == null) {
         query = query.withOverriddenContext(
             ImmutableMap.of(
-                "timeout",
+                QueryContextKeys.TIMEOUT,
                 config.getMaxIdleTime().toStandardDuration().getMillis()
             )
         );


### PR DESCRIPTION
This helps when searching for where timeout is used because you can search for usages of `QueryContextKeys.TIMEOUT`