### PR TITLE
Preserve dimension order across indexes during ingestion

### DIFF
--- a/processing/src/main/java/io/druid/segment/IndexIO.java
+++ b/processing/src/main/java/io/druid/segment/IndexIO.java
@@ -610,6 +610,7 @@ public class IndexIO
             continue;
           }
 
+          int emptyStrIdx = dictionary.indexOf("");
           List<Integer> singleValCol = null;
           VSizeIndexed multiValCol = VSizeIndexed.readFromByteBuffer(dimBuffer.asReadOnlyBuffer());
           GenericIndexed<ImmutableBitmap> bitmaps = bitmapIndexes.get(dimension);
@@ -626,7 +627,7 @@ public class IndexIO
             if (rowValue.size() > 1) {
               onlyOneValue = false;
             }
-            if (rowValue.size() == 0) {
+            if (rowValue.size() == 0 || rowValue.get(0) == emptyStrIdx) {
               if (nullsSet == null) {
                 nullsSet = bitmapFactory.makeEmptyMutableBitmap();
               }

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
@@ -104,7 +104,7 @@ public class SegmentMetadataQueryTest
             new ColumnAnalysis(
                 ValueType.STRING.toString(),
                 10881,
-                1,
+                2,
                 null
             )
         ), 71982,
@@ -135,7 +135,7 @@ public class SegmentMetadataQueryTest
             new ColumnAnalysis(
                 ValueType.STRING.toString(),
                 21762,
-                1,
+                2,
                 null
             )
         ),

--- a/processing/src/test/java/io/druid/segment/QueryableIndexIndexableAdapterTest.java
+++ b/processing/src/test/java/io/druid/segment/QueryableIndexIndexableAdapterTest.java
@@ -74,6 +74,8 @@ public class QueryableIndexIndexableAdapterTest {
 
     IndexableAdapter adapter = new QueryableIndexIndexableAdapter(index);
     BitmapIndexSeeker bitmapIndexSeeker = adapter.getBitmapIndexSeeker("dim1");
+    IndexedInts indexedIntsNull = bitmapIndexSeeker.seek(null);
+    Assert.assertEquals(0, indexedIntsNull.size());
     IndexedInts indexedInts0 = bitmapIndexSeeker.seek("0");
     Assert.assertEquals(0, indexedInts0.size());
     IndexedInts indexedInts1 = bitmapIndexSeeker.seek("1");


### PR DESCRIPTION
Partially addresses issue #658 

Related to https://github.com/druid-io/druid-api/pull/68

This changes the RealtimePlumber and IndexGeneratorJob so that when an index is persisted, the next index created will inherit the dimension order built up by the previous index.

This is to better support arbitrary dimension orders when schema-less ingestion is used.

When merging indexes, the index merger will now attempt to find the largest common dimension ordering across the indexes, e.g.:

Index 1 dims: DimA, DimB
Index 2 dims: DimC
Index 3 dims: DimC, DimA, DimB

The ordering that will be used will be DimC, DimA, DimB as that encompasses all of the shorter orderings.

If no common order is found, the merger will fall back to the original lexicographic dimension ordering.

To support this change, the persisted indexes now include null dimensions and the dimension encoding dictionaries will now always have an entry for the empty string. This is done so that previously seen dimensions are not dropped in case an index does not receive any events with values for that dimension.

LIMITATIONS:
- Dimension order can be passed between the FireHydrants within a Sink, but not across Sinks.
- Dimension orders can be passed between indexes within a single partition during batch ingestion, but not across partitions.
