### PR TITLE
Add more verbose logging to SQLMetadataRuleManager

### DIFF
--- a/common/src/main/java/io/druid/audit/AuditInfo.java
+++ b/common/src/main/java/io/druid/audit/AuditInfo.java
@@ -89,4 +89,14 @@ public class AuditInfo
     result = 31 * result + ip.hashCode();
     return result;
   }
+
+  @Override
+  public String toString()
+  {
+    return "AuditInfo{" +
+           "author='" + author + '\'' +
+           ", comment='" + comment + '\'' +
+           ", ip='" + ip + '\'' +
+           '}';
+  }
 }


### PR DESCRIPTION
Had a problem today when I was trying to update some rules. This would have helped.