### PR TITLE
Explicitly set code coverage maven plugin versions (DO NOT MERGE, STRESS TESTING TRAVIS)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -676,11 +676,12 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
+                <version>2.7</version>
             </plugin>
             <plugin>
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
-                <version>4.0.0</version>
+                <version>4.2.0</version>
             </plugin>
         </plugins>
         <pluginManagement>


### PR DESCRIPTION
Fixes #3067 

The test mentioned in the issue still "fails", but coverage tests continue locally.