### PR TITLE
new local lru cache

### DIFF
--- a/server/src/main/java/io/druid/client/cache/LocalCacheProvider.java
+++ b/server/src/main/java/io/druid/client/cache/LocalCacheProvider.java
@@ -37,11 +37,15 @@ public class LocalCacheProvider implements CacheProvider
 
   @JsonProperty
   @Min(0)
+  private int concurrencyLevel = 4;
+
+  @JsonProperty
+  @Min(0)
   private int logEvictionCount = 0;
 
   @Override
   public Cache get()
   {
-    return new MapCache(new ByteCountingLRUMap(initialSize, logEvictionCount, sizeInBytes));
+    return new MapCache(new ByteCountingLRUMap(initialSize, concurrencyLevel, logEvictionCount, sizeInBytes));
   }
 }

--- a/server/src/test/java/io/druid/client/cache/ByteCountingLRUMapTest.java
+++ b/server/src/test/java/io/druid/client/cache/ByteCountingLRUMapTest.java
@@ -65,8 +65,13 @@ public class ByteCountingLRUMapTest
     Assert.assertEquals(ByteBuffer.wrap(eightyEightVal), ByteBuffer.wrap(map.get(tenKey)));
 
     map.put(twoByte, oneByte.array());
-    assertMapValues(2, 101, 2);
-    Assert.assertEquals(ByteBuffer.wrap(eightyEightVal), ByteBuffer.wrap(map.get(tenKey)));
+    assertMapValues(1, 3, 3);
+    Assert.assertNull(map.get(tenKey));
+    Assert.assertEquals(oneByte, ByteBuffer.wrap(map.get(twoByte)));
+
+    map.put(tenKey, twoByte.array());
+    assertMapValues(2, 15, 3);
+    Assert.assertEquals(twoByte, ByteBuffer.wrap(map.get(tenKey)));
     Assert.assertEquals(oneByte, ByteBuffer.wrap(map.get(twoByte)));
 
     Iterator<ByteBuffer> it = map.keySet().iterator();
@@ -80,10 +85,10 @@ public class ByteCountingLRUMapTest
     for(ByteBuffer buf : toRemove) {
       map.remove(buf);
     }
-    assertMapValues(1, 3, 2);
+    assertMapValues(1, 3, 4);
 
     map.remove(twoByte);
-    assertMapValues(0, 0, 2);
+    assertMapValues(0, 0, 5);
   }
 
   private void assertMapValues(final int size, final int numBytes, final int evictionCount)


### PR DESCRIPTION
When we set Historical cache to the flowing Configuration
```
druid.cache.type=local
druid.cache.sizeInBytes=2000000000 //almost 2G
```
we find the historical have 5.6G of cache data.

And when we change to 
```
druid.cache.type=local
druid.cache.sizeInBytes=500000000 //almost 500M
```
we find the historical have 2G of cache data.

Historical cache data is larger than the configured druid.cache.sizeInBytes.