### PR TITLE
take away default for groupBy/having

### DIFF
--- a/processing/src/main/java/io/druid/query/groupby/having/HavingSpec.java
+++ b/processing/src/main/java/io/druid/query/groupby/having/HavingSpec.java
@@ -27,7 +27,7 @@ import io.druid.data.input.Row;
  * A "having" clause that filters aggregated/dimension value. This is similar to SQL's "having"
  * clause.
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = AlwaysHavingSpec.class)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes(value = {
     @JsonSubTypes.Type(name = "and", value = AndHavingSpec.class),
     @JsonSubTypes.Type(name = "or", value = OrHavingSpec.class),
@@ -35,7 +35,8 @@ import io.druid.data.input.Row;
     @JsonSubTypes.Type(name = "greaterThan", value = GreaterThanHavingSpec.class),
     @JsonSubTypes.Type(name = "lessThan", value = LessThanHavingSpec.class),
     @JsonSubTypes.Type(name = "equalTo", value = EqualToHavingSpec.class),
-    @JsonSubTypes.Type(name = "dimSelector", value = DimensionSelectorHavingSpec.class)
+    @JsonSubTypes.Type(name = "dimSelector", value = DimensionSelectorHavingSpec.class),
+    @JsonSubTypes.Type(name = "always", value = AlwaysHavingSpec.class)
 })
 public interface HavingSpec
 {


### PR DESCRIPTION
One of our teams was getting incorrect results from druid without realizing it right away, because they had a typo in the having clause inside a groupBy query.  This did not report an error, because there is a default for the "having" spec.  We think that there should not be a default for the "having" spec, because that makes it very easy to have unintended, incorrect results without anyone realizing it.