### PR TITLE
Limit PortFinder to 0xFFFF

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/overlord/PortFinder.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/PortFinder.java
@@ -95,7 +95,8 @@ public class PortFinder
 
   private int chooseNext(int start)
   {
-    for (int i = start; i < Integer.MAX_VALUE; i++) {
+    // up to unsigned short max (65535)
+    for (int i = start; i <= 0xFFFF; i++) {
       if (!usedPorts.contains(i)) {
         return i;
       }


### PR DESCRIPTION
Incredibly unlikely to hit, but possible depending on what the start port is set to.

Fixes https://github.com/druid-io/druid/issues/2546