### PR TITLE
change expected response from ACCEPTED to OK

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunner.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunner.java
@@ -511,7 +511,7 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
             response.getContent()
         );
 
-        if (!response.getStatus().equals(HttpResponseStatus.ACCEPTED)) {
+        if (!HttpResponseStatus.OK.equals(response.getStatus())) {
           log.error("Shutdown failed for %s! Are you sure the task was running?", taskId);
         }
       }


### PR DESCRIPTION
RTR is checking for a 202 Accepted but WorkerResource.doShutdown() sends back a 200 OK:

https://github.com/druid-io/druid/blob/master/indexing-service/src/main/java/io/druid/indexing/worker/http/WorkerResource.java#L169
