### PR TITLE
Limit number of jetty threads that can be used by lookups

### DIFF
--- a/server/src/main/java/io/druid/query/lookup/LookupModule.java
+++ b/server/src/main/java/io/druid/query/lookup/LookupModule.java
@@ -47,6 +47,7 @@ import io.druid.guice.annotations.Smile;
 import io.druid.initialization.DruidModule;
 import io.druid.server.DruidNode;
 import io.druid.server.initialization.ZkPathsConfig;
+import io.druid.server.initialization.jetty.JettyBindings;
 import io.druid.server.listener.announcer.ListenerResourceAnnouncer;
 import io.druid.server.listener.announcer.ListeningAnnouncerConfig;
 import io.druid.server.listener.resource.AbstractListenerHandler;
@@ -88,6 +89,11 @@ public class LookupModule implements DruidModule
     LifecycleModule.register(binder, LookupResourceListenerAnnouncer.class);
     // Nothing else starts this, so we bind it to get it to start
     binder.bind(LookupResourceListenerAnnouncer.class).in(ManageLifecycle.class);
+    JettyBindings.addQosFilter(
+        binder,
+        ListenerResource.BASE_PATH + "/" + LookupCoordinatorManager.LOOKUP_LISTEN_ANNOUNCE_KEY,
+        2 // 1 for "normal" operation and 1 for "emergency" or other
+    );
   }
 }
 


### PR DESCRIPTION
It is possible for too many lookup management requests to lock up too many jetty threads. This puts a hard limit on the number of jetty threads that can be used for lookup management.

This is a temporary patch to prevent https://github.com/druid-io/druid/issues/3063 from locking up a cluster (and arguably should be done regardless of #3063)

A more full-fledged "keep lookups from locking themselves out" patch is forthcoming.