### PR TITLE
Document how to use roaring bitmaps

### DIFF
--- a/docs/content/ingestion/batch-ingestion.md
+++ b/docs/content/ingestion/batch-ingestion.md
@@ -191,9 +191,9 @@ The following properties can be used to tune how the MapReduce job is configured
 
 |Field|Type|Description|Required|
 |-----|----|-----------|--------|
-|bitmap|String|The type of bitmap indexes to create. Set to `roaring` to use Roaring Bitmaps. Set to `concise` to use Concise bitmaps.|no (default = concise)|
-|dimensionCompression|String|The compression type for dimension columns. Choose from `LZ4`, `LZF` or `uncompressed`.|no (default = LZ4)|
-|metricCompression|String|The compression type for metric columns. Choose from `LZ4`, `LZF` or `uncompressed`.|no (default = LZ4)|
+|bitmap|String|The type of bitmap index to create. Choose from `roaring` or `concise`, or null to use the default (`concise`).|No|
+|dimensionCompression|String|Compression format for dimension columns. Choose from `LZ4`, `LZF`, or `uncompressed`. `The default is LZ4`.|No|
+|metricCompression|String|Compression format for dimension columns. Choose from `LZ4`, `LZF`, or `uncompressed`. `The default is LZ4`.|No|
 
 ### Partitioning specification
 

--- a/docs/content/ingestion/batch-ingestion.md
+++ b/docs/content/ingestion/batch-ingestion.md
@@ -192,8 +192,8 @@ The following properties can be used to tune how the MapReduce job is configured
 |Field|Type|Description|Required|
 |-----|----|-----------|--------|
 |bitmap|String|The type of bitmap index to create. Choose from `roaring` or `concise`, or null to use the default (`concise`).|No|
-|dimensionCompression|String|Compression format for dimension columns. Choose from `LZ4`, `LZF`, or `uncompressed`. `The default is LZ4`.|No|
-|metricCompression|String|Compression format for dimension columns. Choose from `LZ4`, `LZF`, or `uncompressed`. `The default is LZ4`.|No|
+|dimensionCompression|String|Compression format for dimension columns. Choose from `LZ4`, `LZF`, or `uncompressed`. The default is `LZ4`.|No|
+|metricCompression|String|Compression format for dimension columns. Choose from `LZ4`, `LZF`, or `uncompressed`. The default is `LZ4`.|No|
 
 ### Partitioning specification
 

--- a/docs/content/ingestion/batch-ingestion.md
+++ b/docs/content/ingestion/batch-ingestion.md
@@ -193,7 +193,7 @@ The following properties can be used to tune how the MapReduce job is configured
 |-----|----|-----------|--------|
 |bitmap|String|The type of bitmap index to create. Choose from `roaring` or `concise`, or null to use the default (`concise`).|No|
 |dimensionCompression|String|Compression format for dimension columns. Choose from `LZ4`, `LZF`, or `uncompressed`. The default is `LZ4`.|No|
-|metricCompression|String|Compression format for dimension columns. Choose from `LZ4`, `LZF`, or `uncompressed`. The default is `LZ4`.|No|
+|metricCompression|String|Compression format for metric columns. Choose from `LZ4`, `LZF`, or `uncompressed`. The default is `LZ4`.|No|
 
 ### Partitioning specification
 

--- a/docs/content/ingestion/batch-ingestion.md
+++ b/docs/content/ingestion/batch-ingestion.md
@@ -162,6 +162,7 @@ The tuningConfig is optional and default parameters will be used if no tuningCon
 |combineText|Boolean|Use CombineTextInputFormat to combine multiple files into a file split. This can speed up Hadoop jobs when processing a large number of small files.|no (default == false)|
 |useCombiner|Boolean|Use Hadoop combiner to merge rows at mapper if possible.|no (default == false)|
 |jobProperties|Object|A map of properties to add to the Hadoop job configuration, see below for details.|no (default == null)|
+|indexSpec|Object|Tune how data is indexed. See below for more information.|no|
 |buildV9Directly|Boolean|Build v9 index directly instead of building v8 index and converting it to v9 format.|no (default = false)|
 |numBackgroundPersistThreads|Integer|The number of new background threads to use for incremental persists. Using this feature causes a notable increase in memory pressure and cpu usage but will make the job finish more quickly. If changing from the default of 0 (use current thread for persists), we recommend setting it to 1.|no (default == 0)|
 
@@ -185,6 +186,14 @@ The following properties can be used to tune how the MapReduce job is configured
 |...|String|See [Mapred configuration](https://hadoop.apache.org/docs/stable/hadoop-mapreduce-client/hadoop-mapreduce-client-core/mapred-default.xml) for more configuration parameters.|
 
 **Please note that using `mapreduce.job.user.classpath.first` is an expert feature and should not be used without a deep understanding of Hadoop and Java class loading mechanism.**
+
+#### IndexSpec
+
+|Field|Type|Description|Required|
+|-----|----|-----------|--------|
+|bitmap|String|The type of bitmap indexes to create. Set to `roaring` to use Roaring Bitmaps. Set to `concise` to use Concise bitmaps.|no (default = concise)|
+|dimensionCompression|String|The compression type for dimension columns. Choose from `LZ4`, `LZF` or `uncompressed`.|no (default = LZ4)|
+|metricCompression|String|The compression type for metric columns. Choose from `LZ4`, `LZF` or `uncompressed`.|no (default = LZ4)|
 
 ### Partitioning specification
 

--- a/docs/content/ingestion/stream-pull.md
+++ b/docs/content/ingestion/stream-pull.md
@@ -99,6 +99,9 @@ The property `druid.realtime.specFile` has the path of a file (absolute or relat
       "basePersistDirectory": "\/tmp\/realtime\/basePersist",
       "rejectionPolicy": {
         "type": "serverTime"
+      },
+      "indexSpec": {
+         "bitmap":"roaring"
       }
     }
   }
@@ -155,6 +158,9 @@ The tuningConfig is optional and default parameters will be used if no tuningCon
 |mergeThreadPriority|int|If `-XX:+UseThreadPriorities` is properly enabled, this will set the thread priority of the merging thread to `Thread.NORM_PRIORITY` plus this value within the bounds of `Thread.MIN_PRIORITY` and `Thread.MAX_PRIORITY`. A value of 0 indicates to not change the thread priority.|no (default = 0; inherit and do not override)|
 |reportParseExceptions|Boolean|If true, exceptions encountered during parsing will be thrown and will halt ingestion. If false, unparseable rows and fields will be skipped. If an entire row is skipped, the "unparseable" counter will be incremented. If some fields in a row were parseable and some were not, the parseable fields will be indexed and the "unparseable" counter will not be incremented.|false|
 |handoffConditionTimeout|long|Milliseconds to wait for segment handoff. It must be >= 0 and 0 means wait forerver.|0|
+|indexSpec|Object|Tune how data is indexed. See below for more information.|no|
+|reportParseExceptions|Boolean|If true, exceptions encountered during parsing will be thrown and will halt ingestion. If false, unparseable rows and fields will be skipped. If an entire row is skipped, the "unparseable" counter will be incremented. If some fields in a row were parseable and some were not, the parseable fields will be indexed and the "unparseable" counter will not be incremented.|false|
+|handoffConditionTimeout|long|Milliseconds to wait for segment handoff. It must be >= 0 and 0 means wait forerver.|0|
 
 Before enabling thread priority settings, users are highly encouraged to read the [original pull request](https://github.com/druid-io/druid/pull/984) and other documentation about proper use of `-XX:+UseThreadPriorities`. 
 
@@ -166,6 +172,13 @@ The following policies are available:
 * `messageTime` &ndash; Can be used for non-"current time" as long as that data is relatively in sequence. Events are rejected if they are less than `windowPeriod` from the event with the latest timestamp. Hand off only occurs if an event is seen after the segmentGranularity and `windowPeriod` (hand off will not periodically occur unless you have a constant stream of data).
 * `none` &ndash; All events are accepted. Never hands off data unless shutdown() is called on the configured firehose.
 
+### Index Spec
+
+|Field|Type|Description|Required|
+|-----|----|-----------|--------|
+|bitmap|string|type of bitmap to use (e.g. roaring or concise), null to use the default.Defaults to the bitmap type specified by the (deprecated) "druid.processing.bitmap.type" setting| No|
+|dimensionCompression|string|compression format for dimension columns. The default, null, means no compression|No|
+|metricCompression|string|compression format for metric columns, null to use the default.|No|
 
 #### Sharding
 

--- a/docs/content/ingestion/stream-pull.md
+++ b/docs/content/ingestion/stream-pull.md
@@ -93,15 +93,12 @@ The property `druid.realtime.specFile` has the path of a file (absolute or relat
     },
     "tuningConfig": {
       "type" : "realtime",
-      "maxRowsInMemory": 500000,
+      "maxRowsInMemory": 75000,
       "intermediatePersistPeriod": "PT10m",
       "windowPeriod": "PT10m",
       "basePersistDirectory": "\/tmp\/realtime\/basePersist",
       "rejectionPolicy": {
         "type": "serverTime"
-      },
-      "indexSpec": {
-         "bitmap":"roaring"
       }
     }
   }

--- a/docs/content/ingestion/stream-pull.md
+++ b/docs/content/ingestion/stream-pull.md
@@ -156,8 +156,6 @@ The tuningConfig is optional and default parameters will be used if no tuningCon
 |reportParseExceptions|Boolean|If true, exceptions encountered during parsing will be thrown and will halt ingestion. If false, unparseable rows and fields will be skipped. If an entire row is skipped, the "unparseable" counter will be incremented. If some fields in a row were parseable and some were not, the parseable fields will be indexed and the "unparseable" counter will not be incremented.|false|
 |handoffConditionTimeout|long|Milliseconds to wait for segment handoff. It must be >= 0 and 0 means wait forerver.|0|
 |indexSpec|Object|Tune how data is indexed. See below for more information.|no|
-|reportParseExceptions|Boolean|If true, exceptions encountered during parsing will be thrown and will halt ingestion. If false, unparseable rows and fields will be skipped. If an entire row is skipped, the "unparseable" counter will be incremented. If some fields in a row were parseable and some were not, the parseable fields will be indexed and the "unparseable" counter will not be incremented.|false|
-|handoffConditionTimeout|long|Milliseconds to wait for segment handoff. It must be >= 0 and 0 means wait forerver.|0|
 
 Before enabling thread priority settings, users are highly encouraged to read the [original pull request](https://github.com/druid-io/druid/pull/984) and other documentation about proper use of `-XX:+UseThreadPriorities`. 
 
@@ -173,9 +171,9 @@ The following policies are available:
 
 |Field|Type|Description|Required|
 |-----|----|-----------|--------|
-|bitmap|string|type of bitmap to use (e.g. roaring or concise), null to use the default.Defaults to the bitmap type specified by the (deprecated) "druid.processing.bitmap.type" setting| No|
-|dimensionCompression|string|compression format for dimension columns. The default, null, means no compression|No|
-|metricCompression|string|compression format for metric columns, null to use the default.|No|
+|bitmap|String|The type of bitmap index to create. Choose from `roaring` or `concise`, or null to use the default (`concise`).|No|
+|dimensionCompression|String|Compression format for dimension columns. Choose from `LZ4`, `LZF`, or `uncompressed`. `The default is LZ4`.|No|
+|metricCompression|String|Compression format for dimension columns. Choose from `LZ4`, `LZF`, or `uncompressed`. `The default is LZ4`.|No|
 
 #### Sharding
 

--- a/docs/content/ingestion/stream-pull.md
+++ b/docs/content/ingestion/stream-pull.md
@@ -173,7 +173,7 @@ The following policies are available:
 |-----|----|-----------|--------|
 |bitmap|String|The type of bitmap index to create. Choose from `roaring` or `concise`, or null to use the default (`concise`).|No|
 |dimensionCompression|String|Compression format for dimension columns. Choose from `LZ4`, `LZF`, or `uncompressed`. The default is `LZ4`.|No|
-|metricCompression|String|Compression format for dimension columns. Choose from `LZ4`, `LZF`, or `uncompressed`. The default is `LZ4`.|No|
+|metricCompression|String|Compression format for metric columns. Choose from `LZ4`, `LZF`, or `uncompressed`. The default is `LZ4`.|No|
 
 #### Sharding
 

--- a/docs/content/ingestion/stream-pull.md
+++ b/docs/content/ingestion/stream-pull.md
@@ -172,8 +172,8 @@ The following policies are available:
 |Field|Type|Description|Required|
 |-----|----|-----------|--------|
 |bitmap|String|The type of bitmap index to create. Choose from `roaring` or `concise`, or null to use the default (`concise`).|No|
-|dimensionCompression|String|Compression format for dimension columns. Choose from `LZ4`, `LZF`, or `uncompressed`. `The default is LZ4`.|No|
-|metricCompression|String|Compression format for dimension columns. Choose from `LZ4`, `LZF`, or `uncompressed`. `The default is LZ4`.|No|
+|dimensionCompression|String|Compression format for dimension columns. Choose from `LZ4`, `LZF`, or `uncompressed`. The default is `LZ4`.|No|
+|metricCompression|String|Compression format for dimension columns. Choose from `LZ4`, `LZF`, or `uncompressed`. The default is `LZ4`.|No|
 
 #### Sharding
 

--- a/processing/src/main/java/io/druid/segment/IndexSpec.java
+++ b/processing/src/main/java/io/druid/segment/IndexSpec.java
@@ -81,7 +81,8 @@ public class IndexSpec
    *                           Defaults to the bitmap type specified by the (deprecated) "druid.processing.bitmap.type"
    *                           setting, or, if none was set, uses the default @{link BitmapSerde.DefaultBitmapSerdeFactory}
    *
-   * @param dimensionCompression compression format for dimension columns. The default, null, means no compression
+   * @param dimensionCompression compression format for dimension columns, null to use the default
+   *                             Defaults to @{link CompressedObjectStrategy.DEFAULT_COMPRESSION_STRATEGY}
    *
    * @param metricCompression compression format for metric columns, null to use the default.
    *                          Defaults to @{link CompressedObjectStrategy.DEFAULT_COMPRESSION_STRATEGY}


### PR DESCRIPTION
This fixes #2408.
While not all indexSpec properties are explained, it does explain how roaring bitmaps can be turned on.