### PR TITLE
[QTL] Datasource as lookupTier

### DIFF
--- a/docs/content/querying/lookups.md
+++ b/docs/content/querying/lookups.md
@@ -291,9 +291,8 @@ To configure a Broker / Router / Historical / Peon to announce itself as part of
 
 |Property | Description | Default |
 |---------|-------------|---------|
-|`druid.lookup.tierName`| The tier for **lookups** for this node. This is independent of other tiers.|`__default`|
-|`druid.lookup.lookupTierIsDatasource`|For some things like indexing service tasks, the datasource is passed in the runtime properties of a task. This option fetches the tierName from the same value as the datasource for the task. It is suggested to only use this as peon options for the indexing service, if at all. If true, `druid.lookup.tierName` MUST NOT be specified|`"false"`|
-
+|`druid.lookup.lookupTier`| The tier for **lookups** for this node. This is independent of other tiers.|`__default`|
+|`druid.lookup.lookupTierIsDatasource`|For some things like indexing service tasks, the datasource is passed in the runtime properties of a task. This option fetches the tierName from the same value as the datasource for the task. It is suggested to only use this as peon options for the indexing service, if at all. If true, `druid.lookup.lookupTier` MUST NOT be specified|`"false"`|
 
 ## Saving configuration across restarts
 

--- a/docs/content/querying/lookups.md
+++ b/docs/content/querying/lookups.md
@@ -292,6 +292,7 @@ To configure a Broker / Router / Historical / Peon to announce itself as part of
 |Property | Description | Default |
 |---------|-------------|---------|
 |`druid.lookup.tierName`| The tier for **lookups** for this node. This is independent of other tiers.|`__default`|
+|`druid.lookup.lookupTierIsDatasource`|For some things like indexing service tasks, the datasource is passed in the runtime properties of a task. This option fetches the tierName from the same value as the datasource for the task. It is suggested to only use this as peon options for the indexing service, if at all. If true, `druid.lookup.tierName` MUST NOT be specified|`"false"`|
 
 
 ## Saving configuration across restarts

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/ForkingTaskRunner.java
@@ -347,7 +347,7 @@ public class ForkingTaskRunner implements TaskRunner, TaskLogStreamer
                                 }
                               }
 
-                              // Add dataSource and taskId for metrics
+                              // Add dataSource and taskId for metrics or logging
                               command.add(
                                   String.format(
                                       "-D%s%s=%s",

--- a/server/src/main/java/io/druid/server/initialization/jetty/JettyServerModule.java
+++ b/server/src/main/java/io/druid/server/initialization/jetty/JettyServerModule.java
@@ -233,7 +233,7 @@ public class JettyServerModule extends JerseyServletModule
 
     public JettyMonitor(String dataSource, String taskId)
     {
-      this.dimensions = MonitorsConfig.mapOfDimensionAndTaskID(dataSource, taskId);
+      this.dimensions = MonitorsConfig.mapOfDatasourceAndTaskID(dataSource, taskId);
     }
 
     @Override

--- a/server/src/main/java/io/druid/server/initialization/jetty/JettyServerModule.java
+++ b/server/src/main/java/io/druid/server/initialization/jetty/JettyServerModule.java
@@ -57,18 +57,19 @@ import io.druid.server.initialization.ServerConfig;
 import io.druid.server.metrics.DataSourceTaskIdHolder;
 import io.druid.server.metrics.MetricsModule;
 import io.druid.server.metrics.MonitorsConfig;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
-import javax.servlet.ServletException;
 import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
+
+import javax.servlet.ServletException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  */

--- a/server/src/main/java/io/druid/server/metrics/DataSourceTaskIdHolder.java
+++ b/server/src/main/java/io/druid/server/metrics/DataSourceTaskIdHolder.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.metrics;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import io.druid.query.DruidMetrics;
+
+public class DataSourceTaskIdHolder
+{
+  @Named(MonitorsConfig.METRIC_DIMENSION_PREFIX + DruidMetrics.DATASOURCE)
+  @Inject(optional = true)
+  String dataSource = null;
+  @Named(MonitorsConfig.METRIC_DIMENSION_PREFIX + DruidMetrics.ID)
+  @Inject(optional = true)
+  String taskId = null;
+
+  public String getDataSource()
+  {
+    return dataSource;
+  }
+
+  public String getTaskId()
+  {
+    return taskId;
+  }
+}

--- a/server/src/main/java/io/druid/server/metrics/DataSourceTaskIdHolder.java
+++ b/server/src/main/java/io/druid/server/metrics/DataSourceTaskIdHolder.java
@@ -21,14 +21,15 @@ package io.druid.server.metrics;
 
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
-import io.druid.query.DruidMetrics;
 
 public class DataSourceTaskIdHolder
 {
-  @Named(MonitorsConfig.METRIC_DIMENSION_PREFIX + DruidMetrics.DATASOURCE)
+  public static final String DATA_SOURCE_BINDING = "druidDataSource";
+  public static final String TASK_ID_BINDING = "druidTaskId";
+  @Named(DATA_SOURCE_BINDING)
   @Inject(optional = true)
   String dataSource = null;
-  @Named(MonitorsConfig.METRIC_DIMENSION_PREFIX + DruidMetrics.ID)
+  @Named(TASK_ID_BINDING)
   @Inject(optional = true)
   String taskId = null;
 

--- a/server/src/main/java/io/druid/server/metrics/MetricsModule.java
+++ b/server/src/main/java/io/druid/server/metrics/MetricsModule.java
@@ -41,6 +41,7 @@ import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.LazySingleton;
 import io.druid.guice.ManageLifecycle;
 import io.druid.query.ExecutorServiceMonitor;
+
 import java.util.List;
 import java.util.Set;
 
@@ -110,7 +111,7 @@ public class MetricsModule implements Module
       DataSourceTaskIdHolder dataSourceTaskIdHolder
   )
   {
-    return new JvmMonitor(MonitorsConfig.mapOfDimensionAndTaskID(
+    return new JvmMonitor(MonitorsConfig.mapOfDatasourceAndTaskID(
         dataSourceTaskIdHolder.getDataSource(),
         dataSourceTaskIdHolder.getTaskId()
     ));
@@ -122,7 +123,7 @@ public class MetricsModule implements Module
       DataSourceTaskIdHolder dataSourceTaskIdHolder
   )
   {
-    return new JvmCpuMonitor(MonitorsConfig.mapOfDimensionAndTaskID(
+    return new JvmCpuMonitor(MonitorsConfig.mapOfDatasourceAndTaskID(
         dataSourceTaskIdHolder.getDataSource(),
         dataSourceTaskIdHolder.getTaskId()
     ));
@@ -134,7 +135,7 @@ public class MetricsModule implements Module
       DataSourceTaskIdHolder dataSourceTaskIdHolder
   )
   {
-    return new SysMonitor(MonitorsConfig.mapOfDimensionAndTaskID(
+    return new SysMonitor(MonitorsConfig.mapOfDatasourceAndTaskID(
         dataSourceTaskIdHolder.getDataSource(),
         dataSourceTaskIdHolder.getTaskId()
     ));

--- a/server/src/main/java/io/druid/server/metrics/MetricsModule.java
+++ b/server/src/main/java/io/druid/server/metrics/MetricsModule.java
@@ -40,11 +40,8 @@ import io.druid.guice.DruidBinders;
 import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.LazySingleton;
 import io.druid.guice.ManageLifecycle;
-import io.druid.query.DruidMetrics;
 import io.druid.query.ExecutorServiceMonitor;
-
 import java.util.List;
-import java.util.Properties;
 import java.util.Set;
 
 /**
@@ -67,6 +64,8 @@ public class MetricsModule implements Module
     JsonConfigProvider.bind(binder, "druid.monitoring", MonitorsConfig.class);
 
     DruidBinders.metricMonitorBinder(binder); // get the binder so that it will inject the empty set at a minimum.
+
+    binder.bind(DataSourceTaskIdHolder.class).in(LazySingleton.class);
 
     binder.bind(EventReceiverFirehoseRegister.class).in(LazySingleton.class);
     binder.bind(ExecutorServiceMonitor.class).in(LazySingleton.class);
@@ -107,39 +106,37 @@ public class MetricsModule implements Module
 
   @Provides
   @ManageLifecycle
-  public JvmMonitor getJvmMonitor(Properties props)
+  public JvmMonitor getJvmMonitor(
+      DataSourceTaskIdHolder dataSourceTaskIdHolder
+  )
   {
-    return new JvmMonitor(MonitorsConfig.extractDimensions(props,
-                                                           Lists.newArrayList(
-                                                               DruidMetrics.DATASOURCE,
-                                                               DruidMetrics.TASK_ID
-                                                           )
+    return new JvmMonitor(MonitorsConfig.mapOfDimensionAndTaskID(
+        dataSourceTaskIdHolder.getDataSource(),
+        dataSourceTaskIdHolder.getTaskId()
     ));
   }
 
   @Provides
   @ManageLifecycle
-  public JvmCpuMonitor getJvmCpuMonitor(Properties props)
+  public JvmCpuMonitor getJvmCpuMonitor(
+      DataSourceTaskIdHolder dataSourceTaskIdHolder
+  )
   {
-    return new JvmCpuMonitor(MonitorsConfig.extractDimensions(props,
-                                                              Lists.newArrayList(
-                                                                  DruidMetrics.DATASOURCE,
-                                                                  DruidMetrics.TASK_ID
-                                                              )
+    return new JvmCpuMonitor(MonitorsConfig.mapOfDimensionAndTaskID(
+        dataSourceTaskIdHolder.getDataSource(),
+        dataSourceTaskIdHolder.getTaskId()
     ));
   }
 
   @Provides
   @ManageLifecycle
-  public SysMonitor getSysMonitor(Properties props)
+  public SysMonitor getSysMonitor(
+      DataSourceTaskIdHolder dataSourceTaskIdHolder
+  )
   {
-    return new SysMonitor(MonitorsConfig.extractDimensions(props,
-                                                           Lists.newArrayList(
-                                                               DruidMetrics.DATASOURCE,
-                                                               DruidMetrics.TASK_ID
-                                                           )
+    return new SysMonitor(MonitorsConfig.mapOfDimensionAndTaskID(
+        dataSourceTaskIdHolder.getDataSource(),
+        dataSourceTaskIdHolder.getTaskId()
     ));
   }
-
-
 }

--- a/server/src/main/java/io/druid/server/metrics/MonitorsConfig.java
+++ b/server/src/main/java/io/druid/server/metrics/MonitorsConfig.java
@@ -22,12 +22,12 @@ package io.druid.server.metrics;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Lists;
 import com.metamx.metrics.Monitor;
-
-import javax.validation.constraints.NotNull;
+import io.druid.query.DruidMetrics;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import javax.validation.constraints.NotNull;
 
 /**
  */
@@ -50,6 +50,22 @@ public class MonitorsConfig
     return "MonitorsConfig{" +
            "monitors=" + monitors +
            '}';
+  }
+
+
+  public static Map<String, String[]> mapOfDimensionAndTaskID(
+      final String dimension,
+      final String taskId
+  )
+  {
+    final Map<String, String[]> dimensionMap = new HashMap<>();
+    if (dimension != null) {
+      dimensionMap.put(DruidMetrics.DATASOURCE, new String[]{dimension});
+    }
+    if (taskId != null) {
+      dimensionMap.put(DruidMetrics.ID, new String[]{taskId});
+    }
+    return dimensionMap;
   }
 
   public static Map<String, String[]> extractDimensions(Properties props, List<String> dimensions)

--- a/server/src/main/java/io/druid/server/metrics/MonitorsConfig.java
+++ b/server/src/main/java/io/druid/server/metrics/MonitorsConfig.java
@@ -20,14 +20,16 @@
 package io.druid.server.metrics;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.metamx.metrics.Monitor;
 import io.druid.query.DruidMetrics;
+
+import javax.validation.constraints.NotNull;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import javax.validation.constraints.NotNull;
 
 /**
  */
@@ -53,19 +55,19 @@ public class MonitorsConfig
   }
 
 
-  public static Map<String, String[]> mapOfDimensionAndTaskID(
-      final String dimension,
+  public static Map<String, String[]> mapOfDatasourceAndTaskID(
+      final String datasource,
       final String taskId
   )
   {
-    final Map<String, String[]> dimensionMap = new HashMap<>();
-    if (dimension != null) {
-      dimensionMap.put(DruidMetrics.DATASOURCE, new String[]{dimension});
+    final ImmutableMap.Builder<String, String[]> builder = ImmutableMap.builder();
+    if (datasource != null) {
+      builder.put(DruidMetrics.DATASOURCE, new String[]{datasource});
     }
     if (taskId != null) {
-      dimensionMap.put(DruidMetrics.ID, new String[]{taskId});
+      builder.put(DruidMetrics.ID, new String[]{taskId});
     }
-    return dimensionMap;
+    return builder.build();
   }
 
   public static Map<String, String[]> extractDimensions(Properties props, List<String> dimensions)

--- a/server/src/test/java/io/druid/query/lookup/LookupListeningAnnouncerConfigTest.java
+++ b/server/src/test/java/io/druid/query/lookup/LookupListeningAnnouncerConfigTest.java
@@ -40,7 +40,7 @@ import org.junit.Test;
 public class LookupListeningAnnouncerConfigTest
 {
   private static final String propertyBase = "some.property";
-  private static final Injector injector = Initialization.makeInjectorWithModules(
+  private final Injector injector = Initialization.makeInjectorWithModules(
       GuiceInjectors.makeStartupInjector(),
       ImmutableList.of(
           new Module()
@@ -52,7 +52,8 @@ public class LookupListeningAnnouncerConfigTest
                   binder, Key.get(DruidNode.class, Self.class), new DruidNode("test-inject", null, null)
               );
             }
-          }
+          },
+          new LookupModule()
       )
   );
 

--- a/server/src/test/java/io/druid/query/lookup/LookupListeningAnnouncerConfigTest.java
+++ b/server/src/test/java/io/druid/query/lookup/LookupListeningAnnouncerConfigTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.lookup;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import io.druid.guice.GuiceInjectors;
+import io.druid.guice.JsonConfigProvider;
+import io.druid.guice.JsonConfigurator;
+import io.druid.guice.annotations.Self;
+import io.druid.initialization.Initialization;
+import io.druid.query.DruidMetrics;
+import io.druid.server.DruidNode;
+import io.druid.server.metrics.MonitorsConfig;
+import java.util.Properties;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class LookupListeningAnnouncerConfigTest
+{
+  private static final String propertyBase = "some.property";
+  private static final Injector injector = Initialization.makeInjectorWithModules(
+      GuiceInjectors.makeStartupInjector(),
+      ImmutableList.of(
+          new Module()
+          {
+            @Override
+            public void configure(Binder binder)
+            {
+              JsonConfigProvider.bindInstance(
+                  binder, Key.get(DruidNode.class, Self.class), new DruidNode("test-inject", null, null)
+              );
+            }
+          }
+      )
+  );
+
+  private final Properties properties = injector.getInstance(Properties.class);
+
+  @Before
+  public void setUp()
+  {
+    properties.clear();
+  }
+
+  @Test
+  public void testDefaultInjection()
+  {
+    final JsonConfigurator configurator = injector.getBinding(JsonConfigurator.class).getProvider().get();
+    final JsonConfigProvider<LookupListeningAnnouncerConfig> configProvider = JsonConfigProvider.of(
+        propertyBase,
+        LookupListeningAnnouncerConfig.class
+    );
+    configProvider.inject(properties, configurator);
+    final LookupListeningAnnouncerConfig config = configProvider.get().get();
+    Assert.assertEquals(LookupListeningAnnouncerConfig.DEFAULT_TIER, config.getLookupTier());
+  }
+
+  @Test
+  public void testSimpleInjection()
+  {
+    final String lookupTier = "some_tier";
+    final JsonConfigurator configurator = injector.getBinding(JsonConfigurator.class).getProvider().get();
+    properties.put(propertyBase + ".lookupTier", lookupTier);
+    final JsonConfigProvider<LookupListeningAnnouncerConfig> configProvider = JsonConfigProvider.of(
+        propertyBase,
+        LookupListeningAnnouncerConfig.class
+    );
+    configProvider.inject(properties, configurator);
+    final LookupListeningAnnouncerConfig config = configProvider.get().get();
+    Assert.assertEquals(lookupTier, config.getLookupTier());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testFailsOnEmptyTier()
+  {
+    final JsonConfigurator configurator = injector.getBinding(JsonConfigurator.class).getProvider().get();
+    properties.put(propertyBase + ".lookupTier", "");
+    final JsonConfigProvider<LookupListeningAnnouncerConfig> configProvider = JsonConfigProvider.of(
+        propertyBase,
+        LookupListeningAnnouncerConfig.class
+    );
+    configProvider.inject(properties, configurator);
+    final LookupListeningAnnouncerConfig config = configProvider.get().get();
+    config.getLookupTier();
+  }
+
+  @Test
+  public void testDatasourceInjection()
+  {
+    final String lookupTier = "some_tier";
+    final JsonConfigurator configurator = injector.getBinding(JsonConfigurator.class).getProvider().get();
+    properties.put(propertyBase + ".lookupTierIsDatasource", "true");
+    properties.put(MonitorsConfig.METRIC_DIMENSION_PREFIX + DruidMetrics.DATASOURCE, lookupTier);
+    final JsonConfigProvider<LookupListeningAnnouncerConfig> configProvider = JsonConfigProvider.of(
+        propertyBase,
+        LookupListeningAnnouncerConfig.class
+    );
+    configProvider.inject(properties, configurator);
+    final LookupListeningAnnouncerConfig config = configProvider.get().get();
+    Assert.assertEquals(lookupTier, config.getLookupTier());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testFailsInjection()
+  {
+    final String lookupTier = "some_tier";
+    final JsonConfigurator configurator = injector.getBinding(JsonConfigurator.class).getProvider().get();
+    properties.put(propertyBase + ".lookupTier", lookupTier);
+    properties.put(propertyBase + ".lookupTierIsDatasource", "true");
+    final JsonConfigProvider<LookupListeningAnnouncerConfig> configProvider = JsonConfigProvider.of(
+        propertyBase,
+        LookupListeningAnnouncerConfig.class
+    );
+    configProvider.inject(properties, configurator);
+    final LookupListeningAnnouncerConfig config = configProvider.get().get();
+    Assert.assertEquals(lookupTier, config.getLookupTier());
+  }
+}

--- a/server/src/test/java/io/druid/query/lookup/LookupListeningAnnouncerConfigTest.java
+++ b/server/src/test/java/io/druid/query/lookup/LookupListeningAnnouncerConfigTest.java
@@ -30,13 +30,13 @@ import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.JsonConfigurator;
 import io.druid.guice.annotations.Self;
 import io.druid.initialization.Initialization;
-import io.druid.query.DruidMetrics;
 import io.druid.server.DruidNode;
-import io.druid.server.metrics.MonitorsConfig;
-import java.util.Properties;
+import io.druid.server.metrics.DataSourceTaskIdHolder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Properties;
 
 public class LookupListeningAnnouncerConfigTest
 {
@@ -54,7 +54,7 @@ public class LookupListeningAnnouncerConfigTest
               );
               binder.bind(Key.get(
                   String.class,
-                  Names.named(MonitorsConfig.METRIC_DIMENSION_PREFIX + DruidMetrics.DATASOURCE)
+                  Names.named(DataSourceTaskIdHolder.DATA_SOURCE_BINDING)
               )).toInstance("some_datasource");
             }
           },

--- a/server/src/test/java/io/druid/query/lookup/LookupListeningAnnouncerConfigTest.java
+++ b/server/src/test/java/io/druid/query/lookup/LookupListeningAnnouncerConfigTest.java
@@ -24,6 +24,7 @@ import com.google.inject.Binder;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
+import com.google.inject.name.Names;
 import io.druid.guice.GuiceInjectors;
 import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.JsonConfigurator;
@@ -51,6 +52,10 @@ public class LookupListeningAnnouncerConfigTest
               JsonConfigProvider.bindInstance(
                   binder, Key.get(DruidNode.class, Self.class), new DruidNode("test-inject", null, null)
               );
+              binder.bind(Key.get(
+                  String.class,
+                  Names.named(MonitorsConfig.METRIC_DIMENSION_PREFIX + DruidMetrics.DATASOURCE)
+              )).toInstance("some_datasource");
             }
           },
           new LookupModule()
@@ -110,17 +115,15 @@ public class LookupListeningAnnouncerConfigTest
   @Test
   public void testDatasourceInjection()
   {
-    final String lookupTier = "some_tier";
     final JsonConfigurator configurator = injector.getBinding(JsonConfigurator.class).getProvider().get();
     properties.put(propertyBase + ".lookupTierIsDatasource", "true");
-    properties.put(MonitorsConfig.METRIC_DIMENSION_PREFIX + DruidMetrics.DATASOURCE, lookupTier);
     final JsonConfigProvider<LookupListeningAnnouncerConfig> configProvider = JsonConfigProvider.of(
         propertyBase,
         LookupListeningAnnouncerConfig.class
     );
     configProvider.inject(properties, configurator);
     final LookupListeningAnnouncerConfig config = configProvider.get().get();
-    Assert.assertEquals(lookupTier, config.getLookupTier());
+    Assert.assertEquals("some_datasource", config.getLookupTier());
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/server/src/test/java/io/druid/server/metrics/MetricsModuleTest.java
+++ b/server/src/test/java/io/druid/server/metrics/MetricsModuleTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.metrics;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.name.Names;
+import io.druid.guice.GuiceInjectors;
+import io.druid.guice.JsonConfigProvider;
+import io.druid.guice.annotations.Self;
+import io.druid.initialization.Initialization;
+import io.druid.query.DruidMetrics;
+import io.druid.server.DruidNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MetricsModuleTest
+{
+  @Test
+  public void testSimpleInjection()
+  {
+    final Injector injector = Initialization.makeInjectorWithModules(
+        GuiceInjectors.makeStartupInjector(),
+        ImmutableList.of(new Module()
+        {
+
+          @Override
+          public void configure(Binder binder)
+          {
+            JsonConfigProvider.bindInstance(
+                binder, Key.get(DruidNode.class, Self.class), new DruidNode("test-inject", null, null)
+            );
+          }
+        })
+    );
+    final DataSourceTaskIdHolder dimensionIdHolder = new DataSourceTaskIdHolder();
+    injector.injectMembers(dimensionIdHolder);
+    Assert.assertNull(dimensionIdHolder.getDataSource());
+    Assert.assertNull(dimensionIdHolder.getTaskId());
+  }
+
+  @Test
+  public void testSimpleInjectionWithValues()
+  {
+    final String dataSource = "some datasource";
+    final String taskId = "some task";
+    final Injector injector = Initialization.makeInjectorWithModules(
+        GuiceInjectors.makeStartupInjector(),
+        ImmutableList.of(new Module()
+        {
+
+          @Override
+          public void configure(Binder binder)
+          {
+            JsonConfigProvider.bindInstance(
+                binder, Key.get(DruidNode.class, Self.class), new DruidNode("test-inject", null, null)
+            );
+            binder.bind(Key.get(
+                String.class,
+                Names.named(MonitorsConfig.METRIC_DIMENSION_PREFIX + DruidMetrics.DATASOURCE)
+            )).toInstance(dataSource);
+            binder.bind(Key.get(String.class, Names.named(MonitorsConfig.METRIC_DIMENSION_PREFIX + DruidMetrics.ID)))
+                  .toInstance(taskId);
+          }
+        })
+    );
+    final DataSourceTaskIdHolder dimensionIdHolder = new DataSourceTaskIdHolder();
+    injector.injectMembers(dimensionIdHolder);
+    Assert.assertEquals(dataSource, dimensionIdHolder.getDataSource());
+    Assert.assertEquals(taskId, dimensionIdHolder.getTaskId());
+  }
+}

--- a/server/src/test/java/io/druid/server/metrics/MetricsModuleTest.java
+++ b/server/src/test/java/io/druid/server/metrics/MetricsModuleTest.java
@@ -29,7 +29,6 @@ import io.druid.guice.GuiceInjectors;
 import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.annotations.Self;
 import io.druid.initialization.Initialization;
-import io.druid.query.DruidMetrics;
 import io.druid.server.DruidNode;
 import org.junit.Assert;
 import org.junit.Test;
@@ -77,9 +76,9 @@ public class MetricsModuleTest
             );
             binder.bind(Key.get(
                 String.class,
-                Names.named(MonitorsConfig.METRIC_DIMENSION_PREFIX + DruidMetrics.DATASOURCE)
+                Names.named(DataSourceTaskIdHolder.DATA_SOURCE_BINDING)
             )).toInstance(dataSource);
-            binder.bind(Key.get(String.class, Names.named(MonitorsConfig.METRIC_DIMENSION_PREFIX + DruidMetrics.ID)))
+            binder.bind(Key.get(String.class, Names.named(DataSourceTaskIdHolder.TASK_ID_BINDING)))
                   .toInstance(taskId);
           }
         })

--- a/services/src/main/java/io/druid/cli/CliPeon.java
+++ b/services/src/main/java/io/druid/cli/CliPeon.java
@@ -67,7 +67,6 @@ import io.druid.indexing.overlord.ThreadPoolTaskRunner;
 import io.druid.indexing.worker.executor.ExecutorLifecycle;
 import io.druid.indexing.worker.executor.ExecutorLifecycleConfig;
 import io.druid.metadata.IndexerSQLMetadataStorageCoordinator;
-import io.druid.query.DruidMetrics;
 import io.druid.query.QuerySegmentWalker;
 import io.druid.query.lookup.LookupModule;
 import io.druid.segment.loading.DataSegmentArchiver;
@@ -87,7 +86,7 @@ import io.druid.segment.realtime.plumber.SegmentHandoffNotifierFactory;
 import io.druid.server.QueryResource;
 import io.druid.server.initialization.jetty.ChatHandlerServerModule;
 import io.druid.server.initialization.jetty.JettyServerInitializer;
-import io.druid.server.metrics.MonitorsConfig;
+import io.druid.server.metrics.DataSourceTaskIdHolder;
 import org.eclipse.jetty.server.Server;
 
 import java.io.File;
@@ -246,7 +245,7 @@ public class CliPeon extends GuiceRunnable
 
           @Provides
           @LazySingleton
-          @Named(MonitorsConfig.METRIC_DIMENSION_PREFIX + DruidMetrics.DATASOURCE)
+          @Named(DataSourceTaskIdHolder.DATA_SOURCE_BINDING)
           public String getDataSourceFromTask(final Task task)
           {
             return task.getDataSource();
@@ -254,7 +253,7 @@ public class CliPeon extends GuiceRunnable
 
           @Provides
           @LazySingleton
-          @Named(MonitorsConfig.METRIC_DIMENSION_PREFIX + DruidMetrics.ID)
+          @Named(DataSourceTaskIdHolder.TASK_ID_BINDING)
           public String getTaskIDFromTask(final Task task)
           {
             return task.getId();

--- a/services/src/main/java/io/druid/cli/CliPeon.java
+++ b/services/src/main/java/io/druid/cli/CliPeon.java
@@ -88,13 +88,14 @@ import io.druid.server.QueryResource;
 import io.druid.server.initialization.jetty.ChatHandlerServerModule;
 import io.druid.server.initialization.jetty.JettyServerInitializer;
 import io.druid.server.metrics.MonitorsConfig;
+import org.eclipse.jetty.server.Server;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
-import org.eclipse.jetty.server.Server;
 
 /**
  */


### PR DESCRIPTION
* Adds an option to let indexing service tasks pull their lookup tier from the datasource they are working for.

This allows things spawned via indexing service to tag themselves with the datasource they are running for.

As a quick note so it isn't lost in the comments below:

This uses an object with optional injection fields. I had a hard time figuring out how to make an optional binding in 4.0-beta (4.0 has [OptionalBinder](https://google.github.io/guice/api-docs/4.0/javadoc/com/google/inject/multibindings/OptionalBinder.html) which might work later) This is the best workaround I could come up with. Make an object bound everywhere (via `MetricsModule`), but the fields in the object be optional, and therefore can be bound whenever it makes sense.