### PR TITLE
Add timeout to shutdown request to middle manager for indexing service

### DIFF
--- a/docs/content/configuration/indexing-service.md
+++ b/docs/content/configuration/indexing-service.md
@@ -81,6 +81,7 @@ The following configs only apply if the overlord is running in remote mode:
 |`druid.indexer.runner.compressZnodes`|Indicates whether or not the overlord should expect middle managers to compress Znodes.|true|
 |`druid.indexer.runner.maxZnodeBytes`|The maximum size Znode in bytes that can be created in Zookeeper.|524288|
 |`druid.indexer.runner.taskCleanupTimeout`|How long to wait before failing a task after a middle manager is disconnected from Zookeeper.|PT15M|
+|`druid.indexer.runner.taskShutdownLinkTimeout`|How long to wait on a shutdown request to a middle manager before timing out|PT1M|
 
 There are additional configs for autoscaling (if it is enabled):
 

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
@@ -42,6 +42,9 @@ public class RemoteTaskRunnerConfig
   @Min(10 * 1024)
   private long maxZnodeBytes = 512 * 1024;
 
+  @JsonProperty
+  private Period taskShutdownLinkTimeout = new Period("PT1M");
+
   public Period getTaskAssignmentTimeout()
   {
     return taskAssignmentTimeout;
@@ -60,5 +63,10 @@ public class RemoteTaskRunnerConfig
   public long getMaxZnodeBytes()
   {
     return maxZnodeBytes;
+  }
+
+  public Period getTaskShutdownLinkTimeout()
+  {
+    return taskShutdownLinkTimeout;
   }
 }

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/TestRemoteTaskRunnerConfig.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/TestRemoteTaskRunnerConfig.java
@@ -51,6 +51,12 @@ public class TestRemoteTaskRunnerConfig extends RemoteTaskRunnerConfig
   }
 
   @Override
+  public Period getTaskShutdownLinkTimeout()
+  {
+    return timeout;
+  }
+
+  @Override
   public String getMinWorkerVersion()
   {
     return "";

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
             <dependency>
                 <groupId>com.metamx</groupId>
                 <artifactId>http-client</artifactId>
-                <version>1.0.2</version>
+                <version>1.0.4</version>
             </dependency>
             <dependency>
                 <groupId>com.metamx</groupId>

--- a/server/src/main/java/io/druid/server/router/CoordinatorRuleManager.java
+++ b/server/src/main/java/io/druid/server/router/CoordinatorRuleManager.java
@@ -158,7 +158,7 @@ public class CoordinatorRuleManager
       ).get();
 
       if (response.getStatus().equals(HttpResponseStatus.FOUND)) {
-        url = response.getResponse().getHeader("Location");
+        url = response.getResponse().headers().get("Location");
         log.info("Redirecting rule request to [%s]", url);
         response = httpClient.go(
             new Request(


### PR DESCRIPTION
If the middle manager has a catastrophic failure, the overlord can hang here while holding `TaskQueue` `giant.lock()`, causing other indexing service `TaskQueue` to lock up waiting for it to free..