### PR TITLE
remove references to chathandler type "announce"; it's the default

### DIFF
--- a/docs/content/configuration/indexing-service.md
+++ b/docs/content/configuration/indexing-service.md
@@ -271,7 +271,6 @@ Additional peon configs include:
 |`druid.indexer.task.hadoopWorkingPath`|Temporary working directory for Hadoop tasks.|/tmp/druid-indexing|
 |`druid.indexer.task.defaultRowFlushBoundary`|Highest row count before persisting to disk. Used for indexing generating tasks.|50000|
 |`druid.indexer.task.defaultHadoopCoordinates`|Hadoop version to use with HadoopIndexTasks that do not request a particular version.|org.apache.hadoop:hadoop-client:2.3.0|
-|`druid.indexer.task.chathandler.type`|Choices are "noop" and "announce". Certain tasks will use service discovery to announce an HTTP endpoint that events can be posted to.|noop|
 
 If the peon is running in remote mode, there must be an overlord up and running. Peons in remote mode can set the following configurations:
 

--- a/docs/content/ingestion/firehose.md
+++ b/docs/content/ingestion/firehose.md
@@ -178,8 +178,7 @@ This can be used to merge data from more than one firehoses.
 
 
 #### EventReceiverFirehose
-EventReceiverFirehoseFactory can be used to ingest events using http endpoint.
-when using this firehose `druid.realtime.chathandler.type` needs to be set to `announce` in runtime.properties.
+EventReceiverFirehoseFactory can be used to ingest events using an http endpoint.
 
 ```json
 {
@@ -188,7 +187,7 @@ when using this firehose `druid.realtime.chathandler.type` needs to be set to `a
   "bufferSize": 10000
 }
 ```
-when using above firehose the events can be sent via submitting a POST request to the http endpoint -
+When using this firehose, events can be sent by submitting a POST request to the http endpoint -
 `http://<peonHost>:<port>/druid/worker/v1/chat/<eventReceiverServiceName>/push-events/`
 
 |property|description|required?|

--- a/services/src/main/java/io/druid/guice/RealtimeModule.java
+++ b/services/src/main/java/io/druid/guice/RealtimeModule.java
@@ -65,7 +65,7 @@ public class RealtimeModule implements Module
         binder,
         "druid.realtime.chathandler.type",
         Key.get(ChatHandlerProvider.class),
-        Key.get(NoopChatHandlerProvider.class)
+        Key.get(ServiceAnnouncingChatHandlerProvider.class)
     );
     final MapBinder<String, ChatHandlerProvider> handlerProviderBinder = PolyBind.optionBinder(
         binder, Key.get(ChatHandlerProvider.class)


### PR DESCRIPTION
Commit https://github.com/druid-io/druid/commit/bf71d079f373a5f8761acb186472f89259612b5d changed the default chathandler type to announce.  It's no longer necessary to set druid.realtime.chathandler.type to announce when using the EventReceiverFirehose.

I considered changing "noop" to "announce" as the default in the table showing peon configs, but under the assumption that there'd be no reason to change from the default of "announce" to "noop", I thought it better to remove the row from the table.
