### PR TITLE
Set a non-zero exit code when error in command parsing

### DIFF
--- a/services/src/main/java/io/druid/cli/Main.java
+++ b/services/src/main/java/io/druid/cli/Main.java
@@ -109,6 +109,7 @@ public class Main
       System.out.println(e.getMessage());
       System.out.println("===");
       cli.parse(new String[]{"help"}).run();
+      System.exit(1);
     }
   }
 }


### PR DESCRIPTION
This is helpful for things like automated build scripts that should fail if a command syntax changes, and the script does not notice. Without this change a script may think the command completed successfully.