### PR TITLE
integration-tests: stop using kill=false to disable segments

### DIFF
--- a/integration-tests/src/main/java/io/druid/testing/clients/CoordinatorResourceTestClient.java
+++ b/integration-tests/src/main/java/io/druid/testing/clients/CoordinatorResourceTestClient.java
@@ -122,23 +122,30 @@ public class CoordinatorResourceTestClient
 
   public void unloadSegmentsForDataSource(String dataSource, Interval interval)
   {
-    killDataSource(dataSource, false, interval);
+    try {
+      makeRequest(
+          HttpMethod.DELETE,
+          String.format(
+              "%sdatasources/%s",
+              getCoordinatorURL(),
+              dataSource
+          )
+      );
+    }
+    catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
   }
 
   public void deleteSegmentsDataSource(String dataSource, Interval interval)
-  {
-    killDataSource(dataSource, true, interval);
-  }
-
-  private void killDataSource(String dataSource, boolean kill, Interval interval)
   {
     try {
       makeRequest(
           HttpMethod.DELETE,
           String.format(
-              "%sdatasources/%s/intervals/%s?kill=%s",
+              "%sdatasources/%s/intervals/%s?kill=true",
               getCoordinatorURL(),
-              dataSource, interval.toString().replace("/", "_"), kill
+              dataSource, interval.toString().replace("/", "_")
           )
       );
     }

--- a/integration-tests/src/test/java/io/druid/tests/indexer/ITKafkaTest.java
+++ b/integration-tests/src/test/java/io/druid/tests/indexer/ITKafkaTest.java
@@ -273,7 +273,7 @@ public class ITKafkaTest extends AbstractIndexerTest
   }
 
   @AfterClass
-  public void afterClass()
+  public void afterClass() throws Exception
   {
     LOG.info("teardown");
 
@@ -285,12 +285,7 @@ public class ITKafkaTest extends AbstractIndexerTest
 
     // remove segments
     if (segmentsExist) {
-      try {
         unloadAndKillData(DATASOURCE);
-      }
-      catch (Exception e) {
-        LOG.warn("exception while removing segments: [%s]", e.getMessage());
-      }
     }
   }
 }


### PR DESCRIPTION
I want to address the first issue in
     https://github.com/druid-io/druid/issues/2467
because it is making our 0.9.0 builds fail.

In addition to modifying CoordinatorResourceTestClient.java to use the documented endpoint to disable segments, I want to modify ITKafkaTest so that it doesn't swallow the exception if it can't clean up its segments (the test should fail in that case, as the other tests do).