### PR TITLE
fix realtime index task json description in doc

### DIFF
--- a/docs/content/misc/tasks.md
+++ b/docs/content/misc/tasks.md
@@ -200,33 +200,33 @@ The indexing service can also run real-time tasks. These tasks effectively trans
 
             ]
           }
-        },
-        "metricsSpec": [
-          {
-            "type": "count",
-            "name": "count"
-          },
-          {
-            "type": "doubleSum",
-            "name": "added",
-            "fieldName": "added"
-          },
-          {
-            "type": "doubleSum",
-            "name": "deleted",
-            "fieldName": "deleted"
-          },
-          {
-            "type": "doubleSum",
-            "name": "delta",
-            "fieldName": "delta"
-          }
-        ],
-        "granularitySpec": {
-          "type": "uniform",
-          "segmentGranularity": "DAY",
-          "queryGranularity": "NONE"
         }
+      },
+      "metricsSpec": [
+        {
+          "type": "count",
+          "name": "count"
+        },
+        {
+          "type": "doubleSum",
+          "name": "added",
+          "fieldName": "added"
+        },
+        {
+          "type": "doubleSum",
+          "name": "deleted",
+          "fieldName": "deleted"
+        },
+        {
+          "type": "doubleSum",
+          "name": "delta",
+          "fieldName": "delta"
+        }
+      ],
+      "granularitySpec": {
+        "type": "uniform",
+        "segmentGranularity": "DAY",
+        "queryGranularity": "NONE"
       }
     },
     "ioConfig": {


### PR DESCRIPTION
The "metricsSpec" and "granularitySpec" should not be within the "parser" section.