### PR TITLE
ability to not rollup at index time, make pre aggregation an option

### DIFF
--- a/benchmarks/src/main/java/io/druid/benchmark/indexing/IncrementalIndexReadBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/indexing/IncrementalIndexReadBenchmark.java
@@ -81,6 +81,9 @@ public class IncrementalIndexReadBenchmark
   @Param({"basic"})
   private String schema;
 
+  @Param({"true", "false"})
+  private boolean rollup;
+
   private static final Logger log = new Logger(IncrementalIndexReadBenchmark.class);
   private static final int RNG_SEED = 9999;
   private IncrementalIndex incIndex;
@@ -124,6 +127,7 @@ public class IncrementalIndexReadBenchmark
             .withQueryGranularity(QueryGranularities.NONE)
             .withMetrics(schemaInfo.getAggsArray())
             .withDimensionsSpec(new DimensionsSpec(null, null, null))
+            .withRollup(rollup)
             .build(),
         true,
         false,

--- a/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexIngestionBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexIngestionBenchmark.java
@@ -63,6 +63,9 @@ public class IndexIngestionBenchmark
   @Param({"basic"})
   private String schema;
 
+  @Param({"true", "false"})
+  private boolean rollup;
+
   private static final Logger log = new Logger(IndexIngestionBenchmark.class);
   private static final int RNG_SEED = 9999;
 
@@ -107,6 +110,7 @@ public class IndexIngestionBenchmark
             .withQueryGranularity(QueryGranularities.NONE)
             .withMetrics(schemaInfo.getAggsArray())
             .withDimensionsSpec(new DimensionsSpec(null, null, null))
+            .withRollup(rollup)
             .build(),
         true,
         false,

--- a/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexIngestionBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexIngestionBenchmark.java
@@ -115,7 +115,7 @@ public class IndexIngestionBenchmark
         true,
         false,
         true,
-        rowsPerSegment
+        rowsPerSegment * 2
     );
   }
 

--- a/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexMergeBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexMergeBenchmark.java
@@ -75,6 +75,9 @@ public class IndexMergeBenchmark
   @Param({"basic"})
   private String schema;
 
+  @Param({"true", "false"})
+  private boolean rollup;
+
   private static final Logger log = new Logger(IndexMergeBenchmark.class);
   private static final int RNG_SEED = 9999;
   private static final IndexMerger INDEX_MERGER;
@@ -155,6 +158,7 @@ public class IndexMergeBenchmark
             .withQueryGranularity(QueryGranularities.NONE)
             .withMetrics(schemaInfo.getAggsArray())
             .withDimensionsSpec(new DimensionsSpec(null, null, null))
+            .withRollup(rollup)
             .build(),
         true,
         false,
@@ -174,7 +178,7 @@ public class IndexMergeBenchmark
     log.info(tmpFile.getAbsolutePath() + " isFile: " + tmpFile.isFile() + " isDir:" + tmpFile.isDirectory());
     tmpFile.deleteOnExit();
 
-    File mergedFile = INDEX_MERGER.mergeQueryableIndex(indexesToMerge, schemaInfo.getAggsArray(), tmpFile, new IndexSpec());
+    File mergedFile = INDEX_MERGER.mergeQueryableIndex(indexesToMerge, rollup, schemaInfo.getAggsArray(), tmpFile, new IndexSpec());
 
     blackhole.consume(mergedFile);
 
@@ -192,7 +196,7 @@ public class IndexMergeBenchmark
     log.info(tmpFile.getAbsolutePath() + " isFile: " + tmpFile.isFile() + " isDir:" + tmpFile.isDirectory());
     tmpFile.deleteOnExit();
 
-    File mergedFile = INDEX_MERGER_V9.mergeQueryableIndex(indexesToMerge, schemaInfo.getAggsArray(), tmpFile, new IndexSpec());
+    File mergedFile = INDEX_MERGER_V9.mergeQueryableIndex(indexesToMerge, rollup, schemaInfo.getAggsArray(), tmpFile, new IndexSpec());
 
     blackhole.consume(mergedFile);
 

--- a/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexPersistBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexPersistBenchmark.java
@@ -72,6 +72,9 @@ public class IndexPersistBenchmark
   @Param({"basic"})
   private String schema;
 
+  @Param({"true", "false"})
+  private boolean rollup;
+
   private static final Logger log = new Logger(IndexPersistBenchmark.class);
   private static final int RNG_SEED = 9999;
 
@@ -156,6 +159,7 @@ public class IndexPersistBenchmark
             .withQueryGranularity(QueryGranularities.NONE)
             .withMetrics(schemaInfo.getAggsArray())
             .withDimensionsSpec(new DimensionsSpec(null, null, null))
+            .withRollup(rollup)
             .build(),
         true,
         false,

--- a/docs/content/ingestion/index.md
+++ b/docs/content/ingestion/index.md
@@ -186,6 +186,7 @@ This spec is used to generated segments with uniform intervals.
 | type | string | The type of granularity spec. | no (default == 'uniform') |
 | segmentGranularity | string | The granularity to create segments at. | no (default == 'DAY') |
 | queryGranularity | string | The minimum granularity to be able to query results at and the granularity of the data inside the segment. E.g. a value of "minute" will mean that data is aggregated at minutely granularity. That is, if there are collisions in the tuple (minute(timestamp), dimensions), then it will aggregate values together using the aggregators instead of storing individual rows. | no (default == 'NONE') |
+| rollup | boolean | rollup or not | no (default == true) |
 | intervals | string | A list of intervals for the raw data being ingested. Ignored for real-time ingestion. | yes for batch, no for real-time |
 
 ### Arbitrary Granularity Spec
@@ -196,6 +197,7 @@ This spec is used to generate segments with arbitrary intervals (it tries to cre
 |-------|------|-------------|----------|
 | type | string | The type of granularity spec. | no (default == 'uniform') |
 | queryGranularity | string | The minimum granularity to be able to query results at and the granularity of the data inside the segment. E.g. a value of "minute" will mean that data is aggregated at minutely granularity. That is, if there are collisions in the tuple (minute(timestamp), dimensions), then it will aggregate values together using the aggregators instead of storing individual rows. | no (default == 'NONE') |
+| rollup | boolean | rollup or not | no (default == true) |
 | intervals | string | A list of intervals for the raw data being ingested. Ignored for real-time ingestion. | yes for batch, no for real-time |
 
 # IO Config

--- a/docs/content/ingestion/tasks.md
+++ b/docs/content/ingestion/tasks.md
@@ -159,7 +159,10 @@ Append tasks append a list of segments together into a single segment (one after
 
 ### Merge Task
 
-Merge tasks merge a list of segments together. Any common timestamps are merged. The grammar is:
+Merge tasks merge a list of segments together. Any common timestamps are merged.
+If rollup is disabled as part of ingestion, common timestamps are not merged and rows are reorderded by their timestamp.
+
+The grammar is:
 
 ```json
 {
@@ -167,6 +170,7 @@ Merge tasks merge a list of segments together. Any common timestamps are merged.
     "id": <task_id>,
     "dataSource": <task_datasource>,
     "aggregations": <list of aggregators>,
+    "rollup": <whether or not to rollup data during a merge>,
     "segments": <JSON list of DataSegment objects to merge>
 }
 ```

--- a/docs/content/ingestion/tasks.md
+++ b/docs/content/ingestion/tasks.md
@@ -160,7 +160,7 @@ Append tasks append a list of segments together into a single segment (one after
 ### Merge Task
 
 Merge tasks merge a list of segments together. Any common timestamps are merged.
-If rollup is disabled as part of ingestion, common timestamps are not merged and rows are reorderded by their timestamp.
+If rollup is disabled as part of ingestion, common timestamps are not merged and rows are reordered by their timestamp.
 
 The grammar is:
 

--- a/docs/content/querying/segmentmetadataquery.md
+++ b/docs/content/querying/segmentmetadataquery.md
@@ -11,6 +11,7 @@ Segment metadata queries return per-segment information about:
 * Interval the segment covers
 * Column type of all the columns in the segment
 * Estimated total segment byte size in if it was stored in a flat format
+* Is the segment rolled up
 * Segment id
 
 ```json
@@ -142,6 +143,11 @@ null if the aggregators are unknown or unmergeable (if merging is enabled).
 * Merging can be strict or lenient. See *lenientAggregatorMerge* below for details.
 
 * The form of the result is a map of column name to aggregator.
+
+#### rollup
+
+* `rollup` in the result is true/false/null.
+* When merging is enabled, if some are rollup, others are not, result is null.
 
 ### lenientAggregatorMerge
 

--- a/indexing-hadoop/src/main/java/io/druid/indexer/DetermineHashedPartitionsJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/DetermineHashedPartitionsJob.java
@@ -142,6 +142,7 @@ public class DetermineHashedPartitionsJob implements Jobby
             new UniformGranularitySpec(
                 config.getGranularitySpec().getSegmentGranularity(),
                 config.getGranularitySpec().getQueryGranularity(),
+                config.getGranularitySpec().isRollup(),
                 intervals
             )
         );

--- a/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
@@ -226,6 +226,7 @@ public class IndexGeneratorJob implements Jobby
         .withDimensionsSpec(config.getSchema().getDataSchema().getParser())
         .withQueryGranularity(config.getSchema().getDataSchema().getGranularitySpec().getQueryGranularity())
         .withMetrics(aggs)
+        .withRollup(config.getSchema().getDataSchema().getGranularitySpec().isRollup())
         .build();
 
     OnheapIncrementalIndex newIndex = new OnheapIncrementalIndex(
@@ -514,13 +515,14 @@ public class IndexGeneratorJob implements Jobby
         ProgressIndicator progressIndicator
     ) throws IOException
     {
+      boolean rollup = config.getSchema().getDataSchema().getGranularitySpec().isRollup();
       if (config.isBuildV9Directly()) {
         return HadoopDruidIndexerConfig.INDEX_MERGER_V9.mergeQueryableIndex(
-            indexes, aggs, file, config.getIndexSpec(), progressIndicator
+            indexes, rollup, aggs, file, config.getIndexSpec(), progressIndicator
         );
       } else {
         return HadoopDruidIndexerConfig.INDEX_MERGER.mergeQueryableIndex(
-            indexes, aggs, file, config.getIndexSpec(), progressIndicator
+            indexes, rollup, aggs, file, config.getIndexSpec(), progressIndicator
         );
       }
     }

--- a/indexing-hadoop/src/main/java/io/druid/indexer/path/GranularUnprocessedPathSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/path/GranularUnprocessedPathSpec.java
@@ -112,6 +112,7 @@ public class GranularUnprocessedPathSpec extends GranularityPathSpec
         new UniformGranularitySpec(
             segmentGranularity,
             config.getGranularitySpec().getQueryGranularity(),
+            config.getGranularitySpec().isRollup(),
             Lists.newArrayList(bucketsToRun)
         )
     );

--- a/indexing-service/src/main/java/io/druid/indexing/common/index/YeOldePlumberSchool.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/index/YeOldePlumberSchool.java
@@ -188,7 +188,7 @@ public class YeOldePlumberSchool implements PlumberSchool
             }
 
             fileToUpload = new File(tmpSegmentDir, "merged");
-            theIndexMerger.mergeQueryableIndex(indexes, schema.getAggregators(), fileToUpload, config.getIndexSpec());
+            theIndexMerger.mergeQueryableIndex(indexes, schema.getGranularitySpec().isRollup(), schema.getAggregators(), fileToUpload, config.getIndexSpec());
           }
 
           // Map merged segment so we can extract dimensions

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/MergeTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/MergeTask.java
@@ -44,6 +44,7 @@ public class MergeTask extends MergeTaskBase
 {
   @JsonIgnore
   private final List<AggregatorFactory> aggregators;
+  private final Boolean rollup;
   private final IndexSpec indexSpec;
 
   @JsonCreator
@@ -52,12 +53,14 @@ public class MergeTask extends MergeTaskBase
       @JsonProperty("dataSource") String dataSource,
       @JsonProperty("segments") List<DataSegment> segments,
       @JsonProperty("aggregations") List<AggregatorFactory> aggregators,
+      @JsonProperty("rollup") Boolean rollup,
       @JsonProperty("indexSpec") IndexSpec indexSpec,
       @JsonProperty("context") Map<String, Object> context
   )
   {
     super(id, dataSource, segments, context);
     this.aggregators = Preconditions.checkNotNull(aggregators, "null aggregations");
+    this.rollup = rollup == null ? Boolean.TRUE : rollup;
     this.indexSpec = indexSpec == null ? new IndexSpec() : indexSpec;
   }
 
@@ -82,6 +85,7 @@ public class MergeTask extends MergeTaskBase
               }
             }
         ),
+        rollup,
         aggregators.toArray(new AggregatorFactory[aggregators.size()]),
         outDir,
         indexSpec

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
@@ -176,6 +176,7 @@ public class TaskSerdeTest
         "foo",
         segments,
         aggregators,
+        true,
         indexSpec,
         null
     );

--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
@@ -355,6 +355,14 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
       mergedId = "merged";
     }
 
+    final Boolean rollup;
+
+    if (arg1.isRollup() != null && arg2.isRollup() != null && arg1.isRollup().equals(arg2.isRollup())) {
+      rollup = arg1.isRollup();
+    } else {
+      rollup = null;
+    }
+
     return new SegmentAnalysis(
         mergedId,
         newIntervals,
@@ -363,7 +371,8 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
         arg1.getNumRows() + arg2.getNumRows(),
         aggregators.isEmpty() ? null : aggregators,
         timestampSpec,
-        queryGranularity
+        queryGranularity,
+        rollup
     );
   }
 
@@ -378,7 +387,8 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
         analysis.getNumRows(),
         analysis.getAggregators(),
         analysis.getTimestampSpec(),
-        analysis.getQueryGranularity()
+        analysis.getQueryGranularity(),
+        analysis.isRollup()
     );
   }
 }

--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
@@ -148,6 +148,19 @@ public class SegmentMetadataQueryRunnerFactory implements QueryRunnerFactory<Seg
           queryGranularity = null;
         }
 
+        Boolean rollup = null;
+        if (query.hasRollup()) {
+          if (metadata == null) {
+            metadata = segment.asStorageAdapter().getMetadata();
+          }
+          rollup = metadata != null ? metadata.isRollup() : null;
+          if (rollup == null) {
+            // in this case, this segment is built before no-rollup function is coded,
+            // thus it is built with rollup
+            rollup = Boolean.TRUE;
+          }
+        }
+
         return Sequences.simple(
             Arrays.asList(
                 new SegmentAnalysis(
@@ -158,7 +171,8 @@ public class SegmentMetadataQueryRunnerFactory implements QueryRunnerFactory<Seg
                     numRows,
                     aggregators,
                     timestampSpec,
-                    queryGranularity
+                    queryGranularity,
+                    rollup
                 )
             )
         );

--- a/processing/src/main/java/io/druid/query/metadata/metadata/SegmentAnalysis.java
+++ b/processing/src/main/java/io/druid/query/metadata/metadata/SegmentAnalysis.java
@@ -40,6 +40,7 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
   private final Map<String, AggregatorFactory> aggregators;
   private final TimestampSpec timestampSpec;
   private final QueryGranularity queryGranularity;
+  private final Boolean rollup;
 
   @JsonCreator
   public SegmentAnalysis(
@@ -50,7 +51,8 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
       @JsonProperty("numRows") long numRows,
       @JsonProperty("aggregators") Map<String, AggregatorFactory> aggregators,
       @JsonProperty("timestampSpec") TimestampSpec timestampSpec,
-      @JsonProperty("queryGranularity") QueryGranularity queryGranularity
+      @JsonProperty("queryGranularity") QueryGranularity queryGranularity,
+      @JsonProperty("rollup") Boolean rollup
   )
   {
     this.id = id;
@@ -61,6 +63,7 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
     this.aggregators = aggregators;
     this.timestampSpec = timestampSpec;
     this.queryGranularity = queryGranularity;
+    this.rollup = rollup;
   }
 
   @JsonProperty
@@ -106,6 +109,12 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
   }
 
   @JsonProperty
+  public Boolean isRollup()
+  {
+    return rollup;
+  }
+
+  @JsonProperty
   public Map<String, AggregatorFactory> getAggregators()
   {
     return aggregators;
@@ -123,6 +132,7 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
            ", aggregators=" + aggregators +
            ", timestampSpec=" + timestampSpec +
            ", queryGranularity=" + queryGranularity +
+           ", rollup=" + rollup +
            '}';
   }
 
@@ -141,6 +151,7 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
     SegmentAnalysis that = (SegmentAnalysis) o;
     return size == that.size &&
            numRows == that.numRows &&
+           rollup == that.rollup &&
            Objects.equals(id, that.id) &&
            Objects.equals(interval, that.interval) &&
            Objects.equals(columns, that.columns) &&
@@ -156,7 +167,7 @@ public class SegmentAnalysis implements Comparable<SegmentAnalysis>
   @Override
   public int hashCode()
   {
-    return Objects.hash(id, interval, columns, size, numRows, aggregators, timestampSpec, queryGranularity);
+    return Objects.hash(id, interval, columns, size, numRows, aggregators, timestampSpec, queryGranularity, rollup);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/metadata/metadata/SegmentMetadataQuery.java
+++ b/processing/src/main/java/io/druid/query/metadata/metadata/SegmentMetadataQuery.java
@@ -58,7 +58,8 @@ public class SegmentMetadataQuery extends BaseQuery<SegmentAnalysis>
     AGGREGATORS,
     MINMAX,
     TIMESTAMPSPEC,
-    QUERYGRANULARITY;
+    QUERYGRANULARITY,
+    ROLLUP;
 
     @JsonValue
     @Override
@@ -197,6 +198,11 @@ public class SegmentMetadataQuery extends BaseQuery<SegmentAnalysis>
   public boolean hasQueryGranularity()
   {
     return analysisTypes.contains(AnalysisType.QUERYGRANULARITY);
+  }
+
+  public boolean hasRollup()
+  {
+    return analysisTypes.contains(AnalysisType.ROLLUP);
   }
 
   public boolean hasMinMax()

--- a/processing/src/main/java/io/druid/segment/Metadata.java
+++ b/processing/src/main/java/io/druid/segment/Metadata.java
@@ -49,6 +49,9 @@ public class Metadata
   @JsonProperty
   private QueryGranularity queryGranularity;
 
+  @JsonProperty
+  private Boolean rollup;
+
   public Metadata()
   {
     container = new ConcurrentHashMap<>();
@@ -84,6 +87,17 @@ public class Metadata
   public Metadata setQueryGranularity(QueryGranularity queryGranularity)
   {
     this.queryGranularity = queryGranularity;
+    return this;
+  }
+
+  public Boolean isRollup()
+  {
+    return rollup;
+  }
+
+  public Metadata setRollup(Boolean rollup)
+  {
+    this.rollup = rollup;
     return this;
   }
 
@@ -128,6 +142,7 @@ public class Metadata
 
     List<TimestampSpec> timestampSpecsToMerge = new ArrayList<>();
     List<QueryGranularity> gransToMerge = new ArrayList<>();
+    List<Boolean> rollupToMerge = new ArrayList<>();
 
     for (Metadata metadata : toBeMerged) {
       if (metadata != null) {
@@ -143,6 +158,10 @@ public class Metadata
         if (gransToMerge != null) {
           gransToMerge.add(metadata.getQueryGranularity());
         }
+
+        if (rollupToMerge != null) {
+          rollupToMerge.add(metadata.isRollup());
+        }
         mergedContainer.putAll(metadata.container);
       } else {
         //if metadata and hence aggregators and queryGranularity for some segment being merged are unknown then
@@ -150,6 +169,7 @@ public class Metadata
         aggregatorsToMerge = null;
         timestampSpecsToMerge = null;
         gransToMerge = null;
+        rollupToMerge = null;
       }
     }
 
@@ -172,6 +192,23 @@ public class Metadata
       result.setQueryGranularity(QueryGranularity.mergeQueryGranularities(gransToMerge));
     }
 
+    Boolean rollup = null;
+    if (rollupToMerge != null && !rollupToMerge.isEmpty()) {
+      rollup = rollupToMerge.get(0);
+      for (Boolean r : rollupToMerge) {
+        if (r == null) {
+          rollup = null;
+          break;
+        } else if (!r.equals(rollup)) {
+          rollup = null;
+          break;
+        } else {
+          rollup = r;
+        }
+      }
+    }
+
+    result.setRollup(rollup);
     result.container.putAll(mergedContainer);
     return result;
 
@@ -199,6 +236,9 @@ public class Metadata
     if (timestampSpec != null ? !timestampSpec.equals(metadata.timestampSpec) : metadata.timestampSpec != null) {
       return false;
     }
+    if (rollup != null ? !rollup.equals(metadata.rollup) : metadata.rollup != null) {
+      return false;
+    }
     return queryGranularity != null
            ? queryGranularity.equals(metadata.queryGranularity)
            : metadata.queryGranularity == null;
@@ -212,6 +252,7 @@ public class Metadata
     result = 31 * result + Arrays.hashCode(aggregators);
     result = 31 * result + (timestampSpec != null ? timestampSpec.hashCode() : 0);
     result = 31 * result + (queryGranularity != null ? queryGranularity.hashCode() : 0);
+    result = 31 * result + (rollup != null ? rollup.hashCode() : 0);
     return result;
   }
 
@@ -223,6 +264,7 @@ public class Metadata
            ", aggregators=" + Arrays.toString(aggregators) +
            ", timestampSpec=" + timestampSpec +
            ", queryGranularity=" + queryGranularity +
+           ", rollup=" + rollup +
            '}';
   }
 }

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -1369,7 +1369,7 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
      * @return the previous value associated with the specified key, or
      * {@code null} if there was no mapping for the key.
      */
-    Integer getRowIndexForRollup(TimeAndDims key);
+    Integer getPriorIndex(TimeAndDims key);
 
     long getMinTimeMillis();
 
@@ -1408,7 +1408,7 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
     }
 
     @Override
-    public Integer getRowIndexForRollup(TimeAndDims key)
+    public Integer getPriorIndex(TimeAndDims key)
     {
       return facts.get(key);
     }
@@ -1502,7 +1502,7 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
     }
 
     @Override
-    public Integer getRowIndexForRollup(TimeAndDims key)
+    public Integer getPriorIndex(TimeAndDims key)
     {
       // always return null to indicate that no prior key cause we always add new row
       return null;

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexSchema.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexSchema.java
@@ -30,18 +30,21 @@ import io.druid.query.aggregation.AggregatorFactory;
  */
 public class IncrementalIndexSchema
 {
+  public static final boolean DEFAULT_ROLLUP = true;
   private final long minTimestamp;
   private final TimestampSpec timestampSpec;
   private final QueryGranularity gran;
   private final DimensionsSpec dimensionsSpec;
   private final AggregatorFactory[] metrics;
+  private final boolean rollup;
 
   public IncrementalIndexSchema(
       long minTimestamp,
       TimestampSpec timestampSpec,
       QueryGranularity gran,
       DimensionsSpec dimensionsSpec,
-      AggregatorFactory[] metrics
+      AggregatorFactory[] metrics,
+      boolean rollup
   )
   {
     this.minTimestamp = minTimestamp;
@@ -49,6 +52,7 @@ public class IncrementalIndexSchema
     this.gran = gran;
     this.dimensionsSpec = dimensionsSpec;
     this.metrics = metrics;
+    this.rollup = rollup;
   }
 
   public long getMinTimestamp()
@@ -76,6 +80,11 @@ public class IncrementalIndexSchema
     return metrics;
   }
 
+  public boolean isRollup()
+  {
+    return rollup;
+  }
+
   public static class Builder
   {
     private long minTimestamp;
@@ -83,6 +92,7 @@ public class IncrementalIndexSchema
     private QueryGranularity gran;
     private DimensionsSpec dimensionsSpec;
     private AggregatorFactory[] metrics;
+    private boolean rollup;
 
     public Builder()
     {
@@ -90,6 +100,7 @@ public class IncrementalIndexSchema
       this.gran = QueryGranularities.NONE;
       this.dimensionsSpec = new DimensionsSpec(null, null, null);
       this.metrics = new AggregatorFactory[]{};
+      this.rollup = true;
     }
 
     public Builder withMinTimestamp(long minTimestamp)
@@ -147,10 +158,16 @@ public class IncrementalIndexSchema
       return this;
     }
 
+    public Builder withRollup(boolean rollup)
+    {
+      this.rollup = rollup;
+      return this;
+    }
+
     public IncrementalIndexSchema build()
     {
       return new IncrementalIndexSchema(
-          minTimestamp, timestampSpec, gran, dimensionsSpec, metrics
+          minTimestamp, timestampSpec, gran, dimensionsSpec, metrics, rollup
       );
     }
   }

--- a/processing/src/main/java/io/druid/segment/incremental/OffheapIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OffheapIncrementalIndex.java
@@ -220,7 +220,7 @@ public class OffheapIncrementalIndex extends IncrementalIndex<BufferAggregator>
     int bufferOffset;
 
     synchronized (this) {
-      final Integer priorIndex = facts.getRowIndexForRollup(key);
+      final Integer priorIndex = facts.getPriorIndex(key);
       if (null != priorIndex) {
         final int[] indexAndOffset = indexAndOffsets.get(priorIndex);
         bufferIndex = indexAndOffset[0];
@@ -267,7 +267,7 @@ public class OffheapIncrementalIndex extends IncrementalIndex<BufferAggregator>
         }
 
         // Last ditch sanity checks
-        if (numEntries.get() >= maxRowCount && facts.getRowIndexForRollup(key) == null) {
+        if (numEntries.get() >= maxRowCount && facts.getPriorIndex(key) == null) {
           throw new IndexSizeExceededException("Maximum number of rows [%d] reached", maxRowCount);
         }
 

--- a/processing/src/main/java/io/druid/segment/incremental/OffheapIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OffheapIncrementalIndex.java
@@ -20,7 +20,6 @@
 package io.druid.segment.incremental;
 
 import com.google.common.base.Supplier;
-import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
 import com.metamx.common.IAE;
 import com.metamx.common.ISE;
@@ -34,14 +33,10 @@ import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.BufferAggregator;
 import io.druid.segment.ColumnSelectorFactory;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -55,7 +50,7 @@ public class OffheapIncrementalIndex extends IncrementalIndex<BufferAggregator>
   private final List<ResourceHolder<ByteBuffer>> aggBuffers = new ArrayList<>();
   private final List<int[]> indexAndOffsets = new ArrayList<>();
 
-  private final ConcurrentMap<TimeAndDims, Integer> facts;
+  private final FactsHolder facts;
 
   private final AtomicInteger indexIncrement = new AtomicInteger(0);
 
@@ -80,15 +75,12 @@ public class OffheapIncrementalIndex extends IncrementalIndex<BufferAggregator>
       StupidPool<ByteBuffer> bufferPool
   )
   {
-    super(incrementalIndexSchema, deserializeComplexMetrics, reportParseExceptions, sortFacts);
+    super(incrementalIndexSchema, deserializeComplexMetrics, reportParseExceptions);
     this.maxRowCount = maxRowCount;
     this.bufferPool = bufferPool;
 
-    if (sortFacts) {
-      this.facts = new ConcurrentSkipListMap<>(dimsComparator());
-    } else {
-      this.facts = new ConcurrentHashMap<>();
-    }
+    this.facts = incrementalIndexSchema.isRollup() ? new RollupFactsHolder(sortFacts, dimsComparator())
+                                                   : new PlainFactsHolder(sortFacts);
 
     //check that stupid pool gives buffers that can hold at least one row's aggregators
     ResourceHolder<ByteBuffer> bb = bufferPool.take();
@@ -114,10 +106,34 @@ public class OffheapIncrementalIndex extends IncrementalIndex<BufferAggregator>
         new IncrementalIndexSchema.Builder().withMinTimestamp(minTimestamp)
                                             .withQueryGranularity(gran)
                                             .withMetrics(metrics)
+                                            .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
                                             .build(),
         deserializeComplexMetrics,
         reportParseExceptions,
         sortFacts,
+        maxRowCount,
+        bufferPool
+    );
+  }
+
+  public OffheapIncrementalIndex(
+      long minTimestamp,
+      QueryGranularity gran,
+      boolean rollup,
+      final AggregatorFactory[] metrics,
+      int maxRowCount,
+      StupidPool<ByteBuffer> bufferPool
+  )
+  {
+    this(
+        new IncrementalIndexSchema.Builder().withMinTimestamp(minTimestamp)
+                                            .withQueryGranularity(gran)
+                                            .withMetrics(metrics)
+                                            .withRollup(rollup)
+                                            .build(),
+        true,
+        true,
+        true,
         maxRowCount,
         bufferPool
     );
@@ -132,20 +148,17 @@ public class OffheapIncrementalIndex extends IncrementalIndex<BufferAggregator>
   )
   {
     this(
-        new IncrementalIndexSchema.Builder().withMinTimestamp(minTimestamp)
-                                            .withQueryGranularity(gran)
-                                            .withMetrics(metrics)
-                                            .build(),
-        true,
-        true,
-        true,
+        minTimestamp,
+        gran,
+        IncrementalIndexSchema.DEFAULT_ROLLUP,
+        metrics,
         maxRowCount,
         bufferPool
     );
   }
 
   @Override
-  public ConcurrentMap<TimeAndDims, Integer> getFacts()
+  public FactsHolder getFacts()
   {
     return facts;
   }
@@ -207,7 +220,7 @@ public class OffheapIncrementalIndex extends IncrementalIndex<BufferAggregator>
     int bufferOffset;
 
     synchronized (this) {
-      final Integer priorIndex = facts.get(key);
+      final Integer priorIndex = facts.getRowIndexForRollup(key);
       if (null != priorIndex) {
         final int[] indexAndOffset = indexAndOffsets.get(priorIndex);
         bufferIndex = indexAndOffset[0];
@@ -254,7 +267,7 @@ public class OffheapIncrementalIndex extends IncrementalIndex<BufferAggregator>
         }
 
         // Last ditch sanity checks
-        if (numEntries.get() >= maxRowCount && !facts.containsKey(key)) {
+        if (numEntries.get() >= maxRowCount && facts.getRowIndexForRollup(key) == null) {
           throw new IndexSizeExceededException("Maximum number of rows [%d] reached", maxRowCount);
         }
 

--- a/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -180,7 +180,7 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
       Supplier<InputRow> rowSupplier
   ) throws IndexSizeExceededException
   {
-    final Integer priorIndex = facts.getRowIndexForRollup(key);
+    final Integer priorIndex = facts.getPriorIndex(key);
 
     Aggregator[] aggs;
 
@@ -196,7 +196,7 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
       concurrentSet(rowIndex, aggs);
 
       // Last ditch sanity checks
-      if (numEntries.get() >= maxRowCount && facts.getRowIndexForRollup(key) == null) {
+      if (numEntries.get() >= maxRowCount && facts.getPriorIndex(key) == null) {
         throw new IndexSizeExceededException("Maximum number of rows [%d] reached", maxRowCount);
       }
       final Integer prev = facts.putIfAbsent(key, rowIndex);

--- a/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -50,7 +49,7 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
   private static final Logger log = new Logger(OnheapIncrementalIndex.class);
 
   private final ConcurrentHashMap<Integer, Aggregator[]> aggregators = new ConcurrentHashMap<>();
-  private final ConcurrentMap<TimeAndDims, Integer> facts;
+  private final FactsHolder facts;
   private final AtomicInteger indexIncrement = new AtomicInteger(0);
   protected final int maxRowCount;
   private volatile Map<String, ColumnSelectorFactory> selectors;
@@ -65,14 +64,11 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
       int maxRowCount
   )
   {
-    super(incrementalIndexSchema, deserializeComplexMetrics, reportParseExceptions, sortFacts);
+    super(incrementalIndexSchema, deserializeComplexMetrics, reportParseExceptions);
     this.maxRowCount = maxRowCount;
 
-    if (sortFacts) {
-      this.facts = new ConcurrentSkipListMap<>(dimsComparator());
-    } else {
-      this.facts = new ConcurrentHashMap<>();
-    }
+    this.facts = incrementalIndexSchema.isRollup() ? new RollupFactsHolder(sortFacts, dimsComparator())
+                                                   : new PlainFactsHolder(sortFacts);
   }
 
   public OnheapIncrementalIndex(
@@ -89,10 +85,32 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
         new IncrementalIndexSchema.Builder().withMinTimestamp(minTimestamp)
                                             .withQueryGranularity(gran)
                                             .withMetrics(metrics)
+                                            .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
                                             .build(),
         deserializeComplexMetrics,
         reportParseExceptions,
         sortFacts,
+        maxRowCount
+    );
+  }
+
+  public OnheapIncrementalIndex(
+      long minTimestamp,
+      QueryGranularity gran,
+      boolean rollup,
+      final AggregatorFactory[] metrics,
+      int maxRowCount
+  )
+  {
+    this(
+        new IncrementalIndexSchema.Builder().withMinTimestamp(minTimestamp)
+                                            .withQueryGranularity(gran)
+                                            .withMetrics(metrics)
+                                            .withRollup(rollup)
+                                            .build(),
+        true,
+        true,
+        true,
         maxRowCount
     );
   }
@@ -105,13 +123,10 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
   )
   {
     this(
-        new IncrementalIndexSchema.Builder().withMinTimestamp(minTimestamp)
-                                            .withQueryGranularity(gran)
-                                            .withMetrics(metrics)
-                                            .build(),
-        true,
-        true,
-        true,
+        minTimestamp,
+        gran,
+        IncrementalIndexSchema.DEFAULT_ROLLUP,
+        metrics,
         maxRowCount
     );
   }
@@ -126,7 +141,7 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
   }
 
   @Override
-  public ConcurrentMap<TimeAndDims, Integer> getFacts()
+  public FactsHolder getFacts()
   {
     return facts;
   }
@@ -165,7 +180,7 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
       Supplier<InputRow> rowSupplier
   ) throws IndexSizeExceededException
   {
-    final Integer priorIndex = facts.get(key);
+    final Integer priorIndex = facts.getRowIndexForRollup(key);
 
     Aggregator[] aggs;
 
@@ -181,7 +196,7 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
       concurrentSet(rowIndex, aggs);
 
       // Last ditch sanity checks
-      if (numEntries.get() >= maxRowCount && !facts.containsKey(key)) {
+      if (numEntries.get() >= maxRowCount && facts.getRowIndexForRollup(key) == null) {
         throw new IndexSizeExceededException("Maximum number of rows [%d] reached", maxRowCount);
       }
       final Integer prev = facts.putIfAbsent(key, rowIndex);

--- a/processing/src/test/java/io/druid/query/QueryRunnerTestHelper.java
+++ b/processing/src/test/java/io/druid/query/QueryRunnerTestHelper.java
@@ -323,11 +323,15 @@ public class QueryRunnerTestHelper
       throws IOException
   {
     final IncrementalIndex rtIndex = TestIndex.getIncrementalTestIndex();
+    final IncrementalIndex noRollupRtIndex = TestIndex.getNoRollupIncrementalTestIndex();
     final QueryableIndex mMappedTestIndex = TestIndex.getMMappedTestIndex();
+    final QueryableIndex noRollupMMappedTestIndex = TestIndex.getNoRollupMMappedTestIndex();
     final QueryableIndex mergedRealtimeIndex = TestIndex.mergedRealtimeIndex();
     return ImmutableList.of(
         makeQueryRunner(factory, new IncrementalIndexSegment(rtIndex, segmentId)),
+        makeQueryRunner(factory, new IncrementalIndexSegment(noRollupRtIndex, segmentId)),
         makeQueryRunner(factory, new QueryableIndexSegment(segmentId, mMappedTestIndex)),
+        makeQueryRunner(factory, new QueryableIndexSegment(segmentId, noRollupMMappedTestIndex)),
         makeQueryRunner(factory, new QueryableIndexSegment(segmentId, mergedRealtimeIndex))
     );
   }

--- a/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
@@ -28,21 +28,16 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.google.common.base.Function;
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Closeables;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.metamx.common.IAE;
 import com.metamx.common.guava.CloseQuietly;
 import com.metamx.common.guava.Sequence;
 import com.metamx.common.guava.Sequences;
 import com.metamx.common.guava.Yielder;
 import com.metamx.common.guava.YieldingAccumulator;
-
-import io.druid.collections.StupidPool;
 import io.druid.data.input.Row;
 import io.druid.data.input.impl.InputRowParser;
 import io.druid.data.input.impl.StringInputRowParser;
@@ -56,16 +51,12 @@ import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerFactory;
 import io.druid.query.QueryRunnerTestHelper;
 import io.druid.query.QueryToolChest;
-import io.druid.query.QueryWatcher;
 import io.druid.query.groupby.GroupByQueryConfig;
-import io.druid.query.groupby.GroupByQueryEngine;
-import io.druid.query.groupby.GroupByQueryQueryToolChest;
 import io.druid.query.groupby.GroupByQueryRunnerFactory;
 import io.druid.query.groupby.GroupByQueryRunnerTest;
 import io.druid.query.select.SelectQueryEngine;
 import io.druid.query.select.SelectQueryQueryToolChest;
 import io.druid.query.select.SelectQueryRunnerFactory;
-import io.druid.segment.AbstractSegment;
 import io.druid.segment.IndexIO;
 import io.druid.segment.IndexMerger;
 import io.druid.segment.IndexSpec;
@@ -75,7 +66,6 @@ import io.druid.segment.Segment;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
 import org.junit.rules.TemporaryFolder;
@@ -84,7 +74,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -334,7 +323,7 @@ public class AggregationTestHelper
         for (File file : toMerge) {
           indexes.add(indexIO.loadIndex(file));
         }
-        indexMerger.mergeQueryableIndex(indexes, metrics, outDir, new IndexSpec());
+        indexMerger.mergeQueryableIndex(indexes, true, metrics, outDir, new IndexSpec());
 
         for (QueryableIndex qi : indexes) {
           qi.close();

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
@@ -87,6 +87,7 @@ public class SegmentMetadataQueryQueryToolChestTest
         100,
         null,
         null,
+        null,
         null
     );
 
@@ -117,6 +118,7 @@ public class SegmentMetadataQueryQueryToolChestTest
             "baz", new DoubleSumAggregatorFactory("baz", "baz")
         ),
         null,
+        null,
         null
     );
     final SegmentAnalysis analysis2 = new SegmentAnalysis(
@@ -129,6 +131,7 @@ public class SegmentMetadataQueryQueryToolChestTest
             "foo", new LongSumAggregatorFactory("foo", "foo"),
             "bar", new DoubleSumAggregatorFactory("bar", "bar")
         ),
+        null,
         null,
         null
     );
@@ -162,6 +165,7 @@ public class SegmentMetadataQueryQueryToolChestTest
         0,
         null,
         null,
+        null,
         null
     );
     final SegmentAnalysis analysis2 = new SegmentAnalysis(
@@ -174,6 +178,7 @@ public class SegmentMetadataQueryQueryToolChestTest
             "foo", new LongSumAggregatorFactory("foo", "foo"),
             "bar", new DoubleSumAggregatorFactory("bar", "bar")
         ),
+        null,
         null,
         null
     );
@@ -199,6 +204,7 @@ public class SegmentMetadataQueryQueryToolChestTest
         0,
         null,
         null,
+        null,
         null
     );
     final SegmentAnalysis analysis2 = new SegmentAnalysis(
@@ -207,6 +213,7 @@ public class SegmentMetadataQueryQueryToolChestTest
         Maps.<String, ColumnAnalysis>newHashMap(),
         0,
         0,
+        null,
         null,
         null,
         null
@@ -230,6 +237,7 @@ public class SegmentMetadataQueryQueryToolChestTest
             "bar", new DoubleSumAggregatorFactory("bar", "bar")
         ),
         null,
+        null,
         null
     );
     final SegmentAnalysis analysis2 = new SegmentAnalysis(
@@ -243,6 +251,7 @@ public class SegmentMetadataQueryQueryToolChestTest
             "bar", new DoubleMaxAggregatorFactory("bar", "bar"),
             "baz", new LongMaxAggregatorFactory("baz", "baz")
         ),
+        null,
         null,
         null
     );
@@ -262,6 +271,72 @@ public class SegmentMetadataQueryQueryToolChestTest
             mergeLenient(analysis1, analysis2)
         ).getAggregators()
     );
+  }
+
+  @Test
+  public void testMergeRollup()
+  {
+    final SegmentAnalysis analysis1 = new SegmentAnalysis(
+        "id",
+        null,
+        Maps.<String, ColumnAnalysis>newHashMap(),
+        0,
+        0,
+        null,
+        null,
+        null,
+        null
+    );
+    final SegmentAnalysis analysis2 = new SegmentAnalysis(
+        "id",
+        null,
+        Maps.<String, ColumnAnalysis>newHashMap(),
+        0,
+        0,
+        null,
+        null,
+        null,
+        false
+    );
+    final SegmentAnalysis analysis3 = new SegmentAnalysis(
+        "id",
+        null,
+        Maps.<String, ColumnAnalysis>newHashMap(),
+        0,
+        0,
+        null,
+        null,
+        null,
+        false
+    );
+    final SegmentAnalysis analysis4 = new SegmentAnalysis(
+        "id",
+        null,
+        Maps.<String, ColumnAnalysis>newHashMap(),
+        0,
+        0,
+        null,
+        null,
+        null,
+        true
+    );
+    final SegmentAnalysis analysis5 = new SegmentAnalysis(
+        "id",
+        null,
+        Maps.<String, ColumnAnalysis>newHashMap(),
+        0,
+        0,
+        null,
+        null,
+        null,
+        true
+    );
+
+    Assert.assertNull(mergeStrict(analysis1, analysis2).isRollup());
+    Assert.assertNull(mergeStrict(analysis1, analysis4).isRollup());
+    Assert.assertNull(mergeStrict(analysis2, analysis4).isRollup());
+    Assert.assertFalse(mergeStrict(analysis2, analysis3).isRollup());
+    Assert.assertTrue(mergeStrict(analysis4, analysis5).isRollup());
   }
 
   private static SegmentAnalysis mergeStrict(SegmentAnalysis analysis1, SegmentAnalysis analysis2)

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
@@ -47,10 +47,12 @@ import io.druid.query.metadata.metadata.ListColumnIncluderator;
 import io.druid.query.metadata.metadata.SegmentAnalysis;
 import io.druid.query.metadata.metadata.SegmentMetadataQuery;
 import io.druid.segment.IncrementalIndexSegment;
+import io.druid.segment.QueryableIndex;
 import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.TestHelper;
 import io.druid.segment.TestIndex;
 import io.druid.segment.column.ValueType;
+import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.timeline.LogicalSegment;
 import org.joda.time.Interval;
 import org.junit.Assert;
@@ -78,26 +80,30 @@ public class SegmentMetadataQueryTest
   @SuppressWarnings("unchecked")
   public static QueryRunner makeMMappedQueryRunner(
       String segmentId,
+      boolean rollup,
       QueryRunnerFactory factory
   )
   {
+    QueryableIndex index = rollup ? TestIndex.getMMappedTestIndex() : TestIndex.getNoRollupMMappedTestIndex();
     return QueryRunnerTestHelper.makeQueryRunner(
         factory,
         segmentId,
-        new QueryableIndexSegment(segmentId, TestIndex.getMMappedTestIndex())
+        new QueryableIndexSegment(segmentId, index)
     );
   }
 
   @SuppressWarnings("unchecked")
   public static QueryRunner makeIncrementalIndexQueryRunner(
       String segmentId,
+      boolean rollup,
       QueryRunnerFactory factory
   )
   {
+    IncrementalIndex index = rollup ? TestIndex.getIncrementalTestIndex() : TestIndex.getNoRollupIncrementalTestIndex();
     return QueryRunnerTestHelper.makeQueryRunner(
         factory,
         segmentId,
-        new IncrementalIndexSegment(TestIndex.getIncrementalTestIndex(), segmentId)
+        new IncrementalIndexSegment(index, segmentId)
     );
   }
 
@@ -105,35 +111,42 @@ public class SegmentMetadataQueryTest
   private final QueryRunner runner2;
   private final boolean mmap1;
   private final boolean mmap2;
+  private final boolean rollup1;
+  private final boolean rollup2;
   private final boolean differentIds;
   private final SegmentMetadataQuery testQuery;
   private final SegmentAnalysis expectedSegmentAnalysis1;
   private final SegmentAnalysis expectedSegmentAnalysis2;
 
-  @Parameterized.Parameters(name = "mmap1 = {0}, mmap2 = {1}, differentIds = {2}")
+  @Parameterized.Parameters(name = "mmap1 = {0}, mmap2 = {1}, rollup1 = {2}, rollup2 = {3}, differentIds = {4}")
   public static Collection<Object[]> constructorFeeder()
   {
     return ImmutableList.of(
-        new Object[]{true, true, false},
-        new Object[]{true, false, false},
-        new Object[]{false, true, false},
-        new Object[]{false, false, false},
-        new Object[]{false, false, true}
+        new Object[]{true, true, true, true, false},
+        new Object[]{true, false, true, false, false},
+        new Object[]{false, true, true, false, false},
+        new Object[]{false, false, false, false, false},
+        new Object[]{false, false, true, true, false},
+        new Object[]{false, false, false, true, true}
     );
   }
 
   public SegmentMetadataQueryTest(
       boolean mmap1,
       boolean mmap2,
+      boolean rollup1,
+      boolean rollup2,
       boolean differentIds
   )
   {
     final String id1 = differentIds ? "testSegment1" : "testSegment";
     final String id2 = differentIds ? "testSegment2" : "testSegment";
-    this.runner1 = mmap1 ? makeMMappedQueryRunner(id1, FACTORY) : makeIncrementalIndexQueryRunner(id1, FACTORY);
-    this.runner2 = mmap2 ? makeMMappedQueryRunner(id2, FACTORY) : makeIncrementalIndexQueryRunner(id2, FACTORY);
+    this.runner1 = mmap1 ? makeMMappedQueryRunner(id1, rollup1, FACTORY) : makeIncrementalIndexQueryRunner(id1, rollup1, FACTORY);
+    this.runner2 = mmap2 ? makeMMappedQueryRunner(id2, rollup2, FACTORY) : makeIncrementalIndexQueryRunner(id2, rollup2, FACTORY);
     this.mmap1 = mmap1;
     this.mmap2 = mmap2;
+    this.rollup1 = rollup1;
+    this.rollup2 = rollup2;
     this.differentIds = differentIds;
     testQuery = Druids.newSegmentMetadataQueryBuilder()
                       .dataSource("testing")
@@ -183,6 +196,7 @@ public class SegmentMetadataQueryTest
         1209,
         null,
         null,
+        null,
         null
     );
     expectedSegmentAnalysis2 = new SegmentAnalysis(
@@ -226,6 +240,7 @@ public class SegmentMetadataQueryTest
         1209,
         null,
         null,
+        null,
         null
     );
   }
@@ -240,6 +255,75 @@ public class SegmentMetadataQueryTest
     );
 
     Assert.assertEquals(Arrays.asList(expectedSegmentAnalysis1), results);
+  }
+
+  @Test
+  public void testSegmentMetadataQueryWithRollupMerge()
+  {
+    SegmentAnalysis mergedSegmentAnalysis = new SegmentAnalysis(
+        differentIds ? "merged" : "testSegment",
+        null,
+        ImmutableMap.of(
+            "placement",
+            new ColumnAnalysis(
+                ValueType.STRING.toString(),
+                false,
+                0,
+                0,
+                null,
+                null,
+                null
+            ),
+            "placementish",
+            new ColumnAnalysis(
+                ValueType.STRING.toString(),
+                true,
+                0,
+                0,
+                null,
+                null,
+                null
+            )
+        ),
+        0,
+        expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows(),
+        null,
+        null,
+        null,
+        rollup1 != rollup2 ? null : rollup1
+    );
+
+    QueryToolChest toolChest = FACTORY.getToolchest();
+
+    ExecutorService exec = Executors.newCachedThreadPool();
+    QueryRunner myRunner = new FinalizeResultsQueryRunner<>(
+        toolChest.mergeResults(
+            FACTORY.mergeRunners(
+                MoreExecutors.sameThreadExecutor(),
+                Lists.<QueryRunner<SegmentAnalysis>>newArrayList(
+                    toolChest.preMergeQueryDecoration(runner1),
+                    toolChest.preMergeQueryDecoration(runner2)
+                )
+            )
+        ),
+        toolChest
+    );
+
+    TestHelper.assertExpectedObjects(
+        ImmutableList.of(mergedSegmentAnalysis),
+        myRunner.run(
+            Druids.newSegmentMetadataQueryBuilder()
+                  .dataSource("testing")
+                  .intervals("2013/2014")
+                  .toInclude(new ListColumnIncluderator(Arrays.asList("placement", "placementish")))
+                  .analysisTypes(SegmentMetadataQuery.AnalysisType.ROLLUP)
+                  .merge(true)
+                  .build(),
+            Maps.newHashMap()
+        ),
+        "failed SegmentMetadata merging query"
+    );
+    exec.shutdownNow();
   }
 
   @Test
@@ -272,6 +356,7 @@ public class SegmentMetadataQueryTest
         ),
         0,
         expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows(),
+        null,
         null,
         null,
         null
@@ -340,6 +425,7 @@ public class SegmentMetadataQueryTest
         ),
         0,
         expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows(),
+        null,
         null,
         null,
         null
@@ -459,6 +545,7 @@ public class SegmentMetadataQueryTest
         expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows(),
         null,
         null,
+        null,
         null
     );
 
@@ -508,6 +595,7 @@ public class SegmentMetadataQueryTest
         ),
         0,
         expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows(),
+        null,
         null,
         null,
         null
@@ -572,6 +660,7 @@ public class SegmentMetadataQueryTest
         expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows(),
         expectedAggregators,
         null,
+        null,
         null
     );
 
@@ -630,6 +719,7 @@ public class SegmentMetadataQueryTest
         expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows(),
         null,
         new TimestampSpec("ds", "auto", null),
+        null,
         null
     );
 
@@ -688,7 +778,8 @@ public class SegmentMetadataQueryTest
         expectedSegmentAnalysis1.getNumRows() + expectedSegmentAnalysis2.getNumRows(),
         null,
         null,
-        QueryGranularities.NONE
+        QueryGranularities.NONE,
+        null
     );
 
     QueryToolChest toolChest = FACTORY.getToolchest();

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataUnionQueryTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataUnionQueryTest.java
@@ -19,25 +19,15 @@
 
 package io.druid.query.metadata;
 
-import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.metamx.common.guava.Sequence;
 import com.metamx.common.guava.Sequences;
-import io.druid.collections.StupidPool;
 import io.druid.query.Druids;
 import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerFactory;
 import io.druid.query.QueryRunnerTestHelper;
-import io.druid.query.Result;
-import io.druid.query.TestQueryRunners;
-import io.druid.query.aggregation.AggregatorFactory;
-import io.druid.query.aggregation.DoubleMaxAggregatorFactory;
-import io.druid.query.aggregation.DoubleMinAggregatorFactory;
-import io.druid.query.aggregation.PostAggregator;
 import io.druid.query.metadata.metadata.ColumnAnalysis;
 import io.druid.query.metadata.metadata.ListColumnIncluderator;
 import io.druid.query.metadata.metadata.SegmentAnalysis;
@@ -47,18 +37,13 @@ import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.TestHelper;
 import io.druid.segment.TestIndex;
 import io.druid.segment.column.ValueType;
-import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @RunWith(Parameterized.class)
 public class SegmentMetadataUnionQueryTest
@@ -125,6 +110,7 @@ public class SegmentMetadataUnionQueryTest
         ),
         mmap ? 287928 : 291020,
         4836,
+        null,
         null,
         null,
         null

--- a/processing/src/test/java/io/druid/segment/EmptyIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/EmptyIndexTest.java
@@ -61,6 +61,7 @@ public class EmptyIndexTest
     );
     TestHelper.getTestIndexMerger().merge(
         Lists.<IndexableAdapter>newArrayList(emptyIndexAdapter),
+        true,
         new AggregatorFactory[0],
         tmpDir,
         new IndexSpec()

--- a/processing/src/test/java/io/druid/segment/IndexBuilder.java
+++ b/processing/src/test/java/io/druid/segment/IndexBuilder.java
@@ -25,7 +25,6 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import io.druid.data.input.InputRow;
-import io.druid.query.aggregation.Aggregator;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.segment.incremental.IncrementalIndex;
@@ -33,7 +32,6 @@ import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.IndexSizeExceededException;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -161,6 +159,7 @@ public class IndexBuilder
                     }
                   }
               ),
+              true,
               Iterables.toArray(
                   Iterables.transform(
                       Arrays.asList(schema.getMetrics()),

--- a/processing/src/test/java/io/druid/segment/IndexMergerV9WithSpatialIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerV9WithSpatialIndexTest.java
@@ -489,6 +489,7 @@ public class IndexMergerV9WithSpatialIndexTest
                   INDEX_IO.loadIndex(secondFile),
                   INDEX_IO.loadIndex(thirdFile)
               ),
+              true,
               METRIC_AGGS,
               mergedFile,
               indexSpec

--- a/processing/src/test/java/io/druid/segment/MetadataTest.java
+++ b/processing/src/test/java/io/druid/segment/MetadataTest.java
@@ -52,6 +52,7 @@ public class MetadataTest
         };
     metadata.setAggregators(aggregators);
     metadata.setQueryGranularity(QueryGranularities.ALL);
+    metadata.setRollup(Boolean.FALSE);
 
     Metadata other = jsonMapper.readValue(
         jsonMapper.writeValueAsString(metadata),
@@ -81,12 +82,14 @@ public class MetadataTest
     m1.setAggregators(aggs);
     m1.setTimestampSpec(new TimestampSpec("ds", "auto", null));
     m1.setQueryGranularity(QueryGranularities.ALL);
+    m1.setRollup(Boolean.FALSE);
 
     Metadata m2 = new Metadata();
     m2.put("k", "v");
     m2.setAggregators(aggs);
     m2.setTimestampSpec(new TimestampSpec("ds", "auto", null));
     m2.setQueryGranularity(QueryGranularities.ALL);
+    m2.setRollup(Boolean.FALSE);
 
     Metadata merged = new Metadata();
     merged.put("k", "v");
@@ -96,6 +99,7 @@ public class MetadataTest
         }
     );
     merged.setTimestampSpec(new TimestampSpec("ds", "auto", null));
+    merged.setRollup(Boolean.FALSE);
     merged.setQueryGranularity(QueryGranularities.ALL);
     Assert.assertEquals(merged, Metadata.merge(ImmutableList.of(m1, m2), null));
 
@@ -108,6 +112,7 @@ public class MetadataTest
     merged.setAggregators(null);
     merged.setTimestampSpec(null);
     merged.setQueryGranularity(null);
+    merged.setRollup(null);
     Assert.assertEquals(merged, Metadata.merge(metadataToBeMerged, null));
 
     //merge check with client explicitly providing merged aggregators
@@ -123,6 +128,7 @@ public class MetadataTest
 
     merged.setTimestampSpec(new TimestampSpec("ds", "auto", null));
     merged.setQueryGranularity(QueryGranularities.ALL);
+    m1.setRollup(Boolean.TRUE);
     Assert.assertEquals(
         merged,
         Metadata.merge(ImmutableList.of(m1, m2), explicitAggs)

--- a/processing/src/test/java/io/druid/segment/SchemalessIndex.java
+++ b/processing/src/test/java/io/druid/segment/SchemalessIndex.java
@@ -197,6 +197,7 @@ public class SchemalessIndex
         mergedIndex = INDEX_IO.loadIndex(
             INDEX_MERGER.mergeQueryableIndex(
                 Arrays.asList(INDEX_IO.loadIndex(topFile), INDEX_IO.loadIndex(bottomFile)),
+                true,
                 METRIC_AGGS,
                 mergedFile,
                 indexSpec
@@ -242,6 +243,7 @@ public class SchemalessIndex
         QueryableIndex index = INDEX_IO.loadIndex(
             INDEX_MERGER.mergeQueryableIndex(
                 Arrays.asList(rowPersistedIndexes.get(index1), rowPersistedIndexes.get(index2)),
+                true,
                 METRIC_AGGS,
                 mergedFile,
                 indexSpec
@@ -280,7 +282,7 @@ public class SchemalessIndex
         }
 
         QueryableIndex index = INDEX_IO.loadIndex(
-            INDEX_MERGER.mergeQueryableIndex(indexesToMerge, METRIC_AGGS, mergedFile, indexSpec)
+            INDEX_MERGER.mergeQueryableIndex(indexesToMerge, true, METRIC_AGGS, mergedFile, indexSpec)
         );
 
         return index;
@@ -533,6 +535,7 @@ public class SchemalessIndex
                       }
                   )
               ),
+              true,
               METRIC_AGGS,
               mergedFile,
               indexSpec

--- a/processing/src/test/java/io/druid/segment/TestIndex.java
+++ b/processing/src/test/java/io/druid/segment/TestIndex.java
@@ -90,7 +90,9 @@ public class TestIndex
   }
 
   private static IncrementalIndex realtimeIndex = null;
+  private static IncrementalIndex noRollupRealtimeIndex = null;
   private static QueryableIndex mmappedIndex = null;
+  private static QueryableIndex noRollupMmappedIndex = null;
   private static QueryableIndex mergedRealtime = null;
 
   public static IncrementalIndex getIncrementalTestIndex()
@@ -102,6 +104,17 @@ public class TestIndex
     }
 
     return realtimeIndex = makeRealtimeIndex("druid.sample.tsv");
+  }
+
+  public static IncrementalIndex getNoRollupIncrementalTestIndex()
+  {
+    synchronized (log) {
+      if (noRollupRealtimeIndex != null) {
+        return noRollupRealtimeIndex;
+      }
+    }
+
+    return noRollupRealtimeIndex = makeRealtimeIndex("druid.sample.tsv", false);
   }
 
   public static QueryableIndex getMMappedTestIndex()
@@ -116,6 +129,20 @@ public class TestIndex
     mmappedIndex = persistRealtimeAndLoadMMapped(incrementalIndex);
 
     return mmappedIndex;
+  }
+
+  public static QueryableIndex getNoRollupMMappedTestIndex()
+  {
+    synchronized (log) {
+      if (noRollupMmappedIndex != null) {
+        return noRollupMmappedIndex;
+      }
+    }
+
+    IncrementalIndex incrementalIndex = getNoRollupIncrementalTestIndex();
+    noRollupMmappedIndex = persistRealtimeAndLoadMMapped(incrementalIndex);
+
+    return noRollupMmappedIndex;
   }
 
   public static QueryableIndex mergedRealtimeIndex()
@@ -149,6 +176,7 @@ public class TestIndex
         mergedRealtime = INDEX_IO.loadIndex(
             INDEX_MERGER.mergeQueryableIndex(
                 Arrays.asList(INDEX_IO.loadIndex(topFile), INDEX_IO.loadIndex(bottomFile)),
+                true,
                 METRIC_AGGS,
                 mergedFile,
                 indexSpec
@@ -165,22 +193,33 @@ public class TestIndex
 
   public static IncrementalIndex makeRealtimeIndex(final String resourceFilename)
   {
+    return makeRealtimeIndex(resourceFilename, true);
+  }
+
+  public static IncrementalIndex makeRealtimeIndex(final String resourceFilename, boolean rollup)
+  {
     final URL resource = TestIndex.class.getClassLoader().getResource(resourceFilename);
     if (resource == null) {
       throw new IllegalArgumentException("cannot find resource " + resourceFilename);
     }
     log.info("Realtime loading index file[%s]", resource);
     CharSource stream = Resources.asByteSource(resource).asCharSource(Charsets.UTF_8);
-    return makeRealtimeIndex(stream);
+    return makeRealtimeIndex(stream, rollup);
   }
 
   public static IncrementalIndex makeRealtimeIndex(final CharSource source)
+  {
+    return makeRealtimeIndex(source, true);
+  }
+
+  public static IncrementalIndex makeRealtimeIndex(final CharSource source, boolean rollup)
   {
     final IncrementalIndexSchema schema = new IncrementalIndexSchema.Builder()
         .withMinTimestamp(new DateTime("2011-01-12T00:00:00.000Z").getMillis())
         .withTimestampSpec(new TimestampSpec("ds", "auto", null))
         .withQueryGranularity(QueryGranularities.NONE)
         .withMetrics(METRIC_AGGS)
+        .withRollup(rollup)
         .build();
     final IncrementalIndex retVal = new OnheapIncrementalIndex(schema, true, 10000);
 
@@ -188,7 +227,11 @@ public class TestIndex
       return loadIncrementalIndex(retVal, source);
     }
     catch (Exception e) {
-      realtimeIndex = null;
+      if (rollup) {
+        realtimeIndex = null;
+      } else {
+        noRollupRealtimeIndex = null;
+      }
       throw Throwables.propagate(e);
     }
   }

--- a/processing/src/test/java/io/druid/segment/filter/SpatialFilterBonusTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/SpatialFilterBonusTest.java
@@ -439,6 +439,7 @@ public class SpatialFilterBonusTest
                   INDEX_IO.loadIndex(secondFile),
                   INDEX_IO.loadIndex(thirdFile)
               ),
+              true,
               METRIC_AGGS,
               mergedFile,
               indexSpec

--- a/processing/src/test/java/io/druid/segment/filter/SpatialFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/SpatialFilterTest.java
@@ -493,6 +493,7 @@ public class SpatialFilterTest
       QueryableIndex mergedRealtime = INDEX_IO.loadIndex(
           INDEX_MERGER.mergeQueryableIndex(
               Arrays.asList(INDEX_IO.loadIndex(firstFile), INDEX_IO.loadIndex(secondFile), INDEX_IO.loadIndex(thirdFile)),
+              true,
               METRIC_AGGS,
               mergedFile,
               indexSpec

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexTest.java
@@ -92,6 +92,7 @@ public class IncrementalIndexTest
         .withQueryGranularity(QueryGranularities.MINUTE)
         .withDimensionsSpec(dimensions)
         .withMetrics(metrics)
+        .withRollup(true)
         .build();
 
     final List<Object[]> constructors = Lists.newArrayList();

--- a/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
+++ b/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
@@ -146,7 +146,7 @@ public class OnheapIncrementalIndexBenchmark extends AbstractBenchmark
     ) throws IndexSizeExceededException
     {
 
-      final Integer priorIdex = getFacts().getRowIndexForRollup(key);
+      final Integer priorIdex = getFacts().getPriorIndex(key);
 
       Aggregator[] aggs;
 
@@ -169,7 +169,7 @@ public class OnheapIncrementalIndexBenchmark extends AbstractBenchmark
 
 
         // Last ditch sanity checks
-        if (numEntries.get() >= maxRowCount && getFacts().getRowIndexForRollup(key) == null) {
+        if (numEntries.get() >= maxRowCount && getFacts().getPriorIndex(key) == null) {
           throw new IndexSizeExceededException("Maximum number of rows reached");
         }
         final Integer prev = getFacts().putIfAbsent(key, rowIndex);

--- a/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
+++ b/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
@@ -146,7 +146,7 @@ public class OnheapIncrementalIndexBenchmark extends AbstractBenchmark
     ) throws IndexSizeExceededException
     {
 
-      final Integer priorIdex = getFacts().get(key);
+      final Integer priorIdex = getFacts().getRowIndexForRollup(key);
 
       Aggregator[] aggs;
 
@@ -169,7 +169,7 @@ public class OnheapIncrementalIndexBenchmark extends AbstractBenchmark
 
 
         // Last ditch sanity checks
-        if (numEntries.get() >= maxRowCount && !getFacts().containsKey(key)) {
+        if (numEntries.get() >= maxRowCount && getFacts().getRowIndexForRollup(key) == null) {
           throw new IndexSizeExceededException("Maximum number of rows reached");
         }
         final Integer prev = getFacts().putIfAbsent(key, rowIndex);

--- a/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexTest.java
@@ -28,6 +28,7 @@ import io.druid.query.aggregation.LongMaxAggregatorFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -79,8 +80,8 @@ public class OnheapIncrementalIndexTest
       public void run()
       {
         while (!Thread.interrupted()) {
-          for (int row : index.getFacts().values()) {
-            if (index.getMetricLongValue(row, 0) != 1) {
+          for (Map.Entry<IncrementalIndex.TimeAndDims, Integer> row : index.getFacts().entrySet()) {
+            if (index.getMetricLongValue(row.getValue(), 0) != 1) {
               checkFailedCount.addAndGet(1);
             }
           }

--- a/server/src/main/java/io/druid/segment/indexing/granularity/ArbitraryGranularitySpec.java
+++ b/server/src/main/java/io/druid/segment/indexing/granularity/ArbitraryGranularitySpec.java
@@ -41,14 +41,17 @@ public class ArbitraryGranularitySpec implements GranularitySpec
 {
   private final TreeSet<Interval> intervals;
   private final QueryGranularity queryGranularity;
+  private final Boolean rollup;
 
   @JsonCreator
   public ArbitraryGranularitySpec(
       @JsonProperty("queryGranularity") QueryGranularity queryGranularity,
+      @JsonProperty("rollup") Boolean rollup,
       @JsonProperty("intervals") List<Interval> inputIntervals
   )
   {
     this.queryGranularity = queryGranularity;
+    this.rollup = rollup == null ? Boolean.TRUE : rollup;
     this.intervals = Sets.newTreeSet(Comparators.intervalsByStartThenEnd());
 
     if (inputIntervals == null) {
@@ -80,6 +83,14 @@ public class ArbitraryGranularitySpec implements GranularitySpec
     }
   }
 
+  public ArbitraryGranularitySpec(
+      QueryGranularity queryGranularity,
+      List<Interval> inputIntervals
+  )
+  {
+    this(queryGranularity, true, inputIntervals);
+  }
+
   @Override
   @JsonProperty("intervals")
   public Optional<SortedSet<Interval>> bucketIntervals()
@@ -107,6 +118,13 @@ public class ArbitraryGranularitySpec implements GranularitySpec
   }
 
   @Override
+  @JsonProperty("rollup")
+  public boolean isRollup()
+  {
+    return rollup;
+  }
+
+  @Override
   @JsonProperty("queryGranularity")
   public QueryGranularity getQueryGranularity()
   {
@@ -128,6 +146,9 @@ public class ArbitraryGranularitySpec implements GranularitySpec
     if (!intervals.equals(that.intervals)) {
       return false;
     }
+    if (!rollup.equals(that.rollup)) {
+      return false;
+    }
     return !(queryGranularity != null
              ? !queryGranularity.equals(that.queryGranularity)
              : that.queryGranularity != null);
@@ -138,6 +159,7 @@ public class ArbitraryGranularitySpec implements GranularitySpec
   public int hashCode()
   {
     int result = intervals.hashCode();
+    result = 31 * result + rollup.hashCode();
     result = 31 * result + (queryGranularity != null ? queryGranularity.hashCode() : 0);
     return result;
   }

--- a/server/src/main/java/io/druid/segment/indexing/granularity/GranularitySpec.java
+++ b/server/src/main/java/io/druid/segment/indexing/granularity/GranularitySpec.java
@@ -57,6 +57,8 @@ public interface GranularitySpec
 
   public Granularity getSegmentGranularity();
 
+  public boolean isRollup();
+
   public QueryGranularity getQueryGranularity();
 
 }

--- a/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -540,6 +540,7 @@ public class AppenderatorImpl implements Appenderator
       final File mergedFile;
       mergedFile = indexMerger.mergeQueryableIndex(
           indexes,
+          schema.getGranularitySpec().isRollup(),
           schema.getAggregators(),
           mergedTarget,
           tuningConfig.getIndexSpec()

--- a/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -412,6 +412,7 @@ public class RealtimePlumber implements Plumber
 
               final File mergedFile = indexMerger.mergeQueryableIndex(
                   indexes,
+                  schema.getGranularitySpec().isRollup(),
                   schema.getAggregators(),
                   mergedTarget,
                   config.getIndexSpec()

--- a/server/src/main/java/io/druid/segment/realtime/plumber/Sink.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/Sink.java
@@ -236,6 +236,7 @@ public class Sink implements Iterable<FireHydrant>
         .withQueryGranularity(schema.getGranularitySpec().getQueryGranularity())
         .withDimensionsSpec(schema.getParser())
         .withMetrics(schema.getAggregators())
+        .withRollup(schema.getGranularitySpec().isRollup())
         .build();
     final IncrementalIndex newIndex = new OnheapIncrementalIndex(indexSchema, reportParseExceptions, maxRowsInMemory);
 

--- a/server/src/test/java/io/druid/segment/indexing/granularity/ArbitraryGranularityTest.java
+++ b/server/src/test/java/io/druid/segment/indexing/granularity/ArbitraryGranularityTest.java
@@ -49,6 +49,8 @@ public class ArbitraryGranularityTest
         new Interval("2012-01-01T00Z/2012-01-03T00Z")
     ));
 
+    Assert.assertTrue(spec.isRollup());
+
     Assert.assertEquals(
         Lists.newArrayList(
             new Interval("2012-01-01T00Z/2012-01-03T00Z"),
@@ -120,6 +122,21 @@ public class ArbitraryGranularityTest
     }
 
     Assert.assertTrue("Exception thrown", thrown);
+  }
+
+  @Test
+  public void testRollupSetting()
+  {
+    List<Interval> intervals = Lists.newArrayList(
+        new Interval("2012-01-08T00Z/2012-01-11T00Z"),
+        new Interval("2012-02-01T00Z/2012-03-01T00Z"),
+        new Interval("2012-01-07T00Z/2012-01-08T00Z"),
+        new Interval("2012-01-03T00Z/2012-01-04T00Z"),
+        new Interval("2012-01-01T00Z/2012-01-03T00Z")
+    );
+    final GranularitySpec spec = new ArbitraryGranularitySpec(QueryGranularities.NONE, false, intervals);
+
+    Assert.assertFalse(spec.isRollup());
   }
 
   @Test

--- a/server/src/test/java/io/druid/segment/indexing/granularity/UniformGranularityTest.java
+++ b/server/src/test/java/io/druid/segment/indexing/granularity/UniformGranularityTest.java
@@ -31,6 +31,8 @@ import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.List;
+
 public class UniformGranularityTest
 {
   private static final ObjectMapper jsonMapper = new DefaultObjectMapper();
@@ -48,6 +50,8 @@ public class UniformGranularityTest
             new Interval("2012-01-01T00Z/2012-01-03T00Z")
         )
     );
+
+    Assert.assertTrue(spec.isRollup());
 
     Assert.assertEquals(
         Lists.newArrayList(
@@ -91,6 +95,20 @@ public class UniformGranularityTest
         Optional.of(new Interval("2012-01-08T00Z/2012-01-09T00Z")),
         spec.bucketInterval(new DateTime("2012-01-08T01Z"))
     );
+  }
+
+  @Test
+  public void testRollupSetting()
+  {
+    List<Interval> intervals = Lists.newArrayList(
+        new Interval("2012-01-08T00Z/2012-01-11T00Z"),
+        new Interval("2012-01-07T00Z/2012-01-08T00Z"),
+        new Interval("2012-01-03T00Z/2012-01-04T00Z"),
+        new Interval("2012-01-01T00Z/2012-01-03T00Z")
+    );
+    final GranularitySpec spec = new UniformGranularitySpec(Granularity.DAY, QueryGranularities.NONE, false, intervals);
+
+    Assert.assertFalse(spec.isRollup());
   }
 
   @Test


### PR DESCRIPTION
here is the Proposal https://groups.google.com/forum/#!msg/druid-development/GE8QtSMdoFo/BhEkLIOjBAAJ

In our case, we need to keep all details instead of rollup duplicate rows, so here is the patch.
We believe there should be no impact to query part if not rollup

In this patch
1. we add an "rollup" option in IncrementalIndexSchema and a new NoRollupGranularitySpec
2. add "rollup" option to mergeQueryableIndex() and merge() in IndexMerger. and do not use CombiningIterable in rowMergerFn if not rollup, then all rows will be kept without combine duplicate rows to one row. If not rollup, it is ordered by timestamp instead of timeAndDims
3. changes to related classes and doc due to the 1,2
4. in IncrementalIndex, do not directly use facts map, use FactsHolder instead. if rollup, use RollupFactsHolder which just delegates to the original facts map. if no rollup, use PlainFactsHolder, which keeps all duplicate rows in a list as ConcurrentMap < Long, Queue < Pair < TimeAndDims, Integer > > >, the key is timestamp, the value is the list of < timeAndDims,rowNum > pair.
5. update IncrementalIndexStorageAdapter to use FactsHolder instead of the facts map
6. add rollup info to SegmentMetadataQuery, also in metadata.drd when persist
7. benchmark