### PR TITLE
fixed #2003 ColumnSelectorBitmapIndexSelector throws NPE for dimension not supporting bitmap

### DIFF
--- a/processing/src/main/java/io/druid/segment/ColumnSelectorBitmapIndexSelector.java
+++ b/processing/src/main/java/io/druid/segment/ColumnSelectorBitmapIndexSelector.java
@@ -121,7 +121,7 @@ public class ColumnSelectorBitmapIndexSelector implements BitmapIndexSelector
     }
 
     if (!column.getCapabilities().hasBitmapIndexes()) {
-      bitmapFactory.makeEmptyImmutableBitmap();
+      return bitmapFactory.makeEmptyImmutableBitmap();
     }
 
     return column.getBitmapIndex().getBitmap(value);


### PR DESCRIPTION
Trivial fix for #2003.