### PR TITLE
[FIX]: Parquet Extension - Upgrade parquet-avro to 1.8.1 - Somtimes file not splitted will throw IndexOutOfBounds Exception

### DIFF
--- a/extensions-contrib/parquet-extensions/pom.xml
+++ b/extensions-contrib/parquet-extensions/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-avro</artifactId>
-            <version>1.8.0</version>
+            <version>1.8.1</version>
         </dependency>
         <dependency>
             <groupId>io.druid</groupId>


### PR DESCRIPTION
In some case, parquet extension will fail to read the files, and change 1.8.0 to 1.8.1 will fix it.