### PR TITLE
Fix race where results from an IncrementalIndexSegment could be cached.

### DIFF
--- a/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -409,7 +409,11 @@ public class AppenderatorImpl implements Appenderator
                                               @Override
                                               public QueryRunner<T> apply(final FireHydrant hydrant)
                                               {
-                                                if (skipIncrementalSegment && !hydrant.hasSwapped()) {
+                                                // Hydrant might swap at any point, but if it's swapped at the start
+                                                // then we know it's *definitely* swapped.
+                                                final boolean hydrantDefinitelySwapped = hydrant.hasSwapped();
+
+                                                if (skipIncrementalSegment && !hydrantDefinitelySwapped) {
                                                   return new NoopQueryRunner<>();
                                                 }
 
@@ -421,7 +425,7 @@ public class AppenderatorImpl implements Appenderator
                                                       segment.rhs
                                                   );
 
-                                                  if (hydrant.hasSwapped() // only use caching if data is immutable
+                                                  if (hydrantDefinitelySwapped // only use caching if data is immutable
                                                       && cache.isLocal() // hydrants may not be in sync between replicas, make sure cache is local
                                                       ) {
                                                     return new CachingQueryRunner<>(

--- a/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -334,7 +334,11 @@ public class RealtimePlumber implements Plumber
                                           @Override
                                           public QueryRunner<T> apply(FireHydrant input)
                                           {
-                                            if (skipIncrementalSegment && !input.hasSwapped()) {
+                                            // Hydrant might swap at any point, but if it's swapped at the start
+                                            // then we know it's *definitely* swapped.
+                                            final boolean hydrantDefinitelySwapped = input.hasSwapped();
+
+                                            if (skipIncrementalSegment && !hydrantDefinitelySwapped) {
                                               return new NoopQueryRunner<T>();
                                             }
 
@@ -346,7 +350,7 @@ public class RealtimePlumber implements Plumber
                                                   segment.rhs
                                               );
 
-                                              if (input.hasSwapped() // only use caching if data is immutable
+                                              if (hydrantDefinitelySwapped // only use caching if data is immutable
                                                   && cache.isLocal() // hydrants may not be in sync between replicas, make sure cache is local
                                                   ) {
                                                 return new CachingQueryRunner<>(


### PR DESCRIPTION
It's possible for an incremental index segment to be acquired through getAndIncrementSegment, then for a swap to happen in another thread, then for the subsequent hasSwapped call to return "true".