### PR TITLE
removed documentation about (removed) DeleteTask

### DIFF
--- a/docs/content/misc/tasks.md
+++ b/docs/content/misc/tasks.md
@@ -305,19 +305,6 @@ Merge tasks merge a list of segments together. Any common timestamps are merged.
 Segment Destroying Tasks
 ------------------------
 
-### Delete Task
-
-Delete tasks create empty segments with no data. The grammar is:
-
-```json
-{
-    "type": "delete",
-    "id": <task_id>,
-    "dataSource": <task_datasource>,
-    "segments": <JSON list of DataSegment objects to delete>
-}
-```
-
 ### Kill Task
 
 Kill tasks delete all information about a segment and removes it from deep storage. Killable segments must be disabled (used==0) in the Druid segment table. The available grammar is:


### PR DESCRIPTION
Based on conversation with FJ on IRC:


> mmschiff
> 1:47 Hey fj, wondering if you have any information about the status of the delete segment task? I am digging through the indexing service and dont see it mentioned
> fj
> 1:47 mmschiff, the kill task?
> fj
> 1:47 http://druid.io/docs/latest/misc/tasks.html
> mmschiff
> 1:49 nah, delete. New (empty) segment version for the same time interval
> 1:49 the one above it in the docs
> 1:49 has this been deprecated?
> fj
> 2:01 mmschiff, ah, might have been deleted, let me check with himanshu
> mmschiff
> 2:01 yeah, this is what it looks like based on the JsonSubtypes in the Task interface
> 2:02 if so, we should pull this from the docs
> fj 
> 2:02 yeah, the code is gone
> 2:02 we removed it awhile ago
> 2:02 the docs need to be updated

