### PR TITLE
[Backport] Fix SegmentMetadataQuery when queryGranularity is requested but not present.

### DIFF
--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
@@ -132,7 +132,7 @@ public class SegmentMetadataQueryRunnerFactory implements QueryRunnerFactory<Seg
           if (metadata == null) {
             metadata = segment.asStorageAdapter().getMetadata();
           }
-          queryGranularity = metadata.getQueryGranularity();
+          queryGranularity = metadata != null ? metadata.getQueryGranularity() : null;
         } else {
           queryGranularity = null;
         }


### PR DESCRIPTION
Backport of #3181 to 0.9.1.