### PR TITLE
callbacks registered to Log4jShutdown is not executed when stop is called

### DIFF
--- a/services/src/main/java/io/druid/cli/CliPeon.java
+++ b/services/src/main/java/io/druid/cli/CliPeon.java
@@ -232,22 +232,22 @@ public class CliPeon extends GuiceRunnable
       Injector injector = makeInjector();
       try {
         final Lifecycle lifecycle = initLifecycle(injector);
-        Runtime.getRuntime().addShutdownHook(
-            new Thread(
-                new Runnable()
-                {
-                  @Override
-                  public void run()
-                  {
-                    log.info("Running shutdown hook");
-                    lifecycle.stop();
-                  }
-                }
-            )
+        final Thread hook = new Thread(
+            new Runnable()
+            {
+              @Override
+              public void run()
+              {
+                log.info("Running shutdown hook");
+                lifecycle.stop();
+              }
+            }
         );
+        Runtime.getRuntime().addShutdownHook(hook);
         injector.getInstance(ExecutorLifecycle.class).join();
         // Explicitly call lifecycle stop, dont rely on shutdown hook.
         lifecycle.stop();
+        Runtime.getRuntime().removeShutdownHook(hook);
       }
       catch (Throwable t) {
         log.error(t, "Error when starting up.  Failing.");


### PR DESCRIPTION
`ShutdownCallbackRegistry#addShutdownCallback` is expected to register `callback to be executed upon shutdown`. But in Log4jShutdown, it's not.