### PR TITLE
Migrate TestDerbyConnector to a JUnit @Rule

### DIFF
--- a/server/src/test/java/io/druid/metadata/SQLMetadataConnectorTest.java
+++ b/server/src/test/java/io/druid/metadata/SQLMetadataConnectorTest.java
@@ -19,6 +19,7 @@ package io.druid.metadata;
 import com.google.common.base.Suppliers;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.tweak.HandleCallback;
@@ -28,15 +29,16 @@ import java.util.LinkedList;
 
 public class SQLMetadataConnectorTest
 {
+  @Rule
+  public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule = new TestDerbyConnector.DerbyConnectorRule();
+
   private TestDerbyConnector connector;
-  private MetadataStorageTablesConfig tablesConfig = MetadataStorageTablesConfig.fromBase("test");
+  private MetadataStorageTablesConfig tablesConfig;
 
   @Before
   public void setUp() throws Exception {
-    connector = new TestDerbyConnector(
-        Suppliers.ofInstance(new MetadataStorageConnectorConfig()),
-        Suppliers.ofInstance(tablesConfig)
-    );
+    connector = derbyConnectorRule.getConnector();
+    tablesConfig = derbyConnectorRule.metadataTablesConfigSupplier().get();
   }
 
   @Test

--- a/server/src/test/java/io/druid/metadata/SQLMetadataStorageActionHandlerTest.java
+++ b/server/src/test/java/io/druid/metadata/SQLMetadataStorageActionHandlerTest.java
@@ -20,16 +20,15 @@ package io.druid.metadata;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.metamx.common.Pair;
 import io.druid.jackson.DefaultObjectMapper;
 import org.joda.time.DateTime;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.HashSet;
@@ -37,20 +36,16 @@ import java.util.Map;
 
 public class SQLMetadataStorageActionHandlerTest
 {
+  @Rule
+  public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule = new TestDerbyConnector.DerbyConnectorRule();
+
   private static final ObjectMapper jsonMapper = new DefaultObjectMapper();
-  private TestDerbyConnector connector;
-  private MetadataStorageTablesConfig tablesConfig = MetadataStorageTablesConfig.fromBase("test");
   private SQLMetadataStorageActionHandler<Map<String, Integer>, Map<String, Integer>, Map<String, String>, Map<String, Integer>> handler;
 
   @Before
   public void setUp() throws Exception
   {
-    MetadataStorageConnectorConfig config = new MetadataStorageConnectorConfig();
-
-    connector = new TestDerbyConnector(
-        Suppliers.ofInstance(config),
-        Suppliers.ofInstance(tablesConfig)
-    );
+    TestDerbyConnector connector = derbyConnectorRule.getConnector();
 
     final String entryType = "entry";
     final String entryTable = "entries";
@@ -105,12 +100,6 @@ public class SQLMetadataStorageActionHandlerTest
         logTable,
         lockTable
     );
-  }
-
-  @After
-  public void tearDown()
-  {
-    connector.tearDown();
   }
 
   @Test

--- a/server/src/test/java/io/druid/metadata/TestDerbyConnector.java
+++ b/server/src/test/java/io/druid/metadata/TestDerbyConnector.java
@@ -18,31 +18,112 @@
 package io.druid.metadata;
 
 import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import io.druid.metadata.storage.derby.DerbyConnector;
 import org.junit.Assert;
+import org.junit.rules.ExternalResource;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.exceptions.UnableToObtainConnectionException;
 
 import java.sql.SQLException;
+import java.util.UUID;
 
 public class TestDerbyConnector extends DerbyConnector
 {
+  private final String jdbcUri;
+
   public TestDerbyConnector(
       Supplier<MetadataStorageConnectorConfig> config,
       Supplier<MetadataStorageTablesConfig> dbTables
   )
   {
-    super(config, dbTables, new DBI("jdbc:derby:memory:druidTest;create=true"));
+    this(config, dbTables, "jdbc:derby:memory:druidTest" + dbSafeUUID());
+  }
+
+  protected TestDerbyConnector(
+      Supplier<MetadataStorageConnectorConfig> config,
+      Supplier<MetadataStorageTablesConfig> dbTables,
+      String jdbcUri
+  )
+  {
+    super(config, dbTables, new DBI(jdbcUri + ";create=true"));
+    this.jdbcUri = jdbcUri;
   }
 
   public void tearDown()
   {
     try {
-      new DBI("jdbc:derby:memory:druidTest;drop=true").open().close();
-    } catch(UnableToObtainConnectionException e) {
+      new DBI(jdbcUri + ";drop=true").open().close();
+    }
+    catch (UnableToObtainConnectionException e) {
       SQLException cause = (SQLException) e.getCause();
       // error code "08006" indicates proper shutdown
-      Assert.assertEquals("08006", cause.getSQLState());
+      Assert.assertEquals(String.format("Derby not shutdown: [%s]", cause.toString()), "08006", cause.getSQLState());
+    }
+  }
+
+  private static String dbSafeUUID()
+  {
+    return UUID.randomUUID().toString().replace("-", "");
+  }
+
+  public String getJdbcUri()
+  {
+    return jdbcUri;
+  }
+  
+  public static class DerbyConnectorRule extends ExternalResource
+  {
+    private TestDerbyConnector connector;
+    private final Supplier<MetadataStorageTablesConfig> dbTables;
+    private final MetadataStorageConnectorConfig connectorConfig;
+
+    public DerbyConnectorRule()
+    {
+      this(Suppliers.ofInstance(MetadataStorageTablesConfig.fromBase("druidTest")));
+    }
+
+    public DerbyConnectorRule(
+        Supplier<MetadataStorageTablesConfig> dbTables
+    )
+    {
+      this.dbTables = dbTables;
+      this.connectorConfig = new MetadataStorageConnectorConfig()
+      {
+        @Override
+        public String getConnectURI()
+        {
+          return connector.getJdbcUri();
+        }
+      };
+    }
+
+    @Override
+    protected void before() throws Throwable
+    {
+      connector = new TestDerbyConnector(Suppliers.ofInstance(connectorConfig), dbTables);
+      connector.getDBI().open().close(); // create db
+    }
+
+    @Override
+    protected void after()
+    {
+      connector.tearDown();
+    }
+
+    public TestDerbyConnector getConnector()
+    {
+      return connector;
+    }
+
+    public MetadataStorageConnectorConfig getMetadataConnectorConfig()
+    {
+      return connectorConfig;
+    }
+
+    public Supplier<MetadataStorageTablesConfig> metadataTablesConfigSupplier()
+    {
+      return dbTables;
     }
   }
 }


### PR DESCRIPTION
* Adds UUID to every test's DB name as well as table space (for default behavior)
Hopefully this reduces the irregular test failures.