### PR TITLE
Adding reverse lookup function to LookupExtractor.

### DIFF
--- a/extensions/kafka-extraction-namespace/src/main/java/io/druid/server/namespace/KafkaExtractionNamespaceFactory.java
+++ b/extensions/kafka-extraction-namespace/src/main/java/io/druid/server/namespace/KafkaExtractionNamespaceFactory.java
@@ -20,12 +20,16 @@
 package io.druid.server.namespace;
 
 import com.google.common.base.Function;
+import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import io.druid.query.extraction.namespace.ExtractionNamespaceFunctionFactory;
 import io.druid.query.extraction.namespace.KafkaExtractionNamespace;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
@@ -47,7 +51,7 @@ public class KafkaExtractionNamespaceFactory implements ExtractionNamespaceFunct
 
 
   @Override
-  public Function<String, String> build(KafkaExtractionNamespace extractionNamespace, final Map<String, String> cache)
+  public Function<String, String> buildFn(KafkaExtractionNamespace extractionNamespace, final Map<String, String> cache)
   {
     return new Function<String, String>()
     {
@@ -59,6 +63,28 @@ public class KafkaExtractionNamespaceFactory implements ExtractionNamespaceFunct
           return null;
         }
         return Strings.emptyToNull(cache.get(input));
+      }
+    };
+  }
+
+  @Override
+  public Function<String, List<String>> buildReverseFn(
+      KafkaExtractionNamespace extractionNamespace, final Map<String, String> cache
+  )
+  {
+    return new Function<String, List<String>>()
+    {
+      @Nullable
+      @Override
+      public List<String> apply(@Nullable final String value)
+      {
+        return Lists.newArrayList(Maps.filterKeys(cache, new Predicate<String>()
+        {
+          @Override public boolean apply(@Nullable String key)
+          {
+            return cache.get(key).equals(Strings.nullToEmpty(value));
+          }
+        }).keySet());
       }
     };
   }

--- a/extensions/namespace-lookup/src/main/java/io/druid/query/extraction/namespace/ExtractionNamespaceFunctionFactory.java
+++ b/extensions/namespace-lookup/src/main/java/io/druid/query/extraction/namespace/ExtractionNamespaceFunctionFactory.java
@@ -21,6 +21,7 @@ package io.druid.query.extraction.namespace;
 
 import com.google.common.base.Function;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
@@ -39,7 +40,16 @@ public interface ExtractionNamespaceFunctionFactory<T extends ExtractionNamespac
    *
    * @return A function which will perform an extraction in accordance with the desires of the ExtractionNamespace
    */
-  Function<String, String> build(T extractionNamespace, Map<String, String> cache);
+  Function<String, String> buildFn(T extractionNamespace, Map<String, String> cache);
+
+
+  /**
+   * @param extractionNamespace The ExtractionNamespace for which a manipulating reverse function is needed.
+   * @param cache view of the cache containing the function mapping.
+   *
+   * @return A function that will perform reverse lookup.
+   */
+  Function<String, List<String>> buildReverseFn(T extractionNamespace, final Map<String, String> cache);
 
   /**
    * This function is called once if `ExtractionNamespace.getUpdateMs() == 0`, or every update if
@@ -54,7 +64,7 @@ public interface ExtractionNamespaceFunctionFactory<T extends ExtractionNamespac
    * @param lastVersion         The version which was last cached
    * @param swap                The temporary Map into which data may be placed and will be "swapped" with the proper
    *                            namespace Map in NamespaceExtractionCacheManager. Implementations which cannot offer
-   *                            a swappable cache of the data may ignore this but must make sure `build(...)` returns
+   *                            a swappable cache of the data may ignore this but must make sure `buildFn(...)` returns
    *                            a proper Function.
    *
    * @return A callable that will be used to refresh resources of the namespace and return the version string used in

--- a/extensions/namespace-lookup/src/main/java/io/druid/server/namespace/JDBCExtractionNamespaceFunctionFactory.java
+++ b/extensions/namespace-lookup/src/main/java/io/druid/server/namespace/JDBCExtractionNamespaceFunctionFactory.java
@@ -20,7 +20,10 @@
 package io.druid.server.namespace;
 
 import com.google.common.base.Function;
+import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.metamx.common.Pair;
 import io.druid.common.utils.JodaUtils;
 import io.druid.query.extraction.namespace.ExtractionNamespaceFunctionFactory;
@@ -51,7 +54,7 @@ public class JDBCExtractionNamespaceFunctionFactory
   private final ConcurrentMap<String, DBI> dbiCache = new ConcurrentHashMap<>();
 
   @Override
-  public Function<String, String> build(JDBCExtractionNamespace extractionNamespace, final Map<String, String> cache)
+  public Function<String, String> buildFn(JDBCExtractionNamespace extractionNamespace, final Map<String, String> cache)
   {
     return new Function<String, String>()
     {
@@ -63,6 +66,28 @@ public class JDBCExtractionNamespaceFunctionFactory
           return null;
         }
         return Strings.emptyToNull(cache.get(input));
+      }
+    };
+  }
+
+  @Override
+  public Function<String, List<String>> buildReverseFn(
+      JDBCExtractionNamespace extractionNamespace, final Map<String, String> cache
+  )
+  {
+    return new Function<String, List<String>>()
+    {
+      @Nullable
+      @Override
+      public List<String> apply(@Nullable final String value)
+      {
+        return Lists.newArrayList(Maps.filterKeys(cache, new Predicate<String>()
+        {
+          @Override public boolean apply(@Nullable String key)
+          {
+            return cache.get(key).equals(Strings.nullToEmpty(value));
+          }
+        }).keySet());
       }
     };
   }

--- a/extensions/namespace-lookup/src/main/java/io/druid/server/namespace/URIExtractionNamespaceFunctionFactory.java
+++ b/extensions/namespace-lookup/src/main/java/io/druid/server/namespace/URIExtractionNamespaceFunctionFactory.java
@@ -20,8 +20,11 @@
 package io.druid.server.namespace;
 
 import com.google.common.base.Function;
+import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.io.ByteSource;
 import com.google.inject.Inject;
 import com.metamx.common.CompressionUtils;
@@ -42,6 +45,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
@@ -64,7 +68,7 @@ public class URIExtractionNamespaceFunctionFactory implements ExtractionNamespac
   }
 
   @Override
-  public Function<String, String> build(URIExtractionNamespace extractionNamespace, final Map<String, String> cache)
+  public Function<String, String> buildFn(URIExtractionNamespace extractionNamespace, final Map<String, String> cache)
   {
     return new Function<String, String>()
     {
@@ -76,6 +80,29 @@ public class URIExtractionNamespaceFunctionFactory implements ExtractionNamespac
           return null;
         }
         return Strings.emptyToNull(cache.get(input));
+      }
+    };
+  }
+
+  @Override
+  public Function<String, List<String>> buildReverseFn(
+      URIExtractionNamespace extractionNamespace, final Map<String, String> cache
+  )
+  {
+    return new Function<String, List<String>>()
+    {
+      @Nullable
+      @Override
+      public List<String> apply(@Nullable final String value)
+      {
+        return Lists.newArrayList(Maps.filterKeys(cache, new Predicate<String>()
+        {
+          @Override
+          public boolean apply(@Nullable String key)
+          {
+            return cache.get(key).equals(Strings.nullToEmpty(value));
+          }
+        }).keySet());
       }
     };
   }

--- a/extensions/namespace-lookup/src/main/java/io/druid/server/namespace/cache/OffHeapNamespaceExtractionCacheManager.java
+++ b/extensions/namespace-lookup/src/main/java/io/druid/server/namespace/cache/OffHeapNamespaceExtractionCacheManager.java
@@ -35,6 +35,7 @@ import org.mapdb.DBMaker;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -57,11 +58,13 @@ public class OffHeapNamespaceExtractionCacheManager extends NamespaceExtractionC
       Lifecycle lifecycle,
       @Named("namespaceExtractionFunctionCache")
       ConcurrentMap<String, Function<String, String>> fnCache,
+      @Named("namespaceReverseExtractionFunctionCache")
+      ConcurrentMap<String, Function<String, List<String>>> reverseFnCache,
       ServiceEmitter emitter,
       final Map<Class<? extends ExtractionNamespace>, ExtractionNamespaceFunctionFactory<?>> namespaceFunctionFactoryMap
   )
   {
-    super(lifecycle, fnCache, emitter, namespaceFunctionFactoryMap);
+    super(lifecycle, fnCache, reverseFnCache, emitter, namespaceFunctionFactoryMap);
     try {
       tmpFile = File.createTempFile("druidMapDB", getClass().getCanonicalName());
       log.info("Using file [%s] for mapDB off heap namespace cache", tmpFile.getAbsolutePath());

--- a/extensions/namespace-lookup/src/main/java/io/druid/server/namespace/cache/OnHeapNamespaceExtractionCacheManager.java
+++ b/extensions/namespace-lookup/src/main/java/io/druid/server/namespace/cache/OnHeapNamespaceExtractionCacheManager.java
@@ -28,6 +28,7 @@ import com.metamx.emitter.service.ServiceEmitter;
 import io.druid.query.extraction.namespace.ExtractionNamespace;
 import io.druid.query.extraction.namespace.ExtractionNamespaceFunctionFactory;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -46,11 +47,13 @@ public class OnHeapNamespaceExtractionCacheManager extends NamespaceExtractionCa
       final Lifecycle lifecycle,
       @Named("namespaceExtractionFunctionCache")
       final ConcurrentMap<String, Function<String, String>> fnCache,
+      @Named("namespaceReverseExtractionFunctionCache")
+      final ConcurrentMap<String, Function<String, List<String>>> reverseFnCache,
       final ServiceEmitter emitter,
       final Map<Class<? extends ExtractionNamespace>, ExtractionNamespaceFunctionFactory<?>> namespaceFunctionFactoryMap
   )
   {
-    super(lifecycle, fnCache, emitter, namespaceFunctionFactoryMap);
+    super(lifecycle, fnCache, reverseFnCache,emitter, namespaceFunctionFactoryMap);
   }
 
   @Override

--- a/extensions/namespace-lookup/src/test/java/io/druid/query/extraction/namespace/NamespacedExtractorTest.java
+++ b/extensions/namespace-lookup/src/test/java/io/druid/query/extraction/namespace/NamespacedExtractorTest.java
@@ -27,6 +27,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -46,6 +49,17 @@ public class NamespacedExtractorTest
       return Strings.isNullOrEmpty(input) ? null : input;
     }
   };
+
+  private static final Function<String, List<String>> NOOP_REVERSE_FN = new Function<String, List<String>>()
+  {
+    @Nullable
+    @Override
+    public List<String> apply(@Nullable String input)
+    {
+      return Strings.isNullOrEmpty(input) ? Collections.<String>emptyList() : Arrays.asList(input);
+    }
+  };
+
   private static final Function<String, Function<String, String>> defaultFnFinder = new Function<String, Function<String, String>>()
   {
     @Nullable
@@ -56,6 +70,17 @@ public class NamespacedExtractorTest
       return fn == null ? NOOP_FN : fn;
     }
   };
+
+  private static final Function<String,Function<String, List<String>>> defaultReverseFnFinder = new Function<String, Function<String,List<String>>>()
+  {
+    @Nullable
+    @Override
+    public Function<String, java.util.List<String>> apply(@Nullable final String value)
+    {
+      return NOOP_REVERSE_FN;
+    }
+  };
+
   @BeforeClass
   public static void setupStatic()
   {
@@ -108,20 +133,26 @@ public class NamespacedExtractorTest
   @Test
   public void testSimpleNamespace()
   {
-    NamespacedExtractor namespacedExtractor = new NamespacedExtractor(defaultFnFinder, "noop");
+    NamespacedExtractor namespacedExtractor = new NamespacedExtractor(defaultFnFinder, defaultReverseFnFinder, "noop");
     for (int i = 0; i < 10; ++i) {
       final String val = UUID.randomUUID().toString();
       Assert.assertEquals(val, namespacedExtractor.apply(val));
+      Assert.assertEquals(Arrays.asList(val), namespacedExtractor.unApply(val));
     }
     Assert.assertEquals("", namespacedExtractor.apply(""));
     Assert.assertNull(namespacedExtractor.apply(null));
+    Assert.assertEquals(Collections.emptyList(), namespacedExtractor.unApply(null));
     Assert.assertEquals("The awesomeness", namespacedExtractor.apply("The awesomeness"));
   }
 
   @Test
   public void testUnknownNamespace()
   {
-    NamespacedExtractor namespacedExtractor = new NamespacedExtractor(defaultFnFinder, "HFJDKSHFUINEWUINIUENFIUENFUNEWI");
+    NamespacedExtractor namespacedExtractor = new NamespacedExtractor(
+        defaultFnFinder,
+        defaultReverseFnFinder,
+        "HFJDKSHFUINEWUINIUENFIUENFUNEWI"
+    );
     for (int i = 0; i < 10; ++i) {
       final String val = UUID.randomUUID().toString();
       Assert.assertEquals(val, namespacedExtractor.apply(val));
@@ -133,7 +164,7 @@ public class NamespacedExtractorTest
   @Test
   public void testTurtles()
   {
-    NamespacedExtractor namespacedExtractor = new NamespacedExtractor(defaultFnFinder, "turtles");
+    NamespacedExtractor namespacedExtractor = new NamespacedExtractor(defaultFnFinder, defaultReverseFnFinder, "turtles");
     for (int i = 0; i < 10; ++i) {
       final String val = UUID.randomUUID().toString();
       Assert.assertEquals("turtle", namespacedExtractor.apply(val));
@@ -145,7 +176,7 @@ public class NamespacedExtractorTest
   @Test
   public void testEmpty()
   {
-    NamespacedExtractor namespacedExtractor = new NamespacedExtractor(defaultFnFinder, "empty");
+    NamespacedExtractor namespacedExtractor = new NamespacedExtractor(defaultFnFinder, defaultReverseFnFinder, "empty");
     Assert.assertEquals("", namespacedExtractor.apply(""));
     Assert.assertEquals("", namespacedExtractor.apply(null));
     Assert.assertEquals("", namespacedExtractor.apply("anything"));
@@ -154,7 +185,7 @@ public class NamespacedExtractorTest
   @Test
   public void testNull()
   {
-    NamespacedExtractor namespacedExtractor = new NamespacedExtractor(defaultFnFinder, "null");
+    NamespacedExtractor namespacedExtractor = new NamespacedExtractor(defaultFnFinder, defaultReverseFnFinder, "null");
     Assert.assertNull(namespacedExtractor.apply(""));
     Assert.assertNull(namespacedExtractor.apply(null));
   }
@@ -162,7 +193,7 @@ public class NamespacedExtractorTest
   @Test
   public void testBlankMissingValueIsNull()
   {
-    NamespacedExtractor namespacedExtractor = new NamespacedExtractor(defaultFnFinder, "null");
+    NamespacedExtractor namespacedExtractor = new NamespacedExtractor(defaultFnFinder, defaultReverseFnFinder, "null");
     Assert.assertNull(namespacedExtractor.apply("fh43u1i2"));
     Assert.assertNull(namespacedExtractor.apply(""));
     Assert.assertNull(namespacedExtractor.apply(null));

--- a/extensions/namespace-lookup/src/test/java/io/druid/server/namespace/NamespacedExtractorModuleTest.java
+++ b/extensions/namespace-lookup/src/test/java/io/druid/server/namespace/NamespacedExtractorModuleTest.java
@@ -49,6 +49,7 @@ import java.io.OutputStreamWriter;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -84,6 +85,7 @@ public class NamespacedExtractorModuleTest
     cacheManager = new OnHeapNamespaceExtractionCacheManager(
         lifecycle,
         new ConcurrentHashMap<String, Function<String, String>>(),
+        new ConcurrentHashMap<String, Function<String, List<String>>>(),
         new NoopServiceEmitter(), factoryMap
     );
     fnCache.clear();

--- a/extensions/namespace-lookup/src/test/java/io/druid/server/namespace/URIExtractionNamespaceFunctionFactoryTest.java
+++ b/extensions/namespace-lookup/src/test/java/io/druid/server/namespace/URIExtractionNamespaceFunctionFactoryTest.java
@@ -24,6 +24,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
 import com.metamx.common.UOE;
 import com.metamx.common.lifecycle.Lifecycle;
 import com.metamx.emitter.service.ServiceEmitter;
@@ -60,6 +61,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -136,11 +138,13 @@ public class URIExtractionNamespaceFunctionFactoryTest
         OnHeapNamespaceExtractionCacheManager.class.getConstructor(
             Lifecycle.class,
             ConcurrentMap.class,
+            ConcurrentMap.class,
             ServiceEmitter.class,
             Map.class
         ),
         OffHeapNamespaceExtractionCacheManager.class.getConstructor(
             Lifecycle.class,
+            ConcurrentMap.class,
             ConcurrentMap.class,
             ServiceEmitter.class,
             Map.class
@@ -172,6 +176,7 @@ public class URIExtractionNamespaceFunctionFactoryTest
               try {
                 manager = constructor.newInstance(
                     new Lifecycle(),
+                    new ConcurrentHashMap<String, Function<String, String>>(),
                     new ConcurrentHashMap<String, Function<String, String>>(),
                     new NoopServiceEmitter(),
                     new HashMap<Class<? extends ExtractionNamespace>, ExtractionNamespaceFunctionFactory<?>>()
@@ -222,9 +227,11 @@ public class URIExtractionNamespaceFunctionFactoryTest
     this.outStreamSupplier = outStreamSupplier;
     this.lifecycle = new Lifecycle();
     this.fnCache = new ConcurrentHashMap<>();
+    this.reverseFnCache = new ConcurrentHashMap<>();
     this.manager = cacheManagerConstructor.newInstance(
         lifecycle,
         fnCache,
+        reverseFnCache,
         new NoopServiceEmitter(),
         namespaceFunctionFactoryMap
     );
@@ -251,6 +258,7 @@ public class URIExtractionNamespaceFunctionFactoryTest
   private URIExtractionNamespaceFunctionFactory factory;
   private URIExtractionNamespace namespace;
   private ConcurrentHashMap<String, Function<String, String>> fnCache;
+  private ConcurrentHashMap<String, Function<String, List<String>>> reverseFnCache;
 
   @Before
   public void setUp() throws Exception
@@ -262,7 +270,16 @@ public class URIExtractionNamespaceFunctionFactoryTest
     final ObjectMapper mapper = new DefaultObjectMapper();
     try (OutputStream ostream = outStreamSupplier.apply(tmpFile)) {
       try (OutputStreamWriter out = new OutputStreamWriter(ostream)) {
-        out.write(mapper.writeValueAsString(ImmutableMap.<String, String>of("foo", "bar")));
+        out.write(mapper.writeValueAsString(ImmutableMap.<String, String>of(
+            "boo",
+            "bar",
+            "foo",
+            "bar",
+            "",
+            "MissingValue",
+            "emptyString",
+            ""
+        )));
       }
     }
     factory = new URIExtractionNamespaceFunctionFactory(
@@ -297,6 +314,20 @@ public class URIExtractionNamespaceFunctionFactoryTest
     }
     Assert.assertEquals("bar", fn.apply("foo"));
     Assert.assertEquals(null, fn.apply("baz"));
+  }
+
+  @Test
+  public void testReverseFunction() throws InterruptedException
+  {
+    Assert.assertNull(reverseFnCache.get(namespace.getNamespace()));
+    NamespaceExtractionCacheManagersTest.waitFor(manager.schedule(namespace));
+    Function<String, List<String>> reverseFn = reverseFnCache.get(namespace.getNamespace());
+    Assert.assertNotNull(reverseFn);
+    Assert.assertEquals(Sets.newHashSet("boo", "foo"), Sets.newHashSet(reverseFn.apply("bar")));
+    Assert.assertEquals(Sets.newHashSet(""), Sets.newHashSet(reverseFn.apply("MissingValue")));
+    Assert.assertEquals(Sets.newHashSet("emptyString"), Sets.newHashSet(reverseFn.apply("")));
+    Assert.assertEquals(Sets.newHashSet("emptyString"), Sets.newHashSet(reverseFn.apply(null)));
+    Assert.assertEquals(Collections.EMPTY_LIST, reverseFn.apply("baz"));
   }
 
   @Test

--- a/extensions/namespace-lookup/src/test/java/io/druid/server/namespace/cache/NamespaceExtractionCacheManagerExecutorsTest.java
+++ b/extensions/namespace-lookup/src/test/java/io/druid/server/namespace/cache/NamespaceExtractionCacheManagerExecutorsTest.java
@@ -56,6 +56,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
@@ -80,6 +81,7 @@ public class NamespaceExtractionCacheManagerExecutorsTest
   private NamespaceExtractionCacheManager manager;
   private File tmpFile;
   private final ConcurrentMap<String, Function<String, String>> fnCache = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, Function<String, List<String>>> reverseFnCache = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, Object> cacheUpdateAlerts = new ConcurrentHashMap<>();
 
   private final AtomicLong numRuns = new AtomicLong(0L);
@@ -114,7 +116,7 @@ public class NamespaceExtractionCacheManagerExecutorsTest
       }
     };
     manager = new OnHeapNamespaceExtractionCacheManager(
-        lifecycle, fnCache, new NoopServiceEmitter(),
+        lifecycle, fnCache, reverseFnCache, new NoopServiceEmitter(),
         ImmutableMap.<Class<? extends ExtractionNamespace>, ExtractionNamespaceFunctionFactory<?>>of(
             URIExtractionNamespace.class,
             factory

--- a/extensions/namespace-lookup/src/test/java/io/druid/server/namespace/cache/NamespaceExtractionCacheManagersTest.java
+++ b/extensions/namespace-lookup/src/test/java/io/druid/server/namespace/cache/NamespaceExtractionCacheManagersTest.java
@@ -62,11 +62,13 @@ public class NamespaceExtractionCacheManagersTest
     ArrayList<Object[]> params = new ArrayList<>();
 
     ConcurrentMap<String, Function<String, String>> fnMap = new ConcurrentHashMap<String, Function<String, String>>();
+    ConcurrentMap<String, Function<String, List<String>>> reverserFnMap = new ConcurrentHashMap<String, Function<String, List<String>>>();
     params.add(
         new Object[]{
                    new OffHeapNamespaceExtractionCacheManager(
                    lifecycle,
                    fnMap,
+                   reverserFnMap,
                    new NoopServiceEmitter(),
                    ImmutableMap.<Class<? extends ExtractionNamespace>, ExtractionNamespaceFunctionFactory<?>>of()
                ), fnMap
@@ -77,6 +79,7 @@ public class NamespaceExtractionCacheManagersTest
             new OnHeapNamespaceExtractionCacheManager(
                 lifecycle,
                 fnMap,
+                reverserFnMap,
                 new NoopServiceEmitter(),
                 ImmutableMap.<Class<? extends ExtractionNamespace>, ExtractionNamespaceFunctionFactory<?>>of()
             ), fnMap

--- a/processing/src/main/java/io/druid/query/extraction/LookupExtractor.java
+++ b/processing/src/main/java/io/druid/query/extraction/LookupExtractor.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
+import java.util.List;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes(value = {
@@ -38,6 +39,18 @@ public interface LookupExtractor
    * @return The lookup, or null key cannot have the lookup applied to it and should be treated as missing.
    */
   @Nullable String apply(@NotNull String key);
+
+  /**
+   * Provide the reverse mapping from a given value to a list of keys
+   * @param value the value to apply the reverse lookup
+   *              Null and empty are considered to be the same value = nullToEmpty(value)
+   *
+   * @return the list of keys that maps to value or empty list.
+   * Note that for the case of a none existing value in the lookup we have to cases either return an empty list OR list with null element.
+   * returning an empty list implies that user want to ignore such a lookup value.
+   * In the other hand returning a list with the null element implies user want to map the none existing value to the key null.
+   */
+  List<String> unApply(String value);
 
   /**
    * Create a cache key for use in results caching

--- a/processing/src/main/java/io/druid/query/extraction/MapLookupExtractor.java
+++ b/processing/src/main/java/io/druid/query/extraction/MapLookupExtractor.java
@@ -23,15 +23,19 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.metamx.common.StringUtils;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 @JsonTypeName("map")
@@ -58,6 +62,19 @@ public class MapLookupExtractor implements LookupExtractor
   public String apply(@NotNull String val)
   {
     return map.get(val);
+  }
+
+  @Override
+  public List<String> unApply(final String value)
+  {
+    return Lists.newArrayList(Maps.filterKeys(map, new Predicate<String>()
+    {
+      @Override public boolean apply(@Nullable String key)
+      {
+        return map.get(key).equals(Strings.nullToEmpty(value));
+      }
+    }).keySet());
+
   }
 
   @Override

--- a/processing/src/test/java/io/druid/query/extraction/MapLookupExtractorTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/MapLookupExtractorTest.java
@@ -20,20 +20,36 @@
 package io.druid.query.extraction;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
 
 
 public class MapLookupExtractorTest
 {
-  private final MapLookupExtractor fn = new MapLookupExtractor(ImmutableMap.of("foo", "bar"));
+  private final Map lookupMap = ImmutableMap.of("foo", "bar", "null", "", "empty String", "", "","empty_string");
+  private final MapLookupExtractor fn = new MapLookupExtractor(lookupMap);
+
+  @Test
+  public void testUnApply()
+  {
+    Assert.assertEquals(Arrays.asList("foo"), fn.unApply("bar"));
+    Assert.assertEquals(Sets.newHashSet("null", "empty String"), Sets.newHashSet(fn.unApply("")));
+    Assert.assertEquals("Null value should be equal to empty string",
+                        Sets.newHashSet("null", "empty String"),
+                        Sets.newHashSet(fn.unApply(null)));
+    Assert.assertEquals(Sets.newHashSet(""), Sets.newHashSet(fn.unApply("empty_string")));
+    Assert.assertEquals("not existing value returns empty list", Collections.EMPTY_LIST, fn.unApply("not There"));
+  }
 
   @Test
   public void testGetMap() throws Exception
   {
-    Assert.assertEquals(ImmutableMap.of("foo", "bar"), fn.getMap());
+    Assert.assertEquals(lookupMap, fn.getMap());
   }
 
   @Test
@@ -46,7 +62,7 @@ public class MapLookupExtractorTest
   @Test
   public void testGetCacheKey() throws Exception
   {
-    final MapLookupExtractor fn2 = new MapLookupExtractor(ImmutableMap.of("foo", "bar"));
+    final MapLookupExtractor fn2 = new MapLookupExtractor(ImmutableMap.copyOf(lookupMap));
     Assert.assertArrayEquals(fn.getCacheKey(), fn2.getCacheKey());
     final MapLookupExtractor fn3 = new MapLookupExtractor(ImmutableMap.of("foo2", "bar"));
     Assert.assertFalse(Arrays.equals(fn.getCacheKey(), fn3.getCacheKey()));
@@ -57,7 +73,7 @@ public class MapLookupExtractorTest
   @Test
   public void testEquals() throws Exception
   {
-    final MapLookupExtractor fn2 = new MapLookupExtractor(ImmutableMap.of("foo", "bar"));
+    final MapLookupExtractor fn2 = new MapLookupExtractor(ImmutableMap.copyOf(lookupMap));
     Assert.assertEquals(fn, fn2);
     final MapLookupExtractor fn3 = new MapLookupExtractor(ImmutableMap.of("foo2", "bar"));
     Assert.assertNotEquals(fn, fn3);
@@ -68,7 +84,7 @@ public class MapLookupExtractorTest
   @Test
   public void testHashCode() throws Exception
   {
-    final MapLookupExtractor fn2 = new MapLookupExtractor(ImmutableMap.of("foo", "bar"));
+    final MapLookupExtractor fn2 = new MapLookupExtractor(ImmutableMap.copyOf(lookupMap));
     Assert.assertEquals(fn.hashCode(), fn2.hashCode());
     final MapLookupExtractor fn3 = new MapLookupExtractor(ImmutableMap.of("foo2", "bar"));
     Assert.assertNotEquals(fn.hashCode(), fn3.hashCode());


### PR DESCRIPTION
This PR adds to the LookupExtractor `unApply`  function in order to perform reverse lookup.

Part of this PR is to clean most of the unused import. 