### PR TITLE
Support filtering on _time with column scan

### DIFF
--- a/benchmarks/src/main/java/io/druid/benchmark/ColumnScanBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/ColumnScanBenchmark.java
@@ -1,0 +1,311 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.benchmark;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.metamx.common.guava.Sequence;
+import com.metamx.common.guava.Sequences;
+import io.druid.common.utils.JodaUtils;
+import io.druid.data.input.InputRow;
+import io.druid.data.input.MapBasedInputRow;
+import io.druid.granularity.QueryGranularity;
+import io.druid.jackson.DefaultObjectMapper;
+import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.query.dimension.DefaultDimensionSpec;
+import io.druid.query.dimension.ExtractionDimensionSpec;
+import io.druid.query.extraction.ExtractionFn;
+import io.druid.query.extraction.TimeFormatExtractionFn;
+import io.druid.segment.Cursor;
+import io.druid.segment.DimensionSelector;
+import io.druid.segment.IndexIO;
+import io.druid.segment.IndexMergerV9;
+import io.druid.segment.IndexSpec;
+import io.druid.segment.QueryableIndex;
+import io.druid.segment.QueryableIndexStorageAdapter;
+import io.druid.segment.StorageAdapter;
+import io.druid.segment.column.Column;
+import io.druid.segment.column.ColumnConfig;
+import io.druid.segment.data.IndexedInts;
+import io.druid.segment.filter.ExtractionFilter;
+import io.druid.segment.incremental.IncrementalIndex;
+import io.druid.segment.incremental.OnheapIncrementalIndex;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Interval;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+public class ColumnScanBenchmark
+{
+  static final int TIMESTAMP_DUPLICATE_COUNT = 100;
+  static final int MAX_ROWS = 250000;
+  static final String SECOND_TIME_NAME = "time2";
+
+  private static final IndexMergerV9 INDEX_MERGER_V9;
+  private static final IndexIO INDEX_IO;
+  public static final ObjectMapper JSON_MAPPER;
+
+  private QueryableIndex qIndex;
+
+  private static AggregatorFactory[] AGGS;
+
+  private Random rng;
+  private Random rng2;
+  private File tmpFile;
+
+  private StorageAdapter qAdapter;
+
+  private boolean initialized = false;
+
+  static {
+    JSON_MAPPER = new DefaultObjectMapper();
+    INDEX_IO = new IndexIO(
+        JSON_MAPPER,
+        new ColumnConfig()
+        {
+          @Override
+          public int columnCacheSizeBytes()
+          {
+            return 0;
+          }
+        }
+    );
+    INDEX_MERGER_V9 = new IndexMergerV9(JSON_MAPPER, INDEX_IO);
+  }
+
+  static {
+    final ArrayList<AggregatorFactory> ingestAggregatorFactories = new ArrayList<>();
+    AGGS = ingestAggregatorFactories.toArray(new AggregatorFactory[0]);
+  }
+
+  @Setup
+  public void setup() throws IOException
+  {
+    if(initialized) {
+      return;
+    }
+
+    rng = new Random(9999);
+    rng2 = new Random(9999);
+
+    IncrementalIndex index = makeIncIndex();
+    File tmpFile = File.createTempFile("IndexedIntsWrappingBenchmark-INDEX-", String.valueOf(rng.nextInt(10)));
+    tmpFile.delete();
+    tmpFile.mkdirs();
+    System.out.println(tmpFile.getAbsolutePath() + " isFile: " + tmpFile.isFile() + " isDir:" + tmpFile.isDirectory());
+    tmpFile.deleteOnExit();
+    File indexFile = INDEX_MERGER_V9.persist(
+        index,
+        tmpFile,
+        new IndexSpec()
+    );
+    index.close();
+    index = null;
+
+    //File theIndex = new File("/Users/user/bench_index/64dim_card20000");
+
+    if (qIndex != null) {
+      qIndex.close();
+    }
+    qIndex = makeQueryableIndexFromFile(indexFile);
+    qAdapter = new QueryableIndexStorageAdapter(qIndex);
+    initialized = true;
+  }
+
+  private IncrementalIndex makeIncIndex() throws IOException
+  {
+    IncrementalIndex index = new OnheapIncrementalIndex(
+        0,
+        QueryGranularity.NONE,
+        AGGS,
+        MAX_ROWS
+    );
+
+    int row_id = 0;
+    int ts_count = 0;
+    long timestamp = 1000L;
+    for (int i = 0; i < MAX_ROWS; i++) {
+      if (ts_count >= TIMESTAMP_DUPLICATE_COUNT) {
+        ts_count = 0;
+        timestamp += 3600001L; // jump an hour
+      } else {
+        ts_count += 1;
+      }
+      row_id += 1;
+      InputRow row = getStringRow(timestamp, row_id);
+      index.add(row);
+    }
+
+    return index;
+  }
+
+  private QueryableIndex makeQueryableIndex(IncrementalIndex incIndex) throws IOException
+  {
+    QueryableIndex index =
+        INDEX_IO.loadIndex(
+            INDEX_MERGER_V9.persist(
+                incIndex,
+                tmpFile,
+                new IndexSpec()
+            )
+        );
+    return index;
+  }
+
+  private QueryableIndex makeQueryableIndexFromFile(File file) throws IOException
+  {
+    QueryableIndex index =
+        INDEX_IO.loadIndex(file);
+    return index;
+  }
+
+  private MapBasedInputRow getStringRow(long timestamp, int row_id)
+  {
+    List<String> dimensionList = new ArrayList<>();
+    dimensionList.add(SECOND_TIME_NAME);
+    dimensionList.add("row_id");
+
+    ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
+    builder.put(SECOND_TIME_NAME, new DateTime(timestamp, DateTimeZone.UTC).toString());
+    builder.put("row_id", row_id);
+    return new MapBasedInputRow(timestamp, dimensionList, builder.build());
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void loadMainTime(Blackhole blackhole) throws Exception
+  {
+    ExtractionFn extfn = new TimeFormatExtractionFn("H", DateTimeZone.UTC, null);
+    ExtractionFilter hrFilter = new ExtractionFilter(
+        Column.TIME_COLUMN_NAME,
+        "8",
+        extfn
+    );
+
+    int sum = 0;
+    Sequence<Cursor> qCursors = qAdapter.makeCursors(
+        hrFilter,
+        new Interval(0L, JodaUtils.MAX_INSTANT),
+        QueryGranularity.ALL,
+        false
+    );
+
+    Cursor qCursor = Sequences.toList(Sequences.limit(qCursors, 1), Lists.<Cursor>newArrayList()).get(0);
+
+    DimensionSelector selector = qCursor.makeDimensionSelector(new ExtractionDimensionSpec(
+        Column.TIME_COLUMN_NAME,
+        Column.TIME_COLUMN_NAME,
+        extfn
+    ));
+
+    DimensionSelector rowNumSelector = qCursor.makeDimensionSelector(new DefaultDimensionSpec("row_id", "row_id"));
+
+
+    for (int i = 0; i < MAX_ROWS; i++) {
+      if (qCursor.isDone()) {
+        System.out.println("CURSOR DONE, i=" + i);
+        break;
+      }
+      IndexedInts row = selector.getRow();
+      for (int val : row) {
+        sum += val;
+        blackhole.consume(val);
+      }
+      IndexedInts row2 = rowNumSelector.getRow();
+      for (int val : row2) {
+        sum += val;
+        blackhole.consume(val);
+      }
+
+      qCursor.advance();
+    }
+    blackhole.consume(sum);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void loadSecondTime(Blackhole blackhole) throws Exception
+  {
+    ExtractionFn extfn = new TimeFormatExtractionFn("H", DateTimeZone.UTC, null);
+    ExtractionFilter hrFilter = new ExtractionFilter(
+        SECOND_TIME_NAME,
+        "8",
+        extfn
+    );
+
+    int sum = 0;
+    Sequence<Cursor> qCursors = qAdapter.makeCursors(
+        hrFilter,
+        new Interval(0L, JodaUtils.MAX_INSTANT),
+        QueryGranularity.ALL,
+        false
+    );
+    Cursor qCursor = Sequences.toList(Sequences.limit(qCursors, 1), Lists.<Cursor>newArrayList()).get(0);
+
+    DimensionSelector selector = qCursor.makeDimensionSelector(new ExtractionDimensionSpec(
+        SECOND_TIME_NAME,
+        SECOND_TIME_NAME,
+        extfn
+    ));
+
+    DimensionSelector rowNumSelector = qCursor.makeDimensionSelector(new DefaultDimensionSpec("row_id", "row_id"));
+
+
+    for (int i = 0; i < MAX_ROWS; i++) {
+      if (qCursor.isDone()) {
+        System.out.println("CURSOR DONE, i=" + i);
+        break;
+      }
+
+      IndexedInts row = selector.getRow();
+      for (int val : row) {
+        sum += val;
+        blackhole.consume(val);
+      }
+
+      IndexedInts row2 = rowNumSelector.getRow();
+      for (int val : row2) {
+        sum += val;
+        blackhole.consume(val);
+      }
+
+      qCursor.advance();
+    }
+    blackhole.consume(sum);
+  }
+}

--- a/processing/src/main/java/io/druid/query/filter/BitmapIndexSelector.java
+++ b/processing/src/main/java/io/druid/query/filter/BitmapIndexSelector.java
@@ -19,6 +19,7 @@
 
 package io.druid.query.filter;
 
+import com.google.common.base.Predicate;
 import com.metamx.collections.bitmap.BitmapFactory;
 import com.metamx.collections.bitmap.ImmutableBitmap;
 import com.metamx.collections.spatial.ImmutableRTree;
@@ -33,4 +34,7 @@ public interface BitmapIndexSelector
   public BitmapFactory getBitmapFactory();
   public ImmutableBitmap getBitmapIndex(String dimension, String value);
   public ImmutableRTree getSpatialIndex(String dimension);
+
+  // for scans on dims that don't have bitmap indexes
+  public ImmutableBitmap getBitmapIndexFromColumnScan(String dimension, Predicate predicate);
 }

--- a/processing/src/main/java/io/druid/segment/filter/BoundFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/BoundFilter.java
@@ -32,17 +32,17 @@ public class BoundFilter extends DimensionPredicateFilter
   public BoundFilter(final BoundDimFilter boundDimFilter)
   {
     super(
-        boundDimFilter.getDimension(), new Predicate<String>()
+        boundDimFilter.getDimension(), new Predicate()
         {
-          private volatile Predicate<String> predicate;
+          private volatile Predicate predicate;
 
           @Override
-          public boolean apply(String input)
+          public boolean apply(Object input)
           {
             return function().apply(input);
           }
 
-          private Predicate<String> function()
+          private Predicate function()
           {
             if (predicate == null) {
               final Comparator<String> comparator;
@@ -51,11 +51,12 @@ public class BoundFilter extends DimensionPredicateFilter
               } else {
                 comparator = new LexicographicTopNMetricSpec(null).getComparator(null, null);
               }
-              predicate = new Predicate<String>()
+              predicate = new Predicate()
               {
                 @Override
-                public boolean apply(String input)
+                public boolean apply(Object inputObj)
                 {
+                  String input = inputObj == null ? null : inputObj.toString();
                   if (input == null) {
                     return false;
                   }

--- a/processing/src/main/java/io/druid/segment/filter/RegexFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/RegexFilter.java
@@ -34,14 +34,14 @@ public class RegexFilter extends DimensionPredicateFilter
   {
     super(
         dimension,
-        new Predicate<String>()
+        new Predicate()
         {
           Pattern compiled = Pattern.compile(pattern);
 
           @Override
-          public boolean apply(String input)
+          public boolean apply(Object input)
           {
-            return (input != null) && compiled.matcher(input).find();
+            return (input != null) && compiled.matcher(input.toString()).find();
           }
         }
     );

--- a/processing/src/main/java/io/druid/segment/filter/SearchQueryFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/SearchQueryFilter.java
@@ -38,12 +38,13 @@ public class SearchQueryFilter extends DimensionPredicateFilter
   {
     super(
         dimension,
-        new Predicate<String>()
+        new Predicate()
         {
           @Override
-          public boolean apply(@Nullable String input)
+          public boolean apply(@Nullable Object input)
           {
-            return query.accept(input);
+            String inputStr = input == null ? null : input.toString();
+            return query.accept(inputStr);
           }
         }
     );

--- a/processing/src/test/java/io/druid/segment/filter/ExtractionDimFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/ExtractionDimFilterTest.java
@@ -19,6 +19,7 @@
 
 package io.druid.segment.filter;
 
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.metamx.collections.bitmap.BitmapFactory;
@@ -106,6 +107,12 @@ public class ExtractionDimFilterTest
 
     @Override
     public ImmutableRTree getSpatialIndex(String dimension)
+    {
+      return null;
+    }
+
+    @Override
+    public ImmutableBitmap getBitmapIndexFromColumnScan(String dimension, Predicate predicate)
     {
       return null;
     }


### PR DESCRIPTION
This PR allows filters to be applied to the special __time column which does not have a dictionary/bitmap index. 

- Updates makeValueMatcher functions in IncrementalIndexStorageAdapter to support __time column
- Adds a function for performing a full scan on the __time column to ColumnSelectorBitmapIndex.

A benchmark has been included for comparing the performance of a full scan on __time vs. bitmap index-based filtering on a String column that contains ISO timestamps.

Example results for various cardinalities, loadMainTime reads from the __time column, loadSecondTime reads from the String time column.
```
250,000 rows

cardinality=1
ColumnScanBenchmark.loadMainTime    avgt   10  11335.082 ± 466.723  us/op
ColumnScanBenchmark.loadSecondTime  avgt   10     51.619 ±   5.596  us/op

cardinality=100
Benchmark                           Mode  Cnt      Score     Error  Units
ColumnScanBenchmark.loadMainTime    avgt   10  11974.823 ± 462.547  us/op
ColumnScanBenchmark.loadSecondTime  avgt   10   1003.198 ±  48.338  us/op

cardinality=2500
Benchmark                           Mode  Cnt      Score      Error  Units
ColumnScanBenchmark.loadMainTime    avgt   10  13735.795 ± 1074.677  us/op
ColumnScanBenchmark.loadSecondTime  avgt   10  10604.697 ±  384.406  us/op

cardinality=25000
Benchmark                           Mode  Cnt      Score      Error  Units
ColumnScanBenchmark.loadMainTime    avgt   10  16357.802 ±  329.982  us/op
ColumnScanBenchmark.loadSecondTime  avgt   10  92038.803 ± 3612.285  us/op

cardinality=50000
Benchmark                           Mode  Cnt       Score      Error  Units
ColumnScanBenchmark.loadMainTime    avgt   10   18931.669 ± 1024.174  us/op
ColumnScanBenchmark.loadSecondTime  avgt   10  166773.346 ± 4018.626  us/op

cardinality=125000
Benchmark                           Mode  Cnt       Score       Error  Units
ColumnScanBenchmark.loadMainTime    avgt   10   29742.121 ±   872.175  us/op
ColumnScanBenchmark.loadSecondTime  avgt   10  500961.399 ± 13750.984  us/op

cardinality=250000
ColumnScanBenchmark.loadMainTime    avgt   10   46596.902 ±  2686.601  us/op
ColumnScanBenchmark.loadSecondTime  avgt   10  998234.222 ± 38658.422  us/op
```

-----
Fixes https://github.com/druid-io/druid/issues/2652