### PR TITLE
fix test failure

### DIFF
--- a/server/src/test/java/io/druid/initialization/InitializationTest.java
+++ b/server/src/test/java/io/druid/initialization/InitializationTest.java
@@ -194,7 +194,8 @@ public class InitializationTest
     Assert.assertArrayEquals(
         "Non-exist root extensionsDir should return an empty array of File",
         new File[]{},
-        Initialization.getExtensionFilesToLoad(new ExtensionsConfig(){
+        Initialization.getExtensionFilesToLoad(new ExtensionsConfig()
+        {
           @Override
           public String getDirectory()
           {
@@ -414,17 +415,15 @@ public class InitializationTest
                 + File.pathSeparator
                 + tmpDir2.getAbsolutePath() + File.separator + "*";
 
-    List<URL> expected = ImmutableList.<URL>builder()
-                                      .add(tmpDir1a.toURI().toURL())
-                                      .add(tmpDir1b.toURI().toURL())
-                                      .add(tmpDir3.toURI().toURL())
-                                      .add(tmpDir2c.toURI().toURL())
-                                      .add(tmpDir2d.toURI().toURL())
-                                      .add(tmpDir2e.toURI().toURL())
-                                      .build();
+    // getURLsForClasspath uses listFiles which does NOT guarantee any ordering for the name strings.
+    List<URL> urLsForClasspath = Initialization.getURLsForClasspath(cp);
+    Assert.assertEquals(Sets.newHashSet(tmpDir1a.toURI().toURL(), tmpDir1b.toURI().toURL()),
+                        Sets.newHashSet(urLsForClasspath.subList(0, 2)));
+    Assert.assertEquals(tmpDir3.toURI().toURL(), urLsForClasspath.get(2));
+    Assert.assertEquals(Sets.newHashSet(tmpDir2c.toURI().toURL(), tmpDir2d.toURI().toURL(), tmpDir2e.toURI().toURL()),
+                        Sets.newHashSet(urLsForClasspath.subList(3, 6)));
 
 
-    Assert.assertEquals(expected, Initialization.getURLsForClasspath(cp));
   }
 
   public static class TestDruidModule implements DruidModule


### PR DESCRIPTION
faced this on one build machine - 
Stack trace for failure - 
```
testGetURLsForClasspath(io.druid.initialization.InitializationTest)  Time elapsed: 0.005 sec  <<< FAILURE!
java.lang.AssertionError: expected:<[file:/tmp/junit8239382685391326532/junit7107855072822041723/a.jar, file:/tmp/junit8239382685391326532/junit7107855072822041723/b.jar, file:/tmp/junit8239382685391326532/junit9023400287923209794/, file:/tmp/junit8239382685391326532/junit2560840224131288597/c.jar, file:/tmp/junit8239382685391326532/junit2560840224131288597/d.jar, file:/tmp/junit8239382685391326532/junit2560840224131288597/e.JAR]> but was:<[file:/tmp/junit8239382685391326532/junit7107855072822041723/b.jar, file:/tmp/junit8239382685391326532/junit7107855072822041723/a.jar, file:/tmp/junit8239382685391326532/junit9023400287923209794/, file:/tmp/junit8239382685391326532/junit2560840224131288597/c.jar, file:/tmp/junit8239382685391326532/junit2560840224131288597/e.JAR, file:/tmp/junit8239382685391326532/junit2560840224131288597/d.jar]>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:743)
	at org.junit.Assert.assertEquals(Assert.java:118)
	at org.junit.Assert.assertEquals(Assert.java:144)
	at io.druid.initialization.InitializationTest.testGetURLsForClasspath(InitializationTest.java:427)
```