### PR TITLE
Allow setting upper limit on the number of cache segments a broker will try to fetch.

### DIFF
--- a/docs/content/configuration/broker.md
+++ b/docs/content/configuration/broker.md
@@ -90,5 +90,6 @@ You can optionally only configure caching to be enabled on the broker by setting
 |`druid.broker.cache.useCache`|true, false|Enable the cache on the broker.|false|
 |`druid.broker.cache.populateCache`|true, false|Populate the cache on the broker.|false|
 |`druid.broker.cache.unCacheable`|All druid query types|All query types to not cache.|`["groupBy", "select"]`|
+|`druid.broker.cache.cacheBulkMergeLimit`|positive integer or 0|Queries with more segments than this number will not attempt to fetch from cache at the broker level, leaving potential caching fetches (and cache result merging) to the historicals|`Integer.MAX_VALUE`|
 
 See [cache configuration](caching.html) for how to configure cache settings.

--- a/server/src/main/java/io/druid/client/cache/CacheConfig.java
+++ b/server/src/main/java/io/druid/client/cache/CacheConfig.java
@@ -40,6 +40,10 @@ public class CacheConfig
   private int numBackgroundThreads = 0;
 
   @JsonProperty
+  @Min(0)
+  private int cacheBulkMergeLimit = Integer.MAX_VALUE;
+
+  @JsonProperty
   private List<String> unCacheable = Arrays.asList(Query.GROUP_BY, Query.SELECT);
 
   public boolean isPopulateCache()
@@ -54,6 +58,11 @@ public class CacheConfig
 
   public int getNumBackgroundThreads(){
     return numBackgroundThreads;
+  }
+
+  public int getCacheBulkMergeLimit()
+  {
+    return cacheBulkMergeLimit;
   }
 
   public boolean isQueryCacheable(Query query)


### PR DESCRIPTION
Quite simply, there are times when the broker tries to get segment caches for stuff it probably won't be able to fetch within its timeout. Usually in these cases even if the cache were fetched, the merge time (single threaded) on the broker is undesirable. As such this allows setting an upper limit on the number of segments the broker will attempt to fetch from cache and merge.