### PR TITLE
fix topN filtering on multi-valued dimension bug

### DIFF
--- a/processing/src/main/java/io/druid/query/dimension/ListFilteredDimensionSpec.java
+++ b/processing/src/main/java/io/druid/query/dimension/ListFilteredDimensionSpec.java
@@ -110,7 +110,7 @@ public class ListFilteredDimensionSpec extends BaseFilteredDimensionSpec
       @Override
       public int getValueCardinality()
       {
-        return matched.size();
+        return selector.getValueCardinality();
       }
 
       @Override

--- a/processing/src/main/java/io/druid/query/dimension/RegexFilteredDimensionSpec.java
+++ b/processing/src/main/java/io/druid/query/dimension/RegexFilteredDimensionSpec.java
@@ -95,7 +95,7 @@ public class RegexFilteredDimensionSpec extends BaseFilteredDimensionSpec
       @Override
       public int getValueCardinality()
       {
-        return bitSetOfIds.cardinality();
+        return selector.getValueCardinality();
       }
 
       @Override

--- a/processing/src/test/java/io/druid/query/MultiValuedDimensionTest.java
+++ b/processing/src/test/java/io/druid/query/MultiValuedDimensionTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.Module;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import com.metamx.common.guava.Sequence;
 import com.metamx.common.guava.Sequences;
@@ -37,11 +38,18 @@ import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.query.dimension.DefaultDimensionSpec;
 import io.druid.query.dimension.DimensionSpec;
+import io.druid.query.dimension.ListFilteredDimensionSpec;
 import io.druid.query.dimension.RegexFilteredDimensionSpec;
 import io.druid.query.filter.SelectorDimFilter;
 import io.druid.query.groupby.GroupByQuery;
 import io.druid.query.groupby.GroupByQueryRunnerTestHelper;
 import io.druid.query.spec.LegacySegmentSpec;
+import io.druid.query.topn.TopNQuery;
+import io.druid.query.topn.TopNQueryBuilder;
+import io.druid.query.topn.TopNQueryConfig;
+import io.druid.query.topn.TopNQueryQueryToolChest;
+import io.druid.query.topn.TopNQueryRunnerFactory;
+import io.druid.query.topn.TopNResultValue;
 import io.druid.segment.IncrementalIndexSegment;
 import io.druid.segment.IndexSpec;
 import io.druid.segment.QueryableIndex;
@@ -50,6 +58,7 @@ import io.druid.segment.TestHelper;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.commons.io.FileUtils;
+import org.joda.time.DateTime;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -58,6 +67,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 /**
  */
@@ -248,6 +258,63 @@ public class MultiValuedDimensionTest
     );
 
     TestHelper.assertExpectedObjects(expectedResults, Sequences.toList(result, new ArrayList<Row>()), "");
+  }
+
+  @Test
+  public void testTopNWithDimFilterAndWithFilteredDimSpec() throws Exception
+  {
+    TopNQuery query = new TopNQueryBuilder()
+        .dataSource("xx")
+        .granularity(QueryGranularity.ALL)
+        .dimension(new ListFilteredDimensionSpec(
+            new DefaultDimensionSpec("tags", "tags"),
+            ImmutableList.of("t3"),
+            null
+        ))
+        .metric("count")
+        .intervals(QueryRunnerTestHelper.fullOnInterval)
+        .aggregators(
+            Arrays.asList(
+                new AggregatorFactory[]
+                    {
+                        new CountAggregatorFactory("count")
+                    }
+            ))
+        .threshold(5)
+        .filters(new SelectorDimFilter("tags", "t3")).build();
+
+    QueryRunnerFactory factory = new TopNQueryRunnerFactory(
+        TestQueryRunners.getPool(),
+        new TopNQueryQueryToolChest(
+            new TopNQueryConfig(),
+            QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
+        ),
+        QueryRunnerTestHelper.NOOP_QUERYWATCHER
+    );
+    QueryRunner<Result<TopNResultValue>> runner = QueryRunnerTestHelper.makeQueryRunner(
+        factory,
+        new QueryableIndexSegment("sid1", queryableIndex)
+    );
+    Map<String, Object> context = Maps.newHashMap();
+    Sequence<Result<TopNResultValue>> result = runner.run(query, context);
+    List<Result<TopNResultValue>> expectedResults = Arrays.asList(
+        new Result<TopNResultValue>(
+            new DateTime("2011-01-12T00:00:00.000Z"),
+            new TopNResultValue(
+                Arrays.<Map<String, Object>>asList(
+                    ImmutableMap.<String, Object>of(
+                        "tags", "t3",
+                        "count", 2L
+                    )
+                )
+            )
+        )
+    );
+    TestHelper.assertExpectedObjects(
+        expectedResults,
+        Sequences.toList(result, new ArrayList<Result<TopNResultValue>>()),
+        ""
+    );
   }
 
   @AfterClass


### PR DESCRIPTION
When i backport #2130 to our version and use topn with it, it throw ArrayIndexOutOfBoundsException.
```
2016-01-12T09:35:54,627 ERROR [processing-2] io.druid.query.ChainedExecutionQueryRunner - Exception with one of the sequences!
java.lang.ArrayIndexOutOfBoundsException: 17
        at io.druid.query.topn.PooledTopNAlgorithm.aggregateDimValue(PooledTopNAlgorithm.java:255) ~[druid-processing-0.8.3-rc2.jar:0.8.3-rc2]
        at io.druid.query.topn.PooledTopNAlgorithm.scanAndAggregate(PooledTopNAlgorithm.java:226) ~[druid-processing-0.8.3-rc2.jar:0.8.3-rc2]
        at io.druid.query.topn.PooledTopNAlgorithm.scanAndAggregate(PooledTopNAlgorithm.java:37) ~[druid-processing-0.8.3-rc2.jar:0.8.3-rc2]
        at io.druid.query.topn.BaseTopNAlgorithm.run(BaseTopNAlgorithm.java:92) ~[druid-processing-0.8.3-rc2.jar:0.8.3-rc2]
        at io.druid.query.topn.TopNMapFn.apply(TopNMapFn.java:57) ~[druid-processing-0.8.3-rc2.jar:0.8.3-rc2]
        at io.druid.query.topn.TopNMapFn.apply(TopNMapFn.java:26) ~[druid-processing-0.8.3-rc2.jar:0.8.3-rc2]
        at io.druid.query.topn.TopNQueryEngine$1.apply(TopNQueryEngine.java:82) ~[druid-processing-0.8.3-rc2.jar:0.8.3-rc2]
        at io.druid.query.topn.TopNQueryEngine$1.apply(TopNQueryEngine.java:77) ~[druid-processing-0.8.3-rc2.jar:0.8.3-rc2]
        at com.metamx.common.guava.MappingYieldingAccumulator.accumulate(MappingYieldingAccumulator.java:57) ~[java-util-0.27.4.jar:?]
        at com.metamx.common.guava.FilteringYieldingAccumulator.accumulate(FilteringYieldingAccumulator.java:69) ~[java-util-0.27.4.jar:?]
        at com.metamx.common.guava.MappingYieldingAccumulator.accumulate(MappingYieldingAccumulator.java:57) ~[java-util-0.27.4.jar:?]
        at com.metamx.common.guava.BaseSequence.makeYielder(BaseSequence.java:104) ~[java-util-0.27.4.jar:?]
        at com.metamx.common.guava.BaseSequence.toYielder(BaseSequence.java:81) ~[java-util-0.27.4.jar:?]
        at com.metamx.common.guava.MappedSequence.toYielder(MappedSequence.java:46) ~[java-util-0.27.4.jar:?]
        at com.metamx.common.guava.ResourceClosingSequence.toYielder(ResourceClosingSequence.java:41) ~[java-util-0.27.4.jar:?]
        at com.metamx.common.guava.FilteredSequence.toYielder(FilteredSequence.java:52) ~[java-util-0.27.4.jar:?]
        at com.metamx.common.guava.MappedSequence.toYielder(MappedSequence.java:46) ~[java-util-0.27.4.jar:?]
        at com.metamx.common.guava.FilteredSequence.toYielder(FilteredSequence.java:52) ~[java-util-0.27.4.jar:?]        at com.metamx.common.guava.ResourceClosingSequence.toYielder(ResourceClosingSequence.java:41) ~[java-util-0.27.4.jar:?]        at com.metamx.common.guava.YieldingSequenceBase.accumulate(YieldingSequenceBase.java:34) ~[java-util-0.27.4.jar:?]        at io.druid.query.MetricsEmittingQueryRunner$1.accumulate(MetricsEmittingQueryRunner.java:118) ~[druid-processing-0.8.3-rc2.jar:0.8.3-rc2]        at com.metamx.common.guava.MappedSequence.accumulate(MappedSequence.java:40) ~[java-util-0.27.4.jar:?]
        at com.metamx.common.guava.Sequences$1.accumulate(Sequences.java:90) ~[java-util-0.27.4.jar:?]
        at io.druid.query.MetricsEmittingQueryRunner$1.accumulate(MetricsEmittingQueryRunner.java:118) ~[druid-processing-0.8.3-rc2.jar:0.8.3-rc2]
        at io.druid.query.spec.SpecificSegmentQueryRunner$2$1.call(SpecificSegmentQueryRunner.java:85) ~[druid-processing-0.8.3-rc2.jar:0.8.3-rc2]
        at io.druid.query.spec.SpecificSegmentQueryRunner.doNamed(SpecificSegmentQueryRunner.java:169) ~[druid-processing-0.8.3-rc2.jar:0.8.3-rc2]
        at io.druid.query.spec.SpecificSegmentQueryRunner.access$400(SpecificSegmentQueryRunner.java:39) ~[druid-processing-0.8.3-rc2.jar:0.8.3-rc2]
        at io.druid.query.spec.SpecificSegmentQueryRunner$2.doItNamed(SpecificSegmentQueryRunner.java:160) ~[druid-processing-0.8.3-rc2.jar:0.8.3-rc2]
        at io.druid.query.spec.SpecificSegmentQueryRunner$2.accumulate(SpecificSegmentQueryRunner.java:78) ~[druid-processing-0.8.3-rc2.jar:0.8.3-rc2]
        at io.druid.query.CPUTimeMetricQueryRunner$1.accumulate(CPUTimeMetricQueryRunner.java:83) ~[druid-processing-0.8.3-rc2.jar:0.8.3-rc2]
        at com.metamx.common.guava.Sequences$1.accumulate(Sequences.java:90) ~[java-util-0.27.4.jar:?]
        at com.metamx.common.guava.Sequences.toList(Sequences.java:113) ~[java-util-0.27.4.jar:?]
        at io.druid.query.ChainedExecutionQueryRunner$1$1$1.call(ChainedExecutionQueryRunner.java:130) [druid-processing-0.8.3-rc2.jar:0.8.3-rc2]
        at io.druid.query.ChainedExecutionQueryRunner$1$1$1.call(ChainedExecutionQueryRunner.java:120) [druid-processing-0.8.3-rc2.jar:0.8.3-rc2]
        at java.util.concurrent.FutureTask.run(FutureTask.java:262) [?:1.7.0_51]
        at io.druid.query.PrioritizedExecutorService$PrioritizedListenableFutureTask.run(PrioritizedExecutorService.java:222) [druid-processing-0.8.3-rc2.jar:0.8.3-rc2]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [?:1.7.0_51]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [?:1.7.0_51]
```