### PR TITLE
Close out some potential Yielder resource leaks.

### DIFF
--- a/common/src/main/java/io/druid/collections/OrderedMergeSequence.java
+++ b/common/src/main/java/io/druid/collections/OrderedMergeSequence.java
@@ -34,13 +34,13 @@ import java.util.PriorityQueue;
 /**
  * An OrderedMergeIterator is an iterator that merges together multiple sorted iterators.  It is written assuming
  * that the input Iterators are provided in order.  That is, it places an extra restriction in the input iterators.
- *
+ * <p/>
  * Normally a merge operation could operate with the actual input iterators in any order as long as the actual values
  * in the iterators are sorted.  This requires that not only the individual values be sorted, but that the iterators
  * be provided in the order of the first element of each iterator.
- *
+ * <p/>
  * If this doesn't make sense, check out OrderedMergeSequenceTest.testScrewsUpOnOutOfOrderBeginningOfList()
- *
+ * <p/>
  * It places this extra restriction on the input data in order to implement an optimization that allows it to
  * remain as lazy as possible in the face of a common case where the iterators are just appended one after the other.
  */
@@ -116,8 +116,7 @@ public class OrderedMergeSequence<T> implements Sequence<T>
                 throw Throwables.propagate(e);
               }
               return null;
-            }
-            else {
+            } else {
               yield();
             }
 
@@ -125,8 +124,18 @@ public class OrderedMergeSequence<T> implements Sequence<T>
           }
         }
     );
-
-    return makeYielder(pQueue, oldDudeAtCrosswalk, initValue, accumulator);
+    try {
+      return makeYielder(pQueue, oldDudeAtCrosswalk, initValue, accumulator);
+    }
+    catch (RuntimeException ex) {
+      try {
+        oldDudeAtCrosswalk.close();
+      }
+      catch (IOException e) {
+        ex.addSuppressed(ex);
+      }
+      throw ex;
+    }
   }
 
   private <OutType> Yielder<OutType> makeYielder(
@@ -141,19 +150,16 @@ public class OrderedMergeSequence<T> implements Sequence<T>
       Yielder<T> yielder;
       if (oldDudeAtCrosswalk.isDone()) {
         yielder = pQueue.remove();
-      }
-      else if (pQueue.isEmpty()) {
+      } else if (pQueue.isEmpty()) {
         yielder = oldDudeAtCrosswalk.get();
         oldDudeAtCrosswalk = oldDudeAtCrosswalk.next(null);
-      }
-      else {
+      } else {
         Yielder<T> queueYielder = pQueue.peek();
         Yielder<T> iterYielder = oldDudeAtCrosswalk.get();
 
         if (ordering.compare(queueYielder.get(), iterYielder.get()) <= 0) {
           yielder = pQueue.remove();
-        }
-        else {
+        } else {
           yielder = oldDudeAtCrosswalk.get();
           oldDudeAtCrosswalk = oldDudeAtCrosswalk.next(null);
         }
@@ -168,8 +174,7 @@ public class OrderedMergeSequence<T> implements Sequence<T>
         catch (IOException e) {
           throw Throwables.propagate(e);
         }
-      }
-      else {
+      } else {
         pQueue.add(yielder);
       }
     }
@@ -204,7 +209,7 @@ public class OrderedMergeSequence<T> implements Sequence<T>
       @Override
       public void close() throws IOException
       {
-        while(!pQueue.isEmpty()) {
+        while (!pQueue.isEmpty()) {
           pQueue.remove().close();
         }
       }

--- a/common/src/main/java/io/druid/common/guava/CombiningSequence.java
+++ b/common/src/main/java/io/druid/common/guava/CombiningSequence.java
@@ -73,9 +73,19 @@ public class CombiningSequence<T> implements Sequence<T>
     );
 
     combiningAccumulator.setRetVal(initValue);
-    Yielder<T> baseYielder = baseSequence.toYielder(null, combiningAccumulator);
+    final Yielder<T> baseYielder = baseSequence.toYielder(null, combiningAccumulator);
 
-    return makeYielder(baseYielder, combiningAccumulator, false);
+    try {
+      return makeYielder(baseYielder, combiningAccumulator, false);
+    }catch(RuntimeException ex){
+      try {
+        baseYielder.close();
+      }
+      catch (IOException e) {
+        ex.addSuppressed(e);
+      }
+      throw ex;
+    }
   }
 
   public <OutType, T> Yielder<OutType> makeYielder(

--- a/processing/src/main/java/io/druid/query/MetricsEmittingQueryRunner.java
+++ b/processing/src/main/java/io/druid/query/MetricsEmittingQueryRunner.java
@@ -18,7 +18,6 @@
 package io.druid.query;
 
 import com.google.common.base.Function;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.metamx.common.guava.Accumulator;
 import com.metamx.common.guava.Sequence;
@@ -28,7 +27,6 @@ import com.metamx.emitter.service.ServiceEmitter;
 import com.metamx.emitter.service.ServiceMetricEvent;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -159,7 +157,18 @@ public class MetricsEmittingQueryRunner<T> implements QueryRunner<T>
           throw e;
         }
 
-        return makeYielder(startTime, retVal, builder);
+        try {
+          return makeYielder(startTime, retVal, builder);
+        }
+        catch (RuntimeException ex) {
+          try {
+            retVal.close();
+          }
+          catch (IOException e) {
+            ex.addSuppressed(e);
+          }
+          throw ex;
+        }
       }
 
       private <OutType> Yielder<OutType> makeYielder(

--- a/processing/src/main/java/io/druid/query/spec/SpecificSegmentQueryRunner.java
+++ b/processing/src/main/java/io/druid/query/spec/SpecificSegmentQueryRunner.java
@@ -110,7 +110,19 @@ public class SpecificSegmentQueryRunner<T> implements QueryRunner<T>
               @Override
               public Yielder<OutType> call() throws Exception
               {
-                return makeYielder(baseSequence.toYielder(initValue, accumulator));
+                final Yielder<OutType> yielder = baseSequence.toYielder(initValue, accumulator);
+                try {
+                  return makeYielder(yielder);
+                }
+                catch (RuntimeException ex) {
+                  try {
+                    yielder.close();
+                  }
+                  catch (IOException e) {
+                    ex.addSuppressed(e);
+                  }
+                  throw ex;
+                }
               }
             }
         );


### PR DESCRIPTION
Makes sure all instances of toYielder have their result closed out or returned as a return value.