### PR TITLE
New plumber

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/common/task/RealtimeIndexTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/RealtimeIndexTask.java
@@ -20,12 +20,14 @@ package io.druid.indexing.common.task;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
 import com.metamx.common.guava.CloseQuietly;
 import com.metamx.common.parsers.ParseException;
 import com.metamx.emitter.EmittingLogger;
+import io.druid.data.input.Committer;
 import io.druid.data.input.Firehose;
 import io.druid.data.input.InputRow;
 import io.druid.indexing.common.TaskLock;
@@ -46,15 +48,15 @@ import io.druid.segment.indexing.RealtimeTuningConfig;
 import io.druid.segment.realtime.FireDepartment;
 import io.druid.segment.realtime.RealtimeMetricsMonitor;
 import io.druid.segment.realtime.SegmentPublisher;
+import io.druid.segment.realtime.plumber.Committers;
 import io.druid.segment.realtime.plumber.Plumber;
+import io.druid.segment.realtime.plumber.PlumberSchool;
 import io.druid.segment.realtime.plumber.RealtimePlumberSchool;
-import io.druid.segment.realtime.plumber.Sink;
 import io.druid.segment.realtime.plumber.VersioningPolicy;
 import io.druid.server.coordination.DataSegmentAnnouncer;
 import io.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
-import org.joda.time.Period;
 
 import java.io.File;
 import java.io.IOException;
@@ -78,8 +80,8 @@ public class RealtimeIndexTask extends AbstractTask
   static String makeTaskId(String dataSource, int partitionNumber, DateTime timestamp, int randomBits)
   {
     final StringBuilder suffix = new StringBuilder(8);
-    for(int i = 0; i < Ints.BYTES * 2; ++i) {
-      suffix.append((char)('a' + ((randomBits >>> (i * 4)) & 0x0F)));
+    for (int i = 0; i < Ints.BYTES * 2; ++i) {
+      suffix.append((char) ('a' + ((randomBits >>> (i * 4)) & 0x0F)));
     }
     return String.format(
         "index_realtime_%s_%d_%s_%s",
@@ -248,8 +250,8 @@ public class RealtimeIndexTask extends AbstractTask
     DataSchema dataSchema = spec.getDataSchema();
     RealtimeIOConfig realtimeIOConfig = spec.getIOConfig();
     RealtimeTuningConfig tuningConfig = spec.getTuningConfig()
-                                              .withBasePersistDirectory(new File(toolbox.getTaskWorkDir(), "persist"))
-                                              .withVersioningPolicy(versioningPolicy);
+                                            .withBasePersistDirectory(new File(toolbox.getTaskWorkDir(), "persist"))
+                                            .withVersioningPolicy(versioningPolicy);
 
     final FireDepartment fireDepartment = new FireDepartment(
         dataSchema,
@@ -263,7 +265,7 @@ public class RealtimeIndexTask extends AbstractTask
     // NOTE: that redundant realtime tasks will upload to the same location. This can cause index.zip and
     // NOTE: descriptor.json to mismatch, or it can cause historical nodes to load different instances of the
     // NOTE: "same" segment.
-    final RealtimePlumberSchool plumberSchool = new RealtimePlumberSchool(
+    final PlumberSchool plumberSchool = new RealtimePlumberSchool(
         toolbox.getEmitter(),
         toolbox.getQueryRunnerFactoryConglomerate(),
         toolbox.getSegmentPusher(),
@@ -277,6 +279,7 @@ public class RealtimeIndexTask extends AbstractTask
 
     // Delay firehose connection to avoid claiming input resources while the plumber is starting up.
     Firehose firehose = null;
+    Supplier<Committer> committerSupplier = null;
 
     try {
       plumber.startJob();
@@ -285,11 +288,10 @@ public class RealtimeIndexTask extends AbstractTask
       toolbox.getMonitorScheduler().addMonitor(metricsMonitor);
 
       // Set up firehose
-      final Period intermediatePersistPeriod = spec.getTuningConfig().getIntermediatePersistPeriod();
       firehose = spec.getIOConfig().getFirehoseFactory().connect(spec.getDataSchema().getParser());
+      committerSupplier = Committers.supplierFromFirehose(firehose);
 
       // Time to read data!
-      long nextFlush = new DateTime().plus(intermediatePersistPeriod).getMillis();
       while (firehose.hasMore()) {
         final InputRow inputRow;
 
@@ -308,25 +310,14 @@ public class RealtimeIndexTask extends AbstractTask
           continue;
         }
 
-        int currCount = plumber.add(inputRow);
-        if (currCount == -1) {
+        int numRows = plumber.add(inputRow, committerSupplier);
+        if (numRows == -1) {
           fireDepartment.getMetrics().incrementThrownAway();
           log.debug("Throwing away event[%s]", inputRow);
-
-          if (System.currentTimeMillis() > nextFlush) {
-            plumber.persist(firehose.commit());
-            nextFlush = new DateTime().plus(intermediatePersistPeriod).getMillis();
-          }
-
           continue;
         }
 
         fireDepartment.getMetrics().incrementProcessed();
-        final Sink sink = plumber.getSink(inputRow.getTimestampFromEpoch());
-        if ((sink != null && !sink.canAppendRow()) || System.currentTimeMillis() > nextFlush) {
-          plumber.persist(firehose.commit());
-          nextFlush = new DateTime().plus(intermediatePersistPeriod).getMillis();
-        }
       }
     }
     catch (Throwable e) {
@@ -338,7 +329,7 @@ public class RealtimeIndexTask extends AbstractTask
     finally {
       if (normalExit) {
         try {
-          plumber.persist(firehose.commit());
+          plumber.persist(committerSupplier.get());
           plumber.finishJob();
         }
         catch (Exception e) {

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/IndexTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/IndexTaskTest.java
@@ -18,7 +18,6 @@
 package io.druid.indexing.common.task;
 
 import com.google.common.collect.Lists;
-import com.google.common.io.Files;
 import com.metamx.common.Granularity;
 import io.druid.data.input.impl.CSVParseSpec;
 import io.druid.data.input.impl.DimensionsSpec;
@@ -308,7 +307,11 @@ public class IndexTaskTest
         null,
         new IndexSpec()
     );
-    RealtimeTuningConfig realtimeTuningConfig = IndexTask.convertTuningConfig(spec, config);
+    RealtimeTuningConfig realtimeTuningConfig = IndexTask.convertTuningConfig(
+        spec,
+        config.getRowFlushBoundary(),
+        config.getIndexSpec()
+    );
     Assert.assertEquals(realtimeTuningConfig.getMaxRowsInMemory(), config.getRowFlushBoundary());
     Assert.assertEquals(realtimeTuningConfig.getShardSpec(), spec);
     Assert.assertEquals(realtimeTuningConfig.getIndexSpec(), indexSpec);

--- a/server/src/main/java/io/druid/segment/realtime/plumber/Committers.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/Committers.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.realtime.plumber;
+
+import com.google.common.base.Supplier;
+import io.druid.data.input.Committer;
+import io.druid.data.input.Firehose;
+import io.druid.data.input.FirehoseV2;
+
+public class Committers
+{
+  private static final Committer NIL = new Committer()
+  {
+    @Override
+    public Object getMetadata()
+    {
+      return null;
+    }
+
+    @Override
+    public void run()
+    {
+      // Do nothing
+    }
+  };
+
+  public static Supplier<Committer> supplierFromRunnable(final Runnable runnable)
+  {
+    return supplierOf(
+        new Committer()
+        {
+          @Override
+          public Object getMetadata()
+          {
+            return null;
+          }
+
+          @Override
+          public void run()
+          {
+            runnable.run();
+          }
+        }
+    );
+  }
+
+  public static Supplier<Committer> supplierFromFirehose(final Firehose firehose)
+  {
+    return new Supplier<Committer>()
+    {
+      @Override
+      public Committer get()
+      {
+        final Runnable commitRunnable = firehose.commit();
+        return new Committer()
+        {
+          @Override
+          public Object getMetadata()
+          {
+            return null;
+          }
+
+          @Override
+          public void run()
+          {
+            commitRunnable.run();
+          }
+        };
+      }
+    };
+  }
+
+  public static Supplier<Committer> supplierFromFirehoseV2(final FirehoseV2 firehose)
+  {
+    return new Supplier<Committer>()
+    {
+      @Override
+      public Committer get()
+      {
+        return firehose.makeCommitter();
+      }
+    };
+  }
+
+  public static Committer nil()
+  {
+    return NIL;
+  }
+
+  public static Supplier<Committer> supplierOf(final Committer committer)
+  {
+    return new Supplier<Committer>()
+    {
+      @Override
+      public Committer get()
+      {
+        return committer;
+      }
+    };
+  }
+}

--- a/server/src/main/java/io/druid/segment/realtime/plumber/Plumber.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/Plumber.java
@@ -17,6 +17,7 @@
 
 package io.druid.segment.realtime.plumber;
 
+import com.google.common.base.Supplier;
 import io.druid.data.input.Committer;
 import io.druid.data.input.InputRow;
 import io.druid.query.Query;
@@ -31,30 +32,30 @@ public interface Plumber
    *
    * @return the metadata of the "newest" segment that might have previously been persisted
    */
-  public Object startJob();
+  Object startJob();
 
   /**
-   * @param row - the row to insert
+   * @param row               the row to insert
+   * @param committerSupplier supplier of a committer associated with all data that has been added, including this row
+   *
    * @return - positive numbers indicate how many summarized rows exist in the index for that timestamp,
    * -1 means a row was thrown away because it was too late
    */
-  public int add(InputRow row) throws IndexSizeExceededException;
-  public <T> QueryRunner<T> getQueryRunner(Query<T> query);
+  int add(InputRow row, Supplier<Committer> committerSupplier) throws IndexSizeExceededException;
+
+  <T> QueryRunner<T> getQueryRunner(Query<T> query);
 
   /**
    * Persist any in-memory indexed data to durable storage. This may be only somewhat durable, e.g. the
    * machine's local disk.
    *
-   * @param commitRunnable code to run after persisting data
+   * @param committer committer to use after persisting data
    */
-  void persist(Committer commitRunnable);
-  void persist(Runnable commitRunnable);
+  void persist(Committer committer);
 
   /**
    * Perform any final processing and clean up after ourselves. Should be called after all data has been
    * fed into sinks and persisted.
    */
-  public void finishJob();
-
-  public Sink getSink(long timestamp);
+  void finishJob();
 }

--- a/server/src/test/java/io/druid/segment/realtime/RealtimeManagerTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/RealtimeManagerTest.java
@@ -20,6 +20,7 @@
 package io.druid.segment.realtime;
 
 import com.google.common.base.Stopwatch;
+import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;
 import com.metamx.common.Granularity;
 import com.metamx.common.ISE;
@@ -193,7 +194,7 @@ public class RealtimeManagerTest
     Assert.assertEquals(2, realtimeManager.getMetrics("test").unparseable());
     Assert.assertTrue(plumber.isStartedJob());
     Assert.assertTrue(plumber.isFinishedJob());
-    Assert.assertEquals(1, plumber.getPersistCount());
+    Assert.assertEquals(0, plumber.getPersistCount());
   }
 
   @Test
@@ -214,7 +215,7 @@ public class RealtimeManagerTest
     Assert.assertEquals(2, realtimeManager2.getMetrics("testV2").unparseable());
     Assert.assertTrue(plumber2.isStartedJob());
     Assert.assertTrue(plumber2.isFinishedJob());
-    Assert.assertEquals(1, plumber2.getPersistCount());
+    Assert.assertEquals(0, plumber2.getPersistCount());
   }
 
   private TestInputRowHolder makeRow(final long timestamp)
@@ -440,7 +441,7 @@ public class RealtimeManagerTest
     }
 
     @Override
-    public int add(InputRow row) throws IndexSizeExceededException
+    public int add(InputRow row, Supplier<Committer> committerSupplier) throws IndexSizeExceededException
     {
       if (row == null) {
         return -1;
@@ -470,7 +471,7 @@ public class RealtimeManagerTest
     }
 
     @Override
-    public void persist(Runnable commitRunnable)
+    public void persist(Committer committer)
     {
       persistCount++;
     }
@@ -479,12 +480,6 @@ public class RealtimeManagerTest
     public void finishJob()
     {
       finishedJob = true;
-    }
-
-    @Override
-    public void persist(Committer commitRunnable)
-    {
-      persistCount++;
     }
   }
 }


### PR DESCRIPTION
Modify Plumbers in these ways,

1) Persist using Committer instead of Runnable. (Although the metadata object
   is ignored in this patch)

2) Remove the getSink method.

3) Plumbers are now responsible for time-based and hydrant-full-based periodic
   committing. (FireChief, RealtimeIndexTask, and IndexTask used to do this)

The purpose of these changes is to make it possible to implement Plumbers using
Appenderators, which is a hopefully more useful interface for things like transactional
ingestion and windowPeriodless ingestion. Thinking of something like this for
the interface:

  https://gist.github.com/gianm/7d8f83619aada126fcd9