### PR TITLE
Check for non-daemon threads when CliPeon exits

### DIFF
--- a/services/src/main/java/io/druid/cli/CliPeon.java
+++ b/services/src/main/java/io/druid/cli/CliPeon.java
@@ -76,6 +76,7 @@ import org.eclipse.jetty.server.Server;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 /**
  */
@@ -223,6 +224,15 @@ public class CliPeon extends GuiceRunnable
             )
         );
         injector.getInstance(ExecutorLifecycle.class).join();
+
+        // Sanity check to help debug unexpected non-daemon threads
+        final Set<Thread> threadSet = Thread.getAllStackTraces().keySet();
+        for (Thread thread : threadSet) {
+          if (!thread.isDaemon() && thread != Thread.currentThread()) {
+            log.info("Thread [%s] is non daemon.", thread);
+          }
+        }
+
         // Explicitly call lifecycle stop, dont rely on shutdown hook.
         lifecycle.stop();
       }


### PR DESCRIPTION
Ideally only the main thread would be damon. This does a sanity check to help debug potential future issues expecting only non-daemon threads.