### PR TITLE
Fix UT and documentation to the extraction filter

### DIFF
--- a/docs/content/querying/aggregations.md
+++ b/docs/content/querying/aggregations.md
@@ -185,7 +185,7 @@ A filtered aggregator wraps any given aggregator, but only aggregates the values
 
 This makes it possible to compute the results of a filtered and an unfiltered aggregation simultaneously, without having to issue multiple queries, and use both results as part of post-aggregations.
 
-*Limitations:* The filtered aggregator currently only supports 'or', 'and', 'selector' and 'not' filters, i.e. matching one or multiple dimensions against a single value.
+*Limitations:* The filtered aggregator currently only supports 'or', 'and', 'selector', 'not' and 'Extraction' filters, i.e. matching one or multiple dimensions against a single value.
 
 *Note:* If only the filtered results are required, consider putting the filter on the query itself, which will be much faster since it does not require scanning all the data.
 

--- a/docs/content/querying/filters.md
+++ b/docs/content/querying/filters.md
@@ -80,3 +80,36 @@ The following matches any dimension values for the dimension `name` between `'ba
   "function" : "function(x) { return(x >= 'bar' && x <= 'foo') }"
 }
 ```
+
+### Extraction filter
+
+Extraction filter matches a dimension using some specific [Extraction function](./dimensionspecs.html#extraction-functions).
+The filter matches the values for which the extraction function has transformation entry `input_key=output_value` where
+ `output_value` is equal to the filter `value` and `input_key` is present as dimension.
+
+**Example**
+The following matches dimension values in `[product_1, product_3, product_5]` for the column `product`
+
+```json
+{
+    "filter": {
+        "type": "extraction",
+        "dimension": "product",
+        "value": "bar_1",
+        "extractionFn": {
+            "type": "lookup",
+            "lookup": {
+                "type": "map",
+                "map": {
+                    "product_1": "bar_1",
+                    "product_5": "bar_1",
+                    "product_3": "bar_1"
+                }
+            },
+            "replaceMissingValueWith": "",
+            "retainMissingValue": false,
+            "injective": false
+        }
+    }
+}
+```

--- a/docs/content/querying/filters.md
+++ b/docs/content/querying/filters.md
@@ -105,10 +105,7 @@ The following matches dimension values in `[product_1, product_3, product_5]` fo
                     "product_5": "bar_1",
                     "product_3": "bar_1"
                 }
-            },
-            "replaceMissingValueWith": "",
-            "retainMissingValue": false,
-            "injective": false
+            }
         }
     }
 }

--- a/docs/content/querying/filters.md
+++ b/docs/content/querying/filters.md
@@ -84,7 +84,7 @@ The following matches any dimension values for the dimension `name` between `'ba
 ### Extraction filter
 
 Extraction filter matches a dimension using some specific [Extraction function](./dimensionspecs.html#extraction-functions).
-The filter matches the values for which the extraction function has transformation entry `input_key=output_value` where
+The following filter matches the values for which the extraction function has transformation entry `input_key=output_value` where
  `output_value` is equal to the filter `value` and `input_key` is present as dimension.
 
 **Example**

--- a/extensions/kafka-extraction-namespace/src/main/java/io/druid/server/namespace/KafkaExtractionNamespaceFactory.java
+++ b/extensions/kafka-extraction-namespace/src/main/java/io/druid/server/namespace/KafkaExtractionNamespaceFactory.java
@@ -24,13 +24,10 @@ import com.google.common.base.Strings;
 import com.google.inject.Inject;
 import io.druid.query.extraction.namespace.ExtractionNamespaceFunctionFactory;
 import io.druid.query.extraction.namespace.KafkaExtractionNamespace;
-import io.druid.query.extraction.namespace.URIExtractionNamespace;
-import io.druid.server.namespace.cache.NamespaceExtractionCacheManager;
 
 import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  *

--- a/extensions/kafka-extraction-namespace/src/main/java/io/druid/server/namespace/KafkaExtractionNamespaceModule.java
+++ b/extensions/kafka-extraction-namespace/src/main/java/io/druid/server/namespace/KafkaExtractionNamespaceModule.java
@@ -19,7 +19,6 @@
 
 package io.druid.server.namespace;
 
-import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -27,19 +26,13 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
-import com.google.inject.Injector;
 import com.google.inject.Provides;
-import com.google.inject.TypeLiteral;
-import com.google.inject.multibindings.MapBinder;
 import com.google.inject.name.Named;
 import io.druid.guice.LazySingleton;
 import io.druid.guice.LifecycleModule;
 import io.druid.guice.annotations.Json;
 import io.druid.initialization.DruidModule;
-import io.druid.query.extraction.namespace.ExtractionNamespace;
-import io.druid.query.extraction.namespace.ExtractionNamespaceFunctionFactory;
 import io.druid.query.extraction.namespace.KafkaExtractionNamespace;
-import io.druid.server.namespace.cache.NamespaceExtractionCacheManager;
 
 import java.io.IOException;
 import java.util.List;

--- a/processing/src/main/java/io/druid/query/filter/ExtractionDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/ExtractionDimFilter.java
@@ -43,7 +43,6 @@ public class ExtractionDimFilter implements DimFilter
   )
   {
     Preconditions.checkArgument(dimension != null, "dimension must not be null");
-    Preconditions.checkArgument(value != null, "value must not be null");
     Preconditions.checkArgument(extractionFn != null || dimExtractionFn != null, "extraction function must not be null");
 
     this.dimension = dimension;

--- a/processing/src/main/java/io/druid/segment/column/SimpleDictionaryEncodedColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/SimpleDictionaryEncodedColumn.java
@@ -72,6 +72,7 @@ public class SimpleDictionaryEncodedColumn
   @Override
   public String lookupName(int id)
   {
+    //Empty to Null will ensure that null and empty are equivalent for extraction function
     return Strings.emptyToNull(cachedLookups.get(id));
   }
 

--- a/processing/src/main/java/io/druid/segment/column/SimpleDictionaryEncodedColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/SimpleDictionaryEncodedColumn.java
@@ -17,6 +17,7 @@
 
 package io.druid.segment.column;
 
+import com.google.common.base.Strings;
 import com.metamx.common.guava.CloseQuietly;
 import io.druid.segment.data.CachingIndexed;
 import io.druid.segment.data.IndexedInts;
@@ -71,7 +72,7 @@ public class SimpleDictionaryEncodedColumn
   @Override
   public String lookupName(int id)
   {
-    return cachedLookups.get(id);
+    return Strings.emptyToNull(cachedLookups.get(id));
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/filter/ExtractionFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/ExtractionFilter.java
@@ -17,17 +17,19 @@
 
 package io.druid.segment.filter;
 
+import com.google.common.base.Predicate;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.metamx.collections.bitmap.ImmutableBitmap;
-import com.metamx.collections.bitmap.WrappedImmutableConciseBitmap;
 import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.filter.BitmapIndexSelector;
 import io.druid.query.filter.Filter;
 import io.druid.query.filter.ValueMatcher;
 import io.druid.query.filter.ValueMatcherFactory;
 import io.druid.segment.ColumnSelectorFactory;
+import io.druid.segment.DimensionSelector;
 import io.druid.segment.data.Indexed;
-import it.uniroma3.mat.extendedset.intset.ImmutableConciseSet;
+import io.druid.segment.data.IndexedInts;
 
 import java.util.List;
 
@@ -54,15 +56,20 @@ public class ExtractionFilter implements Filter
   {
     final Indexed<String> allDimVals = selector.getDimensionValues(dimension);
     final List<Filter> filters = Lists.newArrayList();
-    if (allDimVals != null) {
-      for (int i = 0; i < allDimVals.size(); i++) {
+    if (allDimVals != null)
+    {
+      for (int i = 0; i < allDimVals.size(); i++)
+      {
         String dimVal = allDimVals.get(i);
-        if (value.equals(fn.apply(dimVal))) {
+        if (value.equals(fn.apply(dimVal)))
+        {
           filters.add(new SelectorFilter(dimension, dimVal));
         }
       }
+    } else if (value.equals(fn.apply(null)))
+    {
+      filters.add(new SelectorFilter(dimension, null));
     }
-
     return filters;
   }
 
@@ -79,13 +86,39 @@ public class ExtractionFilter implements Filter
   @Override
   public ValueMatcher makeMatcher(ValueMatcherFactory factory)
   {
-    throw new UnsupportedOperationException();
+    return factory.makeValueMatcher(dimension, new Predicate<String>()
+    {
+      @Override public boolean apply(String input)
+      {
+        // Assuming that a null/absent/empty dimension are equivalent from the druid perspective
+        return value.equals(fn.apply(Strings.emptyToNull(input)));
+      }
+    });
   }
 
   @Override
-  public ValueMatcher makeMatcher(ColumnSelectorFactory factory)
+  public ValueMatcher makeMatcher(ColumnSelectorFactory columnSelectorFactory)
   {
-    throw new UnsupportedOperationException();
+    final DimensionSelector dimensionSelector = columnSelectorFactory.makeDimensionSelector(dimension, null);
+    if (dimensionSelector == null) {
+      return new BooleanValueMatcher(Strings.isNullOrEmpty(fn.apply(value)));
+    } else {
+      return new ValueMatcher()
+      {
+        @Override
+        public boolean matches()
+        {
+          final IndexedInts row = dimensionSelector.getRow();
+          final int size = row.size();
+          for (int i = 0; i < size; ++i) {
+            if (value.equals(fn.apply(dimensionSelector.lookupName(row.get(i))))) {
+              return true;
+            }
+          }
+          return false;
+        }
+      };
+    }
   }
 
 }

--- a/processing/src/main/java/io/druid/segment/filter/ExtractionFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/ExtractionFilter.java
@@ -82,14 +82,14 @@ public class ExtractionFilter implements Filter
         }
       };
     }
-    if (allDimVals != null) {
-      for (int i = 0; i < allDimVals.size(); i++) {
-        String dimVal = allDimVals.get(i);
-        if (value.equals(Strings.nullToEmpty(fn.apply(dimVal)))) {
-          filters.add(new SelectorFilter(dimension, dimVal));
-        }
+
+    for (int i = 0; i < allDimVals.size(); i++) {
+      String dimVal = allDimVals.get(i);
+      if (value.equals(Strings.nullToEmpty(fn.apply(dimVal)))) {
+        filters.add(new SelectorFilter(dimension, dimVal));
       }
     }
+
     return filters;
   }
 

--- a/processing/src/main/java/io/druid/segment/filter/ExtractionFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/ExtractionFilter.java
@@ -46,7 +46,7 @@ public class ExtractionFilter implements Filter
   public ExtractionFilter(String dimension, String value, ExtractionFn fn)
   {
     this.dimension = dimension;
-    this.value = value;
+    this.value = Strings.nullToEmpty(value);
     this.fn = fn;
   }
 

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -400,10 +400,46 @@ public class GroupByQueryRunnerTest
     TestHelper.assertExpectedObjects(expectedResults, results, "");
   }
 
-  @Test public void testGroupByWithExtractionDimFilterEmptyResult()
+  @Test
+  public  void testGroupByWithExtractionDimFilterCaseNullValue()
   {
     Map<String, String> extractionMap = new HashMap<>();
-    extractionMap.put("mezzanine", "mezzanine0");
+    extractionMap.put("automotive", "automotive0");
+    extractionMap.put("business", "business0");
+    extractionMap.put("entertainment", "entertainment0");
+    extractionMap.put("health", "health0");
+    extractionMap.put("mezzanine", "");
+    extractionMap.put("news", null);
+    extractionMap.put("premium", "premium0");
+    extractionMap.put("technology", "technology0");
+    extractionMap.put("travel", "travel0");
+
+
+    MapLookupExtractor mapLookupExtractor = new MapLookupExtractor(extractionMap);
+    LookupExtractionFn lookupExtractionFn = new LookupExtractionFn(mapLookupExtractor, false, null, true);
+    GroupByQuery query = GroupByQuery.builder().setDataSource(QueryRunnerTestHelper.dataSource)
+                                     .setQuerySegmentSpec(QueryRunnerTestHelper.firstToThird)
+                                     .setDimensions(Lists.<DimensionSpec>newArrayList(new DefaultDimensionSpec("quality", "alias")))
+                                     .setAggregatorSpecs(
+                                         Arrays.asList(QueryRunnerTestHelper.rowsCount, new LongSumAggregatorFactory("idx", "index")))
+                                     .setGranularity(QueryRunnerTestHelper.dayGran)
+                                     .setDimFilter(new ExtractionDimFilter("quality", "", lookupExtractionFn, null))
+                                     .build();
+    List<Row> expectedResults = Arrays.asList(
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-01", "alias", "mezzanine", "rows", 3L, "idx", 2870L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-01", "alias", "news", "rows", 1L, "idx", 121L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "alias", "mezzanine", "rows", 3L, "idx", 2447L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "alias", "news", "rows", 1L, "idx", 114L));
+
+    Iterable<Row> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);
+    TestHelper.assertExpectedObjects(expectedResults, results, "");
+  }
+
+  @Test public void testGroupByWithExtractionDimFilterWhenValueNotThere()
+  {
+    Map<String, String> extractionMap = new HashMap<>();
+    extractionMap.put("mezzanine", "");
+    extractionMap.put("news", null);
 
     MapLookupExtractor mapLookupExtractor = new MapLookupExtractor(extractionMap);
     LookupExtractionFn lookupExtractionFn = new LookupExtractionFn(mapLookupExtractor, false, null, true);
@@ -412,7 +448,8 @@ public class GroupByQueryRunnerTest
         .setQuerySegmentSpec(QueryRunnerTestHelper.firstToThird)
         .setDimensions(Lists.<DimensionSpec>newArrayList(new DefaultDimensionSpec("quality", "alias")))
         .setAggregatorSpecs(
-            Arrays.asList(QueryRunnerTestHelper.rowsCount, new LongSumAggregatorFactory("idx", "index")))
+            Arrays.asList(QueryRunnerTestHelper.rowsCount, new LongSumAggregatorFactory("idx", "index"))
+        )
         .setGranularity(QueryRunnerTestHelper.dayGran)
         .setDimFilter(new ExtractionDimFilter("quality", "NOT_THERE", lookupExtractionFn, null)).build();
     List<Row> expectedResults = Arrays.asList();
@@ -420,6 +457,7 @@ public class GroupByQueryRunnerTest
     Iterable<Row> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);
     TestHelper.assertExpectedObjects(expectedResults, results, "");
   }
+
 
   @Test public void testGroupByWithExtractionDimFilterNullDims()
   {

--- a/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerTest.java
@@ -1611,7 +1611,6 @@ public class TopNQueryRunnerTest
   }
 
 
-
   @Test
   public void testTopNDimExtractionFastTopNOptimalWithReplaceMissing()
   {
@@ -3119,8 +3118,10 @@ public class TopNQueryRunnerTest
     );
     assertExpectedResults(expectedResults, query);
   }
+
   @Test
-  public void testAlphaNumericTopNWithNullPreviousStop(){
+  public void testAlphaNumericTopNWithNullPreviousStop()
+  {
     TopNQuery query = new TopNQueryBuilder()
         .dataSource(QueryRunnerTestHelper.dataSource)
         .granularity(QueryGranularity.ALL)
@@ -3159,15 +3160,22 @@ public class TopNQueryRunnerTest
     LookupExtractionFn lookupExtractionFn = new LookupExtractionFn(mapLookupExtractor, false, null, true);
 
     TopNQuery query = new TopNQueryBuilder().dataSource(QueryRunnerTestHelper.dataSource)
-        .granularity(QueryRunnerTestHelper.allGran)
-        .dimension(QueryRunnerTestHelper.marketDimension)
-        .metric("rows")
-        .threshold(3)
-        .intervals(QueryRunnerTestHelper.firstToThird)
-        .aggregators(QueryRunnerTestHelper.commonAggregators)
-        .postAggregators(Arrays.<PostAggregator>asList(QueryRunnerTestHelper.addRowsIndexConstant))
-        .filters(new ExtractionDimFilter(QueryRunnerTestHelper.marketDimension, "spot0", lookupExtractionFn, null))
-        .build();
+                                            .granularity(QueryRunnerTestHelper.allGran)
+                                            .dimension(QueryRunnerTestHelper.marketDimension)
+                                            .metric("rows")
+                                            .threshold(3)
+                                            .intervals(QueryRunnerTestHelper.firstToThird)
+                                            .aggregators(QueryRunnerTestHelper.commonAggregators)
+                                            .postAggregators(Arrays.<PostAggregator>asList(QueryRunnerTestHelper.addRowsIndexConstant))
+                                            .filters(
+                                                new ExtractionDimFilter(
+                                                    QueryRunnerTestHelper.marketDimension,
+                                                    "spot0",
+                                                    lookupExtractionFn,
+                                                    null
+                                                )
+                                            )
+                                            .build();
 
     List<Result<TopNResultValue>> expectedResults = Arrays.asList(
         new Result<>(
@@ -3190,10 +3198,10 @@ public class TopNQueryRunnerTest
   }
 
   @Test
-  public void testTopNWithExtractionFilterNoExistingValue()
+  public void testTopNWithExtractionFilterAndFilteredAggregatorCaseNoExistingValue()
   {
     Map<String, String> extractionMap = new HashMap<>();
-    extractionMap.put("","NULL");
+    extractionMap.put("", "NULL");
 
     MapLookupExtractor mapLookupExtractor = new MapLookupExtractor(extractionMap);
     LookupExtractionFn lookupExtractionFn = new LookupExtractionFn(mapLookupExtractor, false, null, true);
@@ -3205,11 +3213,19 @@ public class TopNQueryRunnerTest
         .metric(QueryRunnerTestHelper.indexMetric)
         .threshold(4)
         .intervals(QueryRunnerTestHelper.fullOnInterval)
-        .aggregators(Lists.newArrayList(Iterables.concat(QueryRunnerTestHelper.commonAggregators, Lists.newArrayList(
-                new FilteredAggregatorFactory(new DoubleMaxAggregatorFactory("maxIndex", "index"),
-                    extractionFilter),
-                //new DoubleMaxAggregatorFactory("maxIndex", "index"),
-                new DoubleMinAggregatorFactory("minIndex", "index")))))
+        .aggregators(
+            Lists.newArrayList(
+                Iterables.concat(
+                    QueryRunnerTestHelper.commonAggregators, Lists.newArrayList(
+                        new FilteredAggregatorFactory(
+                            new DoubleMaxAggregatorFactory("maxIndex", "index"),
+                            extractionFilter
+                        ),
+                        new DoubleMinAggregatorFactory("minIndex", "index")
+                    )
+                )
+            )
+        )
         .postAggregators(Arrays.<PostAggregator>asList(QueryRunnerTestHelper.addRowsIndexConstant));
     TopNQuery topNQueryWithNULLValueExtraction = topNQueryBuilder
         .filters(extractionFilter)


### PR DESCRIPTION
This PR has several fix and unit test for extraction filter:
- Fix extractionFilter by implementing both make matcher in `ExtractionFilter`
- Fix getBitmapIndex to consider the case dim is null 
- Unit Test for exractionFn with empty result and null_column
- UT for TopN queries with Extraction filter
- Fix to make sure that empty string are converted to null