### PR TITLE
Change DefaultObjectMapper to NOT overwrite final fields unless explicitly asked to

### DIFF
--- a/extensions/rabbitmq/src/main/java/io/druid/firehose/rabbitmq/RabbitMQFirehoseFactory.java
+++ b/extensions/rabbitmq/src/main/java/io/druid/firehose/rabbitmq/RabbitMQFirehoseFactory.java
@@ -107,11 +107,13 @@ public class RabbitMQFirehoseFactory implements FirehoseFactory<StringInputRowPa
   @JsonCreator
   public RabbitMQFirehoseFactory(
       @JsonProperty("connection") JacksonifiedConnectionFactory connectionFactory,
-      @JsonProperty("config") RabbitMQFirehoseConfig config
+      @JsonProperty("config") RabbitMQFirehoseConfig config,
+      // See https://github.com/druid-io/druid/pull/1922
+      @JsonProperty("connectionFactory") JacksonifiedConnectionFactory connectionFactoryCOMPAT
   ) throws Exception
   {
     this.connectionFactory = connectionFactory == null
-                             ? JacksonifiedConnectionFactory.makeDefaultConnectionFactory()
+                             ? connectionFactoryCOMPAT == null ? JacksonifiedConnectionFactory.makeDefaultConnectionFactory() : connectionFactoryCOMPAT
                              : connectionFactory;
     this.config = config == null ? RabbitMQFirehoseConfig.makeDefaultConfig() : config;
 

--- a/extensions/rabbitmq/src/main/java/io/druid/firehose/rabbitmq/RabbitMQFirehoseFactory.java
+++ b/extensions/rabbitmq/src/main/java/io/druid/firehose/rabbitmq/RabbitMQFirehoseFactory.java
@@ -123,7 +123,7 @@ public class RabbitMQFirehoseFactory implements FirehoseFactory<StringInputRowPa
     return config;
   }
 
-  @JsonProperty
+  @JsonProperty("connection")
   public JacksonifiedConnectionFactory getConnectionFactory()
   {
     return connectionFactory;

--- a/extensions/rabbitmq/src/test/java/io/druid/examples/rabbitmq/RabbitMQFirehoseFactoryTest.java
+++ b/extensions/rabbitmq/src/test/java/io/druid/examples/rabbitmq/RabbitMQFirehoseFactoryTest.java
@@ -64,7 +64,8 @@ public class RabbitMQFirehoseFactoryTest
 
     RabbitMQFirehoseFactory factory = new RabbitMQFirehoseFactory(
         connectionFactory,
-        config
+        config,
+        null
     );
 
     byte[] bytes = mapper.writeValueAsBytes(factory);
@@ -86,7 +87,8 @@ public class RabbitMQFirehoseFactoryTest
 
     RabbitMQFirehoseFactory factory = new RabbitMQFirehoseFactory(
         connectionFactory,
-        config
+        config,
+        null
     );
 
     byte[] bytes = mapper.writeValueAsBytes(factory);

--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopTuningConfig.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopTuningConfig.java
@@ -56,7 +56,8 @@ public class HadoopTuningConfig implements TuningConfig
         false,
         null,
         false,
-        false
+        false,
+        null
     );
   }
 
@@ -88,7 +89,9 @@ public class HadoopTuningConfig implements TuningConfig
       final @JsonProperty("ignoreInvalidRows") boolean ignoreInvalidRows,
       final @JsonProperty("jobProperties") Map<String, String> jobProperties,
       final @JsonProperty("combineText") boolean combineText,
-      final @JsonProperty("useCombiner") Boolean useCombiner
+      final @JsonProperty("useCombiner") Boolean useCombiner,
+      // See https://github.com/druid-io/druid/pull/1922
+      final @JsonProperty("rowFlushBoundary") Integer maxRowsInMemoryCOMPAT
   )
   {
     this.workingPath = workingPath;
@@ -96,7 +99,7 @@ public class HadoopTuningConfig implements TuningConfig
     this.partitionsSpec = partitionsSpec == null ? DEFAULT_PARTITIONS_SPEC : partitionsSpec;
     this.shardSpecs = shardSpecs == null ? DEFAULT_SHARD_SPECS : shardSpecs;
     this.indexSpec = indexSpec == null ? DEFAULT_INDEX_SPEC : indexSpec;
-    this.rowFlushBoundary = maxRowsInMemory == null ? DEFAULT_ROW_FLUSH_BOUNDARY : maxRowsInMemory;
+    this.rowFlushBoundary = maxRowsInMemory == null ? maxRowsInMemoryCOMPAT == null ?  DEFAULT_ROW_FLUSH_BOUNDARY : maxRowsInMemoryCOMPAT : maxRowsInMemory;
     this.leaveIntermediate = leaveIntermediate;
     this.cleanupOnFailure = cleanupOnFailure == null ? true : cleanupOnFailure;
     this.overwriteFiles = overwriteFiles;
@@ -201,7 +204,8 @@ public class HadoopTuningConfig implements TuningConfig
         ignoreInvalidRows,
         jobProperties,
         combineText,
-        useCombiner
+        useCombiner,
+        null
     );
   }
 
@@ -220,7 +224,8 @@ public class HadoopTuningConfig implements TuningConfig
         ignoreInvalidRows,
         jobProperties,
         combineText,
-        useCombiner
+        useCombiner,
+        null
     );
   }
 
@@ -239,7 +244,8 @@ public class HadoopTuningConfig implements TuningConfig
         ignoreInvalidRows,
         jobProperties,
         combineText,
-        useCombiner
+        useCombiner,
+        null
     );
   }
 }

--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopTuningConfig.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopTuningConfig.java
@@ -138,7 +138,7 @@ public class HadoopTuningConfig implements TuningConfig
     return indexSpec;
   }
 
-  @JsonProperty
+  @JsonProperty("maxRowsInMemory")
   public int getRowFlushBoundary()
   {
     return rowFlushBoundary;

--- a/indexing-hadoop/src/test/java/io/druid/indexer/BatchDeltaIngestionTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/BatchDeltaIngestionTest.java
@@ -380,7 +380,8 @@ public class BatchDeltaIngestionTest
                 false,
                 null,
                 false,
-                false
+                false,
+                null
             )
         )
     );

--- a/indexing-hadoop/src/test/java/io/druid/indexer/DetermineHashedPartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/DetermineHashedPartitionsJobTest.java
@@ -160,7 +160,8 @@ public class DetermineHashedPartitionsJobTest
             false,
             null,
             false,
-            false
+            false,
+            null
         )
     );
     this.indexerConfig = new HadoopDruidIndexerConfig(ingestionSpec);

--- a/indexing-hadoop/src/test/java/io/druid/indexer/DeterminePartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/DeterminePartitionsJobTest.java
@@ -263,7 +263,8 @@ public class DeterminePartitionsJobTest
                 false,
                 null,
                 false,
-                false
+                false,
+                null
             )
         )
     );

--- a/indexing-hadoop/src/test/java/io/druid/indexer/HadoopDruidIndexerConfigTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/HadoopDruidIndexerConfigTest.java
@@ -204,7 +204,8 @@ public class HadoopDruidIndexerConfigTest
             false,
             null,
             false,
-            false
+            false,
+            null
         )
     );
     HadoopDruidIndexerConfig config = HadoopDruidIndexerConfig.fromSpec(spec);

--- a/indexing-hadoop/src/test/java/io/druid/indexer/HadoopTuningConfigTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/HadoopTuningConfigTest.java
@@ -52,7 +52,8 @@ public class HadoopTuningConfigTest
         true,
         null,
         true,
-        true
+        true,
+        null
     );
 
     HadoopTuningConfig actual = jsonReadWriteRead(jsonMapper.writeValueAsString(expected), HadoopTuningConfig.class);

--- a/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobTest.java
@@ -394,7 +394,8 @@ public class IndexGeneratorJobTest
                 false,
                 ImmutableMap.of(JobContext.NUM_REDUCES, "0"), //verifies that set num reducers is ignored
                 false,
-                useCombiner
+                useCombiner,
+                null
             )
         )
     );

--- a/indexing-hadoop/src/test/java/io/druid/indexer/JobHelperTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/JobHelperTest.java
@@ -112,7 +112,8 @@ public class JobHelperTest
                     "THISISMYACCESSKEY"
                 ),
                 false,
-                false
+                false,
+                null
             )
         )
     );

--- a/indexing-hadoop/src/test/java/io/druid/indexer/updater/HadoopConverterJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/updater/HadoopConverterJobTest.java
@@ -200,7 +200,8 @@ public class HadoopConverterJobTest
                 false,
                 null,
                 false,
-                false
+                false,
+                null
             )
         )
     );

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/MoveTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/MoveTask.java
@@ -106,7 +106,7 @@ public class MoveTask extends AbstractFixedIntervalTask
     return TaskStatus.success(getId());
   }
 
-  @JsonProperty
+  @JsonProperty("target")
   public Map<String, Object> getTargetLoadSpec()
   {
     return targetLoadSpec;

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/MoveTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/MoveTask.java
@@ -46,7 +46,9 @@ public class MoveTask extends AbstractFixedIntervalTask
       @JsonProperty("dataSource") String dataSource,
       @JsonProperty("interval") Interval interval,
       @JsonProperty("target") Map<String, Object> targetLoadSpec,
-      @JsonProperty("context") Map<String, Object> context
+      @JsonProperty("context") Map<String, Object> context,
+      // See https://github.com/druid-io/druid/pull/1922
+      @JsonProperty("targetLoadSpec") Map<String, Object> targetLoadSpecCOMPAT
   )
   {
     super(
@@ -55,7 +57,7 @@ public class MoveTask extends AbstractFixedIntervalTask
         interval,
         context
     );
-    this.targetLoadSpec = targetLoadSpec;
+    this.targetLoadSpec = targetLoadSpec == null ? targetLoadSpecCOMPAT : targetLoadSpec;
   }
 
   @Override

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
@@ -501,6 +501,7 @@ public class TaskSerdeTest
         "foo",
         new Interval("2010-01-01/P1D"),
         ImmutableMap.<String, Object>of("bucket", "hey", "baseKey", "what"),
+        null,
         null
     );
 

--- a/processing/src/main/java/io/druid/jackson/DefaultObjectMapper.java
+++ b/processing/src/main/java/io/druid/jackson/DefaultObjectMapper.java
@@ -53,6 +53,7 @@ public class DefaultObjectMapper extends ObjectMapper
     configure(MapperFeature.AUTO_DETECT_FIELDS, false);
     configure(MapperFeature.AUTO_DETECT_IS_GETTERS, false);
     configure(MapperFeature.AUTO_DETECT_SETTERS, false);
+    configure(MapperFeature.ALLOW_FINAL_FIELDS_AS_MUTATORS, false);
     configure(SerializationFeature.INDENT_OUTPUT, false);
   }
 


### PR DESCRIPTION
https://groups.google.com/d/msg/jackson-user/1EFZzvhu_j0/NnDNahOZFAAJ

Turns out Jackson will very happily auto-detect final fields and overwrite them. This was causing a few bugs in how things were named to go unnoticed.

This is labeled as Discuss because it breaks backwards compatibility, and is intended to show a few locations where naming errors exist. If it is deemed we should fix this behavior I can add backwards compatibility. 

If accepted there is a risk that some POJOs which do not have proper serde tests may break.

Another option is to leave the behavior as is, and simply have it generally be known that this behavior exists in Jackson.