### PR TITLE
Fix a couple of problems with lookups

### DIFF
--- a/extensions/namespace-lookup/src/main/java/io/druid/query/extraction/NamespacedExtractor.java
+++ b/extensions/namespace-lookup/src/main/java/io/druid/query/extraction/NamespacedExtractor.java
@@ -49,7 +49,7 @@ public class NamespacedExtractor extends LookupExtractor
   public NamespacedExtractor(
       @NotNull @JacksonInject @Named("dimExtractionNamespace")
       final Function<String, Function<String, String>> namespaces,
-      @NotNull @JacksonInject @Named("reverseDimExtractionNamespace")
+      @NotNull @JacksonInject @Named("dimReverseExtractionNamespace")
       final Function<String, Function<String, List<String>>> reverseNamespaces,
       @NotNull @JsonProperty(value = "namespace", required = true)
       final String namespace

--- a/processing/src/main/java/io/druid/query/extraction/LookupExtractor.java
+++ b/processing/src/main/java/io/druid/query/extraction/LookupExtractor.java
@@ -44,7 +44,7 @@ public abstract class LookupExtractor
    * @return The lookup, or null key cannot have the lookup applied to it and should be treated as missing.
    */
   @Nullable
-  abstract String apply(@NotNull String key);
+  public abstract String apply(@NotNull String key);
 
   /**
    * @param keys set of keys to apply lookup for each element
@@ -54,7 +54,7 @@ public abstract class LookupExtractor
    * User can override this method if there is a better way to perform bulk lookup
    */
 
-  Map<String, String> applyAll(Iterable<String> keys)
+  public Map<String, String> applyAll(Iterable<String> keys)
   {
     if (keys == null) {
       return Collections.emptyMap();
@@ -88,7 +88,7 @@ public abstract class LookupExtractor
    * User can override this method if there is a better way to perform bulk reverse lookup
    */
 
-  Map<String, List<String>> unapplyAll(Iterable<String> values)
+  public Map<String, List<String>> unapplyAll(Iterable<String> values)
   {
     if (values == null) {
       return Collections.emptyMap();
@@ -107,5 +107,5 @@ public abstract class LookupExtractor
    */
 
   @Nullable
-  abstract byte[] getCacheKey();
+  public abstract byte[] getCacheKey();
 }


### PR DESCRIPTION
1. LookupExtractor abstract methods need to be public, led to AbstractMethodError at runtime when using implementations from extensions (like NamespacedExtractor). The jvm does not allow overrides of package-private methods across classloaders.
2. `dimReverseExtractionNamespace` in NamespacedExtractor was spelled wrong, led to guice inject failure at runtime.