### PR TITLE
Javascript filter with multiple columns

### DIFF
--- a/docs/content/querying/filters.md
+++ b/docs/content/querying/filters.md
@@ -93,7 +93,7 @@ The following matches values of the given two dimensions `dim1` and `dim2` are t
 ```json
 {
   "type" : "javascript",
-  "dimension" : ["dim1","dim2"]
+  "dimensions" : ["dim1","dim2"]
   "function" : "function(x, y) { return x === y }"
 }
 ```

--- a/docs/content/querying/filters.md
+++ b/docs/content/querying/filters.md
@@ -58,15 +58,23 @@ The filter specified at field can be any other filter defined on this page.
 
 ### JavaScript filter
 
-The JavaScript filter matches a dimension against the specified JavaScript function predicate. The filter matches values for which the function returns true.
+The JavaScript filter matches dimensions against the specified JavaScript function predicate. The filter matches values for which the function returns true.
 
-The function takes a single argument, the dimension value, and returns either true or false.
+The function takes the same number of arguments as the dimension values, and returns either true or false.
 
 ```json
 {
   "type" : "javascript",
   "dimension" : <dimension_string>,
   "function" : "function(value) { <...> }"
+}
+```
+or 
+```json
+{
+  "type" : "javascript",
+  "dimensions" : <array of dimension_strings>,
+  "function" : "function(value1, value2, ...) { <...> }"
 }
 ```
 
@@ -78,6 +86,15 @@ The following matches any dimension values for the dimension `name` between `'ba
   "type" : "javascript",
   "dimension" : "name",
   "function" : "function(x) { return(x >= 'bar' && x <= 'foo') }"
+}
+```
+
+The following matches values of the given two dimensions `dim1` and `dim2` are the same
+```json
+{
+  "type" : "javascript",
+  "dimension" : ["dim1","dim2"]
+  "function" : "function(x, y) { return x === y }"
 }
 ```
 

--- a/docs/content/querying/filters.md
+++ b/docs/content/querying/filters.md
@@ -65,14 +65,6 @@ The function takes the same number of arguments as the dimension values, and ret
 ```json
 {
   "type" : "javascript",
-  "dimension" : <dimension_string>,
-  "function" : "function(value) { <...> }"
-}
-```
-or 
-```json
-{
-  "type" : "javascript",
   "dimensions" : <array of dimension_strings>,
   "function" : "function(value1, value2, ...) { <...> }"
 }

--- a/processing/src/main/java/io/druid/query/filter/JavaScriptDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/JavaScriptDimFilter.java
@@ -35,31 +35,20 @@ public class JavaScriptDimFilter implements DimFilter
 
   @JsonCreator
   public JavaScriptDimFilter(
+      // for backwards compatibility
       @JsonProperty("dimension") String dimension,
       @JsonProperty("dimensions") String[] dimensions,
       @JsonProperty("function") String function
   )
   {
-    Preconditions.checkArgument(dimension != null || dimensions != null, "dimension or dimensions must not be null");
-    Preconditions.checkArgument(!(dimension != null && dimensions != null), "both dimension and dimensions are defined");
+    Preconditions.checkArgument(dimension != null ^ dimensions != null, "dimensions(xor dimension) must not be null");
     Preconditions.checkArgument(function != null, "function must not be null");
-    this.dimensions = (dimension != null) ? new String[]{dimension} : dimensions;
+    this.dimensions = (dimensions != null) ? dimensions : new String[]{dimension};
     this.function = function;
   }
 
   @JsonProperty
-  public String getDimension()
-  {
-    return (dimensions.length == 1) ? dimensions[0] : null;
-  }
-
-  @JsonProperty
   public String[] getDimensions()
-  {
-    return (dimensions.length > 1) ? dimensions: null;
-  }
-
-  public String[] getAllDimensions()
   {
     return dimensions;
   }

--- a/processing/src/main/java/io/druid/query/filter/JavaScriptDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/JavaScriptDimFilter.java
@@ -90,10 +90,8 @@ public class JavaScriptDimFilter implements DimFilter
   @Override
   public String toString()
   {
-    String dimensionString = (dimensions.length == 1) ? "dimension='" + dimensions[0] + '\''
-                                                      : "dimensions=['" + Joiner.on("', '").join(dimensions) + "']";
     return "JavaScriptDimFilter{" +
-           dimensionString +
+           "dimensions=['" + Joiner.on("', '").join(dimensions) + "']" +
            ", function='" + function + '\'' +
            '}';
   }

--- a/processing/src/main/java/io/druid/query/filter/ValueMatcherFactory.java
+++ b/processing/src/main/java/io/druid/query/filter/ValueMatcherFactory.java
@@ -28,5 +28,6 @@ public interface ValueMatcherFactory
 {
   public ValueMatcher makeValueMatcher(String dimension, String value);
   public ValueMatcher makeValueMatcher(String dimension, Predicate<String> value);
+  public ValueMatcher makeValueMatcher(String[] dimensions, Predicate<String[]> value);
   public ValueMatcher makeValueMatcher(String dimension, Bound bound);
 }

--- a/processing/src/main/java/io/druid/segment/filter/Filters.java
+++ b/processing/src/main/java/io/druid/segment/filter/Filters.java
@@ -93,7 +93,7 @@ public class Filters
     } else if (dimFilter instanceof JavaScriptDimFilter) {
       final JavaScriptDimFilter javaScriptDimFilter = (JavaScriptDimFilter) dimFilter;
 
-      filter = new JavaScriptFilter(javaScriptDimFilter.getDimension(), javaScriptDimFilter.getFunction());
+      filter = new JavaScriptFilter(javaScriptDimFilter.getAllDimensions(), javaScriptDimFilter.getFunction());
     } else if (dimFilter instanceof SpatialDimFilter) {
       final SpatialDimFilter spatialDimFilter = (SpatialDimFilter) dimFilter;
 

--- a/processing/src/main/java/io/druid/segment/filter/Filters.java
+++ b/processing/src/main/java/io/druid/segment/filter/Filters.java
@@ -93,7 +93,7 @@ public class Filters
     } else if (dimFilter instanceof JavaScriptDimFilter) {
       final JavaScriptDimFilter javaScriptDimFilter = (JavaScriptDimFilter) dimFilter;
 
-      filter = new JavaScriptFilter(javaScriptDimFilter.getAllDimensions(), javaScriptDimFilter.getFunction());
+      filter = new JavaScriptFilter(javaScriptDimFilter.getDimensions(), javaScriptDimFilter.getFunction());
     } else if (dimFilter instanceof SpatialDimFilter) {
       final SpatialDimFilter spatialDimFilter = (SpatialDimFilter) dimFilter;
 

--- a/processing/src/main/java/io/druid/segment/filter/JavaScriptFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/JavaScriptFilter.java
@@ -76,18 +76,18 @@ public class JavaScriptFilter implements Filter
           Iterator<String> iterator = dimValuesIterator[iteratingIndex];
           if (iterator.hasNext()) {
             currentDim[iteratingIndex] = iterator.next();
-            if (predicate.applyInContext(cx, currentDim))
-            {
-              // update bitmap
-              ImmutableBitmap overlap = null;
-              for (int idx = 0; idx < dimension.length; idx++) {
-                ImmutableBitmap dimBitMap = selector.getBitmapIndex(dimension[idx], currentDim[idx]);
-                overlap = (overlap == null) ? dimBitMap : overlap.intersection(dimBitMap);
+            if (iteratingIndex == 0) {
+              if (predicate.applyInContext(cx, currentDim))
+              {
+                // update bitmap
+                ImmutableBitmap overlap = null;
+                for (int idx = 0; idx < dimension.length; idx++) {
+                  ImmutableBitmap dimBitMap = selector.getBitmapIndex(dimension[idx], currentDim[idx]);
+                  overlap = (overlap == null) ? dimBitMap : overlap.intersection(dimBitMap);
+                }
+                bitmap = bitmap.union(overlap);
               }
-              bitmap = bitmap.union(overlap);
-            }
-
-            if (iteratingIndex > 0) {
+            } else {
               // reset inner loop iterators
               for (int idx = 0; idx < iteratingIndex; idx++) {
                 dimValuesIterator[idx] = dimValuesList[idx].iterator();

--- a/processing/src/main/java/io/druid/segment/filter/JavaScriptFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/JavaScriptFilter.java
@@ -76,25 +76,26 @@ public class JavaScriptFilter implements Filter
           Iterator<String> iterator = dimValuesIterator[iteratingIndex];
           if (iterator.hasNext()) {
             currentDim[iteratingIndex] = iterator.next();
-            if (iteratingIndex == 0) {
-              if (predicate.applyInContext(cx, currentDim))
-              {
-                // update bitmap
-                ImmutableBitmap overlap = null;
-                for (int idx = 0; idx < dimension.length; idx++) {
-                  ImmutableBitmap dimBitMap = selector.getBitmapIndex(dimension[idx], currentDim[idx]);
-                  overlap = (overlap == null) ? dimBitMap : overlap.intersection(dimBitMap);
-                }
-                bitmap = bitmap.union(overlap);
-              }
-            } else {
+            if (iteratingIndex > 0) {
               // reset inner loop iterators
               for (int idx = 0; idx < iteratingIndex; idx++) {
                 dimValuesIterator[idx] = dimValuesList[idx].iterator();
+                currentDim[idx] = dimValuesIterator[idx].next();
               }
               // move to the most inner loop
               iteratingIndex = 0;
             }
+            if (predicate.applyInContext(cx, currentDim))
+            {
+              // update bitmap
+              ImmutableBitmap overlap = null;
+              for (int idx = 0; idx < dimension.length; idx++) {
+                ImmutableBitmap dimBitMap = selector.getBitmapIndex(dimension[idx], currentDim[idx]);
+                overlap = (overlap == null) ? dimBitMap : overlap.intersection(dimBitMap);
+              }
+              bitmap = bitmap.union(overlap);
+            }
+
           } else {
             iteratingIndex++;
             if (iteratingIndex == dimension.length) break;

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
@@ -723,14 +723,16 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
           while (true) {
             currentIdx[currentIteratorIdx]++;
             if (currentIdx[currentIteratorIdx] < selected[currentIteratorIdx].length) {
-              if (predicate.apply(current)) {
-                return true;
-              }
+              current[currentIteratorIdx] = selected[currentIteratorIdx][currentIdx[currentIteratorIdx]];
               if (currentIteratorIdx > 0) {
                 for (int idx = 0; idx < currentIteratorIdx; idx++) {
                   currentIdx[idx] = 0;
+                  current[idx] = selected[idx][0];
                 }
                 currentIteratorIdx = 0;
+              }
+              if (predicate.apply(current)) {
+                return true;
               }
             } else {
               currentIteratorIdx++;

--- a/processing/src/test/java/io/druid/query/filter/JavaScriptDimFilterSerDesrTest.java
+++ b/processing/src/test/java/io/druid/query/filter/JavaScriptDimFilterSerDesrTest.java
@@ -29,16 +29,14 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 public class JavaScriptDimFilterSerDesrTest
 {
   private static ObjectMapper mapper;
 
-  private final String actualJSFilter1 = "{\"type\":\"javascript\",\"dimension\":\"dimTest\",\"dimensions\":null,\"function\":\"function(d1) { return true }\"}";
-  private final String actualJSFilter2 = "{\"type\":\"javascript\",\"dimension\":null,\"dimensions\":[\"dimTest1\",\"dimTest2\"],\"function\":\"function(d1, d2) { return d1 === d2 }\"}";
-  private final String actualJSFilterSkipNull1 = "{\"type\":\"javascript\",\"dimension\":\"dimTest\",\"function\":\"function(d1) { return true }\"}";
-  private final String actualJSFilterSkipNull2 = "{\"type\":\"javascript\",\"dimensions\":[\"dimTest1\",\"dimTest2\"],\"function\":\"function(d1, d2) { return d1 === d2 }\"}";
+  private final String JSFilter = "{\"type\":\"javascript\",\"dimensions\":[\"dimTest1\",\"dimTest2\"],\"function\":\"function(d1, d2) { return d1 === d2 }\"}";
+  private final String JSFilterBackwardCompatible = "{\"type\":\"javascript\",\"dimension\":\"dimTest\",\"function\":\"function(d1) { return true }\"}";
+  private final String JSFilterRewritten = "{\"type\":\"javascript\",\"dimensions\":[\"dimTest\"],\"function\":\"function(d1) { return true }\"}";
 
   @Before
   public void setUp()
@@ -50,7 +48,7 @@ public class JavaScriptDimFilterSerDesrTest
   @Test
   public void testDeserialization1() throws IOException
   {
-    final JavaScriptDimFilter actualJSDimFilter = mapper.reader(DimFilter.class).readValue(actualJSFilter1);
+    final JavaScriptDimFilter actualJSDimFilter = mapper.reader(DimFilter.class).readValue(JSFilterBackwardCompatible);
     final JavaScriptDimFilter expectedJSDimFilter =
         new JavaScriptDimFilter("dimTest", null, "function(d1) { return true }");
     Assert.assertEquals(expectedJSDimFilter, actualJSDimFilter);
@@ -59,25 +57,7 @@ public class JavaScriptDimFilterSerDesrTest
   @Test
   public void testDeserialization2() throws IOException
   {
-    final JavaScriptDimFilter actualJSDimFilter = mapper.reader(DimFilter.class).readValue(actualJSFilter2);
-    final JavaScriptDimFilter expectedJSDimFilter =
-        new JavaScriptDimFilter(null, new String[]{"dimTest1", "dimTest2"}, "function(d1, d2) { return d1 === d2 }");
-    Assert.assertEquals(expectedJSDimFilter, actualJSDimFilter);
-  }
-
-  @Test
-  public void testDeserialization3() throws IOException
-  {
-    final JavaScriptDimFilter actualJSDimFilter = mapper.reader(DimFilter.class).readValue(actualJSFilterSkipNull1);
-    final JavaScriptDimFilter expectedJSDimFilter =
-        new JavaScriptDimFilter("dimTest", null, "function(d1) { return true }");
-    Assert.assertEquals(expectedJSDimFilter, actualJSDimFilter);
-  }
-
-  @Test
-  public void testDeserialization4() throws IOException
-  {
-    final JavaScriptDimFilter actualJSDimFilter = mapper.reader(DimFilter.class).readValue(actualJSFilterSkipNull2);
+    final JavaScriptDimFilter actualJSDimFilter = mapper.reader(DimFilter.class).readValue(JSFilter);
     final JavaScriptDimFilter expectedJSDimFilter =
         new JavaScriptDimFilter(null, new String[]{"dimTest1", "dimTest2"}, "function(d1, d2) { return d1 === d2 }");
     Assert.assertEquals(expectedJSDimFilter, actualJSDimFilter);
@@ -86,17 +66,17 @@ public class JavaScriptDimFilterSerDesrTest
   @Test
   public void testSerialization1() throws IOException
   {
-    final JavaScriptDimFilter JSDimFilter = new JavaScriptDimFilter("dimTest", null, "function(d1) { return true }");
+    final JavaScriptDimFilter JSDimFilter =
+        new JavaScriptDimFilter(null, new String[]{"dimTest1", "dimTest2"}, "function(d1, d2) { return d1 === d2 }");
     final String expectedJSDimFilter = mapper.writeValueAsString(JSDimFilter);
-    Assert.assertEquals(expectedJSDimFilter, actualJSFilter1);
+    Assert.assertEquals(expectedJSDimFilter, JSFilter);
   }
 
   @Test
   public void testSerialization2() throws IOException
   {
-    final JavaScriptDimFilter JSDimFilter =
-        new JavaScriptDimFilter(null, new String[]{"dimTest1", "dimTest2"}, "function(d1, d2) { return d1 === d2 }");
+    final JavaScriptDimFilter JSDimFilter = new JavaScriptDimFilter("dimTest", null, "function(d1) { return true }");
     final String expectedJSDimFilter = mapper.writeValueAsString(JSDimFilter);
-    Assert.assertEquals(expectedJSDimFilter, actualJSFilter2);
+    Assert.assertEquals(expectedJSDimFilter, JSFilterRewritten);
   }
 }

--- a/processing/src/test/java/io/druid/query/filter/JavaScriptDimFilterSerDesrTest.java
+++ b/processing/src/test/java/io/druid/query/filter/JavaScriptDimFilterSerDesrTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import io.druid.guice.GuiceInjectors;
+import io.druid.guice.annotations.Json;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class JavaScriptDimFilterSerDesrTest
+{
+  private static ObjectMapper mapper;
+
+  private final String actualJSFilter1 = "{\"type\":\"javascript\",\"dimension\":\"dimTest\",\"dimensions\":null,\"function\":\"function(d1) { return true }\"}";
+  private final String actualJSFilter2 = "{\"type\":\"javascript\",\"dimension\":null,\"dimensions\":[\"dimTest1\",\"dimTest2\"],\"function\":\"function(d1, d2) { return d1 === d2 }\"}";
+  private final String actualJSFilterSkipNull1 = "{\"type\":\"javascript\",\"dimension\":\"dimTest\",\"function\":\"function(d1) { return true }\"}";
+  private final String actualJSFilterSkipNull2 = "{\"type\":\"javascript\",\"dimensions\":[\"dimTest1\",\"dimTest2\"],\"function\":\"function(d1, d2) { return d1 === d2 }\"}";
+
+  @Before
+  public void setUp()
+  {
+    Injector defaultInjector = GuiceInjectors.makeStartupInjector();
+    mapper = defaultInjector.getInstance(Key.get(ObjectMapper.class, Json.class));
+  }
+
+  @Test
+  public void testDeserialization1() throws IOException
+  {
+    final JavaScriptDimFilter actualJSDimFilter = mapper.reader(DimFilter.class).readValue(actualJSFilter1);
+    final JavaScriptDimFilter expectedJSDimFilter =
+        new JavaScriptDimFilter("dimTest", null, "function(d1) { return true }");
+    Assert.assertEquals(expectedJSDimFilter, actualJSDimFilter);
+  }
+
+  @Test
+  public void testDeserialization2() throws IOException
+  {
+    final JavaScriptDimFilter actualJSDimFilter = mapper.reader(DimFilter.class).readValue(actualJSFilter2);
+    final JavaScriptDimFilter expectedJSDimFilter =
+        new JavaScriptDimFilter(null, new String[]{"dimTest1", "dimTest2"}, "function(d1, d2) { return d1 === d2 }");
+    Assert.assertEquals(expectedJSDimFilter, actualJSDimFilter);
+  }
+
+  @Test
+  public void testDeserialization3() throws IOException
+  {
+    final JavaScriptDimFilter actualJSDimFilter = mapper.reader(DimFilter.class).readValue(actualJSFilterSkipNull1);
+    final JavaScriptDimFilter expectedJSDimFilter =
+        new JavaScriptDimFilter("dimTest", null, "function(d1) { return true }");
+    Assert.assertEquals(expectedJSDimFilter, actualJSDimFilter);
+  }
+
+  @Test
+  public void testDeserialization4() throws IOException
+  {
+    final JavaScriptDimFilter actualJSDimFilter = mapper.reader(DimFilter.class).readValue(actualJSFilterSkipNull2);
+    final JavaScriptDimFilter expectedJSDimFilter =
+        new JavaScriptDimFilter(null, new String[]{"dimTest1", "dimTest2"}, "function(d1, d2) { return d1 === d2 }");
+    Assert.assertEquals(expectedJSDimFilter, actualJSDimFilter);
+  }
+
+  @Test
+  public void testSerialization1() throws IOException
+  {
+    final JavaScriptDimFilter JSDimFilter = new JavaScriptDimFilter("dimTest", null, "function(d1) { return true }");
+    final String expectedJSDimFilter = mapper.writeValueAsString(JSDimFilter);
+    Assert.assertEquals(expectedJSDimFilter, actualJSFilter1);
+  }
+
+  @Test
+  public void testSerialization2() throws IOException
+  {
+    final JavaScriptDimFilter JSDimFilter =
+        new JavaScriptDimFilter(null, new String[]{"dimTest1", "dimTest2"}, "function(d1, d2) { return d1 === d2 }");
+    final String expectedJSDimFilter = mapper.writeValueAsString(JSDimFilter);
+    Assert.assertEquals(expectedJSDimFilter, actualJSFilter2);
+  }
+}

--- a/processing/src/test/java/io/druid/query/filter/JavaScriptDimFilterTest.java
+++ b/processing/src/test/java/io/druid/query/filter/JavaScriptDimFilterTest.java
@@ -28,10 +28,18 @@ public class JavaScriptDimFilterTest
 {
 
   @Test
-  public void testGetCacheKey()
+  public void testGetCacheKey1()
   {
-    JavaScriptDimFilter javaScriptDimFilter = new JavaScriptDimFilter("dim", "fn");
-    JavaScriptDimFilter javaScriptDimFilter2 = new JavaScriptDimFilter("di", "mfn");
+    JavaScriptDimFilter javaScriptDimFilter = new JavaScriptDimFilter("dim", null, "fn");
+    JavaScriptDimFilter javaScriptDimFilter2 = new JavaScriptDimFilter("di", null, "mfn");
+    Assert.assertFalse(Arrays.equals(javaScriptDimFilter.getCacheKey(), javaScriptDimFilter2.getCacheKey()));
+  }
+
+  @Test
+  public void testGetCacheKey2()
+  {
+    JavaScriptDimFilter javaScriptDimFilter = new JavaScriptDimFilter(null, new String[]{"dim1", "dim2"}, "fn");
+    JavaScriptDimFilter javaScriptDimFilter2 = new JavaScriptDimFilter(null, new String[]{"dim1", "dim"}, "2fn");
     Assert.assertFalse(Arrays.equals(javaScriptDimFilter.getCacheKey(), javaScriptDimFilter2.getCacheKey()));
   }
 }

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -2348,7 +2348,7 @@ public class GroupByQueryRunnerTest
         .setDataSource(QueryRunnerTestHelper.dataSource)
         .setQuerySegmentSpec(QueryRunnerTestHelper.firstToThird)
         .setDimensions(Lists.<DimensionSpec>newArrayList(new DefaultDimensionSpec("quality", "alias")))
-        .setDimFilter(new JavaScriptDimFilter("quality", "function(dim){ return true; }"))
+        .setDimFilter(new JavaScriptDimFilter("quality", null, "function(dim){ return true; }"))
         .setAggregatorSpecs(
             Arrays.asList(
                 QueryRunnerTestHelper.rowsCount,
@@ -2407,7 +2407,7 @@ public class GroupByQueryRunnerTest
         .setDataSource(QueryRunnerTestHelper.dataSource)
         .setQuerySegmentSpec(QueryRunnerTestHelper.firstToThird)
         .setDimensions(Lists.<DimensionSpec>newArrayList(new DefaultDimensionSpec("quality", "alias")))
-        .setDimFilter(new JavaScriptDimFilter("quality", "function(dim){ return true; }"))
+        .setDimFilter(new JavaScriptDimFilter("quality", null, "function(dim){ return true; }"))
         .setAggregatorSpecs(
             Arrays.asList(
                 QueryRunnerTestHelper.rowsCount,
@@ -2690,7 +2690,7 @@ public class GroupByQueryRunnerTest
         .setDataSource(QueryRunnerTestHelper.dataSource)
         .setQuerySegmentSpec(QueryRunnerTestHelper.firstToThird)
         .setDimensions(Lists.<DimensionSpec>newArrayList(new DefaultDimensionSpec("quality", "alias")))
-        .setDimFilter(new JavaScriptDimFilter("quality", "function(dim){ return true; }"))
+        .setDimFilter(new JavaScriptDimFilter("quality", null, "function(dim){ return true; }"))
         .setAggregatorSpecs(
             Arrays.asList(
                 QueryRunnerTestHelper.rowsCount,
@@ -2951,7 +2951,7 @@ public class GroupByQueryRunnerTest
         .setDataSource(QueryRunnerTestHelper.dataSource)
         .setQuerySegmentSpec(QueryRunnerTestHelper.firstToThird)
         .setDimensions(Lists.<DimensionSpec>newArrayList(new DefaultDimensionSpec("quality", "alias")))
-        .setDimFilter(new JavaScriptDimFilter("quality", "function(dim){ return true; }"))
+        .setDimFilter(new JavaScriptDimFilter("quality", null, "function(dim){ return true; }"))
         .setAggregatorSpecs(
             Arrays.asList(
                 QueryRunnerTestHelper.rowsCount,
@@ -3209,7 +3209,7 @@ public class GroupByQueryRunnerTest
         .setDataSource(QueryRunnerTestHelper.dataSource)
         .setQuerySegmentSpec(QueryRunnerTestHelper.firstToThird)
         .setDimensions(Lists.<DimensionSpec>newArrayList(new DefaultDimensionSpec("quality", "alias")))
-        .setDimFilter(new JavaScriptDimFilter("market", "function(dim){ return true; }"))
+        .setDimFilter(new JavaScriptDimFilter("market", null, "function(dim){ return true; }"))
         .setAggregatorSpecs(
             Arrays.asList(
                 QueryRunnerTestHelper.rowsCount,
@@ -4293,6 +4293,36 @@ public class GroupByQueryRunnerTest
     Iterable<Row> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);
     TestHelper.assertExpectedObjects(expectedResults, results, "");
 
+  }
+
+  @Test
+  public void testJavaScriptDimFilterWithMultipleDimensions()
+  {
+    GroupByQuery query = GroupByQuery
+        .builder()
+        .setDataSource(QueryRunnerTestHelper.dataSource)
+        .setQuerySegmentSpec(QueryRunnerTestHelper.firstToThird)
+        .setDimensions(Lists.<DimensionSpec>newArrayList(new DefaultDimensionSpec("market", "mkt"), new DefaultDimensionSpec("quality", "alias")))
+        .setDimFilter(new JavaScriptDimFilter(null, new String[]{"market", "quality"}, "function(d1, d2){ return d1.length == d2.length; }"))
+        .setAggregatorSpecs(
+            Arrays.asList(
+                QueryRunnerTestHelper.rowsCount,
+                new LongSumAggregatorFactory("idx", "index")
+            )
+        )
+        .setGranularity(QueryRunnerTestHelper.dayGran)
+        .build();
+
+    List<Row> expectedResults = Arrays.asList(
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-01", "alias", "news", "mkt", "spot", "rows", 1L, "idx", 121L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-01", "alias", "premium", "mkt", "upfront", "rows", 1L, "idx", 1234L),
+
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "alias", "news", "mkt", "spot", "rows", 1L, "idx", 114L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "alias", "premium", "mkt", "upfront", "rows", 1L, "idx", 1049L)
+    );
+
+    Iterable<Row> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);
+    TestHelper.assertExpectedObjects(expectedResults, results, "");
   }
 
 }

--- a/processing/src/test/java/io/druid/segment/filter/JavaScriptDimFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/JavaScriptDimFilterTest.java
@@ -238,8 +238,6 @@ public class JavaScriptDimFilterTest
     );
   }
 
-  /*
-   * commented because complement() of roaring bitmap does not work correctly yet
   @Test
   public void testNot()
   {
@@ -269,5 +267,4 @@ public class JavaScriptDimFilterTest
         ).getBitmapIndex(BITMAP_INDEX_SELECTOR).size()
     );
   }
-  */
 }

--- a/processing/src/test/java/io/druid/segment/filter/JavaScriptDimFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/JavaScriptDimFilterTest.java
@@ -46,10 +46,19 @@ import java.util.Map;
 @RunWith(Parameterized.class)
 public class JavaScriptDimFilterTest
 {
+  /*
+   *  3 row values of three dimensions
+   *
+   *     foo  |  bar  |  baz
+   *     ====================
+   *     foo1 |  bar1 |  foo1
+   *     foo2 |  foo3 |  foo3
+   *     foo3 |  foo1 |  foo3
+   */
   private static final Map<String, String[]> DIM_VALS = ImmutableMap.of(
       "foo", new String[]{"foo1", "foo2", "foo3"},
-      "bar", new String[]{"bar1", "foo3", "foo1"},
-      "baz", new String[]{"foo1", "foo3", "foo3"}
+      "bar", new String[]{"bar1", "foo1", "foo3"},
+      "baz", new String[]{"foo1", "foo3"}
   );
 
   @Parameterized.Parameters
@@ -80,24 +89,22 @@ public class JavaScriptDimFilterTest
     final MutableBitmap mutableBitmapbar2 = bitmapFactory.makeEmptyMutableBitmap();
     final MutableBitmap mutableBitmapbar3 = bitmapFactory.makeEmptyMutableBitmap();
     mutableBitmapbar1.add(0);
-    mutableBitmapbar2.add(1);
-    mutableBitmapbar3.add(2);
+    mutableBitmapbar2.add(2);
+    mutableBitmapbar3.add(1);
     Map<String, ImmutableBitmap> bar = new LinkedHashMap<>();
     bar.put("bar1", bitmapFactory.makeImmutableBitmap(mutableBitmapbar1));
-    bar.put("foo3", bitmapFactory.makeImmutableBitmap(mutableBitmapbar2));
-    bar.put("foo1", bitmapFactory.makeImmutableBitmap(mutableBitmapbar3));
+    bar.put("foo1", bitmapFactory.makeImmutableBitmap(mutableBitmapbar2));
+    bar.put("foo3", bitmapFactory.makeImmutableBitmap(mutableBitmapbar3));
     this.bitmapMap.put("bar", bar);
 
     final MutableBitmap mutableBitmapbaz1 = bitmapFactory.makeEmptyMutableBitmap();
     final MutableBitmap mutableBitmapbaz2 = bitmapFactory.makeEmptyMutableBitmap();
-    final MutableBitmap mutableBitmapbaz3 = bitmapFactory.makeEmptyMutableBitmap();
     mutableBitmapbaz1.add(0);
     mutableBitmapbaz2.add(1);
-    mutableBitmapbaz3.add(2);
+    mutableBitmapbaz2.add(2);
     Map<String, ImmutableBitmap> baz = new LinkedHashMap<>();
     baz.put("foo1", bitmapFactory.makeImmutableBitmap(mutableBitmapbaz1));
     baz.put("foo3", bitmapFactory.makeImmutableBitmap(mutableBitmapbaz2));
-    baz.put("foo3", bitmapFactory.makeImmutableBitmap(mutableBitmapbaz3));
     this.bitmapMap.put("baz", baz);
 
     this.factory = bitmapFactory;

--- a/processing/src/test/java/io/druid/segment/filter/JavaScriptDimFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/JavaScriptDimFilterTest.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.filter;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.metamx.collections.bitmap.BitmapFactory;
+import com.metamx.collections.bitmap.ConciseBitmapFactory;
+import com.metamx.collections.bitmap.ImmutableBitmap;
+import com.metamx.collections.bitmap.MutableBitmap;
+import com.metamx.collections.bitmap.RoaringBitmapFactory;
+import com.metamx.collections.spatial.ImmutableRTree;
+import io.druid.query.filter.BitmapIndexSelector;
+import io.druid.query.filter.DimFilters;
+import io.druid.query.filter.JavaScriptDimFilter;
+import io.druid.segment.data.ArrayIndexed;
+import io.druid.segment.data.Indexed;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ *
+ */
+@RunWith(Parameterized.class)
+public class JavaScriptDimFilterTest
+{
+  private static final Map<String, String[]> DIM_VALS = ImmutableMap.of(
+      "foo", new String[]{"foo1", "foo2", "foo3"},
+      "bar", new String[]{"bar1", "foo3", "foo1"},
+      "baz", new String[]{"foo1", "foo3", "foo3"}
+  );
+
+  @Parameterized.Parameters
+  public static Iterable<Object[]> constructorFeeder()
+  {
+    return ImmutableList.of(
+        new Object[]{new ConciseBitmapFactory()},
+        new Object[]{new RoaringBitmapFactory()}
+    );
+  }
+
+  public JavaScriptDimFilterTest(BitmapFactory bitmapFactory)
+  {
+    bitmapMap = new LinkedHashMap<>();
+    final MutableBitmap mutableBitmapfoo1 = bitmapFactory.makeEmptyMutableBitmap();
+    final MutableBitmap mutableBitmapfoo2 = bitmapFactory.makeEmptyMutableBitmap();
+    final MutableBitmap mutableBitmapfoo3 = bitmapFactory.makeEmptyMutableBitmap();
+    mutableBitmapfoo1.add(0);
+    mutableBitmapfoo2.add(1);
+    mutableBitmapfoo3.add(2);
+    Map<String, ImmutableBitmap> foo = new LinkedHashMap<>();
+    foo.put("foo1", bitmapFactory.makeImmutableBitmap(mutableBitmapfoo1));
+    foo.put("foo2", bitmapFactory.makeImmutableBitmap(mutableBitmapfoo2));
+    foo.put("foo3", bitmapFactory.makeImmutableBitmap(mutableBitmapfoo3));
+    this.bitmapMap.put("foo", foo);
+
+    final MutableBitmap mutableBitmapbar1 = bitmapFactory.makeEmptyMutableBitmap();
+    final MutableBitmap mutableBitmapbar2 = bitmapFactory.makeEmptyMutableBitmap();
+    final MutableBitmap mutableBitmapbar3 = bitmapFactory.makeEmptyMutableBitmap();
+    mutableBitmapbar1.add(0);
+    mutableBitmapbar2.add(1);
+    mutableBitmapbar3.add(2);
+    Map<String, ImmutableBitmap> bar = new LinkedHashMap<>();
+    bar.put("bar1", bitmapFactory.makeImmutableBitmap(mutableBitmapbar1));
+    bar.put("foo3", bitmapFactory.makeImmutableBitmap(mutableBitmapbar2));
+    bar.put("foo1", bitmapFactory.makeImmutableBitmap(mutableBitmapbar3));
+    this.bitmapMap.put("bar", bar);
+
+    final MutableBitmap mutableBitmapbaz1 = bitmapFactory.makeEmptyMutableBitmap();
+    final MutableBitmap mutableBitmapbaz2 = bitmapFactory.makeEmptyMutableBitmap();
+    final MutableBitmap mutableBitmapbaz3 = bitmapFactory.makeEmptyMutableBitmap();
+    mutableBitmapbaz1.add(0);
+    mutableBitmapbaz2.add(1);
+    mutableBitmapbaz3.add(2);
+    Map<String, ImmutableBitmap> baz = new LinkedHashMap<>();
+    baz.put("foo1", bitmapFactory.makeImmutableBitmap(mutableBitmapbaz1));
+    baz.put("foo3", bitmapFactory.makeImmutableBitmap(mutableBitmapbaz2));
+    baz.put("foo3", bitmapFactory.makeImmutableBitmap(mutableBitmapbaz3));
+    this.bitmapMap.put("baz", baz);
+
+    this.factory = bitmapFactory;
+  }
+
+  private final BitmapFactory factory;
+  private final Map<String, Map<String, ImmutableBitmap>> bitmapMap;
+
+  private final BitmapIndexSelector BITMAP_INDEX_SELECTOR = new BitmapIndexSelector()
+  {
+    @Override
+    public Indexed<String> getDimensionValues(String dimension)
+    {
+      final String[] vals = DIM_VALS.get(dimension);
+      return vals == null ? null : new ArrayIndexed<String>(vals, String.class);
+    }
+
+    @Override
+    public int getNumRows()
+    {
+      return 3;
+    }
+
+    @Override
+    public BitmapFactory getBitmapFactory()
+    {
+      return factory;
+    }
+
+    @Override
+    public ImmutableBitmap getBitmapIndex(String dimension, String value)
+    {
+      return bitmapMap.get(dimension).get(value);
+    }
+
+    @Override
+    public ImmutableRTree getSpatialIndex(String dimension)
+    {
+      return null;
+    }
+  };
+  private static final String javaScript = "function(dim1, dim2) { return dim1 === dim2 }";
+  private static final String[] dimensions1 = {"foo", "bar"};
+  private static final String[] dimensions2 = {"foo", "baz"};
+
+  @Test
+  public void testEmpty()
+  {
+    JavaScriptFilter javaScriptFilter = new JavaScriptFilter(
+        dimensions1, javaScript
+    );
+    ImmutableBitmap immutableBitmap = javaScriptFilter.getBitmapIndex(BITMAP_INDEX_SELECTOR);
+    Assert.assertEquals(0, immutableBitmap.size());
+  }
+
+  @Test
+  public void testNormal()
+  {
+    JavaScriptFilter javaScriptFilter = new JavaScriptFilter(
+        dimensions2, javaScript
+    );
+    ImmutableBitmap immutableBitmap = javaScriptFilter.getBitmapIndex(BITMAP_INDEX_SELECTOR);
+    Assert.assertEquals(2, immutableBitmap.size());
+  }
+
+  @Test
+  public void testOr()
+  {
+    Assert.assertEquals(
+        2, Filters.convertDimensionFilters(
+            DimFilters.or(
+                new JavaScriptDimFilter(
+                    null,
+                    dimensions2,
+                    javaScript
+                )
+            )
+        ).getBitmapIndex(BITMAP_INDEX_SELECTOR).size()
+    );
+
+    Assert.assertEquals(
+        2,
+        Filters.convertDimensionFilters(
+            DimFilters.or(
+                new JavaScriptDimFilter(
+                    null,
+                    dimensions1,
+                    javaScript
+                ),
+                new JavaScriptDimFilter(
+                    null,
+                    dimensions2,
+                    javaScript
+                )
+            )
+        ).getBitmapIndex(BITMAP_INDEX_SELECTOR).size()
+    );
+  }
+
+  @Test
+  public void testAnd()
+  {
+    Assert.assertEquals(
+        2, Filters.convertDimensionFilters(
+            DimFilters.or(
+                new JavaScriptDimFilter(
+                    null,
+                    dimensions2,
+                    javaScript
+                )
+            )
+        ).getBitmapIndex(BITMAP_INDEX_SELECTOR).size()
+    );
+
+    Assert.assertEquals(
+        0,
+        Filters.convertDimensionFilters(
+            DimFilters.and(
+                new JavaScriptDimFilter(
+                    null,
+                    dimensions1,
+                    javaScript
+                ),
+                new JavaScriptDimFilter(
+                    null,
+                    dimensions2,
+                    javaScript
+                )
+            )
+        ).getBitmapIndex(BITMAP_INDEX_SELECTOR).size()
+    );
+  }
+
+  @Test
+  public void testNot()
+  {
+
+    Assert.assertEquals(
+        2, Filters.convertDimensionFilters(
+            DimFilters.or(
+                new JavaScriptDimFilter(
+                    null,
+                    dimensions2,
+                    javaScript
+                )
+            )
+        ).getBitmapIndex(BITMAP_INDEX_SELECTOR).size()
+    );
+
+    ImmutableBitmap result = Filters.convertDimensionFilters(
+        DimFilters.not(
+            new JavaScriptDimFilter(
+                null,
+                dimensions2,
+                javaScript
+            )
+        )
+    ).getBitmapIndex(BITMAP_INDEX_SELECTOR);
+
+    Assert.assertEquals(
+        1,
+        Filters.convertDimensionFilters(
+            DimFilters.not(
+                new JavaScriptDimFilter(
+                    null,
+                    dimensions2,
+                    javaScript
+                )
+            )
+        ).getBitmapIndex(BITMAP_INDEX_SELECTOR).size()
+    );
+  }
+}

--- a/processing/src/test/java/io/druid/segment/filter/JavaScriptDimFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/JavaScriptDimFilterTest.java
@@ -231,6 +231,8 @@ public class JavaScriptDimFilterTest
     );
   }
 
+  /*
+   * commented because complement() of roaring bitmap does not work correctly yet
   @Test
   public void testNot()
   {
@@ -247,16 +249,6 @@ public class JavaScriptDimFilterTest
         ).getBitmapIndex(BITMAP_INDEX_SELECTOR).size()
     );
 
-    ImmutableBitmap result = Filters.convertDimensionFilters(
-        DimFilters.not(
-            new JavaScriptDimFilter(
-                null,
-                dimensions2,
-                javaScript
-            )
-        )
-    ).getBitmapIndex(BITMAP_INDEX_SELECTOR);
-
     Assert.assertEquals(
         1,
         Filters.convertDimensionFilters(
@@ -270,4 +262,5 @@ public class JavaScriptDimFilterTest
         ).getBitmapIndex(BITMAP_INDEX_SELECTOR).size()
     );
   }
+  */
 }


### PR DESCRIPTION
This PR fixes #2187 

It is implemented like nested loop self-join.
So, if the number of columns increases, it would take much time.
For backward compatibility, usage of javascript filter with one column is maintained.

Currently, complement() of roaring bitmap does not work correctly yet,
test code with NotFilter is commented temporarily.