### PR TITLE
Quickstart: Use hadoopyString for batch indexing instead of string.

### DIFF
--- a/examples/quickstart/wikiticker-index.json
+++ b/examples/quickstart/wikiticker-index.json
@@ -17,7 +17,7 @@
         "intervals" : ["2015-09-12/2015-09-13"]
       },
       "parser" : {
-        "type" : "string",
+        "type" : "hadoopyString",
         "parseSpec" : {
           "format" : "json",
           "dimensionsSpec" : {


### PR DESCRIPTION
The hadoop indexing docs suggest using hadoopyString instead of string parser, so we should follow that recommendation in the example. I tested the quickstart with this change and it still works.