### PR TITLE
[BACKPORT #1842] Do not pass `druid.indexer.runner.javaOpts` to Peon as a property

### DIFF
--- a/indexing-service/src/main/java/io/druid/guice/IndexingServiceModuleHelper.java
+++ b/indexing-service/src/main/java/io/druid/guice/IndexingServiceModuleHelper.java
@@ -26,10 +26,11 @@ import io.druid.server.initialization.IndexerZkConfig;
  */
 public class IndexingServiceModuleHelper
 {
+  public static final String INDEXER_RUNNER_PROPERTY_PREFIX = "druid.indexer.runner";
   public static void configureTaskRunnerConfigs(Binder binder)
   {
-    JsonConfigProvider.bind(binder, "druid.indexer.runner", ForkingTaskRunnerConfig.class);
-    JsonConfigProvider.bind(binder, "druid.indexer.runner", RemoteTaskRunnerConfig.class);
+    JsonConfigProvider.bind(binder, INDEXER_RUNNER_PROPERTY_PREFIX, ForkingTaskRunnerConfig.class);
+    JsonConfigProvider.bind(binder, INDEXER_RUNNER_PROPERTY_PREFIX, RemoteTaskRunnerConfig.class);
     JsonConfigProvider.bind(binder, "druid.zk.paths.indexer", IndexerZkConfig.class);
   }
 }

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/ForkingTaskRunner.java
@@ -242,7 +242,7 @@ public class ForkingTaskRunner implements TaskRunner, TaskLogStreamer
 
                               // Override task specific javaOpts
                               Object taskJavaOpts = task.getContextValue(
-                                  "druid.indexer.runner.javaOpts"
+                                  ForkingTaskRunnerConfig.JAVA_OPTS_PROPERTY
                               );
                               if (taskJavaOpts != null) {
                                 Iterables.addAll(
@@ -253,7 +253,9 @@ public class ForkingTaskRunner implements TaskRunner, TaskLogStreamer
 
                               for (String propName : props.stringPropertyNames()) {
                                 for (String allowedPrefix : config.getAllowedPrefixes()) {
-                                  if (propName.startsWith(allowedPrefix)) {
+                                  // See https://github.com/druid-io/druid/issues/1841
+                                  if (propName.startsWith(allowedPrefix)
+                                      && !ForkingTaskRunnerConfig.JAVA_OPTS_PROPERTY.equals(propName)) {
                                     command.add(
                                         String.format(
                                             "-D%s=%s",

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/config/ForkingTaskRunnerConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/config/ForkingTaskRunnerConfig.java
@@ -19,6 +19,7 @@ package io.druid.indexing.overlord.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Lists;
+import io.druid.guice.IndexingServiceModuleHelper;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -27,6 +28,9 @@ import java.util.List;
 
 public class ForkingTaskRunnerConfig
 {
+  public static final String JAVA_OPTS_PROPERTY = IndexingServiceModuleHelper.INDEXER_RUNNER_PROPERTY_PREFIX
+                                                  + ".javaOpts";
+
   @JsonProperty
   @NotNull
   private String javaCommand = "java";


### PR DESCRIPTION
* Still places `druid.indexer.runner.javaOpts` on the command line, but the Peon no longer tries to have the property `druid.indexer.runner.javaOpts` set
* Fixes https://github.com/druid-io/druid/issues/1841