### PR TITLE
loading properties not depending specific classloader

### DIFF
--- a/docs/content/tutorials/quickstart.md
+++ b/docs/content/tutorials/quickstart.md
@@ -70,11 +70,11 @@ This tutorial runs every Druid process on the same system. In a large distribute
 many of these Druid processes can still be co-located together.
 
 ```bash
-java `cat conf-quickstart/druid/historical/jvm.config | xargs` -cp conf-quickstart/druid/_common:conf-quickstart/druid/historical:lib/* io.druid.cli.Main server historical
-java `cat conf-quickstart/druid/broker/jvm.config | xargs` -cp conf-quickstart/druid/_common:conf-quickstart/druid/broker:lib/* io.druid.cli.Main server broker
-java `cat conf-quickstart/druid/coordinator/jvm.config | xargs` -cp conf-quickstart/druid/_common:conf-quickstart/druid/coordinator:lib/* io.druid.cli.Main server coordinator
-java `cat conf-quickstart/druid/overlord/jvm.config | xargs` -cp conf-quickstart/druid/_common:conf-quickstart/druid/overlord:lib/* io.druid.cli.Main server overlord
-java `cat conf-quickstart/druid/middleManager/jvm.config | xargs` -cp conf-quickstart/druid/_common:conf-quickstart/druid/middleManager:lib/* io.druid.cli.Main server middleManager
+java `cat conf-quickstart/druid/historical/jvm.config | xargs` -cp conf-quickstart/druid:lib/* io.druid.cli.Main server historical
+java `cat conf-quickstart/druid/broker/jvm.config | xargs` -cp conf-quickstart/druid:lib/* io.druid.cli.Main server broker
+java `cat conf-quickstart/druid/coordinator/jvm.config | xargs` -cp conf-quickstart/druid:lib/* io.druid.cli.Main server coordinator
+java `cat conf-quickstart/druid/overlord/jvm.config | xargs` -cp conf-quickstart/druid:lib/* io.druid.cli.Main server overlord
+java `cat conf-quickstart/druid/middleManager/jvm.config | xargs` -cp conf-quickstart:lib/* io.druid.cli.Main server middleManager
 ```
 
 You should see a log message printed out for each service that starts up.

--- a/processing/src/main/java/io/druid/guice/GuiceInjectors.java
+++ b/processing/src/main/java/io/druid/guice/GuiceInjectors.java
@@ -27,7 +27,6 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import io.druid.jackson.JacksonModule;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -35,12 +34,12 @@ import java.util.List;
  */
 public class GuiceInjectors
 {
-  public static Collection<Module> makeDefaultStartupModules()
+  public static Collection<Module> makeDefaultStartupModules(String... propertiesLocations)
   {
     return ImmutableList.<Module>of(
         new DruidGuiceExtensions(),
         new JacksonModule(),
-        new PropertiesModule(Arrays.asList("common.runtime.properties", "runtime.properties")),
+        new PropertiesModule(propertiesLocations),
         new ConfigModule(),
         new Module()
         {
@@ -54,9 +53,9 @@ public class GuiceInjectors
     );
   }
 
-  public static Injector makeStartupInjector()
+  public static Injector makeStartupInjector(String... propertiesLocations)
   {
-    return Guice.createInjector(makeDefaultStartupModules());
+    return Guice.createInjector(makeDefaultStartupModules(propertiesLocations));
   }
 
   public static Injector makeStartupInjectorWithModules(Iterable<? extends Module> modules)

--- a/processing/src/test/java/io/druid/guice/MetadataStorageTablesConfigTest.java
+++ b/processing/src/test/java/io/druid/guice/MetadataStorageTablesConfigTest.java
@@ -30,7 +30,6 @@ import io.druid.metadata.MetadataStorageTablesConfig;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.Properties;
 
 public class MetadataStorageTablesConfigTest
@@ -44,7 +43,7 @@ public class MetadataStorageTablesConfigTest
           @Override
           public void configure(Binder binder)
           {
-            binder.install(new PropertiesModule(Arrays.asList("test.runtime.properties")));
+            binder.install(new PropertiesModule("test.runtime.properties"));
             binder.install(new ConfigModule());
             binder.install(new DruidGuiceExtensions());
             JsonConfigProvider.bind(binder, "druid.metadata.storage.tables", MetadataStorageTablesConfig.class);

--- a/server/src/main/java/io/druid/initialization/Initialization.java
+++ b/server/src/main/java/io/druid/initialization/Initialization.java
@@ -20,6 +20,7 @@
 package io.druid.initialization;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -46,6 +47,7 @@ import io.druid.guice.LifecycleModule;
 import io.druid.guice.LocalDataStorageDruidModule;
 import io.druid.guice.MetadataConfigModule;
 import io.druid.guice.ParsersModule;
+import io.druid.guice.PropertiesModule;
 import io.druid.guice.QueryRunnerFactoryModule;
 import io.druid.guice.QueryableModule;
 import io.druid.guice.ServerModule;
@@ -277,6 +279,15 @@ public class Initialization
 
   public static Injector makeInjectorWithModules(final Injector baseInjector, Iterable<? extends Module> modules)
   {
+    return makeInjectorWithModules(baseInjector, Optional.<PropertiesModule>absent(), modules);
+  }
+
+  public static Injector makeInjectorWithModules(
+      final Injector baseInjector,
+      Optional<PropertiesModule> propertiesModule,
+      Iterable<? extends Module> modules
+  )
+  {
     final ModuleList defaultModules = new ModuleList(baseInjector);
     defaultModules.addModules(
         new Log4jShutterDownerModule(),
@@ -308,6 +319,9 @@ public class Initialization
     );
 
     ModuleList actualModules = new ModuleList(baseInjector);
+    if (propertiesModule.isPresent()) {
+      actualModules.addModule(propertiesModule.get());
+    }
     actualModules.addModule(DruidSecondaryModule.class);
     for (Object module : modules) {
       actualModules.addModule(module);

--- a/server/src/main/java/io/druid/server/AsyncQueryForwardingServlet.java
+++ b/server/src/main/java/io/druid/server/AsyncQueryForwardingServlet.java
@@ -69,6 +69,9 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet
   private static final String QUERY_ATTRIBUTE = "io.druid.proxy.query";
   private static final String OBJECTMAPPER_ATTRIBUTE = "io.druid.proxy.objectMapper";
 
+  private static final int CANCELLATION_TIMEOUT_MILLIS = 500;
+  private static final int MAX_QUEUED_CANCELLATIONS = 64;
+
   private static void handleException(HttpServletResponse response, ObjectMapper objectMapper, Exception exception)
       throws IOException
   {
@@ -93,6 +96,8 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet
   private final ServiceEmitter emitter;
   private final RequestLogger requestLogger;
 
+  private HttpClient broadcastClient;
+
   public AsyncQueryForwardingServlet(
       @Json ObjectMapper jsonMapper,
       @Smile ObjectMapper smileMapper,
@@ -110,6 +115,23 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet
     this.httpClientConfig = httpClientConfig;
     this.emitter = emitter;
     this.requestLogger = requestLogger;
+  }
+
+  @Override
+  public void init() throws ServletException
+  {
+    // separate client with more aggressive connection timeouts
+    // to prevent cancellations requests from blocking queries
+    broadcastClient = httpClientProvider.get();
+    broadcastClient.setConnectTimeout(CANCELLATION_TIMEOUT_MILLIS);
+    broadcastClient.setMaxRequestsQueuedPerDestination(MAX_QUEUED_CANCELLATIONS);
+
+    try {
+      broadcastClient.start();
+    } catch(Exception e) {
+      throw new ServletException(e);
+    }
+    super.init();
   }
 
   @Override
@@ -132,9 +154,10 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet
         // to keep the code simple, the proxy servlet will also send a request to one of the default brokers
         if (!host.equals(defaultHost)) {
           // issue async requests
-          getHttpClient()
+          broadcastClient
               .newRequest(rewriteURI(request, host))
               .method(HttpMethod.DELETE)
+              .timeout(CANCELLATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
               .send(
                   new Response.CompleteListener()
                   {

--- a/services/src/main/java/io/druid/cli/CliBroker.java
+++ b/services/src/main/java/io/druid/cli/CliBroker.java
@@ -19,6 +19,7 @@
 
 package io.druid.cli;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Module;
@@ -39,6 +40,7 @@ import io.druid.guice.Jerseys;
 import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.LazySingleton;
 import io.druid.guice.LifecycleModule;
+import io.druid.guice.PropertiesModule;
 import io.druid.query.MapQueryToolChestWarehouse;
 import io.druid.query.QuerySegmentWalker;
 import io.druid.query.QueryToolChestWarehouse;
@@ -54,6 +56,7 @@ import io.druid.server.metrics.MetricsModule;
 import io.druid.server.router.TieredBrokerConfig;
 import org.eclipse.jetty.server.Server;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -116,5 +119,11 @@ public class CliBroker extends ServerRunnable
         },
         new LookupModule()
     );
+  }
+
+  @Override
+  protected Optional<PropertiesModule> getPropertiesModules()
+  {
+    return Optional.of(new PropertiesModule("broker/runtime.properties"));
   }
 }

--- a/services/src/main/java/io/druid/cli/CliCoordinator.java
+++ b/services/src/main/java/io/druid/cli/CliCoordinator.java
@@ -20,6 +20,7 @@
 package io.druid.cli;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Module;
@@ -37,6 +38,7 @@ import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.LazySingleton;
 import io.druid.guice.LifecycleModule;
 import io.druid.guice.ManageLifecycle;
+import io.druid.guice.PropertiesModule;
 import io.druid.metadata.MetadataRuleManager;
 import io.druid.metadata.MetadataRuleManagerConfig;
 import io.druid.metadata.MetadataRuleManagerProvider;
@@ -160,5 +162,11 @@ public class CliCoordinator extends ServerRunnable
           }
         }
     );
+  }
+
+  @Override
+  protected Optional<PropertiesModule> getPropertiesModules()
+  {
+    return Optional.of(new PropertiesModule("coordinator/runtime.properties"));
   }
 }

--- a/services/src/main/java/io/druid/cli/CliHistorical.java
+++ b/services/src/main/java/io/druid/cli/CliHistorical.java
@@ -19,6 +19,7 @@
 
 package io.druid.cli;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Module;
@@ -34,6 +35,7 @@ import io.druid.guice.LazySingleton;
 import io.druid.guice.LifecycleModule;
 import io.druid.guice.ManageLifecycle;
 import io.druid.guice.NodeTypeConfig;
+import io.druid.guice.PropertiesModule;
 import io.druid.query.QuerySegmentWalker;
 import io.druid.query.lookup.LookupModule;
 import io.druid.server.QueryResource;
@@ -93,5 +95,11 @@ public class CliHistorical extends ServerRunnable
         },
         new LookupModule()
     );
+  }
+
+  @Override
+  protected Optional<PropertiesModule> getPropertiesModules()
+  {
+    return Optional.of(new PropertiesModule("historical/runtime.properties"));
   }
 }

--- a/services/src/main/java/io/druid/cli/CliMiddleManager.java
+++ b/services/src/main/java/io/druid/cli/CliMiddleManager.java
@@ -19,6 +19,7 @@
 
 package io.druid.cli;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Module;
@@ -35,6 +36,7 @@ import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.LazySingleton;
 import io.druid.guice.LifecycleModule;
 import io.druid.guice.ManageLifecycle;
+import io.druid.guice.PropertiesModule;
 import io.druid.guice.annotations.Self;
 import io.druid.indexing.common.config.TaskConfig;
 import io.druid.indexing.overlord.ForkingTaskRunner;
@@ -48,7 +50,6 @@ import io.druid.segment.realtime.firehose.ChatHandlerProvider;
 import io.druid.server.DruidNode;
 import io.druid.server.initialization.jetty.JettyServerInitializer;
 import org.eclipse.jetty.server.Server;
-import org.joda.time.DateTime;
 
 import java.util.List;
 
@@ -114,5 +115,11 @@ public class CliMiddleManager extends ServerRunnable
         new IndexingServiceFirehoseModule(),
         new IndexingServiceTaskLogsModule()
     );
+  }
+
+  @Override
+  protected Optional<PropertiesModule> getPropertiesModules()
+  {
+    return Optional.of(new PropertiesModule("middleManager/runtime.properties"));
   }
 }

--- a/services/src/main/java/io/druid/cli/CliOverlord.java
+++ b/services/src/main/java/io/druid/cli/CliOverlord.java
@@ -19,6 +19,7 @@
 
 package io.druid.cli;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Injector;
@@ -44,6 +45,7 @@ import io.druid.guice.LifecycleModule;
 import io.druid.guice.ListProvider;
 import io.druid.guice.ManageLifecycle;
 import io.druid.guice.PolyBind;
+import io.druid.guice.PropertiesModule;
 import io.druid.indexing.common.actions.LocalTaskActionClientFactory;
 import io.druid.indexing.common.actions.TaskActionClientFactory;
 import io.druid.indexing.common.actions.TaskActionToolbox;
@@ -217,6 +219,13 @@ public class CliOverlord extends ServerRunnable
         new IndexingServiceFirehoseModule(),
         new IndexingServiceTaskLogsModule()
     );
+  }
+
+
+  @Override
+  protected Optional<PropertiesModule> getPropertiesModules()
+  {
+    return Optional.of(new PropertiesModule("overlord/runtime.properties"));
   }
 
   /**

--- a/services/src/main/java/io/druid/cli/CliRealtime.java
+++ b/services/src/main/java/io/druid/cli/CliRealtime.java
@@ -19,12 +19,14 @@
 
 package io.druid.cli;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.name.Names;
 import com.metamx.common.logger.Logger;
 import io.airlift.airline.Command;
+import io.druid.guice.PropertiesModule;
 import io.druid.guice.RealtimeModule;
 import io.druid.query.lookup.LookupModule;
 import io.druid.server.initialization.jetty.ChatHandlerServerModule;
@@ -63,5 +65,11 @@ public class CliRealtime extends ServerRunnable
         new ChatHandlerServerModule(),
         new LookupModule()
     );
+  }
+
+  @Override
+  protected Optional<PropertiesModule> getPropertiesModules()
+  {
+    return Optional.of(new PropertiesModule("realtime/runtime.properties"));
   }
 }

--- a/services/src/main/java/io/druid/cli/CliRouter.java
+++ b/services/src/main/java/io/druid/cli/CliRouter.java
@@ -19,6 +19,7 @@
 
 package io.druid.cli;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Module;
@@ -34,6 +35,7 @@ import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.LazySingleton;
 import io.druid.guice.LifecycleModule;
 import io.druid.guice.ManageLifecycle;
+import io.druid.guice.PropertiesModule;
 import io.druid.guice.annotations.Self;
 import io.druid.guice.http.JettyHttpClientModule;
 import io.druid.query.lookup.LookupModule;
@@ -109,5 +111,11 @@ public class CliRouter extends ServerRunnable
         },
         new LookupModule()
     );
+  }
+
+  @Override
+  protected Optional<PropertiesModule> getPropertiesModules()
+  {
+    return Optional.of(new PropertiesModule("router/runtime.properties"));
   }
 }

--- a/services/src/main/java/io/druid/cli/GuiceRunnable.java
+++ b/services/src/main/java/io/druid/cli/GuiceRunnable.java
@@ -19,6 +19,7 @@
 
 package io.druid.cli;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Ordering;
 import com.google.inject.Inject;
@@ -26,6 +27,7 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.metamx.common.lifecycle.Lifecycle;
 import com.metamx.common.logger.Logger;
+import io.druid.guice.PropertiesModule;
 import io.druid.initialization.Initialization;
 import io.druid.initialization.LogLevelAdjuster;
 import io.druid.server.log.StartupLoggingConfig;
@@ -54,11 +56,15 @@ public abstract class GuiceRunnable implements Runnable
 
   protected abstract List<? extends Module> getModules();
 
+  protected Optional<PropertiesModule> getPropertiesModules() {
+    return Optional.absent();
+  }
+
   public Injector makeInjector()
   {
     try {
       return Initialization.makeInjectorWithModules(
-          baseInjector, getModules()
+          baseInjector, getPropertiesModules(), getModules()
       );
     }
     catch (Exception e) {


### PR DESCRIPTION
One of my colleague wanted some druid servers(broker and historical?) embedded in his java process but it wasn't work because all servers tried to read the same configuration file.

Current property loading mechanism for servers depends on class loader and we should make class loader for specific server before start. This is generally ok but when using druid server embedded in other process, it makes some trouble for managing it. this is for that.