### PR TITLE
Add ability to provide taskResource for IndexTask.

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/common/task/AbstractFixedIntervalTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/AbstractFixedIntervalTask.java
@@ -40,6 +40,22 @@ public abstract class AbstractFixedIntervalTask extends AbstractTask
 
   protected AbstractFixedIntervalTask(
       String id,
+      TaskResource taskResource,
+      String dataSource,
+      Interval interval
+  )
+  {
+    this(
+        id,
+        id,
+        taskResource == null ? new TaskResource(id, 1) : taskResource,
+        dataSource,
+        interval
+    );
+  }
+
+  protected AbstractFixedIntervalTask(
+      String id,
       String groupId,
       String dataSource,
       Interval interval

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
@@ -141,9 +141,25 @@ public class IndexTask extends AbstractFixedIntervalTask
 
   private final ObjectMapper jsonMapper;
 
+  private String taskId;
+
+  /**
+   * This overloaded constructor without @JsonCreator exists to allow for
+   * unit tests simulating a call to IndexTask without taskResource.
+   */
+  public IndexTask(
+      String id,
+      IndexIngestionSpec ingestionSchema,
+      ObjectMapper jsonMapper
+  )
+  {
+    this(id, new TaskResource(makeId(id, ingestionSchema), 1), ingestionSchema, jsonMapper);
+  }
+
   @JsonCreator
   public IndexTask(
       @JsonProperty("id") String id,
+      @JsonProperty("resource") TaskResource taskResource,
       @JsonProperty("spec") IndexIngestionSpec ingestionSchema,
       @JacksonInject ObjectMapper jsonMapper
   )
@@ -151,6 +167,7 @@ public class IndexTask extends AbstractFixedIntervalTask
     super(
         // _not_ the version, just something uniqueish
         makeId(id, ingestionSchema),
+        taskResource,
         makeDataSource(ingestionSchema),
         makeInterval(ingestionSchema)
     );

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
@@ -102,6 +102,54 @@ public class TaskSerdeTest
   }
 
   @Test
+  public void testIndexTaskwithResourceSerde() throws Exception
+  {
+    final IndexTask task = new IndexTask(
+        null,
+        new TaskResource("rofl", 2),
+        new IndexTask.IndexIngestionSpec(
+            new DataSchema(
+                "foo",
+                null,
+                new AggregatorFactory[]{new DoubleSumAggregatorFactory("met", "met")},
+                new UniformGranularitySpec(
+                    Granularity.DAY,
+                    null,
+                    ImmutableList.of(new Interval("2010-01-01/P2D"))
+                )
+            ),
+            new IndexTask.IndexIOConfig(new LocalFirehoseFactory(new File("lol"), "rofl", null)),
+            new IndexTask.IndexTuningConfig(10000, 10, -1, indexSpec)
+        ),
+        jsonMapper
+    );
+
+    for (final Module jacksonModule : new FirehoseModule().getJacksonModules()) {
+      jsonMapper.registerModule(jacksonModule);
+    }
+    InjectableValues inject = new InjectableValues.Std()
+        .addValue(ObjectMapper.class, jsonMapper);
+    final String json = jsonMapper.writeValueAsString(task);
+
+    Thread.sleep(100); // Just want to run the clock a bit to make sure the task id doesn't change
+    final IndexTask task2 = jsonMapper.reader(Task.class).with(inject).readValue(json);
+
+    Assert.assertEquals("foo", task.getDataSource());
+    Assert.assertEquals(new Interval("2010-01-01/P2D"), task.getInterval());
+
+    Assert.assertEquals(task.getId(), task2.getId());
+    Assert.assertEquals(2, task.getTaskResource().getRequiredCapacity());
+    Assert.assertEquals("rofl", task.getTaskResource().getAvailabilityGroup());
+    Assert.assertEquals(task.getTaskResource().getRequiredCapacity(), task2.getTaskResource().getRequiredCapacity());
+    Assert.assertEquals(task.getTaskResource().getAvailabilityGroup(), task2.getTaskResource().getAvailabilityGroup());
+    Assert.assertEquals(task.getGroupId(), task2.getGroupId());
+    Assert.assertEquals(task.getDataSource(), task2.getDataSource());
+    Assert.assertEquals(task.getInterval(), task2.getInterval());
+    Assert.assertTrue(task.getIngestionSchema().getIOConfig().getFirehoseFactory() instanceof LocalFirehoseFactory);
+    Assert.assertTrue(task2.getIngestionSchema().getIOConfig().getFirehoseFactory() instanceof LocalFirehoseFactory);
+  }
+
+  @Test
   public void testMergeTaskSerde() throws Exception
   {
     final MergeTask task = new MergeTask(


### PR DESCRIPTION
I had the need to specify requiredCapacity for ingestSegment IndexTask. I added another overloaded constructor to the AbstractFixedIntervalTask class to handle an incoming taskResource attribute. I overloaded the IndexTask constructor to support all internal implementations of IndexTask. I added a new @JsonProperty for taskResource to the primary constructor, with an inline if to handle the case when someone does not use the resource JSON node. I am using this on some of my systems, and I also added a unit test to verify that this works.