### PR TITLE
Fix caching of skipEmptyBuckets for TimeseriesQuery.

### DIFF
--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
@@ -105,14 +105,14 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
   public ServiceMetricEvent.Builder makeMetricBuilder(TimeseriesQuery query)
   {
     return DruidMetrics.makePartialQueryTimeMetric(query)
-                          .setDimension(
-                              "numMetrics",
-                              String.valueOf(query.getAggregatorSpecs().size())
-                          )
-                          .setDimension(
-                              "numComplexMetrics",
-                              String.valueOf(DruidMetrics.findNumComplexAggs(query.getAggregatorSpecs()))
-                          );
+                       .setDimension(
+                           "numMetrics",
+                           String.valueOf(query.getAggregatorSpecs().size())
+                       )
+                       .setDimension(
+                           "numComplexMetrics",
+                           String.valueOf(DruidMetrics.findNumComplexAggs(query.getAggregatorSpecs()))
+                       );
   }
 
   @Override
@@ -135,12 +135,14 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
         final byte[] filterBytes = dimFilter == null ? new byte[]{} : dimFilter.getCacheKey();
         final byte[] aggregatorBytes = QueryCacheHelper.computeAggregatorBytes(query.getAggregatorSpecs());
         final byte[] granularityBytes = query.getGranularity().cacheKey();
-        final byte descending = query.isDescending() ? (byte)1 : 0;
+        final byte descending = query.isDescending() ? (byte) 1 : 0;
+        final byte skipEmptyBuckets = query.isSkipEmptyBuckets() ? (byte) 1 : 0;
 
         return ByteBuffer
-            .allocate(2 + granularityBytes.length + filterBytes.length + aggregatorBytes.length)
+            .allocate(3 + granularityBytes.length + filterBytes.length + aggregatorBytes.length)
             .put(TIMESERIES_QUERY)
             .put(descending)
+            .put(skipEmptyBuckets)
             .put(granularityBytes)
             .put(filterBytes)
             .put(aggregatorBytes)


### PR DESCRIPTION
skipEmptyBuckets needs to be part of the cache key, because it can affect the results for an individual segment.