### PR TITLE
query tests: add max and min to segment metadata query results

### DIFF
--- a/integration-tests/src/test/resources/queries/twitterstream_queries.json
+++ b/integration-tests/src/test/resources/queries/twitterstream_queries.json
@@ -597,6 +597,8 @@
                         "hasMultipleValues": false,
                         "size": 7773438,
                         "cardinality": 2,
+                        "minValue":"No",
+                        "maxValue":"Yes",
                         "errorMessage": null
                     }
                 },
@@ -613,6 +615,8 @@
                         "hasMultipleValues": false,
                         "size": 7901000,
                         "cardinality": 2,
+                        "minValue":"No",
+                        "maxValue":"Yes",
                         "errorMessage": null
                     }
                 },
@@ -629,6 +633,8 @@
                         "hasMultipleValues": false,
                         "size": 7405654,
                         "cardinality": 2,
+                        "minValue":"No",
+                        "maxValue":"Yes",
                         "errorMessage": null
                     }
                 },

--- a/integration-tests/src/test/resources/queries/wikipedia_editstream_queries.json
+++ b/integration-tests/src/test/resources/queries/wikipedia_editstream_queries.json
@@ -1048,6 +1048,8 @@
                         "hasMultipleValues": false,
                         "size": 41922148,
                         "cardinality": 208,
+                        "minValue":"",
+                        "maxValue":"mmx._unknown",
                         "errorMessage": null
                     },
                     "language": {
@@ -1055,6 +1057,8 @@
                         "hasMultipleValues": false,
                         "size": 8924222,
                         "cardinality": 36,
+                        "minValue":"ar",
+                        "maxValue":"zh",
                         "errorMessage": null
                     }
                 },


### PR DESCRIPTION
because of https://github.com/druid-io/druid/pull/2208