### PR TITLE
add control and status endpoints to KafkaIndexTask

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIOConfig.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIOConfig.java
@@ -29,12 +29,14 @@ import java.util.Map;
 public class KafkaIOConfig implements IOConfig
 {
   private static final boolean DEFAULT_USE_TRANSACTION = true;
+  private static final boolean DEFAULT_PAUSE_AFTER_READ = false;
 
   private final String baseSequenceName;
   private final KafkaPartitions startPartitions;
   private final KafkaPartitions endPartitions;
   private final Map<String, String> consumerProperties;
   private final boolean useTransaction;
+  private final boolean pauseAfterRead;
 
   @JsonCreator
   public KafkaIOConfig(
@@ -42,7 +44,8 @@ public class KafkaIOConfig implements IOConfig
       @JsonProperty("startPartitions") KafkaPartitions startPartitions,
       @JsonProperty("endPartitions") KafkaPartitions endPartitions,
       @JsonProperty("consumerProperties") Map<String, String> consumerProperties,
-      @JsonProperty("useTransaction") Boolean useTransaction
+      @JsonProperty("useTransaction") Boolean useTransaction,
+      @JsonProperty("pauseAfterRead") Boolean pauseAfterRead
   )
   {
     this.baseSequenceName = Preconditions.checkNotNull(baseSequenceName, "baseSequenceName");
@@ -50,6 +53,7 @@ public class KafkaIOConfig implements IOConfig
     this.endPartitions = Preconditions.checkNotNull(endPartitions, "endPartitions");
     this.consumerProperties = Preconditions.checkNotNull(consumerProperties, "consumerProperties");
     this.useTransaction = useTransaction != null ? useTransaction : DEFAULT_USE_TRANSACTION;
+    this.pauseAfterRead = pauseAfterRead != null ? pauseAfterRead : DEFAULT_PAUSE_AFTER_READ;
 
     Preconditions.checkArgument(
         startPartitions.getTopic().equals(endPartitions.getTopic()),
@@ -101,6 +105,12 @@ public class KafkaIOConfig implements IOConfig
     return useTransaction;
   }
 
+  @JsonProperty
+  public boolean isPauseAfterRead()
+  {
+    return pauseAfterRead;
+  }
+
   @Override
   public String toString()
   {
@@ -110,6 +120,7 @@ public class KafkaIOConfig implements IOConfig
            ", endPartitions=" + endPartitions +
            ", consumerProperties=" + consumerProperties +
            ", useTransaction=" + useTransaction +
+           ", pauseAfterRead=" + pauseAfterRead +
            '}';
   }
 }

--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -19,6 +19,8 @@
 
 package io.druid.indexing.kafka;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Charsets;
@@ -137,6 +139,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 @RunWith(Parameterized.class)
 public class KafkaIndexTaskTest
@@ -159,6 +162,7 @@ public class KafkaIndexTaskTest
   private final List<Task> runningTasks = Lists.newArrayList();
 
   private static final Logger log = new Logger(KafkaIndexTaskTest.class);
+  private static final ObjectMapper objectMapper = new DefaultObjectMapper();
 
   private static final DataSchema DATA_SCHEMA;
 
@@ -175,7 +179,6 @@ public class KafkaIndexTaskTest
   );
 
   static {
-    ObjectMapper objectMapper = new DefaultObjectMapper();
     DATA_SCHEMA = new DataSchema(
         "test_ds",
         objectMapper.convertValue(
@@ -298,7 +301,8 @@ public class KafkaIndexTaskTest
             new KafkaPartitions("topic0", ImmutableMap.of(0, 2L)),
             new KafkaPartitions("topic0", ImmutableMap.of(0, 5L)),
             kafkaServer.consumerProperties(),
-            true
+            true,
+            false
         ),
         null
     );
@@ -337,7 +341,8 @@ public class KafkaIndexTaskTest
             new KafkaPartitions("topic0", ImmutableMap.of(0, 2L)),
             new KafkaPartitions("topic0", ImmutableMap.of(0, 5L)),
             kafkaServer.consumerProperties(),
-            true
+            true,
+            false
         ),
         null
     );
@@ -345,7 +350,7 @@ public class KafkaIndexTaskTest
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for the task to start reading
-    while (!task.hasStartedReading()) {
+    while (task.getStatus() != KafkaIndexTask.Status.READING) {
       Thread.sleep(10);
     }
 
@@ -395,7 +400,8 @@ public class KafkaIndexTaskTest
             new KafkaPartitions("topic0", ImmutableMap.of(0, 2L)),
             new KafkaPartitions("topic0", ImmutableMap.of(0, 2L)),
             kafkaServer.consumerProperties(),
-            true
+            true,
+            false
         ),
         null
     );
@@ -433,7 +439,8 @@ public class KafkaIndexTaskTest
             new KafkaPartitions("topic0", ImmutableMap.of(0, 2L)),
             new KafkaPartitions("topic0", ImmutableMap.of(0, 5L)),
             kafkaServer.consumerProperties(),
-            true
+            true,
+            false
         ),
         null
     );
@@ -482,7 +489,8 @@ public class KafkaIndexTaskTest
             new KafkaPartitions("topic0", ImmutableMap.of(0, 2L)),
             new KafkaPartitions("topic0", ImmutableMap.of(0, 5L)),
             kafkaServer.consumerProperties(),
-            true
+            true,
+            false
         ),
         null
     );
@@ -530,7 +538,8 @@ public class KafkaIndexTaskTest
             new KafkaPartitions("topic0", ImmutableMap.of(0, 2L)),
             new KafkaPartitions("topic0", ImmutableMap.of(0, 7L)),
             kafkaServer.consumerProperties(),
-            true
+            true,
+            false
         ),
         null
     );
@@ -560,7 +569,8 @@ public class KafkaIndexTaskTest
             new KafkaPartitions("topic0", ImmutableMap.of(0, 2L)),
             new KafkaPartitions("topic0", ImmutableMap.of(0, 5L)),
             kafkaServer.consumerProperties(),
-            true
+            true,
+            false
         ),
         null
     );
@@ -571,7 +581,8 @@ public class KafkaIndexTaskTest
             new KafkaPartitions("topic0", ImmutableMap.of(0, 2L)),
             new KafkaPartitions("topic0", ImmutableMap.of(0, 5L)),
             kafkaServer.consumerProperties(),
-            true
+            true,
+            false
         ),
         null
     );
@@ -622,7 +633,8 @@ public class KafkaIndexTaskTest
             new KafkaPartitions("topic0", ImmutableMap.of(0, 2L)),
             new KafkaPartitions("topic0", ImmutableMap.of(0, 5L)),
             kafkaServer.consumerProperties(),
-            true
+            true,
+            false
         ),
         null
     );
@@ -633,7 +645,8 @@ public class KafkaIndexTaskTest
             new KafkaPartitions("topic0", ImmutableMap.of(0, 3L)),
             new KafkaPartitions("topic0", ImmutableMap.of(0, 7L)),
             kafkaServer.consumerProperties(),
-            true
+            true,
+            false
         ),
         null
     );
@@ -685,6 +698,7 @@ public class KafkaIndexTaskTest
             new KafkaPartitions("topic0", ImmutableMap.of(0, 2L)),
             new KafkaPartitions("topic0", ImmutableMap.of(0, 5L)),
             kafkaServer.consumerProperties(),
+            false,
             false
         ),
         null
@@ -696,6 +710,7 @@ public class KafkaIndexTaskTest
             new KafkaPartitions("topic0", ImmutableMap.of(0, 3L)),
             new KafkaPartitions("topic0", ImmutableMap.of(0, 7L)),
             kafkaServer.consumerProperties(),
+            false,
             false
         ),
         null
@@ -753,7 +768,8 @@ public class KafkaIndexTaskTest
             new KafkaPartitions("topic0", ImmutableMap.of(0, 2L, 1, 0L)),
             new KafkaPartitions("topic0", ImmutableMap.of(0, 5L, 1, 2L)),
             kafkaServer.consumerProperties(),
-            true
+            true,
+            false
         ),
         null
     );
@@ -807,7 +823,8 @@ public class KafkaIndexTaskTest
             new KafkaPartitions("topic0", ImmutableMap.of(0, 2L)),
             new KafkaPartitions("topic0", ImmutableMap.of(0, 5L)),
             kafkaServer.consumerProperties(),
-            true
+            true,
+            false
         ),
         null
     );
@@ -818,7 +835,8 @@ public class KafkaIndexTaskTest
             new KafkaPartitions("topic0", ImmutableMap.of(1, 0L)),
             new KafkaPartitions("topic0", ImmutableMap.of(1, 1L)),
             kafkaServer.consumerProperties(),
-            true
+            true,
+            false
         ),
         null
     );
@@ -871,7 +889,8 @@ public class KafkaIndexTaskTest
             new KafkaPartitions("topic0", ImmutableMap.of(0, 2L)),
             new KafkaPartitions("topic0", ImmutableMap.of(0, 5L)),
             kafkaServer.consumerProperties(),
-            true
+            true,
+            false
         ),
         null
     );
@@ -891,9 +910,9 @@ public class KafkaIndexTaskTest
 
     Assert.assertEquals(2, countEvents(task1));
 
-    // Stop gracefully
+    // Stop without publishing segment
     task1.stopGracefully();
-    Assert.assertEquals(TaskStatus.Status.FAILED, future1.get().getStatusCode());
+    Assert.assertEquals(TaskStatus.Status.SUCCESS, future1.get().getStatusCode());
 
     // Start a new task
     final KafkaIndexTask task2 = createTask(
@@ -903,7 +922,8 @@ public class KafkaIndexTaskTest
             new KafkaPartitions("topic0", ImmutableMap.of(0, 2L)),
             new KafkaPartitions("topic0", ImmutableMap.of(0, 5L)),
             kafkaServer.consumerProperties(),
-            true
+            true,
+            false
         ),
         null
     );
@@ -940,6 +960,172 @@ public class KafkaIndexTaskTest
     // Check segments in deep storage
     Assert.assertEquals(ImmutableList.of("c"), readSegmentDim1(desc1));
     Assert.assertEquals(ImmutableList.of("d", "e"), readSegmentDim1(desc2));
+  }
+
+  @Test(timeout = 60_000L)
+  public void testRunWithPauseAndResume() throws Exception
+  {
+    final KafkaIndexTask task = createTask(
+        null,
+        new KafkaIOConfig(
+            "sequence0",
+            new KafkaPartitions("topic0", ImmutableMap.of(0, 2L)),
+            new KafkaPartitions("topic0", ImmutableMap.of(0, 5L)),
+            kafkaServer.consumerProperties(),
+            true,
+            false
+        ),
+        null
+    );
+
+    final ListenableFuture<TaskStatus> future = runTask(task);
+
+    // Insert some data, but not enough for the task to finish
+    try (final KafkaProducer<byte[], byte[]> kafkaProducer = kafkaServer.newProducer()) {
+      for (ProducerRecord<byte[], byte[]> record : Iterables.limit(RECORDS, 4)) {
+        kafkaProducer.send(record).get();
+      }
+    }
+
+    while (countEvents(task) != 2) {
+      Thread.sleep(25);
+    }
+
+    Assert.assertEquals(2, countEvents(task));
+    Assert.assertEquals(KafkaIndexTask.Status.READING, task.getStatus());
+
+    Map<Integer, Long> currentOffsets = objectMapper.readValue(
+        task.pause(0).getEntity().toString(),
+        new TypeReference<Map<Integer, Long>>()
+        {
+        }
+    );
+    Assert.assertEquals(KafkaIndexTask.Status.PAUSED, task.getStatus());
+
+    // Insert remaining data
+    try (final KafkaProducer<byte[], byte[]> kafkaProducer = kafkaServer.newProducer()) {
+      for (ProducerRecord<byte[], byte[]> record : Iterables.skip(RECORDS, 4)) {
+        kafkaProducer.send(record).get();
+      }
+    }
+
+    try {
+      future.get(10, TimeUnit.SECONDS);
+      Assert.fail("Task completed when it should have been paused");
+    }
+    catch (TimeoutException e) {
+      // carry on..
+    }
+
+    Assert.assertEquals(currentOffsets, task.getCurrentOffsets());
+
+    task.resume();
+
+    Assert.assertEquals(TaskStatus.Status.SUCCESS, future.get().getStatusCode());
+    Assert.assertEquals(task.getEndOffsets(), task.getCurrentOffsets());
+
+    // Check metrics
+    Assert.assertEquals(3, task.getFireDepartmentMetrics().processed());
+    Assert.assertEquals(0, task.getFireDepartmentMetrics().unparseable());
+    Assert.assertEquals(0, task.getFireDepartmentMetrics().thrownAway());
+
+    // Check published metadata
+    SegmentDescriptor desc1 = SD(task, "2010/P1D", 0);
+    SegmentDescriptor desc2 = SD(task, "2011/P1D", 0);
+    Assert.assertEquals(ImmutableSet.of(desc1, desc2), publishedDescriptors());
+    Assert.assertEquals(
+        new KafkaDataSourceMetadata(new KafkaPartitions("topic0", ImmutableMap.of(0, 5L))),
+        metadataStorageCoordinator.getDataSourceMetadata(DATA_SCHEMA.getDataSource())
+    );
+
+    // Check segments in deep storage
+    Assert.assertEquals(ImmutableList.of("c"), readSegmentDim1(desc1));
+    Assert.assertEquals(ImmutableList.of("d", "e"), readSegmentDim1(desc2));
+  }
+
+  @Test(timeout = 60_000L)
+  public void testRunAndPauseAfterReadWithModifiedEndOffsets() throws Exception
+  {
+    final KafkaIndexTask task = createTask(
+        null,
+        new KafkaIOConfig(
+            "sequence0",
+            new KafkaPartitions("topic0", ImmutableMap.of(0, 1L)),
+            new KafkaPartitions("topic0", ImmutableMap.of(0, 3L)),
+            kafkaServer.consumerProperties(),
+            true,
+            true
+        ),
+        null
+    );
+
+    final ListenableFuture<TaskStatus> future = runTask(task);
+
+    try (final KafkaProducer<byte[], byte[]> kafkaProducer = kafkaServer.newProducer()) {
+      for (ProducerRecord<byte[], byte[]> record : RECORDS) {
+        kafkaProducer.send(record).get();
+      }
+    }
+
+    while (task.getStatus() != KafkaIndexTask.Status.PAUSED) {
+      Thread.sleep(25);
+    }
+
+    // reached the end of the assigned offsets and paused instead of publishing
+    Assert.assertEquals(task.getEndOffsets(), task.getCurrentOffsets());
+    Assert.assertEquals(KafkaIndexTask.Status.PAUSED, task.getStatus());
+
+    Assert.assertEquals(ImmutableMap.of(0, 3L), task.getEndOffsets());
+    Map<Integer, Long> newEndOffsets = ImmutableMap.of(0, 4L);
+    task.setEndOffsets(newEndOffsets, false);
+    Assert.assertEquals(newEndOffsets, task.getEndOffsets());
+    Assert.assertEquals(KafkaIndexTask.Status.PAUSED, task.getStatus());
+    task.resume();
+
+    while (task.getStatus() != KafkaIndexTask.Status.PAUSED) {
+      Thread.sleep(25);
+    }
+
+    // reached the end of the updated offsets and paused
+    Assert.assertEquals(newEndOffsets, task.getCurrentOffsets());
+    Assert.assertEquals(KafkaIndexTask.Status.PAUSED, task.getStatus());
+
+    // try again but with resume flag == true
+    newEndOffsets = ImmutableMap.of(0, 6L);
+    task.setEndOffsets(newEndOffsets, true);
+    Assert.assertEquals(newEndOffsets, task.getEndOffsets());
+    Assert.assertNotEquals(KafkaIndexTask.Status.PAUSED, task.getStatus());
+
+    while (task.getStatus() != KafkaIndexTask.Status.PAUSED) {
+      Thread.sleep(25);
+    }
+
+    Assert.assertEquals(newEndOffsets, task.getCurrentOffsets());
+    Assert.assertEquals(KafkaIndexTask.Status.PAUSED, task.getStatus());
+
+    task.resume();
+
+    Assert.assertEquals(TaskStatus.Status.SUCCESS, future.get().getStatusCode());
+
+    // Check metrics
+    Assert.assertEquals(4, task.getFireDepartmentMetrics().processed());
+    Assert.assertEquals(1, task.getFireDepartmentMetrics().unparseable());
+    Assert.assertEquals(0, task.getFireDepartmentMetrics().thrownAway());
+
+    // Check published metadata
+    SegmentDescriptor desc1 = SD(task, "2009/P1D", 0);
+    SegmentDescriptor desc2 = SD(task, "2010/P1D", 0);
+    SegmentDescriptor desc3 = SD(task, "2011/P1D", 0);
+    Assert.assertEquals(ImmutableSet.of(desc1, desc2, desc3), publishedDescriptors());
+    Assert.assertEquals(
+        new KafkaDataSourceMetadata(new KafkaPartitions("topic0", ImmutableMap.of(0, 6L))),
+        metadataStorageCoordinator.getDataSourceMetadata(DATA_SCHEMA.getDataSource())
+    );
+
+    // Check segments in deep storage
+    Assert.assertEquals(ImmutableList.of("b"), readSegmentDim1(desc1));
+    Assert.assertEquals(ImmutableList.of("c"), readSegmentDim1(desc2));
+    Assert.assertEquals(ImmutableList.of("d", "e"), readSegmentDim1(desc3));
   }
 
   private ListenableFuture<TaskStatus> runTask(final Task task)
@@ -1015,6 +1201,7 @@ public class KafkaIndexTaskTest
         DATA_SCHEMA,
         tuningConfig,
         ioConfig,
+        null,
         null
     );
   }

--- a/indexing-service/src/test/java/io/druid/indexing/common/TestUtils.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/TestUtils.java
@@ -30,6 +30,8 @@ import io.druid.segment.IndexIO;
 import io.druid.segment.IndexMerger;
 import io.druid.segment.IndexMergerV9;
 import io.druid.segment.column.ColumnConfig;
+import io.druid.segment.realtime.firehose.ChatHandlerProvider;
+import io.druid.segment.realtime.firehose.NoopChatHandlerProvider;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -70,6 +72,7 @@ public class TestUtils
             .addValue(IndexIO.class, indexIO)
             .addValue(IndexMerger.class, indexMerger)
             .addValue(ObjectMapper.class, jsonMapper)
+            .addValue(ChatHandlerProvider.class, new NoopChatHandlerProvider())
     );
   }
 


### PR DESCRIPTION
Added the following HTTP endpoints to KafkaIndexTask:
1) [GET /offsets/current] - Return which offsets we are currently processing
2) [GET /offsets/end] - Return the offsets that the task will read until
3) [POST /offsets/end] - Modify the ending offsets to allow the task to continue reading or stop early
4) [POST /stop?publish=true/false] - Signal the task to stop early, either abruptly or gracefully (stop reading and publish segment with what we currently have). In both cases it returns a SUCCESS status
5) [POST /pause?timeout=x] - Signal the task to pause reading, either indefinitely or with a provided timeout to resume
6) [GET /status] - Return the task's state
7) [POST /resume] - Signal the task to resume reading
8) [GET /time/start] - Returns the timestamp when the task began running

These endpoints are required for implementing functionality for #2656, specifically:
(1) exposes the offset currently being read and allows us to start the next tasks early
(4) allows us to stop redundant replicas when another has completed without generating a failed status
(all) allows us to stop tasks gracefully in a coordinated way across replicas (by pausing and then setting the end offsets so that they all finish at the same place) - this enables graceful immediate schema rollover as well as time-based task lifetimes instead of number of event based
(all) in conjunction with a pauseAfterRead flag in KafkaIOConfig, provides a framework to enable leader/follower capabilities, where followers will pause when they are done reading their offsets until the leader assigns a new set of ending offsets

