### PR TITLE
Inner Query  should build on sub query

### DIFF
--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryQueryToolChest.java
@@ -164,7 +164,7 @@ public class GroupByQueryQueryToolChest extends QueryToolChest<Row, GroupByQuery
       }
 
       // We need the inner incremental index to have all the columns required by the outer query
-      final GroupByQuery innerQuery = new GroupByQuery.Builder(query)
+      final GroupByQuery innerQuery = new GroupByQuery.Builder(subquery)
           .setAggregatorSpecs(aggs)
           .setInterval(subquery.getIntervals())
           .setPostAggregatorSpecs(Lists.<PostAggregator>newArrayList())


### PR DESCRIPTION
Like following query:
```sql
SELECT 
   device, LONG_SUM(pv) as pv, HYPER_UNIQUE(hyper_uv) as hyper_uv 
FROM
  (SELECT
         device, cast, LONG_SUM(pv_sum) as pv, HYPER_UNIQUE(uv) as hyper_uv 
   FROM dsp_report        
   WHERE interval BETWEEN 2015-08-04T00:00:00 AND 2015-08-05T00:00:00
   AND area = '0A' BREAK BY 'all' GROUP BY device, cast
   ) 
WHERE interval BETWEEN 2015-08-04T00:00:00 AND 2015-08-05T00:00:00 AND cast = 1 BREAK BY 'all' GROUP BY device ;
```
![subquery](https://cloud.githubusercontent.com/assets/1724869/9302983/6ce1f726-450d-11e5-9f0c-4d5c9271cda9.jpg)
don't return anything,not as except.
look into the code path:
```java
   final GroupByQuery innerQuery = new GroupByQuery.Builder(query)
          .setAggregatorSpecs(aggs)
          .setInterval(subquery.getIntervals())
          .setPostAggregatorSpecs(Lists.<PostAggregator>newArrayList())
          .build();

```
Inner Query  should build on sub query