### PR TITLE
adding flag ignoreNullValue to approxHisto aggregator factory

### DIFF
--- a/extensions/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregator.java
+++ b/extensions/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregator.java
@@ -19,7 +19,7 @@ package io.druid.query.aggregation.histogram;
 
 import com.google.common.primitives.Longs;
 import io.druid.query.aggregation.Aggregator;
-import io.druid.segment.FloatColumnSelector;
+import io.druid.segment.ObjectColumnSelector;
 
 import java.util.Comparator;
 
@@ -40,7 +40,8 @@ public class ApproximateHistogramAggregator implements Aggregator
   }
 
   private final String name;
-  private final FloatColumnSelector selector;
+  private final ObjectColumnSelector selector;
+  private final boolean ignoreNullValue;
   private final int resolution;
   private final float lowerLimit;
   private final float upperLimit;
@@ -49,7 +50,8 @@ public class ApproximateHistogramAggregator implements Aggregator
 
   public ApproximateHistogramAggregator(
       String name,
-      FloatColumnSelector selector,
+      ObjectColumnSelector selector,
+      boolean ignoreNullValue,
       int resolution,
       float lowerLimit,
       float upperLimit
@@ -57,6 +59,7 @@ public class ApproximateHistogramAggregator implements Aggregator
   {
     this.name = name;
     this.selector = selector;
+    this.ignoreNullValue = ignoreNullValue;
     this.resolution = resolution;
     this.lowerLimit = lowerLimit;
     this.upperLimit = upperLimit;
@@ -66,7 +69,11 @@ public class ApproximateHistogramAggregator implements Aggregator
   @Override
   public void aggregate()
   {
-    histogram.offer(selector.get());
+    Object val = selector.get();
+
+    if(val != null || !ignoreNullValue) {
+      histogram.offer(ApproximateHistogramAggregatorFactory.convertToFloat(val));
+    }
   }
 
   @Override

--- a/extensions/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregatorFactory.java
+++ b/extensions/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregatorFactory.java
@@ -47,7 +47,7 @@ public class ApproximateHistogramFoldingAggregatorFactory extends ApproximateHis
       @JsonProperty("upperLimit") Float upperLimit
   )
   {
-    super(name, fieldName, resolution, numBuckets, lowerLimit, upperLimit);
+    super(name, fieldName, resolution, numBuckets, lowerLimit, upperLimit, false);
   }
 
   @Override

--- a/extensions/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorTest.java
+++ b/extensions/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorTest.java
@@ -18,7 +18,7 @@
 package io.druid.query.aggregation.histogram;
 
 import io.druid.query.aggregation.BufferAggregator;
-import io.druid.query.aggregation.TestFloatColumnSelector;
+import io.druid.query.aggregation.TestObjectColumnSelector;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -26,7 +26,7 @@ import java.nio.ByteBuffer;
 
 public class ApproximateHistogramAggregatorTest
 {
-  private void aggregateBuffer(TestFloatColumnSelector selector, BufferAggregator agg, ByteBuffer buf, int position)
+  private void aggregateBuffer(TestObjectColumnSelector selector, BufferAggregator agg, ByteBuffer buf, int position)
   {
     agg.aggregate(buf, position);
     selector.increment();
@@ -35,22 +35,22 @@ public class ApproximateHistogramAggregatorTest
   @Test
   public void testBufferAggregate() throws Exception
   {
-    final float[] values = {23, 19, 10, 16, 36, 2, 9, 32, 30, 45};
     final int resolution = 5;
     final int numBuckets = 5;
 
-    final TestFloatColumnSelector selector = new TestFloatColumnSelector(values);
+    final int numInputs = 10;
+    final TestObjectColumnSelector selector = new TestObjectColumnSelector(23f, 19f, 10f, 16f, 36f, 2f, 9f, 32f, 30f, 45f);
 
     ApproximateHistogramAggregatorFactory factory = new ApproximateHistogramAggregatorFactory(
-        "billy", "billy", resolution, numBuckets, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY
+        "billy", "billy", resolution, numBuckets, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY, false
     );
-    ApproximateHistogramBufferAggregator agg = new ApproximateHistogramBufferAggregator(selector, resolution, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY);
+    ApproximateHistogramBufferAggregator agg = new ApproximateHistogramBufferAggregator(selector, false, resolution, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY);
 
     ByteBuffer buf = ByteBuffer.allocate(factory.getMaxIntermediateSize());
     int position = 0;
 
     agg.init(buf, position);
-    for (int i = 0; i < values.length; i++) {
+    for (int i = 0; i < numInputs; i++) {
       aggregateBuffer(selector, agg, buf, position);
     }
 

--- a/extensions/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
+++ b/extensions/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
@@ -154,7 +154,8 @@ public class ApproximateHistogramGroupByQueryTest
         10,
         5,
         Float.NEGATIVE_INFINITY,
-        Float.POSITIVE_INFINITY
+        Float.POSITIVE_INFINITY,
+        false
     );
 
     GroupByQuery query = new GroupByQuery.Builder()
@@ -228,7 +229,8 @@ public class ApproximateHistogramGroupByQueryTest
         10,
         5,
         Float.NEGATIVE_INFINITY,
-        Float.POSITIVE_INFINITY
+        Float.POSITIVE_INFINITY,
+        false
     );
 
     GroupByQuery query = new GroupByQuery.Builder()

--- a/extensions/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramPostAggregatorTest.java
+++ b/extensions/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramPostAggregatorTest.java
@@ -17,7 +17,7 @@
 
 package io.druid.query.aggregation.histogram;
 
-import io.druid.query.aggregation.TestFloatColumnSelector;
+import io.druid.query.aggregation.TestObjectColumnSelector;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -26,8 +26,6 @@ import java.util.Map;
 
 public class ApproximateHistogramPostAggregatorTest
 {
-  static final float[] VALUES = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-
   protected ApproximateHistogram buildHistogram(int size, float[] values)
   {
     ApproximateHistogram h = new ApproximateHistogram(size);
@@ -40,11 +38,12 @@ public class ApproximateHistogramPostAggregatorTest
   @Test
   public void testCompute()
   {
-    ApproximateHistogram ah = buildHistogram(10, VALUES);
-    final TestFloatColumnSelector selector = new TestFloatColumnSelector(VALUES);
+    float[] values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    ApproximateHistogram ah = buildHistogram(10, values);
+    final TestObjectColumnSelector selector = new TestObjectColumnSelector(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
-    ApproximateHistogramAggregator agg = new ApproximateHistogramAggregator("price", selector, 10, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY);
-    for (int i = 0; i < VALUES.length; i++) {
+    ApproximateHistogramAggregator agg = new ApproximateHistogramAggregator("price", selector, false, 10, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY);
+    for (int i = 0; i < values.length; i++) {
       agg.aggregate();
       selector.increment();
     }

--- a/extensions/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramTopNQueryTest.java
+++ b/extensions/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramTopNQueryTest.java
@@ -27,8 +27,8 @@ import io.druid.query.QueryRunnerTestHelper;
 import io.druid.query.Result;
 import io.druid.query.TestQueryRunners;
 import io.druid.query.aggregation.AggregatorFactory;
-import io.druid.query.aggregation.DoubleMinAggregatorFactory;
 import io.druid.query.aggregation.DoubleMaxAggregatorFactory;
+import io.druid.query.aggregation.DoubleMinAggregatorFactory;
 import io.druid.query.aggregation.PostAggregator;
 import io.druid.query.topn.TopNQuery;
 import io.druid.query.topn.TopNQueryBuilder;
@@ -45,7 +45,6 @@ import org.junit.runners.Parameterized;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -103,7 +102,8 @@ public class ApproximateHistogramTopNQueryTest
         10,
         5,
         Float.NEGATIVE_INFINITY,
-        Float.POSITIVE_INFINITY
+        Float.POSITIVE_INFINITY,
+        false
     );
 
     TopNQuery query = new TopNQueryBuilder()


### PR DESCRIPTION
current approxHisto aggregator factory would consider absent metric value to be equal to 0.0f, in some cases we would like to just ignore such rows instead of defaulting to something.