### PR TITLE
Fix getCacheKey for DimFilters

### DIFF
--- a/processing/src/main/java/io/druid/query/filter/DimFilterCacheHelper.java
+++ b/processing/src/main/java/io/druid/query/filter/DimFilterCacheHelper.java
@@ -35,6 +35,7 @@ class DimFilterCacheHelper
   static final byte JAVASCRIPT_CACHE_ID = 0x7;
   static final byte SPATIAL_CACHE_ID = 0x8;
   static final byte IN_CACHE_ID = 0x9;
+  static final byte STRING_SEPARATOR = (byte) 0xFF;
 
   static byte[] computeCacheKey(byte cacheIdKey, List<DimFilter> filters)
   {

--- a/processing/src/main/java/io/druid/query/filter/ExtractionDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/ExtractionDimFilter.java
@@ -43,7 +43,10 @@ public class ExtractionDimFilter implements DimFilter
   )
   {
     Preconditions.checkArgument(dimension != null, "dimension must not be null");
-    Preconditions.checkArgument(extractionFn != null || dimExtractionFn != null, "extraction function must not be null");
+    Preconditions.checkArgument(
+        extractionFn != null || dimExtractionFn != null,
+        "extraction function must not be null"
+    );
 
     this.dimension = dimension;
     this.value = value;
@@ -74,9 +77,10 @@ public class ExtractionDimFilter implements DimFilter
     byte[] dimensionBytes = StringUtils.toUtf8(dimension);
     byte[] valueBytes = StringUtils.toUtf8(value);
 
-    return ByteBuffer.allocate(1 + dimensionBytes.length + valueBytes.length)
+    return ByteBuffer.allocate(2 + dimensionBytes.length + valueBytes.length)
                      .put(DimFilterCacheHelper.EXTRACTION_CACHE_ID)
                      .put(dimensionBytes)
+                     .put(DimFilterCacheHelper.STRING_SEPARATOR)
                      .put(valueBytes)
                      .array();
   }

--- a/processing/src/main/java/io/druid/query/filter/InDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/InDimFilter.java
@@ -50,7 +50,7 @@ public class InDimFilter implements DimFilter
     ByteBuffer filterCacheKey = ByteBuffer.allocate(2 + dimensionBytes.length + valuesBytesSize)
                                           .put(DimFilterCacheHelper.IN_CACHE_ID)
                                           .put(dimensionBytes)
-                                          .put((byte) 0xFF);
+                                          .put(DimFilterCacheHelper.STRING_SEPARATOR);
     for (byte [] bytes: valuesBytes) {
       filterCacheKey.put(bytes)
                     .put((byte) 0xFF);

--- a/processing/src/main/java/io/druid/query/filter/JavaScriptDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/JavaScriptDimFilter.java
@@ -59,11 +59,12 @@ public class JavaScriptDimFilter implements DimFilter
     final byte[] dimensionBytes = StringUtils.toUtf8(dimension);
     final byte[] functionBytes = StringUtils.toUtf8(function);
 
-    return ByteBuffer.allocate(1 + dimensionBytes.length + functionBytes.length)
-        .put(DimFilterCacheHelper.JAVASCRIPT_CACHE_ID)
-        .put(dimensionBytes)
-        .put(functionBytes)
-        .array();
+    return ByteBuffer.allocate(2 + dimensionBytes.length + functionBytes.length)
+                     .put(DimFilterCacheHelper.JAVASCRIPT_CACHE_ID)
+                     .put(dimensionBytes)
+                     .put(DimFilterCacheHelper.STRING_SEPARATOR)
+                     .put(functionBytes)
+                     .array();
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/RegexDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/RegexDimFilter.java
@@ -61,11 +61,12 @@ public class RegexDimFilter implements DimFilter
     final byte[] dimensionBytes = StringUtils.toUtf8(dimension);
     final byte[] patternBytes = StringUtils.toUtf8(pattern);
 
-    return ByteBuffer.allocate(1 + dimensionBytes.length + patternBytes.length)
-        .put(DimFilterCacheHelper.REGEX_CACHE_ID)
-        .put(dimensionBytes)
-        .put(patternBytes)
-        .array();
+    return ByteBuffer.allocate(2 + dimensionBytes.length + patternBytes.length)
+                     .put(DimFilterCacheHelper.REGEX_CACHE_ID)
+                     .put(dimensionBytes)
+                     .put(DimFilterCacheHelper.STRING_SEPARATOR)
+                     .put(patternBytes)
+                     .array();
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/SearchQueryDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/SearchQueryDimFilter.java
@@ -61,9 +61,10 @@ public class SearchQueryDimFilter implements DimFilter
     final byte[] dimensionBytes = StringUtils.toUtf8(dimension);
     final byte[] queryBytes = query.getCacheKey();
 
-    return ByteBuffer.allocate(1 + dimensionBytes.length + queryBytes.length)
+    return ByteBuffer.allocate(2 + dimensionBytes.length + queryBytes.length)
                      .put(DimFilterCacheHelper.SEARCH_QUERY_TYPE_ID)
                      .put(dimensionBytes)
+                     .put(DimFilterCacheHelper.STRING_SEPARATOR)
                      .put(queryBytes)
                      .array();
   }

--- a/processing/src/main/java/io/druid/query/filter/SelectorDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/SelectorDimFilter.java
@@ -49,9 +49,10 @@ public class SelectorDimFilter implements DimFilter
     byte[] dimensionBytes = StringUtils.toUtf8(dimension);
     byte[] valueBytes = (value == null) ? new byte[]{} : StringUtils.toUtf8(value);
 
-    return ByteBuffer.allocate(1 + dimensionBytes.length + valueBytes.length)
+    return ByteBuffer.allocate(2 + dimensionBytes.length + valueBytes.length)
                      .put(DimFilterCacheHelper.SELECTOR_CACHE_ID)
                      .put(dimensionBytes)
+                     .put(DimFilterCacheHelper.STRING_SEPARATOR)
                      .put(valueBytes)
                      .array();
   }

--- a/processing/src/main/java/io/druid/query/filter/SpatialDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/SpatialDimFilter.java
@@ -50,9 +50,10 @@ public class SpatialDimFilter implements DimFilter
     byte[] dimBytes = StringUtils.toUtf8(dimension);
     byte[] boundBytes = bound.getCacheKey();
 
-    return ByteBuffer.allocate(1 + dimBytes.length + boundBytes.length)
+    return ByteBuffer.allocate(2 + dimBytes.length + boundBytes.length)
                      .put(DimFilterCacheHelper.SPATIAL_CACHE_ID)
                      .put(dimBytes)
+                     .put(DimFilterCacheHelper.STRING_SEPARATOR)
                      .put(boundBytes)
                      .array();
   }

--- a/processing/src/test/java/io/druid/query/filter/ExtractionDimFilterTest.java
+++ b/processing/src/test/java/io/druid/query/filter/ExtractionDimFilterTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.filter;
+
+import io.druid.query.extraction.ExtractionFn;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class ExtractionDimFilterTest
+{
+
+  @Test
+  public void testGetCacheKey()
+  {
+    ExtractionDimFilter extractionDimFilter = new ExtractionDimFilter(
+        "abc",
+        "d",
+        EasyMock.createMock(ExtractionFn.class),
+        null
+    );
+    ExtractionDimFilter extractionDimFilter2 = new ExtractionDimFilter(
+        "ab",
+        "cd",
+        EasyMock.createMock(ExtractionFn.class),
+        null
+    );
+    Assert.assertFalse(Arrays.equals(extractionDimFilter.getCacheKey(), extractionDimFilter2.getCacheKey()));
+  }
+}

--- a/processing/src/test/java/io/druid/query/filter/InDimFilterSerDesrTest.java
+++ b/processing/src/test/java/io/druid/query/filter/InDimFilterSerDesrTest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.druid.query.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/processing/src/test/java/io/druid/query/filter/JavaScriptDimFilterTest.java
+++ b/processing/src/test/java/io/druid/query/filter/JavaScriptDimFilterTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.filter;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class JavaScriptDimFilterTest
+{
+
+  @Test
+  public void testGetCacheKey()
+  {
+    JavaScriptDimFilter javaScriptDimFilter = new JavaScriptDimFilter("dim", "fn");
+    JavaScriptDimFilter javaScriptDimFilter2 = new JavaScriptDimFilter("di", "mfn");
+    Assert.assertFalse(Arrays.equals(javaScriptDimFilter.getCacheKey(), javaScriptDimFilter2.getCacheKey()));
+  }
+}

--- a/processing/src/test/java/io/druid/query/filter/RegexDimFilterTest.java
+++ b/processing/src/test/java/io/druid/query/filter/RegexDimFilterTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.filter;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class RegexDimFilterTest
+{
+
+  @Test
+  public void testGetCacheKey()
+  {
+    RegexDimFilter regexDimFilter = new RegexDimFilter("dim", "reg");
+    RegexDimFilter regexDimFilter2 = new RegexDimFilter("di", "mreg");
+    Assert.assertFalse(Arrays.equals(regexDimFilter.getCacheKey(), regexDimFilter2.getCacheKey()));
+  }
+}

--- a/processing/src/test/java/io/druid/query/filter/SearchQueryDimFilterTest.java
+++ b/processing/src/test/java/io/druid/query/filter/SearchQueryDimFilterTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.filter;
+
+import com.metamx.common.StringUtils;
+import io.druid.query.search.search.SearchQuerySpec;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class SearchQueryDimFilterTest
+{
+
+  @Test
+  public void testGetCacheKey()
+  {
+    SearchQueryDimFilter searchQueryDimFilter = new SearchQueryDimFilter("dim", new SearchQuerySpec()
+    {
+      @Override
+      public boolean accept(String dimVal)
+      {
+        return false;
+      }
+
+      @Override
+      public byte[] getCacheKey()
+      {
+        return StringUtils.toUtf8("value");
+      }
+    });
+
+    SearchQueryDimFilter searchQueryDimFilter2 = new SearchQueryDimFilter("di", new SearchQuerySpec()
+    {
+      @Override
+      public boolean accept(String dimVal)
+      {
+        return false;
+      }
+
+      @Override
+      public byte[] getCacheKey()
+      {
+        return StringUtils.toUtf8("mvalue");
+      }
+    });
+    Assert.assertFalse(Arrays.equals(searchQueryDimFilter.getCacheKey(), searchQueryDimFilter2.getCacheKey()));
+  }
+}

--- a/processing/src/test/java/io/druid/query/filter/SelectorDimFilterTest.java
+++ b/processing/src/test/java/io/druid/query/filter/SelectorDimFilterTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.filter;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class SelectorDimFilterTest
+{
+  @Test
+  public void testGetCacheKey()
+  {
+    SelectorDimFilter selectorDimFilter = new SelectorDimFilter("abc", "d");
+    SelectorDimFilter selectorDimFilter2 = new SelectorDimFilter("ab", "cd");
+    Assert.assertFalse(Arrays.equals(selectorDimFilter.getCacheKey(), selectorDimFilter2.getCacheKey()));
+  }
+}


### PR DESCRIPTION
getCacheKey was not making separator between two consecutive strings which can lead to a collision of keys