### PR TITLE
Store AggregatorFactory[] in segment metadata

### DIFF
--- a/docs/content/misc/tasks.md
+++ b/docs/content/misc/tasks.md
@@ -284,7 +284,8 @@ Append tasks append a list of segments together into a single segment (one after
     "type": "append",
     "id": <task_id>,
     "dataSource": <task_datasource>,
-    "segments": <JSON list of DataSegment objects to append>
+    "segments": <JSON list of DataSegment objects to append>,
+    "aggregations": <optional list of aggregators>
 }
 ```
 

--- a/extensions/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchAggregatorFactory.java
+++ b/extensions/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchAggregatorFactory.java
@@ -41,7 +41,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-public abstract class SketchAggregatorFactory implements AggregatorFactory
+public abstract class SketchAggregatorFactory extends AggregatorFactory
 {
   public static final int DEFAULT_MAX_SKETCH_SIZE = 16384;
 

--- a/extensions/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchMergeAggregatorFactory.java
+++ b/extensions/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchMergeAggregatorFactory.java
@@ -67,7 +67,7 @@ public class SketchMergeAggregatorFactory extends SketchAggregatorFactory
   @Override
   public AggregatorFactory getCombiningFactory()
   {
-    return new SketchMergeAggregatorFactory(name, name, size, shouldFinalize, true);
+    return new SketchMergeAggregatorFactory(name, name, size, shouldFinalize, false);
   }
 
   @Override

--- a/extensions/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchMergeAggregatorFactory.java
+++ b/extensions/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchMergeAggregatorFactory.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.yahoo.sketches.theta.Sketch;
 import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.query.aggregation.AggregatorFactoryNotMergeableException;
 
 import java.util.Collections;
 import java.util.List;
@@ -66,7 +67,25 @@ public class SketchMergeAggregatorFactory extends SketchAggregatorFactory
   @Override
   public AggregatorFactory getCombiningFactory()
   {
-    return new SketchMergeAggregatorFactory(name, name, size, shouldFinalize, isInputThetaSketch);
+    return new SketchMergeAggregatorFactory(name, name, size, shouldFinalize, true);
+  }
+
+  @Override
+  public AggregatorFactory getMergingFactory(AggregatorFactory other) throws AggregatorFactoryNotMergeableException
+  {
+    if (other.getName().equals(this.getName()) && other instanceof SketchMergeAggregatorFactory) {
+      SketchMergeAggregatorFactory castedOther = (SketchMergeAggregatorFactory) other;
+
+      return new SketchMergeAggregatorFactory(
+          name,
+          name,
+          Math.max(size, castedOther.size),
+          shouldFinalize,
+          true
+      );
+    } else {
+      throw new AggregatorFactoryNotMergeableException(this, other);
+    }
   }
 
   @JsonProperty

--- a/extensions/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
+++ b/extensions/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
@@ -29,6 +29,7 @@ import com.google.common.primitives.Ints;
 import com.metamx.common.StringUtils;
 import io.druid.query.aggregation.Aggregator;
 import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.query.aggregation.AggregatorFactoryNotMergeableException;
 import io.druid.query.aggregation.BufferAggregator;
 import io.druid.segment.ColumnSelectorFactory;
 import org.apache.commons.codec.binary.Base64;
@@ -114,6 +115,26 @@ public class ApproximateHistogramAggregatorFactory extends AggregatorFactory
   public AggregatorFactory getCombiningFactory()
   {
     return new ApproximateHistogramFoldingAggregatorFactory(name, name, resolution, numBuckets, lowerLimit, upperLimit);
+  }
+
+  @Override
+  public AggregatorFactory getMergingFactory(AggregatorFactory other) throws AggregatorFactoryNotMergeableException
+  {
+    if (other.getName().equals(this.getName()) && other instanceof ApproximateHistogramAggregatorFactory) {
+      ApproximateHistogramAggregatorFactory castedOther = (ApproximateHistogramAggregatorFactory) other;
+
+      return new ApproximateHistogramFoldingAggregatorFactory(
+          name,
+          name,
+          Math.max(resolution, castedOther.resolution),
+          numBuckets,
+          Math.min(lowerLimit, castedOther.lowerLimit),
+          Math.max(upperLimit, castedOther.upperLimit)
+      );
+
+    } else {
+      throw new AggregatorFactoryNotMergeableException(this, other);
+    }
   }
 
   @Override

--- a/extensions/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
+++ b/extensions/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
@@ -39,7 +39,7 @@ import java.util.Comparator;
 import java.util.List;
 
 @JsonTypeName("approxHistogram")
-public class ApproximateHistogramAggregatorFactory implements AggregatorFactory
+public class ApproximateHistogramAggregatorFactory extends AggregatorFactory
 {
   private static final byte CACHE_TYPE_ID = 0x8;
 

--- a/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
@@ -469,11 +469,11 @@ public class IndexGeneratorJob implements Jobby
     {
       if (config.isBuildV9Directly()) {
         return HadoopDruidIndexerConfig.INDEX_MERGER_V9.persist(
-            index, interval, file, null, config.getIndexSpec(), progressIndicator
+            index, interval, file, config.getIndexSpec(), progressIndicator
         );
       } else {
         return HadoopDruidIndexerConfig.INDEX_MERGER.persist(
-            index, interval, file, null, config.getIndexSpec(), progressIndicator
+            index, interval, file, config.getIndexSpec(), progressIndicator
         );
       }
     }

--- a/indexing-service/src/main/java/io/druid/indexing/common/index/YeOldePlumberSchool.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/index/YeOldePlumberSchool.java
@@ -222,7 +222,6 @@ public class YeOldePlumberSchool implements PlumberSchool
             indexMerger.persist(
                 indexToPersist.getIndex(),
                 dirToPersist,
-                null,
                 config.getIndexSpec()
             );
 

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
@@ -391,6 +391,9 @@ public class TaskSerdeTest
         null,
         "foo",
         segments,
+        ImmutableList.<AggregatorFactory>of(
+            new CountAggregatorFactory("cnt")
+        ),
         indexSpec,
         null
     );
@@ -417,6 +420,7 @@ public class TaskSerdeTest
     Assert.assertEquals("foo", task3.getDataSource());
     Assert.assertEquals(new Interval("2010-01-01/P2D"), task3.getInterval());
     Assert.assertEquals(task3.getSegments(), segments);
+    Assert.assertEquals(task.getAggregators(), task2.getAggregators());
   }
 
   @Test

--- a/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
@@ -154,7 +154,7 @@ public class IngestSegmentFirehoseFactoryTest
     if (!persistDir.mkdirs() && !persistDir.exists()) {
       throw new IOException(String.format("Could not create directory at [%s]", persistDir.getAbsolutePath()));
     }
-    INDEX_MERGER.persist(index, persistDir, null, indexSpec);
+    INDEX_MERGER.persist(index, persistDir, indexSpec);
 
     final TaskLockbox tl = new TaskLockbox(ts);
     final IndexerSQLMetadataStorageCoordinator mdc = new IndexerSQLMetadataStorageCoordinator(null, null, null)

--- a/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTimelineTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTimelineTest.java
@@ -230,7 +230,7 @@ public class IngestSegmentFirehoseFactoryTimelineTest
     }
 
     try {
-      INDEX_MERGER.persist(index, persistDir, null, new IndexSpec());
+      INDEX_MERGER.persist(index, persistDir, new IndexSpec());
     }
     catch (IOException e) {
       throw Throwables.propagate(e);

--- a/processing/src/main/java/io/druid/query/aggregation/AggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/AggregatorFactory.java
@@ -34,13 +34,13 @@ import java.util.List;
  * provided to the Aggregator through the MetricSelector object, so whatever creates that object gets to choose how
  * the data is actually stored and accessed.
  */
-public interface AggregatorFactory
+public abstract class AggregatorFactory
 {
-  public Aggregator factorize(ColumnSelectorFactory metricFactory);
+  public abstract Aggregator factorize(ColumnSelectorFactory metricFactory);
 
-  public BufferAggregator factorizeBuffered(ColumnSelectorFactory metricFactory);
+  public abstract BufferAggregator factorizeBuffered(ColumnSelectorFactory metricFactory);
 
-  public Comparator getComparator();
+  public abstract Comparator getComparator();
 
   /**
    * A method that knows how to combine the outputs of the getIntermediate() method from the Aggregators
@@ -53,7 +53,7 @@ public interface AggregatorFactory
    *
    * @return an object representing the combination of lhs and rhs, this can be a new object or a mutation of the inputs
    */
-  public Object combine(Object lhs, Object rhs);
+  public abstract Object combine(Object lhs, Object rhs);
 
   /**
    * Returns an AggregatorFactory that can be used to combine the output of aggregators from this factory.  This
@@ -62,14 +62,14 @@ public interface AggregatorFactory
    *
    * @return a new Factory that can be used for operations on top of data output from the current factory.
    */
-  public AggregatorFactory getCombiningFactory();
+  public abstract AggregatorFactory getCombiningFactory();
 
   /**
    * Gets a list of all columns that this AggregatorFactory will scan
    *
    * @return AggregatorFactories for the columns to scan of the parent AggregatorFactory
    */
-  public List<AggregatorFactory> getRequiredColumns();
+  public abstract List<AggregatorFactory> getRequiredColumns();
 
   /**
    * A method that knows how to "deserialize" the object from whatever form it might have been put into
@@ -79,7 +79,7 @@ public interface AggregatorFactory
    *
    * @return the deserialized object
    */
-  public Object deserialize(Object object);
+  public abstract Object deserialize(Object object);
 
   /**
    * "Finalizes" the computation of an object.  Primarily useful for complex types that have a different mergeable
@@ -89,27 +89,27 @@ public interface AggregatorFactory
    *
    * @return the finalized value that should be returned for the initial query
    */
-  public Object finalizeComputation(Object object);
+  public abstract Object finalizeComputation(Object object);
 
-  public String getName();
+  public abstract String getName();
 
-  public List<String> requiredFields();
+  public abstract List<String> requiredFields();
 
-  public byte[] getCacheKey();
+  public abstract byte[] getCacheKey();
 
-  public String getTypeName();
+  public abstract String getTypeName();
 
   /**
    * Returns the maximum size that this aggregator will require in bytes for intermediate storage of results.
    *
    * @return the maximum number of bytes that an aggregator of this type will require for intermediate result storage.
    */
-  public int getMaxIntermediateSize();
+  public abstract int getMaxIntermediateSize();
 
   /**
    * Returns the starting value for a corresponding aggregator. For example, 0 for sums, - Infinity for max, an empty mogrifier
    *
    * @return the starting value for a corresponding aggregator.
    */
-  public Object getAggregatorStartValue();
+  public abstract Object getAggregatorStartValue();
 }

--- a/processing/src/main/java/io/druid/query/aggregation/AggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/AggregatorFactory.java
@@ -65,6 +65,22 @@ public abstract class AggregatorFactory
   public abstract AggregatorFactory getCombiningFactory();
 
   /**
+   * Returns an AggregatorFactory that can be used to merge the output of aggregators from this factory and
+   * other factory.
+   * This method is relevant only for AggregatorFactory which can be used at ingestion time.
+   *
+   * @return a new Factory that can be used for merging the output of aggregators from this factory and other.
+   */
+  public AggregatorFactory getMergingFactory(AggregatorFactory other) throws AggregatorFactoryNotMergeableException
+  {
+    if (other.getName().equals(this.getName()) && this.getClass() == other.getClass()) {
+      return getCombiningFactory();
+    } else {
+      throw new AggregatorFactoryNotMergeableException(this, other);
+    }
+  }
+
+  /**
    * Gets a list of all columns that this AggregatorFactory will scan
    *
    * @return AggregatorFactories for the columns to scan of the parent AggregatorFactory

--- a/processing/src/main/java/io/druid/query/aggregation/AggregatorFactoryNotMergeableException.java
+++ b/processing/src/main/java/io/druid/query/aggregation/AggregatorFactoryNotMergeableException.java
@@ -1,0 +1,57 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.query.aggregation;
+
+/**
+ */
+public class AggregatorFactoryNotMergeableException extends Exception
+{
+  public AggregatorFactoryNotMergeableException()
+  {
+  }
+
+  public AggregatorFactoryNotMergeableException(String formatText, Object... arguments)
+  {
+    super(String.format(formatText, arguments));
+  }
+
+  public AggregatorFactoryNotMergeableException(Throwable cause, String formatText, Object... arguments)
+  {
+    super(String.format(formatText, arguments), cause);
+  }
+
+  public AggregatorFactoryNotMergeableException(Throwable cause)
+  {
+    super(cause);
+  }
+
+  public AggregatorFactoryNotMergeableException(AggregatorFactory af1, AggregatorFactory af2)
+  {
+    this(
+        "can't merge [%s : %s] and [%s : %s] , with detailed info [%s] and [%s]",
+        af1.getName(),
+        af1.getClass().getName(),
+        af2.getName(),
+        af2.getClass().getName(),
+        af1,
+        af2
+    );
+  }
+}

--- a/processing/src/main/java/io/druid/query/aggregation/CountAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/CountAggregatorFactory.java
@@ -32,7 +32,7 @@ import java.util.List;
 
 /**
  */
-public class CountAggregatorFactory implements AggregatorFactory
+public class CountAggregatorFactory extends AggregatorFactory
 {
   private static final byte[] CACHE_KEY = new byte[]{0x0};
   private final String name;

--- a/processing/src/main/java/io/druid/query/aggregation/DoubleMaxAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/DoubleMaxAggregatorFactory.java
@@ -33,7 +33,7 @@ import java.util.List;
 
 /**
  */
-public class DoubleMaxAggregatorFactory implements AggregatorFactory
+public class DoubleMaxAggregatorFactory extends AggregatorFactory
 {
   private static final byte CACHE_TYPE_ID = 0x3;
 

--- a/processing/src/main/java/io/druid/query/aggregation/DoubleMaxAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/DoubleMaxAggregatorFactory.java
@@ -84,6 +84,16 @@ public class DoubleMaxAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory getMergingFactory(AggregatorFactory other) throws AggregatorFactoryNotMergeableException
+  {
+    if (other.getName().equals(this.getName()) && this.getClass() == other.getClass()) {
+      return getCombiningFactory();
+    } else {
+      throw new AggregatorFactoryNotMergeableException(this, other);
+    }
+  }
+
+  @Override
   public List<AggregatorFactory> getRequiredColumns()
   {
     return Arrays.<AggregatorFactory>asList(new DoubleMaxAggregatorFactory(fieldName, fieldName));

--- a/processing/src/main/java/io/druid/query/aggregation/DoubleMinAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/DoubleMinAggregatorFactory.java
@@ -33,7 +33,7 @@ import java.util.List;
 
 /**
  */
-public class DoubleMinAggregatorFactory implements AggregatorFactory
+public class DoubleMinAggregatorFactory extends AggregatorFactory
 {
   private static final byte CACHE_TYPE_ID = 0x4;
 

--- a/processing/src/main/java/io/druid/query/aggregation/DoubleMinAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/DoubleMinAggregatorFactory.java
@@ -84,6 +84,16 @@ public class DoubleMinAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory getMergingFactory(AggregatorFactory other) throws AggregatorFactoryNotMergeableException
+  {
+    if (other.getName().equals(this.getName()) && this.getClass() == other.getClass()) {
+      return getCombiningFactory();
+    } else {
+      throw new AggregatorFactoryNotMergeableException(this, other);
+    }
+  }
+
+  @Override
   public List<AggregatorFactory> getRequiredColumns()
   {
     return Arrays.<AggregatorFactory>asList(new DoubleMinAggregatorFactory(fieldName, fieldName));

--- a/processing/src/main/java/io/druid/query/aggregation/DoubleSumAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/DoubleSumAggregatorFactory.java
@@ -87,6 +87,16 @@ public class DoubleSumAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory getMergingFactory(AggregatorFactory other) throws AggregatorFactoryNotMergeableException
+  {
+    if (other.getName().equals(this.getName()) && this.getClass() == other.getClass()) {
+      return getCombiningFactory();
+    } else {
+      throw new AggregatorFactoryNotMergeableException(this, other);
+    }
+  }
+
+  @Override
   public List<AggregatorFactory> getRequiredColumns()
   {
     return Arrays.<AggregatorFactory>asList(new DoubleSumAggregatorFactory(fieldName, fieldName));

--- a/processing/src/main/java/io/druid/query/aggregation/DoubleSumAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/DoubleSumAggregatorFactory.java
@@ -33,7 +33,7 @@ import java.util.List;
 
 /**
  */
-public class DoubleSumAggregatorFactory implements AggregatorFactory
+public class DoubleSumAggregatorFactory extends AggregatorFactory
 {
   private static final byte CACHE_TYPE_ID = 0x2;
 

--- a/processing/src/main/java/io/druid/query/aggregation/FilteredAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/FilteredAggregatorFactory.java
@@ -30,7 +30,7 @@ import java.nio.ByteBuffer;
 import java.util.Comparator;
 import java.util.List;
 
-public class FilteredAggregatorFactory implements AggregatorFactory
+public class FilteredAggregatorFactory extends AggregatorFactory
 {
   private static final byte CACHE_TYPE_ID = 0x9;
 

--- a/processing/src/main/java/io/druid/query/aggregation/HistogramAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/HistogramAggregatorFactory.java
@@ -34,7 +34,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
-public class HistogramAggregatorFactory implements AggregatorFactory
+public class HistogramAggregatorFactory extends AggregatorFactory
 {
   private static final byte CACHE_TYPE_ID = 0x7;
 

--- a/processing/src/main/java/io/druid/query/aggregation/HistogramAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/HistogramAggregatorFactory.java
@@ -101,12 +101,6 @@ public class HistogramAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public AggregatorFactory getMergingFactory(AggregatorFactory other) throws AggregatorFactoryNotMergeableException
-  {
-    throw new UnsupportedOperationException("can't merge HistogramAggregatorFactory");
-  }
-
-  @Override
   public List<AggregatorFactory> getRequiredColumns()
   {
     return Arrays.<AggregatorFactory>asList(new HistogramAggregatorFactory(fieldName, fieldName, breaksList));

--- a/processing/src/main/java/io/druid/query/aggregation/HistogramAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/HistogramAggregatorFactory.java
@@ -101,6 +101,12 @@ public class HistogramAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory getMergingFactory(AggregatorFactory other) throws AggregatorFactoryNotMergeableException
+  {
+    throw new UnsupportedOperationException("can't merge HistogramAggregatorFactory");
+  }
+
+  @Override
   public List<AggregatorFactory> getRequiredColumns()
   {
     return Arrays.<AggregatorFactory>asList(new HistogramAggregatorFactory(fieldName, fieldName, breaksList));

--- a/processing/src/main/java/io/druid/query/aggregation/JavaScriptAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/JavaScriptAggregatorFactory.java
@@ -138,6 +138,18 @@ public class JavaScriptAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory getMergingFactory(AggregatorFactory other) throws AggregatorFactoryNotMergeableException
+  {
+    if (other.getName().equals(this.getName()) && other.getClass() == this.getClass()) {
+      JavaScriptAggregatorFactory castedOther = (JavaScriptAggregatorFactory) other;
+      if (this.fnCombine.equals(castedOther.fnCombine) && this.fnReset.equals(castedOther.fnReset)) {
+        return getCombiningFactory();
+      }
+    }
+    throw new AggregatorFactoryNotMergeableException(this, other);
+  }
+
+  @Override
   public List<AggregatorFactory> getRequiredColumns()
   {
     return Lists.transform(

--- a/processing/src/main/java/io/druid/query/aggregation/JavaScriptAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/JavaScriptAggregatorFactory.java
@@ -42,7 +42,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Comparator;
 import java.util.List;
 
-public class JavaScriptAggregatorFactory implements AggregatorFactory
+public class JavaScriptAggregatorFactory extends AggregatorFactory
 {
   private static final byte CACHE_TYPE_ID = 0x6;
 

--- a/processing/src/main/java/io/druid/query/aggregation/LongMaxAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/LongMaxAggregatorFactory.java
@@ -33,7 +33,7 @@ import java.util.List;
 
 /**
  */
-public class LongMaxAggregatorFactory implements AggregatorFactory
+public class LongMaxAggregatorFactory extends AggregatorFactory
 {
   private static final byte CACHE_TYPE_ID = 0xA;
 

--- a/processing/src/main/java/io/druid/query/aggregation/LongMaxAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/LongMaxAggregatorFactory.java
@@ -84,6 +84,16 @@ public class LongMaxAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory getMergingFactory(AggregatorFactory other) throws AggregatorFactoryNotMergeableException
+  {
+    if (other.getName().equals(this.getName()) && this.getClass() == other.getClass()) {
+      return getCombiningFactory();
+    } else {
+      throw new AggregatorFactoryNotMergeableException(this, other);
+    }
+  }
+
+  @Override
   public List<AggregatorFactory> getRequiredColumns()
   {
     return Arrays.<AggregatorFactory>asList(new LongMaxAggregatorFactory(fieldName, fieldName));

--- a/processing/src/main/java/io/druid/query/aggregation/LongMinAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/LongMinAggregatorFactory.java
@@ -84,6 +84,16 @@ public class LongMinAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory getMergingFactory(AggregatorFactory other) throws AggregatorFactoryNotMergeableException
+  {
+    if (other.getName().equals(this.getName()) && this.getClass() == other.getClass()) {
+      return getCombiningFactory();
+    } else {
+      throw new AggregatorFactoryNotMergeableException(this, other);
+    }
+  }
+
+  @Override
   public List<AggregatorFactory> getRequiredColumns()
   {
     return Arrays.<AggregatorFactory>asList(new LongMinAggregatorFactory(fieldName, fieldName));

--- a/processing/src/main/java/io/druid/query/aggregation/LongMinAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/LongMinAggregatorFactory.java
@@ -33,7 +33,7 @@ import java.util.List;
 
 /**
  */
-public class LongMinAggregatorFactory implements AggregatorFactory
+public class LongMinAggregatorFactory extends AggregatorFactory
 {
   private static final byte CACHE_TYPE_ID = 0xB;
 

--- a/processing/src/main/java/io/druid/query/aggregation/LongSumAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/LongSumAggregatorFactory.java
@@ -33,7 +33,7 @@ import java.util.List;
 
 /**
  */
-public class LongSumAggregatorFactory implements AggregatorFactory
+public class LongSumAggregatorFactory extends AggregatorFactory
 {
   private static final byte CACHE_TYPE_ID = 0x1;
 

--- a/processing/src/main/java/io/druid/query/aggregation/LongSumAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/LongSumAggregatorFactory.java
@@ -87,6 +87,16 @@ public class LongSumAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory getMergingFactory(AggregatorFactory other) throws AggregatorFactoryNotMergeableException
+  {
+    if (other.getName().equals(this.getName()) && this.getClass() == other.getClass()) {
+      return getCombiningFactory();
+    } else {
+      throw new AggregatorFactoryNotMergeableException(this, other);
+    }
+  }
+
+  @Override
   public List<AggregatorFactory> getRequiredColumns()
   {
     return Arrays.<AggregatorFactory>asList(new LongSumAggregatorFactory(fieldName, fieldName));

--- a/processing/src/main/java/io/druid/query/aggregation/cardinality/CardinalityAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/cardinality/CardinalityAggregatorFactory.java
@@ -43,7 +43,7 @@ import java.nio.ByteBuffer;
 import java.util.Comparator;
 import java.util.List;
 
-public class CardinalityAggregatorFactory implements AggregatorFactory
+public class CardinalityAggregatorFactory extends AggregatorFactory
 {
   public static Object estimateCardinality(Object object)
   {

--- a/processing/src/main/java/io/druid/query/aggregation/cardinality/CardinalityAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/cardinality/CardinalityAggregatorFactory.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Lists;
 import com.metamx.common.StringUtils;
 import io.druid.query.aggregation.Aggregator;
 import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.query.aggregation.AggregatorFactoryNotMergeableException;
 import io.druid.query.aggregation.Aggregators;
 import io.druid.query.aggregation.BufferAggregator;
 import io.druid.query.aggregation.hyperloglog.HyperLogLogCollector;
@@ -145,6 +146,12 @@ public class CardinalityAggregatorFactory extends AggregatorFactory
   public AggregatorFactory getCombiningFactory()
   {
     return new HyperUniquesAggregatorFactory(name, name);
+  }
+
+  @Override
+  public AggregatorFactory getMergingFactory(AggregatorFactory other) throws AggregatorFactoryNotMergeableException
+  {
+    throw new UnsupportedOperationException("can't merge CardinalityAggregatorFactory");
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
@@ -38,7 +38,7 @@ import java.util.List;
 
 /**
  */
-public class HyperUniquesAggregatorFactory implements AggregatorFactory
+public class HyperUniquesAggregatorFactory extends AggregatorFactory
 {
   public static Object estimateCardinality(Object object)
   {

--- a/processing/src/main/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
@@ -25,6 +25,7 @@ import com.metamx.common.IAE;
 import com.metamx.common.StringUtils;
 import io.druid.query.aggregation.Aggregator;
 import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.query.aggregation.AggregatorFactoryNotMergeableException;
 import io.druid.query.aggregation.Aggregators;
 import io.druid.query.aggregation.BufferAggregator;
 import io.druid.segment.ColumnSelectorFactory;
@@ -137,6 +138,16 @@ public class HyperUniquesAggregatorFactory extends AggregatorFactory
   public AggregatorFactory getCombiningFactory()
   {
     return new HyperUniquesAggregatorFactory(name, name);
+  }
+
+  @Override
+  public AggregatorFactory getMergingFactory(AggregatorFactory other) throws AggregatorFactoryNotMergeableException
+  {
+    if (other.getName().equals(this.getName()) && this.getClass() == other.getClass()) {
+      return getCombiningFactory();
+    } else {
+      throw new AggregatorFactoryNotMergeableException(this, other);
+    }
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/IndexIO.java
+++ b/processing/src/main/java/io/druid/segment/IndexIO.java
@@ -19,7 +19,6 @@
 
 package io.druid.segment;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
@@ -1040,15 +1039,13 @@ public class IndexIO
         segmentBitmapSerdeFactory = new BitmapSerde.LegacyBitmapSerdeFactory();
       }
 
-      Map<String, Object> metadata = null;
+      Metadata metadata = null;
       ByteBuffer metadataBB = smooshedFiles.mapFile("metadata.drd");
       if (metadataBB != null) {
         try {
           metadata = mapper.readValue(
               serializerUtils.readBytes(metadataBB, metadataBB.remaining()),
-              new TypeReference<Map<String, Object>>()
-              {
-              }
+              Metadata.class
           );
         }
         catch (IOException ex) {

--- a/processing/src/main/java/io/druid/segment/IndexMerger.java
+++ b/processing/src/main/java/io/druid/segment/IndexMerger.java
@@ -125,11 +125,10 @@ public class IndexMerger
   public File persist(
       final IncrementalIndex index,
       File outDir,
-      Map<String, Object> segmentMetadata,
       IndexSpec indexSpec
   ) throws IOException
   {
-    return persist(index, index.getInterval(), outDir, segmentMetadata, indexSpec);
+    return persist(index, index.getInterval(), outDir, indexSpec);
   }
 
   /**
@@ -148,18 +147,16 @@ public class IndexMerger
       final IncrementalIndex index,
       final Interval dataInterval,
       File outDir,
-      Map<String, Object> segmentMetadata,
       IndexSpec indexSpec
   ) throws IOException
   {
-    return persist(index, dataInterval, outDir, segmentMetadata, indexSpec, new BaseProgressIndicator());
+    return persist(index, dataInterval, outDir, indexSpec, new BaseProgressIndicator());
   }
 
   public File persist(
       final IncrementalIndex index,
       final Interval dataInterval,
       File outDir,
-      Map<String, Object> segmentMetadata,
       IndexSpec indexSpec,
       ProgressIndicator progress
   ) throws IOException
@@ -197,14 +194,16 @@ public class IndexMerger
         ),
         index.getMetricAggs(),
         outDir,
-        segmentMetadata,
         indexSpec,
         progress
     );
   }
 
   public File mergeQueryableIndex(
-      List<QueryableIndex> indexes, final AggregatorFactory[] metricAggs, File outDir, IndexSpec indexSpec
+      List<QueryableIndex> indexes,
+      final AggregatorFactory[] metricAggs,
+      File outDir,
+      IndexSpec indexSpec
   ) throws IOException
   {
     return mergeQueryableIndex(indexes, metricAggs, outDir, indexSpec, new BaseProgressIndicator());
@@ -238,7 +237,6 @@ public class IndexMerger
         indexAdapteres,
         metricAggs,
         outDir,
-        null,
         indexSpec,
         progress
     );
@@ -248,11 +246,10 @@ public class IndexMerger
       List<IndexableAdapter> indexes,
       final AggregatorFactory[] metricAggs,
       File outDir,
-      Map<String, Object> segmentMetadata,
       IndexSpec indexSpec
   ) throws IOException
   {
-    return merge(indexes, metricAggs, outDir, segmentMetadata, indexSpec, new BaseProgressIndicator());
+    return merge(indexes, metricAggs, outDir, indexSpec, new BaseProgressIndicator());
   }
 
   private static List<String> getLexicographicMergedDimensions(List<IndexableAdapter> indexes)
@@ -291,7 +288,6 @@ public class IndexMerger
       List<IndexableAdapter> indexes,
       final AggregatorFactory[] metricAggs,
       File outDir,
-      Map<String, Object> segmentMetadata,
       IndexSpec indexSpec,
       ProgressIndicator progress
   ) throws IOException
@@ -375,7 +371,6 @@ public class IndexMerger
         progress,
         mergedDimensions,
         mergedMetrics,
-        segmentMetadata,
         rowMergerFn,
         indexSpec
     );
@@ -399,7 +394,6 @@ public class IndexMerger
           progress,
           Lists.newArrayList(adapter.getDimensionNames()),
           Lists.newArrayList(adapter.getMetricNames()),
-          null,
           new Function<ArrayList<Iterable<Rowboat>>, Iterable<Rowboat>>()
           {
             @Nullable
@@ -414,6 +408,7 @@ public class IndexMerger
     }
   }
 
+
   public File append(
       List<IndexableAdapter> indexes, File outDir, IndexSpec indexSpec
   ) throws IOException
@@ -422,7 +417,10 @@ public class IndexMerger
   }
 
   public File append(
-      List<IndexableAdapter> indexes, File outDir, IndexSpec indexSpec, ProgressIndicator progress
+      List<IndexableAdapter> indexes,
+      File outDir,
+      IndexSpec indexSpec,
+      ProgressIndicator progress
   ) throws IOException
   {
     FileUtils.deleteDirectory(outDir);
@@ -470,7 +468,15 @@ public class IndexMerger
       }
     };
 
-    return makeIndexFiles(indexes, outDir, progress, mergedDimensions, mergedMetrics, null, rowMergerFn, indexSpec);
+    return makeIndexFiles(
+        indexes,
+        outDir,
+        progress,
+        mergedDimensions,
+        mergedMetrics,
+        rowMergerFn,
+        indexSpec
+    );
   }
 
   protected File makeIndexFiles(
@@ -479,11 +485,24 @@ public class IndexMerger
       final ProgressIndicator progress,
       final List<String> mergedDimensions,
       final List<String> mergedMetrics,
-      final Map<String, Object> segmentMetadata,
       final Function<ArrayList<Iterable<Rowboat>>, Iterable<Rowboat>> rowMergerFn,
       final IndexSpec indexSpec
   ) throws IOException
   {
+    List<Metadata> metadataList = Lists.transform(
+        indexes,
+        new Function<IndexableAdapter, Metadata>()
+        {
+          @Nullable
+          @Override
+          public Metadata apply(IndexableAdapter input)
+          {
+            return input.getMetaData();
+          }
+        }
+    );
+    Metadata segmentMetadata = Metadata.merge(metadataList);
+
     final Map<String, ValueType> valueTypes = Maps.newTreeMap(Ordering.<String>natural().nullsFirst());
     final Map<String, String> metricTypeNames = Maps.newTreeMap(Ordering.<String>natural().nullsFirst());
     final Map<String, ColumnCapabilitiesImpl> columnCapabilities = Maps.newHashMap();
@@ -1297,7 +1316,7 @@ public class IndexMerger
     return true;
   }
 
-  private void writeMetadataToFile(File metadataFile, Map<String, Object> metadata) throws IOException
+  private void writeMetadataToFile(File metadataFile, Metadata metadata) throws IOException
   {
     try (FileOutputStream metadataFileOutputStream = new FileOutputStream(metadataFile);
          FileChannel metadataFilechannel = metadataFileOutputStream.getChannel()

--- a/processing/src/main/java/io/druid/segment/IndexableAdapter.java
+++ b/processing/src/main/java/io/druid/segment/IndexableAdapter.java
@@ -49,4 +49,6 @@ public interface IndexableAdapter
   String getMetricType(String metric);
 
   ColumnCapabilities getCapabilities(String column);
+
+  Metadata getMetadata();
 }

--- a/processing/src/main/java/io/druid/segment/Metadata.java
+++ b/processing/src/main/java/io/druid/segment/Metadata.java
@@ -1,0 +1,108 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.segment;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ */
+public class Metadata
+{
+  // container is used for arbitrary key-value pairs in segment metadata e.g.
+  // kafka firehose uses it to store commit offset
+  @JsonProperty
+  private final Map<String, Object> container;
+
+  public Metadata()
+  {
+    container = new HashMap<>();
+  }
+
+  public Metadata addAll(Metadata other)
+  {
+    if (other != null) {
+      container.putAll(other.container);
+    }
+    return this;
+  }
+
+  public Object get(String key)
+  {
+    return container.get(key);
+  }
+
+  public Metadata put(String key, Object value)
+  {
+    if (value != null) {
+      container.put(key, value);
+    }
+    return this;
+  }
+
+  public boolean isEmpty()
+  {
+    return container.isEmpty();
+  }
+
+  public static Metadata merge(List<Metadata> metadataList)
+  {
+    Metadata result = new Metadata();
+    for (Metadata md : metadataList) {
+      if (md != null) {
+        result.container.putAll(md.container);
+      }
+    }
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Metadata metadata = (Metadata) o;
+
+    return container.equals(metadata.container);
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return container.hashCode();
+  }
+
+  @Override
+  public String toString()
+  {
+    return "Metadata{" +
+           "container=" + container +
+           '}';
+  }
+}

--- a/processing/src/main/java/io/druid/segment/QueryableIndex.java
+++ b/processing/src/main/java/io/druid/segment/QueryableIndex.java
@@ -35,7 +35,7 @@ public interface QueryableIndex extends ColumnSelector, Closeable
   public Indexed<String> getColumnNames();
   public Indexed<String> getAvailableDimensions();
   public BitmapFactory getBitmapFactoryForDimensions();
-  public Metadata getMetaData();
+  public Metadata getMetadata();
 
   /**
    * The close method shouldn't actually be here as this is nasty. We will adjust it in the future.

--- a/processing/src/main/java/io/druid/segment/QueryableIndex.java
+++ b/processing/src/main/java/io/druid/segment/QueryableIndex.java
@@ -25,7 +25,6 @@ import org.joda.time.Interval;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.Map;
 
 /**
  */
@@ -36,7 +35,7 @@ public interface QueryableIndex extends ColumnSelector, Closeable
   public Indexed<String> getColumnNames();
   public Indexed<String> getAvailableDimensions();
   public BitmapFactory getBitmapFactoryForDimensions();
-  public Map<String, Object> getMetaData();
+  public Metadata getMetaData();
 
   /**
    * The close method shouldn't actually be here as this is nasty. We will adjust it in the future.

--- a/processing/src/main/java/io/druid/segment/QueryableIndexIndexableAdapter.java
+++ b/processing/src/main/java/io/druid/segment/QueryableIndexIndexableAdapter.java
@@ -62,6 +62,7 @@ public class QueryableIndexIndexableAdapter implements IndexableAdapter
   private final int numRows;
   private final QueryableIndex input;
   private final List<String> availableDimensions;
+  private final Metadata metadata;
 
   public QueryableIndexIndexableAdapter(QueryableIndex input)
   {
@@ -83,6 +84,8 @@ public class QueryableIndexIndexableAdapter implements IndexableAdapter
         log.info("No dictionary on dimension[%s]", dim);
       }
     }
+
+    this.metadata = input.getMetaData();
   }
 
   @Override
@@ -379,8 +382,10 @@ public class QueryableIndexIndexableAdapter implements IndexableAdapter
         }
         if (lastVal != null) {
           if (GenericIndexed.STRING_STRATEGY.compare(value, lastVal) <= 0) {
-            throw new ISE("Value[%s] is less than the last value[%s] I have, cannot be.",
-                value, lastVal);
+            throw new ISE(
+                "Value[%s] is less than the last value[%s] I have, cannot be.",
+                value, lastVal
+            );
           }
           return new EmptyIndexedInts();
         }
@@ -398,12 +403,20 @@ public class QueryableIndexIndexableAdapter implements IndexableAdapter
           }
           return ret;
         } else if (compareResult < 0) {
-          throw new ISE("Skipped currValue[%s], currIndex[%,d]; incoming value[%s]",
-              currVal, currIndex, value);
+          throw new ISE(
+              "Skipped currValue[%s], currIndex[%,d]; incoming value[%s]",
+              currVal, currIndex, value
+          );
         } else {
           return new EmptyIndexedInts();
         }
       }
     };
+  }
+
+  @Override
+  public Metadata getMetadata()
+  {
+    return metadata;
   }
 }

--- a/processing/src/main/java/io/druid/segment/QueryableIndexIndexableAdapter.java
+++ b/processing/src/main/java/io/druid/segment/QueryableIndexIndexableAdapter.java
@@ -85,7 +85,7 @@ public class QueryableIndexIndexableAdapter implements IndexableAdapter
       }
     }
 
-    this.metadata = input.getMetaData();
+    this.metadata = input.getMetadata();
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/RowboatFilteringIndexAdapter.java
+++ b/processing/src/main/java/io/druid/segment/RowboatFilteringIndexAdapter.java
@@ -99,4 +99,10 @@ public class RowboatFilteringIndexAdapter implements IndexableAdapter
   {
     return baseAdapter.getBitmapIndexSeeker(dimension);
   }
+
+  @Override
+  public Metadata getMetadata()
+  {
+    return baseAdapter.getMetadata();
+  }
 }

--- a/processing/src/main/java/io/druid/segment/SimpleQueryableIndex.java
+++ b/processing/src/main/java/io/druid/segment/SimpleQueryableIndex.java
@@ -39,7 +39,7 @@ public class SimpleQueryableIndex implements QueryableIndex
   private final BitmapFactory bitmapFactory;
   private final Map<String, Column> columns;
   private final SmooshedFileMapper fileMapper;
-  private final Map<String, Object> metadata;
+  private final Metadata metadata;
 
   public SimpleQueryableIndex(
       Interval dataInterval,
@@ -48,7 +48,7 @@ public class SimpleQueryableIndex implements QueryableIndex
       BitmapFactory bitmapFactory,
       Map<String, Column> columns,
       SmooshedFileMapper fileMapper,
-      Map<String, Object> metadata
+      Metadata metadata
   )
   {
     Preconditions.checkNotNull(columns.get(Column.TIME_COLUMN_NAME));
@@ -104,7 +104,7 @@ public class SimpleQueryableIndex implements QueryableIndex
   }
 
   @Override
-  public Map<String, Object> getMetaData()
+  public Metadata getMetaData()
   {
     return metadata;
   }

--- a/processing/src/main/java/io/druid/segment/SimpleQueryableIndex.java
+++ b/processing/src/main/java/io/druid/segment/SimpleQueryableIndex.java
@@ -104,7 +104,7 @@ public class SimpleQueryableIndex implements QueryableIndex
   }
 
   @Override
-  public Metadata getMetaData()
+  public Metadata getMetadata()
   {
     return metadata;
   }

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -44,6 +44,7 @@ import io.druid.segment.ColumnSelectorFactory;
 import io.druid.segment.DimensionSelector;
 import io.druid.segment.FloatColumnSelector;
 import io.druid.segment.LongColumnSelector;
+import io.druid.segment.Metadata;
 import io.druid.segment.ObjectColumnSelector;
 import io.druid.segment.column.Column;
 import io.druid.segment.column.ColumnCapabilities;
@@ -262,6 +263,7 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
   private final AggregatorFactory[] metrics;
   private final AggregatorType[] aggs;
   private final boolean deserializeComplexMetrics;
+  private final Metadata metadata;
 
   private final Map<String, MetricDesc> metricDescs;
   private final Map<String, DimensionDesc> dimensionDescs;
@@ -298,6 +300,7 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
     this.metrics = incrementalIndexSchema.getMetrics();
     this.rowTransformers = new CopyOnWriteArrayList<>();
     this.deserializeComplexMetrics = deserializeComplexMetrics;
+    this.metadata = new Metadata();
 
     this.aggs = initAggs(metrics, rowSupplier, deserializeComplexMetrics);
     this.columnCapabilities = Maps.newHashMap();
@@ -619,6 +622,16 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
   public ConcurrentNavigableMap<TimeAndDims, Integer> getSubMap(TimeAndDims start, TimeAndDims end)
   {
     return getFacts().subMap(start, end);
+  }
+
+  public Metadata getMetadata()
+  {
+    return metadata;
+  }
+
+  public void addAllToMetadata(Metadata toAdd)
+  {
+    metadata.addAll(toAdd);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -300,7 +300,8 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
     this.metrics = incrementalIndexSchema.getMetrics();
     this.rowTransformers = new CopyOnWriteArrayList<>();
     this.deserializeComplexMetrics = deserializeComplexMetrics;
-    this.metadata = new Metadata();
+
+    this.metadata = new Metadata().setAggregators(getCombiningAggregators(metrics));
 
     this.aggs = initAggs(metrics, rowSupplier, deserializeComplexMetrics);
     this.columnCapabilities = Maps.newHashMap();
@@ -629,9 +630,13 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
     return metadata;
   }
 
-  public void addAllToMetadata(Metadata toAdd)
+  private static AggregatorFactory[] getCombiningAggregators(AggregatorFactory[] aggregators)
   {
-    metadata.addAll(toAdd);
+    AggregatorFactory[] combiningAggregators = new AggregatorFactory[aggregators.length];
+    for (int i = 0; i < aggregators.length; i++) {
+      combiningAggregators[i] = aggregators[i].getCombiningFactory();
+    }
+    return combiningAggregators;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexAdapter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexAdapter.java
@@ -29,6 +29,7 @@ import com.metamx.collections.bitmap.MutableBitmap;
 import com.metamx.common.ISE;
 import com.metamx.common.logger.Logger;
 import io.druid.segment.IndexableAdapter;
+import io.druid.segment.Metadata;
 import io.druid.segment.Rowboat;
 import io.druid.segment.column.BitmapIndexSeeker;
 import io.druid.segment.column.ColumnCapabilities;
@@ -58,6 +59,7 @@ public class IncrementalIndexAdapter implements IndexableAdapter
   private final IncrementalIndex<?> index;
   private final Map<String, Map<String, MutableBitmap>> invertedIndexes;
   private final Set<String> hasNullValueDimensions;
+  private final Metadata metadata;
 
   public IncrementalIndexAdapter(
       Interval dataInterval, IncrementalIndex<?> index, BitmapFactory bitmapFactory
@@ -65,6 +67,8 @@ public class IncrementalIndexAdapter implements IndexableAdapter
   {
     this.dataInterval = dataInterval;
     this.index = index;
+    this.metadata = index.getMetadata();
+
     this.invertedIndexes = Maps.newHashMap();
     /* Sometimes it's hard to tell whether one dimension contains a null value or not.
      * If one dimension had show a null or empty value explicitly, then yes, it contains
@@ -397,5 +401,11 @@ public class IncrementalIndexAdapter implements IndexableAdapter
     {
 
     }
+  }
+
+  @Override
+  public Metadata getMetadata()
+  {
+    return metadata;
   }
 }

--- a/processing/src/test/java/io/druid/query/MultiValuedDimensionTest.java
+++ b/processing/src/test/java/io/druid/query/MultiValuedDimensionTest.java
@@ -123,7 +123,7 @@ public class MultiValuedDimensionTest
 
     persistedSegmentDir = Files.createTempDir();
     TestHelper.getTestIndexMerger()
-              .persist(incrementalIndex, persistedSegmentDir, ImmutableMap.<String, Object>of(), new IndexSpec());
+              .persist(incrementalIndex, persistedSegmentDir, new IndexSpec());
 
     queryableIndex = TestHelper.getTestIndexIO().loadIndex(persistedSegmentDir);
   }

--- a/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
@@ -326,7 +326,7 @@ public class AggregationTestHelper
         catch (IndexSizeExceededException ex) {
           File tmp = tempFolder.newFolder();
           toMerge.add(tmp);
-          indexMerger.persist(index, tmp, null, new IndexSpec());
+          indexMerger.persist(index, tmp, new IndexSpec());
           index.close();
           index = new OnheapIncrementalIndex(minTimestamp, gran, metrics, deserializeComplexMetrics, maxRowCount);
         }
@@ -335,7 +335,7 @@ public class AggregationTestHelper
       if (toMerge.size() > 0) {
         File tmp = tempFolder.newFolder();
         toMerge.add(tmp);
-        indexMerger.persist(index, tmp, null, new IndexSpec());
+        indexMerger.persist(index, tmp, new IndexSpec());
 
         List<QueryableIndex> indexes = new ArrayList<>(toMerge.size());
         for (File file : toMerge) {
@@ -347,7 +347,7 @@ public class AggregationTestHelper
           qi.close();
         }
       } else {
-        indexMerger.persist(index, outDir, null, new IndexSpec());
+        indexMerger.persist(index, outDir, new IndexSpec());
       }
     }
     finally {

--- a/processing/src/test/java/io/druid/query/aggregation/AggregatorFactoryTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/AggregatorFactoryTest.java
@@ -1,0 +1,80 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.query.aggregation;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ */
+public class AggregatorFactoryTest
+{
+
+  @Test
+  public void testMergeAggregators()
+  {
+    Assert.assertNull(AggregatorFactory.mergeAggregators(null));
+    Assert.assertNull(AggregatorFactory.mergeAggregators(ImmutableList.<AggregatorFactory[]>of()));
+
+    List<AggregatorFactory[]> aggregatorsToBeMerged = new ArrayList<>();
+
+    aggregatorsToBeMerged.add(null);
+    Assert.assertNull(AggregatorFactory.mergeAggregators(aggregatorsToBeMerged));
+
+    AggregatorFactory[] emptyAggFactory = new AggregatorFactory[0];
+
+    aggregatorsToBeMerged.clear();
+    aggregatorsToBeMerged.add(emptyAggFactory);
+    Assert.assertArrayEquals(emptyAggFactory, AggregatorFactory.mergeAggregators(aggregatorsToBeMerged));
+
+    aggregatorsToBeMerged.clear();
+    aggregatorsToBeMerged.add(emptyAggFactory);
+    aggregatorsToBeMerged.add(null);
+    Assert.assertNull(AggregatorFactory.mergeAggregators(aggregatorsToBeMerged));
+
+    aggregatorsToBeMerged.clear();
+    AggregatorFactory[] af1 = new AggregatorFactory[]{
+        new LongMaxAggregatorFactory("name", "fieldName1")
+    };
+    AggregatorFactory[] af2 = new AggregatorFactory[]{
+        new LongMaxAggregatorFactory("name", "fieldName2")
+    };
+    Assert.assertArrayEquals(
+        new AggregatorFactory[]{
+            new LongMaxAggregatorFactory("name", "name")
+        },
+        AggregatorFactory.mergeAggregators(ImmutableList.of(af1, af2))
+    );
+
+    aggregatorsToBeMerged.clear();
+    af1 = new AggregatorFactory[]{
+        new LongMaxAggregatorFactory("name", "fieldName1")
+    };
+    af2 = new AggregatorFactory[]{
+        new DoubleMaxAggregatorFactory("name", "fieldName2")
+    };
+    Assert.assertNull(AggregatorFactory.mergeAggregators(ImmutableList.of(af1, af2))
+    );
+  }
+}

--- a/processing/src/test/java/io/druid/segment/EmptyIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/EmptyIndexTest.java
@@ -63,7 +63,6 @@ public class EmptyIndexTest
         Lists.<IndexableAdapter>newArrayList(emptyIndexAdapter),
         new AggregatorFactory[0],
         tmpDir,
-        null,
         new IndexSpec()
     );
 

--- a/processing/src/test/java/io/druid/segment/IndexMergerTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerTest.java
@@ -57,7 +57,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 @RunWith(Parameterized.class)
 public class IndexMergerTest
@@ -142,7 +141,6 @@ public class IndexMergerTest
             INDEX_MERGER.persist(
                 toPersist,
                 tempDir,
-                null,
                 indexSpec
             )
         )
@@ -180,7 +178,6 @@ public class IndexMergerTest
             INDEX_MERGER.persist(
                 toPersist,
                 tempDir,
-                null,
                 indexSpec
             )
         )
@@ -231,7 +228,6 @@ public class IndexMergerTest
             INDEX_MERGER.persist(
                 toPersist1,
                 tempDir1,
-                null,
                 indexSpec
             )
         )
@@ -273,10 +269,14 @@ public class IndexMergerTest
   {
     final long timestamp = System.currentTimeMillis();
 
+    Metadata segmentMetadata = new Metadata();
+    segmentMetadata.put("key", "value");
+
     IncrementalIndex toPersist = IncrementalIndexTest.createIndex(null);
+    toPersist.addAllToMetadata(segmentMetadata);
+
     IncrementalIndexTest.populateIndex(timestamp, toPersist);
 
-    Map<String, Object> segmentMetadata = ImmutableMap.<String, Object>of("key", "value");
 
     final File tempDir = temporaryFolder.newFolder();
     QueryableIndex index = closer.closeLater(
@@ -284,7 +284,6 @@ public class IndexMergerTest
             INDEX_MERGER.persist(
                 toPersist,
                 tempDir,
-                segmentMetadata,
                 indexSpec
             )
         )
@@ -338,7 +337,6 @@ public class IndexMergerTest
             INDEX_MERGER.persist(
                 toPersist1,
                 tempDir1,
-                null,
                 indexSpec
             )
         )
@@ -353,7 +351,6 @@ public class IndexMergerTest
             INDEX_MERGER.persist(
                 toPersist2,
                 tempDir2,
-                null,
                 indexSpec
             )
         )
@@ -422,7 +419,6 @@ public class IndexMergerTest
             INDEX_MERGER.persist(
                 toPersist1,
                 tmpDir1,
-                null,
                 indexSpec
             )
         )
@@ -432,7 +428,6 @@ public class IndexMergerTest
             INDEX_MERGER.persist(
                 toPersist1,
                 tmpDir2,
-                null,
                 indexSpec
             )
         )
@@ -461,6 +456,7 @@ public class IndexMergerTest
     assertDimCompression(index2, indexSpec.getDimensionCompressionStrategy());
     assertDimCompression(merged, indexSpec.getDimensionCompressionStrategy());
   }
+
 
   @Test
   public void testAppendRetainsValues() throws Exception
@@ -536,7 +532,6 @@ public class IndexMergerTest
             INDEX_MERGER.persist(
                 toPersist1,
                 tempDir1,
-                null,
                 indexSpec
             )
         )
@@ -606,7 +601,7 @@ public class IndexMergerTest
     );
 
     QueryableIndex index1 = closer.closeLater(
-        INDEX_IO.loadIndex(INDEX_MERGER.persist(toPersist1, tempDir1, null, indexSpec))
+        INDEX_IO.loadIndex(INDEX_MERGER.persist(toPersist1, tempDir1, indexSpec))
     );
 
     final IndexableAdapter queryableAdapter = new QueryableIndexIndexableAdapter(index1);
@@ -668,7 +663,6 @@ public class IndexMergerTest
             INDEX_MERGER.persist(
                 toPersist1,
                 tempDir1,
-                null,
                 indexSpec
             )
         )
@@ -754,7 +748,6 @@ public class IndexMergerTest
             INDEX_MERGER.persist(
                 toPersist1,
                 tmpDir,
-                null,
                 indexSpec
             )
         )
@@ -765,7 +758,6 @@ public class IndexMergerTest
             INDEX_MERGER.persist(
                 toPersist2,
                 tmpDir2,
-                null,
                 indexSpec
             )
         )
@@ -776,7 +768,6 @@ public class IndexMergerTest
             INDEX_MERGER.persist(
                 toPersist3,
                 tmpDir3,
-                null,
                 indexSpec
             )
         )
@@ -826,7 +817,6 @@ public class IndexMergerTest
             INDEX_MERGER.persist(
                 toPersistA,
                 tmpDirA,
-                null,
                 indexSpec
             )
         )
@@ -837,7 +827,6 @@ public class IndexMergerTest
             INDEX_MERGER.persist(
                 toPersistB,
                 tmpDirB,
-                null,
                 indexSpec
             )
         )
@@ -954,7 +943,6 @@ public class IndexMergerTest
             INDEX_MERGER.persist(
                 toPersistA,
                 tmpDirA,
-                null,
                 indexSpec
             )
         )
@@ -965,7 +953,6 @@ public class IndexMergerTest
             INDEX_MERGER.persist(
                 toPersistB,
                 tmpDirB,
-                null,
                 indexSpec
             )
         )

--- a/processing/src/test/java/io/druid/segment/IndexMergerV9CompatibilityTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerV9CompatibilityTest.java
@@ -170,12 +170,13 @@ public class IndexMergerV9CompatibilityTest
         DEFAULT_AGG_FACTORIES,
         1000000
     );
+    toPersist.getMetadata().put("key", "value");
     for (InputRow event : events) {
       toPersist.add(event);
     }
     tmpDir = Files.createTempDir();
     persistTmpDir = new File(tmpDir, "persistDir");
-    INDEX_MERGER.persist(toPersist, persistTmpDir, null, INDEX_SPEC);
+    INDEX_MERGER.persist(toPersist, persistTmpDir, INDEX_SPEC);
   }
 
   @After
@@ -191,10 +192,9 @@ public class IndexMergerV9CompatibilityTest
     QueryableIndex index = null;
     try {
       outDir = Files.createTempDir();
-      Map<String, Object> segmentMetadata = ImmutableMap.<String, Object>of("key", "value");
-      index = INDEX_IO.loadIndex(INDEX_MERGER_V9.persist(toPersist, outDir, segmentMetadata, INDEX_SPEC));
+      index = INDEX_IO.loadIndex(INDEX_MERGER_V9.persist(toPersist, outDir, INDEX_SPEC));
 
-      Assert.assertEquals(segmentMetadata, index.getMetaData());
+      Assert.assertEquals("value", index.getMetadata().get("key"));
     }
     finally {
       if (index != null) {
@@ -237,6 +237,7 @@ public class IndexMergerV9CompatibilityTest
   {
     final File outDir = INDEX_MERGER.append(
         ImmutableList.<IndexableAdapter>of(new QueryableIndexIndexableAdapter(closer.closeLater(INDEX_IO.loadIndex(inDir)))),
+        null,
         tmpDir,
         INDEX_SPEC
     );

--- a/processing/src/test/java/io/druid/segment/IndexMergerV9Test.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerV9Test.java
@@ -57,7 +57,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 @RunWith(Parameterized.class)
 public class IndexMergerV9Test
@@ -142,7 +141,6 @@ public class IndexMergerV9Test
             INDEX_MERGER.persist(
                 toPersist,
                 tempDir,
-                null,
                 indexSpec
             )
         )
@@ -180,7 +178,6 @@ public class IndexMergerV9Test
             INDEX_MERGER.persist(
                 toPersist,
                 tempDir,
-                null,
                 indexSpec
             )
         )
@@ -217,8 +214,7 @@ public class IndexMergerV9Test
 
     IncrementalIndex toPersist = IncrementalIndexTest.createIndex(null);
     IncrementalIndexTest.populateIndex(timestamp, toPersist);
-
-    Map<String, Object> segmentMetadata = ImmutableMap.<String, Object>of("key", "value");
+    toPersist.getMetadata().put("key", "value");
 
     final File tempDir = temporaryFolder.newFolder();
     QueryableIndex index = closer.closeLater(
@@ -226,7 +222,6 @@ public class IndexMergerV9Test
             INDEX_MERGER.persist(
                 toPersist,
                 tempDir,
-                segmentMetadata,
                 indexSpec
             )
         )
@@ -238,7 +233,7 @@ public class IndexMergerV9Test
 
     assertDimCompression(index, indexSpec.getDimensionCompressionStrategy());
 
-    Assert.assertEquals(segmentMetadata, index.getMetaData());
+    Assert.assertEquals("value", index.getMetadata().get("key"));
   }
 
   @Test
@@ -280,7 +275,6 @@ public class IndexMergerV9Test
             INDEX_MERGER.persist(
                 toPersist1,
                 tempDir1,
-                null,
                 indexSpec
             )
         )
@@ -295,7 +289,6 @@ public class IndexMergerV9Test
             INDEX_MERGER.persist(
                 toPersist2,
                 tempDir2,
-                null,
                 indexSpec
             )
         )
@@ -364,7 +357,6 @@ public class IndexMergerV9Test
             INDEX_MERGER.persist(
                 toPersist1,
                 tmpDir1,
-                null,
                 indexSpec
             )
         )
@@ -374,7 +366,6 @@ public class IndexMergerV9Test
             INDEX_MERGER.persist(
                 toPersist1,
                 tmpDir2,
-                null,
                 indexSpec
             )
         )
@@ -425,7 +416,6 @@ public class IndexMergerV9Test
             INDEX_MERGER.persist(
                 toPersist1,
                 tempDir1,
-                null,
                 indexSpec
             )
         )
@@ -482,7 +472,7 @@ public class IndexMergerV9Test
     QueryableIndex index1 = closer.closeLater(
         INDEX_IO.loadIndex(
             INDEX_MERGER.append(
-                ImmutableList.<IndexableAdapter>of(incrementalAdapter), tempDir1, indexSpec
+                ImmutableList.<IndexableAdapter>of(incrementalAdapter), null, tempDir1, indexSpec
             )
         )
     );
@@ -537,7 +527,6 @@ public class IndexMergerV9Test
             INDEX_MERGER.persist(
                 toPersist1,
                 tempDir1,
-                null,
                 indexSpec
             )
         )
@@ -607,7 +596,7 @@ public class IndexMergerV9Test
     );
 
     QueryableIndex index1 = closer.closeLater(
-        INDEX_IO.loadIndex(INDEX_MERGER.persist(toPersist1, tempDir1, null, indexSpec))
+        INDEX_IO.loadIndex(INDEX_MERGER.persist(toPersist1, tempDir1, indexSpec))
     );
 
     final IndexableAdapter queryableAdapter = new QueryableIndexIndexableAdapter(index1);
@@ -669,7 +658,6 @@ public class IndexMergerV9Test
             INDEX_MERGER.persist(
                 toPersist1,
                 tempDir1,
-                null,
                 indexSpec
             )
         )
@@ -751,7 +739,6 @@ public class IndexMergerV9Test
             INDEX_MERGER.persist(
                 toPersistA,
                 tmpDirA,
-                null,
                 indexSpec
             )
         )
@@ -762,7 +749,6 @@ public class IndexMergerV9Test
             INDEX_MERGER.persist(
                 toPersistB,
                 tmpDirB,
-                null,
                 indexSpec
             )
         )
@@ -879,7 +865,6 @@ public class IndexMergerV9Test
             INDEX_MERGER.persist(
                 toPersistA,
                 tmpDirA,
-                null,
                 indexSpec
             )
         )
@@ -890,7 +875,6 @@ public class IndexMergerV9Test
             INDEX_MERGER.persist(
                 toPersistB,
                 tmpDirB,
-                null,
                 indexSpec
             )
         )

--- a/processing/src/test/java/io/druid/segment/IndexMergerV9WithSpatialIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerV9WithSpatialIndexTest.java
@@ -258,7 +258,7 @@ public class IndexMergerV9WithSpatialIndexTest
     tmpFile.mkdirs();
     tmpFile.deleteOnExit();
 
-    INDEX_MERGER_V9.persist(theIndex, tmpFile, null, indexSpec);
+    INDEX_MERGER_V9.persist(theIndex, tmpFile, indexSpec);
     return INDEX_IO.loadIndex(tmpFile);
   }
 
@@ -478,9 +478,9 @@ public class IndexMergerV9WithSpatialIndexTest
       mergedFile.mkdirs();
       mergedFile.deleteOnExit();
 
-      INDEX_MERGER_V9.persist(first, DATA_INTERVAL, firstFile, null, indexSpec);
-      INDEX_MERGER_V9.persist(second, DATA_INTERVAL, secondFile, null, indexSpec);
-      INDEX_MERGER_V9.persist(third, DATA_INTERVAL, thirdFile, null, indexSpec);
+      INDEX_MERGER_V9.persist(first, DATA_INTERVAL, firstFile, indexSpec);
+      INDEX_MERGER_V9.persist(second, DATA_INTERVAL, secondFile, indexSpec);
+      INDEX_MERGER_V9.persist(third, DATA_INTERVAL, thirdFile, indexSpec);
 
       QueryableIndex mergedRealtime = INDEX_IO.loadIndex(
           INDEX_MERGER_V9.mergeQueryableIndex(

--- a/processing/src/test/java/io/druid/segment/MetadataTest.java
+++ b/processing/src/test/java/io/druid/segment/MetadataTest.java
@@ -1,0 +1,118 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.segment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import io.druid.jackson.DefaultObjectMapper;
+import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.query.aggregation.DoubleMaxAggregatorFactory;
+import io.druid.query.aggregation.LongMaxAggregatorFactory;
+import io.druid.query.aggregation.LongSumAggregatorFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ */
+public class MetadataTest
+{
+  @Test
+  public void testSerde() throws Exception
+  {
+    ObjectMapper jsonMapper = new DefaultObjectMapper();
+
+    Metadata metadata = new Metadata();
+    metadata.put("k", "v");
+
+    AggregatorFactory[] aggregators = new AggregatorFactory[]
+        {
+            new LongSumAggregatorFactory("out", "in")
+        };
+    metadata.setAggregators(aggregators);
+
+    Metadata other = jsonMapper.readValue(
+        jsonMapper.writeValueAsString(metadata),
+        Metadata.class
+    );
+
+    Assert.assertEquals(metadata, other);
+  }
+
+  @Test
+  public void testMerge()
+  {
+    Assert.assertNull(Metadata.merge(null, null));
+    Assert.assertNull(Metadata.merge(ImmutableList.<Metadata>of(), null));
+
+    List<Metadata> metadataToBeMerged = new ArrayList<>();
+
+    metadataToBeMerged.add(null);
+    Assert.assertNull(Metadata.merge(metadataToBeMerged, null));
+
+    //sanity merge check
+    AggregatorFactory[] aggs = new AggregatorFactory[] {
+        new LongMaxAggregatorFactory("n", "f")
+    };
+    Metadata m1 = new Metadata();
+    m1.put("k", "v");
+    m1.setAggregators(aggs);
+
+    Metadata m2 = new Metadata();
+    m2.put("k", "v");
+    m2.setAggregators(aggs);
+
+    Metadata merged = new Metadata();
+    merged.put("k", "v");
+    merged.setAggregators(
+        new AggregatorFactory[]{
+            new LongMaxAggregatorFactory("n", "n")
+        }
+    );
+    Assert.assertEquals(merged, Metadata.merge(ImmutableList.of(m1, m2), null));
+
+    //merge check with one metadata being null
+    metadataToBeMerged.clear();
+    metadataToBeMerged.add(m1);
+    metadataToBeMerged.add(m2);
+    metadataToBeMerged.add(null);
+
+    merged.setAggregators(null);
+    Assert.assertEquals(merged, Metadata.merge(metadataToBeMerged, null));
+
+    //merge check with client explicitly providing merged aggregators
+    AggregatorFactory[] explicitAggs = new AggregatorFactory[] {
+        new DoubleMaxAggregatorFactory("x", "y")
+    };
+    merged.setAggregators(explicitAggs);
+
+    Assert.assertEquals(
+        merged,
+        Metadata.merge(metadataToBeMerged, explicitAggs)
+    );
+
+    Assert.assertEquals(
+        merged,
+        Metadata.merge(ImmutableList.of(m1, m2), explicitAggs)
+    );
+  }
+}

--- a/processing/src/test/java/io/druid/segment/QueryableIndexIndexableAdapterTest.java
+++ b/processing/src/test/java/io/druid/segment/QueryableIndexIndexableAdapterTest.java
@@ -19,8 +19,7 @@
 
 package io.druid.segment;
 
-import java.io.File;
-
+import com.metamx.common.ISE;
 import io.druid.segment.column.BitmapIndexSeeker;
 import io.druid.segment.data.CompressedObjectStrategy;
 import io.druid.segment.data.ConciseBitmapSerdeFactory;
@@ -28,13 +27,12 @@ import io.druid.segment.data.IncrementalIndexTest;
 import io.druid.segment.data.IndexedInts;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexAdapter;
-
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import com.metamx.common.ISE;
+import java.io.File;
 
 public class QueryableIndexIndexableAdapterTest {
   private final static IndexMerger INDEX_MERGER = TestHelper.getTestIndexMerger();
@@ -69,7 +67,6 @@ public class QueryableIndexIndexableAdapterTest {
             INDEX_MERGER.persist(
                 toPersist,
                 tempDir,
-                null,
                 INDEX_SPEC
             )
         )

--- a/processing/src/test/java/io/druid/segment/SchemalessIndex.java
+++ b/processing/src/test/java/io/druid/segment/SchemalessIndex.java
@@ -191,8 +191,8 @@ public class SchemalessIndex
         mergedFile.mkdirs();
         mergedFile.deleteOnExit();
 
-        INDEX_MERGER.persist(top, topFile, null, indexSpec);
-        INDEX_MERGER.persist(bottom, bottomFile, null, indexSpec);
+        INDEX_MERGER.persist(top, topFile, indexSpec);
+        INDEX_MERGER.persist(bottom, bottomFile, indexSpec);
 
         mergedIndex = INDEX_IO.loadIndex(
             INDEX_MERGER.mergeQueryableIndex(
@@ -361,7 +361,7 @@ public class SchemalessIndex
           tmpFile.mkdirs();
           tmpFile.deleteOnExit();
 
-          INDEX_MERGER.persist(rowIndex, tmpFile, null, indexSpec);
+          INDEX_MERGER.persist(rowIndex, tmpFile, indexSpec);
           rowPersistedIndexes.add(INDEX_IO.loadIndex(tmpFile));
         }
       }
@@ -421,7 +421,7 @@ public class SchemalessIndex
       theFile.mkdirs();
       theFile.deleteOnExit();
       filesToMap.add(theFile);
-      INDEX_MERGER.persist(index, theFile, null, indexSpec);
+      INDEX_MERGER.persist(index, theFile, indexSpec);
     }
 
     return filesToMap;

--- a/processing/src/test/java/io/druid/segment/SchemalessIndex.java
+++ b/processing/src/test/java/io/druid/segment/SchemalessIndex.java
@@ -495,7 +495,7 @@ public class SchemalessIndex
           )
       );
 
-      return INDEX_IO.loadIndex(INDEX_MERGER.append(adapters, mergedFile, indexSpec));
+      return INDEX_IO.loadIndex(INDEX_MERGER.append(adapters, null, mergedFile, indexSpec));
     }
     catch (IOException e) {
       throw Throwables.propagate(e);

--- a/processing/src/test/java/io/druid/segment/TestHelper.java
+++ b/processing/src/test/java/io/druid/segment/TestHelper.java
@@ -38,9 +38,10 @@ public class TestHelper
   private static final IndexMerger INDEX_MERGER;
   private static final IndexMergerV9 INDEX_MERGER_V9;
   private static final IndexIO INDEX_IO;
-  public static final ObjectMapper JSON_MAPPER = new DefaultObjectMapper();
+  public static final ObjectMapper JSON_MAPPER;
 
   static {
+    JSON_MAPPER = new DefaultObjectMapper();
     INDEX_IO = new IndexIO(
         JSON_MAPPER,
         new ColumnConfig()
@@ -54,6 +55,11 @@ public class TestHelper
     );
     INDEX_MERGER = new IndexMerger(JSON_MAPPER, INDEX_IO);
     INDEX_MERGER_V9 = new IndexMergerV9(JSON_MAPPER, INDEX_IO);
+  }
+
+  public static ObjectMapper getTestObjectMapper()
+  {
+    return JSON_MAPPER;
   }
 
 

--- a/processing/src/test/java/io/druid/segment/TestIndex.java
+++ b/processing/src/test/java/io/druid/segment/TestIndex.java
@@ -143,8 +143,8 @@ public class TestIndex
         mergedFile.mkdirs();
         mergedFile.deleteOnExit();
 
-        INDEX_MERGER.persist(top, DATA_INTERVAL, topFile, null, indexSpec);
-        INDEX_MERGER.persist(bottom, DATA_INTERVAL, bottomFile, null, indexSpec);
+        INDEX_MERGER.persist(top, DATA_INTERVAL, topFile, indexSpec);
+        INDEX_MERGER.persist(bottom, DATA_INTERVAL, bottomFile, indexSpec);
 
         mergedRealtime = INDEX_IO.loadIndex(
             INDEX_MERGER.mergeQueryableIndex(
@@ -243,7 +243,7 @@ public class TestIndex
       someTmpFile.mkdirs();
       someTmpFile.deleteOnExit();
 
-      INDEX_MERGER.persist(index, someTmpFile, null, indexSpec);
+      INDEX_MERGER.persist(index, someTmpFile, indexSpec);
       return INDEX_IO.loadIndex(someTmpFile);
     }
     catch (IOException e) {

--- a/processing/src/test/java/io/druid/segment/data/IncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/data/IncrementalIndexTest.java
@@ -128,6 +128,16 @@ public class IncrementalIndexTest
     );
   }
 
+  public static AggregatorFactory[] getDefaultAggregatorFactories()
+  {
+    return defaultAggregatorFactories;
+  }
+
+  public static AggregatorFactory[] getDefaultCombiningAggregatorFactories()
+  {
+    return defaultCombiningAggregatorFactories;
+  }
+
   public static IncrementalIndex createIndex(AggregatorFactory[] aggregatorFactories)
   {
     if (null == aggregatorFactories) {
@@ -186,6 +196,10 @@ public class IncrementalIndexTest
       new CountAggregatorFactory(
           "count"
       )
+  };
+
+  private static final AggregatorFactory[] defaultCombiningAggregatorFactories = new AggregatorFactory[]{
+      defaultAggregatorFactories[0].getCombiningFactory()
   };
 
   @Test

--- a/processing/src/test/java/io/druid/segment/filter/SpatialFilterBonusTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/SpatialFilterBonusTest.java
@@ -237,7 +237,7 @@ public class SpatialFilterBonusTest
     tmpFile.mkdirs();
     tmpFile.deleteOnExit();
 
-    INDEX_MERGER.persist(theIndex, tmpFile, null, indexSpec);
+    INDEX_MERGER.persist(theIndex, tmpFile, indexSpec);
     return INDEX_IO.loadIndex(tmpFile);
   }
 
@@ -417,9 +417,9 @@ public class SpatialFilterBonusTest
       mergedFile.mkdirs();
       mergedFile.deleteOnExit();
 
-      INDEX_MERGER.persist(first, DATA_INTERVAL, firstFile, null, indexSpec);
-      INDEX_MERGER.persist(second, DATA_INTERVAL, secondFile, null, indexSpec);
-      INDEX_MERGER.persist(third, DATA_INTERVAL, thirdFile, null, indexSpec);
+      INDEX_MERGER.persist(first, DATA_INTERVAL, firstFile, indexSpec);
+      INDEX_MERGER.persist(second, DATA_INTERVAL, secondFile, indexSpec);
+      INDEX_MERGER.persist(third, DATA_INTERVAL, thirdFile, indexSpec);
 
       QueryableIndex mergedRealtime = INDEX_IO.loadIndex(
           INDEX_MERGER.mergeQueryableIndex(

--- a/processing/src/test/java/io/druid/segment/filter/SpatialFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/SpatialFilterTest.java
@@ -266,7 +266,7 @@ public class SpatialFilterTest
     tmpFile.mkdirs();
     tmpFile.deleteOnExit();
 
-    INDEX_MERGER.persist(theIndex, tmpFile, null, indexSpec);
+    INDEX_MERGER.persist(theIndex, tmpFile, indexSpec);
     return INDEX_IO.loadIndex(tmpFile);
   }
 
@@ -486,9 +486,9 @@ public class SpatialFilterTest
       mergedFile.mkdirs();
       mergedFile.deleteOnExit();
 
-      INDEX_MERGER.persist(first, DATA_INTERVAL, firstFile, null, indexSpec);
-      INDEX_MERGER.persist(second, DATA_INTERVAL, secondFile, null, indexSpec);
-      INDEX_MERGER.persist(third, DATA_INTERVAL, thirdFile, null, indexSpec);
+      INDEX_MERGER.persist(first, DATA_INTERVAL, firstFile, indexSpec);
+      INDEX_MERGER.persist(second, DATA_INTERVAL, secondFile, indexSpec);
+      INDEX_MERGER.persist(third, DATA_INTERVAL, thirdFile, indexSpec);
 
       QueryableIndex mergedRealtime = INDEX_IO.loadIndex(
           INDEX_MERGER.mergeQueryableIndex(

--- a/server/src/test/java/io/druid/segment/realtime/firehose/IngestSegmentFirehoseTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/firehose/IngestSegmentFirehoseTest.java
@@ -124,7 +124,7 @@ public class IngestSegmentFirehoseTest
       for (String line : rows) {
         index.add(parser.parse(line));
       }
-      indexMerger.persist(index, segmentDir, null, new IndexSpec());
+      indexMerger.persist(index, segmentDir, new IndexSpec());
     }
     finally {
       if (index != null) {


### PR DESCRIPTION
This PR adds the list of aggregators used to create a segment to it's metadata which is persisted in metadata.drd file. This feature aids
1) implementation of hadoop "reindexing/merging" task so that it can merge intervals automatically with minimal user input.
2) UI implementations to present a list of aggregators to users

Also, this PR improves the segment metadata framework which allows adding more stuff easily  e.g. QueryGranularity (not added in this PR though)

In order to implement this feature, following notable changes were made.
1) AggregatorFactory is made an abstract class, a new method was added to AggregatorFactory with a default implementation (also AggregatorFactory was converted to an abstract class), this is required in order to correctly "merge"
aggregator factories. This is a `backward incompatible` change.
```
/**
 * Returns an AggregatorFactory that can be used to merge the output of aggregators from this factory and
 * other factory.
 * This method is relevant only for AggregatorFactory which can be used at ingestion time.
 *
 * @return a new Factory that can be used for merging the output of aggregators from this factory and other.
 */
public AggregatorFactory getMergingFactory(AggregatorFactory other) throws AggregatorFactoryNotMergeableException


```

2) User can optionally supply the list of Aggregators to AppendTask so as to explicitly specify list of aggregators to be stored inside the segment metadata of final appended segment.

