### PR TITLE
efficiently use hdfs namespace quota

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
@@ -75,7 +75,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -689,18 +688,19 @@ public class IndexGeneratorJob implements Jobby
         }
         final FileSystem outputFS = new Path(config.getSchema().getIOConfig().getSegmentOutputPath())
             .getFileSystem(context.getConfiguration());
+        final DataSegment segmentTemplate = new DataSegment(
+            config.getDataSource(),
+            interval,
+            config.getSchema().getTuningConfig().getVersion(),
+            null,
+            ImmutableList.copyOf(allDimensionNames),
+            metricNames,
+            config.getShardSpec(bucket).getActualSpec(),
+            -1,
+            -1
+        );
         final DataSegment segment = JobHelper.serializeOutIndex(
-            new DataSegment(
-                config.getDataSource(),
-                interval,
-                config.getSchema().getTuningConfig().getVersion(),
-                null,
-                ImmutableList.copyOf(allDimensionNames),
-                metricNames,
-                config.getShardSpec(bucket).getActualSpec(),
-                -1,
-                -1
-            ),
+            segmentTemplate,
             context.getConfiguration(),
             context,
             context.getTaskAttemptID(),
@@ -708,10 +708,7 @@ public class IndexGeneratorJob implements Jobby
             JobHelper.makeSegmentOutputPath(
                 new Path(config.getSchema().getIOConfig().getSegmentOutputPath()),
                 outputFS,
-                config.getSchema().getDataSchema().getDataSource(),
-                config.getSchema().getTuningConfig().getVersion(),
-                config.getSchema().getDataSchema().getGranularitySpec().bucketInterval(bucket.time).get(),
-                bucket.partitionNum
+                segmentTemplate
             )
         );
 

--- a/indexing-hadoop/src/main/java/io/druid/indexer/updater/HadoopConverterJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/updater/HadoopConverterJob.java
@@ -539,10 +539,7 @@ public class HadoopConverterJob
           JobHelper.makeSegmentOutputPath(
               baseOutputPath,
               outputFS,
-              finalSegmentTemplate.getDataSource(),
-              finalSegmentTemplate.getVersion(),
-              finalSegmentTemplate.getInterval(),
-              finalSegmentTemplate.getShardSpec().getPartitionNum()
+              finalSegmentTemplate
           )
       );
       context.progress();

--- a/indexing-hadoop/src/test/java/io/druid/indexer/HadoopDruidIndexerConfigTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/HadoopDruidIndexerConfigTest.java
@@ -121,7 +121,7 @@ public class HadoopDruidIndexerConfigTest
         )
     );
     Assert.assertEquals(
-        "hdfs://server:9100/tmp/druid/datatest/source/20120710T050000.000Z_20120710T060000.000Z/some_brand_new_version/4712",
+        "hdfs://server:9100/tmp/druid/datatest/source/20120710T050000.000Z_20120710T060000.000Z_some_brand_new_version_4712",
         path.toString()
     );
   }

--- a/indexing-hadoop/src/test/java/io/druid/indexer/HadoopDruidIndexerConfigTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/HadoopDruidIndexerConfigTest.java
@@ -32,7 +32,9 @@ import io.druid.jackson.DefaultObjectMapper;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.segment.indexing.DataSchema;
 import io.druid.segment.indexing.granularity.UniformGranularitySpec;
+import io.druid.timeline.DataSegment;
 import io.druid.timeline.partition.HashBasedNumberedShardSpec;
+import io.druid.timeline.partition.NumberedShardSpec;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
@@ -102,14 +104,21 @@ public class HadoopDruidIndexerConfigTest
         )
     );
 
-    Bucket bucket = new Bucket(4711, new DateTime(2012, 07, 10, 5, 30), 4712);
+    Bucket bucket = new Bucket(4712, new DateTime(2012, 07, 10, 5, 30), 4712);
     Path path = JobHelper.makeSegmentOutputPath(
         new Path(cfg.getSchema().getIOConfig().getSegmentOutputPath()),
         new DistributedFileSystem(),
-        cfg.getSchema().getDataSchema().getDataSource(),
-        cfg.getSchema().getTuningConfig().getVersion(),
-        cfg.getSchema().getDataSchema().getGranularitySpec().bucketInterval(bucket.time).get(),
-        bucket.partitionNum
+        new DataSegment(
+            cfg.getSchema().getDataSchema().getDataSource(),
+            cfg.getSchema().getDataSchema().getGranularitySpec().bucketInterval(bucket.time).get(),
+            cfg.getSchema().getTuningConfig().getVersion(),
+            null,
+            null,
+            null,
+            new NumberedShardSpec(bucket.partitionNum, 5000),
+            -1,
+            -1
+        )
     );
     Assert.assertEquals(
         "hdfs://server:9100/tmp/druid/datatest/source/20120710T050000.000Z_20120710T060000.000Z/some_brand_new_version/4712",
@@ -155,14 +164,21 @@ public class HadoopDruidIndexerConfigTest
         )
     );
 
-    Bucket bucket = new Bucket(4711, new DateTime(2012, 07, 10, 5, 30), 4712);
+    Bucket bucket = new Bucket(4712, new DateTime(2012, 07, 10, 5, 30), 4712);
     Path path = JobHelper.makeSegmentOutputPath(
         new Path(cfg.getSchema().getIOConfig().getSegmentOutputPath()),
         new LocalFileSystem(),
-        cfg.getSchema().getDataSchema().getDataSource(),
-        cfg.getSchema().getTuningConfig().getVersion(),
-        cfg.getSchema().getDataSchema().getGranularitySpec().bucketInterval(bucket.time).get(),
-        bucket.partitionNum
+        new DataSegment(
+            cfg.getSchema().getDataSchema().getDataSource(),
+            cfg.getSchema().getDataSchema().getGranularitySpec().bucketInterval(bucket.time).get(),
+            cfg.getSchema().getTuningConfig().getVersion(),
+            null,
+            null,
+            null,
+            new NumberedShardSpec(bucket.partitionNum, 5000),
+            -1,
+            -1
+        )
     );
     Assert.assertEquals(
         "file:/tmp/dru:id/data:test/the:data:source/2012-07-10T05:00:00.000Z_2012-07-10T06:00:00.000Z/some:brand:new:version/4712",

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <apache.curator.version>2.9.1</apache.curator.version>
         <jetty.version>9.2.5.v20141112</jetty.version>
         <jersey.version>1.19</jersey.version>
-        <druid.api.version>0.3.16</druid.api.version>
+        <druid.api.version>0.3.17</druid.api.version>
         <!-- Watch out for Hadoop compatibility when updating to >= 2.5; see https://github.com/druid-io/druid/pull/1669 -->
         <jackson.version>2.4.6</jackson.version>
         <log4j.version>2.5</log4j.version>


### PR DESCRIPTION
depends on https://github.com/druid-io/druid-api/pull/73 and a new release 0.3.17 in druid-api

hdfs namenode file name quota is scarce resource and we need to be efficient in how and how much we utilized it. in the best case this reduces 2 per segment.