### PR TITLE
Allow long values in the key or value fields for URIExtractionNamespace

### DIFF
--- a/extensions/namespace-lookup/src/main/java/io/druid/query/extraction/namespace/URIExtractionNamespace.java
+++ b/extensions/namespace-lookup/src/main/java/io/druid/query/extraction/namespace/URIExtractionNamespace.java
@@ -187,18 +187,18 @@ public class URIExtractionNamespace implements ExtractionNamespace
     public Map<String, String> parse(String input)
     {
       final Map<String, Object> inner = delegate.parse(input);
-      final String k = (String) Preconditions.checkNotNull(
+      final String k = Preconditions.checkNotNull(
           inner.get(key),
           "Key column [%s] missing data in line [%s]",
           key,
           input
-      );
-      final String val = (String) Preconditions.checkNotNull(
+      ).toString(); // Just in case is long
+      final String val = Preconditions.checkNotNull(
           inner.get(value),
           "Value column [%s] missing data in line [%s]",
           value,
           input
-      );
+      ).toString();
       return ImmutableMap.<String, String>of(k, val);
     }
 


### PR DESCRIPTION
Sometimes people like to put Long values in JSON or other stuff. This helps make sure those cases get parsed correctly without having to do an extra ETL step to convert it to string