### PR TITLE
Cleanup kafka-extraction-namespace

### DIFF
--- a/extensions/kafka-extraction-namespace/pom.xml
+++ b/extensions/kafka-extraction-namespace/pom.xml
@@ -87,32 +87,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifest>
-              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-              <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-            </manifest>
-          </archive>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
Remove extra build defines in kafka-extraction-namespace's pom.xml

Fixes some build problems we have internally when moving to maven 3.3.3