### PR TITLE
fixed #1873, add ability to express CONCAT as an extractionFn

### DIFF
--- a/docs/content/querying/dimensionspecs.md
+++ b/docs/content/querying/dimensionspecs.md
@@ -223,3 +223,14 @@ A null dimension value can be mapped to a specific value by specifying the empty
 This allows distinguishing between a null dimension and a lookup resulting in a null.
 For example, specifying `{"":"bar","bat":"baz"}` with dimension values `[null, "foo", "bat"]` and replacing missing values with `"oof"` will yield results of `["bar", "oof", "baz"]`.
 Omitting the empty string key will cause the missing value to take over. For example, specifying `{"bat":"baz"}` with dimension values `[null, "foo", "bat"]` and replacing missing values with `"oof"` will yield results of `["oof", "oof", "baz"]`.
+
+
+### Concat Extraction Function
+
+Returns the dimension value formatted according to the given format string.
+
+```json
+{ "type" : "concat", "format" : <sprintf_expression> }
+```
+
+For example if you want to concat "[" and "]" before and after the actual dimension value, you need to specify "[%s]" as format string.

--- a/processing/src/main/java/io/druid/query/extraction/ConcatExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/ConcatExtractionFn.java
@@ -1,0 +1,104 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.query.extraction;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.metamx.common.StringUtils;
+
+import java.nio.ByteBuffer;
+
+/**
+ *
+ */
+public class ConcatExtractionFn extends DimExtractionFn
+{
+  private final String format;
+
+  @JsonCreator
+  public ConcatExtractionFn(@JsonProperty("format") String format)
+  {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(format), "format string should not be empty");
+    this.format = format;
+  }
+
+  @JsonProperty
+  public String getFormat()
+  {
+    return format;
+  }
+
+  @Override
+  public byte[] getCacheKey()
+  {
+    byte[] bytes = StringUtils.toUtf8(format);
+    return ByteBuffer.allocate(1 + bytes.length)
+                     .put(ExtractionCacheHelper.CACHE_TYPE_ID_CONCAT)
+                     .put(bytes)
+                     .array();
+  }
+
+  @Override
+  public String apply(String value)
+  {
+    return String.format(format, value);
+  }
+
+  /**
+   * when values are null, format result may not conform to the previous ordering.
+   *
+   * @return
+   */
+  @Override
+  public boolean preservesOrdering()
+  {
+    return false;
+  }
+
+  @Override
+  public ExtractionType getExtractionType()
+  {
+    return ExtractionType.MANY_TO_ONE;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ConcatExtractionFn that = (ConcatExtractionFn) o;
+
+    return format.equals(that.format);
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return format.hashCode();
+  }
+}

--- a/processing/src/main/java/io/druid/query/extraction/DimExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/DimExtractionFn.java
@@ -24,7 +24,7 @@ public abstract class DimExtractionFn implements ExtractionFn
   @Override
   public String apply(Object value)
   {
-    return apply(value.toString());
+    return apply(value == null ? null : value.toString());
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/extraction/ExtractionCacheHelper.java
+++ b/processing/src/main/java/io/druid/query/extraction/ExtractionCacheHelper.java
@@ -1,0 +1,36 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.query.extraction;
+
+/**
+ *
+ */
+public class ExtractionCacheHelper
+{
+  public static final byte CACHE_TYPE_ID_TIME_DIM = 0x0;
+  public static final byte CACHE_TYPE_ID_REGEX = 0x1;
+  public static final byte CACHE_TYPE_ID_MATCHING_DIM = 0x2;
+  public static final byte CACHE_TYPE_ID_SEARCH_QUERY = 0x3;
+  public static final byte CACHE_TYPE_ID_JAVASCRIPT = 0x4;
+  public static final byte CACHE_TYPE_ID_TIME_FORMAT = 0x5;
+  public static final byte CACHE_TYPE_ID_IDENTITY = 0x6;
+  public static final byte CACHE_TYPE_ID_LOOKUP = 0x7;
+  public static final byte CACHE_TYPE_ID_CONCAT = 0x8;
+}

--- a/processing/src/main/java/io/druid/query/extraction/ExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/ExtractionFn.java
@@ -31,7 +31,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @JsonSubTypes.Type(name = "javascript", value = JavascriptExtractionFn.class),
     @JsonSubTypes.Type(name = "timeFormat", value = TimeFormatExtractionFn.class),
     @JsonSubTypes.Type(name = "identity", value = IdentityExtractionFn.class),
-    @JsonSubTypes.Type(name = "lookup", value = LookupExtractionFn.class)
+    @JsonSubTypes.Type(name = "lookup", value = LookupExtractionFn.class),
+    @JsonSubTypes.Type(name = "concat", value = ConcatExtractionFn.class)
 })
 /**
  * An ExtractionFn is a function that can be used to transform the values of a column (typically a dimension)
@@ -52,7 +53,7 @@ public interface ExtractionFn
 
   /**
    * The "extraction" function.  This should map a value into some other String value.
-   *
+   * <p>
    * In order to maintain the "null and empty string are equivalent" semantics that Druid provides, the
    * empty string is considered invalid output for this method and should instead return null.  This is
    * a contract on the method rather than enforced at a lower level in order to eliminate a global check
@@ -70,7 +71,7 @@ public interface ExtractionFn
 
   /**
    * Offers information on whether the extraction will preserve the original ordering of the values.
-   * <p/>
+   * <p>
    * Some optimizations of queries is possible if ordering is preserved.  Null values *do* count towards
    * ordering.
    *

--- a/processing/src/main/java/io/druid/query/extraction/IdentityExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/IdentityExtractionFn.java
@@ -23,11 +23,10 @@ import com.google.common.base.Strings;
 
 public class IdentityExtractionFn implements ExtractionFn
 {
-  private static final byte CACHE_TYPE_ID = 0x6;
   @Override
   public byte[] getCacheKey()
   {
-    return new byte[]{CACHE_TYPE_ID};
+    return new byte[]{ExtractionCacheHelper.CACHE_TYPE_ID_IDENTITY};
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/extraction/JavascriptExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/JavascriptExtractionFn.java
@@ -59,8 +59,6 @@ public class JavascriptExtractionFn implements ExtractionFn
     };
   }
 
-  private static final byte CACHE_TYPE_ID = 0x4;
-
   private final String function;
   private final Function<Object, String> fn;
   private final boolean injective;
@@ -95,7 +93,7 @@ public class JavascriptExtractionFn implements ExtractionFn
   {
     byte[] bytes = StringUtils.toUtf8(function);
     return ByteBuffer.allocate(1 + bytes.length)
-                     .put(CACHE_TYPE_ID)
+                     .put(ExtractionCacheHelper.CACHE_TYPE_ID_JAVASCRIPT)
                      .put(bytes)
                      .array();
   }

--- a/processing/src/main/java/io/druid/query/extraction/LookupExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/LookupExtractionFn.java
@@ -33,8 +33,6 @@ import java.io.IOException;
 
 public class LookupExtractionFn extends FunctionalExtraction
 {
-  private static final byte CACHE_TYPE_ID = 0x7;
-
   private final LookupExtractor lookup;
 
   @JsonCreator
@@ -94,7 +92,7 @@ public class LookupExtractionFn extends FunctionalExtraction
   {
     try {
       final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-      outputStream.write(CACHE_TYPE_ID);
+      outputStream.write(ExtractionCacheHelper.CACHE_TYPE_ID_LOOKUP);
       outputStream.write(lookup.getCacheKey());
       if (getReplaceMissingValueWith() != null) {
         outputStream.write(StringUtils.toUtf8(getReplaceMissingValueWith()));

--- a/processing/src/main/java/io/druid/query/extraction/MatchingDimExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/MatchingDimExtractionFn.java
@@ -30,8 +30,6 @@ import java.util.regex.Pattern;
  */
 public class MatchingDimExtractionFn extends DimExtractionFn
 {
-  private static final byte CACHE_TYPE_ID = 0x2;
-
   private final String expr;
   private final Pattern pattern;
 
@@ -51,7 +49,7 @@ public class MatchingDimExtractionFn extends DimExtractionFn
   {
     byte[] exprBytes = StringUtils.toUtf8(expr);
     return ByteBuffer.allocate(1 + exprBytes.length)
-                     .put(CACHE_TYPE_ID)
+                     .put(ExtractionCacheHelper.CACHE_TYPE_ID_MATCHING_DIM)
                      .put(exprBytes)
                      .array();
   }

--- a/processing/src/main/java/io/druid/query/extraction/RegexDimExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/RegexDimExtractionFn.java
@@ -31,8 +31,6 @@ import java.util.regex.Pattern;
  */
 public class RegexDimExtractionFn extends DimExtractionFn
 {
-  private static final byte CACHE_TYPE_ID = 0x1;
-
   private final String expr;
   private final Pattern pattern;
 
@@ -52,7 +50,7 @@ public class RegexDimExtractionFn extends DimExtractionFn
   {
     byte[] exprBytes = StringUtils.toUtf8(expr);
     return ByteBuffer.allocate(1 + exprBytes.length)
-                     .put(CACHE_TYPE_ID)
+                     .put(ExtractionCacheHelper.CACHE_TYPE_ID_REGEX)
                      .put(exprBytes)
                      .array();
   }

--- a/processing/src/main/java/io/druid/query/extraction/SearchQuerySpecDimExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/SearchQuerySpecDimExtractionFn.java
@@ -28,8 +28,6 @@ import java.nio.ByteBuffer;
  */
 public class SearchQuerySpecDimExtractionFn extends DimExtractionFn
 {
-  private static final byte CACHE_TYPE_ID = 0x3;
-
   private final SearchQuerySpec searchQuerySpec;
 
   @JsonCreator
@@ -53,7 +51,7 @@ public class SearchQuerySpecDimExtractionFn extends DimExtractionFn
   {
     byte[] specBytes = searchQuerySpec.getCacheKey();
     return ByteBuffer.allocate(1 + specBytes.length)
-                     .put(CACHE_TYPE_ID)
+                     .put(ExtractionCacheHelper.CACHE_TYPE_ID_SEARCH_QUERY)
                      .put(specBytes)
                      .array();
   }

--- a/processing/src/main/java/io/druid/query/extraction/TimeDimExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/TimeDimExtractionFn.java
@@ -31,8 +31,6 @@ import java.util.Date;
  */
 public class TimeDimExtractionFn extends DimExtractionFn
 {
-  private static final byte CACHE_TYPE_ID = 0x0;
-
   private final String timeFormat;
   private final SimpleDateFormat timeFormatter;
   private final String resultFormat;
@@ -60,7 +58,7 @@ public class TimeDimExtractionFn extends DimExtractionFn
   {
     byte[] timeFormatBytes = StringUtils.toUtf8(timeFormat);
     return ByteBuffer.allocate(1 + timeFormatBytes.length)
-                     .put(CACHE_TYPE_ID)
+                     .put(ExtractionCacheHelper.CACHE_TYPE_ID_TIME_DIM)
                      .put(timeFormatBytes)
                      .array();
   }

--- a/processing/src/main/java/io/druid/query/extraction/TimeFormatExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/TimeFormatExtractionFn.java
@@ -32,8 +32,6 @@ import java.util.Locale;
 
 public class TimeFormatExtractionFn implements ExtractionFn
 {
-  private static final byte CACHE_TYPE_ID = 0x5;
-
   private final DateTimeZone tz;
   private final String pattern;
   private final Locale locale;
@@ -82,7 +80,7 @@ public class TimeFormatExtractionFn implements ExtractionFn
   {
     byte[] exprBytes = StringUtils.toUtf8(pattern + "\u0001" + tz.getID() + "\u0001" + locale.toLanguageTag());
     return ByteBuffer.allocate(1 + exprBytes.length)
-                     .put(CACHE_TYPE_ID)
+                     .put(ExtractionCacheHelper.CACHE_TYPE_ID_TIME_FORMAT)
                      .put(exprBytes)
                      .array();
   }
@@ -102,7 +100,7 @@ public class TimeFormatExtractionFn implements ExtractionFn
   @Override
   public String apply(String value)
   {
-    return apply((Object)value);
+    return apply((Object) value);
   }
 
   @Override

--- a/processing/src/test/java/io/druid/query/extraction/ConcatExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/ConcatExtractionFnTest.java
@@ -1,0 +1,67 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.query.extraction;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.druid.jackson.DefaultObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class ConcatExtractionFnTest
+{
+
+  @Test
+  public void testApply() throws Exception
+  {
+    ConcatExtractionFn fn = new ConcatExtractionFn("[%s]");
+    long test = 1000L;
+    Assert.assertEquals("[1000]", fn.apply(test));
+  }
+
+  @Test
+  public void testApplyNull() throws Exception
+  {
+    ConcatExtractionFn fn = new ConcatExtractionFn("[%s]");
+    String test = null;
+    Assert.assertEquals("[null]", fn.apply(test));
+  }
+
+  @Test
+  public void testSerde() throws Exception
+  {
+    final ObjectMapper objectMapper = new DefaultObjectMapper();
+    final String json = "{ \"type\" : \"concat\", \"format\" : \"[%s]\" }";
+    ConcatExtractionFn extractionFn = (ConcatExtractionFn) objectMapper.readValue(json, ExtractionFn.class);
+
+    Assert.assertEquals("[%s]", extractionFn.getFormat());
+
+    // round trip
+    Assert.assertEquals(
+        extractionFn,
+        objectMapper.readValue(
+            objectMapper.writeValueAsBytes(extractionFn),
+            ExtractionFn.class
+        )
+    );
+  }
+}


### PR DESCRIPTION
Add a dimension extraction function to support formatting value. The implementation internal uses String#format method.

the DSL:

```
{
  "type": "concat",
  "format": "[%s]"
}
```