### PR TITLE
integration-tests/README: fix link to docker-install

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -3,7 +3,7 @@ Integration Testing
 
 ## Installing Docker
 
-Please refer to instructions at [https://github.com/druid-io/docker-druid/blob/master/docker-install.md]()
+Please refer to instructions at [https://github.com/druid-io/docker-druid/blob/master/docker-install.md](https://github.com/druid-io/docker-druid/blob/master/docker-install.md).
 
 ## Creating the Docker VM
 


### PR DESCRIPTION
In integration-tests/README, the link that says
https://github.com/druid-io/docker-druid/blob/master/docker-install.md
does not point there, because the parentheses that are supposed to contain the URL are empty.