### PR TITLE
Remove unnecessary type check in TimeAndDimsComp

### DIFF
--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -1240,26 +1240,6 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
 
       int index = 0;
       while (retVal == 0 && index < numComparisons) {
-        ValueType lhsType = lhs.types[index];
-        ValueType rhsType = rhs.types[index];
-
-        if (lhsType == null) {
-          if (rhsType == null) {
-            ++index;
-            continue;
-          }
-          return -1;
-        }
-
-        if (rhsType == null) {
-          return 1;
-        }
-
-        retVal = lhsType.compareTo(rhsType);
-        if (retVal != 0) {
-          return retVal;
-        }
-
         final int[] lhsIdxs = lhs.dims[index];
         final int[] rhsIdxs = rhs.dims[index];
 


### PR DESCRIPTION
Removes the unnecessary type check in TimeAndDimsComp.

If indexing with a schema, the dimension ordering will not change across rows, so the type check is unneeded.

If doing schemaless indexing, new dimensions will be appended to the dimension ordering. If there are two rows with a different number of dimensions, the ordering of dimensions up to the missing dimensions will be the same.