### PR TITLE
Fix Doc data-formats.md

### DIFF
--- a/docs/content/ingestion/data-formats.md
+++ b/docs/content/ingestion/data-formats.md
@@ -69,7 +69,7 @@ Since the CSV data cannot contain the column names (no header is allowed), these
     "timestampSpec" : {
       "column" : "timestamp"
     },
-    "columns" : ["timestamp","page","language","user","unpatrolled","newPage","robot","anonymous","namespace","continent","country","region","city"],
+    "columns" : ["timestamp","page","language","user","unpatrolled","newPage","robot","anonymous","namespace","continent","country","region","city","added","deleted","delta"],
     "dimensionsSpec" : {
       "dimensions" : ["page","language","user","unpatrolled","newPage","robot","anonymous","namespace","continent","country","region","city"]
     }
@@ -83,7 +83,7 @@ Since the CSV data cannot contain the column names (no header is allowed), these
     "timestampSpec" : {
       "column" : "timestamp"
     },
-    "columns" : ["timestamp","page","language","user","unpatrolled","newPage","robot","anonymous","namespace","continent","country","region","city"],
+    "columns" : ["timestamp","page","language","user","unpatrolled","newPage","robot","anonymous","namespace","continent","country","region","city","added","deleted","delta"],
     "delimiter":"|",
     "dimensionsSpec" : {
       "dimensions" : ["page","language","user","unpatrolled","newPage","robot","anonymous","namespace","continent","country","region","city"]


### PR DESCRIPTION
This PR is for a change in the data-formats.md doc. 
For the sample schema for CSV and TSV data types, the "columns" field should include all of the column names that the data correspond to. Currently, the "columns" field does not include column names of the metrics (which are "added", "deleted", and "delta" in this Wikipedia data example). Without these column names in the schema, Druid will not be able to recognize the data corresponding to these column names and will produce incorrect query results.
This PR updates the doc to add the metrics column names to the "columns" field so that all column names are included in the field.