### PR TITLE
fix behaviour of middlemanagers around ZK disconnects , fixes #709

### DIFF
--- a/docs/content/configuration/indexing-service.md
+++ b/docs/content/configuration/indexing-service.md
@@ -70,6 +70,7 @@ The following configs only apply if the overlord is running in remote mode:
 |`druid.indexer.runner.minWorkerVersion`|The minimum middle manager version to send tasks to. |"0"|
 |`druid.indexer.runner.compressZnodes`|Indicates whether or not the overlord should expect middle managers to compress Znodes.|true|
 |`druid.indexer.runner.maxZnodeBytes`|The maximum size Znode in bytes that can be created in Zookeeper.|524288|
+|`druid.indexer.runner.taskCleanupTimeout`|How long to wait before failing a task after a middle manager is disconnected from Zookeeper.|PT15M|
 
 There are additional configs for autoscaling (if it is enabled):
 

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/SimpleResourceManagementStrategy.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/SimpleResourceManagementStrategy.java
@@ -187,7 +187,7 @@ public class SimpleResourceManagementStrategy implements ResourceManagementStrat
           final Predicate<ZkWorker> isLazyWorker = createLazyWorkerPredicate(config);
           final List<String> laziestWorkerIps =
               Lists.transform(
-                  runner.markWokersLazy(isLazyWorker, excessWorkers),
+                  runner.markWorkersLazy(isLazyWorker, excessWorkers),
                   new Function<ZkWorker, String>()
                   {
                     @Override

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
@@ -32,6 +32,10 @@ public class RemoteTaskRunnerConfig
   private Period taskAssignmentTimeout = new Period("PT5M");
 
   @JsonProperty
+  @NotNull
+  private Period taskCleanupTimeout = new Period("PT15M");
+
+  @JsonProperty
   private String minWorkerVersion = "0";
 
   @JsonProperty
@@ -41,6 +45,11 @@ public class RemoteTaskRunnerConfig
   public Period getTaskAssignmentTimeout()
   {
     return taskAssignmentTimeout;
+  }
+
+  @JsonProperty
+  public Period getTaskCleanupTimeout(){
+    return taskCleanupTimeout;
   }
 
   public String getMinWorkerVersion()

--- a/indexing-service/src/main/java/io/druid/indexing/worker/TaskAnnouncement.java
+++ b/indexing-service/src/main/java/io/druid/indexing/worker/TaskAnnouncement.java
@@ -34,8 +34,13 @@ public class TaskAnnouncement
 
   public static TaskAnnouncement create(Task task, TaskStatus status)
   {
-    Preconditions.checkArgument(status.getId().equals(task.getId()), "task id == status id");
-    return new TaskAnnouncement(null, null, status, task.getTaskResource());
+    return create(task.getId(), task.getTaskResource(), status);
+  }
+
+  public static TaskAnnouncement create(String taskId, TaskResource resource, TaskStatus status)
+  {
+    Preconditions.checkArgument(status.getId().equals(taskId), "task id == status id");
+    return new TaskAnnouncement(null, null, status, resource);
   }
 
   @JsonCreator

--- a/indexing-service/src/main/java/io/druid/indexing/worker/WorkerTaskMonitor.java
+++ b/indexing-service/src/main/java/io/druid/indexing/worker/WorkerTaskMonitor.java
@@ -84,6 +84,19 @@ public class WorkerTaskMonitor
   public void start()
   {
     try {
+      // cleanup any old running task announcements which are invalid after restart
+      for (TaskAnnouncement announcement : workerCuratorCoordinator.getAnnouncements()){
+        if(announcement.getTaskStatus().isRunnable()) {
+          workerCuratorCoordinator.updateAnnouncement(
+              TaskAnnouncement.create(
+                  announcement.getTaskId(),
+                  announcement.getTaskResource(),
+                  TaskStatus.failure(announcement.getTaskId())
+              )
+          );
+        }
+      }
+
       pathChildrenCache.getListenable().addListener(
           new PathChildrenCacheListener()
           {
@@ -122,7 +135,7 @@ public class WorkerTaskMonitor
                         TaskStatus taskStatus;
                         try {
                           workerCuratorCoordinator.unannounceTask(task.getId());
-                          workerCuratorCoordinator.announceTastAnnouncement(
+                          workerCuratorCoordinator.announceTaskAnnouncement(
                               TaskAnnouncement.create(
                                   task,
                                   TaskStatus.running(task.getId())

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTest.java
@@ -26,6 +26,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.metamx.common.concurrent.ScheduledExecutorFactory;
+import com.metamx.common.concurrent.ScheduledExecutors;
+import com.metamx.common.lifecycle.Lifecycle;
 import com.metamx.emitter.EmittingLogger;
 import com.metamx.emitter.service.ServiceEmitter;
 import io.druid.common.guava.DSuppliers;
@@ -51,6 +54,7 @@ import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.test.TestingCluster;
 import org.apache.zookeeper.CreateMode;
 import org.easymock.EasyMock;
+import org.joda.time.Period;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -59,6 +63,7 @@ import org.junit.Test;
 import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -79,6 +84,7 @@ public class RemoteTaskRunnerTest
   private TestMergeTask task;
 
   private Worker worker;
+  private RemoteTaskRunnerConfig config;
 
   @Before
   public void setUp() throws Exception
@@ -361,6 +367,18 @@ public class RemoteTaskRunnerTest
     TaskStatus status = future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
     Assert.assertEquals(TaskStatus.Status.FAILED, status.getStatusCode());
+    Assert.assertTrue(
+        TestUtils.conditionValid(
+            new IndexingServiceCondition()
+            {
+              @Override
+              public boolean isValid()
+              {
+                return remoteTaskRunner.getRemovedWorkerCleanups().isEmpty();
+              }
+            }
+        )
+    );
   }
 
   @Test
@@ -389,12 +407,11 @@ public class RemoteTaskRunnerTest
   private void doSetup() throws Exception
   {
     makeWorker();
-    makeRemoteTaskRunner();
+    makeRemoteTaskRunner(new TestRemoteTaskRunnerConfig(new Period("PT1S")));
   }
 
-  private void makeRemoteTaskRunner() throws Exception
+  private void makeRemoteTaskRunner(RemoteTaskRunnerConfig config) throws Exception
   {
-    RemoteTaskRunnerConfig config = new TestRemoteTaskRunnerConfig();
     remoteTaskRunner = new RemoteTaskRunner(
         jsonMapper,
         config,
@@ -411,7 +428,8 @@ public class RemoteTaskRunnerTest
         cf,
         new SimplePathChildrenCacheFactory.Builder().build(),
         null,
-        DSuppliers.of(new AtomicReference<>(WorkerBehaviorConfig.defaultConfig()))
+        DSuppliers.of(new AtomicReference<>(WorkerBehaviorConfig.defaultConfig())),
+        ScheduledExecutors.fixed(1, "Remote-Task-Runner-Cleanup--%d")
     );
 
     remoteTaskRunner.start();
@@ -505,7 +523,7 @@ public class RemoteTaskRunnerTest
     remoteTaskRunner.run(task);
     Assert.assertTrue(taskAnnounced(task.getId()));
     mockWorkerRunningTask(task);
-    Collection<ZkWorker> lazyworkers = remoteTaskRunner.markWokersLazy(
+    Collection<ZkWorker> lazyworkers = remoteTaskRunner.markWorkersLazy(
         new Predicate<ZkWorker>()
         {
           @Override
@@ -526,7 +544,7 @@ public class RemoteTaskRunnerTest
     doSetup();
     remoteTaskRunner.run(task);
     Assert.assertTrue(taskAnnounced(task.getId()));
-    Collection<ZkWorker> lazyworkers = remoteTaskRunner.markWokersLazy(
+    Collection<ZkWorker> lazyworkers = remoteTaskRunner.markWorkersLazy(
         new Predicate<ZkWorker>()
         {
           @Override
@@ -545,7 +563,7 @@ public class RemoteTaskRunnerTest
   public void testFindLazyWorkerNotRunningAnyTask() throws Exception
   {
     doSetup();
-    Collection<ZkWorker> lazyworkers = remoteTaskRunner.markWokersLazy(
+    Collection<ZkWorker> lazyworkers = remoteTaskRunner.markWorkersLazy(
         new Predicate<ZkWorker>()
         {
           @Override
@@ -557,6 +575,56 @@ public class RemoteTaskRunnerTest
     );
     Assert.assertEquals(1, lazyworkers.size());
     Assert.assertEquals(1, remoteTaskRunner.getLazyWorkers().size());
+  }
+
+  @Test
+  public void testWorkerZKReconnect() throws Exception
+  {
+    makeWorker();
+    makeRemoteTaskRunner(new TestRemoteTaskRunnerConfig(new Period("PT5M")));
+    Future<TaskStatus> future = remoteTaskRunner.run(task);
+
+    Assert.assertTrue(taskAnnounced(task.getId()));
+    mockWorkerRunningTask(task);
+
+    Assert.assertTrue(workerRunningTask(task.getId()));
+    byte[] bytes = cf.getData().forPath(announcementsPath);
+    cf.delete().forPath(announcementsPath);
+    // worker task cleanup scheduled
+    Assert.assertTrue(
+        TestUtils.conditionValid(
+            new IndexingServiceCondition()
+            {
+              @Override
+              public boolean isValid()
+              {
+                return remoteTaskRunner.getRemovedWorkerCleanups().containsKey(worker.getHost());
+              }
+            }
+        )
+    );
+
+    // Worker got reconnected
+    cf.create().forPath(announcementsPath, bytes);
+
+    // worker task cleanup should get cancelled and removed
+    Assert.assertTrue(
+        TestUtils.conditionValid(
+            new IndexingServiceCondition()
+            {
+              @Override
+              public boolean isValid()
+              {
+                return !remoteTaskRunner.getRemovedWorkerCleanups().containsKey(worker.getHost());
+              }
+            }
+        )
+    );
+
+    mockWorkerCompleteSuccessfulTask(task);
+    TaskStatus status = future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    Assert.assertEquals(status.getStatusCode(), TaskStatus.Status.SUCCESS);
+    Assert.assertEquals(TaskStatus.Status.SUCCESS, status.getStatusCode());
   }
 
 }

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/TestRemoteTaskRunnerConfig.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/TestRemoteTaskRunnerConfig.java
@@ -24,10 +24,23 @@ import org.joda.time.Period;
  */
 public class TestRemoteTaskRunnerConfig extends RemoteTaskRunnerConfig
 {
+  private final Period timeout;
+
+  public TestRemoteTaskRunnerConfig(Period timeout)
+  {
+    this.timeout = timeout;
+  }
+
   @Override
   public Period getTaskAssignmentTimeout()
   {
-    return new Period("PT1S");
+    return timeout;
+  }
+
+  @Override
+  public Period getTaskCleanupTimeout()
+  {
+    return timeout;
   }
 
   @Override

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/SimpleResourceManagementStrategyTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/SimpleResourceManagementStrategyTest.java
@@ -275,7 +275,7 @@ public class SimpleResourceManagementStrategyTest
             new TestZkWorker(testTask)
         )
     ).times(2);
-    EasyMock.expect(runner.markWokersLazy((Predicate<ZkWorker>) EasyMock.anyObject(), EasyMock.anyInt())).andReturn(
+    EasyMock.expect(runner.markWorkersLazy((Predicate<ZkWorker>) EasyMock.anyObject(), EasyMock.anyInt())).andReturn(
         Arrays.<ZkWorker>asList(
             new TestZkWorker(testTask)
         )
@@ -318,7 +318,7 @@ public class SimpleResourceManagementStrategyTest
         )
     ).times(2);
     EasyMock.expect(runner.getLazyWorkers()).andReturn(Lists.<ZkWorker>newArrayList()).times(2);
-    EasyMock.expect(runner.markWokersLazy((Predicate<ZkWorker>) EasyMock.anyObject(), EasyMock.anyInt())).andReturn(
+    EasyMock.expect(runner.markWorkersLazy((Predicate<ZkWorker>) EasyMock.anyObject(), EasyMock.anyInt())).andReturn(
         Arrays.<ZkWorker>asList(
             new TestZkWorker(testTask)
         )
@@ -368,7 +368,7 @@ public class SimpleResourceManagementStrategyTest
         )
     ).times(2);
     EasyMock.expect(runner.getLazyWorkers()).andReturn(Lists.<ZkWorker>newArrayList());
-    EasyMock.expect(runner.markWokersLazy((Predicate<ZkWorker>) EasyMock.anyObject(), EasyMock.anyInt())).andReturn(
+    EasyMock.expect(runner.markWorkersLazy((Predicate<ZkWorker>) EasyMock.anyObject(), EasyMock.anyInt())).andReturn(
         Collections.<ZkWorker>emptyList()
     );
     EasyMock.replay(runner);
@@ -412,7 +412,7 @@ public class SimpleResourceManagementStrategyTest
         )
     ).times(3);
     EasyMock.expect(runner.getLazyWorkers()).andReturn(Lists.<ZkWorker>newArrayList());
-    EasyMock.expect(runner.markWokersLazy((Predicate<ZkWorker>) EasyMock.anyObject(), EasyMock.anyInt())).andReturn(
+    EasyMock.expect(runner.markWorkersLazy((Predicate<ZkWorker>) EasyMock.anyObject(), EasyMock.anyInt())).andReturn(
         Collections.<ZkWorker>emptyList()
     );
     EasyMock.replay(runner);


### PR DESCRIPTION
At present there are multiple places from which the task status can get deleted which leads to issues where the state of middle manager and overlord gets out of sync when either the middle manager is rebooted. Also the state changes can be lost during leadership changes. 

This PR makes the overlord to be the *only* thing that deletes the status, and for it to *not* be an ephemeral node. 
The changes include - 
1) change task status *not* to be ephemeral nodes 
2) If a middlemanager is restarted it updates the task status for tasks running from previous run to FAILED. 
3) RemoteTaskRunner now waits for configurable grace period before failing a task when the worker is temporarily disconnected from ZK. 
4) RemoteTaskRunner ensures proper cleanup of task status nodes. 