### PR TITLE
Make jetty scheduler threads daemon thread

### DIFF
--- a/server/src/main/java/io/druid/server/initialization/jetty/JettyServerModule.java
+++ b/server/src/main/java/io/druid/server/initialization/jetty/JettyServerModule.java
@@ -51,6 +51,7 @@ import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
 
 import javax.servlet.ServletException;
 import java.util.Map;
@@ -160,6 +161,10 @@ public class JettyServerModule extends JerseyServletModule
     threadPool.setDaemon(true);
 
     final Server server = new Server(threadPool);
+
+    // Without this bean set, the default ScheduledExecutorScheduler runs as non-daemon, causing lifecycle hooks to fail
+    // to fire on main exit. Related bug: https://github.com/druid-io/druid/pull/1627
+    server.addBean(new ScheduledExecutorScheduler("JettyScheduler", true), true);
 
     ServerConnector connector = new ServerConnector(server);
     connector.setPort(node.getPort());


### PR DESCRIPTION
Fixes bug from https://github.com/druid-io/druid/pull/1627

I was able to reproduce it locally for peons that answered a query. Turns out that Jetty was spawning a scheduler which was not marked as daemon.