### PR TITLE
Add jitter to the retries for RemoteTaskActionClient

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/common/actions/RemoteTaskActionClient.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/actions/RemoteTaskActionClient.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
+import java.util.Random;
 
 public class RemoteTaskActionClient implements TaskActionClient
 {
@@ -49,6 +50,7 @@ public class RemoteTaskActionClient implements TaskActionClient
   private final ServerDiscoverySelector selector;
   private final RetryPolicyFactory retryPolicyFactory;
   private final ObjectMapper jsonMapper;
+  private final Random random = new Random();
 
   private static final Logger log = new Logger(RemoteTaskActionClient.class);
 
@@ -133,7 +135,7 @@ public class RemoteTaskActionClient implements TaskActionClient
           throw e;
         } else {
           try {
-            final long sleepTime = delay.getMillis();
+            final long sleepTime = jitter(delay.getMillis());
             log.info("Will try again in [%s].", new Duration(sleepTime).toString());
             Thread.sleep(sleepTime);
           }
@@ -143,6 +145,12 @@ public class RemoteTaskActionClient implements TaskActionClient
         }
       }
     }
+  }
+
+  private long jitter(long input){
+    final double jitter = random.nextGaussian() * input / 4.0;
+    long retval = input + (long)jitter;
+    return retval < 0 ? 0 : retval;
   }
 
   private URI makeServiceUri(final Server instance) throws URISyntaxException


### PR DESCRIPTION
I submitted some tasks which ended up crashing out due to JVM issues. And since they all had the same timeouts and waits for retries, every time the service came back online it would get hammered again all at the same time.