### PR TITLE
fix ConcurrentModificationException in CachingClusteredClient.run()

### DIFF
--- a/common/src/main/java/io/druid/timeline/VersionedIntervalTimeline.java
+++ b/common/src/main/java/io/druid/timeline/VersionedIntervalTimeline.java
@@ -244,7 +244,7 @@ public class VersionedIntervalTimeline<VersionType, ObjectType> implements Timel
               new TimelineObjectHolder<VersionType, ObjectType>(
                   object.getTrueInterval(),
                   object.getVersion(),
-                  object.getPartitionHolder()
+                  new PartitionHolder<ObjectType>(object.getPartitionHolder())
               )
           );
         }

--- a/common/src/main/java/io/druid/timeline/VersionedIntervalTimeline.java
+++ b/common/src/main/java/io/druid/timeline/VersionedIntervalTimeline.java
@@ -453,7 +453,7 @@ public class VersionedIntervalTimeline<VersionType, ObjectType> implements Timel
             new TimelineObjectHolder<VersionType, ObjectType>(
                 timelineInterval,
                 val.getVersion(),
-                val.getPartitionHolder()
+                new PartitionHolder<ObjectType>(val.getPartitionHolder())
             )
         );
       }


### PR DESCRIPTION
I had encountered an error in broker log
```
java.util.ConcurrentModificationException
at java.util.TreeMap$PrivateEntryIterator.nextEntry(TreeMap.java:1207)
at java.util.TreeMap$KeyIterator.next(TreeMap.java:1261)
at io.druid.client.CachingClusteredClient.run(CachingClusteredClient.java:224)
```
this exception is thrown from line 2 of this block
```java
    for (TimelineObjectHolder<String, ServerSelector> holder : filteredServersLookup) {
      for (PartitionChunk<ServerSelector> chunk : holder.getObject()) {
        ServerSelector selector = chunk.getObject();
        final SegmentDescriptor descriptor = new SegmentDescriptor(
            holder.getInterval(), holder.getVersion(), chunk.getChunkNumber()
        );

        segments.add(Pair.of(selector, descriptor));
      }
    }
```
The iteration of holder.getObject() is actually the iteration of TreeSet < PartitionChunk  <  T  >  > holderSet in PartitionHolder, and TreeSet is not thread safe.

In BrokerServerView,  will finally add a new chunk to holderSet by
`timeline.add(segment.getInterval(), segment.getVersion(), segment.getShardSpec().createChunk(selector))`
when I have a realtime task using LinearShardSpec, a new chunk will be announced and added in BrokerServerView.

And in broker, the CachingClusteredClient will iterate the holderSet when query.

Thus, the holderSet is written and read by different threads which causing ConcurrentModificationException

This patch just modify `VersionedIntervalTimeline.lookup` to use `new PartitionHolder<ObjectType>(val.getPartitionHolder())` to obtain a new copy of holderSet