### PR TITLE
fix default number of connections on broker config documentation

### DIFF
--- a/docs/content/configuration/broker.md
+++ b/docs/content/configuration/broker.md
@@ -36,7 +36,7 @@ Druid uses Jetty to serve HTTP requests.
 |--------|-----------|-------|
 |`druid.server.http.numThreads`|Number of threads for HTTP requests.|10|
 |`druid.server.http.maxIdleTime`|The Jetty max idle time for a connection.|PT5m|
-|`druid.broker.http.numConnections`|Size of connection pool for the Broker to connect to historical and real-time nodes. If there are more queries than this number that all need to speak to the same node, then they will queue up.|5|
+|`druid.broker.http.numConnections`|Size of connection pool for the Broker to connect to historical and real-time nodes. If there are more queries than this number that all need to speak to the same node, then they will queue up.|20|
 |`druid.broker.http.readTimeout`|The timeout for data reads.|PT15M|
 
 #### Retry Policy


### PR DESCRIPTION
On the website, it says that the default number of connection is 5 (http://druid.io/docs/0.8.3/configuration/broker.html), but in DruidHttpClientConfig, the default is set as 20. I think the documentation is outdated.