### PR TITLE
Allow IncrementalIndex to store Long/Float dimensions

### DIFF
--- a/benchmarks/src/main/java/io/druid/benchmark/IncrementalIndexAddRowsBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/IncrementalIndexAddRowsBenchmark.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.benchmark;
+
+import com.google.common.collect.ImmutableMap;
+import io.druid.data.input.InputRow;
+import io.druid.data.input.MapBasedInputRow;
+import io.druid.granularity.QueryGranularity;
+import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.query.aggregation.CountAggregatorFactory;
+import io.druid.query.aggregation.DoubleSumAggregatorFactory;
+import io.druid.query.aggregation.LongSumAggregatorFactory;
+import io.druid.segment.incremental.IncrementalIndex;
+import io.druid.segment.incremental.OnheapIncrementalIndex;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+public class IncrementalIndexAddRowsBenchmark
+{
+  private IncrementalIndex incIndex;
+  private IncrementalIndex incFloatIndex;
+  private IncrementalIndex incStrIndex;
+  private static AggregatorFactory[] aggs;
+  static final int dimensionCount = 8;
+  private Random rng;
+  static final int maxRows = 250000;
+
+  private ArrayList<InputRow> longRows = new ArrayList<InputRow>();
+  private ArrayList<InputRow> floatRows = new ArrayList<InputRow>();
+  private ArrayList<InputRow> stringRows = new ArrayList<InputRow>();
+
+
+  static {
+    final ArrayList<AggregatorFactory> ingestAggregatorFactories = new ArrayList<>(dimensionCount + 1);
+    ingestAggregatorFactories.add(new CountAggregatorFactory("rows"));
+    for (int i = 0; i < dimensionCount; ++i) {
+      ingestAggregatorFactories.add(
+          new LongSumAggregatorFactory(
+              String.format("sumResult%s", i),
+              String.format("Dim_%s", i)
+          )
+      );
+      ingestAggregatorFactories.add(
+          new DoubleSumAggregatorFactory(
+              String.format("doubleSumResult%s", i),
+              String.format("Dim_%s", i)
+          )
+      );
+    }
+    aggs = ingestAggregatorFactories.toArray(new AggregatorFactory[0]);
+  }
+
+  private MapBasedInputRow getLongRow(long timestamp, int rowID, int dimensionCount)
+  {
+    List<String> dimensionList = new ArrayList<String>(dimensionCount);
+    ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
+    for (int i = 0; i < dimensionCount; i++) {
+      String dimName = String.format("Dim_%d", i);
+      dimensionList.add(dimName);
+      builder.put(dimName, rng.nextLong());
+    }
+    return new MapBasedInputRow(timestamp, dimensionList, builder.build());
+  }
+
+  private MapBasedInputRow getFloatRow(long timestamp, int rowID, int dimensionCount)
+  {
+    List<String> dimensionList = new ArrayList<String>(dimensionCount);
+    ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
+    for (int i = 0; i < dimensionCount; i++) {
+      String dimName = String.format("Dim_%d", i);
+      dimensionList.add(dimName);
+      builder.put(dimName, rng.nextFloat());
+    }
+    return new MapBasedInputRow(timestamp, dimensionList, builder.build());
+  }
+
+  private MapBasedInputRow getStringRow(long timestamp, int rowID, int dimensionCount)
+  {
+    List<String> dimensionList = new ArrayList<String>(dimensionCount);
+    ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
+    for (int i = 0; i < dimensionCount; i++) {
+      String dimName = String.format("Dim_%d", i);
+      dimensionList.add(dimName);
+      builder.put(dimName, String.valueOf(rng.nextLong()));
+    }
+    return new MapBasedInputRow(timestamp, dimensionList, builder.build());
+  }
+
+  private IncrementalIndex makeIncIndex()
+  {
+    return new OnheapIncrementalIndex(
+        0,
+        QueryGranularity.NONE,
+        aggs,
+        false,
+        false,
+        maxRows
+    );
+  }
+
+  @Setup
+  public void setup() throws IOException
+  {
+    rng = new Random(9999);
+
+    for (int i = 0; i < maxRows; i++) {
+      longRows.add(getLongRow(0, i, dimensionCount));
+    }
+
+    for (int i = 0; i < maxRows; i++) {
+      floatRows.add(getFloatRow(0, i, dimensionCount));
+    }
+
+    for (int i = 0; i < maxRows; i++) {
+      stringRows.add(getStringRow(0, i, dimensionCount));
+    }
+  }
+
+  @Setup(Level.Iteration)
+  public void setup2() throws IOException
+  {
+    ;
+    incIndex = makeIncIndex();
+    incFloatIndex = makeIncIndex();
+    incStrIndex = makeIncIndex();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @OperationsPerInvocation(maxRows)
+  public void normalLongs(Blackhole blackhole) throws Exception
+  {
+    for (int i = 0; i < maxRows; i++) {
+      InputRow row = longRows.get(i);
+      int rv = incIndex.add(row);
+      blackhole.consume(rv);
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @OperationsPerInvocation(maxRows)
+  public void normalFloats(Blackhole blackhole) throws Exception
+  {
+    for (int i = 0; i < maxRows; i++) {
+      InputRow row = floatRows.get(i);
+      int rv = incFloatIndex.add(row);
+      blackhole.consume(rv);
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @OperationsPerInvocation(maxRows)
+  public void normalStrings(Blackhole blackhole) throws Exception
+  {
+    for (int i = 0; i < maxRows; i++) {
+      InputRow row = stringRows.get(i);
+      int rv = incStrIndex.add(row);
+      blackhole.consume(rv);
+    }
+  }
+}

--- a/processing/src/main/java/io/druid/query/filter/ValueMatcherFactory.java
+++ b/processing/src/main/java/io/druid/query/filter/ValueMatcherFactory.java
@@ -26,7 +26,7 @@ import com.metamx.collections.spatial.search.Bound;
  */
 public interface ValueMatcherFactory
 {
-  public ValueMatcher makeValueMatcher(String dimension, String value);
-  public ValueMatcher makeValueMatcher(String dimension, Predicate<String> value);
+  public ValueMatcher makeValueMatcher(String dimension, Comparable value);
+  public ValueMatcher makeValueMatcher(String dimension, Predicate value);
   public ValueMatcher makeValueMatcher(String dimension, Bound bound);
 }

--- a/processing/src/main/java/io/druid/segment/incremental/SpatialDimensionRowTransformer.java
+++ b/processing/src/main/java/io/druid/segment/incremental/SpatialDimensionRowTransformer.java
@@ -126,7 +126,8 @@ public class SpatialDimensionRowTransformer implements Function<InputRow, InputR
       @Override
       public Object getRaw(String dimension)
       {
-        return row.getRaw(dimension);
+        List<String> retVal = spatialLookup.get(dimension);
+        return (retVal == null) ? row.getRaw(dimension) : retVal;
       }
 
       @Override

--- a/server/src/test/java/io/druid/segment/realtime/plumber/RealtimePlumberSchoolTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/plumber/RealtimePlumberSchoolTest.java
@@ -656,7 +656,7 @@ public class RealtimePlumberSchoolTest
       @Override
       public Object getRaw(String dimension)
       {
-        return null;
+        return dimVals;
       }
 
       @Override


### PR DESCRIPTION
This PR updates IncrementalIndex such that it can ingest and store Long/Float dimensions in addition to Strings. It is intended as a step towards the larger goals being discussed in the following topic:

https://groups.google.com/forum/#!topic/druid-development/obtfNJnXPDg/discussion

* DimDim is now a generic class instead of assuming String values. The TimeAndDims grouping key class now stores dimension values as Comparable[] instead of String[].

* The PR does not change the DimensionSelector or *Adapter interfaces to support non-String types, so query/index persist behavior is unchanged, nor does this PR provide a way for the user to specify non-String dimension types in the ingestion schema. 

* Schema-less dimension type discovery is not enabled in the PR (newly discovered dims are assumed to be Strings). 

* The PR includes a JMH benchmark that adds rows with Long/Float/String columns to an IncrementalIndex.

I ran the row-adding benchmark with type discovery enabled for testing purposes and the numbers are shown below:

```
java -jar target/benchmarks.jar IncrementalIndexAddRowsBenchmark -f 1 -i 20 -wi 10
```

With patch, non-String dims:
```
Run complete. Total time: 00:08:05

Benchmark                                       Mode  Cnt   Score   Error  Units
IncrementalIndexAddRowsBenchmark.normalFloats   avgt   20  18.918 ± 3.063  us/op
IncrementalIndexAddRowsBenchmark.normalLongs    avgt   20  10.783 ± 0.394  us/op
IncrementalIndexAddRowsBenchmark.normalStrings  avgt   20  28.218 ± 2.513  us/op
```
Without patch, String dims only:
```
Run complete. Total time: 00:09:34

Benchmark                                       Mode  Cnt   Score   Error  Units
IncrementalIndexAddRowsBenchmark.normalFloats   avgt   20  19.977 ± 2.803  us/op
IncrementalIndexAddRowsBenchmark.normalLongs    avgt   20  20.520 ± 3.298  us/op
IncrementalIndexAddRowsBenchmark.normalStrings  avgt   20  29.656 ± 3.261  us/op
```