### PR TITLE
Associate groupBy v2 resources with the Sequence lifecycle.

### DIFF
--- a/docs/content/querying/groupbyquery.md
+++ b/docs/content/querying/groupbyquery.md
@@ -203,3 +203,4 @@ When using the "v2" strategy, the following query context parameters apply:
 |--------|-----------|
 |`groupByStrategy`|Overrides the value of `druid.query.groupBy.defaultStrategy` for this query.|
 |`bufferGrouperInitialBuckets`|Overrides the value of `druid.query.groupBy.bufferGrouperInitialBuckets` for this query.|
+|`maxOnDiskStorage`|Can be used to lower the value of `druid.query.groupBy.maxOnDiskStorage` for this query.|

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryConfig.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryConfig.java
@@ -26,6 +26,14 @@ import io.druid.query.groupby.strategy.GroupByStrategySelector;
  */
 public class GroupByQueryConfig
 {
+  public static final String CTX_KEY_STRATEGY = "groupByStrategy";
+  private static final String CTX_KEY_IS_SINGLE_THREADED = "groupByIsSingleThreaded";
+  private static final String CTX_KEY_MAX_INTERMEDIATE_ROWS = "maxIntermediateRows";
+  private static final String CTX_KEY_MAX_RESULTS = "maxResults";
+  private static final String CTX_KEY_BUFFER_GROUPER_INITIAL_BUCKETS = "bufferGrouperInitialBuckets";
+  private static final String CTX_KEY_BUFFER_GROUPER_MAX_SIZE = "bufferGrouperMaxSize";
+  private static final String CTX_KEY_MAX_ON_DISK_STORAGE = "maxOnDiskStorage";
+
   @JsonProperty
   private String defaultStrategy = GroupByStrategySelector.STRATEGY_V1;
 
@@ -106,5 +114,33 @@ public class GroupByQueryConfig
   public long getMaxOnDiskStorage()
   {
     return maxOnDiskStorage;
+  }
+
+  public GroupByQueryConfig withOverrides(final GroupByQuery query)
+  {
+    final GroupByQueryConfig newConfig = new GroupByQueryConfig();
+    newConfig.defaultStrategy = query.getContextValue(CTX_KEY_STRATEGY, getDefaultStrategy());
+    newConfig.singleThreaded = query.getContextBoolean(CTX_KEY_IS_SINGLE_THREADED, isSingleThreaded());
+    newConfig.maxIntermediateRows = Math.min(
+        query.getContextValue(CTX_KEY_MAX_INTERMEDIATE_ROWS, getMaxIntermediateRows()),
+        getMaxIntermediateRows()
+    );
+    newConfig.maxResults = Math.min(
+        query.getContextValue(CTX_KEY_MAX_RESULTS, getMaxResults()),
+        getMaxResults()
+    );
+    newConfig.bufferGrouperInitialBuckets = query.getContextValue(
+        CTX_KEY_BUFFER_GROUPER_INITIAL_BUCKETS,
+        getBufferGrouperInitialBuckets()
+    );
+    newConfig.bufferGrouperMaxSize = Math.min(
+        query.getContextValue(CTX_KEY_BUFFER_GROUPER_MAX_SIZE, getBufferGrouperMaxSize()),
+        getBufferGrouperMaxSize()
+    );
+    newConfig.maxOnDiskStorage = Math.min(
+        ((Number)query.getContextValue(CTX_KEY_MAX_ON_DISK_STORAGE, getMaxOnDiskStorage())).longValue(),
+        getMaxOnDiskStorage()
+    );
+    return newConfig;
   }
 }

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryEngine.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryEngine.java
@@ -68,8 +68,6 @@ import java.util.NoSuchElementException;
  */
 public class GroupByQueryEngine
 {
-  private static final String CTX_KEY_MAX_INTERMEDIATE_ROWS = "maxIntermediateRows";
-
   private final Supplier<GroupByQueryConfig> config;
   private final StupidPool<ByteBuffer> intermediateResultsBufferPool;
 
@@ -310,16 +308,12 @@ public class GroupByQueryEngine
 
     public RowIterator(GroupByQuery query, final Cursor cursor, ByteBuffer metricsBuffer, GroupByQueryConfig config)
     {
+      final GroupByQueryConfig querySpecificConfig = config.withOverrides(query);
+
       this.query = query;
       this.cursor = cursor;
       this.metricsBuffer = metricsBuffer;
-
-      this.maxIntermediateRows = Math.min(
-          query.getContextValue(
-              CTX_KEY_MAX_INTERMEDIATE_ROWS,
-              config.getMaxIntermediateRows()
-          ), config.getMaxIntermediateRows()
-      );
+      this.maxIntermediateRows = querySpecificConfig.getMaxIntermediateRows();
 
       unprocessedKeys = null;
       delegate = Iterators.emptyIterator();

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryHelper.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryHelper.java
@@ -45,7 +45,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class GroupByQueryHelper
 {
-  private static final String CTX_KEY_MAX_RESULTS = "maxResults";
   public final static String CTX_KEY_SORT_RESULTS = "sortResults";
 
   public static <T> Pair<IncrementalIndex, Accumulator<IncrementalIndex, T>> createIndexAccumulatorPair(
@@ -54,6 +53,7 @@ public class GroupByQueryHelper
       StupidPool<ByteBuffer> bufferPool
   )
   {
+    final GroupByQueryConfig querySpecificConfig = config.withOverrides(query);
     final QueryGranularity gran = query.getGranularity();
     final long timeStart = query.getIntervals().get(0).getStartMillis();
 
@@ -97,7 +97,7 @@ public class GroupByQueryHelper
           false,
           true,
           sortResults,
-          Math.min(query.getContextValue(CTX_KEY_MAX_RESULTS, config.getMaxResults()), config.getMaxResults()),
+          querySpecificConfig.getMaxResults(),
           bufferPool
       );
     } else {
@@ -110,7 +110,7 @@ public class GroupByQueryHelper
           false,
           true,
           sortResults,
-          Math.min(query.getContextValue(CTX_KEY_MAX_RESULTS, config.getMaxResults()), config.getMaxResults())
+          querySpecificConfig.getMaxResults()
       );
     }
 

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/BufferGrouper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/BufferGrouper.java
@@ -60,6 +60,7 @@ public class BufferGrouper<KeyType extends Comparable<KeyType>> implements Group
 {
   private static final Logger log = new Logger(BufferGrouper.class);
 
+  private static final int MIN_INITIAL_BUCKETS = 4;
   private static final int DEFAULT_INITIAL_BUCKETS = 1024;
   private static final float MAX_LOAD_FACTOR = 0.75f;
   private static final int HASH_SIZE = Ints.BYTES;
@@ -104,7 +105,7 @@ public class BufferGrouper<KeyType extends Comparable<KeyType>> implements Group
     this.aggregators = new BufferAggregator[aggregatorFactories.length];
     this.aggregatorOffsets = new int[aggregatorFactories.length];
     this.bufferGrouperMaxSize = bufferGrouperMaxSize;
-    this.initialBuckets = initialBuckets > 0 ? initialBuckets : DEFAULT_INITIAL_BUCKETS;
+    this.initialBuckets = initialBuckets > 0 ? Math.max(MIN_INITIAL_BUCKETS, initialBuckets) : DEFAULT_INITIAL_BUCKETS;
 
     int offset = HASH_SIZE + keySize;
     for (int i = 0; i < aggregatorFactories.length; i++) {

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
@@ -148,7 +148,7 @@ public class GroupByQueryEngineV2
   private static class GroupByEngineIterator implements Iterator<Row>, Closeable
   {
     private final GroupByQuery query;
-    private final GroupByQueryConfig config;
+    private final GroupByQueryConfig querySpecificConfig;
     private final Cursor cursor;
     private final ByteBuffer buffer;
     private final Grouper.KeySerde<ByteBuffer> keySerde;
@@ -174,7 +174,7 @@ public class GroupByQueryEngineV2
       final int dimCount = query.getDimensions().size();
 
       this.query = query;
-      this.config = config;
+      this.querySpecificConfig = config.withOverrides(query);
       this.cursor = cursor;
       this.buffer = buffer;
       this.keySerde = keySerde;
@@ -213,8 +213,8 @@ public class GroupByQueryEngineV2
           cursor,
           query.getAggregatorSpecs()
                .toArray(new AggregatorFactory[query.getAggregatorSpecs().size()]),
-          config.getBufferGrouperMaxSize(),
-          GroupByStrategyV2.getBufferGrouperInitialBuckets(config, query)
+          querySpecificConfig.getBufferGrouperMaxSize(),
+          querySpecificConfig.getBufferGrouperInitialBuckets()
       );
 
 outer:

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/Grouper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/Grouper.java
@@ -22,6 +22,7 @@ package io.druid.query.groupby.epinephelinae;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Closeable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -36,7 +37,7 @@ import java.util.Iterator;
  *
  * @param <KeyType> type of the key that will be passed in
  */
-public interface Grouper<KeyType extends Comparable<KeyType>>
+public interface Grouper<KeyType extends Comparable<KeyType>> extends Closeable
 {
   /**
    * Aggregate the current row with the provided key. Some implementations are thread-safe and
@@ -67,6 +68,7 @@ public interface Grouper<KeyType extends Comparable<KeyType>>
   /**
    * Close the grouper and release associated resources.
    */
+  @Override
   void close();
 
   /**

--- a/processing/src/main/java/io/druid/query/groupby/strategy/GroupByStrategySelector.java
+++ b/processing/src/main/java/io/druid/query/groupby/strategy/GroupByStrategySelector.java
@@ -27,7 +27,6 @@ import io.druid.query.groupby.GroupByQueryConfig;
 
 public class GroupByStrategySelector
 {
-  public static final String CTX_KEY_STRATEGY = "groupByStrategy";
   public static final String STRATEGY_V2 = "v2";
   public static final String STRATEGY_V1 = "v1";
 
@@ -49,7 +48,7 @@ public class GroupByStrategySelector
 
   public GroupByStrategy strategize(GroupByQuery query)
   {
-    final String strategyString = query.getContextValue(CTX_KEY_STRATEGY, config.getDefaultStrategy());
+    final String strategyString = config.withOverrides(query).getDefaultStrategy();
 
     switch (strategyString) {
       case STRATEGY_V2:

--- a/processing/src/main/java/io/druid/query/groupby/strategy/GroupByStrategyV1.java
+++ b/processing/src/main/java/io/druid/query/groupby/strategy/GroupByStrategyV1.java
@@ -99,7 +99,7 @@ public class GroupByStrategyV1 implements GroupByStrategy
                     //no merging needed at historicals because GroupByQueryRunnerFactory.mergeRunners(..) would return
                     //merged results
                     GroupByQueryQueryToolChest.GROUP_BY_MERGE_KEY, false,
-                    GroupByStrategySelector.CTX_KEY_STRATEGY, GroupByStrategySelector.STRATEGY_V1
+                    GroupByQueryConfig.CTX_KEY_STRATEGY, GroupByStrategySelector.STRATEGY_V1
                 )
             ),
             responseContext

--- a/processing/src/main/java/io/druid/query/groupby/strategy/GroupByStrategyV2.java
+++ b/processing/src/main/java/io/druid/query/groupby/strategy/GroupByStrategyV2.java
@@ -142,7 +142,7 @@ public class GroupByStrategyV2 implements GroupByStrategy
                 ).withOverriddenContext(
                     ImmutableMap.<String, Object>of(
                         "finalize", false,
-                        GroupByStrategySelector.CTX_KEY_STRATEGY, GroupByStrategySelector.STRATEGY_V2,
+                        GroupByQueryConfig.CTX_KEY_STRATEGY, GroupByStrategySelector.STRATEGY_V2,
                         CTX_KEY_FUDGE_TIMESTAMP, fudgeTimestamp
                     )
                 ),
@@ -202,10 +202,5 @@ public class GroupByStrategyV2 implements GroupByStrategy
   )
   {
     return GroupByQueryEngineV2.process(query, storageAdapter, bufferPool, configSupplier.get());
-  }
-
-  public static int getBufferGrouperInitialBuckets(final GroupByQueryConfig config, final GroupByQuery query)
-  {
-    return query.getContextValue("bufferGrouperInitialBuckets", config.getBufferGrouperInitialBuckets());
   }
 }


### PR DESCRIPTION
This fixes a potential issue where groupBy resources could be allocated to
create a Sequence, but then the Sequence is never used, and thus the resources
are never freed.

I'm not sure if this would be an issue in production or not (it depends on whether
something doing merging would `run` a QueryRunner but then not use the Sequence).
It did cause issues in the unit tests though, and fixing it would be good in general, so
here is a patch.

Also simplifies how groupBy handles config overrides (this made the new
unit test easier to write).