### PR TITLE
Updated log4j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <druid.api.version>0.3.15</druid.api.version>
         <!-- Watch out for Hadoop compatibility when updating to >= 2.5; see https://github.com/druid-io/druid/pull/1669 -->
         <jackson.version>2.4.6</jackson.version>
-        <log4j.version>2.4.1</log4j.version>
+        <log4j.version>2.5</log4j.version>
         <slf4j.version>1.7.12</slf4j.version>
         <hadoop.compile.version>2.3.0</hadoop.compile.version>
     </properties>


### PR DESCRIPTION
Version 2.5 fixes https://issues.apache.org/jira/browse/LOG4J2-435 which allows limiting the number of log files produced.
This is needed so we can keep from running out of disk space due to the high amount of logging produced by druid.