### PR TITLE
Make first few allocatePendingSegment retries quiet.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     </scm>
 
     <properties>
-        <metamx.java-util.version>0.27.7</metamx.java-util.version>
+        <metamx.java-util.version>0.27.9</metamx.java-util.version>
         <apache.curator.version>2.9.1</apache.curator.version>
         <jetty.version>9.2.5.v20141112</jetty.version>
         <jersey.version>1.19</jersey.version>

--- a/server/src/main/java/io/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/io/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -72,6 +72,8 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
 {
   private static final Logger log = new Logger(IndexerSQLMetadataStorageCoordinator.class);
 
+  private static int ALLOCATE_SEGMENT_QUIET_TRIES = 3;
+
   private final ObjectMapper jsonMapper;
   private final MetadataStorageTablesConfig dbTables;
   private final SQLMetadataConnector connector;
@@ -490,7 +492,9 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
 
             return newIdentifier;
           }
-        }
+        },
+        ALLOCATE_SEGMENT_QUIET_TRIES,
+        SQLMetadataConnector.DEFAULT_MAX_TRIES
     );
   }
 


### PR DESCRIPTION
Some light retrying can happen during normal operation (SELECT -> INSERT races) and the
ensuing log messages would be scary for users.