### PR TITLE
Make the TaskQueue big lock fair

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/TaskQueue.java
@@ -76,7 +76,7 @@ public class TaskQueue
   private final TaskLockbox taskLockbox;
   private final ServiceEmitter emitter;
 
-  private final ReentrantLock giant = new ReentrantLock();
+  private final ReentrantLock giant = new ReentrantLock(true);
   private final Condition managementMayBeNecessary = giant.newCondition();
   private final ExecutorService managerExec = Executors.newSingleThreadExecutor(
       new ThreadFactoryBuilder()


### PR DESCRIPTION
This is related to https://github.com/druid-io/druid/pull/1862 where there might be a timeout during a shutdown request.

If the big lock is not fair, then it is very possible for the `while(active)` loop to simply acquire the big lock again and timeout again.

This makes the big lock fair to allow multiple other operations to squeak in between retries.