### PR TITLE
In JobHelper.makeSegmentOutputPath(..) use DataSegmentPusherUtils

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
@@ -75,7 +75,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -689,18 +688,19 @@ public class IndexGeneratorJob implements Jobby
         }
         final FileSystem outputFS = new Path(config.getSchema().getIOConfig().getSegmentOutputPath())
             .getFileSystem(context.getConfiguration());
+        final DataSegment segmentTemplate = new DataSegment(
+            config.getDataSource(),
+            interval,
+            config.getSchema().getTuningConfig().getVersion(),
+            null,
+            ImmutableList.copyOf(allDimensionNames),
+            metricNames,
+            config.getShardSpec(bucket).getActualSpec(),
+            -1,
+            -1
+        );
         final DataSegment segment = JobHelper.serializeOutIndex(
-            new DataSegment(
-                config.getDataSource(),
-                interval,
-                config.getSchema().getTuningConfig().getVersion(),
-                null,
-                ImmutableList.copyOf(allDimensionNames),
-                metricNames,
-                config.getShardSpec(bucket).getActualSpec(),
-                -1,
-                -1
-            ),
+            segmentTemplate,
             context.getConfiguration(),
             context,
             context.getTaskAttemptID(),
@@ -708,10 +708,7 @@ public class IndexGeneratorJob implements Jobby
             JobHelper.makeSegmentOutputPath(
                 new Path(config.getSchema().getIOConfig().getSegmentOutputPath()),
                 outputFS,
-                config.getSchema().getDataSchema().getDataSource(),
-                config.getSchema().getTuningConfig().getVersion(),
-                config.getSchema().getDataSchema().getGranularitySpec().bucketInterval(bucket.time).get(),
-                bucket.partitionNum
+                segmentTemplate
             )
         );
 

--- a/indexing-hadoop/src/main/java/io/druid/indexer/updater/HadoopConverterJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/updater/HadoopConverterJob.java
@@ -539,10 +539,7 @@ public class HadoopConverterJob
           JobHelper.makeSegmentOutputPath(
               baseOutputPath,
               outputFS,
-              finalSegmentTemplate.getDataSource(),
-              finalSegmentTemplate.getVersion(),
-              finalSegmentTemplate.getInterval(),
-              finalSegmentTemplate.getShardSpec().getPartitionNum()
+              finalSegmentTemplate
           )
       );
       context.progress();

--- a/indexing-hadoop/src/test/java/io/druid/indexer/HadoopDruidIndexerConfigTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/HadoopDruidIndexerConfigTest.java
@@ -32,7 +32,9 @@ import io.druid.jackson.DefaultObjectMapper;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.segment.indexing.DataSchema;
 import io.druid.segment.indexing.granularity.UniformGranularitySpec;
+import io.druid.timeline.DataSegment;
 import io.druid.timeline.partition.HashBasedNumberedShardSpec;
+import io.druid.timeline.partition.NumberedShardSpec;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
@@ -106,10 +108,17 @@ public class HadoopDruidIndexerConfigTest
     Path path = JobHelper.makeSegmentOutputPath(
         new Path(cfg.getSchema().getIOConfig().getSegmentOutputPath()),
         new DistributedFileSystem(),
-        cfg.getSchema().getDataSchema().getDataSource(),
-        cfg.getSchema().getTuningConfig().getVersion(),
-        cfg.getSchema().getDataSchema().getGranularitySpec().bucketInterval(bucket.time).get(),
-        bucket.partitionNum
+        new DataSegment(
+            cfg.getSchema().getDataSchema().getDataSource(),
+            cfg.getSchema().getDataSchema().getGranularitySpec().bucketInterval(bucket.time).get(),
+            cfg.getSchema().getTuningConfig().getVersion(),
+            null,
+            null,
+            null,
+            new NumberedShardSpec(bucket.partitionNum, 5000),
+            -1,
+            -1
+        )
     );
     Assert.assertEquals(
         "hdfs://server:9100/tmp/druid/datatest/source/20120710T050000.000Z_20120710T060000.000Z/some_brand_new_version/4712",
@@ -159,10 +168,17 @@ public class HadoopDruidIndexerConfigTest
     Path path = JobHelper.makeSegmentOutputPath(
         new Path(cfg.getSchema().getIOConfig().getSegmentOutputPath()),
         new LocalFileSystem(),
-        cfg.getSchema().getDataSchema().getDataSource(),
-        cfg.getSchema().getTuningConfig().getVersion(),
-        cfg.getSchema().getDataSchema().getGranularitySpec().bucketInterval(bucket.time).get(),
-        bucket.partitionNum
+        new DataSegment(
+            cfg.getSchema().getDataSchema().getDataSource(),
+            cfg.getSchema().getDataSchema().getGranularitySpec().bucketInterval(bucket.time).get(),
+            cfg.getSchema().getTuningConfig().getVersion(),
+            null,
+            null,
+            null,
+            new NumberedShardSpec(bucket.partitionNum, 5000),
+            -1,
+            -1
+        )
     );
     Assert.assertEquals(
         "file:/tmp/dru:id/data:test/the:data:source/2012-07-10T05:00:00.000Z_2012-07-10T06:00:00.000Z/some:brand:new:version/4712",


### PR DESCRIPTION
instead of duplicating the storage direction location semantics.

i noticed it while doing https://github.com/druid-io/druid/pull/2412