### PR TITLE
make singleThreaded groupBy query config overridable at query time

### DIFF
--- a/docs/content/configuration/broker.md
+++ b/docs/content/configuration/broker.md
@@ -67,7 +67,6 @@ The broker uses processing configs for nested groupBy queries. And, optionally, 
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.query.groupBy.singleThreaded`|Run single threaded group By queries.|false|
 |`druid.query.groupBy.maxIntermediateRows`|Maximum number of intermediate rows. This can be lowered at query time by `maxIntermediateRows` attribute in query context.|50000|
 |`druid.query.groupBy.maxResults`|Maximum number of results.  This can be lowered at query time by `maxResults` attribute in query context.|500000|
 

--- a/docs/content/querying/query-context.md
+++ b/docs/content/querying/query-context.md
@@ -20,4 +20,5 @@ The query context is used for various query configuration parameters.
 |minTopNThreshold | `1000`              | The top minTopNThreshold local results from each segment are returned for merging to determine the global topN. |
 |`maxResults`|500000|Maximum number of results groupBy query can process. Default value used can be changed by `druid.query.groupBy.maxResults` in druid configuration at broker and historical nodes. At query time you can only lower the value.|
 |`maxIntermediateRows`|50000|Maximum number of intermediate rows while processing single segment for groupBy query. Default value used can be changed by `druid.query.groupBy.maxIntermediateRows` in druid configuration at broker and historical nodes. At query time you can only lower the value.|
+|`groupByIsSingleThreaded`|false|Whether to run single threaded group By queries. Default value used can be changed by `druid.query.groupBy.singleThreaded` in druid configuration at historical nodes.|
 

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryRunnerFactory.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryRunnerFactory.java
@@ -19,45 +19,28 @@
 
 package io.druid.query.groupby;
 
-import com.google.common.base.Function;
 import com.google.common.base.Supplier;
-import com.google.common.base.Throwables;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
 import com.metamx.common.ISE;
-import com.metamx.common.Pair;
-import com.metamx.common.guava.Accumulator;
 import com.metamx.common.guava.Sequence;
-import com.metamx.common.guava.Sequences;
 import com.metamx.common.logger.Logger;
 import io.druid.collections.StupidPool;
 import io.druid.data.input.Row;
 import io.druid.guice.annotations.Global;
-import io.druid.query.AbstractPrioritizedCallable;
-import io.druid.query.BaseQuery;
-import io.druid.query.ConcatQueryRunner;
-import io.druid.query.GroupByParallelQueryRunner;
+import io.druid.query.GroupByMergedQueryRunner;
 import io.druid.query.Query;
-import io.druid.query.QueryContextKeys;
-import io.druid.query.QueryInterruptedException;
 import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerFactory;
 import io.druid.query.QueryToolChest;
 import io.druid.query.QueryWatcher;
 import io.druid.segment.Segment;
 import io.druid.segment.StorageAdapter;
-import io.druid.segment.incremental.IncrementalIndex;
 
 import java.nio.ByteBuffer;
 import java.util.Map;
-import java.util.Queue;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  */
@@ -97,94 +80,7 @@ public class GroupByQueryRunnerFactory implements QueryRunnerFactory<Row, GroupB
   {
     // mergeRunners should take ListeningExecutorService at some point
     final ListeningExecutorService queryExecutor = MoreExecutors.listeningDecorator(exec);
-
-    if (config.get().isSingleThreaded()) {
-      return new ConcatQueryRunner<>(
-          Sequences.map(
-              Sequences.simple(queryRunners),
-              new Function<QueryRunner<Row>, QueryRunner<Row>>()
-              {
-                @Override
-                public QueryRunner<Row> apply(final QueryRunner<Row> input)
-                {
-                  return new QueryRunner<Row>()
-                  {
-                    @Override
-                    public Sequence<Row> run(final Query<Row> query, final Map<String, Object> responseContext)
-                    {
-                      final GroupByQuery queryParam = (GroupByQuery) query;
-                      final Pair<IncrementalIndex, Accumulator<IncrementalIndex, Row>> indexAccumulatorPair = GroupByQueryHelper
-                          .createIndexAccumulatorPair(
-                              queryParam,
-                              config.get(),
-                              computationBufferPool
-                          );
-                      final Pair<Queue, Accumulator<Queue, Row>> bySegmentAccumulatorPair = GroupByQueryHelper.createBySegmentAccumulatorPair();
-                      final int priority = BaseQuery.getContextPriority(query, 0);
-                      final boolean bySegment = BaseQuery.getContextBySegment(query, false);
-
-                      final ListenableFuture<Void> future = queryExecutor.submit(
-                          new AbstractPrioritizedCallable<Void>(priority)
-                          {
-                            @Override
-                            public Void call() throws Exception
-                            {
-                              if (bySegment) {
-                                input.run(queryParam, responseContext)
-                                     .accumulate(
-                                         bySegmentAccumulatorPair.lhs,
-                                         bySegmentAccumulatorPair.rhs
-                                     );
-                              } else {
-                                input.run(query, responseContext)
-                                     .accumulate(indexAccumulatorPair.lhs, indexAccumulatorPair.rhs);
-                              }
-
-                              return null;
-                            }
-                          }
-                      );
-                      try {
-                        queryWatcher.registerQuery(query, future);
-                        final Number timeout = query.getContextValue(QueryContextKeys.TIMEOUT, (Number) null);
-                        if (timeout == null) {
-                          future.get();
-                        } else {
-                          future.get(timeout.longValue(), TimeUnit.MILLISECONDS);
-                        }
-                      }
-                      catch (InterruptedException e) {
-                        log.warn(e, "Query interrupted, cancelling pending results, query id [%s]", query.getId());
-                        future.cancel(true);
-                        throw new QueryInterruptedException(e);
-                      }
-                      catch (CancellationException e) {
-                        throw new QueryInterruptedException(e);
-                      }
-                      catch (TimeoutException e) {
-                        log.info("Query timeout, cancelling pending results for query id [%s]", query.getId());
-                        future.cancel(true);
-                        throw new QueryInterruptedException(e);
-                      }
-                      catch (ExecutionException e) {
-                        throw Throwables.propagate(e.getCause());
-                      }
-
-                      if (bySegment) {
-                        return Sequences.simple(bySegmentAccumulatorPair.lhs);
-                      }
-
-                      return Sequences.simple(indexAccumulatorPair.lhs.iterableWithPostAggregations(null, query.isDescending()));
-                    }
-                  };
-                }
-              }
-          )
-      );
-    } else {
-
-      return new GroupByParallelQueryRunner(queryExecutor, config, queryWatcher, computationBufferPool, queryRunners);
-    }
+    return new GroupByMergedQueryRunner(queryExecutor, config, queryWatcher, computationBufferPool, queryRunners);
   }
 
   @Override


### PR DESCRIPTION
some users found that you get better throughput by using singleThreaded processing for small groupBy queries while parallel for large groupBy queries. this allows both to be used appropriately when user knows how much data groupBy query is going to process. also, this allows rapid benchmarking for both on same cluster and data.