### PR TITLE
Allow memcached error mode to be configured

### DIFF
--- a/docs/content/configuration/broker.md
+++ b/docs/content/configuration/broker.md
@@ -110,3 +110,4 @@ You can optionally only configure caching to be enabled on the broker by setting
 |`druid.cache.maxObjectSize`|Maximum object size in bytes for a Memcached object.|52428800 (50 MB)|
 |`druid.cache.memcachedPrefix`|Key prefix for all keys in Memcached.|druid|
 |`druid.cache.numConnections`|Number of memcached connections to use.|1|
+|`druid.cache.failureMode`|Failure mode when there is a problem communicating with memcached(`cancel` or `retry`)|`cancel`|

--- a/docs/content/configuration/historical.md
+++ b/docs/content/configuration/historical.md
@@ -101,3 +101,4 @@ You can optionally only configure caching to be enabled on the historical by set
 |`druid.cache.hosts`|Command separated list of Memcached hosts `<host:port>`.|none|
 |`druid.cache.maxObjectSize`|Maximum object size in bytes for a Memcached object.|52428800 (50 MB)|
 |`druid.cache.memcachedPrefix`|Key prefix for all keys in Memcached.|druid|
+|`druid.cache.failureMode`|Failure mode when there is a problem communicating with memcached(`cancel` or `retry`)|`cancel`|

--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -248,6 +248,7 @@ You can enable caching of results at the broker/historical using following confi
 |`druid.cache.hosts`|Command separated list of Memcached hosts `<host:port>`.|none|
 |`druid.cache.maxObjectSize`|Maximum object size in bytes for a Memcached object.|52428800 (50 MB)|
 |`druid.cache.memcachedPrefix`|Key prefix for all keys in Memcached.|druid|
+|`druid.cache.failureMode`|Failure mode when there is a problem communicating with memcached(`cancel` or `retry`)|`cancel`|
 
 ### Indexing Service Discovery
 

--- a/server/src/main/java/io/druid/client/cache/MemcachedCache.java
+++ b/server/src/main/java/io/druid/client/cache/MemcachedCache.java
@@ -40,7 +40,6 @@ import io.druid.collections.StupidResourceHolder;
 import net.spy.memcached.AddrUtil;
 import net.spy.memcached.ConnectionFactory;
 import net.spy.memcached.ConnectionFactoryBuilder;
-import net.spy.memcached.FailureMode;
 import net.spy.memcached.HashAlgorithm;
 import net.spy.memcached.MemcachedClient;
 import net.spy.memcached.MemcachedClientIF;
@@ -336,7 +335,7 @@ public class MemcachedCache implements Cache
           .setProtocol(ConnectionFactoryBuilder.Protocol.BINARY)
           .setLocatorType(ConnectionFactoryBuilder.Locator.CONSISTENT)
           .setDaemon(true)
-          .setFailureMode(FailureMode.Cancel)
+          .setFailureMode(config.getFailureMode())
           .setTranscoder(transcoder)
           .setShouldOptimize(true)
           .setOpQueueMaxBlockTime(config.getTimeout())

--- a/server/src/test/java/io/druid/client/cache/MemcachedCacheConfigTest.java
+++ b/server/src/test/java/io/druid/client/cache/MemcachedCacheConfigTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.client.cache;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.spy.memcached.FailureMode;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class MemcachedCacheConfigTest
+{
+  private static final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  public void testSerDe() throws IOException
+  {
+    String data = "{"
+                  + "\"expiration\":100,"
+                  + "\"timeout\":20,"
+                  + "\"hosts\":\"192.168.1.1,192.168.1.1.2\","
+                  + "\"maxObjectSize\":9898,"
+                  + "\"readBufferSize\":43819,"
+                  + "\"memcachedPrefix\":\"somethingPrefix\","
+                  + "\"maxOperationQueueSize\":10,"
+                  + "\"failureMode\":\"retry\""
+                  + "}";
+    MemcachedCacheConfig config = mapper.readValue(data, MemcachedCacheConfig.class);
+    Assert.assertEquals(100, config.getExpiration());
+    Assert.assertEquals(20, config.getTimeout());
+    Assert.assertEquals("192.168.1.1,192.168.1.1.2", config.getHosts());
+    Assert.assertEquals(9898, config.getMaxObjectSize());
+    Assert.assertEquals(43819, config.getReadBufferSize());
+    Assert.assertEquals("somethingPrefix", config.getMemcachedPrefix());
+    Assert.assertEquals(10, config.getMaxOperationQueueSize());
+    Assert.assertEquals(FailureMode.Retry, config.getFailureMode());
+
+    Assert.assertEquals(
+        config,
+        mapper.readValue(
+          mapper.writeValueAsBytes(config),
+          MemcachedCacheConfig.class
+        )
+    );
+  }
+}


### PR DESCRIPTION
This allows a user to redefine the memcached failure mode (for example, Retry) but retains prior behavior of Failure.