### PR TITLE
Adding custom mapper for json processing exception

### DIFF
--- a/server/src/main/java/io/druid/server/initialization/jetty/CustomExceptionMapper.java
+++ b/server/src/main/java/io/druid/server/initialization/jetty/CustomExceptionMapper.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.initialization.jetty;
+
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.google.common.collect.ImmutableMap;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class CustomExceptionMapper implements ExceptionMapper<JsonMappingException>
+{
+  @Override
+  public Response toResponse(JsonMappingException exception)
+  {
+    return Response.status(Response.Status.BAD_REQUEST)
+                   .entity(ImmutableMap.of(
+                       "error",
+                       exception.getMessage() == null ? "unknown json mapping exception" : exception.getMessage()
+                   ))
+                   .build();
+  }
+}

--- a/server/src/main/java/io/druid/server/initialization/jetty/JettyServerModule.java
+++ b/server/src/main/java/io/druid/server/initialization/jetty/JettyServerModule.java
@@ -73,6 +73,8 @@ public class JettyServerModule extends JerseyServletModule
 
     binder.bind(GuiceContainer.class).to(DruidGuiceContainer.class);
     binder.bind(DruidGuiceContainer.class).in(Scopes.SINGLETON);
+    binder.bind(CustomExceptionMapper.class).in(Singleton.class);
+
     serve("/*").with(DruidGuiceContainer.class);
 
     Jerseys.addResource(binder, StatusResource.class);


### PR DESCRIPTION
Custom exception mapper to return bad request instead of returning 500. 