### PR TITLE
support Federationed HDFS

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
@@ -392,6 +392,7 @@ public class JobHelper
     // TODO: Make this a part of Pushers or Pullers
     switch (outputFS.getScheme()) {
       case "hdfs":
+      case "viewfs":
         loadSpec = ImmutableMap.<String, Object>of(
             "type", "hdfs",
             "path", indexOutURI.toString()
@@ -547,7 +548,7 @@ public class JobHelper
       DataSegment segment
   )
   {
-    String segmentDir = "hdfs".equals(fileSystem.getScheme())
+    String segmentDir = "hdfs".equals(fileSystem.getScheme()) || "viewfs".equals(fileSystem.getScheme())
                         ? DataSegmentPusherUtil.getHdfsStorageDir(segment)
                         : DataSegmentPusherUtil.getStorageDir(segment);
     return new Path(prependFSIfNullScheme(fileSystem, basePath), String.format("./%s", segmentDir));


### PR DESCRIPTION
When using a Federation HDFS as the deep storage, the following exception occurred when running HadoopDruidIndexer.

```
2016-03-07 11:03:26,130 ERROR [Thread-5] io.druid.indexer.JobHelper: Exception in retry loop
java.lang.IllegalArgumentException: Pathname /tmp/olap-druid/demo/2016-02-15T00:00:00.000Z_2016-02-16T00:00:00.000Z/2016-03-07T11:01:39.723Z/0/index.zip.0 from /tmp/olap-druid/demo/2016-02-15T00:00:00.000Z_2016-02-16T00:00:00.000Z/2016-03-07T11:01:39.723Z/0/index.zip.0 is not a valid DFS filename.
	at org.apache.hadoop.hdfs.DistributedFileSystem.getPathName(DistributedFileSystem.java:194)
	at org.apache.hadoop.hdfs.DistributedFileSystem.access$000(DistributedFileSystem.java:102)
	at org.apache.hadoop.hdfs.DistributedFileSystem$6.doCall(DistributedFileSystem.java:394)
	at org.apache.hadoop.hdfs.DistributedFileSystem$6.doCall(DistributedFileSystem.java:390)
	at org.apache.hadoop.fs.FileSystemLinkResolver.resolve(FileSystemLinkResolver.java:81)
	at org.apache.hadoop.hdfs.DistributedFileSystem.create(DistributedFileSystem.java:390)
	at org.apache.hadoop.hdfs.DistributedFileSystem.create(DistributedFileSystem.java:334)
	at org.apache.hadoop.fs.FilterFileSystem.create(FilterFileSystem.java:178)
	at org.apache.hadoop.fs.viewfs.ChRootedFileSystem.create(ChRootedFileSystem.java:181)
	at org.apache.hadoop.fs.viewfs.ViewFileSystem.create(ViewFileSystem.java:302)
	at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:926)
	at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:887)
	at io.druid.indexer.JobHelper$4.push(JobHelper.java:366)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:190)
	at org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:103)
	at com.sun.proxy.$Proxy67.push(Unknown Source)
	at io.druid.indexer.JobHelper.serializeOutIndex(JobHelper.java:384)
	at io.druid.indexer.IndexGeneratorJob$IndexGeneratorReducer.reduce(IndexGeneratorJob.java:625)
	at io.druid.indexer.IndexGeneratorJob$IndexGeneratorReducer.reduce(IndexGeneratorJob.java:466)
	at org.apache.hadoop.mapreduce.Reducer.run(Reducer.java:171)
	at org.apache.hadoop.mapred.ReduceTask.runNewReducer(ReduceTask.java:627)
	at org.apache.hadoop.mapred.ReduceTask.run(ReduceTask.java:389)
	at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:167)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:415)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1556)
	at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:162)
```

The problem is HDFS doesn't allow ":" character in path. Druid has already tried to use ISODateTimeFormat to avoid ":" in segment output path, but only when FS schema == "hdfs".

In Federation case, the default FS schema is "viewfs" not "hdfs", this PR takes this into account.