### PR TITLE
Make S3DataSegmentMover not bother checking for items if they are the same

### DIFF
--- a/extensions-core/s3-extensions/src/test/java/io/druid/storage/s3/S3DataSegmentMoverTest.java
+++ b/extensions-core/s3-extensions/src/test/java/io/druid/storage/s3/S3DataSegmentMoverTest.java
@@ -112,7 +112,7 @@ public class S3DataSegmentMoverTest
   }
   
   @Test
-  public void testIgnoresGoneButAllreadyMoved() throws Exception
+  public void testIgnoresGoneButAlreadyMoved() throws Exception
   {
     MockStorageService mockS3Client = new MockStorageService();
     S3DataSegmentMover mover = new S3DataSegmentMover(mockS3Client, new S3DataSegmentPusherConfig());

--- a/extensions-core/s3-extensions/src/test/java/io/druid/storage/s3/S3DataSegmentMoverTest.java
+++ b/extensions-core/s3-extensions/src/test/java/io/druid/storage/s3/S3DataSegmentMoverTest.java
@@ -112,7 +112,7 @@ public class S3DataSegmentMoverTest
   }
   
   @Test
-  public void testIgnoresMissing() throws Exception
+  public void testIgnoresGoneButAllreadyMoved() throws Exception
   {
     MockStorageService mockS3Client = new MockStorageService();
     S3DataSegmentMover mover = new S3DataSegmentMover(mockS3Client, new S3DataSegmentPusherConfig());

--- a/extensions-core/s3-extensions/src/test/java/io/druid/storage/s3/S3DataSegmentMoverTest.java
+++ b/extensions-core/s3-extensions/src/test/java/io/druid/storage/s3/S3DataSegmentMoverTest.java
@@ -110,6 +110,52 @@ public class S3DataSegmentMoverTest
         ImmutableMap.<String, Object>of("baseKey", "targetBaseKey", "bucket", "archive")
     );
   }
+  
+  @Test
+  public void testIgnoresMissing() throws Exception
+  {
+    MockStorageService mockS3Client = new MockStorageService();
+    S3DataSegmentMover mover = new S3DataSegmentMover(mockS3Client, new S3DataSegmentPusherConfig());
+    mover.move(new DataSegment(
+        "test",
+        new Interval("2013-01-01/2013-01-02"),
+        "1",
+        ImmutableMap.<String, Object>of(
+            "key",
+            "baseKey/test/2013-01-01T00:00:00.000Z_2013-01-02T00:00:00.000Z/1/0/index.zip",
+            "bucket",
+            "DOES NOT EXIST"
+        ),
+        ImmutableList.of("dim1", "dim1"),
+        ImmutableList.of("metric1", "metric2"),
+        new NoneShardSpec(),
+        0,
+        1
+    ), ImmutableMap.<String, Object>of("bucket", "DOES NOT EXIST", "baseKey", "baseKey"));
+  }
+
+  @Test(expected = SegmentLoadingException.class)
+  public void testFailsToMoveMissing() throws Exception
+  {
+    MockStorageService mockS3Client = new MockStorageService();
+    S3DataSegmentMover mover = new S3DataSegmentMover(mockS3Client, new S3DataSegmentPusherConfig());
+    mover.move(new DataSegment(
+        "test",
+        new Interval("2013-01-01/2013-01-02"),
+        "1",
+        ImmutableMap.<String, Object>of(
+            "key",
+            "baseKey/test/2013-01-01T00:00:00.000Z_2013-01-02T00:00:00.000Z/1/0/index.zip",
+            "bucket",
+            "DOES NOT EXIST"
+        ),
+        ImmutableList.of("dim1", "dim1"),
+        ImmutableList.of("metric1", "metric2"),
+        new NoneShardSpec(),
+        0,
+        1
+    ), ImmutableMap.<String, Object>of("bucket", "DOES NOT EXIST", "baseKey", "baseKey2"));
+  }
 
   private class MockStorageService extends RestS3Service {
     Map<String, Set<String>> storage = Maps.newHashMap();


### PR DESCRIPTION
Right now, if you have an expiration policy on stuff in S3, and it has been removed due to that policy, the archive task will fail even if the source and target are the same (no move needed) with the following:

```
io.druid.indexing.overlord.ThreadPoolTaskRunner - Exception while running task[ArchiveTask{id=REDACTED, type=archive, dataSource=REDACTED}]
io.druid.segment.loading.SegmentLoadingException: Unable to move file [s3://REDACTED] to [s3://REDACTED], not present in either source or target location
	at io.druid.storage.s3.S3DataSegmentMover$2.call(S3DataSegmentMover.java:158) ~[?:?]
	at io.druid.storage.s3.S3DataSegmentMover$2.call(S3DataSegmentMover.java:117) ~[?:?]
	at com.metamx.common.RetryUtils.retry(RetryUtils.java:38) ~[druid-selfcontained-0.9.0-rc3-mmx3.jar:0.9.0-rc3-mmx3]
	at io.druid.storage.s3.S3Utils.retryS3Operation(S3Utils.java:87) ~[?:?]
	at io.druid.storage.s3.S3DataSegmentMover.safeMove(S3DataSegmentMover.java:115) ~[?:?]
	at io.druid.storage.s3.S3DataSegmentMover.move(S3DataSegmentMover.java:80) ~[?:?]
	at io.druid.storage.s3.S3DataSegmentArchiver.archive(S3DataSegmentArchiver.java:53) ~[?:?]
	at io.druid.segment.loading.OmniDataSegmentArchiver.archive(OmniDataSegmentArchiver.java:43) ~[druid-selfcontained-0.9.0-rc3-mmx3.jar:0.9.0-rc3-mmx3]
	at io.druid.indexing.common.task.ArchiveTask.run(ArchiveTask.java:98) ~[druid-selfcontained-0.9.0-rc3-mmx3.jar:0.9.0-rc3-mmx3]
	at io.druid.indexing.overlord.ThreadPoolTaskRunner$ThreadPoolTaskRunnerCallable.call(ThreadPoolTaskRunner.java:338) [druid-selfcontained-0.9.0-rc3-mmx3.jar:0.9.0-rc3-mmx3]
	at io.druid.indexing.overlord.ThreadPoolTaskRunner$ThreadPoolTaskRunnerCallable.call(ThreadPoolTaskRunner.java:318) [druid-selfcontained-0.9.0-rc3-mmx3.jar:0.9.0-rc3-mmx3]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_72]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_72]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_72]
	at java.lang.Thread.run(Thread.java:745) [?:1.8.0_72]
```

This PR moves the check for source/dest equality to the top to avoid such a condition.