### PR TITLE
.gitignore new distribution artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ target
 *.log
 *.DS_Store
 _site
+/distribution/druid_extensions
+/distribution/hadoop_druid_dependencies


### PR DESCRIPTION
It's useful to leave these around after a build for the purposes of running
locally, and so it's also useful to .gitignore them.