### PR TITLE
[fix doc]: Coordinator druid.coordinator.merge.on triggers an Append Task

### DIFF
--- a/docs/content/configuration/coordinator.md
+++ b/docs/content/configuration/coordinator.md
@@ -82,7 +82,7 @@ Issuing a GET request at the same URL will return the spec that is currently in 
 |--------|-----------|-------|
 |`millisToWaitBeforeDeleting`|How long does the coordinator need to be active before it can start removing (marking unused) segments in metadata storage.|900000 (15 mins)|
 |`mergeBytesLimit`|The maximum number of bytes to merge (for segments).|524288000L|
-|`mergeSegmentsLimit`|The maximum number of segments that can be in a single [merge task](../misc/tasks.html).|100|
+|`mergeSegmentsLimit`|The maximum number of segments that can be in a single [append task](../misc/tasks.html).|100|
 |`maxSegmentsToMove`|The maximum number of segments that can be moved at any given time.|5|
 |`replicantLifetime`|The maximum number of coordinator runs for a segment to be replicated before we start alerting.|15|
 |`replicationThrottleLimit`|The maximum number of segments that can be replicated at one time.|10|


### PR DESCRIPTION
Setting druid.coordinator.merge.on=true actually triggers an Append Task instead of Merge Task