### PR TITLE
Better timing and locking in NamespaceExtractionCacheManagerExecutorsTest

### DIFF
--- a/extensions/namespace-lookup/src/main/java/io/druid/server/namespace/cache/NamespaceExtractionCacheManager.java
+++ b/extensions/namespace-lookup/src/main/java/io/druid/server/namespace/cache/NamespaceExtractionCacheManager.java
@@ -148,9 +148,9 @@ public abstract class NamespaceExtractionCacheManager
     );
   }
 
-  protected void waitForServiceToEnd(long time, TimeUnit unit) throws InterruptedException
+  protected boolean waitForServiceToEnd(long time, TimeUnit unit) throws InterruptedException
   {
-    listeningScheduledExecutorService.awaitTermination(time, unit);
+    return listeningScheduledExecutorService.awaitTermination(time, unit);
   }
 
 


### PR DESCRIPTION
Was buggy on concurrent delete test. This handles things in better locking manner overall, and less reliant on explicit sleeps.