### PR TITLE
Fix NPE caused by stopping a RealtimeIndexTask before firehose connects

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/overlord/ThreadPoolTaskRunner.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/ThreadPoolTaskRunner.java
@@ -144,7 +144,7 @@ public class ThreadPoolTaskRunner implements TaskRunner, QuerySegmentWalker
              .addData("taskId", task.getId())
              .addData("dataSource", task.getDataSource())
              .emit();
-          log.warn(e, "Graceful shutdown of task[%s] aborted with exception.");
+          log.warn(e, "Graceful shutdown of task[%s] aborted with exception.", task.getId());
           error = true;
         }
       } else {

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/RealtimeIndexTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/RealtimeIndexTaskTest.java
@@ -536,6 +536,22 @@ public class RealtimeIndexTaskTest
     }
   }
 
+  @Test(timeout = 10000L)
+  public void testStopBeforeStarting() throws Exception
+  {
+    final File directory = tempFolder.newFolder();
+    final RealtimeIndexTask task1 = makeRealtimeTask(null);
+
+    task1.stopGracefully();
+    final TestIndexerMetadataStorageCoordinator mdc = new TestIndexerMetadataStorageCoordinator();
+    final TaskToolbox taskToolbox = makeToolbox(task1, mdc, directory);
+    final ListenableFuture<TaskStatus> statusFuture = runTask(task1, taskToolbox);
+
+    // Wait for the task to finish.
+    final TaskStatus taskStatus = statusFuture.get();
+    Assert.assertEquals(TaskStatus.Status.SUCCESS, taskStatus.getStatusCode());
+  }
+
   private ListenableFuture<TaskStatus> runTask(final Task task, final TaskToolbox toolbox)
   {
     return taskExec.submit(


### PR DESCRIPTION
Exception was on `firehose.close()`

```
java.lang.NullPointerException
	at io.druid.indexing.common.task.RealtimeIndexTask.stopGracefully(RealtimeIndexTask.java:452)
```

Also, fix the log message that logs this so it actually properly shows the task id instead of [%s]. (in a separate commit)