### PR TITLE
Adjust realtime constraints in the docs.

### DIFF
--- a/docs/content/ingestion/realtime-ingestion.md
+++ b/docs/content/ingestion/realtime-ingestion.md
@@ -252,5 +252,5 @@ The following table summarizes constraints between settings in the spec file for
 |intermediatePersistPeriod| The max time (ISO8601 Period) between flushes of ingested rows from memory to disk | avoid excessive flushing | number of un-persisted rows in memory also constrained by maxRowsInMemory |
 |maxRowsInMemory| The max number of ingested rows to hold in memory before a flush to disk | number of un-persisted post-aggregation rows in memory is also constrained by intermediatePersistPeriod | use this to avoid running out of heap if too many rows in an intermediatePersistPeriod |
 
-The normal, expected use cases have the following overall constraints: `queryGranularity < intermediatePersistPeriod =< windowPeriod  < segmentGranularity`
+The normal, expected use cases have the following overall constraints: `intermediatePersistPeriod ≤ windowPeriod < segmentGranularity` and `queryGranularity ≤ segmentGranularity`
 


### PR DESCRIPTION
Because it's ok for queryGranularity to equal segmentGranularity.