### PR TITLE
Overlord: Avoid a scary Jersey warning.

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/common/actions/TaskActionHolder.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/actions/TaskActionHolder.java
@@ -25,10 +25,10 @@ import io.druid.indexing.common.task.Task;
 
 /**
  */
-public class TaskActionHolder<T>
+public class TaskActionHolder
 {
   private final Task task;
-  private final TaskAction<T> action;
+  private final TaskAction action;
 
   @JsonCreator
   public TaskActionHolder(
@@ -47,7 +47,7 @@ public class TaskActionHolder<T>
   }
 
   @JsonProperty
-  public TaskAction<T> getAction()
+  public TaskAction getAction()
   {
     return action;
   }

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/http/OverlordResource.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/http/OverlordResource.java
@@ -39,7 +39,6 @@ import io.druid.indexing.common.TaskStatus;
 import io.druid.indexing.common.actions.TaskActionClient;
 import io.druid.indexing.common.actions.TaskActionHolder;
 import io.druid.indexing.common.task.Task;
-import io.druid.indexing.overlord.RemoteTaskRunner;
 import io.druid.indexing.overlord.TaskMaster;
 import io.druid.indexing.overlord.TaskQueue;
 import io.druid.indexing.overlord.TaskRunner;
@@ -259,7 +258,7 @@ public class OverlordResource
   @POST
   @Path("/action")
   @Produces(MediaType.APPLICATION_JSON)
-  public <T> Response doAction(final TaskActionHolder<T> holder)
+  public Response doAction(final TaskActionHolder holder)
   {
     return asLeaderWith(
         taskMaster.getTaskActionClient(holder.getTask()),
@@ -275,7 +274,7 @@ public class OverlordResource
             // or token that gets passed around.
 
             try {
-              final T ret = taskActionClient.submit(holder.getAction());
+              final Object ret = taskActionClient.submit(holder.getAction());
               retMap = Maps.newHashMap();
               retMap.put("result", ret);
             }


### PR DESCRIPTION
Avoids the following message from being printed on Overlord startup:

```
WARNING: Parameter 1 of type io.druid.indexing.common.actions.TaskActionHolder<T> from
public <T> javax.ws.rs.core.Response io.druid.indexing.overlord.http.OverlordResource.doAction
(io.druid.indexing.common.actions.TaskActionHolder<T>) is not resolvable to a concrete type
```