### PR TITLE
Fix JavaScriptConfig.

### DIFF
--- a/api/src/main/java/io/druid/js/JavaScriptConfig.java
+++ b/api/src/main/java/io/druid/js/JavaScriptConfig.java
@@ -29,16 +29,18 @@ public class JavaScriptConfig
 
   private static final JavaScriptConfig DEFAULT = new JavaScriptConfig(false);
 
-  private final boolean disabled;
+  @JsonProperty
+  private boolean disabled = false;
 
-  public JavaScriptConfig(
-      @JsonProperty("disabled") boolean disabled
-  )
+  public JavaScriptConfig()
+  {
+  }
+
+  public JavaScriptConfig(boolean disabled)
   {
     this.disabled = disabled;
   }
 
-  @JsonProperty
   public boolean isDisabled()
   {
     return disabled;

--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -307,4 +307,4 @@ the following properties.
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.javascript.disable`|Set to "true" to disable JavaScript functionality. This affects the JavaScript parser, filter, extractionFn, aggregator, and post-aggregator.|false|
+|`druid.javascript.disabled`|Set to "true" to disable JavaScript functionality. This affects the JavaScript parser, filter, extractionFn, aggregator, and post-aggregator.|false|

--- a/server/src/test/java/io/druid/guice/JavaScriptModuleTest.java
+++ b/server/src/test/java/io/druid/guice/JavaScriptModuleTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.guice;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import io.druid.js.JavaScriptConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.validation.Validation;
+import javax.validation.Validator;
+import java.util.Properties;
+
+public class JavaScriptModuleTest
+{
+  @Test
+  public void testInjectionDefault() throws Exception
+  {
+    JavaScriptConfig config = makeInjectorWithProperties(new Properties()).getInstance(JavaScriptConfig.class);
+    Assert.assertFalse(config.isDisabled());
+  }
+
+  @Test
+  public void testInjectionDisabled() throws Exception
+  {
+    final Properties props = new Properties();
+    props.setProperty("druid.javascript.disabled", "true");
+    JavaScriptConfig config = makeInjectorWithProperties(props).getInstance(JavaScriptConfig.class);
+    Assert.assertTrue(config.isDisabled());
+  }
+
+  private Injector makeInjectorWithProperties(final Properties props)
+  {
+    return Guice.createInjector(
+        ImmutableList.of(
+            new DruidGuiceExtensions(),
+            new Module()
+            {
+              @Override
+              public void configure(Binder binder)
+              {
+                binder.bind(Validator.class).toInstance(Validation.buildDefaultValidatorFactory().getValidator());
+                binder.bind(JsonConfigurator.class).in(LazySingleton.class);
+                binder.bind(Properties.class).toInstance(props);
+              }
+            },
+            new JavaScriptModule()
+        )
+    );
+  }
+}


### PR DESCRIPTION
Was missing a `@JsonProperty` annotation needed by the json configurator, also the docs had a typo.