### PR TITLE
Better defaults for Retry policy for task actions

### DIFF
--- a/docs/content/configuration/indexing-service.md
+++ b/docs/content/configuration/indexing-service.md
@@ -298,6 +298,6 @@ If the peon is running in remote mode, there must be an overlord up and running.
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.peon.taskActionClient.retry.minWait`|The minimum retry time to communicate with overlord.|PT1M|
-|`druid.peon.taskActionClient.retry.maxWait`|The maximum retry time to communicate with overlord.|PT10M|
-|`druid.peon.taskActionClient.retry.maxRetryCount`|The maximum number of retries to communicate with overlord.|10|
+|`druid.peon.taskActionClient.retry.minWait`|The minimum retry time to communicate with overlord.|PT5S|
+|`druid.peon.taskActionClient.retry.maxWait`|The maximum retry time to communicate with overlord.|PT1M|
+|`druid.peon.taskActionClient.retry.maxRetryCount`|The maximum number of retries to communicate with overlord.|60|

--- a/indexing-service/src/main/java/io/druid/indexing/common/RetryPolicyConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/RetryPolicyConfig.java
@@ -27,13 +27,13 @@ import org.joda.time.Period;
 public class RetryPolicyConfig
 {
   @JsonProperty
-  private Period minWait = new Period("PT1M");
+  private Period minWait = new Period("PT5S");
 
   @JsonProperty
-  private Period maxWait = new Period("PT10M");
+  private Period maxWait = new Period("PT1M");
 
   @JsonProperty
-  private long maxRetryCount = 10;
+  private long maxRetryCount = 60;
 
   public Period getMinWait()
   {


### PR DESCRIPTION
This PR changes defaults for retry config of task actions to be a bit more aggressive
by reducing the maxWait.

Current defaults were 1 min to 10 mins, which
lead to a very delayed recovery in case there are any transient network
issues between the overlord and the peons.