### PR TITLE
[doc] fix doc format

### DIFF
--- a/docs/content/tutorials/tutorial-the-druid-cluster.md
+++ b/docs/content/tutorials/tutorial-the-druid-cluster.md
@@ -23,6 +23,7 @@ cd druid-<version>
 
 ## External Dependencies
 Druid requires 3 external dependencies.
+
 * A "deep storage" that acts as a data repository. This is generally distributed storage like HDFS or S3. For prototyping or experimentation on a single machine, Druid can use the local filesystem.
 * A "metadata storage" to hold configuration and metadata information. This is generally a small, shared database like MySQL or PostgreSQL. For prototyping or experimentation on a single machine, Druid can use a local instance of [Apache Derby](http://db.apache.org/derby/).
 * [Apache Zookeeper](http://zookeeper.apache.org/) for coordination among different pieces of the cluster.


### PR DESCRIPTION
As below, "External Dependencies" section should display as a **list** of 3 elements, but the generated html compact these to one paragraph:

![screen shot 2016-02-03 at 4 18 13 pm](https://cloud.githubusercontent.com/assets/1212008/12776654/cc6ff318-ca92-11e5-855e-d0a456ad58e1.png)