### PR TITLE
Add pending task based resource management autoscaling strategy

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunner.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunner.java
@@ -382,6 +382,17 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
     return ImmutableList.copyOf(pendingTasks.values());
   }
 
+  public Collection<Task> getPendingTaskPayloads()
+  {
+    // return a snapshot of current pending task payloads.
+    return ImmutableList.copyOf(pendingTaskPayloads.values());
+  }
+
+  public RemoteTaskRunnerConfig getConfig()
+  {
+    return config;
+  }
+
   @Override
   public Collection<RemoteTaskRunnerWorkItem> getKnownTasks()
   {

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/WorkerTaskRunner.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/WorkerTaskRunner.java
@@ -19,6 +19,8 @@
 package io.druid.indexing.overlord;
 
 import com.google.common.base.Predicate;
+import io.druid.indexing.common.task.Task;
+import io.druid.indexing.overlord.config.WorkerTaskRunnerConfig;
 import io.druid.indexing.worker.Worker;
 
 import java.util.Collection;
@@ -44,4 +46,9 @@ public interface WorkerTaskRunner extends TaskRunner
    * @return
    */
   Collection<Worker> markWorkersLazy(Predicate<ImmutableWorkerInfo> isLazyWorker, int maxWorkers);
+
+  WorkerTaskRunnerConfig getConfig();
+
+  Collection<Task> getPendingTaskPayloads();
+
 }

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/AbstractWorkerResourceManagementStrategy.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/AbstractWorkerResourceManagementStrategy.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.indexing.overlord.autoscaling;
+
+import com.metamx.common.concurrent.ScheduledExecutors;
+import com.metamx.emitter.EmittingLogger;
+import io.druid.granularity.PeriodGranularity;
+import io.druid.indexing.overlord.WorkerTaskRunner;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+import org.joda.time.Period;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ */
+public abstract class AbstractWorkerResourceManagementStrategy implements ResourceManagementStrategy<WorkerTaskRunner>
+{
+  private static final EmittingLogger log = new EmittingLogger(AbstractWorkerResourceManagementStrategy.class);
+
+  private final ResourceManagementSchedulerConfig resourceManagementSchedulerConfig;
+  private final ScheduledExecutorService exec;
+  private final Object lock = new Object();
+
+  private volatile boolean started = false;
+
+  protected AbstractWorkerResourceManagementStrategy(
+      ResourceManagementSchedulerConfig resourceManagementSchedulerConfig,
+      ScheduledExecutorService exec
+  )
+  {
+    this.resourceManagementSchedulerConfig = resourceManagementSchedulerConfig;
+    this.exec = exec;
+  }
+
+  @Override
+  public void startManagement(final WorkerTaskRunner runner)
+  {
+    synchronized (lock) {
+      if (started) {
+        return;
+      }
+
+      log.info("Started Resource Management Scheduler");
+
+      ScheduledExecutors.scheduleAtFixedRate(
+          exec,
+          resourceManagementSchedulerConfig.getProvisionPeriod().toStandardDuration(),
+          new Runnable()
+          {
+            @Override
+            public void run()
+            {
+              // Any Errors are caught by ScheduledExecutors
+              doProvision(runner);
+            }
+          }
+      );
+
+      // Schedule termination of worker nodes periodically
+      Period period = resourceManagementSchedulerConfig.getTerminatePeriod();
+      PeriodGranularity granularity = new PeriodGranularity(
+          period,
+          resourceManagementSchedulerConfig.getOriginTime(),
+          null
+      );
+      final long startTime = granularity.next(granularity.truncate(new DateTime().getMillis()));
+
+      ScheduledExecutors.scheduleAtFixedRate(
+          exec,
+          new Duration(System.currentTimeMillis(), startTime),
+          resourceManagementSchedulerConfig.getTerminatePeriod().toStandardDuration(),
+          new Runnable()
+          {
+            @Override
+            public void run()
+            {
+              // Any Errors are caught by ScheduledExecutors
+              doTerminate(runner);
+            }
+          }
+      );
+
+      started = true;
+
+    }
+  }
+
+  abstract boolean doTerminate(WorkerTaskRunner runner);
+
+  abstract boolean doProvision(WorkerTaskRunner runner);
+
+  @Override
+  public void stopManagement()
+  {
+    synchronized (lock) {
+      if (!started) {
+        return;
+      }
+      log.info("Stopping Resource Management Scheduler");
+      exec.shutdown();
+      started = false;
+    }
+  }
+
+}

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerResourceManagementConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerResourceManagementConfig.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.indexing.overlord.autoscaling;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.joda.time.Period;
+
+/**
+ */
+public class PendingTaskBasedWorkerResourceManagementConfig extends SimpleWorkerResourceManagementConfig
+{
+  @JsonProperty
+  private int maxScalingStep = 10;
+
+
+  public int getMaxScalingStep()
+  {
+    return maxScalingStep;
+  }
+
+  public PendingTaskBasedWorkerResourceManagementConfig setMaxScalingStep(int maxScalingStep)
+  {
+    this.maxScalingStep = maxScalingStep;
+    return this;
+  }
+
+  public PendingTaskBasedWorkerResourceManagementConfig setWorkerIdleTimeout(Period workerIdleTimeout)
+  {
+    super.setWorkerIdleTimeout(workerIdleTimeout);
+    return this;
+  }
+
+  public PendingTaskBasedWorkerResourceManagementConfig setMaxScalingDuration(Period maxScalingDuration)
+  {
+    super.setMaxScalingDuration(maxScalingDuration);
+    return this;
+  }
+
+  public PendingTaskBasedWorkerResourceManagementConfig setNumEventsToTrack(int numEventsToTrack)
+  {
+    super.setNumEventsToTrack(numEventsToTrack);
+    return this;
+  }
+
+  public PendingTaskBasedWorkerResourceManagementConfig setWorkerVersion(String workerVersion)
+  {
+    super.setWorkerVersion(workerVersion);
+    return this;
+  }
+
+  public PendingTaskBasedWorkerResourceManagementConfig setPendingTaskTimeout(Period pendingTaskTimeout)
+  {
+    super.setPendingTaskTimeout(pendingTaskTimeout);
+    return this;
+  }
+
+}

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerResourceManagementStrategy.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerResourceManagementStrategy.java
@@ -1,0 +1,412 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.indexing.overlord.autoscaling;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.base.Supplier;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import com.metamx.common.concurrent.ScheduledExecutorFactory;
+import com.metamx.emitter.EmittingLogger;
+import io.druid.indexing.common.task.Task;
+import io.druid.indexing.overlord.ImmutableWorkerInfo;
+import io.druid.indexing.overlord.WorkerTaskRunner;
+import io.druid.indexing.overlord.config.WorkerTaskRunnerConfig;
+import io.druid.indexing.overlord.setup.WorkerBehaviorConfig;
+import io.druid.indexing.overlord.setup.WorkerSelectStrategy;
+import io.druid.indexing.worker.Worker;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ */
+public class PendingTaskBasedWorkerResourceManagementStrategy extends AbstractWorkerResourceManagementStrategy
+{
+  private static final EmittingLogger log = new EmittingLogger(PendingTaskBasedWorkerResourceManagementStrategy.class);
+
+  private final PendingTaskBasedWorkerResourceManagementConfig config;
+  private final Supplier<WorkerBehaviorConfig> workerConfigRef;
+  private final ScalingStats scalingStats;
+
+  private final Object lock = new Object();
+  private final Set<String> currentlyProvisioning = Sets.newHashSet();
+  private final Set<String> currentlyTerminating = Sets.newHashSet();
+
+  private DateTime lastProvisionTime = new DateTime();
+  private DateTime lastTerminateTime = new DateTime();
+
+  @Inject
+  public PendingTaskBasedWorkerResourceManagementStrategy(
+      PendingTaskBasedWorkerResourceManagementConfig config,
+      Supplier<WorkerBehaviorConfig> workerConfigRef,
+      ResourceManagementSchedulerConfig resourceManagementSchedulerConfig,
+      ScheduledExecutorFactory factory
+  )
+  {
+    this(
+        config,
+        workerConfigRef,
+        resourceManagementSchedulerConfig,
+        factory.create(1, "PendingTaskBasedResourceManagement-manager--%d")
+    );
+  }
+
+  public PendingTaskBasedWorkerResourceManagementStrategy(
+      PendingTaskBasedWorkerResourceManagementConfig config,
+      Supplier<WorkerBehaviorConfig> workerConfigRef,
+      ResourceManagementSchedulerConfig resourceManagementSchedulerConfig,
+      ScheduledExecutorService exec
+  )
+  {
+    super(resourceManagementSchedulerConfig, exec);
+    this.config = config;
+    this.workerConfigRef = workerConfigRef;
+    this.scalingStats = new ScalingStats(config.getNumEventsToTrack());
+  }
+
+  @Override
+  public boolean doProvision(WorkerTaskRunner runner)
+  {
+    Collection<Task> pendingTasks = runner.getPendingTaskPayloads();
+    Collection<ImmutableWorkerInfo> workers = runner.getWorkers();
+    synchronized (lock) {
+      boolean didProvision = false;
+      final WorkerBehaviorConfig workerConfig = workerConfigRef.get();
+      if (workerConfig == null || workerConfig.getAutoScaler() == null) {
+        log.error("No workerConfig available, cannot provision new workers.");
+        return false;
+      }
+
+      final Collection<String> workerNodeIds = getWorkerNodeIDs(
+          Collections2.transform(
+              workers,
+              new Function<ImmutableWorkerInfo, Worker>()
+              {
+                @Override
+                public Worker apply(ImmutableWorkerInfo input)
+                {
+                  return input.getWorker();
+                }
+              }
+          ),
+          workerConfig
+      );
+      currentlyProvisioning.removeAll(workerNodeIds);
+      if (currentlyProvisioning.isEmpty()) {
+        int want = getScaleUpNodeCount(
+            runner.getConfig(),
+            workerConfig,
+            pendingTasks,
+            workers
+        );
+        while (want > 0) {
+          final AutoScalingData provisioned = workerConfig.getAutoScaler().provision();
+          final List<String> newNodes = provisioned == null ? ImmutableList.<String>of() : provisioned.getNodeIds();
+          if (newNodes.isEmpty()) {
+            log.warn("NewNodes is empty, returning from provision loop");
+            break;
+          } else {
+            currentlyProvisioning.addAll(newNodes);
+            lastProvisionTime = new DateTime();
+            scalingStats.addProvisionEvent(provisioned);
+            want -= provisioned.getNodeIds().size();
+            didProvision = true;
+          }
+        }
+      } else {
+        Duration durSinceLastProvision = new Duration(lastProvisionTime, new DateTime());
+        log.info("%s provisioning. Current wait time: %s", currentlyProvisioning, durSinceLastProvision);
+        if (durSinceLastProvision.isLongerThan(config.getMaxScalingDuration().toStandardDuration())) {
+          log.makeAlert("Worker node provisioning taking too long!")
+             .addData("millisSinceLastProvision", durSinceLastProvision.getMillis())
+             .addData("provisioningCount", currentlyProvisioning.size())
+             .emit();
+
+          workerConfig.getAutoScaler().terminateWithIds(Lists.newArrayList(currentlyProvisioning));
+          currentlyProvisioning.clear();
+        }
+      }
+
+      return didProvision;
+    }
+  }
+
+  private static Collection<String> getWorkerNodeIDs(Collection<Worker> workers, WorkerBehaviorConfig workerConfig)
+  {
+    return workerConfig.getAutoScaler().ipToIdLookup(
+        Lists.newArrayList(
+            Iterables.transform(
+                workers,
+                new Function<Worker, String>()
+                {
+                  @Override
+                  public String apply(Worker input)
+                  {
+                    return input.getIp();
+                  }
+                }
+            )
+        )
+    );
+  }
+
+  int getScaleUpNodeCount(
+      final WorkerTaskRunnerConfig remoteTaskRunnerConfig,
+      final WorkerBehaviorConfig workerConfig,
+      final Collection<Task> pendingTasks,
+      final Collection<ImmutableWorkerInfo> workers
+  )
+  {
+    final int minWorkerCount = workerConfig.getAutoScaler().getMinNumWorkers();
+    final int maxWorkerCount = workerConfig.getAutoScaler().getMaxNumWorkers();
+    final Predicate<ImmutableWorkerInfo> isValidWorker = ResourceManagementUtil.createValidWorkerPredicate(config);
+    final int currValidWorkers = Collections2.filter(workers, isValidWorker).size();
+
+    // If there are no worker, spin up minWorkerCount, we cannot determine the exact capacity here to fulfill the need since
+    // we are not aware of the expectedWorkerCapacity.
+    int moreWorkersNeeded = currValidWorkers == 0 ? minWorkerCount : getWorkersNeededToAssignTasks(
+        remoteTaskRunnerConfig,
+        workerConfig,
+        pendingTasks,
+        workers
+    );
+
+    int want = Math.max(
+        minWorkerCount - currValidWorkers,
+        // Additional workers needed to reach minWorkerCount
+        Math.min(config.getMaxScalingStep(), moreWorkersNeeded)
+        // Additional workers needed to run current pending tasks
+    );
+
+    if (want > 0 && currValidWorkers >= maxWorkerCount) {
+      log.warn("Unable to provision more workers. Current workerCount[%d] maximum workerCount[%d].");
+      return 0;
+    }
+    want = Math.min(want, maxWorkerCount - currValidWorkers);
+    return want;
+  }
+
+  int getWorkersNeededToAssignTasks(
+      final WorkerTaskRunnerConfig workerTaskRunnerConfig,
+      final WorkerBehaviorConfig workerConfig,
+      final Collection<Task> pendingTasks,
+      final Collection<ImmutableWorkerInfo> workers
+  )
+  {
+    final Collection<ImmutableWorkerInfo> validWorkers = Collections2.filter(
+        workers,
+        ResourceManagementUtil.createValidWorkerPredicate(config)
+    );
+
+    Map<String, ImmutableWorkerInfo> workersMap = Maps.newHashMap();
+    for (ImmutableWorkerInfo worker : validWorkers) {
+      workersMap.put(worker.getWorker().getHost(), worker);
+    }
+    WorkerSelectStrategy workerSelectStrategy = workerConfig.getSelectStrategy();
+    int need = 0;
+    int capacity = getExpectedWorkerCapacity(workers);
+
+    // Simulate assigning tasks to dummy workers using configured workerSelectStrategy
+    // the number of additional workers needed to assign all the pending tasks is noted
+    for (Task task : pendingTasks) {
+      Optional<ImmutableWorkerInfo> selectedWorker = workerSelectStrategy.findWorkerForTask(
+          workerTaskRunnerConfig,
+          ImmutableMap.copyOf(workersMap),
+          task
+      );
+      final ImmutableWorkerInfo workerRunningTask;
+      if (selectedWorker.isPresent()) {
+        workerRunningTask = selectedWorker.get();
+      } else {
+        // None of the existing worker can run this task, we need to provision one worker for it.
+        // create a dummy worker and try to simulate assigning task to it.
+        workerRunningTask = createDummyWorker("dummy" + need, capacity, workerTaskRunnerConfig.getMinWorkerVersion());
+        need++;
+      }
+      // Update map with worker running task
+      workersMap.put(workerRunningTask.getWorker().getHost(), workerWithTask(workerRunningTask, task));
+    }
+    return need;
+  }
+
+  @Override
+  public boolean doTerminate(WorkerTaskRunner runner)
+  {
+    Collection<ImmutableWorkerInfo> zkWorkers = runner.getWorkers();
+    synchronized (lock) {
+      final WorkerBehaviorConfig workerConfig = workerConfigRef.get();
+      if (workerConfig == null) {
+        log.warn("No workerConfig available, cannot terminate workers.");
+        return false;
+      }
+
+      if (!currentlyProvisioning.isEmpty()) {
+        log.debug("Already provisioning nodes, Not Terminating any nodes.");
+        return false;
+      }
+
+      boolean didTerminate = false;
+      final Collection<String> workerNodeIds = getWorkerNodeIDs(runner.getLazyWorkers(), workerConfig);
+      final Set<String> stillExisting = Sets.newHashSet();
+      for (String s : currentlyTerminating) {
+        if (workerNodeIds.contains(s)) {
+          stillExisting.add(s);
+        }
+      }
+      currentlyTerminating.clear();
+      currentlyTerminating.addAll(stillExisting);
+
+      if (currentlyTerminating.isEmpty()) {
+        final int maxWorkersToTerminate = maxWorkersToTerminate(zkWorkers, workerConfig);
+        final Predicate<ImmutableWorkerInfo> isLazyWorker = ResourceManagementUtil.createLazyWorkerPredicate(config);
+        final List<String> laziestWorkerIps =
+            Lists.newArrayList(
+                Collections2.transform(
+                    runner.markWorkersLazy(isLazyWorker, maxWorkersToTerminate),
+                    new Function<Worker, String>()
+                    {
+                      @Override
+                      public String apply(Worker zkWorker)
+                      {
+                        return zkWorker.getIp();
+                      }
+                    }
+                )
+            );
+        if (laziestWorkerIps.isEmpty()) {
+          log.debug("Found no lazy workers");
+        } else {
+          log.info(
+              "Terminating %,d lazy workers: %s",
+              laziestWorkerIps.size(),
+              Joiner.on(", ").join(laziestWorkerIps)
+          );
+
+          final AutoScalingData terminated = workerConfig.getAutoScaler().terminate(laziestWorkerIps);
+          if (terminated != null) {
+            currentlyTerminating.addAll(terminated.getNodeIds());
+            lastTerminateTime = new DateTime();
+            scalingStats.addTerminateEvent(terminated);
+            didTerminate = true;
+          }
+        }
+      } else {
+        Duration durSinceLastTerminate = new Duration(lastTerminateTime, new DateTime());
+
+        log.info("%s terminating. Current wait time: %s", currentlyTerminating, durSinceLastTerminate);
+
+        if (durSinceLastTerminate.isLongerThan(config.getMaxScalingDuration().toStandardDuration())) {
+          log.makeAlert("Worker node termination taking too long!")
+             .addData("millisSinceLastTerminate", durSinceLastTerminate.getMillis())
+             .addData("terminatingCount", currentlyTerminating.size())
+             .emit();
+
+          currentlyTerminating.clear();
+        }
+      }
+
+      return didTerminate;
+    }
+  }
+
+  private int maxWorkersToTerminate(Collection<ImmutableWorkerInfo> zkWorkers, WorkerBehaviorConfig workerConfig)
+  {
+    final Predicate<ImmutableWorkerInfo> isValidWorker = ResourceManagementUtil.createValidWorkerPredicate(config);
+    final int currValidWorkers = Collections2.filter(zkWorkers, isValidWorker).size();
+    final int invalidWorkers = zkWorkers.size() - currValidWorkers;
+    final int minWorkers = workerConfig.getAutoScaler().getMinNumWorkers();
+
+    // Max workers that can be terminated
+    // All invalid workers + any lazy workers above minCapacity
+    return invalidWorkers + Math.max(
+        0,
+        Math.min(
+            config.getMaxScalingStep(),
+            currValidWorkers - minWorkers
+        )
+    );
+  }
+
+  @Override
+  public ScalingStats getStats()
+  {
+    return scalingStats;
+  }
+
+  private static int getExpectedWorkerCapacity(final Collection<ImmutableWorkerInfo> workers)
+  {
+    int size = workers.size();
+    if (size == 0) {
+      // No existing workers assume capacity per worker as 1
+      return 1;
+    } else {
+      // Assume all workers have same capacity
+      return workers.iterator().next().getWorker().getCapacity();
+    }
+  }
+
+  private static ImmutableWorkerInfo workerWithTask(ImmutableWorkerInfo immutableWorker, Task task)
+  {
+    return new ImmutableWorkerInfo(
+        immutableWorker.getWorker(),
+        immutableWorker.getCurrCapacityUsed() + 1,
+        Sets.union(
+            immutableWorker.getAvailabilityGroups(),
+            Sets.newHashSet(
+                task.getTaskResource()
+                    .getAvailabilityGroup()
+            )
+        ),
+        Sets.union(
+            immutableWorker.getRunningTasks(),
+            Sets.newHashSet(
+                task.getId()
+            )
+        ),
+        DateTime.now()
+    );
+  }
+
+  private static ImmutableWorkerInfo createDummyWorker(String host, int capacity, String version)
+  {
+    return new ImmutableWorkerInfo(
+        new Worker(host, "-2", capacity, version),
+        0,
+        Sets.<String>newHashSet(),
+        Sets.<String>newHashSet(),
+        DateTime.now()
+    );
+  }
+}

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/ResourceManagementUtil.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/ResourceManagementUtil.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.indexing.overlord.autoscaling;
+
+import com.google.common.base.Predicate;
+import com.metamx.common.ISE;
+import io.druid.indexing.overlord.ImmutableWorkerInfo;
+import io.druid.indexing.overlord.ZkWorker;
+import io.druid.indexing.worker.Worker;
+
+public class ResourceManagementUtil
+{
+  public static Predicate<ImmutableWorkerInfo> createValidWorkerPredicate(
+      final SimpleWorkerResourceManagementConfig config
+  )
+  {
+    return new Predicate<ImmutableWorkerInfo>()
+    {
+      @Override
+      public boolean apply(ImmutableWorkerInfo worker)
+      {
+        final String minVersion = config.getWorkerVersion();
+        if (minVersion == null) {
+          throw new ISE("No minVersion found! It should be set in your runtime properties or configuration database.");
+        }
+        return worker.isValidVersion(minVersion);
+      }
+    };
+  }
+
+  public static Predicate<ImmutableWorkerInfo> createLazyWorkerPredicate(
+      final SimpleWorkerResourceManagementConfig config
+  )
+  {
+    final Predicate<ImmutableWorkerInfo> isValidWorker = createValidWorkerPredicate(config);
+
+    return new Predicate<ImmutableWorkerInfo>()
+    {
+      @Override
+      public boolean apply(ImmutableWorkerInfo worker)
+      {
+        final boolean itHasBeenAWhile = System.currentTimeMillis() - worker.getLastCompletedTaskTime().getMillis()
+                                        >= config.getWorkerIdleTimeout().toStandardDuration().getMillis();
+        return itHasBeenAWhile || !isValidWorker.apply(worker);
+      }
+    };
+  }
+
+}

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/SimpleWorkerResourceManagementConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/SimpleWorkerResourceManagementConfig.java
@@ -24,7 +24,7 @@ import org.joda.time.Period;
 
 /**
  */
-public class SimpleResourceManagementConfig
+public class SimpleWorkerResourceManagementConfig
 {
   @JsonProperty
   private Period workerIdleTimeout = new Period("PT90m");
@@ -49,7 +49,7 @@ public class SimpleResourceManagementConfig
     return workerIdleTimeout;
   }
 
-  public SimpleResourceManagementConfig setWorkerIdleTimeout(Period workerIdleTimeout)
+  public SimpleWorkerResourceManagementConfig setWorkerIdleTimeout(Period workerIdleTimeout)
   {
     this.workerIdleTimeout = workerIdleTimeout;
     return this;
@@ -60,7 +60,7 @@ public class SimpleResourceManagementConfig
     return maxScalingDuration;
   }
 
-  public SimpleResourceManagementConfig setMaxScalingDuration(Period maxScalingDuration)
+  public SimpleWorkerResourceManagementConfig setMaxScalingDuration(Period maxScalingDuration)
   {
     this.maxScalingDuration = maxScalingDuration;
     return this;
@@ -71,7 +71,7 @@ public class SimpleResourceManagementConfig
     return numEventsToTrack;
   }
 
-  public SimpleResourceManagementConfig setNumEventsToTrack(int numEventsToTrack)
+  public SimpleWorkerResourceManagementConfig setNumEventsToTrack(int numEventsToTrack)
   {
     this.numEventsToTrack = numEventsToTrack;
     return this;
@@ -82,7 +82,7 @@ public class SimpleResourceManagementConfig
     return pendingTaskTimeout;
   }
 
-  public SimpleResourceManagementConfig setPendingTaskTimeout(Period pendingTaskTimeout)
+  public SimpleWorkerResourceManagementConfig setPendingTaskTimeout(Period pendingTaskTimeout)
   {
     this.pendingTaskTimeout = pendingTaskTimeout;
     return this;
@@ -93,7 +93,7 @@ public class SimpleResourceManagementConfig
     return workerVersion;
   }
 
-  public SimpleResourceManagementConfig setWorkerVersion(String workerVersion)
+  public SimpleWorkerResourceManagementConfig setWorkerVersion(String workerVersion)
   {
     this.workerVersion = workerVersion;
     return this;
@@ -105,7 +105,7 @@ public class SimpleResourceManagementConfig
     return workerPort;
   }
 
-  public SimpleResourceManagementConfig setWorkerPort(int workerPort)
+  public SimpleWorkerResourceManagementConfig setWorkerPort(int workerPort)
   {
     this.workerPort = workerPort;
     return this;

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/ec2/EC2AutoScaler.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/ec2/EC2AutoScaler.java
@@ -39,7 +39,7 @@ import com.google.common.collect.Lists;
 import com.metamx.emitter.EmittingLogger;
 import io.druid.indexing.overlord.autoscaling.AutoScaler;
 import io.druid.indexing.overlord.autoscaling.AutoScalingData;
-import io.druid.indexing.overlord.autoscaling.SimpleResourceManagementConfig;
+import io.druid.indexing.overlord.autoscaling.SimpleWorkerResourceManagementConfig;
 
 import java.util.List;
 
@@ -54,7 +54,7 @@ public class EC2AutoScaler implements AutoScaler<EC2EnvironmentConfig>
   private final int maxNumWorkers;
   private final EC2EnvironmentConfig envConfig;
   private final AmazonEC2 amazonEC2Client;
-  private final SimpleResourceManagementConfig config;
+  private final SimpleWorkerResourceManagementConfig config;
 
   @JsonCreator
   public EC2AutoScaler(
@@ -62,7 +62,7 @@ public class EC2AutoScaler implements AutoScaler<EC2EnvironmentConfig>
       @JsonProperty("maxNumWorkers") int maxNumWorkers,
       @JsonProperty("envConfig") EC2EnvironmentConfig envConfig,
       @JacksonInject AmazonEC2 amazonEC2Client,
-      @JacksonInject SimpleResourceManagementConfig config
+      @JacksonInject SimpleWorkerResourceManagementConfig config
   )
   {
     this.minNumWorkers = minNumWorkers;

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
@@ -28,7 +28,7 @@ import javax.validation.constraints.NotNull;
 
 /**
  */
-public class RemoteTaskRunnerConfig
+public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
 {
   @JsonProperty
   @NotNull
@@ -37,9 +37,6 @@ public class RemoteTaskRunnerConfig
   @JsonProperty
   @NotNull
   private Period taskCleanupTimeout = new Period("PT15M");
-
-  @JsonProperty
-  private String minWorkerVersion = "0";
 
   @JsonProperty
   @Min(10 * 1024)
@@ -60,11 +57,6 @@ public class RemoteTaskRunnerConfig
   @JsonProperty
   public Period getTaskCleanupTimeout(){
     return taskCleanupTimeout;
-  }
-
-  public String getMinWorkerVersion()
-  {
-    return minWorkerVersion;
   }
 
   public int getMaxZnodeBytes()
@@ -107,7 +99,7 @@ public class RemoteTaskRunnerConfig
     if (!taskCleanupTimeout.equals(that.taskCleanupTimeout)) {
       return false;
     }
-    if (!minWorkerVersion.equals(that.minWorkerVersion)) {
+    if (!getMinWorkerVersion().equals(that.getMinWorkerVersion())) {
       return false;
     }
     return taskShutdownLinkTimeout.equals(that.taskShutdownLinkTimeout);
@@ -119,7 +111,7 @@ public class RemoteTaskRunnerConfig
   {
     int result = taskAssignmentTimeout.hashCode();
     result = 31 * result + taskCleanupTimeout.hashCode();
-    result = 31 * result + minWorkerVersion.hashCode();
+    result = 31 * result + getMinWorkerVersion().hashCode();
     result = 31 * result + maxZnodeBytes;
     result = 31 * result + taskShutdownLinkTimeout.hashCode();
     result = 31 * result + pendingTasksRunnerNumThreads;
@@ -132,7 +124,7 @@ public class RemoteTaskRunnerConfig
     return "RemoteTaskRunnerConfig{" +
            "taskAssignmentTimeout=" + taskAssignmentTimeout +
            ", taskCleanupTimeout=" + taskCleanupTimeout +
-           ", minWorkerVersion='" + minWorkerVersion + '\'' +
+           ", minWorkerVersion='" + getMinWorkerVersion() + '\'' +
            ", maxZnodeBytes=" + maxZnodeBytes +
            ", taskShutdownLinkTimeout=" + taskShutdownLinkTimeout +
            ", pendingTasksRunnerNumThreads=" + pendingTasksRunnerNumThreads +

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/config/WorkerTaskRunnerConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/config/WorkerTaskRunnerConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.indexing.overlord.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class WorkerTaskRunnerConfig
+{
+  @JsonProperty
+  private String minWorkerVersion = "0";
+
+  public String getMinWorkerVersion()
+  {
+    return minWorkerVersion;
+  }
+}

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/setup/EqualDistributionWorkerSelectStrategy.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/setup/EqualDistributionWorkerSelectStrategy.java
@@ -26,6 +26,7 @@ import com.google.common.primitives.Ints;
 import io.druid.indexing.common.task.Task;
 import io.druid.indexing.overlord.ImmutableWorkerInfo;
 import io.druid.indexing.overlord.config.RemoteTaskRunnerConfig;
+import io.druid.indexing.overlord.config.WorkerTaskRunnerConfig;
 
 import java.util.Comparator;
 import java.util.TreeSet;
@@ -36,7 +37,7 @@ public class EqualDistributionWorkerSelectStrategy implements WorkerSelectStrate
 {
   @Override
   public Optional<ImmutableWorkerInfo> findWorkerForTask(
-      RemoteTaskRunnerConfig config, ImmutableMap<String, ImmutableWorkerInfo> zkWorkers, Task task
+      WorkerTaskRunnerConfig config, ImmutableMap<String, ImmutableWorkerInfo> zkWorkers, Task task
   )
   {
     final TreeSet<ImmutableWorkerInfo> sortedWorkers = Sets.newTreeSet(

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/setup/FillCapacityWithAffinityWorkerSelectStrategy.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/setup/FillCapacityWithAffinityWorkerSelectStrategy.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Sets;
 import io.druid.indexing.common.task.Task;
 import io.druid.indexing.overlord.ImmutableWorkerInfo;
 import io.druid.indexing.overlord.config.RemoteTaskRunnerConfig;
+import io.druid.indexing.overlord.config.WorkerTaskRunnerConfig;
 
 import java.util.List;
 import java.util.Set;
@@ -59,7 +60,7 @@ public class FillCapacityWithAffinityWorkerSelectStrategy extends FillCapacityWo
 
   @Override
   public Optional<ImmutableWorkerInfo> findWorkerForTask(
-      final RemoteTaskRunnerConfig config,
+      final WorkerTaskRunnerConfig config,
       final ImmutableMap<String, ImmutableWorkerInfo> zkWorkers,
       final Task task
   )

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/setup/FillCapacityWorkerSelectStrategy.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/setup/FillCapacityWorkerSelectStrategy.java
@@ -26,6 +26,7 @@ import com.google.common.primitives.Ints;
 import io.druid.indexing.common.task.Task;
 import io.druid.indexing.overlord.ImmutableWorkerInfo;
 import io.druid.indexing.overlord.config.RemoteTaskRunnerConfig;
+import io.druid.indexing.overlord.config.WorkerTaskRunnerConfig;
 
 import java.util.Comparator;
 import java.util.TreeSet;
@@ -36,7 +37,7 @@ public class FillCapacityWorkerSelectStrategy implements WorkerSelectStrategy
 {
   @Override
   public Optional<ImmutableWorkerInfo> findWorkerForTask(
-      final RemoteTaskRunnerConfig config,
+      final WorkerTaskRunnerConfig config,
       final ImmutableMap<String, ImmutableWorkerInfo> zkWorkers,
       final Task task
   )

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/setup/JavaScriptWorkerSelectStrategy.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/setup/JavaScriptWorkerSelectStrategy.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableMap;
 import io.druid.indexing.common.task.Task;
 import io.druid.indexing.overlord.ImmutableWorkerInfo;
 import io.druid.indexing.overlord.config.RemoteTaskRunnerConfig;
+import io.druid.indexing.overlord.config.WorkerTaskRunnerConfig;
 
 import javax.script.Compilable;
 import javax.script.Invocable;
@@ -39,7 +40,7 @@ public class JavaScriptWorkerSelectStrategy implements WorkerSelectStrategy
 {
   public static interface SelectorFunction
   {
-    public String apply(RemoteTaskRunnerConfig config, ImmutableMap<String, ImmutableWorkerInfo> zkWorkers, Task task);
+    public String apply(WorkerTaskRunnerConfig config, ImmutableMap<String, ImmutableWorkerInfo> zkWorkers, Task task);
   }
 
   private final SelectorFunction fnSelector;
@@ -62,7 +63,7 @@ public class JavaScriptWorkerSelectStrategy implements WorkerSelectStrategy
 
   @Override
   public Optional<ImmutableWorkerInfo> findWorkerForTask(
-      RemoteTaskRunnerConfig config, ImmutableMap<String, ImmutableWorkerInfo> zkWorkers, Task task
+      WorkerTaskRunnerConfig config, ImmutableMap<String, ImmutableWorkerInfo> zkWorkers, Task task
   )
   {
     String worker = fnSelector.apply(config, zkWorkers, task);

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/setup/WorkerSelectStrategy.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/setup/WorkerSelectStrategy.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableMap;
 import io.druid.indexing.common.task.Task;
 import io.druid.indexing.overlord.ImmutableWorkerInfo;
 import io.druid.indexing.overlord.config.RemoteTaskRunnerConfig;
+import io.druid.indexing.overlord.config.WorkerTaskRunnerConfig;
 
 /**
  * The {@link io.druid.indexing.overlord.RemoteTaskRunner} uses this class to select a worker to assign tasks to.
@@ -49,7 +50,7 @@ public interface WorkerSelectStrategy
    * @return A {@link io.druid.indexing.overlord.ImmutableWorkerInfo} to run the task if one is available.
    */
   Optional<ImmutableWorkerInfo> findWorkerForTask(
-      final RemoteTaskRunnerConfig config,
+      final WorkerTaskRunnerConfig config,
       final ImmutableMap<String, ImmutableWorkerInfo> zkWorkers,
       final Task task
   );

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerFactoryTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerFactoryTest.java
@@ -29,10 +29,10 @@ import com.metamx.http.client.HttpClient;
 import io.druid.curator.PotentiallyGzippedCompressionProvider;
 import io.druid.indexing.common.TestUtils;
 import io.druid.indexing.overlord.autoscaling.ResourceManagementSchedulerConfig;
-import io.druid.indexing.overlord.autoscaling.SimpleResourceManagementConfig;
+import io.druid.indexing.overlord.autoscaling.SimpleWorkerResourceManagementConfig;
+import io.druid.indexing.overlord.autoscaling.SimpleWorkerResourceManagementStrategy;
 import io.druid.indexing.overlord.config.RemoteTaskRunnerConfig;
 import io.druid.indexing.overlord.setup.WorkerBehaviorConfig;
-import io.druid.jackson.DefaultObjectMapper;
 import io.druid.server.initialization.IndexerZkConfig;
 import io.druid.server.initialization.ZkPathsConfig;
 import junit.framework.Assert;
@@ -109,7 +109,7 @@ public class RemoteTaskRunnerFactoryTest
         return ScheduledExecutors.fixed(i, s);
       }
     };
-    SimpleResourceManagementConfig resourceManagementConfig = new SimpleResourceManagementConfig();
+    SimpleWorkerResourceManagementConfig resourceManagementConfig = new SimpleWorkerResourceManagementConfig();
     ResourceManagementSchedulerConfig resourceManagementSchedulerConfig = new ResourceManagementSchedulerConfig()
     {
       @Override
@@ -126,14 +126,19 @@ public class RemoteTaskRunnerFactoryTest
         httpClient,
         workerBehaviorConfig,
         executorFactory,
-        resourceManagementConfig,
-        resourceManagementSchedulerConfig
+        resourceManagementSchedulerConfig,
+        new SimpleWorkerResourceManagementStrategy(
+            resourceManagementConfig,
+            workerBehaviorConfig,
+            resourceManagementSchedulerConfig,
+            executorFactory
+        )
     );
-    Assert.assertEquals(0, executorCount.get());
+    Assert.assertEquals(1, executorCount.get());
     RemoteTaskRunner remoteTaskRunner1 = factory.build();
     Assert.assertEquals(2, executorCount.get());
     RemoteTaskRunner remoteTaskRunner2 = factory.build();
-    Assert.assertEquals(4, executorCount.get());
+    Assert.assertEquals(3, executorCount.get());
 
   }
 }

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/EC2AutoScalerTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/EC2AutoScalerTest.java
@@ -66,7 +66,7 @@ public class EC2AutoScalerTest
   private DescribeInstancesResult describeInstancesResult;
   private Reservation reservation;
   private Instance instance;
-  private SimpleResourceManagementConfig managementConfig;
+  private SimpleWorkerResourceManagementConfig managementConfig;
 
   @Before
   public void setUp() throws Exception
@@ -81,7 +81,7 @@ public class EC2AutoScalerTest
         .withImageId(AMI_ID)
         .withPrivateIpAddress(IP);
 
-    managementConfig = new SimpleResourceManagementConfig().setWorkerPort(8080).setWorkerVersion("");
+    managementConfig = new SimpleWorkerResourceManagementConfig().setWorkerPort(8080).setWorkerVersion("");
   }
 
   @After


### PR DESCRIPTION
Issues with current autoscaling : 

1. when lots of tasks are getting started, SimpleResourceManagementStrategy can wait too long to provision new nodes as it provisions 1 node at a time and then waits for that node to come online before starting another. 
2. SimpleResourceManagementStrategy maintains a targetWorkerCount based on the number of current  running tasks. During an indexing service upgrade an entire copy of the RT cluster is made. This copy remains mostly idle for the first hour (or few hours) while tasks slowly get launched on it. This causes reluctance to do anything risky with real time nodes as upgrades become very expensive

This PR adds PendingTaskBasedAutoscalingStrategy as an attempt to resolve above two issues. 
PendingTaskBasedAutoscalingStrategy takes into account the state of pending tasks, available capacity on existing nodes and the task assignment strategy to determine how many nodes to scale to.
During an upgrade, only minWorkerNodes (instead of duplicating complete cluster) will be created as the service is updated and after that nodes are added as new tasks are added to the queue.  

The default resource management strategy is still be the old one which can be replaced by the new strategy once it gets tested well in production environments. 