### PR TITLE
add rejectionPolicy to KafkaIndexTask to optionally ignore events outside of a window period

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorSpec.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorSpec.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import io.druid.guice.annotations.Json;
-import io.druid.indexing.kafka.KafkaIndexTaskClient;
 import io.druid.indexing.kafka.KafkaIndexTaskClientFactory;
 import io.druid.indexing.kafka.KafkaTuningConfig;
 import io.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
@@ -62,7 +61,7 @@ public class KafkaSupervisorSpec implements SupervisorSpec
     this.dataSchema = Preconditions.checkNotNull(dataSchema, "dataSchema");
     this.tuningConfig = tuningConfig != null
                         ? tuningConfig
-                        : new KafkaTuningConfig(null, null, null, null, null, null, null, null, null);
+                        : new KafkaTuningConfig(null, null, null, null, null, null, null, null, null, null, null);
     this.ioConfig = Preconditions.checkNotNull(ioConfig, "ioConfig");
 
     this.taskStorage = taskStorage;

--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -1192,7 +1192,9 @@ public class KafkaIndexTaskTest
         null,
         buildV9Directly,
         reportParseExceptions,
-        handoffConditionTimeout
+        handoffConditionTimeout,
+        null,
+        null
     );
     return new KafkaIndexTask(
         taskId,

--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaTuningConfigTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaTuningConfigTest.java
@@ -1,0 +1,114 @@
+/*
+ *
+ *  Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ *  or more contributor license agreements. See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership. Metamarkets licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ * /
+ *
+ */
+
+package io.druid.indexing.kafka;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.druid.jackson.DefaultObjectMapper;
+import io.druid.segment.IndexSpec;
+import io.druid.segment.indexing.TuningConfig;
+import io.druid.segment.realtime.plumber.NoopRejectionPolicyFactory;
+import io.druid.segment.realtime.plumber.ServerTimeRejectionPolicyFactory;
+import org.joda.time.Period;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+
+public class KafkaTuningConfigTest
+{
+  private final ObjectMapper mapper;
+
+  public KafkaTuningConfigTest()
+  {
+    mapper = new DefaultObjectMapper();
+    mapper.registerModules((Iterable<Module>) new KafkaIndexTaskModule().getJacksonModules());
+  }
+
+  @Test
+  public void testSerdeWithDefaults() throws Exception
+  {
+    String jsonStr = "{\"type\": \"kafka\"}";
+
+    KafkaTuningConfig config = (KafkaTuningConfig) mapper.readValue(
+        mapper.writeValueAsString(
+            mapper.readValue(
+                jsonStr,
+                TuningConfig.class
+            )
+        ),
+        TuningConfig.class
+    );
+
+    Assert.assertNotNull(config.getBasePersistDirectory());
+    Assert.assertEquals(75000, config.getMaxRowsInMemory());
+    Assert.assertEquals(5_000_000, config.getMaxRowsPerSegment());
+    Assert.assertEquals(new Period("PT10M"), config.getIntermediatePersistPeriod());
+    Assert.assertEquals(0, config.getMaxPendingPersists());
+    Assert.assertEquals(new IndexSpec(), config.getIndexSpec());
+    Assert.assertEquals(false, config.getBuildV9Directly());
+    Assert.assertEquals(false, config.isReportParseExceptions());
+    Assert.assertEquals(0, config.getHandoffConditionTimeout());
+    Assert.assertTrue(config.getRejectionPolicyFactory() instanceof NoopRejectionPolicyFactory);
+    Assert.assertEquals(new Period("P1D"), config.getWindowPeriod());
+  }
+
+  @Test
+  public void testSerdeWithNonDefaults() throws Exception
+  {
+    String jsonStr = "{\n"
+                     + "  \"type\": \"kafka\",\n"
+                     + "  \"basePersistDirectory\": \"/tmp/xxx\",\n"
+                     + "  \"maxRowsInMemory\": 100,\n"
+                     + "  \"maxRowsPerSegment\": 100,\n"
+                     + "  \"intermediatePersistPeriod\": \"PT1H\",\n"
+                     + "  \"maxPendingPersists\": 100,\n"
+                     + "  \"buildV9Directly\": true,\n"
+                     + "  \"reportParseExceptions\": true,\n"
+                     + "  \"handoffConditionTimeout\": 100,\n"
+                     + "  \"rejectionPolicy\": {\"type\": \"serverTime\"},\n"
+                     + "  \"windowPeriod\": \"PT1H\"\n"
+                     + "}";
+
+    KafkaTuningConfig config = (KafkaTuningConfig) mapper.readValue(
+        mapper.writeValueAsString(
+            mapper.readValue(
+                jsonStr,
+                TuningConfig.class
+            )
+        ),
+        TuningConfig.class
+    );
+
+    Assert.assertEquals(new File("/tmp/xxx"), config.getBasePersistDirectory());
+    Assert.assertEquals(100, config.getMaxRowsInMemory());
+    Assert.assertEquals(100, config.getMaxRowsPerSegment());
+    Assert.assertEquals(new Period("PT1H"), config.getIntermediatePersistPeriod());
+    Assert.assertEquals(100, config.getMaxPendingPersists());
+    Assert.assertEquals(true, config.getBuildV9Directly());
+    Assert.assertEquals(true, config.isReportParseExceptions());
+    Assert.assertEquals(100, config.getHandoffConditionTimeout());
+    Assert.assertTrue(config.getRejectionPolicyFactory() instanceof ServerTimeRejectionPolicyFactory);
+    Assert.assertEquals(new Period("PT1H"), config.getWindowPeriod());
+  }
+}

--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -162,6 +162,8 @@ public class KafkaSupervisorTest extends EasyMockSupport
         null,
         true,
         false,
+        null,
+        null,
         null
     );
   }


### PR DESCRIPTION
this will allow running batch ingestion tasks outside of the window period interval and never conflicting with kafka realtime task regarding lock acquisition
this is a workaround till https://github.com/druid-io/druid/pull/1679 is merged.

by default no events are rejected. however, if user is doing batch resets for previous day's data then they can set the windowPeriod to 1 day and that will ensure that kafka task and batch task would not interfere with each other and kafka task would simply drop events older than a day.