### PR TITLE
Update bytebuffer-collections and add basic ConciseComplementBenchmark for testing concise complements

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -52,13 +52,6 @@
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
-    <!-- Used to test https://github.com/metamx/extendedset/pull/3
-    <dependency>
-      <groupId>com.metamx</groupId>
-      <artifactId>extendedset</artifactId>
-      <version>1.3.9-SNAPSHOT</version>
-    </dependency>
-    -->
   </dependencies>
 
   <properties>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -52,6 +52,13 @@
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
+    <!-- Used to test https://github.com/metamx/extendedset/pull/3
+    <dependency>
+      <groupId>com.metamx</groupId>
+      <artifactId>extendedset</artifactId>
+      <version>1.3.9-SNAPSHOT</version>
+    </dependency>
+    -->
   </dependencies>
 
   <properties>

--- a/benchmarks/src/main/java/io/druid/benchmark/ConciseComplementBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/ConciseComplementBenchmark.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.benchmark;
+
+
+import it.uniroma3.mat.extendedset.intset.ImmutableConciseSet;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+public class ConciseComplementBenchmark
+{
+
+  // Number of rows to read, the test will read random rows
+  @Param({"1000", "10000", "100000", "1000000", "1000000"})
+  int emptyRows;
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void uncompressed(Blackhole blackhole)
+  {
+    final ImmutableConciseSet set = ImmutableConciseSet.complement(null, emptyRows);
+    blackhole.consume(set);
+    assert (emptyRows == set.size());
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
             <dependency>
                 <groupId>com.metamx</groupId>
                 <artifactId>bytebuffer-collections</artifactId>
-                <version>0.1.5</version>
+                <version>0.1.6</version>
             </dependency>
             <dependency>
                 <groupId>com.metamx</groupId>


### PR DESCRIPTION
used to test https://github.com/metamx/extendedset/pull/3

Shows multiple orders of magnitude speedup.