### PR TITLE
Throw an IAE when baseDir is null in LocalFireHose

### DIFF
--- a/server/src/main/java/io/druid/segment/realtime/firehose/LocalFirehoseFactory.java
+++ b/server/src/main/java/io/druid/segment/realtime/firehose/LocalFirehoseFactory.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
+import com.metamx.common.IAE;
 import com.metamx.common.ISE;
 import com.metamx.emitter.EmittingLogger;
 import io.druid.data.input.Firehose;
@@ -84,6 +85,9 @@ public class LocalFirehoseFactory implements FirehoseFactory<StringInputRowParse
   @Override
   public Firehose connect(StringInputRowParser firehoseParser) throws IOException
   {
+    if (baseDir == null) {
+      throw new IAE("baseDir is null");
+    }
     log.info("Searching for all [%s] in and beneath [%s]", filter, baseDir.getAbsoluteFile());
 
     Collection<File> foundFiles = FileUtils.listFiles(


### PR DESCRIPTION
I got a NPE when `baseDir` in `LocalFireHose` is null, which took me a little time to figure out the problem. I think it would be better checking whether `baseDir` is null and throw IAE in such case in order that people could get to know the reason quickly.

```
2016-01-20T16:10:53,344 INFO [task-runner-0] io.druid.indexing.common.actions.RemoteTaskActionClient - Performing action for task[index_wikipedia_2016-01-20T16:10:43.946Z]: LockListAction{}
2016-01-20T16:10:53,346 INFO [task-runner-0] io.druid.indexing.common.actions.RemoteTaskActionClient - Submitting action for task[index_wikipedia_2016-01-20T16:10:43.946Z] to overlord[http://211.197.218.220:8090/druid/indexer/v1/action]: LockListAction{}
2016-01-20T16:10:53,402 ERROR [task-runner-0] io.druid.indexing.overlord.ThreadPoolTaskRunner - Exception while running task[IndexTask{id=index_wikipedia_2016-01-20T16:10:43.946Z, type=index, dataSource=wikipedia}]
java.lang.NullPointerException
	at io.druid.segment.realtime.firehose.LocalFirehoseFactory.connect(LocalFirehoseFactory.java:87) ~[druid-server-0.9.0-SNAPSHOT.jar:0.9.0-SNAPSHOT]
	at io.druid.segment.realtime.firehose.LocalFirehoseFactory.connect(LocalFirehoseFactory.java:45) ~[druid-server-0.9.0-SNAPSHOT.jar:0.9.0-SNAPSHOT]
	at io.druid.indexing.common.task.IndexTask.getDataIntervals(IndexTask.java:239) ~[druid-indexing-service-0.9.0-SNAPSHOT.jar:0.9.0-SNAPSHOT]
	at io.druid.indexing.common.task.IndexTask.run(IndexTask.java:197) ~[druid-indexing-service-0.9.0-SNAPSHOT.jar:0.9.0-SNAPSHOT]
	at io.druid.indexing.overlord.ThreadPoolTaskRunner$ThreadPoolTaskRunnerCallable.call(ThreadPoolTaskRunner.java:288) [druid-indexing-service-0.9.0-SNAPSHOT.jar:0.9.0-SNAPSHOT]
	at io.druid.indexing.overlord.ThreadPoolTaskRunner$ThreadPoolTaskRunnerCallable.call(ThreadPoolTaskRunner.java:268) [druid-indexing-service-0.9.0-SNAPSHOT.jar:0.9.0-SNAPSHOT]
	at java.util.concurrent.FutureTask.run(FutureTask.java:262) [?:1.7.0_71]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [?:1.7.0_71]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [?:1.7.0_71]
	at java.lang.Thread.run(Thread.java:745) [?:1.7.0_71]
2016-01-20T16:10:53,412 INFO [task-runner-0] io.druid.indexing.worker.executor.ExecutorLifecycle - Task completed with status: {
  "id" : "index_wikipedia_2016-01-20T16:10:43.946Z",
  "status" : "FAILED",
  "duration" : 65
}
```

```
    "ioConfig": {
      "type": "index",
      "firehose": {
        "type": "local",
        "baseDir": "",
        "filter": "wikipedia_data.json"
      }
    }
```
 