### PR TITLE
docs: change OR to AND inside query docs about multi-value dims

### DIFF
--- a/docs/content/querying/groupbyquery.md
+++ b/docs/content/querying/groupbyquery.md
@@ -100,7 +100,7 @@ To pull it all together, the above query would return *n\*m* data points, up to 
 
 groupBy queries can group on multi-value dimensions. When grouping on a multi-value dimension, _all_ values
 from matching rows will be used to generate one group per value. It's possible for a query to return more groups than
-there are rows. For example, a groupBy on the dimension `tags` with filter `"t1" OR "t3"` would match only row1, and
+there are rows. For example, a groupBy on the dimension `tags` with filter `"t1" AND "t3"` would match only row1, and
 generate a result with three groups: `t1`, `t2`, and `t3`. If you only need to include values that match
 your filter, you can use a [filtered dimensionSpec](dimensionspecs.html#filtered-dimensionspecs). This can also
 improve performance.

--- a/docs/content/querying/topnquery.md
+++ b/docs/content/querying/topnquery.md
@@ -133,7 +133,7 @@ The format of the results would look like so:
 
 topN queries can group on multi-value dimensions. When grouping on a multi-value dimension, _all_ values
 from matching rows will be used to generate one group per value. It's possible for a query to return more groups than
-there are rows. For example, a topN on the dimension `tags` with filter `"t1" OR "t3"` would match only row1, and
+there are rows. For example, a topN on the dimension `tags` with filter `"t1" AND "t3"` would match only row1, and
 generate a result with three groups: `t1`, `t2`, and `t3`. If you only need to include values that match
 your filter, you can use a [filtered dimensionSpec](dimensionspecs.html#filtered-dimensionspecs). This can also
 improve performance.


### PR DESCRIPTION
### Behavior on multi-value dimensions
... For example, a topN/groupBy on the dimension `tags` with filter `"t1" OR "t3"` would match only row1, and
generate a result with three groups: `t1`, `t2`, and `t3`....

should be 

### Behavior on multi-value dimensions
... For example, a topN/groupBy on the dimension `tags` with filter `"t1" AND "t3"` would match only row1, and
generate a result with three groups: `t1`, `t2`, and `t3`....