### PR TITLE
Fix overlapping segments in IngestSegmentFirehose, DatasourceInputFormat

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceInputSplit.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceInputSplit.java
@@ -19,30 +19,28 @@
 
 package io.druid.indexer.hadoop;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.base.Preconditions;
+import io.druid.indexer.HadoopDruidIndexerConfig;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapreduce.InputSplit;
+
+import javax.validation.constraints.NotNull;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.base.Preconditions;
-import io.druid.indexer.HadoopDruidIndexerConfig;
-import io.druid.timeline.DataSegment;
-import org.apache.hadoop.io.Writable;
-import org.apache.hadoop.mapreduce.InputSplit;
-
-import javax.validation.constraints.NotNull;
-
 public class DatasourceInputSplit extends InputSplit implements Writable
 {
-  private List<DataSegment> segments = null;
+  private List<WindowedDataSegment> segments = null;
 
   //required for deserialization
   public DatasourceInputSplit()
   {
   }
 
-  public DatasourceInputSplit(@NotNull List<DataSegment> segments)
+  public DatasourceInputSplit(@NotNull List<WindowedDataSegment> segments)
   {
     Preconditions.checkArgument(segments != null && segments.size() > 0, "no segments");
     this.segments = segments;
@@ -52,8 +50,8 @@ public class DatasourceInputSplit extends InputSplit implements Writable
   public long getLength() throws IOException, InterruptedException
   {
     long size = 0;
-    for (DataSegment segment : segments) {
-      size += segment.getSize();
+    for (WindowedDataSegment segment : segments) {
+      size += segment.getSegment().getSize();
     }
     return size;
   }
@@ -64,7 +62,7 @@ public class DatasourceInputSplit extends InputSplit implements Writable
     return new String[]{};
   }
 
-  public List<DataSegment> getSegments()
+  public List<WindowedDataSegment> getSegments()
   {
     return segments;
   }
@@ -80,7 +78,7 @@ public class DatasourceInputSplit extends InputSplit implements Writable
   {
     segments = HadoopDruidIndexerConfig.jsonMapper.readValue(
         in.readUTF(),
-        new TypeReference<List<DataSegment>>()
+        new TypeReference<List<WindowedDataSegment>>()
         {
         }
     );

--- a/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/WindowedDataSegment.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/WindowedDataSegment.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.indexer.hadoop;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.druid.timeline.DataSegment;
+import org.joda.time.Interval;
+
+import java.util.Objects;
+
+public class WindowedDataSegment
+{
+  private final DataSegment segment;
+  private final Interval interval;
+
+  @JsonCreator
+  public WindowedDataSegment(
+      @JsonProperty("segment") final DataSegment segment,
+      @JsonProperty("interval") final Interval interval
+  )
+  {
+    this.segment = segment;
+    this.interval = interval;
+  }
+
+  @JsonProperty
+  public DataSegment getSegment()
+  {
+    return segment;
+  }
+
+  @JsonProperty
+  public Interval getInterval()
+  {
+    return interval;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    WindowedDataSegment that = (WindowedDataSegment) o;
+    return Objects.equals(segment, that.segment) &&
+           Objects.equals(interval, that.interval);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(segment, interval);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "WindowedDataSegment{" +
+           "segment=" + segment +
+           ", interval=" + interval +
+           '}';
+  }
+
+  public static WindowedDataSegment of(final DataSegment segment)
+  {
+    return new WindowedDataSegment(segment, segment.getInterval());
+  }
+}

--- a/indexing-hadoop/src/main/java/io/druid/indexer/path/DatasourcePathSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/path/DatasourcePathSpec.java
@@ -20,6 +20,7 @@
 package io.druid.indexer.path;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
@@ -31,8 +32,8 @@ import com.metamx.common.logger.Logger;
 import io.druid.indexer.HadoopDruidIndexerConfig;
 import io.druid.indexer.hadoop.DatasourceIngestionSpec;
 import io.druid.indexer.hadoop.DatasourceInputFormat;
+import io.druid.indexer.hadoop.WindowedDataSegment;
 import io.druid.query.aggregation.AggregatorFactory;
-import io.druid.timeline.DataSegment;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.lib.input.MultipleInputs;
@@ -48,11 +49,12 @@ public class DatasourcePathSpec implements PathSpec
   private final ObjectMapper mapper;
   private final DatasourceIngestionSpec ingestionSpec;
   private final long maxSplitSize;
-  private final List<DataSegment> segments;
+  private final List<WindowedDataSegment> segments;
 
+  @JsonCreator
   public DatasourcePathSpec(
       @JacksonInject ObjectMapper mapper,
-      @JsonProperty("segments") List<DataSegment> segments,
+      @JsonProperty("segments") List<WindowedDataSegment> segments,
       @JsonProperty("ingestionSpec") DatasourceIngestionSpec spec,
       @JsonProperty("maxSplitSize") Long maxSplitSize
   )
@@ -61,7 +63,7 @@ public class DatasourcePathSpec implements PathSpec
     this.segments = segments;
     this.ingestionSpec = Preconditions.checkNotNull(spec, "null ingestionSpec");
 
-    if(maxSplitSize == null) {
+    if (maxSplitSize == null) {
       this.maxSplitSize = 0;
     } else {
       this.maxSplitSize = maxSplitSize.longValue();
@@ -69,7 +71,7 @@ public class DatasourcePathSpec implements PathSpec
   }
 
   @JsonProperty
-  public List<DataSegment> getSegments()
+  public List<WindowedDataSegment> getSegments()
   {
     return segments;
   }
@@ -110,12 +112,12 @@ public class DatasourcePathSpec implements PathSpec
             Iterables.concat(
                 Iterables.transform(
                     segments,
-                    new Function<DataSegment, Iterable<String>>()
+                    new Function<WindowedDataSegment, Iterable<String>>()
                     {
                       @Override
-                      public Iterable<String> apply(DataSegment dataSegment)
+                      public Iterable<String> apply(WindowedDataSegment dataSegment)
                       {
-                        return dataSegment.getDimensions();
+                        return dataSegment.getSegment().getDimensions();
                       }
                     }
                 )

--- a/indexing-hadoop/src/main/java/io/druid/indexer/updater/HadoopConverterJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/updater/HadoopConverterJob.java
@@ -33,6 +33,7 @@ import com.metamx.common.ISE;
 import com.metamx.common.logger.Logger;
 import io.druid.indexer.JobHelper;
 import io.druid.indexer.hadoop.DatasourceInputSplit;
+import io.druid.indexer.hadoop.WindowedDataSegment;
 import io.druid.segment.IndexIO;
 import io.druid.segment.IndexMerger;
 import io.druid.timeline.DataSegment;
@@ -476,7 +477,7 @@ public class HadoopConverterJob
       final String tmpDirLoc = context.getConfiguration().get(TMP_FILE_LOC_KEY);
       final File tmpDir = Paths.get(tmpDirLoc).toFile();
 
-      final DataSegment segment  = Iterables.getOnlyElement(((DatasourceInputSplit) split).getSegments());
+      final DataSegment segment  = Iterables.getOnlyElement(((DatasourceInputSplit) split).getSegments()).getSegment();
 
       final HadoopDruidConverterConfig config = converterConfigFromConfiguration(context.getConfiguration());
 
@@ -584,7 +585,7 @@ public class HadoopConverterJob
             @Override
             public InputSplit apply(DataSegment input)
             {
-              return new DatasourceInputSplit(ImmutableList.of(input));
+              return new DatasourceInputSplit(ImmutableList.of(WindowedDataSegment.of(input)));
             }
           }
       );

--- a/indexing-hadoop/src/test/java/io/druid/indexer/hadoop/DatasourceInputFormatTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/hadoop/DatasourceInputFormatTest.java
@@ -40,7 +40,7 @@ import java.util.List;
  */
 public class DatasourceInputFormatTest
 {
-  private List<DataSegment> segments;
+  private List<WindowedDataSegment> segments;
   private Configuration config;
   private JobContext context;
 
@@ -48,47 +48,53 @@ public class DatasourceInputFormatTest
   public void setUp() throws Exception
   {
     segments = ImmutableList.of(
-        new DataSegment(
-            "test1",
-            Interval.parse("2000/3000"),
-            "ver",
-            ImmutableMap.<String, Object>of(
-                "type", "local",
-                "path", "/tmp/index1.zip"
-            ),
-            ImmutableList.of("host"),
-            ImmutableList.of("visited_sum", "unique_hosts"),
-            new NoneShardSpec(),
-            9,
-            2
+        WindowedDataSegment.of(
+            new DataSegment(
+                "test1",
+                Interval.parse("2000/3000"),
+                "ver",
+                ImmutableMap.<String, Object>of(
+                    "type", "local",
+                    "path", "/tmp/index1.zip"
+                ),
+                ImmutableList.of("host"),
+                ImmutableList.of("visited_sum", "unique_hosts"),
+                new NoneShardSpec(),
+                9,
+                2
+            )
         ),
-        new DataSegment(
-            "test2",
-            Interval.parse("2050/3000"),
-            "ver",
-            ImmutableMap.<String, Object>of(
-                "type", "hdfs",
-                "path", "/tmp/index2.zip"
-            ),
-            ImmutableList.of("host"),
-            ImmutableList.of("visited_sum", "unique_hosts"),
-            new NoneShardSpec(),
-            9,
-            11
+        WindowedDataSegment.of(
+            new DataSegment(
+                "test2",
+                Interval.parse("2050/3000"),
+                "ver",
+                ImmutableMap.<String, Object>of(
+                    "type", "hdfs",
+                    "path", "/tmp/index2.zip"
+                ),
+                ImmutableList.of("host"),
+                ImmutableList.of("visited_sum", "unique_hosts"),
+                new NoneShardSpec(),
+                9,
+                11
+            )
         ),
-        new DataSegment(
-            "test3",
-            Interval.parse("2030/3000"),
-            "ver",
-            ImmutableMap.<String, Object>of(
-                "type", "hdfs",
-                "path", "/tmp/index3.zip"
-            ),
-            ImmutableList.of("host"),
-            ImmutableList.of("visited_sum", "unique_hosts"),
-            new NoneShardSpec(),
-            9,
-            4
+        WindowedDataSegment.of(
+            new DataSegment(
+                "test3",
+                Interval.parse("2030/3000"),
+                "ver",
+                ImmutableMap.<String, Object>of(
+                    "type", "hdfs",
+                    "path", "/tmp/index3.zip"
+                ),
+                ImmutableList.of("host"),
+                ImmutableList.of("visited_sum", "unique_hosts"),
+                new NoneShardSpec(),
+                9,
+                4
+            )
         )
     );
 

--- a/indexing-hadoop/src/test/java/io/druid/indexer/hadoop/DatasourceInputSplitTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/hadoop/DatasourceInputSplitTest.java
@@ -39,21 +39,25 @@ public class DatasourceInputSplitTest
   @Test
   public void testSerde() throws Exception
   {
+    Interval interval = Interval.parse("2000/3000");
     DatasourceInputSplit expected = new DatasourceInputSplit(
         Lists.newArrayList(
-            new DataSegment(
-                "test",
-                Interval.parse("2000/3000"),
-                "ver",
-                ImmutableMap.<String, Object>of(
-                    "type", "local",
-                    "path", "/tmp/index.zip"
+            new WindowedDataSegment(
+                new DataSegment(
+                    "test",
+                    Interval.parse("2000/3000"),
+                    "ver",
+                    ImmutableMap.<String, Object>of(
+                        "type", "local",
+                        "path", "/tmp/index.zip"
+                    ),
+                    ImmutableList.of("host"),
+                    ImmutableList.of("visited_sum", "unique_hosts"),
+                    new NoneShardSpec(),
+                    9,
+                    12334
                 ),
-                ImmutableList.of("host"),
-                ImmutableList.of("visited_sum", "unique_hosts"),
-                new NoneShardSpec(),
-                9,
-                12334
+                interval
             )
         )
     );

--- a/indexing-hadoop/src/test/java/io/druid/indexer/hadoop/DatasourceRecordReaderTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/hadoop/DatasourceRecordReaderTest.java
@@ -55,7 +55,7 @@ public class DatasourceRecordReaderTest
                 this.getClass().getClassLoader().getResource("test-segment/index.zip").getPath()
             )
         );
-    InputSplit split = new DatasourceInputSplit(Lists.newArrayList(segment));
+    InputSplit split = new DatasourceInputSplit(Lists.newArrayList(WindowedDataSegment.of(segment)));
 
     Configuration config = new Configuration();
     config.set(

--- a/indexing-hadoop/src/test/java/io/druid/indexer/hadoop/WindowedDataSegmentTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/hadoop/WindowedDataSegmentTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.indexer.hadoop;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.druid.jackson.DefaultObjectMapper;
+import io.druid.timeline.DataSegment;
+import io.druid.timeline.partition.NoneShardSpec;
+import org.joda.time.Interval;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class WindowedDataSegmentTest
+{
+  private static final ObjectMapper MAPPER = new DefaultObjectMapper();
+  private static final DataSegment SEGMENT = new DataSegment(
+      "test1",
+      Interval.parse("2000/3000"),
+      "ver",
+      ImmutableMap.<String, Object>of(
+          "type", "local",
+          "path", "/tmp/index1.zip"
+      ),
+      ImmutableList.of("host"),
+      ImmutableList.of("visited_sum", "unique_hosts"),
+      new NoneShardSpec(),
+      9,
+      2
+  );
+
+  @Test
+  public void testSerdeFullWindow() throws IOException
+  {
+    final WindowedDataSegment windowedDataSegment = WindowedDataSegment.of(SEGMENT);
+    final WindowedDataSegment roundTrip = MAPPER.readValue(
+        MAPPER.writeValueAsBytes(windowedDataSegment),
+        WindowedDataSegment.class
+    );
+    Assert.assertEquals(windowedDataSegment, roundTrip);
+    Assert.assertEquals(SEGMENT, roundTrip.getSegment());
+    Assert.assertEquals(SEGMENT.getInterval(), roundTrip.getInterval());
+  }
+
+  @Test
+  public void testSerdePartialWindow() throws IOException
+  {
+    final Interval partialInterval = new Interval("2500/3000");
+    final WindowedDataSegment windowedDataSegment = new WindowedDataSegment(SEGMENT, partialInterval);
+    final WindowedDataSegment roundTrip = MAPPER.readValue(
+        MAPPER.writeValueAsBytes(windowedDataSegment),
+        WindowedDataSegment.class
+    );
+    Assert.assertEquals(windowedDataSegment, roundTrip);
+    Assert.assertEquals(SEGMENT, roundTrip.getSegment());
+    Assert.assertEquals(partialInterval, roundTrip.getInterval());
+  }
+}

--- a/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
@@ -179,37 +179,7 @@ public class IngestSegmentFirehoseFactoryTest
         ts,
         new TaskActionToolbox(tl, mdc, newMockEmitter())
     );
-
-    final ObjectMapper objectMapper = new DefaultObjectMapper();
-    objectMapper.registerModule(
-        new SimpleModule("testModule").registerSubtypes(LocalLoadSpec.class)
-    );
-
-    final GuiceAnnotationIntrospector guiceIntrospector = new GuiceAnnotationIntrospector();
-    objectMapper.setAnnotationIntrospectors(
-        new AnnotationIntrospectorPair(
-            guiceIntrospector, objectMapper.getSerializationConfig().getAnnotationIntrospector()
-        ),
-        new AnnotationIntrospectorPair(
-            guiceIntrospector, objectMapper.getDeserializationConfig().getAnnotationIntrospector()
-        )
-    );
-    objectMapper.setInjectableValues(
-        new GuiceInjectableValues(
-            GuiceInjectors.makeStartupInjectorWithModules(
-                ImmutableList.of(
-                    new Module()
-                    {
-                      @Override
-                      public void configure(Binder binder)
-                      {
-                        binder.bind(LocalDataSegmentPuller.class);
-                      }
-                    }
-                )
-            )
-        )
-    );
+    final ObjectMapper objectMapper = newObjectMapper();
     final TaskToolboxFactory taskToolboxFactory = new TaskToolboxFactory(
         new TaskConfig(tmpDir.getAbsolutePath(), null, null, 50000, null),
         tac,
@@ -330,6 +300,41 @@ public class IngestSegmentFirehoseFactoryTest
       }
     }
     return values;
+  }
+
+  public static ObjectMapper newObjectMapper()
+  {
+    final ObjectMapper objectMapper = new DefaultObjectMapper();
+    objectMapper.registerModule(
+        new SimpleModule("testModule").registerSubtypes(LocalLoadSpec.class)
+    );
+
+    final GuiceAnnotationIntrospector guiceIntrospector = new GuiceAnnotationIntrospector();
+    objectMapper.setAnnotationIntrospectors(
+        new AnnotationIntrospectorPair(
+            guiceIntrospector, objectMapper.getSerializationConfig().getAnnotationIntrospector()
+        ),
+        new AnnotationIntrospectorPair(
+            guiceIntrospector, objectMapper.getDeserializationConfig().getAnnotationIntrospector()
+        )
+    );
+    objectMapper.setInjectableValues(
+        new GuiceInjectableValues(
+            GuiceInjectors.makeStartupInjectorWithModules(
+                ImmutableList.of(
+                    new Module()
+                    {
+                      @Override
+                      public void configure(Binder binder)
+                      {
+                        binder.bind(LocalDataSegmentPuller.class);
+                      }
+                    }
+                )
+            )
+        )
+    );
+    return objectMapper;
   }
 
   public IngestSegmentFirehoseFactoryTest(

--- a/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTimelineTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTimelineTest.java
@@ -1,0 +1,423 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.indexing.firehose;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.client.repackaged.com.google.common.base.Throwables;
+import com.google.api.client.util.Sets;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.io.Files;
+import com.google.inject.Binder;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import io.druid.common.utils.JodaUtils;
+import io.druid.data.input.Firehose;
+import io.druid.data.input.InputRow;
+import io.druid.data.input.MapBasedInputRow;
+import io.druid.data.input.impl.DimensionsSpec;
+import io.druid.data.input.impl.InputRowParser;
+import io.druid.data.input.impl.JSONParseSpec;
+import io.druid.data.input.impl.MapInputRowParser;
+import io.druid.data.input.impl.TimestampSpec;
+import io.druid.granularity.QueryGranularity;
+import io.druid.indexing.common.SegmentLoaderFactory;
+import io.druid.indexing.common.TaskToolboxFactory;
+import io.druid.indexing.common.actions.SegmentListUsedAction;
+import io.druid.indexing.common.actions.TaskAction;
+import io.druid.indexing.common.actions.TaskActionClient;
+import io.druid.indexing.common.actions.TaskActionClientFactory;
+import io.druid.indexing.common.config.TaskConfig;
+import io.druid.indexing.common.task.Task;
+import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.query.aggregation.LongSumAggregatorFactory;
+import io.druid.query.filter.NoopDimFilter;
+import io.druid.segment.IndexMerger;
+import io.druid.segment.IndexSpec;
+import io.druid.segment.incremental.IncrementalIndexSchema;
+import io.druid.segment.incremental.IndexSizeExceededException;
+import io.druid.segment.incremental.OnheapIncrementalIndex;
+import io.druid.segment.loading.SegmentLoaderConfig;
+import io.druid.segment.loading.SegmentLoaderLocalCacheManager;
+import io.druid.segment.loading.StorageLocationConfig;
+import io.druid.server.metrics.NoopServiceEmitter;
+import io.druid.timeline.DataSegment;
+import io.druid.timeline.partition.LinearShardSpec;
+import org.apache.commons.io.FileUtils;
+import org.joda.time.DateTime;
+import org.joda.time.Interval;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+@RunWith(Parameterized.class)
+public class IngestSegmentFirehoseFactoryTimelineTest
+{
+  private static final String DATA_SOURCE = "foo";
+  private static final String TIME_COLUMN = "t";
+  private static final String[] DIMENSIONS = new String[]{"d1"};
+  private static final String[] METRICS = new String[]{"m1"};
+  private static final InputRowParser<Map<String, Object>> ROW_PARSER = new MapInputRowParser(
+      new JSONParseSpec(
+          new TimestampSpec(TIME_COLUMN, "auto", null),
+          new DimensionsSpec(
+              Arrays.asList(DIMENSIONS),
+              null,
+              null
+          )
+      )
+  );
+
+  private final IngestSegmentFirehoseFactory factory;
+  private final File tmpDir;
+  private final int expectedCount;
+  private final long expectedSum;
+
+  public IngestSegmentFirehoseFactoryTimelineTest(
+      String name,
+      IngestSegmentFirehoseFactory factory,
+      File tmpDir,
+      int expectedCount,
+      long expectedSum
+  )
+  {
+    this.factory = factory;
+    this.tmpDir = tmpDir;
+    this.expectedCount = expectedCount;
+    this.expectedSum = expectedSum;
+  }
+
+  @Test
+  public void testSimple() throws Exception
+  {
+    int count = 0;
+    long sum = 0;
+
+    try (final Firehose firehose = factory.connect(ROW_PARSER)) {
+      while (firehose.hasMore()) {
+        final InputRow row = firehose.nextRow();
+        count++;
+        sum += row.getLongMetric(METRICS[0]);
+      }
+    }
+
+    Assert.assertEquals("count", expectedCount, count);
+    Assert.assertEquals("sum", expectedSum, sum);
+  }
+
+  @After
+  public void tearDown() throws Exception
+  {
+    FileUtils.deleteDirectory(tmpDir);
+  }
+
+  private static TestCase TC(
+      String intervalString,
+      int expectedCount,
+      long expectedSum,
+      DataSegmentMaker... segmentMakers
+  )
+  {
+    final File tmpDir = Files.createTempDir();
+    final Set<DataSegment> segments = Sets.newHashSet();
+    for (DataSegmentMaker segmentMaker : segmentMakers) {
+      segments.add(segmentMaker.make(tmpDir));
+    }
+
+    return new TestCase(
+        tmpDir,
+        new Interval(intervalString),
+        expectedCount,
+        expectedSum,
+        segments
+    );
+  }
+
+  private static DataSegmentMaker DS(
+      String intervalString,
+      String version,
+      int partitionNum,
+      InputRow... rows
+  )
+  {
+    return new DataSegmentMaker(new Interval(intervalString), version, partitionNum, Arrays.asList(rows));
+  }
+
+  private static InputRow IR(String timeString, long metricValue)
+  {
+    return new MapBasedInputRow(
+        new DateTime(timeString).getMillis(),
+        Arrays.asList(DIMENSIONS),
+        ImmutableMap.<String, Object>of(
+            TIME_COLUMN, new DateTime(timeString).toString(),
+            DIMENSIONS[0], "bar",
+            METRICS[0], metricValue
+        )
+    );
+  }
+
+  private static Map<String, Object> persist(File tmpDir, InputRow... rows)
+  {
+    final File persistDir = new File(tmpDir, UUID.randomUUID().toString());
+    final IncrementalIndexSchema schema = new IncrementalIndexSchema.Builder()
+        .withQueryGranularity(QueryGranularity.NONE)
+        .withMinTimestamp(JodaUtils.MIN_INSTANT)
+        .withDimensionsSpec(ROW_PARSER)
+        .withMetrics(
+            new AggregatorFactory[]{
+                new LongSumAggregatorFactory(METRICS[0], METRICS[0])
+            }
+        )
+        .build();
+    final OnheapIncrementalIndex index = new OnheapIncrementalIndex(schema, rows.length);
+
+    for (InputRow row : rows) {
+      try {
+        index.add(row);
+      }
+      catch (IndexSizeExceededException e) {
+        throw Throwables.propagate(e);
+      }
+    }
+
+    try {
+      IndexMerger.persist(index, persistDir, null, new IndexSpec());
+    }
+    catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+
+    return ImmutableMap.<String, Object>of(
+        "type", "local",
+        "path", persistDir.getAbsolutePath()
+    );
+  }
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> constructorFeeder()
+  {
+    final List<TestCase> testCases = ImmutableList.of(
+        TC(
+            "2000/2000T02", 3, 7,
+            DS("2000/2000T01", "v1", 0, IR("2000", 1), IR("2000T00:01", 2)),
+            DS("2000T01/2000T02", "v1", 0, IR("2000T01", 4))
+        ) /* Adjacent segments */,
+        TC(
+            "2000/2000T02", 3, 7,
+            DS("2000/2000T02", "v1", 0, IR("2000", 1), IR("2000T00:01", 2), IR("2000T01", 8)),
+            DS("2000T01/2000T02", "v2", 0, IR("2000T01:01", 4))
+        ) /* 1H segment overlayed on top of 2H segment */,
+        TC(
+            "2000/2000T02", 4, 15,
+            DS("2000/2000T02", "v1", 0, IR("2000", 1), IR("2000T00:01", 2), IR("2000T01", 8)),
+            DS("2000/2000T02", "v1", 1, IR("2000T01:01", 4))
+        ) /* Segment set with two segments for the same interval */,
+        TC(
+            "2000T01/2000T02", 1, 2,
+            DS("2000/2000T03", "v1", 0, IR("2000", 1), IR("2000T01", 2), IR("2000T02", 4))
+        ) /* Segment wider than desired interval */,
+        TC(
+            "2000T02/2000T04", 2, 12,
+            DS("2000/2000T03", "v1", 0, IR("2000", 1), IR("2000T01", 2), IR("2000T02", 4)),
+            DS("2000T03/2000T04", "v1", 0, IR("2000T03", 8))
+        ) /* Segment intersecting desired interval */
+    );
+
+    final List<Object[]> constructors = Lists.newArrayList();
+
+    for (final TestCase testCase : testCases) {
+      final ObjectMapper objectMapper = IngestSegmentFirehoseFactoryTest.newObjectMapper();
+      final TaskActionClient taskActionClient = new TaskActionClient()
+      {
+        @Override
+        public <RetType> RetType submit(TaskAction<RetType> taskAction) throws IOException
+        {
+          if (taskAction instanceof SegmentListUsedAction) {
+            // Expect the interval we asked for
+            final SegmentListUsedAction action = (SegmentListUsedAction) taskAction;
+            if (action.getInterval().equals(testCase.interval)) {
+              return (RetType) ImmutableList.copyOf(testCase.segments);
+            } else {
+              throw new IllegalArgumentException("WTF");
+            }
+          } else {
+            throw new UnsupportedOperationException();
+          }
+        }
+      };
+      final TaskToolboxFactory taskToolboxFactory = new TaskToolboxFactory(
+          new TaskConfig(testCase.tmpDir.getAbsolutePath(), null, null, 50000, null),
+          new TaskActionClientFactory()
+          {
+            @Override
+            public TaskActionClient create(Task task)
+            {
+              return taskActionClient;
+            }
+          },
+          new NoopServiceEmitter(),
+          null, // segment pusher
+          null, // segment killer
+          null, // segment mover
+          null, // segment archiver
+          null, // segment announcer
+          null, // new segment server view
+          null, // query runner factory conglomerate corporation unionized collective
+          null, // query executor service
+          null, // monitor scheduler
+          new SegmentLoaderFactory(
+              new SegmentLoaderLocalCacheManager(
+                  null,
+                  new SegmentLoaderConfig()
+                  {
+                    @Override
+                    public List<StorageLocationConfig> getLocations()
+                    {
+                      return Lists.newArrayList();
+                    }
+                  }, objectMapper
+              )
+          ),
+          objectMapper
+      );
+      final Injector injector = Guice.createInjector(
+          new Module()
+          {
+            @Override
+            public void configure(Binder binder)
+            {
+              binder.bind(TaskToolboxFactory.class).toInstance(taskToolboxFactory);
+            }
+          }
+      );
+      final IngestSegmentFirehoseFactory factory = new IngestSegmentFirehoseFactory(
+          DATA_SOURCE,
+          testCase.interval,
+          new NoopDimFilter(),
+          Arrays.asList(DIMENSIONS),
+          Arrays.asList(METRICS),
+          injector
+      );
+
+      constructors.add(
+          new Object[]{
+              testCase.toString(),
+              factory,
+              testCase.tmpDir,
+              testCase.expectedCount,
+              testCase.expectedSum
+          }
+      );
+    }
+
+    return constructors;
+  }
+
+  private static class TestCase
+  {
+    final File tmpDir;
+    final Interval interval;
+    final int expectedCount;
+    final long expectedSum;
+    final Set<DataSegment> segments;
+
+    public TestCase(
+        File tmpDir,
+        Interval interval,
+        int expectedCount,
+        long expectedSum,
+        Set<DataSegment> segments
+    )
+    {
+      this.tmpDir = tmpDir;
+      this.interval = interval;
+      this.expectedCount = expectedCount;
+      this.expectedSum = expectedSum;
+      this.segments = segments;
+    }
+
+    @Override
+    public String toString()
+    {
+      final List<String> segmentIdentifiers = Lists.newArrayList();
+      for (DataSegment segment : segments) {
+        segmentIdentifiers.add(segment.getIdentifier());
+      }
+      return "TestCase{" +
+             "interval=" + interval +
+             ", expectedCount=" + expectedCount +
+             ", expectedSum=" + expectedSum +
+             ", segments=" + segmentIdentifiers +
+             '}';
+    }
+  }
+
+  private static class DataSegmentMaker
+  {
+    final Interval interval;
+    final String version;
+    final int partitionNum;
+    final List<InputRow> rows;
+
+    public DataSegmentMaker(
+        Interval interval,
+        String version,
+        int partitionNum,
+        List<InputRow> rows
+    )
+    {
+      this.interval = interval;
+      this.version = version;
+      this.partitionNum = partitionNum;
+      this.rows = rows;
+    }
+
+    public DataSegment make(File tmpDir)
+    {
+      final Map<String, Object> loadSpec = persist(tmpDir, Iterables.toArray(rows, InputRow.class));
+
+      return new DataSegment(
+          DATA_SOURCE,
+          interval,
+          version,
+          loadSpec,
+          Arrays.asList(DIMENSIONS),
+          Arrays.asList(METRICS),
+          new LinearShardSpec(partitionNum),
+          -1,
+          0L
+      );
+    }
+  }
+}

--- a/server/src/main/java/io/druid/segment/realtime/firehose/WindowedStorageAdapter.java
+++ b/server/src/main/java/io/druid/segment/realtime/firehose/WindowedStorageAdapter.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.realtime.firehose;
+
+import io.druid.segment.StorageAdapter;
+import org.joda.time.Interval;
+
+public class WindowedStorageAdapter
+{
+  private final StorageAdapter adapter;
+  private final Interval interval;
+
+  public WindowedStorageAdapter(StorageAdapter adapter, Interval interval)
+  {
+    this.adapter = adapter;
+    this.interval = interval;
+  }
+
+  public StorageAdapter getAdapter()
+  {
+    return adapter;
+  }
+
+  public Interval getInterval()
+  {
+    return interval;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "WindowedStorageAdapter{" +
+           "adapter=" + adapter +
+           ", interval=" + interval +
+           '}';
+  }
+}


### PR DESCRIPTION
Fixes #1678. IngestSegmentFirehose (and its users) need to remember which
windows of which segments should actually be read, based on a timeline.