### PR TITLE
Downgrade Jackson to 2.4.6.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,8 @@
         <jetty.version>9.2.13.v20150730</jetty.version>
         <jersey.version>1.19</jersey.version>
         <druid.api.version>0.3.11</druid.api.version>
-        <jackson.version>2.6.1</jackson.version>
+        <!-- Watch out for Hadoop compatibility when updating to >= 2.5; see https://github.com/druid-io/druid/pull/1669 -->
+        <jackson.version>2.4.6</jackson.version>
         <log4j.version>2.3</log4j.version>
         <slf4j.version>1.7.12</slf4j.version>
         <hadoop.compile.version>2.3.0</hadoop.compile.version>

--- a/processing/src/main/java/io/druid/jackson/JodaStuff.java
+++ b/processing/src/main/java/io/druid/jackson/JodaStuff.java
@@ -48,7 +48,7 @@ class JodaStuff
     module.addSerializer(DateTime.class, ToStringSerializer.instance);
     module.addDeserializer(Interval.class, new JodaStuff.IntervalDeserializer());
     module.addSerializer(Interval.class, ToStringSerializer.instance);
-    JsonDeserializer<?> periodDeserializer = new PeriodDeserializer(true);
+    JsonDeserializer<?> periodDeserializer = new PeriodDeserializer();
     module.addDeserializer(Period.class, (JsonDeserializer<Period>) periodDeserializer);
     module.addSerializer(Period.class, ToStringSerializer.instance);
     module.addDeserializer(Duration.class, new DurationDeserializer());


### PR DESCRIPTION
Addresses hadoop problems with 2.5.x and 2.6.x; see #1669