### PR TITLE
Adding filters for TimeBoundary on backend

### DIFF
--- a/docs/content/querying/timeboundaryquery.md
+++ b/docs/content/querying/timeboundaryquery.md
@@ -9,6 +9,7 @@ Time boundary queries return the earliest and latest data points of a data set. 
     "queryType" : "timeBoundary",
     "dataSource": "sample_datasource",
     "bound"     : < "maxTime" | "minTime" > # optional, defaults to returning both timestamps if not set 
+    "filter"    : { "type": "and", "fields": [<filter>, <filter>, ...] } # optional
 }
 ```
 
@@ -19,6 +20,7 @@ There are 3 main parts to a time boundary query:
 |queryType|This String should always be "timeBoundary"; this is the first thing Druid looks at to figure out how to interpret the query|yes|
 |dataSource|A String or Object defining the data source to query, very similar to a table in a relational database. See [DataSource](../querying/datasource.html) for more information.|yes|
 |bound   | Optional, set to `maxTime` or `minTime` to return only the latest or earliest timestamp. Default to returning both if not set| no |
+|filter|See [Filters](../querying/filters.html)|no|
 |context|See [Context](../querying/query-context.html)|no|
 
 The format of the result is:

--- a/processing/src/main/java/io/druid/query/Druids.java
+++ b/processing/src/main/java/io/druid/query/Druids.java
@@ -775,6 +775,7 @@ public class Druids
     private DataSource dataSource;
     private QuerySegmentSpec querySegmentSpec;
     private String bound;
+    private DimFilter dimFilter;
     private Map<String, Object> context;
 
     public TimeBoundaryQueryBuilder()
@@ -782,6 +783,7 @@ public class Druids
       dataSource = null;
       querySegmentSpec = null;
       bound = null;
+      dimFilter = null;
       context = null;
     }
 
@@ -791,6 +793,7 @@ public class Druids
           dataSource,
           querySegmentSpec,
           bound,
+          dimFilter,
           context
       );
     }
@@ -837,6 +840,12 @@ public class Druids
     public TimeBoundaryQueryBuilder bound(String b)
     {
       bound = b;
+      return this;
+    }
+
+    public TimeBoundaryQueryBuilder filters(String dimensionName, String value)
+    {
+      dimFilter = new SelectorDimFilter(dimensionName, value, null);
       return this;
     }
 

--- a/processing/src/main/java/io/druid/query/Druids.java
+++ b/processing/src/main/java/io/druid/query/Druids.java
@@ -804,6 +804,7 @@ public class Druids
           .dataSource(builder.dataSource)
           .intervals(builder.querySegmentSpec)
           .bound(builder.bound)
+          .filters(builder.dimFilter)
           .context(builder.context);
     }
 
@@ -846,6 +847,18 @@ public class Druids
     public TimeBoundaryQueryBuilder filters(String dimensionName, String value)
     {
       dimFilter = new SelectorDimFilter(dimensionName, value, null);
+      return this;
+    }
+
+    public TimeBoundaryQueryBuilder filters(String dimensionName, String value, String... values)
+    {
+      dimFilter = new InDimFilter(dimensionName, Lists.asList(value, values), null);
+      return this;
+    }
+
+    public TimeBoundaryQueryBuilder filters(DimFilter f)
+    {
+      dimFilter = f;
       return this;
     }
 

--- a/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQuery.java
+++ b/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQuery.java
@@ -136,10 +136,12 @@ public class TimeBoundaryQuery extends BaseQuery<Result<TimeBoundaryResultValue>
 
   public byte[] getCacheKey()
   {
+    final byte[] filterBytes = dimFilter == null ? new byte[]{} : dimFilter.getCacheKey();
     final byte[] boundBytes = StringUtils.toUtf8(bound);
     return ByteBuffer.allocate(1 + boundBytes.length)
                      .put(CACHE_TYPE_ID)
                      .put(boundBytes)
+                     .put(filterBytes)
                      .array();
   }
 

--- a/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQuery.java
+++ b/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQuery.java
@@ -31,6 +31,7 @@ import io.druid.query.Query;
 import io.druid.query.Result;
 import io.druid.query.spec.MultipleIntervalSegmentSpec;
 import io.druid.query.spec.QuerySegmentSpec;
+import io.druid.query.filter.DimFilter;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
@@ -52,6 +53,7 @@ public class TimeBoundaryQuery extends BaseQuery<Result<TimeBoundaryResultValue>
 
   private static final byte CACHE_TYPE_ID = 0x0;
 
+  private final DimFilter dimFilter;
   private final String bound;
 
   @JsonCreator
@@ -59,6 +61,7 @@ public class TimeBoundaryQuery extends BaseQuery<Result<TimeBoundaryResultValue>
       @JsonProperty("dataSource") DataSource dataSource,
       @JsonProperty("intervals") QuerySegmentSpec querySegmentSpec,
       @JsonProperty("bound") String bound,
+      @JsonProperty("filter") DimFilter dimFilter,
       @JsonProperty("context") Map<String, Object> context
   )
   {
@@ -70,19 +73,23 @@ public class TimeBoundaryQuery extends BaseQuery<Result<TimeBoundaryResultValue>
         context
     );
 
+    this.dimFilter = dimFilter;
     this.bound = bound == null ? "" : bound;
   }
 
   @Override
-  public boolean hasFilters()
-  {
-    return false;
-  }
+  public boolean hasFilters() { return dimFilter != null; }
 
   @Override
   public String getType()
   {
     return Query.TIME_BOUNDARY;
+  }
+
+  @JsonProperty("filter")
+  public DimFilter getDimensionsFilter()
+  {
+    return dimFilter;
   }
 
   @JsonProperty
@@ -98,6 +105,7 @@ public class TimeBoundaryQuery extends BaseQuery<Result<TimeBoundaryResultValue>
         getDataSource(),
         getQuerySegmentSpec(),
         bound,
+        dimFilter,
         computeOverridenContext(contextOverrides)
     );
   }
@@ -109,6 +117,7 @@ public class TimeBoundaryQuery extends BaseQuery<Result<TimeBoundaryResultValue>
         getDataSource(),
         spec,
         bound,
+        dimFilter,
         getContext()
     );
   }
@@ -120,6 +129,7 @@ public class TimeBoundaryQuery extends BaseQuery<Result<TimeBoundaryResultValue>
         dataSource,
         getQuerySegmentSpec(),
         bound,
+        dimFilter,
         getContext()
     );
   }
@@ -211,6 +221,7 @@ public class TimeBoundaryQuery extends BaseQuery<Result<TimeBoundaryResultValue>
            ", querySegmentSpec=" + getQuerySegmentSpec() +
            ", duration=" + getDuration() +
            ", bound=" + bound +
+           ", dimFilter=" + dimFilter.toString() +
            '}';
   }
 
@@ -233,6 +244,8 @@ public class TimeBoundaryQuery extends BaseQuery<Result<TimeBoundaryResultValue>
       return false;
     }
 
+    if (dimFilter != null ? !dimFilter.equals(that.dimFilter) : that.dimFilter != null) return false;
+
     return true;
   }
 
@@ -241,6 +254,7 @@ public class TimeBoundaryQuery extends BaseQuery<Result<TimeBoundaryResultValue>
   {
     int result = super.hashCode();
     result = 31 * result + bound.hashCode();
+    result = 31 * result + (dimFilter != null ? dimFilter.hashCode() : 0);
     return result;
   }
 }

--- a/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQuery.java
+++ b/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQuery.java
@@ -221,7 +221,7 @@ public class TimeBoundaryQuery extends BaseQuery<Result<TimeBoundaryResultValue>
            ", querySegmentSpec=" + getQuerySegmentSpec() +
            ", duration=" + getDuration() +
            ", bound=" + bound +
-           ", dimFilter=" + dimFilter.toString() +
+           ", dimFilter=" + dimFilter +
            '}';
   }
 

--- a/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQuery.java
+++ b/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQuery.java
@@ -78,7 +78,9 @@ public class TimeBoundaryQuery extends BaseQuery<Result<TimeBoundaryResultValue>
   }
 
   @Override
-  public boolean hasFilters() { return dimFilter != null; }
+  public boolean hasFilters() {
+    return dimFilter != null;
+  }
 
   @Override
   public String getType()
@@ -138,9 +140,11 @@ public class TimeBoundaryQuery extends BaseQuery<Result<TimeBoundaryResultValue>
   {
     final byte[] filterBytes = dimFilter == null ? new byte[]{} : dimFilter.getCacheKey();
     final byte[] boundBytes = StringUtils.toUtf8(bound);
-    return ByteBuffer.allocate(1 + boundBytes.length)
+    final byte delimiter = (byte) 0xff;
+    return ByteBuffer.allocate(2 + boundBytes.length + filterBytes.length)
                      .put(CACHE_TYPE_ID)
                      .put(boundBytes)
+                     .put(delimiter)
                      .put(filterBytes)
                      .array();
   }
@@ -246,7 +250,9 @@ public class TimeBoundaryQuery extends BaseQuery<Result<TimeBoundaryResultValue>
       return false;
     }
 
-    if (dimFilter != null ? !dimFilter.equals(that.dimFilter) : that.dimFilter != null) return false;
+    if (dimFilter != null ? !dimFilter.equals(that.dimFilter) : that.dimFilter != null) {
+      return false;
+    }
 
     return true;
   }

--- a/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQueryQueryToolChest.java
@@ -59,32 +59,6 @@ public class TimeBoundaryQueryQueryToolChest
   };
 
   @Override
-  public <T extends LogicalSegment> List<T> filterSegments(TimeBoundaryQuery query, List<T> segments)
-  {
-    if (segments.size() <= 1) {
-      return segments;
-    }
-
-    final T min = query.isMaxTime() ? null : segments.get(0);
-    final T max = query.isMinTime() ? null : segments.get(segments.size() - 1);
-
-    return Lists.newArrayList(
-        Iterables.filter(
-            segments,
-            new Predicate<T>()
-            {
-              @Override
-              public boolean apply(T input)
-              {
-                return (min != null && input.getInterval().overlaps(min.getInterval())) ||
-                       (max != null && input.getInterval().overlaps(max.getInterval()));
-              }
-            }
-        )
-    );
-  }
-
-  @Override
   public QueryRunner<Result<TimeBoundaryResultValue>> mergeResults(
       final QueryRunner<Result<TimeBoundaryResultValue>> runner
   )

--- a/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQueryQueryToolChest.java
@@ -59,6 +59,32 @@ public class TimeBoundaryQueryQueryToolChest
   };
 
   @Override
+  public <T extends LogicalSegment> List<T> filterSegments(TimeBoundaryQuery query, List<T> segments)
+  {
+    if (segments.size() <= 1 || query.hasFilters()) {
+      return segments;
+    }
+
+    final T min = query.isMaxTime() ? null : segments.get(0);
+    final T max = query.isMinTime() ? null : segments.get(segments.size() - 1);
+
+    return Lists.newArrayList(
+        Iterables.filter(
+            segments,
+            new Predicate<T>()
+            {
+              @Override
+              public boolean apply(T input)
+              {
+                return (min != null && input.getInterval().overlaps(min.getInterval())) ||
+                       (max != null && input.getInterval().overlaps(max.getInterval()));
+              }
+            }
+        )
+    );
+  }
+
+  @Override
   public QueryRunner<Result<TimeBoundaryResultValue>> mergeResults(
       final QueryRunner<Result<TimeBoundaryResultValue>> runner
   )

--- a/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQueryRunnerFactory.java
+++ b/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQueryRunnerFactory.java
@@ -92,14 +92,16 @@ public class TimeBoundaryQueryRunnerFactory
       this.adapter = segment.asStorageAdapter();
     }
 
-    private Function<Cursor, Result<DateTime>> skipToFirstMatching = new Function<Cursor, Result<DateTime>>()
+    private final Function<Cursor, Result<DateTime>> skipToFirstMatching = new Function<Cursor, Result<DateTime>>()
     {
       @Override
       public Result<DateTime> apply(Cursor cursor)
       {
-        if (cursor.isDone()) { return null; }
+        if (cursor.isDone()) {
+          return null;
+        }
         final LongColumnSelector timestampColumnSelector = cursor.makeLongColumnSelector(Column.TIME_COLUMN_NAME);
-        DateTime timestamp = new DateTime(timestampColumnSelector.get());
+        final DateTime timestamp = new DateTime(timestampColumnSelector.get());
         return new Result<>(adapter.getInterval().getStart(), timestamp);
       }
     };
@@ -111,7 +113,10 @@ public class TimeBoundaryQueryRunnerFactory
           Filters.toFilter(legacyQuery.getDimensionsFilter()),
           descending, new AllGranularity(), skipToFirstMatching
       );
-      List<Result<DateTime>> resultList = Sequences.toList(resultSequence, Lists.<Result<DateTime>>newArrayList());
+      final List<Result<DateTime>> resultList = Sequences.toList(
+          Sequences.limit(resultSequence, 1),
+          Lists.<Result<DateTime>>newArrayList()
+      );
       if (resultList.size() > 0) {
         return resultList.get(0).getValue();
       }

--- a/processing/src/test/java/io/druid/query/QueryRunnerTestHelper.java
+++ b/processing/src/test/java/io/druid/query/QueryRunnerTestHelper.java
@@ -82,7 +82,6 @@ public class QueryRunnerTestHelper
 
   public static final String segmentId = "testSegment";
   public static final String dataSource = "testing";
-  public static final String truncatedDataSource = "testing2";
   public static final UnionDataSource unionDataSource = new UnionDataSource(
       Lists.transform(
           Lists.newArrayList(dataSource, dataSource, dataSource, dataSource), new Function<String, TableDataSource>()

--- a/processing/src/test/java/io/druid/query/QueryRunnerTestHelper.java
+++ b/processing/src/test/java/io/druid/query/QueryRunnerTestHelper.java
@@ -82,6 +82,7 @@ public class QueryRunnerTestHelper
 
   public static final String segmentId = "testSegment";
   public static final String dataSource = "testing";
+  public static final String truncatedDataSource = "testing2";
   public static final UnionDataSource unionDataSource = new UnionDataSource(
       Lists.transform(
           Lists.newArrayList(dataSource, dataSource, dataSource, dataSource), new Function<String, TableDataSource>()

--- a/processing/src/test/java/io/druid/query/timeboundary/TimeBoundaryQueryQueryToolChestTest.java
+++ b/processing/src/test/java/io/druid/query/timeboundary/TimeBoundaryQueryQueryToolChestTest.java
@@ -45,6 +45,7 @@ public class TimeBoundaryQueryQueryToolChestTest
       new TableDataSource("test"),
       null,
       null,
+      null,
       null
   );
 
@@ -52,6 +53,7 @@ public class TimeBoundaryQueryQueryToolChestTest
       new TableDataSource("test"),
       null,
       TimeBoundaryQuery.MAX_TIME,
+      null,
       null
   );
 
@@ -59,6 +61,7 @@ public class TimeBoundaryQueryQueryToolChestTest
       new TableDataSource("test"),
       null,
       TimeBoundaryQuery.MIN_TIME,
+      null,
       null
   );
 
@@ -179,6 +182,7 @@ public class TimeBoundaryQueryQueryToolChestTest
                         )
                     )
                 ),
+                null,
                 null,
                 null
             )

--- a/processing/src/test/java/io/druid/query/timeboundary/TimeBoundaryQueryQueryToolChestTest.java
+++ b/processing/src/test/java/io/druid/query/timeboundary/TimeBoundaryQueryQueryToolChestTest.java
@@ -78,94 +78,41 @@ public class TimeBoundaryQueryQueryToolChestTest
     };
   }
 
-  @Test
-  public void testFilterSegments() throws Exception
+  public void arbitraryFilterSegmentsTest(TimeBoundaryQuery query) throws Exception
   {
-    List<LogicalSegment> segments = new TimeBoundaryQueryQueryToolChest().filterSegments(
-        TIME_BOUNDARY_QUERY,
-        Arrays.asList(
-            createLogicalSegment(new Interval("2013-01-01/P1D")),
-            createLogicalSegment(new Interval("2013-01-01T01/PT1H")),
-            createLogicalSegment(new Interval("2013-01-01T02/PT1H")),
-            createLogicalSegment(new Interval("2013-01-02/P1D")),
-            createLogicalSegment(new Interval("2013-01-03T01/PT1H")),
-            createLogicalSegment(new Interval("2013-01-03T02/PT1H")),
-            createLogicalSegment(new Interval("2013-01-03/P1D"))
-        )
-    );
-
-    Assert.assertEquals(6, segments.size());
-
-    List<LogicalSegment> expected = Arrays.asList(
+    List inputSegments = Arrays.asList(
         createLogicalSegment(new Interval("2013-01-01/P1D")),
         createLogicalSegment(new Interval("2013-01-01T01/PT1H")),
         createLogicalSegment(new Interval("2013-01-01T02/PT1H")),
+        createLogicalSegment(new Interval("2013-01-02/P1D")),
         createLogicalSegment(new Interval("2013-01-03T01/PT1H")),
         createLogicalSegment(new Interval("2013-01-03T02/PT1H")),
         createLogicalSegment(new Interval("2013-01-03/P1D"))
     );
+    List<LogicalSegment> segments = new TimeBoundaryQueryQueryToolChest().filterSegments(
+        query, inputSegments
+    );
 
-    for (int i = 0; i < segments.size(); i++) {
-       Assert.assertEquals(segments.get(i).getInterval(), expected.get(i).getInterval());
-    }
+    Assert.assertEquals(7, segments.size());
+    Assert.assertEquals(inputSegments, segments);
+  }
+
+  @Test
+  public void testFilterSegments() throws Exception
+  {
+    arbitraryFilterSegmentsTest(TIME_BOUNDARY_QUERY);
   }
 
   @Test
   public void testMaxTimeFilterSegments() throws Exception
   {
-    List<LogicalSegment> segments = new TimeBoundaryQueryQueryToolChest().filterSegments(
-        MAXTIME_BOUNDARY_QUERY,
-        Arrays.asList(
-            createLogicalSegment(new Interval("2013-01-01/P1D")),
-            createLogicalSegment(new Interval("2013-01-01T01/PT1H")),
-            createLogicalSegment(new Interval("2013-01-01T02/PT1H")),
-            createLogicalSegment(new Interval("2013-01-02/P1D")),
-            createLogicalSegment(new Interval("2013-01-03T01/PT1H")),
-            createLogicalSegment(new Interval("2013-01-03T02/PT1H")),
-            createLogicalSegment(new Interval("2013-01-03/P1D"))
-        )
-    );
-
-    Assert.assertEquals(3, segments.size());
-
-    List<LogicalSegment> expected = Arrays.asList(
-        createLogicalSegment(new Interval("2013-01-03T01/PT1H")),
-        createLogicalSegment(new Interval("2013-01-03T02/PT1H")),
-        createLogicalSegment(new Interval("2013-01-03/P1D"))
-    );
-
-    for (int i = 0; i < segments.size(); i++) {
-      Assert.assertEquals(segments.get(i).getInterval(), expected.get(i).getInterval());
-    }
+    arbitraryFilterSegmentsTest(MAXTIME_BOUNDARY_QUERY);
   }
 
   @Test
   public void testMinTimeFilterSegments() throws Exception
   {
-    List<LogicalSegment> segments = new TimeBoundaryQueryQueryToolChest().filterSegments(
-        MINTIME_BOUNDARY_QUERY,
-        Arrays.asList(
-            createLogicalSegment(new Interval("2013-01-01/P1D")),
-            createLogicalSegment(new Interval("2013-01-01T01/PT1H")),
-            createLogicalSegment(new Interval("2013-01-01T02/PT1H")),
-            createLogicalSegment(new Interval("2013-01-02/P1D")),
-            createLogicalSegment(new Interval("2013-01-03T01/PT1H")),
-            createLogicalSegment(new Interval("2013-01-03T02/PT1H")),
-            createLogicalSegment(new Interval("2013-01-03/P1D"))
-        )
-    );
-
-    Assert.assertEquals(3, segments.size());
-
-    List<LogicalSegment> expected = Arrays.asList(
-        createLogicalSegment(new Interval("2013-01-01/P1D")),
-        createLogicalSegment(new Interval("2013-01-01T01/PT1H")),
-        createLogicalSegment(new Interval("2013-01-01T02/PT1H"))
-    );
-
-    for (int i = 0; i < segments.size(); i++) {
-      Assert.assertEquals(segments.get(i).getInterval(), expected.get(i).getInterval());
-    }
+    arbitraryFilterSegmentsTest(MINTIME_BOUNDARY_QUERY);
   }
 
   @Test

--- a/processing/src/test/java/io/druid/query/timeboundary/TimeBoundaryQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/timeboundary/TimeBoundaryQueryRunnerTest.java
@@ -23,13 +23,30 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.MapMaker;
 import com.google.common.collect.Iterables;
+import com.google.common.io.CharSource;
 import com.metamx.common.guava.Sequences;
+import io.druid.granularity.QueryGranularities;
 import io.druid.query.Druids;
 import io.druid.query.QueryRunner;
+import io.druid.query.QueryRunnerFactory;
 import io.druid.query.QueryRunnerTestHelper;
 import io.druid.query.Result;
 import io.druid.query.TableDataSource;
+import io.druid.query.ordering.StringComparators;
+import io.druid.segment.IncrementalIndexSegment;
+import io.druid.segment.incremental.IncrementalIndex;
+import io.druid.segment.incremental.IncrementalIndexSchema;
+import io.druid.segment.incremental.OnheapIncrementalIndex;
+import io.druid.segment.Segment;
+import io.druid.segment.TestIndex;
+import io.druid.timeline.DataSegment;
+import io.druid.timeline.TimelineObjectHolder;
+import io.druid.timeline.VersionedIntervalTimeline;
+import io.druid.timeline.partition.NoneShardSpec;
+import io.druid.timeline.partition.SingleElementPartitionChunk;
 import org.joda.time.DateTime;
+import org.joda.time.Interval;
+import org.apache.commons.lang.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -57,6 +74,12 @@ public class TimeBoundaryQueryRunnerTest
   }
 
   private final QueryRunner runner;
+  private static final QueryRunnerFactory factory = new TimeBoundaryQueryRunnerFactory(
+      QueryRunnerTestHelper.NOOP_QUERYWATCHER
+  );
+  private static Segment segment0;
+  private static Segment segment1;
+  private static List<String> segmentIdentifiers;
 
   public TimeBoundaryQueryRunnerTest(
       QueryRunner runner
@@ -65,29 +88,121 @@ public class TimeBoundaryQueryRunnerTest
     this.runner = runner;
   }
 
+  // Adapted from MultiSegmentSelectQueryTest, with modifications to make filtering meaningful
+  public static final String[] V_0112 = {
+      "2011-01-12T01:00:00.000Z	spot	business	preferred	bpreferred	100.000000",
+      "2011-01-12T02:00:00.000Z	spot	entertainment	preferred	epreferred	100.000000",
+      "2011-01-13T00:00:00.000Z	spot	automotive	preferred	apreferred	100.000000",
+      "2011-01-13T01:00:00.000Z	spot	business	preferred	bpreferred	100.000000",
+  };
+  public static final String[] V_0113 = {
+      "2011-01-14T00:00:00.000Z	spot	automotive	preferred	apreferred	94.874713",
+      "2011-01-14T02:00:00.000Z	spot	entertainment	preferred	epreferred	110.087299",
+      "2011-01-15T00:00:00.000Z	spot	automotive	preferred	apreferred	94.874713",
+      "2011-01-15T01:00:00.000Z	spot	business	preferred	bpreferred	103.629399",
+      "2011-01-16T00:00:00.000Z	spot	automotive	preferred	apreferred	94.874713",
+      "2011-01-16T01:00:00.000Z	spot	business	preferred	bpreferred	103.629399",
+      "2011-01-16T02:00:00.000Z	spot	entertainment	preferred	epreferred	110.087299",
+      "2011-01-17T01:00:00.000Z	spot	business	preferred	bpreferred	103.629399",
+      "2011-01-17T02:00:00.000Z	spot	entertainment	preferred	epreferred	110.087299",
+  };
+
+  private static IncrementalIndex newIndex(String minTimeStamp)
+  {
+    return newIndex(minTimeStamp, 10000);
+  }
+
+  private static IncrementalIndex newIndex(String minTimeStamp, int maxRowCount)
+  {
+    final IncrementalIndexSchema schema = new IncrementalIndexSchema.Builder()
+        .withMinTimestamp(new DateTime(minTimeStamp).getMillis())
+        .withQueryGranularity(QueryGranularities.HOUR)
+        .withMetrics(TestIndex.METRIC_AGGS)
+        .build();
+    return new OnheapIncrementalIndex(schema, true, maxRowCount);
+  }
+
+  private static String makeIdentifier(IncrementalIndex index, String version)
+  {
+    return makeIdentifier(index.getInterval(), version);
+  }
+
+  private static String makeIdentifier(Interval interval, String version)
+  {
+    return DataSegment.makeDataSegmentIdentifier(
+        QueryRunnerTestHelper.dataSource,
+        interval.getStart(),
+        interval.getEnd(),
+        version,
+        new NoneShardSpec()
+    );
+  }
+
+  private QueryRunner getCustomRunner() throws IOException {
+    CharSource v_0112 = CharSource.wrap(StringUtils.join(V_0112, "\n"));
+    CharSource v_0113 = CharSource.wrap(StringUtils.join(V_0113, "\n"));
+
+    IncrementalIndex index0 = TestIndex.loadIncrementalIndex(newIndex("2011-01-12T00:00:00.000Z"), v_0112);
+    IncrementalIndex index1 = TestIndex.loadIncrementalIndex(newIndex("2011-01-14T00:00:00.000Z"), v_0113);
+
+    segment0 = new IncrementalIndexSegment(index0, makeIdentifier(index0, "v1"));
+    segment1 = new IncrementalIndexSegment(index1, makeIdentifier(index1, "v1"));
+
+    VersionedIntervalTimeline<String, Segment> timeline = new VersionedIntervalTimeline(StringComparators.LEXICOGRAPHIC);
+    timeline.add(index0.getInterval(), "v1", new SingleElementPartitionChunk(segment0));
+    timeline.add(index1.getInterval(), "v1", new SingleElementPartitionChunk(segment1));
+
+    segmentIdentifiers = Lists.newArrayList();
+    for (TimelineObjectHolder<String, ?> holder : timeline.lookup(new Interval("2011-01-12/2011-01-17"))) {
+      segmentIdentifiers.add(makeIdentifier(holder.getInterval(), holder.getVersion()));
+    }
+
+    return QueryRunnerTestHelper.makeFilteringQueryRunner(timeline, factory);
+  }
+
   @Test
   @SuppressWarnings("unchecked")
-  public void testFilteredTimeBoundaryQuery()
+  public void testFilteredTimeBoundaryQuery() throws IOException
   {
+    QueryRunner customRunner = getCustomRunner();
     TimeBoundaryQuery timeBoundaryQuery = Druids.newTimeBoundaryQueryBuilder()
                                                 .dataSource("testing")
                                                 .filters("quality", "automotive")
                                                 .build();
+    Assert.assertTrue(timeBoundaryQuery.hasFilters());
     HashMap<String,Object> context = new HashMap<String, Object>();
     Iterable<Result<TimeBoundaryResultValue>> results = Sequences.toList(
-        runner.run(timeBoundaryQuery, context),
+        customRunner.run(timeBoundaryQuery, context),
         Lists.<Result<TimeBoundaryResultValue>>newArrayList()
     );
 
-    /* If not, then no rows matched the filter--what is expected behavior in that case? */
     Assert.assertTrue(Iterables.size(results) > 0);
 
     TimeBoundaryResultValue val = results.iterator().next().getValue();
     DateTime minTime = val.getMinTime();
     DateTime maxTime = val.getMaxTime();
 
-    Assert.assertEquals(new DateTime("2011-01-12T00:00:00.000Z"), minTime);
-    Assert.assertEquals(new DateTime("2011-04-15T00:00:00.000Z"), maxTime);
+    Assert.assertEquals(new DateTime("2011-01-13T00:00:00.000Z"), minTime);
+    Assert.assertEquals(new DateTime("2011-01-16T00:00:00.000Z"), maxTime);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testFilteredTimeBoundaryQueryNoMatches() throws IOException
+  {
+    QueryRunner customRunner = getCustomRunner();
+    TimeBoundaryQuery timeBoundaryQuery = Druids.newTimeBoundaryQueryBuilder()
+                                                .dataSource("testing")
+                                                .filters("quality", "foobar") // foobar dimension does not exist
+                                                .build();
+    Assert.assertTrue(timeBoundaryQuery.hasFilters());
+    HashMap<String,Object> context = new HashMap<String, Object>();
+    Iterable<Result<TimeBoundaryResultValue>> results = Sequences.toList(
+        customRunner.run(timeBoundaryQuery, context),
+        Lists.<Result<TimeBoundaryResultValue>>newArrayList()
+    );
+
+    Assert.assertTrue(Iterables.size(results) == 0);
   }
 
   @Test
@@ -97,6 +212,7 @@ public class TimeBoundaryQueryRunnerTest
     TimeBoundaryQuery timeBoundaryQuery = Druids.newTimeBoundaryQueryBuilder()
                                                 .dataSource("testing")
                                                 .build();
+    Assert.assertFalse(timeBoundaryQuery.hasFilters());
     HashMap<String,Object> context = new HashMap<String, Object>();
     Iterable<Result<TimeBoundaryResultValue>> results = Sequences.toList(
         runner.run(timeBoundaryQuery, context),

--- a/server/src/test/java/io/druid/server/router/QueryHostFinderTest.java
+++ b/server/src/test/java/io/druid/server/router/QueryHostFinderTest.java
@@ -127,6 +127,7 @@ public class QueryHostFinderTest
             new TableDataSource("test"),
             new MultipleIntervalSegmentSpec(Arrays.<Interval>asList(new Interval("2011-08-31/2011-09-01"))),
             null,
+            null,
             null
         )
     );


### PR DESCRIPTION
This adds support for adding filters in TimeBoundaryQuerys.

Questions: 
1) In TimeBoundaryQueryRunnerFactory.java, did I add the functionality in a reasonable way?
2) In TimeBoundaryQueryRunnerTest.java, it isn't apparent that the filtering is working, since the current filter matches for all rows. I can't figure out how the dataSource() function works or how to find a list of dataSources and their associated logfiles, help on that would be appreciated as well.
3) What other changes do I need to make to finalize this? (I'm guessing there's some stuff to do with the JSON queries)

Thanks.