### PR TITLE
Backport #1967 - Add datasource and taskId to metrics emitted by peons

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/ForkingTaskRunner.java
@@ -52,7 +52,9 @@ import io.druid.indexing.common.task.Task;
 import io.druid.indexing.common.tasklogs.LogUtils;
 import io.druid.indexing.overlord.config.ForkingTaskRunnerConfig;
 import io.druid.indexing.worker.config.WorkerConfig;
+import io.druid.query.DruidMetrics;
 import io.druid.server.DruidNode;
+import io.druid.server.metrics.MonitorsConfig;
 import io.druid.tasklogs.TaskLogPusher;
 import io.druid.tasklogs.TaskLogStreamer;
 import org.apache.commons.io.FileUtils;
@@ -295,6 +297,24 @@ public class ForkingTaskRunner implements TaskRunner, TaskLogStreamer
                                   }
                                 }
                               }
+
+                              // Add dataSource and taskId for metrics
+                              command.add(
+                                  String.format(
+                                      "-D%s%s=%s",
+                                      MonitorsConfig.METRIC_DIMENSION_PREFIX,
+                                      DruidMetrics.DATASOURCE,
+                                      task.getDataSource()
+                                  )
+                              );
+                              command.add(
+                                  String.format(
+                                      "-D%s%s=%s",
+                                      MonitorsConfig.METRIC_DIMENSION_PREFIX,
+                                      DruidMetrics.TASK_ID,
+                                      task.getId()
+                                  )
+                              );
 
                               command.add(String.format("-Ddruid.host=%s", childHost));
                               command.add(String.format("-Ddruid.port=%d", childPort));

--- a/processing/src/main/java/io/druid/query/DruidMetrics.java
+++ b/processing/src/main/java/io/druid/query/DruidMetrics.java
@@ -36,6 +36,7 @@ public class DruidMetrics
   public final static String TYPE = "type";
   public final static String INTERVAL = "interval";
   public final static String ID = "id";
+  public final static String TASK_ID = "taskId";
   public final static String STATUS = "status";
 
   // task metrics

--- a/server/src/main/java/io/druid/server/metrics/MonitorsConfig.java
+++ b/server/src/main/java/io/druid/server/metrics/MonitorsConfig.java
@@ -28,6 +28,8 @@ import java.util.List;
  */
 public class MonitorsConfig
 {
+  public final static String METRIC_DIMENSION_PREFIX = "druid.metrics.emitter.dimension.";
+
   @JsonProperty("monitors")
   @NotNull
   private List<Class<? extends Monitor>> monitors = Lists.newArrayList();


### PR DESCRIPTION
This PR adds the datasource and taskId to the jvm and sys metrics emitted by the peons.