### PR TITLE
fix pull-deps remoteRepository option

### DIFF
--- a/docs/content/operations/pull-deps.md
+++ b/docs/content/operations/pull-deps.md
@@ -27,9 +27,9 @@ layout: doc_page
 
     A local repostiry that Maven will use to put downloaded files. Then pull-deps will lay these files out into the extensions directory as needed.
 
-`-r` or `--remoteRepositories`
+`-r` or `--remoteRepository`
 
-    A JSON Array list of remote repositories to load dependencies from.
+    Add a remote repository to the default remote repository list, which includes https://repo1.maven.org/maven2/ and https://metamx.artifactoryonline.com/metamx/pub-libs-releases-local
 
 `-d` or `--defaultVersion`
 

--- a/services/src/main/java/io/druid/cli/PullDependencies.java
+++ b/services/src/main/java/io/druid/cli/PullDependencies.java
@@ -106,11 +106,11 @@ public class PullDependencies implements Runnable
   public String localRepository = String.format("%s/%s", System.getProperty("user.home"), ".m2/repository");
 
   @Option(
-      name = {"-r", "--remoteRepositories"},
-      title = "A JSON Array list of remote repositories to load dependencies from.",
+      name = {"-r", "--remoteRepository"},
+      title = "Add a remote repository to the default remote repository list, which includes https://repo1.maven.org/maven2/ and https://metamx.artifactoryonline.com/metamx/pub-libs-releases-local",
       required = false
   )
-  List<String> remoteRepositories = ImmutableList.of(
+  List<String> remoteRepositories = Lists.newArrayList(
       "https://repo1.maven.org/maven2/",
       "https://metamx.artifactoryonline.com/metamx/pub-libs-releases-local"
   );
@@ -156,6 +156,12 @@ public class PullDependencies implements Runnable
 
     createRootExtensionsDirectory(extensionsDir);
     createRootExtensionsDirectory(hadoopDependenciesDir);
+
+    log.info(
+        "Start pull-deps with local repository [%s] and remote repositories [%s]",
+        localRepository,
+        remoteRepositories
+    );
 
     try {
       log.info("Start downloading dependencies for extension coordinates: [%s]", coordinates);


### PR DESCRIPTION
airline command doesn't support directly setting a list with its option value, instead you have to provide multiple options in order to add value to the list. This PR changes --remoteRepositories to --remoteRepository so that it works in the same fashion as --coordinate option.