### PR TITLE
Update to guice-4.1.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
     <properties>
         <metamx.java-util.version>0.27.9</metamx.java-util.version>
         <apache.curator.version>2.10.0</apache.curator.version>
+        <guice.version>4.1.0</guice.version>
         <jetty.version>9.2.5.v20141112</jetty.version>
         <jersey.version>1.19</jersey.version>
         <!-- Watch out for Hadoop compatibility when updating to >= 2.5; see https://github.com/druid-io/druid/pull/1669 -->
@@ -258,17 +259,17 @@
             <dependency>
                 <groupId>com.google.inject</groupId>
                 <artifactId>guice</artifactId>
-                <version>4.0-beta</version>
+                <version>${guice.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.inject.extensions</groupId>
                 <artifactId>guice-servlet</artifactId>
-                <version>4.0-beta</version>
+                <version>${guice.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.inject.extensions</groupId>
                 <artifactId>guice-multibindings</artifactId>
-                <version>4.0-beta</version>
+                <version>${guice.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.ibm.icu</groupId>


### PR DESCRIPTION
Fixes https://github.com/google/guice/issues/757 among other issues. I tried out the quickstart (batch & streaming with tranquility) and it still worked after this change.

Possibly related: https://groups.google.com/d/msg/druid-user/i1oPmt9ltR8/Z1xAIk3uBgAJ