### PR TITLE
Revert "query tests: add max and min to segment metadata query results"

### DIFF
--- a/integration-tests/src/test/resources/queries/twitterstream_queries.json
+++ b/integration-tests/src/test/resources/queries/twitterstream_queries.json
@@ -597,8 +597,6 @@
                         "hasMultipleValues": false,
                         "size": 7773438,
                         "cardinality": 2,
-                        "minValue":"No",
-                        "maxValue":"Yes",
                         "errorMessage": null
                     }
                 },
@@ -615,8 +613,6 @@
                         "hasMultipleValues": false,
                         "size": 7901000,
                         "cardinality": 2,
-                        "minValue":"No",
-                        "maxValue":"Yes",
                         "errorMessage": null
                     }
                 },
@@ -633,8 +629,6 @@
                         "hasMultipleValues": false,
                         "size": 7405654,
                         "cardinality": 2,
-                        "minValue":"No",
-                        "maxValue":"Yes",
                         "errorMessage": null
                     }
                 },

--- a/integration-tests/src/test/resources/queries/wikipedia_editstream_queries.json
+++ b/integration-tests/src/test/resources/queries/wikipedia_editstream_queries.json
@@ -1048,8 +1048,6 @@
                         "hasMultipleValues": false,
                         "size": 41922148,
                         "cardinality": 208,
-                        "minValue":"",
-                        "maxValue":"mmx._unknown",
                         "errorMessage": null
                     },
                     "language": {
@@ -1057,8 +1055,6 @@
                         "hasMultipleValues": false,
                         "size": 8924222,
                         "cardinality": 36,
-                        "minValue":"ar",
-                        "maxValue":"zh",
                         "errorMessage": null
                     }
                 },


### PR DESCRIPTION
This reverts commit 740dd3a83787a71c2b177679994399d58dd9f057.

this was backported to 0.9.0 in https://github.com/druid-io/druid/pull/2487 . however, 0.9.0 does not have #2208 , so this is actually failing the integration tests on 0.9.0 branch.