### PR TITLE
lazily create comparators for row columns when needed

### DIFF
--- a/processing/src/main/java/io/druid/query/groupby/GroupByQuery.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQuery.java
@@ -628,9 +628,6 @@ public class GroupByQuery extends BaseQuery<Row>
     if (limitSpec != null ? !limitSpec.equals(that.limitSpec) : that.limitSpec != null) {
       return false;
     }
-    if (limitFn != null ? !limitFn.equals(that.limitFn) : that.limitFn != null) {
-      return false;
-    }
     if (postAggregatorSpecs != null
         ? !postAggregatorSpecs.equals(that.postAggregatorSpecs)
         : that.postAggregatorSpecs != null) {

--- a/processing/src/main/java/io/druid/query/groupby/orderby/OrderByColumnSpec.java
+++ b/processing/src/main/java/io/druid/query/groupby/orderby/OrderByColumnSpec.java
@@ -173,6 +173,33 @@ public class OrderByColumnSpec
   }
 
   @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    OrderByColumnSpec that = (OrderByColumnSpec) o;
+
+    if (!dimension.equals(that.dimension)) {
+      return false;
+    }
+    return direction == that.direction;
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = dimension.hashCode();
+    result = 31 * result + direction.hashCode();
+    return result;
+  }
+
+  @Override
   public String toString()
   {
     return "OrderByColumnSpec{" +

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryTest.java
@@ -20,14 +20,19 @@
 package io.druid.query.groupby;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.query.Query;
 import io.druid.query.QueryRunnerTestHelper;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.LongSumAggregatorFactory;
+import io.druid.query.aggregation.PostAggregator;
+import io.druid.query.aggregation.post.FieldAccessPostAggregator;
 import io.druid.query.dimension.DefaultDimensionSpec;
 import io.druid.query.dimension.DimensionSpec;
+import io.druid.query.groupby.orderby.DefaultLimitSpec;
+import io.druid.query.groupby.orderby.OrderByColumnSpec;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -53,6 +58,13 @@ public class GroupByQueryTest
             )
         )
         .setGranularity(QueryRunnerTestHelper.dayGran)
+        .setPostAggregatorSpecs(ImmutableList.<PostAggregator>of(new FieldAccessPostAggregator("x", "idx")))
+        .setLimitSpec(
+            new DefaultLimitSpec(
+                ImmutableList.of(new OrderByColumnSpec("alias", OrderByColumnSpec.Direction.ASCENDING)),
+                100
+            )
+        )
         .build();
 
     String json = jsonMapper.writeValueAsString(query);

--- a/processing/src/test/java/io/druid/query/groupby/orderby/DefaultLimitSpecTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/orderby/DefaultLimitSpecTest.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.groupby.orderby;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import com.metamx.common.guava.Sequence;
+import com.metamx.common.guava.Sequences;
+import io.druid.data.input.MapBasedRow;
+import io.druid.data.input.Row;
+import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.query.aggregation.LongSumAggregatorFactory;
+import io.druid.query.aggregation.PostAggregator;
+import io.druid.query.aggregation.post.ArithmeticPostAggregator;
+import io.druid.query.aggregation.post.ConstantPostAggregator;
+import io.druid.query.dimension.DefaultDimensionSpec;
+import io.druid.query.dimension.DimensionSpec;
+import io.druid.segment.TestHelper;
+import org.joda.time.DateTime;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ */
+public class DefaultLimitSpecTest
+{
+  private final List<Row> testRowsList;
+  private final Sequence<Row> testRowsSequence;
+
+  public DefaultLimitSpecTest()
+  {
+    testRowsList = ImmutableList.of(
+        createRow("2011-04-01", "k1", 9.0d, "k2", 2L, "k3", 3L),
+        createRow("2011-04-01", "k1", 10.0d, "k2", 1L, "k3", 2L),
+        createRow("2011-04-01", "k1", 20.0d, "k2", 3L, "k3", 1L)
+    );
+
+    testRowsSequence = Sequences.simple(testRowsList);
+  }
+
+  @Test
+  public void testSerde() throws Exception
+  {
+    ObjectMapper mapper = TestHelper.getObjectMapper();
+
+    //defaults
+    String json = "{\"type\": \"default\"}";
+
+    DefaultLimitSpec spec = mapper.readValue(
+        mapper.writeValueAsString(mapper.readValue(json, DefaultLimitSpec.class)),
+        DefaultLimitSpec.class
+    );
+
+    Assert.assertEquals(
+        new DefaultLimitSpec(null, null),
+        spec
+    );
+
+    //non-defaults
+    json = "{\n"
+           + "  \"type\":\"default\",\n"
+           + "  \"columns\":[{\"dimension\":\"d\",\"direction\":\"ASCENDING\"}],\n"
+           + "  \"limit\":10\n"
+           + "}";
+
+    spec = mapper.readValue(
+        mapper.writeValueAsString(mapper.readValue(json, DefaultLimitSpec.class)),
+        DefaultLimitSpec.class
+    );
+
+    Assert.assertEquals(
+        new DefaultLimitSpec(ImmutableList.of(new OrderByColumnSpec("d", OrderByColumnSpec.Direction.ASCENDING)), 10),
+        spec
+    );
+  }
+
+  @Test
+  public void testBuildSimple()
+  {
+    DefaultLimitSpec limitSpec = new DefaultLimitSpec(
+        ImmutableList.<OrderByColumnSpec>of(),
+        2
+    );
+
+    Function<Sequence<Row>, Sequence<Row>> limitFn = limitSpec.build(
+        ImmutableList.<DimensionSpec>of(),
+        ImmutableList.<AggregatorFactory>of(),
+        ImmutableList.<PostAggregator>of()
+    );
+
+    Assert.assertEquals(
+        ImmutableList.of(testRowsList.get(0), testRowsList.get(1)),
+        Sequences.toList(limitFn.apply(testRowsSequence), new ArrayList<Row>())
+    );
+  }
+
+  @Test
+  public void testBuildWithExplicitOrder()
+  {
+    DefaultLimitSpec limitSpec = new DefaultLimitSpec(
+        ImmutableList.of(
+            new OrderByColumnSpec("k1", OrderByColumnSpec.Direction.ASCENDING)
+        ),
+        2
+    );
+
+    Function<Sequence<Row>, Sequence<Row>> limitFn = limitSpec.build(
+        ImmutableList.<DimensionSpec>of(
+            new DefaultDimensionSpec("k1", "k1")
+        ),
+        ImmutableList.<AggregatorFactory>of(
+            new LongSumAggregatorFactory("k2", "k2")
+        ),
+        ImmutableList.<PostAggregator>of(
+            new ConstantPostAggregator("k3", 1L)
+        )
+    );
+    Assert.assertEquals(
+        ImmutableList.of(testRowsList.get(1), testRowsList.get(2)),
+        Sequences.toList(limitFn.apply(testRowsSequence), new ArrayList<Row>())
+    );
+
+    // if there is an aggregator with same name then that is used to build ordering
+    limitFn = limitSpec.build(
+        ImmutableList.<DimensionSpec>of(
+            new DefaultDimensionSpec("k1", "k1")
+        ),
+        ImmutableList.<AggregatorFactory>of(
+            new LongSumAggregatorFactory("k1", "k1")
+        ),
+        ImmutableList.<PostAggregator>of(
+            new ConstantPostAggregator("k3", 1L)
+        )
+    );
+    Assert.assertEquals(
+        ImmutableList.of(testRowsList.get(0), testRowsList.get(1)),
+        Sequences.toList(limitFn.apply(testRowsSequence), new ArrayList<Row>())
+    );
+
+    // if there is a post-aggregator with same name then that is used to build ordering
+    limitFn = limitSpec.build(
+        ImmutableList.<DimensionSpec>of(
+            new DefaultDimensionSpec("k1", "k1")
+        ),
+        ImmutableList.<AggregatorFactory>of(
+            new LongSumAggregatorFactory("k2", "k2")
+        ),
+        ImmutableList.<PostAggregator>of(
+            new ArithmeticPostAggregator(
+                "k1",
+                "+",
+                ImmutableList.<PostAggregator>of(
+                    new ConstantPostAggregator("x", 1),
+                    new ConstantPostAggregator("y", 1))
+            )
+        )
+    );
+    Assert.assertEquals(
+        ImmutableList.of(testRowsList.get(0), testRowsList.get(1)),
+        Sequences.toList(limitFn.apply(testRowsSequence), new ArrayList<Row>())
+    );
+  }
+
+  private Row createRow(String timestamp, Object... vals)
+  {
+    Preconditions.checkArgument(vals.length % 2 == 0);
+
+    Map<String, Object> theVals = Maps.newHashMap();
+    for (int i = 0; i < vals.length; i += 2) {
+      theVals.put(vals[i].toString(), vals[i + 1]);
+    }
+
+    DateTime ts = new DateTime(timestamp);
+    return new MapBasedRow(ts, theVals);
+  }
+}


### PR DESCRIPTION
currently DefaultLimitSpec eagerly creates comparators for all dimensions, aggregators and post-aggregators even if they are not needed. this fails groupBy query deserialization when default limit spec is used on a dimension and there exists an aggregator or post-aggregator that does not implement `getComparator()`, see the UT update in GroupByQueryTest which fails without the change in this PR.
DefaultLimitSpec should only create comparators for the specific orderings specified by the user.
