### PR TITLE
Add missing timeline test for VersionedIntervalTimelineTest

### DIFF
--- a/common/src/test/java/io/druid/timeline/VersionedIntervalTimelineTest.java
+++ b/common/src/test/java/io/druid/timeline/VersionedIntervalTimelineTest.java
@@ -1495,6 +1495,16 @@ public class VersionedIntervalTimelineTest
     );
   }
 
+  @Test
+  public void testNotFoundReturnsEmpty() throws Exception
+  {
+    timeline = makeStringIntegerTimeline();
+
+    add("2011-04-01/2011-04-09", "1", 1);
+
+    Assert.assertTrue(timeline.lookup(Interval.parse("1970/1980")).isEmpty());
+  }
+  
   private Pair<Interval, Pair<String, PartitionHolder<Integer>>> createExpected(
       String intervalString,
       String version,


### PR DESCRIPTION
This seems assumed in several places but I couldn't find an explicit check for it.