### PR TITLE
do not drop post-aggs in TimeseriesQueryToolChest.makePreComputeManipulatorFn

### DIFF
--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
@@ -238,8 +238,8 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
       @Override
       public Result<TimeseriesResultValue> apply(Result<TimeseriesResultValue> result)
       {
-        final Map<String, Object> values = Maps.newHashMap();
         final TimeseriesResultValue holder = result.getValue();
+        final Map<String, Object> values = Maps.newHashMap(holder.getBaseObject());
         if (calculatePostAggs) {
           // put non finalized aggregators for calculating dependent post Aggregators
           for (AggregatorFactory agg : query.getAggregatorSpecs()) {


### PR DESCRIPTION
new behavior is consistent with TopN and GroupBy.

That said, I am changing it for following reason.
We are working on a custom query type to fulfill a specific internal use case and use DirectDruidClient which was dropping all the post-aggregations returned for Timeseries query because it passes the result through toolChest.makePreComputeManipulatorFn(..) for deserialization and removing post-aggs for timeseries as a side effect.