### PR TITLE
say explicitly that local firehose searches dirs recursively for files

### DIFF
--- a/docs/content/ingestion/firehose.md
+++ b/docs/content/ingestion/firehose.md
@@ -108,7 +108,7 @@ A sample local firehose spec is shown below:
 |--------|-----------|---------|
 |type|This should be "local".|yes|
 |filter|A wildcard filter for files. See [here](http://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/filefilter/WildcardFileFilter.html) for more information.|yes|
-|baseDir|location of baseDirectory containing files to be ingested. |yes|
+|baseDir|directory to search recursively for files to be ingested. |yes|
 
 #### IngestSegmentFirehose
 

--- a/server/src/main/java/io/druid/segment/realtime/firehose/LocalFirehoseFactory.java
+++ b/server/src/main/java/io/druid/segment/realtime/firehose/LocalFirehoseFactory.java
@@ -82,7 +82,7 @@ public class LocalFirehoseFactory implements FirehoseFactory<StringInputRowParse
   @Override
   public Firehose connect(StringInputRowParser firehoseParser) throws IOException
   {
-    log.info("Searching for all [%s] in [%s]", filter, baseDir.getAbsoluteFile());
+    log.info("Searching for all [%s] in and beneath [%s]", filter, baseDir.getAbsoluteFile());
 
     Collection<File> foundFiles = FileUtils.listFiles(
         baseDir.getAbsoluteFile(),
@@ -93,6 +93,7 @@ public class LocalFirehoseFactory implements FirehoseFactory<StringInputRowParse
     if (foundFiles == null || foundFiles.isEmpty()) {
       throw new ISE("Found no files to ingest! Check your schema.");
     }
+    log.info ("Found files: " + foundFiles);
 
     final LinkedList<File> files = Lists.newLinkedList(
         foundFiles


### PR DESCRIPTION
I'd like to change the description of the local firehose to make it more clear that the search of the directory specified by baseDir is done recursively through subdirectories.  I guess I should have realized that from the use of "baseDir" itself, but as an old Unix user I'm not used to commands being done recursively unless I specifically say so (I know, git -add ...).  

If we make it more clear that the search is recursive, it might save someone from accidentally ingesting data that they didn't intend.

I think it would also be nice to change the "Searching for" log message in the task log to say that it's searching "in and beneath" the directory, because to someone totally literal like me, searching "in" a directory means  searching only in that directory.  If we add a log message showing what files are being used, it could help with diagnosing the problem if an ingestion task didn't do what was expected because of using files that weren't intended to be used.

(I'm assuming here that the recursion was intentional.)
