### PR TITLE
Make the ServiceEmitter take a Provider instead of a Supplier of DruidNode

### DIFF
--- a/server/src/main/java/io/druid/server/initialization/EmitterModule.java
+++ b/server/src/main/java/io/druid/server/initialization/EmitterModule.java
@@ -17,7 +17,6 @@
 
 package io.druid.server.initialization;
 
-import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;
 import com.google.inject.Binder;
 import com.google.inject.Binding;
@@ -74,7 +73,7 @@ public class EmitterModule implements Module
 
   @Provides
   @ManageLifecycle
-  public ServiceEmitter getServiceEmitter(@Self Supplier<DruidNode> configSupplier, Emitter emitter)
+  public ServiceEmitter getServiceEmitter(@Self Provider<DruidNode> configSupplier, Emitter emitter)
   {
     final DruidNode config = configSupplier.get();
     final ServiceEmitter retVal = new ServiceEmitter(config.getServiceName(), config.getHostAndPort(), emitter);


### PR DESCRIPTION
Ran into this one while writing some untit tests.

The following code fails without this change:

```java
  @Test
  public void testBasicInjection() throws Exception
  {
    Injector injector = Initialization.makeInjectorWithModules(
        GuiceInjectors.makeStartupInjector(), ImmutableList.of(
            new Module()
            {
              @Override
              public void configure(Binder binder)
              {
                binder.bind(Key.get(DruidNode.class, Self.class)).toInstance(new DruidNode("testService", "localhost", -1));
                binder.bind(Cache.class).toProvider(MemcachedCacheProvider.class);
              }
            }
        )
    );
    Cache cache = injector.getInstance(Cache.class);
    Assert.assertEquals(MemcachedCache.class,cache.getClass());
  }
```