### PR TITLE
Fix failure in nested groupBy with multiple aggregators with same…

### DIFF
--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryQueryToolChest.java
@@ -159,8 +159,18 @@ public class GroupByQueryQueryToolChest extends QueryToolChest<Row, GroupByQuery
 
       final Sequence<Row> subqueryResult = mergeGroupByResults(subquery, runner, context);
       final List<AggregatorFactory> aggs = Lists.newArrayList();
+
       for (AggregatorFactory aggregatorFactory : query.getAggregatorSpecs()) {
-        aggs.addAll(aggregatorFactory.getRequiredColumns());
+        for (final AggregatorFactory column : aggregatorFactory.getRequiredColumns()) {
+          if (!Iterables.any(aggs, new Predicate<AggregatorFactory>() {
+            @Override
+            public boolean apply(AggregatorFactory existingAgg) {
+              return existingAgg.getName().equals(column.getName());
+            }
+          })) {
+            aggs.add(column);
+          }
+        }
       }
 
       // We need the inner incremental index to have all the columns required by the outer query


### PR DESCRIPTION
…fieldName

Seems to be a side effect of using an intermediate IncrementalIndex to handle nested group bys. Fix is to prevent adding multiple columns with the same fieldName to the index. The AggregatorFactory type may be lost since it doesn't add subsequent factories with the same name, but I don't think that affects the function of the intermediate index.

This is a hack in the sense that the real solution is to re-write groupbys to not require massaging the data to work with IncrementalIndex.

Closes #1419