### PR TITLE
backport #1868 to 0.8.2

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/worker/WorkerCuratorCoordinator.java
+++ b/indexing-service/src/main/java/io/druid/indexing/worker/WorkerCuratorCoordinator.java
@@ -103,7 +103,7 @@ public class WorkerCuratorCoordinator
           ImmutableMap.of("created", new DateTime().toString())
       );
       announcer.start();
-      announcer.announce(getAnnouncementsPathForWorker(), jsonMapper.writeValueAsBytes(worker));
+      announcer.announce(getAnnouncementsPathForWorker(), jsonMapper.writeValueAsBytes(worker), false);
 
       started = true;
     }
@@ -117,8 +117,6 @@ public class WorkerCuratorCoordinator
       if (!started) {
         return;
       }
-
-      announcer.unannounce(getAnnouncementsPathForWorker());
       announcer.stop();
 
       started = false;

--- a/server/src/main/java/io/druid/server/coordination/AbstractDataSegmentAnnouncer.java
+++ b/server/src/main/java/io/druid/server/coordination/AbstractDataSegmentAnnouncer.java
@@ -66,7 +66,7 @@ public abstract class AbstractDataSegmentAnnouncer implements DataSegmentAnnounc
       try {
         final String path = makeAnnouncementPath();
         log.info("Announcing self[%s] at [%s]", server, path);
-        announcer.announce(path, jsonMapper.writeValueAsBytes(server));
+        announcer.announce(path, jsonMapper.writeValueAsBytes(server), false);
       }
       catch (JsonProcessingException e) {
         throw Throwables.propagate(e);


### PR DESCRIPTION
Removing parent paths causes watchers of the "announcements" path to get stuck
and stop seeing new updates.