### PR TITLE
Update ByteBuffer collections

### DIFF
--- a/indexing-hadoop/src/test/java/io/druid/indexer/updater/HadoopConverterJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/updater/HadoopConverterJobTest.java
@@ -373,7 +373,7 @@ public class HadoopConverterJobTest
         new HadoopDruidConverterConfig(
             DATASOURCE,
             interval,
-            new IndexSpec(new RoaringBitmapSerdeFactory(), "uncompressed", "uncompressed"),
+            new IndexSpec(new RoaringBitmapSerdeFactory(true), "uncompressed", "uncompressed"),
             oldSemgments,
             true,
             tmpDir.toURI(),
@@ -476,7 +476,7 @@ public class HadoopConverterJobTest
         new HadoopDruidConverterConfig(
             DATASOURCE,
             interval,
-            new IndexSpec(new RoaringBitmapSerdeFactory(), "uncompressed", "uncompressed"),
+            new IndexSpec(new RoaringBitmapSerdeFactory(true), "uncompressed", "uncompressed"),
             oldSemgments,
             true,
             tmpDir.toURI(),

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
@@ -400,7 +400,7 @@ public class TaskSerdeTest
     );
     final ConvertSegmentTask convertSegmentTaskOriginal = ConvertSegmentTask.create(
         segment,
-        new IndexSpec(new RoaringBitmapSerdeFactory(), "lzf", "uncompressed"),
+        new IndexSpec(new RoaringBitmapSerdeFactory(true), "lzf", "uncompressed"),
         false,
         true
     );

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
             <dependency>
                 <groupId>com.metamx</groupId>
                 <artifactId>bytebuffer-collections</artifactId>
-                <version>0.1.6</version>
+                <version>0.1.7</version>
             </dependency>
             <dependency>
                 <groupId>com.metamx</groupId>

--- a/processing/src/main/java/io/druid/segment/data/RoaringBitmapSerdeFactory.java
+++ b/processing/src/main/java/io/druid/segment/data/RoaringBitmapSerdeFactory.java
@@ -17,6 +17,8 @@
 
 package io.druid.segment.data;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Ordering;
 import com.metamx.collections.bitmap.BitmapFactory;
 import com.metamx.collections.bitmap.ImmutableBitmap;
@@ -31,7 +33,21 @@ import java.nio.ByteBuffer;
 public class RoaringBitmapSerdeFactory implements BitmapSerdeFactory
 {
   private static final ObjectStrategy<ImmutableBitmap> objectStrategy = new ImmutableRoaringBitmapObjectStrategy();
-  private static final BitmapFactory bitmapFactory = new RoaringBitmapFactory();
+  private final BitmapFactory bitmapFactory;
+  private final boolean compressRunOnSerialization;
+
+  @JsonCreator
+  public RoaringBitmapSerdeFactory(@JsonProperty("compressRunOnSerialization") boolean compressRunOnSerialization)
+  {
+    this.compressRunOnSerialization = compressRunOnSerialization;
+    this. bitmapFactory = new RoaringBitmapFactory(compressRunOnSerialization);
+  }
+
+  @JsonProperty
+  public boolean getcompressRunOnSerialization()
+  {
+    return compressRunOnSerialization;
+  }
 
   @Override
   public ObjectStrategy<ImmutableBitmap> getObjectStrategy()
@@ -102,18 +118,30 @@ public class RoaringBitmapSerdeFactory implements BitmapSerdeFactory
   @Override
   public String toString()
   {
-    return "RoaringBitmapSerdeFactory{}";
+    return "RoaringBitmapSerdeFactory{" +
+           "compressRunOnSerialization=" + compressRunOnSerialization +
+           '}';
   }
 
   @Override
   public boolean equals(Object o)
   {
-    return this == o || o instanceof RoaringBitmapSerdeFactory;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    RoaringBitmapSerdeFactory that = (RoaringBitmapSerdeFactory) o;
+
+    return compressRunOnSerialization == that.compressRunOnSerialization;
+
   }
 
   @Override
   public int hashCode()
   {
-    return 0;
+    return (compressRunOnSerialization ? 1 : 0);
   }
 }

--- a/processing/src/test/java/io/druid/segment/IndexMakerParameterizedTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMakerParameterizedTest.java
@@ -69,7 +69,7 @@ public class IndexMakerParameterizedTest
     return Collections2.transform(
         Sets.cartesianProduct(
             ImmutableList.of(
-                ImmutableSet.of(new RoaringBitmapSerdeFactory(), new ConciseBitmapSerdeFactory()),
+                ImmutableSet.of(new RoaringBitmapSerdeFactory(true), new ConciseBitmapSerdeFactory()),
                 ImmutableSet.of(
                     CompressedObjectStrategy.CompressionStrategy.LZ4,
                     CompressedObjectStrategy.CompressionStrategy.LZF

--- a/processing/src/test/java/io/druid/segment/IndexMergerTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerTest.java
@@ -65,7 +65,7 @@ public class IndexMergerTest
     return Collections2.transform(
         Sets.cartesianProduct(
             ImmutableList.of(
-                ImmutableSet.of(new RoaringBitmapSerdeFactory(), new ConciseBitmapSerdeFactory()),
+                ImmutableSet.of(new RoaringBitmapSerdeFactory(true), new ConciseBitmapSerdeFactory()),
                 ImmutableSet.of(
                     CompressedObjectStrategy.CompressionStrategy.LZ4,
                     CompressedObjectStrategy.CompressionStrategy.LZF

--- a/processing/src/test/java/io/druid/segment/IndexSpecTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexSpecTest.java
@@ -43,7 +43,7 @@ public class IndexSpecTest
     final String json = "{ \"bitmap\" : { \"type\" : \"roaring\" }, \"dimensionCompression\" : \"lz4\", \"metricCompression\" : \"lzf\" }";
 
     final IndexSpec spec = objectMapper.readValue(json, IndexSpec.class);
-    Assert.assertEquals(new RoaringBitmapSerdeFactory(), spec.getBitmapSerdeFactory());
+    Assert.assertEquals(new RoaringBitmapSerdeFactory(true), spec.getBitmapSerdeFactory());
     Assert.assertEquals(CompressedObjectStrategy.CompressionStrategy.LZ4, spec.getDimensionCompressionStrategy());
     Assert.assertEquals(CompressedObjectStrategy.CompressionStrategy.LZF, spec.getMetricCompressionStrategy());
 

--- a/processing/src/test/java/io/druid/segment/data/BitmapCreationBenchmark.java
+++ b/processing/src/test/java/io/druid/segment/data/BitmapCreationBenchmark.java
@@ -46,14 +46,17 @@ public class BitmapCreationBenchmark extends AbstractBenchmark
   private static final Logger log = new Logger(BitmapCreationBenchmark.class);
 
   @Parameterized.Parameters
-  public static List<Class<? extends BitmapSerdeFactory>[]> factoryClasses()
+  public static List<BitmapSerdeFactory[]> factoryClasses()
   {
-    return Arrays.<Class<? extends BitmapSerdeFactory>[]>asList(
-        (Class<? extends BitmapSerdeFactory>[]) Arrays.<Class<? extends BitmapSerdeFactory>>asList(
-            ConciseBitmapSerdeFactory.class
+    return Arrays.<BitmapSerdeFactory[]>asList(
+        (BitmapSerdeFactory[]) Arrays.<BitmapSerdeFactory>asList(
+            new ConciseBitmapSerdeFactory()
         ).toArray(),
-        (Class<? extends BitmapSerdeFactory>[]) Arrays.<Class<? extends BitmapSerdeFactory>>asList(
-            RoaringBitmapSerdeFactory.class
+        (BitmapSerdeFactory[]) Arrays.<BitmapSerdeFactory>asList(
+            new RoaringBitmapSerdeFactory(false)
+        ).toArray(),
+        (BitmapSerdeFactory[]) Arrays.<BitmapSerdeFactory>asList(
+            new RoaringBitmapSerdeFactory(true)
         ).toArray()
     );
   }
@@ -61,12 +64,11 @@ public class BitmapCreationBenchmark extends AbstractBenchmark
   final BitmapFactory factory;
   final ObjectStrategy<ImmutableBitmap> objectStrategy;
 
-  public BitmapCreationBenchmark(Class<? extends BitmapSerdeFactory> clazz)
+  public BitmapCreationBenchmark(BitmapSerdeFactory bitmapSerdeFactory)
       throws IllegalAccessException, InstantiationException
   {
-    BitmapSerdeFactory serdeFactory = clazz.newInstance();
-    factory = serdeFactory.getBitmapFactory();
-    objectStrategy = serdeFactory.getObjectStrategy();
+    factory = bitmapSerdeFactory.getBitmapFactory();
+    objectStrategy = bitmapSerdeFactory.getObjectStrategy();
   }
 
   private static final int numBits = 100000;
@@ -78,9 +80,9 @@ public class BitmapCreationBenchmark extends AbstractBenchmark
   @AfterClass
   public static void cleanupAfterClass()
   {
-    List<Class<? extends BitmapSerdeFactory>[]> classes = factoryClasses();
-    for (int i = 0; i < classes.size(); ++i) {
-      log.info("Entry [%d] is %s", i, classes.get(i)[0].getCanonicalName());
+    List<BitmapSerdeFactory[]> factories = factoryClasses();
+    for (int i = 0; i < factories.size(); ++i) {
+      log.info("Entry [%d] is %s", i, factories.get(i)[0]);
     }
   }
 

--- a/processing/src/test/java/io/druid/segment/data/BitmapSerdeFactoryTest.java
+++ b/processing/src/test/java/io/druid/segment/data/BitmapSerdeFactoryTest.java
@@ -50,12 +50,6 @@ public class BitmapSerdeFactoryTest
   {
     Assert.assertTrue(
         mapper.readValue(
-            "{\"type\":\"roaring\"}",
-            BitmapSerdeFactory.class
-        ) instanceof RoaringBitmapSerdeFactory
-    );
-    Assert.assertTrue(
-        mapper.readValue(
             "{\"type\":\"roaring\"}}",
             BitmapSerdeFactory.class
         ) instanceof RoaringBitmapSerdeFactory

--- a/processing/src/test/java/io/druid/segment/data/BitmapSerdeFactoryTest.java
+++ b/processing/src/test/java/io/druid/segment/data/BitmapSerdeFactoryTest.java
@@ -24,23 +24,65 @@ import org.junit.Test;
 
 public class BitmapSerdeFactoryTest
 {
+  private final ObjectMapper mapper = new DefaultObjectMapper();
+
   @Test
   public void testSerialization() throws Exception
   {
-    ObjectMapper mapper = new DefaultObjectMapper();
-    Assert.assertEquals("{\"type\":\"roaring\"}", mapper.writeValueAsString(new RoaringBitmapSerdeFactory()));
+    Assert.assertEquals(
+        "{\"type\":\"roaring\",\"compressRunOnSerialization\":false}",
+        mapper.writeValueAsString(new RoaringBitmapSerdeFactory(false))
+    );
     Assert.assertEquals("{\"type\":\"concise\"}", mapper.writeValueAsString(new ConciseBitmapSerdeFactory()));
     Assert.assertEquals("{\"type\":\"concise\"}", mapper.writeValueAsString(BitmapSerde.createLegacyFactory()));
-    Assert.assertEquals("{\"type\":\"concise\"}", mapper.writeValueAsString(new BitmapSerde.DefaultBitmapSerdeFactory()));
-    Assert.assertEquals("{\"type\":\"concise\"}", mapper.writeValueAsString(new BitmapSerde.LegacyBitmapSerdeFactory()));
+    Assert.assertEquals(
+        "{\"type\":\"concise\"}",
+        mapper.writeValueAsString(new BitmapSerde.DefaultBitmapSerdeFactory())
+    );
+    Assert.assertEquals(
+        "{\"type\":\"concise\"}",
+        mapper.writeValueAsString(new BitmapSerde.LegacyBitmapSerdeFactory())
+    );
   }
 
   @Test
   public void testDeserialization() throws Exception
   {
-    ObjectMapper mapper = new DefaultObjectMapper();
-    Assert.assertTrue(mapper.readValue("{\"type\":\"roaring\"}", BitmapSerdeFactory.class) instanceof RoaringBitmapSerdeFactory);
-    Assert.assertTrue(mapper.readValue("{\"type\":\"concise\"}", BitmapSerdeFactory.class) instanceof ConciseBitmapSerdeFactory);
-    Assert.assertTrue(mapper.readValue("{\"type\":\"BitmapSerde$SomeRandomClass\"}", BitmapSerdeFactory.class) instanceof ConciseBitmapSerdeFactory);
+    Assert.assertTrue(
+        mapper.readValue(
+            "{\"type\":\"roaring\"}",
+            BitmapSerdeFactory.class
+        ) instanceof RoaringBitmapSerdeFactory
+    );
+    Assert.assertTrue(
+        mapper.readValue(
+            "{\"type\":\"roaring\"}}",
+            BitmapSerdeFactory.class
+        ) instanceof RoaringBitmapSerdeFactory
+    );
+    Assert.assertTrue(
+        mapper.readValue(
+            "{\"type\":\"concise\"}",
+            BitmapSerdeFactory.class
+        ) instanceof ConciseBitmapSerdeFactory
+    );
+    Assert.assertTrue(
+        mapper.readValue(
+            "{\"type\":\"BitmapSerde$SomeRandomClass\"}",
+            BitmapSerdeFactory.class
+        ) instanceof ConciseBitmapSerdeFactory
+    );
+  }
+
+  @Test
+  public void testRoaringBitmapFactorySerde() throws Exception
+  {
+
+    RoaringBitmapSerdeFactory bitmapSerdeFactory = (RoaringBitmapSerdeFactory) mapper.readValue(
+        "{\"type\":\"roaring\",\"compressRunOnSerialization\":true}}",
+        BitmapSerdeFactory.class
+    );
+    Assert.assertTrue(bitmapSerdeFactory.getcompressRunOnSerialization());
+
   }
 }


### PR DESCRIPTION
Updated to Roaring 0.5.1 and run benchmarks. 

Microbenchmark results - 
https://gist.github.com/nishantmonu51/d0c45b4742141d8b7b50
the benchmarks compare 3 modes - concise, roaring and roaring_compress which is roaring compressed with run length encoding. 
The time of interest is the time.bench result, and lower is better. 

1. For random setting of bits, both roaring and roaring_compress is MUCH faster than Concise.
2. For linear adding of bits, starting at 0 and going up, Roaring compressed is the fastest (~18% faster than concise) 
3. For linear adding of bits, starting at the max and going to bit 0, Roaring compressed is fastest (~25% faster than concise)
4. For serialization to byte arrays, roaring compressed is 2.5x SLOWER and roaring is 2.8x SLOWER than concise
5. For deserialization from byte arrays, roaring compressed 6% slower than concise and roaring is 9% faster than concise.

For full integration results, a 1G subsample of the TPC-H data (as was used in druid's prior benchmarks) was used - ( benchmark results here - https://gist.github.com/nishantmonu51/30458c5c4f3f857bfdb4)
1. Index Time - Almost equal (Insufficient data to show which one is better)
    Concise - 20 min 5 sec
    Roaring - 20 min 47 sec
    Roaring Compressed - 20 min 37 sec
2. Index Size (size of smoosh file)- 17% INCREASE in size when using Roaring
    Concise - 494M
    Roaring - 579M
    Roaring compressed - TODO
3. Query Performance - 
    - Simple TopN and Timeseries remains unaffected 
    - TopN with regex filters shows significant improvement (~40%) with roaring as compared to concise
TODO -  compare with roaring compressed.

