### PR TITLE
Add docs and benchmark for JSON flattening parser

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -51,6 +51,16 @@
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.github.wnameless</groupId>
+      <artifactId>json-flattener</artifactId>
+      <version>0.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <properties>

--- a/benchmarks/src/main/java/io/druid/benchmark/FlattenJSONBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/FlattenJSONBenchmark.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.benchmark;
+
+import io.druid.data.input.InputRow;
+import io.druid.data.input.impl.StringInputRowParser;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+public class FlattenJSONBenchmark
+{
+  private static final int numEvents = 1000000;
+
+  List<String> flatInputs;
+  List<String> nestedInputs;
+  StringInputRowParser flatParser;
+  StringInputRowParser nestedParser;
+  int flatCounter = 0;
+  int nestedCounter = 0;
+
+  @Setup
+  public void prepare() throws Exception
+  {
+    FlattenJSONBenchmarkUtil gen = new FlattenJSONBenchmarkUtil();
+    flatInputs = new ArrayList<String>();
+    for (int i = 0; i < numEvents; i++) {
+      flatInputs.add(gen.generateFlatEvent());
+    }
+    nestedInputs = new ArrayList<String>();
+    for (int i = 0; i < numEvents; i++) {
+      nestedInputs.add(gen.generateNestedEvent());
+    }
+
+    flatParser = gen.getFlatParser();
+    nestedParser = gen.getNestedParser();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public InputRow baseline()
+  {
+    InputRow parsed = flatParser.parse(flatInputs.get(flatCounter));
+    flatCounter = (flatCounter + 1) % numEvents;
+    return parsed;
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public InputRow flatten()
+  {
+    InputRow parsed = nestedParser.parse(nestedInputs.get(nestedCounter));
+    nestedCounter = (nestedCounter + 1) % numEvents;
+    return parsed;
+  }
+
+}

--- a/benchmarks/src/main/java/io/druid/benchmark/FlattenJSONBenchmarkUtil.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/FlattenJSONBenchmarkUtil.java
@@ -1,0 +1,381 @@
+package io.druid.benchmark;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.wnameless.json.flattener.JsonFlattener;
+import com.google.common.collect.ImmutableList;
+import io.druid.data.input.impl.DimensionsSpec;
+import io.druid.data.input.impl.JSONParseSpec;
+import io.druid.data.input.impl.ParseFlattenSpec;
+import io.druid.data.input.impl.StringInputRowParser;
+import io.druid.data.input.impl.TimestampSpec;
+import io.druid.jackson.DefaultObjectMapper;
+
+import java.util.List;
+import java.util.Random;
+
+public class FlattenJSONBenchmarkUtil
+{
+  private Random rng;
+  private final ObjectMapper mapper = new DefaultObjectMapper();
+  private static final String DEFAULT_TIMESTAMP = "2015-09-12T12:10:53.155Z";
+
+  public FlattenJSONBenchmarkUtil()
+  {
+    this.rng = new Random(9999);
+    mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.PUBLIC_ONLY);
+    mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+  }
+
+  public StringInputRowParser getFlatParser()
+  {
+    return new StringInputRowParser(
+        new JSONParseSpec(
+            new TimestampSpec("ts", "iso", null),
+            new DimensionsSpec(null, null, null),
+            null
+        )
+    );
+  }
+
+  public StringInputRowParser getNestedParser()
+  {
+    List<String> metrics = ImmutableList.of(
+        "m3",
+        "m4",
+        "$e3.m1",
+        "$e3.m2",
+        "$e3.m3",
+        "$e3.m4",
+        "$e3.am1[0]",
+        "$e3.am1[1]",
+        "$e3.am1[2]",
+        "$e3.am1[3]",
+        "$e4.e4.m4"
+    );
+
+    ParseFlattenSpec flattenSpec = new ParseFlattenSpec(true, "$", metrics);
+    StringInputRowParser nestedParser = new StringInputRowParser(
+        new JSONParseSpec(
+            new TimestampSpec("ts", "iso", null),
+            new DimensionsSpec(
+                ImmutableList.of(
+                    "d1",
+                    "d2",
+                    "$e1.d1",
+                    "$e1.d2",
+                    "$e2.d3",
+                    "$e2.d4",
+                    "$e2.d5",
+                    "$e2.d6",
+                    "$e2.ad1[0]",
+                    "$e2.ad1[1]",
+                    "$e2.ad1[2]",
+                    "$ae1[0].d1",
+                    "$ae1[1].d1",
+                    "$ae1[2].e1.d2"
+                ), null, null
+            ),
+            flattenSpec
+        )
+    );
+    return nestedParser;
+  }
+
+
+  public String generateFlatEvent() throws Exception
+  {
+    String nestedEvent = generateNestedEvent();
+    String flatEvent = JsonFlattener.flatten(nestedEvent);
+    return flatEvent;
+  }
+
+  /*
+  e.g.,
+
+  {
+  "d1":"-889954295",
+  "d2":"-1724267856",
+  "m3":0.1429096312550323,
+  "m4":-7491190942271782800,
+  "e1":{"d1":"2044704643",
+        "d2":"743384585"},
+  "e2":{"d3":"1879234327",
+        "d4":"1248394579",
+        "d5":"-639742676",
+        "d6":"1334864967",
+        "ad1":["-684042233","-1368392605","1826364033"]},
+  "e3":{"m1":1026394465228315487,
+        "m2":0.27737174619459004,
+        "m3":0.011921350960908628,
+        "m4":-7507319256575520484,
+        "am1":[-2383262648875933574,-3980663171371801209,-8225906222712163481,6074309311406287835]},
+  "e4":{"e4":{"m4":32836881083689842}},
+  "ae1":[{"d1":"-1797792200"},{"d1":"142582995"},{"e1":{"d2":"-1341994709"}}],
+  "ts":"2015-09-12T12:10:53.155Z"
+  }
+  */
+  public String generateNestedEvent() throws Exception
+  {
+    BenchmarkEvent nestedDims1 = new BenchmarkEvent(
+        null,
+        String.valueOf(rng.nextInt()), String.valueOf(rng.nextInt()), null, null, null, null,
+        null, null, null, null,
+        null, null, null, null,
+        null, null, null
+    );
+
+    String[] dimsArray1 = {String.valueOf(rng.nextInt()), String.valueOf(rng.nextInt()), String.valueOf(rng.nextInt())};
+    BenchmarkEvent nestedDims2 = new BenchmarkEvent(
+        null,
+        null, null, String.valueOf(rng.nextInt()), String.valueOf(rng.nextInt()), String.valueOf(rng.nextInt()), String.valueOf(rng.nextInt()),
+        null, null, null, null,
+        null, null, null, null,
+        dimsArray1, null, null
+    );
+
+    Long[] metricsArray1 = {rng.nextLong(), rng.nextLong(), rng.nextLong(), rng.nextLong()};
+    BenchmarkEvent nestedMetrics1 = new BenchmarkEvent(
+        null,
+        null, null, null, null, null, null,
+        rng.nextLong(), rng.nextDouble(), rng.nextDouble(), rng.nextLong(),
+        null, null, null, null,
+        null, metricsArray1, null
+    );
+
+    BenchmarkEvent nestedMetrics2 = new BenchmarkEvent(
+        null,
+        null, null, null, null, null, null,
+        null, null, null, rng.nextLong(),
+        null, null, null, null,
+        null, null, null
+    );
+
+    BenchmarkEvent metricsWrapper = new BenchmarkEvent(
+        null,
+        null, null, null, null, null, null,
+        null, null, null, null,
+        null, null, null, nestedMetrics2,
+        null, null, null
+    );
+
+    //nest some dimensions in an array!
+    BenchmarkEvent arrayNestedDim1 = new BenchmarkEvent(
+        null,
+        String.valueOf(rng.nextInt()), null, null, null, null, null,
+        null, null, null, null,
+        null, null, null, null,
+        null, null, null
+    );
+    BenchmarkEvent arrayNestedDim2 = new BenchmarkEvent(
+        null,
+        String.valueOf(rng.nextInt()), null, null, null, null, null,
+        null, null, null, null,
+        null, null, null, null,
+        null, null, null
+    );
+    BenchmarkEvent arrayNestedDim3 = new BenchmarkEvent(
+        null,
+        null, String.valueOf(rng.nextInt()), null, null, null, null,
+        null, null, null, null,
+        null, null, null, null,
+        null, null, null
+    );
+    BenchmarkEvent arrayNestedWrapper = new BenchmarkEvent(
+        null,
+        null, null, null, null, null, null,
+        null, null, null, null,
+        arrayNestedDim3, null, null, null,
+        null, null, null
+    );
+    BenchmarkEvent[] eventArray = {arrayNestedDim1, arrayNestedDim2, arrayNestedWrapper};
+
+    BenchmarkEvent wrapper = new BenchmarkEvent(
+        DEFAULT_TIMESTAMP,
+        String.valueOf(rng.nextInt()), String.valueOf(rng.nextInt()), null, null, null, null,
+        null, null, rng.nextDouble(), rng.nextLong(),
+        nestedDims1, nestedDims2, nestedMetrics1, metricsWrapper,
+        null, null, eventArray
+    );
+
+    return mapper.writeValueAsString(wrapper);
+  }
+
+  public class BenchmarkEvent
+  {
+
+    public String ts;
+
+    @JsonProperty
+    public String getTs()
+    {
+      return ts;
+    }
+
+    @JsonProperty
+    public String getD1()
+    {
+      return d1;
+    }
+
+    @JsonProperty
+    public String getD2()
+    {
+      return d2;
+    }
+
+    @JsonProperty
+    public String getD3()
+    {
+      return d3;
+    }
+
+    @JsonProperty
+    public String getD4()
+    {
+      return d4;
+    }
+
+    @JsonProperty
+    public String getD5()
+    {
+      return d5;
+    }
+
+    @JsonProperty
+    public String getD6()
+    {
+      return d6;
+    }
+
+    @JsonProperty
+    public Long getM1()
+    {
+      return m1;
+    }
+
+    @JsonProperty
+    public Double getM2()
+    {
+      return m2;
+    }
+
+    @JsonProperty
+    public Double getM3()
+    {
+      return m3;
+    }
+
+    @JsonProperty
+    public Long getM4()
+    {
+      return m4;
+    }
+
+    @JsonProperty
+    public BenchmarkEvent getE1()
+    {
+      return e1;
+    }
+
+    @JsonProperty
+    public BenchmarkEvent getE2()
+    {
+      return e2;
+    }
+
+    @JsonProperty
+    public BenchmarkEvent getE3()
+    {
+      return e3;
+    }
+
+    @JsonProperty
+    public BenchmarkEvent getE4()
+    {
+      return e4;
+    }
+
+    @JsonProperty
+    public String[] getAd1()
+    {
+      return ad1;
+    }
+
+    @JsonProperty
+    public Long[] getAm1()
+    {
+      return am1;
+    }
+
+    @JsonProperty
+    public BenchmarkEvent[] getAe1()
+    {
+      return ae1;
+    }
+
+    public String d1;
+    public String d2;
+    public String d3;
+    public String d4;
+    public String d5;
+    public String d6;
+    public Long m1;
+    public Double m2;
+    public Double m3;
+    public Long m4;
+    public BenchmarkEvent e1;
+    public BenchmarkEvent e2;
+    public BenchmarkEvent e3;
+    public BenchmarkEvent e4;
+    public String[] ad1;
+    public Long[] am1;
+    public BenchmarkEvent[] ae1;
+
+    @JsonCreator
+    public BenchmarkEvent(
+        @JsonProperty("ts") String ts,
+        @JsonProperty("d1") String d1,
+        @JsonProperty("d2") String d2,
+        @JsonProperty("d3") String d3,
+        @JsonProperty("d4") String d4,
+        @JsonProperty("d5") String d5,
+        @JsonProperty("d6") String d6,
+        @JsonProperty("m1") Long m1,
+        @JsonProperty("m2") Double m2,
+        @JsonProperty("m3") Double m3,
+        @JsonProperty("m4") Long m4,
+        @JsonProperty("e1") BenchmarkEvent e1,
+        @JsonProperty("e2") BenchmarkEvent e2,
+        @JsonProperty("e3") BenchmarkEvent e3,
+        @JsonProperty("e4") BenchmarkEvent e4,
+        @JsonProperty("ad1") String[] ad1,
+        @JsonProperty("am1") Long[] am1,
+        @JsonProperty("ae1") BenchmarkEvent[] ae1
+    )
+    {
+      this.ts = ts;
+      this.d1 = d1;
+      this.d2 = d2;
+      this.d3 = d3;
+      this.d4 = d4;
+      this.d5 = d5;
+      this.d6 = d6;
+      this.m1 = m1;
+      this.m2 = m2;
+      this.m3 = m3;
+      this.m4 = m4;
+      this.e1 = e1;
+      this.e2 = e2;
+      this.e3 = e3;
+      this.e4 = e4;
+      this.ad1 = ad1;
+      this.am1 = am1;
+      this.ae1 = ae1;
+    }
+  }
+}

--- a/benchmarks/src/main/test/io/druid/benchmark/FlattenJSONBenchmarkUtilTest.java
+++ b/benchmarks/src/main/test/io/druid/benchmark/FlattenJSONBenchmarkUtilTest.java
@@ -1,0 +1,93 @@
+package io.druid.benchmark;
+
+import io.druid.data.input.InputRow;
+import io.druid.data.input.MapBasedRow;
+import io.druid.data.input.impl.StringInputRowParser;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class FlattenJSONBenchmarkUtilTest
+{
+  @Test
+  public void testOne() throws Exception {
+    FlattenJSONBenchmarkUtil eventGen = new FlattenJSONBenchmarkUtil();
+
+    String newEvent = eventGen.generateFlatEvent();
+    String newEvent2 = eventGen.generateNestedEvent();
+
+    StringInputRowParser flatParser = eventGen.getFlatParser();
+    StringInputRowParser nestedParser = eventGen.getNestedParser();
+
+    InputRow parsed = flatParser.parse(newEvent);
+    InputRow parsed2 = nestedParser.parse(newEvent2);
+
+    Map<String, Object> event = ((MapBasedRow) parsed).getEvent();
+    Map<String, Object> event2 = ((MapBasedRow) parsed2).getEvent();
+
+    /*
+    for (String key : event.keySet()) {
+      System.out.println("Assert.assertEquals(\"" + event.get(key).toString() + "\", event.get(\"" + key + "\").toString());");
+    }
+    */
+    Assert.assertEquals("2015-09-12T12:10:53.155Z", event.get("ts").toString());
+    Assert.assertEquals("-1170723877", event.get("d1").toString());
+    Assert.assertEquals("238976084", event.get("d2").toString());
+    Assert.assertEquals("0.9818780016507468", event.get("m3").toString());
+    Assert.assertEquals("-3.8218837693501747E18", event.get("m4").toString());
+    Assert.assertEquals("-509091100", event.get("e1.d1").toString());
+    Assert.assertEquals("274706327", event.get("e1.d2").toString());
+    Assert.assertEquals("870378185", event.get("e2.d3").toString());
+    Assert.assertEquals("-377775321", event.get("e2.d4").toString());
+    Assert.assertEquals("-1797988763", event.get("e2.d5").toString());
+    Assert.assertEquals("1309474524", event.get("e2.d6").toString());
+    Assert.assertEquals("129047958", event.get("e2.ad1[0]").toString());
+    Assert.assertEquals("1658972185", event.get("e2.ad1[1]").toString());
+    Assert.assertEquals("-997010830", event.get("e2.ad1[2]").toString());
+    Assert.assertEquals("-5.8772014847368817E18", event.get("e3.m1").toString());
+    Assert.assertEquals("0.4375433369079904", event.get("e3.m2").toString());
+    Assert.assertEquals("0.8510482953607659", event.get("e3.m3").toString());
+    Assert.assertEquals("-2.3832626488759337E18", event.get("e3.m4").toString());
+    Assert.assertEquals("7.9789762132607068E18", event.get("e3.am1[0]").toString());
+    Assert.assertEquals("-7.8634787235005573E18", event.get("e3.am1[1]").toString());
+    Assert.assertEquals("8.7372945568982446E18", event.get("e3.am1[2]").toString());
+    Assert.assertEquals("3.1928124802414899E18", event.get("e3.am1[3]").toString());
+    Assert.assertEquals("-3.9806631713718011E18", event.get("e4.e4.m4").toString());
+    Assert.assertEquals("-1915243040", event.get("ae1[0].d1").toString());
+    Assert.assertEquals("-2020543641", event.get("ae1[1].d1").toString());
+    Assert.assertEquals("1414285347", event.get("ae1[2].e1.d2").toString());
+
+    /*
+    for (String key : event2.keySet()) {
+      System.out.println("Assert.assertEquals(\"" + event2.get(key).toString() + "\", event2.get(\"" + key + "\").toString());");
+    }
+    */
+    Assert.assertEquals("728062074", event2.get("$ae1[0].d1").toString());
+    Assert.assertEquals("1701675101", event2.get("$ae1[1].d1").toString());
+    Assert.assertEquals("1887775139", event2.get("$ae1[2].e1.d2").toString());
+    Assert.assertEquals("1375814994", event2.get("$e1.d1").toString());
+    Assert.assertEquals("-1747933975", event2.get("$e1.d2").toString());
+    Assert.assertEquals("1616761116", event2.get("$e2.ad1[0]").toString());
+    Assert.assertEquals("7645432", event2.get("$e2.ad1[1]").toString());
+    Assert.assertEquals("679897970", event2.get("$e2.ad1[2]").toString());
+    Assert.assertEquals("-1797792200", event2.get("$e2.d3").toString());
+    Assert.assertEquals("142582995", event2.get("$e2.d4").toString());
+    Assert.assertEquals("-1341994709", event2.get("$e2.d5").toString());
+    Assert.assertEquals("-889954295", event2.get("$e2.d6").toString());
+    Assert.assertEquals("678995794", event2.get("d1").toString());
+    Assert.assertEquals("-1744549866", event2.get("d2").toString());
+    Assert.assertEquals("2015-09-12T12:10:53.155Z", event2.get("ts").toString());
+    Assert.assertEquals("0.7279915615037622", event2.get("m3").toString());
+    Assert.assertEquals("977083178034247050", event2.get("m4").toString());
+    Assert.assertEquals("1940993614184952155", event2.get("$e3.m1").toString());
+    Assert.assertEquals("0.55936084127688", event2.get("$e3.m2").toString());
+    Assert.assertEquals("0.22821798320943232", event2.get("$e3.m3").toString());
+    Assert.assertEquals("8176144126231114468", event2.get("$e3.m4").toString());
+    Assert.assertEquals("-7405674050450245158", event2.get("$e3.am1[0]").toString());
+    Assert.assertEquals("150970357863018887", event2.get("$e3.am1[1]").toString());
+    Assert.assertEquals("3261802881806411610", event2.get("$e3.am1[2]").toString());
+    Assert.assertEquals("8492292414932401114", event2.get("$e3.am1[3]").toString());
+    Assert.assertEquals("-1192952196729165097", event2.get("$e4.e4.m4").toString());
+  }
+}


### PR DESCRIPTION
Docs and JMH-based benchmark code for druid-api pull request:
https://github.com/druid-io/druid-api/pull/64

Benchmark results from my development laptop:

1000 iterations:
java -jar target/benchmarks.jar FlattenJSONBenchmark -wi 1 -i 1000 -f 1 -v EXTRA
=====================
Result "baseline":
  25.255 ±(99.9%) 0.579 us/op [Average]
  (min, avg, max) = (17.255, 25.255, 66.038), stdev = 5.552
  CI (99.9%): [24.676, 25.835] (assumes normal distribution)

Result "flatten":
  30.952 ±(99.9%) 0.479 us/op [Average]
  (min, avg, max) = (23.905, 30.952, 92.745), stdev = 4.594
  CI (99.9%): [30.473, 31.432] (assumes normal distribution)

# Run complete. Total time: 00:37:07

Benchmark                      Mode   Cnt   Score   Error  Units
FlattenJSONBenchmark.baseline  avgt  1000  25.255 ± 0.579  us/op
FlattenJSONBenchmark.flatten   avgt  1000  30.952 ± 0.479  us/op

————————————————
500 iterations
java -jar target/benchmarks.jar FlattenJSONBenchmark -wi 1 -i 500 -f 1 -v EXTRA

Result "baseline":
  20.296 ±(99.9%) 0.316 us/op [Average]
  (min, avg, max) = (17.375, 20.296, 39.709), stdev = 2.136
  CI (99.9%): [19.980, 20.612] (assumes normal distribution)

Result "flatten":
  30.609 ±(99.9%) 0.842 us/op [Average]
  (min, avg, max) = (23.753, 30.609, 102.414), stdev = 5.688
  CI (99.9%): [29.767, 31.451] (assumes normal distribution)

# Run complete. Total time: 00:18:57

Benchmark                      Mode  Cnt   Score   Error  Units
FlattenJSONBenchmark.baseline  avgt  500  20.296 ± 0.316  us/op
FlattenJSONBenchmark.flatten   avgt  500  30.609 ± 0.842  us/op

————————————————
Another run of 500 iterations

Result "baseline":
  20.614 ±(99.9%) 0.272 us/op [Average]
  (min, avg, max) = (17.422, 20.614, 36.896), stdev = 1.836
  CI (99.9%): [20.342, 20.886] (assumes normal distribution)

Result "flatten":
  28.907 ±(99.9%) 1.017 us/op [Average]
  (min, avg, max) = (25.470, 28.907, 173.991), stdev = 6.868
  CI (99.9%): [27.890, 29.924] (assumes normal distribution)

# Run complete. Total time: 00:18:53

Benchmark                      Mode  Cnt   Score   Error  Units
FlattenJSONBenchmark.baseline  avgt  500  20.614 ± 0.272  us/op
FlattenJSONBenchmark.flatten   avgt  500  28.907 ± 1.017  us/op

