### PR TITLE
Allow user to set cost balancer threads more than or equal to the number of cores.

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/CoordinatorDynamicConfig.java
+++ b/server/src/main/java/io/druid/server/coordinator/CoordinatorDynamicConfig.java
@@ -57,10 +57,7 @@ public class CoordinatorDynamicConfig
     this.replicantLifetime = replicantLifetime;
     this.replicationThrottleLimit = replicationThrottleLimit;
     this.emitBalancingStats = emitBalancingStats;
-    this.balancerComputeThreads = Math.min(
-        Math.max(balancerComputeThreads, 1),
-        Math.max(Runtime.getRuntime().availableProcessors() - 1, 1)
-    );
+    this.balancerComputeThreads = Math.max(balancerComputeThreads, 1);
     this.killDataSourceWhitelist = killDataSourceWhitelist;
   }
 

--- a/server/src/test/java/io/druid/server/http/CoordinatorDynamicConfigTest.java
+++ b/server/src/test/java/io/druid/server/http/CoordinatorDynamicConfigTest.java
@@ -40,6 +40,7 @@ public class CoordinatorDynamicConfigTest
                      + "  \"maxSegmentsToMove\": 1,\n"
                      + "  \"replicantLifetime\": 1,\n"
                      + "  \"replicationThrottleLimit\": 1,\n"
+                     + "  \"balancerComputeThreads\": 2, \n"
                      + "  \"emitBalancingStats\": true,\n"
                      + "  \"killDataSourceWhitelist\": [\"test\"]\n"
                      + "}\n";
@@ -56,7 +57,7 @@ public class CoordinatorDynamicConfigTest
     );
 
     Assert.assertEquals(
-        new CoordinatorDynamicConfig(1, 1, 1, 1, 1, 1, 1, true, ImmutableSet.of("test")),
+        new CoordinatorDynamicConfig(1, 1, 1, 1, 1, 1, 2, true, ImmutableSet.of("test")),
         actual
     );
   }


### PR DESCRIPTION
Allow user to set cost balancer threads more than or equal to the number of cores.
FWIW, I am unable to set balancer threads to 4 on a machine having 2 cpu cores. 