### PR TITLE
Configurable value replacement on match failure for RegexExtractionFn

### DIFF
--- a/docs/content/configuration/production-cluster.md
+++ b/docs/content/configuration/production-cluster.md
@@ -61,7 +61,7 @@ druid.cache.maxOperationQueueSize=1073741824
 druid.cache.readBufferSize=10485760
 
 # Indexing Service Service Discovery
-druid.selectors.indexing.serviceName=druid:prod:overlord
+druid.selectors.indexing.serviceName=druid:overlord
 
 # Coordinator Service Discovery
 druid.selectors.coordinator.serviceName=druid:prod:coordinator
@@ -103,7 +103,7 @@ Runtime.properties:
 ```
 druid.host=#{IP_ADDR}
 druid.port=8080
-druid.service=druid/prod/overlord
+druid.service=druid/overlord
 
 # Only required if you are autoscaling middle managers
 druid.indexer.autoscale.doAutoscale=true
@@ -159,7 +159,7 @@ Runtime.properties:
 ```
 druid.host=#{IP_ADDR}
 druid.port=8080
-druid.service=druid/prod/middlemanager
+druid.service=druid/middlemanager
 
 # Store task logs in deep storage
 druid.indexer.logs.type=s3
@@ -223,7 +223,7 @@ Runtime.properties:
 ```
 druid.host=#{IP_ADDR}
 druid.port=8080
-druid.service=druid/prod/coordinator
+druid.service=druid/coordinator
 ```
 
 ### Historical Node
@@ -263,7 +263,7 @@ Runtime.properties:
 ```
 druid.host=#{IP_ADDR}
 druid.port=8080
-druid.service=druid/prod/historical
+druid.service=druid/historical
 
 druid.historical.cache.useCache=true
 druid.historical.cache.populateCache=true
@@ -320,7 +320,7 @@ Runtime.properties:
 ```
 druid.host=#{IP_ADDR}
 druid.port=8080
-druid.service=druid/prod/broker
+druid.service=druid/broker
 
 druid.broker.http.numConnections=20
 druid.broker.http.readTimeout=PT5M
@@ -374,7 +374,7 @@ Runtime.properties:
 ```
 druid.host=#{IP_ADDR}
 druid.port=8080
-druid.service=druid/prod/realtime
+druid.service=druid/realtime
 
 druid.processing.buffer.sizeBytes=1073741824
 druid.processing.numThreads=7

--- a/docs/content/development/router.md
+++ b/docs/content/development/router.md
@@ -47,12 +47,12 @@ Runtime.properties:
 ```
 druid.host=#{IP_ADDR}:8080
 druid.port=8080
-druid.service=druid/prod/router
+druid.service=druid/router
 
 druid.processing.numThreads=1
-druid.router.defaultBrokerServiceName=druid:prod:broker-cold
-druid.router.coordinatorServiceName=druid:prod:coordinator
-druid.router.tierToBrokerMap={"hot":"druid:prod:broker-hot","_default_tier":"druid:prod:broker-cold"}
+druid.router.defaultBrokerServiceName=druid:broker-cold
+druid.router.coordinatorServiceName=druid:coordinator
+druid.router.tierToBrokerMap={"hot":"druid:broker-hot","_default_tier":"druid:broker-cold"}
 druid.router.http.numConnections=50
 druid.router.http.readTimeout=PT5M
 
@@ -69,11 +69,11 @@ The router module uses several of the default modules in [Configuration](../conf
 
 |Property|Possible Values|Description|Default|
 |--------|---------------|-----------|-------|
-|`druid.router.defaultBrokerServiceName`|Any string.|The default broker to connect to in case service discovery fails.|"". Must be set.|
+|`druid.router.defaultBrokerServiceName`|Any string.|The default broker to connect to in case service discovery fails.|druid/broker|
 |`druid.router.tierToBrokerMap`|An ordered JSON map of tiers to broker names. The priority of brokers is based on the ordering.|Queries for a certain tier of data are routed to their appropriate broker.|{"_default": "<defaultBrokerServiceName>"}|
 |`druid.router.defaultRule`|Any string.|The default rule for all datasources.|"_default"|
 |`druid.router.rulesEndpoint`|Any string.|The coordinator endpoint to extract rules from.|"/druid/coordinator/v1/rules"|
-|`druid.router.coordinatorServiceName`|Any string.|The service discovery name of the coordinator.|null. Must be set.|
+|`druid.router.coordinatorServiceName`|Any string.|The service discovery name of the coordinator.|druid/coordinator|
 |`druid.router.pollPeriod`|Any ISO8601 duration.|How often to poll for new rules.|PT1M|
 |`druid.router.strategies`|An ordered JSON array of objects.|All custom strategies to use for routing.|[{"type":"timeBoundary"},{"type":"priority"}]|
 

--- a/docs/content/querying/dimensionspecs.md
+++ b/docs/content/querying/dimensionspecs.md
@@ -49,11 +49,25 @@ Returns the first matching group for the given regular expression.
 If there is no match, it returns the dimension value as is.
 
 ```json
-{ "type" : "regex", "expr" : <regular_expression> }
+{
+  "type" : "regex", "expr" : <regular_expression>,
+  "replaceMissingValues" : true,
+  "replaceMissingValuesWith" : "foobar",
+  "injective" : false
+}
 ```
 
 For example, using `"expr" : "(\\w\\w\\w).*"` will transform
 `'Monday'`, `'Tuesday'`, `'Wednesday'` into `'Mon'`, `'Tue'`, `'Wed'`.
+
+If the `replaceMissingValues` property is true, the extraction function will transform dimension values that do not match the regex pattern to a user-specified String.
+
+The `replaceMissingValuesWith` property sets the String that unmatched dimension values will be replaced with, if `replaceMissingValues` is true.
+
+For example, if `expr` is `"(a\w+)"` in the example JSON above, a regex that matches words starting with the letter `a`, the extraction function will convert a dimension value like `banana` to `foobar`.
+
+The `injective` property specifies if the regex function preserves uniqueness. The default value is `false` meaning uniqueness is not preserved
+
 
 ### Partial Extraction Function
 

--- a/docs/content/tutorials/tutorial-the-druid-cluster.md
+++ b/docs/content/tutorials/tutorial-the-druid-cluster.md
@@ -136,7 +136,7 @@ In the directory, there should be a `runtime.properties` file with the following
 ```
 druid.host=localhost
 druid.port=8081
-druid.service=coordinator
+druid.service=druid/coordinator
 
 # The coordinator begins assignment operations after the start delay.
 # We override the default here to start things up faster for examples.
@@ -167,7 +167,7 @@ In the directory we just created, we should have the file `runtime.properties` w
 ```
 druid.host=localhost
 druid.port=8083
-druid.service=historical
+druid.service=druid/historical
 
 # We can only 1 scan segment in parallel with these configs.
 # Our intermediate buffer is also very small so longer topNs will be slow.
@@ -200,7 +200,7 @@ In the directory, there should be a `runtime.properties` file with the following
 ```
 druid.host=localhost
 druid.port=8082
-druid.service=broker
+druid.service=druid/broker
 
 druid.broker.cache.useCache=true
 druid.broker.cache.populateCache=true
@@ -267,7 +267,7 @@ The configurations are located in `config/realtime/runtime.properties` and shoul
 ```
 druid.host=localhost
 druid.port=8084
-druid.service=realtime
+druid.service=druid/realtime
 
 # We can only 1 scan segment in parallel with these configs.
 # Our intermediate buffer is also very small so longer topNs will be slow.

--- a/examples/config/_common/common.runtime.properties
+++ b/examples/config/_common/common.runtime.properties
@@ -42,8 +42,8 @@ druid.storage.storageDirectory=/tmp/druid/localStorage
 druid.cache.type=local
 druid.cache.sizeInBytes=10000000
 
-# Indexing service discovery
-druid.selectors.indexing.serviceName=overlord
+# Indexing service discovery. Update this if you change your overlord's "druid.service".
+# druid.selectors.indexing.serviceName=druid/overlord
 
 # Monitoring (disabled for examples, if you enable SysMonitor, make sure to include sigar jar in your cp)
 # druid.monitoring.monitors=["com.metamx.metrics.SysMonitor","com.metamx.metrics.JvmMonitor"]

--- a/examples/config/broker/runtime.properties
+++ b/examples/config/broker/runtime.properties
@@ -15,10 +15,10 @@
 # limitations under the License.
 #
 
-# Default host: localhost. Default port: 8082. If you run each node type on its own node in production, you should override these values to be IP:8080
+# Default host, port, service name.
 #druid.host=localhost
 #druid.port=8082
-druid.service=broker
+#druid.service=druid/broker
 
 # We enable using the local query cache here
 druid.broker.cache.useCache=true

--- a/examples/config/coordinator/runtime.properties
+++ b/examples/config/coordinator/runtime.properties
@@ -15,10 +15,10 @@
 # limitations under the License.
 #
 
-# Default host: localhost. Default port: 8081. If you run each node type on its own node in production, you should override these values to be IP:8080
+# Default host, port, service name.
 #druid.host=localhost
 #druid.port=8081
-druid.service=coordinator
+#druid.service=druid/coordinator
 
 # The coordinator begins assignment operations after the start delay.
 # We override the default here to start things up faster for examples.

--- a/examples/config/historical/runtime.properties
+++ b/examples/config/historical/runtime.properties
@@ -15,10 +15,10 @@
 # limitations under the License.
 #
 
-# Default host: localhost. Default port: 8083. If you run each node type on its own node in production, you should override these values to be IP:8080
+# Default host, port, service name.
 #druid.host=localhost
 #druid.port=8083
-druid.service=historical
+#druid.service=druid/historical
 
 
 # Our intermediate buffer is also very small so longer topNs will be slow.

--- a/examples/config/middleManager/runtime.properties
+++ b/examples/config/middleManager/runtime.properties
@@ -21,6 +21,8 @@
 # uncomment following property in overlord/runtime.properties
 # druid.indexer.runner.type=remote
 
-druid.service=middleManager
+# Default host, port, service name.
+#druid.host=localhost
+#druid.port=8091
+#druid.service=druid/middlemanager
 druid.indexer.runner.javaOpts=-server -Xmx256m
-

--- a/examples/config/overlord/runtime.properties
+++ b/examples/config/overlord/runtime.properties
@@ -15,10 +15,10 @@
 # limitations under the License.
 #
 
-# Default host: localhost. Default port: 8090. If you run each node type on its own node in production, you should override these values to be IP:8080
+# Default host, port, service name.
 #druid.host=localhost
 #druid.port=8090
-druid.service=overlord
+#druid.service=druid/overlord
 
 # Run the overlord in local mode with a single peon to execute tasks
 # This is not recommended for production.

--- a/examples/config/realtime/runtime.properties
+++ b/examples/config/realtime/runtime.properties
@@ -15,10 +15,10 @@
 # limitations under the License.
 #
 
-# Default host: localhost. Default port: 8084. If you run each node type on its own node in production, you should override these values to be IP:8080
+# Default host, port, service name.
 #druid.host=localhost
 #druid.port=8084
-druid.service=realtime
+#druid.service=druid/realtime
 
 # We can only 1 scan segment in parallel with these configs.
 # Our intermediate buffer is also very small so longer topNs will be slow.

--- a/examples/config/router/runtime.properties
+++ b/examples/config/router/runtime.properties
@@ -17,7 +17,9 @@
 # under the License.
 #
 
-druid.service=router
-druid.router.defaultBrokerServiceName=broker
-druid.router.coordinatorServiceName=coordinator
+# Default service name.
+#druid.service=druid/router
 
+# Default broker, coordinator locators.
+#druid.router.defaultBrokerServiceName=druid:broker
+#druid.router.coordinatorServiceName=druid:coordinator

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -730,7 +730,7 @@ public class GroupByQueryRunnerTest
   @Test
   public void testGroupByWithNullProducingDimExtractionFn()
   {
-    final ExtractionFn nullExtractionFn = new RegexDimExtractionFn("(\\w{1})")
+    final ExtractionFn nullExtractionFn = new RegexDimExtractionFn("(\\w{1})", false, null, false)
     {
       @Override
       public byte[] getCacheKey()
@@ -797,7 +797,7 @@ public class GroupByQueryRunnerTest
    */
   public void testGroupByWithEmptyStringProducingDimExtractionFn()
   {
-    final ExtractionFn emptyStringExtractionFn = new RegexDimExtractionFn("(\\w{1})")
+    final ExtractionFn emptyStringExtractionFn = new RegexDimExtractionFn("(\\w{1})", false, null, false)
     {
       @Override
       public byte[] getCacheKey()

--- a/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerTest.java
@@ -1519,7 +1519,7 @@ public class TopNQueryRunnerTest
         .dimension(
             new ExtractionDimensionSpec(
                 QueryRunnerTestHelper.qualityDimension, QueryRunnerTestHelper.qualityDimension,
-                new RegexDimExtractionFn(".(.)"), null
+                new RegexDimExtractionFn(".(.)", false, null, false), null
             )
         )
         .metric("index")
@@ -1568,7 +1568,7 @@ public class TopNQueryRunnerTest
             new ExtractionDimensionSpec(
                 QueryRunnerTestHelper.marketDimension,
                 QueryRunnerTestHelper.marketDimension,
-                new RegexDimExtractionFn("(.)"),
+                new RegexDimExtractionFn("(.)", false, null, false),
                 null
             )
         )
@@ -2074,7 +2074,7 @@ public class TopNQueryRunnerTest
             new ExtractionDimensionSpec(
                 QueryRunnerTestHelper.marketDimension,
                 QueryRunnerTestHelper.marketDimension,
-                new RegexDimExtractionFn("(.)"),
+                new RegexDimExtractionFn("(.)", false, null, false),
                 null
             )
         )
@@ -2128,7 +2128,7 @@ public class TopNQueryRunnerTest
             new ExtractionDimensionSpec(
                 QueryRunnerTestHelper.marketDimension,
                 QueryRunnerTestHelper.marketDimension,
-                new RegexDimExtractionFn("..(.)"),
+                new RegexDimExtractionFn("..(.)", false, null, false),
                 null
             )
         )
@@ -2182,7 +2182,7 @@ public class TopNQueryRunnerTest
             new ExtractionDimensionSpec(
                 QueryRunnerTestHelper.marketDimension,
                 QueryRunnerTestHelper.marketDimension,
-                new RegexDimExtractionFn("(.)"),
+                new RegexDimExtractionFn("(.)", false, null, false),
                 null
             )
         )
@@ -2300,7 +2300,7 @@ public class TopNQueryRunnerTest
             new ExtractionDimensionSpec(
                 QueryRunnerTestHelper.marketDimension,
                 QueryRunnerTestHelper.marketDimension,
-                new RegexDimExtractionFn("(.)"),
+                new RegexDimExtractionFn("(.)", false, null, false),
                 null
             )
         )
@@ -2347,7 +2347,7 @@ public class TopNQueryRunnerTest
             new ExtractionDimensionSpec(
                 QueryRunnerTestHelper.marketDimension,
                 QueryRunnerTestHelper.marketDimension,
-                new RegexDimExtractionFn("..(.)"),
+                new RegexDimExtractionFn("..(.)", false, null, false),
                 null
             )
         )


### PR DESCRIPTION
Addresses issue #2064 

This adds 3 new parameters to the RegexExtractionFn:

replaceMissingValues: Boolean, if a regex match fails, replace the dimval with a user specified value instead of returning the orignal dimval, default is false

replaceMissingValuesWith: String, replace dimval with this value when regex match fails if replaceMissingValues == true

injective: Boolean, currently unused, but same usage as "injective" property in the JavaScriptExtractionFn and LookupExtractionFn
