### PR TITLE
Dimension compression UNCOMPRESSED should not use CompressedVSizeIntsIndexedWriter

### DIFF
--- a/processing/src/main/java/io/druid/segment/IndexSpec.java
+++ b/processing/src/main/java/io/druid/segment/IndexSpec.java
@@ -138,7 +138,8 @@ public class IndexSpec
 
   private static CompressedObjectStrategy.CompressionStrategy dimensionCompressionStrategyForName(String compression)
   {
-    return compression.equals(UNCOMPRESSED) ? null :
+    return compression.equals(UNCOMPRESSED) ?
+           CompressedObjectStrategy.CompressionStrategy.UNCOMPRESSED :
            CompressedObjectStrategy.CompressionStrategy.valueOf(compression.toUpperCase());
   }
 

--- a/processing/src/test/java/io/druid/segment/IndexSpecTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexSpecTest.java
@@ -65,4 +65,11 @@ public class IndexSpecTest
     Assert.assertEquals(CompressedObjectStrategy.CompressionStrategy.LZ4, spec.getDimensionCompressionStrategy());
     Assert.assertEquals(CompressedObjectStrategy.CompressionStrategy.LZ4, spec.getMetricCompressionStrategy());
   }
+
+  @Test
+  public void testUncompressed() throws Exception
+  {
+    final IndexSpec spec = new IndexSpec(null, "uncompressed", null);
+    Assert.assertEquals(CompressedObjectStrategy.CompressionStrategy.UNCOMPRESSED, spec.getDimensionCompressionStrategy());
+  }
 }

--- a/processing/src/test/java/io/druid/segment/IndexSpecTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexSpecTest.java
@@ -51,7 +51,10 @@ public class IndexSpecTest
     final IndexSpec spec = objectMapper.readValue(json, IndexSpec.class);
 
     Assert.assertEquals(IndexSpec.UNCOMPRESSED, spec.getDimensionCompression());
-    Assert.assertEquals(null, spec.getDimensionCompressionStrategy());
+    Assert.assertEquals(
+        CompressedObjectStrategy.CompressionStrategy.UNCOMPRESSED,
+        spec.getDimensionCompressionStrategy()
+    );
     Assert.assertEquals(spec, objectMapper.readValue(objectMapper.writeValueAsBytes(spec), IndexSpec.class));
   }
 


### PR DESCRIPTION
Generally Indices for dimension are not compressed well and makes bigger (~50%) sized output. But by setting dimension compressed UNCOMPRESSED, the output is always pad with 64K, which is default size of CompressedPools. I think we should use VSizeIndexedIntsWriter instead of CompressedVSizeIntsIndexedWriter in UNCOMPRESSED configuration.

--
 
We are testing druid in industry realm and I've unexpectedly found that the size reduction of data could be important appeal point of using druid (1/10 ~ 1/30 for parquet/snappy but druid easily achieves 1/100). Trying to make this more apparent I've found in the most cases compressing index makes bigger sized footprint than original size of it. But disabling compression made 64K padding attached and makes it bigger again. This is try for fixing that.