### PR TITLE
Move lookup config doc to proper location

### DIFF
--- a/docs/content/development/extensions-core/namespaced-lookup.md
+++ b/docs/content/development/extensions-core/namespaced-lookup.md
@@ -12,10 +12,6 @@ Make sure to [include](../../operations/including-extensions.html) `druid-namesp
 
 ## Configuration
 
-|Property|Description|Default|
-|--------|-----------|-------|
-|`druid.lookup.snapshotWorkingDir`| Working path used to store snapshot of current lookup configuration, leaving this property null will disable snapshot/bootstrap utility|null|
-
 Namespaced lookups are appropriate for lookups which are not possible to pass at query time due to their size, 
 or are not desired to be passed at query time because the data is to reside in and be handled by the Druid servers. 
 Namespaced lookups can be specified as part of the runtime properties file. The property is a list of the namespaces 

--- a/docs/content/querying/lookups.md
+++ b/docs/content/querying/lookups.md
@@ -292,3 +292,12 @@ To configure a Broker / Router / Historical / Peon to announce itself as part of
 |Property | Description | Default |
 |---------|-------------|---------|
 |`druid.lookup.tierName`| The tier for **lookups** for this node. This is independent of other tiers.|`__default`|
+
+
+## Saving configuration across restarts
+
+It is possible to save the configuration across restarts such that a node will not have to wait for coordinator action to re-populate its lookups. To do this the following property is set:
+
+|Property|Description|Default|
+|--------|-----------|-------|
+|`druid.lookup.snapshotWorkingDir`| Working path used to store snapshot of current lookup configuration, leaving this property null will disable snapshot/bootstrap utility|null|


### PR DESCRIPTION
Factory state saving is part of core druid, not an extension.