### PR TITLE
Fix extension reference in Kafka namespaced lookup docs.

### DIFF
--- a/docs/content/development/extensions-core/kafka-extraction-namespace.md
+++ b/docs/content/development/extensions-core/kafka-extraction-namespace.md
@@ -12,7 +12,7 @@ Make sure to [include](../../operations/including-extensions.html) `druid-namesp
 
 Note that this lookup does not employ a `pollPeriod`.
 
-If you need updates to populate as promptly as possible, it is possible to plug into a kafka topic whose key is the old value and message is the desired new value (both in UTF-8). This requires the following extension: "io.druid.extensions:kafka-extraction-namespace"
+If you need updates to populate as promptly as possible, it is possible to plug into a kafka topic whose key is the old value and message is the desired new value (both in UTF-8).
 
 ```json
 {


### PR DESCRIPTION
The reference to io.druid.extensions:kafka-extraction-namespace is wrong (should
be druid-kafka-extraction-namespace) and unnecessary (the extension id is written
at the top of the doc file).

I snuck this change into #2732 so there is no need to backport it.