### PR TITLE
Fixed the broken link in the doc (other-hadoop.html)

### DIFF
--- a/docs/content/operations/other-hadoop.md
+++ b/docs/content/operations/other-hadoop.md
@@ -76,7 +76,7 @@ Another workaround solution is to build a custom fat jar of Druid using [sbt](ht
 
 (2) Make a new directory named 'druid_build'.
 
-(3) Cd to 'druid_build' and create the build.sbt file with the content [here](./use_sbt_to_build_fat_jar.md).
+(3) Cd to 'druid_build' and create the build.sbt file with the content [here](./use_sbt_to_build_fat_jar.html).
 
 You can always add more building targets or remove the ones you don't need.
 


### PR DESCRIPTION
This fixes the link in http://druid.io/docs/latest/operations/other-hadoop.html
The fixed link : 
http://druid.io/docs/latest/operations/use_sbt_to_build_fat_jar.md => http://druid.io/docs/latest/operations/use_sbt_to_build_fat_jar.html