### PR TITLE
Revert "update jetty to 9.2.13.v20150730 (latest Java 7 compatible ve…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <properties>
         <metamx.java-util.version>0.27.4</metamx.java-util.version>
         <apache.curator.version>2.8.0</apache.curator.version>
-        <jetty.version>9.2.13.v20150730</jetty.version>
+        <jetty.version>9.2.5.v20141112</jetty.version>
         <jersey.version>1.19</jersey.version>
         <druid.api.version>0.3.13</druid.api.version>
         <!-- Watch out for Hadoop compatibility when updating to >= 2.5; see https://github.com/druid-io/druid/pull/1669 -->


### PR DESCRIPTION
This reverts commit ac4a856a17b6934e5bd6884aaf7453df7d039279.

Revert jetty version until https://github.com/druid-io/druid/issues/1807 is fixed. 