### PR TITLE
[pull-deps] skip creating root extension directories when --clean is not set

### DIFF
--- a/services/src/main/java/io/druid/cli/PullDependencies.java
+++ b/services/src/main/java/io/druid/cli/PullDependencies.java
@@ -448,6 +448,10 @@ public class PullDependencies implements Runnable
 
   private void createRootExtensionsDirectory(File atLocation)
   {
+    if (atLocation.isDirectory()) {
+      log.info("Root extension directory [%s] already exists, skip creating");
+      return;
+    }
     if (!atLocation.mkdirs()) {
       throw new ISE(
           String.format(

--- a/services/src/test/java/io/druid/cli/PullDependenciesTest.java
+++ b/services/src/test/java/io/druid/cli/PullDependenciesTest.java
@@ -157,9 +157,9 @@ public class PullDependenciesTest
   }
 
   /**
-   * If --clean is not specified and something already exists at druid.extensions.directory, ISE should be thrown
+   * If --clean is not specified and root extension directory already exists, skip creating.
    */
-  @Test(expected = ISE.class)
+  @Test()
   public void testPullDependencies_root_extension_dir_exists()
   {
     rootExtensionsDir.mkdir();
@@ -167,13 +167,32 @@ public class PullDependenciesTest
   }
 
   /**
-   * If --clean is not specified and something already exists at druid.extensions.hadoopDependenciesDir,
-   * ISE should be thrown
+   * A file exists on the root extension directory path, but it's not a directory, throw ISE.
    */
   @Test(expected = ISE.class)
+  public void testPullDependencies_root_extension_dir_bad_state() throws IOException
+  {
+    Assert.assertTrue(rootExtensionsDir.createNewFile());
+    pullDependencies.run();
+  }
+
+  /**
+   * If --clean is not specified and hadoop dependencies directory already exists, skip creating.
+   */
+  @Test()
   public void testPullDependencies_root_hadoop_dependencies_dir_exists()
   {
     rootHadoopDependenciesDir.mkdir();
+    pullDependencies.run();
+  }
+
+  /**
+   * A file exists on the root hadoop dependencies directory path, but it's not a directory, throw ISE.
+   */
+  @Test(expected = ISE.class)
+  public void testPullDependencies_root_hadoop_dependencies_dir_bad_state() throws IOException
+  {
+    Assert.assertTrue(rootHadoopDependenciesDir.createNewFile());
     pullDependencies.run();
   }
 


### PR DESCRIPTION
Fixes #2885 
If --clean flag is not set, skip creating root extension directories if they already exist.