### PR TITLE
fix success flag emitted in router query metrics

### DIFF
--- a/server/src/main/java/io/druid/server/AsyncQueryForwardingServlet.java
+++ b/server/src/main/java/io/druid/server/AsyncQueryForwardingServlet.java
@@ -274,7 +274,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet
                         "query/time",
                         requestTime,
                         "success",
-                        true
+                        result.isSucceeded()
                     )
                 )
             )


### PR DESCRIPTION
check the success flag on result instead of always returning true. 