### PR TITLE
fix calculation of expected timestamp for  ITRealtimeIndexTaskTest query

### DIFF
--- a/integration-tests/src/test/java/io/druid/tests/indexer/ITRealtimeIndexTaskTest.java
+++ b/integration-tests/src/test/java/io/druid/tests/indexer/ITRealtimeIndexTaskTest.java
@@ -81,6 +81,7 @@ public class ITRealtimeIndexTaskTest extends AbstractIndexerTest
   private final DateTimeFormatter TIMESTAMP_FMT = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss'.000Z'");
   private DateTime dtFirst;            // timestamp of 1st event
   private DateTime dtLast;             // timestamp of last event
+  private DateTime dtGroupBy;          // timestamp for expected response for groupBy query
 
   @Inject
   ServerDiscoveryFactory factory;
@@ -130,9 +131,7 @@ public class ITRealtimeIndexTaskTest extends AbstractIndexerTest
           .replace("%%TIMESERIES_RESPONSE_TIMESTAMP%%", TIMESTAMP_FMT.print(dtFirst))
           .replace("%%POST_AG_REQUEST_START%%", INTERVAL_FMT.print(dtFirst))
           .replace("%%POST_AG_REQUEST_END%%", INTERVAL_FMT.print(dtLast.plusMinutes(2)))
-          .replace(
-              "%%POST_AG_RESPONSE_TIMESTAMP%%",
-              TIMESTAMP_FMT.print(dtLast.minusSeconds(24).withSecondOfMinute(0))
+          .replace("%%POST_AG_RESPONSE_TIMESTAMP%%", TIMESTAMP_FMT.print(dtGroupBy.withSecondOfMinute(0))
           );
 
       // should hit the queries all on realtime task or some on realtime task
@@ -215,6 +214,8 @@ public class ITRealtimeIndexTaskTest extends AbstractIndexerTest
       while ((line = reader.readLine()) != null) {
         if (i == 15) { // for the 15th line, use a time before the window
           dt = dt.minusMinutes(10);
+        } else if (i == 16) { // remember this time to use in the expected response from the groupBy query
+          dtGroupBy = dt;
         } else if (i == 18) { // use a time 6 seconds ago so it will be out of order
           dt = dt.minusSeconds(6);
         }


### PR DESCRIPTION
The test RealtimeIndexTaskTest sends 22 events with current timestamps.  It sleeps for 4 seconds between sending the events.

One of the queries it does uses minute granularity and expects to see a response whose timestamp is the minute during which the 16th event was sent.  The test currently computes the expected response timestamp by subtracting 24 seconds (6*4) from the timestamp on the last (22nd) event sent.  Of course, we can't depend on sleep to come back exactly in some number of seconds.  We've seen a test failure where the timestamp on the next to last event was 2016-03-31T01:10:19,997 and the timestamp on the last event was 2016-03-31T01:10:24,004.  This made the test compute the expected timestamp for the 16th event as a second later than the actual timestamp.

To fix this, have the test remember what timestamp it put on the 16th event.
