### PR TITLE
if chathandler is noop, log using warn instead of info

### DIFF
--- a/server/src/main/java/io/druid/segment/realtime/firehose/EventReceiverFirehoseFactory.java
+++ b/server/src/main/java/io/druid/segment/realtime/firehose/EventReceiverFirehoseFactory.java
@@ -110,7 +110,7 @@ public class EventReceiverFirehoseFactory implements FirehoseFactory<MapInputRow
         chatHandlerProvider.get().register(serviceName.replaceAll(".*:", ""), firehose); // rofl
       }
     } else {
-      log.info("No chathandler detected");
+      log.warn("No chathandler detected");
     }
 
     eventReceiverFirehoseRegister.register(serviceName, firehose);


### PR DESCRIPTION
I suggest that if the info message "No chathandler detected" were changed to a warning, it might help people figure out what's wrong if they are using tranquility but have druid.indexer.task.chathandler.type set to noop instead of announcer.

This might be because they accidentally set it to noop, or (in a possible future) if they didn't set it at all and the default has gone back to being noop.

What reason is there for setting the type to noop?  I wonder if maybe it should be an error if that is done.

The history seems to be that the default was originally noop, then became announce in
https://github.com/druid-io/druid/commit/bf71d079f373a5f8761acb186472f89259612b5d
then went back to noop in
https://github.com/druid-io/druid/commit/7803ca07e7c9e291003fab3d1878945dc2a76eee
then went back to announce again in
https://github.com/druid-io/druid/commit/88858ea1c3fb462bb878c1379cf3eaa4bec80b27
and
https://github.com/druid-io/druid/pull/1552#issuecomment-124790486
