### PR TITLE
wikipediaQueryTest: use big timeouts in hopes of preventing spurious failures

### DIFF
--- a/integration-tests/src/test/resources/queries/wikipedia_editstream_queries.json
+++ b/integration-tests/src/test/resources/queries/wikipedia_editstream_queries.json
@@ -15,7 +15,7 @@
             "context": {
                 "useCache": "true",
                 "populateCache": "true",
-                "timeout": 60000
+                "timeout": 360000
             }
         },
         "expectedResults": [
@@ -78,7 +78,7 @@
             "context": {
                 "useCache": "true",
                 "populateCache": "true",
-                "timeout": 60000
+                "timeout": 360000
             }
         },
         "expectedResults": [
@@ -179,7 +179,7 @@
             "context": {
                 "useCache": "true",
                 "populateCache": "true",
-                "timeout": 60000
+                "timeout": 360000
             }
         },
         "expectedResults": [
@@ -266,7 +266,7 @@
             "context": {
                 "useCache": "true",
                 "populateCache": "true",
-                "timeout": 60000
+                "timeout": 360000
             }
         },
         "expectedResults": [
@@ -301,7 +301,7 @@
             "context": {
                 "useCache": "true",
                 "populateCache": "true",
-                "timeout": 60000
+                "timeout": 360000
             }
         },
         "expectedResults": [
@@ -488,7 +488,7 @@
             "context": {
                 "useCache": "true",
                 "populateCache": "true",
-                "timeout": 120000
+                "timeout": 360000
             }
         },
         "expectedResults": [
@@ -609,7 +609,7 @@
             "context": {
                 "useCache": "true",
                 "populateCache": "true",
-                "timeout": 120000
+                "timeout": 360000
             }
         },
         "expectedResults": [
@@ -699,7 +699,7 @@
             "context": {
                 "useCache": "true",
                 "populateCache": "true",
-                "timeout": 60000
+                "timeout": 360000
             }
         },
         "expectedResults": [
@@ -774,7 +774,7 @@
             "context": {
                 "useCache": "true",
                 "populateCache": "true",
-                "timeout": 60000
+                "timeout": 360000
             }
         },
         "expectedResults": [
@@ -838,7 +838,7 @@
             "context": {
                 "useCache": "true",
                 "populateCache": "true",
-                "timeout": 60000
+                "timeout": 360000
             }
         },
         "expectedResults": [
@@ -910,7 +910,7 @@
             "context": {
                 "useCache": "true",
                 "populateCache": "true",
-                "timeout": 60000
+                "timeout": 360000
             }
         },
         "expectedResults": [
@@ -988,7 +988,7 @@
             "context": {
                 "useCache": "true",
                 "populateCache": "true",
-                "timeout": 60000
+                "timeout": 360000
             }
         },
         "expectedResults": [
@@ -1014,7 +1014,7 @@
             "context": {
                 "useCache": "true",
                 "populateCache": "true",
-                "timeout": 60000
+                "timeout": 360000
             }
         },
         "expectedResults": [


### PR DESCRIPTION
I'm closing in on being able to run integration tests using dependencies on the community test jars - I have that working using local jars and will be able to use the ones from the maven repository when druid 0.9 is released.  The last thing is that the topN queries in ITWikipediaQueryTest still are sometimes timing out.  Since this is not a performance test, I want to make all of the timeouts really big.