### PR TITLE
Add druid.indexer.server.maxChatRequests for QoS; deprecate separate ports.

### DIFF
--- a/docs/content/configuration/indexing-service.md
+++ b/docs/content/configuration/indexing-service.md
@@ -257,7 +257,7 @@ Middle managers pass their configurations down to their child peons. The middle 
 |`druid.indexer.runner.javaOpts`|-X Java options to run the peon in its own JVM. Can be either a string or a json string list. Quotable parameters or parameters with spaces are encouraged to use json string lists|""|
 |`druid.indexer.runner.maxZnodeBytes`|The maximum size Znode in bytes that can be created in Zookeeper.|524288|
 |`druid.indexer.runner.startPort`|The port that peons begin running on.|8100|
-|`druid.indexer.runner.separateIngestionEndpoint`|Use separate server and consequently separate jetty thread pool for ingesting events|false|
+|`druid.indexer.runner.separateIngestionEndpoint`|*Deprecated.* Use separate server and consequently separate jetty thread pool for ingesting events|false|
 |`druid.worker.ip`|The IP of the worker.|localhost|
 |`druid.worker.version`|Version identifier for the middle manager.|0|
 |`druid.worker.capacity`|Maximum number of tasks the middle manager can accept.|Number of available processors - 1|
@@ -276,19 +276,21 @@ Additional peon configs include:
 |`druid.peon.mode`|Choices are "local" and "remote". Setting this to local means you intend to run the peon as a standalone node (Not recommended).|remote|
 |`druid.indexer.task.baseDir`|Base temporary working directory.|`System.getProperty("java.io.tmpdir")`|
 |`druid.indexer.task.baseTaskDir`|Base temporary working directory for tasks.|`${druid.indexer.task.baseDir}/persistent/tasks`|
-|`druid.indexer.task.hadoopWorkingPath`|Temporary working directory for Hadoop tasks.|`/tmp/druid-indexing`|
-|`druid.indexer.task.defaultRowFlushBoundary`|Highest row count before persisting to disk. Used for indexing generating tasks.|50000|
 |`druid.indexer.task.defaultHadoopCoordinates`|Hadoop version to use with HadoopIndexTasks that do not request a particular version.|org.apache.hadoop:hadoop-client:2.3.0|
-|`druid.indexer.task.restoreTasksOnRestart`|If true, middleManagers will attempt to stop tasks gracefully on shutdown and restore them on restart.|false|
-|`druid.indexer.task.gracefulShutdownTimeout`|Wait this long on middleManager restart for restorable tasks to gracefully exit.|PT5M|
+|`druid.indexer.task.defaultRowFlushBoundary`|Highest row count before persisting to disk. Used for indexing generating tasks.|50000|
 |`druid.indexer.task.directoryLockTimeout`|Wait this long for zombie peons to exit before giving up on their replacements.|PT10M|
+|`druid.indexer.task.gracefulShutdownTimeout`|Wait this long on middleManager restart for restorable tasks to gracefully exit.|PT5M|
+|`druid.indexer.task.hadoopWorkingPath`|Temporary working directory for Hadoop tasks.|`/tmp/druid-indexing`|
+|`druid.indexer.task.restoreTasksOnRestart`|If true, middleManagers will attempt to stop tasks gracefully on shutdown and restore them on restart.|false|
+|`druid.indexer.server.maxChatRequests`|Maximum number of concurrent requests served by a task's chat handler. Set to 0 to disable limiting.|0|
 
-If `druid.indexer.runner.separateIngestionEndpoint` is set to true then following configurations are available for the ingestion server at peon:
+If the deprecated `druid.indexer.runner.separateIngestionEndpoint` property is set to true then following configurations
+are available for the ingestion server at peon:
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.indexer.server.chathandler.http.numThreads`|Number of threads for HTTP requests.|Math.max(10, (Number of available processors * 17) / 16 + 2) + 30|
-|`druid.indexer.server.chathandler.http.maxIdleTime`|The Jetty max idle time for a connection.|PT5m|
+|`druid.indexer.server.chathandler.http.numThreads`|*Deprecated.* Number of threads for HTTP requests.|Math.max(10, (Number of available processors * 17) / 16 + 2) + 30|
+|`druid.indexer.server.chathandler.http.maxIdleTime`|*Deprecated.* The Jetty max idle time for a connection.|PT5m|
 
 If the peon is running in remote mode, there must be an overlord up and running. Peons in remote mode can set the following configurations:
 

--- a/server/src/main/java/io/druid/server/initialization/jetty/JettyBindings.java
+++ b/server/src/main/java/io/druid/server/initialization/jetty/JettyBindings.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.initialization.jetty;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.multibindings.Multibinder;
+import com.metamx.common.logger.Logger;
+import org.eclipse.jetty.servlets.QoSFilter;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.Filter;
+import java.util.EnumSet;
+import java.util.Map;
+
+public class JettyBindings
+{
+  private static final Logger log = new Logger(JettyBindings.class);
+
+  private JettyBindings()
+  {
+    // No instantiation.
+  }
+
+  public static void addQosFilter(Binder binder, String path, int maxRequests)
+  {
+    if (maxRequests <= 0) {
+      return;
+    }
+
+    Multibinder.newSetBinder(binder, ServletFilterHolder.class)
+               .addBinding()
+               .toInstance(new QosFilterHolder(path, maxRequests));
+  }
+
+  private static class QosFilterHolder implements ServletFilterHolder
+  {
+    private final String path;
+    private final int maxRequests;
+
+    public QosFilterHolder(String path, int maxRequests)
+    {
+      this.path = path;
+      this.maxRequests = maxRequests;
+    }
+
+    @Override
+    public Filter getFilter()
+    {
+      return new QoSFilter();
+    }
+
+    @Override
+    public Class<? extends Filter> getFilterClass()
+    {
+      return QoSFilter.class;
+    }
+
+    @Override
+    public Map<String, String> getInitParameters()
+    {
+      return ImmutableMap.of("maxRequests", String.valueOf(maxRequests));
+    }
+
+    @Override
+    public String getPath()
+    {
+      return path;
+    }
+
+    @Override
+    public EnumSet<DispatcherType> getDispatcherType()
+    {
+      return null;
+    }
+  }
+}

--- a/server/src/test/java/io/druid/server/initialization/JettyQosTest.java
+++ b/server/src/test/java/io/druid/server/initialization/JettyQosTest.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.initialization;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.client.repackaged.com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.inject.Binder;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.metamx.http.client.HttpClient;
+import com.metamx.http.client.Request;
+import com.metamx.http.client.response.StatusResponseHandler;
+import com.metamx.http.client.response.StatusResponseHolder;
+import io.druid.concurrent.Execs;
+import io.druid.guice.GuiceInjectors;
+import io.druid.guice.Jerseys;
+import io.druid.guice.JsonConfigProvider;
+import io.druid.guice.LazySingleton;
+import io.druid.guice.LifecycleModule;
+import io.druid.guice.annotations.Self;
+import io.druid.initialization.Initialization;
+import io.druid.server.DruidNode;
+import io.druid.server.initialization.jetty.JettyBindings;
+import io.druid.server.initialization.jetty.JettyServerInitializer;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.jboss.netty.handler.codec.http.HttpMethod;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class JettyQosTest extends BaseJettyTest
+{
+  @Override
+  protected Injector setupInjector()
+  {
+    return Initialization.makeInjectorWithModules(
+        GuiceInjectors.makeStartupInjector(),
+        ImmutableList.<Module>of(
+            new Module()
+            {
+              @Override
+              public void configure(Binder binder)
+              {
+                JsonConfigProvider.bindInstance(
+                    binder, Key.get(DruidNode.class, Self.class), new DruidNode("test", "localhost", null)
+                );
+                binder.bind(JettyServerInitializer.class).to(JettyServerInit.class).in(LazySingleton.class);
+                Jerseys.addResource(binder, SlowResource.class);
+                Jerseys.addResource(binder, ExceptionResource.class);
+                Jerseys.addResource(binder, DefaultResource.class);
+                JettyBindings.addQosFilter(binder, "/slow/*", 2);
+                final ServerConfig serverConfig = new ObjectMapper().convertValue(
+                    ImmutableMap.of("numThreads", "10"),
+                    ServerConfig.class
+                );
+                binder.bind(ServerConfig.class).toInstance(serverConfig);
+                LifecycleModule.register(binder, Server.class);
+              }
+            }
+        )
+    );
+  }
+
+  @Test
+  public void testNumThreads()
+  {
+    // Just make sure the injector stuff for this test is actually working.
+    Assert.assertEquals(
+        10,
+        ((QueuedThreadPool) server.getThreadPool()).getMaxThreads()
+    );
+  }
+
+  @Test(timeout = 60_000L)
+  public void testQoS() throws Exception
+  {
+    final int fastThreads = 20;
+    final int slowThreads = 15;
+    final int slowRequestsPerThread = 5;
+    final int fastRequestsPerThread = 200;
+    final HttpClient fastClient = new ClientHolder(fastThreads).getClient();
+    final HttpClient slowClient = new ClientHolder(slowThreads).getClient();
+    final ExecutorService fastPool = Execs.multiThreaded(fastThreads, "fast-%d");
+    final ExecutorService slowPool = Execs.multiThreaded(slowThreads, "slow-%d");
+    final CountDownLatch latch = new CountDownLatch(fastThreads * fastRequestsPerThread);
+    final AtomicLong fastCount = new AtomicLong();
+    final AtomicLong slowCount = new AtomicLong();
+    final AtomicLong fastElapsed = new AtomicLong();
+    final AtomicLong slowElapsed = new AtomicLong();
+
+    for (int i = 0; i < slowThreads; i++) {
+      slowPool.submit(new Runnable()
+      {
+        @Override
+        public void run()
+        {
+          for (int i = 0; i < slowRequestsPerThread; i++) {
+            long startTime = System.currentTimeMillis();
+            try {
+              ListenableFuture<StatusResponseHolder> go =
+                  slowClient.go(
+                      new Request(HttpMethod.GET, new URL("http://localhost:" + port + "/slow/hello")),
+                      new StatusResponseHandler(Charset.defaultCharset())
+                  );
+              go.get();
+              slowCount.incrementAndGet();
+              slowElapsed.addAndGet(System.currentTimeMillis() - startTime);
+            }
+            catch (InterruptedException e) {
+              // BE COOL
+            }
+            catch (Exception e) {
+              e.printStackTrace();
+              throw Throwables.propagate(e);
+            }
+          }
+        }
+      });
+    }
+
+    // wait for jetty server pool to completely fill up
+    while (server.getThreadPool().getIdleThreads() != 0) {
+      Thread.sleep(25);
+    }
+
+    for (int i = 0; i < fastThreads; i++) {
+      fastPool.submit(new Runnable()
+      {
+        @Override
+        public void run()
+        {
+          for (int i = 0; i < fastRequestsPerThread; i++) {
+            long startTime = System.currentTimeMillis();
+            try {
+              ListenableFuture<StatusResponseHolder> go =
+                  fastClient.go(
+                      new Request(HttpMethod.GET, new URL("http://localhost:" + port + "/default")),
+                      new StatusResponseHandler(Charset.defaultCharset())
+                  );
+              go.get();
+              fastCount.incrementAndGet();
+              fastElapsed.addAndGet(System.currentTimeMillis() - startTime);
+              latch.countDown();
+            }
+            catch (InterruptedException e) {
+              // BE COOL
+            }
+            catch (Exception e) {
+              e.printStackTrace();
+              throw Throwables.propagate(e);
+            }
+          }
+        }
+      });
+    }
+
+    // Wait for all fast requests to be served
+    latch.await();
+
+    slowPool.shutdownNow();
+    fastPool.shutdown();
+
+    // check that fast requests finished quickly
+    Assert.assertTrue(fastElapsed.get() / fastCount.get() < 500);
+  }
+}

--- a/server/src/test/java/io/druid/server/initialization/JettyTest.java
+++ b/server/src/test/java/io/druid/server/initialization/JettyTest.java
@@ -20,17 +20,36 @@
 package io.druid.server.initialization;
 
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.inject.Binder;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.multibindings.Multibinder;
 import com.metamx.http.client.Request;
 import com.metamx.http.client.response.InputStreamResponseHandler;
 import com.metamx.http.client.response.StatusResponseHandler;
 import com.metamx.http.client.response.StatusResponseHolder;
+import io.druid.guice.GuiceInjectors;
+import io.druid.guice.Jerseys;
+import io.druid.guice.JsonConfigProvider;
+import io.druid.guice.LazySingleton;
+import io.druid.guice.LifecycleModule;
+import io.druid.guice.annotations.Self;
+import io.druid.initialization.Initialization;
+import io.druid.server.DruidNode;
+import io.druid.server.initialization.jetty.JettyServerInitializer;
+import io.druid.server.initialization.jetty.ServletFilterHolder;
 import org.apache.commons.io.IOUtils;
+import org.eclipse.jetty.server.Server;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import javax.servlet.DispatcherType;
+import javax.servlet.Filter;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,6 +57,8 @@ import java.io.StringWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.util.EnumSet;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -46,6 +67,72 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class JettyTest extends BaseJettyTest
 {
+  @Override
+  protected Injector setupInjector()
+  {
+    return Initialization.makeInjectorWithModules(
+        GuiceInjectors.makeStartupInjector(),
+        ImmutableList.<Module>of(
+            new Module()
+            {
+              @Override
+              public void configure(Binder binder)
+              {
+                JsonConfigProvider.bindInstance(
+                    binder, Key.get(DruidNode.class, Self.class), new DruidNode("test", "localhost", null)
+                );
+                binder.bind(JettyServerInitializer.class).to(JettyServerInit.class).in(LazySingleton.class);
+
+                Multibinder<ServletFilterHolder> multibinder = Multibinder.newSetBinder(
+                    binder,
+                    ServletFilterHolder.class
+                );
+
+                multibinder.addBinding().toInstance(
+                    new ServletFilterHolder()
+                    {
+
+                      @Override
+                      public String getPath()
+                      {
+                        return "/*";
+                      }
+
+                      @Override
+                      public Map<String, String> getInitParameters()
+                      {
+                        return null;
+                      }
+
+                      @Override
+                      public Class<? extends Filter> getFilterClass()
+                      {
+                        return DummyAuthFilter.class;
+                      }
+
+                      @Override
+                      public Filter getFilter()
+                      {
+                        return null;
+                      }
+
+                      @Override
+                      public EnumSet<DispatcherType> getDispatcherType()
+                      {
+                        return null;
+                      }
+                    });
+
+                Jerseys.addResource(binder, SlowResource.class);
+                Jerseys.addResource(binder, ExceptionResource.class);
+                Jerseys.addResource(binder, DefaultResource.class);
+                LifecycleModule.register(binder, Server.class);
+              }
+            }
+        )
+    );
+
+  }
 
   @Test
   @Ignore // this test will deadlock if it hits an issue, so ignored by default

--- a/services/src/main/java/io/druid/cli/CliPeon.java
+++ b/services/src/main/java/io/druid/cli/CliPeon.java
@@ -189,7 +189,6 @@ public class CliPeon extends GuiceRunnable
 
             binder.bind(JettyServerInitializer.class).to(QueryJettyServerInitializer.class);
             Jerseys.addResource(binder, QueryResource.class);
-            Jerseys.addResource(binder, ChatHandlerResource.class);
             LifecycleModule.register(binder, QueryResource.class);
             LifecycleModule.register(binder, LookupReferencesManager.class);
             binder.bind(NodeTypeConfig.class).toInstance(new NodeTypeConfig(nodeType));

--- a/services/src/main/java/io/druid/guice/RealtimeModule.java
+++ b/services/src/main/java/io/druid/guice/RealtimeModule.java
@@ -105,7 +105,6 @@ public class RealtimeModule implements Module
     binder.bind(NodeTypeConfig.class).toInstance(new NodeTypeConfig("realtime"));
     binder.bind(JettyServerInitializer.class).to(QueryJettyServerInitializer.class).in(LazySingleton.class);
     Jerseys.addResource(binder, QueryResource.class);
-    Jerseys.addResource(binder, ChatHandlerResource.class);
     LifecycleModule.register(binder, QueryResource.class);
     LifecycleModule.register(binder, LookupReferencesManager.class);
     LifecycleModule.register(binder, Server.class);


### PR DESCRIPTION
- Add druid.indexer.server.maxChatRequests, which sets up a QoSFilter on the main Jetty server.
- Deprecate druid.indexer.runner.separateIngestionEndpoint
- Deprecate druid.indexer.server.chathandler.*