### PR TITLE
acl for zookeeper is added

### DIFF
--- a/server/src/main/java/io/druid/curator/CuratorConfig.java
+++ b/server/src/main/java/io/druid/curator/CuratorConfig.java
@@ -36,6 +36,9 @@ public class CuratorConfig
 
   @JsonProperty("compress")
   private boolean enableCompression = true;
+  
+  @JsonProperty("acl")
+  private boolean enableAcl = false;
 
   public String getZkHosts()
   {
@@ -65,5 +68,15 @@ public class CuratorConfig
   public void setEnableCompression(Boolean enableCompression)
   {
     this.enableCompression = enableCompression;
+  }
+  
+  public Boolean getEnableAcl()
+  {
+    return enableAcl;
+  }
+
+  public void setEnableAcl(Boolean enableAcl)
+  {
+    this.enableAcl = enableAcl;
   }
 }

--- a/server/src/main/java/io/druid/curator/CuratorModule.java
+++ b/server/src/main/java/io/druid/curator/CuratorModule.java
@@ -24,13 +24,22 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.metamx.common.lifecycle.Lifecycle;
 import com.metamx.common.logger.Logger;
+
 import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.LazySingleton;
+
+import org.apache.curator.framework.api.ACLProvider;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.imps.DefaultACLProvider;
 import org.apache.curator.retry.BoundedExponentialBackoffRetry;
 
 import java.io.IOException;
+
+import java.util.List;
+
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.data.ACL;
 
 /**
  */
@@ -55,6 +64,7 @@ public class CuratorModule implements Module
                                .sessionTimeoutMs(config.getZkSessionTimeoutMs())
             .retryPolicy(new BoundedExponentialBackoffRetry(1000, 45000, 30))
             .compressionProvider(new PotentiallyGzippedCompressionProvider(config.getEnableCompression()))
+            .aclProvider(config.getEnableAcl() ? new SecuredACLProvider() : new DefaultACLProvider())
             .build();
 
     lifecycle.addHandler(
@@ -78,4 +88,19 @@ public class CuratorModule implements Module
 
     return framework;
   }
+  
+  class SecuredACLProvider implements ACLProvider 
+  {
+		@Override
+		public List<ACL> getDefaultAcl() 
+		{
+			return ZooDefs.Ids.CREATOR_ALL_ACL;
+		}
+
+		@Override
+		public List<ACL> getAclForPath(String path) 
+		{
+			return ZooDefs.Ids.CREATOR_ALL_ACL;
+		}
+	}
 }


### PR DESCRIPTION
With this patch you can enable ACL security for zookeeper. By default it will be disabled. In order to enable it you should add this line in your druid properties file:
druid.zk.service.acl=true