### PR TITLE
separate ingestion and query thread pool

### DIFF
--- a/docs/content/configuration/indexing-service.md
+++ b/docs/content/configuration/indexing-service.md
@@ -251,6 +251,7 @@ Middle managers pass their configurations down to their child peons. The middle 
 |`druid.indexer.runner.javaOpts`|-X Java options to run the peon in its own JVM.|""|
 |`druid.indexer.runner.maxZnodeBytes`|The maximum size Znode in bytes that can be created in Zookeeper.|524288|
 |`druid.indexer.runner.startPort`|The port that peons begin running on.|8100|
+|`druid.indexer.runner.separateIngestionEndpoint`|Use separate server and consequently separate jetty thread pool for ingesting events|false|
 |`druid.worker.ip`|The IP of the worker.|localhost|
 |`druid.worker.version`|Version identifier for the middle manager.|0|
 |`druid.worker.capacity`|Maximum number of tasks the middle manager can accept.|Number of available processors - 1|
@@ -272,6 +273,13 @@ Additional peon configs include:
 |`druid.indexer.task.hadoopWorkingPath`|Temporary working directory for Hadoop tasks.|/tmp/druid-indexing|
 |`druid.indexer.task.defaultRowFlushBoundary`|Highest row count before persisting to disk. Used for indexing generating tasks.|50000|
 |`druid.indexer.task.defaultHadoopCoordinates`|Hadoop version to use with HadoopIndexTasks that do not request a particular version.|org.apache.hadoop:hadoop-client:2.3.0|
+
+If `druid.indexer.runner.separateIngestionEndpoint` is set to true then following configurations are available for the ingestion server at peon:
+
+|Property|Description|Default|
+|--------|-----------|-------|
+|`druid.indexer.server.chathandler.http.numThreads`|Number of threads for HTTP requests.|Math.max(10, (Number of available processors * 17) / 16 + 2) + 30|
+|`druid.indexer.server.chathandler.http.maxIdleTime`|The Jetty max idle time for a connection.|PT5m|
 
 If the peon is running in remote mode, there must be an overlord up and running. Peons in remote mode can set the following configurations:
 

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/PortFinder.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/PortFinder.java
@@ -19,6 +19,7 @@ package io.druid.indexing.overlord;
 
 import com.google.common.collect.Sets;
 import com.metamx.common.ISE;
+import com.metamx.common.Pair;
 
 import java.io.IOException;
 import java.net.BindException;
@@ -72,6 +73,17 @@ public class PortFinder
     }
     usedPorts.add(port);
     return port;
+  }
+
+  public synchronized Pair<Integer, Integer> findTwoConsecutiveUnusedPorts()
+  {
+    int firstPort = chooseNext(startPort);
+    while (!canBind(firstPort) || !canBind(firstPort + 1)) {
+      firstPort = chooseNext(firstPort + 1);
+    }
+    usedPorts.add(firstPort);
+    usedPorts.add(firstPort + 1);
+    return new Pair<>(firstPort, firstPort + 1);
   }
 
   public synchronized void markPortUnused(int port)

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/config/ForkingTaskRunnerConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/config/ForkingTaskRunnerConfig.java
@@ -65,6 +65,13 @@ public class ForkingTaskRunnerConfig
       "hadoop"
   );
 
+  @JsonProperty
+  private boolean separateIngestionEndpoint = false;
+
+  public boolean isSeparateIngestionEndpoint() {
+    return separateIngestionEndpoint;
+  }
+
   public String getJavaCommand()
   {
     return javaCommand;

--- a/server/src/main/java/io/druid/guice/annotations/RemoteChatHandler.java
+++ b/server/src/main/java/io/druid/guice/annotations/RemoteChatHandler.java
@@ -1,0 +1,34 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.guice.annotations;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@BindingAnnotation
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RemoteChatHandler
+{
+}

--- a/server/src/main/java/io/druid/segment/realtime/firehose/ServiceAnnouncingChatHandlerProvider.java
+++ b/server/src/main/java/io/druid/segment/realtime/firehose/ServiceAnnouncingChatHandlerProvider.java
@@ -23,8 +23,8 @@ import com.google.inject.Inject;
 import com.metamx.common.ISE;
 import com.metamx.common.logger.Logger;
 import io.druid.curator.discovery.ServiceAnnouncer;
-import io.druid.guice.annotations.Self;
 import io.druid.server.DruidNode;
+import io.druid.guice.annotations.RemoteChatHandler;
 
 import java.util.concurrent.ConcurrentMap;
 
@@ -43,7 +43,7 @@ public class ServiceAnnouncingChatHandlerProvider implements ChatHandlerProvider
 
   @Inject
   public ServiceAnnouncingChatHandlerProvider(
-      @Self DruidNode node,
+      @RemoteChatHandler DruidNode node,
       ServiceAnnouncer serviceAnnouncer
   )
   {

--- a/server/src/main/java/io/druid/server/initialization/jetty/ChatHandlerServerModule.java
+++ b/server/src/main/java/io/druid/server/initialization/jetty/ChatHandlerServerModule.java
@@ -1,0 +1,78 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.server.initialization.jetty;
+
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.metamx.common.lifecycle.Lifecycle;
+import com.metamx.common.logger.Logger;
+import io.druid.guice.JsonConfigProvider;
+import io.druid.guice.LazySingleton;
+import io.druid.guice.LifecycleModule;
+import io.druid.guice.annotations.RemoteChatHandler;
+import io.druid.guice.annotations.Self;
+import io.druid.server.DruidNode;
+import io.druid.server.initialization.ServerConfig;
+import org.eclipse.jetty.server.Server;
+
+import java.util.Properties;
+
+/**
+ */
+public class ChatHandlerServerModule implements Module
+{
+  private static final Logger log = new Logger(ChatHandlerServerModule.class);
+
+  @Inject
+  private Properties properties;
+
+  @Override
+  public void configure(Binder binder)
+  {
+    /** If "druid.indexer.task.chathandler.port" property is set then we assume that a
+     * separate Jetty Server with it's own {@link ServerConfig} is required for ingestion apart from the query server
+     * otherwise we bind {@link DruidNode} annotated with {@link RemoteChatHandler} to {@literal @}{@link Self} {@link DruidNode}
+     * so that same Jetty Server is used for querying as well as ingestion
+     */
+    if (properties.containsKey("druid.indexer.task.chathandler.port")) {
+      log.info("Spawning separate ingestion server at port [%s]", properties.get("druid.indexer.task.chathandler.port"));
+      JsonConfigProvider.bind(binder, "druid.indexer.task.chathandler", DruidNode.class, RemoteChatHandler.class);
+      JsonConfigProvider.bind(binder, "druid.indexer.server.chathandler.http", ServerConfig.class, RemoteChatHandler.class);
+      LifecycleModule.register(binder, Server.class, RemoteChatHandler.class);
+    } else {
+      binder.bind(DruidNode.class).annotatedWith(RemoteChatHandler.class).to(Key.get(DruidNode.class, Self.class));
+      binder.bind(ServerConfig.class).annotatedWith(RemoteChatHandler.class).to(Key.get(ServerConfig.class));
+    }
+  }
+
+  @Provides
+  @LazySingleton
+  @RemoteChatHandler
+  public Server getServer(Injector injector, Lifecycle lifecycle, @RemoteChatHandler DruidNode node, @RemoteChatHandler ServerConfig config)
+  {
+    final Server server = JettyServerModule.makeJettyServer(node, config);
+    JettyServerModule.initializeServer(injector, lifecycle, server);
+    return server;
+  }
+}

--- a/server/src/test/java/io/druid/curator/discovery/ServiceAnnouncerTest.java
+++ b/server/src/test/java/io/druid/curator/discovery/ServiceAnnouncerTest.java
@@ -1,0 +1,108 @@
+/*
+ * Druid - a distributed column store.
+ * Copyright 2012 - 2015 Metamarkets Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.druid.curator.discovery;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
+import com.metamx.common.ISE;
+import io.druid.curator.CuratorTestBase;
+import org.apache.curator.x.discovery.ServiceDiscovery;
+import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
+import org.apache.curator.x.discovery.ServiceInstance;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+public class ServiceAnnouncerTest extends CuratorTestBase
+{
+  @Before
+  public void setUp() throws Exception
+  {
+    setupServerAndCurator();
+  }
+
+  @Test
+  public void testServiceAnnouncement() throws Exception
+  {
+    curator.start();
+    List<String> serviceNames = ImmutableList.of(
+        "druid/overlord",
+        "druid/coordinator",
+        "druid/firehose/tranquility_test-50-0000-0000"
+    );
+    final ServiceDiscovery serviceDiscovery = createAndAnnounceServices(serviceNames);
+    Assert.assertTrue(
+        Iterators.all(
+            serviceNames.iterator(),
+            new Predicate<String>()
+            {
+              @Override
+              public boolean apply(String input)
+              {
+                try {
+                  return serviceDiscovery.queryForInstances(input.replaceAll("/", ":")).size() == 1;
+                }
+                catch (Exception e) {
+                  throw new ISE(
+                      "Something went wrong while finding instance with name [%s] in Service Discovery",
+                      input
+                  );
+                }
+              }
+            }
+        )
+    );
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testServiceAnnouncementFail() throws Exception
+  {
+    curator.start();
+    createAndAnnounceServices(ImmutableList.of("placeholder/\u0001"));
+  }
+
+  private ServiceDiscovery createAndAnnounceServices(List<String> serviceNames) throws Exception
+  {
+    int port = 1000;
+    ServiceDiscovery<Void> serviceDiscovery =
+        ServiceDiscoveryBuilder.builder(Void.class)
+                               .basePath("/test")
+                               .client(curator)
+                               .build();
+    for (String serviceName: serviceNames) {
+      String serviceNameToUse = CuratorServiceUtils.makeCanonicalServiceName(serviceName);
+      ServiceInstance instance = ServiceInstance.<Void>builder()
+                                                .name(serviceNameToUse)
+                                                .address("localhost")
+                                                .port(port++)
+                                                .build();
+      serviceDiscovery.registerService(instance);
+    }
+    return serviceDiscovery;
+  }
+
+  @After
+  public void tearDown()
+  {
+    tearDownServerAndCurator();
+  }
+}

--- a/services/src/main/java/io/druid/cli/CliPeon.java
+++ b/services/src/main/java/io/druid/cli/CliPeon.java
@@ -70,6 +70,7 @@ import io.druid.segment.realtime.firehose.ChatHandlerResource;
 import io.druid.segment.realtime.firehose.NoopChatHandlerProvider;
 import io.druid.segment.realtime.firehose.ServiceAnnouncingChatHandlerProvider;
 import io.druid.server.QueryResource;
+import io.druid.server.initialization.jetty.ChatHandlerServerModule;
 import io.druid.server.initialization.jetty.JettyServerInitializer;
 import org.eclipse.jetty.server.Server;
 
@@ -198,7 +199,8 @@ public class CliPeon extends GuiceRunnable
 
           }
         },
-        new IndexingServiceFirehoseModule()
+        new IndexingServiceFirehoseModule(),
+        new ChatHandlerServerModule()
     );
   }
 

--- a/services/src/main/java/io/druid/cli/CliRealtime.java
+++ b/services/src/main/java/io/druid/cli/CliRealtime.java
@@ -24,6 +24,7 @@ import com.google.inject.name.Names;
 import com.metamx.common.logger.Logger;
 import io.airlift.airline.Command;
 import io.druid.guice.RealtimeModule;
+import io.druid.server.initialization.jetty.ChatHandlerServerModule;
 
 import java.util.List;
 
@@ -54,7 +55,8 @@ public class CliRealtime extends ServerRunnable
             binder.bindConstant().annotatedWith(Names.named("serviceName")).to("druid/realtime");
             binder.bindConstant().annotatedWith(Names.named("servicePort")).to(8084);
           }
-        }
+        },
+        new ChatHandlerServerModule()
     );
   }
 }

--- a/services/src/main/java/io/druid/guice/RealtimeModule.java
+++ b/services/src/main/java/io/druid/guice/RealtimeModule.java
@@ -35,7 +35,6 @@ import io.druid.segment.realtime.firehose.NoopChatHandlerProvider;
 import io.druid.segment.realtime.firehose.ServiceAnnouncingChatHandlerProvider;
 import io.druid.server.QueryResource;
 import io.druid.server.initialization.jetty.JettyServerInitializer;
-
 import org.eclipse.jetty.server.Server;
 
 import java.util.List;
@@ -44,6 +43,7 @@ import java.util.List;
  */
 public class RealtimeModule implements Module
 {
+
   @Override
   public void configure(Binder binder)
   {


### PR DESCRIPTION
When the ingestion and query rate for a realtime index task using the event receiver firehose is quite high, then having different thread pools for handling ingestion and querying will be quite useful. The separation will be useful in case ingestion and querying takes a while to respond for example deserializing sketch objects during ingestion or responding to a slow query. Thus, the ingestion cannot not block queries and vice-versa as they can be tuned independently. 