### PR TITLE
Fail travis builds faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ jdk:
   - oraclejdk8
 
 script:
-  - mvn test -B
-  - mvn clean -Pstrict compile test-compile -B
+  - mvn test -B && mvn clean -Pstrict compile test-compile -B
 
 after_success:
   - mvn clean cobertura:cobertura coveralls:report -pl '!benchmarks,!distribution'


### PR DESCRIPTION
Testing build process

The code-validation steps in https://github.com/druid-io/druid/pull/2247 are handy, but can get challenging to find the failure when the test fails but the compile succeeds. This is using the suggestion at https://docs.travis-ci.com/user/customizing-the-build/#Customizing-the-Build-Step on how to fail immediately.