### PR TITLE
Allow writing InputRowParser extensions that use hadoop/any libraries

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerConfig.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerConfig.java
@@ -103,7 +103,8 @@ public class HadoopDruidIndexerConfig
                     binder, Key.get(DruidNode.class, Self.class), new DruidNode("hadoop-indexer", null, null)
                 );
               }
-            }
+            },
+            new IndexingHadoopModule()
         )
     );
     jsonMapper = injector.getInstance(ObjectMapper.class);

--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerMapper.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerMapper.java
@@ -104,11 +104,9 @@ public abstract class HadoopDruidIndexerMapper<KEYOUT, VALUEOUT> extends Mapper<
   {
     if (parser instanceof StringInputRowParser && value instanceof Text) {
       //Note: This is to ensure backward compatibility with 0.7.0 and before
+      //HadoopyStringInputRowParser can handle this and this special case is not needed
+      //except for backward compatibility
       return ((StringInputRowParser) parser).parse(value.toString());
-    } else if (parser instanceof StringInputRowParser && value instanceof BytesWritable) {
-      BytesWritable valueBytes = (BytesWritable) value;
-      ByteBuffer valueBuffer = ByteBuffer.wrap(valueBytes.getBytes(), 0, valueBytes.getLength());
-      return ((StringInputRowParser) parser).parse(valueBuffer);
     } else if (value instanceof InputRow) {
       return (InputRow) value;
     } else {

--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopyStringInputRowParser.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopyStringInputRowParser.java
@@ -1,0 +1,69 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.indexer;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.metamx.common.IAE;
+import io.druid.data.input.InputRow;
+import io.druid.data.input.impl.InputRowParser;
+import io.druid.data.input.impl.ParseSpec;
+import io.druid.data.input.impl.StringInputRowParser;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.Text;
+
+import java.nio.ByteBuffer;
+
+/**
+ */
+public class HadoopyStringInputRowParser implements InputRowParser<Object>
+{
+  private final StringInputRowParser parser;
+
+  public HadoopyStringInputRowParser(@JsonProperty("parseSpec") ParseSpec parseSpec)
+  {
+    this.parser = new StringInputRowParser(parseSpec);
+  }
+
+  @Override
+  public InputRow parse(Object input)
+  {
+    if (input instanceof Text) {
+      return parser.parse(((Text) input).toString());
+    } else if (input instanceof BytesWritable) {
+      BytesWritable valueBytes = (BytesWritable) input;
+      return parser.parse(ByteBuffer.wrap(valueBytes.getBytes(), 0, valueBytes.getLength()));
+    } else {
+      throw new IAE("can't convert type [%s] to InputRow", input.getClass().getName());
+    }
+  }
+
+  @JsonProperty
+  @Override
+  public ParseSpec getParseSpec()
+  {
+    return parser.getParseSpec();
+  }
+
+  @Override
+  public InputRowParser withParseSpec(ParseSpec parseSpec)
+  {
+    return new HadoopyStringInputRowParser(parseSpec);
+  }
+}

--- a/indexing-hadoop/src/main/java/io/druid/indexer/IndexingHadoopModule.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/IndexingHadoopModule.java
@@ -1,0 +1,50 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.indexer;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.inject.Binder;
+import io.druid.initialization.DruidModule;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ */
+public class IndexingHadoopModule implements DruidModule
+{
+  @Override
+  public List<? extends Module> getJacksonModules()
+  {
+    return Arrays.<Module>asList(
+        new SimpleModule("IndexingHadoopModule")
+            .registerSubtypes(
+                new NamedType(HadoopyStringInputRowParser.class, "hadoopyString")
+            )
+    );
+  }
+
+  @Override
+  public void configure(Binder binder)
+  {
+  }
+}

--- a/indexing-hadoop/src/test/java/io/druid/indexer/BatchDeltaIngestionTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/BatchDeltaIngestionTest.java
@@ -340,13 +340,16 @@ public class BatchDeltaIngestionTest
         new HadoopIngestionSpec(
             new DataSchema(
                 "website",
-                new StringInputRowParser(
-                    new CSVParseSpec(
-                        new TimestampSpec("timestamp", "yyyyMMddHH", null),
-                        new DimensionsSpec(ImmutableList.of("host"), null, null),
-                        null,
-                        ImmutableList.of("timestamp", "host", "host2", "visited_num")
-                    )
+                MAPPER.convertValue(
+                    new StringInputRowParser(
+                        new CSVParseSpec(
+                            new TimestampSpec("timestamp", "yyyyMMddHH", null),
+                            new DimensionsSpec(ImmutableList.of("host"), null, null),
+                            null,
+                            ImmutableList.of("timestamp", "host", "host2", "visited_num")
+                        )
+                    ),
+                    Map.class
                 ),
                 new AggregatorFactory[]{
                     new LongSumAggregatorFactory("visited_sum", "visited_num"),
@@ -354,7 +357,8 @@ public class BatchDeltaIngestionTest
                 },
                 new UniformGranularitySpec(
                     Granularity.DAY, QueryGranularity.NONE, ImmutableList.of(INTERVAL_FULL)
-                )
+                ),
+                MAPPER
             ),
             new HadoopIOConfig(
                 inputSpec,

--- a/indexing-hadoop/src/test/java/io/druid/indexer/DetermineHashedPartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/DetermineHashedPartitionsJobTest.java
@@ -108,26 +108,36 @@ public class DetermineHashedPartitionsJobTest
     HadoopIngestionSpec ingestionSpec = new HadoopIngestionSpec(
         new DataSchema(
             "test_schema",
-            new StringInputRowParser(
-                new DelimitedParseSpec(
-                    new TimestampSpec("ts", null, null),
-                    new DimensionsSpec(ImmutableList.of("market", "quality", "placement", "placementish"), null, null),
-                    "\t",
-                    null,
-                    Arrays.asList("ts",
-                                  "market",
-                                  "quality",
-                                  "placement",
-                                  "placementish",
-                                  "index")
-                )
+            HadoopDruidIndexerConfig.jsonMapper.convertValue(
+                new StringInputRowParser(
+                    new DelimitedParseSpec(
+                        new TimestampSpec("ts", null, null),
+                        new DimensionsSpec(
+                            ImmutableList.of("market", "quality", "placement", "placementish"),
+                            null,
+                            null
+                        ),
+                        "\t",
+                        null,
+                        Arrays.asList(
+                            "ts",
+                            "market",
+                            "quality",
+                            "placement",
+                            "placementish",
+                            "index"
+                        )
+                    )
+                ),
+                Map.class
             ),
             new AggregatorFactory[]{new DoubleSumAggregatorFactory("index", "index")},
             new UniformGranularitySpec(
                 Granularity.DAY,
                 QueryGranularity.NONE,
                 ImmutableList.of(new Interval(interval))
-            )
+            ),
+            HadoopDruidIndexerConfig.jsonMapper
         ),
         new HadoopIOConfig(
             ImmutableMap.<String, Object>of(

--- a/indexing-hadoop/src/test/java/io/druid/indexer/DeterminePartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/DeterminePartitionsJobTest.java
@@ -223,18 +223,22 @@ public class DeterminePartitionsJobTest
         new HadoopIngestionSpec(
             new DataSchema(
                 "website",
-                new StringInputRowParser(
-                    new CSVParseSpec(
-                        new TimestampSpec("timestamp", "yyyyMMddHH", null),
-                        new DimensionsSpec(ImmutableList.of("host", "country"), null, null),
-                        null,
-                        ImmutableList.of("timestamp", "host", "country", "visited_num")
-                    )
+                HadoopDruidIndexerConfig.jsonMapper.convertValue(
+                    new StringInputRowParser(
+                        new CSVParseSpec(
+                            new TimestampSpec("timestamp", "yyyyMMddHH", null),
+                            new DimensionsSpec(ImmutableList.of("host", "country"), null, null),
+                            null,
+                            ImmutableList.of("timestamp", "host", "country", "visited_num")
+                        )
+                    ),
+                    Map.class
                 ),
                 new AggregatorFactory[]{new LongSumAggregatorFactory("visited_num", "visited_num")},
                 new UniformGranularitySpec(
                     Granularity.DAY, QueryGranularity.NONE, ImmutableList.of(new Interval(interval))
-                )
+                ),
+                HadoopDruidIndexerConfig.jsonMapper
             ),
             new HadoopIOConfig(
                 ImmutableMap.<String, Object>of(

--- a/indexing-hadoop/src/test/java/io/druid/indexer/HadoopDruidIndexerConfigTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/HadoopDruidIndexerConfigTest.java
@@ -17,6 +17,7 @@
 
 package io.druid.indexer;
 
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
@@ -45,7 +46,11 @@ import java.util.List;
  */
 public class HadoopDruidIndexerConfigTest
 {
-  private static final ObjectMapper jsonMapper = new DefaultObjectMapper();
+  private static final ObjectMapper jsonMapper;
+  static {
+    jsonMapper = new DefaultObjectMapper();
+    jsonMapper.setInjectableValues(new InjectableValues.Std().addValue(ObjectMapper.class, jsonMapper));
+  }
 
   public static <T> T jsonReadWriteRead(String s, Class<T> klass)
   {
@@ -175,12 +180,17 @@ public class HadoopDruidIndexerConfigTest
 
     HadoopIngestionSpec spec = new HadoopIngestionSpec(
         new DataSchema(
-            "foo", null, new AggregatorFactory[0], new UniformGranularitySpec(
-            Granularity.MINUTE,
-            QueryGranularity.MINUTE,
-            ImmutableList.of(new Interval("2010-01-01/P1D"))
-        )
-        ), new HadoopIOConfig(ImmutableMap.<String, Object>of("paths", "bar", "type", "static"), null, null),
+            "foo",
+            null,
+            new AggregatorFactory[0],
+            new UniformGranularitySpec(
+                Granularity.MINUTE,
+                QueryGranularity.MINUTE,
+                ImmutableList.of(new Interval("2010-01-01/P1D"))
+            ),
+            jsonMapper
+        ),
+        new HadoopIOConfig(ImmutableMap.<String, Object>of("paths", "bar", "type", "static"), null, null),
         new HadoopTuningConfig(
             null,
             null,

--- a/indexing-hadoop/src/test/java/io/druid/indexer/HadoopIngestionSpecTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/HadoopIngestionSpecTest.java
@@ -17,15 +17,16 @@
 
 package io.druid.indexer;
 
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import io.druid.indexer.partitions.HashedPartitionsSpec;
-import io.druid.metadata.MetadataStorageConnectorConfig;
 import io.druid.indexer.partitions.PartitionsSpec;
 import io.druid.indexer.partitions.SingleDimensionPartitionsSpec;
 import io.druid.indexer.updater.MetadataStorageUpdaterJobSpec;
 import io.druid.jackson.DefaultObjectMapper;
+import io.druid.metadata.MetadataStorageConnectorConfig;
 import io.druid.segment.indexing.granularity.UniformGranularitySpec;
 import org.joda.time.Interval;
 import org.junit.Assert;
@@ -33,7 +34,11 @@ import org.junit.Test;
 
 public class HadoopIngestionSpecTest
 {
-  private static final ObjectMapper jsonMapper = new DefaultObjectMapper();
+  private static final ObjectMapper jsonMapper;
+  static {
+    jsonMapper = new DefaultObjectMapper();
+    jsonMapper.setInjectableValues(new InjectableValues.Std().addValue(ObjectMapper.class, jsonMapper));
+  }
 
   @Test
   public void testGranularitySpec()

--- a/indexing-hadoop/src/test/java/io/druid/indexer/HadoopIngestionSpecUpdateDatasourcePathSpecSegmentsTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/HadoopIngestionSpecUpdateDatasourcePathSpecSegmentsTest.java
@@ -19,6 +19,9 @@
 
 package io.druid.indexer;
 
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -50,7 +53,15 @@ public class HadoopIngestionSpecUpdateDatasourcePathSpecSegmentsTest
   private final String testDatasource = "test";
   private final Interval testDatasourceInterval = new Interval("1970/3000");
   private final Interval testDatasourceIntervalPartial = new Interval("2050/3000");
-  private final ObjectMapper jsonMapper = new DefaultObjectMapper();
+  private final ObjectMapper jsonMapper;
+
+  public HadoopIngestionSpecUpdateDatasourcePathSpecSegmentsTest()
+  {
+    jsonMapper = new DefaultObjectMapper();
+    jsonMapper.setInjectableValues(
+        new InjectableValues.Std().addValue(ObjectMapper.class, jsonMapper)
+    );
+  }
 
   private static final DataSegment SEGMENT = new DataSegment(
       "test1",
@@ -155,7 +166,8 @@ public class HadoopIngestionSpecUpdateDatasourcePathSpecSegmentsTest
                 ImmutableList.of(
                     new Interval("2010-01-01/P1D")
                 )
-            )
+            ),
+            jsonMapper
         ),
         new HadoopIOConfig(
             jsonMapper.convertValue(datasourcePathSpec, Map.class),

--- a/indexing-hadoop/src/test/java/io/druid/indexer/HadoopyStringInputRowParserTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/HadoopyStringInputRowParserTest.java
@@ -1,0 +1,51 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.indexer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.druid.data.input.impl.InputRowParser;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+/**
+ */
+public class HadoopyStringInputRowParserTest
+{
+  @Test
+  public void testSerde() throws Exception
+  {
+    String jsonStr = "{"
+                     + "\"type\":\"hadoopyString\","
+                     + "\"parseSpec\":{\"format\":\"json\",\"timestampSpec\":{\"column\":\"xXx\"},\"dimensionsSpec\":{}}"
+                     + "}";
+
+    ObjectMapper jsonMapper = HadoopDruidIndexerConfig.jsonMapper;
+    InputRowParser parser = jsonMapper.readValue(
+        jsonMapper.writeValueAsString(
+            jsonMapper.readValue(jsonStr, InputRowParser.class)
+        ),
+        InputRowParser.class
+    );
+
+    Assert.assertTrue(parser instanceof HadoopyStringInputRowParser);
+    Assert.assertEquals("xXx", parser.getParseSpec().getTimestampSpec().getTimestampColumn());
+  }
+}

--- a/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorCombinerTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorCombinerTest.java
@@ -47,6 +47,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  */
@@ -62,13 +63,16 @@ public class IndexGeneratorCombinerTest
         new HadoopIngestionSpec(
             new DataSchema(
                 "website",
-                new StringInputRowParser(
-                    new CSVParseSpec(
-                        new TimestampSpec("timestamp", "yyyyMMddHH", null),
-                        new DimensionsSpec(ImmutableList.of("host"), null, null),
-                        null,
-                        ImmutableList.of("timestamp", "host", "visited")
-                    )
+                HadoopDruidIndexerConfig.jsonMapper.convertValue(
+                    new StringInputRowParser(
+                        new CSVParseSpec(
+                            new TimestampSpec("timestamp", "yyyyMMddHH", null),
+                            new DimensionsSpec(ImmutableList.of("host"), null, null),
+                            null,
+                            ImmutableList.of("timestamp", "host", "visited")
+                        )
+                    ),
+                    Map.class
                 ),
                 new AggregatorFactory[]{
                     new LongSumAggregatorFactory("visited_sum", "visited"),
@@ -76,7 +80,8 @@ public class IndexGeneratorCombinerTest
                 },
                 new UniformGranularitySpec(
                     Granularity.DAY, QueryGranularity.NONE, ImmutableList.of(Interval.parse("2010/2011"))
-                )
+                ),
+                HadoopDruidIndexerConfig.jsonMapper
             ),
             new HadoopIOConfig(
                 ImmutableMap.<String, Object>of(

--- a/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobTest.java
@@ -331,13 +331,16 @@ public class IndexGeneratorJobTest
         new HadoopIngestionSpec(
             new DataSchema(
                 "website",
-                new StringInputRowParser(
-                    new CSVParseSpec(
-                        new TimestampSpec("timestamp", "yyyyMMddHH", null),
-                        new DimensionsSpec(ImmutableList.of("host"), null, null),
-                        null,
-                        ImmutableList.of("timestamp", "host", "visited_num")
-                    )
+                mapper.convertValue(
+                    new StringInputRowParser(
+                        new CSVParseSpec(
+                            new TimestampSpec("timestamp", "yyyyMMddHH", null),
+                            new DimensionsSpec(ImmutableList.of("host"), null, null),
+                            null,
+                            ImmutableList.of("timestamp", "host", "visited_num")
+                        )
+                    ),
+                    Map.class
                 ),
                 new AggregatorFactory[]{
                     new LongSumAggregatorFactory("visited_num", "visited_num"),
@@ -345,7 +348,8 @@ public class IndexGeneratorJobTest
                 },
                 new UniformGranularitySpec(
                     Granularity.DAY, QueryGranularity.NONE, ImmutableList.of(this.interval)
-                )
+                ),
+                mapper
             ),
             new HadoopIOConfig(
                 ImmutableMap.copyOf(inputSpec),

--- a/indexing-hadoop/src/test/java/io/druid/indexer/JobHelperTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/JobHelperTest.java
@@ -66,18 +66,22 @@ public class JobHelperTest
         new HadoopIngestionSpec(
             new DataSchema(
                 "website",
-                new StringInputRowParser(
-                    new CSVParseSpec(
-                        new TimestampSpec("timestamp", "yyyyMMddHH", null),
-                        new DimensionsSpec(ImmutableList.of("host"), null, null),
-                        null,
-                        ImmutableList.of("timestamp", "host", "visited_num")
-                    )
+                HadoopDruidIndexerConfig.jsonMapper.convertValue(
+                    new StringInputRowParser(
+                        new CSVParseSpec(
+                            new TimestampSpec("timestamp", "yyyyMMddHH", null),
+                            new DimensionsSpec(ImmutableList.of("host"), null, null),
+                            null,
+                            ImmutableList.of("timestamp", "host", "visited_num")
+                        )
+                    ),
+                    Map.class
                 ),
                 new AggregatorFactory[]{new LongSumAggregatorFactory("visited_num", "visited_num")},
                 new UniformGranularitySpec(
                     Granularity.DAY, QueryGranularity.NONE, ImmutableList.of(this.interval)
-                )
+                ),
+                HadoopDruidIndexerConfig.jsonMapper
             ),
             new HadoopIOConfig(
                 ImmutableMap.<String, Object>of(

--- a/indexing-hadoop/src/test/java/io/druid/indexer/path/DatasourcePathSpecTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/path/DatasourcePathSpecTest.java
@@ -60,6 +60,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  */
@@ -176,20 +177,24 @@ public class DatasourcePathSpecTest
         new HadoopIngestionSpec(
             new DataSchema(
                 ingestionSpec.getDataSource(),
-                new StringInputRowParser(
-                    new CSVParseSpec(
-                        new TimestampSpec("timestamp", "yyyyMMddHH", null),
-                        new DimensionsSpec(null, null, null),
-                        null,
-                        ImmutableList.of("timestamp", "host", "visited")
-                    )
+                HadoopDruidIndexerConfig.jsonMapper.convertValue(
+                    new StringInputRowParser(
+                        new CSVParseSpec(
+                            new TimestampSpec("timestamp", "yyyyMMddHH", null),
+                            new DimensionsSpec(null, null, null),
+                            null,
+                            ImmutableList.of("timestamp", "host", "visited")
+                        )
+                    ),
+                    Map.class
                 ),
                 new AggregatorFactory[]{
                     new LongSumAggregatorFactory("visited_sum", "visited")
                 },
                 new UniformGranularitySpec(
                     Granularity.DAY, QueryGranularity.NONE, ImmutableList.of(Interval.parse("2000/3000"))
-                )
+                ),
+                HadoopDruidIndexerConfig.jsonMapper
             ),
             new HadoopIOConfig(
                 ImmutableMap.<String, Object>of(

--- a/indexing-hadoop/src/test/java/io/druid/indexer/updater/HadoopConverterJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/updater/HadoopConverterJobTest.java
@@ -156,14 +156,17 @@ public class HadoopConverterJobTest
         new HadoopIngestionSpec(
             new DataSchema(
                 DATASOURCE,
-                new StringInputRowParser(
-                    new DelimitedParseSpec(
-                        new TimestampSpec("ts", "iso", null),
-                        new DimensionsSpec(Arrays.asList(TestIndex.DIMENSIONS), null, null),
-                        "\t",
-                        "\u0001",
-                        Arrays.asList(TestIndex.COLUMNS)
-                    )
+                HadoopDruidIndexerConfig.jsonMapper.convertValue(
+                    new StringInputRowParser(
+                        new DelimitedParseSpec(
+                            new TimestampSpec("ts", "iso", null),
+                            new DimensionsSpec(Arrays.asList(TestIndex.DIMENSIONS), null, null),
+                            "\t",
+                            "\u0001",
+                            Arrays.asList(TestIndex.COLUMNS)
+                        )
+                    ),
+                    Map.class
                 ),
                 new AggregatorFactory[]{
                     new DoubleSumAggregatorFactory(TestIndex.METRICS[0], TestIndex.METRICS[0]),
@@ -173,7 +176,8 @@ public class HadoopConverterJobTest
                     Granularity.MONTH,
                     QueryGranularity.DAY,
                     ImmutableList.<Interval>of(interval)
-                )
+                ),
+                HadoopDruidIndexerConfig.jsonMapper
             ),
             new HadoopIOConfig(
                 ImmutableMap.<String, Object>of(

--- a/indexing-service/src/test/java/io/druid/indexing/common/TestRealtimeTask.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/TestRealtimeTask.java
@@ -17,11 +17,14 @@
 
 package io.druid.indexing.common;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.druid.indexing.common.task.RealtimeIndexTask;
 import io.druid.indexing.common.task.TaskResource;
+import io.druid.jackson.DefaultObjectMapper;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.segment.indexing.DataSchema;
 import io.druid.segment.indexing.RealtimeIOConfig;
@@ -46,14 +49,15 @@ public class TestRealtimeTask extends RealtimeIndexTask
       @JsonProperty("id") String id,
       @JsonProperty("resource") TaskResource taskResource,
       @JsonProperty("dataSource") String dataSource,
-      @JsonProperty("taskStatus") TaskStatus status
+      @JsonProperty("taskStatus") TaskStatus status,
+      @JacksonInject ObjectMapper mapper
   )
   {
     super(
         id,
         taskResource,
         new FireDepartment(
-            new DataSchema(dataSource, null, new AggregatorFactory[]{}, null), new RealtimeIOConfig(
+            new DataSchema(dataSource, null, new AggregatorFactory[]{}, null, mapper), new RealtimeIOConfig(
             new LocalFirehoseFactory(new File("lol"), "rofl", null), new PlumberSchool()
         {
           @Override

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/IndexTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/IndexTaskTest.java
@@ -17,6 +17,7 @@
 
 package io.druid.indexing.common.task;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.metamx.common.Granularity;
 import io.druid.data.input.impl.CSVParseSpec;
@@ -56,12 +57,14 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 public class IndexTaskTest
 {
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
   private final IndexSpec indexSpec = new IndexSpec();
+  private final ObjectMapper jsonMapper = new DefaultObjectMapper();
 
   @Test
   public void testDeterminePartitions() throws Exception
@@ -82,21 +85,24 @@ public class IndexTaskTest
         new IndexTask.IndexIngestionSpec(
             new DataSchema(
                 "test",
-                new StringInputRowParser(
-                    new CSVParseSpec(
-                        new TimestampSpec(
-                            "ts",
-                            "auto",
-                            null
-                        ),
-                        new DimensionsSpec(
-                            Arrays.asList("ts"),
-                            Lists.<String>newArrayList(),
-                            Lists.<SpatialDimensionSchema>newArrayList()
-                        ),
-                        null,
-                        Arrays.asList("ts", "dim", "val")
-                    )
+                jsonMapper.convertValue(
+                    new StringInputRowParser(
+                        new CSVParseSpec(
+                            new TimestampSpec(
+                                "ts",
+                                "auto",
+                                null
+                            ),
+                            new DimensionsSpec(
+                                Arrays.asList("ts"),
+                                Lists.<String>newArrayList(),
+                                Lists.<SpatialDimensionSchema>newArrayList()
+                            ),
+                            null,
+                            Arrays.asList("ts", "dim", "val")
+                        )
+                    ),
+                    Map.class
                 ),
                 new AggregatorFactory[]{
                     new LongSumAggregatorFactory("val", "val")
@@ -105,7 +111,8 @@ public class IndexTaskTest
                     Granularity.DAY,
                     QueryGranularity.MINUTE,
                     Arrays.asList(new Interval("2014/2015"))
-                )
+                ),
+                jsonMapper
             ),
             new IndexTask.IndexIOConfig(
                 new LocalFirehoseFactory(
@@ -149,21 +156,24 @@ public class IndexTaskTest
         new IndexTask.IndexIngestionSpec(
             new DataSchema(
                 "test",
-                new StringInputRowParser(
-                    new CSVParseSpec(
-                        new TimestampSpec(
-                            "ts",
-                            "auto",
-                            null
-                        ),
-                        new DimensionsSpec(
-                            Arrays.asList("ts"),
-                            Lists.<String>newArrayList(),
-                            Lists.<SpatialDimensionSchema>newArrayList()
-                        ),
-                        null,
-                        Arrays.asList("ts", "dim", "val")
-                    )
+                jsonMapper.convertValue(
+                    new StringInputRowParser(
+                        new CSVParseSpec(
+                            new TimestampSpec(
+                                "ts",
+                                "auto",
+                                null
+                            ),
+                            new DimensionsSpec(
+                                Arrays.asList("ts"),
+                                Lists.<String>newArrayList(),
+                                Lists.<SpatialDimensionSchema>newArrayList()
+                            ),
+                            null,
+                            Arrays.asList("ts", "dim", "val")
+                        )
+                    ),
+                    Map.class
                 ),
                 new AggregatorFactory[]{
                     new LongSumAggregatorFactory("val", "val")
@@ -171,7 +181,8 @@ public class IndexTaskTest
                 new ArbitraryGranularitySpec(
                     QueryGranularity.MINUTE,
                     Arrays.asList(new Interval("2014/2015"))
-                )
+                ),
+                jsonMapper
             ),
             new IndexTask.IndexIOConfig(
                 new LocalFirehoseFactory(
@@ -257,21 +268,24 @@ public class IndexTaskTest
         new IndexTask.IndexIngestionSpec(
             new DataSchema(
                 "test",
-                new StringInputRowParser(
-                    new CSVParseSpec(
-                        new TimestampSpec(
-                            "ts",
-                            "auto",
-                            null
-                        ),
-                        new DimensionsSpec(
-                            Arrays.asList("dim"),
-                            Lists.<String>newArrayList(),
-                            Lists.<SpatialDimensionSchema>newArrayList()
-                        ),
-                        null,
-                        Arrays.asList("ts", "dim", "val")
-                    )
+                jsonMapper.convertValue(
+                    new StringInputRowParser(
+                        new CSVParseSpec(
+                            new TimestampSpec(
+                                "ts",
+                                "auto",
+                                null
+                            ),
+                            new DimensionsSpec(
+                                Arrays.asList("dim"),
+                                Lists.<String>newArrayList(),
+                                Lists.<SpatialDimensionSchema>newArrayList()
+                            ),
+                            null,
+                            Arrays.asList("ts", "dim", "val")
+                        )
+                    ),
+                    Map.class
                 ),
                 new AggregatorFactory[]{
                     new LongSumAggregatorFactory("val", "val")
@@ -280,7 +294,8 @@ public class IndexTaskTest
                     Granularity.HOUR,
                     QueryGranularity.HOUR,
                     Arrays.asList(new Interval("2015-03-01T08:00:00Z/2015-03-01T09:00:00Z"))
-                )
+                ),
+                jsonMapper
             ),
             new IndexTask.IndexIOConfig(
                 new LocalFirehoseFactory(

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
@@ -56,7 +56,11 @@ import java.io.IOException;
 
 public class TaskSerdeTest
 {
-  private static final ObjectMapper jsonMapper = new DefaultObjectMapper();
+  private static final ObjectMapper jsonMapper;
+  static  {
+    jsonMapper = new DefaultObjectMapper();
+    jsonMapper.setInjectableValues(new InjectableValues.Std().addValue(ObjectMapper.class, jsonMapper));
+  }
 
   private final IndexSpec indexSpec = new IndexSpec();
 
@@ -75,7 +79,8 @@ public class TaskSerdeTest
                     Granularity.DAY,
                     null,
                     ImmutableList.of(new Interval("2010-01-01/P2D"))
-                )
+                ),
+                jsonMapper
             ),
             new IndexTask.IndexIOConfig(new LocalFirehoseFactory(new File("lol"), "rofl", null)),
             new IndexTask.IndexTuningConfig(10000, 10, -1, indexSpec)
@@ -120,7 +125,8 @@ public class TaskSerdeTest
                     Granularity.DAY,
                     null,
                     ImmutableList.of(new Interval("2010-01-01/P2D"))
-                )
+                ),
+                jsonMapper
             ),
             new IndexTask.IndexIOConfig(new LocalFirehoseFactory(new File("lol"), "rofl", null)),
             new IndexTask.IndexTuningConfig(10000, 10, -1, indexSpec)
@@ -277,7 +283,8 @@ public class TaskSerdeTest
                 "foo",
                 null,
                 new AggregatorFactory[0],
-                new UniformGranularitySpec(Granularity.HOUR, QueryGranularity.NONE, null)
+                new UniformGranularitySpec(Granularity.HOUR, QueryGranularity.NONE, null),
+                jsonMapper
             ),
             new RealtimeIOConfig(
                 new LocalFirehoseFactory(new File("lol"), "rofl", null), new PlumberSchool()
@@ -534,7 +541,8 @@ public class TaskSerdeTest
                 Granularity.DAY,
                 null,
                 ImmutableList.of(new Interval("2010-01-01/P1D"))
-            )
+            ),
+                jsonMapper
             ), new HadoopIOConfig(ImmutableMap.<String, Object>of("paths", "bar"), null, null), null
         ),
         null,

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTest.java
@@ -191,15 +191,15 @@ public class RemoteTaskRunnerTest
   {
     doSetup();
 
-    TestRealtimeTask task1 = new TestRealtimeTask("rt1", new TaskResource("rt1", 1), "foo", TaskStatus.running("rt1"));
+    TestRealtimeTask task1 = new TestRealtimeTask("rt1", new TaskResource("rt1", 1), "foo", TaskStatus.running("rt1"), jsonMapper);
     remoteTaskRunner.run(task1);
     Assert.assertTrue(taskAnnounced(task1.getId()));
     mockWorkerRunningTask(task1);
 
-    TestRealtimeTask task2 = new TestRealtimeTask("rt2", new TaskResource("rt1", 1), "foo", TaskStatus.running("rt2"));
+    TestRealtimeTask task2 = new TestRealtimeTask("rt2", new TaskResource("rt1", 1), "foo", TaskStatus.running("rt2"), jsonMapper);
     remoteTaskRunner.run(task2);
 
-    TestRealtimeTask task3 = new TestRealtimeTask("rt3", new TaskResource("rt2", 1), "foo", TaskStatus.running("rt3"));
+    TestRealtimeTask task3 = new TestRealtimeTask("rt3", new TaskResource("rt2", 1), "foo", TaskStatus.running("rt3"), jsonMapper);
     remoteTaskRunner.run(task3);
 
     Assert.assertTrue(
@@ -236,15 +236,15 @@ public class RemoteTaskRunnerTest
   {
     doSetup();
 
-    TestRealtimeTask task1 = new TestRealtimeTask("rt1", new TaskResource("rt1", 1), "foo", TaskStatus.running("rt1"));
+    TestRealtimeTask task1 = new TestRealtimeTask("rt1", new TaskResource("rt1", 1), "foo", TaskStatus.running("rt1"), jsonMapper);
     remoteTaskRunner.run(task1);
     Assert.assertTrue(taskAnnounced(task1.getId()));
     mockWorkerRunningTask(task1);
 
-    TestRealtimeTask task2 = new TestRealtimeTask("rt2", new TaskResource("rt2", 3), "foo", TaskStatus.running("rt2"));
+    TestRealtimeTask task2 = new TestRealtimeTask("rt2", new TaskResource("rt2", 3), "foo", TaskStatus.running("rt2"), jsonMapper);
     remoteTaskRunner.run(task2);
 
-    TestRealtimeTask task3 = new TestRealtimeTask("rt3", new TaskResource("rt3", 2), "foo", TaskStatus.running("rt3"));
+    TestRealtimeTask task3 = new TestRealtimeTask("rt3", new TaskResource("rt3", 2), "foo", TaskStatus.running("rt3"), jsonMapper);
     remoteTaskRunner.run(task3);
     Assert.assertTrue(taskAnnounced(task3.getId()));
     mockWorkerRunningTask(task3);

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLifecycleTest.java
@@ -336,6 +336,7 @@ public class TaskLifecycleTest
     );
     indexSpec = new IndexSpec();
 
+    mapper = new DefaultObjectMapper();
     if (taskStorageType.equals("HeapMemoryTaskStorage")) {
       ts = new HeapMemoryTaskStorage(
           new TaskStorageConfig(null)
@@ -344,7 +345,6 @@ public class TaskLifecycleTest
       );
     } else if (taskStorageType.equals("MetadataTaskStorage")) {
       testDerbyConnector = derbyConnectorRule.getConnector();
-      mapper = new DefaultObjectMapper();
       mapper.registerSubtypes(
           new NamedType(MockExceptionalFirehoseFactory.class, "mockExcepFirehoseFactory"),
           new NamedType(MockFirehoseFactory.class, "mockFirehoseFactory")
@@ -479,7 +479,8 @@ public class TaskLifecycleTest
                     Granularity.DAY,
                     null,
                     ImmutableList.of(new Interval("2010-01-01/P2D"))
-                )
+                ),
+                mapper
             ),
             new IndexTask.IndexIOConfig(new MockFirehoseFactory(false)),
             new IndexTask.IndexTuningConfig(10000, 10, -1, indexSpec)
@@ -536,7 +537,8 @@ public class TaskLifecycleTest
                     Granularity.DAY,
                     null,
                     ImmutableList.of(new Interval("2010-01-01/P1D"))
-                )
+                ),
+                mapper
             ),
             new IndexTask.IndexIOConfig(new MockExceptionalFirehoseFactory()),
             new IndexTask.IndexTuningConfig(10000, 10, -1, indexSpec)
@@ -800,7 +802,8 @@ public class TaskLifecycleTest
         "test_ds",
         null,
         new AggregatorFactory[]{new LongSumAggregatorFactory("count", "rows")},
-        new UniformGranularitySpec(Granularity.DAY, QueryGranularity.NONE, null)
+        new UniformGranularitySpec(Granularity.DAY, QueryGranularity.NONE, null),
+        mapper
     );
     RealtimeIOConfig realtimeIOConfig = new RealtimeIOConfig(
         new MockFirehoseFactory(true),
@@ -863,7 +866,8 @@ public class TaskLifecycleTest
                     Granularity.DAY,
                     null,
                     ImmutableList.of(new Interval("2010-01-01/P2D"))
-                )
+                ),
+                mapper
             ),
             new IndexTask.IndexIOConfig(new MockFirehoseFactory(false)),
             new IndexTask.IndexTuningConfig(10000, 10, -1, indexSpec)

--- a/indexing-service/src/test/java/io/druid/indexing/worker/TaskAnnouncementTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/worker/TaskAnnouncementTest.java
@@ -46,7 +46,7 @@ public class TaskAnnouncementTest
         "theid",
         new TaskResource("rofl", 2),
         new FireDepartment(
-            new DataSchema("foo", null, new AggregatorFactory[0], null),
+            new DataSchema("foo", null, new AggregatorFactory[0], null, new DefaultObjectMapper()),
             new RealtimeIOConfig(
                 new LocalFirehoseFactory(new File("lol"), "rofl", null), new PlumberSchool()
             {

--- a/server/src/main/java/io/druid/segment/indexing/granularity/ArbitraryGranularitySpec.java
+++ b/server/src/main/java/io/druid/segment/indexing/granularity/ArbitraryGranularitySpec.java
@@ -110,4 +110,33 @@ public class ArbitraryGranularitySpec implements GranularitySpec
   {
     return queryGranularity;
   }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ArbitraryGranularitySpec that = (ArbitraryGranularitySpec) o;
+
+    if (!intervals.equals(that.intervals)) {
+      return false;
+    }
+    return !(queryGranularity != null
+             ? !queryGranularity.equals(that.queryGranularity)
+             : that.queryGranularity != null);
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = intervals.hashCode();
+    result = 31 * result + (queryGranularity != null ? queryGranularity.hashCode() : 0);
+    return result;
+  }
 }

--- a/server/src/test/java/io/druid/segment/realtime/FireDepartmentTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/FireDepartmentTest.java
@@ -17,6 +17,7 @@
 
 package io.druid.segment.realtime;
 
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.metamx.common.Granularity;
 import io.druid.data.input.impl.DimensionsSpec;
@@ -36,6 +37,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Map;
 
 /**
  */
@@ -45,28 +47,33 @@ public class FireDepartmentTest
   public void testSerde() throws Exception
   {
     ObjectMapper jsonMapper = new DefaultObjectMapper();
+    jsonMapper.setInjectableValues(new InjectableValues.Std().addValue(ObjectMapper.class, jsonMapper));
 
     FireDepartment schema = new FireDepartment(
         new DataSchema(
             "foo",
-            new StringInputRowParser(
-                new JSONParseSpec(
-                    new TimestampSpec(
-                        "timestamp",
-                        "auto",
-                        null
-                    ),
-                    new DimensionsSpec(
-                        Arrays.asList("dim1", "dim2"),
-                        null,
-                        null
+            jsonMapper.convertValue(
+                new StringInputRowParser(
+                    new JSONParseSpec(
+                        new TimestampSpec(
+                            "timestamp",
+                            "auto",
+                            null
+                        ),
+                        new DimensionsSpec(
+                            Arrays.asList("dim1", "dim2"),
+                            null,
+                            null
+                        )
                     )
-                )
+                ),
+                Map.class
             ),
             new AggregatorFactory[]{
                 new CountAggregatorFactory("count")
             },
-            new UniformGranularitySpec(Granularity.HOUR, QueryGranularity.MINUTE, null)
+            new UniformGranularitySpec(Granularity.HOUR, QueryGranularity.MINUTE, null),
+            jsonMapper
         ),
         new RealtimeIOConfig(
             null,

--- a/server/src/test/java/io/druid/segment/realtime/RealtimeManagerTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/RealtimeManagerTest.java
@@ -19,6 +19,7 @@
 
 package io.druid.segment.realtime;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;
@@ -34,6 +35,7 @@ import io.druid.data.input.InputRow;
 import io.druid.data.input.Row;
 import io.druid.data.input.impl.InputRowParser;
 import io.druid.granularity.QueryGranularity;
+import io.druid.jackson.DefaultObjectMapper;
 import io.druid.query.Query;
 import io.druid.query.QueryRunner;
 import io.druid.query.aggregation.AggregatorFactory;
@@ -81,17 +83,21 @@ public class RealtimeManagerTest
         makeRow(new DateTime().getMillis())
     );
 
+    ObjectMapper jsonMapper = new DefaultObjectMapper();
+
     schema = new DataSchema(
         "test",
         null,
         new AggregatorFactory[]{new CountAggregatorFactory("rows")},
-        new UniformGranularitySpec(Granularity.HOUR, QueryGranularity.NONE, null)
+        new UniformGranularitySpec(Granularity.HOUR, QueryGranularity.NONE, null),
+        jsonMapper
     );
     schema2 = new DataSchema(
         "testV2",
         null,
         new AggregatorFactory[]{new CountAggregatorFactory("rows")},
-        new UniformGranularitySpec(Granularity.HOUR, QueryGranularity.NONE, null)
+        new UniformGranularitySpec(Granularity.HOUR, QueryGranularity.NONE, null),
+        jsonMapper
     );
     RealtimeIOConfig ioConfig = new RealtimeIOConfig(
         new FirehoseFactory()

--- a/server/src/test/java/io/druid/segment/realtime/plumber/SinkTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/plumber/SinkTest.java
@@ -23,6 +23,7 @@ import com.metamx.common.Granularity;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.Row;
 import io.druid.granularity.QueryGranularity;
+import io.druid.jackson.DefaultObjectMapper;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.segment.indexing.DataSchema;
@@ -48,7 +49,8 @@ public class SinkTest
         "test",
         null,
         new AggregatorFactory[]{new CountAggregatorFactory("rows")},
-        new UniformGranularitySpec(Granularity.HOUR, QueryGranularity.MINUTE, null)
+        new UniformGranularitySpec(Granularity.HOUR, QueryGranularity.MINUTE, null),
+        new DefaultObjectMapper()
     );
 
     final Interval interval = new Interval("2013-01-01/2013-01-02");


### PR DESCRIPTION
This PR is a result of discussion https://github.com/druid-io/druid/pull/1682#discussion-diff-38207513
 in #1682 . This patch
1)  now allows users to write custom InputRowParser for specific cases while hadoop ingestion and can depend upon hadoop or any other libs
2) reverts the special handling introduced for BytesWritable in  #1682 and handles it via a HadoopyStringInputRowParser