### PR TITLE
handle a NPE in LookupCoordinatorManager.start()

### DIFF
--- a/server/src/main/java/io/druid/server/lookup/cache/LookupCoordinatorManager.java
+++ b/server/src/main/java/io/druid/server/lookup/cache/LookupCoordinatorManager.java
@@ -551,6 +551,10 @@ public class LookupCoordinatorManager
                 LOG.info("Not started. Returning");
                 return;
               }
+              if (allLookupTiers == null) {
+                LOG.info("Not updating lookups because no data exists");
+                return;
+              }
               for (final String tier : allLookupTiers.keySet()) {
                 try {
                   final Map<String, Map<String, Object>> allLookups = allLookupTiers.get(tier);


### PR DESCRIPTION
`LookupCoordinatorManager` throws a NPE when it starts if there isn't any record in the `druid_config` table in the meta db. This NPE makes the updating thread stop working which means the coordinator can't see any lookup data unless restarted. 

