### PR TITLE
allow one cache connection per processing thread

### DIFF
--- a/docs/content/configuration/broker.md
+++ b/docs/content/configuration/broker.md
@@ -103,3 +103,4 @@ You can optionally only configure caching to be enabled on the broker by setting
 |`druid.cache.hosts`|Command separated list of Memcached hosts `<host:port>`.|none|
 |`druid.cache.maxObjectSize`|Maximum object size in bytes for a Memcached object.|52428800 (50 MB)|
 |`druid.cache.memcachedPrefix`|Key prefix for all keys in Memcached.|druid|
+|`druid.cache.separateConnectionPerThread`|Whether to use a separate cache connection per processing thread.|false|

--- a/server/src/main/java/io/druid/client/cache/MemcachedCacheConfig.java
+++ b/server/src/main/java/io/druid/client/cache/MemcachedCacheConfig.java
@@ -51,6 +51,10 @@ public class MemcachedCacheConfig
   @JsonProperty
   private long maxOperationQueueSize = 0;
 
+  // use a separate connection per processing thread to increase cache throughput
+  @JsonProperty
+  private boolean separateConnectionPerThread = false;
+
   public int getExpiration()
   {
     return expiration;
@@ -84,5 +88,10 @@ public class MemcachedCacheConfig
   public int getReadBufferSize()
   {
     return readBufferSize;
+  }
+
+  public boolean isSeparateConnectionPerThread()
+  {
+    return separateConnectionPerThread;
   }
 }

--- a/server/src/test/java/io/druid/client/cache/MemcachedCacheBenchmark.java
+++ b/server/src/test/java/io/druid/client/cache/MemcachedCacheBenchmark.java
@@ -20,6 +20,7 @@ package io.druid.client.cache;
 import com.google.caliper.Param;
 import com.google.caliper.Runner;
 import com.google.caliper.SimpleBenchmark;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.Lists;
 import net.spy.memcached.AddrUtil;
 import net.spy.memcached.ConnectionFactoryBuilder;
@@ -77,7 +78,7 @@ public class MemcachedCacheBenchmark extends SimpleBenchmark
 
 
     cache = new MemcachedCache(
-        client,
+        Suppliers.ofInstance(client),
         new MemcachedCacheConfig()
         {
           @Override

--- a/server/src/test/java/io/druid/client/cache/MemcachedCacheTest.java
+++ b/server/src/test/java/io/druid/client/cache/MemcachedCacheTest.java
@@ -19,6 +19,8 @@ package io.druid.client.cache;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.primitives.Ints;
@@ -110,7 +112,7 @@ public class MemcachedCacheTest
   @Before
   public void setUp() throws Exception
   {
-    MemcachedClientIF client = new MockMemcachedClient();
+    Supplier<MemcachedClientIF> client = Suppliers.<MemcachedClientIF>ofInstance(new MockMemcachedClient());
     cache = new MemcachedCache(client, memcachedCacheConfig);
   }
 


### PR DESCRIPTION
The memcached client uses a single connection and bulks operations together, causing processing threads to time out waiting for results of other threads when lots of cache items get requested. This adds a setting to allow each processing thread its own cache connection.