### PR TITLE
Check lower bound of replicant values for rules

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/rules/ForeverLoadRule.java
+++ b/server/src/main/java/io/druid/server/coordinator/rules/ForeverLoadRule.java
@@ -36,6 +36,7 @@ public class ForeverLoadRule extends LoadRule
       @JsonProperty("tieredReplicants") Map<String, Integer> tieredReplicants
   )
   {
+    validateTieredReplicants(tieredReplicants);
     this.tieredReplicants = tieredReplicants;
   }
 

--- a/server/src/main/java/io/druid/server/coordinator/rules/IntervalLoadRule.java
+++ b/server/src/main/java/io/druid/server/coordinator/rules/IntervalLoadRule.java
@@ -41,6 +41,7 @@ public class IntervalLoadRule extends LoadRule
       @JsonProperty("tieredReplicants") Map<String, Integer> tieredReplicants
   )
   {
+    validateTieredReplicants(tieredReplicants);
     this.interval = interval;
     this.tieredReplicants = tieredReplicants;
   }

--- a/server/src/main/java/io/druid/server/coordinator/rules/LoadRule.java
+++ b/server/src/main/java/io/druid/server/coordinator/rules/LoadRule.java
@@ -20,6 +20,7 @@ package io.druid.server.coordinator.rules;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.MinMaxPriorityQueue;
+import com.metamx.common.IAE;
 import com.metamx.emitter.EmittingLogger;
 import io.druid.server.coordinator.BalancerStrategy;
 import io.druid.server.coordinator.CoordinatorStats;
@@ -238,6 +239,13 @@ public abstract class LoadRule implements Rule
     }
 
     return stats;
+  }
+
+  protected void validateTieredReplicants(Map<String, Integer> tieredReplicants){
+    for (Map.Entry<String, Integer> entry: tieredReplicants.entrySet()) {
+      if (entry.getValue() < 0)
+        throw new IAE("Replicant value [%d] is less than 0, which is not allowed", entry.getValue());
+    }
   }
 
   public abstract Map<String, Integer> getTieredReplicants();

--- a/server/src/main/java/io/druid/server/coordinator/rules/PeriodLoadRule.java
+++ b/server/src/main/java/io/druid/server/coordinator/rules/PeriodLoadRule.java
@@ -42,6 +42,7 @@ public class PeriodLoadRule extends LoadRule
       @JsonProperty("tieredReplicants") Map<String, Integer> tieredReplicants
   )
   {
+    validateTieredReplicants(tieredReplicants);
     this.period = period;
     this.tieredReplicants = tieredReplicants;
   }


### PR DESCRIPTION
Do not allow replicant values less than 0. In case of negative replicant value, the coordinator will try to remove more replicas of segment than the actual number of replicas and can start throwing warning "Wtf, holder was null? I have no servers serving [%s]?", segment.getIdentifier()"