### PR TITLE
Bind NodeTypeConfig in all druid services

### DIFF
--- a/services/src/main/java/io/druid/cli/CliBroker.java
+++ b/services/src/main/java/io/druid/cli/CliBroker.java
@@ -39,6 +39,7 @@ import io.druid.guice.Jerseys;
 import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.LazySingleton;
 import io.druid.guice.LifecycleModule;
+import io.druid.guice.NodeTypeConfig;
 import io.druid.query.MapQueryToolChestWarehouse;
 import io.druid.query.QuerySegmentWalker;
 import io.druid.query.QueryToolChestWarehouse;
@@ -90,6 +91,8 @@ public class CliBroker extends ServerRunnable
             binder.bind(CachingClusteredClient.class).in(LazySingleton.class);
             binder.bind(BrokerServerView.class).in(LazySingleton.class);
             binder.bind(TimelineServerView.class).to(BrokerServerView.class).in(LazySingleton.class);
+
+            binder.bind(NodeTypeConfig.class).toInstance(new NodeTypeConfig("broker"));
 
             JsonConfigProvider.bind(binder, "druid.broker.cache", CacheConfig.class);
             binder.install(new CacheModule());

--- a/services/src/main/java/io/druid/cli/CliCoordinator.java
+++ b/services/src/main/java/io/druid/cli/CliCoordinator.java
@@ -40,6 +40,7 @@ import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.LazySingleton;
 import io.druid.guice.LifecycleModule;
 import io.druid.guice.ManageLifecycle;
+import io.druid.guice.NodeTypeConfig;
 import io.druid.guice.annotations.CoordinatorIndexingServiceHelper;
 import io.druid.metadata.MetadataRuleManager;
 import io.druid.metadata.MetadataRuleManagerConfig;
@@ -123,6 +124,8 @@ public class CliCoordinator extends ServerRunnable
             binder.bind(MetadataStorage.class)
                   .toProvider(MetadataStorageProvider.class)
                   .in(ManageLifecycle.class);
+
+            binder.bind(NodeTypeConfig.class).toInstance(new NodeTypeConfig("coordinator"));
 
             JsonConfigProvider.bind(binder, "druid.manager.segments", MetadataSegmentManagerConfig.class);
             JsonConfigProvider.bind(binder, "druid.manager.rules", MetadataRuleManagerConfig.class);

--- a/services/src/main/java/io/druid/cli/CliInternalHadoopIndexer.java
+++ b/services/src/main/java/io/druid/cli/CliInternalHadoopIndexer.java
@@ -33,6 +33,7 @@ import com.metamx.common.logger.Logger;
 import io.airlift.airline.Arguments;
 import io.airlift.airline.Command;
 import io.druid.guice.LazySingleton;
+import io.druid.guice.NodeTypeConfig;
 import io.druid.indexer.HadoopDruidDetermineConfigurationJob;
 import io.druid.indexer.HadoopDruidIndexerConfig;
 import io.druid.indexer.HadoopDruidIndexerJob;
@@ -84,6 +85,8 @@ public class CliInternalHadoopIndexer extends GuiceRunnable
           {
             binder.bindConstant().annotatedWith(Names.named("serviceName")).to("druid/internal-hadoop-indexer");
             binder.bindConstant().annotatedWith(Names.named("servicePort")).to(0);
+            binder.bind(NodeTypeConfig.class).toInstance(new NodeTypeConfig("hadoop-indexer"));
+
 
             // bind metadata storage config based on HadoopIOConfig
             MetadataStorageUpdaterJobSpec metadataSpec = getHadoopDruidIndexerConfig().getSchema()

--- a/services/src/main/java/io/druid/cli/CliMiddleManager.java
+++ b/services/src/main/java/io/druid/cli/CliMiddleManager.java
@@ -35,6 +35,7 @@ import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.LazySingleton;
 import io.druid.guice.LifecycleModule;
 import io.druid.guice.ManageLifecycle;
+import io.druid.guice.NodeTypeConfig;
 import io.druid.guice.annotations.Self;
 import io.druid.indexing.common.config.TaskConfig;
 import io.druid.indexing.overlord.ForkingTaskRunner;
@@ -80,6 +81,8 @@ public class CliMiddleManager extends ServerRunnable
             binder.bindConstant().annotatedWith(Names.named("servicePort")).to(8091);
 
             IndexingServiceModuleHelper.configureTaskRunnerConfigs(binder);
+
+            binder.bind(NodeTypeConfig.class).toInstance(new NodeTypeConfig("middleManager"));
 
             JsonConfigProvider.bind(binder, "druid.indexer.task", TaskConfig.class);
             JsonConfigProvider.bind(binder, "druid.worker", WorkerConfig.class);

--- a/services/src/main/java/io/druid/cli/CliOverlord.java
+++ b/services/src/main/java/io/druid/cli/CliOverlord.java
@@ -43,6 +43,7 @@ import io.druid.guice.LazySingleton;
 import io.druid.guice.LifecycleModule;
 import io.druid.guice.ListProvider;
 import io.druid.guice.ManageLifecycle;
+import io.druid.guice.NodeTypeConfig;
 import io.druid.guice.PolyBind;
 import io.druid.indexing.common.actions.LocalTaskActionClientFactory;
 import io.druid.indexing.common.actions.TaskActionClientFactory;
@@ -120,6 +121,8 @@ public class CliOverlord extends ServerRunnable
                   .annotatedWith(Names.named("serviceName"))
                   .to(IndexingServiceSelectorConfig.DEFAULT_SERVICE_NAME);
             binder.bindConstant().annotatedWith(Names.named("servicePort")).to(8090);
+
+            binder.bind(NodeTypeConfig.class).toInstance(new NodeTypeConfig("overlord"));
 
             JsonConfigProvider.bind(binder, "druid.indexer.queue", TaskQueueConfig.class);
             JsonConfigProvider.bind(binder, "druid.indexer.task", TaskConfig.class);

--- a/services/src/main/java/io/druid/cli/CliRouter.java
+++ b/services/src/main/java/io/druid/cli/CliRouter.java
@@ -34,6 +34,7 @@ import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.LazySingleton;
 import io.druid.guice.LifecycleModule;
 import io.druid.guice.ManageLifecycle;
+import io.druid.guice.NodeTypeConfig;
 import io.druid.guice.annotations.Self;
 import io.druid.guice.http.JettyHttpClientModule;
 import io.druid.query.lookup.LookupModule;
@@ -76,6 +77,8 @@ public class CliRouter extends ServerRunnable
           {
             binder.bindConstant().annotatedWith(Names.named("serviceName")).to("druid/router");
             binder.bindConstant().annotatedWith(Names.named("servicePort")).to(8888);
+
+            binder.bind(NodeTypeConfig.class).toInstance(new NodeTypeConfig("router"));
 
             JsonConfigProvider.bind(binder, "druid.router", TieredBrokerConfig.class);
 

--- a/services/src/test/java/io/druid/cli/MainTest.java
+++ b/services/src/test/java/io/druid/cli/MainTest.java
@@ -20,16 +20,31 @@
 package io.druid.cli;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
 import com.google.inject.Injector;
 import io.druid.guice.GuiceInjectors;
+import io.druid.guice.NodeTypeConfig;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.util.Map;
+
 @RunWith(Parameterized.class)
 public class MainTest
 {
+  private Map<Class, String> nodeTypeMap = ImmutableMap.<Class, String>builder()
+      .put(CliOverlord.class, "overlord")
+      .put(CliBroker.class, "broker")
+      .put(CliHistorical.class, "historical")
+      .put(CliCoordinator.class, "coordinator")
+      .put(CliMiddleManager.class, "middleManager")
+      .put(CliRealtime.class, "realtime")
+      .put(CliRealtimeExample.class, "realtime")
+      .put(CliRouter.class, "router").build();
+
   @Parameterized.Parameters(name = "{0}")
   public static Iterable<Object[]> constructorFeeder()
   {
@@ -55,6 +70,7 @@ public class MainTest
         new Object[]{new CliRouter()}
     );
   }
+
   private final GuiceRunnable runnable;
   public MainTest(GuiceRunnable runnable)
   {
@@ -65,6 +81,10 @@ public class MainTest
   {
     final Injector injector = GuiceInjectors.makeStartupInjector();
     injector.injectMembers(runnable);
-    Assert.assertNotNull(runnable.makeInjector());
+    final Injector runnableInjector = runnable.makeInjector();
+    Assert.assertNotNull(runnableInjector);
+
+    NodeTypeConfig nodeTypeConfig = runnableInjector.getInstance(NodeTypeConfig.class);
+    Assert.assertEquals(nodeTypeMap.get(runnable.getClass()), nodeTypeConfig.getNodeType());
   }
 }


### PR DESCRIPTION
Binds a NodeTypeConfig instance for all druid services. 

The historical, peon, and realtime services already had the binding, this PR adds a similar binding for the other services.