### PR TITLE
Fix Query metrics for query timeout

### DIFF
--- a/server/src/main/java/io/druid/server/AsyncQueryForwardingServlet.java
+++ b/server/src/main/java/io/druid/server/AsyncQueryForwardingServlet.java
@@ -322,6 +322,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet
                         requestTime,
                         "success",
                         result.isSucceeded()
+                        && result.getResponse().getStatus() == javax.ws.rs.core.Response.Status.OK.getStatusCode()
                     )
                 )
             )


### PR DESCRIPTION
This PR has these changes - 
1) Adds query/time to request log metrics emitted for timed-out/interrupted. Fixes #2070 
2) Adds a new flag success to query/time metrics and emit query/time for timed-out/interrupted queries also. 
2) Fixes the success flag for metrics emitted by router. Add a check for the status of response.