### PR TITLE
Fix NPE in TopNLexicographicResultBuilder.addEntry()

### DIFF
--- a/processing/src/main/java/io/druid/query/topn/TopNLexicographicResultBuilder.java
+++ b/processing/src/main/java/io/druid/query/topn/TopNLexicographicResultBuilder.java
@@ -131,7 +131,7 @@ public class TopNLexicographicResultBuilder implements TopNResultBuilder
   public TopNResultBuilder addEntry(DimensionAndMetricValueExtractor dimensionAndMetricValueExtractor)
   {
     Object dimensionValueObj = dimensionAndMetricValueExtractor.getDimensionValue(dimSpec.getOutputName());
-    String dimensionValue = dimensionValueObj.toString();
+    String dimensionValue = dimensionValueObj == null ? null : dimensionValueObj.toString();
 
     if (shouldAdd(dimensionValue)) {
       pQueue.add(


### PR DESCRIPTION
Fixes an NPE introduced in https://github.com/druid-io/druid/pull/2607
