### PR TITLE
minor documentation fixes in Tasks.md, index.md, indexing-service.md

### DIFF
--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -68,7 +68,7 @@ The indexing service also uses its own set of paths. These configs can be includ
 If `druid.zk.paths.base` and `druid.zk.paths.indexer.base` are both set, and none of the other `druid.zk.paths.*` or `druid.zk.paths.indexer.*` values are set, then the other properties will be evaluated relative to their respective `base`.
 For example, if `druid.zk.paths.base` is set to `/druid1` and `druid.zk.paths.indexer.base` is set to `/druid2` then `druid.zk.paths.announcementsPath` will default to `/druid1/announcements` while `druid.zk.paths.indexer.announcementsPath` will default to `/druid2/announcements`.
 
-The following path is used service discovery and are **not** affected by `druid.zk.paths.base` and **must** be specified separately.
+The following path is used for service discovery. It is **not** affected by `druid.zk.paths.base` and **must** be specified separately.
 
 |Property|Description|Default|
 |--------|-----------|-------|

--- a/docs/content/configuration/indexing-service.md
+++ b/docs/content/configuration/indexing-service.md
@@ -95,7 +95,7 @@ The overlord can dynamically change worker behavior.
 The JSON object can be submitted to the overlord via a POST request at:
 
 ```
-http://<COORDINATOR_IP>:<port>/druid/indexer/v1/worker
+http://<OVERLORD_IP>:<port>/druid/indexer/v1/worker
 ```
 
 Optional Header Parameters for auditing the config change can also be specified.
@@ -153,7 +153,7 @@ Issuing a GET request at the same URL will return the current worker config spec
 To view the audit history of worker config issue a GET request to the URL -
 
 ```
-http://<COORDINATOR_IP>:<port>/druid/indexer/v1/worker/history?interval=<interval>
+http://<OVERLORD_IP>:<port>/druid/indexer/v1/worker/history?interval=<interval>
 ```
 
 default value of interval can be specified by setting `druid.audit.manager.auditHistoryMillis` (1 week if not configured) in overlord runtime.properties.

--- a/docs/content/misc/tasks.md
+++ b/docs/content/misc/tasks.md
@@ -251,7 +251,6 @@ The indexing service can also run real-time tasks. These tasks effectively trans
       "maxRowsInMemory": 500000,
       "intermediatePersistPeriod": "PT10m",
       "windowPeriod": "PT10m",
-      "basePersistDirectory": "\/tmp\/realtime\/basePersist",
       "rejectionPolicy": {
         "type": "serverTime"
       }


### PR DESCRIPTION
In misc/Tasks.md, the specification for a realtime indexing task includes this line:
      "basePersistDirectory": "\/tmp\/realtime\/basePersist"
But, realtime indexing tasks do not use this for the location of the persist directory; they all seem to use /tmp/druid/persistent.  I'm suggesting that the line be removed.

In Configuration/index.md, I fixed a sentence that had broken grammar, I hope giving it the correct meaning.

In Configuration/indexing-service.md, it shows two endpoints using COORDINATOR_IP.  These seem like they should be OVERLORD_IP.  If I use the coordinator ip I get a Not Found error.