### PR TITLE
Distribution: pull-deps compiled hadoop version

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -68,6 +68,8 @@
                                 <argument>${project.parent.version}</argument>
                                 <argument>-l</argument>
                                 <argument>${settings.localRepository}</argument>
+                                <argument>-h</argument>
+                                <argument>org.apache.hadoop:hadoop-client:${hadoop.compile.version}</argument>
                                 <argument>-c</argument>
                                 <argument>io.druid.extensions:druid-examples</argument>
                                 <argument>-c</argument>


### PR DESCRIPTION
I spent quite some time, after updating hadoop version, to figure out why in the distribution directory I still had hadoop-client-2.3.0 dependencies. With this patch, the same version used to compile is added to the deps. Tested with 2.4.0 and 2.6.0-cdh5.7.0.