### PR TITLE
Make PrioritizedExecutorService optionally FIFO

### DIFF
--- a/docs/content/configuration/broker.md
+++ b/docs/content/configuration/broker.md
@@ -58,6 +58,7 @@ The broker uses processing configs for nested groupBy queries. And, optionally, 
 |`druid.processing.formatString`|Realtime and historical nodes use this format string to name their processing threads.|processing-%s|
 |`druid.processing.numThreads`|The number of processing threads to have available for parallel processing of segments. Our rule of thumb is `num_cores - 1`, which means that even under heavy load there will still be one core available to do background tasks like talking with ZooKeeper and pulling down segments. If only one core is available, this property defaults to the value `1`.|Number of cores - 1 (or 1)|
 |`druid.processing.columnCache.sizeBytes`|Maximum size in bytes for the dimension value lookup cache. Any value greater than `0` enables the cache. It is currently disabled by default. Enabling the lookup cache can significantly improve the performance of aggregators operating on dimension values, such as the JavaScript aggregator, or cardinality aggregator, but can slow things down if the cache hit rate is low (i.e. dimensions with few repeating values). Enabling it may also require additional garbage collection tuning to avoid long GC pauses.|`0` (disabled)|
+|`druid.processing.fifo`|If the processing queue should treat tasks of equal priority in a FIFO manner|`false`|
 
 #### General Query Configuration
 

--- a/docs/content/configuration/historical.md
+++ b/docs/content/configuration/historical.md
@@ -56,6 +56,7 @@ Druid uses Jetty to serve HTTP requests.
 |`druid.processing.formatString`|Realtime and historical nodes use this format string to name their processing threads.|processing-%s|
 |`druid.processing.numThreads`|The number of processing threads to have available for parallel processing of segments. Our rule of thumb is `num_cores - 1`, which means that even under heavy load there will still be one core available to do background tasks like talking with ZooKeeper and pulling down segments. If only one core is available, this property defaults to the value `1`.|Number of cores - 1 (or 1)|
 |`druid.processing.columnCache.sizeBytes`|Maximum size in bytes for the dimension value lookup cache. Any value greater than `0` enables the cache. It is currently disabled by default. Enabling the lookup cache can significantly improve the performance of aggregators operating on dimension values, such as the JavaScript aggregator, or cardinality aggregator, but can slow things down if the cache hit rate is low (i.e. dimensions with few repeating values). Enabling it may also require additional garbage collection tuning to avoid long GC pauses.|`0` (disabled)|
+|`druid.processing.fifo`|If the processing queue should treat tasks of equal priority in a FIFO manner|`false`|
 
 #### General Query Configuration
 

--- a/processing/src/main/java/io/druid/query/DruidProcessingConfig.java
+++ b/processing/src/main/java/io/druid/query/DruidProcessingConfig.java
@@ -42,4 +42,10 @@ public abstract class DruidProcessingConfig extends ExecutorServiceConfig implem
   {
     return 0;
   }
+
+  @Config(value = "${base_path}.fifo")
+  public boolean isFifo()
+  {
+    return false;
+  }
 }

--- a/processing/src/main/java/io/druid/query/PrioritizedCallable.java
+++ b/processing/src/main/java/io/druid/query/PrioritizedCallable.java
@@ -21,5 +21,5 @@ import java.util.concurrent.Callable;
 
 public interface PrioritizedCallable<V> extends Callable<V>
 {
-  public int getPriority();
+  int getPriority();
 }

--- a/processing/src/main/java/io/druid/query/PrioritizedRunnable.java
+++ b/processing/src/main/java/io/druid/query/PrioritizedRunnable.java
@@ -19,5 +19,5 @@ package io.druid.query;
 
 public interface PrioritizedRunnable extends Runnable
 {
-  public int getPriority();
+  int getPriority();
 }

--- a/processing/src/test/java/io/druid/query/ChainedExecutionQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/ChainedExecutionQueryRunnerTest.java
@@ -62,7 +62,7 @@ public class ChainedExecutionQueryRunnerTest
   public void testQueryCancellation() throws Exception
   {
     ExecutorService exec = PrioritizedExecutorService.create(
-        new Lifecycle(), new ExecutorServiceConfig()
+        new Lifecycle(), new DruidProcessingConfig()
         {
           @Override
           public String getFormatString()
@@ -189,7 +189,7 @@ public class ChainedExecutionQueryRunnerTest
   public void testQueryTimeout() throws Exception
   {
     ExecutorService exec = PrioritizedExecutorService.create(
-        new Lifecycle(), new ExecutorServiceConfig()
+        new Lifecycle(), new DruidProcessingConfig()
         {
           @Override
           public String getFormatString()

--- a/processing/src/test/java/io/druid/query/PrioritizedExecutorServiceTest.java
+++ b/processing/src/test/java/io/druid/query/PrioritizedExecutorServiceTest.java
@@ -17,32 +17,70 @@
 
 package io.druid.query;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
-import com.metamx.common.concurrent.ExecutorServiceConfig;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.metamx.common.lifecycle.Lifecycle;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.internal.AssumptionViolatedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.util.List;
+import java.util.Random;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  */
+@RunWith(Parameterized.class)
 public class PrioritizedExecutorServiceTest
 {
-  private ExecutorService exec;
+  private PrioritizedExecutorService exec;
   private CountDownLatch latch;
   private CountDownLatch finishLatch;
+  private final boolean useFifo;
+  private final DruidProcessingConfig config;
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Iterable<Object[]> constructorFeeder()
+  {
+    return ImmutableList.of(new Object[]{true}, new Object[]{false});
+  }
+
+  public PrioritizedExecutorServiceTest(final boolean useFifo)
+  {
+    this.useFifo = useFifo;
+    this.config = new DruidProcessingConfig()
+    {
+      @Override
+      public String getFormatString()
+      {
+        return null;
+      }
+
+      @Override
+      public boolean isFifo()
+      {
+        return useFifo;
+      }
+    };
+  }
 
   @Before
   public void setUp() throws Exception
   {
     exec = PrioritizedExecutorService.create(
         new Lifecycle(),
-        new ExecutorServiceConfig()
+        new DruidProcessingConfig()
         {
           @Override
           public String getFormatString()
@@ -55,11 +93,23 @@ public class PrioritizedExecutorServiceTest
           {
             return 1;
           }
+
+          @Override
+          public boolean isFifo()
+          {
+            return useFifo;
+          }
         }
     );
 
     latch = new CountDownLatch(1);
     finishLatch = new CountDownLatch(3);
+  }
+
+  @After
+  public void tearDown()
+  {
+    exec.shutdownNow();
   }
 
   /**
@@ -129,5 +179,223 @@ public class PrioritizedExecutorServiceTest
 
     List<Integer> expected = ImmutableList.of(2, 0, -1);
     Assert.assertEquals(expected, ImmutableList.copyOf(order));
+  }
+
+  // Make sure entries are processed FIFO
+  @Test
+  public void testOrderedExecutionEqualPriorityRunnable() throws ExecutionException, InterruptedException
+  {
+    final int numTasks = 100;
+    final List<ListenableFuture<?>> futures = Lists.newArrayListWithExpectedSize(numTasks);
+    final AtomicInteger hasRun = new AtomicInteger(0);
+    for (int i = 0; i < numTasks; ++i) {
+      futures.add(exec.submit(getCheckingPrioritizedRunnable(i, hasRun)));
+    }
+    latch.countDown();
+    checkFutures(futures);
+  }
+
+  @Test
+  public void testOrderedExecutionEqualPriorityCallable() throws ExecutionException, InterruptedException
+  {
+    final int numTasks = 1_000;
+    final List<ListenableFuture<?>> futures = Lists.newArrayListWithExpectedSize(numTasks);
+    final AtomicInteger hasRun = new AtomicInteger(0);
+    for (int i = 0; i < numTasks; ++i) {
+      futures.add(exec.submit(getCheckingPrioritizedCallable(i, hasRun)));
+    }
+    latch.countDown();
+    checkFutures(futures);
+  }
+
+  @Test
+  public void testOrderedExecutionEqualPriorityMix() throws ExecutionException, InterruptedException
+  {
+    exec = new PrioritizedExecutorService(
+        exec.threadPoolExecutor, true, 0, config
+    );
+    final int numTasks = 1_000;
+    final List<ListenableFuture<?>> futures = Lists.newArrayListWithExpectedSize(numTasks);
+    final AtomicInteger hasRun = new AtomicInteger(0);
+    final Random random = new Random(789401);
+    for (int i = 0; i < numTasks; ++i) {
+      switch (random.nextInt(4)) {
+        case 0:
+          futures.add(exec.submit(getCheckingPrioritizedCallable(i, hasRun)));
+          break;
+        case 1:
+          futures.add(exec.submit(getCheckingPrioritizedRunnable(i, hasRun)));
+          break;
+        case 2:
+          futures.add(exec.submit(getCheckingCallable(i, hasRun)));
+          break;
+        case 3:
+          futures.add(exec.submit(getCheckingRunnable(i, hasRun)));
+          break;
+        default:
+          Assert.fail("Bad random result");
+      }
+    }
+    latch.countDown();
+    checkFutures(futures);
+  }
+
+  @Test
+  public void testOrderedExecutionMultiplePriorityMix() throws ExecutionException, InterruptedException
+  {
+    final int DEFAULT = 0;
+    final int MIN = -1;
+    final int MAX = 1;
+    exec = new PrioritizedExecutorService(exec.threadPoolExecutor, true, DEFAULT, config);
+    final int numTasks = 999;
+    final int[] priorities = new int[]{MAX, DEFAULT, MIN};
+    final int tasksPerPriority = numTasks / priorities.length;
+    final int[] priorityOffsets = new int[]{0, tasksPerPriority, tasksPerPriority * 2};
+    final List<ListenableFuture<?>> futures = Lists.newArrayListWithExpectedSize(numTasks);
+    final AtomicInteger hasRun = new AtomicInteger(0);
+    final Random random = new Random(789401);
+    for (int i = 0; i < numTasks; ++i) {
+      final int priorityBucket = i % priorities.length;
+      final int myPriority = priorities[priorityBucket];
+      final int priorityOffset = priorityOffsets[priorityBucket];
+      final int expectedPriorityOrder = i / priorities.length;
+      if (random.nextBoolean()) {
+        futures.add(
+            exec.submit(
+                getCheckingPrioritizedCallable(
+                    priorityOffset + expectedPriorityOrder,
+                    hasRun,
+                    myPriority
+                )
+            )
+        );
+      } else {
+        futures.add(
+            exec.submit(
+                getCheckingPrioritizedRunnable(
+                    priorityOffset + expectedPriorityOrder,
+                    hasRun,
+                    myPriority
+                )
+            )
+        );
+      }
+    }
+    latch.countDown();
+    checkFutures(futures);
+  }
+
+  private void checkFutures(Iterable<ListenableFuture<?>> futures) throws InterruptedException, ExecutionException
+  {
+    for (ListenableFuture<?> future : futures) {
+      try {
+        future.get();
+      }
+      catch (ExecutionException e) {
+        if (!(e.getCause() instanceof AssumptionViolatedException)) {
+          throw e;
+        }
+      }
+    }
+  }
+
+  private PrioritizedCallable<Boolean> getCheckingPrioritizedCallable(
+      final int myOrder,
+      final AtomicInteger hasRun
+  )
+  {
+    return getCheckingPrioritizedCallable(myOrder, hasRun, 0);
+  }
+
+  private PrioritizedCallable<Boolean> getCheckingPrioritizedCallable(
+      final int myOrder,
+      final AtomicInteger hasRun,
+      final int priority
+  )
+  {
+    final Callable<Boolean> delegate = getCheckingCallable(myOrder, hasRun);
+    return new AbstractPrioritizedCallable<Boolean>(priority)
+    {
+      @Override
+      public Boolean call() throws Exception
+      {
+        return delegate.call();
+      }
+    };
+  }
+
+  private Callable<Boolean> getCheckingCallable(
+      final int myOrder,
+      final AtomicInteger hasRun
+  )
+  {
+    final Runnable runnable = getCheckingRunnable(myOrder, hasRun);
+    return new Callable<Boolean>()
+    {
+      @Override
+      public Boolean call()
+      {
+        runnable.run();
+        return true;
+      }
+    };
+  }
+
+  private Runnable getCheckingRunnable(
+      final int myOrder,
+      final AtomicInteger hasRun
+  )
+  {
+    return new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        try {
+          latch.await();
+        }
+        catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw Throwables.propagate(e);
+        }
+        if (useFifo) {
+          Assert.assertEquals(myOrder, hasRun.getAndIncrement());
+        } else {
+          Assume.assumeTrue(Integer.compare(myOrder, hasRun.getAndIncrement()) == 0);
+        }
+      }
+    };
+  }
+
+
+  private PrioritizedRunnable getCheckingPrioritizedRunnable(
+      final int myOrder,
+      final AtomicInteger hasRun
+  )
+  {
+    return getCheckingPrioritizedRunnable(myOrder, hasRun, 0);
+  }
+
+  private PrioritizedRunnable getCheckingPrioritizedRunnable(
+      final int myOrder,
+      final AtomicInteger hasRun,
+      final int priority
+  )
+  {
+    final Runnable delegate = getCheckingRunnable(myOrder, hasRun);
+    return new PrioritizedRunnable()
+    {
+      @Override
+      public int getPriority()
+      {
+        return priority;
+      }
+
+      @Override
+      public void run()
+      {
+        delegate.run();
+      }
+    };
   }
 }

--- a/server/src/main/java/io/druid/guice/DruidProcessingModule.java
+++ b/server/src/main/java/io/druid/guice/DruidProcessingModule.java
@@ -82,7 +82,7 @@ public class DruidProcessingModule implements Module
   @Processing
   @ManageLifecycle
   public ExecutorService getProcessingExecutorService(
-      ExecutorServiceConfig config,
+      DruidProcessingConfig config,
       ServiceEmitter emitter,
       Lifecycle lifecycle
   )


### PR DESCRIPTION
The contract on `java.util.concurrent.PriorityBlockingQueue` explicitly states [ Operations on this class make no guarantees about the ordering of elements with equal priority ](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/PriorityBlockingQueue.html)

This adds a comparison in the execution queue to evaluate priority first, and then consider insertion order second.

The goal here is that the query times become more predictable.

In the prior implementation, segment scans of equal priority would be randomly chosen.

In the scenario where there is significant backpressure (constant waiting results in the segment processing queue), the current implementation will have a high variance between the effective time to first byte processed and the eventual termination of the query. This PR attempts to make the variance smaller. This will reduce the likelihood of randomly super-fast queries (ones that were randomly chosen to be executed early) and randomly super-slow queries (ones that had one or more processing tasks thrown under the bus by the prioritizing strategy). But overall the time to chug through the processing queue, and overall query resource usage on the historical and SCVs is expected to stay the same.

Another way to say it is that a prior long-running query could previously be lengthened even MORE by submitting another long-running query. In the prior case, the long running queries would have an increased variance in query/wait by submitting two of them in sequence. In this PR both long-running queries would have a lower variance in query/wait, but the difference between the average query/wait for each query would be larger (the second query would have notably larger query wait, but lower variance on the wait value, and the first query would have a consistent query/wait as if the second had never been issued.). 

One downside to the approach in this PR is that a particularly long-running query has the ability to starve out cluster resources, where the prior implementation could interleave (though randomly) other tasks into a long-running query.

The boolean configuration parameter `druid.processing.fifo` controls the enabling or disabling of this behavior with a default of prior non-fifo behavior