### PR TITLE
[wip] trying/finding fix for announcer test failures

### DIFF
--- a/server/src/test/java/io/druid/curator/CuratorTestBase.java
+++ b/server/src/test/java/io/druid/curator/CuratorTestBase.java
@@ -20,9 +20,8 @@
 package io.druid.curator;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.api.client.repackaged.com.google.common.base.Throwables;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
-import com.metamx.common.guava.CloseQuietly;
 import io.druid.client.DruidServer;
 import io.druid.server.initialization.ZkPathsConfig;
 import io.druid.timeline.DataSegment;
@@ -34,6 +33,8 @@ import org.apache.curator.test.Timing;
 import org.apache.curator.utils.ZKPaths;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
+
+import java.io.IOException;
 
 /**
  */
@@ -152,8 +153,13 @@ public class CuratorTestBase
 
   protected void tearDownServerAndCurator()
   {
-    CloseQuietly.close(curator);
-    CloseQuietly.close(server);
+    try {
+      curator.close();
+      server.close();
+    } catch(IOException ex)
+    {
+      throw Throwables.propagate(ex);
+    }
   }
 
 }

--- a/server/src/test/java/io/druid/curator/announcement/AnnouncerTest.java
+++ b/server/src/test/java/io/druid/curator/announcement/AnnouncerTest.java
@@ -32,7 +32,6 @@ import org.apache.zookeeper.data.Stat;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Set;
@@ -128,7 +127,6 @@ public class AnnouncerTest extends CuratorTestBase
     Assert.assertNull("expect /somewhere/test2 unannounced", curator.checkExists().forPath(testPath2));
   }
 
-  @Ignore // https://github.com/druid-io/druid/issues/2167
   @Test(timeout = 60_000L)
   public void testSessionKilled() throws Exception
   {


### PR DESCRIPTION
my guess is that curator  throws some exception while cleanup and ignoring same leads to visible errors like announcer test failures.

will try build with this patch many times to see if announcer test failure is reproduced and if there is indeed an exception thrown by the cleanup code.

to fix #2167