### PR TITLE
[doc] add description for /druid/coordinator/v1/loadqueue?full

### DIFF
--- a/docs/content/design/coordinator.md
+++ b/docs/content/design/coordinator.md
@@ -76,6 +76,8 @@ Returns the number of segments to load and drop, as well as the total segment lo
 
 * `/druid/coordinator/v1/loadqueue?full`
 
+Returns the serialized JSON of segments to load and drop for each historical node.
+
 #### Metadata store information
 
 * `/druid/coordinator/v1/metadata/datasources`


### PR DESCRIPTION
description missing for the bullet: /druid/coordinator/v1/loadqueue?full