### PR TITLE
Abstractify hadoopy indexer configuration.

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerConfig.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerConfig.java
@@ -53,9 +53,7 @@ import io.druid.timeline.DataSegment;
 import io.druid.timeline.partition.ShardSpec;
 import io.druid.timeline.partition.ShardSpecLookup;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.Job;
 import org.joda.time.DateTime;
@@ -246,7 +244,8 @@ public class HadoopDruidIndexerConfig
     return schema.getTuningConfig().getPartitionsSpec();
   }
 
-  public IndexSpec getIndexSpec() {
+  public IndexSpec getIndexSpec()
+  {
     return schema.getTuningConfig().getIndexSpec();
   }
 
@@ -486,35 +485,6 @@ public class HadoopDruidIndexerConfig
   public Path makeDescriptorInfoPath(DataSegment segment)
   {
     return new Path(makeDescriptorInfoDir(), String.format("%s.json", segment.getIdentifier().replace(":", "")));
-  }
-
-  public Path makeSegmentOutputPath(FileSystem fileSystem, Bucket bucket)
-  {
-    final Interval bucketInterval = schema.getDataSchema().getGranularitySpec().bucketInterval(bucket.time).get();
-    if (fileSystem instanceof DistributedFileSystem) {
-      return new Path(
-          String.format(
-              "%s/%s/%s_%s/%s/%s",
-              schema.getIOConfig().getSegmentOutputPath(),
-              schema.getDataSchema().getDataSource(),
-              bucketInterval.getStart().toString(ISODateTimeFormat.basicDateTime()),
-              bucketInterval.getEnd().toString(ISODateTimeFormat.basicDateTime()),
-              schema.getTuningConfig().getVersion().replace(":", "_"),
-              bucket.partitionNum
-          )
-      );
-    }
-    return new Path(
-        String.format(
-            "%s/%s/%s_%s/%s/%s",
-            schema.getIOConfig().getSegmentOutputPath(),
-            schema.getDataSchema().getDataSource(),
-            bucketInterval.getStart().toString(),
-            bucketInterval.getEnd().toString(),
-            schema.getTuningConfig().getVersion(),
-            bucket.partitionNum
-        )
-    );
   }
 
   public void addJobProperties(Job job)

--- a/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
@@ -18,26 +18,47 @@
 package io.druid.indexer;
 
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;
 import com.google.common.io.OutputSupplier;
+import com.metamx.common.IAE;
 import com.metamx.common.ISE;
 import com.metamx.common.logger.Logger;
+import io.druid.segment.SegmentUtils;
+import io.druid.timeline.DataSegment;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.filecache.DistributedCache;
+import org.apache.hadoop.fs.CreateFlag;
+import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalFileSystem;
+import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.retry.RetryPolicies;
+import org.apache.hadoop.io.retry.RetryProxy;
 import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.mapreduce.lib.input.CombineTextInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+import org.apache.hadoop.util.Progressable;
+import org.joda.time.Interval;
+import org.joda.time.format.ISODateTimeFormat;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 /**
  */
@@ -46,6 +67,9 @@ public class JobHelper
   private static final Logger log = new Logger(JobHelper.class);
 
   private static final Set<Path> existing = Sets.newHashSet();
+
+  private static final int NUM_RETRIES = 6;
+  private static final int SECONDS_BETWEEN_RETRIES = 10;
 
 
   public static void setupClasspath(
@@ -103,7 +127,8 @@ public class JobHelper
     injectSystemProperties(job.getConfiguration());
   }
 
-  public static Configuration injectSystemProperties(Configuration conf) {
+  public static Configuration injectSystemProperties(Configuration conf)
+  {
     for (String propName : System.getProperties().stringPropertyNames()) {
       if (propName.startsWith("hadoop.")) {
         conf.set(propName.substring("hadoop.".length()), System.getProperty(propName));
@@ -164,12 +189,240 @@ public class JobHelper
 
   public static void setInputFormat(Job job, HadoopDruidIndexerConfig indexerConfig)
   {
-    if(indexerConfig.getInputFormatClass() != null) {
+    if (indexerConfig.getInputFormatClass() != null) {
       job.setInputFormatClass(indexerConfig.getInputFormatClass());
     } else if (indexerConfig.isCombineText()) {
       job.setInputFormatClass(CombineTextInputFormat.class);
     } else {
       job.setInputFormatClass(TextInputFormat.class);
     }
+  }
+
+  public static DataSegment serializeOutIndex(
+      final DataSegment segmentTemplate,
+      final Configuration configuration,
+      final Progressable progressable,
+      final TaskAttemptID taskAttemptID,
+      final File mergedBase,
+      final Path segmentBasePath
+  )
+      throws IOException
+  {
+    final FileSystem outputFS = FileSystem.get(segmentBasePath.toUri(), configuration);
+    final FileContext fileContext = FileContext.getFileContext(segmentBasePath.toUri(), configuration);
+    final Path tmpPath = new Path(segmentBasePath, String.format("index.zip.%d", taskAttemptID.getId()));
+    final AtomicLong size = new AtomicLong(0L);
+    final DataPusher zipPusher = (DataPusher) RetryProxy.create(
+        DataPusher.class, new DataPusher()
+        {
+          @Override
+          public void push() throws IOException
+          {
+            try (OutputStream outputStream = fileContext.create(
+                tmpPath,
+                EnumSet.of(CreateFlag.OVERWRITE, CreateFlag.CREATE),
+                Options.CreateOpts.createParent(),
+                Options.CreateOpts.bufferSize(256 * 1024)
+            )) {
+              size.set(zipAndCopyDir(mergedBase, outputStream, progressable));
+              outputStream.flush();
+            }
+            catch (IOException | RuntimeException exception) {
+              log.error(exception, "Exception in retry loop");
+              throw exception;
+            }
+          }
+        },
+        RetryPolicies.retryUpToMaximumCountWithFixedSleep(NUM_RETRIES, SECONDS_BETWEEN_RETRIES, TimeUnit.SECONDS)
+    );
+    zipPusher.push();
+    log.info("Zipped %,d bytes to [%s]", size.get(), tmpPath.toUri());
+
+    final Path finalIndexZipFilePath = new Path(segmentBasePath, "index.zip");
+    final URI indexOutURI = finalIndexZipFilePath.toUri();
+    final ImmutableMap<String, Object> loadSpec;
+    // TODO: Make this a part of Pushers or Pullers
+    switch (outputFS.getScheme()) {
+      case "hdfs":
+        loadSpec = ImmutableMap.<String, Object>of(
+            "type", "hdfs",
+            "path", indexOutURI.toString()
+        );
+        break;
+      case "s3":
+      case "s3n":
+        loadSpec = ImmutableMap.<String, Object>of(
+            "type", "s3_zip",
+            "bucket", indexOutURI.getHost(),
+            "key", indexOutURI.getPath().substring(1) // remove the leading "/"
+        );
+        break;
+      case "file":
+        loadSpec = ImmutableMap.<String, Object>of(
+            "type", "local",
+            "path", indexOutURI.getPath()
+        );
+        break;
+      default:
+        throw new IAE("Unknown file system scheme [%s]", outputFS.getScheme());
+    }
+    final DataSegment finalSegment = segmentTemplate
+        .withLoadSpec(loadSpec)
+        .withSize(size.get())
+        .withBinaryVersion(SegmentUtils.getVersionFromDir(mergedBase));
+    fileContext.rename(tmpPath, finalIndexZipFilePath, Options.Rename.OVERWRITE);
+    writeSegmentDescriptor(
+        outputFS,
+        finalSegment,
+        new Path(segmentBasePath, "descriptor.json"),
+        fileContext,
+        progressable
+    );
+    return finalSegment;
+  }
+
+  public static void writeSegmentDescriptor(
+      final FileSystem outputFS,
+      final DataSegment segment,
+      final Path descriptorPath,
+      final FileContext fileContext,
+      final Progressable progressable
+  )
+      throws IOException
+  {
+    final DataPusher descriptorPusher = (DataPusher) RetryProxy.create(
+        DataPusher.class, new DataPusher()
+        {
+          @Override
+          public void push() throws IOException
+          {
+            try {
+              progressable.progress();
+              if (outputFS.exists(descriptorPath)) {
+                if (!fileContext.delete(descriptorPath, false)) {
+                  throw new IOException(String.format("Failed to delete descriptor at [%s]", descriptorPath));
+                }
+              }
+              try (final OutputStream descriptorOut = fileContext.create(
+                  descriptorPath,
+                  EnumSet.of(CreateFlag.OVERWRITE, CreateFlag.CREATE),
+                  Options.CreateOpts.bufferSize(256 * 1024),
+                  Options.CreateOpts.createParent()
+              )) {
+                HadoopDruidIndexerConfig.jsonMapper.writeValue(descriptorOut, segment);
+                descriptorOut.flush();
+              }
+            }
+            catch (RuntimeException | IOException ex) {
+              log.info(ex, "Error in retry loop");
+              throw ex;
+            }
+          }
+        },
+        RetryPolicies.retryUpToMaximumCountWithFixedSleep(NUM_RETRIES, SECONDS_BETWEEN_RETRIES, TimeUnit.SECONDS)
+    );
+    descriptorPusher.push();
+  }
+
+  /**
+   * Simple interface for retry operations
+   */
+  public interface DataPusher
+  {
+    void push() throws IOException;
+  }
+
+  public static long zipAndCopyDir(
+      File baseDir,
+      OutputStream baseOutputStream,
+      Progressable progressable
+  ) throws IOException
+  {
+    long size = 0L;
+    try (ZipOutputStream outputStream = new ZipOutputStream(baseOutputStream)) {
+      List<String> filesToCopy = Arrays.asList(baseDir.list());
+      for (String fileName : filesToCopy) {
+        final File fileToCopy = new File(baseDir, fileName);
+        if (java.nio.file.Files.isRegularFile(fileToCopy.toPath())) {
+          size += copyFileToZipStream(fileToCopy, outputStream, progressable);
+        } else {
+          log.warn("File at [%s] is not a regular file! skipping as part of zip", fileToCopy.getPath());
+        }
+      }
+      outputStream.flush();
+    }
+    return size;
+  }
+
+  public static long copyFileToZipStream(
+      File file,
+      ZipOutputStream zipOutputStream,
+      Progressable progressable
+  ) throws IOException
+  {
+    createNewZipEntry(zipOutputStream, file);
+    long numRead = 0;
+    try (FileInputStream inputStream = new FileInputStream(file)) {
+      byte[] buf = new byte[0x10000];
+      for (int bytesRead = inputStream.read(buf); bytesRead >= 0; bytesRead = inputStream.read(buf)) {
+        progressable.progress();
+        if (bytesRead == 0) {
+          continue;
+        }
+        zipOutputStream.write(buf, 0, bytesRead);
+        progressable.progress();
+        numRead += bytesRead;
+      }
+    }
+    zipOutputStream.closeEntry();
+    progressable.progress();
+    return numRead;
+  }
+
+  private static void createNewZipEntry(ZipOutputStream out, File file) throws IOException
+  {
+    log.info("Creating new ZipEntry[%s]", file.getName());
+    out.putNextEntry(new ZipEntry(file.getName()));
+  }
+
+  public static Path makeSegmentOutputPath(
+      Path basePath,
+      FileSystem fileSystem,
+      String dataSource,
+      String version,
+      Interval interval,
+      int partitionNum
+  )
+  {
+    Path outputPath = new Path(prependFSIfNullScheme(fileSystem, basePath), "./" + dataSource);
+    if ("hdfs".equals(fileSystem.getScheme())) {
+      outputPath = new Path(
+          outputPath, String.format(
+          "./%s_%s",
+          interval.getStart().toString(ISODateTimeFormat.basicDateTime()),
+          interval.getEnd().toString(ISODateTimeFormat.basicDateTime())
+      )
+      );
+      outputPath = new Path(outputPath, version.replace(":", "_"));
+    } else {
+      outputPath = new Path(
+          outputPath, String.format(
+          "./%s_%s",
+          interval.getStart().toString(),
+          interval.getEnd().toString()
+      )
+      );
+      outputPath = new Path(outputPath, String.format("./%s", version));
+    }
+    outputPath = new Path(outputPath, Integer.toString(partitionNum));
+    return outputPath;
+  }
+
+  public static Path prependFSIfNullScheme(FileSystem fs, Path path)
+  {
+    if (path.toUri().getScheme() == null) {
+      path = new Path(fs.getUri().toString(), String.format("./%s", path));
+    }
+    return path;
   }
 }

--- a/indexing-hadoop/src/test/java/io/druid/indexer/HadoopDruidIndexerConfigTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/HadoopDruidIndexerConfigTest.java
@@ -96,7 +96,14 @@ public class HadoopDruidIndexerConfigTest
     );
 
     Bucket bucket = new Bucket(4711, new DateTime(2012, 07, 10, 5, 30), 4712);
-    Path path = cfg.makeSegmentOutputPath(new DistributedFileSystem(), bucket);
+    Path path = JobHelper.makeSegmentOutputPath(
+        new Path(cfg.getSchema().getIOConfig().getSegmentOutputPath()),
+        new DistributedFileSystem(),
+        cfg.getSchema().getDataSchema().getDataSource(),
+        cfg.getSchema().getTuningConfig().getVersion(),
+        cfg.getSchema().getDataSchema().getGranularitySpec().bucketInterval(bucket.time).get(),
+        bucket.partitionNum
+    );
     Assert.assertEquals(
         "hdfs://server:9100/tmp/druid/datatest/source/20120710T050000.000Z_20120710T060000.000Z/some_brand_new_version/4712",
         path.toString()
@@ -142,9 +149,16 @@ public class HadoopDruidIndexerConfigTest
     );
 
     Bucket bucket = new Bucket(4711, new DateTime(2012, 07, 10, 5, 30), 4712);
-    Path path = cfg.makeSegmentOutputPath(new LocalFileSystem(), bucket);
+    Path path = JobHelper.makeSegmentOutputPath(
+        new Path(cfg.getSchema().getIOConfig().getSegmentOutputPath()),
+        new LocalFileSystem(),
+        cfg.getSchema().getDataSchema().getDataSource(),
+        cfg.getSchema().getTuningConfig().getVersion(),
+        cfg.getSchema().getDataSchema().getGranularitySpec().bucketInterval(bucket.time).get(),
+        bucket.partitionNum
+    );
     Assert.assertEquals(
-        "/tmp/dru:id/data:test/the:data:source/2012-07-10T05:00:00.000Z_2012-07-10T06:00:00.000Z/some:brand:new:version/4712",
+        "file:/tmp/dru:id/data:test/the:data:source/2012-07-10T05:00:00.000Z_2012-07-10T06:00:00.000Z/some:brand:new:version/4712",
         path.toString()
     );
 


### PR DESCRIPTION
* Moves many items to JobHelper
* Remove dependencies of these functions on HadoopDruidIndexerConfig in favor of more general items
* Changes functionalities of some of the path methods to always return a path with scheme
* Adds retry to uploads
* Change output loadSpec determining from using outputFS.getClass().getName() to using outputFS.getScheme()