### PR TITLE
TaskActionToolbox: Remove allowOlderVersions, lift interval constraint

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/common/actions/SegmentMetadataUpdateAction.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/actions/SegmentMetadataUpdateAction.java
@@ -59,7 +59,7 @@ public class SegmentMetadataUpdateAction implements TaskAction<Void>
       Task task, TaskActionToolbox toolbox
   ) throws IOException
   {
-    toolbox.verifyTaskLocksAndSinglePartitionSettitude(task, segments, true);
+    toolbox.verifyTaskLocks(task, segments);
     toolbox.getIndexerMetadataStorageCoordinator().updateSegmentMetadata(segments);
 
     // Emit metrics

--- a/indexing-service/src/main/java/io/druid/indexing/common/actions/SegmentNukeAction.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/actions/SegmentNukeAction.java
@@ -59,7 +59,7 @@ public class SegmentNukeAction implements TaskAction<Void>
   @Override
   public Void perform(Task task, TaskActionToolbox toolbox) throws IOException
   {
-    toolbox.verifyTaskLocksAndSinglePartitionSettitude(task, segments, true);
+    toolbox.verifyTaskLocks(task, segments);
     toolbox.getIndexerMetadataStorageCoordinator().deleteSegments(segments);
 
     // Emit metrics

--- a/indexing-service/src/main/java/io/druid/indexing/common/actions/TaskActionToolbox.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/actions/TaskActionToolbox.java
@@ -83,24 +83,19 @@ public class TaskActionToolbox
     return true;
   }
 
-  public void verifyTaskLocksAndSinglePartitionSettitude(
+  public void verifyTaskLocks(
       final Task task,
-      final Set<DataSegment> segments,
-      final boolean allowOlderVersions
+      final Set<DataSegment> segments
   )
   {
-    if (!taskLockCoversSegments(task, segments, allowOlderVersions)) {
+    if (!taskLockCoversSegments(task, segments)) {
       throw new ISE("Segments not covered by locks for task: %s", task.getId());
-    }
-    if (!segmentsAreFromSamePartitionSet(segments)) {
-      throw new ISE("Segments are not in the same partition set: %s", segments);
     }
   }
 
   public boolean taskLockCoversSegments(
       final Task task,
-      final Set<DataSegment> segments,
-      final boolean allowOlderVersions
+      final Set<DataSegment> segments
   )
   {
     // Verify that each of these segments falls under some lock
@@ -110,22 +105,18 @@ public class TaskActionToolbox
     // NOTE: insert some segments from the task but not others.
 
     final List<TaskLock> taskLocks = getTaskLockbox().findLocksForTask(task);
-    for(final DataSegment segment : segments) {
+    for (final DataSegment segment : segments) {
       final boolean ok = Iterables.any(
           taskLocks, new Predicate<TaskLock>()
-      {
-        @Override
-        public boolean apply(TaskLock taskLock)
-        {
-          final boolean versionOk = allowOlderVersions
-                                    ? taskLock.getVersion().compareTo(segment.getVersion()) >= 0
-                                    : taskLock.getVersion().equals(segment.getVersion());
-
-          return versionOk
-                 && taskLock.getDataSource().equals(segment.getDataSource())
-                 && taskLock.getInterval().contains(segment.getInterval());
-        }
-      }
+          {
+            @Override
+            public boolean apply(TaskLock taskLock)
+            {
+              return taskLock.getDataSource().equals(segment.getDataSource())
+                     && taskLock.getInterval().contains(segment.getInterval())
+                     && taskLock.getVersion().compareTo(segment.getVersion()) >= 0;
+            }
+          }
       );
 
       if (!ok) {

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/ConvertSegmentTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/ConvertSegmentTask.java
@@ -378,7 +378,7 @@ public class ConvertSegmentTask extends AbstractFixedIntervalTask
       DataSegment updatedSegment = segment.withVersion(String.format("%s_v%s", segment.getVersion(), outVersion));
       updatedSegment = toolbox.getSegmentPusher().push(outLocation, updatedSegment);
 
-      actionClient.submit(new SegmentInsertAction(Sets.newHashSet(updatedSegment)).withAllowOlderVersions(true));
+      actionClient.submit(new SegmentInsertAction(Sets.newHashSet(updatedSegment)));
     } else {
       log.info("Conversion failed.");
     }


### PR DESCRIPTION
allowOlderVersions has been stuck true for a while due to a bug (introduced in
566a3a61), but I think it's actually OK this way. I think it's reasonable to
expect tasks to choose versions in some way that makes sense, so long as they
don't choose one larger than their taskLock version. This is still verified.

The interval constraint was introduced to force tasks to break up their
segment insert lists into manageable chunks. They are already doing this, and
I think it's reasonable to expect them to do so without enforcement.

Lifting these constraints paves the way for transactional insertion of segments
that have varying versions and may be for varying intervals.