### PR TITLE
simplify merging of results on broker

### DIFF
--- a/benchmarks/src/main/java/io/druid/benchmark/MergeSequenceBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/MergeSequenceBenchmark.java
@@ -1,0 +1,118 @@
+package io.druid.benchmark;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Ordering;
+import com.google.common.primitives.Ints;
+import com.metamx.common.guava.Accumulator;
+import com.metamx.common.guava.MergeSequence;
+import com.metamx.common.guava.Sequence;
+import com.metamx.common.guava.Sequences;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Benchmark)
+public class MergeSequenceBenchmark
+{
+
+  // Number of Sequences to Merge
+  @Param({"1000"})
+  int count;
+
+  // Number of elements in each sequence
+  @Param({"1000", "10000"})
+  int sequenceLength;
+
+  // Number of sequences to merge at once
+  @Param({"10", "100"})
+  int mergeAtOnce;
+
+  private List<Sequence<Integer>> sequences;
+
+  @Setup
+  public void setup()
+  {
+    Random rand = new Random(0);
+    sequences = Lists.newArrayList();
+    for (int i = 0; i < count; i++) {
+      int[] sequence = new int[sequenceLength];
+      for (int j = 0; j < sequenceLength; j++) {
+        sequence[j] = rand.nextInt();
+      }
+      sequences.add(Sequences.simple(Ints.asList(sequence)));
+    }
+
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void mergeHierarchical(Blackhole blackhole)
+  {
+    Iterator<Sequence<Integer>> iterator = sequences.iterator();
+    List<Sequence<Integer>> partialMerged = new ArrayList<Sequence<Integer>>();
+    List<Sequence<Integer>> toMerge = new ArrayList<Sequence<Integer>>();
+
+    while (iterator.hasNext()) {
+      toMerge.add(iterator.next());
+      if (toMerge.size() == mergeAtOnce) {
+        partialMerged.add(new MergeSequence<Integer>(Ordering.<Integer>natural(), Sequences.simple(toMerge)));
+        toMerge = new ArrayList<Sequence<Integer>>();
+      }
+    }
+
+    if (!toMerge.isEmpty()) {
+      partialMerged.add(new MergeSequence<Integer>(Ordering.<Integer>natural(), Sequences.simple(toMerge)));
+    }
+    MergeSequence<Integer> mergeSequence = new MergeSequence(
+        Ordering.<Integer>natural(),
+        Sequences.simple(partialMerged)
+    );
+    Integer accumulate = mergeSequence.accumulate(
+        0, new Accumulator<Integer, Integer>()
+        {
+          @Override
+          public Integer accumulate(Integer accumulated, Integer in)
+          {
+            return accumulated + in;
+          }
+        }
+    );
+    blackhole.consume(accumulate);
+
+
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void mergeFlat(final Blackhole blackhole)
+  {
+    MergeSequence<Integer> mergeSequence = new MergeSequence(Ordering.<Integer>natural(), Sequences.simple(sequences));
+    Integer accumulate = mergeSequence.accumulate(
+        0, new Accumulator<Integer, Integer>()
+        {
+          @Override
+          public Integer accumulate(Integer accumulated, Integer in)
+          {
+            return accumulated + in;
+          }
+        }
+    );
+    blackhole.consume(accumulate);
+
+  }
+
+
+}


### PR DESCRIPTION
simplify merging of results in CachingClusteredClient. 

simple benchmark shows we can gain around 30% improvement
```
Benchmark                                 (count)  (mergeAtOnce)  (sequenceLength)  Mode  Cnt     Score     Error  Units
MergeSequenceBenchmark.mergeFlat             1000             10              1000  avgt    5   149.994 ?  32.826  ms/op
MergeSequenceBenchmark.mergeFlat             1000             10             10000  avgt    5  1419.632 ?  84.037  ms/op
MergeSequenceBenchmark.mergeFlat             1000            100              1000  avgt    5   142.981 ?   3.408  ms/op
MergeSequenceBenchmark.mergeFlat             1000            100             10000  avgt    5  1402.059 ?  38.021  ms/op
MergeSequenceBenchmark.mergeHierarchical     1000             10              1000  avgt    5   219.093 ?  21.111  ms/op
MergeSequenceBenchmark.mergeHierarchical     1000             10             10000  avgt    5  2082.478 ?  40.744  ms/op
MergeSequenceBenchmark.mergeHierarchical     1000            100              1000  avgt    5   222.390 ?  31.853  ms/op
MergeSequenceBenchmark.mergeHierarchical     1000            100             10000  avgt    5  2082.059 ? 115.988  ms/op
```