### PR TITLE
fix NPE with filtered aggregator at ingestion time

### DIFF
--- a/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -155,12 +155,15 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
     } else {
       aggs = new Aggregator[metrics.length];
 
+      rowContainer.set(row);
       for (int i = 0; i < metrics.length; i++) {
         final AggregatorFactory agg = metrics[i];
         aggs[i] = agg.factorize(
             selectors.get(agg.getName())
         );
       }
+      rowContainer.set(null);
+
       final Integer rowIndex = indexIncrement.getAndIncrement();
 
       concurrentSet(rowIndex, aggs);


### PR DESCRIPTION
This PR fixes #2061 

NPE of #2061 is from filtered aggregator factory references RowSupplier at factorize() when row of RowSupplier is not set yet.
This patch delays the access of RowSupplier from makeMatcher() to ValueMatcher.matches(). 

It works only for aggregator with selector filter because extraction filter is not supported at ingestion time as cardinality is not fixed at ingestion time