### PR TITLE
updating doc regarding logging emitter feature to only log metrics or alerts

### DIFF
--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -134,6 +134,7 @@ The Druid servers emit various metrics and alerts via something we call an Emitt
 |--------|-----------|-------|
 |`druid.emitter.logging.loggerClass`|Choices: HttpPostEmitter, LoggingEmitter, NoopServiceEmitter, ServiceEmitter. The class used for logging.|LoggingEmitter|
 |`druid.emitter.logging.logLevel`|Choices: debug, info, warn, error. The log level at which message are logged.|info|
+|`druid.emitter.logging.eventsToLog`|Choices: METRICS, ALERTS or ALL. Type of events to log, others will be ignored.|ALL|
 
 #### Http Emitter Module
 

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
             <dependency>
                 <groupId>com.metamx</groupId>
                 <artifactId>emitter</artifactId>
-                <version>0.3.6</version>
+                <version>0.3.7</version>
             </dependency>
             <dependency>
                 <groupId>com.metamx</groupId>


### PR DESCRIPTION
depends on https://github.com/metamx/emitter/pull/17 and release of emitter-0.3.7 .