### PR TITLE
Remove metrics emitting from caching clustered client

### DIFF
--- a/docs/content/operations/metrics.md
+++ b/docs/content/operations/metrics.md
@@ -29,7 +29,6 @@ Available Metrics
 |Metric|Description|Dimensions|Normal Value|
 |------|-----------|----------|------------|
 |`query/time`|Milliseconds taken to complete a query.|Common: dataSource, type, interval, hasFilters, duration, context, remoteAddress, id. Aggregation Queries: numMetrics, numComplexMetrics. GroupBy: numDimensions. TopN: threshold, dimension.|< 1s|
-|`query/node/time`|Milliseconds taken to query individual historical/realtime nodes.|id, status, server.|< 1s|
 |`query/intervalChunk/time`|Only emitted if interval chunking is enabled. Milliseconds required to query an interval chunk.|id, status, chunkInterval (if interval chunking is enabled).|< 1s|
 
 ### Historical

--- a/server/src/test/java/io/druid/client/CachingClusteredClientTest.java
+++ b/server/src/test/java/io/druid/client/CachingClusteredClientTest.java
@@ -217,7 +217,6 @@ public class CachingClusteredClientTest
   protected VersionedIntervalTimeline<String, ServerSelector> timeline;
   protected TimelineServerView serverView;
   protected Cache cache;
-  protected ServiceEmitter emitter;
   DruidServer[] servers;
 
   public CachingClusteredClientTest(int randomSeed)
@@ -247,7 +246,6 @@ public class CachingClusteredClientTest
     timeline = new VersionedIntervalTimeline<>(Ordering.<String>natural());
     serverView = EasyMock.createStrictMock(TimelineServerView.class);
     cache = MapCache.create(100000);
-    emitter = EasyMock.createStrictMock(ServiceEmitter.class);
     client = makeClient(MoreExecutors.sameThreadExecutor());
 
     servers = new DruidServer[]{
@@ -2097,8 +2095,7 @@ public class CachingClusteredClientTest
           {
             return true;
           }
-        },
-        emitter
+        }
     );
   }
 


### PR DESCRIPTION
This caused a major performance regression that is suspected to be due to locking in the `HttpPostEmitter` 