### PR TITLE
Allow SegmentAnalyzer to read columns from StorageAdapter, allow SegmentMetadataQuery to query IncrementalIndexSegments on realtime node

### DIFF
--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
@@ -114,10 +114,6 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
               return arg1;
             }
 
-            if (!query.isMerge()) {
-              throw new ISE("Merging when a merge isn't supposed to happen[%s], [%s]", arg1, arg2);
-            }
-
             List<Interval> newIntervals = JodaUtils.condenseIntervals(
                 Iterables.concat(arg1.getIntervals(), arg2.getIntervals())
             );

--- a/processing/src/main/java/io/druid/segment/QueryableIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/QueryableIndexStorageAdapter.java
@@ -105,6 +105,12 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
   }
 
   @Override
+  public int getNumRows()
+  {
+    return index.getNumRows();
+  }
+
+  @Override
   public DateTime getMinTime()
   {
     GenericColumn column = null;
@@ -134,6 +140,12 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
   public Capabilities getCapabilities()
   {
     return Capabilities.builder().dimensionValuesSorted(true).build();
+  }
+
+  @Override
+  public ColumnCapabilities getColumnCapabilities(String column)
+  {
+    return index.getColumn(column).getCapabilities();
   }
 
   @Override
@@ -275,7 +287,10 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
                     }
 
                     @Override
-                    public DimensionSelector makeDimensionSelector(final String dimension, @Nullable final ExtractionFn extractionFn)
+                    public DimensionSelector makeDimensionSelector(
+                        final String dimension,
+                        @Nullable final ExtractionFn extractionFn
+                    )
                     {
                       final Column columnDesc = index.getColumn(dimension);
                       if (columnDesc == null) {
@@ -296,8 +311,7 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
 
                       if (column == null) {
                         return NULL_DIMENSION_SELECTOR;
-                      }
-                      else if (columnDesc.getCapabilities().hasMultipleValues()) {
+                      } else if (columnDesc.getCapabilities().hasMultipleValues()) {
                         return new DimensionSelector()
                         {
                           @Override
@@ -325,7 +339,9 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
                           public int lookupId(String name)
                           {
                             if (extractionFn != null) {
-                              throw new UnsupportedOperationException("cannot perform lookup when applying an extraction function");
+                              throw new UnsupportedOperationException(
+                                  "cannot perform lookup when applying an extraction function"
+                              );
                             }
                             return column.lookupId(name);
                           }
@@ -388,7 +404,9 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
                           public int lookupId(String name)
                           {
                             if (extractionFn != null) {
-                              throw new UnsupportedOperationException("cannot perform lookup when applying an extraction function");
+                              throw new UnsupportedOperationException(
+                                  "cannot perform lookup when applying an extraction function"
+                              );
                             }
                             return column.lookupId(name);
                           }

--- a/processing/src/main/java/io/druid/segment/StorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/StorageAdapter.java
@@ -17,6 +17,7 @@
 
 package io.druid.segment;
 
+import io.druid.segment.column.ColumnCapabilities;
 import io.druid.segment.data.Indexed;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -42,5 +43,7 @@ public interface StorageAdapter extends CursorFactory
   public DateTime getMinTime();
   public DateTime getMaxTime();
   public Capabilities getCapabilities();
+  public ColumnCapabilities getColumnCapabilities(String column);
+  public int getNumRows();
   public DateTime getMaxIngestedEventTime();
 }


### PR DESCRIPTION
Allows SegmentAnalyzer to create an analysis from a StorageAdapter; this is used during the SegmentMetadataQuery to allow the query to read from IncrementalIndexSegments wrapped by a StorageAdapter.

This allows the metadata query to read columns from the most recent hydrant on the realtime node.

Size calculation is not performed in this alternate path.