### PR TITLE
[bugfix] loading LONG metrics in LegacyIndexLoader

### DIFF
--- a/processing/src/main/java/io/druid/segment/IndexIO.java
+++ b/processing/src/main/java/io/druid/segment/IndexIO.java
@@ -951,7 +951,15 @@ public class IndexIO
 
       for (String metric : index.getAvailableMetrics()) {
         final MetricHolder metricHolder = index.getMetricHolder(metric);
-        if (metricHolder.getType() == MetricHolder.MetricType.FLOAT) {
+        if (metricHolder.getType() == MetricHolder.MetricType.LONG) {
+          columns.put(
+              metric,
+              new ColumnBuilder()
+                  .setType(ValueType.LONG)
+                  .setGenericColumn(new LongGenericColumnSupplier(metricHolder.longType))
+                  .build()
+          );
+        } else if (metricHolder.getType() == MetricHolder.MetricType.FLOAT) {
           columns.put(
               metric,
               new ColumnBuilder()


### PR DESCRIPTION
Currently, there is a possible bug in LegacyIndexLoader loading metrics of `LONG`. When segments whose versions are earlier than v9 are loaded, metrics of LONG are missed out. Querying on these segments will give result of all zeros for those missing LONG metrics. I tested this by producing v8 segments 'manually'.