### PR TITLE
Add hashCode and equals to UniformGranularitySpec

### DIFF
--- a/processing/src/main/java/io/druid/granularity/AllGranularity.java
+++ b/processing/src/main/java/io/druid/granularity/AllGranularity.java
@@ -62,7 +62,7 @@ public final class AllGranularity extends BaseQueryGranularity
   @Override
   public int hashCode()
   {
-    return 0;
+    return 1;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/granularity/NoneGranularity.java
+++ b/processing/src/main/java/io/druid/granularity/NoneGranularity.java
@@ -53,7 +53,7 @@ public final class NoneGranularity extends BaseQueryGranularity
   @Override
   public int hashCode()
   {
-    return 0;
+    return -1;
   }
 
   @Override

--- a/server/src/main/java/io/druid/segment/indexing/granularity/UniformGranularitySpec.java
+++ b/server/src/main/java/io/druid/segment/indexing/granularity/UniformGranularitySpec.java
@@ -100,4 +100,39 @@ public class UniformGranularitySpec implements GranularitySpec
   {
     return Optional.fromNullable(inputIntervals);
   }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    UniformGranularitySpec that = (UniformGranularitySpec) o;
+
+    if (segmentGranularity != that.segmentGranularity) {
+      return false;
+    }
+    if (!queryGranularity.equals(that.queryGranularity)) {
+      return false;
+    }
+    if (inputIntervals != null ? !inputIntervals.equals(that.inputIntervals) : that.inputIntervals != null) {
+      return false;
+    }
+    return !(wrappedSpec != null ? !wrappedSpec.equals(that.wrappedSpec) : that.wrappedSpec != null);
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = segmentGranularity.hashCode();
+    result = 31 * result + queryGranularity.hashCode();
+    result = 31 * result + (inputIntervals != null ? inputIntervals.hashCode() : 0);
+    result = 31 * result + (wrappedSpec != null ? wrappedSpec.hashCode() : 0);
+    return result;
+  }
 }

--- a/server/src/test/java/io/druid/segment/indexing/granularity/UniformGranularityTest.java
+++ b/server/src/test/java/io/druid/segment/indexing/granularity/UniformGranularityTest.java
@@ -22,6 +22,7 @@ import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.metamx.common.Granularity;
+import io.druid.granularity.QueryGranularity;
 import io.druid.jackson.DefaultObjectMapper;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -120,5 +121,96 @@ public class UniformGranularityTest
     catch (Exception e) {
       throw Throwables.propagate(e);
     }
+  }
+
+  @Test
+  public void testEquals()
+  {
+
+    final GranularitySpec spec = new UniformGranularitySpec(
+        Granularity.DAY,
+        null,
+        Lists.newArrayList(
+            new Interval("2012-01-08T00Z/2012-01-11T00Z"),
+            new Interval("2012-01-07T00Z/2012-01-08T00Z"),
+            new Interval("2012-01-03T00Z/2012-01-04T00Z"),
+            new Interval("2012-01-01T00Z/2012-01-03T00Z")
+        )
+    );
+
+    equalsCheck(
+        spec, new UniformGranularitySpec(
+            Granularity.DAY,
+            null,
+            Lists.newArrayList(
+                new Interval("2012-01-08T00Z/2012-01-11T00Z"),
+                new Interval("2012-01-07T00Z/2012-01-08T00Z"),
+                new Interval("2012-01-03T00Z/2012-01-04T00Z"),
+                new Interval("2012-01-01T00Z/2012-01-03T00Z")
+            )
+        )
+    );
+  }
+
+  public void equalsCheck(GranularitySpec spec1, GranularitySpec spec2) {
+    Assert.assertEquals(spec1, spec2);
+    Assert.assertEquals(spec1.hashCode(), spec2.hashCode());
+  }
+
+  @Test
+  public void testNotEquals()
+  {
+    final GranularitySpec spec = new UniformGranularitySpec(
+        Granularity.DAY,
+        null,
+        Lists.newArrayList(
+            new Interval("2012-01-08T00Z/2012-01-11T00Z"),
+            new Interval("2012-01-07T00Z/2012-01-08T00Z"),
+            new Interval("2012-01-03T00Z/2012-01-04T00Z"),
+            new Interval("2012-01-01T00Z/2012-01-03T00Z")
+        )
+    );
+
+    notEqualsCheck(
+        spec, new UniformGranularitySpec(
+            Granularity.YEAR,
+            null,
+            Lists.newArrayList(
+                new Interval("2012-01-08T00Z/2012-01-11T00Z"),
+                new Interval("2012-01-07T00Z/2012-01-08T00Z"),
+                new Interval("2012-01-03T00Z/2012-01-04T00Z"),
+                new Interval("2012-01-01T00Z/2012-01-03T00Z")
+            )
+        )
+    );
+    notEqualsCheck(
+        spec, new UniformGranularitySpec(
+            Granularity.DAY,
+            null,
+            Lists.newArrayList(
+                new Interval("2012-01-08T00Z/2012-01-12T00Z"),
+                new Interval("2012-01-07T00Z/2012-01-08T00Z"),
+                new Interval("2012-01-03T00Z/2012-01-04T00Z"),
+                new Interval("2012-01-01T00Z/2012-01-03T00Z")
+            )
+        )
+    );
+    notEqualsCheck(
+        spec, new UniformGranularitySpec(
+            Granularity.DAY,
+            QueryGranularity.ALL,
+            Lists.newArrayList(
+                new Interval("2012-01-08T00Z/2012-01-11T00Z"),
+                new Interval("2012-01-07T00Z/2012-01-08T00Z"),
+                new Interval("2012-01-03T00Z/2012-01-04T00Z"),
+                new Interval("2012-01-01T00Z/2012-01-03T00Z")
+            )
+        )
+    );
+  }
+
+  private void notEqualsCheck(GranularitySpec spec1, GranularitySpec spec2) {
+    Assert.assertNotEquals(spec1, spec2);
+    Assert.assertNotEquals(spec1.hashCode(), spec2.hashCode());
   }
 }


### PR DESCRIPTION
* Also add hashCode != 0 to AllGranularity and NoneGranularity

This was causing some problems in unit tests in some libraries I'm developing.