### PR TITLE
making NumberedShardSpec elastic

### DIFF
--- a/common/src/main/java/io/druid/timeline/partition/NumberedPartitionChunk.java
+++ b/common/src/main/java/io/druid/timeline/partition/NumberedPartitionChunk.java
@@ -43,7 +43,7 @@ public class NumberedPartitionChunk<T> implements PartitionChunk<T>
   )
   {
     Preconditions.checkArgument(chunkNumber >= 0, "chunkNumber >= 0");
-    Preconditions.checkArgument(chunkNumber < chunks, "chunkNumber < chunks");
+    Preconditions.checkArgument(chunks >= 0, "chunks >= 0");
     this.chunkNumber = chunkNumber;
     this.chunks = chunks;
     this.object = object;
@@ -58,19 +58,28 @@ public class NumberedPartitionChunk<T> implements PartitionChunk<T>
   @Override
   public boolean abuts(final PartitionChunk<T> other)
   {
-    return other instanceof NumberedPartitionChunk && other.getChunkNumber() == chunkNumber + 1;
+    if (other instanceof NumberedPartitionChunk) {
+      NumberedPartitionChunk<T> castedOther = (NumberedPartitionChunk<T>) other;
+      if (castedOther.getChunkNumber() < castedOther.chunks) {
+        return other.getChunkNumber() == chunkNumber + 1;
+      } else {
+        return other.getChunkNumber() > chunkNumber;
+      }
+    } else {
+      return false;
+    }
   }
 
   @Override
   public boolean isStart()
   {
-    return chunkNumber == 0;
+    return chunks > 0 ? chunkNumber == 0 : true;
   }
 
   @Override
   public boolean isEnd()
   {
-    return chunkNumber == chunks - 1;
+    return chunks > 0 ? chunkNumber == chunks - 1 : true;
   }
 
   @Override

--- a/common/src/main/java/io/druid/timeline/partition/PartitionHolder.java
+++ b/common/src/main/java/io/druid/timeline/partition/PartitionHolder.java
@@ -95,6 +95,8 @@ public class PartitionHolder<T> implements Iterable<PartitionChunk<T>>
     Iterator<PartitionChunk<T>> iter = holderSet.iterator();
 
     PartitionChunk<T> curr = iter.next();
+    boolean endSeen = curr.isEnd();
+
     if (!curr.isStart()) {
       return false;
     }
@@ -104,14 +106,14 @@ public class PartitionHolder<T> implements Iterable<PartitionChunk<T>>
       if (!curr.abuts(next)) {
         return false;
       }
+
+      if (next.isEnd()) {
+        endSeen = true;
+      }
       curr = next;
     }
 
-    if (!curr.isEnd()) {
-      return false;
-    }
-
-    return true;
+    return endSeen;
   }
 
   public PartitionChunk<T> getChunk(final int partitionNum)

--- a/server/src/main/java/io/druid/timeline/partition/NumberedShardSpec.java
+++ b/server/src/main/java/io/druid/timeline/partition/NumberedShardSpec.java
@@ -40,7 +40,7 @@ public class NumberedShardSpec implements ShardSpec
   )
   {
     Preconditions.checkArgument(partitionNum >= 0, "partitionNum >= 0");
-    Preconditions.checkArgument(partitionNum < partitions, "partitionNum < partitions");
+    Preconditions.checkArgument(partitions >= 0, "partitions >= 0");
     this.partitionNum = partitionNum;
     this.partitions = partitions;
   }

--- a/server/src/test/java/io/druid/server/shard/NumberedShardSpecTest.java
+++ b/server/src/test/java/io/druid/server/shard/NumberedShardSpecTest.java
@@ -19,15 +19,25 @@ package io.druid.server.shard;
 
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Ordering;
 import io.druid.TestUtil;
+import io.druid.timeline.DataSegment;
+import io.druid.timeline.TimelineObjectHolder;
+import io.druid.timeline.VersionedIntervalTimeline;
+import io.druid.timeline.partition.NumberedPartitionChunk;
 import io.druid.timeline.partition.NumberedShardSpec;
 import io.druid.timeline.partition.PartitionChunk;
 import io.druid.timeline.partition.ShardSpec;
+import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class NumberedShardSpecTest
 {
@@ -96,5 +106,96 @@ public class NumberedShardSpecTest
     Assert.assertFalse(chunks.get(2).abuts(chunks.get(0)));
     Assert.assertFalse(chunks.get(2).abuts(chunks.get(1)));
     Assert.assertFalse(chunks.get(2).abuts(chunks.get(2)));
+  }
+
+  @Test
+  public void testVersionedIntervalTimelineBehaviorForNumberedShardSpec()
+  {
+    //core partition chunks
+    PartitionChunk<String> chunk0 = new NumberedShardSpec(0, 2).createChunk("0");
+    PartitionChunk<String> chunk1 = new NumberedShardSpec(1, 2).createChunk("1");
+
+    //appended partition chunk
+    PartitionChunk<String> chunk4 = new NumberedShardSpec(4, 2).createChunk("4");
+
+    //incomplete partition sets
+    testVersionedIntervalTimelineBehaviorForNumberedShardSpec(
+        ImmutableList.of(chunk0),
+        Collections.EMPTY_SET
+    );
+
+    testVersionedIntervalTimelineBehaviorForNumberedShardSpec(
+        ImmutableList.of(chunk1),
+        Collections.EMPTY_SET
+    );
+
+    testVersionedIntervalTimelineBehaviorForNumberedShardSpec(
+        ImmutableList.of(chunk4),
+        Collections.EMPTY_SET
+    );
+
+
+    testVersionedIntervalTimelineBehaviorForNumberedShardSpec(
+        ImmutableList.of(chunk0, chunk4),
+        Collections.EMPTY_SET
+    );
+
+
+    testVersionedIntervalTimelineBehaviorForNumberedShardSpec(
+        ImmutableList.of(chunk1, chunk4),
+        Collections.EMPTY_SET
+    );
+
+    //complete partition sets
+    testVersionedIntervalTimelineBehaviorForNumberedShardSpec(
+        ImmutableList.of(chunk1, chunk0),
+        ImmutableSet.of("0", "1")
+    );
+
+    testVersionedIntervalTimelineBehaviorForNumberedShardSpec(
+        ImmutableList.of(chunk4, chunk1, chunk0),
+        ImmutableSet.of("0", "1", "4")
+    );
+
+    // a partition set with 0 core partitions
+    chunk0 = new NumberedShardSpec(0, 0).createChunk("0");
+    chunk4 = new NumberedShardSpec(4, 0).createChunk("4");
+
+    testVersionedIntervalTimelineBehaviorForNumberedShardSpec(
+        ImmutableList.of(chunk0),
+        ImmutableSet.of("0")
+    );
+
+    testVersionedIntervalTimelineBehaviorForNumberedShardSpec(
+        ImmutableList.of(chunk4),
+        ImmutableSet.of("4")
+    );
+
+    testVersionedIntervalTimelineBehaviorForNumberedShardSpec(
+        ImmutableList.of(chunk4, chunk0),
+        ImmutableSet.of("0", "4")
+    );
+  }
+
+  private void testVersionedIntervalTimelineBehaviorForNumberedShardSpec(
+      List<PartitionChunk<String>> chunks,
+      Set<String> expectedObjects
+  )
+  {
+    VersionedIntervalTimeline<String, String> timeline = new VersionedIntervalTimeline<>(Ordering.natural());
+    Interval interval = new Interval("2000/3000");
+    String version = "v1";
+    for (PartitionChunk<String> chunk : chunks) {
+      timeline.add(interval, version, chunk);
+    }
+
+    Set<String> actualObjects = new HashSet<>();
+    List<TimelineObjectHolder<String, String>> entries = timeline.lookup(interval);
+    for (TimelineObjectHolder<String, String> entry : entries) {
+      for (PartitionChunk<String> chunk : entry.getObject()) {
+        actualObjects.add(chunk.getObject());
+      }
+    }
+    Assert.assertEquals(expectedObjects, actualObjects);
   }
 }


### PR DESCRIPTION
should fix #1516 
instead of introducing another shard spec, this patch generalizes and makes NumberedShardSpec elastic. this is totally backwards compatible.
With the "realtime delta ingestion" way of appending segments, this will allow "appending" new segments to old data and also to segments produced via batch ingestion. This allows periodic re-indexing with hashed shard spec and for realtime tasks to be able to append segments when needed.