### PR TITLE
Fixed equal distribution strategy when exist disabled middleManagers.

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/overlord/setup/EqualDistributionWorkerSelectStrategy.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/setup/EqualDistributionWorkerSelectStrategy.java
@@ -47,7 +47,17 @@ public class EqualDistributionWorkerSelectStrategy implements WorkerSelectStrate
               ImmutableZkWorker zkWorker, ImmutableZkWorker zkWorker2
           )
           {
-            return -Ints.compare(zkWorker2.getCurrCapacityUsed(), zkWorker.getCurrCapacityUsed());
+            int retVal = -Ints.compare(zkWorker2.getCurrCapacityUsed(), zkWorker.getCurrCapacityUsed());
+            // the version sorting is needed because if the workers have the same currCapacityUsed only one of them is
+            // returned. Exists the possibility that this worker is disabled and doesn't have valid version so can't
+            // run new tasks, so in this case the workers are sorted using version to ensure that if exists enable
+            // workers the comparator return one of them.
+
+            if(retVal == 0) {
+              retVal = zkWorker2.getWorker().getVersion().compareTo(zkWorker.getWorker().getVersion());
+            }
+
+            return retVal;
           }
         }
     );

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/setup/FillCapacityWorkerSelectStrategy.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/setup/FillCapacityWorkerSelectStrategy.java
@@ -50,8 +50,13 @@ public class FillCapacityWorkerSelectStrategy implements WorkerSelectStrategy
           )
           {
             int retVal = Ints.compare(zkWorker2.getCurrCapacityUsed(), zkWorker.getCurrCapacityUsed());
+            // the version sorting is needed because if the workers have the same currCapacityUsed only one of them is
+            // returned. Exists the possibility that this worker is disabled and doesn't have valid version so can't
+            // run new tasks, so in this case the workers are sorted using version to ensure that if exists enable
+            // workers the comparator return one of them.
+
             if (retVal == 0) {
-              retVal = zkWorker.getWorker().getHost().compareTo(zkWorker2.getWorker().getHost());
+              retVal = zkWorker.getWorker().getVersion().compareTo(zkWorker2.getWorker().getVersion());
             }
 
             return retVal;

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/setup/EqualDistributionWorkerSelectStrategyTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/setup/EqualDistributionWorkerSelectStrategyTest.java
@@ -63,4 +63,70 @@ public class EqualDistributionWorkerSelectStrategyTest
     ImmutableZkWorker worker = optional.get();
     Assert.assertEquals("lhost", worker.getWorker().getHost());
   }
+
+  @Test
+  public void testOneDisableWorkerDifferentUsedCapacity() throws Exception
+  {
+    String DISABLED_VERSION = "";
+    final EqualDistributionWorkerSelectStrategy strategy = new EqualDistributionWorkerSelectStrategy();
+
+    Optional<ImmutableZkWorker> optional = strategy.findWorkerForTask(
+        new RemoteTaskRunnerConfig(),
+        ImmutableMap.of(
+                      "lhost",
+                      new ImmutableZkWorker(
+                              new Worker("disableHost", "disableHost", 10, DISABLED_VERSION), 2,
+                              Sets.<String>newHashSet()
+                      ),
+                      "localhost",
+                      new ImmutableZkWorker(
+                              new Worker("enableHost", "enableHost", 10, "v1"), 5,
+                              Sets.<String>newHashSet()
+                      )
+        ),
+        new NoopTask(null, 1, 0, null, null, null)
+        {
+          @Override
+          public String getDataSource()
+                  {
+                      return "foo";
+                  }
+        }
+    );
+    ImmutableZkWorker worker = optional.get();
+    Assert.assertEquals("enableHost", worker.getWorker().getHost());
+  }
+
+  @Test
+  public void testOneDisableWorkerSameUsedCapacity() throws Exception
+  {
+    String DISABLED_VERSION = "";
+    final EqualDistributionWorkerSelectStrategy strategy = new EqualDistributionWorkerSelectStrategy();
+
+    Optional<ImmutableZkWorker> optional = strategy.findWorkerForTask(
+            new RemoteTaskRunnerConfig(),
+            ImmutableMap.of(
+                    "lhost",
+                    new ImmutableZkWorker(
+                            new Worker("disableHost", "disableHost", 10, DISABLED_VERSION), 5,
+                            Sets.<String>newHashSet()
+                    ),
+                    "localhost",
+                    new ImmutableZkWorker(
+                            new Worker("enableHost", "enableHost", 10, "v1"), 5,
+                            Sets.<String>newHashSet()
+                    )
+            ),
+            new NoopTask(null, 1, 0, null, null, null)
+            {
+                @Override
+                public String getDataSource()
+                {
+                    return "foo";
+                }
+            }
+    );
+    ImmutableZkWorker worker = optional.get();
+    Assert.assertEquals("enableHost", worker.getWorker().getHost());
+  }
 }


### PR DESCRIPTION
Hi all,

This week working on our cluster we detected a little issue. When we have for example 5 middleManagers and all of them have the same currentCapacityUsed and some of them are disabled, maybe the new indexing tasks can't start.

MiddleManager | Capacity | CurrentCapacityUsed | Status
------------ | --------- | ------------- | -------
AAA | 10 | 5 | Disabled
BBB | 10 | 5  | Enabled
CCC | 10 | 5 | Enabled
DDD | 10 | 5 | Enabled

On this scenario, maybe the current equal distribution return an unique middleManager if the middleManager that is returned is disabled. The new tasks can't start and go to pending status.

To fix the issue I changed the logic inside equal distribution, now sort the middleManager using the currentCapacityUsed but if two middleManagers have the same currentCapacityUsed, them are sorted using the IP address.
