### PR TITLE
Update bytebuffer-collections to 0.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
             <dependency>
                 <groupId>com.metamx</groupId>
                 <artifactId>bytebuffer-collections</artifactId>
-                <version>0.2.4</version>
+                <version>0.2.5</version>
             </dependency>
             <dependency>
                 <groupId>com.metamx</groupId>


### PR DESCRIPTION
* Adds [polygound bound](https://github.com/metamx/bytebuffer-collections/pull/30) for spatial data. Thanks @scusjs
* Fixes cache key collisions for spatial data
* Update roaring to 0.5.18