### PR TITLE
Adding downstream source when throwing QueryInterruptedException

### DIFF
--- a/processing/src/main/java/io/druid/query/ChainedExecutionQueryRunner.java
+++ b/processing/src/main/java/io/druid/query/ChainedExecutionQueryRunner.java
@@ -163,15 +163,15 @@ public class ChainedExecutionQueryRunner<T> implements QueryRunner<T>
             catch (InterruptedException e) {
               log.warn(e, "Query interrupted, cancelling pending results, query id [%s]", query.getId());
               futures.cancel(true);
-              throw new QueryInterruptedException("Query interrupted");
+              throw new QueryInterruptedException(e);
             }
             catch (CancellationException e) {
-              throw new QueryInterruptedException("Query cancelled");
+              throw new QueryInterruptedException(e);
             }
             catch (TimeoutException e) {
               log.info("Query timeout, cancelling pending results for query id [%s]", query.getId());
               futures.cancel(true);
-              throw new QueryInterruptedException("Query timeout");
+              throw new QueryInterruptedException(e);
             }
             catch (ExecutionException e) {
               throw Throwables.propagate(e.getCause());

--- a/processing/src/main/java/io/druid/query/GroupByParallelQueryRunner.java
+++ b/processing/src/main/java/io/druid/query/GroupByParallelQueryRunner.java
@@ -151,17 +151,17 @@ public class GroupByParallelQueryRunner<T> implements QueryRunner<T>
       log.warn(e, "Query interrupted, cancelling pending results, query id [%s]", query.getId());
       futures.cancel(true);
       indexAccumulatorPair.lhs.close();
-      throw new QueryInterruptedException("Query interrupted");
+      throw new QueryInterruptedException(e);
     }
     catch (CancellationException e) {
       indexAccumulatorPair.lhs.close();
-      throw new QueryInterruptedException("Query cancelled");
+      throw new QueryInterruptedException(e);
     }
     catch (TimeoutException e) {
       indexAccumulatorPair.lhs.close();
       log.info("Query timeout, cancelling pending results for query id [%s]", query.getId());
       futures.cancel(true);
-      throw new QueryInterruptedException("Query timeout");
+      throw new QueryInterruptedException(e);
     }
     catch (ExecutionException e) {
       indexAccumulatorPair.lhs.close();

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryRunnerFactory.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryRunnerFactory.java
@@ -156,15 +156,15 @@ public class GroupByQueryRunnerFactory implements QueryRunnerFactory<Row, GroupB
                       catch (InterruptedException e) {
                         log.warn(e, "Query interrupted, cancelling pending results, query id [%s]", query.getId());
                         future.cancel(true);
-                        throw new QueryInterruptedException("Query interrupted");
+                        throw new QueryInterruptedException(e);
                       }
                       catch (CancellationException e) {
-                        throw new QueryInterruptedException("Query cancelled");
+                        throw new QueryInterruptedException(e);
                       }
                       catch (TimeoutException e) {
                         log.info("Query timeout, cancelling pending results for query id [%s]", query.getId());
                         future.cancel(true);
-                        throw new QueryInterruptedException("Query timeout");
+                        throw new QueryInterruptedException(e);
                       }
                       catch (ExecutionException e) {
                         throw Throwables.propagate(e.getCause());

--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
@@ -184,15 +184,15 @@ public class SegmentMetadataQueryRunnerFactory implements QueryRunnerFactory<Seg
                     catch (InterruptedException e) {
                       log.warn(e, "Query interrupted, cancelling pending results, query id [%s]", query.getId());
                       future.cancel(true);
-                      throw new QueryInterruptedException("Query interrupted");
+                      throw new QueryInterruptedException(e);
                     }
-                    catch (CancellationException e) {
-                      throw new QueryInterruptedException("Query cancelled");
+                    catch(CancellationException e) {
+                      throw new QueryInterruptedException(e);
                     }
                     catch (TimeoutException e) {
                       log.info("Query timeout, cancelling pending results for query id [%s]", query.getId());
                       future.cancel(true);
-                      throw new QueryInterruptedException("Query timeout");
+                      throw new QueryInterruptedException(e);
                     }
                     catch (ExecutionException e) {
                       throw Throwables.propagate(e.getCause());

--- a/processing/src/main/java/io/druid/segment/QueryableIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/QueryableIndexStorageAdapter.java
@@ -339,7 +339,7 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
                     public void advance()
                     {
                       if (Thread.interrupted()) {
-                        throw new QueryInterruptedException();
+                        throw new QueryInterruptedException(new InterruptedException());
                       }
                       cursorOffset.increment();
                     }

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
@@ -264,7 +264,7 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
 
                 while (baseIter.hasNext()) {
                   if (Thread.interrupted()) {
-                    throw new QueryInterruptedException();
+                    throw new QueryInterruptedException(new InterruptedException());
                   }
 
                   currEntry.set(baseIter.next());
@@ -307,7 +307,7 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
                 }
 
                 if (Thread.interrupted()) {
-                  throw new QueryInterruptedException();
+                  throw new QueryInterruptedException( new InterruptedException());
                 }
 
                 boolean foundMatched = false;

--- a/processing/src/test/java/io/druid/query/ChainedExecutionQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/ChainedExecutionQueryRunnerTest.java
@@ -343,7 +343,7 @@ public class ChainedExecutionQueryRunnerTest
           interrupted = true;
           interruptedRunners.offer(this);
           stop.countDown();
-          throw new QueryInterruptedException("I got killed");
+          throw new QueryInterruptedException(e);
         }
       }
 

--- a/server/src/test/java/io/druid/client/DirectDruidClientTest.java
+++ b/server/src/test/java/io/druid/client/DirectDruidClientTest.java
@@ -19,6 +19,8 @@
 
 package io.druid.client;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.Futures;
@@ -257,6 +259,75 @@ public class DirectDruidClientTest
     }
     Assert.assertNotNull(exception);
 
+    EasyMock.verify(httpClient);
+  }
+
+  @Test
+  public void testQueryInterruptionExceptionLogMessage() throws JsonProcessingException
+  {
+    HttpClient httpClient = EasyMock.createMock(HttpClient.class);
+    SettableFuture<Object> interruptionFuture = SettableFuture.create();
+    Capture<Request> capturedRequest = EasyMock.newCapture();
+    String hostName = "localhost:8080";
+    EasyMock.expect(
+        httpClient.go(
+            EasyMock.capture(capturedRequest),
+            EasyMock.<HttpResponseHandler>anyObject()
+        )
+    )
+            .andReturn(interruptionFuture)
+            .anyTimes();
+
+    EasyMock.replay(httpClient);
+
+    DataSegment dataSegment = new DataSegment(
+        "test",
+        new Interval("2013-01-01/2013-01-02"),
+        new DateTime("2013-01-01").toString(),
+        Maps.<String, Object>newHashMap(),
+        Lists.<String>newArrayList(),
+        Lists.<String>newArrayList(),
+        new NoneShardSpec(),
+        0,
+        0L
+    );
+    final ServerSelector serverSelector = new ServerSelector( dataSegment
+        ,
+        new HighestPriorityTierSelectorStrategy(new ConnectionCountServerSelectorStrategy())
+    );
+
+    DirectDruidClient client1 = new DirectDruidClient(
+        new ReflectionQueryToolChestWarehouse(),
+        QueryRunnerTestHelper.NOOP_QUERYWATCHER,
+        new DefaultObjectMapper(),
+        httpClient,
+        hostName,
+        new NoopServiceEmitter()
+    );
+
+    QueryableDruidServer queryableDruidServer = new QueryableDruidServer(
+        new DruidServer("test1", hostName, 0, "historical", DruidServer.DEFAULT_TIER, 0),
+        client1
+    );
+
+    serverSelector.addServerAndUpdateSegment(queryableDruidServer, dataSegment);
+
+    TimeBoundaryQuery query = Druids.newTimeBoundaryQueryBuilder().dataSource("test").build();
+    HashMap<String, List> context = Maps.newHashMap();
+    interruptionFuture.set(new ByteArrayInputStream("{\"error\":\"testing\"}".getBytes()));
+    Sequence results = client1.run(query, context);
+
+    QueryInterruptedException actualException = null;
+    try {
+      Sequences.toList(results, Lists.newArrayList());
+    }
+    catch (QueryInterruptedException e) {
+      actualException = e;
+    }
+    Assert.assertNotNull(actualException);
+    Assert.assertEquals(actualException.getMessage(), QueryInterruptedException.UNKNOWN_EXCEPTION);
+    Assert.assertEquals(actualException.getCauseMessage(), "testing");
+    Assert.assertEquals(actualException.getHost(), hostName);
     EasyMock.verify(httpClient);
   }
 }


### PR DESCRIPTION
Sometimes it is hard to track down exception from the broker back to many realtime replicas and historicals nodes.
This PR enhance the exception tracking by adding the downstream host as part of the exception message.
 