### PR TITLE
An effort to fix transient error in BrokerServerViewTest

### DIFF
--- a/server/src/test/java/io/druid/client/BrokerServerViewTest.java
+++ b/server/src/test/java/io/druid/client/BrokerServerViewTest.java
@@ -371,15 +371,24 @@ public class BrokerServerViewTest extends CuratorTestBase
 
   private void setupZNodeForServer(DruidServer server) throws Exception
   {
+    final String zNodePathAnnounce = ZKPaths.makePath(announcementsPath, server.getHost());
+    final String zNodePathSegment = ZKPaths.makePath(inventoryPath, server.getHost());
+
+    if (curator.checkExists().forPath(zNodePathAnnounce) != null) {
+      curator.delete().guaranteed().forPath(zNodePathAnnounce);
+    }
+    if (curator.checkExists().forPath(zNodePathSegment) != null) {
+      curator.delete().guaranteed().forPath(zNodePathSegment);
+    }
     curator.create()
            .creatingParentsIfNeeded()
            .forPath(
-               ZKPaths.makePath(announcementsPath, server.getHost()),
+               zNodePathAnnounce,
                jsonMapper.writeValueAsBytes(server.getMetadata())
            );
     curator.create()
            .creatingParentsIfNeeded()
-           .forPath(ZKPaths.makePath(inventoryPath, server.getHost()));
+           .forPath(zNodePathSegment);
   }
 
   private DataSegment dataSegmentWithIntervalAndVersion(String intervalStr, String version)


### PR DESCRIPTION
Fixes #1512. This is an effort to  fix the transient error in BrokerServerViewTest. 
Specifically, the transient error is
```
Tests run: 2, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 2.571 sec <<< FAILURE! - in io.druid.client.BrokerServerViewTest
testSingleServerAddedRemovedSegment(io.druid.client.BrokerServerViewTest)  Time elapsed: 1.24 sec  <<< ERROR!
org.apache.zookeeper.KeeperException$NodeExistsException: KeeperErrorCode = NodeExists for /druid/segments/localhost:1234
	at org.apache.zookeeper.KeeperException.create(KeeperException.java:119)
	at org.apache.zookeeper.KeeperException.create(KeeperException.java:51)
	at org.apache.zookeeper.ZooKeeper.create(ZooKeeper.java:783)
	at org.apache.curator.framework.imps.CreateBuilderImpl$11.call(CreateBuilderImpl.java:727)
	at org.apache.curator.framework.imps.CreateBuilderImpl$11.call(CreateBuilderImpl.java:703)
	at org.apache.curator.RetryLoop.callWithRetry(RetryLoop.java:107)
	at org.apache.curator.framework.imps.CreateBuilderImpl.pathInForeground(CreateBuilderImpl.java:699)
	at org.apache.curator.framework.imps.CreateBuilderImpl.protectedPathInForeground(CreateBuilderImpl.java:477)
	at org.apache.curator.framework.imps.CreateBuilderImpl.forPath(CreateBuilderImpl.java:467)
	at org.apache.curator.framework.imps.CreateBuilderImpl.forPath(CreateBuilderImpl.java:447)
	at org.apache.curator.framework.imps.CreateBuilderImpl$4.forPath(CreateBuilderImpl.java:355)
	at org.apache.curator.framework.imps.CreateBuilderImpl$4.forPath(CreateBuilderImpl.java:291)
	at io.druid.client.BrokerServerViewTest.setupZNodeForServer(BrokerServerViewTest.java:383)
	at io.druid.client.BrokerServerViewTest.testSingleServerAddedRemovedSegment(BrokerServerViewTest.java:112)
```