### PR TITLE
workaround to get mvn versions:set working with druid

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <version>2</version>
     </parent>
 
+    <groupId>io.druid</groupId>
     <artifactId>druid</artifactId>
     <version>0.9.2-SNAPSHOT</version>
     <packaging>pom</packaging>


### PR DESCRIPTION
mvn -e versions:set -DnewVersion=<version> throws NPE with druid due to
https://github.com/mojohaus/versions-maven-plugin/issues/5
Setting groupId in parent pom as work around for it.