### PR TITLE
Disable metadata publishing attempt in example script

### DIFF
--- a/examples/bin/run_example_server.sh
+++ b/examples/bin/run_example_server.sh
@@ -39,6 +39,7 @@ JAVA_ARGS="-Xmx512m -Duser.timezone=UTC -Dfile.encoding=UTF-8"
 JAVA_ARGS="${JAVA_ARGS} -Ddruid.realtime.specFile=${SPEC_FILE}"
 JAVA_ARGS="${JAVA_ARGS} -Ddruid.extensions.localRepository=${MAVEN_DIR}"
 JAVA_ARGS="${JAVA_ARGS} -Ddruid.extensions.remoteRepositories=[]"
+JAVA_ARGS="${JAVA_ARGS} -Ddruid.publish.type=noop"
 
 DRUID_CP=${EXAMPLE_LOC}
 #For a pull


### PR DESCRIPTION
Example config no-ops DataSegmentPusher and DataSegmentAnnouncer but
still binds SegmentPublisher to MetadataSegmentPublisher which was
throwing exceptions when it tried to publish and no DB was configured.
Setting this binds NoopSegmentPublisher instead.