### PR TITLE
remove LoggingProgressIndicator from IndexGeneratorJob

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
@@ -35,7 +35,7 @@ import io.druid.data.input.Row;
 import io.druid.data.input.Rows;
 import io.druid.indexer.hadoop.SegmentInputRow;
 import io.druid.query.aggregation.AggregatorFactory;
-import io.druid.segment.LoggingProgressIndicator;
+import io.druid.segment.BaseProgressIndicator;
 import io.druid.segment.ProgressIndicator;
 import io.druid.segment.QueryableIndex;
 import io.druid.segment.incremental.IncrementalIndex;
@@ -446,7 +446,7 @@ public class IndexGeneratorJob implements Jobby
 
     protected ProgressIndicator makeProgressIndicator(final Context context)
     {
-      return new LoggingProgressIndicator("IndexGeneratorJob")
+      return new BaseProgressIndicator()
       {
         @Override
         public void progress()


### PR DESCRIPTION
currently hadoop indexing is failing with following error because IndexGeneratorJob is using LoggingProgressIndicator which uses newer apis from Stopwatch in guava library not available on hadoop. This PR reverts the behavior to be same as it used to be in LegacyIndexGeneratorJob which was removed in #1895 

```
2015-11-05 22:38:55,960 ERROR [main] org.apache.hadoop.mapred.YarnChild: Error running child : java.lang.NoSuchMethodError: com.google.common.base.Stopwatch.createUnstarted()Lcom/google/common/base/Stopwatch;
	at io.druid.segment.LoggingProgressIndicator.<init>(LoggingProgressIndicator.java:42)
	at io.druid.indexer.IndexGeneratorJob$IndexGeneratorReducer$1.<init>(IndexGeneratorJob.java:450)
	at io.druid.indexer.IndexGeneratorJob$IndexGeneratorReducer.makeProgressIndicator(IndexGeneratorJob.java:449)
	at io.druid.indexer.IndexGeneratorJob$IndexGeneratorReducer.reduce(IndexGeneratorJob.java:524)
	at io.druid.indexer.IndexGeneratorJob$IndexGeneratorReducer.reduce(IndexGeneratorJob.java:440)
	at org.apache.hadoop.mapreduce.Reducer.run(Reducer.java:171)
	at org.apache.hadoop.mapred.ReduceTask.runNewReducer(ReduceTask.java:627)
	at org.apache.hadoop.mapred.ReduceTask.run(ReduceTask.java:389)
	at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:163)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:422)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1694)
	at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:158)
```