### PR TITLE
Optimize filter for timeseries, search, and select queries

### DIFF
--- a/processing/src/main/java/io/druid/query/QueryRunnerFactory.java
+++ b/processing/src/main/java/io/druid/query/QueryRunnerFactory.java
@@ -55,7 +55,7 @@ public interface QueryRunnerFactory<T, QueryType extends Query<T>>
    *
    * @param queryExecutor ExecutorService to be used for parallel processing
    * @param queryRunners Individual QueryRunner objects that produce some results
-   * @return a QueryRunner that, when asked, will use the ExecutorService to runt he base QueryRunners
+   * @return a QueryRunner that, when asked, will use the ExecutorService to run the base QueryRunners
    */
   public QueryRunner<T> mergeRunners(ExecutorService queryExecutor, Iterable<QueryRunner<T>> queryRunners);
 

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryQueryToolChest.java
@@ -424,9 +424,6 @@ public class GroupByQueryQueryToolChest extends QueryToolChest<Row, GroupByQuery
               @Override
               public Sequence<Row> run(Query<Row> query, Map<String, Object> responseContext)
               {
-                if (!(query instanceof GroupByQuery)) {
-                  return runner.run(query, responseContext);
-                }
                 GroupByQuery groupByQuery = (GroupByQuery) query;
                 if (groupByQuery.getDimFilter() != null){
                   groupByQuery = groupByQuery.withDimFilter(groupByQuery.getDimFilter().optimize());

--- a/processing/src/main/java/io/druid/query/search/SearchQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/search/SearchQueryQueryToolChest.java
@@ -241,10 +241,28 @@ public class SearchQueryQueryToolChest extends QueryToolChest<Result<SearchResul
   }
 
   @Override
-  public QueryRunner<Result<SearchResultValue>> preMergeQueryDecoration(QueryRunner<Result<SearchResultValue>> runner)
+  public QueryRunner<Result<SearchResultValue>> preMergeQueryDecoration(final QueryRunner<Result<SearchResultValue>> runner)
   {
     return new SearchThresholdAdjustingQueryRunner(
-        intervalChunkingQueryRunnerDecorator.decorate(runner, this),
+        intervalChunkingQueryRunnerDecorator.decorate(
+            new QueryRunner<Result<SearchResultValue>>()
+            {
+              @Override
+              public Sequence<Result<SearchResultValue>> run(
+                  Query<Result<SearchResultValue>> query, Map<String, Object> responseContext
+              )
+              {
+                if (!(query instanceof SearchQuery)) {
+                  return runner.run(query, responseContext);
+                } else {
+                  SearchQuery searchQuery = (SearchQuery) query;
+                  if (searchQuery.getDimensionsFilter() != null) {
+                    searchQuery = searchQuery.withDimFilter(searchQuery.getDimensionsFilter().optimize());
+                  }
+                  return runner.run(searchQuery, responseContext);
+                }
+              }
+            } , this),
         config
     );
   }

--- a/processing/src/main/java/io/druid/query/search/SearchQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/search/SearchQueryQueryToolChest.java
@@ -252,15 +252,11 @@ public class SearchQueryQueryToolChest extends QueryToolChest<Result<SearchResul
                   Query<Result<SearchResultValue>> query, Map<String, Object> responseContext
               )
               {
-                if (!(query instanceof SearchQuery)) {
-                  throw new ISE("Can only handle [%s], got [%s]", SearchQuery.class, query.getClass());
-                } else {
-                  SearchQuery searchQuery = (SearchQuery) query;
-                  if (searchQuery.getDimensionsFilter() != null) {
-                    searchQuery = searchQuery.withDimFilter(searchQuery.getDimensionsFilter().optimize());
-                  }
-                  return runner.run(searchQuery, responseContext);
+                SearchQuery searchQuery = (SearchQuery) query;
+                if (searchQuery.getDimensionsFilter() != null) {
+                  searchQuery = searchQuery.withDimFilter(searchQuery.getDimensionsFilter().optimize());
                 }
+                return runner.run(searchQuery, responseContext);
               }
             } , this),
         config

--- a/processing/src/main/java/io/druid/query/search/SearchQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/search/SearchQueryQueryToolChest.java
@@ -253,7 +253,7 @@ public class SearchQueryQueryToolChest extends QueryToolChest<Result<SearchResul
               )
               {
                 if (!(query instanceof SearchQuery)) {
-                  return runner.run(query, responseContext);
+                  throw new ISE("Can only handle [%s], got [%s]", SearchQuery.class, query.getClass());
                 } else {
                   SearchQuery searchQuery = (SearchQuery) query;
                   if (searchQuery.getDimensionsFilter() != null) {

--- a/processing/src/main/java/io/druid/query/search/search/SearchQuery.java
+++ b/processing/src/main/java/io/druid/query/search/search/SearchQuery.java
@@ -131,6 +131,21 @@ public class SearchQuery extends BaseQuery<Result<SearchResultValue>>
     );
   }
 
+  public SearchQuery withDimFilter(DimFilter dimFilter)
+  {
+    return new SearchQuery(
+        getDataSource(),
+        dimFilter,
+        granularity,
+        limit,
+        getQuerySegmentSpec(),
+        dimensions,
+        querySpec,
+        sortSpec,
+        getContext()
+    );
+  }
+
   @JsonProperty("filter")
   public DimFilter getDimensionsFilter()
   {

--- a/processing/src/main/java/io/druid/query/select/SelectQuery.java
+++ b/processing/src/main/java/io/druid/query/select/SelectQuery.java
@@ -188,6 +188,21 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
     );
   }
 
+  public SelectQuery withDimFilter(DimFilter dimFilter)
+  {
+    return new SelectQuery(
+        getDataSource(),
+        getQuerySegmentSpec(),
+        isDescending(),
+        dimFilter,
+        granularity,
+        dimensions,
+        metrics,
+        pagingSpec,
+        getContext()
+    );
+  }
+
   @Override
   public String toString()
   {

--- a/processing/src/main/java/io/druid/query/select/SelectQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/select/SelectQueryQueryToolChest.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
+import com.metamx.common.ISE;
 import com.metamx.common.StringUtils;
 import com.metamx.common.guava.Comparators;
 import com.metamx.common.guava.Sequence;
@@ -273,7 +274,7 @@ public class SelectQueryQueryToolChest extends QueryToolChest<Result<SelectResul
           )
           {
             if (!(query instanceof SelectQuery)) {
-              return runner.run(query, responseContext);
+              throw new ISE("Can only handle [%s], got [%s]", SelectQuery.class, query.getClass());
             } else {
               SelectQuery selectQuery = (SelectQuery) query;
               if (selectQuery.getDimensionsFilter() != null) {

--- a/processing/src/main/java/io/druid/query/select/SelectQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/select/SelectQueryQueryToolChest.java
@@ -273,15 +273,11 @@ public class SelectQueryQueryToolChest extends QueryToolChest<Result<SelectResul
               Query<Result<SelectResultValue>> query, Map<String, Object> responseContext
           )
           {
-            if (!(query instanceof SelectQuery)) {
-              throw new ISE("Can only handle [%s], got [%s]", SelectQuery.class, query.getClass());
-            } else {
-              SelectQuery selectQuery = (SelectQuery) query;
-              if (selectQuery.getDimensionsFilter() != null) {
-                selectQuery = selectQuery.withDimFilter(selectQuery.getDimensionsFilter().optimize());
-              }
-              return runner.run(selectQuery, responseContext);
+            SelectQuery selectQuery = (SelectQuery) query;
+            if (selectQuery.getDimensionsFilter() != null) {
+              selectQuery = selectQuery.withDimFilter(selectQuery.getDimensionsFilter().optimize());
             }
+            return runner.run(selectQuery, responseContext);
           }
         }, this);
   }

--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesQuery.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesQuery.java
@@ -152,6 +152,20 @@ public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
     );
   }
 
+  public TimeseriesQuery withDimFilter(DimFilter dimFilter)
+  {
+    return new TimeseriesQuery(
+        getDataSource(),
+        getQuerySegmentSpec(),
+        isDescending(),
+        dimFilter,
+        granularity,
+        aggregatorSpecs,
+        postAggregatorSpecs,
+        getContext()
+    );
+  }
+
   @Override
   public String toString()
   {

--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.inject.Inject;
+import com.metamx.common.ISE;
 import com.metamx.common.guava.Sequence;
 import com.metamx.common.guava.nary.BinaryFn;
 import com.metamx.emitter.service.ServiceMetricEvent;
@@ -222,7 +223,7 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
           )
           {
             if (!(query instanceof TimeseriesQuery)) {
-              return runner.run(query, responseContext);
+              throw new ISE("Can only handle [%s], got [%s]", TimeseriesQuery.class, query.getClass());
             } else {
               TimeseriesQuery timeseriesQuery = (TimeseriesQuery) query;
               if (timeseriesQuery.getDimensionsFilter() != null) {

--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
@@ -222,15 +222,11 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
               Query<Result<TimeseriesResultValue>> query, Map<String, Object> responseContext
           )
           {
-            if (!(query instanceof TimeseriesQuery)) {
-              throw new ISE("Can only handle [%s], got [%s]", TimeseriesQuery.class, query.getClass());
-            } else {
-              TimeseriesQuery timeseriesQuery = (TimeseriesQuery) query;
-              if (timeseriesQuery.getDimensionsFilter() != null) {
-                timeseriesQuery = timeseriesQuery.withDimFilter(timeseriesQuery.getDimensionsFilter().optimize());
-              }
-              return runner.run(timeseriesQuery, responseContext);
+            TimeseriesQuery timeseriesQuery = (TimeseriesQuery) query;
+            if (timeseriesQuery.getDimensionsFilter() != null) {
+              timeseriesQuery = timeseriesQuery.withDimFilter(timeseriesQuery.getDimensionsFilter().optimize());
             }
+            return runner.run(timeseriesQuery, responseContext);
           }
         }, this);
   }

--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.inject.Inject;
+import com.metamx.common.guava.Sequence;
 import com.metamx.common.guava.nary.BinaryFn;
 import com.metamx.emitter.service.ServiceMetricEvent;
 import io.druid.granularity.QueryGranularity;
@@ -210,9 +211,27 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
   }
 
   @Override
-  public QueryRunner<Result<TimeseriesResultValue>> preMergeQueryDecoration(QueryRunner<Result<TimeseriesResultValue>> runner)
+  public QueryRunner<Result<TimeseriesResultValue>> preMergeQueryDecoration(final QueryRunner<Result<TimeseriesResultValue>> runner)
   {
-    return intervalChunkingQueryRunnerDecorator.decorate(runner, this);
+    return intervalChunkingQueryRunnerDecorator.decorate(
+        new QueryRunner<Result<TimeseriesResultValue>>()
+        {
+          @Override
+          public Sequence<Result<TimeseriesResultValue>> run(
+              Query<Result<TimeseriesResultValue>> query, Map<String, Object> responseContext
+          )
+          {
+            if (!(query instanceof TimeseriesQuery)) {
+              return runner.run(query, responseContext);
+            } else {
+              TimeseriesQuery timeseriesQuery = (TimeseriesQuery) query;
+              if (timeseriesQuery.getDimensionsFilter() != null) {
+                timeseriesQuery = timeseriesQuery.withDimFilter(timeseriesQuery.getDimensionsFilter().optimize());
+              }
+              return runner.run(timeseriesQuery, responseContext);
+            }
+          }
+        }, this);
   }
 
   @Override

--- a/processing/src/test/java/io/druid/query/search/SearchQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/search/SearchQueryRunnerTest.java
@@ -82,12 +82,15 @@ public class SearchQueryRunnerTest
   }
 
   private final QueryRunner runner;
+  private final QueryRunner decoratedRunner;
 
   public SearchQueryRunnerTest(
       QueryRunner runner
   )
   {
     this.runner = runner;
+    this.decoratedRunner = toolChest.postMergeQueryDecoration(
+            toolChest.mergeResults(toolChest.preMergeQueryDecoration(runner)));
   }
 
   @Test
@@ -369,7 +372,6 @@ public class SearchQueryRunnerTest
                               .build();
 
     checkSearchQuery(query, expectedHits);
-    checkSearchQuery(query, toolChest.mergeResults(toolChest.preMergeQueryDecoration(runner)), expectedHits);
   }
 
   @Test
@@ -551,6 +553,7 @@ public class SearchQueryRunnerTest
   private void checkSearchQuery(Query searchQuery, List<SearchHit> expectedResults)
   {
     checkSearchQuery(searchQuery, runner, expectedResults);
+    checkSearchQuery(searchQuery, decoratedRunner, expectedResults);
   }
 
   private void checkSearchQuery(Query searchQuery, QueryRunner runner, List<SearchHit> expectedResults)

--- a/processing/src/test/java/io/druid/query/select/SelectQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/select/SelectQueryRunnerTest.java
@@ -99,16 +99,18 @@ public class SelectQueryRunnerTest
   );
   public static final String[] V_0112_0114 = ObjectArrays.concat(V_0112, V_0113, String.class);
 
+  private static final SelectQueryQueryToolChest toolChest = new SelectQueryQueryToolChest(
+      new DefaultObjectMapper(),
+      QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
+  );
+
   @Parameterized.Parameters(name = "{0}:descending={1}")
   public static Iterable<Object[]> constructorFeeder() throws IOException
   {
     return QueryRunnerTestHelper.cartesian(
         QueryRunnerTestHelper.makeQueryRunners(
             new SelectQueryRunnerFactory(
-                new SelectQueryQueryToolChest(
-                    new DefaultObjectMapper(),
-                    QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
-                ),
+                toolChest,
                 new SelectQueryEngine(),
                 QueryRunnerTestHelper.NOOP_QUERYWATCHER
             )
@@ -453,6 +455,61 @@ public class SelectQueryRunnerTest
       );
       verify(expectedResults, results);
     }
+  }
+
+  @Test
+  public void testSelectWithFilterLookupExtractionFn () {
+
+    Map<String, String> extractionMap = new HashMap<>();
+    extractionMap.put("total_market","replaced");
+    MapLookupExtractor mapLookupExtractor = new MapLookupExtractor(extractionMap, false);
+    LookupExtractionFn lookupExtractionFn = new LookupExtractionFn(mapLookupExtractor, false, null, true, true);
+    SelectQuery query = newTestQuery()
+        .intervals(I_0112_0114)
+        .filters(new SelectorDimFilter(QueryRunnerTestHelper.marketDimension, "replaced", lookupExtractionFn))
+        .granularity(QueryRunnerTestHelper.dayGran)
+        .dimensionSpecs(DefaultDimensionSpec.toSpec(QueryRunnerTestHelper.qualityDimension))
+        .metrics(Lists.<String>newArrayList(QueryRunnerTestHelper.indexMetric))
+        .build();
+
+    Iterable<Result<SelectResultValue>> results = Sequences.toList(
+        runner.run(query, Maps.newHashMap()),
+        Lists.<Result<SelectResultValue>>newArrayList()
+    );
+    Iterable<Result<SelectResultValue>> resultsOptimize = Sequences.toList(
+        toolChest.mergeResults(toolChest.preMergeQueryDecoration(runner)).run(query, Maps.newHashMap()),
+        Lists.<Result<SelectResultValue>>newArrayList()
+    );
+
+    final List<List<Map<String, Object>>> events = toEvents(
+        new String[]{
+            EventHolder.timestampKey + ":TIME",
+            null,
+            QueryRunnerTestHelper.qualityDimension + ":STRING",
+            null,
+            null,
+            QueryRunnerTestHelper.indexMetric + ":FLOAT"
+        },
+        // filtered values with day granularity
+        new String[]{
+            "2011-01-12T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1000.000000",
+            "2011-01-12T00:00:00.000Z	total_market	premium	preferred	ppreferred	1000.000000"
+        },
+        new String[]{
+            "2011-01-13T00:00:00.000Z	total_market	mezzanine	preferred	mpreferred	1040.945505",
+            "2011-01-13T00:00:00.000Z	total_market	premium	preferred	ppreferred	1689.012875"
+        }
+    );
+
+    PagingOffset offset = query.getPagingOffset(QueryRunnerTestHelper.segmentId);
+    List<Result<SelectResultValue>> expectedResults = toExpected(
+        events,
+        offset.startOffset(),
+        offset.threshold()
+    );
+
+    verify(expectedResults, results);
+    verify(expectedResults, resultsOptimize);
   }
 
   @Test

--- a/processing/src/test/java/io/druid/query/select/SelectQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/select/SelectQueryRunnerTest.java
@@ -477,8 +477,8 @@ public class SelectQueryRunnerTest
         Lists.<Result<SelectResultValue>>newArrayList()
     );
     Iterable<Result<SelectResultValue>> resultsOptimize = Sequences.toList(
-        toolChest.mergeResults(toolChest.preMergeQueryDecoration(runner)).run(query, Maps.newHashMap()),
-        Lists.<Result<SelectResultValue>>newArrayList()
+        toolChest.postMergeQueryDecoration(toolChest.mergeResults(toolChest.preMergeQueryDecoration(runner))).
+                run(query, Maps.<String, Object>newHashMap()), Lists.<Result<SelectResultValue>>newArrayList()
     );
 
     final List<List<Map<String, Object>>> events = toEvents(

--- a/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerTest.java
@@ -2328,8 +2328,8 @@ public class TimeseriesQueryRunnerTest
     TimeseriesQueryQueryToolChest toolChest = new TimeseriesQueryQueryToolChest(
         QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
     );
-    QueryRunner<Result<TimeseriesResultValue>> optimizedRunner = toolChest.mergeResults(
-        toolChest.preMergeQueryDecoration(runner));
+    QueryRunner<Result<TimeseriesResultValue>> optimizedRunner = toolChest.postMergeQueryDecoration(
+        toolChest.mergeResults(toolChest.preMergeQueryDecoration(runner)));
     Iterable<Result<TimeseriesResultValue>> results2 = Sequences.toList(
         optimizedRunner.run(query, CONTEXT),
         Lists.<Result<TimeseriesResultValue>>newArrayList()

--- a/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerTest.java
@@ -37,6 +37,7 @@ import io.druid.query.aggregation.DoubleMinAggregatorFactory;
 import io.druid.query.aggregation.FilteredAggregatorFactory;
 import io.druid.query.aggregation.LongSumAggregatorFactory;
 import io.druid.query.aggregation.PostAggregator;
+import io.druid.query.extraction.MapLookupExtractor;
 import io.druid.query.filter.AndDimFilter;
 import io.druid.query.filter.BoundDimFilter;
 import io.druid.query.filter.DimFilter;
@@ -44,6 +45,7 @@ import io.druid.query.filter.InDimFilter;
 import io.druid.query.filter.NotDimFilter;
 import io.druid.query.filter.RegexDimFilter;
 import io.druid.query.filter.SelectorDimFilter;
+import io.druid.query.lookup.LookupExtractionFn;
 import io.druid.query.spec.MultipleIntervalSegmentSpec;
 import io.druid.segment.TestHelper;
 import org.joda.time.DateTime;
@@ -2265,5 +2267,74 @@ public class TimeseriesQueryRunnerTest
         Lists.<Result<TimeseriesResultValue>>newArrayList()
     );
     TestHelper.assertExpectedResults(expectedResults, results);
+  }
+
+  @Test
+  public void testTimeSeriesWithSelectionFilterLookupExtractionFn()
+  {
+    Map<String, String> extractionMap = new HashMap<>();
+    extractionMap.put("spot","upfront");
+
+    MapLookupExtractor mapLookupExtractor = new MapLookupExtractor(extractionMap, false);
+    LookupExtractionFn lookupExtractionFn = new LookupExtractionFn(mapLookupExtractor, true, null, true, true);
+    TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
+                                  .dataSource(QueryRunnerTestHelper.dataSource)
+                                  .granularity(QueryRunnerTestHelper.dayGran)
+                                  .filters(
+                                      new SelectorDimFilter(QueryRunnerTestHelper.marketDimension, "upfront", lookupExtractionFn)
+                                  )
+                                  .intervals(QueryRunnerTestHelper.firstToThird)
+                                  .aggregators(
+                                      Arrays.<AggregatorFactory>asList(
+                                          QueryRunnerTestHelper.rowsCount,
+                                          QueryRunnerTestHelper.indexLongSum,
+                                          QueryRunnerTestHelper.qualityUniques
+                                      )
+                                  )
+                                  .postAggregators(Arrays.<PostAggregator>asList(QueryRunnerTestHelper.addRowsIndexConstant))
+                                  .build();
+
+    List<Result<TimeseriesResultValue>> expectedResults = Arrays.asList(
+        new Result<>(
+            new DateTime("2011-04-01"),
+            new TimeseriesResultValue(
+                ImmutableMap.<String, Object>of(
+                    "rows", 11L,
+                    "index", 3783L,
+                    "addRowsIndexConstant", 3795.0,
+                    "uniques", QueryRunnerTestHelper.UNIQUES_9
+                )
+            )
+        ),
+        new Result<>(
+            new DateTime("2011-04-02"),
+            new TimeseriesResultValue(
+                ImmutableMap.<String, Object>of(
+                    "rows", 11L,
+                    "index", 3313L,
+                    "addRowsIndexConstant", 3325.0,
+                    "uniques", QueryRunnerTestHelper.UNIQUES_9
+                )
+            )
+        )
+    );
+
+    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
+        runner.run(query, CONTEXT),
+        Lists.<Result<TimeseriesResultValue>>newArrayList()
+    );
+    TestHelper.assertExpectedResults(expectedResults, results);
+
+    TimeseriesQueryQueryToolChest toolChest = new TimeseriesQueryQueryToolChest(
+        QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
+    );
+    QueryRunner<Result<TimeseriesResultValue>> optimizedRunner = toolChest.mergeResults(
+        toolChest.preMergeQueryDecoration(runner));
+    Iterable<Result<TimeseriesResultValue>> results2 = Sequences.toList(
+        optimizedRunner.run(query, CONTEXT),
+        Lists.<Result<TimeseriesResultValue>>newArrayList()
+    );
+    TestHelper.assertExpectedResults(expectedResults, results2);
+
   }
 }


### PR DESCRIPTION
Fixes #2766 
Added runner that optimizes the dimension filter for TimeSeries, Search, and Select queries. Note these query types are the only queries other than TopN and GroupBy that has dimension filter. The runner is added in preMergeQueryDecoration of QueryToolChest, which should only be called on the broker once for each query.