### PR TITLE
Fix #2782, Unit test failed for DruidProcessingConfigTest.testDeserialization

### DIFF
--- a/processing/src/test/java/io/druid/query/DruidProcessingConfigTest.java
+++ b/processing/src/test/java/io/druid/query/DruidProcessingConfigTest.java
@@ -42,7 +42,11 @@ public class DruidProcessingConfigTest
 
     Assert.assertEquals(1024 * 1024 * 1024, config.intermediateComputeSizeBytes());
     Assert.assertEquals(Integer.MAX_VALUE, config.poolCacheMaxCount());
-    Assert.assertTrue(config.getNumThreads() < Runtime.getRuntime().availableProcessors());
+    if (Runtime.getRuntime().availableProcessors() == 1) {
+      Assert.assertTrue(config.getNumThreads() == 1);
+    } else {
+      Assert.assertTrue(config.getNumThreads() < Runtime.getRuntime().availableProcessors());
+    }
     Assert.assertEquals(0, config.columnCacheSizeBytes());
     Assert.assertFalse(config.isFifo());
 


### PR DESCRIPTION
On systems with only once processor this test fails. Systems with 2 processors are fine.