### PR TITLE
Bug fix in getNewNodes() of ListenerDiscoverer

### DIFF
--- a/server/src/main/java/io/druid/server/listener/announcer/ListenerDiscoverer.java
+++ b/server/src/main/java/io/druid/server/listener/announcer/ListenerDiscoverer.java
@@ -166,7 +166,7 @@ public class ListenerDiscoverer
           }
         }
     );
-    lastSeenMap = priorSeenMap;
+    lastSeenMap = currentMap;
     return retVal;
   }
 

--- a/server/src/test/java/io/druid/server/listener/announcer/ListenerDiscovererTest.java
+++ b/server/src/test/java/io/druid/server/listener/announcer/ListenerDiscovererTest.java
@@ -135,6 +135,12 @@ public class ListenerDiscovererTest extends CuratorTestBase
         ImmutableSet.of(HostAndPort.fromString(node.toString())),
         listenerDiscoverer.getNodes(listenerKey)
     );
+    // 2nd call of two concurrent getNewNodes should return no entry collection
+    listenerDiscoverer.getNewNodes(listenerKey);
+    Assert.assertEquals(
+        0,
+        listenerDiscoverer.getNewNodes(listenerKey).size()
+    );
     Assert.assertEquals(
         ImmutableSet.of(listenerKey, listenerTier),
         ImmutableSet.copyOf(listenerDiscoverer.discoverChildren(null))


### PR DESCRIPTION
During test with LookupCoordinatorManager, 
I see that it periodically updates lookups for all nodes even lookup is unchanged. 

After inspecting code, I found `getNewNodes()` does not work correctly.
It always returns all the nodes and it does not care node is old or new.

This is simple patch to fix that bug.
