### PR TITLE
new interval based cost function

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -52,6 +52,11 @@
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.druid</groupId>
+      <artifactId>druid-server</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.github.wnameless</groupId>
       <artifactId>json-flattener</artifactId>
       <version>0.1.0</version>

--- a/benchmarks/src/main/java/io/druid/server/coordinator/CostBalancerStrategyBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/server/coordinator/CostBalancerStrategyBenchmark.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.coordinator;
+
+import io.druid.timeline.DataSegment;
+import org.joda.time.DateTime;
+import org.joda.time.Interval;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+public class CostBalancerStrategyBenchmark
+{
+  private final static DateTime t0 = new DateTime("2016-01-01T01:00:00Z");
+
+  private List<DataSegment> segments;
+  private DataSegment segment;
+
+  int x1 = 2;
+  int y0 = 3;
+  int y1 = 4;
+
+  int n = 10000;
+
+  @Setup
+  public void setupDummyCluster()
+  {
+    segment = createSegment(t0);
+
+    Random r = new Random(1234);
+    segments = new ArrayList<>(n);
+    for(int i = 0; i < n; ++i) {
+      final DateTime t = t0.minusHours(r.nextInt(365 * 24) - 365*12);
+      segments.add(createSegment(t));
+    }
+  }
+
+  DataSegment createSegment(DateTime t)
+  {
+    return new DataSegment(
+        "test",
+        new Interval(t, t.plusHours(1)),
+        "v1",
+        null,
+        null,
+        null,
+        null,
+        0,
+        0
+    );
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @Fork(1)
+  public double measureCostStrategySingle() throws InterruptedException
+  {
+    double totalCost = 0;
+    for(DataSegment s :  segments) {
+      totalCost += CostBalancerStrategy.computeJointSegmentsCost(segment, s);
+    }
+    return totalCost;
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @Fork(1)
+  public double measureIntervalPenalty() throws InterruptedException
+  {
+    return CostBalancerStrategy.intervalCost(x1, y0, y1);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -556,6 +556,11 @@
                 <artifactId>derbyclient</artifactId>
                 <version>10.11.1.1</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-math3</artifactId>
+                <version>3.6.1</version>
+            </dependency>
 
             <!-- Test Scope -->
             <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -173,6 +173,10 @@
             <groupId>org.apache.derby</groupId>
             <artifactId>derbyclient</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-math3</artifactId>
+        </dependency>
 
         <!-- Tests -->
         <dependency>

--- a/server/src/main/java/io/druid/server/coordinator/CostBalancerStrategy.java
+++ b/server/src/main/java/io/druid/server/coordinator/CostBalancerStrategy.java
@@ -19,44 +19,36 @@
 
 package io.druid.server.coordinator;
 
+import com.google.common.base.Predicates;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.metamx.common.Pair;
 import com.metamx.emitter.EmittingLogger;
 import io.druid.timeline.DataSegment;
-import org.joda.time.DateTime;
+import org.apache.commons.math3.util.FastMath;
 import org.joda.time.Interval;
 
 import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
 
 public class CostBalancerStrategy implements BalancerStrategy
 {
   private static final EmittingLogger log = new EmittingLogger(CostBalancerStrategy.class);
-  private static final long DAY_IN_MILLIS = 1000 * 60 * 60 * 24;
-  private static final long SEVEN_DAYS_IN_MILLIS = 7 * DAY_IN_MILLIS;
-  private static final long THIRTY_DAYS_IN_MILLIS = 30 * DAY_IN_MILLIS;
-  private final long referenceTimestamp;
+
+  static final double HALF_LIFE = 24.0; // cost function half-life in hours
+  static final double LAMBDA = Math.log(2) / HALF_LIFE;
+  static final double INV_LAMBDA_SQUARE = 1 / (LAMBDA * LAMBDA);
+
+  private static final double MILLIS_IN_HOUR = 3_600_000.0;
+  private static final double MILLIS_FACTOR = MILLIS_IN_HOUR / LAMBDA;
+
   private final ListeningExecutorService exec;
 
-  public static long gapMillis(Interval interval1, Interval interval2)
+  public CostBalancerStrategy(ListeningExecutorService exec)
   {
-    if (interval1.getStartMillis() > interval2.getEndMillis()) {
-      return interval1.getStartMillis() - interval2.getEndMillis();
-    } else if (interval2.getStartMillis() > interval1.getEndMillis()) {
-      return interval2.getStartMillis() - interval1.getEndMillis();
-    } else {
-      return 0;
-    }
-  }
-
-  public CostBalancerStrategy(DateTime referenceTimestamp, ListeningExecutorService exec)
-  {
-    this.referenceTimestamp = referenceTimestamp.getMillis();
     this.exec = exec;
   }
 
@@ -81,50 +73,107 @@ public class CostBalancerStrategy implements BalancerStrategy
     return chooseBestServer(proposalSegment, serverHolders, true).rhs;
   }
 
+  static double computeJointSegmentsCost(final DataSegment segment, final Iterable<DataSegment> segmentSet)
+  {
+    double totalCost = 0;
+    for(DataSegment s : segmentSet) {
+      totalCost += computeJointSegmentsCost(segment, s);
+    }
+    return totalCost;
+  }
+
   /**
-   * This defines the unnormalized cost function between two segments.  There is a base cost given by
-   * the minimum size of the two segments and additional penalties.
-   * recencyPenalty: it is more likely that recent segments will be queried together
+   * This defines the unnormalized cost function between two segments.
+   *
    * dataSourcePenalty: if two segments belong to the same data source, they are more likely to be involved
    * in the same queries
-   * gapPenalty: it is more likely that segments close together in time will be queried together
    *
-   * @param segment1 The first DataSegment.
-   * @param segment2 The second DataSegment.
+   * intervalPenalty: it is more likely that segments close together in time will be queried together
+   *
+   * @param segmentA The first DataSegment.
+   * @param segmentB The second DataSegment.
    *
    * @return The joint cost of placing the two DataSegments together on one node.
    */
-  public double computeJointSegmentCosts(final DataSegment segment1, final DataSegment segment2)
+  public static double computeJointSegmentsCost(final DataSegment segmentA, final DataSegment segmentB)
   {
-    final long gapMillis = gapMillis(segment1.getInterval(), segment2.getInterval());
+    final Interval intervalA = segmentA.getInterval();
+    final Interval intervalB = segmentB.getInterval();
 
-    final double baseCost = Math.min(segment1.getSize(), segment2.getSize());
-    double recencyPenalty = 1;
-    double dataSourcePenalty = 1;
-    double gapPenalty = 1;
+    final double t0 = intervalA.getStartMillis();
+    final double t1 = (intervalA.getEndMillis() - t0) / MILLIS_FACTOR;
+    final double start = (intervalB.getStartMillis() - t0) / MILLIS_FACTOR;
+    final double end = (intervalB.getEndMillis() - t0) / MILLIS_FACTOR;
 
-    if (segment1.getDataSource().equals(segment2.getDataSource())) {
-      dataSourcePenalty = 2;
+    final double multiplier = segmentA.getDataSource().equals(segmentB.getDataSource()) ? 2.0 : 1.0;
+
+    return INV_LAMBDA_SQUARE * intervalCost(t1, start, end) * multiplier;
+  }
+
+  /**
+   * Computes the joint cost of two intervals X = [x_0 = 0, x_1) and Y = [y_0, y_1)
+   *
+   * cost(X, Y) = \int_{x_0}^{x_1} \int_{y_0}^{y_1} e^{-\lambda |x-y|}dxdy $$
+   *
+   * lambda = 1 in this particular implementation
+   *
+   * Other values of lambda can be calculated by multiplying inputs by lambda
+   * and multiplying the result by 1 / lambda ^ 2
+   *
+   * Interval start and end are all relative to x_0.
+   * Therefore this function assumes x_0 = 0, x1 >= 0, and y1 > y0
+   *
+   * @param x1 end of interval X
+   * @param y0 start of interval Y
+   * @param y1 end o interval Y
+   * @return joint cost of X and Y
+   */
+  public static double intervalCost(double x1, double y0, double y1)
+  {
+    if (x1 == 0 || y1 == y0) {
+      return 0;
     }
 
-    double segment1diff = referenceTimestamp - segment1.getInterval().getEndMillis();
-    double segment2diff = referenceTimestamp - segment2.getInterval().getEndMillis();
-    if (segment1diff < SEVEN_DAYS_IN_MILLIS && segment2diff < SEVEN_DAYS_IN_MILLIS) {
-      recencyPenalty = (2 - segment1diff / SEVEN_DAYS_IN_MILLIS) * (2 - segment2diff / SEVEN_DAYS_IN_MILLIS);
+    if(y0 < 0) {
+      // swap X and Y
+      double tmp = x1;
+      x1 = y1 - y0;
+      y1 = tmp - y0;
+      y0 = -y0;
     }
 
-    /** gap is null if the two segment intervals overlap or if they're adjacent */
-    if (gapMillis == 0) {
-      gapPenalty = 2;
-    } else {
-      if (gapMillis < THIRTY_DAYS_IN_MILLIS) {
-        gapPenalty = 2 - gapMillis / THIRTY_DAYS_IN_MILLIS;
+    // Y overlaps X
+    if (y0 < x1) {
+      /**
+       * X   [ A )[ B )[ C )   or  [ A )[ B )
+       * Y        [   )                 [   )[ C )
+       *
+       * A could be empty if y0 == 0
+       * C could be empty if y1 == x1
+       *
+       * cost(X, Y) = cost(A, Y) + cost(B, C) + cost(B, B)
+       */
+      final double beta;  // b1 - y0
+      final double gamma; // c1 - y0
+      if(y1 <= x1) {
+        beta = y1 - y0;
+        gamma = x1 - y0;
+      } else {
+        beta = x1 - y0;
+        gamma = y1 - y0;
       }
+      return intervalCost(y0, y0, y1) +
+             intervalCost(beta, beta, gamma) +
+             // cost of exactly overlapping intervals of size beta
+             2 * (beta + FastMath.exp(-beta) - 1);
+    } else {
+      final double exy0 = FastMath.exp(x1 - y0);
+      final double exy1 = FastMath.exp(x1 - y1);
+      final double ey0 = FastMath.exp(0f - y0);
+      final double ey1 = FastMath.exp(0f - y1);
+
+      return (ey1 - ey0) - (exy1 - exy0);
     }
-
-    final double cost = baseCost * recencyPenalty * dataSourcePenalty * gapPenalty;
-
-    return cost;
   }
 
   public BalancerSegmentHolder pickSegmentToMove(final List<ServerHolder> serverHolders)
@@ -144,11 +193,9 @@ public class CostBalancerStrategy implements BalancerStrategy
   {
     double cost = 0;
     for (ServerHolder server : serverHolders) {
-      DataSegment[] segments = server.getServer().getSegments().values().toArray(new DataSegment[]{});
-      for (int i = 0; i < segments.length; ++i) {
-        for (int j = i; j < segments.length; ++j) {
-          cost += computeJointSegmentCosts(segments[i], segments[j]);
-        }
+      Iterable<DataSegment> segments = server.getServer().getSegments().values();
+      for (DataSegment s : segments) {
+        cost += computeJointSegmentsCost(s, segments);
       }
     }
     return cost;
@@ -168,8 +215,8 @@ public class CostBalancerStrategy implements BalancerStrategy
   {
     double cost = 0;
     for (ServerHolder server : serverHolders) {
-      for (DataSegment segment : server.getServer().getSegments().values()) {
-        cost += computeJointSegmentCosts(segment, segment);
+      for (DataSegment segment :  server.getServer().getSegments().values()) {
+        cost += computeJointSegmentsCost(segment, segment);
       }
     }
     return cost;
@@ -211,17 +258,20 @@ public class CostBalancerStrategy implements BalancerStrategy
       }
 
       /** The contribution to the total cost of a given server by proposing to move the segment to that server is... */
-      double cost = 0f;
+      double cost = 0d;
+
       /**  the sum of the costs of other (exclusive of the proposalSegment) segments on the server */
-      for (DataSegment segment : server.getServer().getSegments().values()) {
-        if (!proposalSegment.equals(segment)) {
-          cost += computeJointSegmentCosts(proposalSegment, segment);
-        }
-      }
+      cost += computeJointSegmentsCost(
+          proposalSegment,
+          Iterables.filter(
+              server.getServer().getSegments().values(),
+              Predicates.not(Predicates.equalTo(proposalSegment))
+          )
+      );
+
       /**  plus the costs of segments that will be loaded */
-      for (DataSegment segment : server.getPeon().getSegmentsToLoad()) {
-        cost += computeJointSegmentCosts(proposalSegment, segment);
-      }
+      cost += computeJointSegmentsCost(proposalSegment, server.getPeon().getSegmentsToLoad());
+
       return cost;
     }
     return Double.POSITIVE_INFINITY;

--- a/server/src/main/java/io/druid/server/coordinator/CostBalancerStrategyFactory.java
+++ b/server/src/main/java/io/druid/server/coordinator/CostBalancerStrategyFactory.java
@@ -35,9 +35,9 @@ public class CostBalancerStrategyFactory implements BalancerStrategyFactory
   }
 
   @Override
-  public BalancerStrategy createBalancerStrategy(DateTime referenceTimestamp)
+  public CostBalancerStrategy createBalancerStrategy(DateTime referenceTimestamp)
   {
-    return new CostBalancerStrategy(referenceTimestamp, exec);
+    return new CostBalancerStrategy(exec);
   }
 
   @Override

--- a/server/src/test/java/io/druid/server/coordinator/CostBalancerStrategyBenchmark.java
+++ b/server/src/test/java/io/druid/server/coordinator/CostBalancerStrategyBenchmark.java
@@ -1,29 +1,26 @@
 /*
  * Licensed to Metamarkets Group Inc. (Metamarkets) under one
- * or more contributor license agreements. See the NOTICE file
+ * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
- * regarding copyright ownership. Metamarkets licenses this file
+ * regarding copyright ownership.  Metamarkets licenses this file
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at
+ * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
 
-package io.druid.server.coordination;
+package io.druid.server.coordinator;
 
 import com.carrotsearch.junitbenchmarks.AbstractBenchmark;
 import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
-import io.druid.server.coordinator.CostBalancerStrategy;
-import io.druid.server.coordinator.CostBalancerStrategyFactory;
-import io.druid.server.coordinator.ServerHolder;
 import io.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -58,7 +55,7 @@ public class CostBalancerStrategyBenchmark extends AbstractBenchmark
 
   public CostBalancerStrategyBenchmark(CostBalancerStrategyFactory factory)
   {
-    this.strategy = (CostBalancerStrategy) factory.createBalancerStrategy(DateTime.now());
+    this.strategy = factory.createBalancerStrategy(DateTime.now());
   }
 
   private static List<ServerHolder> serverHolderList;
@@ -99,16 +96,4 @@ public class CostBalancerStrategyBenchmark extends AbstractBenchmark
     }
     sum = diff;
   }
-
-  @BenchmarkOptions(warmupRounds = 1000, benchmarkRounds = 1000000)
-  @Test
-  public void testBalancerGapMillis()
-  {
-    long diff = 0;
-    for (int i = 0; i < 1000; i++) {
-      diff = diff + CostBalancerStrategy.gapMillis(interval1, interval2);
-    }
-    sum = diff;
-  }
-
 }

--- a/server/src/test/java/io/druid/server/coordinator/CostBalancerStrategyTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/CostBalancerStrategyTest.java
@@ -1,23 +1,23 @@
 /*
  * Licensed to Metamarkets Group Inc. (Metamarkets) under one
- * or more contributor license agreements. See the NOTICE file
+ * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
- * regarding copyright ownership. Metamarkets licenses this file
+ * regarding copyright ownership.  Metamarkets licenses this file
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at
+ * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
 
-package io.druid.server.coordination;
+package io.druid.server.coordinator;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -25,18 +25,12 @@ import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.druid.client.ImmutableDruidDataSource;
 import io.druid.client.ImmutableDruidServer;
-import io.druid.concurrent.Execs;
-import io.druid.server.coordinator.BalancerStrategy;
-import io.druid.server.coordinator.CostBalancerStrategy;
-import io.druid.server.coordinator.LoadQueuePeonTester;
-import io.druid.server.coordinator.ServerHolder;
+import io.druid.server.coordination.DruidServerMetadata;
 import io.druid.timeline.DataSegment;
 import org.easymock.EasyMock;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.joda.time.Interval;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.List;
@@ -45,7 +39,7 @@ import java.util.concurrent.Executors;
 
 public class CostBalancerStrategyTest
 {
-  private static final Interval day = DateTime.now().toDateMidnight().toInterval();
+  private static final Interval day = new Interval("2015-01-01T00/2015-01-01T01");
 
   /**
    * Create Druid cluster with serverCount servers having maxSegments segments each, and 1 server with 98 segment
@@ -125,9 +119,7 @@ public class CostBalancerStrategyTest
     List<ServerHolder> serverHolderList = setupDummyCluster(10, 20);
     DataSegment segment = getSegment(1000);
 
-    final DateTime referenceTimestamp = new DateTime("2014-01-01");
     BalancerStrategy strategy = new CostBalancerStrategy(
-        referenceTimestamp,
         MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(4))
     );
     ServerHolder holder = strategy.findNewSegmentHomeReplicator(segment, serverHolderList);
@@ -143,7 +135,6 @@ public class CostBalancerStrategyTest
 
     final DateTime referenceTimestamp = new DateTime("2014-01-01");
     BalancerStrategy strategy = new CostBalancerStrategy(
-        referenceTimestamp,
         MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(1))
     );
     ServerHolder holder = strategy.findNewSegmentHomeReplicator(segment, serverHolderList);
@@ -156,10 +147,9 @@ public class CostBalancerStrategyTest
   {
     DateTime referenceTime = new DateTime("2014-01-01T00:00:00");
     CostBalancerStrategy strategy = new CostBalancerStrategy(
-        referenceTime,
         MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(4))
     );
-    double segmentCost = strategy.computeJointSegmentCosts(
+    double segmentCost = strategy.computeJointSegmentsCost(
         getSegment(
             100,
             "DUMMY",
@@ -172,12 +162,54 @@ public class CostBalancerStrategyTest
             101,
             "DUMMY",
             new Interval(
-                referenceTime.minusDays(2),
-                referenceTime.minusDays(2).plusHours(1)
+                referenceTime.minusHours(2),
+                referenceTime.minusHours(2).plusHours(1)
             )
         )
     );
-    Assert.assertEquals(138028.62811791385d, segmentCost, 0);
+
+    Assert.assertEquals(
+        CostBalancerStrategy.INV_LAMBDA_SQUARE * CostBalancerStrategy.intervalCost(
+            1 * CostBalancerStrategy.LAMBDA,
+            -2 * CostBalancerStrategy.LAMBDA,
+            -1 * CostBalancerStrategy.LAMBDA
+        ) * 2,
+        segmentCost, 1e-6);
   }
 
+  @Test
+  public void testIntervalCost() throws Exception
+  {
+    // additivity
+    Assert.assertEquals(CostBalancerStrategy.intervalCost(1, 1, 3),
+                        CostBalancerStrategy.intervalCost(1, 1, 2) +
+                        CostBalancerStrategy.intervalCost(1, 2, 3), 1e-6);
+
+    Assert.assertEquals(CostBalancerStrategy.intervalCost(2, 1, 3),
+                        CostBalancerStrategy.intervalCost(2, 1, 2) +
+                        CostBalancerStrategy.intervalCost(2, 2, 3), 1e-6);
+
+    Assert.assertEquals(CostBalancerStrategy.intervalCost(3, 1, 2),
+                        CostBalancerStrategy.intervalCost(1, 1, 2) +
+                        CostBalancerStrategy.intervalCost(1, 0, 1) +
+                        CostBalancerStrategy.intervalCost(1, 1, 2), 1e-6);
+
+    // no overlap [0, 1) [1, 2)
+    Assert.assertEquals(0.3995764, CostBalancerStrategy.intervalCost(1, 1, 2), 1e-6);
+    // no overlap [0, 1) [-1, 0)
+    Assert.assertEquals(0.3995764, CostBalancerStrategy.intervalCost(1, -1, 0), 1e-6);
+
+    // exact overlap [0, 1), [0, 1)
+    Assert.assertEquals(0.7357589, CostBalancerStrategy.intervalCost(1, 0, 1), 1e-6);
+    // exact overlap [0, 2), [0, 2)
+    Assert.assertEquals(2.270671, CostBalancerStrategy.intervalCost(2, 0, 2), 1e-6);
+    // partial overlap [0, 2), [1, 3)
+    Assert.assertEquals(1.681908, CostBalancerStrategy.intervalCost(2, 1, 3), 1e-6);
+    // partial overlap [0, 2), [1, 2)
+    Assert.assertEquals(1.135335, CostBalancerStrategy.intervalCost(2, 1, 2), 1e-6);
+    // partial overlap [0, 2), [0, 1)
+    Assert.assertEquals(1.135335, CostBalancerStrategy.intervalCost(2, 0, 1), 1e-6);
+    // partial overlap [0, 3), [1, 2)
+    Assert.assertEquals(1.534912, CostBalancerStrategy.intervalCost(3, 1, 2), 1e-6);
+  }
 }


### PR DESCRIPTION
Our current segment balancing algorithm uses a cost function which has some unintended effects on the distribution of segments in the cluster. While it keeps the total number of segments roughly balanced across nodes, it does not evenly distribute segments within a given interval. This leads to many queries hitting only a fraction of the historical nodes in the cluster.

This is a proposal to revamp the cost function to address those shortcoming and improve overall segment distribution.

TL;DR here's how segment distribution has improved in the days since we rolled out this improved cost function to one of our Druid clusters (each dot is a segment, each color represents a different data source).

![c](https://cloud.githubusercontent.com/assets/815147/15304742/e477a38e-1b73-11e6-8386-ae5bc0ea78a9.gif)

### Issues with our existing cost function

Here is a breakdown of the issues with the current cost function

1. Segments tend to form clusters with large gaps in between

  If you have take segments roughly 30 days apart, the existing `gapPenalty` causes the cost of putting a segment anywhere between those two to be higher than adding a segment that overlaps with them. This causes the balancing to converge to form clusters of segments ~30 days apart as seen below.

  ![c_t_000](https://cloud.githubusercontent.com/assets/815147/15303719/0bf09de0-1b6e-11e6-9c47-f0eae4ca08a5.jpg)

2. Segments for recent time intervals tend to be distributed unevenly

 The recencyPenalty, in combination with the gapPenalty, makes the cost function non-trivial for recent segments and causes strange gaps of data within the most recent 7 days worth of data.

  ![h_t_000](https://cloud.githubusercontent.com/assets/815147/15303999/b321cb2e-1b6f-11e6-9651-4e031baefc76.jpg)

3. The base joint cost between two segments is tied to segment byte sizes. This causes cost to be affected by different levels compression, and not necessarily tied to the actual cost of scanning a segment. 

### Improved cost function

Our improved cost function is designed to be simple and have the following properties:

1. Our cost function reflect the cost of scanning a segment.
2. The joint cost should reflect the likelihood of segments being scanned simultaneously, i.e. the joint cost of querying two time-slices should decrease based on how far apart they are.
3. Our cost function should be additive, i.e. given three intervals A, B, and C, cost(A, B union C) = cost(A, B) + cost(A, C)

To satisfy 1. we will assume that the cost of scanning a unit time-slice of data is constant. This means our cost function will only depend on segment intervals.

  > Note: In practice, this means that if all segments in a cluster have the same segment granularity, then the cpu time spent scanning each partition should be roughly constant. Ensuring the unit of computation is constant is also good practice to reduce variance in segment scan times across the cluster.

To model the joint cost of querying two time-slices and satisfy 2., we use an exponential decay `exp(-lambda * t)`, where lambda defines the rate at which the interaction decays, and t is the relative time differences between two to time slices. Currently lambda is set to give the decay a half-life of 24 hours.

Since we assume the cost of querying each time-slice is constant, we can compute the joint cost of two segments by simply integrating over the segment intervals, i.e. for two segments X and Y covering intervals [x_0, x_1) and [y_0, y_1) respectively, our joint cost becomes:

<img width="245" alt="screen shot 2016-05-16 at 3 41 55 pm" src="https://cloud.githubusercontent.com/assets/815147/15306118/c52cdf72-1b7c-11e6-981c-923336ee554b.png">

This has the nice property of being additive as in 3. and of having a closed form solution.

One nice side-effect of additivity is that re-indexing the same data at different segment granularities (e.g. going form hourly segments to daily segments) will not affect the joint cost, assuming the cost of scanning a unit of time stays the same per shard.

Segments of the same datasources are of course more likely to be queried simultaneously, so we multiply the cost by a constant factor (2 in this case) if the two segments are from the same data source. This ensures that if two datasources are distributed equally, we are more likely to spread them across servers.

Hopefully this all makes sense, but comments are of course welcome.

Regarding performance, the new cost function is more expensive to compute than the existing one, but thanks to the optimizations in #2910 it will not be worse than what we have in our current release, and maybe even a little bit faster still.

The results of rolling out this new cost function speak for themselves. You can see how segment distribution has massively improved in our Druid cluster for the problem cases depicted above.  

![h](https://cloud.githubusercontent.com/assets/815147/15306407/34381466-1b7f-11e6-9728-34937581ba62.gif)

![c](https://cloud.githubusercontent.com/assets/815147/15304742/e477a38e-1b73-11e6-8386-ae5bc0ea78a9.gif)
