### PR TITLE
[WIP] Add initial documentation for benchmarks in io.druid.benchmark

### DIFF
--- a/docs/content/development/benchmarks.md
+++ b/docs/content/development/benchmarks.md
@@ -1,0 +1,41 @@
+---
+layout: doc_page
+---
+
+### Benchmarks
+The following benchmarks exist in the io.druid.benchmark package and may be useful as a starting point for developers 
+interested in evaluating the performance impact of potential changes.
+
+#### ColumnScanBenchmark
+* Compares the difference between filtering on a column via a full scan and filtering on a column using its dictionary and bitmap indexes. 
+* The benchmark functions apply an extraction filter to the __time column and a String dimension containing ISO8601 timestamps.
+
+#### CompressedIndexedIntsBenchmark
+Description TBD
+
+#### CompressedVSizeIndexedBenchmark
+Description TBD
+
+#### ConciseComplementBenchmark
+Description TBD
+
+#### FlattenJSONBenchmark
+* Evaluates performance of processing nested JSON events using the JSONPathParser from druid-api.
+* FlattenJSONBenchmarkUtil in the benchmarks package provides functions for generating nested JSON events.
+
+#### IncrementalIndexAddRowsBenchmark
+* Evaluates the performance of ingesting events in IncrementalIndex with different dimension value types.
+* There are benchmark functions for testing ingestion of String, Long, and Float dimensions.
+
+#### IndexedIntsWrappingBenchmark
+* Evaluates performance of primitive boxing/unboxing, type casting, and use of a wrapper class when reading from a list of IndexedInts.
+
+#### MergeSequenceBenchmark
+Description TBD
+
+#### QueryableIndexLoadingBenchmark
+* Compares the performance difference between reading from a QueryableIndex using IndexedInts directly and via a wrapper class that casts integer primitives to Comparable
+
+#### StupidPoolConcurrencyBenchmark
+Description TBD
+

--- a/docs/content/toc.md
+++ b/docs/content/toc.md
@@ -91,6 +91,7 @@
   * [Build From Source](../development/build.html)
   * [Versioning](../development/versioning.html)
   * [Integration](../development/integrating-druid-with-other-technologies.html)
+  * [Benchmarks](../development/benchmarks.html)
   * Experimental Features
     * [Overview](../development/experimental.html)
     * [Geographic Queries](../development/geo.html)


### PR DESCRIPTION
Adds a starting document that explains what the various benchmarks in io.druid.benchmark do.

I've added a description for the benchmarks I've introduced; I'm not familiar with the other benchmarks, so hopefully others can add to this doc in later in PRs.

NOTE:
This contains description for benchmarks introduced by PRs that have not been merged, namely:
https://github.com/druid-io/druid/pull/2673: ColumnScanBenchmark
https://github.com/druid-io/druid/pull/2621: IndexedIntsWrappingBenchmark, QueryableIndexLoadingBenchmark
