### PR TITLE
[WIP] segment management using HTTP Endpoints

### DIFF
--- a/server/src/main/java/io/druid/server/coordination/SegmentManager.java
+++ b/server/src/main/java/io/druid/server/coordination/SegmentManager.java
@@ -1,0 +1,515 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.coordination;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Queues;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.metamx.common.ISE;
+import com.metamx.common.concurrent.ScheduledExecutorFactory;
+import com.metamx.common.lifecycle.LifecycleStart;
+import com.metamx.common.lifecycle.LifecycleStop;
+import com.metamx.emitter.EmittingLogger;
+import io.druid.concurrent.Execs;
+import io.druid.segment.loading.SegmentLoaderConfig;
+import io.druid.segment.loading.SegmentLoadingException;
+import io.druid.server.initialization.ZkPathsConfig;
+import io.druid.timeline.DataSegment;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.PathChildrenCache;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
+import org.apache.curator.utils.ZKPaths;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ */
+@Singleton
+public class SegmentManager implements DataSegmentChangeHandler
+{
+  private static final EmittingLogger log = new EmittingLogger(SegmentManager.class);
+
+  private final Object lock = new Object();
+
+  private final ObjectMapper jsonMapper;
+  private final SegmentLoaderConfig config;
+  private final DruidServerMetadata me;
+  private final DataSegmentAnnouncer announcer;
+  private final ServerManager serverManager;
+  private final ScheduledExecutorService exec;
+  private final ConcurrentSkipListSet<DataSegment> segmentsToDelete;
+
+
+  private volatile boolean started = false;
+
+  @Inject
+  public SegmentManager(
+      ObjectMapper jsonMapper,
+      SegmentLoaderConfig config,
+      DruidServerMetadata me,
+      DataSegmentAnnouncer announcer,
+      ServerManager serverManager,
+      ScheduledExecutorFactory factory
+  )
+  {
+    this.jsonMapper = jsonMapper;
+    this.config = config;
+    this.me = me;
+    this.announcer = announcer;
+    this.serverManager = serverManager;
+
+    this.exec = factory.create(1, "SegmentManager-Exec--%d");
+    this.segmentsToDelete = new ConcurrentSkipListSet<>();
+  }
+
+  @LifecycleStart
+  public void start() throws IOException
+  {
+    synchronized (lock) {
+      if (started) {
+        return;
+      }
+
+      log.info("Starting SegmentManager for server[%s]", me.getName());
+      loadLocalCache();
+      started = true;
+    }
+  }
+
+  @LifecycleStop
+  public void stop()
+  {
+    log.info("Stopping SegmentManager for [%s]", me);
+    synchronized (lock) {
+      if (!started) {
+        return;
+      }
+      started = false;
+    }
+  }
+
+  public boolean isStarted()
+  {
+    return started;
+  }
+
+  public void loadLocalCache()
+  {
+    final long start = System.currentTimeMillis();
+    File baseDir = config.getInfoDir();
+    if (!baseDir.exists() && !config.getInfoDir().mkdirs()) {
+      return;
+    }
+
+    List<DataSegment> cachedSegments = Lists.newArrayList();
+    File[] segmentsToLoad = baseDir.listFiles();
+    for (int i = 0; i < segmentsToLoad.length; i++) {
+      File file = segmentsToLoad[i];
+      log.info("Loading segment cache file [%d/%d][%s].", i, segmentsToLoad.length, file);
+      try {
+        DataSegment segment = jsonMapper.readValue(file, DataSegment.class);
+        if (serverManager.isSegmentCached(segment)) {
+          cachedSegments.add(segment);
+        } else {
+          log.warn("Unable to find cache file for %s. Deleting lookup entry", segment.getIdentifier());
+
+          File segmentInfoCacheFile = new File(config.getInfoDir(), segment.getIdentifier());
+          if (!segmentInfoCacheFile.delete()) {
+            log.warn("Unable to delete segmentInfoCacheFile[%s]", segmentInfoCacheFile);
+          }
+        }
+      }
+      catch (Exception e) {
+        log.makeAlert(e, "Failed to load segment from segmentInfo file")
+           .addData("file", file)
+           .emit();
+      }
+    }
+
+    addSegments(
+        cachedSegments,
+        new DataSegmentChangeCallback()
+        {
+          @Override
+          public void execute()
+          {
+            log.info("Cache load took %,d ms", System.currentTimeMillis() - start);
+          }
+        }
+    );
+  }
+
+  public DataSegmentChangeHandler getDataSegmentChangeHandler()
+  {
+    return SegmentManager.this;
+  }
+
+  /**
+   * Load a single segment. If the segment is loaded succesfully, this function simply returns. Otherwise it will
+   * throw a SegmentLoadingException
+   *
+   * @throws SegmentLoadingException
+   */
+  private void loadSegment(DataSegment segment, DataSegmentChangeCallback callback) throws SegmentLoadingException
+  {
+    final boolean loaded;
+    try {
+      loaded = serverManager.loadSegment(segment);
+    }
+    catch (Exception e) {
+      removeSegment(segment, callback);
+      throw new SegmentLoadingException(e, "Exception loading segment[%s]", segment.getIdentifier());
+    }
+
+    if (loaded) {
+      File segmentInfoCacheFile = new File(config.getInfoDir(), segment.getIdentifier());
+      if (!segmentInfoCacheFile.exists()) {
+        try {
+          jsonMapper.writeValue(segmentInfoCacheFile, segment);
+        }
+        catch (IOException e) {
+          removeSegment(segment, callback);
+          throw new SegmentLoadingException(
+              e, "Failed to write to disk segment info cache file[%s]", segmentInfoCacheFile
+          );
+        }
+      }
+    }
+  }
+
+  @Override
+  public void addSegment(DataSegment segment, DataSegmentChangeCallback callback)
+  {
+    try {
+      log.info("Loading segment %s", segment.getIdentifier());
+      /*
+         The lock below is used to prevent a race condition when the scheduled runnable in removeSegment() starts,
+         and if(segmentsToDelete.remove(segment)) returns true, in which case historical will start deleting segment
+         files. At that point, it's possible that right after the "if" check, addSegment() is called and actually loads
+         the segment, which makes dropping segment and downloading segment happen at the same time.
+       */
+      if (segmentsToDelete.contains(segment)) {
+        /*
+           Both contains(segment) and remove(segment) can be moved inside the synchronized block. However, in that case,
+           each time when addSegment() is called, it has to wait for the lock in order to make progress, which will make
+           things slow. Given that in most cases segmentsToDelete.contains(segment) returns false, it will save a lot of
+           cost of acquiring lock by doing the "contains" check outside the synchronized block.
+         */
+        synchronized (lock) {
+          segmentsToDelete.remove(segment);
+        }
+      }
+      loadSegment(segment, callback);
+      if (!announcer.isAnnounced(segment)) {
+        try {
+          announcer.announceSegment(segment);
+        }
+        catch (IOException e) {
+          throw new SegmentLoadingException(e, "Failed to announce segment[%s]", segment.getIdentifier());
+        }
+      }
+    }
+    catch (SegmentLoadingException e) {
+      log.makeAlert(e, "Failed to load segment for dataSource")
+         .addData("segment", segment)
+         .emit();
+    }
+    finally {
+      callback.execute();
+    }
+  }
+
+  private void addSegments(Collection<DataSegment> segments, final DataSegmentChangeCallback callback)
+  {
+    ExecutorService loadingExecutor = null;
+    try (final BackgroundSegmentAnnouncer backgroundSegmentAnnouncer =
+             new BackgroundSegmentAnnouncer(announcer, exec, config.getAnnounceIntervalMillis())) {
+
+      backgroundSegmentAnnouncer.startAnnouncing();
+
+      loadingExecutor = Execs.multiThreaded(config.getNumBootstrapThreads(), "SegmentManager-loading-%s");
+
+      final int numSegments = segments.size();
+      final CountDownLatch latch = new CountDownLatch(numSegments);
+      final AtomicInteger counter = new AtomicInteger(0);
+      final CopyOnWriteArrayList<DataSegment> failedSegments = new CopyOnWriteArrayList<>();
+      for (final DataSegment segment : segments) {
+        loadingExecutor.submit(
+            new Runnable()
+            {
+              @Override
+              public void run()
+              {
+                try {
+                  log.info(
+                      "Loading segment[%d/%d][%s]",
+                      counter.getAndIncrement(),
+                      numSegments,
+                      segment.getIdentifier()
+                  );
+                  loadSegment(segment, callback);
+                  if (!announcer.isAnnounced(segment)) {
+                    try {
+                      backgroundSegmentAnnouncer.announceSegment(segment);
+                    }
+                    catch (InterruptedException e) {
+                      Thread.currentThread().interrupt();
+                      throw new SegmentLoadingException(e, "Loading Interrupted");
+                    }
+                  }
+                }
+                catch (SegmentLoadingException e) {
+                  log.error(e, "[%s] failed to load", segment.getIdentifier());
+                  failedSegments.add(segment);
+                }
+                finally {
+                  latch.countDown();
+                }
+              }
+            }
+        );
+      }
+
+      try {
+        latch.await();
+
+        if (failedSegments.size() > 0) {
+          log.makeAlert("%,d errors seen while loading segments", failedSegments.size())
+             .addData("failedSegments", failedSegments);
+        }
+      }
+      catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        log.makeAlert(e, "LoadingInterrupted");
+      }
+
+      backgroundSegmentAnnouncer.finishAnnouncing();
+    }
+    catch (SegmentLoadingException e) {
+      log.makeAlert(e, "Failed to load segments -- likely problem with announcing.")
+         .addData("numSegments", segments.size())
+         .emit();
+    }
+    finally {
+      callback.execute();
+      if (loadingExecutor != null) {
+        loadingExecutor.shutdownNow();
+      }
+    }
+  }
+
+
+  @Override
+  public void removeSegment(final DataSegment segment, final DataSegmentChangeCallback callback)
+  {
+    try {
+      announcer.unannounceSegment(segment);
+      segmentsToDelete.add(segment);
+
+      log.info("Completely removing [%s] in [%,d] millis", segment.getIdentifier(), config.getDropSegmentDelayMillis());
+      exec.schedule(
+          new Runnable()
+          {
+            @Override
+            public void run()
+            {
+              try {
+                synchronized (lock) {
+                  if (segmentsToDelete.remove(segment)) {
+                    serverManager.dropSegment(segment);
+
+                    File segmentInfoCacheFile = new File(config.getInfoDir(), segment.getIdentifier());
+                    if (!segmentInfoCacheFile.delete()) {
+                      log.warn("Unable to delete segmentInfoCacheFile[%s]", segmentInfoCacheFile);
+                    }
+                  }
+                }
+              }
+              catch (Exception e) {
+                log.makeAlert(e, "Failed to remove segment! Possible resource leak!")
+                   .addData("segment", segment)
+                   .emit();
+              }
+            }
+          },
+          config.getDropSegmentDelayMillis(),
+          TimeUnit.MILLISECONDS
+      );
+    }
+    catch (Exception e) {
+      log.makeAlert(e, "Failed to remove segment")
+         .addData("segment", segment)
+         .emit();
+    }
+    finally {
+      callback.execute();
+    }
+  }
+
+  private static class BackgroundSegmentAnnouncer implements AutoCloseable
+  {
+    private static final EmittingLogger log = new EmittingLogger(BackgroundSegmentAnnouncer.class);
+
+    private final int intervalMillis;
+    private final DataSegmentAnnouncer announcer;
+    private final ScheduledExecutorService exec;
+    private final LinkedBlockingQueue<DataSegment> queue;
+    private final SettableFuture<Boolean> doneAnnouncing;
+
+    private final Object lock = new Object();
+
+    private volatile boolean finished = false;
+    private volatile ScheduledFuture startedAnnouncing = null;
+    private volatile ScheduledFuture nextAnnoucement = null;
+
+    public BackgroundSegmentAnnouncer(
+        DataSegmentAnnouncer announcer,
+        ScheduledExecutorService exec,
+        int intervalMillis
+    )
+    {
+      this.announcer = announcer;
+      this.exec = exec;
+      this.intervalMillis = intervalMillis;
+      this.queue = Queues.newLinkedBlockingQueue();
+      this.doneAnnouncing = SettableFuture.create();
+    }
+
+    public void announceSegment(final DataSegment segment) throws InterruptedException
+    {
+      if (finished) {
+        throw new ISE("Announce segment called after finishAnnouncing");
+      }
+      queue.put(segment);
+    }
+
+    public void startAnnouncing()
+    {
+      if (intervalMillis <= 0) {
+        return;
+      }
+
+      log.info("Starting background segment announcing task");
+
+      // schedule background announcing task
+      nextAnnoucement = startedAnnouncing = exec.schedule(
+          new Runnable()
+          {
+            @Override
+            public void run()
+            {
+              synchronized (lock) {
+                try {
+                  if (!(finished && queue.isEmpty())) {
+                    final List<DataSegment> segments = Lists.newLinkedList();
+                    queue.drainTo(segments);
+                    try {
+                      announcer.announceSegments(segments);
+                      nextAnnoucement = exec.schedule(this, intervalMillis, TimeUnit.MILLISECONDS);
+                    }
+                    catch (IOException e) {
+                      doneAnnouncing.setException(
+                          new SegmentLoadingException(e, "Failed to announce segments[%s]", segments)
+                      );
+                    }
+                  } else {
+                    doneAnnouncing.set(true);
+                  }
+                }
+                catch (Exception e) {
+                  doneAnnouncing.setException(e);
+                }
+              }
+            }
+          },
+          intervalMillis,
+          TimeUnit.MILLISECONDS
+      );
+    }
+
+    public void finishAnnouncing() throws SegmentLoadingException
+    {
+      synchronized (lock) {
+        finished = true;
+        // announce any remaining segments
+        try {
+          final List<DataSegment> segments = Lists.newLinkedList();
+          queue.drainTo(segments);
+          announcer.announceSegments(segments);
+        }
+        catch (Exception e) {
+          throw new SegmentLoadingException(e, "Failed to announce segments[%s]", queue);
+        }
+
+        // get any exception that may have been thrown in background annoucing
+        try {
+          // check in case intervalMillis is <= 0
+          if (startedAnnouncing != null) {
+            startedAnnouncing.cancel(false);
+          }
+          // - if the task is waiting on the lock, then the queue will be empty by the time it runs
+          // - if the task just released it, then the lock ensures any exception is set in doneAnnouncing
+          if (doneAnnouncing.isDone()) {
+            doneAnnouncing.get();
+          }
+        }
+        catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new SegmentLoadingException(e, "Loading Interrupted");
+        }
+        catch (ExecutionException e) {
+          throw new SegmentLoadingException(e.getCause(), "Background Announcing Task Failed");
+        }
+      }
+      log.info("Completed background segment announcing");
+    }
+
+    @Override
+    public void close()
+    {
+      // stop background scheduling
+      synchronized (lock) {
+        finished = true;
+        if (nextAnnoucement != null) {
+          nextAnnoucement.cancel(false);
+        }
+      }
+    }
+  }
+}

--- a/server/src/main/java/io/druid/server/coordination/ZkCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordination/ZkCoordinator.java
@@ -59,7 +59,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  */
-public class ZkCoordinator implements DataSegmentChangeHandler
+public class ZkCoordinator
 {
   private static final EmittingLogger log = new EmittingLogger(ZkCoordinator.class);
 
@@ -70,11 +70,7 @@ public class ZkCoordinator implements DataSegmentChangeHandler
   private final SegmentLoaderConfig config;
   private final DruidServerMetadata me;
   private final CuratorFramework curator;
-  private final DataSegmentAnnouncer announcer;
-  private final ServerManager serverManager;
-  private final ScheduledExecutorService exec;
-  private final ConcurrentSkipListSet<DataSegment> segmentsToDelete;
-
+  private final DataSegmentChangeHandler segmentChangeHandler;
 
   private volatile PathChildrenCache loadQueueCache;
   private volatile boolean started = false;
@@ -85,10 +81,8 @@ public class ZkCoordinator implements DataSegmentChangeHandler
       SegmentLoaderConfig config,
       ZkPathsConfig zkPaths,
       DruidServerMetadata me,
-      DataSegmentAnnouncer announcer,
       CuratorFramework curator,
-      ServerManager serverManager,
-      ScheduledExecutorFactory factory
+      DataSegmentChangeHandler segmentChangeHandler
   )
   {
     this.jsonMapper = jsonMapper;
@@ -96,11 +90,7 @@ public class ZkCoordinator implements DataSegmentChangeHandler
     this.config = config;
     this.me = me;
     this.curator = curator;
-    this.announcer = announcer;
-    this.serverManager = serverManager;
-
-    this.exec = factory.create(1, "ZkCoordinator-Exec--%d");
-    this.segmentsToDelete = new ConcurrentSkipListSet<>();
+    this.segmentChangeHandler = segmentChangeHandler;
   }
 
   @LifecycleStart
@@ -130,8 +120,6 @@ public class ZkCoordinator implements DataSegmentChangeHandler
         curator.newNamespaceAwareEnsurePath(servedSegmentsLocation).ensure(curator.getZookeeperClient());
         curator.newNamespaceAwareEnsurePath(liveSegmentsLocation).ensure(curator.getZookeeperClient());
 
-        loadLocalCache();
-
         loadQueueCache.getListenable().addListener(
             new PathChildrenCacheListener()
             {
@@ -150,7 +138,7 @@ public class ZkCoordinator implements DataSegmentChangeHandler
 
                     try {
                       request.go(
-                          getDataSegmentChangeHandler(),
+                          segmentChangeHandler,
                           new DataSegmentChangeCallback()
                           {
                             boolean hasRun = false;
@@ -241,387 +229,5 @@ public class ZkCoordinator implements DataSegmentChangeHandler
     return started;
   }
 
-  public void loadLocalCache()
-  {
-    final long start = System.currentTimeMillis();
-    File baseDir = config.getInfoDir();
-    if (!baseDir.exists() && !config.getInfoDir().mkdirs()) {
-      return;
-    }
 
-    List<DataSegment> cachedSegments = Lists.newArrayList();
-    File[] segmentsToLoad = baseDir.listFiles();
-    for (int i = 0; i < segmentsToLoad.length; i++) {
-      File file = segmentsToLoad[i];
-      log.info("Loading segment cache file [%d/%d][%s].", i, segmentsToLoad.length, file);
-      try {
-        DataSegment segment = jsonMapper.readValue(file, DataSegment.class);
-        if (serverManager.isSegmentCached(segment)) {
-          cachedSegments.add(segment);
-        } else {
-          log.warn("Unable to find cache file for %s. Deleting lookup entry", segment.getIdentifier());
-
-          File segmentInfoCacheFile = new File(config.getInfoDir(), segment.getIdentifier());
-          if (!segmentInfoCacheFile.delete()) {
-            log.warn("Unable to delete segmentInfoCacheFile[%s]", segmentInfoCacheFile);
-          }
-        }
-      }
-      catch (Exception e) {
-        log.makeAlert(e, "Failed to load segment from segmentInfo file")
-           .addData("file", file)
-           .emit();
-      }
-    }
-
-    addSegments(
-        cachedSegments,
-        new DataSegmentChangeCallback()
-        {
-          @Override
-          public void execute()
-          {
-            log.info("Cache load took %,d ms", System.currentTimeMillis() - start);
-          }
-        }
-    );
-  }
-
-  public DataSegmentChangeHandler getDataSegmentChangeHandler()
-  {
-    return ZkCoordinator.this;
-  }
-
-  /**
-   * Load a single segment. If the segment is loaded succesfully, this function simply returns. Otherwise it will
-   * throw a SegmentLoadingException
-   *
-   * @throws SegmentLoadingException
-   */
-  private void loadSegment(DataSegment segment, DataSegmentChangeCallback callback) throws SegmentLoadingException
-  {
-    final boolean loaded;
-    try {
-      loaded = serverManager.loadSegment(segment);
-    }
-    catch (Exception e) {
-      removeSegment(segment, callback);
-      throw new SegmentLoadingException(e, "Exception loading segment[%s]", segment.getIdentifier());
-    }
-
-    if (loaded) {
-      File segmentInfoCacheFile = new File(config.getInfoDir(), segment.getIdentifier());
-      if (!segmentInfoCacheFile.exists()) {
-        try {
-          jsonMapper.writeValue(segmentInfoCacheFile, segment);
-        }
-        catch (IOException e) {
-          removeSegment(segment, callback);
-          throw new SegmentLoadingException(
-              e, "Failed to write to disk segment info cache file[%s]", segmentInfoCacheFile
-          );
-        }
-      }
-    }
-  }
-
-  @Override
-  public void addSegment(DataSegment segment, DataSegmentChangeCallback callback)
-  {
-    try {
-      log.info("Loading segment %s", segment.getIdentifier());
-      /*
-         The lock below is used to prevent a race condition when the scheduled runnable in removeSegment() starts,
-         and if(segmentsToDelete.remove(segment)) returns true, in which case historical will start deleting segment
-         files. At that point, it's possible that right after the "if" check, addSegment() is called and actually loads
-         the segment, which makes dropping segment and downloading segment happen at the same time.
-       */
-      if (segmentsToDelete.contains(segment)) {
-        /*
-           Both contains(segment) and remove(segment) can be moved inside the synchronized block. However, in that case,
-           each time when addSegment() is called, it has to wait for the lock in order to make progress, which will make
-           things slow. Given that in most cases segmentsToDelete.contains(segment) returns false, it will save a lot of
-           cost of acquiring lock by doing the "contains" check outside the synchronized block.
-         */
-        synchronized (lock) {
-          segmentsToDelete.remove(segment);
-        }
-      }
-      loadSegment(segment, callback);
-      if (!announcer.isAnnounced(segment)) {
-        try {
-          announcer.announceSegment(segment);
-        }
-        catch (IOException e) {
-          throw new SegmentLoadingException(e, "Failed to announce segment[%s]", segment.getIdentifier());
-        }
-      }
-    }
-    catch (SegmentLoadingException e) {
-      log.makeAlert(e, "Failed to load segment for dataSource")
-         .addData("segment", segment)
-         .emit();
-    }
-    finally {
-      callback.execute();
-    }
-  }
-
-  private void addSegments(Collection<DataSegment> segments, final DataSegmentChangeCallback callback)
-  {
-    ExecutorService loadingExecutor = null;
-    try (final BackgroundSegmentAnnouncer backgroundSegmentAnnouncer =
-             new BackgroundSegmentAnnouncer(announcer, exec, config.getAnnounceIntervalMillis())) {
-
-      backgroundSegmentAnnouncer.startAnnouncing();
-
-      loadingExecutor = Execs.multiThreaded(config.getNumBootstrapThreads(), "ZkCoordinator-loading-%s");
-
-      final int numSegments = segments.size();
-      final CountDownLatch latch = new CountDownLatch(numSegments);
-      final AtomicInteger counter = new AtomicInteger(0);
-      final CopyOnWriteArrayList<DataSegment> failedSegments = new CopyOnWriteArrayList<>();
-      for (final DataSegment segment : segments) {
-        loadingExecutor.submit(
-            new Runnable()
-            {
-              @Override
-              public void run()
-              {
-                try {
-                  log.info(
-                      "Loading segment[%d/%d][%s]",
-                      counter.getAndIncrement(),
-                      numSegments,
-                      segment.getIdentifier()
-                  );
-                  loadSegment(segment, callback);
-                  if (!announcer.isAnnounced(segment)) {
-                    try {
-                      backgroundSegmentAnnouncer.announceSegment(segment);
-                    }
-                    catch (InterruptedException e) {
-                      Thread.currentThread().interrupt();
-                      throw new SegmentLoadingException(e, "Loading Interrupted");
-                    }
-                  }
-                }
-                catch (SegmentLoadingException e) {
-                  log.error(e, "[%s] failed to load", segment.getIdentifier());
-                  failedSegments.add(segment);
-                }
-                finally {
-                  latch.countDown();
-                }
-              }
-            }
-        );
-      }
-
-      try {
-        latch.await();
-
-        if (failedSegments.size() > 0) {
-          log.makeAlert("%,d errors seen while loading segments", failedSegments.size())
-             .addData("failedSegments", failedSegments);
-        }
-      }
-      catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        log.makeAlert(e, "LoadingInterrupted");
-      }
-
-      backgroundSegmentAnnouncer.finishAnnouncing();
-    }
-    catch (SegmentLoadingException e) {
-      log.makeAlert(e, "Failed to load segments -- likely problem with announcing.")
-         .addData("numSegments", segments.size())
-         .emit();
-    }
-    finally {
-      callback.execute();
-      if (loadingExecutor != null) {
-        loadingExecutor.shutdownNow();
-      }
-    }
-  }
-
-
-  @Override
-  public void removeSegment(final DataSegment segment, final DataSegmentChangeCallback callback)
-  {
-    try {
-      announcer.unannounceSegment(segment);
-      segmentsToDelete.add(segment);
-
-      log.info("Completely removing [%s] in [%,d] millis", segment.getIdentifier(), config.getDropSegmentDelayMillis());
-      exec.schedule(
-          new Runnable()
-          {
-            @Override
-            public void run()
-            {
-              try {
-                synchronized (lock) {
-                  if (segmentsToDelete.remove(segment)) {
-                    serverManager.dropSegment(segment);
-
-                    File segmentInfoCacheFile = new File(config.getInfoDir(), segment.getIdentifier());
-                    if (!segmentInfoCacheFile.delete()) {
-                      log.warn("Unable to delete segmentInfoCacheFile[%s]", segmentInfoCacheFile);
-                    }
-                  }
-                }
-              }
-              catch (Exception e) {
-                log.makeAlert(e, "Failed to remove segment! Possible resource leak!")
-                   .addData("segment", segment)
-                   .emit();
-              }
-            }
-          },
-          config.getDropSegmentDelayMillis(),
-          TimeUnit.MILLISECONDS
-      );
-    }
-    catch (Exception e) {
-      log.makeAlert(e, "Failed to remove segment")
-         .addData("segment", segment)
-         .emit();
-    }
-    finally {
-      callback.execute();
-    }
-  }
-
-  private static class BackgroundSegmentAnnouncer implements AutoCloseable
-  {
-    private static final EmittingLogger log = new EmittingLogger(BackgroundSegmentAnnouncer.class);
-
-    private final int intervalMillis;
-    private final DataSegmentAnnouncer announcer;
-    private final ScheduledExecutorService exec;
-    private final LinkedBlockingQueue<DataSegment> queue;
-    private final SettableFuture<Boolean> doneAnnouncing;
-
-    private final Object lock = new Object();
-
-    private volatile boolean finished = false;
-    private volatile ScheduledFuture startedAnnouncing = null;
-    private volatile ScheduledFuture nextAnnoucement = null;
-
-    public BackgroundSegmentAnnouncer(
-        DataSegmentAnnouncer announcer,
-        ScheduledExecutorService exec,
-        int intervalMillis
-    )
-    {
-      this.announcer = announcer;
-      this.exec = exec;
-      this.intervalMillis = intervalMillis;
-      this.queue = Queues.newLinkedBlockingQueue();
-      this.doneAnnouncing = SettableFuture.create();
-    }
-
-    public void announceSegment(final DataSegment segment) throws InterruptedException
-    {
-      if (finished) {
-        throw new ISE("Announce segment called after finishAnnouncing");
-      }
-      queue.put(segment);
-    }
-
-    public void startAnnouncing()
-    {
-      if (intervalMillis <= 0) {
-        return;
-      }
-
-      log.info("Starting background segment announcing task");
-
-      // schedule background announcing task
-      nextAnnoucement = startedAnnouncing = exec.schedule(
-          new Runnable()
-          {
-            @Override
-            public void run()
-            {
-              synchronized (lock) {
-                try {
-                  if (!(finished && queue.isEmpty())) {
-                    final List<DataSegment> segments = Lists.newLinkedList();
-                    queue.drainTo(segments);
-                    try {
-                      announcer.announceSegments(segments);
-                      nextAnnoucement = exec.schedule(this, intervalMillis, TimeUnit.MILLISECONDS);
-                    }
-                    catch (IOException e) {
-                      doneAnnouncing.setException(
-                          new SegmentLoadingException(e, "Failed to announce segments[%s]", segments)
-                      );
-                    }
-                  } else {
-                    doneAnnouncing.set(true);
-                  }
-                }
-                catch (Exception e) {
-                  doneAnnouncing.setException(e);
-                }
-              }
-            }
-          },
-          intervalMillis,
-          TimeUnit.MILLISECONDS
-      );
-    }
-
-    public void finishAnnouncing() throws SegmentLoadingException
-    {
-      synchronized (lock) {
-        finished = true;
-        // announce any remaining segments
-        try {
-          final List<DataSegment> segments = Lists.newLinkedList();
-          queue.drainTo(segments);
-          announcer.announceSegments(segments);
-        }
-        catch (Exception e) {
-          throw new SegmentLoadingException(e, "Failed to announce segments[%s]", queue);
-        }
-
-        // get any exception that may have been thrown in background annoucing
-        try {
-          // check in case intervalMillis is <= 0
-          if (startedAnnouncing != null) {
-            startedAnnouncing.cancel(false);
-          }
-          // - if the task is waiting on the lock, then the queue will be empty by the time it runs
-          // - if the task just released it, then the lock ensures any exception is set in doneAnnouncing
-          if (doneAnnouncing.isDone()) {
-            doneAnnouncing.get();
-          }
-        }
-        catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-          throw new SegmentLoadingException(e, "Loading Interrupted");
-        }
-        catch (ExecutionException e) {
-          throw new SegmentLoadingException(e.getCause(), "Background Announcing Task Failed");
-        }
-      }
-      log.info("Completed background segment announcing");
-    }
-
-    @Override
-    public void close()
-    {
-      // stop background scheduling
-      synchronized (lock) {
-        finished = true;
-        if (nextAnnoucement != null) {
-          nextAnnoucement.cancel(false);
-        }
-      }
-    }
-  }
 }

--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinatorConfig.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinatorConfig.java
@@ -75,6 +75,12 @@ public abstract class DruidCoordinatorConfig
     return new Duration(15 * 60 * 1000);
   }
 
+  @Config("druid.coordinator.load.status.poll.duration")
+  public Duration getLoadStatusPollDuration()
+  {
+    return new Duration(1000);
+  }
+
   @Config("druid.coordinator.console.static")
   public String getConsoleStatic()
   {

--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinatorConfig.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinatorConfig.java
@@ -75,7 +75,7 @@ public abstract class DruidCoordinatorConfig
     return new Duration(15 * 60 * 1000);
   }
 
-  @Config("druid.coordinator.load.status.poll.duration")
+  @Config("druid.coordinator.load.status.pollDuration")
   public Duration getLoadStatusPollDuration()
   {
     return new Duration(1000);

--- a/server/src/main/java/io/druid/server/coordinator/HttpLoadQueuePeon.java
+++ b/server/src/main/java/io/druid/server/coordinator/HttpLoadQueuePeon.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.coordinator;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Charsets;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Maps;
+import com.metamx.common.ISE;
+import com.metamx.emitter.EmittingLogger;
+import com.metamx.http.client.HttpClient;
+import com.metamx.http.client.Request;
+import com.metamx.http.client.response.StatusResponseHandler;
+import com.metamx.http.client.response.StatusResponseHolder;
+import io.druid.server.coordination.DataSegmentChangeRequest;
+import io.druid.server.coordination.SegmentChangeRequestNoop;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.CuratorWatcher;
+import org.apache.curator.utils.ZKPaths;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.data.Stat;
+import org.jboss.netty.handler.codec.http.HttpMethod;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+
+import javax.annotation.Nullable;
+import javax.ws.rs.core.MediaType;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class HttpLoadQueuePeon extends LoadQueuePeon
+{
+  private static final EmittingLogger log = new EmittingLogger(HttpLoadQueuePeon.class);
+
+  private final HttpClient httpClient;
+  private final String baseURL;
+  private final ObjectMapper jsonMapper;
+  private final ScheduledExecutorService processingExecutor;
+  private final DruidCoordinatorConfig config;
+  private final StatusResponseHandler responseHandler;
+  private final Map<DataSegmentChangeRequest, Runnable> pendingRequests = Maps.newConcurrentMap();
+
+  HttpLoadQueuePeon(
+      final HttpClient httpClient,
+      String baseURL,
+      ObjectMapper jsonMapper,
+      ScheduledExecutorService processingExecutor,
+      ExecutorService callbackExecutor,
+      DruidCoordinatorConfig config
+  )
+  {
+    super(baseURL, processingExecutor, callbackExecutor);
+    this.httpClient = httpClient;
+    this.baseURL = baseURL;
+    this.jsonMapper = jsonMapper;
+    this.processingExecutor = processingExecutor;
+    this.config = config;
+    this.responseHandler = new StatusResponseHandler(Charsets.UTF_8);
+    processingExecutor.scheduleAtFixedRate(
+        new Runnable()
+        {
+          @Override
+          public void run()
+          {
+            try {
+              final List<DataSegmentChangeRequest> remotePendingRequests = getRemotePendingRequests();
+              Map<DataSegmentChangeRequest, Runnable> completedRequests = Maps.newHashMap(Maps.filterKeys(
+                  pendingRequests,
+                  new Predicate<DataSegmentChangeRequest>()
+                  {
+                    @Override
+                    public boolean apply(
+                        DataSegmentChangeRequest request
+                    )
+                    {
+                      return !remotePendingRequests.contains(request);
+                    }
+                  }
+              ));
+              for (Map.Entry<DataSegmentChangeRequest, Runnable> completedRequest : completedRequests.entrySet()) {
+                completedRequest.getValue().run();
+                pendingRequests.remove(completedRequest.getKey());
+              }
+            }
+            catch (Exception e) {
+              log.error("Exception while fetching remote requests, Will retry again..", e);
+            }
+          }
+        },
+        config.getLoadStatusPollDuration().getMillis(),
+        config.getLoadStatusPollDuration().getMillis(),
+        TimeUnit.MILLISECONDS
+    );
+
+  }
+
+  private List<DataSegmentChangeRequest> getRemotePendingRequests() throws Exception
+  {
+    StatusResponseHolder response = httpClient.go(
+        new Request(
+            HttpMethod.GET, new URL(String.format("%s/pendingRequests", baseURL))
+        ),
+        responseHandler
+    ).get();
+    if (!response.getStatus().equals(HttpResponseStatus.OK)) {
+      throw new ISE(
+          "Error while fetching pending Requests on url[%s] status[%s] content[%s]",
+          baseURL,
+          response.getStatus(),
+          response.getContent()
+      );
+    }
+    return jsonMapper.readValue(
+        response.getContent(),
+        new TypeReference<List<DataSegmentChangeRequest>>()
+        {
+        }
+    );
+  }
+
+
+  @Override
+  void processHolder(final SegmentHolder holder)
+  {
+    try {
+      StatusResponseHolder response = httpClient.go(
+          new Request(
+              HttpMethod.POST, new URL(String.format("%s/processRequest", baseURL))
+          ).setContent(
+              MediaType.APPLICATION_JSON,
+              jsonMapper.writeValueAsBytes(holder.getChangeRequest())
+          ),
+          responseHandler
+      ).get();
+
+      if (!response.getStatus().equals(HttpResponseStatus.OK)) {
+        throw new ISE(
+            "Error while processing SegmentChangeRequest on url[%s] status[%s] content[%s]",
+            baseURL,
+            response.getStatus(),
+            response.getContent()
+        );
+      }
+      // Add to pending Requests will be called when the request completes.
+      pendingRequests.put(holder.getChangeRequest(), new Runnable()
+      {
+        @Override
+        public void run()
+        {
+          actionCompleted(holder);
+        }
+      });
+
+      // Schedule timeout check.
+      processingExecutor.schedule(
+          new Runnable()
+          {
+            @Override
+            public void run()
+            {
+              if (pendingRequests.remove(holder.getChangeRequest()) != null) {
+                failAssign(holder, new ISE("%s was never processed! Failing this operation!", holder));
+              }
+            }
+          },
+          config.getLoadTimeoutDelay().getMillis(),
+          TimeUnit.MILLISECONDS
+      );
+
+
+    }
+    catch (Exception e) {
+      failAssign(holder, e);
+    }
+  }
+
+
+}

--- a/server/src/main/java/io/druid/server/coordinator/LoadQueueTaskMaster.java
+++ b/server/src/main/java/io/druid/server/coordinator/LoadQueueTaskMaster.java
@@ -55,6 +55,6 @@ public class LoadQueueTaskMaster
 
   public LoadQueuePeon giveMePeon(String basePath)
   {
-    return new LoadQueuePeon(curator, basePath, jsonMapper, peonExec, callbackExec, config);
+    return new ZkLoadQueuePeon(curator, basePath, jsonMapper, peonExec, callbackExec, config);
   }
 }

--- a/server/src/main/java/io/druid/server/coordinator/ZkLoadQueuePeon.java
+++ b/server/src/main/java/io/druid/server/coordinator/ZkLoadQueuePeon.java
@@ -64,7 +64,6 @@ public class ZkLoadQueuePeon extends LoadQueuePeon
   @Override
   void processHolder(final SegmentHolder holder)
   {
-
     try {
       final String path = ZKPaths.makePath(basePath, holder.getSegmentIdentifier());
       final byte[] payload = jsonMapper.writeValueAsBytes(holder.getChangeRequest());

--- a/server/src/main/java/io/druid/server/coordinator/ZkLoadQueuePeon.java
+++ b/server/src/main/java/io/druid/server/coordinator/ZkLoadQueuePeon.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.coordinator;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.metamx.common.ISE;
+import com.metamx.emitter.EmittingLogger;
+import io.druid.server.coordination.SegmentChangeRequestNoop;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.CuratorWatcher;
+import org.apache.curator.utils.ZKPaths;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.data.Stat;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class ZkLoadQueuePeon extends LoadQueuePeon
+{
+  private static final EmittingLogger log = new EmittingLogger(ZkLoadQueuePeon.class);
+
+  private final CuratorFramework curator;
+  private final String basePath;
+  private final ObjectMapper jsonMapper;
+  private final ScheduledExecutorService processingExecutor;
+  private final DruidCoordinatorConfig config;
+
+  ZkLoadQueuePeon(
+      CuratorFramework curator,
+      String basePath,
+      ObjectMapper jsonMapper,
+      ScheduledExecutorService processingExecutor,
+      ExecutorService callbackExecutor,
+      DruidCoordinatorConfig config
+  )
+  {
+    super(basePath, processingExecutor, callbackExecutor);
+    this.curator = curator;
+    this.basePath = basePath;
+    this.jsonMapper = jsonMapper;
+    this.processingExecutor = processingExecutor;
+    this.config = config;
+  }
+
+  @Override
+  void processHolder(final SegmentHolder holder)
+  {
+
+    try {
+      final String path = ZKPaths.makePath(basePath, holder.getSegmentIdentifier());
+      final byte[] payload = jsonMapper.writeValueAsBytes(holder.getChangeRequest());
+      curator.create().withMode(CreateMode.EPHEMERAL).forPath(path, payload);
+
+      processingExecutor.schedule(
+          new Runnable()
+          {
+            @Override
+            public void run()
+            {
+              try {
+                if (curator.checkExists().forPath(path) != null) {
+                  failAssign(holder, new ISE("%s was never removed! Failing this operation!", path));
+                }
+              }
+              catch (Exception e) {
+                failAssign(holder, e);
+              }
+            }
+          },
+          config.getLoadTimeoutDelay().getMillis(),
+          TimeUnit.MILLISECONDS
+      );
+
+      final Stat stat = curator.checkExists().usingWatcher(
+          new CuratorWatcher()
+          {
+            @Override
+            public void process(WatchedEvent watchedEvent) throws Exception
+            {
+              switch (watchedEvent.getType()) {
+                case NodeDeleted:
+                  if (!ZKPaths.getNodeFromPath(path).equals(holder.getSegmentIdentifier())) {
+                    log.warn(
+                        "Server[%s] entry [%s] was removed even though it's not what is currently loading[%s]",
+                        basePath, path, holder
+                    );
+                    return;
+                  }
+                  actionCompleted(holder);
+              }
+            }
+          }
+      ).forPath(path);
+
+      if (stat == null) {
+        final byte[] noopPayload = jsonMapper.writeValueAsBytes(new SegmentChangeRequestNoop());
+
+        // Create a node and then delete it to remove the registered watcher.  This is a work-around for
+        // a zookeeper race condition.  Specifically, when you set a watcher, it fires on the next event
+        // that happens for that node.  If no events happen, the watcher stays registered foreverz.
+        // Couple that with the fact that you cannot set a watcher when you create a node, but what we
+        // want is to create a node and then watch for it to get deleted.  The solution is that you *can*
+        // set a watcher when you check to see if it exists so, we first create the node and then set a
+        // watcher on its existence.  However, if already does not exist by the time the existence check
+        // returns, then the watcher that was set will never fire (nobody will ever create the node
+        // again) and thus lead to a slow, but real, memory leak.  So, we create another node to cause
+        // that watcher to fire and delete it right away.
+        //
+        // We do not create the existence watcher first, because then it will fire when we create the
+        // node and we'll have the same race when trying to refresh that watcher.
+        curator.create().withMode(CreateMode.EPHEMERAL).forPath(path, noopPayload);
+        actionCompleted(holder);
+      }
+
+    }
+    catch (Exception e) {
+      failAssign(holder, e);
+    }
+  }
+}

--- a/server/src/main/java/io/druid/server/coordinator/ZkLoadQueueTaskMaster.java
+++ b/server/src/main/java/io/druid/server/coordinator/ZkLoadQueueTaskMaster.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.coordinator;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import io.druid.client.ImmutableDruidServer;
+import io.druid.server.initialization.ZkPathsConfig;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.utils.ZKPaths;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Provides ZkLoadQueuePeons
+ */
+public class ZkLoadQueueTaskMaster implements LoadQueueTaskMaster
+{
+  private final CuratorFramework curator;
+  private final ObjectMapper jsonMapper;
+  private final ScheduledExecutorService peonExec;
+  private final ExecutorService callbackExec;
+  private final DruidCoordinatorConfig config;
+  private final ZkPathsConfig zkPaths;
+
+  @Inject
+  public ZkLoadQueueTaskMaster(
+      CuratorFramework curator,
+      ObjectMapper jsonMapper,
+      ScheduledExecutorService peonExec,
+      ExecutorService callbackExec,
+      DruidCoordinatorConfig config,
+      ZkPathsConfig zkPaths
+  )
+  {
+    this.curator = curator;
+    this.jsonMapper = jsonMapper;
+    this.peonExec = peonExec;
+    this.callbackExec = callbackExec;
+    this.config = config;
+    this.zkPaths = zkPaths;
+  }
+
+  public LoadQueuePeon giveMePeon(ImmutableDruidServer server)
+  {
+    String basePath = ZKPaths.makePath(zkPaths.getLoadQueuePath(), server.getName());
+    return new ZkLoadQueuePeon(curator, basePath, jsonMapper, peonExec, callbackExec, config);
+  }
+}

--- a/server/src/main/java/io/druid/server/http/HistoricalResource.java
+++ b/server/src/main/java/io/druid/server/http/HistoricalResource.java
@@ -20,6 +20,7 @@
 package io.druid.server.http;
 
 import com.google.common.collect.ImmutableMap;
+import io.druid.server.coordination.SegmentManager;
 import io.druid.server.coordination.ZkCoordinator;
 
 import javax.inject.Inject;
@@ -32,14 +33,14 @@ import javax.ws.rs.core.Response;
 @Path("/druid/historical/v1")
 public class HistoricalResource
 {
-  private final ZkCoordinator coordinator;
+  private final SegmentManager segmentManager;
 
   @Inject
   public HistoricalResource(
-      ZkCoordinator coordinator
+      SegmentManager segmentManager
   )
   {
-    this.coordinator = coordinator;
+    this.segmentManager = segmentManager;
   }
 
   @GET
@@ -47,6 +48,6 @@ public class HistoricalResource
   @Produces(MediaType.APPLICATION_JSON)
   public Response getLoadStatus()
   {
-    return Response.ok(ImmutableMap.of("cacheInitialized", coordinator.isStarted())).build();
+    return Response.ok(ImmutableMap.of("cacheInitialized", segmentManager.isStarted())).build();
   }
 }

--- a/server/src/main/java/io/druid/server/http/HistoricalResource.java
+++ b/server/src/main/java/io/druid/server/http/HistoricalResource.java
@@ -19,28 +19,48 @@
 
 package io.druid.server.http;
 
+import com.amazonaws.services.dynamodbv2.model.ReturnConsumedCapacity;
+import com.google.api.client.util.Lists;
 import com.google.common.collect.ImmutableMap;
+import io.druid.concurrent.Execs;
+import io.druid.segment.loading.SegmentLoaderConfig;
+import io.druid.server.coordination.DataSegmentChangeCallback;
+import io.druid.server.coordination.DataSegmentChangeRequest;
 import io.druid.server.coordination.SegmentManager;
 import io.druid.server.coordination.ZkCoordinator;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 
 @Path("/druid/historical/v1")
 public class HistoricalResource
 {
   private final SegmentManager segmentManager;
+  private final ExecutorService exec;
+  private final List<DataSegmentChangeRequest> pendingRequests = new CopyOnWriteArrayList<>();
 
   @Inject
   public HistoricalResource(
-      SegmentManager segmentManager
+      SegmentManager segmentManager,
+      SegmentLoaderConfig config
   )
   {
     this.segmentManager = segmentManager;
+    exec = Execs.multiThreaded(
+        config.getNumLoadingThreads(),
+        "SegmentChangeRequestProcessing-%s"
+    );
+
   }
 
   @GET
@@ -50,4 +70,42 @@ public class HistoricalResource
   {
     return Response.ok(ImmutableMap.of("cacheInitialized", segmentManager.isStarted())).build();
   }
+
+  @POST
+  @Path("/processRequest")
+  public Response processSegmentChangeRequest(final DataSegmentChangeRequest request)
+  {
+    try {
+      boolean newRequest = pendingRequests.add(request);
+      if (newRequest) {
+        exec.submit(new Runnable()
+        {
+          @Override
+          public void run()
+          {
+            request.go(segmentManager, new DataSegmentChangeCallback()
+            {
+              @Override
+              public void execute()
+              {
+                pendingRequests.remove(request);
+              }
+            });
+          }
+        });
+      }
+      return Response.ok().build();
+    }
+    catch (Exception e) {
+      return Response.serverError().build();
+    }
+  }
+
+  @GET
+  @Path("/pendingRequests")
+  public Response pendingRequests()
+  {
+    return Response.ok(pendingRequests).build();
+  }
+
 }

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
@@ -131,7 +131,7 @@ public class DruidCoordinatorTest extends CuratorTestBase
         false
     );
     pathChildrenCache = new PathChildrenCache(curator, LOADPATH, true, true, Execs.singleThreaded("coordinator_test_path_children_cache-%d"));
-    loadQueuePeon = new LoadQueuePeon(
+    loadQueuePeon = new ZkLoadQueuePeon(
       curator,
       LOADPATH,
       objectMapper,

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
@@ -232,22 +232,6 @@ public class DruidCoordinatorTest extends CuratorTestBase
     loadManagementPeons.put("from", loadQueuePeon);
     loadManagementPeons.put("to", loadQueuePeon);
 
-    EasyMock.expect(serverInventoryView.getInventoryManagerConfig()).andReturn(
-        new InventoryManagerConfig()
-        {
-          @Override
-          public String getContainerPath()
-          {
-            return "";
-          }
-
-          @Override
-          public String getInventoryPath()
-          {
-            return "";
-          }
-        }
-    );
     EasyMock.replay(serverInventoryView);
 
     coordinator.moveSegment(

--- a/server/src/test/java/io/druid/server/coordinator/LoadQueuePeonTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/LoadQueuePeonTest.java
@@ -82,7 +82,7 @@ public class LoadQueuePeonTest extends CuratorTestBase
     final AtomicInteger requestSignalIdx = new AtomicInteger(0);
     final AtomicInteger segmentSignalIdx = new AtomicInteger(0);
 
-    loadQueuePeon = new LoadQueuePeon(
+    loadQueuePeon = new ZkLoadQueuePeon(
         curator,
         LOAD_QUEUE_PATH,
         jsonMapper,
@@ -287,7 +287,7 @@ public class LoadQueuePeonTest extends CuratorTestBase
     final CountDownLatch loadRequestSignal = new CountDownLatch(1);
     final CountDownLatch segmentLoadedSignal = new CountDownLatch(1);
 
-    loadQueuePeon = new LoadQueuePeon(
+    loadQueuePeon = new ZkLoadQueuePeon(
         curator,
         LOAD_QUEUE_PATH,
         jsonMapper,

--- a/server/src/test/java/io/druid/server/coordinator/LoadQueuePeonTester.java
+++ b/server/src/test/java/io/druid/server/coordinator/LoadQueuePeonTester.java
@@ -29,7 +29,7 @@ public class LoadQueuePeonTester extends LoadQueuePeon
 
   public LoadQueuePeonTester()
   {
-    super(null, null, null, null, null, null);
+    super(null, null, null);
   }
 
   @Override
@@ -39,6 +39,12 @@ public class LoadQueuePeonTester extends LoadQueuePeon
   )
   {
     segmentsToLoad.add(segment);
+  }
+
+  @Override
+  void processHolder(SegmentHolder holder)
+  {
+    // Nothing to do
   }
 
   public ConcurrentSkipListSet<DataSegment> getSegmentsToLoad()

--- a/services/src/main/java/io/druid/cli/CliHistorical.java
+++ b/services/src/main/java/io/druid/cli/CliHistorical.java
@@ -36,6 +36,8 @@ import io.druid.guice.ManageLifecycle;
 import io.druid.guice.NodeTypeConfig;
 import io.druid.query.QuerySegmentWalker;
 import io.druid.server.QueryResource;
+import io.druid.server.coordination.DataSegmentChangeHandler;
+import io.druid.server.coordination.SegmentManager;
 import io.druid.server.coordination.ServerManager;
 import io.druid.server.coordination.ZkCoordinator;
 import io.druid.server.http.HistoricalResource;
@@ -75,6 +77,8 @@ public class CliHistorical extends ServerRunnable
             // register Server before binding ZkCoordinator to ensure HTTP endpoints are available immediately
             LifecycleModule.register(binder, Server.class);
             binder.bind(ServerManager.class).in(LazySingleton.class);
+            binder.bind(DataSegmentChangeHandler.class).to(SegmentManager.class).in(ManageLifecycle.class);
+
             binder.bind(ZkCoordinator.class).in(ManageLifecycle.class);
             binder.bind(QuerySegmentWalker.class).to(ServerManager.class).in(LazySingleton.class);
 


### PR DESCRIPTION
Changes for Proposal - #2314 
This PR abstracts out zookeeper interactions in the historical and coordinator for segment management. 
Changes in Historical Nodes - 
1) Extracts segment management from ZKCoordinator into SegmentManager, ZKCoordinator now just listens to the SegmentChangeRequests from Zookeeper and uses SegmentManager to handle those requests 
2) Adds new HTTP End points in Historical Resource which uses SegmentManager to process SegmentChangeRequests

Changes in Coordinator - 
1) Abstract out LoadQueuePeon which handles  load/unload queue and priority for load/unload. 
2) ZKLoadQueuePeon uses zookeeper to process SegmentChangeRequests 
3) HttpLoadQueuePeon uses the new http end-points for segment management
4) Introduce new config "druid.coordinator.load.peon.type" which can be set to "zk" or "http" (default is http)

TODO: 
1) Add unit tests for new endpoints and HttpLoadQueuePeon  
2) Add docs
