### PR TITLE
Fix transient error in BrokerServerViewTest

### DIFF
--- a/server/src/test/java/io/druid/client/BrokerServerViewTest.java
+++ b/server/src/test/java/io/druid/client/BrokerServerViewTest.java
@@ -358,8 +358,6 @@ public class BrokerServerViewTest extends CuratorTestBase
       }
     };
 
-    baseView.start();
-
     brokerServerView = new BrokerServerView(
         EasyMock.createMock(QueryToolChestWarehouse.class),
         EasyMock.createMock(QueryWatcher.class),
@@ -369,6 +367,8 @@ public class BrokerServerViewTest extends CuratorTestBase
         new HighestPriorityTierSelectorStrategy(new RandomServerSelectorStrategy()),
         new NoopServiceEmitter()
     );
+
+    baseView.start();
   }
 
   private void setupZNodeForServer(DruidServer server) throws Exception


### PR DESCRIPTION
The patch aims to fix the second failure in #1512 
The reason it fails is because if ```ServerInventoryView``` starts before ```BrokerServerView``` is constructed, there is a chance that ```INITIALIZED``` event is triggered in the ```ContainerCacheListener``` before ```BrokerServerView``` registers its segmentCallbacks, which results in our latch never getting counted down.