### PR TITLE
Add comparator to HyperUniquesFinalizingPostAggregator.

### DIFF
--- a/processing/src/main/java/io/druid/query/Queries.java
+++ b/processing/src/main/java/io/druid/query/Queries.java
@@ -55,7 +55,7 @@ public class Queries
             missing.isEmpty(),
             "Missing fields [%s] for postAggregator [%s]", missing, postAgg.getName()
         );
-        Preconditions.checkArgument(combinedAggNames.add(postAgg.getName()), "[%s] already defined");
+        Preconditions.checkArgument(combinedAggNames.add(postAgg.getName()), "[%s] already defined", postAgg.getName());
       }
     }
   }

--- a/processing/src/main/java/io/druid/query/aggregation/hyperloglog/HyperUniqueFinalizingPostAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/hyperloglog/HyperUniqueFinalizingPostAggregator.java
@@ -22,6 +22,7 @@ package io.druid.query.aggregation.hyperloglog;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 import io.druid.query.aggregation.PostAggregator;
 
@@ -33,6 +34,15 @@ import java.util.Set;
  */
 public class HyperUniqueFinalizingPostAggregator implements PostAggregator
 {
+  private static final Comparator<Double> DOUBLE_COMPARATOR = Ordering.from(new Comparator<Double>()
+  {
+    @Override
+    public int compare(Double lhs, Double rhs)
+    {
+      return Double.compare(lhs, rhs);
+    }
+  }).nullsFirst();
+
   private final String name;
   private final String fieldName;
 
@@ -56,9 +66,9 @@ public class HyperUniqueFinalizingPostAggregator implements PostAggregator
   }
 
   @Override
-  public Comparator getComparator()
+  public Comparator<Double> getComparator()
   {
-    throw new UnsupportedOperationException();
+    return DOUBLE_COMPARATOR;
   }
 
   @Override


### PR DESCRIPTION
This makes it possible to do groupBys with clauses like "HAVING uniques > 10".
Beforehand you couldn't do it with either an aggregator (because it returns
an HLLV1 which the havingSpec can't understand) or a finalized postaggregator
(because it didn't have a comparator).

Now you can at least do it with a finalizing postaggregator. Trying it with
the aggregator alone still doesn't work.

Added some topN and groupBy tests verifying the comparator, and added an
`@Ignore` test that should pass if havingSpecs are made work on the aggregator
directly.