### PR TITLE
Support virtual column for select query

### DIFF
--- a/benchmarks/src/main/java/io/druid/benchmark/FilterPartitionBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/FilterPartitionBenchmark.java
@@ -61,6 +61,7 @@ import io.druid.segment.LongColumnSelector;
 import io.druid.segment.QueryableIndex;
 import io.druid.segment.QueryableIndexStorageAdapter;
 import io.druid.segment.StorageAdapter;
+import io.druid.segment.VirtualColumns;
 import io.druid.segment.column.Column;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.data.IndexedInts;
@@ -238,7 +239,7 @@ public class FilterPartitionBenchmark
   public void stringRead(Blackhole blackhole) throws Exception
   {
     StorageAdapter sa = new QueryableIndexStorageAdapter(qIndex);
-    Sequence<Cursor> cursors = sa.makeCursors(null, schemaInfo.getDataInterval(), QueryGranularities.ALL, false);
+    Sequence<Cursor> cursors = makeCursors(sa, null);
 
     Sequence<List<String>> stringListSeq = readCursors(cursors, blackhole);
     List<String> strings = Sequences.toList(Sequences.limit(stringListSeq, 1), Lists.<List<String>>newArrayList()).get(0);
@@ -253,7 +254,7 @@ public class FilterPartitionBenchmark
   public void longRead(Blackhole blackhole) throws Exception
   {
     StorageAdapter sa = new QueryableIndexStorageAdapter(qIndex);
-    Sequence<Cursor> cursors = sa.makeCursors(null, schemaInfo.getDataInterval(), QueryGranularities.ALL, false);
+    Sequence<Cursor> cursors = makeCursors(sa, null);
 
     Sequence<List<Long>> longListSeq = readCursorsLong(cursors, blackhole);
     List<Long> strings = Sequences.toList(Sequences.limit(longListSeq, 1), Lists.<List<Long>>newArrayList()).get(0);
@@ -268,7 +269,7 @@ public class FilterPartitionBenchmark
   public void timeFilterNone(Blackhole blackhole) throws Exception
   {
     StorageAdapter sa = new QueryableIndexStorageAdapter(qIndex);
-    Sequence<Cursor> cursors = sa.makeCursors(timeFilterNone, schemaInfo.getDataInterval(), QueryGranularities.ALL, false);
+    Sequence<Cursor> cursors = makeCursors(sa, timeFilterNone);
 
     Sequence<List<Long>> longListSeq = readCursorsLong(cursors, blackhole);
     List<Long> strings = Sequences.toList(Sequences.limit(longListSeq, 1), Lists.<List<Long>>newArrayList()).get(0);
@@ -283,7 +284,7 @@ public class FilterPartitionBenchmark
   public void timeFilterHalf(Blackhole blackhole) throws Exception
   {
     StorageAdapter sa = new QueryableIndexStorageAdapter(qIndex);
-    Sequence<Cursor> cursors = sa.makeCursors(timeFilterHalf, schemaInfo.getDataInterval(), QueryGranularities.ALL, false);
+    Sequence<Cursor> cursors = makeCursors(sa, timeFilterHalf);
 
     Sequence<List<Long>> longListSeq = readCursorsLong(cursors, blackhole);
     List<Long> strings = Sequences.toList(Sequences.limit(longListSeq, 1), Lists.<List<Long>>newArrayList()).get(0);
@@ -298,7 +299,7 @@ public class FilterPartitionBenchmark
   public void timeFilterAll(Blackhole blackhole) throws Exception
   {
     StorageAdapter sa = new QueryableIndexStorageAdapter(qIndex);
-    Sequence<Cursor> cursors = sa.makeCursors(timeFilterAll, schemaInfo.getDataInterval(), QueryGranularities.ALL, false);
+    Sequence<Cursor> cursors = makeCursors(sa, timeFilterAll);
 
     Sequence<List<Long>> longListSeq = readCursorsLong(cursors, blackhole);
     List<Long> strings = Sequences.toList(Sequences.limit(longListSeq, 1), Lists.<List<Long>>newArrayList()).get(0);
@@ -315,7 +316,7 @@ public class FilterPartitionBenchmark
     Filter filter = new SelectorFilter("dimSequential", "199");
 
     StorageAdapter sa = new QueryableIndexStorageAdapter(qIndex);
-    Sequence<Cursor> cursors = sa.makeCursors(filter, schemaInfo.getDataInterval(), QueryGranularities.ALL, false);
+    Sequence<Cursor> cursors = makeCursors(sa, filter);
 
     Sequence<List<String>> stringListSeq = readCursors(cursors, blackhole);
     List<String> strings = Sequences.toList(Sequences.limit(stringListSeq, 1), Lists.<List<String>>newArrayList()).get(0);
@@ -332,7 +333,7 @@ public class FilterPartitionBenchmark
     Filter filter = new NoBitmapSelectorFilter("dimSequential", "199");
 
     StorageAdapter sa = new QueryableIndexStorageAdapter(qIndex);
-    Sequence<Cursor> cursors = sa.makeCursors(filter, schemaInfo.getDataInterval(), QueryGranularities.ALL, false);
+    Sequence<Cursor> cursors = makeCursors(sa, filter);
 
     Sequence<List<String>> stringListSeq = readCursors(cursors, blackhole);
     List<String> strings = Sequences.toList(Sequences.limit(stringListSeq, 1), Lists.<List<String>>newArrayList()).get(0);
@@ -349,7 +350,7 @@ public class FilterPartitionBenchmark
     Filter filter = new SelectorDimFilter("dimSequential", "super-199", JS_EXTRACTION_FN).toFilter();
 
     StorageAdapter sa = new QueryableIndexStorageAdapter(qIndex);
-    Sequence<Cursor> cursors = sa.makeCursors(filter, schemaInfo.getDataInterval(), QueryGranularities.ALL, false);
+    Sequence<Cursor> cursors = makeCursors(sa, filter);
 
     Sequence<List<String>> stringListSeq = readCursors(cursors, blackhole);
     List<String> strings = Sequences.toList(Sequences.limit(stringListSeq, 1), Lists.<List<String>>newArrayList()).get(0);
@@ -366,7 +367,7 @@ public class FilterPartitionBenchmark
     Filter filter = new NoBitmapSelectorDimFilter("dimSequential", "super-199", JS_EXTRACTION_FN).toFilter();
 
     StorageAdapter sa = new QueryableIndexStorageAdapter(qIndex);
-    Sequence<Cursor> cursors = sa.makeCursors(filter, schemaInfo.getDataInterval(), QueryGranularities.ALL, false);
+    Sequence<Cursor> cursors = makeCursors(sa, filter);
 
     Sequence<List<String>> stringListSeq = readCursors(cursors, blackhole);
     List<String> strings = Sequences.toList(Sequences.limit(stringListSeq, 1), Lists.<List<String>>newArrayList()).get(0);
@@ -385,7 +386,7 @@ public class FilterPartitionBenchmark
     Filter orFilter = new OrFilter(Arrays.<Filter>asList(filter, filter2));
 
     StorageAdapter sa = new QueryableIndexStorageAdapter(qIndex);
-    Sequence<Cursor> cursors = sa.makeCursors(orFilter, schemaInfo.getDataInterval(), QueryGranularities.ALL, false);
+    Sequence<Cursor> cursors = makeCursors(sa, orFilter);
 
     Sequence<List<String>> stringListSeq = readCursors(cursors, blackhole);
     List<String> strings = Sequences.toList(Sequences.limit(stringListSeq, 1), Lists.<List<String>>newArrayList()).get(0);
@@ -404,7 +405,7 @@ public class FilterPartitionBenchmark
     Filter orFilter = new OrFilter(Arrays.<Filter>asList(filter, filter2));
 
     StorageAdapter sa = new QueryableIndexStorageAdapter(qIndex);
-    Sequence<Cursor> cursors = sa.makeCursors(Filters.convertToCNF(orFilter), schemaInfo.getDataInterval(), QueryGranularities.ALL, false);
+    Sequence<Cursor> cursors = makeCursors(sa, Filters.convertToCNF(orFilter));
 
     Sequence<List<String>> stringListSeq = readCursors(cursors, blackhole);
     List<String> strings = Sequences.toList(Sequences.limit(stringListSeq, 1), Lists.<List<String>>newArrayList()).get(0);
@@ -446,7 +447,7 @@ public class FilterPartitionBenchmark
     );
 
     StorageAdapter sa = new QueryableIndexStorageAdapter(qIndex);
-    Sequence<Cursor> cursors = sa.makeCursors(dimFilter3.toFilter(), schemaInfo.getDataInterval(), QueryGranularities.ALL, false);
+    Sequence<Cursor> cursors = makeCursors(sa, dimFilter3.toFilter());
 
     Sequence<List<String>> stringListSeq = readCursors(cursors, blackhole);
     List<String> strings = Sequences.toList(Sequences.limit(stringListSeq, 1), Lists.<List<String>>newArrayList()).get(0);
@@ -488,13 +489,18 @@ public class FilterPartitionBenchmark
     );
 
     StorageAdapter sa = new QueryableIndexStorageAdapter(qIndex);
-    Sequence<Cursor> cursors = sa.makeCursors(Filters.convertToCNF(dimFilter3.toFilter()), schemaInfo.getDataInterval(), QueryGranularities.ALL, false);
+    Sequence<Cursor> cursors = makeCursors(sa, Filters.convertToCNF(dimFilter3.toFilter()));
 
     Sequence<List<String>> stringListSeq = readCursors(cursors, blackhole);
     List<String> strings = Sequences.toList(Sequences.limit(stringListSeq, 1), Lists.<List<String>>newArrayList()).get(0);
     for (String st : strings) {
       blackhole.consume(st);
     }
+  }
+
+  private Sequence<Cursor> makeCursors(StorageAdapter sa, Filter filter)
+  {
+    return sa.makeCursors(filter, schemaInfo.getDataInterval(), VirtualColumns.EMPTY, QueryGranularities.ALL, false);
   }
 
   private Sequence<List<String>> readCursors(Sequence<Cursor> cursors, final Blackhole blackhole)

--- a/benchmarks/src/main/java/io/druid/benchmark/indexing/IncrementalIndexReadBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/indexing/IncrementalIndexReadBenchmark.java
@@ -45,6 +45,7 @@ import io.druid.query.ordering.StringComparators;
 import io.druid.query.search.search.ContainsSearchQuerySpec;
 import io.druid.segment.Cursor;
 import io.druid.segment.DimensionSelector;
+import io.druid.segment.VirtualColumns;
 import io.druid.segment.data.IndexedInts;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
@@ -143,7 +144,7 @@ public class IncrementalIndexReadBenchmark
   public void read(Blackhole blackhole) throws Exception
   {
     IncrementalIndexStorageAdapter sa = new IncrementalIndexStorageAdapter(incIndex);
-    Sequence<Cursor> cursors = sa.makeCursors(null, schemaInfo.getDataInterval(), QueryGranularities.ALL, false);
+    Sequence<Cursor> cursors = makeCursors(sa, null);
     Cursor cursor = Sequences.toList(Sequences.limit(cursors, 1), Lists.<Cursor>newArrayList()).get(0);
 
     List<DimensionSelector> selectors = new ArrayList<>();
@@ -178,7 +179,7 @@ public class IncrementalIndexReadBenchmark
     );
 
     IncrementalIndexStorageAdapter sa = new IncrementalIndexStorageAdapter(incIndex);
-    Sequence<Cursor> cursors = sa.makeCursors(filter.toFilter(), schemaInfo.getDataInterval(), QueryGranularities.ALL, false);
+    Sequence<Cursor> cursors = makeCursors(sa, filter);
     Cursor cursor = Sequences.toList(Sequences.limit(cursors, 1), Lists.<Cursor>newArrayList()).get(0);
 
     List<DimensionSelector> selectors = new ArrayList<>();
@@ -195,5 +196,16 @@ public class IncrementalIndexReadBenchmark
       }
       cursor.advance();
     }
+  }
+
+  private Sequence<Cursor> makeCursors(IncrementalIndexStorageAdapter sa, DimFilter filter)
+  {
+    return sa.makeCursors(
+        filter.toFilter(),
+        schemaInfo.getDataInterval(),
+        VirtualColumns.EMPTY,
+        QueryGranularities.ALL,
+        false
+    );
   }
 }

--- a/extensions-contrib/virtual-columns/pom.xml
+++ b/extensions-contrib/virtual-columns/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ ~ or more contributor license agreements. See the NOTICE file
+ ~ distributed with this work for additional information
+ ~ regarding copyright ownership. Metamarkets licenses this file
+ ~ to you under the Apache License, Version 2.0 (the
+ ~ "License"); you may not use this file except in compliance
+ ~ with the License. You may obtain a copy of the License at
+ ~
+ ~ http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied. See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.druid.extensions.contrib</groupId>
+    <artifactId>druid-virtual-columns</artifactId>
+    <name>druid-virtual-columns</name>
+    <description>druid-virtual-columns</description>
+
+    <parent>
+        <groupId>io.druid</groupId>
+        <artifactId>druid</artifactId>
+        <version>0.9.3-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.druid</groupId>
+            <artifactId>druid-api</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.druid</groupId>
+            <artifactId>druid-common</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.druid</groupId>
+            <artifactId>druid-processing</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Tests -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.druid</groupId>
+            <artifactId>druid-processing</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/extensions-contrib/virtual-columns/src/main/java/io/druid/segment/DruidVirtualColumnsModule.java
+++ b/extensions-contrib/virtual-columns/src/main/java/io/druid/segment/DruidVirtualColumnsModule.java
@@ -1,0 +1,44 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.segment;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import io.druid.initialization.DruidModule;
+
+import java.util.List;
+
+/**
+ */
+public class DruidVirtualColumnsModule implements DruidModule
+{
+  @Override
+  public List<? extends Module> getJacksonModules()
+  {
+    return ImmutableList.of(new SimpleModule().registerSubtypes(MapVirtualColumn.class));
+  }
+
+  @Override
+  public void configure(Binder binder)
+  {
+  }
+}

--- a/extensions-contrib/virtual-columns/src/main/java/io/druid/segment/MapVirtualColumn.java
+++ b/extensions-contrib/virtual-columns/src/main/java/io/druid/segment/MapVirtualColumn.java
@@ -124,6 +124,12 @@ public class MapVirtualColumn implements VirtualColumn
   }
 
   @Override
+  public boolean usesDotNotation()
+  {
+    return true;
+  }
+
+  @Override
   public byte[] getCacheKey()
   {
     byte[] key = StringUtils.toUtf8(keyDimension);

--- a/extensions-contrib/virtual-columns/src/main/resources/META-INF/services/io.druid.initialization.DruidModule
+++ b/extensions-contrib/virtual-columns/src/main/resources/META-INF/services/io.druid.initialization.DruidModule
@@ -1,0 +1,1 @@
+io.druid.segment.DruidVirtualColumnsModule

--- a/extensions-contrib/virtual-columns/src/test/java/io/druid/segment/MapVirtualColumnTest.java
+++ b/extensions-contrib/virtual-columns/src/test/java/io/druid/segment/MapVirtualColumnTest.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package io.druid.query.select;
+package io.druid.segment;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -34,12 +34,13 @@ import io.druid.query.Druids;
 import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerTestHelper;
 import io.druid.query.Result;
-import io.druid.segment.IncrementalIndexSegment;
-import io.druid.segment.MapVirtualColumn;
-import io.druid.segment.QueryableIndex;
-import io.druid.segment.QueryableIndexSegment;
-import io.druid.segment.TestIndex;
-import io.druid.segment.VirtualColumn;
+import io.druid.query.select.EventHolder;
+import io.druid.query.select.PagingSpec;
+import io.druid.query.select.SelectQuery;
+import io.druid.query.select.SelectQueryEngine;
+import io.druid.query.select.SelectQueryQueryToolChest;
+import io.druid.query.select.SelectQueryRunnerFactory;
+import io.druid.query.select.SelectResultValue;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.OnheapIncrementalIndex;

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
         <module>extensions-contrib/orc-extensions</module>
         <module>extensions-contrib/time-min-max</module>
         <module>extensions-contrib/google-extensions</module>
+        <module>extensions-contrib/virtual-columns</module>
     </modules>
 
     <dependencyManagement>

--- a/processing/src/main/java/io/druid/query/Druids.java
+++ b/processing/src/main/java/io/druid/query/Druids.java
@@ -54,6 +54,7 @@ import io.druid.query.spec.QuerySegmentSpec;
 import io.druid.query.timeboundary.TimeBoundaryQuery;
 import io.druid.query.timeboundary.TimeBoundaryResultValue;
 import io.druid.query.timeseries.TimeseriesQuery;
+import io.druid.segment.VirtualColumn;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
@@ -1103,6 +1104,7 @@ public class Druids
     private QueryGranularity granularity;
     private List<DimensionSpec> dimensions;
     private List<String> metrics;
+    private List<VirtualColumn> virtualColumns;
     private PagingSpec pagingSpec;
 
     public SelectQueryBuilder()
@@ -1125,7 +1127,10 @@ public class Druids
           descending,
           dimFilter,
           granularity,
-          dimensions, metrics, pagingSpec,
+          dimensions,
+          metrics,
+          virtualColumns,
+          pagingSpec,
           context
       );
     }
@@ -1225,6 +1230,12 @@ public class Druids
     public SelectQueryBuilder metrics(List<String> m)
     {
       metrics = m;
+      return this;
+    }
+
+    public SelectQueryBuilder virtualColumns(List<VirtualColumn> vcs)
+    {
+      virtualColumns = vcs;
       return this;
     }
 

--- a/processing/src/main/java/io/druid/query/QueryRunnerHelper.java
+++ b/processing/src/main/java/io/druid/query/QueryRunnerHelper.java
@@ -30,6 +30,7 @@ import io.druid.java.util.common.logger.Logger;
 import io.druid.query.filter.Filter;
 import io.druid.segment.Cursor;
 import io.druid.segment.StorageAdapter;
+import io.druid.segment.VirtualColumns;
 import org.joda.time.Interval;
 
 import java.io.Closeable;
@@ -46,6 +47,7 @@ public class QueryRunnerHelper
       final StorageAdapter adapter,
       List<Interval> queryIntervals,
       Filter filter,
+      VirtualColumns virtualColumns,
       boolean descending,
       QueryGranularity granularity,
       final Function<Cursor, Result<T>> mapFn
@@ -57,7 +59,7 @@ public class QueryRunnerHelper
 
     return Sequences.filter(
         Sequences.map(
-            adapter.makeCursors(filter, queryIntervals.get(0), granularity, descending),
+            adapter.makeCursors(filter, queryIntervals.get(0), virtualColumns, granularity, descending),
             new Function<Cursor, Result<T>>()
             {
               @Override

--- a/processing/src/main/java/io/druid/query/dimension/DefaultDimensionSpec.java
+++ b/processing/src/main/java/io/druid/query/dimension/DefaultDimensionSpec.java
@@ -36,6 +36,11 @@ import java.util.List;
  */
 public class DefaultDimensionSpec implements DimensionSpec
 {
+  public static DefaultDimensionSpec of(String dimensionName)
+  {
+    return new DefaultDimensionSpec(dimensionName, dimensionName);
+  }
+
   public static List<DimensionSpec> toSpec(String... dimensionNames)
   {
     return toSpec(Arrays.asList(dimensionNames));

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryEngine.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryEngine.java
@@ -48,6 +48,7 @@ import io.druid.query.filter.Filter;
 import io.druid.segment.Cursor;
 import io.druid.segment.DimensionSelector;
 import io.druid.segment.StorageAdapter;
+import io.druid.segment.VirtualColumns;
 import io.druid.segment.data.IndexedInts;
 import io.druid.segment.filter.Filters;
 import org.joda.time.DateTime;
@@ -100,6 +101,7 @@ public class GroupByQueryEngine
     final Sequence<Cursor> cursors = storageAdapter.makeCursors(
         filter,
         intervals.get(0),
+        VirtualColumns.EMPTY,
         query.getGranularity(),
         false
     );

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
@@ -41,6 +41,7 @@ import io.druid.query.groupby.strategy.GroupByStrategyV2;
 import io.druid.segment.Cursor;
 import io.druid.segment.DimensionSelector;
 import io.druid.segment.StorageAdapter;
+import io.druid.segment.VirtualColumns;
 import io.druid.segment.data.EmptyIndexedInts;
 import io.druid.segment.data.IndexedInts;
 import io.druid.segment.filter.Filters;
@@ -83,6 +84,7 @@ public class GroupByQueryEngineV2
     final Sequence<Cursor> cursors = storageAdapter.makeCursors(
         Filters.toFilter(query.getDimFilter()),
         intervals.get(0),
+         VirtualColumns.EMPTY,
         query.getGranularity(),
         false
     );

--- a/processing/src/main/java/io/druid/query/metadata/SegmentAnalyzer.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentAnalyzer.java
@@ -39,6 +39,7 @@ import io.druid.segment.DimensionSelector;
 import io.druid.segment.QueryableIndex;
 import io.druid.segment.Segment;
 import io.druid.segment.StorageAdapter;
+import io.druid.segment.VirtualColumns;
 import io.druid.segment.column.BitmapIndex;
 import io.druid.segment.column.Column;
 import io.druid.segment.column.ColumnCapabilities;
@@ -248,7 +249,13 @@ public class SegmentAnalyzer
       final long end = storageAdapter.getMaxTime().getMillis();
 
       final Sequence<Cursor> cursors =
-          storageAdapter.makeCursors(null, new Interval(start, end), QueryGranularities.ALL, false);
+          storageAdapter.makeCursors(
+              null,
+              new Interval(start, end),
+              VirtualColumns.EMPTY,
+              QueryGranularities.ALL,
+              false
+          );
 
       size = cursors.accumulate(
           0L,

--- a/processing/src/main/java/io/druid/query/search/SearchQueryRunner.java
+++ b/processing/src/main/java/io/druid/query/search/SearchQueryRunner.java
@@ -52,6 +52,7 @@ import io.druid.segment.DimensionSelector;
 import io.druid.segment.QueryableIndex;
 import io.druid.segment.Segment;
 import io.druid.segment.StorageAdapter;
+import io.druid.segment.VirtualColumns;
 import io.druid.segment.column.BitmapIndex;
 import io.druid.segment.column.Column;
 import io.druid.segment.column.GenericColumn;
@@ -197,7 +198,13 @@ public class SearchQueryRunner implements QueryRunner<Result<SearchResultValue>>
       dimsToSearch = dimensions;
     }
 
-    final Sequence<Cursor> cursors = adapter.makeCursors(filter, interval, query.getGranularity(), descending);
+    final Sequence<Cursor> cursors = adapter.makeCursors(
+        filter,
+        interval,
+        VirtualColumns.EMPTY,
+        query.getGranularity(),
+        descending
+    );
 
     final TreeMap<SearchHit, MutableInt> retVal = cursors.accumulate(
         Maps.<SearchHit, SearchHit, MutableInt>newTreeMap(query.getSort().getComparator()),

--- a/processing/src/main/java/io/druid/query/select/SelectQuery.java
+++ b/processing/src/main/java/io/druid/query/select/SelectQuery.java
@@ -31,9 +31,11 @@ import io.druid.query.Result;
 import io.druid.query.dimension.DimensionSpec;
 import io.druid.query.filter.DimFilter;
 import io.druid.query.spec.QuerySegmentSpec;
+import io.druid.segment.VirtualColumn;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  */
@@ -44,6 +46,7 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
   private final QueryGranularity granularity;
   private final List<DimensionSpec> dimensions;
   private final List<String> metrics;
+  private final List<VirtualColumn> virtualColumns;
   private final PagingSpec pagingSpec;
 
   @JsonCreator
@@ -55,6 +58,7 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
       @JsonProperty("granularity") QueryGranularity granularity,
       @JsonProperty("dimensions") List<DimensionSpec> dimensions,
       @JsonProperty("metrics") List<String> metrics,
+      @JsonProperty("virtualColumns") List<VirtualColumn> virtualColumns,
       @JsonProperty("pagingSpec") PagingSpec pagingSpec,
       @JsonProperty("context") Map<String, Object> context
   )
@@ -63,6 +67,7 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
     this.dimFilter = dimFilter;
     this.granularity = granularity;
     this.dimensions = dimensions;
+    this.virtualColumns = virtualColumns;
     this.metrics = metrics;
     this.pagingSpec = pagingSpec;
 
@@ -128,6 +133,12 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
     return metrics;
   }
 
+  @JsonProperty
+  public List<VirtualColumn> getVirtualColumns()
+  {
+    return virtualColumns;
+  }
+
   public PagingOffset getPagingOffset(String identifier)
   {
     return pagingSpec.getOffset(identifier, isDescending());
@@ -143,6 +154,7 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
         granularity,
         dimensions,
         metrics,
+        virtualColumns,
         pagingSpec,
         getContext()
     );
@@ -159,6 +171,7 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
         granularity,
         dimensions,
         metrics,
+        virtualColumns,
         pagingSpec,
         getContext()
     );
@@ -174,6 +187,7 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
         granularity,
         dimensions,
         metrics,
+        virtualColumns,
         pagingSpec,
         computeOverridenContext(contextOverrides)
     );
@@ -189,6 +203,7 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
         granularity,
         dimensions,
         metrics,
+        virtualColumns,
         pagingSpec,
         getContext()
     );
@@ -204,6 +219,7 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
         granularity,
         dimensions,
         metrics,
+        virtualColumns,
         pagingSpec,
         getContext()
     );
@@ -220,6 +236,7 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
            ", granularity=" + granularity +
            ", dimensions=" + dimensions +
            ", metrics=" + metrics +
+           ", virtualColumns=" + virtualColumns +
            ", pagingSpec=" + pagingSpec +
            '}';
   }
@@ -239,19 +256,22 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
 
     SelectQuery that = (SelectQuery) o;
 
-    if (dimFilter != null ? !dimFilter.equals(that.dimFilter) : that.dimFilter != null) {
+    if (!Objects.equals(dimFilter, that.dimFilter)) {
       return false;
     }
-    if (dimensions != null ? !dimensions.equals(that.dimensions) : that.dimensions != null) {
+    if (!Objects.equals(granularity, that.granularity)) {
       return false;
     }
-    if (granularity != null ? !granularity.equals(that.granularity) : that.granularity != null) {
+    if (!Objects.equals(dimensions, that.dimensions)) {
       return false;
     }
-    if (metrics != null ? !metrics.equals(that.metrics) : that.metrics != null) {
+    if (!Objects.equals(metrics, that.metrics)) {
       return false;
     }
-    if (pagingSpec != null ? !pagingSpec.equals(that.pagingSpec) : that.pagingSpec != null) {
+    if (!Objects.equals(virtualColumns, that.virtualColumns)) {
+      return false;
+    }
+    if (!Objects.equals(pagingSpec, that.pagingSpec)) {
       return false;
     }
 
@@ -266,6 +286,7 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
     result = 31 * result + (granularity != null ? granularity.hashCode() : 0);
     result = 31 * result + (dimensions != null ? dimensions.hashCode() : 0);
     result = 31 * result + (metrics != null ? metrics.hashCode() : 0);
+    result = 31 * result + (virtualColumns != null ? virtualColumns.hashCode() : 0);
     result = 31 * result + (pagingSpec != null ? pagingSpec.hashCode() : 0);
     return result;
   }

--- a/processing/src/main/java/io/druid/query/select/SelectQueryEngine.java
+++ b/processing/src/main/java/io/druid/query/select/SelectQueryEngine.java
@@ -37,6 +37,7 @@ import io.druid.segment.LongColumnSelector;
 import io.druid.segment.ObjectColumnSelector;
 import io.druid.segment.Segment;
 import io.druid.segment.StorageAdapter;
+import io.druid.segment.VirtualColumns;
 import io.druid.segment.column.Column;
 import io.druid.segment.data.IndexedInts;
 import io.druid.segment.filter.Filters;
@@ -89,6 +90,7 @@ public class SelectQueryEngine
         adapter,
         query.getQuerySegmentSpec().getIntervals(),
         filter,
+        VirtualColumns.valueOf(query.getVirtualColumns()),
         query.isDescending(),
         query.getGranularity(),
         new Function<Cursor, Result<SelectResultValue>>()

--- a/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQueryRunnerFactory.java
+++ b/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQueryRunnerFactory.java
@@ -39,6 +39,7 @@ import io.druid.segment.Cursor;
 import io.druid.segment.LongColumnSelector;
 import io.druid.segment.Segment;
 import io.druid.segment.StorageAdapter;
+import io.druid.segment.VirtualColumns;
 import io.druid.segment.column.Column;
 import io.druid.segment.filter.Filters;
 import org.joda.time.DateTime;
@@ -111,7 +112,7 @@ public class TimeBoundaryQueryRunnerFactory
       final Sequence<Result<DateTime>> resultSequence = QueryRunnerHelper.makeCursorBasedQuery(
           adapter,
           legacyQuery.getQuerySegmentSpec().getIntervals(),
-          Filters.toFilter(legacyQuery.getDimensionsFilter()),
+          Filters.toFilter(legacyQuery.getDimensionsFilter()), VirtualColumns.EMPTY,
           descending,
           new AllGranularity(),
           this.skipToFirstMatching

--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryEngine.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryEngine.java
@@ -29,6 +29,7 @@ import io.druid.query.filter.Filter;
 import io.druid.segment.Cursor;
 import io.druid.segment.SegmentMissingException;
 import io.druid.segment.StorageAdapter;
+import io.druid.segment.VirtualColumns;
 import io.druid.segment.filter.Filters;
 
 import java.util.List;
@@ -51,6 +52,7 @@ public class TimeseriesQueryEngine
         adapter,
         query.getQuerySegmentSpec().getIntervals(),
         filter,
+        VirtualColumns.EMPTY,
         query.isDescending(),
         query.getGranularity(),
         new Function<Cursor, Result<TimeseriesResultValue>>()

--- a/processing/src/main/java/io/druid/query/topn/TopNQueryEngine.java
+++ b/processing/src/main/java/io/druid/query/topn/TopNQueryEngine.java
@@ -35,6 +35,7 @@ import io.druid.segment.Capabilities;
 import io.druid.segment.Cursor;
 import io.druid.segment.SegmentMissingException;
 import io.druid.segment.StorageAdapter;
+import io.druid.segment.VirtualColumns;
 import io.druid.segment.column.Column;
 import io.druid.segment.filter.Filters;
 import org.joda.time.Interval;
@@ -74,7 +75,7 @@ public class TopNQueryEngine
 
     return Sequences.filter(
         Sequences.map(
-            adapter.makeCursors(filter, queryIntervals.get(0), granularity, query.isDescending()),
+            adapter.makeCursors(filter, queryIntervals.get(0), VirtualColumns.EMPTY, granularity, query.isDescending()),
             new Function<Cursor, Result<TopNResultValue>>()
             {
               @Override

--- a/processing/src/main/java/io/druid/segment/CursorFactory.java
+++ b/processing/src/main/java/io/druid/segment/CursorFactory.java
@@ -28,5 +28,11 @@ import org.joda.time.Interval;
  */
 public interface CursorFactory
 {
-  public Sequence<Cursor> makeCursors(Filter filter, Interval interval, QueryGranularity gran, boolean descending);
+  public Sequence<Cursor> makeCursors(
+      Filter filter,
+      Interval interval,
+      VirtualColumns virtualColumns,
+      QueryGranularity gran,
+      boolean descending
+  );
 }

--- a/processing/src/main/java/io/druid/segment/MapVirtualColumn.java
+++ b/processing/src/main/java/io/druid/segment/MapVirtualColumn.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import com.metamx.common.StringUtils;
+import io.druid.query.dimension.DefaultDimensionSpec;
+import io.druid.query.filter.DimFilterUtils;
+import io.druid.segment.data.IndexedInts;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+/**
+ */
+public class MapVirtualColumn implements VirtualColumn
+{
+  private static final byte VC_TYPE_ID = 0x00;
+
+  private final String outputName;
+  private final String keyDimension;
+  private final String valueDimension;
+
+  @JsonCreator
+  public MapVirtualColumn(
+      @JsonProperty("keyDimension") String keyDimension,
+      @JsonProperty("valueDimension") String valueDimension,
+      @JsonProperty("outputName") String outputName
+  )
+  {
+    Preconditions.checkArgument(keyDimension != null, "key dimension should not be null");
+    Preconditions.checkArgument(valueDimension != null, "value dimension should not be null");
+    Preconditions.checkArgument(outputName != null, "output name should not be null");
+
+    this.keyDimension = keyDimension;
+    this.valueDimension = valueDimension;
+    this.outputName = outputName;
+  }
+
+  @Override
+  public ObjectColumnSelector init(String dimension, ColumnSelectorFactory factory)
+  {
+    final DimensionSelector keySelector = factory.makeDimensionSelector(DefaultDimensionSpec.of(keyDimension));
+    final DimensionSelector valueSelector = factory.makeDimensionSelector(DefaultDimensionSpec.of(valueDimension));
+
+    int index = dimension.indexOf('.');
+    if (index < 0) {
+      return new ObjectColumnSelector<Map>()
+      {
+        @Override
+        public Class classOfObject()
+        {
+          return Map.class;
+        }
+
+        @Override
+        public Map get()
+        {
+          final IndexedInts keyIndices = keySelector.getRow();
+          final IndexedInts valueIndices = valueSelector.getRow();
+          if (keyIndices == null || valueIndices == null) {
+            return null;
+          }
+          final int limit = Math.min(keyIndices.size(), valueIndices.size());
+          final Map<String, String> map = Maps.newHashMapWithExpectedSize(limit);
+          for (int i = 0; i < limit; i++) {
+            map.put(
+                keySelector.lookupName(keyIndices.get(i)),
+                valueSelector.lookupName(valueIndices.get(i))
+            );
+          }
+          return map;
+        }
+      };
+    }
+
+    final int keyId = keySelector.lookupId(dimension.substring(index + 1));
+
+    return new ObjectColumnSelector<String>()
+    {
+      @Override
+      public Class classOfObject()
+      {
+        return String.class;
+      }
+
+      @Override
+      public String get()
+      {
+        final IndexedInts keyIndices = keySelector.getRow();
+        final IndexedInts valueIndices = valueSelector.getRow();
+        if (keyIndices == null || valueIndices == null) {
+          return null;
+        }
+        final int limit = Math.min(keyIndices.size(), valueIndices.size());
+        for (int i = 0; i < limit; i++) {
+          if (keyIndices.get(i) == keyId) {
+            return valueSelector.lookupName(valueIndices.get(i));
+          }
+        }
+        return null;
+      }
+    };
+  }
+
+  @Override
+  public byte[] getCacheKey()
+  {
+    byte[] key = StringUtils.toUtf8(keyDimension);
+    byte[] value = StringUtils.toUtf8(valueDimension);
+    byte[] output = StringUtils.toUtf8(outputName);
+
+    return ByteBuffer.allocate(3 + key.length + value.length + output.length)
+                     .put(VC_TYPE_ID)
+                     .put(key).put(DimFilterUtils.STRING_SEPARATOR)
+                     .put(value).put(DimFilterUtils.STRING_SEPARATOR)
+                     .put(output)
+                     .array();
+  }
+
+  @JsonProperty
+  public String getKeyDimension()
+  {
+    return keyDimension;
+  }
+
+  @JsonProperty
+  public String getValueDimension()
+  {
+    return valueDimension;
+  }
+
+  @JsonProperty
+  public String getOutputName()
+  {
+    return outputName;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof MapVirtualColumn)) {
+      return false;
+    }
+
+    MapVirtualColumn that = (MapVirtualColumn) o;
+
+    if (!keyDimension.equals(that.keyDimension)) {
+      return false;
+    }
+    if (!valueDimension.equals(that.valueDimension)) {
+      return false;
+    }
+    if (!outputName.equals(that.outputName)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = keyDimension.hashCode();
+    result = 31 * result + valueDimension.hashCode();
+    result = 31 * result + outputName.hashCode();
+    return result;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "MapVirtualColumn{" +
+           "keyDimension='" + keyDimension + '\'' +
+           ", valueDimension='" + valueDimension + '\'' +
+           ", outputName='" + outputName + '\'' +
+           '}';
+  }
+}

--- a/processing/src/main/java/io/druid/segment/VirtualColumn.java
+++ b/processing/src/main/java/io/druid/segment/VirtualColumn.java
@@ -19,20 +19,48 @@
 
 package io.druid.segment;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 /**
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes(value = {
-    @JsonSubTypes.Type(name = "map", value = MapVirtualColumn.class)
-})
+/**
+ * Virtual columns are "views" created over a ColumnSelectorFactory. They can potentially draw from multiple
+ * underlying columns, although they always present themselves as if they were a single column.
+ */
 public interface VirtualColumn
 {
+  /**
+   * Output name of this column.
+   *
+   * @return name
+   */
   String getOutputName();
 
-  ObjectColumnSelector init(String dimension, ColumnSelectorFactory factory);
+  /**
+   * Build a selector corresponding to this virtual column. Also provides the name that the
+   * virtual column was referenced with, which is useful if this column uses dot notation.
+   *
+   * @param columnName the name this virtual column was referenced with
+   * @param factory column selector factory
+   * @return the selector
+   */
+  ObjectColumnSelector init(String columnName, ColumnSelectorFactory factory);
 
+  /**
+   * Indicates that this virtual column can be referenced with dot notation. For example,
+   * a virtual column named "foo" could be referred to as "foo.bar" with the Cursor it is
+   * registered with. In that case, init will be called with columnName "foo.bar" rather
+   * than "foo".
+   *
+   * @return whether to use dot notation
+   */
+  boolean usesDotNotation();
+
+  /**
+   * Returns cache key
+   *
+   * @return cache key
+   */
   byte[] getCacheKey();
 }

--- a/processing/src/main/java/io/druid/segment/VirtualColumn.java
+++ b/processing/src/main/java/io/druid/segment/VirtualColumn.java
@@ -17,26 +17,22 @@
  * under the License.
  */
 
-package io.druid.segment.column;
+package io.druid.segment;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 /**
-*/
-public enum ValueType
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(value = {
+    @JsonSubTypes.Type(name = "map", value = MapVirtualColumn.class)
+})
+public interface VirtualColumn
 {
-  FLOAT,
-  LONG,
-  STRING,
-  COMPLEX;
+  String getOutputName();
 
-  public static ValueType typeFor(Class clazz)
-  {
-    if (clazz == String.class) {
-      return STRING;
-    } else if (clazz == float.class || clazz == Float.TYPE) {
-      return FLOAT;
-    } else if (clazz == long.class || clazz == Long.TYPE) {
-      return LONG;
-    }
-    return COMPLEX;
-  }
+  ObjectColumnSelector init(String dimension, ColumnSelectorFactory factory);
+
+  byte[] getCacheKey();
 }

--- a/processing/src/main/java/io/druid/segment/VirtualColumns.java
+++ b/processing/src/main/java/io/druid/segment/VirtualColumns.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ */
+public class VirtualColumns
+{
+  public static final VirtualColumns EMPTY = new VirtualColumns(
+      ImmutableMap.<String, VirtualColumn>of()
+  );
+
+  public static VirtualColumns valueOf(List<VirtualColumn> virtualColumns) {
+    if (virtualColumns == null || virtualColumns.isEmpty()) {
+      return EMPTY;
+    }
+    Map<String, VirtualColumn> map = Maps.newHashMap();
+    for (VirtualColumn vc : virtualColumns) {
+      map.put(vc.getOutputName(), vc);
+    }
+    return new VirtualColumns(map);
+  }
+
+  private final Map<String, VirtualColumn> virtualColumns;
+
+  public VirtualColumns(Map<String, VirtualColumn> virtualColumns)
+  {
+    this.virtualColumns = virtualColumns;
+  }
+
+  public VirtualColumn getVirtualColumn(String dimension)
+  {
+    int index = dimension.indexOf('.');
+    return virtualColumns.get(index < 0 ? dimension : dimension.substring(0, index));
+  }
+
+  public boolean isEmpty()
+  {
+    return virtualColumns.isEmpty();
+  }
+}

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
@@ -54,8 +54,11 @@ import io.druid.segment.NumericColumnSelector;
 import io.druid.segment.ObjectColumnSelector;
 import io.druid.segment.SingleScanTimeDimSelector;
 import io.druid.segment.StorageAdapter;
+import io.druid.segment.VirtualColumn;
+import io.druid.segment.VirtualColumns;
 import io.druid.segment.column.Column;
 import io.druid.segment.column.ColumnCapabilities;
+import io.druid.segment.column.ColumnCapabilitiesImpl;
 import io.druid.segment.column.ValueType;
 import io.druid.segment.data.Indexed;
 import io.druid.segment.data.ListIndexed;
@@ -201,6 +204,7 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
   public Sequence<Cursor> makeCursors(
       final Filter filter,
       final Interval interval,
+      final VirtualColumns virtualColumns,
       final QueryGranularity gran,
       final boolean descending
   )
@@ -503,11 +507,16 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
 
                 IncrementalIndex.DimensionDesc dimensionDesc = index.getDimension(column);
 
-                if (dimensionDesc != null) {
+                if (dimensionDesc == null) {
+                  VirtualColumn virtualColumn = virtualColumns.getVirtualColumn(column);
+                  if (virtualColumn != null) {
+                    return virtualColumn.init(column, this);
+                  }
+                  return null;
+                } else {
 
                   final int dimensionIndex = dimensionDesc.getIndex();
                   final DimensionIndexer indexer = dimensionDesc.getIndexer();
-                  final ColumnCapabilities capabilities = dimensionDesc.getCapabilities();
 
                   return new ObjectColumnSelector<Object>()
                   {
@@ -536,14 +545,20 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
                     }
                   };
                 }
-
-                return null;
               }
 
               @Override
               public ColumnCapabilities getColumnCapabilities(String columnName)
               {
-                return index.getCapabilities(columnName);
+                ColumnCapabilities capabilities = index.getCapabilities(columnName);
+                if (capabilities == null && !virtualColumns.isEmpty()) {
+                  VirtualColumn virtualColumn = virtualColumns.getVirtualColumn(columnName);
+                  if (virtualColumn != null) {
+                    Class clazz = virtualColumn.init(columnName, this).classOfObject();
+                    capabilities = new ColumnCapabilitiesImpl().setType(ValueType.typeFor(clazz));
+                  }
+                }
+                return capabilities;
               }
 
               @Override

--- a/processing/src/test/java/io/druid/query/select/MapVirtualColumnTest.java
+++ b/processing/src/test/java/io/druid/query/select/MapVirtualColumnTest.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.select;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.io.CharSource;
+import io.druid.data.input.impl.DelimitedParseSpec;
+import io.druid.data.input.impl.DimensionsSpec;
+import io.druid.data.input.impl.StringInputRowParser;
+import io.druid.data.input.impl.TimestampSpec;
+import io.druid.granularity.QueryGranularities;
+import io.druid.jackson.DefaultObjectMapper;
+import io.druid.java.util.common.guava.Sequences;
+import io.druid.query.Druids;
+import io.druid.query.QueryRunner;
+import io.druid.query.QueryRunnerTestHelper;
+import io.druid.query.Result;
+import io.druid.segment.IncrementalIndexSegment;
+import io.druid.segment.MapVirtualColumn;
+import io.druid.segment.QueryableIndex;
+import io.druid.segment.QueryableIndexSegment;
+import io.druid.segment.TestIndex;
+import io.druid.segment.VirtualColumn;
+import io.druid.segment.incremental.IncrementalIndex;
+import io.druid.segment.incremental.IncrementalIndexSchema;
+import io.druid.segment.incremental.OnheapIncrementalIndex;
+import org.joda.time.DateTime;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static io.druid.query.QueryRunnerTestHelper.allGran;
+import static io.druid.query.QueryRunnerTestHelper.dataSource;
+import static io.druid.query.QueryRunnerTestHelper.fullOnInterval;
+import static io.druid.query.QueryRunnerTestHelper.makeQueryRunner;
+import static io.druid.query.QueryRunnerTestHelper.transformToConstructionFeeder;
+
+/**
+ */
+@RunWith(Parameterized.class)
+public class MapVirtualColumnTest
+{
+  @Parameterized.Parameters
+  public static Iterable<Object[]> constructorFeeder() throws IOException
+  {
+    SelectQueryRunnerFactory factory = new SelectQueryRunnerFactory(
+        new SelectQueryQueryToolChest(
+            new DefaultObjectMapper(),
+            QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
+        ),
+        new SelectQueryEngine(),
+        QueryRunnerTestHelper.NOOP_QUERYWATCHER
+    );
+
+    final IncrementalIndexSchema schema = new IncrementalIndexSchema.Builder()
+        .withMinTimestamp(new DateTime("2011-01-12T00:00:00.000Z").getMillis())
+        .withQueryGranularity(QueryGranularities.NONE)
+        .build();
+    final IncrementalIndex index = new OnheapIncrementalIndex(schema, true, 10000);
+
+    final StringInputRowParser parser = new StringInputRowParser(
+        new DelimitedParseSpec(
+            new TimestampSpec("ts", "iso", null),
+            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(Arrays.asList("dim", "keys", "values")), null, null),
+            "\t",
+            ",",
+            Arrays.asList("ts", "dim", "keys", "values")
+        )
+        , "utf8"
+    );
+
+    CharSource input = CharSource.wrap(
+        "2011-01-12T00:00:00.000Z\ta\tkey1,key2,key3\tvalue1,value2,value3\n" +
+        "2011-01-12T00:00:00.000Z\tb\tkey4,key5,key6\tvalue4\n" +
+        "2011-01-12T00:00:00.000Z\tc\tkey1,key5\tvalue1,value5,value9\n"
+    );
+
+    IncrementalIndex index1 = TestIndex.loadIncrementalIndex(index, input, parser);
+    QueryableIndex index2 = TestIndex.persistRealtimeAndLoadMMapped(index1);
+
+    return transformToConstructionFeeder(
+        Arrays.asList(
+            makeQueryRunner(factory, "index1", new IncrementalIndexSegment(index1, "index1"), "incremental"),
+            makeQueryRunner(factory, "index2", new QueryableIndexSegment("index2", index2), "queryable")
+        )
+    );
+  }
+
+  private final QueryRunner runner;
+
+  public MapVirtualColumnTest(QueryRunner runner)
+  {
+    this.runner = runner;
+  }
+
+  private Druids.SelectQueryBuilder testBuilder()
+  {
+    return Druids.newSelectQueryBuilder()
+                 .dataSource(dataSource)
+                 .granularity(allGran)
+                 .intervals(fullOnInterval)
+                 .pagingSpec(new PagingSpec(null, 3));
+  }
+
+  @Test
+  public void testBasic() throws Exception
+  {
+    Druids.SelectQueryBuilder builder = testBuilder();
+
+    List<Map> expectedResults = Arrays.<Map>asList(
+        mapOf(
+            "dim", "a",
+            "params.key1", "value1",
+            "params.key3", "value3",
+            "params.key5", null,
+            "params", mapOf("key1", "value1", "key2", "value2", "key3", "value3")
+        ),
+        mapOf(
+            "dim", "b",
+            "params.key1", null,
+            "params.key3", null,
+            "params.key5", null,
+            "params", mapOf("key4", "value4")
+        ),
+        mapOf(
+            "dim", "c",
+            "params.key1", "value1",
+            "params.key3", null,
+            "params.key5", "value5",
+            "params", mapOf("key1", "value1", "key5", "value5")
+        )
+    );
+    List<VirtualColumn> virtualColumns = Arrays.<VirtualColumn>asList(new MapVirtualColumn("keys", "values", "params"));
+    SelectQuery selectQuery = builder.dimensions(Arrays.asList("dim"))
+                                     .metrics(Arrays.asList("params.key1", "params.key3", "params.key5", "params"))
+                                     .virtualColumns(virtualColumns)
+                                     .build();
+    checkSelectQuery(selectQuery, expectedResults);
+  }
+
+  private Map mapOf(Object... elements)
+  {
+    Map map = Maps.newHashMap();
+    for (int i = 0; i < elements.length; i += 2) {
+      map.put(elements[i], elements[i + 1]);
+    }
+    return map;
+  }
+
+  private void checkSelectQuery(SelectQuery searchQuery, List<Map> expected) throws Exception
+  {
+    List<Result<SelectResultValue>> results = Sequences.toList(
+        runner.run(searchQuery, ImmutableMap.of()),
+        Lists.<Result<SelectResultValue>>newArrayList()
+    );
+    Assert.assertEquals(1, results.size());
+
+    List<EventHolder> events = results.get(0).getValue().getEvents();
+
+    Assert.assertEquals(expected.size(), events.size());
+    for (int i = 0; i < events.size(); i++) {
+      Map event = events.get(i).getEvent();
+      event.remove(EventHolder.timestampKey);
+      Assert.assertEquals(expected.get(i), event);
+    }
+  }
+}

--- a/processing/src/test/java/io/druid/query/select/SelectQuerySpecTest.java
+++ b/processing/src/test/java/io/druid/query/select/SelectQuerySpecTest.java
@@ -48,6 +48,7 @@ public class SelectQuerySpecTest
         + "\"granularity\":{\"type\":\"all\"},"
         + "\"dimensions\":[\"market\",\"quality\"],"
         + "\"metrics\":[\"index\"],"
+        + "\"virtualColumns\":null,"
         + "\"pagingSpec\":{\"pagingIdentifiers\":{},\"threshold\":3},"
         + "\"context\":null}";
 
@@ -59,6 +60,7 @@ public class SelectQuerySpecTest
         + "\"granularity\":{\"type\":\"all\"},"
         + "\"dimensions\":[{\"type\":\"default\",\"dimension\":\"market\",\"outputName\":\"market\"},{\"type\":\"default\",\"dimension\":\"quality\",\"outputName\":\"quality\"}],"
         + "\"metrics\":[\"index\"],"
+        + "\"virtualColumns\":null,"
         + "\"pagingSpec\":{\"pagingIdentifiers\":{},\"threshold\":3,\"fromNext\":false},"
         + "\"context\":null}";
 
@@ -70,6 +72,7 @@ public class SelectQuerySpecTest
         QueryRunnerTestHelper.allGran,
         DefaultDimensionSpec.toSpec(Arrays.<String>asList("market", "quality")),
         Arrays.<String>asList("index"),
+        null,
         new PagingSpec(null, 3),
         null
     );

--- a/processing/src/test/java/io/druid/segment/filter/BaseFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/BaseFilterTest.java
@@ -45,6 +45,7 @@ import io.druid.segment.QueryableIndex;
 import io.druid.segment.QueryableIndexStorageAdapter;
 import io.druid.segment.StorageAdapter;
 import io.druid.segment.TestHelper;
+import io.druid.segment.VirtualColumns;
 import io.druid.segment.data.BitmapSerdeFactory;
 import io.druid.segment.data.ConciseBitmapSerdeFactory;
 import io.druid.segment.data.IndexedInts;
@@ -266,6 +267,7 @@ public abstract class BaseFilterTest
     final Sequence<Cursor> cursors = adapter.makeCursors(
         filter,
         new Interval(JodaUtils.MIN_INSTANT, JodaUtils.MAX_INSTANT),
+        VirtualColumns.EMPTY,
         QueryGranularities.ALL,
         false
     );

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
@@ -49,6 +49,7 @@ import io.druid.query.topn.TopNResultValue;
 import io.druid.segment.Cursor;
 import io.druid.segment.DimensionSelector;
 import io.druid.segment.StorageAdapter;
+import io.druid.segment.VirtualColumns;
 import io.druid.segment.data.IndexedInts;
 import io.druid.segment.filter.SelectorFilter;
 import org.joda.time.DateTime;
@@ -263,6 +264,7 @@ public class IncrementalIndexStorageAdapterTest
       Sequence<Cursor> cursorSequence = adapter.makeCursors(
           new SelectorFilter("sally", "bo"),
           interval,
+          null,
           QueryGranularities.NONE,
           descending
       );
@@ -402,7 +404,7 @@ public class IncrementalIndexStorageAdapterTest
     final StorageAdapter sa = new IncrementalIndexStorageAdapter(index);
 
     Sequence<Cursor> cursors = sa.makeCursors(
-        null, new Interval(timestamp - 60_000, timestamp + 60_000), QueryGranularities.ALL, false
+        null, new Interval(timestamp - 60_000, timestamp + 60_000), VirtualColumns.EMPTY, QueryGranularities.ALL, false
     );
 
     Sequences.toList(

--- a/server/src/main/java/io/druid/segment/realtime/firehose/IngestSegmentFirehose.java
+++ b/server/src/main/java/io/druid/segment/realtime/firehose/IngestSegmentFirehose.java
@@ -39,6 +39,7 @@ import io.druid.segment.Cursor;
 import io.druid.segment.DimensionSelector;
 import io.druid.segment.LongColumnSelector;
 import io.druid.segment.ObjectColumnSelector;
+import io.druid.segment.VirtualColumns;
 import io.druid.segment.column.Column;
 import io.druid.segment.data.IndexedInts;
 import io.druid.segment.filter.Filters;
@@ -76,6 +77,7 @@ public class IngestSegmentFirehose implements Firehose
                         adapter.getAdapter().makeCursors(
                             Filters.toFilter(dimFilter),
                             adapter.getInterval(),
+                            VirtualColumns.EMPTY,
                             granularity,
                             false
                         ), new Function<Cursor, Sequence<InputRow>>()

--- a/services/src/main/java/io/druid/cli/DumpSegment.java
+++ b/services/src/main/java/io/druid/cli/DumpSegment.java
@@ -71,6 +71,7 @@ import io.druid.segment.ObjectColumnSelector;
 import io.druid.segment.QueryableIndex;
 import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.QueryableIndexStorageAdapter;
+import io.druid.segment.VirtualColumns;
 import io.druid.segment.column.BitmapIndex;
 import io.druid.segment.column.Column;
 import io.druid.segment.column.ColumnConfig;
@@ -251,6 +252,7 @@ public class DumpSegment extends GuiceRunnable
     final Sequence<Cursor> cursors = adapter.makeCursors(
         Filters.toFilter(filter),
         index.getDataInterval().withChronology(ISOChronology.getInstanceUTC()),
+        VirtualColumns.EMPTY,
         QueryGranularities.ALL,
         false
     );


### PR DESCRIPTION
It seemed not a proper name but I described this as a virtual column, which is not defined in schema but can be retrieved from other columns in a row by select query.

We are plan to use this to simplify map-like view in Druid. With two dimensions `keys` and `values` which is multi-valued with same length in a row we can make map from them. For example with keys [key1, key2, key3] and values [value1, value2, value3], map type {key1=value1, key2=value2, key3=value3} can be returned to client. 

Below is the query I've used to test. 

```
  "metrics" : [ "params.key1", "params" ],
  "virtualColumns" : [ {
    "type" : "map",
    "keyDimension" : "keys",
    "valueDimension" : "values",
    "outputName" : "params"
  } ],
```
