### PR TITLE
Add metrics for ingest/bytes/received for EventReceiverFirehose

### DIFF
--- a/docs/content/operations/metrics.md
+++ b/docs/content/operations/metrics.md
@@ -171,7 +171,8 @@ The following metric is only available if the EventReceiverFirehoseMonitor modul
 
 |Metric|Description|Dimensions|Normal Value|
 |------|-----------|----------|------------|
-|`ingest/events/buffered`|Number of events queued in the EventReceiverFirehose's buffer|serviceName, bufferCapacity.|Equal to current # of events in the buffer queue.|
+|`ingest/events/buffered`|Number of events queued in the EventReceiverFirehose's buffer|serviceName, dataSource, taskId, bufferCapacity.|Equal to current # of events in the buffer queue.|
+|`ingest/bytes/received`|Number of bytes received by the EventReceiverFirehose.|serviceName, dataSource, taskId.|Varies.|
 
 ## Sys
 

--- a/server/src/main/java/io/druid/server/metrics/EventReceiverFirehoseMetric.java
+++ b/server/src/main/java/io/druid/server/metrics/EventReceiverFirehoseMetric.java
@@ -38,4 +38,11 @@ public interface EventReceiverFirehoseMetric
    * Return the capacity of the buffer.
    */
   int getCapacity();
+
+  /**
+   * Return the number of bytes received by the firehose.
+   */
+  long getBytesReceived();
+
+
 }

--- a/server/src/main/java/io/druid/server/metrics/MetricsModule.java
+++ b/server/src/main/java/io/druid/server/metrics/MetricsModule.java
@@ -40,6 +40,7 @@ import io.druid.guice.DruidBinders;
 import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.LazySingleton;
 import io.druid.guice.ManageLifecycle;
+import io.druid.query.DruidMetrics;
 
 import java.util.HashMap;
 import java.util.List;
@@ -108,35 +109,37 @@ public class MetricsModule implements Module
   @ManageLifecycle
   public JvmMonitor getJvmMonitor(Properties props)
   {
-    return new JvmMonitor(getDimensions(props));
+    return new JvmMonitor(MonitorsConfig.extractDimensions(props,
+                                                           Lists.newArrayList(
+                                                               DruidMetrics.DATASOURCE,
+                                                               DruidMetrics.TASK_ID
+                                                           )
+    ));
   }
 
   @Provides
   @ManageLifecycle
   public JvmCpuMonitor getJvmCpuMonitor(Properties props)
   {
-    return new JvmCpuMonitor(getDimensions(props));
+    return new JvmCpuMonitor(MonitorsConfig.extractDimensions(props,
+                                                              Lists.newArrayList(
+                                                                  DruidMetrics.DATASOURCE,
+                                                                  DruidMetrics.TASK_ID
+                                                              )
+    ));
   }
 
   @Provides
   @ManageLifecycle
   public SysMonitor getSysMonitor(Properties props)
   {
-    return new SysMonitor(getDimensions(props));
+    return new SysMonitor(MonitorsConfig.extractDimensions(props,
+                                                           Lists.newArrayList(
+                                                               DruidMetrics.DATASOURCE,
+                                                               DruidMetrics.TASK_ID
+                                                           )
+    ));
   }
 
-  private Map<String, String[]> getDimensions(Properties props)
-  {
-    Map<String, String[]> dimensions = new HashMap<>();
-    for (String property : props.stringPropertyNames()) {
-      if (property.startsWith(MonitorsConfig.METRIC_DIMENSION_PREFIX)) {
-        dimensions.put(
-            property.substring(MonitorsConfig.METRIC_DIMENSION_PREFIX.length()),
-            new String[]{props.getProperty(property)}
-        );
-      }
-    }
-    return dimensions;
-  }
 
 }

--- a/server/src/main/java/io/druid/server/metrics/MonitorsConfig.java
+++ b/server/src/main/java/io/druid/server/metrics/MonitorsConfig.java
@@ -24,7 +24,10 @@ import com.google.common.collect.Lists;
 import com.metamx.metrics.Monitor;
 
 import javax.validation.constraints.NotNull;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 /**
  */
@@ -47,5 +50,22 @@ public class MonitorsConfig
     return "MonitorsConfig{" +
            "monitors=" + monitors +
            '}';
+  }
+
+  public static Map<String, String[]> extractDimensions(Properties props, List<String> dimensions)
+  {
+    Map<String, String[]> dimensionsMap = new HashMap<>();
+    for (String property : props.stringPropertyNames()) {
+      if (property.startsWith(MonitorsConfig.METRIC_DIMENSION_PREFIX)) {
+        String dimension = property.substring(MonitorsConfig.METRIC_DIMENSION_PREFIX.length());
+        if (dimensions.contains(dimension)) {
+          dimensionsMap.put(
+              dimension,
+              new String[]{props.getProperty(property)}
+          );
+        }
+      }
+    }
+    return dimensionsMap;
   }
 }


### PR DESCRIPTION
This PR has two changes - 
1) Adds metric for ingest/bytes/received for EventReceiverFirehose
2) Add dataSource and taskID to metrics emitted by EventReceiverFirehoseMonitor
