### PR TITLE
idempotent batch delta ingestion

### DIFF
--- a/docs/content/design/coordinator.md
+++ b/docs/content/design/coordinator.md
@@ -105,6 +105,14 @@ Returns a list of all segments for a datasource as stored in the metadata store.
 
 Returns a list of all segments for a datasource with the full segment metadata as stored in the metadata store.
 
+* POST `/druid/coordinator/v1/metadata/datasources/{dataSourceName}/segments`
+
+Returns a list of all segments, overlapping with any of given intervals,  for a datasource as stored in the metadata store. Request body is array of string intervals like [interval1, interval2,...] for example ["2012-01-01T00:00:00.000/2012-01-03T00:00:00.000", "2012-01-05T00:00:00.000/2012-01-07T00:00:00.000"]
+
+* POST `/druid/coordinator/v1/metadata/datasources/{dataSourceName}/segments?full`
+
+Returns a list of all segments, overlapping with any of given intervals, for a datasource with the full segment metadata as stored in the metadata store. Request body is array of string intervals like [interval1, interval2,...] for example ["2012-01-01T00:00:00.000/2012-01-03T00:00:00.000", "2012-01-05T00:00:00.000/2012-01-07T00:00:00.000"]
+
 * `/druid/coordinator/v1/metadata/datasources/{dataSourceName}/segments/{segmentId}`
 
 Returns full segment metadata for a specific segment as stored in the metadata store.

--- a/docs/content/ingestion/update-existing-data.md
+++ b/docs/content/ingestion/update-existing-data.md
@@ -51,6 +51,7 @@ Here is what goes inside `ingestionSpec`:
 |-----|----|-----------|--------|
 |dataSource|String|Druid dataSource name from which you are loading the data.|yes|
 |intervals|List|A list of strings representing ISO-8601 Intervals.|yes|
+|segments|List|A list of segments from which to read the data. It is determined automatically if not specified and the list of segments might change on multiple invocations. But user might want to provide it manually to make the ingestion task idempotent.|no|
 |granularity|String|Defines the granularity of the query while loading data. Default value is "none". See [Granularities](../querying/granularities.html).|no|
 |filter|JSON|See [Filters](../querying/filters.html)|no|
 |dimensions|Array of String|Name of dimension columns to load. By default, the list will be constructed from parseSpec. If parseSpec does not have an explicit list of dimensions then all the dimension columns present in stored data will be read.|no|

--- a/indexing-hadoop/src/test/java/io/druid/indexer/HadoopIngestionSpecUpdateDatasourcePathSpecSegmentsTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/HadoopIngestionSpecUpdateDatasourcePathSpecSegmentsTest.java
@@ -43,6 +43,7 @@ import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -91,7 +92,7 @@ public class HadoopIngestionSpecUpdateDatasourcePathSpecSegmentsTest
     PathSpec pathSpec = new DatasourcePathSpec(
         jsonMapper,
         null,
-        new DatasourceIngestionSpec(testDatasource, testDatasourceInterval, null, null, null, null, null, false),
+        new DatasourceIngestionSpec(testDatasource, testDatasourceInterval, null, null, null, null, null, null, false),
         null
     );
     HadoopDruidIndexerConfig config = testRunUpdateSegmentListIfDatasourcePathSpecIsUsed(
@@ -105,13 +106,77 @@ public class HadoopIngestionSpecUpdateDatasourcePathSpecSegmentsTest
   }
 
   @Test
+  public void testupdateSegmentListIfDatasourcePathSpecWithMatchingUserSegments() throws Exception
+  {
+    PathSpec pathSpec = new DatasourcePathSpec(
+        jsonMapper,
+        null,
+        new DatasourceIngestionSpec(
+            testDatasource,
+            testDatasourceInterval,
+            null,
+            ImmutableList.<DataSegment>of(SEGMENT),
+            null,
+            null,
+            null,
+            null,
+            false
+        ),
+        null
+    );
+    HadoopDruidIndexerConfig config = testRunUpdateSegmentListIfDatasourcePathSpecIsUsed(
+        pathSpec,
+        testDatasourceInterval
+    );
+    Assert.assertEquals(
+        ImmutableList.of(WindowedDataSegment.of(SEGMENT)),
+        ((DatasourcePathSpec) config.getPathSpec()).getSegments()
+    );
+  }
+
+  @Test(expected = IOException.class)
+  public void testupdateSegmentListThrowsExceptionWithUserSegmentsMismatch() throws Exception
+  {
+    PathSpec pathSpec = new DatasourcePathSpec(
+        jsonMapper,
+        null,
+        new DatasourceIngestionSpec(
+            testDatasource,
+            testDatasourceInterval,
+            null,
+            ImmutableList.<DataSegment>of(SEGMENT.withVersion("v2")),
+            null,
+            null,
+            null,
+            null,
+            false
+        ),
+        null
+    );
+    testRunUpdateSegmentListIfDatasourcePathSpecIsUsed(
+        pathSpec,
+        testDatasourceInterval
+    );
+  }
+
+  @Test
   public void testupdateSegmentListIfDatasourcePathSpecIsUsedWithJustDatasourcePathSpecAndPartialInterval()
       throws Exception
   {
     PathSpec pathSpec = new DatasourcePathSpec(
         jsonMapper,
         null,
-        new DatasourceIngestionSpec(testDatasource, testDatasourceIntervalPartial, null, null, null, null, null, false),
+        new DatasourceIngestionSpec(
+            testDatasource,
+            testDatasourceIntervalPartial,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            false
+        ),
         null
     );
     HadoopDruidIndexerConfig config = testRunUpdateSegmentListIfDatasourcePathSpecIsUsed(
@@ -133,7 +198,17 @@ public class HadoopIngestionSpecUpdateDatasourcePathSpecSegmentsTest
             new DatasourcePathSpec(
                 jsonMapper,
                 null,
-                new DatasourceIngestionSpec(testDatasource, testDatasourceInterval, null, null, null, null, null, false),
+                new DatasourceIngestionSpec(
+                    testDatasource,
+                    testDatasourceInterval,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    false
+                ),
                 null
             )
         )

--- a/indexing-hadoop/src/test/java/io/druid/indexer/hadoop/DatasourceIngestionSpecTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/hadoop/DatasourceIngestionSpecTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Lists;
 import io.druid.granularity.QueryGranularity;
 import io.druid.query.filter.SelectorDimFilter;
 import io.druid.segment.TestHelper;
+import io.druid.timeline.DataSegment;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Test;
@@ -45,6 +46,7 @@ public class DatasourceIngestionSpecTest
     DatasourceIngestionSpec expected = new DatasourceIngestionSpec(
         "test",
         interval,
+        null,
         null,
         new SelectorDimFilter("dim", "value"),
         QueryGranularity.DAY,
@@ -84,6 +86,7 @@ public class DatasourceIngestionSpecTest
         null,
         null,
         null,
+        null,
         false
     );
 
@@ -93,6 +96,18 @@ public class DatasourceIngestionSpecTest
     jsonStr = "{\n"
               + "  \"dataSource\": \"test\",\n"
               + "  \"intervals\": [\"2014/2015\", \"2016/2017\"],\n"
+              + "  \"segments\": [{\n"
+              + "    \"dataSource\":\"test\",\n"
+              + "    \"interval\":\"2014-01-01T00:00:00.000Z/2017-01-01T00:00:00.000Z\",\n"
+              + "    \"version\":\"v0\",\n"
+              + "    \"loadSpec\":null,\n"
+              + "    \"dimensions\":\"\",\n"
+              + "    \"metrics\":\"\",\n"
+              + "    \"shardSpec\":{\"type\":\"none\"},\n"
+              + "    \"binaryVersion\":9,\n"
+              + "    \"size\":128,\n"
+              + "    \"identifier\":\"test_2014-01-01T00:00:00.000Z_2017-01-01T00:00:00.000Z_v0\"\n"
+              + "    }],\n"
               + "  \"filter\": { \"type\": \"selector\", \"dimension\": \"dim\", \"value\": \"value\"},\n"
               + "  \"granularity\": \"day\",\n"
               + "  \"dimensions\": [\"d1\", \"d2\"],\n"
@@ -104,6 +119,19 @@ public class DatasourceIngestionSpecTest
         "test",
         null,
         intervals,
+        ImmutableList.of(
+            new DataSegment(
+                "test",
+                Interval.parse("2014/2017"),
+                "v0",
+                null,
+                null,
+                null,
+                null,
+                9,
+                128
+            )
+        ),
         new SelectorDimFilter("dim", "value"),
         QueryGranularity.DAY,
         Lists.newArrayList("d1", "d2"),
@@ -128,7 +156,7 @@ public class DatasourceIngestionSpecTest
     DatasourceIngestionSpec actual = MAPPER.readValue(jsonStr, DatasourceIngestionSpec.class);
 
     Assert.assertEquals(
-        new DatasourceIngestionSpec("test", Interval.parse("2014/2015"), null, null, null, null, null, false),
+        new DatasourceIngestionSpec("test", Interval.parse("2014/2015"), null, null, null, null, null, null, false),
         actual
     );
   }

--- a/indexing-hadoop/src/test/java/io/druid/indexer/hadoop/DatasourceRecordReaderTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/hadoop/DatasourceRecordReaderTest.java
@@ -67,6 +67,7 @@ public class DatasourceRecordReaderTest
                 null,
                 null,
                 null,
+                null,
                 segment.getDimensions(),
                 segment.getMetrics(),
                 false

--- a/indexing-hadoop/src/test/java/io/druid/indexer/path/DatasourcePathSpecTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/path/DatasourcePathSpecTest.java
@@ -80,6 +80,7 @@ public class DatasourcePathSpecTest
         null,
         null,
         null,
+        null,
         false
     );
 


### PR DESCRIPTION
give user the option to specify the segments for dataSource inputSpec,
so that they can do "idempotent" delta ingestion.

Fixes #2099

