### PR TITLE
Speed up filter tests with adapter cache

### DIFF
--- a/processing/src/test/java/io/druid/segment/filter/BoundFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/BoundFilterTest.java
@@ -37,6 +37,7 @@ import io.druid.query.filter.DimFilter;
 import io.druid.segment.IndexBuilder;
 import io.druid.segment.StorageAdapter;
 import org.joda.time.DateTime;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -74,7 +75,13 @@ public class BoundFilterTest extends BaseFilterTest
       boolean optimize
   )
   {
-    super(ROWS, indexBuilder, finisher, optimize);
+    super(testName, ROWS, indexBuilder, finisher, optimize);
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception
+  {
+    BaseFilterTest.tearDown(BoundFilterTest.class.getName());
   }
 
   @Test

--- a/processing/src/test/java/io/druid/segment/filter/InFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/InFilterTest.java
@@ -45,6 +45,7 @@ import io.druid.query.lookup.LookupExtractor;
 import io.druid.segment.IndexBuilder;
 import io.druid.segment.StorageAdapter;
 import org.joda.time.DateTime;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -79,12 +80,6 @@ public class InFilterTest extends BaseFilterTest
       PARSER.parse(ImmutableMap.<String, Object>of("dim0", "f", "dim1", "abc"))
   );
 
-  @Parameterized.Parameters(name = "{0}")
-  public static Collection<Object[]> constructorFeeder() throws IOException
-  {
-    return makeConstructors();
-  }
-
   public InFilterTest(
       String testName,
       IndexBuilder indexBuilder,
@@ -92,17 +87,13 @@ public class InFilterTest extends BaseFilterTest
       boolean optimize
   )
   {
-    super(ROWS, indexBuilder, finisher, optimize);
+    super(testName, ROWS, indexBuilder, finisher, optimize);
   }
 
-  @Before
-  public void setUp() throws IOException
+  @AfterClass
+  public static void tearDown() throws Exception
   {
-    final Pair<StorageAdapter, Closeable> pair = finisher.apply(
-        indexBuilder.tmpDir(temporaryFolder.newFolder()).add(ROWS)
-    );
-    this.adapter = pair.lhs;
-    this.closeable = pair.rhs;
+    BaseFilterTest.tearDown(InFilterTest.class.getName());
   }
 
   @Test

--- a/processing/src/test/java/io/druid/segment/filter/JavaScriptFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/JavaScriptFilterTest.java
@@ -39,6 +39,7 @@ import io.druid.query.lookup.LookupExtractor;
 import io.druid.segment.IndexBuilder;
 import io.druid.segment.StorageAdapter;
 import org.joda.time.DateTime;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -80,7 +81,13 @@ public class JavaScriptFilterTest extends BaseFilterTest
       boolean optimize
   )
   {
-    super(ROWS, indexBuilder, finisher, optimize);
+    super(testName, ROWS, indexBuilder, finisher, optimize);
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception
+  {
+    BaseFilterTest.tearDown(JavaScriptFilterTest.class.getName());
   }
 
   private final String jsNullFilter = "function(x) { return(x === null) }";

--- a/processing/src/test/java/io/druid/segment/filter/NotFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/NotFilterTest.java
@@ -35,6 +35,7 @@ import io.druid.query.filter.SelectorDimFilter;
 import io.druid.segment.IndexBuilder;
 import io.druid.segment.StorageAdapter;
 import org.joda.time.DateTime;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -72,7 +73,13 @@ public class NotFilterTest extends BaseFilterTest
       boolean optimize
   )
   {
-    super(ROWS, indexBuilder, finisher, optimize);
+    super(testName, ROWS, indexBuilder, finisher, optimize);
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception
+  {
+    BaseFilterTest.tearDown(NotFilterTest.class.getName());
   }
 
   @Test

--- a/processing/src/test/java/io/druid/segment/filter/RegexFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/RegexFilterTest.java
@@ -37,6 +37,7 @@ import io.druid.query.filter.RegexDimFilter;
 import io.druid.segment.IndexBuilder;
 import io.druid.segment.StorageAdapter;
 import org.joda.time.DateTime;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -78,7 +79,13 @@ public class RegexFilterTest extends BaseFilterTest
       boolean optimize
   )
   {
-    super(ROWS, indexBuilder, finisher, optimize);
+    super(testName, ROWS, indexBuilder, finisher, optimize);
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception
+  {
+    BaseFilterTest.tearDown(RegexFilterTest.class.getName());
   }
 
   @Test

--- a/processing/src/test/java/io/druid/segment/filter/SearchQueryFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/SearchQueryFilterTest.java
@@ -40,6 +40,7 @@ import io.druid.query.search.search.SearchQuerySpec;
 import io.druid.segment.IndexBuilder;
 import io.druid.segment.StorageAdapter;
 import org.joda.time.DateTime;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -81,7 +82,13 @@ public class SearchQueryFilterTest extends BaseFilterTest
       boolean optimize
   )
   {
-    super(ROWS, indexBuilder, finisher, optimize);
+    super(testName, ROWS, indexBuilder, finisher, optimize);
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception
+  {
+    BaseFilterTest.tearDown(SearchQueryFilterTest.class.getName());
   }
 
   private SearchQuerySpec specForValue(String value)

--- a/processing/src/test/java/io/druid/segment/filter/SelectorFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/SelectorFilterTest.java
@@ -40,6 +40,7 @@ import io.druid.query.lookup.LookupExtractor;
 import io.druid.segment.IndexBuilder;
 import io.druid.segment.StorageAdapter;
 import org.joda.time.DateTime;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -82,7 +83,13 @@ public class SelectorFilterTest extends BaseFilterTest
       boolean optimize
   )
   {
-    super(ROWS, indexBuilder, finisher, optimize);
+    super(testName, ROWS, indexBuilder, finisher, optimize);
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception
+  {
+    BaseFilterTest.tearDown(SelectorFilterTest.class.getName());
   }
 
   @Test


### PR DESCRIPTION
Since JUnit creates a new test object for each test method, the Filter tests currently persist a segment and create a StorageAdapter for each test method/parameterization combination.

This is pretty slow and redundant, so this PR introduces a storage adapter cache so that the segment is only created once for each parameterization in the filter test.

The PR also changes the way rows are read from cursors in the filter tests; retrieving the cursor in the existing manner shown below results in some unclosed buffer warnings in the logs.

```
-    return Iterables.getOnlyElement(Sequences.toList(cursors, Lists.<Cursor>newArrayList()));
```

On my local machine, this brings the running time for each *FilterTest to ~3s, down from 20s or more.