### PR TITLE
periodically emit metric segment/scan/pending

### DIFF
--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -44,6 +44,10 @@
             <artifactId>emitter</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.metamx</groupId>
+            <artifactId>server-metrics</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.ning</groupId>
             <artifactId>compress-lzf</artifactId>
         </dependency>

--- a/processing/src/main/java/io/druid/query/ExecutorServiceMonitor.java
+++ b/processing/src/main/java/io/druid/query/ExecutorServiceMonitor.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query;
+
+import com.google.common.collect.Lists;
+import com.google.inject.Inject;
+import com.metamx.emitter.service.ServiceEmitter;
+import com.metamx.emitter.service.ServiceMetricEvent;
+import com.metamx.metrics.AbstractMonitor;
+
+import java.util.List;
+
+public class ExecutorServiceMonitor extends AbstractMonitor
+{
+
+  private final List<MetricEmitter> metricEmitters;
+  private final ServiceMetricEvent.Builder metricBuilder;
+
+  @Inject
+  public ExecutorServiceMonitor()
+  {
+    this.metricEmitters = Lists.newArrayList();
+    this.metricBuilder = new ServiceMetricEvent.Builder();
+  }
+
+  public void add(MetricEmitter metricEmitter)
+  {
+    metricEmitters.add(metricEmitter);
+  }
+
+  @Override
+  public boolean doMonitor(ServiceEmitter emitter)
+  {
+    for (MetricEmitter metricEmitter : metricEmitters) {
+      metricEmitter.emitMetrics(emitter, metricBuilder);
+    }
+    return true;
+  }
+
+  public static interface MetricEmitter
+  {
+    void emitMetrics(ServiceEmitter emitter, ServiceMetricEvent.Builder metricBuilder);
+  }
+
+}

--- a/server/src/main/java/io/druid/server/metrics/MetricsModule.java
+++ b/server/src/main/java/io/druid/server/metrics/MetricsModule.java
@@ -41,10 +41,9 @@ import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.LazySingleton;
 import io.druid.guice.ManageLifecycle;
 import io.druid.query.DruidMetrics;
+import io.druid.query.ExecutorServiceMonitor;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
@@ -70,6 +69,7 @@ public class MetricsModule implements Module
     DruidBinders.metricMonitorBinder(binder); // get the binder so that it will inject the empty set at a minimum.
 
     binder.bind(EventReceiverFirehoseRegister.class).in(LazySingleton.class);
+    binder.bind(ExecutorServiceMonitor.class).in(LazySingleton.class);
 
     // Instantiate eagerly so that we get everything registered and put into the Lifecycle
     binder.bind(Key.get(MonitorScheduler.class, Names.named("ForTheEagerness")))


### PR DESCRIPTION
Current emit a "segment/scan/pending" metric when a task add to ExecutorService, i think is better to periodically emit the metric.