### PR TITLE
Historical and MiddleManager server announcements should not remove parents.

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/worker/WorkerCuratorCoordinator.java
+++ b/indexing-service/src/main/java/io/druid/indexing/worker/WorkerCuratorCoordinator.java
@@ -103,7 +103,7 @@ public class WorkerCuratorCoordinator
           ImmutableMap.of("created", new DateTime().toString())
       );
       announcer.start();
-      announcer.announce(getAnnouncementsPathForWorker(), jsonMapper.writeValueAsBytes(worker));
+      announcer.announce(getAnnouncementsPathForWorker(), jsonMapper.writeValueAsBytes(worker), false);
 
       started = true;
     }
@@ -117,8 +117,6 @@ public class WorkerCuratorCoordinator
       if (!started) {
         return;
       }
-
-      announcer.unannounce(getAnnouncementsPathForWorker());
       announcer.stop();
 
       started = false;

--- a/server/src/main/java/io/druid/server/coordination/AbstractDataSegmentAnnouncer.java
+++ b/server/src/main/java/io/druid/server/coordination/AbstractDataSegmentAnnouncer.java
@@ -66,7 +66,7 @@ public abstract class AbstractDataSegmentAnnouncer implements DataSegmentAnnounc
       try {
         final String path = makeAnnouncementPath();
         log.info("Announcing self[%s] at [%s]", server, path);
-        announcer.announce(path, jsonMapper.writeValueAsBytes(server));
+        announcer.announce(path, jsonMapper.writeValueAsBytes(server), false);
       }
       catch (JsonProcessingException e) {
         throw Throwables.propagate(e);


### PR DESCRIPTION
Removing parent paths causes watchers of the "announcements" path to get stuck
and stop seeing new updates.

this problem can be reproduced in a totally fresh setup by:

Start a coordinator
Start a historical- it will announce itself and create /druid/announcements
Stop that historical- it will unannounce itself and delete /druid/announcements
The coordinator's pathChildrenCache of /druid/announcements will now never update, even if you start more historicals
There is a similar problem with overlords and middleManagers.