### PR TITLE
correct service names

### DIFF
--- a/docs/content/configuration/production-cluster.md
+++ b/docs/content/configuration/production-cluster.md
@@ -80,10 +80,10 @@ druid.cache.maxOperationQueueSize=1073741824
 druid.cache.readBufferSize=10485760
 
 # Indexing Service Service Discovery
-druid.selectors.indexing.serviceName=druid:overlord
+druid.selectors.indexing.serviceName=druid/overlord
 
 # Coordinator Service Discovery
-druid.selectors.coordinator.serviceName=druid:prod:coordinator
+druid.selectors.coordinator.serviceName=druid/prod/coordinator
 ```
 
 ### Overlord Node

--- a/integration-tests/docker/middlemanager.conf
+++ b/integration-tests/docker/middlemanager.conf
@@ -20,7 +20,7 @@ command=java
   -Ddruid.s3.accessKey=AKIAIMKECRUYKDQGR6YQ
   -Ddruid.s3.secretKey=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
   -Ddruid.worker.ip=%(ENV_HOST_IP)s
-  -Ddruid.selectors.indexing.serviceName=druid:overlord
+  -Ddruid.selectors.indexing.serviceName=druid/overlord
   -Ddruid.indexer.task.chathandler.type=announce
   -cp /usr/local/druid/lib/*
   io.druid.cli.Main server middleManager


### PR DESCRIPTION
use a `/` instead of `:` cause thats how the service names are declared in the respective config files of coordinator and overlord