### PR TITLE
Fix getType() and Json serialization in ClientMergeQuery + serde tests

### DIFF
--- a/server/src/main/java/io/druid/client/indexing/ClientMergeQuery.java
+++ b/server/src/main/java/io/druid/client/indexing/ClientMergeQuery.java
@@ -50,7 +50,7 @@ public class ClientMergeQuery
   @JsonProperty
   public String getType()
   {
-    return "append";
+    return "merge";
   }
 
   @JsonProperty
@@ -65,7 +65,7 @@ public class ClientMergeQuery
     return segments;
   }
 
-  @JsonProperty
+  @JsonProperty("aggregations")
   public List<AggregatorFactory> getAggregators()
   {
     return aggregators;

--- a/server/src/test/java/io/druid/client/indexing/ClientMergeQueryTest.java
+++ b/server/src/test/java/io/druid/client/indexing/ClientMergeQueryTest.java
@@ -42,7 +42,7 @@ public class ClientMergeQueryTest
   @Test
   public void testGetType()
   {
-    Assert.assertEquals("append", CLIENT_MERGE_QUERY.getType());
+    Assert.assertEquals("merge", CLIENT_MERGE_QUERY.getType());
   }
 
   @Test


### PR DESCRIPTION
In Coordinator, there are a bunch of ClientXXXQuery classes whose serialized JSON are same as their corresponding tasks, e.g., ClientMergeQuery corresponds to MergeTask. 
This PR 
1. s/append/merge in getType() for ClientMergeQuery
2. set JsonProperty for getAggregators() for ClientMergeQuery
3. added serde tests between xxxTask and ClientXXXQuery so that changes in xxxTask will propagate to ClientXXXQuery.