### PR TITLE
Support alphanumeric sort in search query

### DIFF
--- a/docs/content/querying/limitspec.md
+++ b/docs/content/querying/limitspec.md
@@ -23,7 +23,8 @@ OrderByColumnSpecs indicate how to do order by operations. Each order-by conditi
 ```json 
 {
     "dimension" : "<Any dimension or metric name>",
-    "direction" : <"ascending"|"descending">
+    "direction" : <"ascending"|"descending">,
+    "dimensionOrder" : <"lexicographic(default)"|"alphanumeric"|"strlen">
 }
 ```
 

--- a/docs/content/querying/searchquery.md
+++ b/docs/content/querying/searchquery.md
@@ -38,7 +38,7 @@ There are several main parts to a search query:
 |intervals|A JSON Object representing ISO-8601 Intervals. This defines the time ranges to run the query over.|yes|
 |searchDimensions|The dimensions to run the search over. Excluding this means the search is run over all dimensions.|no|
 |query|See [SearchQuerySpec](../querying/searchqueryspec.html).|yes|
-|sort|An object specifying how the results of the search should be sorted. Two possible types here are "lexicographic" (the default sort) and "strlen".|no|
+|sort|An object specifying how the results of the search should be sorted. Possible types here are "lexicographic" (the default sort), "alphanumeric" and "strlen".|no|
 |context|See [Context](../querying/query-context.html)|no|
 
 The format of the result is:

--- a/processing/src/main/java/io/druid/query/ordering/StringComparators.java
+++ b/processing/src/main/java/io/druid/query/ordering/StringComparators.java
@@ -107,6 +107,9 @@ public class StringComparators
 
       if (str1 == null)
       {
+        if (str2 == null) {
+          return 0;
+        }
         return -1;
       } else if (str2 == null)
       {

--- a/processing/src/main/java/io/druid/query/ordering/StringComparators.java
+++ b/processing/src/main/java/io/druid/query/ordering/StringComparators.java
@@ -55,15 +55,14 @@ public class StringComparators
   public static class LexicographicComparator implements StringComparator
   {
     private static final Ordering<String> ORDERING = Ordering.from(new Comparator<String>()
+    {
+      @Override
+      public int compare(String s, String s2)
       {
-        @Override
-        public int compare(String s, String s2)
-        {
-          return UnsignedBytes.lexicographicalComparator().compare(
-              StringUtils.toUtf8(s),
-              StringUtils.toUtf8(s2));
-        }
-      }).nullsFirst();
+        return UnsignedBytes.lexicographicalComparator().compare(
+                StringUtils.toUtf8(s), StringUtils.toUtf8(s2));
+      }
+    }).nullsFirst();
     
     @Override
     public int compare(String s, String s2)
@@ -305,13 +304,13 @@ public class StringComparators
   public static class StrlenComparator implements StringComparator
   {
     private static final Ordering<String> ORDERING = Ordering.from(new Comparator<String>()
+    {
+      @Override
+      public int compare(String s, String s2)
       {
-        @Override
-        public int compare(String s, String s2)
-        {
-          return Ints.compare(s.length(), s2.length());
-        }
-      }).nullsFirst().compound(Ordering.natural());
+        return Ints.compare(s.length(), s2.length());
+      }
+    }).nullsFirst().compound(Ordering.natural());
     
     @Override
     public int compare(String s, String s2)

--- a/processing/src/main/java/io/druid/query/ordering/StringComparators.java
+++ b/processing/src/main/java/io/druid/query/ordering/StringComparators.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.google.common.collect.Ordering;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.UnsignedBytes;
 import com.metamx.common.IAE;
@@ -53,6 +54,17 @@ public class StringComparators
   
   public static class LexicographicComparator implements StringComparator
   {
+    private static final Ordering<String> ORDERING = Ordering.from(new Comparator<String>()
+      {
+        @Override
+        public int compare(String s, String s2)
+        {
+          return UnsignedBytes.lexicographicalComparator().compare(
+              StringUtils.toUtf8(s),
+              StringUtils.toUtf8(s2));
+        }
+      }).nullsFirst();
+    
     @Override
     public int compare(String s, String s2)
     {
@@ -60,18 +72,8 @@ public class StringComparators
       if(s == s2){
         return 0;
       }
-      // null first
-      if (s == null) {
-        return -1;
-      }
-      if (s2 == null) {
-        return 1;
-      }
 
-      return UnsignedBytes.lexicographicalComparator().compare(
-          StringUtils.toUtf8(s),
-          StringUtils.toUtf8(s2)
-      );
+      return ORDERING.compare(s, s2);
     }
     
     @Override
@@ -299,25 +301,23 @@ public class StringComparators
 
   public static class StrlenComparator implements StringComparator
   {
+    private static final Ordering<String> ORDERING = Ordering.from(new Comparator<String>()
+      {
+        @Override
+        public int compare(String s, String s2)
+        {
+          return Ints.compare(s.length(), s2.length());
+        }
+      }).nullsFirst().compound(Ordering.natural());
+    
     @Override
     public int compare(String s, String s2)
     {
-      if(s == s2) {
+      if (s == s2) {
         return 0;
       }
-      // null first
-      if (s == null) {
-        return -1;
-      }
-      if (s2 == null) {
-        return 1;
-      }
       
-      int res = Ints.compare(s.length(), s2.length());
-      if (res == 0) {
-        res = s.compareTo(s2);
-      }
-      return res;
+      return ORDERING.compare(s, s2);
     }
 
     @Override

--- a/processing/src/main/java/io/druid/query/search/search/AlphanumericSearchSortSpec.java
+++ b/processing/src/main/java/io/druid/query/search/search/AlphanumericSearchSortSpec.java
@@ -19,43 +19,54 @@
 
 package io.druid.query.search.search;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 import io.druid.query.ordering.StringComparators;
 
 import java.util.Comparator;
 
 /**
  */
-public class StrlenSearchSortSpec implements SearchSortSpec
+public class AlphanumericSearchSortSpec implements SearchSortSpec
 {
-  public StrlenSearchSortSpec()
+  @JsonCreator
+  public AlphanumericSearchSortSpec(
+  )
   {
   }
 
   @Override
   public Comparator<SearchHit> getComparator()
   {
-    return new Comparator<SearchHit>() {
+    return new Comparator<SearchHit>()
+    {
       @Override
-      public int compare(SearchHit s, SearchHit s1)
+      public int compare(SearchHit searchHit1, SearchHit searchHit2)
       {
-        int res = StringComparators.STRLEN.compare(s.getValue(), s1.getValue());
-        if (res == 0) {
-          res = StringComparators.LEXICOGRAPHIC.compare(
-              s.getDimension(), s1.getDimension());
+        int retVal = StringComparators.ALPHANUMERIC.compare(
+            searchHit1.getValue(), searchHit2.getValue());
+        if (retVal == 0) {
+          retVal = StringComparators.LEXICOGRAPHIC.compare(
+              searchHit1.getDimension(), searchHit2.getDimension());
         }
-        return res;
+        return retVal;
       }
     };
+  }
+
+  public String toString()
+  {
+    return "alphanumericSort";
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return (other instanceof AlphanumericSearchSortSpec);
   }
 
   @Override
   public byte[] getCacheKey()
   {
     return toString().getBytes();
-  }
-
-  public String toString()
-  {
-    return "stringLengthSort";
   }
 }

--- a/processing/src/main/java/io/druid/query/search/search/AlphanumericSearchSortSpec.java
+++ b/processing/src/main/java/io/druid/query/search/search/AlphanumericSearchSortSpec.java
@@ -61,7 +61,13 @@ public class AlphanumericSearchSortSpec implements SearchSortSpec
 
   @Override
   public boolean equals(Object other) {
-    return (other instanceof AlphanumericSearchSortSpec);
+    return this == other || other instanceof AlphanumericSearchSortSpec;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return 0;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/search/search/LexicographicSearchSortSpec.java
+++ b/processing/src/main/java/io/druid/query/search/search/LexicographicSearchSortSpec.java
@@ -68,6 +68,12 @@ public class LexicographicSearchSortSpec implements SearchSortSpec
 
   @Override
   public boolean equals(Object other) {
-    return (other instanceof LexicographicSearchSortSpec);
+    return this == other || other instanceof LexicographicSearchSortSpec;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return 0;
   }
 }

--- a/processing/src/main/java/io/druid/query/search/search/LexicographicSearchSortSpec.java
+++ b/processing/src/main/java/io/druid/query/search/search/LexicographicSearchSortSpec.java
@@ -21,6 +21,8 @@ package io.druid.query.search.search;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
+import io.druid.query.ordering.StringComparators;
+
 import java.util.Comparator;
 
 /**
@@ -41,9 +43,12 @@ public class LexicographicSearchSortSpec implements SearchSortSpec
       @Override
       public int compare(SearchHit searchHit, SearchHit searchHit1)
       {
-        int retVal = searchHit.getValue().compareTo(searchHit1.getValue());
+        int retVal = StringComparators.LEXICOGRAPHIC.compare(
+            searchHit.getValue(), searchHit1.getValue());
+
         if (retVal == 0) {
-          retVal = searchHit.getDimension().compareTo(searchHit1.getDimension());
+          retVal = StringComparators.LEXICOGRAPHIC.compare(
+              searchHit.getDimension(), searchHit1.getDimension());
         }
         return retVal;
       }

--- a/processing/src/main/java/io/druid/query/search/search/SearchSortSpec.java
+++ b/processing/src/main/java/io/druid/query/search/search/SearchSortSpec.java
@@ -29,6 +29,7 @@ import java.util.Comparator;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = LexicographicSearchSortSpec.class)
 @JsonSubTypes(value = {
     @JsonSubTypes.Type(name = "lexicographic", value = LexicographicSearchSortSpec.class),
+    @JsonSubTypes.Type(name = "alphanumeric", value = AlphanumericSearchSortSpec.class),
     @JsonSubTypes.Type(name = "strlen", value = StrlenSearchSortSpec.class)
 })
 public interface SearchSortSpec

--- a/processing/src/main/java/io/druid/query/search/search/StrlenSearchSortSpec.java
+++ b/processing/src/main/java/io/druid/query/search/search/StrlenSearchSortSpec.java
@@ -58,4 +58,15 @@ public class StrlenSearchSortSpec implements SearchSortSpec
   {
     return "stringLengthSort";
   }
+
+  @Override
+  public boolean equals(Object other) {
+    return this == other || other instanceof StrlenSearchSortSpec;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return 0;
+  }
 }

--- a/processing/src/test/java/io/druid/query/ordering/StringComparatorsTest.java
+++ b/processing/src/test/java/io/druid/query/ordering/StringComparatorsTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.ordering;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import io.druid.jackson.DefaultObjectMapper;
+import io.druid.query.ordering.StringComparators.StringComparator;
+
+public class StringComparatorsTest
+{
+  
+  private void commonTest(StringComparator comparator)
+  {
+    // equality test
+    Assert.assertTrue(comparator.compare(null, null) == 0);
+    Assert.assertTrue(comparator.compare("", "") == 0);
+    Assert.assertTrue(comparator.compare("123", "123") == 0);
+    Assert.assertTrue(comparator.compare("abc123", "abc123") == 0);
+    
+    // empty strings < non-empty
+    Assert.assertTrue(comparator.compare("", "abc") < 0);
+    Assert.assertTrue(comparator.compare("abc", "") > 0);
+    
+    // null first test
+    Assert.assertTrue(comparator.compare(null, "apple") < 0);
+  }
+  
+  @Test
+  public void testLexicographicComparator()
+  {
+    commonTest(StringComparators.LEXICOGRAPHIC);
+
+    Assert.assertTrue(StringComparators.LEXICOGRAPHIC.compare("apple", "banana") < 0);
+    Assert.assertTrue(StringComparators.LEXICOGRAPHIC.compare("banana", "banana") == 0);
+  }
+
+  @Test
+  public void testAlphanumericComparator()
+  {
+    commonTest(StringComparators.ALPHANUMERIC);
+
+    // numbers < non numeric
+    Assert.assertTrue(StringComparators.ALPHANUMERIC.compare("123", "abc") < 0);
+    Assert.assertTrue(StringComparators.ALPHANUMERIC.compare("abc", "123") > 0);
+
+    // numbers ordered numerically
+    Assert.assertTrue(StringComparators.ALPHANUMERIC.compare("2", "11") < 0);
+    Assert.assertTrue(StringComparators.ALPHANUMERIC.compare("a2", "a11") < 0);
+
+    // leading zeros
+    Assert.assertTrue(StringComparators.ALPHANUMERIC.compare("02", "11") < 0);
+    Assert.assertTrue(StringComparators.ALPHANUMERIC.compare("02", "002") < 0);
+
+    // decimal points ...
+    Assert.assertTrue(StringComparators.ALPHANUMERIC.compare("1.3", "1.5") < 0);
+
+    // ... don't work too well
+    Assert.assertTrue(StringComparators.ALPHANUMERIC.compare("1.3", "1.15") < 0);
+
+    // but you can sort ranges
+    List<String> sorted = Lists.newArrayList("1-5", "11-15", "16-20", "21-25", "26-30", "6-10", "Other");
+    Collections.sort(sorted, StringComparators.ALPHANUMERIC);
+
+    Assert.assertEquals(
+        ImmutableList.of("1-5", "6-10", "11-15", "16-20", "21-25", "26-30", "Other"),
+        sorted
+    );
+
+    List<String> sortedFixedDecimal = Lists.newArrayList(
+        "Other", "[0.00-0.05)", "[0.05-0.10)", "[0.10-0.50)", "[0.50-1.00)",
+        "[1.00-5.00)", "[5.00-10.00)", "[10.00-20.00)"
+    );
+
+    Collections.sort(sortedFixedDecimal, StringComparators.ALPHANUMERIC);
+
+    Assert.assertEquals(
+        ImmutableList.of(
+            "[0.00-0.05)", "[0.05-0.10)", "[0.10-0.50)", "[0.50-1.00)",
+            "[1.00-5.00)", "[5.00-10.00)", "[10.00-20.00)", "Other"
+        ),
+        sortedFixedDecimal
+    ); 
+  }
+
+  @Test
+  public void testStrlenComparator()
+  {
+    commonTest(StringComparators.STRLEN);
+
+    Assert.assertTrue(StringComparators.STRLEN.compare("a", "apple") < 0);
+    Assert.assertTrue(StringComparators.STRLEN.compare("a", "elppa") < 0);
+    Assert.assertTrue(StringComparators.STRLEN.compare("apple", "elppa") < 0);
+  }
+
+  @Test
+  public void testLexicographicComparatorSerdeTest() throws IOException
+  {
+    ObjectMapper jsonMapper = new DefaultObjectMapper();
+    String expectJsonSpec = "{\"type\":\"lexicographic\"}";
+    
+    String jsonSpec = jsonMapper.writeValueAsString(StringComparators.LEXICOGRAPHIC);
+    Assert.assertEquals(expectJsonSpec, jsonSpec);
+    Assert.assertEquals(StringComparators.LEXICOGRAPHIC
+        , jsonMapper.readValue(expectJsonSpec, StringComparators.LexicographicComparator.class));
+  }
+  
+  @Test
+  public void testAlphanumericComparatorSerdeTest() throws IOException
+  {
+    ObjectMapper jsonMapper = new DefaultObjectMapper();
+    String expectJsonSpec = "{\"type\":\"alphanumeric\"}";
+    
+    String jsonSpec = jsonMapper.writeValueAsString(StringComparators.ALPHANUMERIC);
+    Assert.assertEquals(expectJsonSpec, jsonSpec);
+    Assert.assertEquals(StringComparators.ALPHANUMERIC
+        , jsonMapper.readValue(expectJsonSpec, StringComparators.AlphanumericComparator.class));
+  }
+  
+  @Test
+  public void testStrlenComparatorSerdeTest() throws IOException
+  {
+    ObjectMapper jsonMapper = new DefaultObjectMapper();
+    String expectJsonSpec = "{\"type\":\"strlen\"}";
+    
+    String jsonSpec = jsonMapper.writeValueAsString(StringComparators.STRLEN);
+    Assert.assertEquals(expectJsonSpec, jsonSpec);
+    Assert.assertEquals(StringComparators.STRLEN
+        , jsonMapper.readValue(expectJsonSpec, StringComparators.StrlenComparator.class));
+  }
+}

--- a/processing/src/test/java/io/druid/query/search/AlphanumericSearchSortSpecTest.java
+++ b/processing/src/test/java/io/druid/query/search/AlphanumericSearchSortSpecTest.java
@@ -22,7 +22,6 @@ package io.druid.query.search;
 import io.druid.query.search.search.AlphanumericSearchSortSpec;
 import io.druid.query.search.search.SearchHit;
 import io.druid.query.search.search.SearchSortSpec;
-import io.druid.query.search.search.StrlenSearchSortSpec;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/processing/src/test/java/io/druid/query/search/AlphanumericSearchSortSpecTest.java
+++ b/processing/src/test/java/io/druid/query/search/AlphanumericSearchSortSpecTest.java
@@ -17,45 +17,30 @@
  * under the License.
  */
 
-package io.druid.query.search.search;
+package io.druid.query.search;
 
-import io.druid.query.ordering.StringComparators;
-
-import java.util.Comparator;
+import io.druid.query.search.search.AlphanumericSearchSortSpec;
+import io.druid.query.search.search.SearchHit;
+import io.druid.query.search.search.SearchSortSpec;
+import io.druid.query.search.search.StrlenSearchSortSpec;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  */
-public class StrlenSearchSortSpec implements SearchSortSpec
+public class AlphanumericSearchSortSpecTest
 {
-  public StrlenSearchSortSpec()
+  @Test
+  public void testComparator()
   {
-  }
+    SearchSortSpec spec = new AlphanumericSearchSortSpec();
 
-  @Override
-  public Comparator<SearchHit> getComparator()
-  {
-    return new Comparator<SearchHit>() {
-      @Override
-      public int compare(SearchHit s, SearchHit s1)
-      {
-        int res = StringComparators.STRLEN.compare(s.getValue(), s1.getValue());
-        if (res == 0) {
-          res = StringComparators.LEXICOGRAPHIC.compare(
-              s.getDimension(), s1.getDimension());
-        }
-        return res;
-      }
-    };
-  }
+    SearchHit hit1 = new SearchHit("test", "a100");
+    SearchHit hit2 = new SearchHit("test", "a9");
+    SearchHit hit3 = new SearchHit("test", "b0");
 
-  @Override
-  public byte[] getCacheKey()
-  {
-    return toString().getBytes();
-  }
-
-  public String toString()
-  {
-    return "stringLengthSort";
+    Assert.assertTrue(spec.getComparator().compare(hit1, hit2) > 0);
+    Assert.assertTrue(spec.getComparator().compare(hit3, hit1) > 0);
+    Assert.assertTrue(spec.getComparator().compare(hit3, hit2) > 0);
   }
 }

--- a/processing/src/test/java/io/druid/query/search/SearchBinaryFnTest.java
+++ b/processing/src/test/java/io/druid/query/search/SearchBinaryFnTest.java
@@ -22,6 +22,7 @@ package io.druid.query.search;
 import com.google.common.collect.ImmutableList;
 import io.druid.granularity.QueryGranularity;
 import io.druid.query.Result;
+import io.druid.query.search.search.AlphanumericSearchSortSpec;
 import io.druid.query.search.search.LexicographicSearchSortSpec;
 import io.druid.query.search.search.SearchHit;
 import io.druid.query.search.search.StrlenSearchSortSpec;
@@ -270,6 +271,33 @@ public class SearchBinaryFnTest
     Assert.assertEquals(expected.getTimestamp(), actual.getTimestamp());
     assertSearchMergeResult(expected.getValue(), actual.getValue());
   }
+
+  @Test
+  public void testAlphanumericMerge()
+  {
+    AlphanumericSearchSortSpec searchSortSpec = new AlphanumericSearchSortSpec();
+    Comparator<SearchHit> c = searchSortSpec.getComparator();
+
+    Result<SearchResultValue> r1 = new Result<SearchResultValue>(
+        currTime,
+        new SearchResultValue(toHits(c, "blah:a100", "blah:a9", "alah:a100"))
+    );
+
+    Result<SearchResultValue> r2 = new Result<SearchResultValue>(
+        currTime,
+        new SearchResultValue(toHits(c, "blah:b0", "alah:c3"))
+    );
+
+    Result<SearchResultValue> expected = new Result<SearchResultValue>(
+        currTime,
+        new SearchResultValue(toHits(c, "blah:a9", "alah:a100", "blah:a100", "blah:b0", "alah:c3"))
+    );
+
+    Result<SearchResultValue> actual = new SearchBinaryFn(
+        searchSortSpec, QueryGranularity.ALL, Integer.MAX_VALUE).apply(r1, r2);
+    Assert.assertEquals(expected.getTimestamp(), actual.getTimestamp());
+    assertSearchMergeResult(expected.getValue(), actual.getValue());
+  }  
 
   // merge function expects input to be sorted as per comparator
   private List<SearchHit> toHits(Comparator<SearchHit> comparator, String... hits) {


### PR DESCRIPTION
I did the following things.

- support alphanumeric sort in a search query.
- place the same string comparison functions of groupby and search in one class. but there is a slight difference from previous one in functionality like null first.
- support strlen sort for groupby as a side effect.
- update docs about sorting in grouby/search query.