### PR TITLE
Prioritize loading of segments based on segment interval

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     </scm>
 
     <properties>
-        <metamx.java-util.version>0.27.6</metamx.java-util.version>
+        <metamx.java-util.version>0.27.7</metamx.java-util.version>
         <apache.curator.version>2.9.1</apache.curator.version>
         <jetty.version>9.2.5.v20141112</jetty.version>
         <jersey.version>1.19</jersey.version>

--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinatorRuntimeParams.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinatorRuntimeParams.java
@@ -199,7 +199,7 @@ public class DruidCoordinatorRuntimeParams
       this.databaseRuleManager = null;
       this.segmentReplicantLookup = null;
       this.dataSources = Sets.newHashSet();
-      this.availableSegments = Sets.newTreeSet(Comparators.inverse(DataSegment.bucketMonthComparator()));
+      this.availableSegments = Sets.newTreeSet(DruidCoordinator.SEGMENT_COMPARATOR);
       this.loadManagementPeons = Maps.newHashMap();
       this.replicationManager = null;
       this.emitter = null;

--- a/server/src/main/java/io/druid/server/coordinator/LoadQueuePeon.java
+++ b/server/src/main/java/io/druid/server/coordinator/LoadQueuePeon.java
@@ -57,8 +57,6 @@ public class LoadQueuePeon
   private static final int DROP = 0;
   private static final int LOAD = 1;
 
-  private static Comparator<DataSegment> segmentComparator = Comparators.inverse(DataSegment.bucketMonthComparator());
-
   private static void executeCallbacks(List<LoadPeonCallback> callbacks)
   {
     for (LoadPeonCallback callback : callbacks) {
@@ -79,10 +77,10 @@ public class LoadQueuePeon
   private final AtomicInteger failedAssignCount = new AtomicInteger(0);
 
   private final ConcurrentSkipListMap<DataSegment, SegmentHolder> segmentsToLoad = new ConcurrentSkipListMap<>(
-      segmentComparator
+      DruidCoordinator.SEGMENT_COMPARATOR
   );
   private final ConcurrentSkipListMap<DataSegment, SegmentHolder> segmentsToDrop = new ConcurrentSkipListMap<>(
-      segmentComparator
+      DruidCoordinator.SEGMENT_COMPARATOR
   );
 
   private final Object lock = new Object();

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
@@ -23,7 +23,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.common.collect.MapMaker;
+import com.google.common.collect.Maps;
 import com.metamx.common.concurrent.ScheduledExecutorFactory;
 import io.druid.client.DruidDataSource;
 import io.druid.client.DruidServer;
@@ -61,6 +63,7 @@ import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -374,5 +377,46 @@ public class DruidCoordinatorTest extends CuratorTestBase
     Assert.assertNull(coordinator.getCurrentLeader());
     EasyMock.verify(serverInventoryView);
     EasyMock.verify(metadataRuleManager);
+  }
+
+  @Test
+  public void testOrderedAvailableDataSegments()
+  {
+    DruidDataSource dataSource = new DruidDataSource("test", new HashMap());
+    DataSegment[] segments = new DataSegment[]{
+        getSegment("test", new Interval("2016-01-10T03:00:00Z/2016-01-10T04:00:00Z")),
+        getSegment("test", new Interval("2016-01-11T01:00:00Z/2016-01-11T02:00:00Z")),
+        getSegment("test", new Interval("2016-01-09T10:00:00Z/2016-01-09T11:00:00Z")),
+        getSegment("test", new Interval("2016-01-09T10:00:00Z/2016-01-09T12:00:00Z"))
+    };
+    for (DataSegment segment : segments) {
+      dataSource.addSegment(segment.getIdentifier(), segment);
+    }
+
+    EasyMock.expect(databaseSegmentManager.getInventory()).andReturn(
+        ImmutableList.of(dataSource)
+    ).atLeastOnce();
+    EasyMock.replay(databaseSegmentManager);
+    Set<DataSegment> availableSegments = coordinator.getOrderedAvailableDataSegments();
+    DataSegment[] expected = new DataSegment[]{
+        getSegment("test", new Interval("2016-01-11T01:00:00Z/2016-01-11T02:00:00Z")),
+        getSegment("test", new Interval("2016-01-10T03:00:00Z/2016-01-10T04:00:00Z")),
+        getSegment("test", new Interval("2016-01-09T10:00:00Z/2016-01-09T12:00:00Z")),
+        getSegment("test", new Interval("2016-01-09T10:00:00Z/2016-01-09T11:00:00Z"))
+    };
+    Assert.assertEquals(expected.length, availableSegments.size());
+    Assert.assertEquals(expected, availableSegments.toArray());
+    EasyMock.verify(databaseSegmentManager);
+  }
+
+
+  private DataSegment getSegment(String dataSource, Interval interval)
+  {
+    // Not using EasyMock as it hampers the performance of multithreads.
+    DataSegment segment = new DataSegment(
+        dataSource, interval, "dummy_version", Maps.<String, Object>newConcurrentMap(),
+        Lists.<String>newArrayList(), Lists.<String>newArrayList(), null, 0, 0L
+    );
+    return segment;
   }
 }

--- a/server/src/test/java/io/druid/server/coordinator/LoadQueuePeonTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/LoadQueuePeonTest.java
@@ -137,9 +137,27 @@ public class LoadQueuePeonTest extends CuratorTestBase
 
     final List<DataSegment> segmentToLoad = Lists.transform(
         ImmutableList.<String>of(
+            "2014-10-27T00:00:00Z/P1D",
+            "2014-10-29T00:00:00Z/P1M",
             "2014-10-31T00:00:00Z/P1D",
             "2014-10-30T00:00:00Z/P1D",
-            "2014-10-29T00:00:00Z/P1D",
+            "2014-10-28T00:00:00Z/P1D"
+        ), new Function<String, DataSegment>()
+        {
+          @Override
+          public DataSegment apply(String intervalStr)
+          {
+            return dataSegmentWithInterval(intervalStr);
+          }
+        }
+    );
+
+    // segment with latest interval should be loaded first
+    final List<DataSegment> expectedLoadOrder = Lists.transform(
+        ImmutableList.<String>of(
+            "2014-10-29T00:00:00Z/P1M",
+            "2014-10-31T00:00:00Z/P1D",
+            "2014-10-30T00:00:00Z/P1D",
             "2014-10-28T00:00:00Z/P1D",
             "2014-10-27T00:00:00Z/P1D"
         ), new Function<String, DataSegment>()
@@ -235,7 +253,7 @@ public class LoadQueuePeonTest extends CuratorTestBase
       }
     }
 
-    for (DataSegment segment : segmentToLoad) {
+    for (DataSegment segment : expectedLoadOrder) {
       String loadRequestPath = ZKPaths.makePath(LOAD_QUEUE_PATH, segment.getIdentifier());
       Assert.assertTrue(timing.forWaiting().awaitLatch(loadRequestSignal[requestSignalIdx.get()]));
       Assert.assertNotNull(curator.checkExists().forPath(loadRequestPath));


### PR DESCRIPTION
Issue - With current ordering of segments, coordinator uses bucketMonthComparator, In case we have a large number of segments to load/replicate for current month, Segment handoff can get delayed leading to realtime tasks taking a lot longer than complete than usual. 

This PR attempts to prioritize loading latest segments first by ordering segments on basis of interval based comparator. 