### PR TITLE
Rename 'replaceMissingValues...' parameters in RegexExtractionFn

### DIFF
--- a/docs/content/querying/dimensionspecs.md
+++ b/docs/content/querying/dimensionspecs.md
@@ -51,17 +51,17 @@ If there is no match, it returns the dimension value as is.
 ```json
 {
   "type" : "regex", "expr" : <regular_expression>,
-  "replaceMissingValues" : true,
-  "replaceMissingValuesWith" : "foobar"
+  "replaceMissingValue" : true,
+  "replaceMissingValueWith" : "foobar"
 }
 ```
 
 For example, using `"expr" : "(\\w\\w\\w).*"` will transform
 `'Monday'`, `'Tuesday'`, `'Wednesday'` into `'Mon'`, `'Tue'`, `'Wed'`.
 
-If the `replaceMissingValues` property is true, the extraction function will transform dimension values that do not match the regex pattern to a user-specified String. Default value is `false`.
+If the `replaceMissingValue` property is true, the extraction function will transform dimension values that do not match the regex pattern to a user-specified String. Default value is `false`.
 
-The `replaceMissingValuesWith` property sets the String that unmatched dimension values will be replaced with, if `replaceMissingValues` is true. If `replaceMissingValuesWith` is not specified, unmatched dimension values will be replaced with nulls.
+The `replaceMissingValueWith` property sets the String that unmatched dimension values will be replaced with, if `replaceMissingValue` is true. If `replaceMissingValueWith` is not specified, unmatched dimension values will be replaced with nulls.
 
 For example, if `expr` is `"(a\w+)"` in the example JSON above, a regex that matches words starting with the letter `a`, the extraction function will convert a dimension value like `banana` to `foobar`.
 
@@ -323,8 +323,8 @@ Example for chaining [regular expression extraction function](#regular-expressio
     { 
       "type" : "regex", 
       "expr" : "/([^/]+)/", 
-      "replaceMissingValues": false, 
-      "replaceMissingValuesWith": null
+      "replaceMissingValue": false,
+      "replaceMissingValueWith": null
     },
     { 
       "type" : "javascript", 
@@ -409,7 +409,7 @@ The first kind is passed at the query time like `map` implementation.
   "type":"lookup",
   "dimension":"dimensionName",
   "outputName":"dimensionOutputName",
-  "replaceMissingValuesWith":"missing_value",
+  "replaceMissingValueWith":"missing_value",
   "retainMissingValue":false,
   "lookup":{"type": "map", "map":{"key":"value"}, "isOneToOne":false}
 }

--- a/processing/src/main/java/io/druid/query/extraction/RegexDimExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/RegexDimExtractionFn.java
@@ -37,34 +37,34 @@ public class RegexDimExtractionFn extends DimExtractionFn
 
   private final String expr;
   private final Pattern pattern;
-  private final boolean replaceMissingValues;
-  private final String replaceMissingValuesWith;
+  private final boolean replaceMissingValue;
+  private final String replaceMissingValueWith;
 
   @JsonCreator
   public RegexDimExtractionFn(
       @JsonProperty("expr") String expr,
-      @JsonProperty("replaceMissingValues") Boolean replaceMissingValues,
-      @JsonProperty("replaceMissingValuesWith") String replaceMissingValuesWith
+      @JsonProperty("replaceMissingValue") Boolean replaceMissingValue,
+      @JsonProperty("replaceMissingValueWith") String replaceMissingValueWith
   )
   {
     Preconditions.checkNotNull(expr, "expr must not be null");
 
     this.expr = expr;
     this.pattern = Pattern.compile(expr);
-    this.replaceMissingValues = replaceMissingValues == null ? false : replaceMissingValues;
-    this.replaceMissingValuesWith = replaceMissingValuesWith;
+    this.replaceMissingValue = replaceMissingValue == null ? false : replaceMissingValue;
+    this.replaceMissingValueWith = replaceMissingValueWith;
   }
 
   @Override
   public byte[] getCacheKey()
   {
     byte[] exprBytes = StringUtils.toUtf8(expr);
-    byte[] replaceBytes = replaceMissingValues ? new byte[]{1} : new byte[]{0};
+    byte[] replaceBytes = replaceMissingValue ? new byte[]{1} : new byte[]{0};
     byte[] replaceStrBytes;
-    if (replaceMissingValuesWith == null) {
+    if (replaceMissingValueWith == null) {
       replaceStrBytes = new byte[]{};
     } else {
-      replaceStrBytes = StringUtils.toUtf8(replaceMissingValuesWith);
+      replaceStrBytes = StringUtils.toUtf8(replaceMissingValueWith);
     }
 
     int totalLen = 1
@@ -94,7 +94,7 @@ public class RegexDimExtractionFn extends DimExtractionFn
     if (matcher.find()) {
       retVal = matcher.group(1);
     } else {
-      retVal = replaceMissingValues ? replaceMissingValuesWith : dimValue;
+      retVal = replaceMissingValue ? replaceMissingValueWith : dimValue;
     }
     return Strings.emptyToNull(retVal);
   }
@@ -105,16 +105,16 @@ public class RegexDimExtractionFn extends DimExtractionFn
     return expr;
   }
 
-  @JsonProperty("replaceMissingValues")
-  public boolean isReplaceMissingValues()
+  @JsonProperty("replaceMissingValue")
+  public boolean isReplaceMissingValue()
   {
-    return replaceMissingValues;
+    return replaceMissingValue;
   }
 
-  @JsonProperty("replaceMissingValuesWith")
-  public String getReplaceMissingValuesWith()
+  @JsonProperty("replaceMissingValueWith")
+  public String getReplaceMissingValueWith()
   {
-    return replaceMissingValuesWith;
+    return replaceMissingValueWith;
   }
 
   @Override

--- a/processing/src/test/java/io/druid/query/extraction/CascadeExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/CascadeExtractionFnTest.java
@@ -47,7 +47,7 @@ public class CascadeExtractionFnTest {
   private final JavaScriptExtractionFn javascriptExtractionFn = new JavaScriptExtractionFn(function, true);
   private final SubstringDimExtractionFn substringDimExtractionFn = new SubstringDimExtractionFn(0, 7);
   private final String regexDimExtractionFnJson = "{ \"type\" : \"regex\", \"expr\" : \"/([^/]+)/\" , " +
-      "\"replaceMissingValues\": false, \"replaceMissingValuesWith\": null}";
+      "\"replaceMissingValue\": false, \"replaceMissingValueWith\": null}";
   private final String javascriptExtractionFnJson =
       "{ \"type\" : \"javascript\", \"function\" : \"function(str) { return \\\"the \\\".concat(str) }\" }";
   private final String substringDimExtractionFnJson = "{ \"type\" : \"substring\", \"index\" : 0, \"length\" : 7 }";

--- a/processing/src/test/java/io/druid/query/extraction/RegexDimExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/RegexDimExtractionFnTest.java
@@ -158,12 +158,12 @@ public class RegexDimExtractionFnTest
   {
     final ObjectMapper objectMapper = new DefaultObjectMapper();
     final String json = "{ \"type\" : \"regex\", \"expr\" : \".(...)?\" , " +
-                        "\"replaceMissingValues\": true, \"replaceMissingValuesWith\":\"foobar\"}";
+                        "\"replaceMissingValue\": true, \"replaceMissingValueWith\":\"foobar\"}";
     RegexDimExtractionFn extractionFn = (RegexDimExtractionFn) objectMapper.readValue(json, ExtractionFn.class);
 
     Assert.assertEquals(".(...)?", extractionFn.getExpr());
-    Assert.assertTrue(extractionFn.isReplaceMissingValues());
-    Assert.assertEquals("foobar", extractionFn.getReplaceMissingValuesWith());
+    Assert.assertTrue(extractionFn.isReplaceMissingValue());
+    Assert.assertEquals("foobar", extractionFn.getReplaceMissingValueWith());
 
     // round trip
     Assert.assertEquals(


### PR DESCRIPTION
Renames missing value handling parameters for RegexExtractionFn to be more consistent with those in LookupExtractionFn.

Addresses issue https://github.com/druid-io/druid/issues/2535
