### PR TITLE
KafkaIndexTask: Use a separate sequence per Kafka partition

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIOConfig.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIOConfig.java
@@ -30,7 +30,7 @@ public class KafkaIOConfig implements IOConfig
 {
   private static final boolean DEFAULT_USE_TRANSACTION = true;
 
-  private final String sequenceName;
+  private final String baseSequenceName;
   private final KafkaPartitions startPartitions;
   private final KafkaPartitions endPartitions;
   private final Map<String, String> consumerProperties;
@@ -38,14 +38,14 @@ public class KafkaIOConfig implements IOConfig
 
   @JsonCreator
   public KafkaIOConfig(
-      @JsonProperty("sequenceName") String sequenceName,
+      @JsonProperty("baseSequenceName") String baseSequenceName,
       @JsonProperty("startPartitions") KafkaPartitions startPartitions,
       @JsonProperty("endPartitions") KafkaPartitions endPartitions,
       @JsonProperty("consumerProperties") Map<String, String> consumerProperties,
       @JsonProperty("useTransaction") Boolean useTransaction
   )
   {
-    this.sequenceName = Preconditions.checkNotNull(sequenceName, "sequenceName");
+    this.baseSequenceName = Preconditions.checkNotNull(baseSequenceName, "baseSequenceName");
     this.startPartitions = Preconditions.checkNotNull(startPartitions, "startPartitions");
     this.endPartitions = Preconditions.checkNotNull(endPartitions, "endPartitions");
     this.consumerProperties = Preconditions.checkNotNull(consumerProperties, "consumerProperties");
@@ -72,9 +72,9 @@ public class KafkaIOConfig implements IOConfig
   }
 
   @JsonProperty
-  public String getSequenceName()
+  public String getBaseSequenceName()
   {
-    return sequenceName;
+    return baseSequenceName;
   }
 
   @JsonProperty
@@ -105,7 +105,7 @@ public class KafkaIOConfig implements IOConfig
   public String toString()
   {
     return "KafkaIOConfig{" +
-           "sequenceName='" + sequenceName + '\'' +
+           "baseSequenceName='" + baseSequenceName + '\'' +
            ", startPartitions=" + startPartitions +
            ", endPartitions=" + endPartitions +
            ", consumerProperties=" + consumerProperties +

--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/test/TestBroker.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/test/TestBroker.java
@@ -58,6 +58,8 @@ public class TestBroker implements Closeable
   {
     final Properties props = new Properties();
     props.setProperty("zookeeper.connect", zookeeperConnect);
+    props.setProperty("zookeeper.session.timeout.ms", "30000");
+    props.setProperty("zookeeper.connection.timeout.ms", "30000");
     props.setProperty("log.dirs", directory.toString());
     props.setProperty("broker.id", String.valueOf(id));
     props.setProperty("port", String.valueOf(new Random().nextInt(9999) + 10000));

--- a/indexing-service/src/main/java/io/druid/indexing/appenderator/ActionBasedSegmentAllocator.java
+++ b/indexing-service/src/main/java/io/druid/indexing/appenderator/ActionBasedSegmentAllocator.java
@@ -32,22 +32,20 @@ public class ActionBasedSegmentAllocator implements SegmentAllocator
 {
   private final TaskActionClient taskActionClient;
   private final DataSchema dataSchema;
-  private final String sequenceName;
 
   public ActionBasedSegmentAllocator(
       TaskActionClient taskActionClient,
-      DataSchema dataSchema,
-      String sequenceName
+      DataSchema dataSchema
   )
   {
     this.taskActionClient = taskActionClient;
     this.dataSchema = dataSchema;
-    this.sequenceName = sequenceName;
   }
 
   @Override
   public SegmentIdentifier allocate(
       final DateTime timestamp,
+      final String sequenceName,
       final String previousSegmentId
   ) throws IOException
   {

--- a/server/src/main/java/io/druid/segment/realtime/appenderator/FiniteAppenderatorDriverMetadata.java
+++ b/server/src/main/java/io/druid/segment/realtime/appenderator/FiniteAppenderatorDriverMetadata.java
@@ -23,35 +23,36 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
+import java.util.Map;
 
 public class FiniteAppenderatorDriverMetadata
 {
-  private final List<SegmentIdentifier> activeSegments;
-  private final String previousSegmentId;
+  private final Map<String, List<SegmentIdentifier>> activeSegments;
+  private final Map<String, String> lastSegmentIds;
   private final Object callerMetadata;
 
   @JsonCreator
   public FiniteAppenderatorDriverMetadata(
-      @JsonProperty("activeSegments") List<SegmentIdentifier> activeSegments,
-      @JsonProperty("previousSegmentId") String previousSegmentId,
+      @JsonProperty("activeSegments") Map<String, List<SegmentIdentifier>> activeSegments,
+      @JsonProperty("lastSegmentIds") Map<String, String> lastSegmentIds,
       @JsonProperty("callerMetadata") Object callerMetadata
   )
   {
     this.activeSegments = activeSegments;
-    this.previousSegmentId = previousSegmentId;
+    this.lastSegmentIds = lastSegmentIds;
     this.callerMetadata = callerMetadata;
   }
 
   @JsonProperty
-  public List<SegmentIdentifier> getActiveSegments()
+  public Map<String, List<SegmentIdentifier>> getActiveSegments()
   {
     return activeSegments;
   }
 
   @JsonProperty
-  public String getPreviousSegmentId()
+  public Map<String, String> getLastSegmentIds()
   {
-    return previousSegmentId;
+    return lastSegmentIds;
   }
 
   @JsonProperty
@@ -65,7 +66,7 @@ public class FiniteAppenderatorDriverMetadata
   {
     return "FiniteAppenderatorDriverMetadata{" +
            "activeSegments=" + activeSegments +
-           ", previousSegmentId='" + previousSegmentId + '\'' +
+           ", lastSegmentIds=" + lastSegmentIds +
            ", callerMetadata=" + callerMetadata +
            '}';
   }

--- a/server/src/main/java/io/druid/segment/realtime/appenderator/SegmentAllocator.java
+++ b/server/src/main/java/io/druid/segment/realtime/appenderator/SegmentAllocator.java
@@ -29,12 +29,14 @@ public interface SegmentAllocator
    * Allocates a new segment for a given timestamp.
    *
    * @param timestamp         timestamp of the event which triggered this allocation request
-   * @param previousSegmentId segment identifier returned on the previous call to allocate
+   * @param sequenceName      sequenceName for this allocation
+   * @param previousSegmentId segment identifier returned on the previous call to allocate for your sequenceName
    *
    * @return the pending segment identifier, or null if it was impossible to allocate a new segment
    */
   SegmentIdentifier allocate(
       DateTime timestamp,
+      String sequenceName,
       String previousSegmentId
   ) throws IOException;
 }

--- a/server/src/test/java/io/druid/segment/realtime/appenderator/FiniteAppenderatorDriverTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/appenderator/FiniteAppenderatorDriverTest.java
@@ -85,6 +85,7 @@ public class FiniteAppenderatorDriverTest
       )
   );
 
+  SegmentAllocator allocator;
   AppenderatorTester appenderatorTester;
   FiniteAppenderatorDriver driver;
 
@@ -92,9 +93,10 @@ public class FiniteAppenderatorDriverTest
   public void setUp()
   {
     appenderatorTester = new AppenderatorTester(MAX_ROWS_IN_MEMORY);
+    allocator = new TestSegmentAllocator(DATA_SOURCE, Granularity.HOUR);
     driver = new FiniteAppenderatorDriver(
         appenderatorTester.getAppenderator(),
-        new TestSegmentAllocator(DATA_SOURCE, Granularity.HOUR),
+        allocator,
         new TestSegmentHandoffNotifierFactory(),
         new TestUsedSegmentChecker(),
         OBJECT_MAPPER,
@@ -119,7 +121,7 @@ public class FiniteAppenderatorDriverTest
 
     for (int i = 0; i < ROWS.size(); i++) {
       committerSupplier.setMetadata(i + 1);
-      Assert.assertNotNull(driver.add(ROWS.get(i), committerSupplier));
+      Assert.assertNotNull(driver.add(ROWS.get(i), "dummy", committerSupplier));
     }
 
     final SegmentsAndMetadata segmentsAndMetadata = driver.finish(
@@ -212,6 +214,7 @@ public class FiniteAppenderatorDriverTest
     @Override
     public SegmentIdentifier allocate(
         final DateTime timestamp,
+        final String sequenceName,
         final String previousSegmentId
     ) throws IOException
     {


### PR DESCRIPTION
In order to make segment creation deterministic.

This means that each segment will contain data from just one Kafka
partition. So, users will probably not want to have a super high number
of Kafka partitions...

Fixes #2703.