### PR TITLE
Fix performance regression from #2753 in IndexMerger

### DIFF
--- a/processing/src/main/java/io/druid/segment/IndexMerger.java
+++ b/processing/src/main/java/io/druid/segment/IndexMerger.java
@@ -946,9 +946,6 @@ public class IndexMerger
           }
 
           MutableBitmap bitset = bitmapSerdeFactory.getBitmapFactory().makeEmptyMutableBitmap();
-          if ((dictId == 0) && (Iterables.getFirst(dimVals, "") == null)) {
-            bitset.or(nullRowsList.get(i));
-          }
           for (Integer row : CombiningIterable.createSplatted(
               convertedInverteds,
               Ordering.<Integer>natural().nullsFirst()
@@ -956,6 +953,10 @@ public class IndexMerger
             if (row != INVALID_ROW) {
               bitset.add(row);
             }
+          }
+
+          if ((dictId == 0) && (Iterables.getFirst(dimVals, "") == null)) {
+            bitset.or(nullRowsList.get(i));
           }
 
           writer.write(


### PR DESCRIPTION
Fixes #2804 

Reordering the ```bitset.or(nullRowsList.get(i));``` call affects the performance of ConciseSet.add():

```
public class ConciseSet extends AbstractIntSet implements java.io.Serializable
...
  @Override
  public boolean add(int e)
  {
    modCount++;

    // range check
    if (e < ConciseSetUtils.MIN_ALLOWED_SET_BIT || e > ConciseSetUtils.MAX_ALLOWED_INTEGER) {
      throw new IndexOutOfBoundsException(String.valueOf(e));
    }

    // the element can be simply appended
    if (e > last) {
      append(e);
      return true;
    }
```

ConciseSet ```add()``` can optimize when an element being added is an "append".

When the ```bitset.or()``` call is placed before this block below in IndexMerger, it affects the optimization of subsequent ```bitset.add(row)``` calls.

```
for (Integer row : CombiningIterable.createSplatted(
               convertedInverteds,
               Ordering.<Integer>natural().nullsFirst()
           )) {
             if (row != INVALID_ROW) {
               bitset.add(row);
             }
           }
```

-----------
performance numbers using this benchmark:
https://github.com/jon-wei/druid/blob/datagen/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexMergeBenchmark.java

The benchmark creates 5 randomly generated segments with 75,000 rows each and times how long it takes to merge them, for a total of 375,000 rows.

There are 5 dimensions, 1 non-null dimension and 4 dimensions comprised of ~90-95% null rows.

merging without reordering fix:
```
Benchmark                      Mode  Cnt         Score        Error  Units
IndexMergeBenchmark.merge    avgt   15  16045637.529 ± 284039.576  us/op
IndexMergeBenchmark.mergeV9  avgt   15   2749360.023 ±  40849.933  us/op
```

merging with null row handling in question removed:
```
Benchmark                      Mode  Cnt        Score       Error  Units
IndexMergeBenchmark.merge    avgt   15  3683830.050 ± 92200.397  us/op
IndexMergeBenchmark.mergeV9  avgt   15  2765897.113 ± 34061.016  us/op
```

merge with fix (reorder the calls)
```
Benchmark                    Mode  Cnt        Score       Error  Units
IndexMergeBenchmark.merge    avgt   15  3727564.239 ± 51567.596  us/op
IndexMergeBenchmark.mergeV9  avgt   15  2777533.755 ± 56258.551  us/op
``