### PR TITLE
Increase test timeout to prevent failing on slow machines

### DIFF
--- a/processing/src/test/java/io/druid/granularity/QueryGranularityTest.java
+++ b/processing/src/test/java/io/druid/granularity/QueryGranularityTest.java
@@ -749,7 +749,7 @@ public class QueryGranularityTest
     Assert.assertFalse("expectedIter not exhausted!?", expectedIter.hasNext());
   }
   
-  @Test(timeout = 10_000L)
+  @Test(timeout = 60_000L)
   public void testDeadLock() throws Exception
   {
     final URL[] urls = ((URLClassLoader)QueryGranularity.class.getClassLoader()).getURLs();


### PR DESCRIPTION
constantly timing out on one of slow build machines, increasing the timeout fixed it.

```
Running io.druid.granularity.QueryGranularityTest
Tests run: 33, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 11.776
sec - in io.druid.granularity.QueryGranularityTest
```