### PR TITLE
Support ordering granularity different from query granularity for group-by queries

### DIFF
--- a/docs/content/querying/limitspec.md
+++ b/docs/content/querying/limitspec.md
@@ -13,8 +13,18 @@ The default limit spec takes a limit and the list of columns to do an orderBy op
     "type"    : "default",
     "limit"   : <integer_value>,
     "columns" : [list of OrderByColumnSpec],
+    "regroupingGranularity" : [QueryGranularity],
+    "applyLimitPerGroup: <boolean_value>
 }
 ```
+
+|property|description|required?|
+|--------|-----------|---------|
+|type|This String should always be "default". |yes|
+|limit|Number of limit.|yes|
+|columns|Ordering to apply limit; see [OrderByColumnSpec]. |no|
+|regroupingGranularity|Granularity for reordering. see [Granularities](../querying/granularities.html).|no|
+|applyLimitPerGroup|Whether to apply limit to each group; User can possibly get up to <limit> * <number of groups> rows. |no|
 
 #### OrderByColumnSpec
 

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQuery.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQuery.java
@@ -327,6 +327,8 @@ public class GroupByQuery extends BaseQuery<Row>
     private LimitSpec limitSpec = null;
     private List<OrderByColumnSpec> orderByColumnSpecs = Lists.newArrayList();
     private int limit = Integer.MAX_VALUE;
+    private QueryGranularity limitGranularity;
+    private boolean limitPerGroup;
 
     public Builder()
     {
@@ -546,6 +548,20 @@ public class GroupByQuery extends BaseQuery<Row>
       return this;
     }
 
+    public Builder setLimitGranularity(QueryGranularity limitGranularity)
+    {
+      this.limitGranularity = limitGranularity;
+
+      return this;
+    }
+
+    public Builder setLimitPerGroup(boolean limitPerGroup)
+    {
+      this.limitPerGroup = limitPerGroup;
+
+      return this;
+    }
+
     public Builder copy()
     {
       return new Builder(this);
@@ -558,7 +574,7 @@ public class GroupByQuery extends BaseQuery<Row>
         if (orderByColumnSpecs.isEmpty() && limit == Integer.MAX_VALUE) {
           theLimitSpec = new NoopLimitSpec();
         } else {
-          theLimitSpec = new DefaultLimitSpec(orderByColumnSpecs, limit);
+          theLimitSpec = new DefaultLimitSpec(orderByColumnSpecs, limit, limitGranularity, limitPerGroup);
         }
       } else {
         theLimitSpec = limitSpec;


### PR DESCRIPTION
Related to #1926 or #1780.

This patch is first try to introduce ordering granularity which is not equal to query granularity for group by queries. By giving some granularity to limit spec, which is supposed to be bigger than query granularity,

For example, user can group-by a table with day-basis and extract some outstanding values within a week.