### PR TITLE
RemoteTaskActionClient: Fix statusCode check.

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/common/actions/RemoteTaskActionClient.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/actions/RemoteTaskActionClient.java
@@ -108,7 +108,7 @@ public class RemoteTaskActionClient implements TaskActionClient
           throw Throwables.propagate(e);
         }
 
-        if (response.getStatus().getCode() / 200 == 1) {
+        if (response.getStatus().getCode() / 100 == 2) {
           final Map<String, Object> responseDict = jsonMapper.readValue(
               response.getContent(),
               new TypeReference<Map<String, Object>>()


### PR DESCRIPTION
It was supposed to be checking for 2xxs. It was a little too generous and accepted 3xxs as well.