### PR TITLE
support seamless config changes

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/overlord/supervisor/SupervisorResource.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/supervisor/SupervisorResource.java
@@ -63,13 +63,7 @@ public class SupervisorResource
           public Response apply(SupervisorManager manager)
           {
             if (manager.hasSupervisor(spec.getId())) {
-              return Response.status(Response.Status.CONFLICT)
-                             .entity(
-                                 ImmutableMap.of(
-                                     "error",
-                                     String.format("Supervisor already exists for [%s]", spec.getId())
-                                 )
-                             ).build();
+              manager.stopAndRemoveSupervisor(spec.getId(), false);
             }
 
             manager.createAndStartSupervisor(spec);
@@ -160,7 +154,7 @@ public class SupervisorResource
                              .build();
             }
 
-            manager.stopAndRemoveSupervisor(id);
+            manager.stopAndRemoveSupervisor(id, true);
             return Response.ok(ImmutableMap.of("id", id)).build();
           }
         }


### PR DESCRIPTION
Allow users to do seamless schema migrations by submitting the new schema to the POST /druid/indexer/v1/supervisor endpoint. The overlord will shutdown the old supervisor (which will cause its managed tasks to stop reading and begin publishing) and create a new one which uses the new schema.