### PR TITLE
Fix integer overflow in SegmentMetadataQuery numRows.

### DIFF
--- a/processing/src/main/java/io/druid/query/metadata/SegmentAnalyzer.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentAnalyzer.java
@@ -76,7 +76,7 @@ public class SegmentAnalyzer
     this.analysisTypes = analysisTypes;
   }
 
-  public int numRows(Segment segment)
+  public long numRows(Segment segment)
   {
     return Preconditions.checkNotNull(segment, "segment").asStorageAdapter().getNumRows();
   }

--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
@@ -87,7 +87,7 @@ public class SegmentMetadataQueryRunnerFactory implements QueryRunnerFactory<Seg
         SegmentMetadataQuery query = (SegmentMetadataQuery) inQ;
         final SegmentAnalyzer analyzer = new SegmentAnalyzer(query.getAnalysisTypes());
         final Map<String, ColumnAnalysis> analyzedColumns = analyzer.analyze(segment);
-        final int numRows = analyzer.numRows(segment);
+        final long numRows = analyzer.numRows(segment);
         long totalSize = 0;
 
         if (analyzer.analyzingSize()) {

--- a/processing/src/main/java/io/druid/query/metadata/metadata/SegmentAnalysis.java
+++ b/processing/src/main/java/io/druid/query/metadata/metadata/SegmentAnalysis.java
@@ -34,7 +34,7 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
   private final List<Interval> interval;
   private final Map<String, ColumnAnalysis> columns;
   private final long size;
-  private final int numRows;
+  private final long numRows;
   private final Map<String, AggregatorFactory> aggregators;
 
   @JsonCreator
@@ -43,7 +43,7 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
       @JsonProperty("intervals") List<Interval> interval,
       @JsonProperty("columns") Map<String, ColumnAnalysis> columns,
       @JsonProperty("size") long size,
-      @JsonProperty("numRows") int numRows,
+      @JsonProperty("numRows") long numRows,
       @JsonProperty("aggregators") Map<String, AggregatorFactory> aggregators
   )
   {
@@ -80,7 +80,7 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
   }
 
   @JsonProperty
-  public int getNumRows()
+  public long getNumRows()
   {
     return numRows;
   }


### PR DESCRIPTION
`numRows` can easily overflow an int when merging is enabled.