### PR TITLE
Fix sporadic fail of DruidCoordinatorTest#testCoordinatorRun

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
@@ -247,6 +247,16 @@ public class DruidCoordinator
     return retVal;
   }
 
+  CountingMap<String> getLoadPendingDatasources() {
+    final CountingMap<String> retVal = new CountingMap<>();
+    for (LoadQueuePeon peon : loadManagementPeons.values()) {
+      for (DataSegment segment : peon.getSegmentsToLoad()) {
+        retVal.add(segment.getDataSource(), 1);
+      }
+    }
+    return retVal;
+  }
+
   public Map<String, Double> getLoadStatus()
   {
     Map<String, Double> loadStatus = Maps.newHashMap();

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
@@ -338,6 +338,10 @@ public class DruidCoordinatorTest extends CuratorTestBase
     Assert.assertEquals(1, segmentAvailability.size());
     Assert.assertEquals(0l, segmentAvailability.get(dataSource));
 
+    while (coordinator.getLoadPendingDatasources().get(dataSource).get() > 0) {
+      Thread.sleep(50);
+    }
+
     Map<String, CountingMap<String>> replicationStatus = coordinator.getReplicationStatus();
     Assert.assertNotNull(replicationStatus);
     Assert.assertEquals(1, replicationStatus.entrySet().size());


### PR DESCRIPTION
```
io.druid.server.coordinator.DruidCoordinatorTest
testCoordinatorRun(io.druid.server.coordinator.DruidCoordinatorTest)  Time elapsed: 2.689 sec  <<< FAILURE!
java.lang.AssertionError: expected:<1> but was:<0>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:743)
	at org.junit.Assert.assertEquals(Assert.java:118)
	at org.junit.Assert.assertEquals(Assert.java:555)
	at org.junit.Assert.assertEquals(Assert.java:542)
	at io.druid.server.coordinator.DruidCoordinatorTest.testCoordinatorRun(DruidCoordinatorTest.java:349)
```
which can be seen https://travis-ci.org/druid-io/druid/jobs/95022068 or https://travis-ci.org/druid-io/druid/jobs/94920659