### PR TITLE
print *all* HTTP requests to log if configured

### DIFF
--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -76,11 +76,13 @@ The following path is used for service discovery. It is **not** affected by `dru
 
 ### Request Logging
 
-All nodes that can serve queries can also log the requests they see.
+All nodes that can serve queries can also log the query requests they see.
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.request.logging.type`|Choices: noop, file, emitter. How to log every request.|noop|
+|`druid.request.logging.type`|Choices: noop, file, emitter. How to log every query request.|noop|
+
+Note that, you can enable sending all the HTTP requests to log by setting  "io.druid.jetty.RequestLog" to DEBUG level. See [Logging](../configuration/logging.html)
 
 #### File Request Logging
 

--- a/docs/content/configuration/logging.md
+++ b/docs/content/configuration/logging.md
@@ -33,6 +33,12 @@ An example log4j2.xml ships with Druid under config/_common/log4j2.xml, and a sa
     <Root level="info">
       <AppenderRef ref="Console"/>
     </Root>
+
+    <!-- Uncomment to enable logging of all HTTP requests
+    <Logger name="io.druid.jetty.RequestLog" additivity="false" level="DEBUG">
+        <AppenderRef ref="Console"/>
+    </Logger>
+    -->
   </Loggers>
 </Configuration>
 ```

--- a/server/src/main/java/io/druid/server/initialization/jetty/JettyRequestLog.java
+++ b/server/src/main/java/io/druid/server/initialization/jetty/JettyRequestLog.java
@@ -1,0 +1,46 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.server.initialization.jetty;
+
+import com.metamx.common.logger.Logger;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.RequestLog;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.component.AbstractLifeCycle;
+
+
+public class JettyRequestLog extends AbstractLifeCycle implements RequestLog
+{
+  private final static Logger logger = new Logger("io.druid.jetty.RequestLog");
+
+  @Override
+  public void log(Request request, Response response)
+  {
+    if (logger.isDebugEnabled()) {
+      logger.debug(
+          "%s %s %s",
+          request.getMethod(),
+          request.getUri().toString(),
+          request.getProtocol().toString()
+      );
+    }
+  }
+}
+

--- a/server/src/main/java/io/druid/server/initialization/jetty/JettyServerInitUtils.java
+++ b/server/src/main/java/io/druid/server/initialization/jetty/JettyServerInitUtils.java
@@ -19,20 +19,20 @@
 
 package io.druid.server.initialization.jetty;
 
-import java.util.Set;
-
 import com.google.common.base.Joiner;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
 import com.metamx.common.ISE;
-
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.handler.RequestLogHandler;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlets.AsyncGzipFilter;
 import org.eclipse.jetty.servlets.GzipFilter;
 
 import javax.ws.rs.HttpMethod;
+import java.util.Set;
 
 public class JettyServerInitUtils
 {
@@ -62,7 +62,8 @@ public class JettyServerInitUtils
     filterHolder.setInitParameter("checkGzExists", String.valueOf(false));
   }
 
-  public static void addExtensionFilters(ServletContextHandler handler, Injector injector) {
+  public static void addExtensionFilters(ServletContextHandler handler, Injector injector)
+  {
     Set<ServletFilterHolder> extensionFilters = injector.getInstance(Key.get(new TypeLiteral<Set<ServletFilterHolder>>(){}));
 
     for (ServletFilterHolder servletFilterHolder : extensionFilters) {
@@ -83,5 +84,14 @@ public class JettyServerInitUtils
 
       handler.addFilter(holder, servletFilterHolder.getPath(), servletFilterHolder.getDispatcherType());
     }
+  }
+
+  public static Handler getJettyRequestLogHandler()
+  {
+    // Ref: http://www.eclipse.org/jetty/documentation/9.2.6.v20141205/configuring-jetty-request-logs.html
+    RequestLogHandler requestLogHandler = new RequestLogHandler();
+    requestLogHandler.setRequestLog(new JettyRequestLog());
+
+    return requestLogHandler;
   }
 }

--- a/services/src/main/java/io/druid/cli/CliOverlord.java
+++ b/services/src/main/java/io/druid/cli/CliOverlord.java
@@ -254,7 +254,7 @@ public class CliOverlord extends ServerRunnable
       root.addFilter(GuiceFilter.class, "/druid/*", null);
 
       HandlerList handlerList = new HandlerList();
-      handlerList.setHandlers(new Handler[]{root});
+      handlerList.setHandlers(new Handler[]{JettyServerInitUtils.getJettyRequestLogHandler(), root});
 
       server.setHandler(handlerList);
     }

--- a/services/src/main/java/io/druid/cli/CoordinatorJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/CoordinatorJettyServerInitializer.java
@@ -77,8 +77,9 @@ class CoordinatorJettyServerInitializer implements JettyServerInitializer
     root.addFilter(GuiceFilter.class, "/coordinator/*", null);
 
     root.addServlet(new ServletHolder(injector.getInstance(OverlordProxyServlet.class)), "/druid/indexer/*");
+
     HandlerList handlerList = new HandlerList();
-    handlerList.setHandlers(new Handler[]{root});
+    handlerList.setHandlers(new Handler[]{JettyServerInitUtils.getJettyRequestLogHandler(), root});
 
     server.setHandler(handlerList);
   }

--- a/services/src/main/java/io/druid/cli/MiddleManagerJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/MiddleManagerJettyServerInitializer.java
@@ -44,7 +44,13 @@ class MiddleManagerJettyServerInitializer implements JettyServerInitializer
     root.addFilter(GuiceFilter.class, "/*", null);
 
     final HandlerList handlerList = new HandlerList();
-    handlerList.setHandlers(new Handler[]{root, new DefaultHandler()});
+    handlerList.setHandlers(
+        new Handler[]{
+            JettyServerInitUtils.getJettyRequestLogHandler(),
+            root,
+            new DefaultHandler()
+        }
+    );
     server.setHandler(handlerList);
   }
 }

--- a/services/src/main/java/io/druid/cli/QueryJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/QueryJettyServerInitializer.java
@@ -45,7 +45,7 @@ public class QueryJettyServerInitializer implements JettyServerInitializer
     root.addFilter(GuiceFilter.class, "/*", null);
 
     final HandlerList handlerList = new HandlerList();
-    handlerList.setHandlers(new Handler[]{root});
+    handlerList.setHandlers(new Handler[]{JettyServerInitUtils.getJettyRequestLogHandler(), root});
     server.setHandler(handlerList);
   }
 }

--- a/services/src/main/java/io/druid/cli/RouterJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/RouterJettyServerInitializer.java
@@ -100,7 +100,7 @@ public class RouterJettyServerInitializer implements JettyServerInitializer
     root.addFilter(GuiceFilter.class, "/status/*", null);
 
     final HandlerList handlerList = new HandlerList();
-    handlerList.setHandlers(new Handler[]{root});
+    handlerList.setHandlers(new Handler[]{JettyServerInitUtils.getJettyRequestLogHandler(), root});
     server.setHandler(handlerList);
   }
 }


### PR DESCRIPTION
I understand that there is, druid.request.logging.type, which does not look general enough to print all http requests received by server but mainly targeted towards printing query requests.
