### PR TITLE
Make AbstractHttpClientProvider contents lazily instantiated

### DIFF
--- a/server/src/main/java/io/druid/guice/http/AbstractHttpClientProvider.java
+++ b/server/src/main/java/io/druid/guice/http/AbstractHttpClientProvider.java
@@ -36,9 +36,7 @@ public abstract class AbstractHttpClientProvider<HttpClientType> implements Prov
   private final Key<Supplier<DruidHttpClientConfig>> configKey;
   private final Key<SSLContext> sslContextKey;
 
-  private Provider<Supplier<DruidHttpClientConfig>> configProvider;
-  private Provider<Lifecycle> lifecycleProvider;
-  private Binding<SSLContext> sslContextBinding;
+  private Injector injector;
 
   public AbstractHttpClientProvider()
   {
@@ -73,9 +71,7 @@ public abstract class AbstractHttpClientProvider<HttpClientType> implements Prov
   @Inject
   public void configure(Injector injector)
   {
-    configProvider = injector.getProvider(configKey);
-    sslContextBinding = injector.getExistingBinding(sslContextKey);
-    lifecycleProvider = injector.getProvider(Lifecycle.class);
+    this.injector = injector;
   }
 
   public Key<Supplier<DruidHttpClientConfig>> getConfigKey()
@@ -90,16 +86,16 @@ public abstract class AbstractHttpClientProvider<HttpClientType> implements Prov
 
   public Provider<Supplier<DruidHttpClientConfig>> getConfigProvider()
   {
-    return configProvider;
+    return injector.getProvider(configKey);
   }
 
   public Provider<Lifecycle> getLifecycleProvider()
   {
-    return lifecycleProvider;
+    return injector.getProvider(Lifecycle.class);
   }
 
   public Binding<SSLContext> getSslContextBinding()
   {
-    return sslContextBinding;
+    return injector.getExistingBinding(sslContextKey);
   }
 }


### PR DESCRIPTION
Currently AbstractHttpClientProvider instantiates its fields eagerly, which could become problematic when extension modules tries to bind everything they need and expect the druid process to instantiate what they actually do need. Guice tries to fail-fast and verifies that all bindings exist before it does anything, which is a problem because the extension bind some objects that don't necessarily have all of their dependencies bound in all processes.(Referred to #243)

This PR lazily instantiated some fields so that they are created when they are actually needed.