### PR TITLE
use correct ObjectMapper in Index[IO/Merger] in AggregationTestHelper

### DIFF
--- a/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchMergeAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchMergeAggregatorFactory.java
@@ -86,7 +86,7 @@ public class SketchMergeAggregatorFactory extends SketchAggregatorFactory
           name,
           Math.max(size, castedOther.size),
           shouldFinalize,
-          true,
+          false,
           errorBoundsStdDev
       );
     } else {

--- a/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
@@ -69,7 +69,7 @@ import io.druid.segment.IndexSpec;
 import io.druid.segment.QueryableIndex;
 import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.Segment;
-import io.druid.segment.TestHelper;
+import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.commons.io.IOUtils;
@@ -164,10 +164,22 @@ public class AggregationTestHelper
         pool
     );
 
+    IndexIO indexIO = new IndexIO(
+        mapper,
+        new ColumnConfig()
+        {
+          @Override
+          public int columnCacheSizeBytes()
+          {
+            return 0;
+          }
+        }
+    );
+
     return new AggregationTestHelper(
         mapper,
-        TestHelper.getTestIndexMerger(),
-        TestHelper.getTestIndexIO(),
+        new IndexMerger(mapper, indexIO),
+        indexIO,
         toolchest,
         factory,
         tempFolder,
@@ -196,10 +208,22 @@ public class AggregationTestHelper
         QueryRunnerTestHelper.NOOP_QUERYWATCHER
     );
 
+    IndexIO indexIO = new IndexIO(
+        mapper,
+        new ColumnConfig()
+        {
+          @Override
+          public int columnCacheSizeBytes()
+          {
+            return 0;
+          }
+        }
+    );
+
     return new AggregationTestHelper(
         mapper,
-        TestHelper.getTestIndexMerger(),
-        TestHelper.getTestIndexIO(),
+        new IndexMerger(mapper, indexIO),
+        indexIO,
         toolchest,
         factory,
         tempFolder,


### PR DESCRIPTION
or else exceptions are printed in the test because ObjectMapper present in  IndexIO can't deserialize the Sketch aggregators in the segment metadata.
and set isInputThetaSketch to false for merged aggregator, it doesn't change anything but false is more appropriate.