### PR TITLE
Revert "backport #2470 (stop using kill=false)"

### DIFF
--- a/integration-tests/src/main/java/io/druid/testing/clients/CoordinatorResourceTestClient.java
+++ b/integration-tests/src/main/java/io/druid/testing/clients/CoordinatorResourceTestClient.java
@@ -122,30 +122,23 @@ public class CoordinatorResourceTestClient
 
   public void unloadSegmentsForDataSource(String dataSource, Interval interval)
   {
-    try {
-      makeRequest(
-          HttpMethod.DELETE,
-          String.format(
-              "%sdatasources/%s",
-              getCoordinatorURL(),
-              dataSource
-          )
-      );
-    }
-    catch (Exception e) {
-      throw Throwables.propagate(e);
-    }
+    killDataSource(dataSource, false, interval);
   }
 
   public void deleteSegmentsDataSource(String dataSource, Interval interval)
+  {
+    killDataSource(dataSource, true, interval);
+  }
+
+  private void killDataSource(String dataSource, boolean kill, Interval interval)
   {
     try {
       makeRequest(
           HttpMethod.DELETE,
           String.format(
-              "%sdatasources/%s/intervals/%s?kill=true",
+              "%sdatasources/%s?kill=%s&interval=%s",
               getCoordinatorURL(),
-              dataSource, interval.toString().replace("/", "_")
+              dataSource, kill, URLEncoder.encode(interval.toString(), "UTF-8")
           )
       );
     }

--- a/integration-tests/src/test/java/io/druid/tests/indexer/ITKafkaTest.java
+++ b/integration-tests/src/test/java/io/druid/tests/indexer/ITKafkaTest.java
@@ -273,7 +273,7 @@ public class ITKafkaTest extends AbstractIndexerTest
   }
 
   @AfterClass
-  public void afterClass() throws Exception
+  public void afterClass()
   {
     LOG.info("teardown");
 
@@ -285,7 +285,12 @@ public class ITKafkaTest extends AbstractIndexerTest
 
     // remove segments
     if (segmentsExist) {
+      try {
         unloadAndKillData(DATASOURCE);
+      }
+      catch (Exception e) {
+        LOG.warn("exception while removing segments: [%s]", e.getMessage());
+      }
     }
   }
 }


### PR DESCRIPTION
Reverts druid-io/druid#2493

This backport in not needed because https://github.com/druid-io/druid/pull/2276 is not included in 0.9.0 release. The backport is actually failing integration tests in 0.9.0 branch.