### PR TITLE
minor fixes to TimeseriesQuery and Aggregations

### DIFF
--- a/docs/content/querying/aggregations.md
+++ b/docs/content/querying/aggregations.md
@@ -92,7 +92,7 @@ All JavaScript functions must return numerical values.
 ```json
 {
   "type": "javascript",
-  "name": "sum(log(x)/y) + 10",
+  "name": "sum(log(x)*y) + 10",
   "fieldNames": ["x", "y"],
   "fnAggregate" : "function(current, a, b)      { return current + (Math.log(a) * b); }",
   "fnCombine"   : "function(partialA, partialB) { return partialA + partialB; }",
@@ -137,11 +137,11 @@ SELECT COUNT(DISTINCT(value)) FROM (
 
 #### Cardinality by row
 
-When setting `byRow` to `true` it computes the cardinality by row, i.e. the cardinality of distinct dimension combinations
+When setting `byRow` to `true` it computes the cardinality by row, i.e. the cardinality of distinct dimension combinations.
 This is equivalent to something akin to
 
 ```sql
-SELECT COUNT(*) FROM ( SELECT DIM1, DIM2, DIM3 FROM <datasource> GROUP BY DIM1, DIM2, DIM3
+SELECT COUNT(*) FROM ( SELECT DIM1, DIM2, DIM3 FROM <datasource> GROUP BY DIM1, DIM2, DIM3 )
 ```
 
 **Example**

--- a/docs/content/querying/timeseriesquery.md
+++ b/docs/content/querying/timeseriesquery.md
@@ -56,7 +56,7 @@ There are 7 main parts to a timeseries query:
 |postAggregations|See [Post Aggregations](../querying/post-aggregations.html)|no|
 |context|See [Context](../querying/query-context.html)|no|
 
-To pull it all together, the above query would return 2 data points, one for each day between 2012-01-01 and 2012-01-03, from the "sample\_datasource" table. Each data point would be the (long) sum of sample\_fieldName1, the (double) sum of sample\_fieldName2 and the (double) the result of sample\_fieldName1 divided by sample\_fieldName2 for the filter set. The output looks like this:
+To pull it all together, the above query would return 2 data points, one for each day between 2012-01-01 and 2012-01-03, from the "sample\_datasource" table. Each data point would be the (long) sum of sample\_fieldName1, the (double) sum of sample\_fieldName2 and the (double) result of sample\_fieldName1 divided by sample\_fieldName2 for the filter set. The output looks like this:
 
 ```json
 [


### PR DESCRIPTION
TimeseriesQuery.md: and the (double) the result -> and the (double) result

Aggregations.md: sum(log(x)/y) => sum(log(x)*y)
   I assume it was unintentional that the math operation in the name was different than in  the function definition.

Aggregations.md: "combinations This" -> "combinations. This"

Aggregations.md:  added missing ) under Cardinality by row

Maybe someone can explain what it should say in Aggregations.md, in the second cardinality example, where it says "Determine the number of distinct   are assigned to." Was it intentional that the first field name is ""?  That seems to be legal, or at least is accepted by druid, but what does it mean?