### PR TITLE
GroupBy: When possible, sort results on read rather than continuously during insert.

### DIFF
--- a/processing/src/main/java/io/druid/query/GroupByParallelQueryRunner.java
+++ b/processing/src/main/java/io/druid/query/GroupByParallelQueryRunner.java
@@ -175,7 +175,11 @@ public class GroupByParallelQueryRunner<T> implements QueryRunner<T>
     return new ResourceClosingSequence<T>(
         Sequences.simple(
             Iterables.transform(
-                indexAccumulatorPair.lhs.iterableWithPostAggregations(null, query.isDescending()),
+                indexAccumulatorPair.lhs.iterableWithPostAggregations(
+                    null,
+                    false,
+                    GroupByQueryHelper.isSortResults(query)
+                ),
                 new Function<Row, T>()
                 {
                   @Override

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryHelper.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryHelper.java
@@ -45,6 +45,11 @@ public class GroupByQueryHelper
   private static final String CTX_KEY_MAX_RESULTS = "maxResults";
   public final static String CTX_KEY_SORT_RESULTS = "sortResults";
 
+  public static boolean isSortResults(GroupByQuery query)
+  {
+    return query.getContextValue(CTX_KEY_SORT_RESULTS, true);
+  }
+
   public static <T> Pair<IncrementalIndex, Accumulator<IncrementalIndex, T>> createIndexAccumulatorPair(
       final GroupByQuery query,
       final GroupByQueryConfig config,
@@ -82,7 +87,7 @@ public class GroupByQueryHelper
     );
     final IncrementalIndex index;
 
-    final boolean sortResults = query.getContextValue(CTX_KEY_SORT_RESULTS, true);
+    final boolean sortResults = isSortResults(query);
 
     if (query.getContextValue("useOffheap", false)) {
       index = new OffheapIncrementalIndex(

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryRunnerFactory.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryRunnerFactory.java
@@ -174,7 +174,11 @@ public class GroupByQueryRunnerFactory implements QueryRunnerFactory<Row, GroupB
                         return Sequences.simple(bySegmentAccumulatorPair.lhs);
                       }
 
-                      return Sequences.simple(indexAccumulatorPair.lhs.iterableWithPostAggregations(null, query.isDescending()));
+                      return Sequences.simple(indexAccumulatorPair.lhs.iterableWithPostAggregations(
+                          null,
+                          false,
+                          GroupByQueryHelper.isSortResults(queryParam)
+                      ));
                     }
                   };
                 }


### PR DESCRIPTION
Leans on the logic from #2571 with respect to deciding when to sort and when not to sort.

This does involve somewhat more memory use (need to copy the facts to a list and then sort the list). But as the list is just references to already-existing Map.Entry objects, the overhead shouldn't be too bad.

Before:

```
Result "mergeQueryableIndex":
  7899182.389 ±(99.9%) 490250.490 us/op [Average]
  (min, avg, max) = (7346007.865, 7899182.389, 9206588.959), stdev = 564573.193
  CI (99.9%): [7408931.899, 8389432.879] (assumes normal distribution)


# Run complete. Total time: 00:05:35

Benchmark                             Mode  Cnt        Score        Error  Units
GroupByBenchmark.mergeQueryableIndex  avgt   20  7899182.389 ± 490250.490  us/op
```

After:

```
Result "mergeQueryableIndex":
  5952538.010 ±(99.9%) 365008.858 us/op [Average]
  (min, avg, max) = (5645155.827, 5952538.010, 7256515.626), stdev = 420344.744
  CI (99.9%): [5587529.153, 6317546.868] (assumes normal distribution)


# Run complete. Total time: 00:04:25

Benchmark                             Mode  Cnt        Score        Error  Units
GroupByBenchmark.mergeQueryableIndex  avgt   20  5952538.010 ± 365008.858  us/op
```

Depends on #2870 