### PR TITLE
[Backport] Fix NPE in registeredLookup extractionFn when "optimize" is not provided.

### DIFF
--- a/processing/src/main/java/io/druid/query/lookup/RegisteredLookupExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/lookup/RegisteredLookupExtractionFn.java
@@ -55,7 +55,7 @@ public class RegisteredLookupExtractionFn implements ExtractionFn
     this.replaceMissingValueWith = replaceMissingValueWith;
     this.retainMissingValue = retainMissingValue;
     this.injective = injective;
-    this.optimize = optimize;
+    this.optimize = optimize == null ? true : optimize;
     this.lookup = lookup;
   }
 


### PR DESCRIPTION
Backport of #3064 to 0.9.1.