### PR TITLE
adding TestingServer.stop() to hopefully fix zk transient errors

### DIFF
--- a/server/src/test/java/io/druid/curator/CuratorTestBase.java
+++ b/server/src/test/java/io/druid/curator/CuratorTestBase.java
@@ -30,6 +30,8 @@ import org.apache.curator.test.TestingServer;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.ZKPaths;
 
+import java.io.IOException;
+
 /**
  */
 public class CuratorTestBase
@@ -88,6 +90,12 @@ public class CuratorTestBase
   protected void tearDownServerAndCurator()
   {
     CloseQuietly.close(curator);
+    try {
+      server.stop();
+    }
+    catch (IOException ex) {
+      throw new RuntimeException(ex);
+    }
     CloseQuietly.close(server);
   }
 }


### PR DESCRIPTION
should fix errors like
```
BrokerServerViewTest.testSingleServerAddedRemovedSegment:112->setupZNodeForServer:396 » NodeExists
```
as seen in https://travis-ci.org/druid-io/druid/jobs/97777343