### PR TITLE
Change service names in docs, examples to match defaults in the code.

### DIFF
--- a/docs/content/configuration/production-cluster.md
+++ b/docs/content/configuration/production-cluster.md
@@ -61,7 +61,7 @@ druid.cache.maxOperationQueueSize=1073741824
 druid.cache.readBufferSize=10485760
 
 # Indexing Service Service Discovery
-druid.selectors.indexing.serviceName=druid:prod:overlord
+druid.selectors.indexing.serviceName=druid:overlord
 
 ```
 
@@ -101,7 +101,7 @@ Runtime.properties:
 ```
 druid.host=#{IP_ADDR}
 druid.port=8080
-druid.service=druid/prod/overlord
+druid.service=druid/overlord
 
 # Only required if you are autoscaling middle managers
 druid.indexer.autoscale.doAutoscale=true
@@ -157,7 +157,7 @@ Runtime.properties:
 ```
 druid.host=#{IP_ADDR}
 druid.port=8080
-druid.service=druid/prod/middlemanager
+druid.service=druid/middlemanager
 
 # Store task logs in deep storage
 druid.indexer.logs.type=s3
@@ -221,7 +221,7 @@ Runtime.properties:
 ```
 druid.host=#{IP_ADDR}
 druid.port=8080
-druid.service=druid/prod/coordinator
+druid.service=druid/coordinator
 ```
 
 ### Historical Node
@@ -261,7 +261,7 @@ Runtime.properties:
 ```
 druid.host=#{IP_ADDR}
 druid.port=8080
-druid.service=druid/prod/historical
+druid.service=druid/historical
 
 druid.historical.cache.useCache=true
 druid.historical.cache.populateCache=true
@@ -318,7 +318,7 @@ Runtime.properties:
 ```
 druid.host=#{IP_ADDR}
 druid.port=8080
-druid.service=druid/prod/broker
+druid.service=druid/broker
 
 druid.broker.http.numConnections=20
 druid.broker.http.readTimeout=PT5M
@@ -372,7 +372,7 @@ Runtime.properties:
 ```
 druid.host=#{IP_ADDR}
 druid.port=8080
-druid.service=druid/prod/realtime
+druid.service=druid/realtime
 
 druid.processing.buffer.sizeBytes=1073741824
 druid.processing.numThreads=7

--- a/docs/content/development/router.md
+++ b/docs/content/development/router.md
@@ -47,12 +47,12 @@ Runtime.properties:
 ```
 druid.host=#{IP_ADDR}:8080
 druid.port=8080
-druid.service=druid/prod/router
+druid.service=druid/router
 
 druid.processing.numThreads=1
-druid.router.defaultBrokerServiceName=druid:prod:broker-cold
-druid.router.coordinatorServiceName=druid:prod:coordinator
-druid.router.tierToBrokerMap={"hot":"druid:prod:broker-hot","_default_tier":"druid:prod:broker-cold"}
+druid.router.defaultBrokerServiceName=druid:broker-cold
+druid.router.coordinatorServiceName=druid:coordinator
+druid.router.tierToBrokerMap={"hot":"druid:broker-hot","_default_tier":"druid:broker-cold"}
 druid.router.http.numConnections=50
 druid.router.http.readTimeout=PT5M
 
@@ -69,11 +69,11 @@ The router module uses several of the default modules in [Configuration](../conf
 
 |Property|Possible Values|Description|Default|
 |--------|---------------|-----------|-------|
-|`druid.router.defaultBrokerServiceName`|Any string.|The default broker to connect to in case service discovery fails.|"". Must be set.|
+|`druid.router.defaultBrokerServiceName`|Any string.|The default broker to connect to in case service discovery fails.|druid/broker|
 |`druid.router.tierToBrokerMap`|An ordered JSON map of tiers to broker names. The priority of brokers is based on the ordering.|Queries for a certain tier of data are routed to their appropriate broker.|{"_default": "<defaultBrokerServiceName>"}|
 |`druid.router.defaultRule`|Any string.|The default rule for all datasources.|"_default"|
 |`druid.router.rulesEndpoint`|Any string.|The coordinator endpoint to extract rules from.|"/druid/coordinator/v1/rules"|
-|`druid.router.coordinatorServiceName`|Any string.|The service discovery name of the coordinator.|null. Must be set.|
+|`druid.router.coordinatorServiceName`|Any string.|The service discovery name of the coordinator.|druid/coordinator|
 |`druid.router.pollPeriod`|Any ISO8601 duration.|How often to poll for new rules.|PT1M|
 |`druid.router.strategies`|An ordered JSON array of objects.|All custom strategies to use for routing.|[{"type":"timeBoundary"},{"type":"priority"}]|
 

--- a/docs/content/tutorials/tutorial-the-druid-cluster.md
+++ b/docs/content/tutorials/tutorial-the-druid-cluster.md
@@ -136,7 +136,7 @@ In the directory, there should be a `runtime.properties` file with the following
 ```
 druid.host=localhost
 druid.port=8081
-druid.service=coordinator
+druid.service=druid/coordinator
 
 # The coordinator begins assignment operations after the start delay.
 # We override the default here to start things up faster for examples.
@@ -167,7 +167,7 @@ In the directory we just created, we should have the file `runtime.properties` w
 ```
 druid.host=localhost
 druid.port=8083
-druid.service=historical
+druid.service=druid/historical
 
 # We can only 1 scan segment in parallel with these configs.
 # Our intermediate buffer is also very small so longer topNs will be slow.
@@ -200,7 +200,7 @@ In the directory, there should be a `runtime.properties` file with the following
 ```
 druid.host=localhost
 druid.port=8082
-druid.service=broker
+druid.service=druid/broker
 
 druid.broker.cache.useCache=true
 druid.broker.cache.populateCache=true
@@ -267,7 +267,7 @@ The configurations are located in `config/realtime/runtime.properties` and shoul
 ```
 druid.host=localhost
 druid.port=8084
-druid.service=realtime
+druid.service=druid/realtime
 
 # We can only 1 scan segment in parallel with these configs.
 # Our intermediate buffer is also very small so longer topNs will be slow.

--- a/examples/config/_common/common.runtime.properties
+++ b/examples/config/_common/common.runtime.properties
@@ -42,8 +42,8 @@ druid.storage.storageDirectory=/tmp/druid/localStorage
 druid.cache.type=local
 druid.cache.sizeInBytes=10000000
 
-# Indexing service discovery
-druid.selectors.indexing.serviceName=overlord
+# Indexing service discovery. Update this if you change your overlord's "druid.service".
+# druid.selectors.indexing.serviceName=druid/overlord
 
 # Monitoring (disabled for examples, if you enable SysMonitor, make sure to include sigar jar in your cp)
 # druid.monitoring.monitors=["com.metamx.metrics.SysMonitor","com.metamx.metrics.JvmMonitor"]

--- a/examples/config/broker/runtime.properties
+++ b/examples/config/broker/runtime.properties
@@ -15,10 +15,10 @@
 # limitations under the License.
 #
 
-# Default host: localhost. Default port: 8082. If you run each node type on its own node in production, you should override these values to be IP:8080
+# Default host, port, service name.
 #druid.host=localhost
 #druid.port=8082
-druid.service=broker
+#druid.service=druid/broker
 
 # We enable using the local query cache here
 druid.broker.cache.useCache=true

--- a/examples/config/coordinator/runtime.properties
+++ b/examples/config/coordinator/runtime.properties
@@ -15,10 +15,10 @@
 # limitations under the License.
 #
 
-# Default host: localhost. Default port: 8081. If you run each node type on its own node in production, you should override these values to be IP:8080
+# Default host, port, service name.
 #druid.host=localhost
 #druid.port=8081
-druid.service=coordinator
+#druid.service=druid/coordinator
 
 # The coordinator begins assignment operations after the start delay.
 # We override the default here to start things up faster for examples.

--- a/examples/config/historical/runtime.properties
+++ b/examples/config/historical/runtime.properties
@@ -15,10 +15,10 @@
 # limitations under the License.
 #
 
-# Default host: localhost. Default port: 8083. If you run each node type on its own node in production, you should override these values to be IP:8080
+# Default host, port, service name.
 #druid.host=localhost
 #druid.port=8083
-druid.service=historical
+#druid.service=druid/historical
 
 
 # Our intermediate buffer is also very small so longer topNs will be slow.

--- a/examples/config/middleManager/runtime.properties
+++ b/examples/config/middleManager/runtime.properties
@@ -21,6 +21,8 @@
 # uncomment following property in overlord/runtime.properties
 # druid.indexer.runner.type=remote
 
-druid.service=middleManager
+# Default host, port, service name.
+#druid.host=localhost
+#druid.port=8091
+#druid.service=druid/middlemanager
 druid.indexer.runner.javaOpts=-server -Xmx256m
-

--- a/examples/config/overlord/runtime.properties
+++ b/examples/config/overlord/runtime.properties
@@ -15,10 +15,10 @@
 # limitations under the License.
 #
 
-# Default host: localhost. Default port: 8090. If you run each node type on its own node in production, you should override these values to be IP:8080
+# Default host, port, service name.
 #druid.host=localhost
 #druid.port=8090
-druid.service=overlord
+#druid.service=druid/overlord
 
 # Run the overlord in local mode with a single peon to execute tasks
 # This is not recommended for production.

--- a/examples/config/realtime/runtime.properties
+++ b/examples/config/realtime/runtime.properties
@@ -15,10 +15,10 @@
 # limitations under the License.
 #
 
-# Default host: localhost. Default port: 8084. If you run each node type on its own node in production, you should override these values to be IP:8080
+# Default host, port, service name.
 #druid.host=localhost
 #druid.port=8084
-druid.service=realtime
+#druid.service=druid/realtime
 
 # We can only 1 scan segment in parallel with these configs.
 # Our intermediate buffer is also very small so longer topNs will be slow.

--- a/examples/config/router/runtime.properties
+++ b/examples/config/router/runtime.properties
@@ -17,7 +17,9 @@
 # under the License.
 #
 
-druid.service=router
-druid.router.defaultBrokerServiceName=broker
-druid.router.coordinatorServiceName=coordinator
+# Default service name.
+#druid.service=druid/router
 
+# Default broker, coordinator locators.
+#druid.router.defaultBrokerServiceName=druid:broker
+#druid.router.coordinatorServiceName=druid:coordinator


### PR DESCRIPTION
Right now the "production config" docs, the config examples, and the code all have different defaults for service names. This makes it hard to choose the best default in tranquility or for any other program that interacts with Druid through service discovery.

This patch changes them all to "druid/foo".

Also removes the "If you run each node type on its own node in production, you should override these values to be IP:8080" advice as that is not actually necessary.