### PR TITLE
Reference counting, better error handling for resources in groupBy v2.

### DIFF
--- a/common/src/main/java/io/druid/collections/ReferenceCountingResourceHolder.java
+++ b/common/src/main/java/io/druid/collections/ReferenceCountingResourceHolder.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.collections;
+
+import com.metamx.common.ISE;
+import com.metamx.common.logger.Logger;
+
+import java.io.Closeable;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ReferenceCountingResourceHolder<T> implements ResourceHolder<T>
+{
+  private static final Logger log = new Logger(ReferenceCountingResourceHolder.class);
+
+  private final Object lock = new Object();
+  private final T object;
+  private final Closeable closer;
+
+  private int refcount = 1;
+  private boolean didClose = false;
+
+  public ReferenceCountingResourceHolder(final T object, final Closeable closer)
+  {
+    this.object = object;
+    this.closer = closer;
+  }
+
+  @Override
+  public T get()
+  {
+    synchronized (lock) {
+      if (refcount <= 0) {
+        throw new ISE("Already closed!");
+      }
+
+      return object;
+    }
+  }
+
+  public Releaser increment()
+  {
+    synchronized (lock) {
+      if (refcount <= 0) {
+        throw new ISE("Already closed!");
+      }
+
+      refcount++;
+
+      return new Releaser()
+      {
+        final AtomicBoolean didRelease = new AtomicBoolean();
+
+        @Override
+        public void close()
+        {
+          if (didRelease.compareAndSet(false, true)) {
+            decrement();
+          } else {
+            log.warn("WTF?! release called but we are already released!");
+          }
+        }
+
+        @Override
+        protected void finalize() throws Throwable
+        {
+          if (didRelease.compareAndSet(false, true)) {
+            log.warn("Not released! Object was[%s], releasing on finalize of releaser.", object);
+            decrement();
+          }
+        }
+      };
+    }
+  }
+
+  public int getReferenceCount()
+  {
+    synchronized (lock) {
+      return refcount;
+    }
+  }
+
+  @Override
+  public void close()
+  {
+    synchronized (lock) {
+      if (!didClose) {
+        didClose = true;
+        decrement();
+      } else {
+        log.warn(new ISE("Already closed!"), "Already closed");
+      }
+    }
+  }
+
+  @Override
+  protected void finalize() throws Throwable
+  {
+    synchronized (lock) {
+      if (!didClose) {
+        log.warn("Not closed! Object was[%s], closing on finalize of holder.", object);
+        didClose = true;
+        decrement();
+      }
+    }
+  }
+
+  private void decrement()
+  {
+    synchronized (lock) {
+      refcount--;
+      if (refcount <= 0) {
+        try {
+          closer.close();
+        }
+        catch (Exception e) {
+          log.error(e, "WTF?! Close failed, uh oh...");
+        }
+      }
+    }
+  }
+}

--- a/common/src/main/java/io/druid/collections/Releaser.java
+++ b/common/src/main/java/io/druid/collections/Releaser.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.collections;
+
+import java.io.Closeable;
+
+/**
+ * Releaser is like Closeable, but doesn't throw IOExceptions.
+ */
+public interface Releaser extends Closeable
+{
+  @Override
+  void close();
+}

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/CloseableGrouperIterator.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/CloseableGrouperIterator.java
@@ -20,24 +20,29 @@
 package io.druid.query.groupby.epinephelinae;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.Iterator;
 
 public class CloseableGrouperIterator<KeyType extends Comparable<KeyType>, T> implements Iterator<T>, Closeable
 {
   private final Grouper<KeyType> grouper;
   private final Function<Grouper.Entry<KeyType>, T> transformer;
+  private final Closeable closer;
   private final Iterator<Grouper.Entry<KeyType>> iterator;
 
   public CloseableGrouperIterator(
       final Grouper<KeyType> grouper,
       final boolean sorted,
-      final Function<Grouper.Entry<KeyType>, T> transformer
+      final Function<Grouper.Entry<KeyType>, T> transformer,
+      final Closeable closer
   )
   {
     this.grouper = grouper;
     this.transformer = transformer;
+    this.closer = closer;
     this.iterator = grouper.iterator(sorted);
   }
 
@@ -62,6 +67,13 @@ public class CloseableGrouperIterator<KeyType extends Comparable<KeyType>, T> im
   @Override
   public void close()
   {
-    grouper.close();
+    if (closer != null) {
+      try {
+        closer.close();
+      }
+      catch (IOException e) {
+        throw Throwables.propagate(e);
+      }
+    }
   }
 }

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
@@ -314,6 +314,14 @@ outer:
 
               return new MapBasedRow(timestamp, theMap);
             }
+          },
+          new Closeable()
+          {
+            @Override
+            public void close() throws IOException
+            {
+              grouper.close();
+            }
           }
       );
 

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/LimitedTemporaryStorage.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/LimitedTemporaryStorage.java
@@ -59,10 +59,19 @@ public class LimitedTemporaryStorage implements Closeable
     this.maxBytesUsed = maxBytesUsed;
   }
 
+  /**
+   * Create a new temporary file. All methods of the returned output stream may throw
+   * {@link TemporaryStorageFullException} if the temporary storage area fills up.
+   *
+   * @return output stream to the file
+   *
+   * @throws TemporaryStorageFullException if the temporary storage area is full
+   * @throws IOException                   if something goes wrong while creating the file
+   */
   public LimitedOutputStream createFile() throws IOException
   {
     if (bytesUsed.get() >= maxBytesUsed) {
-      throwFullError();
+      throw new TemporaryStorageFullException(maxBytesUsed);
     }
 
     synchronized (files) {
@@ -158,14 +167,9 @@ public class LimitedTemporaryStorage implements Closeable
     private void grab(int n) throws IOException
     {
       if (bytesUsed.addAndGet(n) > maxBytesUsed) {
-        throwFullError();
+        throw new TemporaryStorageFullException(maxBytesUsed);
       }
     }
 
-  }
-
-  private void throwFullError() throws IOException
-  {
-    throw new IOException(String.format("Cannot write to disk, hit limit of %,d bytes.", maxBytesUsed));
   }
 }

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/TemporaryStorageFullException.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/TemporaryStorageFullException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.groupby.epinephelinae;
+
+import java.io.IOException;
+
+public class TemporaryStorageFullException extends IOException
+{
+  public TemporaryStorageFullException(final long maxBytesUsed)
+  {
+    super(String.format("Cannot write to disk, hit limit of %,d bytes.", maxBytesUsed));
+  }
+}


### PR DESCRIPTION
Refcounting prevents releasing the merge buffer, or closing the concurrent
grouper, before the processing threads have all finished.

The better error handling prevents an avalanche of per-runner exceptions
when grouping resources are exhausted, by grouping those all up into a
single merged exception.