### PR TITLE
DataSchema: Exclude metric names from dimension list.

### DIFF
--- a/server/src/main/java/io/druid/segment/indexing/DataSchema.java
+++ b/server/src/main/java/io/druid/segment/indexing/DataSchema.java
@@ -101,6 +101,7 @@ public class DataSchema
     final Set<String> dimensionExclusions = Sets.newHashSet();
     for (AggregatorFactory aggregator : aggregators) {
       dimensionExclusions.addAll(aggregator.requiredFields());
+      dimensionExclusions.add(aggregator.getName());
     }
 
     if (inputRowParser.getParseSpec() != null) {

--- a/server/src/test/java/io/druid/segment/indexing/DataSchemaTest.java
+++ b/server/src/test/java/io/druid/segment/indexing/DataSchemaTest.java
@@ -72,7 +72,7 @@ public class DataSchemaTest
     );
 
     Assert.assertEquals(
-        ImmutableSet.of("time", "col1", "col2"),
+        ImmutableSet.of("time", "col1", "col2", "metric1", "metric2"),
         schema.getParser().getParseSpec().getDimensionsSpec().getDimensionExclusions()
     );
   }
@@ -101,7 +101,7 @@ public class DataSchemaTest
     );
 
     Assert.assertEquals(
-        ImmutableSet.of("dimC", "col1"),
+        ImmutableSet.of("dimC", "col1", "metric1", "metric2"),
         schema.getParser().getParseSpec().getDimensionsSpec().getDimensionExclusions()
     );
   }


### PR DESCRIPTION
Otherwise we could end up with a metric and a dimension with the same column name.