### PR TITLE
Refactoring of IncrementalIndex

### DIFF
--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexAdapter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexAdapter.java
@@ -50,7 +50,7 @@ public class IncrementalIndexAdapter implements IndexableAdapter
 {
   private static final Logger log = new Logger(IncrementalIndexAdapter.class);
   private final Interval dataInterval;
-  private final IncrementalIndex<?> index;
+  private final IncrementalIndex index;
   private final Set<String> hasNullValueDimensions;
 
   private final Map<String, DimensionIndexer> indexers;
@@ -239,16 +239,18 @@ public class IncrementalIndexAdapter implements IndexableAdapter
          */
         return Iterators.transform(
             index.getFacts().entrySet().iterator(),
-            new Function<Map.Entry<IncrementalIndex.TimeAndDims, Integer>, Rowboat>()
+            new Function<Map.Entry<IncrementalIndex.TimeAndDims, Object>, Rowboat>()
             {
               int count = 0;
 
               @Override
-              public Rowboat apply(Map.Entry<IncrementalIndex.TimeAndDims, Integer> input)
+              public Rowboat apply(
+                  Map.Entry<IncrementalIndex.TimeAndDims, Object> input
+              )
               {
                 final IncrementalIndex.TimeAndDims timeAndDims = input.getKey();
                 final int[][] dimValues = timeAndDims.getDims();
-                final int rowOffset = input.getValue();
+                final Object aggrs = input.getValue();
 
                 int[][] dims = new int[dimValues.length][];
                 for (IncrementalIndex.DimensionDesc dimension : dimensions) {
@@ -273,7 +275,7 @@ public class IncrementalIndexAdapter implements IndexableAdapter
 
                 Object[] metrics = new Object[index.getMetricAggs().length];
                 for (int i = 0; i < metrics.length; i++) {
-                  metrics[i] = index.getMetricObjectValue(rowOffset, i);
+                  metrics[i] = index.getMetricObjectValue(aggrs, i);
                 }
 
                 return new Rowboat(

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
@@ -225,8 +225,8 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
 
             return new Cursor()
             {
-              private Iterator<Map.Entry<IncrementalIndex.TimeAndDims, Integer>> baseIter;
-              private ConcurrentNavigableMap<IncrementalIndex.TimeAndDims, Integer> cursorMap;
+              private Iterator<Map.Entry<IncrementalIndex.TimeAndDims, Object>> baseIter;
+              private ConcurrentNavigableMap<IncrementalIndex.TimeAndDims, Object> cursorMap;
               final DateTime time;
               int numAdvanced = -1;
               boolean done;
@@ -613,14 +613,14 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
 
   private static class EntryHolder
   {
-    Map.Entry<IncrementalIndex.TimeAndDims, Integer> currEntry = null;
+    Map.Entry<IncrementalIndex.TimeAndDims, Object> currEntry = null;
 
-    public Map.Entry<IncrementalIndex.TimeAndDims, Integer> get()
+    public Map.Entry<IncrementalIndex.TimeAndDims, Object> get()
     {
       return currEntry;
     }
 
-    public void set(Map.Entry<IncrementalIndex.TimeAndDims, Integer> currEntry)
+    public void set(Map.Entry<IncrementalIndex.TimeAndDims, Object> currEntry)
     {
       this.currEntry = currEntry;
     }
@@ -630,7 +630,7 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
       return currEntry.getKey();
     }
 
-    public Integer getValue()
+    public Object getValue()
     {
       return currEntry.getValue();
     }

--- a/processing/src/test/java/io/druid/query/QueryRunnerTestHelper.java
+++ b/processing/src/test/java/io/druid/query/QueryRunnerTestHelper.java
@@ -310,11 +310,13 @@ public class QueryRunnerTestHelper
   )
       throws IOException
   {
-    final IncrementalIndex rtIndex = TestIndex.getIncrementalTestIndex();
+    final IncrementalIndex rtIndexOnHeap = TestIndex.getIncrementalTestIndex(false);
+    final IncrementalIndex rtIndexOffHeap = TestIndex.getIncrementalTestIndex(true);
     final QueryableIndex mMappedTestIndex = TestIndex.getMMappedTestIndex();
     final QueryableIndex mergedRealtimeIndex = TestIndex.mergedRealtimeIndex();
     return ImmutableList.of(
-        makeQueryRunner(factory, new IncrementalIndexSegment(rtIndex, segmentId)),
+        makeQueryRunner(factory, new IncrementalIndexSegment(rtIndexOnHeap, segmentId)),
+        makeQueryRunner(factory, new IncrementalIndexSegment(rtIndexOffHeap, segmentId)),
         makeQueryRunner(factory, new QueryableIndexSegment(segmentId, mMappedTestIndex)),
         makeQueryRunner(factory, new QueryableIndexSegment(segmentId, mergedRealtimeIndex))
     );
@@ -327,12 +329,14 @@ public class QueryRunnerTestHelper
   )
       throws IOException
   {
-    final IncrementalIndex rtIndex = TestIndex.getIncrementalTestIndex();
+    final IncrementalIndex rtIndexOnHeap = TestIndex.getIncrementalTestIndex(false);
+    final IncrementalIndex rtIndexOffHeap = TestIndex.getIncrementalTestIndex(true);
     final QueryableIndex mMappedTestIndex = TestIndex.getMMappedTestIndex();
     final QueryableIndex mergedRealtimeIndex = TestIndex.mergedRealtimeIndex();
 
     return Arrays.asList(
-        makeUnionQueryRunner(factory, new IncrementalIndexSegment(rtIndex, segmentId)),
+        makeUnionQueryRunner(factory, new IncrementalIndexSegment(rtIndexOnHeap, segmentId)),
+        makeUnionQueryRunner(factory, new IncrementalIndexSegment(rtIndexOffHeap, segmentId)),
         makeUnionQueryRunner(factory, new QueryableIndexSegment(segmentId, mMappedTestIndex)),
         makeUnionQueryRunner(
             factory,

--- a/processing/src/test/java/io/druid/query/metadata/SegmentAnalyzerTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentAnalyzerTest.java
@@ -59,7 +59,7 @@ public class SegmentAnalyzerTest
   private void testIncrementalWorksHelper(EnumSet<SegmentMetadataQuery.AnalysisType> analyses) throws Exception
   {
     final List<SegmentAnalysis> results = getSegmentAnalysises(
-        new IncrementalIndexSegment(TestIndex.getIncrementalTestIndex(), null),
+        new IncrementalIndexSegment(TestIndex.getIncrementalTestIndex(false), null),
         analyses
     );
 

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
@@ -95,7 +95,7 @@ public class SegmentMetadataQueryTest
     return QueryRunnerTestHelper.makeQueryRunner(
         factory,
         segmentId,
-        new IncrementalIndexSegment(TestIndex.getIncrementalTestIndex(), segmentId)
+        new IncrementalIndexSegment(TestIndex.getIncrementalTestIndex(false), segmentId)
     );
   }
 

--- a/processing/src/test/java/io/druid/query/search/SearchQueryRunnerWithCaseTest.java
+++ b/processing/src/test/java/io/druid/query/search/SearchQueryRunnerWithCaseTest.java
@@ -83,8 +83,8 @@ public class SearchQueryRunnerWithCaseTest
         "2011-01-13T00:00:00.000Z\tspot\tautomotive\tpreferred\ta\u0001preferred\t94.874713"
     );
 
-    IncrementalIndex index1 = TestIndex.makeRealtimeIndex(input);
-    IncrementalIndex index2 = TestIndex.makeRealtimeIndex(input);
+    IncrementalIndex index1 = TestIndex.makeRealtimeIndex(input, false);
+    IncrementalIndex index2 = TestIndex.makeRealtimeIndex(input, false);
 
     QueryableIndex index3 = TestIndex.persistRealtimeAndLoadMMapped(index1);
     QueryableIndex index4 = TestIndex.persistRealtimeAndLoadMMapped(index2);

--- a/processing/src/test/java/io/druid/query/topn/TopNQueryQueryToolChestTest.java
+++ b/processing/src/test/java/io/druid/query/topn/TopNQueryQueryToolChestTest.java
@@ -121,7 +121,7 @@ public class TopNQueryQueryToolChestTest
     );
     QueryRunner<Result<TopNResultValue>> runner = QueryRunnerTestHelper.makeQueryRunner(
         factory,
-        new IncrementalIndexSegment(TestIndex.getIncrementalTestIndex(), segmentId)
+        new IncrementalIndexSegment(TestIndex.getIncrementalTestIndex(false), segmentId)
     );
 
     Map<String, Object> context = Maps.newHashMap();

--- a/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerBenchmark.java
+++ b/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerBenchmark.java
@@ -106,7 +106,7 @@ public class TopNQueryRunnerBenchmark extends AbstractBenchmark
         TestCases.rtIndex,
         QueryRunnerTestHelper.makeQueryRunner(
             factory,
-            new IncrementalIndexSegment(TestIndex.getIncrementalTestIndex(), segmentId)
+            new IncrementalIndexSegment(TestIndex.getIncrementalTestIndex(false), segmentId)
         )
     );
     testCaseMap.put(

--- a/processing/src/test/java/io/druid/segment/IndexIOTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexIOTest.java
@@ -261,7 +261,7 @@ public class IndexIOTest
     this.exception = exception;
   }
 
-  final IncrementalIndex<Aggregator> incrementalIndex1 = new OnheapIncrementalIndex(
+  final IncrementalIndex incrementalIndex1 = new OnheapIncrementalIndex(
       new IncrementalIndexSchema.Builder().withMinTimestamp(DEFAULT_INTERVAL.getStart().getMillis())
                                           .withQueryGranularity(QueryGranularity.NONE)
                                           .withMetrics(
@@ -283,7 +283,7 @@ public class IndexIOTest
       1000000
   );
 
-  final IncrementalIndex<Aggregator> incrementalIndex2 = new OnheapIncrementalIndex(
+  final IncrementalIndex incrementalIndex2 = new OnheapIncrementalIndex(
       new IncrementalIndexSchema.Builder().withMinTimestamp(DEFAULT_INTERVAL.getStart().getMillis())
                                           .withQueryGranularity(QueryGranularity.NONE)
                                           .withMetrics(

--- a/processing/src/test/java/io/druid/segment/data/IncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/data/IncrementalIndexTest.java
@@ -610,7 +610,7 @@ public class IncrementalIndexTest
   @Test
   public void testgetDimensions()
   {
-    final IncrementalIndex<Aggregator> incrementalIndex = new OnheapIncrementalIndex(
+    final IncrementalIndex incrementalIndex = new OnheapIncrementalIndex(
         new IncrementalIndexSchema.Builder().withQueryGranularity(QueryGranularity.NONE)
                                             .withMetrics(
                                                 new AggregatorFactory[]{


### PR DESCRIPTION
Current on-heap incremental indexer maps key to integer and maps the integer again to aggregators. Directly mapping key to aggregators would make things simple.