### PR TITLE
Fix IncrementalIndexAdapter getRows(), transform the entrySet iterator instead of entrySet

### DIFF
--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexAdapter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexAdapter.java
@@ -20,6 +20,7 @@
 package io.druid.segment.incremental;
 
 import com.google.common.base.Function;
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
 import com.metamx.collections.bitmap.BitmapFactory;
 import com.metamx.collections.bitmap.MutableBitmap;
@@ -167,9 +168,13 @@ public class IncrementalIndexAdapter implements IndexableAdapter
   @Override
   public Iterable<Rowboat> getRows()
   {
-    return FunctionalIterable
-        .create(index.getFacts().entrySet())
-        .transform(
+    return new Iterable<Rowboat>()
+    {
+      @Override
+      public Iterator<Rowboat> iterator()
+      {
+        return (Iterators.transform(
+            index.getFacts().entrySet().iterator(),
             new Function<Map.Entry<IncrementalIndex.TimeAndDims, Integer>, Rowboat>()
             {
               int count = 0;
@@ -217,7 +222,9 @@ public class IncrementalIndexAdapter implements IndexableAdapter
                 );
               }
             }
-        );
+        ));
+      }
+    };
   }
 
   @Override

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexAdapterTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexAdapterTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.incremental;
+
+import io.druid.segment.IndexSpec;
+import io.druid.segment.IndexableAdapter;
+import io.druid.segment.Rowboat;
+import io.druid.segment.data.CompressedObjectStrategy;
+import io.druid.segment.data.IncrementalIndexTest;
+import io.druid.segment.data.RoaringBitmapSerdeFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class IncrementalIndexAdapterTest
+{
+  @Test
+  public void testGetRowsIterable() throws Exception
+  {
+    final long timestamp = System.currentTimeMillis();
+    IncrementalIndex toPersist1 = IncrementalIndexTest.createIndex(true, null);
+    IncrementalIndexTest.populateIndex(timestamp, toPersist1);
+
+    IndexSpec indexSpec = new IndexSpec(
+        new RoaringBitmapSerdeFactory(),
+        CompressedObjectStrategy.CompressionStrategy.LZ4.name().toLowerCase(),
+        CompressedObjectStrategy.CompressionStrategy.LZ4.name().toLowerCase()
+    );
+
+    final IndexableAdapter incrementalAdapter = new IncrementalIndexAdapter(
+        toPersist1.getInterval(),
+        toPersist1,
+        indexSpec.getBitmapSerdeFactory()
+                 .getBitmapFactory()
+    );
+
+    Iterable<Rowboat> boats = incrementalAdapter.getRows();
+    List<Rowboat> boatList = new ArrayList<>();
+    for (Rowboat boat : boats) {
+      boatList.add(boat);
+    }
+    Assert.assertEquals(2, boatList.size());
+    Assert.assertEquals(0, boatList.get(0).getRowNum());
+    Assert.assertEquals(1, boatList.get(1).getRowNum());
+
+    /* Iterate through the Iterable a few times, check that boat row numbers are correct afterwards */
+    boatList = new ArrayList<>();
+    for (Rowboat boat : boats) {
+      boatList.add(boat);
+    }
+    boatList = new ArrayList<>();
+    for (Rowboat boat : boats) {
+      boatList.add(boat);
+    }
+    boatList = new ArrayList<>();
+    for (Rowboat boat : boats) {
+      boatList.add(boat);
+    }
+    boatList = new ArrayList<>();
+    for (Rowboat boat : boats) {
+      boatList.add(boat);
+    }
+
+    Assert.assertEquals(2, boatList.size());
+    Assert.assertEquals(0, boatList.get(0).getRowNum());
+    Assert.assertEquals(1, boatList.get(1).getRowNum());
+
+  }
+}


### PR DESCRIPTION
The existing Iterable returned by IncrementalIndexAdapter.getRows() does not work correctly if it is walked more than once.

The "count" integer inside the transformation function never gets reset, so after iterating through the getRows() iterable once, the Rowboats that are returned have invalid rowNums.

The patch changes the behavior of getRows() so that a new Iterator is created each time iterator() is called on the returned Iterable; the transform function and its count variable are no longer shared across iterator() calls.

=============

This came up as I was stepping through testPersistMerge() from IndexMergerTest in a debugger, and makeIndexFiles from IndexMerger. When IndexMerger is merging rows:
Iterable<Rowboat> theRows = rowMergerFn.apply(boats);

I looked at the Iterable<Rowboat> objects within "boats" in the debugger; by doing so, the debugger walked through these Iterables, and I saw some BufferOverflow exceptions, because of the rowNum issue mentioned above.


