### PR TITLE
Fix HyperUniquesAggregatorFactory comparator

### DIFF
--- a/processing/src/main/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
@@ -21,6 +21,7 @@ package io.druid.query.aggregation.hyperloglog;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.Ordering;
 import com.metamx.common.IAE;
 import com.metamx.common.StringUtils;
 import io.druid.query.aggregation.Aggregator;
@@ -106,20 +107,7 @@ public class HyperUniquesAggregatorFactory extends AggregatorFactory
   @Override
   public Comparator getComparator()
   {
-    return new Comparator<HyperLogLogCollector>()
-    {
-      @Override
-      public int compare(HyperLogLogCollector lhs, HyperLogLogCollector rhs)
-      {
-        if(lhs == null) {
-          return -1;
-        }
-        if(rhs == null) {
-          return 1;
-        }
-        return lhs.compareTo(rhs);
-      }
-    };
+    return Ordering.<HyperLogLogCollector>natural().nullsFirst();
   }
 
   @Override

--- a/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerTest.java
@@ -377,17 +377,17 @@ public class TopNQueryRunnerTest
             new TopNResultValue(
                 Arrays.<Map<String, Object>>asList(
                     ImmutableMap.<String, Object>builder()
-                                .put("market", "total_market")
-                                .put("uniques", 0)
-                                .build(),
+                        .put("market", "spot")
+                        .put("uniques", 0)
+                        .build(),
                     ImmutableMap.<String, Object>builder()
-                                .put("market", "spot")
-                                .put("uniques", 0)
-                                .build(),
+                        .put("market", "total_market")
+                        .put("uniques", 0)
+                        .build(),
                     ImmutableMap.<String, Object>builder()
-                                .put("market", "upfront")
-                                .put("uniques", 0)
-                                .build()
+                        .put("market", "upfront")
+                        .put("uniques", 0)
+                        .build()
                 )
             )
         )


### PR DESCRIPTION
I noticed an issue with TopN result sorting while working on another PR, in TopNQueryRunnerTest.testTopNOverMissingUniques().

In that test, the metric being sorted on is 0 for all dimension values, but the results were not sorted by dimension value.

Within the TopNNumericResult builder, the HyperUniquesAggregatorFactory comparator was returning an incorrect value (-1 when both objects are null) when called by ```metricComparator.compare()```, which caused the ```dimNameComparator.compare()``` to be skipped.

```
          @Override
          public int compare(DimValHolder d1, DimValHolder d2)
          {
            // Values flipped compared to earlier
            int retVal = metricComparator.compare(d2.getTopNMetricVal(), d1.getTopNMetricVal());

            if (retVal == 0) {
              retVal = dimNameComparator.compare(d1.getDimName(), d2.getDimName());
            }

            return retVal;
          }
``` 