### PR TITLE
let hdfs segment kill be a success when segment file does not exist

### DIFF
--- a/extensions/hdfs-storage/src/test/java/io/druid/storage/hdfs/HdfsDataSegmentKillerTest.java
+++ b/extensions/hdfs-storage/src/test/java/io/druid/storage/hdfs/HdfsDataSegmentKillerTest.java
@@ -95,6 +95,14 @@ public class HdfsDataSegmentKillerTest
     Assert.assertFalse(fs.exists(dataSourceDir));
   }
 
+  @Test
+  public void testKillNonExistingSegment() throws Exception
+  {
+    Configuration config = new Configuration();
+    HdfsDataSegmentKiller killer = new HdfsDataSegmentKiller(config);
+    killer.kill(getSegmentWithPath(new Path("/xxx/", "index.zip").toString()));
+  }
+
   private void makePartitionDirWithIndex(FileSystem fs, Path path) throws IOException
   {
     Assert.assertTrue(fs.mkdirs(path));


### PR DESCRIPTION
Why? sometimes we get into a corrupted hdfs state where things from hdfs got deleted but not from metadata store (happened on a dev cluster during some migration). Then we want to be able to fix the situation by doing a kill task over respective dataSource and interval, so that those entries get deleted from metadata store. currently kill task fails and we have to manually [selectively] clean the db.

so relaxing the behavior to print a warning in that situation instead of failing.