### PR TITLE
Manually fix <tag> from <scm> in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <connection>scm:git:ssh://git@github.com/druid-io/druid.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/druid-io/druid.git</developerConnection>
         <url>https://github.com/druid-io/druid.git</url>
-        <tag>druid-0.8.0-SNAPSHOT</tag>
+        <tag>0.9.0-SNAPSHOT</tag>
     </scm>
 
     <properties>


### PR DESCRIPTION
It obviously hasn't been updating correctly as we go through the versions.

It seemed to break in https://github.com/metamx/druid/commit/0a5bb909a2a87a9a23e0b16ff8119f3c701372b3#diff-600376dffeb79835ede4a0b285078036

Hopefully manually updating it will kick it back into the release cycle