### PR TITLE
Make OnHeapIncrementalIndex clean maps on close()

### DIFF
--- a/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -243,6 +243,18 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
     return concurrentGet(rowOffset)[aggOffset].get();
   }
 
+  /**
+   * Clear out maps to allow GC
+   * NOTE: This is NOT thread-safe with add... so make sure all the adding is DONE before closing
+   */
+  @Override
+  public void close()
+  {
+    super.close();
+    aggregators.clear();
+    facts.clear();
+  }
+
   private static class OnHeapDimDim implements DimDim
   {
     private final Map<String, Integer> falseIds;


### PR DESCRIPTION
Related to https://github.com/druid-io/druid/pull/2149 this PR tries to help make sure any accidental references to an incremental index after its close() method is called has minimal memory impact.