### PR TITLE
integration-tests: update zookeeper version to 3.4.7

### DIFF
--- a/docs/content/operations/including-extensions.md
+++ b/docs/content/operations/including-extensions.md
@@ -21,7 +21,7 @@ To let Druid load your extensions, follow the steps below
 
 1) Specify `druid.extensions.directory` (root directory for normal Druid extensions). If you don' specify it, Druid will use their default value, see [Configuration](../configuration/index.html).
 
-2) Prepare normal extension directories under root extension directory.  Under the root extension directory, you should create sub-directories for each extension you might want to load.  Inside each sub-directory, you can put extension related files in it.  (If you don't want to manually setup the extension directory, Druid also provides a [pull-deps](../pull-deps.html) tool that can help you genereate these directories automatically)
+2) Prepare normal extension directories under root extension directory.  Under the root extension directory, you should create sub-directories for each extension you might want to load.  Inside each sub-directory, you can put extension related files in it.  (If you don't want to manually setup the extension directory, Druid also provides a [pull-deps](../pull-deps.html) tool that can help you generate these directories automatically)
 
 Example:
 
@@ -54,7 +54,7 @@ extensions/
 │   ├── slf4j-log4j12-1.6.1.jar
 │   ├── snappy-java-1.1.1.6.jar
 │   ├── zkclient-0.3.jar
-│   └── zookeeper-3.4.6.jar
+│   └── zookeeper-3.4.7.jar
 └── mysql-metadata-storage
     ├── jdbi-2.32.jar
     ├── mysql-connector-java-5.1.34.jar

--- a/docs/content/tutorials/tutorial-the-druid-cluster.md
+++ b/docs/content/tutorials/tutorial-the-druid-cluster.md
@@ -35,9 +35,9 @@ For deep storage, we will use the local disk in this tutorial, but for productio
 * Install zookeeper.
 
 ```bash
-curl http://www.gtlib.gatech.edu/pub/apache/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz -o zookeeper-3.4.6.tar.gz
-tar xzf zookeeper-3.4.6.tar.gz
-cd zookeeper-3.4.6
+curl http://www.gtlib.gatech.edu/pub/apache/zookeeper/zookeeper-3.4.7/zookeeper-3.4.7.tar.gz -o zookeeper-3.4.7.tar.gz
+tar xzf zookeeper-3.4.7.tar.gz
+cd zookeeper-3.4.7
 cp conf/zoo_sample.cfg conf/zoo.cfg
 ./bin/zkServer.sh start
 cd ..

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -18,9 +18,9 @@ RUN apt-get install -y mysql-server
 RUN apt-get install -y supervisor
 
 # Zookeeper
-RUN wget -q -O - http://www.us.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz | tar -xzf - -C /usr/local \
-      && cp /usr/local/zookeeper-3.4.6/conf/zoo_sample.cfg /usr/local/zookeeper-3.4.6/conf/zoo.cfg \
-      && ln -s /usr/local/zookeeper-3.4.6 /usr/local/zookeeper
+RUN wget -q -O - http://www.us.apache.org/dist/zookeeper/zookeeper-3.4.7/zookeeper-3.4.7.tar.gz | tar -xzf - -C /usr/local \
+      && cp /usr/local/zookeeper-3.4.7/conf/zoo_sample.cfg /usr/local/zookeeper-3.4.7/conf/zoo.cfg \
+      && ln -s /usr/local/zookeeper-3.4.7 /usr/local/zookeeper
 
 # Kafka
 RUN wget -q -O - http://www.us.apache.org/dist/kafka/0.8.2.0/kafka_2.10-0.8.2.0.tgz | tar -xzf - -C /usr/local \


### PR DESCRIPTION
My docker runs stopped working because there's no longer a zookeeper-3.4.6 at http://www.us.apache.org/dist/zookeeper.  If I update to zookeeper-3.4.7, things work.

If we want to stay with 3.4.6, we could switch to getting it from http://archive.apache.org/dist/zookeeper.

(I haven't been able to get things to work using docker-machine.  I'm still using boot2docker.) 