### PR TITLE
Adding optional error bounds to sketch aggs and post-aggs

### DIFF
--- a/extensions/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchEstimateWithErrorBounds.java
+++ b/extensions/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchEstimateWithErrorBounds.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.druid.query.aggregation.datasketches.theta;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Container class used to return estimates in conjunction with 
+ * estimated error bounds.
+ */
+public class SketchEstimateWithErrorBounds
+{
+  final private double estimate;
+  final private double highBound;
+  final private double lowBound;
+  final private int numStdDev;
+  
+  @JsonCreator
+  public SketchEstimateWithErrorBounds(
+      @JsonProperty("estimate") double estimate,
+      @JsonProperty("highBound") double highBound,
+      @JsonProperty("lowBound") double lowBound,
+      @JsonProperty("numStdDev") int numStdDev
+  )
+  {
+    this.estimate = estimate;
+    this.highBound = highBound;
+    this.lowBound = lowBound;
+    this.numStdDev = numStdDev;
+  }
+  
+  @JsonProperty
+  public double getEstimate()
+  {
+    return estimate;
+  }
+
+  @JsonProperty
+  public double getHighBound()
+  {
+    return highBound;
+  }
+
+  @JsonProperty
+  public double getLowBound()
+  {
+    return lowBound;
+  }
+
+  @JsonProperty
+  public int getNumStdDev()
+  {
+    return numStdDev;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "SketchEstimateWithErrorBounds{" +
+        "estimate=" + Double.toString(estimate) +
+        ", highBound=" + Double.toString(highBound) +
+        ", lowBound="+ Double.toString(lowBound) +
+        ", numStdDev=" + Integer.toString(numStdDev) +
+        "}";
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = Double.valueOf(estimate).hashCode();
+    result = 31 * result + Double.valueOf(highBound).hashCode();
+    result = 31 * result + Double.valueOf(lowBound).hashCode();
+    result = 31 * result + Integer.valueOf(numStdDev).hashCode();
+
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj)
+  {
+    if (this == obj) {
+      return true;
+    } else if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    } 
+    
+    SketchEstimateWithErrorBounds that = (SketchEstimateWithErrorBounds) obj;
+    if (estimate != that.estimate ||
+        highBound != that.highBound ||
+        lowBound != that.lowBound ||
+        numStdDev != numStdDev) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/extensions/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/oldapi/OldSketchBuildAggregatorFactory.java
+++ b/extensions/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/oldapi/OldSketchBuildAggregatorFactory.java
@@ -34,6 +34,6 @@ public class OldSketchBuildAggregatorFactory extends SketchMergeAggregatorFactor
       @JsonProperty("size") Integer size
   )
   {
-    super(name, fieldName, size, true, false);
+    super(name, fieldName, size, true, false, null);
   }
 }

--- a/extensions/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/oldapi/OldSketchEstimatePostAggregator.java
+++ b/extensions/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/oldapi/OldSketchEstimatePostAggregator.java
@@ -34,6 +34,6 @@ public class OldSketchEstimatePostAggregator extends SketchEstimatePostAggregato
       @JsonProperty("field") PostAggregator field
   )
   {
-    super(name, field);
+    super(name, field, null);
   }
 }

--- a/extensions/datasketches/src/test/java/io/druid/query/aggregation/datasketches/theta/SketchEstimateWithErrorBoundsTest.java
+++ b/extensions/datasketches/src/test/java/io/druid/query/aggregation/datasketches/theta/SketchEstimateWithErrorBoundsTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to Metamarkets Group Inc. (Metamarkets) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information
@@ -16,25 +16,28 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package io.druid.query.aggregation.datasketches.theta;
 
-package io.druid.query.aggregation.datasketches.theta.oldapi;
+import org.junit.Assert;
+import org.junit.Test;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import io.druid.query.aggregation.datasketches.theta.SketchMergeAggregatorFactory;
+import java.io.IOException;
 
-/**
- */
-public class OldSketchMergeAggregatorFactory extends SketchMergeAggregatorFactory
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.druid.jackson.DefaultObjectMapper;
+
+public class SketchEstimateWithErrorBoundsTest
 {
-  @JsonCreator
-  public OldSketchMergeAggregatorFactory(
-      @JsonProperty("name") String name,
-      @JsonProperty("fieldName") String fieldName,
-      @JsonProperty("size") Integer size,
-      @JsonProperty("shouldFinalize") Boolean shouldFinalize
-  )
+
+  @Test
+  public void testSerde() throws IOException
   {
-    super(name, fieldName, size, shouldFinalize, true, null);
+    ObjectMapper mapper = new DefaultObjectMapper();
+
+    SketchEstimateWithErrorBounds est = new SketchEstimateWithErrorBounds(100.0,101.5,98.5,2);
+    
+    Assert.assertEquals(est, mapper.readValue(
+            mapper.writeValueAsString(est), SketchEstimateWithErrorBounds.class));
   }
+
 }

--- a/extensions/datasketches/src/test/resources/sketch_test_data_group_by_query.json
+++ b/extensions/datasketches/src/test/resources/sketch_test_data_group_by_query.json
@@ -12,6 +12,13 @@
     },
     {
       "type": "thetaSketch",
+      "name": "sids_sketch_count_with_err",
+      "fieldName": "sids_sketch",
+      "size": 16384,
+      "errorBoundsStdDev": 2
+    },
+    {
+      "type": "thetaSketch",
       "name": "non_existing_col_validation",
       "fieldName": "non_existing_col",
       "size": 16384
@@ -21,6 +28,15 @@
     {
       "type": "thetaSketchEstimate",
       "name": "sketchEstimatePostAgg",
+      "field": {
+        "type": "fieldAccess",
+        "fieldName": "sids_sketch_count"
+      }
+    },
+    {
+      "type": "thetaSketchEstimate",
+      "name": "sketchEstimatePostAggWithErrorBounds",
+      "errorBoundsStdDev": 2,
       "field": {
         "type": "fieldAccess",
         "fieldName": "sids_sketch_count"


### PR DESCRIPTION
By setting a new optional parameter, `errorBoundsStdDev`, to the number
of standard deviations to use when computing error bounds, the return
type for both the SketchMergeAggregator and the SketchEstimate
PostAggregator can be changed from a simple double (estimate) to a JSON
object containing the estimate, expected high bound, expected low bound,
and standard devations used when computing bounds (same value as passed
in).