### PR TITLE
explicitly call lifecycle stop

### DIFF
--- a/services/src/main/java/io/druid/cli/CliPeon.java
+++ b/services/src/main/java/io/druid/cli/CliPeon.java
@@ -223,6 +223,8 @@ public class CliPeon extends GuiceRunnable
             )
         );
         injector.getInstance(ExecutorLifecycle.class).join();
+        // Explicitly call lifecycle stop, dont rely on shutdown hook.
+        lifecycle.stop();
       }
       catch (Throwable t) {
         log.error(t, "Error when starting up.  Failing.");


### PR DESCRIPTION
found realtime tasks getting stuck on shutdown even after status being shown as SUCCESS. 
On further investigation found that the vm was waiting for all the daemon threads to shutdown. 
was able to reproduce this locally, calling lifecycle.shutdown explicitly and not relying on the shutdown hook fixes the issue. 