### PR TITLE
Close output streams and channels loudly when creating segments.

### DIFF
--- a/processing/src/main/java/io/druid/segment/MetricHolder.java
+++ b/processing/src/main/java/io/druid/segment/MetricHolder.java
@@ -22,7 +22,6 @@ import com.google.common.io.InputSupplier;
 import com.google.common.io.OutputSupplier;
 import com.metamx.common.IAE;
 import com.metamx.common.ISE;
-import com.metamx.common.guava.CloseQuietly;
 import io.druid.common.utils.SerializerUtils;
 import io.druid.segment.data.CompressedFloatsIndexedSupplier;
 import io.druid.segment.data.CompressedFloatsSupplierSerializer;
@@ -69,24 +68,15 @@ public class MetricHolder
       OutputSupplier<? extends OutputStream> outSupplier, String name, String typeName, GenericIndexedWriter column
   ) throws IOException
   {
-    OutputStream out = null;
-    InputStream in = null;
-
-    try {
-      out = outSupplier.getOutput();
-
+    try (OutputStream out = outSupplier.getOutput()) {
       out.write(version);
       serializerUtils.writeString(out, name);
       serializerUtils.writeString(out, typeName);
 
       final InputSupplier<InputStream> supplier = column.combineStreams();
-      in = supplier.getInput();
-
-      ByteStreams.copy(in, out);
-    }
-    finally {
-      CloseQuietly.close(out);
-      CloseQuietly.close(in);
+      try (InputStream in = supplier.getInput()) {
+        ByteStreams.copy(in, out);
+      }
     }
   }
 


### PR DESCRIPTION
CloseQuietly can suppress errors when closing streams that indicate the file
was not actually written properly.