### PR TITLE
Fix default TaskResource for RealtimeIndexTasks.

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/common/task/AbstractTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/AbstractTask.java
@@ -56,19 +56,25 @@ public abstract class AbstractTask implements Task
 
   protected AbstractTask(String id, String dataSource, Map<String, Object> context)
   {
-    this(id, id, new TaskResource(id, 1), dataSource, context);
+    this(id, null, null, dataSource, context);
   }
 
   protected AbstractTask(String id, String groupId, String dataSource, Map<String, Object> context)
   {
-    this(id, groupId, new TaskResource(id, 1), dataSource, context);
+    this(id, groupId, null, dataSource, context);
   }
 
-  protected AbstractTask(String id, String groupId, TaskResource taskResource, String dataSource, Map<String, Object> context)
+  protected AbstractTask(
+      String id,
+      String groupId,
+      TaskResource taskResource,
+      String dataSource,
+      Map<String, Object> context
+  )
   {
     this.id = Preconditions.checkNotNull(id, "id");
-    this.groupId = Preconditions.checkNotNull(groupId, "groupId");
-    this.taskResource = Preconditions.checkNotNull(taskResource, "resource");
+    this.groupId = groupId == null ? id : groupId;
+    this.taskResource = taskResource == null ? new TaskResource(id, 1) : taskResource;
     this.dataSource = Preconditions.checkNotNull(dataSource, "dataSource");
     this.context = context;
   }

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/RealtimeIndexTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/RealtimeIndexTask.java
@@ -142,7 +142,7 @@ public class RealtimeIndexTask extends AbstractTask
     super(
         id == null ? makeTaskId(fireDepartment) : id,
         String.format("index_realtime_%s", makeDatasource(fireDepartment)),
-        taskResource == null ? new TaskResource(makeTaskId(fireDepartment), 1) : taskResource,
+        taskResource,
         makeDatasource(fireDepartment),
         context
     );

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/RealtimeIndexTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/RealtimeIndexTaskTest.java
@@ -275,6 +275,13 @@ public class RealtimeIndexTaskTest
   }
 
   @Test(timeout = 60_000L)
+  public void testDefaultResource() throws Exception
+  {
+    final RealtimeIndexTask task = makeRealtimeTask(null);
+    Assert.assertEquals(task.getId(), task.getTaskResource().getAvailabilityGroup());
+  }
+
+  @Test(timeout = 60_000L)
   public void testBasics() throws Exception
   {
     final TestIndexerMetadataStorageCoordinator mdc = new TestIndexerMetadataStorageCoordinator();


### PR DESCRIPTION
It was supposed to be the same as the task id, but it wasn't because
"makeTaskId" has a random component.