### PR TITLE
Intern ServerInventoryView inventory objects.

### DIFF
--- a/server/src/main/java/io/druid/client/BatchServerInventoryView.java
+++ b/server/src/main/java/io/druid/client/BatchServerInventoryView.java
@@ -25,6 +25,10 @@ import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.MapMaker;
 import com.google.common.collect.Sets;
@@ -48,6 +52,7 @@ import java.util.concurrent.Executor;
 public class BatchServerInventoryView extends ServerInventoryView<Set<DataSegment>>
     implements FilteredServerInventoryView
 {
+  private static final Interner<DataSegment> DATA_SEGMENT_INTERNER = Interners.newWeakInterner();
   private static final EmittingLogger log = new EmittingLogger(BatchServerInventoryView.class);
 
   final private ConcurrentMap<String, Set<DataSegment>> zNodes = new MapMaker().makeMap();
@@ -187,5 +192,18 @@ public class BatchServerInventoryView extends ServerInventoryView<Set<DataSegmen
   protected void segmentCallbackRemoved(SegmentCallback callback)
   {
     segmentPredicates.remove(callback);
+  }
+
+  @Override
+  protected Set<DataSegment> internInventory(Set<DataSegment> sample)
+  {
+    return ImmutableSet.copyOf(FluentIterable.from(sample).transform(new Function<DataSegment, DataSegment>()
+    {
+      @Override
+      public DataSegment apply(DataSegment input)
+      {
+        return DATA_SEGMENT_INTERNER.intern(input);
+      }
+    }));
   }
 }

--- a/server/src/main/java/io/druid/client/ServerInventoryView.java
+++ b/server/src/main/java/io/druid/client/ServerInventoryView.java
@@ -19,7 +19,6 @@
 
 package io.druid.client;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Charsets;
@@ -101,7 +100,7 @@ public abstract class ServerInventoryView<InventoryType> implements ServerView, 
           public InventoryType deserializeInventory(byte[] bytes)
           {
             try {
-              return jsonMapper.readValue(bytes, typeReference);
+              return internInventory(jsonMapper.<InventoryType>readValue(bytes, typeReference));
             }
             catch (IOException e) {
               CharBuffer.wrap(StringUtils.fromUtf8(bytes).toCharArray());
@@ -192,6 +191,15 @@ public abstract class ServerInventoryView<InventoryType> implements ServerView, 
         inventoryManager.stop();
       }
     }
+  }
+
+  /**
+   * Optionally override to allow interning the inventory
+   * @param sample The inventory to intern
+   * @return An interned instance equal to sample
+   */
+  protected InventoryType internInventory(InventoryType sample) {
+    return sample;
   }
 
   public boolean isStarted()

--- a/server/src/main/java/io/druid/client/SingleServerInventoryView.java
+++ b/server/src/main/java/io/druid/client/SingleServerInventoryView.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
 import com.google.common.collect.MapMaker;
 import com.google.inject.Inject;
 import com.metamx.common.Pair;
@@ -43,6 +45,7 @@ import java.util.concurrent.Executor;
 public class SingleServerInventoryView extends ServerInventoryView<DataSegment> implements FilteredServerInventoryView
 {
   private static final EmittingLogger log = new EmittingLogger(SingleServerInventoryView.class);
+  private static final Interner<DataSegment> DATA_SEGMENT_INTERNER = Interners.newWeakInterner();
 
   final private ConcurrentMap<SegmentCallback, Predicate<Pair<DruidServerMetadata, DataSegment>>> segmentPredicates = new MapMaker()
       .makeMap();
@@ -164,4 +167,9 @@ public class SingleServerInventoryView extends ServerInventoryView<DataSegment> 
     }
   }
 
+  @Override
+  protected DataSegment internInventory(DataSegment sample)
+  {
+    return DATA_SEGMENT_INTERNER.intern(sample);
+  }
 }


### PR DESCRIPTION
Allows replicants of data segments to only take up one chunklet of heap in the server view.

Related to https://github.com/druid-io/druid/issues/3237
