### PR TITLE
Remove incorrect comment.

### DIFF
--- a/extensions/cloudfiles-extensions/src/main/java/io/druid/storage/cloudfiles/CloudFilesDataSegmentPuller.java
+++ b/extensions/cloudfiles-extensions/src/main/java/io/druid/storage/cloudfiles/CloudFilesDataSegmentPuller.java
@@ -34,9 +34,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
-/**
- * A data segment puller that also handles URI data pulls.
- */
 public class CloudFilesDataSegmentPuller implements DataSegmentPuller
 {
 


### PR DESCRIPTION
The CloudFilesDataSegmentPuller can't handle URI data pulls.
This comment was obviously copied from the s3 module and never removed.