### PR TITLE
Add Filters.matchPredicate helper, use it where appropriate.

### DIFF
--- a/processing/src/main/java/io/druid/query/filter/ExtractionDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/ExtractionDimFilter.java
@@ -22,16 +22,10 @@ package io.druid.query.filter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.metamx.common.StringUtils;
 import io.druid.query.extraction.ExtractionFn;
-import io.druid.query.lookup.LookupExtractionFn;
-import io.druid.query.lookup.LookupExtractor;
-import io.druid.segment.filter.SelectorFilter;
 
 import java.nio.ByteBuffer;
-import java.util.List;
-import java.util.Objects;
 
 /**
  * This class is deprecated, use SelectorDimFilter instead: {@link io.druid.query.filter.SelectorDimFilter}
@@ -106,7 +100,7 @@ public class ExtractionDimFilter implements DimFilter
   @Override
   public Filter toFilter()
   {
-    return new SelectorFilter(dimension, value, extractionFn);
+    return new SelectorDimFilter(dimension, value, extractionFn).toFilter();
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/filter/Filters.java
+++ b/processing/src/main/java/io/druid/segment/filter/Filters.java
@@ -20,11 +20,18 @@
 package io.druid.segment.filter;
 
 import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
+import com.metamx.collections.bitmap.ImmutableBitmap;
 import com.metamx.common.guava.FunctionalIterable;
+import io.druid.query.filter.BitmapIndexSelector;
 import io.druid.query.filter.DimFilter;
 import io.druid.query.filter.Filter;
+import io.druid.segment.column.BitmapIndex;
+import io.druid.segment.data.Indexed;
 
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -66,5 +73,80 @@ public class Filters
   public static Filter toFilter(DimFilter dimFilter)
   {
     return dimFilter == null ? null : dimFilter.toFilter();
+  }
+
+  /**
+   * Return the union of bitmaps for all values matching a particular predicate.
+   *
+   * @param dimension dimension to look at
+   * @param selector  bitmap selector
+   * @param predicate predicate to use
+   *
+   * @return bitmap of matching rows
+   */
+  public static ImmutableBitmap matchPredicate(
+      final String dimension,
+      final BitmapIndexSelector selector,
+      final Predicate<String> predicate
+  )
+  {
+    Preconditions.checkNotNull(dimension, "dimension");
+    Preconditions.checkNotNull(selector, "selector");
+    Preconditions.checkNotNull(predicate, "predicate");
+
+    // Missing dimension -> match all rows if the predicate matches null; match no rows otherwise
+    final Indexed<String> dimValues = selector.getDimensionValues(dimension);
+    if (dimValues == null || dimValues.size() == 0) {
+      if (predicate.apply(null)) {
+        return selector.getBitmapFactory().complement(
+            selector.getBitmapFactory().makeEmptyImmutableBitmap(),
+            selector.getNumRows()
+        );
+      } else {
+        return selector.getBitmapFactory().makeEmptyImmutableBitmap();
+      }
+    }
+
+    // Apply predicate to all dimension values and union the matching bitmaps
+    final BitmapIndex bitmapIndex = selector.getBitmapIndex(dimension);
+    return selector.getBitmapFactory().union(
+        new Iterable<ImmutableBitmap>()
+        {
+          @Override
+          public Iterator<ImmutableBitmap> iterator()
+          {
+            return new Iterator<ImmutableBitmap>()
+            {
+              int currIndex = 0;
+
+              @Override
+              public boolean hasNext()
+              {
+                return currIndex < bitmapIndex.getCardinality();
+              }
+
+              @Override
+              public ImmutableBitmap next()
+              {
+                while (currIndex < bitmapIndex.getCardinality() && !predicate.apply(dimValues.get(currIndex))) {
+                  currIndex++;
+                }
+
+                if (currIndex == bitmapIndex.getCardinality()) {
+                  return bitmapIndex.getBitmapFactory().makeEmptyImmutableBitmap();
+                }
+
+                return bitmapIndex.getBitmap(currIndex++);
+              }
+
+              @Override
+              public void remove()
+              {
+                throw new UnsupportedOperationException();
+              }
+            };
+          }
+        }
+    );
   }
 }

--- a/processing/src/main/java/io/druid/segment/filter/SelectorFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/SelectorFilter.java
@@ -19,20 +19,11 @@
 
 package io.druid.segment.filter;
 
-import com.google.common.base.Predicate;
-import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
 import com.metamx.collections.bitmap.ImmutableBitmap;
-import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.filter.BitmapIndexSelector;
 import io.druid.query.filter.Filter;
 import io.druid.query.filter.ValueMatcher;
 import io.druid.query.filter.ValueMatcherFactory;
-import io.druid.segment.data.Indexed;
-
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
 
 /**
  */
@@ -40,68 +31,25 @@ public class SelectorFilter implements Filter
 {
   private final String dimension;
   private final String value;
-  private final ExtractionFn extractionFn;
 
   public SelectorFilter(
       String dimension,
-      String value,
-      ExtractionFn extractionFn
+      String value
   )
   {
     this.dimension = dimension;
-    this.value = Strings.nullToEmpty(value);
-    this.extractionFn = extractionFn;
+    this.value = value;
   }
 
   @Override
   public ImmutableBitmap getBitmapIndex(BitmapIndexSelector selector)
   {
-    if (extractionFn == null) {
-      return selector.getBitmapIndex(dimension, value);
-    } else {
-      final List<Filter> filters = makeFiltersUsingExtractionFn(selector);
-      if (filters.isEmpty()) {
-        return selector.getBitmapFactory().makeEmptyImmutableBitmap();
-      }
-      return new OrFilter(filters).getBitmapIndex(selector);
-    }
+    return selector.getBitmapIndex(dimension, value);
   }
 
   @Override
   public ValueMatcher makeMatcher(ValueMatcherFactory factory)
   {
-    if (extractionFn == null) {
-      return factory.makeValueMatcher(dimension, value);
-    } else {
-      return factory.makeValueMatcher(
-          dimension, new Predicate<String>()
-          {
-            @Override
-            public boolean apply(String input)
-            {
-              // Assuming that a null/absent/empty dimension are equivalent from the druid perspective
-              return value.equals(Strings.nullToEmpty(extractionFn.apply(input)));
-            }
-          }
-      );
-    }
-  }
-
-  private List<Filter> makeFiltersUsingExtractionFn(BitmapIndexSelector selector)
-  {
-    final List<Filter> filters = Lists.newArrayList();
-
-    Iterable<String> allDimVals = selector.getDimensionValues(dimension);
-    if (allDimVals == null) {
-      allDimVals = Lists.newArrayList((String) null);
-    }
-
-    for (String dimVal : allDimVals) {
-      if (value.equals(Strings.nullToEmpty(extractionFn.apply(dimVal)))) {
-        filters.add(new SelectorFilter(dimension, dimVal, null));
-      }
-    }
-
-    return filters;
+    return factory.makeValueMatcher(dimension, value);
   }
 }

--- a/processing/src/test/java/io/druid/segment/filter/ExtractionDimFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/ExtractionDimFilterTest.java
@@ -32,6 +32,8 @@ import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.filter.BitmapIndexSelector;
 import io.druid.query.filter.DimFilters;
 import io.druid.query.filter.ExtractionDimFilter;
+import io.druid.query.filter.Filter;
+import io.druid.query.filter.SelectorDimFilter;
 import io.druid.segment.column.BitmapIndex;
 import io.druid.segment.data.ArrayIndexed;
 import io.druid.segment.data.BitmapSerdeFactory;
@@ -160,9 +162,9 @@ public class ExtractionDimFilterTest
   @Test
   public void testEmpty()
   {
-    SelectorFilter extractionFilter = new SelectorFilter(
+    Filter extractionFilter = new SelectorDimFilter(
         "foo", "NFDJUKFNDSJFNS", DIM_EXTRACTION_FN
-    );
+    ).toFilter();
     ImmutableBitmap immutableBitmap = extractionFilter.getBitmapIndex(BITMAP_INDEX_SELECTOR);
     Assert.assertEquals(0, immutableBitmap.size());
   }
@@ -170,9 +172,9 @@ public class ExtractionDimFilterTest
   @Test
   public void testNull()
   {
-    SelectorFilter extractionFilter = new SelectorFilter(
+    Filter extractionFilter = new SelectorDimFilter(
         "FDHJSFFHDS", "extractDimVal", DIM_EXTRACTION_FN
-    );
+    ).toFilter();
     ImmutableBitmap immutableBitmap = extractionFilter.getBitmapIndex(BITMAP_INDEX_SELECTOR);
     Assert.assertEquals(0, immutableBitmap.size());
   }
@@ -180,9 +182,9 @@ public class ExtractionDimFilterTest
   @Test
   public void testNormal()
   {
-    SelectorFilter extractionFilter = new SelectorFilter(
+    Filter extractionFilter = new SelectorDimFilter(
         "foo", "extractDimVal", DIM_EXTRACTION_FN
-    );
+    ).toFilter();
     ImmutableBitmap immutableBitmap = extractionFilter.getBitmapIndex(BITMAP_INDEX_SELECTOR);
     Assert.assertEquals(1, immutableBitmap.size());
   }

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
@@ -259,7 +259,7 @@ public class IncrementalIndexStorageAdapterTest
 
     for (boolean descending : Arrays.asList(false, true)) {
       Sequence<Cursor> cursorSequence = adapter.makeCursors(
-          new SelectorFilter("sally", "bo", null),
+          new SelectorFilter("sally", "bo"),
           interval,
           QueryGranularity.NONE,
           descending


### PR DESCRIPTION
This approach simplifies code and is generally faster, due to skipping
unnecessary dictionary lookups (see #2850).