### PR TITLE
Fix test so that it can run offline

### DIFF
--- a/server/src/test/java/io/druid/client/cache/CacheDistributionTest.java
+++ b/server/src/test/java/io/druid/client/cache/CacheDistributionTest.java
@@ -140,7 +140,7 @@ public class CacheDistributionTest
   }
 
   private static MemcachedNode dummyNode(String host, int port) {
-    SocketAddress address = new InetSocketAddress(host, port);
+    SocketAddress address = InetSocketAddress.createUnresolved(host, port);
     MemcachedNode node = EasyMock.createNiceMock(MemcachedNode.class);
     EasyMock.expect(node.getSocketAddress()).andReturn(address).anyTimes();
     EasyMock.replay(node);


### PR DESCRIPTION
Test was getting stuck for me when I tried to run it offline while resolving the host. 
creating unresolved SocketAddress works around this.