### PR TITLE
Account for potential gaps in hydrants in sink initialization, hydrant swapping (e.g. h0, h1, h4)

### DIFF
--- a/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -744,6 +744,14 @@ public class RealtimePlumber implements Plumber
               )
           );
         }
+        if (hydrants.isEmpty()) {
+          // Probably encountered a corrupt sink directory
+          log.warn(
+              "Found persisted segment directory with no intermediate segments present at %s, skipping sink creation.",
+              sinkDir.getAbsolutePath()
+          );
+          continue;
+        }
         Sink currSink = new Sink(sinkInterval, schema, config, versioningPolicy.getVersion(sinkInterval), hydrants);
         sinks.put(sinkInterval.getStartMillis(), currSink);
         sinkTimeline.add(


### PR DESCRIPTION
Fixes issues with sink hydrant handling when loading a persisted sink directory with missing hydrants, e.g. persisted sink directory, with hydrants 1 and 3 missing:

$ pwd
.../test-datasource/1970-01-01T00:00:00.000Z_1970-12-31T00:00:00.000Z
$ ls
0 2 4