### PR TITLE
"all" type search query spec

### DIFF
--- a/processing/src/main/java/io/druid/query/search/search/AllSearchQuerySpec.java
+++ b/processing/src/main/java/io/druid/query/search/search/AllSearchQuerySpec.java
@@ -19,22 +19,39 @@
 
 package io.druid.query.search.search;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-
 /**
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes(value = {
-    @JsonSubTypes.Type(name = "contains", value = ContainsSearchQuerySpec.class),
-    @JsonSubTypes.Type(name = "insensitive_contains", value = InsensitiveContainsSearchQuerySpec.class),
-    @JsonSubTypes.Type(name = "fragment", value = FragmentSearchQuerySpec.class),
-    @JsonSubTypes.Type(name = "regex", value = RegexSearchQuerySpec.class),
-    @JsonSubTypes.Type(name = "all", value = AllSearchQuerySpec.class)
-})
-public interface SearchQuerySpec
+public class AllSearchQuerySpec implements SearchQuerySpec
 {
-  public boolean accept(String dimVal);
+  private static final byte CACHE_TYPE_ID = 0x7f;
 
-  public byte[] getCacheKey();
+  @Override
+  public boolean accept(String dimVal)
+  {
+    return true;
+  }
+
+  @Override
+  public byte[] getCacheKey()
+  {
+    return new byte[]{CACHE_TYPE_ID};
+  }
+
+  @Override
+  public boolean equals(Object object)
+  {
+    return object instanceof AllSearchQuerySpec;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return CACHE_TYPE_ID;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "AllSearchQuerySpec{}";
+  }
 }

--- a/processing/src/main/java/io/druid/query/search/search/SearchQuery.java
+++ b/processing/src/main/java/io/druid/query/search/search/SearchQuery.java
@@ -66,10 +66,9 @@ public class SearchQuery extends BaseQuery<Result<SearchResultValue>>
     this.granularity = granularity == null ? QueryGranularities.ALL : granularity;
     this.limit = (limit == 0) ? 1000 : limit;
     this.dimensions = dimensions;
-    this.querySpec = querySpec;
+    this.querySpec = querySpec == null ? new SearchQuerySpec.TakeAll() : querySpec;
 
     Preconditions.checkNotNull(querySegmentSpec, "Must specify an interval");
-    Preconditions.checkNotNull(querySpec, "Must specify a query");
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/search/search/SearchQuery.java
+++ b/processing/src/main/java/io/druid/query/search/search/SearchQuery.java
@@ -66,7 +66,7 @@ public class SearchQuery extends BaseQuery<Result<SearchResultValue>>
     this.granularity = granularity == null ? QueryGranularities.ALL : granularity;
     this.limit = (limit == 0) ? 1000 : limit;
     this.dimensions = dimensions;
-    this.querySpec = querySpec == null ? new SearchQuerySpec.TakeAll() : querySpec;
+    this.querySpec = querySpec == null ? new AllSearchQuerySpec() : querySpec;
 
     Preconditions.checkNotNull(querySegmentSpec, "Must specify an interval");
   }

--- a/processing/src/main/java/io/druid/query/search/search/SearchQuerySpec.java
+++ b/processing/src/main/java/io/druid/query/search/search/SearchQuerySpec.java
@@ -29,11 +29,27 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @JsonSubTypes.Type(name = "contains", value = ContainsSearchQuerySpec.class),
     @JsonSubTypes.Type(name = "insensitive_contains", value = InsensitiveContainsSearchQuerySpec.class),
     @JsonSubTypes.Type(name = "fragment", value = FragmentSearchQuerySpec.class),
-    @JsonSubTypes.Type(name = "regex", value = RegexSearchQuerySpec.class)
+    @JsonSubTypes.Type(name = "regex", value = RegexSearchQuerySpec.class),
+    @JsonSubTypes.Type(name = "all", value = SearchQuerySpec.TakeAll.class)
 })
 public interface SearchQuerySpec
 {
   public boolean accept(String dimVal);
 
   public byte[] getCacheKey();
+
+  class TakeAll implements SearchQuerySpec
+  {
+    @Override
+    public boolean accept(String dimVal)
+    {
+      return true;
+    }
+
+    @Override
+    public byte[] getCacheKey()
+    {
+      return new byte[]{0x7f};
+    }
+  }
 }

--- a/processing/src/test/java/io/druid/query/search/SearchQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/search/SearchQueryRunnerTest.java
@@ -550,6 +550,35 @@ public class SearchQueryRunnerTest
     );
   }
 
+  @Test
+  public void testSearchAll()
+  {
+    List<SearchHit> expectedHits = Lists.newLinkedList();
+    expectedHits.add(new SearchHit(QueryRunnerTestHelper.marketDimension, "spot", 837));
+    expectedHits.add(new SearchHit(QueryRunnerTestHelper.marketDimension, "total_market", 186));
+    expectedHits.add(new SearchHit(QueryRunnerTestHelper.marketDimension, "upfront", 186));
+
+    checkSearchQuery(
+        Druids.newSearchQueryBuilder()
+              .dataSource(QueryRunnerTestHelper.dataSource)
+              .granularity(QueryRunnerTestHelper.allGran)
+              .intervals(QueryRunnerTestHelper.fullOnInterval)
+              .dimensions(QueryRunnerTestHelper.marketDimension)
+              .query("")
+              .build(),
+        expectedHits
+    );
+    checkSearchQuery(
+        Druids.newSearchQueryBuilder()
+              .dataSource(QueryRunnerTestHelper.dataSource)
+              .granularity(QueryRunnerTestHelper.allGran)
+              .intervals(QueryRunnerTestHelper.fullOnInterval)
+              .dimensions(QueryRunnerTestHelper.marketDimension)
+              .build(),
+        expectedHits
+    );
+  }
+
   private void checkSearchQuery(Query searchQuery, List<SearchHit> expectedResults)
   {
     checkSearchQuery(searchQuery, runner, expectedResults);


### PR DESCRIPTION
This is really a trivial patch for easily accepting all values from search query. we can use {"type: "all"} instead of {"type": "contains", "value": ""} or something.