### PR TITLE
Adjust colliding aggregator cache IDs.

### DIFF
--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
@@ -42,7 +42,7 @@ import java.util.List;
 @JsonTypeName("approxHistogram")
 public class ApproximateHistogramAggregatorFactory extends AggregatorFactory
 {
-  private static final byte CACHE_TYPE_ID = 0x8;
+  private static final byte CACHE_TYPE_ID = 12;
 
   protected final String name;
   protected final String fieldName;

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregatorFactory.java
@@ -37,7 +37,7 @@ import java.nio.ByteBuffer;
 @JsonTypeName("approxHistogramFold")
 public class ApproximateHistogramFoldingAggregatorFactory extends ApproximateHistogramAggregatorFactory
 {
-  private static final byte CACHE_TYPE_ID = 0x9;
+  private static final byte CACHE_TYPE_ID = 13;
 
   @JsonCreator
   public ApproximateHistogramFoldingAggregatorFactory(


### PR DESCRIPTION
- Renumbered ApproximateHistogramAggregatorFactory from 8 to 12,
  8 was taken by CardinalityAggregatorFactory
- Renumbered ApproximateHistogramFoldingAggregatorFactory from 9 to 13,
  9 was taken by FilteredAggregatorFactory