### PR TITLE
examples: Switch druid-server, druid-common to "provided".

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -35,11 +35,13 @@
             <groupId>io.druid</groupId>
             <artifactId>druid-server</artifactId>
             <version>${project.parent.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.druid</groupId>
             <artifactId>druid-common</artifactId>
             <version>${project.parent.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
I believe these should be "provided", and having them not-"provided" dramatically increases the size of the tarball.