### PR TITLE
Make GranularityPathSpecTest check with lower-case enums

### DIFF
--- a/indexing-hadoop/src/test/java/io/druid/indexer/path/GranularityPathSpecTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/path/GranularityPathSpecTest.java
@@ -172,7 +172,8 @@ public class GranularityPathSpecTest
     sb.append(pathFormat);
     sb.append("\",");
     sb.append("\"dataGranularity\" : \"");
-    sb.append(granularity.toString());
+    // Double-check Jackson's lower-case enum support
+    sb.append(granularity.toString().toLowerCase());
     sb.append("\",");
     if(inputFormat != null) {
       sb.append("\"inputFormat\" : \"");


### PR DESCRIPTION
This question came up in https://github.com/druid-io/druid/pull/2296 and I wanted to make certain there was a test for it.