### PR TITLE
Some perf Improvements in Broker

### DIFF
--- a/processing/src/main/java/io/druid/query/RetryQueryRunner.java
+++ b/processing/src/main/java/io/druid/query/RetryQueryRunner.java
@@ -19,6 +19,7 @@ package io.druid.query;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.metamx.common.guava.Sequence;
 import com.metamx.common.guava.Sequences;
@@ -90,9 +91,11 @@ public class RetryQueryRunner<T> implements QueryRunner<T>
           if (!config.isReturnPartialResults() && !finalMissingSegs.isEmpty()) {
             throw new SegmentMissingException("No results found for segments[%s]", finalMissingSegs);
           }
+          return toolChest.mergeSequencesUnordered(Sequences.simple(listOfSequences)).toYielder(initValue, accumulator);
         }
-
-        return toolChest.mergeSequencesUnordered(Sequences.simple(listOfSequences)).toYielder(initValue, accumulator);
+        else {
+          return Iterables.getOnlyElement(listOfSequences).toYielder(initValue, accumulator);
+        }
       }
     };
   }

--- a/server/src/test/java/io/druid/client/CachingClusteredClientTest.java
+++ b/server/src/test/java/io/druid/client/CachingClusteredClientTest.java
@@ -762,31 +762,21 @@ public class CachingClusteredClientTest
   @Test
   public void testOutOfOrderSequenceMerging() throws Exception
   {
-    List<Pair<Interval, Sequence<Result<TopNResultValue>>>> sequences =
+    List<Sequence<Result<TopNResultValue>>> sequences =
         Lists.newArrayList(
-            Pair.of(
-                // this could ne the result of a historical node returning the merged result of
-                //     a) an empty result for segment 2011-01-02/2011-01-05
-                // and b) result for a second partition for 2011-01-05/2011-01-10
-                new Interval("2011-01-02/2011-01-10"),
-                Sequences.simple(
-                    makeTopNResults(
-                        new DateTime("2011-01-07"), "a", 50, 4991, "b", 50, 4990, "c", 50, 4989,
-                        new DateTime("2011-01-08"), "a", 50, 4988, "b", 50, 4987, "c", 50, 4986,
-                        new DateTime("2011-01-09"), "a", 50, 4985, "b", 50, 4984, "c", 50, 4983
-                    )
+            Sequences.simple(
+                makeTopNResults(
+                    new DateTime("2011-01-07"), "a", 50, 4991, "b", 50, 4990, "c", 50, 4989,
+                    new DateTime("2011-01-08"), "a", 50, 4988, "b", 50, 4987, "c", 50, 4986,
+                    new DateTime("2011-01-09"), "a", 50, 4985, "b", 50, 4984, "c", 50, 4983
                 )
             ),
-
-            Pair.of(
-                new Interval("2011-01-05/2011-01-10"),
-                Sequences.simple(
-                    makeTopNResults(
-                        new DateTime("2011-01-06T01"), "a", 50, 4991, "b", 50, 4990, "c", 50, 4989,
-                        new DateTime("2011-01-07T01"), "a", 50, 4991, "b", 50, 4990, "c", 50, 4989,
-                        new DateTime("2011-01-08T01"), "a", 50, 4988, "b", 50, 4987, "c", 50, 4986,
-                        new DateTime("2011-01-09T01"), "a", 50, 4985, "b", 50, 4984, "c", 50, 4983
-                    )
+            Sequences.simple(
+                makeTopNResults(
+                    new DateTime("2011-01-06T01"), "a", 50, 4991, "b", 50, 4990, "c", 50, 4989,
+                    new DateTime("2011-01-07T01"), "a", 50, 4991, "b", 50, 4990, "c", 50, 4989,
+                    new DateTime("2011-01-08T01"), "a", 50, 4988, "b", 50, 4987, "c", 50, 4986,
+                    new DateTime("2011-01-09T01"), "a", 50, 4985, "b", 50, 4984, "c", 50, 4983
                 )
             )
         );


### PR DESCRIPTION
1. avoid unnecessary call to MultipleSpecificSegmentSpec.getIntervals()
profiling shows it took upto 6-12% of cpu time in JodaUtils.condenseIntervals

2. Avoid Wrapping with mergeSequence in retryQueryRunner