### PR TITLE
add numRows to segment metadata query response

### DIFF
--- a/docs/content/querying/segmentmetadataquery.md
+++ b/docs/content/querying/segmentmetadataquery.md
@@ -6,6 +6,7 @@ Segment metadata queries return per segment information about:
 
 * Cardinality of all columns in the segment
 * Estimated byte size for the segment columns if they were stored in a flat format
+* Number of rows stored inside the segment
 * Interval the segment covers
 * Column type of all the columns in the segment
 * Estimated total segment byte size in if it was stored in a flat format
@@ -43,7 +44,8 @@ The format of the result is:
     "dim2" : { "type" : "STRING", "size" : 100000, "cardinality" : 1504 },
     "metric1" : { "type" : "FLOAT", "size" : 100000, "cardinality" : null }
   },
-  "size" : 300000
+  "size" : 300000,
+  "numRows" : 5000000
 } ]
 ```
 

--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
@@ -132,7 +132,13 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
               columns.put(columnName, rightColumns.get(columnName));
             }
 
-            return new SegmentAnalysis("merged", newIntervals, columns, arg1.getSize() + arg2.getSize());
+            return new SegmentAnalysis(
+                "merged",
+                newIntervals,
+                columns,
+                arg1.getSize() + arg2.getSize(),
+                arg1.getNumRows() + arg2.getNumRows()
+            );
           }
         };
       }

--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
@@ -122,7 +122,8 @@ public class SegmentMetadataQueryRunnerFactory implements QueryRunnerFactory<Seg
                     segment.getIdentifier(),
                     Arrays.asList(segment.getDataInterval()),
                     columns,
-                    totalSize
+                    totalSize,
+                    numRows
                 )
             )
         );

--- a/processing/src/main/java/io/druid/query/metadata/metadata/SegmentAnalysis.java
+++ b/processing/src/main/java/io/druid/query/metadata/metadata/SegmentAnalysis.java
@@ -30,13 +30,15 @@ public class SegmentAnalysis
   private final List<Interval> interval;
   private final Map<String, ColumnAnalysis> columns;
   private final long size;
+  private final int numRows;
 
   @JsonCreator
   public SegmentAnalysis(
       @JsonProperty("id") String id,
       @JsonProperty("intervals") List<Interval> interval,
       @JsonProperty("columns") Map<String, ColumnAnalysis> columns,
-      @JsonProperty("size") long size
+      @JsonProperty("size") long size,
+      @JsonProperty("numRows") int numRows
 
   )
   {
@@ -44,6 +46,7 @@ public class SegmentAnalysis
     this.interval = interval;
     this.columns = columns;
     this.size = size;
+    this.numRows = numRows;
   }
 
   @JsonProperty
@@ -70,6 +73,12 @@ public class SegmentAnalysis
     return size;
   }
 
+  @JsonProperty
+  public int getNumRows()
+  {
+    return numRows;
+  }
+
   public String toDetailedString()
   {
     return "SegmentAnalysis{" +
@@ -77,6 +86,7 @@ public class SegmentAnalysis
            ", interval=" + interval +
            ", columns=" + columns +
            ", size=" + size +
+           ", numRows=" + numRows +
            '}';
   }
 
@@ -87,6 +97,7 @@ public class SegmentAnalysis
            "id='" + id + '\'' +
            ", interval=" + interval +
            ", size=" + size +
+           ", numRows=" + numRows +
            '}';
   }
 
@@ -105,6 +116,11 @@ public class SegmentAnalysis
     if (size != that.size) {
       return false;
     }
+
+    if (numRows != that.numRows) {
+      return false;
+    }
+
     if (id != null ? !id.equals(that.id) : that.id != null) {
       return false;
     }
@@ -122,6 +138,7 @@ public class SegmentAnalysis
     result = 31 * result + (interval != null ? interval.hashCode() : 0);
     result = 31 * result + (columns != null ? columns.hashCode() : 0);
     result = 31 * result + (int) (size ^ (size >>> 32));
+    result = 31 * result + (int) (numRows ^ (numRows >>> 32));
     return result;
   }
 }

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
@@ -71,7 +71,8 @@ public class SegmentMetadataQueryQueryToolChestTest
                 1,
                 null
             )
-        ), 71982
+        ), 71982,
+        100
     );
 
     Object preparedValue = strategy.prepareForCache().apply(result);

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
@@ -103,7 +103,8 @@ public class SegmentMetadataQueryTest
                 1,
                 null
             )
-        ), 71982
+        ), 71982,
+        1209
     );
   }
 


### PR DESCRIPTION
I often need to see the number of rows in segments for some intervals.  currently you can do that, for example, by sending a group-by query with count aggregator.
however, I think adding numRows to segment metadata query response makes it way more convenient.

also other queries with count aggregator would need to scan the segment in order to compute rows in the segment.