### PR TITLE
override metric name

### DIFF
--- a/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -363,7 +363,9 @@ public class RealtimePlumber implements Plumber
                                           }
                                         }
                                     )
-                                )
+                                ),
+                                "query/segmentAndCache/time",
+                                ImmutableMap.of("segment", theSink.getSegment().getIdentifier())
                             ).withWaitMeasuredFromNow(),
                             new SpecificSegmentSpec(
                                 descriptor


### PR DESCRIPTION
Realtime Plumber has to override metric name, when scanning segments.