### PR TITLE
handle null values in In Filter

### DIFF
--- a/processing/src/main/java/io/druid/query/filter/InDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/InDimFilter.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.metamx.common.StringUtils;
@@ -66,7 +67,7 @@ public class InDimFilter implements DimFilter
     int valuesBytesSize = 0;
     int index = 0;
     for (String value : values) {
-      valuesBytes[index] = StringUtils.toUtf8(value);
+      valuesBytes[index] = StringUtils.toUtf8(Strings.nullToEmpty(value));
       valuesBytesSize += valuesBytes[index].length + 1;
       ++index;
     }

--- a/processing/src/test/java/io/druid/query/filter/InDimFilterSerDesrTest.java
+++ b/processing/src/test/java/io/druid/query/filter/InDimFilterSerDesrTest.java
@@ -66,4 +66,11 @@ public class InDimFilterSerDesrTest
     final InDimFilter inDimFilter_2 = new InDimFilter("dimTest", Arrays.asList("good,bad"));
     Assert.assertNotEquals(inDimFilter_1.getCacheKey(), inDimFilter_2.getCacheKey());
   }
+
+  @Test
+  public void testGetCacheKeyNullValue() throws IOException
+  {
+    InDimFilter inDimFilter = mapper.readValue("{\"type\":\"in\",\"dimension\":\"dimTest\",\"values\":[null]}", InDimFilter.class);
+    Assert.assertNotNull(inDimFilter.getCacheKey());
+  }
 }


### PR DESCRIPTION
If the one of the values in the list in `null`, `getCacheKey` throws NPE