### PR TITLE
Do not consider full servers in CostBalancerStrategy

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/CostBalancerStrategy.java
+++ b/server/src/main/java/io/druid/server/coordinator/CostBalancerStrategy.java
@@ -330,6 +330,10 @@ public class CostBalancerStrategy implements BalancerStrategy
     List<ListenableFuture<Pair<Double, ServerHolder>>> futures = Lists.newArrayList();
 
     for (final ServerHolder server : serverHolders) {
+      if (server.getAvailableSize() < proposalSegment.getSize()) {
+        log.debug("Server %s is too small. Need at least %d", server, proposalSegment.getSize());
+        continue;
+      }
       futures.add(
           exec.submit(
               new Callable<Pair<Double, ServerHolder>>()


### PR DESCRIPTION
Whenever a server is full or near full, the cost balancer will still keep picking that server to assign a segment to. When the server gets the load request, it will fail with a message similar to:

```
com.metamx.common.ISE: Segment[REDACTED:351,586,134] too large for storage[/redacted:18,952,315]
```

Which will show up as a bunch of `segment/assigned/count` in coordinator metrics. But the segment will not be loaded.

This changes behavior to simply skip considering servers which cannot hold a particular segment. If a suitable server is not found, it will show something like the following in the coordinator log:

```
2016-07-22T01:13:04,988 WARN [pool-8-thread-1] io.druid.server.coordinator.rules.LoadRule - Not enough [hot] servers or node capacity to assign segment[dataSource1_2010-01-01T00:00:00.000Z_2010-01-02T00:00:00.000Z_v1]! Expected Replicants[2]
2016-07-22T01:13:04,989 WARN [pool-8-thread-1] io.druid.server.coordinator.rules.LoadRule - Not enough [full] servers or node capacity to assign segment[dataSource1_2010-01-01T00:00:00.000Z_2010-01-02T00:00:00.000Z_v1]! Expected Replicants[1]
```