### PR TITLE
Fix for issue 2021.

### DIFF
--- a/docs/content/design/coordinator.md
+++ b/docs/content/design/coordinator.md
@@ -258,7 +258,7 @@ Optional Header Parameters for auditing the config change can also be specified.
 
 Disables a datasource.
 
-* `/druid/coordinator/v1/datasources/{dataSourceName}?kill=true&interval={myISO8601Interval}>`
+* `/druid/coordinator/v1/datasources/{dataSourceName}/intervals/{interval}?kill=true>`
 
 Runs a [Kill task](../misc/tasks.html) for a given interval and datasource.
 

--- a/docs/content/design/coordinator.md
+++ b/docs/content/design/coordinator.md
@@ -258,7 +258,8 @@ Optional Header Parameters for auditing the config change can also be specified.
 
 Disables a datasource.
 
-* `/druid/coordinator/v1/datasources/{dataSourceName}/intervals/{interval}?kill=true>`
+* `/druid/coordinator/v1/datasources/{dataSourceName}/intervals/{interval}?kill=true`
+* `@Deprecated. /druid/coordinator/v1/datasources/{dataSourceName}?kill=true&interval={myISO8601Interval}`
 
 Runs a [Kill task](../misc/tasks.html) for a given interval and datasource.
 

--- a/integration-tests/src/main/java/io/druid/testing/clients/CoordinatorResourceTestClient.java
+++ b/integration-tests/src/main/java/io/druid/testing/clients/CoordinatorResourceTestClient.java
@@ -74,7 +74,7 @@ public class CoordinatorResourceTestClient
 
   private String getLoadStatusURL()
   {
-      return String.format("%s%s", getCoordinatorURL(), "loadstatus");
+    return String.format("%s%s", getCoordinatorURL(), "loadstatus");
   }
 
   // return a list of the segment dates for the specified datasource
@@ -136,9 +136,9 @@ public class CoordinatorResourceTestClient
       makeRequest(
           HttpMethod.DELETE,
           String.format(
-              "%sdatasources/%s?kill=%s&interval=%s",
+              "%sdatasources/%s/intervals/%s?kill=%s",
               getCoordinatorURL(),
-              dataSource, kill, URLEncoder.encode(interval.toString(), "UTF-8")
+              dataSource, interval.toString().replace("/", "_"), kill
           )
       );
     }

--- a/server/src/main/java/io/druid/server/http/DatasourcesResource.java
+++ b/server/src/main/java/io/druid/server/http/DatasourcesResource.java
@@ -171,6 +171,42 @@ public class DatasourcesResource
   @Path("/{dataSourceName}")
   @Produces(MediaType.APPLICATION_JSON)
   public Response deleteDataSource(
+      @PathParam("dataSourceName") final String dataSourceName,
+      @QueryParam("kill") final String kill,
+      @QueryParam("interval") final String interval
+  )
+  {
+    if (indexingServiceClient == null) {
+      return Response.ok(ImmutableMap.of("error", "no indexing service found")).build();
+    }
+    if (kill != null && Boolean.valueOf(kill)) {
+      try {
+        indexingServiceClient.killSegments(dataSourceName, new Interval(interval));
+      }
+      catch (Exception e) {
+        return Response.serverError().entity(
+            ImmutableMap.of(
+                "error",
+                "Exception occurred. Are you sure you have an indexing service?"
+            )
+        )
+                       .build();
+      }
+    } else {
+      if (!databaseSegmentManager.removeDatasource(dataSourceName)) {
+        return Response.noContent().build();
+      }
+    }
+
+    return Response.ok().build();
+  }
+
+  /*
+  Uncomment this method once the method deleteSourceName (just above this) is deleted.
+  @DELETE
+  @Path("/{dataSourceName}")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response deleteDataSource(
       @PathParam("dataSourceName") final String dataSourceName
   )
   {
@@ -179,6 +215,7 @@ public class DatasourcesResource
     }
     return Response.ok().build();
   }
+  */
 
   @DELETE
   @Path("/{dataSourceName}/intervals/{interval}")
@@ -211,7 +248,7 @@ public class DatasourcesResource
     return Response.ok().build();
   }
 
-	@GET
+  @GET
   @Path("/{dataSourceName}/intervals")
   @Produces(MediaType.APPLICATION_JSON)
   public Response getSegmentDataSourceIntervals(

--- a/server/src/main/java/io/druid/server/http/DatasourcesResource.java
+++ b/server/src/main/java/io/druid/server/http/DatasourcesResource.java
@@ -168,6 +168,7 @@ public class DatasourcesResource
   }
 
   @DELETE
+  @Deprecated
   @Path("/{dataSourceName}")
   @Produces(MediaType.APPLICATION_JSON)
   public Response deleteDataSource(
@@ -200,22 +201,6 @@ public class DatasourcesResource
 
     return Response.ok().build();
   }
-
-  /*
-  Uncomment this method once the method deleteSourceName (just above this) is deleted.
-  @DELETE
-  @Path("/{dataSourceName}")
-  @Produces(MediaType.APPLICATION_JSON)
-  public Response deleteDataSource(
-      @PathParam("dataSourceName") final String dataSourceName
-  )
-  {
-    if (!databaseSegmentManager.removeDatasource(dataSourceName)) {
-      return Response.noContent().build();
-    }
-    return Response.ok().build();
-  }
-  */
 
   @DELETE
   @Path("/{dataSourceName}/intervals/{interval}")

--- a/server/src/main/java/io/druid/server/http/DatasourcesResource.java
+++ b/server/src/main/java/io/druid/server/http/DatasourcesResource.java
@@ -49,6 +49,7 @@ import org.joda.time.Interval;
 import javax.annotation.Nullable;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -167,62 +168,48 @@ public class DatasourcesResource
   }
 
   @DELETE
-	@Deprecated
   @Path("/{dataSourceName}")
   @Produces(MediaType.APPLICATION_JSON)
   public Response deleteDataSource(
+      @PathParam("dataSourceName") final String dataSourceName
+  )
+  {
+    if (!databaseSegmentManager.removeDatasource(dataSourceName)) {
+      return Response.noContent().build();
+    }
+    return Response.ok().build();
+  }
+
+  @DELETE
+  @Path("/{dataSourceName}/intervals/{interval}")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response deleteDataSourceSpecificInterval(
       @PathParam("dataSourceName") final String dataSourceName,
-      @QueryParam("kill") final String kill,
-      @QueryParam("interval") final String interval
+      @PathParam("interval") final String interval,
+      @QueryParam("kill") @DefaultValue("true") final String kill
   )
   {
     if (indexingServiceClient == null) {
       return Response.ok(ImmutableMap.of("error", "no indexing service found")).build();
     }
+    final Interval theInterval = new Interval(interval.replace("_", "/"));
     if (kill != null && Boolean.valueOf(kill)) {
       try {
-        indexingServiceClient.killSegments(dataSourceName, new Interval(interval));
+        indexingServiceClient.killSegments(dataSourceName, new Interval(theInterval));
       }
       catch (Exception e) {
-        return Response.serverError().entity(
-            ImmutableMap.of(
-                "error",
-                "Exception occurred. Are you sure you have an indexing service?"
-            )
-        )
+        return Response.serverError()
+                       .entity(ImmutableMap.of(
+                           "error",
+                           "Exception occurred. Are you sure you have an indexing service?"
+                       ))
                        .build();
       }
     } else {
-      if (!databaseSegmentManager.removeDatasource(dataSourceName)) {
-        return Response.noContent().build();
-      }
+      return Response.ok(ImmutableMap.of("error", "kill is set to false")).build();
     }
-
     return Response.ok().build();
   }
-
-	@DELETE
-	@Path("/{dataSourceName}/intervals/{interval}")
-	@Produces(MediaType.APPLICATION_JSON)
-	public Response deleteDataSourceSpecificInterval(@PathParam("dataSourceName") final String dataSourceName, @PathParam("interval") final String interval, @QueryParam("kill") final String kill)
-	{
-		if (indexingServiceClient == null) {
-			return Response.ok(ImmutableMap.of("error", "no indexing service found")).build();
-		}
-		final Interval theInterval = new Interval(interval.replace("_", "/"));
-		if (kill != null && Boolean.valueOf(kill)) {
-			try {
-				indexingServiceClient.killSegments(dataSourceName, new Interval(theInterval));
-			} catch (Exception e) {
-				return Response.serverError().entity(ImmutableMap.of("error", "Exception occurred. Are you sure you have an indexing service?")).build();
-			}
-		} else {
-			if (!databaseSegmentManager.removeDatasource(dataSourceName)) {
-				return Response.noContent().build();
-			}
-		}
-		return Response.ok().build();
-	}
 
 	@GET
   @Path("/{dataSourceName}/intervals")

--- a/server/src/test/java/io/druid/server/http/DatasourcesResourceTest.java
+++ b/server/src/test/java/io/druid/server/http/DatasourcesResourceTest.java
@@ -25,6 +25,7 @@ import io.druid.client.CoordinatorServerView;
 import io.druid.client.DruidDataSource;
 import io.druid.client.DruidServer;
 import io.druid.client.InventoryView;
+import io.druid.client.indexing.IndexingServiceClient;
 import io.druid.timeline.DataSegment;
 import org.easymock.EasyMock;
 import org.joda.time.Interval;
@@ -383,4 +384,22 @@ public class DatasourcesResourceTest
     }
     EasyMock.verify(inventoryView);
   }
+
+	@Test
+	public void testDeleteDataSourceSpecificInterval() throws Exception
+	{
+		String interval = "2010-01-01_P1D";
+		Interval theInterval = new Interval(interval.replace("_", "/"));
+
+		IndexingServiceClient indexingServiceClient = EasyMock.createStrictMock(IndexingServiceClient.class);
+		indexingServiceClient.killSegments("datasource1", theInterval);
+		EasyMock.expectLastCall().once();
+		EasyMock.replay(indexingServiceClient, server);
+
+		DatasourcesResource datasourcesResource = new DatasourcesResource(inventoryView, null, indexingServiceClient);
+		Response response = datasourcesResource.deleteDataSourceSpecificInterval("datasource1", interval, "true");
+		Assert.assertEquals(200, response.getStatus());
+		EasyMock.verify(indexingServiceClient, server);
+	}
+
 }

--- a/server/src/test/java/io/druid/server/http/DatasourcesResourceTest.java
+++ b/server/src/test/java/io/druid/server/http/DatasourcesResourceTest.java
@@ -424,22 +424,4 @@ public class DatasourcesResourceTest
     EasyMock.verify(indexingServiceClient, server);
   }
 
-  /*
-  Uncomment this unit test once the method testDeleteDataSource(string dataSourceName) is uncommented in class DatasourcesResource
-  @Test
-  public void testDeleteDataSource() throws Exception
-  {
-    MetadataSegmentManager databaseSegmentManager = EasyMock.createStrictMock(MetadataSegmentManager.class);
-    EasyMock.expect(databaseSegmentManager.removeDatasource("datasource1")).andReturn(true).atLeastOnce();
-    EasyMock.replay(server, databaseSegmentManager);
-
-    DatasourcesResource datasourcesResource = new DatasourcesResource(null, databaseSegmentManager, null);
-    Response response = datasourcesResource.deleteDataSource("datasource1");
-
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(null,response.getEntity());
-    EasyMock.verify(databaseSegmentManager, server);
-  }
-  */
-
 }

--- a/server/src/test/java/io/druid/server/http/DatasourcesResourceTest.java
+++ b/server/src/test/java/io/druid/server/http/DatasourcesResourceTest.java
@@ -402,7 +402,7 @@ public class DatasourcesResourceTest
     Response response = datasourcesResource.deleteDataSourceSpecificInterval("datasource1", interval, "true");
 
     Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(null,response.getEntity());
+    Assert.assertEquals(null, response.getEntity());
     EasyMock.verify(indexingServiceClient, server);
   }
 
@@ -424,6 +424,8 @@ public class DatasourcesResourceTest
     EasyMock.verify(indexingServiceClient, server);
   }
 
+  /*
+  Uncomment this unit test once the method testDeleteDataSource(string dataSourceName) is uncommented in class DatasourcesResource
   @Test
   public void testDeleteDataSource() throws Exception
   {
@@ -438,5 +440,6 @@ public class DatasourcesResourceTest
     Assert.assertEquals(null,response.getEntity());
     EasyMock.verify(databaseSegmentManager, server);
   }
+  */
 
 }


### PR DESCRIPTION
In order to ensure consistent handling of interval, this PR has:
Deleted old API supporting DELETE Operation: 
/druid/coordinator/v1/datasources/{dataSourceName}?kill=true&interval={myISO8601Interval}

Added new API to support following DELETE Operations:
 /druid/coordinator/v1/datasources/{dataSourceName}/intervals/{interval}?kill=true
Added a new API method for implementing this. 

Modified existing method to support only DELETE  /druid/coordinator/v1/datasources/{dataSourceName} operation instead of  performing the above two operations using same method.