### PR TITLE
Fix npe thrown from SQLMetadataStorageActionHandler

### DIFF
--- a/server/src/main/java/io/druid/metadata/SQLMetadataStorageActionHandler.java
+++ b/server/src/main/java/io/druid/metadata/SQLMetadataStorageActionHandler.java
@@ -165,16 +165,15 @@ public class SQLMetadataStorageActionHandler<EntryType, StatusType, LogType, Loc
           @Override
           public Optional<EntryType> withHandle(Handle handle) throws Exception
           {
+            byte[] res = handle.createQuery(
+                String.format("SELECT payload FROM %s WHERE id = :id", entryTable)
+            )
+                               .bind("id", entryId)
+                               .map(ByteArrayMapper.FIRST)
+                               .first();
+
             return Optional.fromNullable(
-                jsonMapper.<EntryType>readValue(
-                    handle.createQuery(
-                        String.format("SELECT payload FROM %s WHERE id = :id", entryTable)
-                    )
-                          .bind("id", entryId)
-                          .map(ByteArrayMapper.FIRST)
-                          .first(),
-                    entryType
-                )
+                res == null ? null : jsonMapper.<EntryType>readValue(res, entryType)
             );
           }
         }
@@ -190,16 +189,15 @@ public class SQLMetadataStorageActionHandler<EntryType, StatusType, LogType, Loc
           @Override
           public Optional<StatusType> withHandle(Handle handle) throws Exception
           {
+            byte[] res = handle.createQuery(
+                String.format("SELECT status_payload FROM %s WHERE id = :id", entryTable)
+            )
+                               .bind("id", entryId)
+                               .map(ByteArrayMapper.FIRST)
+                               .first();
+
             return Optional.fromNullable(
-                jsonMapper.<StatusType>readValue(
-                    handle.createQuery(
-                        String.format("SELECT status_payload FROM %s WHERE id = :id", entryTable)
-                    )
-                          .bind("id", entryId)
-                          .map(ByteArrayMapper.FIRST)
-                          .first(),
-                    statusType
-                )
+                res == null ? null : jsonMapper.<StatusType>readValue(res, statusType)
             );
           }
         }

--- a/server/src/test/java/io/druid/metadata/SQLMetadataStorageActionHandlerTest.java
+++ b/server/src/test/java/io/druid/metadata/SQLMetadataStorageActionHandlerTest.java
@@ -118,7 +118,11 @@ public class SQLMetadataStorageActionHandlerTest
         handler.getEntry(entryId)
     );
 
+    Assert.assertEquals(Optional.absent(), handler.getEntry("non_exist_entry"));
+
     Assert.assertEquals(Optional.absent(), handler.getStatus(entryId));
+
+    Assert.assertEquals(Optional.absent(), handler.getStatus("non_exist_entry"));
 
     Assert.assertTrue(handler.setStatus(entryId, true, status1));
 
@@ -180,6 +184,11 @@ public class SQLMetadataStorageActionHandlerTest
     handler.insert(entryId, new DateTime("2014-01-01"), "test", entry, true, status);
 
     Assert.assertEquals(
+        ImmutableList.of(),
+        handler.getLogs("non_exist_entry")
+    );
+
+    Assert.assertEquals(
         ImmutableMap.of(),
         handler.getLocks(entryId)
     );
@@ -205,6 +214,11 @@ public class SQLMetadataStorageActionHandlerTest
     Map<String, Integer> status = ImmutableMap.of("count", 42);
 
     handler.insert(entryId, new DateTime("2014-01-01"), "test", entry, true, status);
+
+    Assert.assertEquals(
+        ImmutableMap.<Long, Map<String, Integer>>of(),
+        handler.getLocks("non_exist_entry")
+    );
 
     Assert.assertEquals(
         ImmutableMap.<Long, Map<String, Integer>>of(),


### PR DESCRIPTION
NPE is thrown from getEntry() and getStatus() in SQLMetadataStorageActionHandler if it's querying for a non-exist entryId.

