### PR TITLE
Fix ITUnionQueryTest failing on machines with less than 4 cores

### DIFF
--- a/integration-tests/docker/middlemanager.conf
+++ b/integration-tests/docker/middlemanager.conf
@@ -10,6 +10,7 @@ command=java
   -Dfile.encoding=UTF-8
   -Ddruid.host=%(ENV_HOST_IP)s
   -Ddruid.zk.service.host=druid-zookeeper-kafka
+  -Ddruid.worker.capacity=8
   -Ddruid.indexer.logs.directory=/shared/tasklogs
   -Ddruid.storage.storageDirectory=/shared/storage
   -Ddruid.indexer.runner.javaOpts=-server -Xmx256m -Xms256m -XX:NewSize=128m -XX:MaxNewSize=128m -XX:+UseConcMarkSweepGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps


### PR DESCRIPTION
ITUnionQueryTest runs 4 realtime tasks and runs a unionQuery over them,
the worker is not able to run all the tasks concurrently on machines
with less cpu cores as it picks default worker capacity.
explicitly specify worker capacity to avoid this.