### PR TITLE
Select query cannot span to next segment with paging

### DIFF
--- a/processing/src/main/java/io/druid/query/select/SelectBinaryFn.java
+++ b/processing/src/main/java/io/druid/query/select/SelectBinaryFn.java
@@ -25,6 +25,8 @@ import io.druid.granularity.QueryGranularity;
 import io.druid.query.Result;
 import org.joda.time.DateTime;
 
+import java.util.List;
+
 /**
  */
 public class SelectBinaryFn
@@ -58,14 +60,22 @@ public class SelectBinaryFn
       return arg1;
     }
 
+    final List<EventHolder> arg1Val = arg1.getValue().getEvents();
+    final List<EventHolder> arg2Val = arg2.getValue().getEvents();
+
+    if (arg1Val == null || arg1Val.isEmpty()) {
+      return arg2;
+    }
+
+    if (arg2Val == null || arg2Val.isEmpty()) {
+      return arg1;
+    }
+
     final DateTime timestamp = (gran instanceof AllGranularity)
                                ? arg1.getTimestamp()
                                : gran.toDateTime(gran.truncate(arg1.getTimestamp().getMillis()));
 
-    SelectResultValueBuilder builder = new SelectResultValueBuilder(timestamp, pagingSpec, descending);
-
-    SelectResultValue arg1Val = arg1.getValue();
-    SelectResultValue arg2Val = arg2.getValue();
+    SelectResultValueBuilder builder = new SelectResultValueBuilder.MergeBuilder(timestamp, pagingSpec, descending);
 
     for (EventHolder event : arg1Val) {
       builder.addEntry(event);

--- a/processing/src/main/java/io/druid/query/select/SelectQuery.java
+++ b/processing/src/main/java/io/druid/query/select/SelectQuery.java
@@ -173,6 +173,21 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
     );
   }
 
+  public SelectQuery withPagingSpec(PagingSpec pagingSpec)
+  {
+    return new SelectQuery(
+        getDataSource(),
+        getQuerySegmentSpec(),
+        isDescending(),
+        dimFilter,
+        granularity,
+        dimensions,
+        metrics,
+        pagingSpec,
+        getContext()
+    );
+  }
+
   @Override
   public String toString()
   {

--- a/processing/src/main/java/io/druid/query/select/SelectQueryEngine.java
+++ b/processing/src/main/java/io/druid/query/select/SelectQueryEngine.java
@@ -20,6 +20,7 @@
 package io.druid.query.select;
 
 import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.metamx.common.ISE;
@@ -33,11 +34,13 @@ import io.druid.segment.DimensionSelector;
 import io.druid.segment.LongColumnSelector;
 import io.druid.segment.ObjectColumnSelector;
 import io.druid.segment.Segment;
+import io.druid.segment.SegmentDesc;
 import io.druid.segment.StorageAdapter;
 import io.druid.segment.column.Column;
 import io.druid.segment.data.IndexedInts;
 import io.druid.segment.filter.Filters;
 import org.joda.time.DateTime;
+import org.joda.time.Interval;
 
 import java.util.List;
 import java.util.Map;
@@ -69,6 +72,11 @@ public class SelectQueryEngine
     } else {
       metrics = query.getMetrics();
     }
+    List<Interval> intervals = query.getQuerySegmentSpec().getIntervals();
+    Preconditions.checkArgument(intervals.size() == 1, "Can only handle a single interval, got[%s]", intervals);
+
+    // should be rewritten with given interval
+    final String segmentId = SegmentDesc.withInterval(segment.getIdentifier(), intervals.get(0));
 
     return QueryRunnerHelper.makeCursorBasedQuery(
         adapter,
@@ -101,7 +109,7 @@ public class SelectQueryEngine
               metSelectors.put(metric, metricSelector);
             }
 
-            final PagingOffset offset = query.getPagingOffset(segment.getIdentifier());
+            final PagingOffset offset = query.getPagingOffset(segmentId);
 
             cursor.advanceTo(offset.startDelta());
 
@@ -145,14 +153,14 @@ public class SelectQueryEngine
 
               builder.addEntry(
                   new EventHolder(
-                      segment.getIdentifier(),
+                      segmentId,
                       lastOffset = offset.current(),
                       theEvent
                   )
               );
             }
 
-            builder.finished(segment.getIdentifier(), lastOffset);
+            builder.finished(segmentId, lastOffset);
 
             return builder.build();
           }

--- a/processing/src/main/java/io/druid/query/select/SelectQueryEngine.java
+++ b/processing/src/main/java/io/druid/query/select/SelectQueryEngine.java
@@ -105,6 +105,7 @@ public class SelectQueryEngine
 
             cursor.advanceTo(offset.startDelta());
 
+            int lastOffset = offset.startOffset();
             for (; !cursor.isDone() && offset.hasNext(); cursor.advance(), offset.next()) {
               final Map<String, Object> theEvent = Maps.newLinkedHashMap();
               theEvent.put(EventHolder.timestampKey, new DateTime(timestampColumnSelector.get()));
@@ -145,11 +146,13 @@ public class SelectQueryEngine
               builder.addEntry(
                   new EventHolder(
                       segment.getIdentifier(),
-                      offset.current(),
+                      lastOffset = offset.current(),
                       theEvent
                   )
               );
             }
+
+            builder.finished(segment.getIdentifier(), lastOffset);
 
             return builder.build();
           }

--- a/processing/src/main/java/io/druid/segment/SegmentDesc.java
+++ b/processing/src/main/java/io/druid/segment/SegmentDesc.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment;
+
+import com.google.common.base.Function;
+import io.druid.timeline.DataSegment;
+import org.joda.time.DateTime;
+import org.joda.time.Interval;
+
+/**
+ * identifier to DataSegment. wishfully included in DataSegment
+ */
+public class SegmentDesc
+{
+  public static Function<String, Interval> INTERVAL_EXTRACTOR = new Function<String, Interval>()
+  {
+    @Override
+    public Interval apply(String identifier)
+    {
+      return valueOf(identifier).getInterval();
+    }
+  };
+
+  // ignores shard spec
+  public static SegmentDesc valueOf(final String identifier)
+  {
+    String[] splits = identifier.split(DataSegment.delimiter);
+    if (splits.length < 4) {
+      throw new IllegalArgumentException("Invalid identifier " + identifier);
+    }
+    String datasource = splits[0];
+    DateTime start = new DateTime(splits[1]);
+    DateTime end = new DateTime(splits[2]);
+    String version = splits[3];
+
+    return new SegmentDesc(
+        datasource,
+        new Interval(start.getMillis(), end.getMillis()),
+        version
+    );
+  }
+
+  private final String dataSource;
+  private final Interval interval;
+  private final String version;
+
+  public SegmentDesc(String dataSource, Interval interval, String version)
+  {
+    this.dataSource = dataSource;
+    this.interval = interval;
+    this.version = version;
+  }
+
+  public String getDataSource()
+  {
+    return dataSource;
+  }
+
+  public Interval getInterval()
+  {
+    return interval;
+  }
+
+  public String getVersion()
+  {
+    return version;
+  }
+}

--- a/processing/src/main/java/io/druid/segment/SegmentDesc.java
+++ b/processing/src/main/java/io/druid/segment/SegmentDesc.java
@@ -20,6 +20,7 @@
 package io.druid.segment;
 
 import com.google.common.base.Function;
+import com.metamx.common.logger.Logger;
 import io.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -29,6 +30,8 @@ import org.joda.time.Interval;
  */
 public class SegmentDesc
 {
+  private static final Logger LOGGER = new Logger(SegmentDesc.class);
+
   public static Function<String, Interval> INTERVAL_EXTRACTOR = new Function<String, Interval>()
   {
     @Override
@@ -55,6 +58,26 @@ public class SegmentDesc
         new Interval(start.getMillis(), end.getMillis()),
         version
     );
+  }
+
+  public static String withInterval(final String identifier, Interval newInterval)
+  {
+    String[] splits = identifier.split(DataSegment.delimiter);
+    if (splits.length < 4) {
+      // happens for test segments which has invalid segment id.. ignore for now
+      LOGGER.warn("Invalid segment identifier " + identifier);
+      return identifier;
+    }
+    StringBuilder builder = new StringBuilder();
+    builder.append(splits[0]).append(DataSegment.delimiter);
+    builder.append(newInterval.getStart()).append(DataSegment.delimiter);
+    builder.append(newInterval.getEnd()).append(DataSegment.delimiter);
+    for (int i = 3; i < splits.length - 1; i++) {
+      builder.append(splits[i]).append(DataSegment.delimiter);
+    }
+    builder.append(splits[splits.length - 1]);
+
+    return builder.toString();
   }
 
   private final String dataSource;

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTestHelper.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTestHelper.java
@@ -27,6 +27,7 @@ import com.metamx.common.guava.Sequences;
 import io.druid.data.input.MapBasedRow;
 import io.druid.data.input.Row;
 import io.druid.query.FinalizeResultsQueryRunner;
+import io.druid.query.Query;
 import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerFactory;
 import io.druid.query.QueryToolChest;
@@ -38,17 +39,17 @@ import java.util.Map;
  */
 public class GroupByQueryRunnerTestHelper
 {
-  public static Iterable<Row> runQuery(QueryRunnerFactory factory, QueryRunner runner, GroupByQuery query)
+  public static <T> Iterable<T> runQuery(QueryRunnerFactory factory, QueryRunner runner, Query<T> query)
   {
 
     QueryToolChest toolChest = factory.getToolchest();
-    QueryRunner theRunner = new FinalizeResultsQueryRunner<>(
+    QueryRunner<T> theRunner = new FinalizeResultsQueryRunner<>(
         toolChest.mergeResults(toolChest.preMergeQueryDecoration(runner)),
         toolChest
     );
 
-    Sequence<Row> queryResult = theRunner.run(query, Maps.newHashMap());
-    return Sequences.toList(queryResult, Lists.<Row>newArrayList());
+    Sequence<T> queryResult = theRunner.run(query, Maps.<String, Object>newHashMap());
+    return Sequences.toList(queryResult, Lists.<T>newArrayList());
   }
 
   public static Row createExpectedRow(final String timestamp, Object... vals)

--- a/processing/src/test/java/io/druid/query/select/MultiSegmentSelectQueryTest.java
+++ b/processing/src/test/java/io/druid/query/select/MultiSegmentSelectQueryTest.java
@@ -26,12 +26,14 @@ import com.google.common.io.CharSource;
 import com.metamx.common.guava.Sequences;
 import io.druid.granularity.QueryGranularity;
 import io.druid.jackson.DefaultObjectMapper;
+import io.druid.query.Druids;
 import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerFactory;
 import io.druid.query.QueryRunnerTestHelper;
 import io.druid.query.Result;
 import io.druid.query.TableDataSource;
 import io.druid.query.dimension.DefaultDimensionSpec;
+import io.druid.query.ordering.StringComparators;
 import io.druid.segment.IncrementalIndexSegment;
 import io.druid.segment.Segment;
 import io.druid.segment.TestIndex;
@@ -39,7 +41,10 @@ import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.timeline.DataSegment;
+import io.druid.timeline.TimelineObjectHolder;
+import io.druid.timeline.VersionedIntervalTimeline;
 import io.druid.timeline.partition.NoneShardSpec;
+import io.druid.timeline.partition.SingleElementPartitionChunk;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.joda.time.DateTime;
@@ -50,7 +55,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -70,50 +74,110 @@ public class MultiSegmentSelectQueryTest
       QueryRunnerTestHelper.NOOP_QUERYWATCHER
   );
 
+  // time modified version of druid.sample.tsv
+  public static final String[] V_0112 = {
+      "2011-01-12T00:00:00.000Z	spot	automotive	preferred	apreferred	100.000000",
+      "2011-01-12T01:00:00.000Z	spot	business	preferred	bpreferred	100.000000",
+      "2011-01-12T02:00:00.000Z	spot	entertainment	preferred	epreferred	100.000000",
+      "2011-01-12T03:00:00.000Z	spot	health	preferred	hpreferred	100.000000",
+      "2011-01-12T04:00:00.000Z	spot	mezzanine	preferred	mpreferred	100.000000",
+      "2011-01-12T05:00:00.000Z	spot	news	preferred	npreferred	100.000000",
+      "2011-01-12T06:00:00.000Z	spot	premium	preferred	ppreferred	100.000000",
+      "2011-01-12T07:00:00.000Z	spot	technology	preferred	tpreferred	100.000000",
+      "2011-01-12T08:00:00.000Z	spot	travel	preferred	tpreferred	100.000000",
+      "2011-01-12T09:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1000.000000",
+      "2011-01-12T10:00:00.000Z	total_market	premium	preferred	ppreferred	1000.000000",
+      "2011-01-12T11:00:00.000Z	upfront	mezzanine	preferred	mpreferred	800.000000	value",
+      "2011-01-12T12:00:00.000Z	upfront	premium	preferred	ppreferred	800.000000	value"
+  };
+  public static final String[] V_0113 = {
+      "2011-01-13T00:00:00.000Z	spot	automotive	preferred	apreferred	94.874713",
+      "2011-01-13T01:00:00.000Z	spot	business	preferred	bpreferred	103.629399",
+      "2011-01-13T02:00:00.000Z	spot	entertainment	preferred	epreferred	110.087299",
+      "2011-01-13T03:00:00.000Z	spot	health	preferred	hpreferred	114.947403",
+      "2011-01-13T04:00:00.000Z	spot	mezzanine	preferred	mpreferred	104.465767",
+      "2011-01-13T05:00:00.000Z	spot	news	preferred	npreferred	102.851683",
+      "2011-01-13T06:00:00.000Z	spot	premium	preferred	ppreferred	108.863011",
+      "2011-01-13T07:00:00.000Z	spot	technology	preferred	tpreferred	111.356672",
+      "2011-01-13T08:00:00.000Z	spot	travel	preferred	tpreferred	106.236928",
+      "2011-01-13T09:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1040.945505",
+      "2011-01-13T10:00:00.000Z	total_market	premium	preferred	ppreferred	1689.012875",
+      "2011-01-13T11:00:00.000Z	upfront	mezzanine	preferred	mpreferred	826.060182	value",
+      "2011-01-13T12:00:00.000Z	upfront	premium	preferred	ppreferred	1564.617729	value"
+  };
+
+  public static final String[] V_OVERRIDE = {
+      "2011-01-12T04:00:00.000Z	spot	automotive	preferred	apreferred	999.000000",
+      "2011-01-12T05:00:00.000Z	spot	business	preferred	bpreferred	999.000000",
+      "2011-01-12T06:00:00.000Z	spot	entertainment	preferred	epreferred	999.000000",
+      "2011-01-12T07:00:00.000Z	spot	health	preferred	hpreferred	999.000000"
+  };
+
   private static Segment segment0;
   private static Segment segment1;
+  private static Segment segment_override;  // this makes segment0 split into three logical segments
+
+  private static List<String> segmentIdentifiers;
 
   private static QueryRunner runner;
 
   @BeforeClass
   public static void setup() throws IOException
   {
-    CharSource v_0112 = CharSource.wrap(StringUtils.join(SelectQueryRunnerTest.V_0112, "\n"));
-    CharSource v_0113 = CharSource.wrap(StringUtils.join(SelectQueryRunnerTest.V_0113, "\n"));
+    CharSource v_0112 = CharSource.wrap(StringUtils.join(V_0112, "\n"));
+    CharSource v_0113 = CharSource.wrap(StringUtils.join(V_0113, "\n"));
+    CharSource v_override = CharSource.wrap(StringUtils.join(V_OVERRIDE, "\n"));
 
-    IncrementalIndex index0 = TestIndex.loadIncrementalIndex(newIncrementalIndex("2011-01-12T00:00:00.000Z"), v_0112);
-    IncrementalIndex index1 = TestIndex.loadIncrementalIndex(newIncrementalIndex("2011-01-13T00:00:00.000Z"), v_0113);
+    IncrementalIndex index0 = TestIndex.loadIncrementalIndex(newIndex("2011-01-12T00:00:00.000Z"), v_0112);
+    IncrementalIndex index1 = TestIndex.loadIncrementalIndex(newIndex("2011-01-13T00:00:00.000Z"), v_0113);
+    IncrementalIndex index2 = TestIndex.loadIncrementalIndex(newIndex("2011-01-12T04:00:00.000Z"), v_override);
 
-    segment0 = new IncrementalIndexSegment(index0, makeIdentifier(index0));
-    segment1 = new IncrementalIndexSegment(index1, makeIdentifier(index1));
+    segment0 = new IncrementalIndexSegment(index0, makeIdentifier(index0, "v1"));
+    segment1 = new IncrementalIndexSegment(index1, makeIdentifier(index1, "v1"));
+    segment_override = new IncrementalIndexSegment(index2, makeIdentifier(index2, "v2"));
 
-    runner = QueryRunnerTestHelper.makeFilteringQueryRunner(Arrays.asList(segment0, segment1), factory);
+    VersionedIntervalTimeline<String, Segment> timeline = new VersionedIntervalTimeline(StringComparators.LEXICOGRAPHIC);
+    timeline.add(index0.getInterval(), "v1", new SingleElementPartitionChunk(segment0));
+    timeline.add(index1.getInterval(), "v1", new SingleElementPartitionChunk(segment1));
+    timeline.add(index2.getInterval(), "v2", new SingleElementPartitionChunk(segment_override));
+
+    segmentIdentifiers = Lists.newArrayList();
+    for (TimelineObjectHolder<String, ?> holder : timeline.lookup(new Interval("2011-01-12/2011-01-14"))) {
+      segmentIdentifiers.add(makeIdentifier(holder.getInterval(), holder.getVersion()));
+    }
+
+    runner = QueryRunnerTestHelper.makeFilteringQueryRunner(timeline, factory);
   }
 
-  private static String makeIdentifier(IncrementalIndex index)
+  private static String makeIdentifier(IncrementalIndex index, String version)
   {
-    Interval interval = index.getInterval();
+    return makeIdentifier(index.getInterval(), version);
+  }
+
+  private static String makeIdentifier(Interval interval, String version)
+  {
     return DataSegment.makeDataSegmentIdentifier(
         QueryRunnerTestHelper.dataSource,
         interval.getStart(),
         interval.getEnd(),
-        "v",
+        version,
         new NoneShardSpec()
     );
   }
 
-  private static IncrementalIndex newIncrementalIndex(String minTimeStamp) {
-    return newIncrementalIndex(minTimeStamp, 10000);
+  private static IncrementalIndex newIndex(String minTimeStamp)
+  {
+    return newIndex(minTimeStamp, 10000);
   }
 
-  private static IncrementalIndex newIncrementalIndex(String minTimeStamp, int maxRowCount)
+  private static IncrementalIndex newIndex(String minTimeStamp, int maxRowCount)
   {
     final IncrementalIndexSchema schema = new IncrementalIndexSchema.Builder()
         .withMinTimestamp(new DateTime(minTimeStamp).getMillis())
-        .withQueryGranularity(QueryGranularity.NONE)
+        .withQueryGranularity(QueryGranularity.HOUR)
         .withMetrics(TestIndex.METRIC_AGGS)
         .build();
-    return new OnheapIncrementalIndex(schema, maxRowCount);
+    return new OnheapIncrementalIndex(schema, true, maxRowCount);
   }
 
   @AfterClass
@@ -121,27 +185,53 @@ public class MultiSegmentSelectQueryTest
   {
     IOUtils.closeQuietly(segment0);
     IOUtils.closeQuietly(segment1);
+    IOUtils.closeQuietly(segment_override);
+  }
+
+  private final Druids.SelectQueryBuilder builder =
+      Druids.newSelectQueryBuilder()
+            .dataSource(new TableDataSource(QueryRunnerTestHelper.dataSource))
+            .intervals(SelectQueryRunnerTest.I_0112_0114)
+            .granularity(QueryRunnerTestHelper.allGran)
+            .dimensionSpecs(DefaultDimensionSpec.toSpec(QueryRunnerTestHelper.dimensions))
+            .pagingSpec(new PagingSpec(null, 3));
+
+  @Test
+  public void testAllGranularityAscending()
+  {
+    SelectQuery query = builder.build();
+
+    for (int[] expected : new int[][]{
+        {2, -1, -1, -1, 3}, {3, 1, -1, -1, 3}, {-1, 3, 0, -1, 3}, {-1, -1, 3, -1, 3}, {-1, -1, 4, 1, 3},
+        {-1, -1, -1, 4, 3}, {-1, -1, -1, 7, 3}, {-1, -1, -1, 10, 3}, {-1, -1, -1, 12, 2}, {-1, -1, -1, 13, 0}
+    }) {
+      List<Result<SelectResultValue>> results = Sequences.toList(
+          runner.run(query, ImmutableMap.of()),
+          Lists.<Result<SelectResultValue>>newArrayList()
+      );
+      Assert.assertEquals(1, results.size());
+
+      SelectResultValue value = results.get(0).getValue();
+      Map<String, Integer> pagingIdentifiers = value.getPagingIdentifiers();
+      for (int i = 0; i < expected.length - 1; i++) {
+        if (expected[i] >= 0) {
+          Assert.assertEquals(expected[i], pagingIdentifiers.get(segmentIdentifiers.get(i)).intValue());
+        }
+      }
+      Assert.assertEquals(expected[expected.length - 1], value.getEvents().size());
+
+      query = query.withPagingSpec(toNextPager(3, query.isDescending(), pagingIdentifiers));
+    }
   }
 
   @Test
-  public void testAllGranularity()
+  public void testAllGranularityDescending()
   {
-    PagingSpec pagingSpec = new PagingSpec(null, 3);
-    SelectQuery query = new SelectQuery(
-        new TableDataSource(QueryRunnerTestHelper.dataSource),
-        SelectQueryRunnerTest.I_0112_0114,
-        false,
-        null,
-        QueryRunnerTestHelper.allGran,
-        DefaultDimensionSpec.toSpec(QueryRunnerTestHelper.dimensions),
-        Arrays.<String>asList(),
-        pagingSpec,
-        null
-    );
+    SelectQuery query = builder.descending(true).build();
 
     for (int[] expected : new int[][]{
-        {2, 0, 3}, {5, 0, 3}, {8, 0, 3}, {11, 0, 3}, {12, 1, 3},
-        {0, 4, 3}, {0, 7, 3}, {0, 10, 3}, {0, 12, 2}, {0, 13, 0}
+        {0, 0, 0, -3, 3}, {0, 0, 0, -6, 3}, {0, 0, 0, -9, 3}, {0, 0, 0, -12, 3}, {0, 0, -2, -13, 3},
+        {0, 0, -5, 0, 3}, {0, -3, 0, 0, 3}, {-2, -4, 0, 0, 3}, {-4, 0, 0, 0, 2}, {-5, 0, 0, 0, 0}
     }) {
       List<Result<SelectResultValue>> results = Sequences.toList(
           runner.run(query, ImmutableMap.of()),
@@ -152,36 +242,25 @@ public class MultiSegmentSelectQueryTest
       SelectResultValue value = results.get(0).getValue();
       Map<String, Integer> pagingIdentifiers = value.getPagingIdentifiers();
 
-      if (expected[0] != 0) {
-        Assert.assertEquals(expected[0], pagingIdentifiers.get(segment0.getIdentifier()).intValue());
+      for (int i = 0; i < expected.length - 1; i++) {
+        if (expected[i] < 0) {
+          Assert.assertEquals(expected[i], pagingIdentifiers.get(segmentIdentifiers.get(i)).intValue());
+        }
       }
-      if (expected[1] != 0) {
-        Assert.assertEquals(expected[1], pagingIdentifiers.get(segment1.getIdentifier()).intValue());
-      }
-      Assert.assertEquals(expected[2], value.getEvents().size());
+      Assert.assertEquals(expected[expected.length - 1], value.getEvents().size());
 
-      query = query.withPagingSpec(toNextPager(3, pagingIdentifiers));
+      query = query.withPagingSpec(toNextPager(3, query.isDescending(), pagingIdentifiers));
     }
   }
 
   @Test
-  public void testDayGranularity()
+  public void testDayGranularityAscending()
   {
-    PagingSpec pagingSpec = new PagingSpec(null, 3);
-    SelectQuery query = new SelectQuery(
-        new TableDataSource(QueryRunnerTestHelper.dataSource),
-        SelectQueryRunnerTest.I_0112_0114,
-        false,
-        null,
-        QueryRunnerTestHelper.dayGran,
-        DefaultDimensionSpec.toSpec(QueryRunnerTestHelper.dimensions),
-        Arrays.<String>asList(),
-        pagingSpec,
-        null
-    );
+    SelectQuery query = builder.granularity(QueryRunnerTestHelper.dayGran).build();
 
     for (int[] expected : new int[][]{
-        {2, 2, 3, 3}, {5, 5, 3, 3}, {8, 8, 3, 3}, {11, 11, 3, 3}, {12, 12, 1, 1}
+        {2, -1, -1, 2, 3, 0, 0, 3}, {3, 1, -1, 5, 1, 2, 0, 3}, {-1, 3, 0, 8, 0, 2, 1, 3},
+        {-1, -1, 3, 11, 0, 0, 3, 3}, {-1, -1, 4, 12, 0, 0, 1, 1}, {-1, -1, 5, 13, 0, 0, 0, 0}
     }) {
       List<Result<SelectResultValue>> results = Sequences.toList(
           runner.run(query, ImmutableMap.of()),
@@ -195,29 +274,57 @@ public class MultiSegmentSelectQueryTest
       Map<String, Integer> pagingIdentifiers0 = value0.getPagingIdentifiers();
       Map<String, Integer> pagingIdentifiers1 = value1.getPagingIdentifiers();
 
-      Assert.assertEquals(1, pagingIdentifiers0.size());
-      Assert.assertEquals(1, pagingIdentifiers1.size());
-
-      if (expected[0] != 0) {
-        Assert.assertEquals(expected[0], pagingIdentifiers0.get(segment0.getIdentifier()).intValue());
+      for (int i = 0; i < 4; i++) {
+        if (expected[i] >= 0) {
+          Map<String, Integer> paging = i < 3 ? pagingIdentifiers0 : pagingIdentifiers1;
+          Assert.assertEquals(expected[i], paging.get(segmentIdentifiers.get(i)).intValue());
+        }
       }
-      if (expected[1] != 0) {
-        Assert.assertEquals(expected[1], pagingIdentifiers1.get(segment1.getIdentifier()).intValue());
-      }
-      Assert.assertEquals(expected[2], value0.getEvents().size());
-      Assert.assertEquals(expected[3], value1.getEvents().size());
 
-      query = query.withPagingSpec(toNextPager(3, pagingIdentifiers0, pagingIdentifiers1));
+      query = query.withPagingSpec(toNextPager(3, query.isDescending(), pagingIdentifiers0, pagingIdentifiers1));
+    }
+  }
+
+  @Test
+  public void testDayGranularityDescending()
+  {
+    QueryGranularity granularity = QueryRunnerTestHelper.dayGran;
+    SelectQuery query = builder.granularity(granularity).descending(true).build();
+
+    for (int[] expected : new int[][]{
+        {0, 0, -3, -3, 0, 0, 3, 3}, {0, -1, -5, -6, 0, 1, 2, 3}, {0, -4, 0, -9, 0, 3, 0, 3},
+        {-3, 0, 0, -12, 3, 0, 0, 3}, {-4, 0, 0, -13, 1, 0, 0, 1}, {-5, 0, 0, -14, 0, 0, 0, 0}
+    }) {
+      List<Result<SelectResultValue>> results = Sequences.toList(
+          runner.run(query, ImmutableMap.of()),
+          Lists.<Result<SelectResultValue>>newArrayList()
+      );
+      Assert.assertEquals(2, results.size());
+
+      SelectResultValue value0 = results.get(0).getValue();
+      SelectResultValue value1 = results.get(1).getValue();
+
+      Map<String, Integer> pagingIdentifiers0 = value0.getPagingIdentifiers();
+      Map<String, Integer> pagingIdentifiers1 = value1.getPagingIdentifiers();
+
+      for (int i = 0; i < 4; i++) {
+        if (expected[i] < 0) {
+          Map<String, Integer> paging = i < 3 ? pagingIdentifiers1 : pagingIdentifiers0;
+          Assert.assertEquals(expected[i], paging.get(segmentIdentifiers.get(i)).intValue());
+        }
+      }
+
+      query = query.withPagingSpec(toNextPager(3, query.isDescending(), pagingIdentifiers0, pagingIdentifiers1));
     }
   }
 
   @SafeVarargs
-  private final PagingSpec toNextPager(int threshold, Map<String, Integer>... pagers)
+  private final PagingSpec toNextPager(int threshold, boolean descending, Map<String, Integer>... pagers)
   {
     LinkedHashMap<String, Integer> next = Maps.newLinkedHashMap();
     for (Map<String, Integer> pager : pagers) {
       for (Map.Entry<String, Integer> entry : pager.entrySet()) {
-        next.put(entry.getKey(), entry.getValue() + 1);
+        next.put(entry.getKey(), descending ? entry.getValue() - 1 : entry.getValue() + 1);
       }
     }
     return new PagingSpec(next, threshold);

--- a/processing/src/test/java/io/druid/query/select/MultiSegmentSelectQueryTest.java
+++ b/processing/src/test/java/io/druid/query/select/MultiSegmentSelectQueryTest.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.select;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.io.CharSource;
+import com.metamx.common.guava.Sequences;
+import io.druid.granularity.QueryGranularity;
+import io.druid.jackson.DefaultObjectMapper;
+import io.druid.query.QueryRunner;
+import io.druid.query.QueryRunnerFactory;
+import io.druid.query.QueryRunnerTestHelper;
+import io.druid.query.Result;
+import io.druid.query.TableDataSource;
+import io.druid.query.dimension.DefaultDimensionSpec;
+import io.druid.segment.IncrementalIndexSegment;
+import io.druid.segment.Segment;
+import io.druid.segment.TestIndex;
+import io.druid.segment.incremental.IncrementalIndex;
+import io.druid.segment.incremental.IncrementalIndexSchema;
+import io.druid.segment.incremental.OnheapIncrementalIndex;
+import io.druid.timeline.DataSegment;
+import io.druid.timeline.partition.NoneShardSpec;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.joda.time.DateTime;
+import org.joda.time.Interval;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ */
+public class MultiSegmentSelectQueryTest
+{
+  private static final SelectQueryQueryToolChest toolChest = new SelectQueryQueryToolChest(
+      new DefaultObjectMapper(),
+      QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
+  );
+
+  private static final QueryRunnerFactory factory = new SelectQueryRunnerFactory(
+      toolChest,
+      new SelectQueryEngine(),
+      QueryRunnerTestHelper.NOOP_QUERYWATCHER
+  );
+
+  private static Segment segment0;
+  private static Segment segment1;
+
+  private static QueryRunner runner;
+
+  @BeforeClass
+  public static void setup() throws IOException
+  {
+    CharSource v_0112 = CharSource.wrap(StringUtils.join(SelectQueryRunnerTest.V_0112, "\n"));
+    CharSource v_0113 = CharSource.wrap(StringUtils.join(SelectQueryRunnerTest.V_0113, "\n"));
+
+    IncrementalIndex index0 = TestIndex.loadIncrementalIndex(newIncrementalIndex("2011-01-12T00:00:00.000Z"), v_0112);
+    IncrementalIndex index1 = TestIndex.loadIncrementalIndex(newIncrementalIndex("2011-01-13T00:00:00.000Z"), v_0113);
+
+    segment0 = new IncrementalIndexSegment(index0, makeIdentifier(index0));
+    segment1 = new IncrementalIndexSegment(index1, makeIdentifier(index1));
+
+    runner = QueryRunnerTestHelper.makeFilteringQueryRunner(Arrays.asList(segment0, segment1), factory);
+  }
+
+  private static String makeIdentifier(IncrementalIndex index)
+  {
+    Interval interval = index.getInterval();
+    return DataSegment.makeDataSegmentIdentifier(
+        QueryRunnerTestHelper.dataSource,
+        interval.getStart(),
+        interval.getEnd(),
+        "v",
+        new NoneShardSpec()
+    );
+  }
+
+  private static IncrementalIndex newIncrementalIndex(String minTimeStamp) {
+    return newIncrementalIndex(minTimeStamp, 10000);
+  }
+
+  private static IncrementalIndex newIncrementalIndex(String minTimeStamp, int maxRowCount)
+  {
+    final IncrementalIndexSchema schema = new IncrementalIndexSchema.Builder()
+        .withMinTimestamp(new DateTime(minTimeStamp).getMillis())
+        .withQueryGranularity(QueryGranularity.NONE)
+        .withMetrics(TestIndex.METRIC_AGGS)
+        .build();
+    return new OnheapIncrementalIndex(schema, maxRowCount);
+  }
+
+  @AfterClass
+  public static void clear()
+  {
+    IOUtils.closeQuietly(segment0);
+    IOUtils.closeQuietly(segment1);
+  }
+
+  @Test
+  public void testAllGranularity()
+  {
+    PagingSpec pagingSpec = new PagingSpec(null, 3);
+    SelectQuery query = new SelectQuery(
+        new TableDataSource(QueryRunnerTestHelper.dataSource),
+        SelectQueryRunnerTest.I_0112_0114,
+        false,
+        null,
+        QueryRunnerTestHelper.allGran,
+        DefaultDimensionSpec.toSpec(QueryRunnerTestHelper.dimensions),
+        Arrays.<String>asList(),
+        pagingSpec,
+        null
+    );
+
+    for (int[] expected : new int[][]{
+        {2, 0, 3}, {5, 0, 3}, {8, 0, 3}, {11, 0, 3}, {12, 1, 3},
+        {0, 4, 3}, {0, 7, 3}, {0, 10, 3}, {0, 12, 2}, {0, 13, 0}
+    }) {
+      List<Result<SelectResultValue>> results = Sequences.toList(
+          runner.run(query, ImmutableMap.of()),
+          Lists.<Result<SelectResultValue>>newArrayList()
+      );
+      Assert.assertEquals(1, results.size());
+
+      SelectResultValue value = results.get(0).getValue();
+      Map<String, Integer> pagingIdentifiers = value.getPagingIdentifiers();
+
+      if (expected[0] != 0) {
+        Assert.assertEquals(expected[0], pagingIdentifiers.get(segment0.getIdentifier()).intValue());
+      }
+      if (expected[1] != 0) {
+        Assert.assertEquals(expected[1], pagingIdentifiers.get(segment1.getIdentifier()).intValue());
+      }
+      Assert.assertEquals(expected[2], value.getEvents().size());
+
+      query = query.withPagingSpec(toNextPager(3, pagingIdentifiers));
+    }
+  }
+
+  @Test
+  public void testDayGranularity()
+  {
+    PagingSpec pagingSpec = new PagingSpec(null, 3);
+    SelectQuery query = new SelectQuery(
+        new TableDataSource(QueryRunnerTestHelper.dataSource),
+        SelectQueryRunnerTest.I_0112_0114,
+        false,
+        null,
+        QueryRunnerTestHelper.dayGran,
+        DefaultDimensionSpec.toSpec(QueryRunnerTestHelper.dimensions),
+        Arrays.<String>asList(),
+        pagingSpec,
+        null
+    );
+
+    for (int[] expected : new int[][]{
+        {2, 2, 3, 3}, {5, 5, 3, 3}, {8, 8, 3, 3}, {11, 11, 3, 3}, {12, 12, 1, 1}
+    }) {
+      List<Result<SelectResultValue>> results = Sequences.toList(
+          runner.run(query, ImmutableMap.of()),
+          Lists.<Result<SelectResultValue>>newArrayList()
+      );
+      Assert.assertEquals(2, results.size());
+
+      SelectResultValue value0 = results.get(0).getValue();
+      SelectResultValue value1 = results.get(1).getValue();
+
+      Map<String, Integer> pagingIdentifiers0 = value0.getPagingIdentifiers();
+      Map<String, Integer> pagingIdentifiers1 = value1.getPagingIdentifiers();
+
+      Assert.assertEquals(1, pagingIdentifiers0.size());
+      Assert.assertEquals(1, pagingIdentifiers1.size());
+
+      if (expected[0] != 0) {
+        Assert.assertEquals(expected[0], pagingIdentifiers0.get(segment0.getIdentifier()).intValue());
+      }
+      if (expected[1] != 0) {
+        Assert.assertEquals(expected[1], pagingIdentifiers1.get(segment1.getIdentifier()).intValue());
+      }
+      Assert.assertEquals(expected[2], value0.getEvents().size());
+      Assert.assertEquals(expected[3], value1.getEvents().size());
+
+      query = query.withPagingSpec(toNextPager(3, pagingIdentifiers0, pagingIdentifiers1));
+    }
+  }
+
+  @SafeVarargs
+  private final PagingSpec toNextPager(int threshold, Map<String, Integer>... pagers)
+  {
+    LinkedHashMap<String, Integer> next = Maps.newLinkedHashMap();
+    for (Map<String, Integer> pager : pagers) {
+      for (Map.Entry<String, Integer> entry : pager.entrySet()) {
+        next.put(entry.getKey(), entry.getValue() + 1);
+      }
+    }
+    return new PagingSpec(next, threshold);
+  }
+}


### PR DESCRIPTION
With coarser granularity than segment, when select query is spanned to next segment, paging returns back to first segment in next query. Below is the paging identifiers returned from query. You can see `{testing_2011-01-12T00:00:00.000Z_2011-01-12T00:00:00.001Z_v=2}` is returned next of `{testing_2011-01-13T00:00:00.000Z_2011-01-13T00:00:00.001Z_v=4}`.

```
{testing_2011-01-12T00:00:00.000Z_2011-01-12T00:00:00.001Z_v=2}
{testing_2011-01-12T00:00:00.000Z_2011-01-12T00:00:00.001Z_v=5}
{testing_2011-01-12T00:00:00.000Z_2011-01-12T00:00:00.001Z_v=8}
{testing_2011-01-12T00:00:00.000Z_2011-01-12T00:00:00.001Z_v=11}
{testing_2011-01-12T00:00:00.000Z_2011-01-12T00:00:00.001Z_v=12, testing_2011-01-13T00:00:00.000Z_2011-01-13T00:00:00.001Z_v=1}
{testing_2011-01-13T00:00:00.000Z_2011-01-13T00:00:00.001Z_v=4}
{testing_2011-01-12T00:00:00.000Z_2011-01-12T00:00:00.001Z_v=2}
{testing_2011-01-12T00:00:00.000Z_2011-01-12T00:00:00.001Z_v=5}
{testing_2011-01-12T00:00:00.000Z_2011-01-12T00:00:00.001Z_v=8}
{testing_2011-01-12T00:00:00.000Z_2011-01-12T00:00:00.001Z_v=11}
```