### PR TITLE
RealtimeTuningConfig: Use different default basePersistDirectory per instance.

### DIFF
--- a/server/src/main/java/io/druid/segment/indexing/RealtimeTuningConfig.java
+++ b/server/src/main/java/io/druid/segment/indexing/RealtimeTuningConfig.java
@@ -40,7 +40,6 @@ public class RealtimeTuningConfig implements TuningConfig
   private static final int defaultMaxRowsInMemory = 75000;
   private static final Period defaultIntermediatePersistPeriod = new Period("PT10M");
   private static final Period defaultWindowPeriod = new Period("PT10M");
-  private static final File defaultBasePersistDirectory = Files.createTempDir();
   private static final VersioningPolicy defaultVersioningPolicy = new IntervalStartVersioningPolicy();
   private static final RejectionPolicyFactory defaultRejectionPolicyFactory = new ServerTimeRejectionPolicyFactory();
   private static final int defaultMaxPendingPersists = 0;
@@ -49,14 +48,19 @@ public class RealtimeTuningConfig implements TuningConfig
   private static final Boolean defaultBuildV9Directly = Boolean.FALSE;
   private static final Boolean defaultReportParseExceptions = Boolean.FALSE;
 
+  private static File createNewBasePersistDirectory()
+  {
+    return Files.createTempDir();
+  }
+
   // Might make sense for this to be a builder
-  public static RealtimeTuningConfig makeDefaultTuningConfig()
+  public static RealtimeTuningConfig makeDefaultTuningConfig(final File basePersistDirectory)
   {
     return new RealtimeTuningConfig(
         defaultMaxRowsInMemory,
         defaultIntermediatePersistPeriod,
         defaultWindowPeriod,
-        defaultBasePersistDirectory,
+        basePersistDirectory == null ? createNewBasePersistDirectory() : basePersistDirectory,
         defaultVersioningPolicy,
         defaultRejectionPolicyFactory,
         defaultMaxPendingPersists,
@@ -105,7 +109,7 @@ public class RealtimeTuningConfig implements TuningConfig
                                      ? defaultIntermediatePersistPeriod
                                      : intermediatePersistPeriod;
     this.windowPeriod = windowPeriod == null ? defaultWindowPeriod : windowPeriod;
-    this.basePersistDirectory = basePersistDirectory == null ? defaultBasePersistDirectory : basePersistDirectory;
+    this.basePersistDirectory = basePersistDirectory == null ? createNewBasePersistDirectory() : basePersistDirectory;
     this.versioningPolicy = versioningPolicy == null ? defaultVersioningPolicy : versioningPolicy;
     this.rejectionPolicyFactory = rejectionPolicyFactory == null
                                   ? defaultRejectionPolicyFactory

--- a/server/src/main/java/io/druid/segment/realtime/FireDepartment.java
+++ b/server/src/main/java/io/druid/segment/realtime/FireDepartment.java
@@ -59,7 +59,7 @@ public class FireDepartment extends IngestionSpec<RealtimeIOConfig, RealtimeTuni
 
     this.dataSchema = dataSchema;
     this.ioConfig = ioConfig;
-    this.tuningConfig = tuningConfig == null ? RealtimeTuningConfig.makeDefaultTuningConfig() : tuningConfig;
+    this.tuningConfig = tuningConfig == null ? RealtimeTuningConfig.makeDefaultTuningConfig(null) : tuningConfig;
 
   }
 

--- a/server/src/test/java/io/druid/segment/indexing/RealtimeTuningConfigTest.java
+++ b/server/src/test/java/io/druid/segment/indexing/RealtimeTuningConfigTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.indexing;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+
+public class RealtimeTuningConfigTest
+{
+  @Test
+  public void testDefaultBasePersistDirectory()
+  {
+    final RealtimeTuningConfig tuningConfig1 = RealtimeTuningConfig.makeDefaultTuningConfig(null);
+    final RealtimeTuningConfig tuningConfig2 = RealtimeTuningConfig.makeDefaultTuningConfig(null);
+    Assert.assertNotEquals(tuningConfig1.getBasePersistDirectory(), tuningConfig2.getBasePersistDirectory());
+  }
+
+  @Test
+  public void testSpecificBasePersistDirectory()
+  {
+    final RealtimeTuningConfig tuningConfig = RealtimeTuningConfig.makeDefaultTuningConfig(
+        new File("/tmp/nonexistent")
+    );
+    Assert.assertEquals(new File("/tmp/nonexistent"), tuningConfig.getBasePersistDirectory());
+  }
+}

--- a/server/src/test/java/io/druid/segment/realtime/FireDepartmentTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/FireDepartmentTest.java
@@ -41,6 +41,7 @@ import io.druid.segment.realtime.plumber.RealtimePlumberSchool;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.Map;
 
@@ -116,7 +117,7 @@ public class FireDepartmentTest
             ),
             null
         ),
-        RealtimeTuningConfig.makeDefaultTuningConfig()
+        RealtimeTuningConfig.makeDefaultTuningConfig(new File("/tmp/nonexistent"))
     );
 
     String json = jsonMapper.writeValueAsString(schema);
@@ -124,5 +125,6 @@ public class FireDepartmentTest
     FireDepartment newSchema = jsonMapper.readValue(json, FireDepartment.class);
 
     Assert.assertEquals(schema.getDataSchema().getDataSource(), newSchema.getDataSchema().getDataSource());
+    Assert.assertEquals("/tmp/nonexistent", schema.getTuningConfig().getBasePersistDirectory().toString());
   }
 }


### PR DESCRIPTION
1) Avoids inadvertent conflicts when running multiple realtime ingestion workloads in the same process
2) Avoids NoClassDefFoundError on RealtimeTuningConfig when Files.createTempDir fails (perhaps java.io.tmpdir doesn't exist)