### PR TITLE
Update mmx emitter to 0.3.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
             <dependency>
                 <groupId>com.metamx</groupId>
                 <artifactId>emitter</artifactId>
-                <version>0.3.4</version>
+                <version>0.3.6</version>
             </dependency>
             <dependency>
                 <groupId>com.metamx</groupId>


### PR DESCRIPTION
* 0.3.5 updated better logging messages
* 0.3.6 updates validator dependency to help prevent stale validator jars from being pulled in