### PR TITLE
Replace deprecated usages for StringInputRowParser and JSONParseSpec

### DIFF
--- a/api/src/test/java/io/druid/data/input/impl/FileIteratingFirehoseTest.java
+++ b/api/src/test/java/io/druid/data/input/impl/FileIteratingFirehoseTest.java
@@ -66,7 +66,8 @@ public class FileIteratingFirehoseTest
               new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("x")), null, null),
               ",",
               ImmutableList.of("ts", "x")
-          )
+          ),
+          null
       );
 
       final FileIteratingFirehose firehose = new FileIteratingFirehose(lineIterators.iterator(), parser);

--- a/api/src/test/java/io/druid/data/input/impl/InputRowParserSerdeTest.java
+++ b/api/src/test/java/io/druid/data/input/impl/InputRowParserSerdeTest.java
@@ -49,7 +49,8 @@ public class InputRowParserSerdeTest
             new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("foo", "bar")), null, null),
             null,
             null
-        )
+        ),
+        null
     );
     final ByteBufferInputRowParser parser2 = jsonMapper.readValue(
         jsonMapper.writeValueAsBytes(parser),
@@ -197,7 +198,8 @@ public class InputRowParserSerdeTest
             new DimensionsSpec(null, null, null),
             flattenSpec,
             null
-        )
+        ),
+        null
     );
 
     final StringInputRowParser parser2 = jsonMapper.readValue(

--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopyStringInputRowParser.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopyStringInputRowParser.java
@@ -38,7 +38,7 @@ public class HadoopyStringInputRowParser implements InputRowParser<Object>
 
   public HadoopyStringInputRowParser(@JsonProperty("parseSpec") ParseSpec parseSpec)
   {
-    this.parser = new StringInputRowParser(parseSpec);
+    this.parser = new StringInputRowParser(parseSpec, null);
   }
 
   @Override

--- a/indexing-hadoop/src/test/java/io/druid/indexer/BatchDeltaIngestionTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/BatchDeltaIngestionTest.java
@@ -349,7 +349,8 @@ public class BatchDeltaIngestionTest
                             new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("host")), null, null),
                             null,
                             ImmutableList.of("timestamp", "host", "host2", "visited_num")
-                        )
+                        ),
+                        null
                     ),
                     Map.class
                 ),

--- a/indexing-hadoop/src/test/java/io/druid/indexer/DetermineHashedPartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/DetermineHashedPartitionsJobTest.java
@@ -126,7 +126,8 @@ public class DetermineHashedPartitionsJobTest
                             "placementish",
                             "index"
                         )
-                    )
+                    ),
+                    null
                 ),
                 Map.class
             ),

--- a/indexing-hadoop/src/test/java/io/druid/indexer/DeterminePartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/DeterminePartitionsJobTest.java
@@ -230,7 +230,8 @@ public class DeterminePartitionsJobTest
                             new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("host", "country")), null, null),
                             null,
                             ImmutableList.of("timestamp", "host", "country", "visited_num")
-                        )
+                        ),
+                        null
                     ),
                     Map.class
                 ),

--- a/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorCombinerTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorCombinerTest.java
@@ -70,7 +70,8 @@ public class IndexGeneratorCombinerTest
                             new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("host")), null, null),
                             null,
                             ImmutableList.of("timestamp", "host", "visited")
-                        )
+                        ),
+                        null
                     ),
                     Map.class
                 ),

--- a/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobTest.java
@@ -143,7 +143,8 @@ public class IndexGeneratorJobTest
                         new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("host")), null, null),
                         null,
                         ImmutableList.of("timestamp", "host", "visited_num")
-                    )
+                    ),
+                    null
                 ),
                 null,
                 aggs1,
@@ -233,7 +234,8 @@ public class IndexGeneratorJobTest
                         new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("host")), null, null),
                         null,
                         ImmutableList.of("timestamp", "host", "visited_num")
-                    )
+                    ),
+                    null
                 ),
                 null,
                 aggs1,
@@ -316,8 +318,11 @@ public class IndexGeneratorJobTest
                 new StringInputRowParser(
                     new JSONParseSpec(
                         new TimestampSpec("ts", "yyyyMMddHH", null),
-                        new DimensionsSpec(null, null, null)
-                    )
+                        new DimensionsSpec(null, null, null),
+                        null,
+                        null
+                    ),
+                    null
                 ),
                 1, // force 1 row max per index for easier testing
                 aggs2,
@@ -345,8 +350,11 @@ public class IndexGeneratorJobTest
                 new StringInputRowParser(
                     new JSONParseSpec(
                         new TimestampSpec("ts", "yyyyMMddHH", null),
-                        new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("B", "F", "M", "Q", "X", "Y")), null, null)
-                    )
+                        new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("B", "F", "M", "Q", "X", "Y")), null, null),
+                        null,
+                        null
+                    ),
+                    null
                 ),
                 1, // force 1 row max per index for easier testing
                 aggs2,

--- a/indexing-hadoop/src/test/java/io/druid/indexer/JobHelperTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/JobHelperTest.java
@@ -75,7 +75,8 @@ public class JobHelperTest
                             new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("host")), null, null),
                             null,
                             ImmutableList.of("timestamp", "host", "visited_num")
-                        )
+                        ),
+                        null
                     ),
                     Map.class
                 ),

--- a/indexing-hadoop/src/test/java/io/druid/indexer/path/DatasourcePathSpecTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/path/DatasourcePathSpecTest.java
@@ -268,7 +268,8 @@ public class DatasourcePathSpecTest
                             new DimensionsSpec(null, null, null),
                             null,
                             ImmutableList.of("timestamp", "host", "visited")
-                        )
+                        ),
+                        null
                     ),
                     Map.class
                 ),

--- a/indexing-hadoop/src/test/java/io/druid/indexer/updater/HadoopConverterJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/updater/HadoopConverterJobTest.java
@@ -164,7 +164,8 @@ public class HadoopConverterJobTest
                             "\t",
                             "\u0001",
                             Arrays.asList(TestIndex.COLUMNS)
-                        )
+                        ),
+                        null
                     ),
                     Map.class
                 ),

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/IndexTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/IndexTaskTest.java
@@ -117,7 +117,8 @@ public class IndexTaskTest
                             ),
                             null,
                             Arrays.asList("ts", "dim", "val")
-                        )
+                        ),
+                        null
                     ),
                     Map.class
                 ),
@@ -189,7 +190,8 @@ public class IndexTaskTest
                             ),
                             null,
                             Arrays.asList("ts", "dim", "val")
-                        )
+                        ),
+                        null
                     ),
                     Map.class
                 ),
@@ -302,7 +304,8 @@ public class IndexTaskTest
                             ),
                             null,
                             Arrays.asList("ts", "dim", "val")
-                        )
+                        ),
+                        null
                     ),
                     Map.class
                 ),

--- a/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
@@ -298,7 +298,9 @@ public class IngestSegmentFirehoseFactoryTest
                     DimensionsSpec.getDefaultSchemas(ImmutableList.<String>of()),
                     ImmutableList.of(DIM_FLOAT_NAME, DIM_LONG_NAME),
                     ImmutableList.<SpatialDimensionSchema>of()
-                )
+                ),
+                null,
+                null
             )
         )
     )) {
@@ -416,7 +418,9 @@ public class IngestSegmentFirehoseFactoryTest
               DimensionsSpec.getDefaultSchemas(ImmutableList.of(DIM_NAME)),
               ImmutableList.of(DIM_FLOAT_NAME, DIM_LONG_NAME),
               ImmutableList.<SpatialDimensionSchema>of()
-          )
+          ),
+          null,
+          null
       )
   );
 

--- a/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTimelineTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTimelineTest.java
@@ -100,7 +100,9 @@ public class IngestSegmentFirehoseFactoryTimelineTest
               DimensionsSpec.getDefaultSchemas(Arrays.asList(DIMENSIONS)),
               null,
               null
-          )
+          ),
+          null,
+          null
       )
   );
 

--- a/server/src/test/java/io/druid/segment/indexing/DataSchemaTest.java
+++ b/server/src/test/java/io/druid/segment/indexing/DataSchemaTest.java
@@ -58,8 +58,11 @@ public class DataSchemaTest
         new StringInputRowParser(
             new JSONParseSpec(
                 new TimestampSpec("time", "auto", null),
-                new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("dimB", "dimA")), null, null)
-            )
+                new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("dimB", "dimA")), null, null),
+                null,
+                null
+            ),
+            null
         ), new TypeReference<Map<String, Object>>() {}
     );
 
@@ -87,8 +90,11 @@ public class DataSchemaTest
         new StringInputRowParser(
             new JSONParseSpec(
                 new TimestampSpec("time", "auto", null),
-                new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("time", "dimA", "dimB", "col2")), ImmutableList.of("dimC"), null)
-            )
+                new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("time", "dimA", "dimB", "col2")), ImmutableList.of("dimC"), null),
+                null,
+                null
+            ),
+            null
         ), new TypeReference<Map<String, Object>>() {}
     );
 
@@ -116,8 +122,11 @@ public class DataSchemaTest
         new StringInputRowParser(
             new JSONParseSpec(
                 new TimestampSpec("time", "auto", null),
-                new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("time", "dimA", "dimB", "metric1")), ImmutableList.of("dimC"), null)
-            )
+                new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("time", "dimA", "dimB", "metric1")), ImmutableList.of("dimC"), null),
+                null,
+                null
+            ),
+            null
         ), new TypeReference<Map<String, Object>>() {}
     );
 
@@ -197,7 +206,9 @@ public class DataSchemaTest
         actual.getParser().getParseSpec(),
         new JSONParseSpec(
             new TimestampSpec("xXx", null, null),
-            new DimensionsSpec(null, Arrays.asList("metric1", "xXx", "col1"), null)
+            new DimensionsSpec(null, Arrays.asList("metric1", "xXx", "col1"), null),
+            null,
+            null
         )
     );
     Assert.assertEquals(

--- a/server/src/test/java/io/druid/segment/realtime/FireDepartmentTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/FireDepartmentTest.java
@@ -86,8 +86,11 @@ public class FireDepartmentTest
                             DimensionsSpec.getDefaultSchemas(Arrays.asList("dim1", "dim2")),
                             null,
                             null
-                        )
-                    )
+                        ),
+                        null,
+                        null
+                    ),
+                    null
                 ),
                 Map.class
             ),

--- a/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorTester.java
+++ b/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorTester.java
@@ -103,7 +103,9 @@ public class AppenderatorTester implements AutoCloseable
         new MapInputRowParser(
             new JSONParseSpec(
                 new TimestampSpec("ts", "auto", null),
-                new DimensionsSpec(null, null, null)
+                new DimensionsSpec(null, null, null),
+                null,
+                null
             )
         ),
         Map.class

--- a/server/src/test/java/io/druid/segment/realtime/firehose/EventReceiverFirehoseTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/firehose/EventReceiverFirehoseTest.java
@@ -83,7 +83,9 @@ public class EventReceiverFirehoseTest
                     "timestamp",
                     "auto",
                     null
-                ), new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("d1")), null, null)
+                ), new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("d1")), null, null),
+                null,
+                null
             )
         )
     );
@@ -213,7 +215,9 @@ public class EventReceiverFirehoseTest
                             "timestamp",
                             "auto",
                             null
-                        ), new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("d1")), null, null)
+                        ), new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("d1")), null, null),
+                        null,
+                        null
                     )
                 )
             );

--- a/server/src/test/java/io/druid/segment/realtime/plumber/RealtimePlumberSchoolTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/plumber/RealtimePlumberSchoolTest.java
@@ -135,8 +135,11 @@ public class RealtimePlumberSchoolTest
             new StringInputRowParser(
                 new JSONParseSpec(
                     new TimestampSpec("timestamp", "auto", null),
-                    new DimensionsSpec(null, null, null)
-                )
+                    new DimensionsSpec(null, null, null),
+                    null,
+                    null
+                ),
+                null
             ),
             Map.class
         ),
@@ -151,8 +154,11 @@ public class RealtimePlumberSchoolTest
             new StringInputRowParser(
                 new JSONParseSpec(
                     new TimestampSpec("timestamp", "auto", null),
-                    new DimensionsSpec(null, null, null)
-                )
+                    new DimensionsSpec(null, null, null),
+                    null,
+                    null
+                ),
+                null
             ),
             Map.class
         ),


### PR DESCRIPTION
This PR replaces deprecated usages for `StringInputRowParser` and `JSONParseSpec`.

- **`StringInputRowParser`**

  - **from**
   ```java
   new StringInputRowParser(parseSpec)
    ```

  - **to**
   ```java
   new StringInputRowParser(parseSpec, null)
    ```

- **`JSONParseSpec`**

  - **from**
   ```java
   new JSONParseSpec(ts, dims)
    ```

  - **to**
   ```java
   new JSONParseSpec(ts, dims, null, null)
    ```

They were deprecated but it seems changing the usages was missed.