### PR TITLE
do not silently ignore rows

### DIFF
--- a/server/src/main/java/io/druid/segment/realtime/firehose/PredicateFirehose.java
+++ b/server/src/main/java/io/druid/segment/realtime/firehose/PredicateFirehose.java
@@ -20,6 +20,7 @@
 package io.druid.segment.realtime.firehose;
 
 import com.google.common.base.Predicate;
+import com.metamx.common.logger.Logger;
 import io.druid.data.input.Firehose;
 import io.druid.data.input.InputRow;
 
@@ -31,6 +32,10 @@ import java.io.IOException;
  */
 public class PredicateFirehose implements Firehose
 {
+  private static final Logger log = new Logger(PredicateFirehose.class);
+  private static final int IGNORE_THRESHOLD = 5000;
+  private long ignored = 0;
+
   private final Firehose firehose;
   private final Predicate<InputRow> predicate;
 
@@ -55,6 +60,11 @@ public class PredicateFirehose implements Firehose
         savedInputRow = row;
         return true;
       }
+      // Do not silently discard the rows
+      if (ignored % IGNORE_THRESHOLD == 0) {
+        log.warn("[%,d] InputRow(s) ignored as they do not satisfy the predicate", ignored);
+      }
+      ignored++;
     }
 
     return false;


### PR DESCRIPTION
One of the teams ran into a situation where the events had timestamp in format "yyyyMMddHH".  At tranquility side Timestamper implementation was correct, but for the TimestampSpec the format was set to "auto" so the timestamp field value was considered milliseconds from epoch at Druid side. Thus, the events were being ignored silently without any errors as they were not in task interval.

Wouldn't it be better to use same timestamp specification for both Druid and Tranquility, not sure if it is possible ?