### PR TITLE
Don't explicitly use UTC timezone

### DIFF
--- a/processing/src/main/java/io/druid/granularity/BaseQueryGranularity.java
+++ b/processing/src/main/java/io/druid/granularity/BaseQueryGranularity.java
@@ -18,7 +18,6 @@
 package io.druid.granularity;
 
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -33,7 +32,7 @@ public abstract class BaseQueryGranularity extends QueryGranularity
 
   public DateTime toDateTime(long offset)
   {
-    return new DateTime(offset, DateTimeZone.UTC);
+    return new DateTime(offset);
   }
 
   public Iterable<Long> iterable(final long start, final long end)


### PR DESCRIPTION
  Don't explicitly use UTC timezone.because otherwise the output of query will always return UTC format timestamp.  I use local timezone  rather than UTC,but  the output always use UTC. That is not what I want. If we don't explicitly use UTC. DateTime choose  default timezone base on  "user.timezone".That is more appropriate for use
