### PR TITLE
Don't check for sortedness if we already know GenericIndexedWriter isn't sorted

### DIFF
--- a/processing/src/main/java/io/druid/segment/data/GenericIndexedWriter.java
+++ b/processing/src/main/java/io/druid/segment/data/GenericIndexedWriter.java
@@ -66,7 +66,7 @@ public class GenericIndexedWriter<T> implements Closeable
 
   public void write(T objectToWrite) throws IOException
   {
-    if (prevObject != null && strategy.compare(prevObject, objectToWrite) >= 0) {
+    if (objectsSorted && prevObject != null && strategy.compare(prevObject, objectToWrite) >= 0) {
       objectsSorted = false;
     }
 


### PR DESCRIPTION
The plumber's incremental persist can spend up to 20% of its time doing the compare if HLL aggs are used. This skips the compare if we already know the data isn't sorted.