### PR TITLE
Ability to skip Incremental Index during query using query context

### DIFF
--- a/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -49,6 +49,7 @@ import io.druid.concurrent.Execs;
 import io.druid.data.input.Committer;
 import io.druid.data.input.InputRow;
 import io.druid.query.MetricsEmittingQueryRunner;
+import io.druid.query.NoopQueryRunner;
 import io.druid.query.Query;
 import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerFactory;
@@ -132,6 +133,8 @@ public class RealtimePlumber implements Plumber
 
   private static final String COMMIT_METADATA_KEY = "%commitMetadata%";
   private static final String COMMIT_METADATA_TIMESTAMP_KEY = "%commitMetadataTimestamp%";
+  private static final String SKIP_INCREMENTAL_SEGMENT = "skipIncrementalSegment";
+
 
   public RealtimePlumber(
       DataSchema schema,
@@ -255,6 +258,7 @@ public class RealtimePlumber implements Plumber
   @Override
   public <T> QueryRunner<T> getQueryRunner(final Query<T> query)
   {
+    final boolean skipIncrementalSegment = query.getContextValue(SKIP_INCREMENTAL_SEGMENT, false);
     final QueryRunnerFactory<T, Query<T>> factory = conglomerate.findFactory(query);
     final QueryToolChest<T, Query<T>> toolchest = factory.getToolchest();
 
@@ -320,6 +324,10 @@ public class RealtimePlumber implements Plumber
                                             // the query for the segment.
                                             if (input == null || input.getSegment() == null) {
                                               return new ReportTimelineMissingSegmentQueryRunner<T>(descriptor);
+                                            }
+
+                                            if (skipIncrementalSegment && !input.hasSwapped()) {
+                                              return new NoopQueryRunner<T>();
                                             }
 
                                             // Prevent the underlying segment from closing when its being iterated


### PR DESCRIPTION
- add adds the ability to skip incremental index when querying results from realtime nodes. 
- default behaviour is to include incrementalIndex in queries.

