### PR TITLE
doc: add information about new serverview coordinator endpoint

### DIFF
--- a/docs/content/design/coordinator.md
+++ b/docs/content/design/coordinator.md
@@ -155,6 +155,10 @@ Returns a map of segment intervals contained within the specified interval to a 
 
 Returns a map of segment intervals contained within the specified interval to a map of segment metadata to a set of server names that contain the segment for an interval.
 
+* `/druid/coordinator/v1/datasources/{dataSourceName}/intervals/{interval}/serverview`
+
+Returns a map of segment intervals contained within the specified interval to information about the servers that contain the segment for an interval.
+
 * `/druid/coordinator/v1/datasources/{dataSourceName}/segments`
 
 Returns a list of all segments for a datasource in the cluster.


### PR DESCRIPTION
The new endpoint 
   /druid/coordinator/v1/datasources/{dataSourceName}/intervals/{interval}/serverview
is very similar to
   /druid/coordinator/v1/datasources/{dataSourceName}/intervals/{interval}?full
but in addition to the new one returning more information about the servers than just their names, the new one is implemented completely differently (using the new timeline).

It might be useful to the reader to give an indication of when it would be necessary (or just more appropriate) to use one of these than the other, but the philosophy of the endpoint descriptions seems to be to give the bare facts about each one.
