### PR TITLE
Clarify parser docs.

### DIFF
--- a/processing/src/test/java/io/druid/data/input/ProtoBufInputRowParserTest.java
+++ b/processing/src/test/java/io/druid/data/input/ProtoBufInputRowParserTest.java
@@ -20,7 +20,7 @@
 package io.druid.data.input;
 
 import io.druid.data.input.impl.DimensionsSpec;
-import io.druid.data.input.impl.JSONParseSpec;
+import io.druid.data.input.impl.TimeAndDimsParseSpec;
 import io.druid.data.input.impl.TimestampSpec;
 import org.joda.time.DateTime;
 import org.junit.Test;
@@ -57,7 +57,7 @@ public class ProtoBufInputRowParserTest
 
     //configure parser with desc file
     ProtoBufInputRowParser parser = new ProtoBufInputRowParser(
-        new JSONParseSpec(
+        new TimeAndDimsParseSpec(
             new TimestampSpec("timestamp", "iso", null),
             new DimensionsSpec(Arrays.asList(DIMENSIONS), Arrays.<String>asList(), null)
         ),


### PR DESCRIPTION
- Clarify what parseSpecs are used for.
- Avro, Protobuf should use timeAndDims parseSpecs.
- Hadoop jobs should use hadoopyString string parsers.

(Backport of #2625)