### PR TITLE
Update com.maxmind.geoip2 to 2.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -612,7 +612,7 @@
             <dependency>
                 <groupId>com.maxmind.geoip2</groupId>
                 <artifactId>geoip2</artifactId>
-                <version>0.4.0</version>
+                <version>2.6.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.httpcomponents</groupId>

--- a/server/src/main/java/io/druid/segment/realtime/firehose/WikipediaIrcDecoder.java
+++ b/server/src/main/java/io/druid/segment/realtime/firehose/WikipediaIrcDecoder.java
@@ -24,9 +24,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.maxmind.db.CHMCache;
 import com.maxmind.geoip2.DatabaseReader;
 import com.maxmind.geoip2.exception.GeoIp2Exception;
-import com.maxmind.geoip2.model.Omni;
+import com.maxmind.geoip2.model.CityResponse;
 import com.metamx.common.logger.Logger;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.Row;
@@ -123,7 +124,7 @@ class WikipediaIrcDecoder implements IrcDecoder
 
   private DatabaseReader openGeoIpDb(File geoDb) {
     try {
-      DatabaseReader reader = new DatabaseReader(geoDb);
+      DatabaseReader reader = new DatabaseReader.Builder(geoDb).withCache(new CHMCache()).build();
       log.info("Using geo ip database at [%s].", geoDb);
       return reader;
     } catch (IOException e) {
@@ -196,7 +197,7 @@ class WikipediaIrcDecoder implements IrcDecoder
     if (anonymous) {
       try {
         final InetAddress ip = InetAddress.getByName(ipMatch.group());
-        final Omni lookup = geoLookup.omni(ip);
+        final CityResponse lookup = geoLookup.city(ip);
 
         dimensions.put("continent", lookup.getContinent().getName());
         dimensions.put("country", lookup.getCountry().getName());


### PR DESCRIPTION
`com.maxmind.geoip2` `2.6.0` depends on `com.google.http-client` `1.15.0-rc` (3 years old).
When trying to include other libraries in Druid that require an up to date version of `com.google.http-client` this causes a problem.

I am not sure if I should include `com.maxmind.db` in the Druid pom.xml file as I import something from it. `com.maxmind.geoip2` already depends on it so I guess it's not necessary?