### PR TITLE
Add missing equals/hashcode to JS, Regex and SearchQuery DimFilters

### DIFF
--- a/processing/src/main/java/io/druid/query/filter/JavaScriptDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/JavaScriptDimFilter.java
@@ -104,4 +104,35 @@ public class JavaScriptDimFilter implements DimFilter
            ", extractionFn='" + extractionFn + '\'' +
            '}';
   }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof JavaScriptDimFilter)) {
+      return false;
+    }
+
+    JavaScriptDimFilter that = (JavaScriptDimFilter) o;
+
+    if (!dimension.equals(that.dimension)) {
+      return false;
+    }
+    if (!function.equals(that.function)) {
+      return false;
+    }
+    return extractionFn != null ? extractionFn.equals(that.extractionFn) : that.extractionFn == null;
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = dimension.hashCode();
+    result = 31 * result + function.hashCode();
+    result = 31 * result + (extractionFn != null ? extractionFn.hashCode() : 0);
+    return result;
+  }
 }

--- a/processing/src/main/java/io/druid/query/filter/RegexDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/RegexDimFilter.java
@@ -106,4 +106,35 @@ public class RegexDimFilter implements DimFilter
            ", extractionFn='" + extractionFn + '\'' +
            '}';
   }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof RegexDimFilter)) {
+      return false;
+    }
+
+    RegexDimFilter that = (RegexDimFilter) o;
+
+    if (!dimension.equals(that.dimension)) {
+      return false;
+    }
+    if (!pattern.equals(that.pattern)) {
+      return false;
+    }
+    return extractionFn != null ? extractionFn.equals(that.extractionFn) : that.extractionFn == null;
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = dimension.hashCode();
+    result = 31 * result + pattern.hashCode();
+    result = 31 * result + (extractionFn != null ? extractionFn.hashCode() : 0);
+    return result;
+  }
 }

--- a/processing/src/main/java/io/druid/query/filter/SearchQueryDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/SearchQueryDimFilter.java
@@ -106,4 +106,35 @@ public class SearchQueryDimFilter implements DimFilter
            ", extractionFn='" + extractionFn + '\'' +
            '}';
   }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof SearchQueryDimFilter)) {
+      return false;
+    }
+
+    SearchQueryDimFilter that = (SearchQueryDimFilter) o;
+
+    if (!dimension.equals(that.dimension)) {
+      return false;
+    }
+    if (!query.equals(that.query)) {
+      return false;
+    }
+    return extractionFn != null ? extractionFn.equals(that.extractionFn) : that.extractionFn == null;
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = dimension.hashCode();
+    result = 31 * result + query.hashCode();
+    result = 31 * result + (extractionFn != null ? extractionFn.hashCode() : 0);
+    return result;
+  }
 }

--- a/processing/src/test/java/io/druid/query/filter/JavaScriptDimFilterTest.java
+++ b/processing/src/test/java/io/druid/query/filter/JavaScriptDimFilterTest.java
@@ -39,4 +39,36 @@ public class JavaScriptDimFilterTest
     JavaScriptDimFilter javaScriptDimFilter3 = new JavaScriptDimFilter("dim", "fn", regexFn);
     Assert.assertFalse(Arrays.equals(javaScriptDimFilter.getCacheKey(), javaScriptDimFilter3.getCacheKey()));
   }
+
+  @Test
+  public void testEquals()
+  {
+    JavaScriptDimFilter javaScriptDimFilter = new JavaScriptDimFilter("dim", "fn", null);
+    JavaScriptDimFilter javaScriptDimFilter2 = new JavaScriptDimFilter("di", "mfn", null);
+    JavaScriptDimFilter javaScriptDimFilter3 = new JavaScriptDimFilter("di", "mfn", null);
+    Assert.assertNotEquals(javaScriptDimFilter, javaScriptDimFilter2);
+    Assert.assertEquals(javaScriptDimFilter2, javaScriptDimFilter3);
+
+    RegexDimExtractionFn regexFn = new RegexDimExtractionFn(".*", false, null);
+    JavaScriptDimFilter javaScriptDimFilter4 = new JavaScriptDimFilter("dim", "fn", regexFn);
+    JavaScriptDimFilter javaScriptDimFilter5 = new JavaScriptDimFilter("dim", "fn", regexFn);
+    Assert.assertNotEquals(javaScriptDimFilter, javaScriptDimFilter3);
+    Assert.assertEquals(javaScriptDimFilter4, javaScriptDimFilter5);
+  }
+
+  @Test
+  public void testHashcode()
+  {
+    JavaScriptDimFilter javaScriptDimFilter = new JavaScriptDimFilter("dim", "fn", null);
+    JavaScriptDimFilter javaScriptDimFilter2 = new JavaScriptDimFilter("di", "mfn", null);
+    JavaScriptDimFilter javaScriptDimFilter3 = new JavaScriptDimFilter("di", "mfn", null);
+    Assert.assertNotEquals(javaScriptDimFilter.hashCode(), javaScriptDimFilter2.hashCode());
+    Assert.assertEquals(javaScriptDimFilter2.hashCode(), javaScriptDimFilter3.hashCode());
+
+    RegexDimExtractionFn regexFn = new RegexDimExtractionFn(".*", false, null);
+    JavaScriptDimFilter javaScriptDimFilter4 = new JavaScriptDimFilter("dim", "fn", regexFn);
+    JavaScriptDimFilter javaScriptDimFilter5 = new JavaScriptDimFilter("dim", "fn", regexFn);
+    Assert.assertNotEquals(javaScriptDimFilter.hashCode(), javaScriptDimFilter3.hashCode());
+    Assert.assertEquals(javaScriptDimFilter4.hashCode(), javaScriptDimFilter5.hashCode());
+  }
 }

--- a/processing/src/test/java/io/druid/query/filter/RegexDimFilterTest.java
+++ b/processing/src/test/java/io/druid/query/filter/RegexDimFilterTest.java
@@ -40,4 +40,39 @@ public class RegexDimFilterTest
     Assert.assertFalse(Arrays.equals(regexDimFilter.getCacheKey(), regexDimFilter3.getCacheKey()));
 
   }
+
+  @Test
+  public void testEquals()
+  {
+    RegexDimFilter regexDimFilter = new RegexDimFilter("dim", "reg", null);
+    RegexDimFilter regexDimFilter2 = new RegexDimFilter("di", "mreg", null);
+    RegexDimFilter regexDimFilter3 = new RegexDimFilter("di", "mreg", null);
+
+    Assert.assertNotEquals(regexDimFilter, regexDimFilter2);
+    Assert.assertEquals(regexDimFilter2, regexDimFilter3);
+
+    RegexDimExtractionFn regexFn = new RegexDimExtractionFn(".*", false, null);
+    RegexDimFilter regexDimFilter4 = new RegexDimFilter("dim", "reg", regexFn);
+    RegexDimFilter regexDimFilter5 = new RegexDimFilter("dim", "reg", regexFn);
+    Assert.assertNotEquals(regexDimFilter, regexDimFilter4);
+    Assert.assertEquals(regexDimFilter4, regexDimFilter5);
+
+  }
+
+  @Test
+  public void testHashcode() {
+    RegexDimFilter regexDimFilter = new RegexDimFilter("dim", "reg", null);
+    RegexDimFilter regexDimFilter2 = new RegexDimFilter("di", "mreg", null);
+    RegexDimFilter regexDimFilter3 = new RegexDimFilter("di", "mreg", null);
+
+    Assert.assertNotEquals(regexDimFilter.hashCode(), regexDimFilter2.hashCode());
+    Assert.assertEquals(regexDimFilter2.hashCode(), regexDimFilter3.hashCode());
+
+    RegexDimExtractionFn regexFn = new RegexDimExtractionFn(".*", false, null);
+    RegexDimFilter regexDimFilter4 = new RegexDimFilter("dim", "reg", regexFn);
+    RegexDimFilter regexDimFilter5 = new RegexDimFilter("dim", "reg", regexFn);
+    Assert.assertNotEquals(regexDimFilter.hashCode(), regexDimFilter4.hashCode());
+    Assert.assertEquals(regexDimFilter4.hashCode(), regexDimFilter5.hashCode());
+  }
+
 }

--- a/processing/src/test/java/io/druid/query/filter/SearchQueryDimFilterTest.java
+++ b/processing/src/test/java/io/druid/query/filter/SearchQueryDimFilterTest.java
@@ -93,4 +93,132 @@ public class SearchQueryDimFilterTest
     );
     Assert.assertFalse(Arrays.equals(searchQueryDimFilter.getCacheKey(), searchQueryDimFilter3.getCacheKey()));
   }
+
+  @Test
+  public void testEquals()
+  {
+    SearchQueryDimFilter searchQueryDimFilter = new SearchQueryDimFilter(
+        "dim",
+        new SearchQuerySpec()
+        {
+          @Override
+          public boolean accept(String dimVal)
+          {
+            return false;
+          }
+
+          @Override
+          public byte[] getCacheKey()
+          {
+            return StringUtils.toUtf8("value");
+          }
+        },
+        null
+    );
+
+    SearchQueryDimFilter searchQueryDimFilter2 = new SearchQueryDimFilter(
+        "di",
+        new SearchQuerySpec()
+        {
+          @Override
+          public boolean accept(String dimVal)
+          {
+            return false;
+          }
+
+          @Override
+          public byte[] getCacheKey()
+          {
+            return StringUtils.toUtf8("mvalue");
+          }
+        },
+        null
+    );
+    Assert.assertNotEquals(searchQueryDimFilter, searchQueryDimFilter2);
+
+    RegexDimExtractionFn regexFn = new RegexDimExtractionFn(".*", false, null);
+    SearchQueryDimFilter searchQueryDimFilter3 = new SearchQueryDimFilter(
+        "dim",
+        new SearchQuerySpec()
+        {
+          @Override
+          public boolean accept(String dimVal)
+          {
+            return false;
+          }
+
+          @Override
+          public byte[] getCacheKey()
+          {
+            return StringUtils.toUtf8("value");
+          }
+        },
+        regexFn
+    );
+    Assert.assertNotEquals(searchQueryDimFilter, searchQueryDimFilter3);
+  }
+
+  @Test
+  public void testHashcode()
+  {
+    SearchQueryDimFilter searchQueryDimFilter = new SearchQueryDimFilter(
+        "dim",
+        new SearchQuerySpec()
+        {
+          @Override
+          public boolean accept(String dimVal)
+          {
+            return false;
+          }
+
+          @Override
+          public byte[] getCacheKey()
+          {
+            return StringUtils.toUtf8("value");
+          }
+        },
+        null
+    );
+
+    SearchQueryDimFilter searchQueryDimFilter2 = new SearchQueryDimFilter(
+        "di",
+        new SearchQuerySpec()
+        {
+          @Override
+          public boolean accept(String dimVal)
+          {
+            return false;
+          }
+
+          @Override
+          public byte[] getCacheKey()
+          {
+            return StringUtils.toUtf8("mvalue");
+          }
+        },
+        null
+    );
+    Assert.assertNotEquals(searchQueryDimFilter.hashCode(), searchQueryDimFilter2.hashCode());
+
+    RegexDimExtractionFn regexFn = new RegexDimExtractionFn(".*", false, null);
+    SearchQueryDimFilter searchQueryDimFilter3 = new SearchQueryDimFilter(
+        "dim",
+        new SearchQuerySpec()
+        {
+          @Override
+          public boolean accept(String dimVal)
+          {
+            return false;
+          }
+
+          @Override
+          public byte[] getCacheKey()
+          {
+            return StringUtils.toUtf8("value");
+          }
+        },
+        regexFn
+    );
+    Assert.assertNotEquals(searchQueryDimFilter.hashCode(), searchQueryDimFilter3.hashCode());
+  }
 }


### PR DESCRIPTION
 I saw that some of the DimFilters implement equals/hashcode, but others didn't. 
This commits adds missing equals() and hashcode() methods to the JavascriptDimFilter, RegexDimFilter and the SearchQueryDimFilter, plus tests for those filters.