### PR TITLE
SegmentMetadataQuery merging fixes.

### DIFF
--- a/common/src/main/java/io/druid/common/guava/CombiningSequence.java
+++ b/common/src/main/java/io/druid/common/guava/CombiningSequence.java
@@ -38,29 +38,25 @@ public class CombiningSequence<T> implements Sequence<T>
   public static <T> CombiningSequence<T> create(
       Sequence<T> baseSequence,
       Ordering<T> ordering,
-      BinaryFn<T, T, T> mergeFn,
-      Function transformFn
+      BinaryFn<T, T, T> mergeFn
   )
   {
-    return new CombiningSequence<T>(baseSequence, ordering, mergeFn, transformFn);
+    return new CombiningSequence<T>(baseSequence, ordering, mergeFn);
   }
 
   private final Sequence<T> baseSequence;
   private final Ordering<T> ordering;
   private final BinaryFn<T, T, T> mergeFn;
-  private final Function transformFn;
 
   public CombiningSequence(
       Sequence<T> baseSequence,
       Ordering<T> ordering,
-      BinaryFn<T, T, T> mergeFn,
-      Function transformFn
+      BinaryFn<T, T, T> mergeFn
   )
   {
     this.baseSequence = baseSequence;
     this.ordering = ordering;
     this.mergeFn = mergeFn;
-    this.transformFn = transformFn;
   }
 
   @Override
@@ -122,9 +118,6 @@ public class CombiningSequence<T> implements Sequence<T>
       @Override
       public OutType get()
       {
-        if (transformFn != null) {
-          return (OutType) transformFn.apply(retVal);
-        }
         return retVal;
       }
 

--- a/common/src/test/java/io/druid/common/guava/CombiningSequenceTest.java
+++ b/common/src/test/java/io/druid/common/guava/CombiningSequenceTest.java
@@ -214,8 +214,7 @@ public class CombiningSequenceTest
 
             return Pair.of(lhs.lhs, lhs.rhs + rhs.rhs);
           }
-        },
-        null
+        }
     );
 
     List<Pair<Integer, Integer>> merged = Sequences.toList(seq, Lists.<Pair<Integer, Integer>>newArrayList());

--- a/processing/src/main/java/io/druid/query/Druids.java
+++ b/processing/src/main/java/io/druid/query/Druids.java
@@ -55,6 +55,8 @@ import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 
@@ -79,9 +81,9 @@ public class Druids
 
   /**
    * A Builder for AndDimFilter.
-   *
+   * <p/>
    * Required: fields() must be called before build()
-   *
+   * <p/>
    * Usage example:
    * <pre><code>
    *   AndDimFilter andDimFilter = Druids.newAndDimFilterBuilder()
@@ -125,9 +127,9 @@ public class Druids
 
   /**
    * A Builder for OrDimFilter.
-   *
+   * <p/>
    * Required: fields() must be called before build()
-   *
+   * <p/>
    * Usage example:
    * <pre><code>
    *   OrDimFilter orDimFilter = Druids.newOrDimFilterBuilder()
@@ -180,9 +182,9 @@ public class Druids
 
   /**
    * A Builder for NotDimFilter.
-   *
+   * <p/>
    * Required: field() must be called before build()
-   *
+   * <p/>
    * Usage example:
    * <pre><code>
    *   NotDimFilter notDimFilter = Druids.newNotDimFilterBuilder()
@@ -226,9 +228,9 @@ public class Druids
 
   /**
    * A Builder for SelectorDimFilter.
-   *
+   * <p/>
    * Required: dimension() and value() must be called before build()
-   *
+   * <p/>
    * Usage example:
    * <pre><code>
    *   Selector selDimFilter = Druids.newSelectorDimFilterBuilder()
@@ -305,10 +307,10 @@ public class Druids
 
   /**
    * A Builder for TimeseriesQuery.
-   *
+   * <p/>
    * Required: dataSource(), intervals(), and aggregators() must be called before build()
    * Optional: filters(), granularity(), postAggregators(), and context() can be called before build()
-   *
+   * <p/>
    * Usage example:
    * <pre><code>
    *   TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
@@ -503,11 +505,11 @@ public class Druids
 
   /**
    * A Builder for SearchQuery.
-   *
+   * <p/>
    * Required: dataSource(), intervals(), dimensions() and query() must be called before build()
-   *
+   * <p/>
    * Optional: filters(), granularity(), and context() can be called before build()
-   *
+   * <p/>
    * Usage example:
    * <pre><code>
    *   SearchQuery query = Druids.newSearchQueryBuilder()
@@ -738,9 +740,9 @@ public class Druids
 
   /**
    * A Builder for TimeBoundaryQuery.
-   *
+   * <p/>
    * Required: dataSource() must be called before build()
-   *
+   * <p/>
    * Usage example:
    * <pre><code>
    *   TimeBoundaryQuery query = new MaxTimeQueryBuilder()
@@ -834,9 +836,9 @@ public class Druids
 
   /**
    * A Builder for Result.
-   *
+   * <p/>
    * Required: timestamp() and value() must be called before build()
-   *
+   * <p/>
    * Usage example:
    * <pre><code>
    *   Result&lt;T&gt; result = Druids.newResultBuilder()
@@ -900,9 +902,9 @@ public class Druids
 
   /**
    * A Builder for SegmentMetadataQuery.
-   *
+   * <p/>
    * Required: dataSource(), intervals() must be called before build()
-   *
+   * <p/>
    * Usage example:
    * <pre><code>
    *   SegmentMetadataQuery query = new SegmentMetadataQueryBuilder()
@@ -918,6 +920,7 @@ public class Druids
     private DataSource dataSource;
     private QuerySegmentSpec querySegmentSpec;
     private ColumnIncluderator toInclude;
+    private EnumSet<SegmentMetadataQuery.AnalysisType> analysisTypes;
     private Boolean merge;
     private Map<String, Object> context;
 
@@ -926,6 +929,7 @@ public class Druids
       dataSource = null;
       querySegmentSpec = null;
       toInclude = null;
+      analysisTypes = null;
       merge = null;
       context = null;
     }
@@ -938,17 +942,22 @@ public class Druids
           toInclude,
           merge,
           context,
-          null,
+          analysisTypes,
           false
       );
     }
 
     public SegmentMetadataQueryBuilder copy(SegmentMetadataQueryBuilder builder)
     {
+      final SegmentMetadataQuery.AnalysisType[] analysisTypesArray =
+          analysisTypes != null
+          ? analysisTypes.toArray(new SegmentMetadataQuery.AnalysisType[analysisTypes.size()])
+          : null;
       return new SegmentMetadataQueryBuilder()
           .dataSource(builder.dataSource)
           .intervals(builder.querySegmentSpec)
           .toInclude(toInclude)
+          .analysisTypes(analysisTypesArray)
           .merge(merge)
           .context(builder.context);
     }
@@ -989,6 +998,17 @@ public class Druids
       return this;
     }
 
+    public SegmentMetadataQueryBuilder analysisTypes(SegmentMetadataQuery.AnalysisType... analysisTypes)
+    {
+      if (analysisTypes == null) {
+        this.analysisTypes = null;
+      } else {
+        this.analysisTypes = analysisTypes.length == 0
+                             ? EnumSet.noneOf(SegmentMetadataQuery.AnalysisType.class)
+                             : EnumSet.copyOf(Arrays.asList(analysisTypes));
+      }
+      return this;
+    }
 
     public SegmentMetadataQueryBuilder merge(boolean merge)
     {
@@ -1010,9 +1030,9 @@ public class Druids
 
   /**
    * A Builder for SelectQuery.
-   *
+   * <p/>
    * Required: dataSource(), intervals() must be called before build()
-   *
+   * <p/>
    * Usage example:
    * <pre><code>
    *   SelectQuery query = new SelectQueryBuilder()
@@ -1164,9 +1184,9 @@ public class Druids
 
   /**
    * A Builder for DataSourceMetadataQuery.
-   *
+   * <p/>
    * Required: dataSource() must be called before build()
-   *
+   * <p/>
    * Usage example:
    * <pre><code>
    *   DataSourceMetadataQueryBuilder query = new DataSourceMetadataQueryBuilder()

--- a/processing/src/main/java/io/druid/query/ResultMergeQueryRunner.java
+++ b/processing/src/main/java/io/druid/query/ResultMergeQueryRunner.java
@@ -40,7 +40,7 @@ public abstract class ResultMergeQueryRunner<T> extends BySegmentSkippingQueryRu
   @Override
   public Sequence<T> doRun(QueryRunner<T> baseRunner, Query<T> query, Map<String, Object> context)
   {
-    return CombiningSequence.create(baseRunner.run(query, context), makeOrdering(query), createMergeFn(query), null);
+    return CombiningSequence.create(baseRunner.run(query, context), makeOrdering(query), createMergeFn(query));
   }
 
   protected abstract Ordering<T> makeOrdering(Query<T> query);

--- a/processing/src/main/java/io/druid/query/metadata/SegmentAnalyzer.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentAnalyzer.java
@@ -59,7 +59,10 @@ public class SegmentAnalyzer
    */
   private static final int NUM_BYTES_IN_TEXT_FLOAT = 8;
 
-  public Map<String, ColumnAnalysis> analyze(QueryableIndex index, EnumSet<SegmentMetadataQuery.AnalysisType> analysisTypes)
+  public Map<String, ColumnAnalysis> analyze(
+      QueryableIndex index,
+      EnumSet<SegmentMetadataQuery.AnalysisType> analysisTypes
+  )
   {
     Preconditions.checkNotNull(index, "Index cannot be null");
 
@@ -100,7 +103,10 @@ public class SegmentAnalyzer
     return columns;
   }
 
-  public Map<String, ColumnAnalysis> analyze(StorageAdapter adapter, EnumSet<SegmentMetadataQuery.AnalysisType> analysisTypes)
+  public Map<String, ColumnAnalysis> analyze(
+      StorageAdapter adapter,
+      EnumSet<SegmentMetadataQuery.AnalysisType> analysisTypes
+  )
   {
     Preconditions.checkNotNull(adapter, "Adapter cannot be null");
     Map<String, ColumnAnalysis> columns = Maps.newTreeMap();
@@ -174,7 +180,11 @@ public class SegmentAnalyzer
     return lengthBasedAnalysis(column, NUM_BYTES_IN_TEXT_FLOAT, analysisTypes);
   }
 
-  private ColumnAnalysis lengthBasedAnalysis(Column column, final int numBytes, EnumSet<SegmentMetadataQuery.AnalysisType> analysisTypes)
+  private ColumnAnalysis lengthBasedAnalysis(
+      Column column,
+      final int numBytes,
+      EnumSet<SegmentMetadataQuery.AnalysisType> analysisTypes
+  )
   {
     final ColumnCapabilities capabilities = column.getCapabilities();
     if (capabilities.hasMultipleValues()) {
@@ -273,16 +283,13 @@ public class SegmentAnalyzer
     );
   }
 
-  private boolean analysisHasSize(EnumSet<SegmentMetadataQuery.AnalysisType> analysisTypes) {
+  private boolean analysisHasSize(EnumSet<SegmentMetadataQuery.AnalysisType> analysisTypes)
+  {
     return analysisTypes.contains(SegmentMetadataQuery.AnalysisType.SIZE);
   }
 
-  private boolean analysisHasCardinality(EnumSet<SegmentMetadataQuery.AnalysisType> analysisTypes) {
+  private boolean analysisHasCardinality(EnumSet<SegmentMetadataQuery.AnalysisType> analysisTypes)
+  {
     return analysisTypes.contains(SegmentMetadataQuery.AnalysisType.CARDINALITY);
   }
-
-  private boolean analysisHasInterva(EnumSet<SegmentMetadataQuery.AnalysisType> analysisTypes) {
-    return analysisTypes.contains(SegmentMetadataQuery.AnalysisType.INTERVAL);
-  }
-
 }


### PR DESCRIPTION
- Fix merging when the INTERVALS analysisType is disabled (was getting NPE) and add a test.

- Remove transformFn from CombiningSequence, use MappingSequence instead. transformFn did
  not work for "accumulate" anyway, which made the tests off (the intervals should have
  been condensed, but were not).

- Add analysisTypes to the Druids segmentMetadataQuery builder to make testing simpler.