### PR TITLE
fixing hadoop test scope dependencies in indexing-hadoop

### DIFF
--- a/indexing-hadoop/pom.xml
+++ b/indexing-hadoop/pom.xml
@@ -108,27 +108,20 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>
             <version>${hadoop.compile.version}</version>
-            <type>test-jar</type>
+            <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-mapreduce-client-jobclient</artifactId>
+            <artifactId>hadoop-common</artifactId>
             <version>${hadoop.compile.version}</version>
-            <type>test-jar</type>
+            <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-minicluster</artifactId>
+            <artifactId>hadoop-hdfs</artifactId>
             <version>${hadoop.compile.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-yarn-server-tests</artifactId>
-            <version>${hadoop.compile.version}</version>
-            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
with #1815  , we are getting following exception on our build machines.
```
io.druid.indexer.HdfsClasspathSetupTest  Time elapsed: 1.657 sec  <<< ERROR!
java.net.UnknownHostException: Invalid host name: local host is: (unknown); destination host is: "localhost.localdomain":44443; java.net.UnknownHostException; For more details see:  http://wiki.apache.org/hadoop/UnknownHost
at org.apache.hadoop.ipc.Client$Connection.<init>(Client.java:400)
at org.apache.hadoop.ipc.Client.getConnection(Client.java:1448)
at org.apache.hadoop.ipc.Client.call(Client.java:1377)
at org.apache.hadoop.ipc.Client.call(Client.java:1359)
at org.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:206)
at com.sun.proxy.$Proxy90.getDatanodeReport(Unknown Source)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.lang.reflect.Method.invoke(Method.java:497)
at org.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:186)
at org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:102)
at com.sun.proxy.$Proxy90.getDatanodeReport(Unknown Source)
at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolTranslatorPB.getDatanodeReport(ClientNamenodeProtocolTranslatorPB.java:555)
at org.apache.hadoop.hdfs.DFSClient.datanodeReport(DFSClient.java:2189)
at org.apache.hadoop.hdfs.MiniDFSCluster.waitActive(MiniDFSCluster.java:1901)
at org.apache.hadoop.hdfs.MiniDFSCluster.waitActive(MiniDFSCluster.java:1920)
at org.apache.hadoop.hdfs.MiniDFSCluster.startDataNodes(MiniDFSCluster.java:1238)
at org.apache.hadoop.hdfs.MiniDFSCluster.initMiniDFSCluster(MiniDFSCluster.java:684)
at org.apache.hadoop.hdfs.MiniDFSCluster.<init>(MiniDFSCluster.java:351)
at org.apache.hadoop.hdfs.MiniDFSCluster$Builder.build(MiniDFSCluster.java:332)
at io.druid.indexer.HdfsClasspathSetupTest.setupStatic(HdfsClasspathSetupTest.java:80)

```

this change fixes the issue.
However, I am not entirely sure of why it fails otherwise.