### PR TITLE
Use default service names in examples.

### DIFF
--- a/examples/config/_common/common.runtime.properties
+++ b/examples/config/_common/common.runtime.properties
@@ -43,7 +43,10 @@ druid.cache.type=local
 druid.cache.sizeInBytes=10000000
 
 # Indexing service discovery
-druid.selectors.indexing.serviceName=overlord
+#druid.selectors.indexing.serviceName=druid:overlord
+
+# Coordinator service discovery
+#druid.selectors.indexing.serviceName=druid:coordinator
 
 # Monitoring (disabled for examples, if you enable SysMonitor, make sure to include sigar jar in your cp)
 # druid.monitoring.monitors=["com.metamx.metrics.SysMonitor","com.metamx.metrics.JvmMonitor"]

--- a/examples/config/broker/runtime.properties
+++ b/examples/config/broker/runtime.properties
@@ -18,7 +18,7 @@
 # Default host: localhost. Default port: 8082. If you run each node type on its own node in production, you should override these values to be IP:8080
 #druid.host=localhost
 #druid.port=8082
-druid.service=broker
+#druid.service=druid/broker
 
 # We enable using the local query cache here
 druid.broker.cache.useCache=true

--- a/examples/config/coordinator/runtime.properties
+++ b/examples/config/coordinator/runtime.properties
@@ -18,7 +18,7 @@
 # Default host: localhost. Default port: 8081. If you run each node type on its own node in production, you should override these values to be IP:8080
 #druid.host=localhost
 #druid.port=8081
-druid.service=coordinator
+#druid.service=druid/coordinator
 
 # The coordinator begins assignment operations after the start delay.
 # We override the default here to start things up faster for examples.

--- a/examples/config/historical/runtime.properties
+++ b/examples/config/historical/runtime.properties
@@ -18,7 +18,7 @@
 # Default host: localhost. Default port: 8083. If you run each node type on its own node in production, you should override these values to be IP:8080
 #druid.host=localhost
 #druid.port=8083
-druid.service=historical
+#druid.service=druid/historical
 
 
 # Our intermediate buffer is also very small so longer topNs will be slow.

--- a/examples/config/middleManager/runtime.properties
+++ b/examples/config/middleManager/runtime.properties
@@ -21,6 +21,6 @@
 # uncomment following property in overlord/runtime.properties
 # druid.indexer.runner.type=remote
 
-druid.service=middleManager
+#druid.service=druid/middlemanager
 druid.indexer.runner.javaOpts=-server -Xmx256m
 

--- a/examples/config/overlord/runtime.properties
+++ b/examples/config/overlord/runtime.properties
@@ -18,7 +18,7 @@
 # Default host: localhost. Default port: 8090. If you run each node type on its own node in production, you should override these values to be IP:8080
 #druid.host=localhost
 #druid.port=8090
-druid.service=overlord
+#druid.service=druid/overlord
 
 # Run the overlord in local mode with a single peon to execute tasks
 # This is not recommended for production.

--- a/examples/config/realtime/runtime.properties
+++ b/examples/config/realtime/runtime.properties
@@ -18,7 +18,7 @@
 # Default host: localhost. Default port: 8084. If you run each node type on its own node in production, you should override these values to be IP:8080
 #druid.host=localhost
 #druid.port=8084
-druid.service=realtime
+#druid.service=druid/realtime
 
 # We can only 1 scan segment in parallel with these configs.
 # Our intermediate buffer is also very small so longer topNs will be slow.

--- a/examples/config/router/runtime.properties
+++ b/examples/config/router/runtime.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-druid.service=router
-druid.router.defaultBrokerServiceName=broker
-druid.router.coordinatorServiceName=coordinator
+#druid.service=druid/router
+#druid.router.defaultBrokerServiceName=druid/broker
+#druid.router.coordinatorServiceName=druid/coordinator
 


### PR DESCRIPTION
Use default service names in druid examples. 
Make them consistent with service names in druid code. 
fixes https://github.com/druid-io/druid/issues/2046