### PR TITLE
Single dimension hash-based partitioning

### DIFF
--- a/docs/content/ingestion/batch-ingestion.md
+++ b/docs/content/ingestion/batch-ingestion.md
@@ -192,6 +192,7 @@ The configuration options are:
 |type|Type of partitionSpec to be used.|"hashed"|
 |targetPartitionSize|Target number of rows to include in a partition, should be a number that targets segments of 500MB\~1GB.|either this or numShards|
 |numShards|Specify the number of partitions directly, instead of a target partition size. Ingestion will run faster, since it can skip the step necessary to select a number of partitions automatically.|either this or targetPartitionSize|
+|partitionDimensions|The dimensions to partition on. Leave blank to select all dimensions. Only used with numShards, will be ignored when targetPartitionSize is set|no|
 
 #### Single-dimension partitioning
 

--- a/indexing-hadoop/src/main/java/io/druid/indexer/DetermineHashedPartitionsJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/DetermineHashedPartitionsJob.java
@@ -179,6 +179,7 @@ public class DetermineHashedPartitionsJob implements Jobby
                       new HashBasedNumberedShardSpec(
                           i,
                           numberOfShards,
+                          null,
                           HadoopDruidIndexerConfig.JSON_MAPPER
                       ),
                       shardCount++

--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidDetermineConfigurationJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidDetermineConfigurationJob.java
@@ -67,7 +67,12 @@ public class HadoopDruidDetermineConfigurationJob implements Jobby
           for (int i = 0; i < shardsPerInterval; i++) {
             specs.add(
                 new HadoopyShardSpec(
-                    new HashBasedNumberedShardSpec(i, shardsPerInterval, HadoopDruidIndexerConfig.JSON_MAPPER),
+                    new HashBasedNumberedShardSpec(
+                        i,
+                        shardsPerInterval,
+                        config.getPartitionsSpec().getPartitionDimensions(),
+                        HadoopDruidIndexerConfig.JSON_MAPPER
+                    ),
                     shardCount++
                 )
             );

--- a/indexing-hadoop/src/main/java/io/druid/indexer/partitions/HashedPartitionsSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/partitions/HashedPartitionsSpec.java
@@ -20,34 +20,51 @@
 package io.druid.indexer.partitions;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import io.druid.indexer.DetermineHashedPartitionsJob;
 import io.druid.indexer.HadoopDruidIndexerConfig;
 import io.druid.indexer.Jobby;
 
 import javax.annotation.Nullable;
+import java.util.List;
 
 public class HashedPartitionsSpec extends AbstractPartitionsSpec
 {
+  private static final List<String> DEFAULT_PARTITION_DIMENSIONS = ImmutableList.of();
+
   public static HashedPartitionsSpec makeDefaultHashedPartitionsSpec()
   {
-    return new HashedPartitionsSpec(null, null, null, null);
+    return new HashedPartitionsSpec(null, null, null, null, null);
   }
+
+  @JsonIgnore
+  private final List<String> partitionDimensions;
 
   @JsonCreator
   public HashedPartitionsSpec(
       @JsonProperty("targetPartitionSize") @Nullable Long targetPartitionSize,
       @JsonProperty("maxPartitionSize") @Nullable Long maxPartitionSize,
       @JsonProperty("assumeGrouped") @Nullable Boolean assumeGrouped,
-      @JsonProperty("numShards") @Nullable Integer numShards
+      @JsonProperty("numShards") @Nullable Integer numShards,
+      @JsonProperty("partitionDimensions") @Nullable List<String> partitionDimensions
   )
   {
     super(targetPartitionSize, maxPartitionSize, assumeGrouped, numShards);
+    this.partitionDimensions = partitionDimensions == null ? DEFAULT_PARTITION_DIMENSIONS : partitionDimensions;
   }
 
   @Override
   public Jobby getPartitionJob(HadoopDruidIndexerConfig config)
   {
     return new DetermineHashedPartitionsJob(config);
+  }
+
+  @Override
+  @JsonProperty
+  public List<String> getPartitionDimensions()
+  {
+    return partitionDimensions;
   }
 }

--- a/indexing-hadoop/src/main/java/io/druid/indexer/partitions/PartitionsSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/partitions/PartitionsSpec.java
@@ -26,6 +26,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.druid.indexer.HadoopDruidIndexerConfig;
 import io.druid.indexer.Jobby;
 
+import java.util.List;
+
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = HashedPartitionsSpec.class)
 @JsonSubTypes(value = {
     @JsonSubTypes.Type(name = "dimension", value = SingleDimensionPartitionsSpec.class),
@@ -51,4 +53,6 @@ public interface PartitionsSpec
   @JsonProperty
   public int getNumShards();
 
+  @JsonProperty
+  public List<String> getPartitionDimensions();
 }

--- a/indexing-hadoop/src/main/java/io/druid/indexer/partitions/SingleDimensionPartitionsSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/partitions/SingleDimensionPartitionsSpec.java
@@ -22,11 +22,13 @@ package io.druid.indexer.partitions;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import io.druid.indexer.DeterminePartitionsJob;
 import io.druid.indexer.HadoopDruidIndexerConfig;
 import io.druid.indexer.Jobby;
 
 import javax.annotation.Nullable;
+import java.util.List;
 
 public class SingleDimensionPartitionsSpec extends AbstractPartitionsSpec
 {
@@ -56,5 +58,12 @@ public class SingleDimensionPartitionsSpec extends AbstractPartitionsSpec
   public Jobby getPartitionJob(HadoopDruidIndexerConfig config)
   {
     return new DeterminePartitionsJob(config);
+  }
+
+  @Override
+  @JsonProperty
+  public List<String> getPartitionDimensions()
+  {
+    return ImmutableList.of();
   }
 }

--- a/indexing-hadoop/src/test/java/io/druid/indexer/BatchDeltaIngestionTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/BatchDeltaIngestionTest.java
@@ -393,7 +393,7 @@ public class BatchDeltaIngestionTest
             INTERVAL_FULL.getStart(),
             ImmutableList.of(
                 new HadoopyShardSpec(
-                    new HashBasedNumberedShardSpec(0, 1, HadoopDruidIndexerConfig.JSON_MAPPER),
+                    new HashBasedNumberedShardSpec(0, 1, null, HadoopDruidIndexerConfig.JSON_MAPPER),
                     0
                 )
             )

--- a/indexing-hadoop/src/test/java/io/druid/indexer/DetermineHashedPartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/DetermineHashedPartitionsJobTest.java
@@ -149,7 +149,7 @@ public class DetermineHashedPartitionsJobTest
         new HadoopTuningConfig(
             tmpDir.getAbsolutePath(),
             null,
-            new HashedPartitionsSpec(targetPartitionSize, null, true, null),
+            new HashedPartitionsSpec(targetPartitionSize, null, true, null, null),
             null,
             null,
             null,

--- a/indexing-hadoop/src/test/java/io/druid/indexer/HadoopDruidIndexerConfigTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/HadoopDruidIndexerConfigTest.java
@@ -193,7 +193,7 @@ public class HadoopDruidIndexerConfigTest
     List<HadoopyShardSpec> specs = Lists.newArrayList();
     final int partitionCount = 10;
     for (int i = 0; i < partitionCount; i++) {
-      specs.add(new HadoopyShardSpec(new HashBasedNumberedShardSpec(i, partitionCount, new DefaultObjectMapper()), i));
+      specs.add(new HadoopyShardSpec(new HashBasedNumberedShardSpec(i, partitionCount, null, new DefaultObjectMapper()), i));
     }
 
     HadoopIngestionSpec spec = new HadoopIngestionSpec(

--- a/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobTest.java
@@ -517,7 +517,7 @@ public class IndexGeneratorJobTest
     List<ShardSpec> specs = Lists.newArrayList();
     if (partitionType.equals("hashed")) {
       for (Integer[] shardInfo : (Integer[][]) shardInfoForEachShard) {
-        specs.add(new HashBasedNumberedShardSpec(shardInfo[0], shardInfo[1], HadoopDruidIndexerConfig.JSON_MAPPER));
+        specs.add(new HashBasedNumberedShardSpec(shardInfo[0], shardInfo[1], null, HadoopDruidIndexerConfig.JSON_MAPPER));
       }
     } else if (partitionType.equals("single")) {
       int partitionNum = 0;

--- a/indexing-hadoop/src/test/java/io/druid/indexer/partitions/HashedPartitionsSpecTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/partitions/HashedPartitionsSpecTest.java
@@ -21,6 +21,7 @@ package io.druid.indexer.partitions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import io.druid.jackson.DefaultObjectMapper;
 import org.junit.Assert;
 import org.junit.Test;
@@ -68,6 +69,12 @@ public class HashedPartitionsSpecTest
           150
       );
 
+      Assert.assertEquals(
+          "getPartitionDimensions",
+          partitionsSpec.getPartitionDimensions(),
+          ImmutableList.of()
+      );
+
       Assert.assertTrue("partitionsSpec", partitionsSpec instanceof HashedPartitionsSpec);
     }
   }
@@ -112,6 +119,12 @@ public class HashedPartitionsSpecTest
         "shardCount",
         partitionsSpec.getNumShards(),
         2
+    );
+
+    Assert.assertEquals(
+        "getPartitionDimensions",
+        partitionsSpec.getPartitionDimensions(),
+        ImmutableList.of()
     );
 
     Assert.assertTrue("partitionsSpec", partitionsSpec instanceof HashedPartitionsSpec);

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
@@ -211,7 +211,7 @@ public class IndexTask extends AbstractFixedIntervalTask
         if (numShards > 0) {
           shardSpecs = Lists.newArrayList();
           for (int i = 0; i < numShards; i++) {
-            shardSpecs.add(new HashBasedNumberedShardSpec(i, numShards, jsonMapper));
+            shardSpecs.add(new HashBasedNumberedShardSpec(i, numShards, null, jsonMapper));
           }
         } else {
           shardSpecs = ImmutableList.<ShardSpec>of(new NoneShardSpec());
@@ -304,7 +304,7 @@ public class IndexTask extends AbstractFixedIntervalTask
       shardSpecs.add(new NoneShardSpec());
     } else {
       for (int i = 0; i < numberOfShards; ++i) {
-        shardSpecs.add(new HashBasedNumberedShardSpec(i, numberOfShards, jsonMapper));
+        shardSpecs.add(new HashBasedNumberedShardSpec(i, numberOfShards, null, jsonMapper));
       }
     }
 


### PR DESCRIPTION
Dimension hash-based partitioning.
Partitioning rows across those segments according to the hash of the partition dimension in each row. So all rows with a particular value for that dimension will go into the same segment.
 
See the requirement https://groups.google.com/forum/#!topic/druid-user/yfAzwStIZGo
and https://groups.google.com/forum/#!topic/druid-development/GXRpXfBzfJs
