### PR TITLE
update indexing in the helper to use multiple persists and merge

### DIFF
--- a/extensions/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregationTest.java
+++ b/extensions/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregationTest.java
@@ -26,7 +26,9 @@ import io.druid.data.input.MapBasedRow;
 import io.druid.granularity.QueryGranularity;
 import io.druid.query.aggregation.AggregationTestHelper;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 
@@ -36,11 +38,14 @@ public class ApproximateHistogramAggregationTest
 {
   private AggregationTestHelper helper;
 
+  @Rule
+  public final TemporaryFolder tempFolder = new TemporaryFolder();
+
   public ApproximateHistogramAggregationTest()
   {
     ApproximateHistogramDruidModule module = new ApproximateHistogramDruidModule();
     module.configure(null);
-    helper = new AggregationTestHelper(Lists.newArrayList(module.getJacksonModules()));
+    helper = new AggregationTestHelper(Lists.newArrayList(module.getJacksonModules()), tempFolder);
   }
 
   @Test

--- a/processing/src/test/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregationTest.java
@@ -27,16 +27,21 @@ import io.druid.granularity.QueryGranularity;
 import io.druid.jackson.AggregatorsModule;
 import io.druid.query.aggregation.AggregationTestHelper;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 
 public class HyperUniquesAggregationTest
 {
+  @Rule
+  public final TemporaryFolder tempFolder = new TemporaryFolder();
+
   @Test
   public void testIngestAndQuery() throws Exception
   {
-    AggregationTestHelper helper = new AggregationTestHelper(Lists.newArrayList(new AggregatorsModule()));
+    AggregationTestHelper helper = new AggregationTestHelper(Lists.newArrayList(new AggregatorsModule()), tempFolder);
 
     String metricSpec = "[{"
                         + "\"type\": \"hyperUnique\","


### PR DESCRIPTION
this catches more issues with our sketch aggregator module implementation related to when intermediate persists happen while ingestion.