### PR TITLE
HdfsTaskLogs: Allow overwriting existing logs.

### DIFF
--- a/extensions/hdfs-storage/src/test/java/io/druid/indexing/common/tasklogs/HdfsTaskLogsTest.java
+++ b/extensions/hdfs-storage/src/test/java/io/druid/indexing/common/tasklogs/HdfsTaskLogsTest.java
@@ -26,36 +26,60 @@ import com.google.common.io.Files;
 import io.druid.storage.hdfs.tasklog.HdfsTaskLogs;
 import io.druid.storage.hdfs.tasklog.HdfsTaskLogsConfig;
 import io.druid.tasklogs.TaskLogs;
-import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Map;
 
 public class HdfsTaskLogsTest
 {
-  @Test
-  public void testSimple() throws Exception
-  {
-    final File tmpDir = Files.createTempDir();
-    try {
-      final File logDir = new File(tmpDir, "logs");
-      final File logFile = new File(tmpDir, "log");
-      Files.write("blah", logFile, Charsets.UTF_8);
-      final TaskLogs taskLogs = new HdfsTaskLogs(new HdfsTaskLogsConfig(logDir.toString()), new Configuration());
-      taskLogs.pushTaskLog("foo", logFile);
+  @Rule
+  public final TemporaryFolder tempFolder = new TemporaryFolder();
 
-      final Map<Long, String> expected = ImmutableMap.of(0L, "blah", 1L, "lah", -2L, "ah", -5L, "blah");
-      for (Map.Entry<Long, String> entry : expected.entrySet()) {
-        final byte[] bytes = ByteStreams.toByteArray(taskLogs.streamTaskLog("foo", entry.getKey()).get().getInput());
-        final String string = new String(bytes);
-        Assert.assertEquals(String.format("Read with offset %,d", entry.getKey()), string, entry.getValue());
-      }
+  @Test
+  public void testStream() throws Exception
+  {
+    final File tmpDir = tempFolder.newFolder();
+    final File logDir = new File(tmpDir, "logs");
+    final File logFile = new File(tmpDir, "log");
+    Files.write("blah", logFile, Charsets.UTF_8);
+    final TaskLogs taskLogs = new HdfsTaskLogs(new HdfsTaskLogsConfig(logDir.toString()), new Configuration());
+    taskLogs.pushTaskLog("foo", logFile);
+
+    final Map<Long, String> expected = ImmutableMap.of(0L, "blah", 1L, "lah", -2L, "ah", -5L, "blah");
+    for (Map.Entry<Long, String> entry : expected.entrySet()) {
+      final String string = readLog(taskLogs, entry.getKey());
+      Assert.assertEquals(String.format("Read with offset %,d", entry.getKey()), string, entry.getValue());
     }
-    finally {
-      FileUtils.deleteDirectory(tmpDir);
-    }
+  }
+
+  @Test
+  public void testOverwrite() throws Exception
+  {
+    final File tmpDir = tempFolder.newFolder();
+    final File logDir = new File(tmpDir, "logs");
+    final File logFile = new File(tmpDir, "log");
+    final TaskLogs taskLogs = new HdfsTaskLogs(new HdfsTaskLogsConfig(logDir.toString()), new Configuration());
+
+    Files.write("blah", logFile, Charsets.UTF_8);
+    taskLogs.pushTaskLog("foo", logFile);
+    Assert.assertEquals("blah", readLog(taskLogs, 0));
+
+    Files.write("blah blah", logFile, Charsets.UTF_8);
+    taskLogs.pushTaskLog("foo", logFile);
+    Assert.assertEquals("blah blah", readLog(taskLogs, 0));
+  }
+
+  private String readLog(TaskLogs taskLogs, long offset) throws IOException
+  {
+    return new String(
+        ByteStreams.toByteArray(taskLogs.streamTaskLog("foo", offset).get().openStream()),
+        Charsets.UTF_8
+    );
   }
 }


### PR DESCRIPTION
Necessary because ForkingTaskRunner pushes logs when gracefully stopping,
but it may need to re-push those logs when the task finishes for real after
restoring.