### PR TITLE
fix-3237 modify DruidBroker to use FilteredServerInventoryView instead of ServerInventoryView

### DIFF
--- a/server/src/main/java/io/druid/server/coordination/broker/DruidBroker.java
+++ b/server/src/main/java/io/druid/server/coordination/broker/DruidBroker.java
@@ -19,16 +19,20 @@
 
 package io.druid.server.coordination.broker;
 
+import com.google.common.base.Predicates;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
+import com.metamx.common.Pair;
 import com.metamx.common.lifecycle.LifecycleStart;
 import com.metamx.common.lifecycle.LifecycleStop;
-import io.druid.client.ServerInventoryView;
+import io.druid.client.FilteredServerInventoryView;
 import io.druid.client.ServerView;
 import io.druid.curator.discovery.ServiceAnnouncer;
 import io.druid.guice.ManageLifecycle;
 import io.druid.guice.annotations.Self;
 import io.druid.server.DruidNode;
+import io.druid.server.coordination.DruidServerMetadata;
+import io.druid.timeline.DataSegment;
 
 @ManageLifecycle
 public class DruidBroker
@@ -39,7 +43,7 @@ public class DruidBroker
 
   @Inject
   public DruidBroker(
-      final ServerInventoryView serverInventoryView,
+      final FilteredServerInventoryView serverInventoryView,
       final @Self DruidNode self,
       final ServiceAnnouncer serviceAnnouncer
   )
@@ -57,7 +61,9 @@ public class DruidBroker
             serviceAnnouncer.announce(self);
             return ServerView.CallbackAction.UNREGISTER;
           }
-        }
+        },
+        // We are not interested in any segment callbacks except view initialization
+        Predicates.<Pair<DruidServerMetadata, DataSegment>>alwaysFalse()
     );
   }
 


### PR DESCRIPTION
modify DruidBroker to use FilteredServerInventoryView instead of
ServerInventoryView to avoid multiple copies of ServerInventoryView getting created. 
fixes #3237 