### PR TITLE
exclude slf4j-log4j12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,16 @@
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
                 <version>3.4.8</version>
+                <exclusions>
+                  <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                  </exclusion>
+                  <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                  </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.curator</groupId>


### PR DESCRIPTION
I believe this was inadvertently pulled in by #2857 and is causing ambiguous slf4j binding.