### PR TITLE
Add debug logging to start of segment manager polling

### DIFF
--- a/server/src/main/java/io/druid/metadata/SQLMetadataSegmentManager.java
+++ b/server/src/main/java/io/druid/metadata/SQLMetadataSegmentManager.java
@@ -425,6 +425,8 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
 
       ConcurrentHashMap<String, DruidDataSource> newDataSources = new ConcurrentHashMap<String, DruidDataSource>();
 
+      log.debug("Starting polling of segment table");
+
       List<DataSegment> segments = dbi.withHandle(
           new HandleCallback<List<DataSegment>>()
           {


### PR DESCRIPTION
When your active segment count starts numbering in the million range, the poll can take some time. This PR puts extra logging in place at a `DEBUG` level to better determine if polling is running.