### PR TITLE
Replace two-column index on pendingSegments table with one-column index.

### DIFF
--- a/server/src/main/java/io/druid/metadata/SQLMetadataConnector.java
+++ b/server/src/main/java/io/druid/metadata/SQLMetadataConnector.java
@@ -197,9 +197,10 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
                 + "  \"end\" VARCHAR(255) NOT NULL,\n"
                 + "  sequence_name VARCHAR(255) NOT NULL,\n"
                 + "  sequence_prev_id VARCHAR(255) NOT NULL,\n"
+                + "  sequence_name_prev_id_sha1 VARCHAR(255) NOT NULL,\n"
                 + "  payload %2$s NOT NULL,\n"
                 + "  PRIMARY KEY (id),\n"
-                + "  UNIQUE (sequence_name, sequence_prev_id)\n"
+                + "  UNIQUE (sequence_name_prev_id_sha1)\n"
                 + ")",
                 tableName, getPayloadType()
             )


### PR DESCRIPTION
Fixes #2319. Note that this change is not backwards compatible, but the table being changed was never in a release, so I think that's okay.

Anyone that already has this table could update its schema (assuming MySQL) by running:

```
ALTER TABLE druid_pendingSegments ADD COLUMN sequence_name_prev_id_sha1 VARCHAR(255) NOT NULL;
ALTER TABLE druid_pendingSegments ADD UNIQUE KEY (sequence_name_prev_id_sha1);
ALTER TABLE druid_pendingSegments DROP INDEX `sequence_name`;
```