### PR TITLE
remove flaky overlord test

### DIFF
--- a/indexing-service/src/test/java/io/druid/indexing/overlord/http/OverlordResourceTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/http/OverlordResourceTest.java
@@ -222,10 +222,6 @@ public class OverlordResourceTest
     NoopTask task_1 = new NoopTask(taskId_1, 0, 0, null, null);
     taskStorage.insert(task_1, TaskStatus.running(taskId_1));
 
-    response = overlordResource.getWaitingTasks();
-    // 1 task that was manually inserted should be in waiting state
-    Assert.assertEquals(1, (((List) response.getEntity()).size()));
-
     // Simulate completion of task_1
     taskCountDownLatches[Integer.parseInt(taskId_1)].countDown();
     // Wait for taskQueue to handle success status of task_1


### PR DESCRIPTION
If a task is manually inserted in the task storage and the task storage sync runs immediately then there won't be any waiting task. This was cause of failure for the build - https://travis-ci.org/druid-io/druid/jobs/70762283