### PR TITLE
add comment for modifying default hadoop coordinates when compiling with diff hadoop version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <jackson.version>2.4.6</jackson.version>
         <log4j.version>2.5</log4j.version>
         <slf4j.version>1.7.12</slf4j.version>
+        <!-- If compiling with different hadoop version also modify default hadoop coordinates in TaskConfig.java -->
         <hadoop.compile.version>2.3.0</hadoop.compile.version>
     </properties>
 

--- a/services/src/main/java/io/druid/cli/CliHadoopIndexer.java
+++ b/services/src/main/java/io/druid/cli/CliHadoopIndexer.java
@@ -27,6 +27,7 @@ import io.airlift.airline.Arguments;
 import io.airlift.airline.Command;
 import io.airlift.airline.Option;
 import io.druid.guice.ExtensionsConfig;
+import io.druid.indexing.common.config.TaskConfig;
 import io.druid.initialization.Initialization;
 
 import java.io.File;
@@ -45,7 +46,7 @@ import java.util.List;
 public class CliHadoopIndexer implements Runnable
 {
 
-  private static final String DEFAULT_HADOOP_COORDINATES = "org.apache.hadoop:hadoop-client:2.3.0";
+  private static final List<String> DEFAULT_HADOOP_COORDINATES = TaskConfig.DEFAULT_DEFAULT_HADOOP_COORDINATES;
 
   private static final Logger log = new Logger(CliHadoopIndexer.class);
 
@@ -57,7 +58,7 @@ public class CliHadoopIndexer implements Runnable
   private List<String> coordinates;
 
   @Option(name = "--no-default-hadoop",
-          description = "don't pull down the default hadoop version (currently " + DEFAULT_HADOOP_COORDINATES + ")",
+          description = "don't pull down the default hadoop version",
           required = false)
   public boolean noDefaultHadoop;
 
@@ -74,7 +75,7 @@ public class CliHadoopIndexer implements Runnable
         allCoordinates.addAll(coordinates);
       }
       if (!noDefaultHadoop) {
-        allCoordinates.add(DEFAULT_HADOOP_COORDINATES);
+        allCoordinates.addAll(DEFAULT_HADOOP_COORDINATES);
       }
 
       final List<URL> extensionURLs = Lists.newArrayList();


### PR DESCRIPTION
1) Modify CliHadoopIndexer to share constant from `TaskConfig.DEFAULT_DEFAULT_HADOOP_COORDINATES`
2) add comment to pom.xml as discussed in
https://github.com/druid-io/druid/pull/3044