### PR TITLE
Bumb Jersey to 1.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
         <metamx.java-util.version>0.27.0</metamx.java-util.version>
         <apache.curator.version>2.8.0</apache.curator.version>
         <jetty.version>9.2.5.v20141112</jetty.version>
+        <jersey.version>1.19</jersey.version>
         <druid.api.version>0.3.9</druid.api.version>
         <jackson.version>2.4.4</jackson.version>
         <log4j.version>2.2</log4j.version>
@@ -334,12 +335,12 @@
             <dependency>
                 <groupId>com.sun.jersey</groupId>
                 <artifactId>jersey-core</artifactId>
-                <version>1.17.1</version>
+                <version>${jersey.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.jersey.contribs</groupId>
                 <artifactId>jersey-guice</artifactId>
-                <version>1.17.1</version>
+                <version>${jersey.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.google.inject</groupId>
@@ -354,7 +355,7 @@
             <dependency>
                 <groupId>com.sun.jersey</groupId>
                 <artifactId>jersey-server</artifactId>
-                <version>1.17.1</version>
+                <version>${jersey.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
As per https://java.net/jira/browse/JERSEY-2429 there seem to be occasional issues with JDK8 and Jersey on older versions. This is a version bump to help make sure no corner cases show up with with Jersey.