### PR TITLE
Fix predicate-based ValueMatcher behavior for IncrementalIndex on missing columns.

### DIFF
--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
@@ -707,7 +707,7 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
     {
       IncrementalIndex.DimensionDesc dimensionDesc = index.getDimension(dimension);
       if (dimensionDesc == null) {
-        return new BooleanValueMatcher(false);
+        return new BooleanValueMatcher(predicate.apply(null));
       }
       final int dimIndex = dimensionDesc.getIndex();
       final IncrementalIndex.DimDim dimDim = dimensionDesc.getValues();


### PR DESCRIPTION
Missing columns should be treated the same as columns containing 100% nulls.

No tests in this PR, but #2727 contains some tests that do catch this as part of a new set of filter tests. (that's how I noticed it)