### PR TITLE
static to non-static conversion for methods in Index[Merger/Maker/IO]

### DIFF
--- a/docs/content/misc/tasks.md
+++ b/docs/content/misc/tasks.md
@@ -119,7 +119,7 @@ The indexSpec is optional and default parameters will be used if not specified.
 
 |property|description|possible values|default|required?|
 |--------|-----------|---------------|-------|---------|
-|bitmap|type of bitmap compression to use for inverted indices.|`"concise"`, `"roaring"`|`"concise"` or the value of `druid.processing.bitmap.type`, if specified|no|
+|bitmap|type of bitmap compression to use for inverted indices.|`"concise"`, `"roaring"`|`"concise"`|no|
 |dimensionCompression|compression format for dimension columns (currently only affects single-value dimensions, multi-value dimensions are always uncompressed)|`"uncompressed"`, `"lz4"`, `"lzf"`|`"lz4"`|no|
 |metricCompression|compression format for metric columns, defaults to LZ4|`"lz4"`, `"lzf"`|`"lz4"`|no|
 

--- a/indexing-hadoop/src/main/java/io/druid/indexer/DetermineHashedPartitionsJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/DetermineHashedPartitionsJob.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.NullWritable;
-import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.Partitioner;
 import org.apache.hadoop.mapreduce.Reducer;
@@ -132,7 +131,7 @@ public class DetermineHashedPartitionsJob implements Jobby
         if (!Utils.exists(groupByJob, fileSystem, intervalInfoPath)) {
           throw new ISE("Path[%s] didn't exist!?", intervalInfoPath);
         }
-        List<Interval> intervals = config.jsonMapper.readValue(
+        List<Interval> intervals = config.JSON_MAPPER.readValue(
             Utils.openInputStream(groupByJob, intervalInfoPath), new TypeReference<List<Interval>>()
         {
         }
@@ -156,7 +155,7 @@ public class DetermineHashedPartitionsJob implements Jobby
           fileSystem = partitionInfoPath.getFileSystem(groupByJob.getConfiguration());
         }
         if (Utils.exists(groupByJob, fileSystem, partitionInfoPath)) {
-          final Long numRows = config.jsonMapper.readValue(
+          final Long numRows = config.JSON_MAPPER.readValue(
               Utils.openInputStream(groupByJob, partitionInfoPath), new TypeReference<Long>()
           {
           }
@@ -178,7 +177,7 @@ public class DetermineHashedPartitionsJob implements Jobby
                       new HashBasedNumberedShardSpec(
                           i,
                           numberOfShards,
-                          HadoopDruidIndexerConfig.jsonMapper
+                          HadoopDruidIndexerConfig.JSON_MAPPER
                       ),
                       shardCount++
                   )
@@ -267,7 +266,7 @@ public class DetermineHashedPartitionsJob implements Jobby
       }
       hyperLogLogs.get(interval)
                   .add(
-                      hashFunction.hashBytes(HadoopDruidIndexerConfig.jsonMapper.writeValueAsBytes(groupKey))
+                      hashFunction.hashBytes(HadoopDruidIndexerConfig.JSON_MAPPER.writeValueAsBytes(groupKey))
                                   .asBytes()
                   );
     }
@@ -324,7 +323,7 @@ public class DetermineHashedPartitionsJob implements Jobby
       );
 
       try {
-        HadoopDruidIndexerConfig.jsonMapper.writerWithType(
+        HadoopDruidIndexerConfig.JSON_MAPPER.writerWithType(
             new TypeReference<Long>()
             {
             }
@@ -350,7 +349,7 @@ public class DetermineHashedPartitionsJob implements Jobby
         );
 
         try {
-          HadoopDruidIndexerConfig.jsonMapper.writerWithType(
+          HadoopDruidIndexerConfig.JSON_MAPPER.writerWithType(
               new TypeReference<List<Interval>>()
               {
               }

--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidDetermineConfigurationJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidDetermineConfigurationJob.java
@@ -65,7 +65,7 @@ public class HadoopDruidDetermineConfigurationJob implements Jobby
           for (int i = 0; i < shardsPerInterval; i++) {
             specs.add(
                 new HadoopyShardSpec(
-                    new HashBasedNumberedShardSpec(i, shardsPerInterval, HadoopDruidIndexerConfig.jsonMapper),
+                    new HashBasedNumberedShardSpec(i, shardsPerInterval, HadoopDruidIndexerConfig.JSON_MAPPER),
                     shardCount++
                 )
             );

--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerConfig.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerConfig.java
@@ -47,6 +47,9 @@ import io.druid.guice.annotations.Self;
 import io.druid.indexer.partitions.PartitionsSpec;
 import io.druid.indexer.path.PathSpec;
 import io.druid.initialization.Initialization;
+import io.druid.segment.IndexIO;
+import io.druid.segment.IndexMaker;
+import io.druid.segment.IndexMerger;
 import io.druid.segment.IndexSpec;
 import io.druid.segment.indexing.granularity.GranularitySpec;
 import io.druid.server.DruidNode;
@@ -68,7 +71,6 @@ import java.io.Reader;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.SortedSet;
 
@@ -84,9 +86,9 @@ public class HadoopDruidIndexerConfig
   public static final Splitter tabSplitter = Splitter.on("\t");
   public static final Joiner tabJoiner = Joiner.on("\t");
   public static final ObjectMapper jsonMapper;
-
-  // workaround to pass down druid.processing.bitmap.type, see IndexGeneratorJob.run()
-  protected static final Properties properties;
+  public static final IndexIO INDEX_IO;
+  public static final IndexMerger INDEX_MERGER;
+  public static final IndexMaker INDEX_MAKER;
 
   private static final String DEFAULT_WORKING_PATH = "/tmp/druid-indexing";
 
@@ -107,8 +109,11 @@ public class HadoopDruidIndexerConfig
             new IndexingHadoopModule()
         )
     );
+
     jsonMapper = injector.getInstance(ObjectMapper.class);
-    properties = injector.getInstance(Properties.class);
+    INDEX_IO = injector.getInstance(IndexIO.class);
+    INDEX_MERGER = injector.getInstance(IndexMerger.class);
+    INDEX_MAKER = injector.getInstance(IndexMaker.class);
   }
 
   public static enum IndexJobCounters

--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerConfig.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerConfig.java
@@ -82,10 +82,10 @@ public class HadoopDruidIndexerConfig
   private static final Injector injector;
 
   public static final String CONFIG_PROPERTY = "druid.indexer.config";
-  public static final Charset javaNativeCharset = Charset.forName("Unicode");
-  public static final Splitter tabSplitter = Splitter.on("\t");
-  public static final Joiner tabJoiner = Joiner.on("\t");
-  public static final ObjectMapper jsonMapper;
+  public static final Charset JAVA_NATIVE_CHARSET = Charset.forName("Unicode");
+  public static final Splitter TAB_SPLITTER = Splitter.on("\t");
+  public static final Joiner TAB_JOINER = Joiner.on("\t");
+  public static final ObjectMapper JSON_MAPPER;
   public static final IndexIO INDEX_IO;
   public static final IndexMerger INDEX_MERGER;
   public static final IndexMaker INDEX_MAKER;
@@ -109,8 +109,7 @@ public class HadoopDruidIndexerConfig
             new IndexingHadoopModule()
         )
     );
-
-    jsonMapper = injector.getInstance(ObjectMapper.class);
+    JSON_MAPPER = injector.getInstance(ObjectMapper.class);
     INDEX_IO = injector.getInstance(IndexIO.class);
     INDEX_MERGER = injector.getInstance(IndexMerger.class);
     INDEX_MAKER = injector.getInstance(IndexMaker.class);
@@ -132,13 +131,13 @@ public class HadoopDruidIndexerConfig
     // the Map<> intermediary
 
     if (argSpec.containsKey("spec")) {
-      return HadoopDruidIndexerConfig.jsonMapper.convertValue(
+      return HadoopDruidIndexerConfig.JSON_MAPPER.convertValue(
           argSpec,
           HadoopDruidIndexerConfig.class
       );
     }
     return new HadoopDruidIndexerConfig(
-        HadoopDruidIndexerConfig.jsonMapper.convertValue(
+        HadoopDruidIndexerConfig.JSON_MAPPER.convertValue(
             argSpec,
             HadoopIngestionSpec.class
         )
@@ -150,7 +149,7 @@ public class HadoopDruidIndexerConfig
   {
     try {
       return fromMap(
-          (Map<String, Object>) HadoopDruidIndexerConfig.jsonMapper.readValue(
+          (Map<String, Object>) HadoopDruidIndexerConfig.JSON_MAPPER.readValue(
               file, new TypeReference<Map<String, Object>>()
               {
               }
@@ -168,7 +167,7 @@ public class HadoopDruidIndexerConfig
     // This is a map to try and prevent dependency screwbally-ness
     try {
       return fromMap(
-          (Map<String, Object>) HadoopDruidIndexerConfig.jsonMapper.readValue(
+          (Map<String, Object>) HadoopDruidIndexerConfig.JSON_MAPPER.readValue(
               str, new TypeReference<Map<String, Object>>()
               {
               }
@@ -190,12 +189,12 @@ public class HadoopDruidIndexerConfig
       Reader reader = new InputStreamReader(fs.open(pt));
 
       return fromMap(
-        (Map<String, Object>) HadoopDruidIndexerConfig.jsonMapper.readValue(
-            reader, new TypeReference<Map<String, Object>>()
-            {
-            }
-            )
-        );
+          (Map<String, Object>) HadoopDruidIndexerConfig.JSON_MAPPER.readValue(
+              reader, new TypeReference<Map<String, Object>>()
+              {
+              }
+          )
+      );
     }
     catch (Exception e) {
       throw Throwables.propagate(e);
@@ -221,7 +220,7 @@ public class HadoopDruidIndexerConfig
   )
   {
     this.schema = spec;
-    this.pathSpec = jsonMapper.convertValue(spec.getIOConfig().getPathSpec(), PathSpec.class);
+    this.pathSpec = JSON_MAPPER.convertValue(spec.getIOConfig().getPathSpec(), PathSpec.class);
     for (Map.Entry<DateTime, List<HadoopyShardSpec>> entry : spec.getTuningConfig().getShardSpecs().entrySet()) {
       if (entry.getValue() == null || entry.getValue().isEmpty()) {
         continue;
@@ -273,7 +272,7 @@ public class HadoopDruidIndexerConfig
   public void setGranularitySpec(GranularitySpec granularitySpec)
   {
     this.schema = schema.withDataSchema(schema.getDataSchema().withGranularitySpec(granularitySpec));
-    this.pathSpec = jsonMapper.convertValue(schema.getIOConfig().getPathSpec(), PathSpec.class);
+    this.pathSpec = JSON_MAPPER.convertValue(schema.getIOConfig().getPathSpec(), PathSpec.class);
   }
 
   public PartitionsSpec getPartitionsSpec()
@@ -299,13 +298,13 @@ public class HadoopDruidIndexerConfig
   public void setVersion(String version)
   {
     this.schema = schema.withTuningConfig(schema.getTuningConfig().withVersion(version));
-    this.pathSpec = jsonMapper.convertValue(schema.getIOConfig().getPathSpec(), PathSpec.class);
+    this.pathSpec = JSON_MAPPER.convertValue(schema.getIOConfig().getPathSpec(), PathSpec.class);
   }
 
   public void setShardSpecs(Map<DateTime, List<HadoopyShardSpec>> shardSpecs)
   {
     this.schema = schema.withTuningConfig(schema.getTuningConfig().withShardSpecs(shardSpecs));
-    this.pathSpec = jsonMapper.convertValue(schema.getIOConfig().getPathSpec(), PathSpec.class);
+    this.pathSpec = JSON_MAPPER.convertValue(schema.getIOConfig().getPathSpec(), PathSpec.class);
   }
 
   public Optional<List<Interval>> getIntervals()
@@ -541,7 +540,7 @@ public class HadoopDruidIndexerConfig
     Configuration conf = job.getConfiguration();
 
     try {
-      conf.set(HadoopDruidIndexerConfig.CONFIG_PROPERTY, HadoopDruidIndexerConfig.jsonMapper.writeValueAsString(this));
+      conf.set(HadoopDruidIndexerConfig.CONFIG_PROPERTY, HadoopDruidIndexerConfig.JSON_MAPPER.writeValueAsString(this));
     }
     catch (IOException e) {
       throw Throwables.propagate(e);
@@ -551,7 +550,7 @@ public class HadoopDruidIndexerConfig
   public void verify()
   {
     try {
-      log.info("Running with config:%n%s", jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(this));
+      log.info("Running with config:%n%s", JSON_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(this));
     }
     catch (IOException e) {
       throw Throwables.propagate(e);

--- a/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
@@ -82,7 +82,7 @@ public class IndexGeneratorJob implements Jobby
   public static List<DataSegment> getPublishedSegments(HadoopDruidIndexerConfig config)
   {
     final Configuration conf = JobHelper.injectSystemProperties(new Configuration());
-    final ObjectMapper jsonMapper = HadoopDruidIndexerConfig.jsonMapper;
+    final ObjectMapper jsonMapper = HadoopDruidIndexerConfig.JSON_MAPPER;
 
     ImmutableList.Builder<DataSegment> publishedSegmentsBuilder = ImmutableList.builder();
 
@@ -262,7 +262,7 @@ public class IndexGeneratorJob implements Jobby
 
       final long truncatedTimestamp = granularitySpec.getQueryGranularity().truncate(inputRow.getTimestampFromEpoch());
       final byte[] hashedDimensions = hashFunction.hashBytes(
-          HadoopDruidIndexerConfig.jsonMapper.writeValueAsBytes(
+          HadoopDruidIndexerConfig.JSON_MAPPER.writeValueAsBytes(
               Rows.toGroupKey(
                   truncatedTimestamp,
                   inputRow

--- a/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
@@ -19,7 +19,6 @@ package io.druid.indexer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
-import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -38,8 +37,6 @@ import io.druid.data.input.Rows;
 import io.druid.indexer.hadoop.SegmentInputRow;
 import io.druid.offheap.OffheapBufferPool;
 import io.druid.query.aggregation.AggregatorFactory;
-import io.druid.segment.IndexIO;
-import io.druid.segment.IndexMaker;
 import io.druid.segment.LoggingProgressIndicator;
 import io.druid.segment.ProgressIndicator;
 import io.druid.segment.QueryableIndex;
@@ -175,18 +172,6 @@ public class IndexGeneratorJob implements Jobby
       FileOutputFormat.setOutputPath(job, config.makeIntermediatePath());
 
       config.addInputPaths(job);
-
-      // hack to get druid.processing.bitmap property passed down to hadoop job.
-      // once IndexIO doesn't rely on globally injected properties, we can move this into the HadoopTuningConfig.
-      final String bitmapProperty = "druid.processing.bitmap.type";
-      final String bitmapType = HadoopDruidIndexerConfig.properties.getProperty(bitmapProperty);
-      if (bitmapType != null) {
-        for (String property : new String[]{"mapreduce.reduce.java.opts", "mapreduce.map.java.opts"}) {
-          // prepend property to allow overriding using hadoop.xxx properties by JobHelper.injectSystemProperties above
-          String value = Strings.nullToEmpty(job.getConfiguration().get(property));
-          job.getConfiguration().set(property, String.format("-D%s=%s %s", bitmapProperty, bitmapType, value));
-        }
-      }
 
       config.intoConfiguration(job);
 
@@ -489,7 +474,7 @@ public class IndexGeneratorJob implements Jobby
         final ProgressIndicator progressIndicator
     ) throws IOException
     {
-      return IndexMaker.persist(
+      return HadoopDruidIndexerConfig.INDEX_MAKER.persist(
           index, interval, file, null, config.getIndexSpec(), progressIndicator
       );
     }
@@ -501,7 +486,7 @@ public class IndexGeneratorJob implements Jobby
         ProgressIndicator progressIndicator
     ) throws IOException
     {
-      return IndexMaker.mergeQueryableIndex(
+      return HadoopDruidIndexerConfig.INDEX_MAKER.mergeQueryableIndex(
           indexes, aggs, file, config.getIndexSpec(), progressIndicator
       );
     }
@@ -614,7 +599,7 @@ public class IndexGeneratorJob implements Jobby
           }
 
           for (File file : toMerge) {
-            indexes.add(IndexIO.loadIndex(file));
+            indexes.add(HadoopDruidIndexerConfig.INDEX_IO.loadIndex(file));
           }
           mergedBase = mergeQueryableIndex(
               indexes, aggregators, new File(baseFlushFile, "merged"), progressIndicator

--- a/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
@@ -462,7 +462,7 @@ public class JobHelper
                   DEFAULT_FS_BUFFER_SIZE,
                   progressable
               )) {
-                HadoopDruidIndexerConfig.jsonMapper.writeValue(descriptorOut, segment);
+                HadoopDruidIndexerConfig.JSON_MAPPER.writeValue(descriptorOut, segment);
                 descriptorOut.flush();
               }
             }

--- a/indexing-hadoop/src/main/java/io/druid/indexer/LegacyIndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/LegacyIndexGeneratorJob.java
@@ -19,8 +19,6 @@ package io.druid.indexer;
 
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.segment.BaseProgressIndicator;
-import io.druid.segment.IndexMerger;
-import io.druid.segment.IndexSpec;
 import io.druid.segment.ProgressIndicator;
 import io.druid.segment.QueryableIndex;
 import io.druid.segment.incremental.IncrementalIndex;
@@ -68,7 +66,7 @@ public class LegacyIndexGeneratorJob extends IndexGeneratorJob
         IncrementalIndex index, Interval interval, File file, ProgressIndicator progressIndicator
     ) throws IOException
     {
-      return IndexMerger.persist(index, interval, file, null, config.getIndexSpec(), progressIndicator);
+      return HadoopDruidIndexerConfig.INDEX_MERGER.persist(index, interval, file, null, config.getIndexSpec(), progressIndicator);
     }
 
     @Override
@@ -79,7 +77,7 @@ public class LegacyIndexGeneratorJob extends IndexGeneratorJob
         ProgressIndicator progressIndicator
     ) throws IOException
     {
-      return IndexMerger.mergeQueryableIndex(indexes, aggs, file, config.getIndexSpec(), progressIndicator);
+      return HadoopDruidIndexerConfig.INDEX_MERGER.mergeQueryableIndex(indexes, aggs, file, config.getIndexSpec(), progressIndicator);
     }
   }
 }

--- a/indexing-hadoop/src/main/java/io/druid/indexer/MetadataStorageUpdaterJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/MetadataStorageUpdaterJob.java
@@ -42,7 +42,7 @@ public class MetadataStorageUpdaterJob implements Jobby
   {
     final List<DataSegment> segments = IndexGeneratorJob.getPublishedSegments(config);
     final String segmentTable = config.getSchema().getIOConfig().getMetadataUpdateSpec().getSegmentTable();
-    handler.publishSegments(segmentTable, segments, HadoopDruidIndexerConfig.jsonMapper);
+    handler.publishSegments(segmentTable, segments, HadoopDruidIndexerConfig.JSON_MAPPER);
 
     return true;
   }

--- a/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceInputFormat.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceInputFormat.java
@@ -26,7 +26,6 @@ import com.metamx.common.ISE;
 import com.metamx.common.logger.Logger;
 import io.druid.data.input.InputRow;
 import io.druid.indexer.HadoopDruidIndexerConfig;
-import io.druid.timeline.DataSegment;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.InputFormat;
@@ -55,7 +54,7 @@ public class DatasourceInputFormat extends InputFormat<NullWritable, InputRow>
     Configuration conf = context.getConfiguration();
 
     String segmentsStr = Preconditions.checkNotNull(conf.get(CONF_INPUT_SEGMENTS), "No segments found to read");
-    List<WindowedDataSegment> segments = HadoopDruidIndexerConfig.jsonMapper.readValue(
+    List<WindowedDataSegment> segments = HadoopDruidIndexerConfig.JSON_MAPPER.readValue(
         segmentsStr,
         new TypeReference<List<WindowedDataSegment>>()
         {

--- a/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceInputSplit.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceInputSplit.java
@@ -70,13 +70,13 @@ public class DatasourceInputSplit extends InputSplit implements Writable
   @Override
   public void write(DataOutput out) throws IOException
   {
-    out.writeUTF(HadoopDruidIndexerConfig.jsonMapper.writeValueAsString(segments));
+    out.writeUTF(HadoopDruidIndexerConfig.JSON_MAPPER.writeValueAsString(segments));
   }
 
   @Override
   public void readFields(DataInput in) throws IOException
   {
-    segments = HadoopDruidIndexerConfig.jsonMapper.readValue(
+    segments = HadoopDruidIndexerConfig.JSON_MAPPER.readValue(
         in.readUTF(),
         new TypeReference<List<WindowedDataSegment>>()
         {

--- a/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceRecordReader.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceRecordReader.java
@@ -66,7 +66,7 @@ public class DatasourceRecordReader extends RecordReader<NullWritable, InputRow>
   @Override
   public void initialize(InputSplit split, final TaskAttemptContext context) throws IOException, InterruptedException
   {
-    spec = readAndVerifyDatasourceIngestionSpec(context.getConfiguration(), HadoopDruidIndexerConfig.jsonMapper);
+    spec = readAndVerifyDatasourceIngestionSpec(context.getConfiguration(), HadoopDruidIndexerConfig.JSON_MAPPER);
 
     List<WindowedDataSegment> segments = ((DatasourceInputSplit) split).getSegments();
 

--- a/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceRecordReader.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceRecordReader.java
@@ -33,7 +33,6 @@ import io.druid.data.input.MapBasedInputRow;
 import io.druid.data.input.MapBasedRow;
 import io.druid.indexer.HadoopDruidIndexerConfig;
 import io.druid.indexer.JobHelper;
-import io.druid.segment.IndexIO;
 import io.druid.segment.QueryableIndex;
 import io.druid.segment.QueryableIndexStorageAdapter;
 import io.druid.segment.realtime.firehose.IngestSegmentFirehose;
@@ -91,7 +90,7 @@ public class DatasourceRecordReader extends RecordReader<NullWritable, InputRow>
               JobHelper.unzipNoGuava(path, context.getConfiguration(), dir, context);
               logger.info("finished fetching segment files");
 
-              QueryableIndex index = IndexIO.loadIndex(dir);
+              QueryableIndex index = HadoopDruidIndexerConfig.INDEX_IO.loadIndex(dir);
               indexes.add(index);
               numRows += index.getNumRows();
 

--- a/indexing-hadoop/src/main/java/io/druid/indexer/updater/HadoopConverterJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/updater/HadoopConverterJob.java
@@ -34,8 +34,6 @@ import com.metamx.common.logger.Logger;
 import io.druid.indexer.JobHelper;
 import io.druid.indexer.hadoop.DatasourceInputSplit;
 import io.druid.indexer.hadoop.WindowedDataSegment;
-import io.druid.segment.IndexIO;
-import io.druid.segment.IndexMerger;
 import io.druid.timeline.DataSegment;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -514,7 +512,7 @@ public class HadoopConverterJob
       if (!outDir.mkdir() && (!outDir.exists() || !outDir.isDirectory())) {
         throw new IOException(String.format("Could not create output directory [%s]", outDir));
       }
-      IndexMerger.convert(
+      HadoopDruidConverterConfig.INDEX_MERGER.convert(
           inDir,
           outDir,
           config.getIndexSpec(),
@@ -522,7 +520,7 @@ public class HadoopConverterJob
       );
       if (config.isValidate()) {
         context.setStatus("Validating");
-        IndexIO.DefaultIndexIOHandler.validateTwoSegments(inDir, outDir);
+        HadoopDruidConverterConfig.INDEX_IO.validateTwoSegments(inDir, outDir);
       }
       context.progress();
       context.setStatus("Starting PUSH");

--- a/indexing-hadoop/src/main/java/io/druid/indexer/updater/HadoopDruidConverterConfig.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/updater/HadoopDruidConverterConfig.java
@@ -34,6 +34,8 @@ import io.druid.guice.GuiceInjectors;
 import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.annotations.Self;
 import io.druid.initialization.Initialization;
+import io.druid.segment.IndexIO;
+import io.druid.segment.IndexMerger;
 import io.druid.segment.IndexSpec;
 import io.druid.server.DruidNode;
 import io.druid.timeline.DataSegment;
@@ -49,6 +51,9 @@ public class HadoopDruidConverterConfig
 {
   public static final String CONFIG_PROPERTY = "io.druid.indexer.updater.converter";
   public static final ObjectMapper jsonMapper;
+  public static final IndexIO INDEX_IO;
+  public static final IndexMerger INDEX_MERGER;
+
   private static final Injector injector = Initialization.makeInjectorWithModules(
       GuiceInjectors.makeStartupInjector(),
       ImmutableList.<Module>of(
@@ -68,6 +73,8 @@ public class HadoopDruidConverterConfig
   static {
     jsonMapper = injector.getInstance(ObjectMapper.class);
     jsonMapper.registerSubtypes(HadoopDruidConverterConfig.class);
+    INDEX_IO = injector.getInstance(IndexIO.class);
+    INDEX_MERGER = injector.getInstance(IndexMerger.class);
   }
 
   private static final TypeReference<Map<String, Object>> mapTypeReference = new TypeReference<Map<String, Object>>()

--- a/indexing-hadoop/src/test/java/io/druid/indexer/BatchDeltaIngestionTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/BatchDeltaIngestionTest.java
@@ -394,7 +394,7 @@ public class BatchDeltaIngestionTest
             INTERVAL_FULL.getStart(),
             ImmutableList.of(
                 new HadoopyShardSpec(
-                    new HashBasedNumberedShardSpec(0, 1, HadoopDruidIndexerConfig.jsonMapper),
+                    new HashBasedNumberedShardSpec(0, 1, HadoopDruidIndexerConfig.JSON_MAPPER),
                     0
                 )
             )

--- a/indexing-hadoop/src/test/java/io/druid/indexer/BatchDeltaIngestionTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/BatchDeltaIngestionTest.java
@@ -70,6 +70,7 @@ public class BatchDeltaIngestionTest
   public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   private static final ObjectMapper MAPPER;
+  private static final IndexIO INDEX_IO;
   private static final Interval INTERVAL_FULL = new Interval("2014-10-22T00:00:00Z/P1D");
   private static final Interval INTERVAL_PARTIAL = new Interval("2014-10-22T00:00:00Z/PT2H");
   private static final DataSegment SEGMENT;
@@ -79,6 +80,7 @@ public class BatchDeltaIngestionTest
     MAPPER.registerSubtypes(new NamedType(HashBasedNumberedShardSpec.class, "hashed"));
     InjectableValues inject = new InjectableValues.Std().addValue(ObjectMapper.class, MAPPER);
     MAPPER.setInjectableValues(inject);
+    INDEX_IO = HadoopDruidIndexerConfig.INDEX_IO;
 
     try {
       SEGMENT = new DefaultObjectMapper()
@@ -314,7 +316,7 @@ public class BatchDeltaIngestionTest
     File tmpUnzippedSegmentDir = temporaryFolder.newFolder();
     new LocalDataSegmentPuller().getSegmentFiles(dataSegment, tmpUnzippedSegmentDir);
 
-    QueryableIndex index = IndexIO.loadIndex(tmpUnzippedSegmentDir);
+    QueryableIndex index = INDEX_IO.loadIndex(tmpUnzippedSegmentDir);
     StorageAdapter adapter = new QueryableIndexStorageAdapter(index);
 
     Firehose firehose = new IngestSegmentFirehose(

--- a/indexing-hadoop/src/test/java/io/druid/indexer/DetermineHashedPartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/DetermineHashedPartitionsJobTest.java
@@ -108,7 +108,7 @@ public class DetermineHashedPartitionsJobTest
     HadoopIngestionSpec ingestionSpec = new HadoopIngestionSpec(
         new DataSchema(
             "test_schema",
-            HadoopDruidIndexerConfig.jsonMapper.convertValue(
+            HadoopDruidIndexerConfig.JSON_MAPPER.convertValue(
                 new StringInputRowParser(
                     new DelimitedParseSpec(
                         new TimestampSpec("ts", null, null),
@@ -137,7 +137,7 @@ public class DetermineHashedPartitionsJobTest
                 QueryGranularity.NONE,
                 ImmutableList.of(new Interval(interval))
             ),
-            HadoopDruidIndexerConfig.jsonMapper
+            HadoopDruidIndexerConfig.JSON_MAPPER
         ),
         new HadoopIOConfig(
             ImmutableMap.<String, Object>of(

--- a/indexing-hadoop/src/test/java/io/druid/indexer/DeterminePartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/DeterminePartitionsJobTest.java
@@ -223,7 +223,7 @@ public class DeterminePartitionsJobTest
         new HadoopIngestionSpec(
             new DataSchema(
                 "website",
-                HadoopDruidIndexerConfig.jsonMapper.convertValue(
+                HadoopDruidIndexerConfig.JSON_MAPPER.convertValue(
                     new StringInputRowParser(
                         new CSVParseSpec(
                             new TimestampSpec("timestamp", "yyyyMMddHH", null),
@@ -238,7 +238,7 @@ public class DeterminePartitionsJobTest
                 new UniformGranularitySpec(
                     Granularity.DAY, QueryGranularity.NONE, ImmutableList.of(new Interval(interval))
                 ),
-                HadoopDruidIndexerConfig.jsonMapper
+                HadoopDruidIndexerConfig.JSON_MAPPER
             ),
             new HadoopIOConfig(
                 ImmutableMap.<String, Object>of(

--- a/indexing-hadoop/src/test/java/io/druid/indexer/HadoopyStringInputRowParserTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/HadoopyStringInputRowParserTest.java
@@ -37,7 +37,7 @@ public class HadoopyStringInputRowParserTest
                      + "\"parseSpec\":{\"format\":\"json\",\"timestampSpec\":{\"column\":\"xXx\"},\"dimensionsSpec\":{}}"
                      + "}";
 
-    ObjectMapper jsonMapper = HadoopDruidIndexerConfig.jsonMapper;
+    ObjectMapper jsonMapper = HadoopDruidIndexerConfig.JSON_MAPPER;
     InputRowParser parser = jsonMapper.readValue(
         jsonMapper.writeValueAsString(
             jsonMapper.readValue(jsonStr, InputRowParser.class)

--- a/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorCombinerTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorCombinerTest.java
@@ -63,7 +63,7 @@ public class IndexGeneratorCombinerTest
         new HadoopIngestionSpec(
             new DataSchema(
                 "website",
-                HadoopDruidIndexerConfig.jsonMapper.convertValue(
+                HadoopDruidIndexerConfig.JSON_MAPPER.convertValue(
                     new StringInputRowParser(
                         new CSVParseSpec(
                             new TimestampSpec("timestamp", "yyyyMMddHH", null),
@@ -81,7 +81,7 @@ public class IndexGeneratorCombinerTest
                 new UniformGranularitySpec(
                     Granularity.DAY, QueryGranularity.NONE, ImmutableList.of(Interval.parse("2010/2011"))
                 ),
-                HadoopDruidIndexerConfig.jsonMapper
+                HadoopDruidIndexerConfig.JSON_MAPPER
             ),
             new HadoopIOConfig(
                 ImmutableMap.<String, Object>of(
@@ -99,7 +99,7 @@ public class IndexGeneratorCombinerTest
     Configuration hadoopConfig = new Configuration();
     hadoopConfig.set(
         HadoopDruidIndexerConfig.CONFIG_PROPERTY,
-        HadoopDruidIndexerConfig.jsonMapper.writeValueAsString(config)
+        HadoopDruidIndexerConfig.JSON_MAPPER.writeValueAsString(config)
     );
 
     Reducer.Context context = EasyMock.createMock(Reducer.Context.class);

--- a/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobTest.java
@@ -339,7 +339,7 @@ public class IndexGeneratorJobTest
   @Before
   public void setUp() throws Exception
   {
-    mapper = HadoopDruidIndexerConfig.jsonMapper;
+    mapper = HadoopDruidIndexerConfig.JSON_MAPPER;
     mapper.registerSubtypes(new NamedType(HashBasedNumberedShardSpec.class, "hashed"));
     mapper.registerSubtypes(new NamedType(SingleDimensionShardSpec.class, "single"));
 
@@ -412,7 +412,7 @@ public class IndexGeneratorJobTest
     List<ShardSpec> specs = Lists.newArrayList();
     if (partitionType.equals("hashed")) {
       for (Integer[] shardInfo : (Integer[][]) shardInfoForEachShard) {
-        specs.add(new HashBasedNumberedShardSpec(shardInfo[0], shardInfo[1], HadoopDruidIndexerConfig.jsonMapper));
+        specs.add(new HashBasedNumberedShardSpec(shardInfo[0], shardInfo[1], HadoopDruidIndexerConfig.JSON_MAPPER));
       }
     } else if (partitionType.equals("single")) {
       int partitionNum = 0;

--- a/indexing-hadoop/src/test/java/io/druid/indexer/JobHelperTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/JobHelperTest.java
@@ -66,7 +66,7 @@ public class JobHelperTest
         new HadoopIngestionSpec(
             new DataSchema(
                 "website",
-                HadoopDruidIndexerConfig.jsonMapper.convertValue(
+                HadoopDruidIndexerConfig.JSON_MAPPER.convertValue(
                     new StringInputRowParser(
                         new CSVParseSpec(
                             new TimestampSpec("timestamp", "yyyyMMddHH", null),
@@ -81,7 +81,7 @@ public class JobHelperTest
                 new UniformGranularitySpec(
                     Granularity.DAY, QueryGranularity.NONE, ImmutableList.of(this.interval)
                 ),
-                HadoopDruidIndexerConfig.jsonMapper
+                HadoopDruidIndexerConfig.JSON_MAPPER
             ),
             new HadoopIOConfig(
                 ImmutableMap.<String, Object>of(

--- a/indexing-hadoop/src/test/java/io/druid/indexer/hadoop/DatasourceRecordReaderTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/hadoop/DatasourceRecordReaderTest.java
@@ -60,7 +60,7 @@ public class DatasourceRecordReaderTest
     Configuration config = new Configuration();
     config.set(
         DatasourceInputFormat.CONF_DRUID_SCHEMA,
-        HadoopDruidIndexerConfig.jsonMapper.writeValueAsString(
+        HadoopDruidIndexerConfig.JSON_MAPPER.writeValueAsString(
             new DatasourceIngestionSpec(
                 segment.getDataSource(),
                 segment.getInterval(),

--- a/indexing-hadoop/src/test/java/io/druid/indexer/path/DatasourcePathSpecTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/path/DatasourcePathSpecTest.java
@@ -177,7 +177,7 @@ public class DatasourcePathSpecTest
         new HadoopIngestionSpec(
             new DataSchema(
                 ingestionSpec.getDataSource(),
-                HadoopDruidIndexerConfig.jsonMapper.convertValue(
+                HadoopDruidIndexerConfig.JSON_MAPPER.convertValue(
                     new StringInputRowParser(
                         new CSVParseSpec(
                             new TimestampSpec("timestamp", "yyyyMMddHH", null),
@@ -194,7 +194,7 @@ public class DatasourcePathSpecTest
                 new UniformGranularitySpec(
                     Granularity.DAY, QueryGranularity.NONE, ImmutableList.of(Interval.parse("2000/3000"))
                 ),
-                HadoopDruidIndexerConfig.jsonMapper
+                HadoopDruidIndexerConfig.JSON_MAPPER
             ),
             new HadoopIOConfig(
                 ImmutableMap.<String, Object>of(

--- a/indexing-hadoop/src/test/java/io/druid/indexer/updater/HadoopConverterJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/updater/HadoopConverterJobTest.java
@@ -156,7 +156,7 @@ public class HadoopConverterJobTest
         new HadoopIngestionSpec(
             new DataSchema(
                 DATASOURCE,
-                HadoopDruidIndexerConfig.jsonMapper.convertValue(
+                HadoopDruidIndexerConfig.JSON_MAPPER.convertValue(
                     new StringInputRowParser(
                         new DelimitedParseSpec(
                             new TimestampSpec("ts", "iso", null),
@@ -177,7 +177,7 @@ public class HadoopConverterJobTest
                     QueryGranularity.DAY,
                     ImmutableList.<Interval>of(interval)
                 ),
-                HadoopDruidIndexerConfig.jsonMapper
+                HadoopDruidIndexerConfig.JSON_MAPPER
             ),
             new HadoopIOConfig(
                 ImmutableMap.<String, Object>of(

--- a/indexing-service/src/main/java/io/druid/indexing/common/TaskToolbox.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/TaskToolbox.java
@@ -19,6 +19,7 @@ package io.druid.indexing.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
@@ -32,6 +33,9 @@ import io.druid.indexing.common.actions.TaskActionClientFactory;
 import io.druid.indexing.common.config.TaskConfig;
 import io.druid.indexing.common.task.Task;
 import io.druid.query.QueryRunnerFactoryConglomerate;
+import io.druid.segment.IndexIO;
+import io.druid.segment.IndexMaker;
+import io.druid.segment.IndexMerger;
 import io.druid.segment.loading.DataSegmentArchiver;
 import io.druid.segment.loading.DataSegmentKiller;
 import io.druid.segment.loading.DataSegmentMover;
@@ -70,6 +74,9 @@ public class TaskToolbox
   private final SegmentLoader segmentLoader;
   private final ObjectMapper objectMapper;
   private final File taskWorkDir;
+  private final IndexMerger indexMerger;
+  private final IndexMaker indexMaker;
+  private final IndexIO indexIO;
 
   public TaskToolbox(
       TaskConfig config,
@@ -87,7 +94,10 @@ public class TaskToolbox
       MonitorScheduler monitorScheduler,
       SegmentLoader segmentLoader,
       ObjectMapper objectMapper,
-      final File taskWorkDir
+      File taskWorkDir,
+      IndexMerger indexMerger,
+      IndexMaker indexMaker,
+      IndexIO indexIO
   )
   {
     this.config = config;
@@ -106,6 +116,9 @@ public class TaskToolbox
     this.segmentLoader = segmentLoader;
     this.objectMapper = objectMapper;
     this.taskWorkDir = taskWorkDir;
+    this.indexMerger = Preconditions.checkNotNull(indexMerger, "Null IndexMerger");
+    this.indexMaker = Preconditions.checkNotNull(indexMaker, "Null IndexMaker");
+    this.indexIO = Preconditions.checkNotNull(indexIO, "Null IndexIO");
   }
 
   public TaskConfig getConfig()
@@ -207,5 +220,20 @@ public class TaskToolbox
   public File getTaskWorkDir()
   {
     return taskWorkDir;
+  }
+
+  public IndexIO getIndexIO()
+  {
+    return indexIO;
+  }
+
+  public IndexMerger getIndexMerger()
+  {
+    return indexMerger;
+  }
+
+  public IndexMaker getIndexMaker()
+  {
+    return indexMaker;
   }
 }

--- a/indexing-service/src/main/java/io/druid/indexing/common/TaskToolboxFactory.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/TaskToolboxFactory.java
@@ -18,6 +18,7 @@
 package io.druid.indexing.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import com.metamx.emitter.service.ServiceEmitter;
 import com.metamx.metrics.MonitorScheduler;
@@ -27,6 +28,9 @@ import io.druid.indexing.common.actions.TaskActionClientFactory;
 import io.druid.indexing.common.config.TaskConfig;
 import io.druid.indexing.common.task.Task;
 import io.druid.query.QueryRunnerFactoryConglomerate;
+import io.druid.segment.IndexIO;
+import io.druid.segment.IndexMaker;
+import io.druid.segment.IndexMerger;
 import io.druid.segment.loading.DataSegmentArchiver;
 import io.druid.segment.loading.DataSegmentKiller;
 import io.druid.segment.loading.DataSegmentMover;
@@ -55,6 +59,9 @@ public class TaskToolboxFactory
   private final MonitorScheduler monitorScheduler;
   private final SegmentLoaderFactory segmentLoaderFactory;
   private final ObjectMapper objectMapper;
+  private final IndexMerger indexMerger;
+  private final IndexMaker indexMaker;
+  private final IndexIO indexIO;
 
   @Inject
   public TaskToolboxFactory(
@@ -71,7 +78,10 @@ public class TaskToolboxFactory
       @Processing ExecutorService queryExecutorService,
       MonitorScheduler monitorScheduler,
       SegmentLoaderFactory segmentLoaderFactory,
-      ObjectMapper objectMapper
+      ObjectMapper objectMapper,
+      IndexMerger indexMerger,
+      IndexMaker indexMaker,
+      IndexIO indexIO
   )
   {
     this.config = config;
@@ -88,6 +98,9 @@ public class TaskToolboxFactory
     this.monitorScheduler = monitorScheduler;
     this.segmentLoaderFactory = segmentLoaderFactory;
     this.objectMapper = objectMapper;
+    this.indexMerger = Preconditions.checkNotNull(indexMerger, "Null IndexMerger");
+    this.indexMaker = Preconditions.checkNotNull(indexMaker, "Null IndexMaker");
+    this.indexIO = Preconditions.checkNotNull(indexIO, "Null IndexIO");
   }
 
   public TaskToolbox build(Task task)
@@ -110,7 +123,10 @@ public class TaskToolboxFactory
         monitorScheduler,
         segmentLoaderFactory.manufacturate(taskWorkDir),
         objectMapper,
-        taskWorkDir
+        taskWorkDir,
+        indexMerger,
+        indexMaker,
+        indexIO
     );
   }
 }

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/AppendTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/AppendTask.java
@@ -25,8 +25,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
-import io.druid.segment.IndexIO;
-import io.druid.segment.IndexMerger;
+import io.druid.indexing.common.TaskToolbox;
 import io.druid.segment.IndexSpec;
 import io.druid.segment.IndexableAdapter;
 import io.druid.segment.QueryableIndexIndexableAdapter;
@@ -64,7 +63,7 @@ public class AppendTask extends MergeTaskBase
   }
 
   @Override
-  public File merge(final Map<DataSegment, File> segments, final File outDir)
+  public File merge(final TaskToolbox toolbox, final Map<DataSegment, File> segments, final File outDir)
       throws Exception
   {
     VersionedIntervalTimeline<String, DataSegment> timeline = new VersionedIntervalTimeline<String, DataSegment>(
@@ -113,7 +112,7 @@ public class AppendTask extends MergeTaskBase
       adapters.add(
           new RowboatFilteringIndexAdapter(
               new QueryableIndexIndexableAdapter(
-                  IndexIO.loadIndex(holder.getFile())
+                  toolbox.getIndexIO().loadIndex(holder.getFile())
               ),
               new Predicate<Rowboat>()
               {
@@ -127,7 +126,7 @@ public class AppendTask extends MergeTaskBase
       );
     }
 
-    return IndexMerger.append(adapters, outDir, indexSpec);
+    return toolbox.getIndexMerger().append(adapters, outDir, indexSpec);
   }
 
   @Override

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/ConvertSegmentTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/ConvertSegmentTask.java
@@ -39,7 +39,6 @@ import io.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
@@ -99,7 +98,12 @@ public class ConvertSegmentTask extends AbstractFixedIntervalTask
    *
    * @return A SegmentConverterTask for the segment with the indexSpec specified.
    */
-  public static ConvertSegmentTask create(DataSegment segment, IndexSpec indexSpec, boolean force, boolean validate, Map<String, Object> context
+  public static ConvertSegmentTask create(
+      DataSegment segment,
+      IndexSpec indexSpec,
+      boolean force,
+      boolean validate,
+      Map<String, Object> context
   )
   {
     final Interval interval = segment.getInterval();
@@ -377,7 +381,7 @@ public class ConvertSegmentTask extends AbstractFixedIntervalTask
 
     final File location = localSegments.get(segment);
     final File outLocation = new File(location, "v9_out");
-    if (IndexIO.convertSegment(location, outLocation, indexSpec, force, validate)) {
+    if (toolbox.getIndexIO().convertSegment(location, outLocation, indexSpec, force, validate)) {
       final int outVersion = IndexIO.getVersionFromDir(outLocation);
 
       // Appending to the version makes a new version that inherits most comparability parameters of the original

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/HadoopIndexTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/HadoopIndexTask.java
@@ -234,7 +234,7 @@ public class HadoopIndexTask extends HadoopTask
       final String schema = args[0];
       String version = args[1];
 
-      final HadoopIngestionSpec theSchema = HadoopDruidIndexerConfig.jsonMapper
+      final HadoopIngestionSpec theSchema = HadoopDruidIndexerConfig.JSON_MAPPER
           .readValue(
               schema,
               HadoopIngestionSpec.class
@@ -257,7 +257,7 @@ public class HadoopIndexTask extends HadoopTask
 
       log.info("Starting a hadoop index generator job...");
       if (job.run()) {
-        return HadoopDruidIndexerConfig.jsonMapper.writeValueAsString(job.getPublishedSegments());
+        return HadoopDruidIndexerConfig.JSON_MAPPER.writeValueAsString(job.getPublishedSegments());
       }
 
       return null;
@@ -272,7 +272,7 @@ public class HadoopIndexTask extends HadoopTask
       final String workingPath = args[1];
       final String segmentOutputPath = args[2];
 
-      final HadoopIngestionSpec theSchema = HadoopDruidIndexerConfig.jsonMapper
+      final HadoopIngestionSpec theSchema = HadoopDruidIndexerConfig.JSON_MAPPER
           .readValue(
               schema,
               HadoopIngestionSpec.class
@@ -287,7 +287,7 @@ public class HadoopIndexTask extends HadoopTask
 
       log.info("Starting a hadoop determine configuration job...");
       if (job.run()) {
-        return HadoopDruidIndexerConfig.jsonMapper.writeValueAsString(config.getSchema());
+        return HadoopDruidIndexerConfig.JSON_MAPPER.writeValueAsString(config.getSchema());
       }
 
       return null;

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
@@ -61,7 +61,6 @@ import io.druid.timeline.DataSegment;
 import io.druid.timeline.partition.HashBasedNumberedShardSpec;
 import io.druid.timeline.partition.NoneShardSpec;
 import io.druid.timeline.partition.ShardSpec;
-import java.util.Map;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
@@ -69,6 +68,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -359,7 +359,9 @@ public class IndexTask extends AbstractFixedIntervalTask
         interval,
         version,
         wrappedDataSegmentPusher,
-        tmpDir
+        tmpDir,
+        toolbox.getIndexMerger(),
+        toolbox.getIndexIO()
     ).findPlumber(
         schema,
         convertTuningConfig(shardSpec, myRowFlushBoundary, ingestionSchema.getTuningConfig().getIndexSpec()),

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/MergeTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/MergeTask.java
@@ -25,9 +25,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import io.druid.indexing.common.TaskToolbox;
 import io.druid.query.aggregation.AggregatorFactory;
-import io.druid.segment.IndexIO;
-import io.druid.segment.IndexMerger;
 import io.druid.segment.IndexSpec;
 import io.druid.segment.QueryableIndex;
 import io.druid.timeline.DataSegment;
@@ -53,7 +52,6 @@ public class MergeTask extends MergeTaskBase
       @JsonProperty("aggregations") List<AggregatorFactory> aggregators,
       @JsonProperty("indexSpec") IndexSpec indexSpec,
       @JsonProperty("context") Map<String, Object> context
-
   )
   {
     super(id, dataSource, segments, context);
@@ -62,10 +60,10 @@ public class MergeTask extends MergeTaskBase
   }
 
   @Override
-  public File merge(final Map<DataSegment, File> segments, final File outDir)
+  public File merge(final TaskToolbox toolbox, final Map<DataSegment, File> segments, final File outDir)
       throws Exception
   {
-    return IndexMerger.mergeQueryableIndex(
+    return toolbox.getIndexMerger().mergeQueryableIndex(
         Lists.transform(
             ImmutableList.copyOf(segments.values()),
             new Function<File, QueryableIndex>()
@@ -74,7 +72,7 @@ public class MergeTask extends MergeTaskBase
               public QueryableIndex apply(@Nullable File input)
               {
                 try {
-                  return IndexIO.loadIndex(input);
+                  return toolbox.getIndexIO().loadIndex(input);
                 }
                 catch (Exception e) {
                   throw Throwables.propagate(e);

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/MergeTaskBase.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/MergeTaskBase.java
@@ -149,7 +149,7 @@ public abstract class MergeTaskBase extends AbstractFixedIntervalTask
       final Map<DataSegment, File> gettedSegments = toolbox.fetchSegments(segments);
 
       // merge files together
-      final File fileToUpload = merge(gettedSegments, new File(taskDir, "merged"));
+      final File fileToUpload = merge(toolbox, gettedSegments, new File(taskDir, "merged"));
 
       emitter.emit(builder.build("merger/numMerged", segments.size()));
       emitter.emit(builder.build("merger/mergeTime", System.currentTimeMillis() - startTime));
@@ -230,7 +230,7 @@ public abstract class MergeTaskBase extends AbstractFixedIntervalTask
     }
   }
 
-  protected abstract File merge(Map<DataSegment, File> segments, File outDir)
+  protected abstract File merge(TaskToolbox taskToolbox, Map<DataSegment, File> segments, File outDir)
       throws Exception;
 
   @JsonProperty

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/RealtimeIndexTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/RealtimeIndexTask.java
@@ -275,7 +275,10 @@ public class RealtimeIndexTask extends AbstractTask
         lockingSegmentAnnouncer,
         segmentPublisher,
         toolbox.getNewSegmentServerView(),
-        toolbox.getQueryExecutorService()
+        toolbox.getQueryExecutorService(),
+        toolbox.getIndexMerger(),
+        toolbox.getIndexMaker(),
+        toolbox.getIndexIO()
     );
 
     this.plumber = plumberSchool.findPlumber(dataSchema, tuningConfig, fireDepartment.getMetrics());

--- a/indexing-service/src/main/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactory.java
+++ b/indexing-service/src/main/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactory.java
@@ -65,6 +65,7 @@ public class IngestSegmentFirehoseFactory implements FirehoseFactory<InputRowPar
   private final List<String> dimensions;
   private final List<String> metrics;
   private final Injector injector;
+  private final IndexIO indexIO;
 
   @JsonCreator
   public IngestSegmentFirehoseFactory(
@@ -73,7 +74,8 @@ public class IngestSegmentFirehoseFactory implements FirehoseFactory<InputRowPar
       @JsonProperty("filter") DimFilter dimFilter,
       @JsonProperty("dimensions") List<String> dimensions,
       @JsonProperty("metrics") List<String> metrics,
-      @JacksonInject Injector injector
+      @JacksonInject Injector injector,
+      @JacksonInject IndexIO indexIO
   )
   {
     Preconditions.checkNotNull(dataSource, "dataSource");
@@ -84,6 +86,7 @@ public class IngestSegmentFirehoseFactory implements FirehoseFactory<InputRowPar
     this.dimensions = dimensions;
     this.metrics = metrics;
     this.injector = injector;
+    this.indexIO = Preconditions.checkNotNull(indexIO, "null IndexIO");
   }
 
   @JsonProperty
@@ -247,7 +250,7 @@ public class IngestSegmentFirehoseFactory implements FirehoseFactory<InputRowPar
                                   try {
                                     return new WindowedStorageAdapter(
                                         new QueryableIndexStorageAdapter(
-                                            IndexIO.loadIndex(
+                                            indexIO.loadIndex(
                                                 Preconditions.checkNotNull(
                                                     segmentFileMap.get(segment),
                                                     "File for segment %s", segment.getIdentifier()

--- a/indexing-service/src/test/java/io/druid/indexing/common/TaskToolboxTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/TaskToolboxTest.java
@@ -28,13 +28,16 @@ import io.druid.indexing.common.actions.TaskActionClientFactory;
 import io.druid.indexing.common.config.TaskConfig;
 import io.druid.indexing.common.task.Task;
 import io.druid.query.QueryRunnerFactoryConglomerate;
+import io.druid.segment.IndexIO;
+import io.druid.segment.IndexMaker;
+import io.druid.segment.IndexMerger;
+import io.druid.segment.loading.DataSegmentArchiver;
 import io.druid.segment.loading.DataSegmentKiller;
 import io.druid.segment.loading.DataSegmentMover;
 import io.druid.segment.loading.DataSegmentPusher;
-import io.druid.segment.loading.SegmentLoaderLocalCacheManager;
-import io.druid.segment.loading.DataSegmentArchiver;
-import io.druid.segment.loading.SegmentLoadingException;
 import io.druid.segment.loading.SegmentLoaderConfig;
+import io.druid.segment.loading.SegmentLoaderLocalCacheManager;
+import io.druid.segment.loading.SegmentLoadingException;
 import io.druid.server.coordination.DataSegmentAnnouncer;
 import io.druid.timeline.DataSegment;
 import org.easymock.EasyMock;
@@ -70,6 +73,9 @@ public class TaskToolboxTest
   private ObjectMapper ObjectMapper = new ObjectMapper();
   private SegmentLoaderLocalCacheManager mockSegmentLoaderLocalCacheManager = EasyMock.createMock(SegmentLoaderLocalCacheManager.class);
   private Task task = EasyMock.createMock(Task.class);
+  private IndexMerger mockIndexMerger = EasyMock.createMock(IndexMerger.class);
+  private IndexMaker mockIndexMaker = EasyMock.createMock(IndexMaker.class);
+  private IndexIO mockIndexIO = EasyMock.createMock(IndexIO.class);
 
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -94,7 +100,10 @@ public class TaskToolboxTest
         mockQueryExecutorService,
         mockMonitorScheduler,
         new SegmentLoaderFactory(mockSegmentLoaderLocalCacheManager),
-        ObjectMapper
+        ObjectMapper,
+        mockIndexMerger,
+        mockIndexMaker,
+        mockIndexIO
     );
   }
 

--- a/indexing-service/src/test/java/io/druid/indexing/common/TestRealtimeTask.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/TestRealtimeTask.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.druid.indexing.common.task.RealtimeIndexTask;
 import io.druid.indexing.common.task.TaskResource;
-import io.druid.jackson.DefaultObjectMapper;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.segment.indexing.DataSchema;
 import io.druid.segment.indexing.RealtimeIOConfig;

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/ConvertSegmentTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/ConvertSegmentTaskTest.java
@@ -17,13 +17,12 @@
 
 package io.druid.indexing.common.task;
 
-import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.druid.jackson.DefaultObjectMapper;
+import io.druid.indexing.common.TestUtils;
 import io.druid.timeline.DataSegment;
 import io.druid.timeline.partition.NoneShardSpec;
-import java.io.IOException;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.junit.Assert;
@@ -33,14 +32,19 @@ import org.junit.Test;
  */
 public class ConvertSegmentTaskTest
 {
-  private DefaultObjectMapper jsonMapper = new DefaultObjectMapper();
+  private final ObjectMapper jsonMapper;
+
+  public ConvertSegmentTaskTest()
+  {
+    TestUtils testUtils = new TestUtils();
+    jsonMapper = testUtils.getTestObjectMapper();
+  }
 
   @Test
   public void testSerializationSimple() throws Exception
   {
     final String dataSource = "billy";
     final Interval interval = new Interval(new DateTime().minus(1000), new DateTime());
-
 
     ConvertSegmentTask task = ConvertSegmentTask.create(dataSource, interval, null, false, true, null);
 

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/HadoopConverterTaskSerDeTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/HadoopConverterTaskSerDeTest.java
@@ -22,7 +22,7 @@ package io.druid.indexing.common.task;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.druid.jackson.DefaultObjectMapper;
+import io.druid.indexing.common.TestUtils;
 import io.druid.segment.IndexSpec;
 import io.druid.segment.data.ConciseBitmapSerdeFactory;
 import io.druid.timeline.DataSegment;
@@ -39,7 +39,7 @@ import java.util.Map;
 
 public class HadoopConverterTaskSerDeTest
 {
-  private static ObjectMapper objectMapper = new DefaultObjectMapper();
+
   private static final String TASK_ID = "task id";
   private static final String DATA_SOURCE = "datasource";
   private static final Interval INTERVAL = Interval.parse("2010/2011");
@@ -68,6 +68,14 @@ public class HadoopConverterTaskSerDeTest
   private static final String OUTPUT_PATH = "/dev/null";
   private static final String CLASSPATH_PREFIX = "something:where:I:need:stuff";
 
+  private final ObjectMapper jsonMapper;
+
+  public HadoopConverterTaskSerDeTest()
+  {
+    TestUtils testUtils = new TestUtils();
+    jsonMapper = testUtils.getTestObjectMapper();
+  }
+
   @Test
   public void testSimpleConverterTaskSerDe() throws IOException
   {
@@ -85,9 +93,9 @@ public class HadoopConverterTaskSerDeTest
         CLASSPATH_PREFIX,
         null
     );
-    final String strOrig = objectMapper.writeValueAsString(orig);
-    HadoopConverterTask other = objectMapper.readValue(strOrig, HadoopConverterTask.class);
-    Assert.assertEquals(strOrig, objectMapper.writeValueAsString(other));
+    final String strOrig = jsonMapper.writeValueAsString(orig);
+    HadoopConverterTask other = jsonMapper.readValue(strOrig, HadoopConverterTask.class);
+    Assert.assertEquals(strOrig, jsonMapper.writeValueAsString(other));
     Assert.assertFalse(orig == other);
     Assert.assertEquals(orig, other);
     assertExpectedTask(other);
@@ -117,13 +125,13 @@ public class HadoopConverterTaskSerDeTest
         parent,
         null
     );
-    final String origString = objectMapper.writeValueAsString(subTask);
-    final HadoopConverterTask.ConverterSubTask otherSub = objectMapper.readValue(
+    final String origString = jsonMapper.writeValueAsString(subTask);
+    final HadoopConverterTask.ConverterSubTask otherSub = jsonMapper.readValue(
         origString,
         HadoopConverterTask.ConverterSubTask.class
     );
     Assert.assertEquals(subTask, otherSub);
-    Assert.assertEquals(origString, objectMapper.writeValueAsString(otherSub));
+    Assert.assertEquals(origString, jsonMapper.writeValueAsString(otherSub));
     Assert.assertEquals(ImmutableList.of(DATA_SEGMENT), otherSub.getSegments());
     Assert.assertFalse(parent == otherSub.getParent());
     Assert.assertEquals(parent, otherSub.getParent());

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/IndexTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/IndexTaskTest.java
@@ -28,13 +28,16 @@ import io.druid.data.input.impl.TimestampSpec;
 import io.druid.granularity.QueryGranularity;
 import io.druid.indexing.common.TaskLock;
 import io.druid.indexing.common.TaskToolbox;
+import io.druid.indexing.common.TestUtils;
 import io.druid.indexing.common.actions.LockListAction;
 import io.druid.indexing.common.actions.TaskAction;
 import io.druid.indexing.common.actions.TaskActionClient;
 import io.druid.indexing.common.actions.TaskActionClientFactory;
-import io.druid.jackson.DefaultObjectMapper;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.LongSumAggregatorFactory;
+import io.druid.segment.IndexIO;
+import io.druid.segment.IndexMaker;
+import io.druid.segment.IndexMerger;
 import io.druid.segment.IndexSpec;
 import io.druid.segment.indexing.DataSchema;
 import io.druid.segment.indexing.RealtimeTuningConfig;
@@ -63,8 +66,21 @@ public class IndexTaskTest
 {
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
-  private final IndexSpec indexSpec = new IndexSpec();
-  private final ObjectMapper jsonMapper = new DefaultObjectMapper();
+  private final IndexSpec indexSpec;
+  private final ObjectMapper jsonMapper;
+  private IndexMerger indexMerger;
+  private IndexMaker indexMaker;
+  private IndexIO indexIO;
+
+  public IndexTaskTest()
+  {
+    indexSpec = new IndexSpec();
+    TestUtils testUtils = new TestUtils();
+    jsonMapper = testUtils.getTestObjectMapper();
+    indexMerger = testUtils.getTestIndexMerger();
+    indexMaker = testUtils.getTestIndexMaker();
+    indexIO = testUtils.getTestIndexIO();
+  }
 
   @Test
   public void testDeterminePartitions() throws Exception
@@ -128,7 +144,7 @@ public class IndexTaskTest
                 indexSpec
             )
         ),
-        new DefaultObjectMapper(),
+        jsonMapper,
         null
     );
 
@@ -193,7 +209,7 @@ public class IndexTaskTest
             ),
             null
         ),
-        new DefaultObjectMapper(),
+        jsonMapper,
         null
     );
 
@@ -243,7 +259,8 @@ public class IndexTaskTest
             segments.add(segment);
             return segment;
           }
-        }, null, null, null, null, null, null, null, null, null, null, temporaryFolder.newFolder()
+        }, null, null, null, null, null, null, null, null, null, null, temporaryFolder.newFolder(),
+            indexMerger, indexMaker, indexIO
         )
     );
 
@@ -306,7 +323,7 @@ public class IndexTaskTest
             ),
             null
         ),
-        new DefaultObjectMapper(),
+        jsonMapper,
         null
     );
 

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/MergeTaskBaseTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/MergeTaskBaseTest.java
@@ -20,6 +20,7 @@ package io.druid.indexing.common.task;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.hash.Hashing;
+import io.druid.indexing.common.TaskToolbox;
 import io.druid.timeline.DataSegment;
 import org.joda.time.Interval;
 import org.junit.Assert;
@@ -44,7 +45,7 @@ public class MergeTaskBaseTest
   final MergeTaskBase testMergeTaskBase = new MergeTaskBase(null, "foo", segments, null)
   {
     @Override
-    protected File merge(Map<DataSegment, File> segments, File outDir) throws Exception
+    protected File merge(TaskToolbox toolbox, Map<DataSegment, File> segments, File outDir) throws Exception
     {
       return null;
     }

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTest.java
@@ -43,7 +43,6 @@ import io.druid.indexing.overlord.config.RemoteTaskRunnerConfig;
 import io.druid.indexing.overlord.setup.WorkerBehaviorConfig;
 import io.druid.indexing.worker.TaskAnnouncement;
 import io.druid.indexing.worker.Worker;
-import io.druid.jackson.DefaultObjectMapper;
 import io.druid.server.initialization.IndexerZkConfig;
 import io.druid.server.initialization.ZkPathsConfig;
 import org.apache.curator.framework.CuratorFramework;
@@ -66,13 +65,14 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class RemoteTaskRunnerTest
 {
-  private static final ObjectMapper jsonMapper = new DefaultObjectMapper();
   private static final Joiner joiner = Joiner.on("/");
   private static final String basePath = "/test/druid";
   private static final String announcementsPath = String.format("%s/indexer/announcements/worker", basePath);
   private static final String tasksPath = String.format("%s/indexer/tasks/worker", basePath);
   private static final String statusPath = String.format("%s/indexer/status/worker", basePath);
   private static final int TIMEOUT_SECONDS = 5;
+
+  private ObjectMapper jsonMapper;
 
   private TestingCluster testingCluster;
   private CuratorFramework cf;
@@ -85,6 +85,9 @@ public class RemoteTaskRunnerTest
   @Before
   public void setUp() throws Exception
   {
+    TestUtils testUtils = new TestUtils();
+    jsonMapper = testUtils.getTestObjectMapper();
+
     testingCluster = new TestingCluster(1);
     testingCluster.start();
 

--- a/indexing-service/src/test/java/io/druid/indexing/worker/TaskAnnouncementTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/worker/TaskAnnouncementTest.java
@@ -19,6 +19,7 @@ package io.druid.indexing.worker;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.druid.indexing.common.TaskStatus;
+import io.druid.indexing.common.TestUtils;
 import io.druid.indexing.common.task.RealtimeIndexTask;
 import io.druid.indexing.common.task.Task;
 import io.druid.indexing.common.task.TaskResource;
@@ -39,6 +40,14 @@ import java.io.File;
 
 public class TaskAnnouncementTest
 {
+  private final ObjectMapper jsonMapper;
+
+  public TaskAnnouncementTest()
+  {
+    TestUtils testUtils = new TestUtils();
+    jsonMapper = testUtils.getTestObjectMapper();
+  }
+
   @Test
   public void testBackwardsCompatibleSerde() throws Exception
   {
@@ -68,7 +77,6 @@ public class TaskAnnouncementTest
     final TaskStatus status = TaskStatus.running(task.getId());
     final TaskAnnouncement announcement = TaskAnnouncement.create(task, status);
 
-    final ObjectMapper jsonMapper = new DefaultObjectMapper();
     final String statusJson = jsonMapper.writeValueAsString(status);
     final String announcementJson = jsonMapper.writeValueAsString(announcement);
 

--- a/indexing-service/src/test/java/io/druid/indexing/worker/WorkerTaskMonitorTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/worker/WorkerTaskMonitorTest.java
@@ -34,7 +34,9 @@ import io.druid.indexing.common.config.TaskConfig;
 import io.druid.indexing.overlord.TestRemoteTaskRunnerConfig;
 import io.druid.indexing.overlord.ThreadPoolTaskRunner;
 import io.druid.indexing.worker.config.WorkerConfig;
-import io.druid.jackson.DefaultObjectMapper;
+import io.druid.segment.IndexIO;
+import io.druid.segment.IndexMaker;
+import io.druid.segment.IndexMerger;
 import io.druid.segment.loading.SegmentLoaderConfig;
 import io.druid.segment.loading.SegmentLoaderLocalCacheManager;
 import io.druid.segment.loading.StorageLocationConfig;
@@ -56,8 +58,6 @@ import java.util.List;
  */
 public class WorkerTaskMonitorTest
 {
-  private static final ObjectMapper jsonMapper = new DefaultObjectMapper();
-
   private static final Joiner joiner = Joiner.on("/");
   private static final String basePath = "/test/druid";
   private static final String tasksPath = String.format("%s/indexer/tasks/worker", basePath);
@@ -71,6 +71,19 @@ public class WorkerTaskMonitorTest
   private TestMergeTask task;
 
   private Worker worker;
+  private ObjectMapper jsonMapper;
+  private IndexMerger indexMerger;
+  private IndexMaker indexMaker;
+  private IndexIO indexIO;
+
+  public WorkerTaskMonitorTest()
+  {
+    TestUtils testUtils = new TestUtils();
+    jsonMapper = testUtils.getTestObjectMapper();
+    indexMerger = testUtils.getTestIndexMerger();
+    indexMaker = testUtils.getTestIndexMaker();
+    indexIO = testUtils.getTestIndexIO();
+  }
 
   @Before
   public void setUp() throws Exception
@@ -143,7 +156,11 @@ public class WorkerTaskMonitorTest
                     }
                     , jsonMapper
                 )
-            ), jsonMapper
+            ),
+                jsonMapper,
+                indexMerger,
+                indexMaker,
+                indexIO
             ),
             null
         ),

--- a/processing/src/main/java/io/druid/segment/IndexSpec.java
+++ b/processing/src/main/java/io/druid/segment/IndexSpec.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import io.druid.segment.data.BitmapSerdeFactory;
 import io.druid.segment.data.CompressedObjectStrategy;
+import io.druid.segment.data.ConciseBitmapSerdeFactory;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -98,7 +99,7 @@ public class IndexSpec
     Preconditions.checkArgument(metricCompression == null || COMPRESSION_NAMES.contains(metricCompression),
                                 "Unknown compression type[%s]", metricCompression);
 
-    this.bitmapSerdeFactory = bitmapSerdeFactory != null ? bitmapSerdeFactory : IndexIO.CONFIGURED_BITMAP_SERDE_FACTORY;
+    this.bitmapSerdeFactory = bitmapSerdeFactory != null ? bitmapSerdeFactory : new ConciseBitmapSerdeFactory();
     this.metricCompression = metricCompression;
     this.dimensionCompression = dimensionCompression;
   }

--- a/processing/src/test/java/io/druid/segment/EmptyIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/EmptyIndexTest.java
@@ -57,7 +57,7 @@ public class EmptyIndexTest
         emptyIndex,
         new ConciseBitmapFactory()
     );
-    IndexMerger.merge(
+    TestHelper.getTestIndexMerger().merge(
         Lists.<IndexableAdapter>newArrayList(emptyIndexAdapter),
         new AggregatorFactory[0],
         tmpDir,
@@ -65,7 +65,7 @@ public class EmptyIndexTest
         new IndexSpec()
     );
 
-    QueryableIndex emptyQueryableIndex = IndexIO.loadIndex(tmpDir);
+    QueryableIndex emptyQueryableIndex = TestHelper.getTestIndexIO().loadIndex(tmpDir);
 
     Assert.assertEquals("getDimensionNames", 0, Iterables.size(emptyQueryableIndex.getAvailableDimensions()));
     Assert.assertEquals("getMetricNames", 0, Iterables.size(emptyQueryableIndex.getColumnNames()));

--- a/processing/src/test/java/io/druid/segment/IndexIOTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexIOTest.java
@@ -337,7 +337,7 @@ public class IndexIOTest
   {
     Exception ex = null;
     try {
-      IndexIO.DefaultIndexIOHandler.validateTwoSegments(adapter1, adapter2);
+      TestHelper.getTestIndexIO().validateTwoSegments(adapter1, adapter2);
     }
     catch (Exception e) {
       ex = e;

--- a/processing/src/test/java/io/druid/segment/IndexMakerParameterizedTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMakerParameterizedTest.java
@@ -63,6 +63,10 @@ public class IndexMakerParameterizedTest
   @Rule
   public final CloserRule closer = new CloserRule(false);
 
+  private final static IndexMaker INDEX_MAKER = TestHelper.getTestIndexMaker();
+  private final static IndexIO INDEX_IO = TestHelper.getTestIndexIO();
+
+
   @Parameterized.Parameters(name = "{index}: bitmap={0}, metric compression={1}, dimension compression={2}")
   public static Collection<Object[]> data()
   {
@@ -129,8 +133,8 @@ public class IndexMakerParameterizedTest
 
     final File tempDir = temporaryFolder.newFolder();
     QueryableIndex index = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMaker.persist(
+        INDEX_IO.loadIndex(
+            INDEX_MAKER.persist(
                 toPersist,
                 tempDir,
                 null,
@@ -181,8 +185,8 @@ public class IndexMakerParameterizedTest
     final File mergedDir = temporaryFolder.newFolder();
 
     QueryableIndex index1 = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMaker.persist(
+        INDEX_IO.loadIndex(
+            INDEX_MAKER.persist(
                 toPersist1,
                 tempDir1,
                 null,
@@ -196,8 +200,8 @@ public class IndexMakerParameterizedTest
     Assert.assertEquals(3, index1.getColumnNames().size());
 
     QueryableIndex index2 = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMaker.persist(
+        INDEX_IO.loadIndex(
+            INDEX_MAKER.persist(
                 toPersist2,
                 tempDir2,
                 null,
@@ -211,8 +215,8 @@ public class IndexMakerParameterizedTest
     Assert.assertEquals(3, index2.getColumnNames().size());
 
     QueryableIndex merged = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMaker.mergeQueryableIndex(
+        INDEX_IO.loadIndex(
+            INDEX_MAKER.mergeQueryableIndex(
                 Arrays.asList(index1, index2),
                 new AggregatorFactory[]{new CountAggregatorFactory("count")},
                 mergedDir,
@@ -265,8 +269,8 @@ public class IndexMakerParameterizedTest
     );
 
     final QueryableIndex index1 = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMaker.persist(
+        INDEX_IO.loadIndex(
+            INDEX_MAKER.persist(
                 toPersist1,
                 tmpDir1,
                 null,
@@ -275,8 +279,8 @@ public class IndexMakerParameterizedTest
         )
     );
     final QueryableIndex index2 = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMaker.persist(
+        INDEX_IO.loadIndex(
+            INDEX_MAKER.persist(
                 toPersist1,
                 tmpDir2,
                 null,
@@ -285,8 +289,8 @@ public class IndexMakerParameterizedTest
         )
     );
     final QueryableIndex merged = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMaker.mergeQueryableIndex(Arrays.asList(index1, index2), new AggregatorFactory[]{}, tmpDir3, indexSpec)
+        INDEX_IO.loadIndex(
+            INDEX_MAKER.mergeQueryableIndex(Arrays.asList(index1, index2), new AggregatorFactory[]{}, tmpDir3, indexSpec)
         )
     );
 
@@ -321,8 +325,8 @@ public class IndexMakerParameterizedTest
     );
 
     QueryableIndex index1 = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMaker.persist(
+        INDEX_IO.loadIndex(
+            INDEX_MAKER.persist(
                 toPersist1,
                 tempDir1,
                 null,
@@ -334,7 +338,7 @@ public class IndexMakerParameterizedTest
 
     final IndexableAdapter queryableAdapter = new QueryableIndexIndexableAdapter(index1);
 
-    IndexIO.DefaultIndexIOHandler.validateTwoSegments(incrementalAdapter, queryableAdapter);
+    INDEX_IO.validateTwoSegments(incrementalAdapter, queryableAdapter);
 
     Assert.assertEquals(2, index1.getColumn(Column.TIME_COLUMN_NAME).getLength());
     Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index1.getAvailableDimensions()));
@@ -342,8 +346,8 @@ public class IndexMakerParameterizedTest
 
 
     QueryableIndex merged = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMaker.mergeQueryableIndex(
+        INDEX_IO.loadIndex(
+            INDEX_MAKER.mergeQueryableIndex(
                 ImmutableList.of(index1),
                 new AggregatorFactory[]{new CountAggregatorFactory("count")},
                 mergedDir,
@@ -356,7 +360,7 @@ public class IndexMakerParameterizedTest
     Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(merged.getAvailableDimensions()));
     Assert.assertEquals(3, merged.getColumnNames().size());
 
-    IndexIO.DefaultIndexIOHandler.validateTwoSegments(tempDir1, mergedDir);
+    INDEX_IO.validateTwoSegments(tempDir1, mergedDir);
 
     assertDimCompression(index1, indexSpec.getDimensionCompressionStrategy());
     assertDimCompression(merged, indexSpec.getDimensionCompressionStrategy());
@@ -380,15 +384,15 @@ public class IndexMakerParameterizedTest
     );
 
     QueryableIndex index1 = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMaker.append(
+        INDEX_IO.loadIndex(
+            INDEX_MAKER.append(
                 ImmutableList.<IndexableAdapter>of(incrementalAdapter), tempDir1, indexSpec
             )
         )
     );
     final IndexableAdapter queryableAdapter = new QueryableIndexIndexableAdapter(index1);
 
-    IndexIO.DefaultIndexIOHandler.validateTwoSegments(incrementalAdapter, queryableAdapter);
+    INDEX_IO.validateTwoSegments(incrementalAdapter, queryableAdapter);
 
     Assert.assertEquals(2, index1.getColumn(Column.TIME_COLUMN_NAME).getLength());
     Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index1.getAvailableDimensions()));
@@ -396,8 +400,8 @@ public class IndexMakerParameterizedTest
 
 
     QueryableIndex merged = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMaker.mergeQueryableIndex(
+        INDEX_IO.loadIndex(
+            INDEX_MAKER.mergeQueryableIndex(
                 ImmutableList.of(index1),
                 new AggregatorFactory[]{new CountAggregatorFactory("count")},
                 mergedDir,
@@ -410,7 +414,7 @@ public class IndexMakerParameterizedTest
     Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(merged.getAvailableDimensions()));
     Assert.assertEquals(3, merged.getColumnNames().size());
 
-    IndexIO.DefaultIndexIOHandler.validateTwoSegments(tempDir1, mergedDir);
+    INDEX_IO.validateTwoSegments(tempDir1, mergedDir);
 
     assertDimCompression(index1, indexSpec.getDimensionCompressionStrategy());
     assertDimCompression(merged, indexSpec.getDimensionCompressionStrategy());
@@ -433,8 +437,8 @@ public class IndexMakerParameterizedTest
     );
 
     QueryableIndex index1 = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMaker.persist(
+        INDEX_IO.loadIndex(
+            INDEX_MAKER.persist(
                 toPersist1,
                 tempDir1,
                 null,
@@ -446,7 +450,7 @@ public class IndexMakerParameterizedTest
 
     final IndexableAdapter queryableAdapter = new QueryableIndexIndexableAdapter(index1);
 
-    IndexIO.DefaultIndexIOHandler.validateTwoSegments(incrementalAdapter, queryableAdapter);
+    INDEX_IO.validateTwoSegments(incrementalAdapter, queryableAdapter);
 
     Assert.assertEquals(2, index1.getColumn(Column.TIME_COLUMN_NAME).getLength());
     Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index1.getAvailableDimensions()));
@@ -461,8 +465,8 @@ public class IndexMakerParameterizedTest
 
 
     QueryableIndex merged = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMaker.mergeQueryableIndex(
+        INDEX_IO.loadIndex(
+            INDEX_MAKER.mergeQueryableIndex(
                 ImmutableList.of(index1),
                 new AggregatorFactory[]{new CountAggregatorFactory("count")},
                 mergedDir,
@@ -475,7 +479,7 @@ public class IndexMakerParameterizedTest
     Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(merged.getAvailableDimensions()));
     Assert.assertEquals(3, merged.getColumnNames().size());
 
-    IndexIO.DefaultIndexIOHandler.validateTwoSegments(tempDir1, mergedDir);
+    INDEX_IO.validateTwoSegments(tempDir1, mergedDir);
 
     assertDimCompression(index1, indexSpec.getDimensionCompressionStrategy());
     assertDimCompression(merged, newSpec.getDimensionCompressionStrategy());
@@ -499,8 +503,8 @@ public class IndexMakerParameterizedTest
     );
 
     QueryableIndex index1 = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMaker.persist(
+        INDEX_IO.loadIndex(
+            INDEX_MAKER.persist(
                 toPersist1,
                 tempDir1,
                 null,
@@ -512,7 +516,7 @@ public class IndexMakerParameterizedTest
 
     final IndexableAdapter queryableAdapter = new QueryableIndexIndexableAdapter(index1);
 
-    IndexIO.DefaultIndexIOHandler.validateTwoSegments(incrementalAdapter, queryableAdapter);
+    INDEX_IO.validateTwoSegments(incrementalAdapter, queryableAdapter);
 
     Assert.assertEquals(2, index1.getColumn(Column.TIME_COLUMN_NAME).getLength());
     Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index1.getAvailableDimensions()));
@@ -520,8 +524,8 @@ public class IndexMakerParameterizedTest
 
 
     QueryableIndex converted = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMaker.convert(
+        INDEX_IO.loadIndex(
+            INDEX_MAKER.convert(
                 tempDir1,
                 convertDir,
                 indexSpec
@@ -533,7 +537,7 @@ public class IndexMakerParameterizedTest
     Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(converted.getAvailableDimensions()));
     Assert.assertEquals(3, converted.getColumnNames().size());
 
-    IndexIO.DefaultIndexIOHandler.validateTwoSegments(tempDir1, convertDir);
+    INDEX_IO.validateTwoSegments(tempDir1, convertDir);
 
     assertDimCompression(index1, indexSpec.getDimensionCompressionStrategy());
     assertDimCompression(converted, indexSpec.getDimensionCompressionStrategy());
@@ -557,8 +561,8 @@ public class IndexMakerParameterizedTest
     );
 
     QueryableIndex index1 = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMaker.persist(
+        INDEX_IO.loadIndex(
+            INDEX_MAKER.persist(
                 toPersist1,
                 tempDir1,
                 null,
@@ -570,7 +574,7 @@ public class IndexMakerParameterizedTest
 
     final IndexableAdapter queryableAdapter = new QueryableIndexIndexableAdapter(index1);
 
-    IndexIO.DefaultIndexIOHandler.validateTwoSegments(incrementalAdapter, queryableAdapter);
+    INDEX_IO.validateTwoSegments(incrementalAdapter, queryableAdapter);
 
     Assert.assertEquals(2, index1.getColumn(Column.TIME_COLUMN_NAME).getLength());
     Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index1.getAvailableDimensions()));
@@ -583,13 +587,13 @@ public class IndexMakerParameterizedTest
         "lz4".equals(indexSpec.getMetricCompression()) ? "lzf" : "lz4"
     );
 
-    QueryableIndex converted = closer.closeLater(IndexIO.loadIndex(IndexMaker.convert(tempDir1, convertDir, newSpec)));
+    QueryableIndex converted = closer.closeLater(INDEX_IO.loadIndex(INDEX_MAKER.convert(tempDir1, convertDir, newSpec)));
 
     Assert.assertEquals(2, converted.getColumn(Column.TIME_COLUMN_NAME).getLength());
     Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(converted.getAvailableDimensions()));
     Assert.assertEquals(3, converted.getColumnNames().size());
 
-    IndexIO.DefaultIndexIOHandler.validateTwoSegments(tempDir1, convertDir);
+    INDEX_IO.validateTwoSegments(tempDir1, convertDir);
 
     assertDimCompression(index1, indexSpec.getDimensionCompressionStrategy());
     assertDimCompression(converted, newSpec.getDimensionCompressionStrategy());

--- a/processing/src/test/java/io/druid/segment/IndexMergerTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerTest.java
@@ -62,6 +62,9 @@ public class IndexMergerTest
   @Rule
   public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
+  private final static IndexMerger INDEX_MERGER = TestHelper.getTestIndexMerger();
+  private final static IndexIO INDEX_IO = TestHelper.getTestIndexIO();
+
   @Parameterized.Parameters(name = "{index}: bitmap={0}, metric compression={1}, dimension compression={2}")
   public static Collection<Object[]> data()
   {
@@ -130,8 +133,8 @@ public class IndexMergerTest
 
     final File tempDir = temporaryFolder.newFolder();
     QueryableIndex index = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMerger.persist(
+        INDEX_IO.loadIndex(
+            INDEX_MERGER.persist(
                 toPersist,
                 tempDir,
                 null,
@@ -159,8 +162,8 @@ public class IndexMergerTest
 
     final File tempDir = temporaryFolder.newFolder();
     QueryableIndex index = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMerger.persist(
+        INDEX_IO.loadIndex(
+            INDEX_MERGER.persist(
                 toPersist,
                 tempDir,
                 segmentMetadata,
@@ -213,8 +216,8 @@ public class IndexMergerTest
     final File mergedDir = temporaryFolder.newFolder();
 
     QueryableIndex index1 = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMerger.persist(
+        INDEX_IO.loadIndex(
+            INDEX_MERGER.persist(
                 toPersist1,
                 tempDir1,
                 null,
@@ -228,8 +231,8 @@ public class IndexMergerTest
     Assert.assertEquals(3, index1.getColumnNames().size());
 
     QueryableIndex index2 = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMerger.persist(
+        INDEX_IO.loadIndex(
+            INDEX_MERGER.persist(
                 toPersist2,
                 tempDir2,
                 null,
@@ -243,8 +246,8 @@ public class IndexMergerTest
     Assert.assertEquals(3, index2.getColumnNames().size());
 
     QueryableIndex merged = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMerger.mergeQueryableIndex(
+        INDEX_IO.loadIndex(
+            INDEX_MERGER.mergeQueryableIndex(
                 Arrays.asList(index1, index2),
                 new AggregatorFactory[]{new CountAggregatorFactory("count")},
                 mergedDir,
@@ -297,8 +300,8 @@ public class IndexMergerTest
     );
 
     final QueryableIndex index1 = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMerger.persist(
+        INDEX_IO.loadIndex(
+            INDEX_MERGER.persist(
                 toPersist1,
                 tmpDir1,
                 null,
@@ -307,8 +310,8 @@ public class IndexMergerTest
         )
     );
     final QueryableIndex index2 = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMerger.persist(
+        INDEX_IO.loadIndex(
+            INDEX_MERGER.persist(
                 toPersist1,
                 tmpDir2,
                 null,
@@ -317,8 +320,8 @@ public class IndexMergerTest
         )
     );
     final QueryableIndex merged = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMerger.mergeQueryableIndex(
+        INDEX_IO.loadIndex(
+            INDEX_MERGER.mergeQueryableIndex(
                 Arrays.asList(index1, index2),
                 new AggregatorFactory[]{},
                 tmpDir3,
@@ -358,8 +361,8 @@ public class IndexMergerTest
     );
 
     QueryableIndex index1 = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMerger.persist(
+        INDEX_IO.loadIndex(
+            INDEX_MERGER.persist(
                 toPersist1,
                 tempDir1,
                 null,
@@ -371,7 +374,7 @@ public class IndexMergerTest
 
     final IndexableAdapter queryableAdapter = new QueryableIndexIndexableAdapter(index1);
 
-    IndexIO.DefaultIndexIOHandler.validateTwoSegments(incrementalAdapter, queryableAdapter);
+    INDEX_IO.validateTwoSegments(incrementalAdapter, queryableAdapter);
 
     Assert.assertEquals(2, index1.getColumn(Column.TIME_COLUMN_NAME).getLength());
     Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index1.getAvailableDimensions()));
@@ -379,8 +382,8 @@ public class IndexMergerTest
 
 
     QueryableIndex merged = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMerger.mergeQueryableIndex(
+        INDEX_IO.loadIndex(
+            INDEX_MERGER.mergeQueryableIndex(
                 ImmutableList.of(index1),
                 new AggregatorFactory[]{new CountAggregatorFactory("count")},
                 mergedDir,
@@ -393,7 +396,7 @@ public class IndexMergerTest
     Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(merged.getAvailableDimensions()));
     Assert.assertEquals(3, merged.getColumnNames().size());
 
-    IndexIO.DefaultIndexIOHandler.validateTwoSegments(tempDir1, mergedDir);
+    INDEX_IO.validateTwoSegments(tempDir1, mergedDir);
 
     assertDimCompression(index1, indexSpec.getDimensionCompressionStrategy());
     assertDimCompression(merged, indexSpec.getDimensionCompressionStrategy());
@@ -417,15 +420,15 @@ public class IndexMergerTest
     );
 
     QueryableIndex index1 = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMerger.append(
+        INDEX_IO.loadIndex(
+            INDEX_MERGER.append(
                 ImmutableList.<IndexableAdapter>of(incrementalAdapter), tempDir1, indexSpec
             )
         )
     );
     final IndexableAdapter queryableAdapter = new QueryableIndexIndexableAdapter(index1);
 
-    IndexIO.DefaultIndexIOHandler.validateTwoSegments(incrementalAdapter, queryableAdapter);
+    INDEX_IO.validateTwoSegments(incrementalAdapter, queryableAdapter);
 
     Assert.assertEquals(2, index1.getColumn(Column.TIME_COLUMN_NAME).getLength());
     Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index1.getAvailableDimensions()));
@@ -433,8 +436,8 @@ public class IndexMergerTest
 
 
     QueryableIndex merged = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMerger.mergeQueryableIndex(
+        INDEX_IO.loadIndex(
+            INDEX_MERGER.mergeQueryableIndex(
                 ImmutableList.of(index1),
                 new AggregatorFactory[]{new CountAggregatorFactory("count")},
                 mergedDir,
@@ -447,7 +450,7 @@ public class IndexMergerTest
     Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(merged.getAvailableDimensions()));
     Assert.assertEquals(3, merged.getColumnNames().size());
 
-    IndexIO.DefaultIndexIOHandler.validateTwoSegments(tempDir1, mergedDir);
+    INDEX_IO.validateTwoSegments(tempDir1, mergedDir);
 
     assertDimCompression(index1, indexSpec.getDimensionCompressionStrategy());
     assertDimCompression(merged, indexSpec.getDimensionCompressionStrategy());
@@ -470,8 +473,8 @@ public class IndexMergerTest
     );
 
     QueryableIndex index1 = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMerger.persist(
+        INDEX_IO.loadIndex(
+            INDEX_MERGER.persist(
                 toPersist1,
                 tempDir1,
                 null,
@@ -483,7 +486,7 @@ public class IndexMergerTest
 
     final IndexableAdapter queryableAdapter = new QueryableIndexIndexableAdapter(index1);
 
-    IndexIO.DefaultIndexIOHandler.validateTwoSegments(incrementalAdapter, queryableAdapter);
+    INDEX_IO.validateTwoSegments(incrementalAdapter, queryableAdapter);
 
     Assert.assertEquals(2, index1.getColumn(Column.TIME_COLUMN_NAME).getLength());
     Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index1.getAvailableDimensions()));
@@ -498,8 +501,8 @@ public class IndexMergerTest
 
 
     QueryableIndex merged = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMerger.mergeQueryableIndex(
+        INDEX_IO.loadIndex(
+            INDEX_MERGER.mergeQueryableIndex(
                 ImmutableList.of(index1),
                 new AggregatorFactory[]{new CountAggregatorFactory("count")},
                 mergedDir,
@@ -512,7 +515,7 @@ public class IndexMergerTest
     Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(merged.getAvailableDimensions()));
     Assert.assertEquals(3, merged.getColumnNames().size());
 
-    IndexIO.DefaultIndexIOHandler.validateTwoSegments(tempDir1, mergedDir);
+    INDEX_IO.validateTwoSegments(tempDir1, mergedDir);
 
     assertDimCompression(index1, indexSpec.getDimensionCompressionStrategy());
     assertDimCompression(merged, newSpec.getDimensionCompressionStrategy());
@@ -545,12 +548,12 @@ public class IndexMergerTest
     );
 
     QueryableIndex index1 = closer.closeLater(
-        IndexIO.loadIndex(IndexMerger.persist(toPersist1, tempDir1, null, indexSpec))
+        INDEX_IO.loadIndex(INDEX_MERGER.persist(toPersist1, tempDir1, null, indexSpec))
     );
 
     final IndexableAdapter queryableAdapter = new QueryableIndexIndexableAdapter(index1);
 
-    IndexIO.DefaultIndexIOHandler.validateTwoSegments(incrementalAdapter, queryableAdapter);
+    INDEX_IO.validateTwoSegments(incrementalAdapter, queryableAdapter);
 
     Assert.assertEquals(2, index1.getColumn(Column.TIME_COLUMN_NAME).getLength());
     Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index1.getAvailableDimensions()));
@@ -558,8 +561,8 @@ public class IndexMergerTest
 
 
     QueryableIndex converted = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMerger.convert(
+        INDEX_IO.loadIndex(
+            INDEX_MERGER.convert(
                 tempDir1,
                 convertDir,
                 indexSpec
@@ -571,7 +574,7 @@ public class IndexMergerTest
     Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(converted.getAvailableDimensions()));
     Assert.assertEquals(4, converted.getColumnNames().size());
 
-    IndexIO.DefaultIndexIOHandler.validateTwoSegments(tempDir1, convertDir);
+    INDEX_IO.validateTwoSegments(tempDir1, convertDir);
 
     assertDimCompression(index1, indexSpec.getDimensionCompressionStrategy());
     assertDimCompression(converted, indexSpec.getDimensionCompressionStrategy());
@@ -603,8 +606,8 @@ public class IndexMergerTest
     );
 
     QueryableIndex index1 = closer.closeLater(
-        IndexIO.loadIndex(
-            IndexMerger.persist(
+        INDEX_IO.loadIndex(
+            INDEX_MERGER.persist(
                 toPersist1,
                 tempDir1,
                 null,
@@ -616,7 +619,7 @@ public class IndexMergerTest
 
     final IndexableAdapter queryableAdapter = new QueryableIndexIndexableAdapter(index1);
 
-    IndexIO.DefaultIndexIOHandler.validateTwoSegments(incrementalAdapter, queryableAdapter);
+    INDEX_IO.validateTwoSegments(incrementalAdapter, queryableAdapter);
 
     Assert.assertEquals(2, index1.getColumn(Column.TIME_COLUMN_NAME).getLength());
     Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index1.getAvailableDimensions()));
@@ -629,13 +632,13 @@ public class IndexMergerTest
         "lz4".equals(indexSpec.getMetricCompression()) ? "lzf" : "lz4"
     );
 
-    QueryableIndex converted = closer.closeLater(IndexIO.loadIndex(IndexMerger.convert(tempDir1, convertDir, newSpec)));
+    QueryableIndex converted = closer.closeLater(INDEX_IO.loadIndex(INDEX_MERGER.convert(tempDir1, convertDir, newSpec)));
 
     Assert.assertEquals(2, converted.getColumn(Column.TIME_COLUMN_NAME).getLength());
     Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(converted.getAvailableDimensions()));
     Assert.assertEquals(4, converted.getColumnNames().size());
 
-    IndexIO.DefaultIndexIOHandler.validateTwoSegments(tempDir1, convertDir);
+    INDEX_IO.validateTwoSegments(tempDir1, convertDir);
 
     assertDimCompression(index1, indexSpec.getDimensionCompressionStrategy());
     assertDimCompression(converted, newSpec.getDimensionCompressionStrategy());

--- a/processing/src/test/java/io/druid/segment/IndexSpecTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexSpecTest.java
@@ -30,13 +30,6 @@ import org.junit.Test;
 public class IndexSpecTest
 {
   @Test
-  public void testConfiguredBitmap() throws Exception
-  {
-    // this is just to make sure testSerde correctly tests the bitmap type override
-    Assert.assertEquals(new ConciseBitmapSerdeFactory(), IndexIO.CONFIGURED_BITMAP_SERDE_FACTORY);
-  }
-
-  @Test
   public void testSerde() throws Exception
   {
     final ObjectMapper objectMapper = new DefaultObjectMapper();
@@ -67,7 +60,6 @@ public class IndexSpecTest
   public void testDefaults() throws Exception
   {
     final IndexSpec spec = new IndexSpec();
-    Assert.assertEquals(IndexIO.CONFIGURED_BITMAP_SERDE_FACTORY, spec.getBitmapSerdeFactory());
     Assert.assertEquals(CompressedObjectStrategy.CompressionStrategy.LZ4, spec.getDimensionCompressionStrategy());
     Assert.assertEquals(CompressedObjectStrategy.CompressionStrategy.LZ4, spec.getMetricCompressionStrategy());
   }

--- a/processing/src/test/java/io/druid/segment/TestHelper.java
+++ b/processing/src/test/java/io/druid/segment/TestHelper.java
@@ -17,11 +17,14 @@
 
 package io.druid.segment;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.metamx.common.guava.Sequence;
 import com.metamx.common.guava.Sequences;
 import io.druid.data.input.Row;
+import io.druid.jackson.DefaultObjectMapper;
 import io.druid.query.Result;
+import io.druid.segment.column.ColumnConfig;
 import org.junit.Assert;
 
 import java.util.Iterator;
@@ -30,6 +33,42 @@ import java.util.Iterator;
  */
 public class TestHelper
 {
+  private static final IndexMerger INDEX_MERGER;
+  private static final IndexMaker INDEX_MAKER;
+  private static final IndexIO INDEX_IO;
+
+  static {
+    ObjectMapper jsonMapper = new DefaultObjectMapper();
+    INDEX_IO = new IndexIO(
+        jsonMapper,
+        new ColumnConfig()
+        {
+          @Override
+          public int columnCacheSizeBytes()
+          {
+            return 0;
+          }
+        }
+    );
+    INDEX_MERGER = new IndexMerger(jsonMapper, INDEX_IO);
+    INDEX_MAKER = new IndexMaker(jsonMapper, INDEX_IO);
+  }
+
+  public static IndexMerger getTestIndexMerger()
+  {
+    return INDEX_MERGER;
+  }
+
+  public static IndexMaker getTestIndexMaker()
+  {
+    return INDEX_MAKER;
+  }
+
+  public static IndexIO getTestIndexIO()
+  {
+    return INDEX_IO;
+  }
+
   public static <T> void assertExpectedResults(Iterable<Result<T>> expectedResults, Sequence<Result<T>> results)
   {
     assertResults(expectedResults, Sequences.toList(results, Lists.<Result<T>>newArrayList()), "");

--- a/processing/src/test/java/io/druid/segment/TestIndex.java
+++ b/processing/src/test/java/io/druid/segment/TestIndex.java
@@ -83,6 +83,9 @@ public class TestIndex
   };
   private static final IndexSpec indexSpec = new IndexSpec();
 
+  private static final IndexMerger INDEX_MERGER = TestHelper.getTestIndexMerger();
+  private static final IndexIO INDEX_IO = TestHelper.getTestIndexIO();
+
   static {
     if (ComplexMetrics.getSerdeForType("hyperUnique") == null) {
       ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde(Hashing.murmur3_128()));
@@ -143,12 +146,12 @@ public class TestIndex
         mergedFile.mkdirs();
         mergedFile.deleteOnExit();
 
-        IndexMerger.persist(top, DATA_INTERVAL, topFile, null, indexSpec);
-        IndexMerger.persist(bottom, DATA_INTERVAL, bottomFile, null, indexSpec);
+        INDEX_MERGER.persist(top, DATA_INTERVAL, topFile, null, indexSpec);
+        INDEX_MERGER.persist(bottom, DATA_INTERVAL, bottomFile, null, indexSpec);
 
-        mergedRealtime = IndexIO.loadIndex(
-            IndexMerger.mergeQueryableIndex(
-                Arrays.asList(IndexIO.loadIndex(topFile), IndexIO.loadIndex(bottomFile)),
+        mergedRealtime = INDEX_IO.loadIndex(
+            INDEX_MERGER.mergeQueryableIndex(
+                Arrays.asList(INDEX_IO.loadIndex(topFile), INDEX_IO.loadIndex(bottomFile)),
                 METRIC_AGGS,
                 mergedFile,
                 indexSpec
@@ -255,8 +258,8 @@ public class TestIndex
       someTmpFile.mkdirs();
       someTmpFile.deleteOnExit();
 
-      IndexMerger.persist(index, someTmpFile, null, indexSpec);
-      return IndexIO.loadIndex(someTmpFile);
+      INDEX_MERGER.persist(index, someTmpFile, null, indexSpec);
+      return INDEX_IO.loadIndex(someTmpFile);
     }
     catch (IOException e) {
       throw Throwables.propagate(e);

--- a/processing/src/test/java/io/druid/segment/filter/SpatialFilterBonusTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/SpatialFilterBonusTest.java
@@ -77,6 +77,9 @@ public class SpatialFilterBonusTest
       new LongSumAggregatorFactory("val", "val")
   };
   private static List<String> DIMS = Lists.newArrayList("dim", "dim.geo");
+  private static final IndexMerger INDEX_MERGER = TestHelper.getTestIndexMerger();
+  private static final IndexIO INDEX_IO = TestHelper.getTestIndexIO();
+
   private final Segment segment;
 
   public SpatialFilterBonusTest(Segment segment)
@@ -232,8 +235,8 @@ public class SpatialFilterBonusTest
     tmpFile.mkdirs();
     tmpFile.deleteOnExit();
 
-    IndexMerger.persist(theIndex, tmpFile, null, indexSpec);
-    return IndexIO.loadIndex(tmpFile);
+    INDEX_MERGER.persist(theIndex, tmpFile, null, indexSpec);
+    return INDEX_IO.loadIndex(tmpFile);
   }
 
   private static QueryableIndex makeMergedQueryableIndex(final IndexSpec indexSpec)
@@ -412,13 +415,17 @@ public class SpatialFilterBonusTest
       mergedFile.mkdirs();
       mergedFile.deleteOnExit();
 
-      IndexMerger.persist(first, DATA_INTERVAL, firstFile, null, indexSpec);
-      IndexMerger.persist(second, DATA_INTERVAL, secondFile, null, indexSpec);
-      IndexMerger.persist(third, DATA_INTERVAL, thirdFile, null, indexSpec);
+      INDEX_MERGER.persist(first, DATA_INTERVAL, firstFile, null, indexSpec);
+      INDEX_MERGER.persist(second, DATA_INTERVAL, secondFile, null, indexSpec);
+      INDEX_MERGER.persist(third, DATA_INTERVAL, thirdFile, null, indexSpec);
 
-      QueryableIndex mergedRealtime = IndexIO.loadIndex(
-          IndexMerger.mergeQueryableIndex(
-              Arrays.asList(IndexIO.loadIndex(firstFile), IndexIO.loadIndex(secondFile), IndexIO.loadIndex(thirdFile)),
+      QueryableIndex mergedRealtime = INDEX_IO.loadIndex(
+          INDEX_MERGER.mergeQueryableIndex(
+              Arrays.asList(
+                  INDEX_IO.loadIndex(firstFile),
+                  INDEX_IO.loadIndex(secondFile),
+                  INDEX_IO.loadIndex(thirdFile)
+              ),
               METRIC_AGGS,
               mergedFile,
               indexSpec

--- a/processing/src/test/java/io/druid/segment/filter/SpatialFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/SpatialFilterTest.java
@@ -70,6 +70,9 @@ import java.util.Random;
 @RunWith(Parameterized.class)
 public class SpatialFilterTest
 {
+  private static IndexMerger INDEX_MERGER = TestHelper.getTestIndexMerger();
+  private static IndexIO INDEX_IO = TestHelper.getTestIndexIO();
+
   public static final int NUM_POINTS = 5000;
   private static Interval DATA_INTERVAL = new Interval("2013-01-01/2013-01-07");
 
@@ -261,8 +264,8 @@ public class SpatialFilterTest
     tmpFile.mkdirs();
     tmpFile.deleteOnExit();
 
-    IndexMerger.persist(theIndex, tmpFile, null, indexSpec);
-    return IndexIO.loadIndex(tmpFile);
+    INDEX_MERGER.persist(theIndex, tmpFile, null, indexSpec);
+    return INDEX_IO.loadIndex(tmpFile);
   }
 
   private static QueryableIndex makeMergedQueryableIndex(IndexSpec indexSpec)
@@ -481,13 +484,13 @@ public class SpatialFilterTest
       mergedFile.mkdirs();
       mergedFile.deleteOnExit();
 
-      IndexMerger.persist(first, DATA_INTERVAL, firstFile, null, indexSpec);
-      IndexMerger.persist(second, DATA_INTERVAL, secondFile, null, indexSpec);
-      IndexMerger.persist(third, DATA_INTERVAL, thirdFile, null, indexSpec);
+      INDEX_MERGER.persist(first, DATA_INTERVAL, firstFile, null, indexSpec);
+      INDEX_MERGER.persist(second, DATA_INTERVAL, secondFile, null, indexSpec);
+      INDEX_MERGER.persist(third, DATA_INTERVAL, thirdFile, null, indexSpec);
 
-      QueryableIndex mergedRealtime = IndexIO.loadIndex(
-          IndexMerger.mergeQueryableIndex(
-              Arrays.asList(IndexIO.loadIndex(firstFile), IndexIO.loadIndex(secondFile), IndexIO.loadIndex(thirdFile)),
+      QueryableIndex mergedRealtime = INDEX_IO.loadIndex(
+          INDEX_MERGER.mergeQueryableIndex(
+              Arrays.asList(INDEX_IO.loadIndex(firstFile), INDEX_IO.loadIndex(secondFile), INDEX_IO.loadIndex(thirdFile)),
               METRIC_AGGS,
               mergedFile,
               indexSpec

--- a/server/src/main/java/io/druid/segment/loading/MMappedQueryableIndexFactory.java
+++ b/server/src/main/java/io/druid/segment/loading/MMappedQueryableIndexFactory.java
@@ -17,6 +17,8 @@
 
 package io.druid.segment.loading;
 
+import com.google.common.base.Preconditions;
+import com.google.inject.Inject;
 import com.metamx.common.logger.Logger;
 import io.druid.segment.IndexIO;
 import io.druid.segment.QueryableIndex;
@@ -30,11 +32,19 @@ public class MMappedQueryableIndexFactory implements QueryableIndexFactory
 {
   private static final Logger log = new Logger(MMappedQueryableIndexFactory.class);
 
+  private final IndexIO indexIO;
+
+  @Inject
+  public MMappedQueryableIndexFactory(IndexIO indexIO)
+  {
+    this.indexIO = Preconditions.checkNotNull(indexIO, "Null IndexIO");
+  }
+
   @Override
   public QueryableIndex factorize(File parentDir) throws SegmentLoadingException
   {
     try {
-      return IndexIO.loadIndex(parentDir);
+      return indexIO.loadIndex(parentDir);
     }
     catch (IOException e) {
       throw new SegmentLoadingException(e, "%s", e.getMessage());

--- a/server/src/main/java/io/druid/segment/realtime/plumber/FlushingPlumber.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/FlushingPlumber.java
@@ -25,6 +25,9 @@ import com.metamx.emitter.service.ServiceEmitter;
 import io.druid.common.guava.ThreadRenamingCallable;
 import io.druid.concurrent.Execs;
 import io.druid.query.QueryRunnerFactoryConglomerate;
+import io.druid.segment.IndexIO;
+import io.druid.segment.IndexMaker;
+import io.druid.segment.IndexMerger;
 import io.druid.segment.indexing.DataSchema;
 import io.druid.segment.indexing.RealtimeTuningConfig;
 import io.druid.segment.realtime.FireDepartmentMetrics;
@@ -59,7 +62,10 @@ public class FlushingPlumber extends RealtimePlumber
       ServiceEmitter emitter,
       QueryRunnerFactoryConglomerate conglomerate,
       DataSegmentAnnouncer segmentAnnouncer,
-      ExecutorService queryExecutorService
+      ExecutorService queryExecutorService,
+      IndexMerger indexMerger,
+      IndexMaker indexMaker,
+      IndexIO indexIO
   )
   {
     super(
@@ -72,7 +78,10 @@ public class FlushingPlumber extends RealtimePlumber
         queryExecutorService,
         null,
         null,
-        null
+        null,
+        indexMerger,
+        indexMaker,
+        indexIO
     );
 
     this.flushDuration = flushDuration;

--- a/server/src/main/java/io/druid/segment/realtime/plumber/FlushingPlumberSchool.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/FlushingPlumberSchool.java
@@ -24,6 +24,9 @@ import com.google.common.base.Preconditions;
 import com.metamx.emitter.service.ServiceEmitter;
 import io.druid.guice.annotations.Processing;
 import io.druid.query.QueryRunnerFactoryConglomerate;
+import io.druid.segment.IndexIO;
+import io.druid.segment.IndexMaker;
+import io.druid.segment.IndexMerger;
 import io.druid.segment.indexing.DataSchema;
 import io.druid.segment.indexing.RealtimeTuningConfig;
 import io.druid.segment.realtime.FireDepartmentMetrics;
@@ -46,6 +49,9 @@ public class FlushingPlumberSchool extends RealtimePlumberSchool
   private final QueryRunnerFactoryConglomerate conglomerate;
   private final DataSegmentAnnouncer segmentAnnouncer;
   private final ExecutorService queryExecutorService;
+  private final IndexMerger indexMerger;
+  private final IndexMaker indexMaker;
+  private final IndexIO indexIO;
 
   @JsonCreator
   public FlushingPlumberSchool(
@@ -53,7 +59,10 @@ public class FlushingPlumberSchool extends RealtimePlumberSchool
       @JacksonInject ServiceEmitter emitter,
       @JacksonInject QueryRunnerFactoryConglomerate conglomerate,
       @JacksonInject DataSegmentAnnouncer segmentAnnouncer,
-      @JacksonInject @Processing ExecutorService queryExecutorService
+      @JacksonInject @Processing ExecutorService queryExecutorService,
+      @JacksonInject IndexMerger indexMerger,
+      @JacksonInject IndexMaker indexMaker,
+      @JacksonInject IndexIO indexIO
   )
   {
     super(
@@ -63,7 +72,10 @@ public class FlushingPlumberSchool extends RealtimePlumberSchool
         segmentAnnouncer,
         null,
         null,
-        queryExecutorService
+        queryExecutorService,
+        indexMerger,
+        indexMaker,
+        indexIO
     );
 
     this.flushDuration = flushDuration == null ? defaultFlushDuration : flushDuration;
@@ -71,6 +83,9 @@ public class FlushingPlumberSchool extends RealtimePlumberSchool
     this.conglomerate = conglomerate;
     this.segmentAnnouncer = segmentAnnouncer;
     this.queryExecutorService = queryExecutorService;
+    this.indexMerger = Preconditions.checkNotNull(indexMerger, "Null IndexMerger");
+    this.indexMaker = Preconditions.checkNotNull(indexMaker, "Null IndexMaker");
+    this.indexIO = Preconditions.checkNotNull(indexIO, "Null IndexIO");
   }
 
   @Override
@@ -90,7 +105,10 @@ public class FlushingPlumberSchool extends RealtimePlumberSchool
         emitter,
         conglomerate,
         segmentAnnouncer,
-        queryExecutorService
+        queryExecutorService,
+        indexMerger,
+        indexMaker,
+        indexIO
     );
   }
 

--- a/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumberSchool.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumberSchool.java
@@ -24,6 +24,9 @@ import com.metamx.emitter.service.ServiceEmitter;
 import io.druid.client.FilteredServerView;
 import io.druid.guice.annotations.Processing;
 import io.druid.query.QueryRunnerFactoryConglomerate;
+import io.druid.segment.IndexIO;
+import io.druid.segment.IndexMaker;
+import io.druid.segment.IndexMerger;
 import io.druid.segment.indexing.DataSchema;
 import io.druid.segment.indexing.RealtimeTuningConfig;
 import io.druid.segment.loading.DataSegmentPusher;
@@ -44,6 +47,9 @@ public class RealtimePlumberSchool implements PlumberSchool
   private final SegmentPublisher segmentPublisher;
   private final FilteredServerView serverView;
   private final ExecutorService queryExecutorService;
+  private final IndexMerger indexMerger;
+  private final IndexMaker indexMaker;
+  private final IndexIO indexIO;
 
   @JsonCreator
   public RealtimePlumberSchool(
@@ -53,7 +59,10 @@ public class RealtimePlumberSchool implements PlumberSchool
       @JacksonInject DataSegmentAnnouncer segmentAnnouncer,
       @JacksonInject SegmentPublisher segmentPublisher,
       @JacksonInject FilteredServerView serverView,
-      @JacksonInject @Processing ExecutorService executorService
+      @JacksonInject @Processing ExecutorService executorService,
+      @JacksonInject IndexMerger indexMerger,
+      @JacksonInject IndexMaker indexMaker,
+      @JacksonInject IndexIO indexIO
   )
   {
     this.emitter = emitter;
@@ -63,6 +72,9 @@ public class RealtimePlumberSchool implements PlumberSchool
     this.segmentPublisher = segmentPublisher;
     this.serverView = serverView;
     this.queryExecutorService = executorService;
+    this.indexMerger = Preconditions.checkNotNull(indexMerger, "Null IndexMerger");
+    this.indexMaker = Preconditions.checkNotNull(indexMaker, "Null IndexMaker");
+    this.indexIO = Preconditions.checkNotNull(indexIO, "Null IndexIO");
   }
 
   @Override
@@ -84,7 +96,10 @@ public class RealtimePlumberSchool implements PlumberSchool
         queryExecutorService,
         dataSegmentPusher,
         segmentPublisher,
-        serverView
+        serverView,
+        indexMerger,
+        indexMaker,
+        indexIO
     );
   }
 

--- a/server/src/test/java/io/druid/segment/loading/SegmentLoaderLocalCacheManagerTest.java
+++ b/server/src/test/java/io/druid/segment/loading/SegmentLoaderLocalCacheManagerTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.druid.jackson.DefaultObjectMapper;
+import io.druid.segment.TestHelper;
 import io.druid.timeline.DataSegment;
 import io.druid.timeline.partition.NoneShardSpec;
 import org.joda.time.Interval;
@@ -72,7 +73,7 @@ public class SegmentLoaderLocalCacheManagerTest
     locations.add(locationConfig);
 
     manager = new SegmentLoaderLocalCacheManager(
-        new MMappedQueryableIndexFactory(),
+        new MMappedQueryableIndexFactory(TestHelper.getTestIndexIO()),
         new SegmentLoaderConfig().withLocations(locations),
         jsonMapper
     );

--- a/server/src/test/java/io/druid/segment/realtime/FireDepartmentTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/FireDepartmentTest.java
@@ -28,6 +28,7 @@ import io.druid.granularity.QueryGranularity;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
+import io.druid.segment.TestHelper;
 import io.druid.segment.indexing.DataSchema;
 import io.druid.segment.indexing.RealtimeIOConfig;
 import io.druid.segment.indexing.RealtimeTuningConfig;
@@ -78,7 +79,16 @@ public class FireDepartmentTest
         new RealtimeIOConfig(
             null,
             new RealtimePlumberSchool(
-                null, null, null, null, null, null, null
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                TestHelper.getTestIndexMerger(),
+                TestHelper.getTestIndexMaker(),
+                TestHelper.getTestIndexIO()
             ),
             null
         ),

--- a/server/src/test/java/io/druid/segment/realtime/firehose/IngestSegmentFirehoseTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/firehose/IngestSegmentFirehoseTest.java
@@ -36,6 +36,7 @@ import io.druid.segment.IndexSpec;
 import io.druid.segment.QueryableIndex;
 import io.druid.segment.QueryableIndexStorageAdapter;
 import io.druid.segment.StorageAdapter;
+import io.druid.segment.TestHelper;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.junit.Assert;
@@ -54,6 +55,9 @@ public class IngestSegmentFirehoseTest
   @Rule
   public final TemporaryFolder tempFolder = new TemporaryFolder();
 
+  private IndexIO indexIO = TestHelper.getTestIndexIO();
+  private IndexMerger indexMerger = TestHelper.getTestIndexMerger();
+
   @Test
   public void testSanity() throws Exception
   {
@@ -62,7 +66,7 @@ public class IngestSegmentFirehoseTest
 
     QueryableIndex qi = null;
     try {
-      qi = IndexIO.loadIndex(segmentDir);
+      qi = indexIO.loadIndex(segmentDir);
       StorageAdapter sa = new QueryableIndexStorageAdapter(qi);
       WindowedStorageAdapter wsa = new WindowedStorageAdapter(sa, sa.getInterval());
       IngestSegmentFirehose firehose = new IngestSegmentFirehose(
@@ -121,7 +125,7 @@ public class IngestSegmentFirehoseTest
       for (String line : rows) {
         index.add(parser.parse(line));
       }
-      IndexMerger.persist(index, segmentDir, null, new IndexSpec());
+      indexMerger.persist(index, segmentDir, null, new IndexSpec());
     }
     finally {
       if (index != null) {

--- a/server/src/test/java/io/druid/segment/realtime/plumber/RealtimePlumberSchoolTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/plumber/RealtimePlumberSchoolTest.java
@@ -30,14 +30,11 @@ import com.metamx.common.Granularity;
 import com.metamx.emitter.service.ServiceEmitter;
 import io.druid.client.FilteredServerView;
 import io.druid.client.ServerView;
-import io.druid.common.utils.JodaUtils;
 import io.druid.data.input.Committer;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.Row;
 import io.druid.data.input.impl.DimensionsSpec;
-import io.druid.data.input.impl.InputRowParser;
 import io.druid.data.input.impl.JSONParseSpec;
-import io.druid.data.input.impl.ParseSpec;
 import io.druid.data.input.impl.StringInputRowParser;
 import io.druid.data.input.impl.TimestampSpec;
 import io.druid.granularity.QueryGranularity;
@@ -47,6 +44,7 @@ import io.druid.query.Query;
 import io.druid.query.QueryRunnerFactory;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
+import io.druid.segment.TestHelper;
 import io.druid.segment.indexing.DataSchema;
 import io.druid.segment.indexing.RealtimeTuningConfig;
 import io.druid.segment.indexing.granularity.UniformGranularitySpec;
@@ -57,7 +55,6 @@ import io.druid.segment.realtime.SegmentPublisher;
 import io.druid.server.coordination.DataSegmentAnnouncer;
 import io.druid.timeline.DataSegment;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.mutable.MutableBoolean;
 import org.easymock.EasyMock;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -198,7 +195,10 @@ public class RealtimePlumberSchoolTest
         announcer,
         segmentPublisher,
         serverView,
-        MoreExecutors.sameThreadExecutor()
+        MoreExecutors.sameThreadExecutor(),
+        TestHelper.getTestIndexMerger(),
+        TestHelper.getTestIndexMaker(),
+        TestHelper.getTestIndexIO()
     );
 
     metrics = new FireDepartmentMetrics();

--- a/services/src/main/java/io/druid/cli/CliInternalHadoopIndexer.java
+++ b/services/src/main/java/io/druid/cli/CliInternalHadoopIndexer.java
@@ -38,11 +38,7 @@ import io.druid.indexer.HadoopIngestionSpec;
 import io.druid.indexer.JobHelper;
 import io.druid.indexer.Jobby;
 import io.druid.indexer.MetadataStorageUpdaterJobHandler;
-import io.druid.indexer.hadoop.DatasourceIngestionSpec;
-import io.druid.indexer.path.DatasourcePathSpec;
 import io.druid.indexer.path.MetadataStoreBasedUsedSegmentLister;
-import io.druid.indexer.path.MultiplePathSpec;
-import io.druid.indexer.path.PathSpec;
 import io.druid.indexer.updater.MetadataStorageUpdaterJobSpec;
 import io.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
 import io.druid.metadata.IndexerSQLMetadataStorageCoordinator;
@@ -119,7 +115,7 @@ public class CliInternalHadoopIndexer extends GuiceRunnable
       config = HadoopDruidIndexerConfig.fromSpec(
           HadoopIngestionSpec.updateSegmentListIfDatasourcePathSpecIsUsed(
               config.getSchema(),
-              HadoopDruidIndexerConfig.jsonMapper,
+              HadoopDruidIndexerConfig.JSON_MAPPER,
               new MetadataStoreBasedUsedSegmentLister(
                   injector.getInstance(IndexerMetadataStorageCoordinator.class)
               )


### PR DESCRIPTION
so that appropriate dependencies can be injected specially ObjectMapper that can handle extensions as well without each having their own static Injector creation.

**Release Notes update:**
this PR removes the support for deprecated property `druid.processing.bitmap` and makes Concise be default.