### PR TITLE
Add the druid artifact version to metrics when emitted

### DIFF
--- a/processing/src/main/java/io/druid/query/DruidMetrics.java
+++ b/processing/src/main/java/io/druid/query/DruidMetrics.java
@@ -20,6 +20,7 @@ package io.druid.query;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.metamx.emitter.service.ServiceMetricEvent;
@@ -37,6 +38,7 @@ public class DruidMetrics
   public final static String INTERVAL = "interval";
   public final static String ID = "id";
   public final static String STATUS = "status";
+  public final static String VERSION = "version";
 
   // task metrics
   public final static String TASK_TYPE = "taskType";
@@ -59,6 +61,7 @@ public class DruidMetrics
   public static <T> ServiceMetricEvent.Builder makePartialQueryTimeMetric(Query<T> query)
   {
     return new ServiceMetricEvent.Builder()
+        .setDimension(VERSION, Strings.nullToEmpty(DruidMetrics.class.getPackage().getImplementationVersion()))
         .setDimension(DATASOURCE, DataSourceUtil.getMetricName(query.getDataSource()))
         .setDimension(TYPE, query.getType())
         .setDimension(


### PR DESCRIPTION
When packaged and executed via `io.druid.cli.Main` (not as part of intellij's run) the following will be added to the event objects: `"version":"0.9.0-SNAPSHOT"` where the appropriate version is specified.

In the event that a strange runtime environment is used (example: when run from intellij) the version will be the empty string.