### PR TITLE
Update commons-io to 2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.0.1</version>
+                <version>2.4</version>
             </dependency>
             <dependency>
                 <groupId>commons-logging</groupId>


### PR DESCRIPTION
Hadoop2.3.0 uses version  2.4 as per http://central.maven.org/maven2/org/apache/hadoop/hadoop-project/2.3.0/hadoop-project-2.3.0.pom