### PR TITLE
Filters: Add filter.toFilter method, use that instead of the instanceof chain in Filters.

### DIFF
--- a/processing/src/main/java/io/druid/query/aggregation/FilteredAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/FilteredAggregatorFactory.java
@@ -60,7 +60,7 @@ public class FilteredAggregatorFactory extends AggregatorFactory
   public Aggregator factorize(ColumnSelectorFactory columnSelectorFactory)
   {
     final ValueMatcherFactory valueMatcherFactory = new FilteredAggregatorValueMatcherFactory(columnSelectorFactory);
-    final ValueMatcher valueMatcher = Filters.convertDimensionFilters(filter).makeMatcher(valueMatcherFactory);
+    final ValueMatcher valueMatcher = Filters.toFilter(filter).makeMatcher(valueMatcherFactory);
     return new FilteredAggregator(
         valueMatcher,
         delegate.factorize(columnSelectorFactory)
@@ -71,7 +71,7 @@ public class FilteredAggregatorFactory extends AggregatorFactory
   public BufferAggregator factorizeBuffered(ColumnSelectorFactory columnSelectorFactory)
   {
     final ValueMatcherFactory valueMatcherFactory = new FilteredAggregatorValueMatcherFactory(columnSelectorFactory);
-    final ValueMatcher valueMatcher = Filters.convertDimensionFilters(filter).makeMatcher(valueMatcherFactory);
+    final ValueMatcher valueMatcher = Filters.toFilter(filter).makeMatcher(valueMatcherFactory);
     return new FilteredBufferAggregator(
         valueMatcher,
         delegate.factorizeBuffered(columnSelectorFactory)

--- a/processing/src/main/java/io/druid/query/filter/AndDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/AndDimFilter.java
@@ -26,6 +26,8 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import io.druid.query.Druids;
+import io.druid.segment.filter.AndFilter;
+import io.druid.segment.filter.Filters;
 
 import java.util.Collections;
 import java.util.List;
@@ -71,6 +73,12 @@ public class AndDimFilter implements DimFilter
         return input.optimize();
       }
     })).build();
+  }
+
+  @Override
+  public Filter toFilter()
+  {
+    return new AndFilter(Filters.toFilters(fields));
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/BoundDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/BoundDimFilter.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.metamx.common.StringUtils;
+import io.druid.segment.filter.BoundFilter;
 
 import java.nio.ByteBuffer;
 
@@ -131,6 +132,12 @@ public class BoundDimFilter implements DimFilter
   public DimFilter optimize()
   {
     return this;
+  }
+
+  @Override
+  public Filter toFilter()
+  {
+    return new BoundFilter(this);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/DimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/DimFilter.java
@@ -48,4 +48,12 @@ public interface DimFilter
    * returning the same filter can be a straightforward default implementation.
    */
   public DimFilter optimize();
+
+  /**
+   * Returns a Filter that implements this DimFilter. This does not generally involve optimizing the DimFilter,
+   * so it does make sense to optimize first and then call toFilter on the resulting DimFilter.
+   *
+   * @return a Filter that implements this DimFilter, or null if this DimFilter is a no-op.
+   */
+  public Filter toFilter();
 }

--- a/processing/src/main/java/io/druid/query/filter/ExtractionDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/ExtractionDimFilter.java
@@ -28,6 +28,7 @@ import com.metamx.common.StringUtils;
 import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.lookup.LookupExtractionFn;
 import io.druid.query.lookup.LookupExtractor;
+import io.druid.segment.filter.ExtractionFilter;
 
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -114,6 +115,12 @@ public class ExtractionDimFilter implements DimFilter
       }
     }
     return this;
+  }
+
+  @Override
+  public Filter toFilter()
+  {
+    return new ExtractionFilter(dimension, value, extractionFn);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/JavaScriptDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/JavaScriptDimFilter.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.metamx.common.StringUtils;
+import io.druid.segment.filter.JavaScriptFilter;
 
 import java.nio.ByteBuffer;
 
@@ -73,6 +74,12 @@ public class JavaScriptDimFilter implements DimFilter
   public DimFilter optimize()
   {
     return this;
+  }
+
+  @Override
+  public Filter toFilter()
+  {
+    return new JavaScriptFilter(dimension, function);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/NoopDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/NoopDimFilter.java
@@ -36,4 +36,10 @@ public class NoopDimFilter implements DimFilter
   {
     return this;
   }
+
+  @Override
+  public Filter toFilter()
+  {
+    return null;
+  }
 }

--- a/processing/src/main/java/io/druid/query/filter/NotDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/NotDimFilter.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import io.druid.query.Druids;
+import io.druid.segment.filter.NotFilter;
 
 import java.nio.ByteBuffer;
 
@@ -59,6 +60,12 @@ public class NotDimFilter implements DimFilter
   public DimFilter optimize()
   {
     return Druids.newNotDimFilterBuilder().field(this.getField().optimize()).build();
+  }
+
+  @Override
+  public Filter toFilter()
+  {
+    return new NotFilter(field.toFilter());
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/OrDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/OrDimFilter.java
@@ -26,6 +26,8 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import io.druid.query.Druids;
+import io.druid.segment.filter.Filters;
+import io.druid.segment.filter.OrFilter;
 
 import java.util.Collections;
 import java.util.List;
@@ -71,6 +73,12 @@ public class OrDimFilter implements DimFilter
         return input.optimize();
       }
     })).build();
+  }
+
+  @Override
+  public Filter toFilter()
+  {
+    return new OrFilter(Filters.toFilters(fields));
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/RegexDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/RegexDimFilter.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.metamx.common.StringUtils;
+import io.druid.segment.filter.RegexFilter;
 
 import java.nio.ByteBuffer;
 
@@ -75,6 +76,12 @@ public class RegexDimFilter implements DimFilter
   public DimFilter optimize()
   {
     return this;
+  }
+
+  @Override
+  public Filter toFilter()
+  {
+    return new RegexFilter(dimension, pattern);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/SearchQueryDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/SearchQueryDimFilter.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.metamx.common.StringUtils;
 import io.druid.query.search.search.SearchQuerySpec;
+import io.druid.segment.filter.SearchQueryFilter;
 
 import java.nio.ByteBuffer;
 
@@ -75,6 +76,12 @@ public class SearchQueryDimFilter implements DimFilter
   public DimFilter optimize()
   {
     return this;
+  }
+
+  @Override
+  public Filter toFilter()
+  {
+    return new SearchQueryFilter(dimension, query);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/SelectorDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/SelectorDimFilter.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.metamx.common.StringUtils;
+import io.druid.segment.filter.SelectorFilter;
 
 import java.nio.ByteBuffer;
 
@@ -63,6 +64,12 @@ public class SelectorDimFilter implements DimFilter
   public DimFilter optimize()
   {
     return this;
+  }
+
+  @Override
+  public Filter toFilter()
+  {
+    return new SelectorFilter(dimension, value);
   }
 
   @JsonProperty

--- a/processing/src/main/java/io/druid/query/filter/SpatialDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/SpatialDimFilter.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.metamx.collections.spatial.search.Bound;
 import com.metamx.common.StringUtils;
+import io.druid.segment.filter.SpatialFilter;
 
 import java.nio.ByteBuffer;
 
@@ -76,6 +77,12 @@ public class SpatialDimFilter implements DimFilter
   public Bound getBound()
   {
     return bound;
+  }
+
+  @Override
+  public Filter toFilter()
+  {
+    return new SpatialFilter(dimension, bound);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryEngine.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryEngine.java
@@ -95,7 +95,7 @@ public class GroupByQueryEngine
     }
 
     final Sequence<Cursor> cursors = storageAdapter.makeCursors(
-        Filters.convertDimensionFilters(query.getDimFilter()),
+        Filters.toFilter(query.getDimFilter()),
         intervals.get(0),
         query.getGranularity(),
         false

--- a/processing/src/main/java/io/druid/query/search/SearchQueryRunner.java
+++ b/processing/src/main/java/io/druid/query/search/SearchQueryRunner.java
@@ -85,7 +85,7 @@ public class SearchQueryRunner implements QueryRunner<Result<SearchResultValue>>
     }
 
     final SearchQuery query = (SearchQuery) input;
-    final Filter filter = Filters.convertDimensionFilters(query.getDimensionsFilter());
+    final Filter filter = Filters.toFilter(query.getDimensionsFilter());
     final List<DimensionSpec> dimensions = query.getDimensions();
     final SearchQuerySpec searchQuerySpec = query.getQuery();
     final int limit = query.getLimit();

--- a/processing/src/main/java/io/druid/query/select/SelectQueryEngine.java
+++ b/processing/src/main/java/io/druid/query/select/SelectQueryEngine.java
@@ -81,7 +81,7 @@ public class SelectQueryEngine
     return QueryRunnerHelper.makeCursorBasedQuery(
         adapter,
         query.getQuerySegmentSpec().getIntervals(),
-        Filters.convertDimensionFilters(query.getDimensionsFilter()),
+        Filters.toFilter(query.getDimensionsFilter()),
         query.isDescending(),
         query.getGranularity(),
         new Function<Cursor, Result<SelectResultValue>>()

--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryEngine.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryEngine.java
@@ -47,7 +47,7 @@ public class TimeseriesQueryEngine
     return QueryRunnerHelper.makeCursorBasedQuery(
         adapter,
         query.getQuerySegmentSpec().getIntervals(),
-        Filters.convertDimensionFilters(query.getDimensionsFilter()),
+        Filters.toFilter(query.getDimensionsFilter()),
         query.isDescending(),
         query.getGranularity(),
         new Function<Cursor, Result<TimeseriesResultValue>>()

--- a/processing/src/main/java/io/druid/query/topn/TopNQueryEngine.java
+++ b/processing/src/main/java/io/druid/query/topn/TopNQueryEngine.java
@@ -64,7 +64,7 @@ public class TopNQueryEngine
     }
 
     final List<Interval> queryIntervals = query.getQuerySegmentSpec().getIntervals();
-    final Filter filter = Filters.convertDimensionFilters(query.getDimensionsFilter());
+    final Filter filter = Filters.toFilter(query.getDimensionsFilter());
     final QueryGranularity granularity = query.getGranularity();
     final Function<Cursor, Result<TopNResultValue>> mapFn = getMapFn(query, adapter);
 

--- a/processing/src/main/java/io/druid/segment/filter/Filters.java
+++ b/processing/src/main/java/io/druid/segment/filter/Filters.java
@@ -20,103 +20,51 @@
 package io.druid.segment.filter;
 
 import com.google.common.base.Function;
-import com.google.common.collect.Lists;
-import io.druid.query.filter.AndDimFilter;
-import io.druid.query.filter.BoundDimFilter;
+import com.google.common.collect.ImmutableList;
+import com.metamx.common.guava.FunctionalIterable;
 import io.druid.query.filter.DimFilter;
-import io.druid.query.filter.ExtractionDimFilter;
 import io.druid.query.filter.Filter;
-import io.druid.query.filter.InDimFilter;
-import io.druid.query.filter.JavaScriptDimFilter;
-import io.druid.query.filter.NotDimFilter;
-import io.druid.query.filter.OrDimFilter;
-import io.druid.query.filter.RegexDimFilter;
-import io.druid.query.filter.SearchQueryDimFilter;
-import io.druid.query.filter.SelectorDimFilter;
-import io.druid.query.filter.SpatialDimFilter;
 
-import javax.annotation.Nullable;
 import java.util.List;
 
 /**
  */
 public class Filters
 {
-  public static List<Filter> convertDimensionFilters(List<DimFilter> filters)
+  /**
+   * Convert a list of DimFilters to a list of Filters.
+   *
+   * @param dimFilters list of DimFilters, should all be non-null
+   *
+   * @return list of Filters
+   */
+  public static List<Filter> toFilters(List<DimFilter> dimFilters)
   {
-    return Lists.transform(
-        filters,
-        new Function<DimFilter, Filter>()
-        {
-          @Override
-          public Filter apply(@Nullable DimFilter input)
-          {
-            return convertDimensionFilters(input);
-          }
-        }
+    return ImmutableList.copyOf(
+        FunctionalIterable
+            .create(dimFilters)
+            .transform(
+                new Function<DimFilter, Filter>()
+                {
+                  @Override
+                  public Filter apply(DimFilter input)
+                  {
+                    return input.toFilter();
+                  }
+                }
+            )
     );
   }
 
-  public static Filter convertDimensionFilters(DimFilter dimFilter)
+  /**
+   * Convert a DimFilter to a Filter.
+   *
+   * @param dimFilter dimFilter
+   *
+   * @return converted filter, or null if input was null
+   */
+  public static Filter toFilter(DimFilter dimFilter)
   {
-    if (dimFilter == null) {
-      return null;
-    }
-
-    Filter filter = null;
-    if (dimFilter instanceof AndDimFilter) {
-      filter = new AndFilter(convertDimensionFilters(((AndDimFilter) dimFilter).getFields()));
-    } else if (dimFilter instanceof OrDimFilter) {
-      filter = new OrFilter(convertDimensionFilters(((OrDimFilter) dimFilter).getFields()));
-    } else if (dimFilter instanceof NotDimFilter) {
-      filter = new NotFilter(convertDimensionFilters(((NotDimFilter) dimFilter).getField()));
-    } else if (dimFilter instanceof SelectorDimFilter) {
-      final SelectorDimFilter selectorDimFilter = (SelectorDimFilter) dimFilter;
-
-      filter = new SelectorFilter(selectorDimFilter.getDimension(), selectorDimFilter.getValue());
-    } else if (dimFilter instanceof ExtractionDimFilter) {
-      final ExtractionDimFilter extractionDimFilter = (ExtractionDimFilter) dimFilter;
-
-      filter = new ExtractionFilter(
-          extractionDimFilter.getDimension(),
-          extractionDimFilter.getValue(),
-          extractionDimFilter.getExtractionFn()
-      );
-    } else if (dimFilter instanceof RegexDimFilter) {
-      final RegexDimFilter regexDimFilter = (RegexDimFilter) dimFilter;
-
-      filter = new RegexFilter(regexDimFilter.getDimension(), regexDimFilter.getPattern());
-    } else if (dimFilter instanceof SearchQueryDimFilter) {
-      final SearchQueryDimFilter searchQueryFilter = (SearchQueryDimFilter) dimFilter;
-
-      filter = new SearchQueryFilter(searchQueryFilter.getDimension(), searchQueryFilter.getQuery());
-    } else if (dimFilter instanceof JavaScriptDimFilter) {
-      final JavaScriptDimFilter javaScriptDimFilter = (JavaScriptDimFilter) dimFilter;
-
-      filter = new JavaScriptFilter(javaScriptDimFilter.getDimension(), javaScriptDimFilter.getFunction());
-    } else if (dimFilter instanceof SpatialDimFilter) {
-      final SpatialDimFilter spatialDimFilter = (SpatialDimFilter) dimFilter;
-
-      filter = new SpatialFilter(spatialDimFilter.getDimension(), spatialDimFilter.getBound());
-    } else if (dimFilter instanceof InDimFilter) {
-      final InDimFilter inDimFilter = (InDimFilter) dimFilter;
-      final List<Filter> listFilters = Lists.transform(
-          inDimFilter.getValues(), new Function<String, Filter>()
-          {
-            @Nullable
-            @Override
-            public Filter apply(@Nullable String input)
-            {
-              return new SelectorFilter(inDimFilter.getDimension(), input);
-            }
-          }
-      );
-
-      filter = new OrFilter(listFilters);
-    } else if (dimFilter instanceof BoundDimFilter) {
-      filter = new BoundFilter((BoundDimFilter) dimFilter);
-    }
-
-    return filter;
+    return dimFilter == null ? null : dimFilter.toFilter();
   }
 }

--- a/processing/src/test/java/io/druid/segment/filter/ExtractionDimFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/ExtractionDimFilterTest.java
@@ -172,7 +172,7 @@ public class ExtractionDimFilterTest
   public void testOr()
   {
     Assert.assertEquals(
-        1, Filters.convertDimensionFilters(
+        1, Filters.toFilter(
             DimFilters.or(
                 new ExtractionDimFilter(
                     "foo",
@@ -186,7 +186,7 @@ public class ExtractionDimFilterTest
 
     Assert.assertEquals(
         1,
-        Filters.convertDimensionFilters(
+        Filters.toFilter(
             DimFilters.or(
                 new ExtractionDimFilter(
                     "foo",
@@ -209,7 +209,7 @@ public class ExtractionDimFilterTest
   public void testAnd()
   {
     Assert.assertEquals(
-        1, Filters.convertDimensionFilters(
+        1, Filters.toFilter(
             DimFilters.or(
                 new ExtractionDimFilter(
                     "foo",
@@ -223,7 +223,7 @@ public class ExtractionDimFilterTest
 
     Assert.assertEquals(
         1,
-        Filters.convertDimensionFilters(
+        Filters.toFilter(
             DimFilters.and(
                 new ExtractionDimFilter(
                     "foo",
@@ -247,7 +247,7 @@ public class ExtractionDimFilterTest
   {
 
     Assert.assertEquals(
-        1, Filters.convertDimensionFilters(
+        1, Filters.toFilter(
             DimFilters.or(
                 new ExtractionDimFilter(
                     "foo",
@@ -261,7 +261,7 @@ public class ExtractionDimFilterTest
 
     Assert.assertEquals(
         1,
-        Filters.convertDimensionFilters(
+        Filters.toFilter(
             DimFilters.not(
                 new ExtractionDimFilter(
                     "foo",

--- a/server/src/main/java/io/druid/segment/realtime/firehose/IngestSegmentFirehose.java
+++ b/server/src/main/java/io/druid/segment/realtime/firehose/IngestSegmentFirehose.java
@@ -73,7 +73,7 @@ public class IngestSegmentFirehose implements Firehose
                 return Sequences.concat(
                     Sequences.map(
                         adapter.getAdapter().makeCursors(
-                            Filters.convertDimensionFilters(dimFilter),
+                            Filters.toFilter(dimFilter),
                             adapter.getInterval(),
                             granularity,
                             false


### PR DESCRIPTION
I believe that the instanceof chain in Filters exists because in the past, Filter
and DimFilter were in different packages (DimFilter was in druid-client and Filter
was in druid-processing). And since druid-client didn't depend on druid-processing,
DimFilter couldn't have a toFilter method. But now it can.