### PR TITLE
Improvements in Lookups related docs

### DIFF
--- a/docs/content/querying/dimensionspecs.md
+++ b/docs/content/querying/dimensionspecs.md
@@ -203,8 +203,8 @@ Example for the `__time` dimension:
 ### Lookup Extraction Function
 
 Lookups are a concept in Druid where dimension values are (optionally) replaced with new values. 
-For more documentation on using lookups, please see [here](../querying/lookups.html). 
-Explicit lookups allow you to specify a set of keys and values to use when performing the extraction.
+A lookup can be of type `namespace` or `map`. A `map` lookup is passed as part of the query. 
+A `namespace` lookup, usually to big to be passed as a part of the query, is populated on all the nodes which handle queries as per [lookups](../querying/lookups.html)
 
 ```json
 {
@@ -254,9 +254,6 @@ Explicit lookups allow you to specify a set of keys and values to use when perfo
   "injective":false
 }
 ```
-
-A lookup can be of type `namespace` or `map`. A `map` lookup is passed as part of the query. 
-A `namespace` lookup is populated on all the nodes which handle queries as per [lookups](../querying/lookups.html)
 
 A property of `retainMissingValue` and `replaceMissingValueWith` can be specified at query time to hint how to handle missing values. Setting `replaceMissingValueWith` to `""` has the same effect as setting it to `null` or omitting the property. Setting `retainMissingValue` to true will use the dimension's original value if it is not found in the lookup. The default values are `replaceMissingValueWith = null` and `retainMissingValue = false` which causes missing values to be treated as missing.
  

--- a/docs/content/querying/dimensionspecs.md
+++ b/docs/content/querying/dimensionspecs.md
@@ -15,7 +15,11 @@ The following JSON fields can be used in a query to operate on dimension values.
 Returns dimension values as is and optionally renames the dimension.
 
 ```json
-{ "type" : "default", "dimension" : <dimension>, "outputName": <output_name> }
+{ 
+  "type" : "default",
+  "dimension" : <dimension>, 
+  "outputName": <output_name> 
+}
 ```
 
 ### Extraction DimensionSpec
@@ -119,7 +123,8 @@ For a regular dimension, it assumes the string is formatted in
 { "type" : "timeFormat",
   "format" : <output_format>,
   "timeZone" : <time_zone> (optional),
-  "locale" : <locale> (optional) }
+  "locale" : <locale> (optional) 
+}
 ```
 
 For example, the following dimension spec returns the day of the week for Montréal in French:
@@ -153,7 +158,8 @@ Time formats are described in the
 ```json
 { "type" : "time",
   "timeFormat" : <input_format>,
-  "resultFormat" : <output_format> }
+  "resultFormat" : <output_format> 
+}
 ```
 
 
@@ -194,7 +200,7 @@ Example for the `__time` dimension:
 }
 ```
 
-### Lookup extraction function
+### Lookup Extraction Function
 
 Lookups are a concept in Druid where dimension values are (optionally) replaced with new values. 
 For more documentation on using lookups, please see [here](../querying/lookups.html). 
@@ -228,7 +234,10 @@ Explicit lookups allow you to specify a set of keys and values to use when perfo
 ```json
 {
   "type":"lookup",
-  "lookup":{"type":"namespace","namespace":"some_lookup"},
+  "lookup":{
+    "type":"namespace",
+    "namespace":"some_lookup"
+  },
   "replaceMissingValueWith":"Unknown",
   "injective":false
 }
@@ -237,7 +246,10 @@ Explicit lookups allow you to specify a set of keys and values to use when perfo
 ```json
 {
   "type":"lookup",
-  "lookup":{"type":"namespace","namespace":"some_lookup"},
+  "lookup":{
+    "type":"namespace",
+    "namespace":"some_lookup"
+  },
   "retainMissingValue":true,
   "injective":false
 }

--- a/docs/content/querying/lookups.md
+++ b/docs/content/querying/lookups.md
@@ -1,7 +1,7 @@
 ---
 layout: doc_page
 ---
-# Lookups
+# Namespace lookups
 
 <div class="note caution">
 Lookups are an <a href="../development/experimental.html">experimental</a> feature.
@@ -13,19 +13,8 @@ a "key" refers to a dimension value to match, and a "value" refers to its replac
 So if you wanted to rename `appid-12345` to `Super Mega Awesome App` then the key would be `appid-12345` and the value 
 would be `Super Mega Awesome App`. 
 
-It is worth noting that lookups support use cases where keys map to unique values (injective) such as a country code and 
-a country name, and also support use cases where multiple IDs map to the same value, e.g. multiple app-ids belonging to 
-a single account manager.
-
-Lookups do not have history. They always use the current data. This means that if the chief account manager for a 
-particular app-id changes, and you issue a query with a lookup to store the app-id to account manager relationship, 
-it will return the current account manager for that app-id REGARDLESS of the time range over which you query.
-
-If you require data time range sensitive lookups, such a use case is not currently supported dynamically at query time, 
-and such data belongs in the raw denormalized data for use in Druid.
-
 Very small lookups (count of keys on the order of a few dozen to a few hundred) can be passed at query time as a "map" 
-lookup as per [dimension specs](../querying/dimensionspecs.html).
+lookup as per [dimension specs](../querying/dimensionspecs.html). This document describes "namespace" lookups, which are usually too big to be passed along the query.
 
 Namespace lookups are appropriate for lookups which are not possible to pass at query time due to their size, 
 or are not desired to be passed at query time because the data is to reside in and be handled by the Druid servers. 

--- a/docs/content/querying/lookups.md
+++ b/docs/content/querying/lookups.md
@@ -14,7 +14,7 @@ So if you wanted to rename `appid-12345` to `Super Mega Awesome App` then the ke
 would be `Super Mega Awesome App`. 
 
 It is worth noting that lookups support use cases where keys map to unique values (injective) such as a country code and 
-a country name, and also supports use cases where multiple IDs map to the same value, e.g. multiple app-ids belonging to 
+a country name, and also support use cases where multiple IDs map to the same value, e.g. multiple app-ids belonging to 
 a single account manager.
 
 Lookups do not have history. They always use the current data. This means that if the chief account manager for a 
@@ -27,9 +27,9 @@ and such data belongs in the raw denormalized data for use in Druid.
 Very small lookups (count of keys on the order of a few dozen to a few hundred) can be passed at query time as a "map" 
 lookup as per [dimension specs](../querying/dimensionspecs.html).
 
-Namespaced lookups are appropriate for lookups which are not possible to pass at query time due to their size, 
+Namespace lookups are appropriate for lookups which are not possible to pass at query time due to their size, 
 or are not desired to be passed at query time because the data is to reside in and be handled by the Druid servers. 
-Namespaced lookups can be specified as part of the runtime properties file. The property is a list of the namespaces 
+Namespace lookups can be specified as part of the runtime properties file. The property is a list of the namespaces 
 described as per the sections on this page. For example:
 
  ```json
@@ -65,7 +65,7 @@ described as per the sections on this page. For example:
    ]
  ```
 
-Proper functionality of Namespaced lookups requires the following extension to be loaded on the broker, peon, and historical nodes: 
+Proper functionality of Namespace lookups requires the following extension to be loaded on the broker, peon, and historical nodes: 
 `druid-namespace-lookup`
 
 ## Cache Settings
@@ -83,7 +83,7 @@ is the Kafka namespace lookup, defined below.
 
 ## URI namespace update
 
-The remapping values for each namespaced lookup can be specified by json as per
+The remapping values for each Namespace lookup can be specified by json as per
 
 ```json
 {
@@ -215,7 +215,7 @@ The `simpleJson` lookupParseSpec does not take any parameters. It is simply a li
 }
 ```
 
-## JDBC namespaced lookup
+## JDBC Namespace lookup
 
 The JDBC lookups will poll a database to populate its local cache. If the `tsColumn` is set it must be able to accept comparisons in the format `'2015-01-01 00:00:00'`. For example, the following must be valid sql for the table `SELECT * FROM some_lookup_table WHERE timestamp_column >  '2015-01-01 00:00:00'`. If `tsColumn` is set, the caching service will attempt to only poll values that were written *after* the last sync. If `tsColumn` is not set, the entire table is pulled every time.
 
@@ -247,7 +247,7 @@ The JDBC lookups will poll a database to populate its local cache. If the `tsCol
 }
 ```
 
-# Kafka namespaced lookup
+# Kafka Namespace lookup
 
 If you need updates to populate as promptly as possible, it is possible to plug into a kafka topic whose key is the old value and message is the desired new value (both in UTF-8). This requires the following extension: "io.druid.extensions:kafka-extraction-namespace"
 


### PR DESCRIPTION
Introducing a little bit more consistency to `Lookups` related docs. 

Also, I noticed that the "Lookups" documents almost entirely describes "Namespace lookups", so I renamed it accordingly. I moved the remaining general information about lookups (that related to both `namespace` and `map` lookups) to "Dimensions Specs" document.