### PR TITLE
Fix ClassCastException in nested v2 groupBys with timeouts.

### DIFF
--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByMergingQueryRunnerV2.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByMergingQueryRunnerV2.java
@@ -42,7 +42,6 @@ import io.druid.collections.ReferenceCountingResourceHolder;
 import io.druid.collections.Releaser;
 import io.druid.common.utils.JodaUtils;
 import io.druid.data.input.Row;
-import io.druid.granularity.QueryGranularities;
 import io.druid.query.AbstractPrioritizedCallable;
 import io.druid.query.BaseQuery;
 import io.druid.query.ChainedExecutionQueryRunner;
@@ -167,8 +166,7 @@ public class GroupByMergingQueryRunnerV2 implements QueryRunner
                 closeOnFailure.add(mergeBufferHolder);
               }
               catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw Throwables.propagate(e);
+                throw new QueryInterruptedException(e);
               }
 
               Pair<Grouper<RowBasedKey>, Accumulator<Grouper<RowBasedKey>, Row>> pair = RowBasedGrouperHelper.createGrouperAccumulatorPair(

--- a/processing/src/main/java/io/druid/query/groupby/orderby/OrderByColumnSpec.java
+++ b/processing/src/main/java/io/druid/query/groupby/orderby/OrderByColumnSpec.java
@@ -213,7 +213,7 @@ public class OrderByColumnSpec
   {
     return "OrderByColumnSpec{" +
            "dimension='" + dimension + '\'' +
-           ", direction=" + direction + '\'' +
+           ", direction='" + direction + '\'' +
            ", dimensionComparator='" + dimensionComparator + '\'' +
            '}';
   }


### PR DESCRIPTION
Add tests for the CCE and for a bunch of other groupBy stuff.

Also avoids setting the interrupted flag when InterruptedExceptions
happen, since this might interfere with resource closing, no other
query does it, and is probably pointless anyway since the thread
is likely to be a jetty thread that we don't actually want to set
an interrupt flag on.

Also fixes toString on OrderByColumnSpec.