### PR TITLE
GroupBy: Apply limit during merge when possible.

### DIFF
--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -965,6 +965,13 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
     return maxIngestedEventTime;
   }
 
+  public enum OverflowAction
+  {
+    FAIL,
+    DROP_LOW,
+    DROP_HIGH
+  }
+
   public static final class DimensionDesc
   {
     private final int index;

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -1687,6 +1687,110 @@ public class GroupByQueryRunnerTest
   }
 
   @Test
+  public void testGroupByWithOrderAndLimitByTwoDimensionsAscending()
+  {
+    GroupByQuery.Builder builder = GroupByQuery
+        .builder()
+        .setDataSource(QueryRunnerTestHelper.dataSource)
+        .setInterval("2011-04-02/2011-04-04")
+        .setDimensions(Lists.<DimensionSpec>newArrayList(
+            new DefaultDimensionSpec("quality", "quality_alias"),
+            new DefaultDimensionSpec("market", "market")
+        ))
+        .setAggregatorSpecs(
+            Arrays.asList(
+                QueryRunnerTestHelper.rowsCount,
+                new LongSumAggregatorFactory("idx", "index")
+            )
+        )
+        .addOrderByColumn("quality_alias", OrderByColumnSpec.Direction.ASCENDING)
+        .addOrderByColumn("market", OrderByColumnSpec.Direction.ASCENDING)
+        .setGranularity(QueryGranularity.ALL);
+
+    final GroupByQuery query = builder.build();
+
+    List<Row> expectedResults = Arrays.asList(
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "spot", "quality_alias", "automotive", "rows", 2L, "idx", 269L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "spot", "quality_alias", "business", "rows", 2L, "idx", 217L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "spot", "quality_alias", "entertainment", "rows", 2L, "idx", 319L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "spot", "quality_alias", "health", "rows", 2L, "idx", 216L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "spot", "quality_alias", "mezzanine", "rows", 2L, "idx", 217L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "total_market", "quality_alias", "mezzanine", "rows", 2L, "idx", 2248L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "upfront", "quality_alias", "mezzanine", "rows", 2L, "idx", 1955L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "spot", "quality_alias", "news", "rows", 2L, "idx", 221L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "spot", "quality_alias", "premium", "rows", 2L, "idx", 257L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "total_market", "quality_alias", "premium", "rows", 2L, "idx", 2342L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "upfront", "quality_alias", "premium", "rows", 2L, "idx", 1817L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "spot", "quality_alias", "technology", "rows", 2L, "idx", 177L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "spot", "quality_alias", "travel", "rows", 2L, "idx", 243L)
+    );
+
+    Map<String, Object> context = Maps.newHashMap();
+    QueryRunner<Row> mergeRunner = factory.getToolchest().mergeResults(runner);
+    TestHelper.assertExpectedObjects(expectedResults, mergeRunner.run(query, context), "no-limit");
+
+    for (int limit = 1 ; limit < expectedResults.size() + 1 ; limit ++) {
+      TestHelper.assertExpectedObjects(
+          Iterables.limit(expectedResults, limit), mergeRunner.run(builder.limit(limit).build(), context),
+          String.format("limited[%d]", limit)
+      );
+    }
+  }
+
+  @Test
+  public void testGroupByWithOrderAndLimitByTwoDimensionsDescending()
+  {
+    GroupByQuery.Builder builder = GroupByQuery
+        .builder()
+        .setDataSource(QueryRunnerTestHelper.dataSource)
+        .setInterval("2011-04-02/2011-04-04")
+        .setDimensions(Lists.<DimensionSpec>newArrayList(
+            new DefaultDimensionSpec("quality", "quality_alias"),
+            new DefaultDimensionSpec("market", "market")
+        ))
+        .setAggregatorSpecs(
+            Arrays.asList(
+                QueryRunnerTestHelper.rowsCount,
+                new LongSumAggregatorFactory("idx", "index")
+            )
+        )
+        .addOrderByColumn("quality_alias", OrderByColumnSpec.Direction.DESCENDING)
+        .addOrderByColumn("market", OrderByColumnSpec.Direction.DESCENDING)
+        .setGranularity(QueryGranularity.ALL);
+
+    final GroupByQuery query = builder.build();
+
+    List<Row> expectedResults = Lists.reverse(
+        Arrays.asList(
+          GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "spot", "quality_alias", "automotive", "rows", 2L, "idx", 269L),
+          GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "spot", "quality_alias", "business", "rows", 2L, "idx", 217L),
+          GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "spot", "quality_alias", "entertainment", "rows", 2L, "idx", 319L),
+          GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "spot", "quality_alias", "health", "rows", 2L, "idx", 216L),
+          GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "spot", "quality_alias", "mezzanine", "rows", 2L, "idx", 217L),
+          GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "total_market", "quality_alias", "mezzanine", "rows", 2L, "idx", 2248L),
+          GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "upfront", "quality_alias", "mezzanine", "rows", 2L, "idx", 1955L),
+          GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "spot", "quality_alias", "news", "rows", 2L, "idx", 221L),
+          GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "spot", "quality_alias", "premium", "rows", 2L, "idx", 257L),
+          GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "total_market", "quality_alias", "premium", "rows", 2L, "idx", 2342L),
+          GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "upfront", "quality_alias", "premium", "rows", 2L, "idx", 1817L),
+          GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "spot", "quality_alias", "technology", "rows", 2L, "idx", 177L),
+          GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "market", "spot", "quality_alias", "travel", "rows", 2L, "idx", 243L)
+      )
+    );
+
+    Map<String, Object> context = Maps.newHashMap();
+    QueryRunner<Row> mergeRunner = factory.getToolchest().mergeResults(runner);
+    TestHelper.assertExpectedObjects(expectedResults, mergeRunner.run(query, context), "no-limit");
+
+    for (int limit = 1 ; limit < expectedResults.size() + 1 ; limit ++) {
+      TestHelper.assertExpectedObjects(
+          Iterables.limit(expectedResults, limit), mergeRunner.run(builder.limit(limit).build(), context),
+          String.format("limited[%d]", limit)
+      );
+    }
+  }
+
+  @Test
   public void testGroupByWithOrderOnHyperUnique()
   {
     GroupByQuery query = new GroupByQuery.Builder()
@@ -2843,7 +2947,7 @@ public class GroupByQueryRunnerTest
   public void testSubqueryWithExtractionFnInOuterQuery()
   {
     //https://github.com/druid-io/druid/issues/2556
-    
+
     GroupByQuery subquery = GroupByQuery
         .builder()
         .setDataSource(QueryRunnerTestHelper.dataSource)

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexTest.java
@@ -110,7 +110,13 @@ public class IncrementalIndexTest
                   public IncrementalIndex createIndex()
                   {
                     return new OffheapIncrementalIndex(
-                        schema, true, true, true, 1000000, new StupidPool<ByteBuffer>(
+                        schema,
+                        true,
+                        true,
+                        true,
+                        IncrementalIndex.OverflowAction.FAIL,
+                        1000000,
+                        new StupidPool<ByteBuffer>(
                             new Supplier<ByteBuffer>()
                             {
                               @Override


### PR DESCRIPTION
Fixes #1872.

Still a couple TODOs, don't merge yet, just looking for feedback.

The idea is that when a groupBy query is ordered on the same dimensions it's grouping on, and doesn't have a having clause, then it's ok to apply the limit on partially merged results rather than waiting for fully merged results. This can speed up the query, and will also prevent it from hitting its maxResults limit if the limit threshold is less than maxResults.