### PR TITLE
pointing pull-deps tool to local maven repository

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -66,6 +66,8 @@
                                 <argument>--clean</argument>
                                 <argument>--defaultVersion</argument>
                                 <argument>${project.parent.version}</argument>
+                                <argument>-l</argument>
+                                <argument>${settings.localRepository}</argument>
                                 <argument>-c</argument>
                                 <argument>io.druid.extensions:druid-examples</argument>
                                 <argument>-c</argument>


### PR DESCRIPTION
Pointing the pull-deps tool within the distribution module POM to the local maven repository via command-line option makes the build more robust when executed in CI environments like Jenkins.

Without this modification, the pull-deps tool would try to construct the path to the local maven repository by using the "user.home" system property which can be brittle within Jenkins builds or  could be hard to set up correctly as it entails making global config changes to Jenkins.

As the path to the local maven repo is available within maven poms as a builtin property, it is safe to use it to point the pull-deps tool to the same repository location that other druid maven modules used to install their artifacts to. 