### PR TITLE
Rollback aws sdk version to 1.10.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk</artifactId>
-                <version>1.10.12</version>
+                <version>1.10.11</version>
                 <exclusions>
                     <exclusion>
                         <groupId>javax.mail</groupId>


### PR DESCRIPTION
See https://github.com/aws/aws-sdk-java/issues/496#issuecomment-133718303 

This error happens in the aws autoscaling:

```
ERROR [ScalingExec--0] com.metamx.common.concurrent.ScheduledExecutors - Uncaught exception.
java.lang.NoSuchFieldError: INSTANCE
        at com.amazonaws.http.conn.SdkConnectionKeepAliveStrategy.getKeepAliveDuration(SdkConnectionKeepAliveStrategy.java:48) ~[druid-selfcontained-ecad18d.jar:ecad18d]
        at org.apache.http.impl.client.DefaultRequestDirector.execute(DefaultRequestDirector.java:533) ~[druid-selfcontained-ecad18d.jar:ecad18d]
        at org.apache.http.impl.client.AbstractHttpClient.execute(AbstractHttpClient.java:906) ~[druid-selfcontained-ecad18d.jar:ecad18d]
        at org.apache.http.impl.client.AbstractHttpClient.execute(AbstractHttpClient.java:805) ~[druid-selfcontained-ecad18d.jar:ecad18d]
        at com.amazonaws.http.AmazonHttpClient.executeOneRequest(AmazonHttpClient.java:728) ~[druid-selfcontained-ecad18d.jar:ecad18d]
        at com.amazonaws.http.AmazonHttpClient.executeHelper(AmazonHttpClient.java:489) ~[druid-selfcontained-ecad18d.jar:ecad18d]
        at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:310) ~[druid-selfcontained-ecad18d.jar:ecad18d]
        at com.amazonaws.services.ec2.AmazonEC2Client.invoke(AmazonEC2Client.java:11783) ~[druid-selfcontained-ecad18d.jar:ecad18d]
        at com.amazonaws.services.ec2.AmazonEC2Client.describeInstances(AmazonEC2Client.java:5905) ~[druid-selfcontained-ecad18d.jar:ecad18d]
        at io.druid.indexing.overlord.autoscaling.ec2.EC2AutoScaler.ipToIdLookup(EC2AutoScaler.java:247) ~[druid-selfcontained-ecad18d.jar:ecad18d]
        at io.druid.indexing.overlord.autoscaling.SimpleResourceManagementStrategy.doProvision(SimpleResourceManagementStrategy.java:87) ~[druid-selfcontained-ecad18d.jar:ecad18d]
```