### PR TITLE
fix passing of config from IndexTuningConfig to RealtimeTuningConfig

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
@@ -118,6 +118,24 @@ public class IndexTask extends AbstractFixedIntervalTask
     );
   }
 
+  static RealtimeTuningConfig convertTuningConfig(ShardSpec spec, IndexTuningConfig config)
+  {
+    return new RealtimeTuningConfig(
+        config.getRowFlushBoundary(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        spec,
+        config.getIndexSpec(),
+        null,
+        null,
+        null
+    );
+  }
+
   @JsonIgnore
   private final IndexIngestionSpec ingestionSchema;
 
@@ -337,20 +355,7 @@ public class IndexTask extends AbstractFixedIntervalTask
         tmpDir
     ).findPlumber(
         schema,
-        new RealtimeTuningConfig(
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            shardSpec,
-            ingestionSchema.getTuningConfig().getIndexSpec(),
-            null,
-            null,
-            null
-        ),
+        convertTuningConfig(shardSpec, ingestionSchema.getTuningConfig()),
         metrics
     );
 

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
@@ -501,6 +501,7 @@ public class IndexTask extends AbstractFixedIntervalTask
     )
     {
       this.targetPartitionSize = targetPartitionSize == 0 ? DEFAULT_TARGET_PARTITION_SIZE : targetPartitionSize;
+      Preconditions.checkArgument(rowFlushBoundary >= 0, "rowFlushBoundary should be positive or zero");
       this.rowFlushBoundary = rowFlushBoundary == 0 ? DEFAULT_ROW_FLUSH_BOUNDARY : rowFlushBoundary;
       this.numShards = numShards == null ? -1 : numShards;
       this.indexSpec = indexSpec == null ? DEFAULT_INDEX_SPEC : indexSpec;

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
@@ -75,7 +75,7 @@ public class TaskSerdeTest
                 )
             ),
             new IndexTask.IndexIOConfig(new LocalFirehoseFactory(new File("lol"), "rofl", null)),
-            new IndexTask.IndexTuningConfig(10000, -1, -1, indexSpec)
+            new IndexTask.IndexTuningConfig(10000, 10, -1, indexSpec)
         ),
         jsonMapper
     );

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLifecycleTest.java
@@ -364,7 +364,7 @@ public class TaskLifecycleTest
                                                  IR("2010-01-02T01", "a", "c", 1)
                                              )
                                          )),
-                                         new IndexTask.IndexTuningConfig(10000, -1, -1, indexSpec)),
+                                         new IndexTask.IndexTuningConfig(10000, 10, -1, indexSpec)),
         TestUtils.MAPPER
     );
 
@@ -418,7 +418,7 @@ public class TaskLifecycleTest
                 )
             ),
             new IndexTask.IndexIOConfig(newMockExceptionalFirehoseFactory()),
-            new IndexTask.IndexTuningConfig(10000, -1, -1, indexSpec)
+            new IndexTask.IndexTuningConfig(10000, 10, -1, indexSpec)
         ),
         TestUtils.MAPPER
     );


### PR DESCRIPTION
- pass rowFlushboundary correctly instead of using default.
- fixes indexTask failing with io.druid.segment.incremental.IndexSizeExceededException when
rowFlushboundary is set higher than
RealtimeTuningConfig.defaultMaxRowsInMemory

- Adds a check for valid rowFlushBoundary and fix tests