### PR TITLE
Simplifying dimension merging

### DIFF
--- a/processing/src/main/java/io/druid/segment/filter/SpatialFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/SpatialFilter.java
@@ -46,9 +46,6 @@ public class SpatialFilter implements Filter
   public ImmutableBitmap getBitmapIndex(final BitmapIndexSelector selector)
   {
     Iterable<ImmutableBitmap> search = selector.getSpatialIndex(dimension).search(bound);
-    for (ImmutableBitmap immutableBitmap : search) {
-      System.out.println(immutableBitmap);
-    }
     return selector.getBitmapFactory().union(search);
   }
 

--- a/processing/src/test/java/io/druid/segment/DictionaryMergeIteratorTest.java
+++ b/processing/src/test/java/io/druid/segment/DictionaryMergeIteratorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment;
+
+import com.google.common.collect.Iterators;
+import io.druid.segment.data.ArrayIndexed;
+import io.druid.segment.data.Indexed;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ */
+public class DictionaryMergeIteratorTest
+{
+
+  @Test
+  public void basicTest()
+  {
+    // a b c d e f
+    String[] s1 = {"a", "c", "d", "e"};   // 0 2 3 4
+    String[] s2 = {"b", "c", "e"};        // 1 2 4
+    String[] s3 = {"a", "d", "f"};        // 0 3 5
+    String[] s4 = {"a", "b", "c"};
+    String[] s5 = {"a", "b", "c", "d", "e", "f"};
+    Indexed<String> i1 = new ArrayIndexed<String>(s1, String.class);
+    Indexed<String> i2 = new ArrayIndexed<String>(s2, String.class);
+    Indexed<String> i3 = new ArrayIndexed<String>(s3, String.class);
+    Indexed<String> i4 = new ArrayIndexed<String>(s4, String.class);
+    Indexed<String> i5 = new ArrayIndexed<String>(s5, String.class);
+
+    IndexMerger.DictionaryMergeIterator iterator = new IndexMerger.DictionaryMergeIterator(new Indexed[]{i1, i2, i3, i4, i5}, false);
+
+    Assert.assertArrayEquals(new String[]{"a", "b", "c", "d", "e", "f"}, Iterators.toArray(iterator, String.class));
+
+    Assert.assertArrayEquals(new int[] {0, 2, 3, 4}, iterator.conversions[0].array());
+    Assert.assertArrayEquals(new int[] {1, 2, 4}, iterator.conversions[1].array());
+    Assert.assertArrayEquals(new int[] {0, 3, 5}, iterator.conversions[2].array());
+    Assert.assertArrayEquals(new int[] {0, 1, 2}, iterator.conversions[3].array());
+    Assert.assertArrayEquals(new int[] {0, 1, 2, 3, 4, 5}, iterator.conversions[4].array());
+
+    Assert.assertTrue(iterator.needConversion(0));
+    Assert.assertTrue(iterator.needConversion(1));
+    Assert.assertTrue(iterator.needConversion(2));
+    Assert.assertFalse(iterator.needConversion(3));
+    Assert.assertFalse(iterator.needConversion(4));
+  }
+}

--- a/processing/src/test/java/io/druid/segment/IndexMergerTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerTest.java
@@ -1668,7 +1668,9 @@ public class IndexMergerTest
     dimConversions.put(0);
     dimConversions.put(2);
     dimConversions.put(4);
-    IndexMerger.DictIdSeeker dictIdSeeker = new IndexMerger.DictIdSeeker((IntBuffer) dimConversions.asReadOnlyBuffer().rewind());
+    IndexMerger.IndexSeeker dictIdSeeker = new IndexMerger.IndexSeekerWithConversion(
+        (IntBuffer) dimConversions.asReadOnlyBuffer().rewind()
+    );
     Assert.assertEquals(0, dictIdSeeker.seek(0));
     Assert.assertEquals(-1, dictIdSeeker.seek(1));
     Assert.assertEquals(1, dictIdSeeker.seek(2));


### PR DESCRIPTION
Currently, dimension merging is processed by two stages. One for dictionary, one for index. If this can be processed by  single stage, total processing time could be deceased.