### PR TITLE
Add hint message for missing `druid.selectors.coordinator.serviceName`

### DIFF
--- a/server/src/main/java/io/druid/client/coordinator/CoordinatorClient.java
+++ b/server/src/main/java/io/druid/client/coordinator/CoordinatorClient.java
@@ -105,7 +105,7 @@ public class CoordinatorClient
     try {
       final Server instance = selector.pick();
       if (instance == null) {
-        throw new ISE("Cannot find instance of coordinator");
+        throw new ISE("Cannot find instance of coordinator.. Did you set `druid.selectors.coordinator.serviceName`?");
       }
 
       return new URI(


### PR DESCRIPTION
I've met the situation described in https://groups.google.com/forum/#!topic/druid-user/cY7cQILdDWM  and took a few hours to fix. Wish others do not suffer this again.