### PR TITLE
ZooKeeper 3.4.7 was unreleased, revert to 3.4.6.

### DIFF
--- a/docs/content/tutorials/tutorial-a-first-look-at-druid.md
+++ b/docs/content/tutorials/tutorial-a-first-look-at-druid.md
@@ -95,7 +95,7 @@ This tutorial only requires Zookeeper be set up.
 * Install zookeeper.
 
 ```bash
-ZOOKEPER_VERSION=zookeeper-3.4.7
+ZOOKEPER_VERSION=zookeeper-3.4.6
 curl http://www.gtlib.gatech.edu/pub/apache/zookeeper/$ZOOKEPER_VERSION/$ZOOKEPER_VERSION.tar.gz -o $ZOOKEPER_VERSION.tar.gz
 tar xzf $ZOOKEPER_VERSION.tar.gz
 cd $ZOOKEPER_VERSION

--- a/docs/content/tutorials/tutorial-the-druid-cluster.md
+++ b/docs/content/tutorials/tutorial-the-druid-cluster.md
@@ -35,9 +35,9 @@ For deep storage, we will use the local disk in this tutorial, but for productio
 * Install zookeeper.
 
 ```bash
-curl http://www.gtlib.gatech.edu/pub/apache/zookeeper/zookeeper-3.4.7/zookeeper-3.4.7.tar.gz -o zookeeper-3.4.7.tar.gz
-tar xzf zookeeper-3.4.7.tar.gz
-cd zookeeper-3.4.7
+curl http://www.gtlib.gatech.edu/pub/apache/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz -o zookeeper-3.4.6.tar.gz
+tar xzf zookeeper-3.4.6.tar.gz
+cd zookeeper-3.4.6
 cp conf/zoo_sample.cfg conf/zoo.cfg
 ./bin/zkServer.sh start
 cd ..

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -18,9 +18,9 @@ RUN apt-get install -y mysql-server
 RUN apt-get install -y supervisor
 
 # Zookeeper
-RUN wget -q -O - http://www.us.apache.org/dist/zookeeper/zookeeper-3.4.7/zookeeper-3.4.7.tar.gz | tar -xzf - -C /usr/local \
-      && cp /usr/local/zookeeper-3.4.7/conf/zoo_sample.cfg /usr/local/zookeeper-3.4.7/conf/zoo.cfg \
-      && ln -s /usr/local/zookeeper-3.4.7 /usr/local/zookeeper
+RUN wget -q -O - http://www.us.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz | tar -xzf - -C /usr/local \
+      && cp /usr/local/zookeeper-3.4.6/conf/zoo_sample.cfg /usr/local/zookeeper-3.4.6/conf/zoo.cfg \
+      && ln -s /usr/local/zookeeper-3.4.6 /usr/local/zookeeper
 
 # Kafka
 RUN wget -q -O - http://www.us.apache.org/dist/kafka/0.8.2.0/kafka_2.10-0.8.2.0.tgz | tar -xzf - -C /usr/local \


### PR DESCRIPTION
3.4.7 is no longer available on mirrors so these commands do not work anymore.

See http://mail-archives.apache.org/mod_mbox/zookeeper-dev/201601.mbox/%3CCAMUR%3DWgzBso%3DpAYbjZUHLcaOH6UkcpA3zC699KfoEdG1KNkf%3DQ%40mail.gmail.com%3E, http://mail-archives.apache.org/mod_mbox/zookeeper-user/201601.mbox/%3C53F921C6-98A3-4360-9971-13968E558D8A%40apache.org%3E