### PR TITLE
TaskLocation: Add toString method.

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/common/TaskLocation.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/TaskLocation.java
@@ -82,4 +82,13 @@ public class TaskLocation
   {
     return Objects.hash(host, port);
   }
+
+  @Override
+  public String toString()
+  {
+    return "TaskLocation{" +
+           "host='" + host + '\'' +
+           ", port=" + port +
+           '}';
+  }
 }


### PR DESCRIPTION
Necessary because these objects are used in log messages.