### PR TITLE
Change default for pendingTasksRunnerNumThreads to 1

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
@@ -47,7 +47,7 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
 
   @JsonProperty
   @Min(1)
-  private int pendingTasksRunnerNumThreads = 3;
+  private int pendingTasksRunnerNumThreads = 1;
 
   public Period getTaskAssignmentTimeout()
   {


### PR DESCRIPTION
Related to https://github.com/druid-io/druid/issues/3174
Makes default config not encounter the suspected cause