### PR TITLE
Optimizations for LexicographicTopNs

### DIFF
--- a/processing/src/main/java/io/druid/query/topn/DimValHolder.java
+++ b/processing/src/main/java/io/druid/query/topn/DimValHolder.java
@@ -64,14 +64,14 @@ public class DimValHolder
   public static class Builder
   {
     private Object topNMetricVal;
-    private String dirName;
+    private String dimName;
     private Object dimValIndex;
     private Map<String, Object> metricValues;
 
     public Builder()
     {
       topNMetricVal = null;
-      dirName = null;
+      dimName = null;
       dimValIndex = null;
       metricValues = null;
     }
@@ -82,9 +82,9 @@ public class DimValHolder
       return this;
     }
 
-    public Builder withDirName(String dirName)
+    public Builder withDimName(String dimName)
     {
-      this.dirName = dirName;
+      this.dimName = dimName;
       return this;
     }
 
@@ -102,7 +102,7 @@ public class DimValHolder
 
     public DimValHolder build()
     {
-      return new DimValHolder(topNMetricVal, dirName, dimValIndex, metricValues);
+      return new DimValHolder(topNMetricVal, dimName, dimValIndex, metricValues);
     }
   }
 }

--- a/processing/src/main/java/io/druid/query/topn/LexicographicTopNMetricSpec.java
+++ b/processing/src/main/java/io/druid/query/topn/LexicographicTopNMetricSpec.java
@@ -41,6 +41,10 @@ public class LexicographicTopNMetricSpec implements TopNMetricSpec
     @Override
     public int compare(String s, String s2)
     {
+      // Avoid conversion to bytes for equal references
+      if(s == s2){
+        return 0;
+      }
       // null first
       if (s == null) {
         return -1;
@@ -48,6 +52,7 @@ public class LexicographicTopNMetricSpec implements TopNMetricSpec
       if (s2 == null) {
         return 1;
       }
+
       return UnsignedBytes.lexicographicalComparator().compare(
           StringUtils.toUtf8(s),
           StringUtils.toUtf8(s2)

--- a/processing/src/main/java/io/druid/query/topn/TopNNumericResultBuilder.java
+++ b/processing/src/main/java/io/druid/query/topn/TopNNumericResultBuilder.java
@@ -41,7 +41,6 @@ import java.util.PriorityQueue;
  */
 public class TopNNumericResultBuilder implements TopNResultBuilder
 {
-
   private final DateTime timestamp;
   private final DimensionSpec dimSpec;
   private final String metricName;
@@ -166,7 +165,7 @@ public class TopNNumericResultBuilder implements TopNResultBuilder
     if (shouldAdd(topNMetricVal)) {
       DimValHolder dimValHolder = new DimValHolder.Builder()
           .withTopNMetricVal(topNMetricVal)
-          .withDirName(dimName)
+          .withDimName(dimName)
           .withDimValIndex(dimValIndex)
           .withMetricValues(metricValues)
           .build();
@@ -195,7 +194,7 @@ public class TopNNumericResultBuilder implements TopNResultBuilder
     if (shouldAdd(dimValue)) {
       final DimValHolder valHolder = new DimValHolder.Builder()
           .withTopNMetricVal(dimValue)
-          .withDirName(dimensionAndMetricValueExtractor.getStringDimensionValue(dimSpec.getOutputName()))
+          .withDimName(dimensionAndMetricValueExtractor.getStringDimensionValue(dimSpec.getOutputName()))
           .withMetricValues(dimensionAndMetricValueExtractor.getBaseObject())
           .build();
       pQueue.add(valHolder);


### PR DESCRIPTION
1) LexicographicTopNMetricSpec.comparator - Avoid String conversion to bytes if reference is equal
2) TopNLexicographicResultBuilder - borrow optimizations from topNNumericResultBuilder 
     -- change storage structure to PriorityQueue
     -- Only add to pQueue when required 
     -- Add Loop unrolling for metrics addition
     -- Re-orders Queue on build() call.
3) Minor Spelling correction in DimValueHolder