### PR TITLE
remove serialization of DruidServer

### DIFF
--- a/server/src/main/java/io/druid/client/DruidServer.java
+++ b/server/src/main/java/io/druid/client/DruidServer.java
@@ -95,31 +95,26 @@ public class DruidServer implements Comparable
     return metadata;
   }
 
-  @JsonProperty
   public String getHost()
   {
     return metadata.getHost();
   }
 
-  @JsonProperty
   public long getCurrSize()
   {
     return currSize;
   }
 
-  @JsonProperty
   public long getMaxSize()
   {
     return metadata.getMaxSize();
   }
 
-  @JsonProperty
   public String getType()
   {
     return metadata.getType();
   }
 
-  @JsonProperty
   public String getTier()
   {
     return metadata.getTier();
@@ -130,13 +125,11 @@ public class DruidServer implements Comparable
     return metadata.isAssignable();
   }
 
-  @JsonProperty
   public int getPriority()
   {
     return metadata.getPriority();
   }
 
-  @JsonProperty
   public Map<String, DataSegment> getSegments()
   {
     // Copying the map slows things down a lot here, don't use Immutable Map here

--- a/server/src/main/java/io/druid/client/ServerInventoryView.java
+++ b/server/src/main/java/io/druid/client/ServerInventoryView.java
@@ -98,17 +98,6 @@ public abstract class ServerInventoryView<InventoryType> implements ServerView, 
           }
 
           @Override
-          public byte[] serializeContainer(DruidServer container)
-          {
-            try {
-              return jsonMapper.writeValueAsBytes(container);
-            }
-            catch (JsonProcessingException e) {
-              throw Throwables.propagate(e);
-            }
-          }
-
-          @Override
           public InventoryType deserializeInventory(byte[] bytes)
           {
             try {
@@ -118,17 +107,6 @@ public abstract class ServerInventoryView<InventoryType> implements ServerView, 
               CharBuffer.wrap(StringUtils.fromUtf8(bytes).toCharArray());
               CharBuffer charBuffer = Charsets.UTF_8.decode(ByteBuffer.wrap(bytes));
               log.error(e, "Could not parse json: %s", charBuffer.toString());
-              throw Throwables.propagate(e);
-            }
-          }
-
-          @Override
-          public byte[] serializeInventory(InventoryType inventory)
-          {
-            try {
-              return jsonMapper.writeValueAsBytes(inventory);
-            }
-            catch (JsonProcessingException e) {
               throw Throwables.propagate(e);
             }
           }

--- a/server/src/main/java/io/druid/curator/inventory/CuratorInventoryManagerStrategy.java
+++ b/server/src/main/java/io/druid/curator/inventory/CuratorInventoryManagerStrategy.java
@@ -24,10 +24,8 @@ package io.druid.curator.inventory;
 public interface CuratorInventoryManagerStrategy<ContainerClass, InventoryClass>
 {
   public ContainerClass deserializeContainer(byte[] bytes);
-  public byte[] serializeContainer(ContainerClass container);
 
   public InventoryClass deserializeInventory(byte[] bytes);
-  public byte[] serializeInventory(InventoryClass inventory);
 
   public void newContainer(ContainerClass newContainer);
   public void deadContainer(ContainerClass deadContainer);

--- a/server/src/main/java/io/druid/server/http/ServersResource.java
+++ b/server/src/main/java/io/druid/server/http/ServersResource.java
@@ -55,6 +55,19 @@ public class ServersResource
         .build();
   }
 
+  private static Map<String, Object> makeFullServer(DruidServer input)
+  {
+    return new ImmutableMap.Builder<String, Object>()
+        .put("host", input.getHost())
+        .put("maxSize", input.getMaxSize())
+        .put("type", input.getType())
+        .put("tier", input.getTier())
+        .put("priority", input.getPriority())
+        .put("segments", input.getSegments())
+        .put("currSize", input.getCurrSize())
+        .build();
+  }
+
   private final InventoryView serverInventoryView;
 
   @Inject
@@ -75,7 +88,21 @@ public class ServersResource
     Response.ResponseBuilder builder = Response.status(Response.Status.OK);
 
     if (full != null) {
-      return builder.entity(Lists.newArrayList(serverInventoryView.getInventory())).build();
+      return builder.entity(
+          Lists.newArrayList(
+              Iterables.transform(
+                  serverInventoryView.getInventory(),
+                  new Function<DruidServer, Map<String, Object>>()
+                  {
+                    @Override
+                    public Map<String, Object> apply(DruidServer input)
+                    {
+                      return makeFullServer(input);
+                    }
+                  }
+              )
+          )
+      ).build();
     } else if (simple != null) {
       return builder.entity(
           Lists.newArrayList(
@@ -130,7 +157,7 @@ public class ServersResource
       return builder.entity(makeSimpleServer(server)).build();
     }
 
-    return builder.entity(server)
+    return builder.entity(makeFullServer(server))
                   .build();
   }
 

--- a/server/src/test/java/io/druid/curator/inventory/CuratorInventoryManagerTest.java
+++ b/server/src/test/java/io/druid/curator/inventory/CuratorInventoryManagerTest.java
@@ -187,21 +187,9 @@ public class CuratorInventoryManagerTest extends io.druid.curator.CuratorTestBas
     }
 
     @Override
-    public byte[] serializeContainer(Map<String, Integer> container)
-    {
-      return new byte[]{};
-    }
-
-    @Override
     public Integer deserializeInventory(byte[] bytes)
     {
       return Ints.fromByteArray(bytes);
-    }
-
-    @Override
-    public byte[] serializeInventory(Integer inventory)
-    {
-      return Ints.toByteArray(inventory);
     }
 
     @Override

--- a/server/src/test/java/io/druid/server/http/ServersResourceTest.java
+++ b/server/src/test/java/io/druid/server/http/ServersResourceTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.http;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import io.druid.client.CoordinatorServerView;
+import io.druid.client.DruidServer;
+import io.druid.jackson.DefaultObjectMapper;
+import io.druid.timeline.DataSegment;
+import org.easymock.EasyMock;
+import org.joda.time.Interval;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+
+public class ServersResourceTest {
+  private DruidServer server;
+  private ServersResource serversResource;
+  private ObjectMapper objectMapper = new DefaultObjectMapper();
+
+  @Before
+  public void setUp()
+  {
+    DruidServer dummyServer = new DruidServer("dummy", "host", 1234L, "type", "tier", 0);
+    DataSegment segment = DataSegment.builder()
+                                     .dataSource("dataSource")
+                                     .interval(new Interval("2016-03-22T14Z/2016-03-22T15Z"))
+                                     .version("v0")
+                                     .size(1L)
+                                     .build();
+    dummyServer.addDataSegment(segment.getIdentifier(), segment);
+
+    CoordinatorServerView inventoryView = EasyMock.createMock(CoordinatorServerView.class);
+    EasyMock.expect(inventoryView.getInventory()).andReturn(ImmutableList.of(dummyServer)).anyTimes();
+    EasyMock.expect(inventoryView.getInventoryValue(dummyServer.getName())).andReturn(dummyServer).anyTimes();
+    EasyMock.replay(inventoryView);
+    server = dummyServer;
+    serversResource = new ServersResource(inventoryView);
+  }
+
+  @Test
+  public void testGetClusterServersFull() throws Exception
+  {
+    Response res = serversResource.getClusterServers("full", null);
+    String result = objectMapper.writeValueAsString(res.getEntity());
+    String expected = "[{\"host\":\"host\","
+                      + "\"maxSize\":1234,"
+                      + "\"type\":\"type\","
+                      + "\"tier\":\"tier\","
+                      + "\"priority\":0,"
+                      + "\"segments\":{\"dataSource_2016-03-22T14:00:00.000Z_2016-03-22T15:00:00.000Z_v0\":"
+                      + "{\"dataSource\":\"dataSource\",\"interval\":\"2016-03-22T14:00:00.000Z/2016-03-22T15:00:00.000Z\",\"version\":\"v0\",\"loadSpec\":{},\"dimensions\":\"\",\"metrics\":\"\","
+                      + "\"shardSpec\":{\"type\":\"none\"},\"binaryVersion\":null,\"size\":1,\"identifier\":\"dataSource_2016-03-22T14:00:00.000Z_2016-03-22T15:00:00.000Z_v0\"}},"
+                      + "\"currSize\":1}]";
+    Assert.assertEquals(expected, result);
+  }
+
+  @Test
+  public void testGetClusterServersSimple() throws Exception
+  {
+    Response res = serversResource.getClusterServers(null, "simple");
+    String result = objectMapper.writeValueAsString(res.getEntity());
+    String expected = "[{\"host\":\"host\",\"tier\":\"tier\",\"type\":\"type\",\"priority\":0,\"currSize\":1,\"maxSize\":1234}]";
+    Assert.assertEquals(expected, result);
+  }
+
+  @Test
+  public void testGetServerFull() throws Exception
+  {
+    Response res = serversResource.getServer(server.getName(), null);
+    String result = objectMapper.writeValueAsString(res.getEntity());
+    String expected = "{\"host\":\"host\","
+                      + "\"maxSize\":1234,"
+                      + "\"type\":\"type\","
+                      + "\"tier\":\"tier\","
+                      + "\"priority\":0,"
+                      + "\"segments\":{\"dataSource_2016-03-22T14:00:00.000Z_2016-03-22T15:00:00.000Z_v0\":"
+                      + "{\"dataSource\":\"dataSource\",\"interval\":\"2016-03-22T14:00:00.000Z/2016-03-22T15:00:00.000Z\",\"version\":\"v0\",\"loadSpec\":{},\"dimensions\":\"\",\"metrics\":\"\","
+                      + "\"shardSpec\":{\"type\":\"none\"},\"binaryVersion\":null,\"size\":1,\"identifier\":\"dataSource_2016-03-22T14:00:00.000Z_2016-03-22T15:00:00.000Z_v0\"}},"
+                      + "\"currSize\":1}";
+    Assert.assertEquals(expected, result);
+  }
+
+  @Test
+  public void testGetServerSimple() throws Exception
+  {
+    Response res = serversResource.getServer(server.getName(), "simple");
+    String result = objectMapper.writeValueAsString(res.getEntity());
+    String expected = "{\"host\":\"host\",\"tier\":\"tier\",\"type\":\"type\",\"priority\":0,\"currSize\":1,\"maxSize\":1234}";
+    Assert.assertEquals(expected, result);
+  }
+
+}


### PR DESCRIPTION
Under the current implementation, when DruidServer can be serialized, and when it is, the serialized object contains every field except for `name`, `dataSources`, and `metadata`. This can be confusing and misleading since deserialized DruidServer has information of all the segments it has but no information of dataSource. In this case, adding a data segment to the server for adding dataSource will fail since it already has the segment on `segments` map. I am not sure why `segments` gets serialized, and since  serialized object doesn't seem to be used anywhere (only DruidServerMetadata is serialized and used), I suggest getting rid of serialization of DruidServer to avoid further confusion.

I originally tried serializing and deserializing DruidServer in order to construct my own TimelineServerView based on the timeline I got from BrokerServerView, and this custom TimelineServerView couldn't return the correct timeline because DruidServer's `dataSources` was `null` while it had `segments` populated. In addition, the server didn't have name (`name == null`) and there was no method to set name.

The correct way of reconstructing DruidServer was to serialize and deserialize DruidServer's DruidServerMetadata and use that to construct a new DruidServer and populate it by calling `addDataSegment` for all data segments. By doing this, I was able to get the DruidServer with all fields being correct and the correct VersionedIntervalTimeline.