### PR TITLE
Removing the md files created for redirection

### DIFF
--- a/docs/content/About-Experimental-Features.md
+++ b/docs/content/About-Experimental-Features.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: development/experimental.html
----

--- a/docs/content/Aggregations.md
+++ b/docs/content/Aggregations.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: querying/aggregations.html
----

--- a/docs/content/ApproxHisto.md
+++ b/docs/content/ApproxHisto.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: development/approximate-histograms.html
----

--- a/docs/content/Batch-ingestion.md
+++ b/docs/content/Batch-ingestion.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: ingestion/batch-ingestion.html
----

--- a/docs/content/Booting-a-production-cluster.md
+++ b/docs/content/Booting-a-production-cluster.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: tutorials/booting-a-production-cluster.html
----

--- a/docs/content/Broker-Config.md
+++ b/docs/content/Broker-Config.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: configuration/broker.html
----

--- a/docs/content/Broker.md
+++ b/docs/content/Broker.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: design/broker.html
----

--- a/docs/content/Build-from-source.md
+++ b/docs/content/Build-from-source.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: development/build.html
----

--- a/docs/content/Cassandra-Deep-Storage.md
+++ b/docs/content/Cassandra-Deep-Storage.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: dependencies/cassandra-deep-storage.html
----

--- a/docs/content/Cluster-setup.md
+++ b/docs/content/Cluster-setup.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: misc/cluster-setup.html
----

--- a/docs/content/Concepts-and-Terminology.md
+++ b/docs/content/Concepts-and-Terminology.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: design/concepts-and-terminology.html
----

--- a/docs/content/Configuration.md
+++ b/docs/content/Configuration.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: configuration/
----

--- a/docs/content/Coordinator-Config.md
+++ b/docs/content/Coordinator-Config.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: configuration/coordinator.html
----

--- a/docs/content/Coordinator.md
+++ b/docs/content/Coordinator.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: design/coordinator.html
----

--- a/docs/content/DataSource.md
+++ b/docs/content/DataSource.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: querying/datasource.html
----

--- a/docs/content/DataSourceMetadataQuery.md
+++ b/docs/content/DataSourceMetadataQuery.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: querying/datasourcemetadataquery.html
----

--- a/docs/content/Data_formats.md
+++ b/docs/content/Data_formats.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: ingestion/data-formats.html
----

--- a/docs/content/Deep-Storage.md
+++ b/docs/content/Deep-Storage.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: dependencies/deep-storage.html
----

--- a/docs/content/Design.md
+++ b/docs/content/Design.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: design/design.html
----

--- a/docs/content/DimensionSpecs.md
+++ b/docs/content/DimensionSpecs.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: querying/dimensionspecs.html
----

--- a/docs/content/Druid-vs-Cassandra.md
+++ b/docs/content/Druid-vs-Cassandra.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: comparisons/druid-vs-cassandra.html
----

--- a/docs/content/Druid-vs-Elasticsearch.md
+++ b/docs/content/Druid-vs-Elasticsearch.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: comparisons/druid-vs-elasticsearch.html
----

--- a/docs/content/Druid-vs-Hadoop.md
+++ b/docs/content/Druid-vs-Hadoop.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: comparisons/druid-vs-hadoop.html
----

--- a/docs/content/Druid-vs-Impala-or-Shark.md
+++ b/docs/content/Druid-vs-Impala-or-Shark.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: comparisons/druid-vs-impala-or-shark.html
----

--- a/docs/content/Druid-vs-Redshift.md
+++ b/docs/content/Druid-vs-Redshift.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: comparisons/druid-vs-redshift.html
----

--- a/docs/content/Druid-vs-Spark.md
+++ b/docs/content/Druid-vs-Spark.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: comparisons/druid-vs-spark.html
----

--- a/docs/content/Druid-vs-Vertica.md
+++ b/docs/content/Druid-vs-Vertica.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: comparisons/druid-vs-vertica.html
----

--- a/docs/content/Evaluate.md
+++ b/docs/content/Evaluate.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: misc/evaluate.html
----

--- a/docs/content/Examples.md
+++ b/docs/content/Examples.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: tutorials/examples.html
----

--- a/docs/content/Filters.md
+++ b/docs/content/Filters.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: querying/filters.html
----

--- a/docs/content/Firehose.md
+++ b/docs/content/Firehose.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: ingestion/firehose.html
----

--- a/docs/content/GeographicQueries.md
+++ b/docs/content/GeographicQueries.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: development/geo.html
----

--- a/docs/content/Granularities.md
+++ b/docs/content/Granularities.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: querying/granularities.html
----

--- a/docs/content/GroupByQuery.md
+++ b/docs/content/GroupByQuery.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: querying/groupbyquery.html
----

--- a/docs/content/Hadoop-Configuration.md
+++ b/docs/content/Hadoop-Configuration.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: configuration/hadoop.html
----

--- a/docs/content/Having.md
+++ b/docs/content/Having.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: querying/having.html
----

--- a/docs/content/Historical-Config.md
+++ b/docs/content/Historical-Config.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: configuration/historical.html
----

--- a/docs/content/Historical.md
+++ b/docs/content/Historical.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: design/historical.html
----

--- a/docs/content/Including-Extensions.md
+++ b/docs/content/Including-Extensions.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: operations/including-extensions.html
----

--- a/docs/content/Indexing-Service-Config.md
+++ b/docs/content/Indexing-Service-Config.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: configuration/indexing-service.html
----

--- a/docs/content/Indexing-Service.md
+++ b/docs/content/Indexing-Service.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: design/indexing-service.html
----

--- a/docs/content/Ingestion-FAQ.md
+++ b/docs/content/Ingestion-FAQ.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: ingestion/faq.html
----

--- a/docs/content/Ingestion-overview.md
+++ b/docs/content/Ingestion-overview.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: ingestion/overview.html
----

--- a/docs/content/Ingestion.md
+++ b/docs/content/Ingestion.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: ingestion/
----

--- a/docs/content/Integrating-Druid-With-Other-Technologies.md
+++ b/docs/content/Integrating-Druid-With-Other-Technologies.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: development/integrating-druid-with-other-technologies.html
----

--- a/docs/content/Libraries.md
+++ b/docs/content/Libraries.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: development/libraries.html
----

--- a/docs/content/LimitSpec.md
+++ b/docs/content/LimitSpec.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: querying/limitspec.html
----

--- a/docs/content/Logging.md
+++ b/docs/content/Logging.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: configuration/logging.html
----

--- a/docs/content/Metadata-storage.md
+++ b/docs/content/Metadata-storage.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: dependencies/metadata-storage.html
----

--- a/docs/content/Metrics.md
+++ b/docs/content/Metrics.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: operations/metrics.html
----

--- a/docs/content/Middlemanager.md
+++ b/docs/content/Middlemanager.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: design/middlemanager.html
----

--- a/docs/content/Modules.md
+++ b/docs/content/Modules.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: development/modules.html
----

--- a/docs/content/Other-Hadoop.md
+++ b/docs/content/Other-Hadoop.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: operations/other-hadoop.html
----

--- a/docs/content/Papers-and-talks.md
+++ b/docs/content/Papers-and-talks.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: misc/papers-and-talks.html
----

--- a/docs/content/Peons.md
+++ b/docs/content/Peons.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: design/peons.html
----

--- a/docs/content/Performance-FAQ.md
+++ b/docs/content/Performance-FAQ.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: operations/performance-faq.html
----

--- a/docs/content/Plumber.md
+++ b/docs/content/Plumber.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: design/plumber.html
----

--- a/docs/content/Post-aggregations.md
+++ b/docs/content/Post-aggregations.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: querying/post-aggregations.html
----

--- a/docs/content/Production-Cluster-Configuration.md
+++ b/docs/content/Production-Cluster-Configuration.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: configuration/production-cluster.html
----

--- a/docs/content/Query-Context.md
+++ b/docs/content/Query-Context.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: querying/query-context.html
----

--- a/docs/content/Querying.md
+++ b/docs/content/Querying.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: querying/querying.html
----

--- a/docs/content/Realtime-Config.md
+++ b/docs/content/Realtime-Config.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: configuration/realtime.html
----

--- a/docs/content/Realtime-ingestion.md
+++ b/docs/content/Realtime-ingestion.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: ingestion/realtime-ingestion.html
----

--- a/docs/content/Realtime.md
+++ b/docs/content/Realtime.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: design/realtime.html
----

--- a/docs/content/Recommendations.md
+++ b/docs/content/Recommendations.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: operations/recommendations.html
----

--- a/docs/content/Rolling-Updates.md
+++ b/docs/content/Rolling-Updates.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: operations/rolling-updates.html
----

--- a/docs/content/Router.md
+++ b/docs/content/Router.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: development/router.html
----

--- a/docs/content/Rule-Configuration.md
+++ b/docs/content/Rule-Configuration.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: operations/rule-configuration.html
----

--- a/docs/content/SearchQuery.md
+++ b/docs/content/SearchQuery.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: querying/searchquery.html
----

--- a/docs/content/SearchQuerySpec.md
+++ b/docs/content/SearchQuerySpec.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: querying/searchqueryspec.html
----

--- a/docs/content/SegmentMetadataQuery.md
+++ b/docs/content/SegmentMetadataQuery.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: querying/segmentmetadataquery.html
----

--- a/docs/content/Segments.md
+++ b/docs/content/Segments.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: design/segments.html
----

--- a/docs/content/SelectQuery.md
+++ b/docs/content/SelectQuery.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: development/select-query.html
----

--- a/docs/content/Simple-Cluster-Configuration.md
+++ b/docs/content/Simple-Cluster-Configuration.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: configuration/simple-cluster.html
----

--- a/docs/content/Tasks.md
+++ b/docs/content/Tasks.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: misc/tasks.html
----

--- a/docs/content/TimeBoundaryQuery.md
+++ b/docs/content/TimeBoundaryQuery.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: querying/timeboundaryquery.html
----

--- a/docs/content/TimeseriesQuery.md
+++ b/docs/content/TimeseriesQuery.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: querying/timeseriesquery.html
----

--- a/docs/content/TopNMetricSpec.md
+++ b/docs/content/TopNMetricSpec.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: querying/topnmetricspec.html
----

--- a/docs/content/TopNQuery.md
+++ b/docs/content/TopNQuery.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: querying/topnquery.html
----

--- a/docs/content/Tutorial:-A-First-Look-at-Druid.md
+++ b/docs/content/Tutorial:-A-First-Look-at-Druid.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: tutorials/tutorial-a-first-look-at-druid.html
----

--- a/docs/content/Tutorial:-All-About-Queries.md
+++ b/docs/content/Tutorial:-All-About-Queries.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: tutorials/tutorial-all-about-queries.html
----

--- a/docs/content/Tutorial:-Loading-Batch-Data.md
+++ b/docs/content/Tutorial:-Loading-Batch-Data.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: tutorials/tutorial-loading-batch-data.html
----

--- a/docs/content/Tutorial:-Loading-Streaming-Data.md
+++ b/docs/content/Tutorial:-Loading-Streaming-Data.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: tutorials/tutorial-loading-streaming-data.html
----

--- a/docs/content/Tutorial:-The-Druid-Cluster.md
+++ b/docs/content/Tutorial:-The-Druid-Cluster.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: tutorials/tutorial-the-druid-cluster.html
----

--- a/docs/content/Tutorials.md
+++ b/docs/content/Tutorials.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: tutorials/
----

--- a/docs/content/Versioning.md
+++ b/docs/content/Versioning.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: development/versioning.html
----

--- a/docs/content/ZooKeeper.md
+++ b/docs/content/ZooKeeper.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: dependencies/zookeeper.html
----

--- a/docs/content/alerts.md
+++ b/docs/content/alerts.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: operations/alerts.html
----

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,5 +1,0 @@
----
-title: this page has moved.
-layout: simple_page
-redirect_to: design/index.html
----


### PR DESCRIPTION
they were created so that search engines would be able to update their caches according to new names, it should be safe to delete those now.
