### PR TITLE
Add StorageAdapter#getColumnTypeName, and various SegmentMetadataQuery adjustments

### DIFF
--- a/docs/content/querying/segmentmetadataquery.md
+++ b/docs/content/querying/segmentmetadataquery.md
@@ -39,19 +39,22 @@ The format of the result is:
   "id" : "some_id",
   "intervals" : [ "2013-05-13T00:00:00.000Z/2013-05-14T00:00:00.000Z" ],
   "columns" : {
-    "__time" : { "type" : "LONG", "size" : 407240380, "cardinality" : null },
-    "dim1" : { "type" : "STRING", "size" : 100000, "cardinality" : 1944 },
-    "dim2" : { "type" : "STRING", "size" : 100000, "cardinality" : 1504 },
-    "metric1" : { "type" : "FLOAT", "size" : 100000, "cardinality" : null }
+    "__time" : { "type" : "LONG", "hasMultipleValues" : false, "size" : 407240380, "cardinality" : null, "errorMessage" : null },
+    "dim1" : { "type" : "STRING", "hasMultipleValues" : false, "size" : 100000, "cardinality" : 1944, "errorMessage" : null },
+    "dim2" : { "type" : "STRING", "hasMultipleValues" : true, "size" : 100000, "cardinality" : 1504, "errorMessage" : null },
+    "metric1" : { "type" : "FLOAT", "hasMultipleValues" : false, "size" : 100000, "cardinality" : null, "errorMessage" : null }
   },
   "size" : 300000,
   "numRows" : 5000000
 } ]
 ```
 
-Dimension columns will have type `STRING`.  
+Dimension columns will have type `STRING`.
 Metric columns will have type `FLOAT` or `LONG` or name of the underlying complex type such as `hyperUnique` in case of COMPLEX metric.
 Timestamp column will have type `LONG`.
+
+If the `errorMessage` field is non-null, you should not trust the other fields in the response. Their contents are
+undefined.
 
 Only columns which are dimensions (ie, have type `STRING`) will have any cardinality. Rest of the columns (timestamp and metric columns) will show cardinality as `null`.
 

--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
@@ -148,7 +148,7 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
             }
 
             List<Interval> newIntervals = null;
-            if (query.hasInterval()) {
+            if (query.analyzingInterval()) {
               //List returned by arg1.getIntervals() is immutable, so a new list needs to
               //be created.
               newIntervals = new ArrayList<>(arg1.getIntervals());

--- a/processing/src/main/java/io/druid/query/metadata/metadata/SegmentAnalysis.java
+++ b/processing/src/main/java/io/druid/query/metadata/metadata/SegmentAnalysis.java
@@ -98,6 +98,7 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
     return "SegmentAnalysis{" +
            "id='" + id + '\'' +
            ", interval=" + interval +
+           ", columns=" + columns +
            ", size=" + size +
            ", numRows=" + numRows +
            '}';

--- a/processing/src/main/java/io/druid/query/metadata/metadata/SegmentMetadataQuery.java
+++ b/processing/src/main/java/io/druid/query/metadata/metadata/SegmentMetadataQuery.java
@@ -151,22 +151,12 @@ public class SegmentMetadataQuery extends BaseQuery<SegmentAnalysis>
   }
 
   @JsonProperty
-  public EnumSet getAnalysisTypes()
+  public EnumSet<AnalysisType> getAnalysisTypes()
   {
     return analysisTypes;
   }
 
-  public boolean hasCardinality()
-  {
-    return analysisTypes.contains(AnalysisType.CARDINALITY);
-  }
-
-  public boolean hasSize()
-  {
-    return analysisTypes.contains(AnalysisType.SIZE);
-  }
-
-  public boolean hasInterval()
+  public boolean analyzingInterval()
   {
     return analysisTypes.contains(AnalysisType.INTERVAL);
   }

--- a/processing/src/main/java/io/druid/segment/QueryableIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/QueryableIndexStorageAdapter.java
@@ -153,6 +153,14 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
   }
 
   @Override
+  public String getColumnTypeName(String columnName)
+  {
+    final Column column = index.getColumn(columnName);
+    final ComplexColumn complexColumn = column.getComplexColumn();
+    return complexColumn != null ? complexColumn.getTypeName() : column.getCapabilities().getType().toString();
+  }
+
+  @Override
   public DateTime getMaxIngestedEventTime()
   {
     // For immutable indexes, maxIngestedEventTime is maxTime.

--- a/processing/src/main/java/io/druid/segment/StorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/StorageAdapter.java
@@ -46,6 +46,13 @@ public interface StorageAdapter extends CursorFactory
   public DateTime getMaxTime();
   public Capabilities getCapabilities();
   public ColumnCapabilities getColumnCapabilities(String column);
+
+  /**
+   * Like {@link ColumnCapabilities#getType()}, but may return a more descriptive string for complex columns.
+   * @param column column name
+   * @return type name
+   */
+  public String getColumnTypeName(String column);
   public int getNumRows();
   public DateTime getMaxIngestedEventTime();
 }

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -569,7 +569,8 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
 
   public String getMetricType(String metric)
   {
-    return metricDescs.get(metric).getType();
+    final MetricDesc metricDesc = metricDescs.get(metric);
+    return metricDesc != null ? metricDesc.getType() : null;
   }
 
   public Interval getInterval()

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
@@ -148,6 +148,13 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
   }
 
   @Override
+  public String getColumnTypeName(String column)
+  {
+    final String metricType = index.getMetricType(column);
+    return metricType != null ? metricType : getColumnCapabilities(column).getType().toString();
+  }
+
+  @Override
   public DateTime getMaxIngestedEventTime()
   {
     return index.getMaxIngestedEventTime();

--- a/processing/src/test/java/io/druid/query/QueryRunnerTestHelper.java
+++ b/processing/src/test/java/io/druid/query/QueryRunnerTestHelper.java
@@ -310,15 +310,13 @@ public class QueryRunnerTestHelper
   )
       throws IOException
   {
-    final IncrementalIndex rtIndex = TestIndex.getIncrementalTestIndex(false);
+    final IncrementalIndex rtIndex = TestIndex.getIncrementalTestIndex();
     final QueryableIndex mMappedTestIndex = TestIndex.getMMappedTestIndex();
     final QueryableIndex mergedRealtimeIndex = TestIndex.mergedRealtimeIndex();
-    final IncrementalIndex rtIndexOffheap = TestIndex.getIncrementalTestIndex(true);
     return ImmutableList.of(
         makeQueryRunner(factory, new IncrementalIndexSegment(rtIndex, segmentId)),
         makeQueryRunner(factory, new QueryableIndexSegment(segmentId, mMappedTestIndex)),
-        makeQueryRunner(factory, new QueryableIndexSegment(segmentId, mergedRealtimeIndex)),
-        makeQueryRunner(factory, new IncrementalIndexSegment(rtIndexOffheap, segmentId))
+        makeQueryRunner(factory, new QueryableIndexSegment(segmentId, mergedRealtimeIndex))
     );
   }
 
@@ -329,10 +327,9 @@ public class QueryRunnerTestHelper
   )
       throws IOException
   {
-    final IncrementalIndex rtIndex = TestIndex.getIncrementalTestIndex(false);
+    final IncrementalIndex rtIndex = TestIndex.getIncrementalTestIndex();
     final QueryableIndex mMappedTestIndex = TestIndex.getMMappedTestIndex();
     final QueryableIndex mergedRealtimeIndex = TestIndex.mergedRealtimeIndex();
-    final IncrementalIndex rtIndexOffheap = TestIndex.getIncrementalTestIndex(true);
 
     return Arrays.asList(
         makeUnionQueryRunner(factory, new IncrementalIndexSegment(rtIndex, segmentId)),
@@ -340,8 +337,7 @@ public class QueryRunnerTestHelper
         makeUnionQueryRunner(
             factory,
             new QueryableIndexSegment(segmentId, mergedRealtimeIndex)
-        ),
-        makeUnionQueryRunner(factory, new IncrementalIndexSegment(rtIndexOffheap, segmentId))
+        )
     );
   }
   /**

--- a/processing/src/test/java/io/druid/query/metadata/SegmentAnalyzerTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentAnalyzerTest.java
@@ -59,7 +59,7 @@ public class SegmentAnalyzerTest
   private void testIncrementalWorksHelper(EnumSet<SegmentMetadataQuery.AnalysisType> analyses) throws Exception
   {
     final List<SegmentAnalysis> results = getSegmentAnalysises(
-        new IncrementalIndexSegment(TestIndex.getIncrementalTestIndex(false), null),
+        new IncrementalIndexSegment(TestIndex.getIncrementalTestIndex(), null),
         analyses
     );
 

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
@@ -67,6 +67,7 @@ public class SegmentMetadataQueryQueryToolChestTest
             "placement",
             new ColumnAnalysis(
                 ValueType.STRING.toString(),
+                true,
                 10881,
                 1,
                 null

--- a/processing/src/test/java/io/druid/query/search/SearchQueryRunnerWithCaseTest.java
+++ b/processing/src/test/java/io/druid/query/search/SearchQueryRunnerWithCaseTest.java
@@ -83,8 +83,8 @@ public class SearchQueryRunnerWithCaseTest
         "2011-01-13T00:00:00.000Z\tspot\tautomotive\tpreferred\ta\u0001preferred\t94.874713"
     );
 
-    IncrementalIndex index1 = TestIndex.makeRealtimeIndex(input, true);
-    IncrementalIndex index2 = TestIndex.makeRealtimeIndex(input, false);
+    IncrementalIndex index1 = TestIndex.makeRealtimeIndex(input);
+    IncrementalIndex index2 = TestIndex.makeRealtimeIndex(input);
 
     QueryableIndex index3 = TestIndex.persistRealtimeAndLoadMMapped(index1);
     QueryableIndex index4 = TestIndex.persistRealtimeAndLoadMMapped(index2);

--- a/processing/src/test/java/io/druid/query/topn/TopNQueryQueryToolChestTest.java
+++ b/processing/src/test/java/io/druid/query/topn/TopNQueryQueryToolChestTest.java
@@ -121,7 +121,7 @@ public class TopNQueryQueryToolChestTest
     );
     QueryRunner<Result<TopNResultValue>> runner = QueryRunnerTestHelper.makeQueryRunner(
         factory,
-        new IncrementalIndexSegment(TestIndex.getIncrementalTestIndex(false), segmentId)
+        new IncrementalIndexSegment(TestIndex.getIncrementalTestIndex(), segmentId)
     );
 
     Map<String, Object> context = Maps.newHashMap();

--- a/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerBenchmark.java
+++ b/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerBenchmark.java
@@ -106,7 +106,7 @@ public class TopNQueryRunnerBenchmark extends AbstractBenchmark
         TestCases.rtIndex,
         QueryRunnerTestHelper.makeQueryRunner(
             factory,
-            new IncrementalIndexSegment(TestIndex.getIncrementalTestIndex(false), segmentId)
+            new IncrementalIndexSegment(TestIndex.getIncrementalTestIndex(), segmentId)
         )
     );
     testCaseMap.put(
@@ -121,13 +121,6 @@ public class TopNQueryRunnerBenchmark extends AbstractBenchmark
         QueryRunnerTestHelper.makeQueryRunner(
             factory,
             new QueryableIndexSegment(segmentId, TestIndex.mergedRealtimeIndex())
-        )
-    );
-    testCaseMap.put(
-        TestCases.rtIndexOffheap,
-        QueryRunnerTestHelper.makeQueryRunner(
-            factory,
-            new IncrementalIndexSegment(TestIndex.getIncrementalTestIndex(true), segmentId)
         )
     );
     //Thread.sleep(10000);

--- a/processing/src/test/java/io/druid/segment/TestIndex.java
+++ b/processing/src/test/java/io/druid/segment/TestIndex.java
@@ -70,7 +70,7 @@ public class TestIndex
       "placementish",
       "partial_null_column",
       "null_column",
-  };
+      };
   public static final String[] METRICS = new String[]{"index"};
   private static final Logger log = new Logger(TestIndex.class);
   private static final Interval DATA_INTERVAL = new Interval("2011-01-12T00:00:00.000Z/2011-05-01T00:00:00.000Z");
@@ -93,7 +93,7 @@ public class TestIndex
   private static QueryableIndex mmappedIndex = null;
   private static QueryableIndex mergedRealtime = null;
 
-  public static IncrementalIndex getIncrementalTestIndex(boolean useOffheap)
+  public static IncrementalIndex getIncrementalTestIndex()
   {
     synchronized (log) {
       if (realtimeIndex != null) {
@@ -101,7 +101,7 @@ public class TestIndex
       }
     }
 
-    return realtimeIndex = makeRealtimeIndex("druid.sample.tsv", useOffheap);
+    return realtimeIndex = makeRealtimeIndex("druid.sample.tsv");
   }
 
   public static QueryableIndex getMMappedTestIndex()
@@ -112,7 +112,7 @@ public class TestIndex
       }
     }
 
-    IncrementalIndex incrementalIndex = getIncrementalTestIndex(false);
+    IncrementalIndex incrementalIndex = getIncrementalTestIndex();
     mmappedIndex = persistRealtimeAndLoadMMapped(incrementalIndex);
 
     return mmappedIndex;
@@ -126,8 +126,8 @@ public class TestIndex
       }
 
       try {
-        IncrementalIndex top = makeRealtimeIndex("druid.sample.tsv.top", false);
-        IncrementalIndex bottom = makeRealtimeIndex("druid.sample.tsv.bottom", false);
+        IncrementalIndex top = makeRealtimeIndex("druid.sample.tsv.top");
+        IncrementalIndex bottom = makeRealtimeIndex("druid.sample.tsv.bottom");
 
         File tmpFile = File.createTempFile("yay", "who");
         tmpFile.delete();
@@ -163,7 +163,7 @@ public class TestIndex
     }
   }
 
-  private static IncrementalIndex makeRealtimeIndex(final String resourceFilename, final boolean useOffheap)
+  private static IncrementalIndex makeRealtimeIndex(final String resourceFilename)
   {
     final URL resource = TestIndex.class.getClassLoader().getResource(resourceFilename);
     if (resource == null) {
@@ -171,10 +171,10 @@ public class TestIndex
     }
     log.info("Realtime loading index file[%s]", resource);
     CharSource stream = Resources.asByteSource(resource).asCharSource(Charsets.UTF_8);
-    return makeRealtimeIndex(stream, useOffheap);
+    return makeRealtimeIndex(stream);
   }
 
-  public static IncrementalIndex makeRealtimeIndex(final CharSource source, final boolean useOffheap)
+  public static IncrementalIndex makeRealtimeIndex(final CharSource source)
   {
     final IncrementalIndexSchema schema = new IncrementalIndexSchema.Builder()
         .withMinTimestamp(new DateTime("2011-01-12T00:00:00.000Z").getMillis())


### PR DESCRIPTION
Added StorageAdapter#getColumnTypeName

Also segmentMetadataQuery stuff:

- Simplify implementation of SegmentAnalyzer.
- Fix type names for realtime complex columns; this used to try to merge a nice type
  name (like "hyperUnique") from mmapped segments with the word "COMPLEX" from incremental
  index segments, leading to a merge failure. Now it always uses the nice name.
- Add hasMultipleValues to ColumnAnalysis.
- Add tests for both mmapped and incremental index segments.
- Update docs to include errorMessage.