### PR TITLE
Revert "update druid console version (#3194)"

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>io.druid</groupId>
             <artifactId>druid-console</artifactId>
-            <version>0.0.3</version>
+            <version>0.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.metamx</groupId>


### PR DESCRIPTION
This reverts commit 5e7b88576c8b61a40bbfbe4398bd3f34603dc1cd. (#3194)

Backport of #3203.