### PR TITLE
fix for #1939, Druid ParseSpec validator

### DIFF
--- a/services/src/main/java/io/druid/cli/validate/DruidJsonValidator.java
+++ b/services/src/main/java/io/druid/cli/validate/DruidJsonValidator.java
@@ -18,16 +18,28 @@
 package io.druid.cli.validate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
+import com.google.common.io.CharSource;
+import com.google.common.io.LineProcessor;
+import com.google.common.io.Resources;
 import com.metamx.common.UOE;
+import com.metamx.common.logger.Logger;
 import io.airlift.airline.Command;
 import io.airlift.airline.Option;
+import io.druid.data.input.InputRow;
+import io.druid.data.input.impl.StringInputRowParser;
 import io.druid.indexer.HadoopDruidIndexerConfig;
 import io.druid.indexing.common.task.Task;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.query.Query;
+import org.apache.commons.io.output.NullWriter;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
 
 /**
  */
@@ -37,11 +49,19 @@ import java.io.File;
 )
 public class DruidJsonValidator implements Runnable
 {
+  private Writer logWriter = new PrintWriter(System.out);
+
   @Option(name = "-f", title = "file", description = "file to validate", required = true)
   public String jsonFile;
 
   @Option(name = "-t", title = "type", description = "the type of schema to validate", required = true)
   public String type;
+
+  @Option(name = "-r", title = "resource", description = "optional resources required for validation", required = false)
+  public String resource;
+
+  @Option(name = "--log", title = "toLogger", description = "redirects any outputs to logger", required = false)
+  public boolean toLogger;
 
   @Override
   public void run()
@@ -53,6 +73,26 @@ public class DruidJsonValidator implements Runnable
 
     final ObjectMapper jsonMapper = new DefaultObjectMapper();
 
+    final ClassLoader loader;
+    if (Thread.currentThread().getContextClassLoader() != null) {
+      loader = Thread.currentThread().getContextClassLoader();
+    } else {
+      loader = DruidJsonValidator.class.getClassLoader();
+    }
+
+    if (toLogger) {
+      logWriter = new NullWriter()
+      {
+        private final Logger logger = new Logger(DruidJsonValidator.class);
+
+        @Override
+        public void write(char[] cbuf, int off, int len)
+        {
+          logger.info(new String(cbuf, off, len));
+        }
+      };
+    }
+
     try {
       if (type.equalsIgnoreCase("query")) {
         jsonMapper.readValue(file, Query.class);
@@ -60,6 +100,40 @@ public class DruidJsonValidator implements Runnable
         jsonMapper.readValue(file, HadoopDruidIndexerConfig.class);
       } else if (type.equalsIgnoreCase("task")) {
         jsonMapper.readValue(file, Task.class);
+      } else if (type.equalsIgnoreCase("parse")) {
+        final StringInputRowParser parser;
+        if (file.isFile()) {
+          logWriter.write("loading parse spec from file '" + file + "'");
+          parser = jsonMapper.readValue(file, StringInputRowParser.class);
+        } else if (loader.getResource(jsonFile) != null) {
+          logWriter.write("loading parse spec from resource '" + jsonFile + "'");
+          parser = jsonMapper.readValue(loader.getResource(jsonFile), StringInputRowParser.class);
+        } else {
+          logWriter.write("cannot find proper spec from 'file'.. regarding it as a json spec");
+          parser = jsonMapper.readValue(jsonFile, StringInputRowParser.class);
+        }
+        if (resource != null) {
+          final CharSource source;
+          if (new File(resource).isFile()) {
+            logWriter.write("loading data from file '" + resource + "'");
+            source = Resources.asByteSource(new File(resource).toURL()).asCharSource(
+                Charset.forName(
+                    parser.getEncoding()
+                )
+            );
+          } else if (loader.getResource(resource) != null) {
+            logWriter.write("loading data from resource '" + resource + "'");
+            source = Resources.asByteSource(loader.getResource(resource)).asCharSource(
+                Charset.forName(
+                    parser.getEncoding()
+                )
+            );
+          } else {
+            logWriter.write("cannot find proper data from 'resource'.. regarding it as data string");
+            source = CharSource.wrap(resource);
+          }
+          readData(parser, source);
+        }
       } else {
         throw new UOE("Unknown type[%s]", type);
       }
@@ -68,5 +142,42 @@ public class DruidJsonValidator implements Runnable
       System.out.println("INVALID JSON!");
       throw Throwables.propagate(e);
     }
+  }
+
+  @VisibleForTesting
+  void setLogWriter(Writer writer)
+  {
+    this.logWriter = writer;
+  }
+
+  private Void readData(final StringInputRowParser parser, final CharSource source)
+      throws IOException
+  {
+    return source.readLines(
+        new LineProcessor<Void>()
+        {
+          private final StringBuilder builder = new StringBuilder();
+
+          @Override
+          public boolean processLine(String line) throws IOException
+          {
+            InputRow parsed = parser.parse(line);
+            builder.append(parsed.getTimestamp());
+            for (String dimension : parsed.getDimensions()) {
+              builder.append('\t');
+              builder.append(parsed.getRaw(dimension));
+            }
+            logWriter.write(builder.toString());
+            builder.setLength(0);
+            return true;
+          }
+
+          @Override
+          public Void getResult()
+          {
+            return null;
+          }
+        }
+    );
   }
 }

--- a/services/src/test/resources/simple_test_data.tsv
+++ b/services/src/test/resources/simple_test_data.tsv
@@ -1,0 +1,1 @@
+2014102000	product_1	pty_country_34

--- a/services/src/test/resources/simple_test_data_record_parser.json
+++ b/services/src/test/resources/simple_test_data_record_parser.json
@@ -1,0 +1,22 @@
+{
+  "type": "string",
+  "parseSpec": {
+    "format": "tsv",
+    "timestampSpec": {
+      "column": "timestamp",
+      "format": "yyyyMMddHH"
+    },
+    "dimensionsSpec": {
+      "dimensions": [
+        "product"
+      ],
+      "dimensionExclusions": [],
+      "spatialDimensions": []
+    },
+    "columns": [
+      "timestamp",
+      "product",
+      "pty_country"
+    ]
+  }
+}

--- a/services/src/test/resources/simple_test_data_record_parser_invalid.json
+++ b/services/src/test/resources/simple_test_data_record_parser_invalid.json
@@ -1,0 +1,23 @@
+{
+  "type": "string",
+  "parseSpec": {
+    "format": "csv",
+    "timestampSpec": {
+      "column": "timestamp",
+      "format": "yyyyMMddHH"
+    },
+    "dimensionsSpec": {
+      "dimensions": [
+        "product"
+      ],
+      "dimensionExclusions": [],
+      "spatialDimensions": []
+    },
+    "columns": [
+      "timestamp",
+      "product",
+      "pty_country",
+      "product"
+    ]
+  }
+}


### PR DESCRIPTION
Made for fun. With this clumsy little codes, you can see the result of parsing. For example,

```
java -cp "lib/*" io.druid.data.input.ParseSpecValidator -i ~/projects/druid/processing/src/test/resources/simple_test_data_record_parser.json -t  ~/projects/druid/processing/src/test/resources/simple_test_data.tsv
````