### PR TITLE
Revert "update druid console version (#3189)"

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>io.druid</groupId>
             <artifactId>druid-console</artifactId>
-            <version>0.0.3</version>
+            <version>0.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.metamx</groupId>


### PR DESCRIPTION
This reverts commit 496b801bc39bec26a4084d6332a1da676091a5dd (#3189).

Issue originally reported in https://groups.google.com/d/msg/druid-user/zentMX_6Rh4/o1dBtBfPBAAJ, is reproducible for me (JS console gives errors like "d3 is not defined" and historical nodes don't show up). Rolling back druid-console fixes it for me.

imo, unless there is a reasonable workaround this should go in 0.9.1.1.