### PR TITLE
Do persist IncrementalIndex in another thread in IndexGeneratorReducer

### DIFF
--- a/docs/content/ingestion/batch-ingestion.md
+++ b/docs/content/ingestion/batch-ingestion.md
@@ -207,6 +207,7 @@ The tuningConfig is optional and default parameters will be used if no tuningCon
 |useCombiner|Boolean|Use hadoop combiner to merge rows at mapper if possible.|no (default == false)|
 |jobProperties|Object|a map of properties to add to the Hadoop job configuration.|no (default == null)|
 |buildV9Directly|Boolean|Whether to build v9 index directly instead of building v8 index and convert it to v9 format|no (default = false)|
+|persistBackgroundCount|Integer|The number of new background threads to use for incremental persists. Using this feature causes a notable increase in memory pressure and cpu usage, but will make the job finish more quickly. If changing from the default of 0 (use current thread for persists), we recommend setting it to 1.|no (default == 0)|
 
 ### Partitioning specification
 

--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopTuningConfig.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopTuningConfig.java
@@ -22,6 +22,7 @@ package io.druid.indexer;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import io.druid.indexer.partitions.HashedPartitionsSpec;
 import io.druid.indexer.partitions.PartitionsSpec;
@@ -43,6 +44,7 @@ public class HadoopTuningConfig implements TuningConfig
   private static final int DEFAULT_ROW_FLUSH_BOUNDARY = 80000;
   private static final boolean DEFAULT_USE_COMBINER = false;
   private static final Boolean DEFAULT_BUILD_V9_DIRECTLY = Boolean.FALSE;
+  private static final int DEFAULT_PERSIST_BACKGROUND_COUNT = 0;
 
   public static HadoopTuningConfig makeDefaultTuningConfig()
   {
@@ -61,7 +63,8 @@ public class HadoopTuningConfig implements TuningConfig
         false,
         false,
         null,
-        DEFAULT_BUILD_V9_DIRECTLY
+        DEFAULT_BUILD_V9_DIRECTLY,
+        DEFAULT_PERSIST_BACKGROUND_COUNT
     );
   }
 
@@ -79,6 +82,7 @@ public class HadoopTuningConfig implements TuningConfig
   private final boolean combineText;
   private final boolean useCombiner;
   private final Boolean buildV9Directly;
+  private final int persistBackgroundCount;
 
   @JsonCreator
   public HadoopTuningConfig(
@@ -97,7 +101,8 @@ public class HadoopTuningConfig implements TuningConfig
       final @JsonProperty("useCombiner") Boolean useCombiner,
       // See https://github.com/druid-io/druid/pull/1922
       final @JsonProperty("rowFlushBoundary") Integer maxRowsInMemoryCOMPAT,
-      final @JsonProperty("buildV9Directly") Boolean buildV9Directly
+      final @JsonProperty("buildV9Directly") Boolean buildV9Directly,
+      final @JsonProperty("persistBackgroundCount") Integer persistBackgroundCount
   )
   {
     this.workingPath = workingPath;
@@ -116,6 +121,8 @@ public class HadoopTuningConfig implements TuningConfig
     this.combineText = combineText;
     this.useCombiner = useCombiner == null ? DEFAULT_USE_COMBINER : useCombiner.booleanValue();
     this.buildV9Directly = buildV9Directly == null ? DEFAULT_BUILD_V9_DIRECTLY : buildV9Directly;
+    this.persistBackgroundCount = persistBackgroundCount == null ? DEFAULT_PERSIST_BACKGROUND_COUNT : persistBackgroundCount;
+    Preconditions.checkArgument(this.persistBackgroundCount >= 0, "Not support persistBackgroundCount < 0");
   }
 
   @JsonProperty
@@ -201,6 +208,12 @@ public class HadoopTuningConfig implements TuningConfig
     return buildV9Directly;
   }
 
+  @JsonProperty
+  public int getPersistBackgroundCount()
+  {
+    return persistBackgroundCount;
+  }
+
   public HadoopTuningConfig withWorkingPath(String path)
   {
     return new HadoopTuningConfig(
@@ -218,7 +231,8 @@ public class HadoopTuningConfig implements TuningConfig
         combineText,
         useCombiner,
         null,
-        buildV9Directly
+        buildV9Directly,
+        persistBackgroundCount
     );
   }
 
@@ -239,7 +253,8 @@ public class HadoopTuningConfig implements TuningConfig
         combineText,
         useCombiner,
         null,
-        buildV9Directly
+        buildV9Directly,
+        persistBackgroundCount
     );
   }
 
@@ -260,7 +275,8 @@ public class HadoopTuningConfig implements TuningConfig
         combineText,
         useCombiner,
         null,
-        buildV9Directly
+        buildV9Directly,
+        persistBackgroundCount
     );
   }
 }

--- a/indexing-hadoop/src/test/java/io/druid/indexer/BatchDeltaIngestionTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/BatchDeltaIngestionTest.java
@@ -382,6 +382,7 @@ public class BatchDeltaIngestionTest
                 false,
                 false,
                 null,
+                null,
                 null
             )
         )

--- a/indexing-hadoop/src/test/java/io/druid/indexer/DetermineHashedPartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/DetermineHashedPartitionsJobTest.java
@@ -161,6 +161,7 @@ public class DetermineHashedPartitionsJobTest
             false,
             false,
             null,
+            null,
             null
         )
     );

--- a/indexing-hadoop/src/test/java/io/druid/indexer/DeterminePartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/DeterminePartitionsJobTest.java
@@ -265,6 +265,7 @@ public class DeterminePartitionsJobTest
                 false,
                 false,
                 null,
+                null,
                 null
             )
         )

--- a/indexing-hadoop/src/test/java/io/druid/indexer/HadoopDruidIndexerConfigTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/HadoopDruidIndexerConfigTest.java
@@ -208,6 +208,7 @@ public class HadoopDruidIndexerConfigTest
             false,
             false,
             null,
+            null,
             null
         )
     );

--- a/indexing-hadoop/src/test/java/io/druid/indexer/HadoopTuningConfigTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/HadoopTuningConfigTest.java
@@ -54,6 +54,7 @@ public class HadoopTuningConfigTest
         true,
         true,
         null,
+        null,
         null
     );
 
@@ -72,6 +73,7 @@ public class HadoopTuningConfigTest
     Assert.assertEquals(ImmutableMap.<String, String>of(), actual.getJobProperties());
     Assert.assertEquals(true, actual.isCombineText());
     Assert.assertEquals(true, actual.getUseCombiner());
+    Assert.assertEquals(0, actual.getPersistBackgroundCount());
 
   }
 

--- a/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobTest.java
@@ -502,7 +502,8 @@ public class IndexGeneratorJobTest
                 false,
                 useCombiner,
                 null,
-                buildV9Directly
+                buildV9Directly,
+                null
             )
         )
     );

--- a/indexing-hadoop/src/test/java/io/druid/indexer/JobHelperTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/JobHelperTest.java
@@ -116,6 +116,7 @@ public class JobHelperTest
                 false,
                 false,
                 null,
+                null,
                 null
             )
         )

--- a/indexing-hadoop/src/test/java/io/druid/indexer/path/GranularityPathSpecTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/path/GranularityPathSpecTest.java
@@ -120,7 +120,7 @@ public class GranularityPathSpecTest
             jsonMapper
         ),
         new HadoopIOConfig(null, null, null),
-        new HadoopTuningConfig(null, null, null, null, null, null, false, false, false, false, null, false, false, null, null)
+        new HadoopTuningConfig(null, null, null, null, null, null, false, false, false, false, null, false, false, null, null, null)
     );
 
     granularityPathSpec.setDataGranularity(Granularity.HOUR);

--- a/indexing-hadoop/src/test/java/io/druid/indexer/updater/HadoopConverterJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/updater/HadoopConverterJobTest.java
@@ -202,6 +202,7 @@ public class HadoopConverterJobTest
                 false,
                 false,
                 null,
+                null,
                 null
             )
         )


### PR DESCRIPTION
Current in IndexGeneratorReducer, the reduce build a small incremental index then persist it until there is no more row, finally merge the persisted indexs.
This patch is to new background threads to do small incremental index persist. Using this feature causes a notable increase in memory pressure and cpu usage, but will make the job finish more quickly.