### PR TITLE
Support min/max values for metadata query

### DIFF
--- a/docs/content/design/broker.md
+++ b/docs/content/design/broker.md
@@ -25,7 +25,7 @@ To determine which nodes to forward queries to, the Broker node first builds a v
 Caching
 -------
 
-Broker nodes employ a cache with a LRU cache invalidation strategy. The broker cache stores per segment results. The cache can be local to each broker node or shared across multiple nodes using an external distributed cache such as [memcached](http://memcached.org/). Each time a broker node receives a query, it ﬁrst maps the query to a set of segments. A subset of these segment results may already exist in the cache and the results can be directly pulled from the cache. For any segment results that do not exist in the cache, the broker node will forward the query to the
+Broker nodes employ a cache with a LRU cache invalidation strategy. The broker cache stores per-segment results. The cache can be local to each broker node or shared across multiple nodes using an external distributed cache such as [memcached](http://memcached.org/). Each time a broker node receives a query, it ﬁrst maps the query to a set of segments. A subset of these segment results may already exist in the cache and the results can be directly pulled from the cache. For any segment results that do not exist in the cache, the broker node will forward the query to the
 historical nodes. Once the historical nodes return their results, the broker will store those results in the cache. Real-time segments are never cached and hence requests for real-time data will always be forwarded to real-time nodes. Real-time data is perpetually changing and caching the results would be unreliable.
 
 HTTP Endpoints

--- a/docs/content/design/index.md
+++ b/docs/content/design/index.md
@@ -90,7 +90,7 @@ Druid is a column store, which means each individual column is stored separately
 in that query, and Druid is pretty good about only scanning exactly what it needs for a query.
 Different columns can also employ different compression methods. Different columns can also have different indexes associated with them.
 
-Druid indexes data on a per shard (segment) level.
+Druid indexes data on a per-shard (segment) level.
 
 ## Loading the Data
 

--- a/docs/content/querying/segmentmetadataquery.md
+++ b/docs/content/querying/segmentmetadataquery.md
@@ -2,9 +2,10 @@
 layout: doc_page
 ---
 # Segment Metadata Queries
-Segment metadata queries return per segment information about:
+Segment metadata queries return per-segment information about:
 
 * Cardinality of all columns in the segment
+* Min/max values of string type columns in the segment
 * Estimated byte size for the segment columns if they were stored in a flat format
 * Number of rows stored inside the segment
 * Interval the segment covers
@@ -103,12 +104,16 @@ This is a list of properties that determines the amount of information returned 
 
 By default, all analysis types will be used. If a property is not needed, omitting it from this list will result in a more efficient query.
 
-There are four types of column analyses:
+There are five types of column analyses:
 
 #### cardinality
 
 * `cardinality` in the result will return the estimated floor of cardinality for each column. Only relevant for
 dimension columns.
+
+#### minmax
+
+* Estimated min/max values for each column. Only relevant for dimension columns.
 
 #### size
 

--- a/processing/src/main/java/io/druid/query/metadata/metadata/SegmentMetadataQuery.java
+++ b/processing/src/main/java/io/druid/query/metadata/metadata/SegmentMetadataQuery.java
@@ -53,7 +53,8 @@ public class SegmentMetadataQuery extends BaseQuery<SegmentAnalysis>
     CARDINALITY,
     SIZE,
     INTERVAL,
-    AGGREGATORS;
+    AGGREGATORS,
+    MINMAX;
 
     @JsonValue
     @Override
@@ -81,7 +82,8 @@ public class SegmentMetadataQuery extends BaseQuery<SegmentAnalysis>
   public static final EnumSet<AnalysisType> DEFAULT_ANALYSIS_TYPES = EnumSet.of(
       AnalysisType.CARDINALITY,
       AnalysisType.SIZE,
-      AnalysisType.INTERVAL
+      AnalysisType.INTERVAL,
+      AnalysisType.MINMAX
   );
 
   private final ColumnIncluderator toInclude;
@@ -177,6 +179,11 @@ public class SegmentMetadataQuery extends BaseQuery<SegmentAnalysis>
     return analysisTypes.contains(AnalysisType.AGGREGATORS);
   }
 
+  public boolean hasMinMax()
+  {
+    return analysisTypes.contains(AnalysisType.MINMAX);
+  }
+
   public byte[] getAnalysisTypesCacheKey()
   {
     int size = 1;
@@ -234,6 +241,20 @@ public class SegmentMetadataQuery extends BaseQuery<SegmentAnalysis>
         dataSource,
         getQuerySegmentSpec(),
         toInclude,
+        merge,
+        getContext(),
+        analysisTypes,
+        usingDefaultInterval,
+        lenientAggregatorMerge
+    );
+  }
+
+  public Query<SegmentAnalysis> withColumns(ColumnIncluderator includerator)
+  {
+    return new SegmentMetadataQuery(
+        getDataSource(),
+        getQuerySegmentSpec(),
+        includerator,
         merge,
         getContext(),
         analysisTypes,

--- a/processing/src/main/java/io/druid/segment/QueryableIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/QueryableIndexStorageAdapter.java
@@ -35,6 +35,7 @@ import io.druid.query.QueryInterruptedException;
 import io.druid.query.dimension.DimensionSpec;
 import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.filter.Filter;
+import io.druid.segment.column.BitmapIndex;
 import io.druid.segment.column.Column;
 import io.druid.segment.column.ColumnCapabilities;
 import io.druid.segment.column.ComplexColumn;
@@ -138,6 +139,28 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
     finally {
       CloseQuietly.close(column);
     }
+  }
+
+  @Override
+  public Comparable getMinValue(String dimension)
+  {
+    Column column = index.getColumn(dimension);
+    if (column != null && column.getCapabilities().hasBitmapIndexes()) {
+      BitmapIndex bitmap = column.getBitmapIndex();
+      return bitmap.getCardinality() > 0 ? bitmap.getValue(0) : null;
+    }
+    return null;
+  }
+
+  @Override
+  public Comparable getMaxValue(String dimension)
+  {
+    Column column = index.getColumn(dimension);
+    if (column != null && column.getCapabilities().hasBitmapIndexes()) {
+      BitmapIndex bitmap = column.getBitmapIndex();
+      return bitmap.getCardinality() > 0 ? bitmap.getValue(bitmap.getCardinality() - 1) : null;
+    }
+    return null;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/StorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/StorageAdapter.java
@@ -44,6 +44,8 @@ public interface StorageAdapter extends CursorFactory
   public int getDimensionCardinality(String column);
   public DateTime getMinTime();
   public DateTime getMaxTime();
+  public Comparable getMinValue(String column);
+  public Comparable getMaxValue(String column);
   public Capabilities getCapabilities();
   public ColumnCapabilities getColumnCapabilities(String column);
 

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -51,6 +51,7 @@ import io.druid.segment.column.Column;
 import io.druid.segment.column.ColumnCapabilities;
 import io.druid.segment.column.ColumnCapabilitiesImpl;
 import io.druid.segment.column.ValueType;
+import io.druid.segment.data.Indexed;
 import io.druid.segment.data.IndexedInts;
 import io.druid.segment.serde.ComplexMetricExtractor;
 import io.druid.segment.serde.ComplexMetricSerde;
@@ -847,6 +848,10 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
 
     public int size();
 
+    public String getMinValue();
+
+    public String getMaxValue();
+
     public int add(String value);
 
     public SortedDimLookup sort();
@@ -897,6 +902,18 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
     public int size()
     {
       return delegate.size();
+    }
+
+    @Override
+    public String getMinValue()
+    {
+      return Strings.nullToEmpty(delegate.getMinValue());
+    }
+
+    @Override
+    public String getMaxValue()
+    {
+      return Strings.nullToEmpty(delegate.getMaxValue());
     }
 
     @Override

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
@@ -137,6 +137,20 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
   }
 
   @Override
+  public Comparable getMinValue(String column)
+  {
+    IncrementalIndex.DimDim dimDim = index.getDimensionValues(column);
+    return dimDim == null ? null : dimDim.getMinValue();
+  }
+
+  @Override
+  public Comparable getMaxValue(String column)
+  {
+    IncrementalIndex.DimDim dimDim = index.getDimensionValues(column);
+    return dimDim == null ? null : dimDim.getMaxValue();
+  }
+
+  @Override
   public Capabilities getCapabilities()
   {
     return Capabilities.builder().dimensionValuesSorted(false).build();

--- a/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -278,6 +278,8 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
   static class OnHeapDimDim implements DimDim
   {
     private final Map<String, Integer> valueToId = Maps.newHashMap();
+    private String minValue = null;
+    private String maxValue = null;
 
     private final List<String> idToValue = Lists.newArrayList();
     private final Object lock;
@@ -326,8 +328,22 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
         final int index = size();
         valueToId.put(value, index);
         idToValue.add(value);
+        minValue = minValue == null || minValue.compareTo(value) > 0 ? value : minValue;
+        maxValue = maxValue == null || maxValue.compareTo(value) < 0 ? value : maxValue;
         return index;
       }
+    }
+
+    @Override
+    public String getMinValue()
+    {
+      return minValue;
+    }
+
+    @Override
+    public String getMaxValue()
+    {
+      return maxValue;
     }
 
     public OnHeapDimLookup sort()

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
@@ -63,7 +63,7 @@ public class SegmentMetadataQueryQueryToolChestTest
         new SegmentMetadataQueryQueryToolChest(null).getCacheStrategy(query);
 
     // Test cache key generation
-    byte[] expectedKey = {0x04, 0x01, (byte) 0xFF, 0x00, 0x01, 0x02};
+    byte[] expectedKey = {0x04, 0x01, (byte) 0xFF, 0x00, 0x01, 0x02, 0x04};
     byte[] actualKey = strategy.computeCacheKey(query);
     Assert.assertArrayEquals(expectedKey, actualKey);
 
@@ -79,6 +79,8 @@ public class SegmentMetadataQueryQueryToolChestTest
                 true,
                 10881,
                 1,
+                "preferred",
+                "preferred",
                 null
             )
         ), 71982,

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
@@ -153,14 +153,18 @@ public class SegmentMetadataQueryTest
                 false,
                 12090,
                 null,
+                null,
+                null,
                 null
             ),
             "placement",
             new ColumnAnalysis(
                 ValueType.STRING.toString(),
                 false,
-                mmap1 ? 10881 : 0,
+                mmap1 ? 10881 : 10764,
                 1,
+                "preferred",
+                "preferred",
                 null
             ),
             "index",
@@ -169,9 +173,11 @@ public class SegmentMetadataQueryTest
                 false,
                 9672,
                 null,
+                null,
+                null,
                 null
             )
-        ), mmap1 ? 71982 : 32643,
+        ), mmap1 ? 71982 : 72755,
         1209,
         null
     );
@@ -187,6 +193,8 @@ public class SegmentMetadataQueryTest
                 false,
                 12090,
                 null,
+                null,
+                null,
                 null
             ),
             "placement",
@@ -195,6 +203,8 @@ public class SegmentMetadataQueryTest
                 false,
                 mmap2 ? 10881 : 0,
                 1,
+                null,
+                null,
                 null
             ),
             "index",
@@ -203,9 +213,12 @@ public class SegmentMetadataQueryTest
                 false,
                 9672,
                 null,
+                null,
+                null,
                 null
             )
-        ), mmap2 ? 71982 : 32643,
+        // null_column will be included only for incremental index, which makes a little bigger result than expected
+        ), mmap2 ? 71982 : 72755,
         1209,
         null
     );
@@ -236,6 +249,8 @@ public class SegmentMetadataQueryTest
                 false,
                 0,
                 1,
+                null,
+                null,
                 null
             ),
             "placementish",
@@ -244,6 +259,8 @@ public class SegmentMetadataQueryTest
                 true,
                 0,
                 9,
+                null,
+                null,
                 null
             )
         ),
@@ -298,6 +315,8 @@ public class SegmentMetadataQueryTest
                 false,
                 0,
                 1,
+                null,
+                null,
                 null
             ),
             "quality_uniques",
@@ -305,6 +324,8 @@ public class SegmentMetadataQueryTest
                 "hyperUnique",
                 false,
                 0,
+                null,
+                null,
                 null,
                 null
             )
@@ -350,6 +371,53 @@ public class SegmentMetadataQueryTest
   @Test
   public void testSegmentMetadataQueryWithDefaultAnalysisMerge()
   {
+    ColumnAnalysis analysis = new ColumnAnalysis(
+        ValueType.STRING.toString(),
+        false,
+        (mmap1 ? 10881 : 10764) + (mmap2 ? 10881 : 10764),
+        1,
+        "preferred",
+        "preferred",
+        null
+    );
+    testSegmentMetadataQueryWithDefaultAnalysisMerge("placement", analysis);
+  }
+
+  @Test
+  public void testSegmentMetadataQueryWithDefaultAnalysisMerge2()
+  {
+    ColumnAnalysis analysis = new ColumnAnalysis(
+        ValueType.STRING.toString(),
+        false,
+        (mmap1 ? 6882 : 6808) + (mmap2 ? 6882 : 6808),
+        3,
+        "spot",
+        "upfront",
+        null
+    );
+    testSegmentMetadataQueryWithDefaultAnalysisMerge("market", analysis);
+  }
+
+  @Test
+  public void testSegmentMetadataQueryWithDefaultAnalysisMerge3()
+  {
+    ColumnAnalysis analysis = new ColumnAnalysis(
+        ValueType.STRING.toString(),
+        false,
+        (mmap1 ? 9765 : 9660) + (mmap2 ? 9765 : 9660),
+        9,
+        "automotive",
+        "travel",
+        null
+    );
+    testSegmentMetadataQueryWithDefaultAnalysisMerge("quality", analysis);
+  }
+
+  private void testSegmentMetadataQueryWithDefaultAnalysisMerge(
+      String column,
+      ColumnAnalysis analysis
+  )
+  {
     SegmentAnalysis mergedSegmentAnalysis = new SegmentAnalysis(
         differentIds ? "merged" : "testSegment",
         ImmutableList.of(expectedSegmentAnalysis1.getIntervals().get(0)),
@@ -360,14 +428,8 @@ public class SegmentMetadataQueryTest
                 false,
                 12090 * 2,
                 null,
-                null
-            ),
-            "placement",
-            new ColumnAnalysis(
-                ValueType.STRING.toString(),
-                false,
-                10881 * ((mmap1 ? 1 : 0) + (mmap2 ? 1 : 0)),
-                1,
+                null,
+                null,
                 null
             ),
             "index",
@@ -376,8 +438,12 @@ public class SegmentMetadataQueryTest
                 false,
                 9672 * 2,
                 null,
+                null,
+                null,
                 null
-            )
+            ),
+            column,
+            analysis
         ),
         expectedSegmentAnalysis1.getSize() + expectedSegmentAnalysis2.getSize(),
         expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows(),
@@ -400,12 +466,11 @@ public class SegmentMetadataQueryTest
         toolChest
     );
 
+    Query query = testQuery.withColumns(new ListColumnIncluderator(Arrays.asList("__time", "index", column)));
+
     TestHelper.assertExpectedObjects(
         ImmutableList.of(mergedSegmentAnalysis),
-        myRunner.run(
-            testQuery,
-            Maps.newHashMap()
-        ),
+        myRunner.run(query, Maps.newHashMap()),
         "failed SegmentMetadata merging query"
     );
     exec.shutdownNow();
@@ -424,6 +489,8 @@ public class SegmentMetadataQueryTest
                 false,
                 0,
                 0,
+                null,
+                null,
                 null
             )
         ),
@@ -482,6 +549,8 @@ public class SegmentMetadataQueryTest
                 false,
                 0,
                 0,
+                null,
+                null,
                 null
             )
         ),

--- a/publications/whitepaper/druid.tex
+++ b/publications/whitepaper/druid.tex
@@ -419,7 +419,7 @@ first maps the query to a set of segments. Results for certain segments may
 already exist in the cache and there is no need to recompute them. For any
 results that do not exist in the cache, the broker node will forward the query
 to the correct historical and real-time nodes. Once historical nodes return
-their results, the broker will cache these results on a per segment basis for
+their results, the broker will cache these results on a per-segment basis for
 future use. This process is illustrated in Figure~\ref{fig:caching}. Real-time
 data is never cached and hence requests for real-time data will always be
 forwarded to real-time nodes. Real-time data is perpetually changing and
@@ -428,7 +428,7 @@ caching the results is unreliable.
 \begin{figure*}
 \centering
 \includegraphics[width = 4.5in]{caching}
-\caption{Results are cached per segment. Queries combine cached results with results computed on historical and real-time nodes.}
+\caption{Results are cached per-segment. Queries combine cached results with results computed on historical and real-time nodes.}
 \label{fig:caching}
 \end{figure*}
 


### PR DESCRIPTION
Support `AnalysisType.MIN_MAX` for metadata queries. Currently it's supported only for string dimension with bitmap index.