### PR TITLE
SQLMetadataConnector: Fix overzealous retries that were preventing EntryExistsException from making it out.

### DIFF
--- a/server/src/main/java/io/druid/metadata/SQLMetadataConnector.java
+++ b/server/src/main/java/io/druid/metadata/SQLMetadataConnector.java
@@ -100,7 +100,10 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
 
   public abstract boolean tableExists(Handle handle, final String tableName);
 
-  public <T> T retryWithHandle(final HandleCallback<T> callback)
+  public <T> T retryWithHandle(
+      final HandleCallback<T> callback,
+      final Predicate<Throwable> myShouldRetry
+  )
   {
     final Callable<T> call = new Callable<T>()
     {
@@ -112,11 +115,16 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
     };
     final int maxTries = 10;
     try {
-      return RetryUtils.retry(call, shouldRetry, maxTries);
+      return RetryUtils.retry(call, myShouldRetry, maxTries);
     }
     catch (Exception e) {
       throw Throwables.propagate(e);
     }
+  }
+
+  public <T> T retryWithHandle(final HandleCallback<T> callback)
+  {
+    return retryWithHandle(callback, shouldRetry);
   }
 
   public <T> T retryTransaction(final TransactionCallback<T> callback)
@@ -399,21 +407,24 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
   }
 
   @Override
-  public void createRulesTable() {
+  public void createRulesTable()
+  {
     if (config.get().isCreateTables()) {
       createRulesTable(tablesConfigSupplier.get().getRulesTable());
     }
   }
 
   @Override
-  public void createConfigTable() {
+  public void createConfigTable()
+  {
     if (config.get().isCreateTables()) {
       createConfigTable(tablesConfigSupplier.get().getConfigTable());
     }
   }
 
   @Override
-  public void createTaskTables() {
+  public void createTaskTables()
+  {
     if (config.get().isCreateTables()) {
       final MetadataStorageTablesConfig tablesConfig = tablesConfigSupplier.get();
       final String entryType = tablesConfig.getTaskEntryType();
@@ -502,7 +513,8 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
     );
   }
   @Override
-  public void createAuditTable() {
+  public void createAuditTable()
+  {
     if (config.get().isCreateTables()) {
       createAuditTable(tablesConfigSupplier.get().getAuditTable());
     }

--- a/server/src/test/java/io/druid/metadata/SQLMetadataStorageActionHandlerTest.java
+++ b/server/src/test/java/io/druid/metadata/SQLMetadataStorageActionHandlerTest.java
@@ -32,6 +32,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -40,6 +41,9 @@ public class SQLMetadataStorageActionHandlerTest
 {
   @Rule
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule = new TestDerbyConnector.DerbyConnectorRule();
+
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
 
   private static final ObjectMapper jsonMapper = new DefaultObjectMapper();
   private SQLMetadataStorageActionHandler<Map<String, Integer>, Map<String, Integer>, Map<String, String>, Map<String, Integer>> handler;
@@ -174,6 +178,19 @@ public class SQLMetadataStorageActionHandlerTest
         ImmutableList.of(status1),
         handler.getInactiveStatusesSince(new DateTime("2014-01-01"))
     );
+  }
+
+  @Test(timeout = 10_000L)
+  public void testRepeatInsert() throws Exception
+  {
+    final String entryId = "abcd";
+    Map<String, Integer> entry = ImmutableMap.of("a", 1);
+    Map<String, Integer> status = ImmutableMap.of("count", 42);
+
+    handler.insert(entryId, new DateTime("2014-01-01"), "test", entry, true, status);
+
+    thrown.expect(EntryExistsException.class);
+    handler.insert(entryId, new DateTime("2014-01-01"), "test", entry, true, status);
   }
 
   @Test


### PR DESCRIPTION
backport #2573 

fixes https://github.com/druid-io/druid/issues/2793