### PR TITLE
support periodic hard delete of segments

### DIFF
--- a/docs/content/configuration/coordinator.md
+++ b/docs/content/configuration/coordinator.md
@@ -28,6 +28,10 @@ The coordinator node uses several of the global configs in [Configuration](../co
 |`druid.coordinator.merge.on`|Boolean flag for whether or not the coordinator should try and merge small segments into a more optimal segment size.|false|
 |`druid.coordinator.conversion.on`|Boolean flag for converting old segment indexing versions to the latest segment indexing version.|false|
 |`druid.coordinator.load.timeout`|The timeout duration for when the coordinator assigns a segment to a historical node.|PT15M|
+|`druid.coordinator.kill.on`|Boolean flag for whether or not the coordinator should submit kill task for unused segments, that is, hard delete them from metadata store and deep storage. If set to true, then for all the whitelisted dataSources, coordinator will submit tasks periodically based on `period` specified. These kill tasks will delete all segments except for the last `durationToRetain` period. Whitelist can be set via dynamic configuration `killDataSourceWhitelist` described later.|false|
+|`druid.coordinator.kill.period`|How often to send kill tasks to the indexing service. Value must be greater than `druid.coordinator.period.indexingPeriod`. Only applies if kill is turned on.|PT1D (1 Day)|
+|`druid.coordinator.kill.durationToRetain`| Do not kill segments in last `durationToRetain`, must be greater or equal to 0. Only applies and MUST be specified if kill is turned on. Note that default value is invalid.|PT-1S (-1 seconds)|
+|`druid.coordinator.kill.maxSegments`|Kill at most n segments per kill task submission, must be greater than 0. Only applies and MUST be specified if kill is turned on. Note that default value is invalid.|0|
 
 ### Metadata Retrieval
 
@@ -67,7 +71,8 @@ A sample coordinator dynamic config JSON object is shown below:
   "maxSegmentsToMove": 5,
   "replicantLifetime": 15,
   "replicationThrottleLimit": 10,
-  "emitBalancingStats": false
+  "emitBalancingStats": false,
+  "killDataSourceWhitelist": ["wikipedia", "testDatasource"]
 }
 ```
 
@@ -82,6 +87,7 @@ Issuing a GET request at the same URL will return the spec that is currently in 
 |`replicantLifetime`|The maximum number of coordinator runs for a segment to be replicated before we start alerting.|15|
 |`replicationThrottleLimit`|The maximum number of segments that can be replicated at one time.|10|
 |`emitBalancingStats`|Boolean flag for whether or not we should emit balancing stats. This is an expensive operation.|false|
+|`killDataSourceWhitelist`|List of dataSources for which kill tasks are sent if property `druid.coordinator.kill.on` is true.|none|
 
 To view the audit history of coordinator dynamic config issue a GET request to the URL -
 

--- a/server/src/main/java/io/druid/metadata/MetadataSegmentManager.java
+++ b/server/src/main/java/io/druid/metadata/MetadataSegmentManager.java
@@ -20,33 +20,44 @@
 package io.druid.metadata;
 
 import io.druid.client.DruidDataSource;
+import org.joda.time.Interval;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  */
 
 public interface MetadataSegmentManager
 {
-  public void start();
+  void start();
 
-  public void stop();
+  void stop();
 
-  public boolean enableDatasource(final String ds);
+  boolean enableDatasource(final String ds);
 
-  public boolean enableSegment(final String segmentId);
+  boolean enableSegment(final String segmentId);
 
-  public boolean removeDatasource(final String ds);
+  boolean removeDatasource(final String ds);
 
-  public boolean removeSegment(String ds, final String segmentID);
+  boolean removeSegment(String ds, final String segmentID);
 
-  public boolean isStarted();
+  boolean isStarted();
 
-  public DruidDataSource getInventoryValue(String key);
+  DruidDataSource getInventoryValue(String key);
 
-  public Collection<DruidDataSource> getInventory();
+  Collection<DruidDataSource> getInventory();
 
-  public Collection<String> getAllDatasourceNames();
+  Collection<String> getAllDatasourceNames();
+
+  /**
+   * Returns top N unused segment intervals in given interval when ordered by segment start time, end time.
+   */
+  List<Interval> getUnusedSegmentIntervals(
+      final String dataSource,
+      final Interval interval,
+      final int limit
+  );
 
   public void poll();
 }

--- a/server/src/main/java/io/druid/server/coordinator/CoordinatorDynamicConfig.java
+++ b/server/src/main/java/io/druid/server/coordinator/CoordinatorDynamicConfig.java
@@ -21,6 +21,8 @@ package io.druid.server.coordinator;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Set;
+
 public class CoordinatorDynamicConfig
 {
   public static final String CONFIG_KEY = "coordinator.config";
@@ -33,6 +35,7 @@ public class CoordinatorDynamicConfig
   private final int replicationThrottleLimit;
   private final int balancerComputeThreads;
   private final boolean emitBalancingStats;
+  private final Set<String> killDataSourceWhitelist;
 
   @JsonCreator
   public CoordinatorDynamicConfig(
@@ -43,7 +46,8 @@ public class CoordinatorDynamicConfig
       @JsonProperty("replicantLifetime") int replicantLifetime,
       @JsonProperty("replicationThrottleLimit") int replicationThrottleLimit,
       @JsonProperty("balancerComputeThreads") int balancerComputeThreads,
-      @JsonProperty("emitBalancingStats") boolean emitBalancingStats
+      @JsonProperty("emitBalancingStats") boolean emitBalancingStats,
+      @JsonProperty("killDataSourceWhitelist") Set<String> killDataSourceWhitelist
   )
   {
     this.maxSegmentsToMove = maxSegmentsToMove;
@@ -57,6 +61,7 @@ public class CoordinatorDynamicConfig
         Math.max(balancerComputeThreads, 1),
         Math.max(Runtime.getRuntime().availableProcessors() - 1, 1)
     );
+    this.killDataSourceWhitelist = killDataSourceWhitelist;
   }
 
   @JsonProperty
@@ -107,6 +112,85 @@ public class CoordinatorDynamicConfig
     return balancerComputeThreads;
   }
 
+  @JsonProperty
+  public Set<String> getKillDataSourceWhitelist()
+  {
+    return killDataSourceWhitelist;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "CoordinatorDynamicConfig{" +
+           "millisToWaitBeforeDeleting=" + millisToWaitBeforeDeleting +
+           ", mergeBytesLimit=" + mergeBytesLimit +
+           ", mergeSegmentsLimit=" + mergeSegmentsLimit +
+           ", maxSegmentsToMove=" + maxSegmentsToMove +
+           ", replicantLifetime=" + replicantLifetime +
+           ", replicationThrottleLimit=" + replicationThrottleLimit +
+           ", balancerComputeThreads=" + balancerComputeThreads +
+           ", emitBalancingStats=" + emitBalancingStats +
+           ", killDataSourceWhitelist=" + killDataSourceWhitelist +
+           '}';
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    CoordinatorDynamicConfig that = (CoordinatorDynamicConfig) o;
+
+    if (millisToWaitBeforeDeleting != that.millisToWaitBeforeDeleting) {
+      return false;
+    }
+    if (mergeBytesLimit != that.mergeBytesLimit) {
+      return false;
+    }
+    if (mergeSegmentsLimit != that.mergeSegmentsLimit) {
+      return false;
+    }
+    if (maxSegmentsToMove != that.maxSegmentsToMove) {
+      return false;
+    }
+    if (replicantLifetime != that.replicantLifetime) {
+      return false;
+    }
+    if (replicationThrottleLimit != that.replicationThrottleLimit) {
+      return false;
+    }
+    if (balancerComputeThreads != that.balancerComputeThreads) {
+      return false;
+    }
+    if (emitBalancingStats != that.emitBalancingStats) {
+      return false;
+    }
+    return !(killDataSourceWhitelist != null
+             ? !killDataSourceWhitelist.equals(that.killDataSourceWhitelist)
+             : that.killDataSourceWhitelist != null);
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = (int) (millisToWaitBeforeDeleting ^ (millisToWaitBeforeDeleting >>> 32));
+    result = 31 * result + (int) (mergeBytesLimit ^ (mergeBytesLimit >>> 32));
+    result = 31 * result + mergeSegmentsLimit;
+    result = 31 * result + maxSegmentsToMove;
+    result = 31 * result + replicantLifetime;
+    result = 31 * result + replicationThrottleLimit;
+    result = 31 * result + balancerComputeThreads;
+    result = 31 * result + (emitBalancingStats ? 1 : 0);
+    result = 31 * result + (killDataSourceWhitelist != null ? killDataSourceWhitelist.hashCode() : 0);
+    return result;
+  }
+
   public static class Builder
   {
     private long millisToWaitBeforeDeleting;
@@ -117,10 +201,11 @@ public class CoordinatorDynamicConfig
     private int replicationThrottleLimit;
     private boolean emitBalancingStats;
     private int balancerComputeThreads;
+    private Set<String> killDataSourceWhitelist;
 
     public Builder()
     {
-      this(15 * 60 * 1000L, 524288000L, 100, 5, 15, 10, 1, false);
+      this(15 * 60 * 1000L, 524288000L, 100, 5, 15, 10, 1, false, null);
     }
 
     private Builder(
@@ -131,7 +216,8 @@ public class CoordinatorDynamicConfig
         int replicantLifetime,
         int replicationThrottleLimit,
         int balancerComputeThreads,
-        boolean emitBalancingStats
+        boolean emitBalancingStats,
+        Set<String> killDataSourceWhitelist
     )
     {
       this.millisToWaitBeforeDeleting = millisToWaitBeforeDeleting;
@@ -142,6 +228,7 @@ public class CoordinatorDynamicConfig
       this.replicationThrottleLimit = replicationThrottleLimit;
       this.emitBalancingStats = emitBalancingStats;
       this.balancerComputeThreads = balancerComputeThreads;
+      this.killDataSourceWhitelist = killDataSourceWhitelist;
     }
 
     public Builder withMillisToWaitBeforeDeleting(long millisToWaitBeforeDeleting)
@@ -186,6 +273,12 @@ public class CoordinatorDynamicConfig
       return this;
     }
 
+    public Builder withKillDataSourceWhitelist(Set<String> killDataSourceWhitelist)
+    {
+      this.killDataSourceWhitelist = killDataSourceWhitelist;
+      return this;
+    }
+
     public CoordinatorDynamicConfig build()
     {
       return new CoordinatorDynamicConfig(
@@ -196,7 +289,8 @@ public class CoordinatorDynamicConfig
           replicantLifetime,
           replicationThrottleLimit,
           balancerComputeThreads,
-          emitBalancingStats
+          emitBalancingStats,
+          killDataSourceWhitelist
       );
     }
   }

--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
@@ -20,6 +20,7 @@
 package io.druid.server.coordinator;
 
 import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
@@ -75,6 +76,7 @@ import org.apache.curator.framework.recipes.leader.Participant;
 import org.apache.curator.utils.ZKPaths;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
+import org.joda.time.Interval;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -623,7 +625,9 @@ public class DruidCoordinator
     }
   }
 
-  private List<DruidCoordinatorHelper> makeIndexingServiceHelpers(final AtomicReference<DatasourceWhitelist> whitelistRef)
+  private List<DruidCoordinatorHelper> makeIndexingServiceHelpers(
+      final AtomicReference<DatasourceWhitelist> whitelistRef
+  )
   {
     List<DruidCoordinatorHelper> helpers = Lists.newArrayList();
 
@@ -655,7 +659,119 @@ public class DruidCoordinator
       );
     }
 
+    if (config.isKillSegments()) {
+      helpers.add(
+          new DruidCoordinatorSegmentKiller(
+              metadataSegmentManager,
+              indexingServiceClient,
+              config.getCoordinatorKillDurationToRetain(),
+              config.getCoordinatorKillPeriod(),
+              config.getCoordinatorKillMaxSegments()
+          )
+      );
+    }
+
     return ImmutableList.copyOf(helpers);
+  }
+
+  static class DruidCoordinatorSegmentKiller implements DruidCoordinatorHelper
+  {
+    
+    private final long period;
+    private final long retainDuration;
+    private final int maxSegmentsToKill;
+    private long lastKillTime = 0;
+
+
+    private final MetadataSegmentManager segmentManager;
+    private final IndexingServiceClient indexingServiceClient;
+
+    DruidCoordinatorSegmentKiller(
+        MetadataSegmentManager segmentManager,
+        IndexingServiceClient indexingServiceClient,
+        Duration retainDuration,
+        Duration period,
+        int maxSegmentsToKill
+    )
+    {
+      this.period = period.getMillis();
+      Preconditions.checkArgument(this.period > 0, "coordinator kill period must be > 0");
+
+      this.retainDuration = retainDuration.getMillis();
+      Preconditions.checkArgument(this.retainDuration >= 0, "coordinator kill retainDuration must be >= 0");
+
+      this.maxSegmentsToKill = maxSegmentsToKill;
+      Preconditions.checkArgument(this.maxSegmentsToKill > 0, "coordinator kill maxSegments must be > 0");
+
+      log.info(
+          "Kill Task scheduling enabled with period [%s], retainDuration [%s], maxSegmentsToKill [%s]",
+          this.period,
+          this.retainDuration,
+          this.maxSegmentsToKill
+      );
+
+      this.segmentManager = segmentManager;
+      this.indexingServiceClient = indexingServiceClient;
+    }
+
+    @Override
+    public DruidCoordinatorRuntimeParams run(DruidCoordinatorRuntimeParams params)
+    {
+      Set<String> whitelist = params.getCoordinatorDynamicConfig().getKillDataSourceWhitelist();
+
+      if (whitelist != null && whitelist.size() > 0 && (lastKillTime + period) < System.currentTimeMillis()) {
+        lastKillTime = System.currentTimeMillis();
+
+        for (String dataSource : whitelist) {
+          final Interval intervalToKill = findIntervalForKillTask(dataSource, maxSegmentsToKill);
+          if (intervalToKill != null) {
+            try {
+              indexingServiceClient.killSegments(dataSource, intervalToKill);
+            }
+            catch (Exception ex) {
+              log.error(ex, "Failed to submit kill task for dataSource [%s]", dataSource);
+              if (Thread.currentThread().isInterrupted()) {
+                log.warn("skipping kill task scheduling because thread is interrupted.");
+                break;
+              }
+            }
+          }
+        }
+      }
+      return params;
+    }
+
+    private Interval findIntervalForKillTask(String dataSource, int limit)
+    {
+      List<Interval> unusedSegmentIntervals = segmentManager.getUnusedSegmentIntervals(
+          dataSource,
+          new Interval(
+              0,
+              System.currentTimeMillis()
+              - retainDuration
+          ),
+          limit
+      );
+
+      if (unusedSegmentIntervals != null && unusedSegmentIntervals.size() > 0) {
+        long start = Long.MIN_VALUE;
+        long end = Long.MAX_VALUE;
+
+        for (Interval interval : unusedSegmentIntervals) {
+          if (start < interval.getStartMillis()) {
+            start = interval.getStartMillis();
+          }
+
+          if (end > interval.getEndMillis()) {
+            end = interval.getEndMillis();
+          }
+        }
+
+        return new Interval(start, end);
+      } else {
+        return null;
+      }
+    }
   }
 
   public static class DruidCoordinatorVersionConverter implements DruidCoordinatorHelper

--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinatorConfig.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinatorConfig.java
@@ -51,6 +51,24 @@ public abstract class DruidCoordinatorConfig
     return false;
   }
 
+  @Config("druid.coordinator.kill.on")
+  public boolean isKillSegments()
+  {
+    return false;
+  }
+
+  @Config("druid.coordinator.kill.period")
+  @Default("P1D")
+  public abstract Duration getCoordinatorKillPeriod();
+
+  @Config("druid.coordinator.kill.durationToRetain")
+  @Default("PT-1s")
+  public abstract Duration getCoordinatorKillDurationToRetain();
+
+  @Config("druid.coordinator.kill.maxSegments")
+  @Default("0")
+  public abstract int getCoordinatorKillMaxSegments();
+
   @Config("druid.coordinator.load.timeout")
   public Duration getLoadTimeoutDelay()
   {

--- a/server/src/test/java/io/druid/metadata/MetadataSegmentManagerTest.java
+++ b/server/src/test/java/io/druid/metadata/MetadataSegmentManagerTest.java
@@ -113,4 +113,22 @@ public class MetadataSegmentManagerTest
     );
     manager.stop();
   }
+
+  @Test
+  public void testGetUnusedSegmentsForInterval() throws Exception
+  {
+    manager.start();
+    manager.poll();
+    Assert.assertTrue(manager.removeDatasource("wikipedia"));
+
+    Assert.assertEquals(
+        ImmutableList.of(segment2.getInterval()),
+        manager.getUnusedSegmentIntervals("wikipedia", new Interval("1970/3000"), 1)
+    );
+
+    Assert.assertEquals(
+        ImmutableList.of(segment2.getInterval(), segment1.getInterval()),
+        manager.getUnusedSegmentIntervals("wikipedia", new Interval("1970/3000"), 5)
+    );
+  }
 }

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorConfigTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorConfigTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.coordinator;
+
+import com.metamx.common.config.Config;
+import org.joda.time.Duration;
+import org.junit.Assert;
+import org.junit.Test;
+import org.skife.config.ConfigurationObjectFactory;
+
+import java.util.Properties;
+
+/**
+ */
+public class DruidCoordinatorConfigTest
+{
+  @Test
+  public void testDeserialization() throws Exception
+  {
+    ConfigurationObjectFactory factory = Config.createFactory(new Properties());
+
+    //with defaults
+    DruidCoordinatorConfig config = factory.build(DruidCoordinatorConfig.class);
+
+    Assert.assertEquals(new Duration("PT300s"), config.getCoordinatorStartDelay());
+    Assert.assertEquals(new Duration("PT60s"), config.getCoordinatorPeriod());
+    Assert.assertEquals(new Duration("PT1800s"), config.getCoordinatorIndexingPeriod());
+    Assert.assertFalse(config.isMergeSegments());
+    Assert.assertFalse(config.isConvertSegments());
+    Assert.assertEquals(new Duration(15 * 60 * 1000), config.getLoadTimeoutDelay());
+    Assert.assertNull(config.getConsoleStatic());
+
+    //with non-defaults
+    Properties props = new Properties();
+    props.setProperty("druid.coordinator.startDelay", "PT1s");
+    props.setProperty("druid.coordinator.period", "PT1s");
+    props.setProperty("druid.coordinator.period.indexingPeriod", "PT1s");
+    props.setProperty("druid.coordinator.merge.on", "true");
+    props.setProperty("druid.coordinator.conversion.on", "true");
+    props.setProperty("druid.coordinator.load.timeout", "PT1s");
+    props.setProperty("druid.coordinator.console.static", "test");
+
+    factory = Config.createFactory(props);
+    config = factory.build(DruidCoordinatorConfig.class);
+
+    Assert.assertEquals(new Duration("PT1s"), config.getCoordinatorStartDelay());
+    Assert.assertEquals(new Duration("PT1s"), config.getCoordinatorPeriod());
+    Assert.assertEquals(new Duration("PT1s"), config.getCoordinatorIndexingPeriod());
+    Assert.assertTrue(config.isMergeSegments());
+    Assert.assertTrue(config.isConvertSegments());
+    Assert.assertEquals(new Duration("PT1s"), config.getLoadTimeoutDelay());
+    Assert.assertEquals("test", config.getConsoleStatic());
+  }
+}

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorConfigTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorConfigTest.java
@@ -44,6 +44,10 @@ public class DruidCoordinatorConfigTest
     Assert.assertEquals(new Duration("PT1800s"), config.getCoordinatorIndexingPeriod());
     Assert.assertFalse(config.isMergeSegments());
     Assert.assertFalse(config.isConvertSegments());
+    Assert.assertFalse(config.isKillSegments());
+    Assert.assertEquals(86400000, config.getCoordinatorKillPeriod().getMillis());
+    Assert.assertEquals(-1000, config.getCoordinatorKillDurationToRetain().getMillis());
+    Assert.assertEquals(0, config.getCoordinatorKillMaxSegments());
     Assert.assertEquals(new Duration(15 * 60 * 1000), config.getLoadTimeoutDelay());
     Assert.assertNull(config.getConsoleStatic());
 
@@ -54,6 +58,10 @@ public class DruidCoordinatorConfigTest
     props.setProperty("druid.coordinator.period.indexingPeriod", "PT1s");
     props.setProperty("druid.coordinator.merge.on", "true");
     props.setProperty("druid.coordinator.conversion.on", "true");
+    props.setProperty("druid.coordinator.kill.on", "true");
+    props.setProperty("druid.coordinator.kill.period", "PT1s");
+    props.setProperty("druid.coordinator.kill.durationToRetain", "PT1s");
+    props.setProperty("druid.coordinator.kill.maxSegments", "10000");
     props.setProperty("druid.coordinator.load.timeout", "PT1s");
     props.setProperty("druid.coordinator.console.static", "test");
 
@@ -65,6 +73,10 @@ public class DruidCoordinatorConfigTest
     Assert.assertEquals(new Duration("PT1s"), config.getCoordinatorIndexingPeriod());
     Assert.assertTrue(config.isMergeSegments());
     Assert.assertTrue(config.isConvertSegments());
+    Assert.assertTrue(config.isKillSegments());
+    Assert.assertEquals(new Duration("PT1s"), config.getCoordinatorKillPeriod());
+    Assert.assertEquals(new Duration("PT1s"), config.getCoordinatorKillDurationToRetain());
+    Assert.assertEquals(10000, config.getCoordinatorKillMaxSegments());
     Assert.assertEquals(new Duration("PT1s"), config.getLoadTimeoutDelay());
     Assert.assertEquals("test", config.getConsoleStatic());
   }

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorRuleRunnerTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorRuleRunnerTest.java
@@ -499,7 +499,7 @@ public class DruidCoordinatorRuleRunnerTest
 
     EasyMock.expect(coordinator.getDynamicConfigs()).andReturn(
         new CoordinatorDynamicConfig(
-            0, 0, 0, 0, 1, 24, 0, false
+            0, 0, 0, 0, 1, 24, 0, false, null
         )
     ).anyTimes();
     coordinator.removeSegment(EasyMock.<DataSegment>anyObject());
@@ -1006,7 +1006,7 @@ public class DruidCoordinatorRuleRunnerTest
   {
     EasyMock.expect(coordinator.getDynamicConfigs()).andReturn(
         new CoordinatorDynamicConfig(
-            0, 0, 0, 0, 1, 7, 0, false
+            0, 0, 0, 0, 1, 7, 0, false, null
         )
     ).atLeastOnce();
     coordinator.removeSegment(EasyMock.<DataSegment>anyObject());
@@ -1182,7 +1182,7 @@ public class DruidCoordinatorRuleRunnerTest
   {
     EasyMock.expect(coordinator.getDynamicConfigs()).andReturn(
         new CoordinatorDynamicConfig(
-            0, 0, 0, 0, 1, 24, 0, false
+            0, 0, 0, 0, 1, 24, 0, false, null
         )
     ).anyTimes();
     coordinator.removeSegment(EasyMock.<DataSegment>anyObject());

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
@@ -115,7 +115,18 @@ public class DruidCoordinatorTest extends CuratorTestBase
     curator.blockUntilConnected();
     curator.create().creatingParentsIfNeeded().forPath(LOADPATH);
     objectMapper = new DefaultObjectMapper();
-    druidCoordinatorConfig = new TestDruidCoordinatorConfig(new Duration(COORDINATOR_START_DELAY), new Duration(COORDINATOR_PERIOD), null, null, null, false, false);
+    druidCoordinatorConfig = new TestDruidCoordinatorConfig(
+        new Duration(COORDINATOR_START_DELAY),
+        new Duration(COORDINATOR_PERIOD),
+        null,
+        null,
+        new Duration(COORDINATOR_PERIOD),
+        null,
+        10,
+        null,
+        false,
+        false
+    );
     pathChildrenCache = new PathChildrenCache(curator, LOADPATH, true, true, Execs.singleThreaded("coordinator_test_path_children_cache-%d"));
     loadQueuePeon = new LoadQueuePeon(
       curator,

--- a/server/src/test/java/io/druid/server/coordinator/LoadQueuePeonTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/LoadQueuePeonTest.java
@@ -88,7 +88,7 @@ public class LoadQueuePeonTest extends CuratorTestBase
         jsonMapper,
         Execs.scheduledSingleThreaded("test_load_queue_peon_scheduled-%d"),
         Execs.singleThreaded("test_load_queue_peon-%d"),
-        new TestDruidCoordinatorConfig(null, null, null, null, null, false, false)
+        new TestDruidCoordinatorConfig(null, null, null, null, null, null, 10, null, false, false)
     );
 
     final CountDownLatch[] loadRequestSignal = new CountDownLatch[5];
@@ -276,7 +276,7 @@ public class LoadQueuePeonTest extends CuratorTestBase
         Execs.scheduledSingleThreaded("test_load_queue_peon_scheduled-%d"),
         Execs.singleThreaded("test_load_queue_peon-%d"),
         // set time-out to 1 ms so that LoadQueuePeon will fail the assignment quickly
-        new TestDruidCoordinatorConfig(null, null, null, new Duration(1), null, false, false)
+        new TestDruidCoordinatorConfig(null, null, null, new Duration(1), null, null, 10, null, false, false)
     );
 
     loadQueueCache.getListenable().addListener(

--- a/server/src/test/java/io/druid/server/coordinator/TestDruidCoordinatorConfig.java
+++ b/server/src/test/java/io/druid/server/coordinator/TestDruidCoordinatorConfig.java
@@ -28,6 +28,9 @@ public class TestDruidCoordinatorConfig extends DruidCoordinatorConfig
   private final Duration coordinatorPeriod;
   private final Duration coordinatorIndexingPeriod;
   private final Duration loadTimeoutDelay;
+  private final Duration coordinatorKillPeriod;
+  private final Duration coordinatorKillDurationToRetain;
+  private final int coordinatorKillMaxSegments;
 
   private final String consoleStatic;
 
@@ -39,6 +42,9 @@ public class TestDruidCoordinatorConfig extends DruidCoordinatorConfig
       Duration coordinatorPeriod,
       Duration coordinatorIndexingPeriod,
       Duration loadTimeoutDelay,
+      Duration coordinatorKillPeriod,
+      Duration coordinatorKillDurationToRetain,
+      int coordinatorKillMaxSegments,
       String consoleStatic,
       boolean mergeSegments,
       boolean convertSegments
@@ -48,6 +54,9 @@ public class TestDruidCoordinatorConfig extends DruidCoordinatorConfig
     this.coordinatorPeriod = coordinatorPeriod;
     this.coordinatorIndexingPeriod = coordinatorIndexingPeriod;
     this.loadTimeoutDelay = loadTimeoutDelay;
+    this.coordinatorKillPeriod = coordinatorKillPeriod;
+    this.coordinatorKillDurationToRetain = coordinatorKillDurationToRetain;
+    this.coordinatorKillMaxSegments = coordinatorKillMaxSegments;
     this.consoleStatic = consoleStatic;
     this.mergeSegments = mergeSegments;
     this.convertSegments = convertSegments;
@@ -81,6 +90,24 @@ public class TestDruidCoordinatorConfig extends DruidCoordinatorConfig
   public boolean isConvertSegments()
   {
     return convertSegments;
+  }
+
+  @Override
+  public Duration getCoordinatorKillPeriod()
+  {
+    return coordinatorKillPeriod;
+  }
+
+  @Override
+  public Duration getCoordinatorKillDurationToRetain()
+  {
+    return coordinatorKillDurationToRetain;
+  }
+
+  @Override
+  public int getCoordinatorKillMaxSegments()
+  {
+    return coordinatorKillMaxSegments;
   }
 
   @Override

--- a/server/src/test/java/io/druid/server/http/CoordinatorDynamicConfigTest.java
+++ b/server/src/test/java/io/druid/server/http/CoordinatorDynamicConfigTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.http;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import io.druid.segment.TestHelper;
+import io.druid.server.coordinator.CoordinatorDynamicConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ */
+public class CoordinatorDynamicConfigTest
+{
+  @Test
+  public void testSerde() throws Exception
+  {
+    String jsonStr = "{\n"
+                     + "  \"millisToWaitBeforeDeleting\": 1,\n"
+                     + "  \"mergeBytesLimit\": 1,\n"
+                     + "  \"mergeSegmentsLimit\" : 1,\n"
+                     + "  \"maxSegmentsToMove\": 1,\n"
+                     + "  \"replicantLifetime\": 1,\n"
+                     + "  \"replicationThrottleLimit\": 1,\n"
+                     + "  \"emitBalancingStats\": true,\n"
+                     + "  \"killDataSourceWhitelist\": [\"test\"]\n"
+                     + "}\n";
+
+    ObjectMapper mapper = TestHelper.getObjectMapper();
+    CoordinatorDynamicConfig actual = mapper.readValue(
+        mapper.writeValueAsString(
+            mapper.readValue(
+                jsonStr,
+                CoordinatorDynamicConfig.class
+            )
+        ),
+        CoordinatorDynamicConfig.class
+    );
+
+    Assert.assertEquals(
+        new CoordinatorDynamicConfig(1, 1, 1, 1, 1, 1, 1, true, ImmutableSet.of("test")),
+        actual
+    );
+  }
+
+  @Test
+  public void testBuilderDefaults()
+  {
+    Assert.assertEquals(
+        new CoordinatorDynamicConfig(900000, 524288000, 100, 5, 15, 10, 1, false, null),
+        new CoordinatorDynamicConfig.Builder().build()
+    );
+  }
+
+  @Test
+  public void testEqualsAndHashCodeSanity()
+  {
+    CoordinatorDynamicConfig config1 = new CoordinatorDynamicConfig(900000, 524288000, 100, 5, 15, 10, 1, false, null);
+    CoordinatorDynamicConfig config2 = new CoordinatorDynamicConfig(900000, 524288000, 100, 5, 15, 10, 1, false, null);
+
+    Assert.assertEquals(config1, config2);
+    Assert.assertEquals(config1.hashCode(), config2.hashCode());
+  }
+}


### PR DESCRIPTION
we have multiple dev and testing druid clusters where appropriate drop rules are configured to disable older segments. currently, we are having to send kill tasks from outside of druid to delete unused data. this feature allows druid to delete unused segments if configured.

For more details, see the updates made to docs/content/configuration/coordinator.md in this PR.