### PR TITLE
Fixed wrong parseSpec in Avro Hadoop Parser

### DIFF
--- a/docs/content/development/extensions-core/avro.md
+++ b/docs/content/development/extensions-core/avro.md
@@ -90,7 +90,7 @@ For example, using Avro Hadoop parser with custom reader's schema file:
       "parser" : {
         "type" : "avro_hadoop",
         "parseSpec" : {
-          "type": "timeAndDims",
+          "format": "timeAndDims",
           "timestampSpec": <standard timestampSpec>,
           "dimensionsSpec": <standard dimensionsSpec>
         }


### PR DESCRIPTION
`parseSpec` should contain `format` instead of `type`. It was wrongly defaulting to `tsv`