### PR TITLE
Ignore case when testing for table existence

### DIFF
--- a/extensions-core/postgresql-metadata-storage/src/main/java/io/druid/metadata/storage/postgresql/PostgreSQLConnector.java
+++ b/extensions-core/postgresql-metadata-storage/src/main/java/io/druid/metadata/storage/postgresql/PostgreSQLConnector.java
@@ -72,7 +72,7 @@ public class PostgreSQLConnector extends SQLMetadataConnector
   public boolean tableExists(final Handle handle, final String tableName)
   {
     return !handle.createQuery(
-        "SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname = 'public' AND tablename LIKE :tableName"
+        "SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname = 'public' AND tablename ILIKE :tableName"
     )
                  .bind("tableName", tableName)
                  .map(StringMapper.FIRST)


### PR DESCRIPTION
Hello,

I'm using druid 0.9.0-rc2 and my metadata database is on postgresql.
I noticed a bunch of errors when starting the Overlord the second time, it couldn't create the (already existing) table `druid_pendingSegments`, no clear error in the logs :

```
Caused by: org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException: java.sql.BatchUpdateException: Batch entry 0 CREATE TABLE druid_pendingSegments (
```

I've started the Overlord myself and notice the query to test the existence doesn't work specifically for `druid_pendingSegments` because of the capital letter, PostgreSQL's "lowercasing" if names are not enclosed in double-quotes iirc.

Thus, I've updated the SQL query to be case insensitive.

```
SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname = 'public' AND tablename LIKE 'druid_pendingSegments'
(n/a)

SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname = 'public' AND tablename ILIKE 'druid_pendingSegments'
druid_pendingsegments
```

The real cause is actually `org.postgresql.util.PSQLException: ERROR: relation "druid_pendingsegments" already exists"`, we can get it using: `((BatchUpdateException) e.getCause().getCause()).getNextException()` in `createTable` catch handler (I didn't added it in the logs, should I?).

Anyway,

Thanks,
