### PR TITLE
Help relieve some memory pressure on brokers & coordinator

### DIFF
--- a/api/src/main/java/io/druid/timeline/partition/NoneShardSpec.java
+++ b/api/src/main/java/io/druid/timeline/partition/NoneShardSpec.java
@@ -19,6 +19,7 @@
 
 package io.druid.timeline.partition;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.metamx.common.ISE;
@@ -32,6 +33,11 @@ import java.util.Set;
  */
 public class NoneShardSpec implements ShardSpec
 {
+  public final static NoneShardSpec INSTANCE = new NoneShardSpec();
+
+  @JsonCreator
+  public static NoneShardSpec instance() { return INSTANCE; }
+
   @Override
   public <T> PartitionChunk<T> createChunk(T obj)
   {

--- a/api/src/test/java/io/druid/timeline/partition/NoneShardSpecTest.java
+++ b/api/src/test/java/io/druid/timeline/partition/NoneShardSpecTest.java
@@ -1,5 +1,8 @@
 package io.druid.timeline.partition;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.druid.TestObjectMapper;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -12,5 +15,18 @@ public class NoneShardSpecTest
     final ShardSpec two = new NoneShardSpec();
     Assert.assertEquals(one, two);
     Assert.assertEquals(one.hashCode(), two.hashCode());
+  }
+
+  @Test
+  public void testSerde() throws Exception
+  {
+    final NoneShardSpec one = NoneShardSpec.INSTANCE;
+    ObjectMapper mapper = new TestObjectMapper();
+    NoneShardSpec serde1 = mapper.readValue(mapper.writeValueAsString(one), NoneShardSpec.class);
+    NoneShardSpec serde2 = mapper.readValue(mapper.writeValueAsString(one), NoneShardSpec.class);
+
+    // Serde should return same object instead of creating new one every time.
+    Assert.assertTrue(serde1 == serde2);
+    Assert.assertTrue(one == serde1);
   }
 }

--- a/indexing-hadoop/src/test/java/io/druid/indexer/BatchDeltaIngestionTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/BatchDeltaIngestionTest.java
@@ -305,8 +305,8 @@ public class BatchDeltaIngestionTest
     Assert.assertEquals("local", dataSegment.getLoadSpec().get("type"));
     Assert.assertEquals(indexZip.getCanonicalPath(), dataSegment.getLoadSpec().get("path"));
     Assert.assertEquals("host", dataSegment.getDimensions().get(0));
-    Assert.assertEquals("visited_sum", dataSegment.getMetrics().get(0));
-    Assert.assertEquals("unique_hosts", dataSegment.getMetrics().get(1));
+    Assert.assertEquals("unique_hosts", dataSegment.getMetrics().get(0));
+    Assert.assertEquals("visited_sum", dataSegment.getMetrics().get(1));
     Assert.assertEquals(Integer.valueOf(9), dataSegment.getBinaryVersion());
 
     HashBasedNumberedShardSpec spec = (HashBasedNumberedShardSpec) dataSegment.getShardSpec();

--- a/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobTest.java
@@ -597,11 +597,11 @@ public class IndexGeneratorJobTest
         if (datasourceName.equals("website")) {
           Assert.assertEquals("website", dataSegment.getDataSource());
           Assert.assertEquals("host", dataSegment.getDimensions().get(0));
-          Assert.assertEquals("visited_num", dataSegment.getMetrics().get(0));
-          Assert.assertEquals("unique_hosts", dataSegment.getMetrics().get(1));
+          Assert.assertEquals("unique_hosts", dataSegment.getMetrics().get(0));
+          Assert.assertEquals("visited_num", dataSegment.getMetrics().get(1));
         } else if (datasourceName.equals("inherit_dims")) {
           Assert.assertEquals("inherit_dims", dataSegment.getDataSource());
-          Assert.assertEquals(ImmutableList.of("X", "Y", "M", "Q", "B", "F"), dataSegment.getDimensions());
+          Assert.assertEquals(ImmutableList.of("B", "F", "M", "Q", "X", "Y"), dataSegment.getDimensions());
           Assert.assertEquals("count", dataSegment.getMetrics().get(0));
         } else if (datasourceName.equals("inherit_dims2")) {
           Assert.assertEquals("inherit_dims2", dataSegment.getDataSource());


### PR DESCRIPTION
Help relieve some memory pressure on the broker and coordinator.
This has a side effect that DataSegment now keeps the dimension/metric names in sorted way.

From Histogram  - 
   6:      18221074      583074368  com.google.common.collect.RegularImmutableList
   8:       9138836      511774816  io.druid.timeline.DataSegment
  16:       3258048       52128768  io.druid.timeline.partition.NoneShardSpec

