### PR TITLE
Fix FilteredAggregators at ingestion time and in groupBy v2 nested queries.

### DIFF
--- a/processing/src/main/java/io/druid/query/dimension/ListFilteredDimensionSpec.java
+++ b/processing/src/main/java/io/druid/query/dimension/ListFilteredDimensionSpec.java
@@ -74,7 +74,10 @@ public class ListFilteredDimensionSpec extends BaseFilteredDimensionSpec
       return selector;
     }
 
-    int selectorCardinality = selector.getValueCardinality();
+    final int selectorCardinality = selector.getValueCardinality();
+    if (selectorCardinality < 0) {
+      throw new UnsupportedOperationException("Cannot decorate a selector with no dictionary");
+    }
     int cardinality = isWhitelist ? values.size() : selectorCardinality - values.size();
 
     int count = 0;

--- a/processing/src/main/java/io/druid/query/dimension/RegexFilteredDimensionSpec.java
+++ b/processing/src/main/java/io/druid/query/dimension/RegexFilteredDimensionSpec.java
@@ -68,7 +68,12 @@ public class RegexFilteredDimensionSpec extends BaseFilteredDimensionSpec
     int count = 0;
     final Map<Integer,Integer> forwardMapping = new HashMap<>();
 
-    for (int i = 0; i < selector.getValueCardinality(); i++) {
+    final int selectorCardinality = selector.getValueCardinality();
+    if (selectorCardinality < 0) {
+      throw new UnsupportedOperationException("Cannot decorate a selector with no dictionary");
+    }
+
+    for (int i = 0; i < selectorCardinality; i++) {
       if (compiledRegex.matcher(Strings.nullToEmpty(selector.lookupName(i))).matches()) {
         forwardMapping.put(i, count++);
       }

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryEngine.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryEngine.java
@@ -68,6 +68,8 @@ import java.util.NoSuchElementException;
  */
 public class GroupByQueryEngine
 {
+  private static final int MISSING_VALUE = -1;
+
   private final Supplier<GroupByQueryConfig> config;
   private final StupidPool<ByteBuffer> intermediateResultsBufferPool;
 
@@ -189,7 +191,7 @@ public class GroupByQueryEngine
         final IndexedInts row = dimSelector.getRow();
         if (row == null || row.size() == 0) {
           ByteBuffer newKey = key.duplicate();
-          newKey.putInt(dimSelector.getValueCardinality());
+          newKey.putInt(MISSING_VALUE);
           unaggregatedBuffers = updateValues(newKey, dims.subList(1, dims.size()));
         } else {
           for (Integer dimValue : row) {
@@ -405,7 +407,7 @@ public class GroupByQueryEngine
                   for (int i = 0; i < dimensions.size(); ++i) {
                     final DimensionSelector dimSelector = dimensions.get(i);
                     final int dimVal = keyBuffer.getInt();
-                    if (dimSelector.getValueCardinality() != dimVal) {
+                    if (MISSING_VALUE != dimVal) {
                       theEvent.put(dimNames.get(i), dimSelector.lookupName(dimVal));
                     }
                   }

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -35,7 +35,6 @@ import com.metamx.common.guava.Accumulator;
 import io.druid.data.input.MapBasedRow;
 import io.druid.data.input.Row;
 import io.druid.granularity.AllGranularity;
-import io.druid.granularity.QueryGranularity;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.dimension.DimensionSpec;
 import io.druid.query.extraction.ExtractionFn;
@@ -527,7 +526,7 @@ public class RowBasedGrouperHelper
         @Override
         public int getValueCardinality()
         {
-          throw new UnsupportedOperationException("value cardinality is unknown");
+          return DimensionSelector.CARDINALITY_UNKNOWN;
         }
 
         @Override

--- a/processing/src/main/java/io/druid/query/topn/AggregateTopNMetricFirstAlgorithm.java
+++ b/processing/src/main/java/io/druid/query/topn/AggregateTopNMetricFirstAlgorithm.java
@@ -61,7 +61,6 @@ public class AggregateTopNMetricFirstAlgorithm implements TopNAlgorithm<int[], T
     return new TopNParams(
         dimSelector,
         cursor,
-        dimSelector.getValueCardinality(),
         Integer.MAX_VALUE
     );
   }
@@ -129,7 +128,7 @@ public class AggregateTopNMetricFirstAlgorithm implements TopNAlgorithm<int[], T
 
   private int[] getDimValSelectorForTopNMetric(TopNParams params, TopNResultBuilder resultBuilder)
   {
-    int[] dimValSelector = new int[params.getDimSelector().getValueCardinality()];
+    int[] dimValSelector = new int[params.getCardinality()];
     Arrays.fill(dimValSelector, SKIP_POSITION_VALUE);
 
     Iterator<DimValHolder> dimValIter = resultBuilder.getTopNIterator();

--- a/processing/src/main/java/io/druid/query/topn/BaseTopNAlgorithm.java
+++ b/processing/src/main/java/io/druid/query/topn/BaseTopNAlgorithm.java
@@ -196,6 +196,10 @@ public abstract class BaseTopNAlgorithm<DimValSelector, DimValAggregateStore, Pa
       ignoreAfterThreshold = false;
       ignoreFirstN = 0;
       keepOnlyN = dimSelector.getValueCardinality();
+
+      if (keepOnlyN < 0) {
+        throw new UnsupportedOperationException("Cannot operate on a dimension with no dictionary");
+      }
     }
 
     @Override

--- a/processing/src/main/java/io/druid/query/topn/DimExtractionTopNAlgorithm.java
+++ b/processing/src/main/java/io/druid/query/topn/DimExtractionTopNAlgorithm.java
@@ -54,7 +54,6 @@ public class DimExtractionTopNAlgorithm extends BaseTopNAlgorithm<Aggregator[][]
     return new TopNParams(
         dimSelector,
         cursor,
-        dimSelector.getValueCardinality(),
         Integer.MAX_VALUE
     );
   }

--- a/processing/src/main/java/io/druid/query/topn/PooledTopNAlgorithm.java
+++ b/processing/src/main/java/io/druid/query/topn/PooledTopNAlgorithm.java
@@ -67,6 +67,10 @@ public class PooledTopNAlgorithm
 
     final int cardinality = dimSelector.getValueCardinality();
 
+    if (cardinality < 0) {
+      throw new UnsupportedOperationException("Cannot operate on a dimension with no dictionary");
+    }
+
     final TopNMetricSpecBuilder<int[]> arrayProvider = new BaseArrayProvider<int[]>(
         dimSelector,
         query,
@@ -102,7 +106,6 @@ public class PooledTopNAlgorithm
     return PooledTopNParams.builder()
                            .withDimSelector(dimSelector)
                            .withCursor(cursor)
-                           .withCardinality(cardinality)
                            .withResultsBufHolder(resultsBufHolder)
                            .withResultsBuf(resultsBuf)
                            .withArrayProvider(arrayProvider)
@@ -517,7 +520,6 @@ public class PooledTopNAlgorithm
     public PooledTopNParams(
         DimensionSelector dimSelector,
         Cursor cursor,
-        int cardinality,
         ResourceHolder<ByteBuffer> resultsBufHolder,
         ByteBuffer resultsBuf,
         int[] aggregatorSizes,
@@ -526,7 +528,7 @@ public class PooledTopNAlgorithm
         TopNMetricSpecBuilder<int[]> arrayProvider
     )
     {
-      super(dimSelector, cursor, cardinality, numValuesPerPass);
+      super(dimSelector, cursor, numValuesPerPass);
 
       this.resultsBufHolder = resultsBufHolder;
       this.resultsBuf = resultsBuf;
@@ -569,7 +571,6 @@ public class PooledTopNAlgorithm
     {
       private DimensionSelector dimSelector;
       private Cursor cursor;
-      private int cardinality;
       private ResourceHolder<ByteBuffer> resultsBufHolder;
       private ByteBuffer resultsBuf;
       private int[] aggregatorSizes;
@@ -581,7 +582,6 @@ public class PooledTopNAlgorithm
       {
         dimSelector = null;
         cursor = null;
-        cardinality = 0;
         resultsBufHolder = null;
         resultsBuf = null;
         aggregatorSizes = null;
@@ -599,12 +599,6 @@ public class PooledTopNAlgorithm
       public Builder withCursor(Cursor cursor)
       {
         this.cursor = cursor;
-        return this;
-      }
-
-      public Builder withCardinality(int cardinality)
-      {
-        this.cardinality = cardinality;
         return this;
       }
 
@@ -649,7 +643,6 @@ public class PooledTopNAlgorithm
         return new PooledTopNParams(
             dimSelector,
             cursor,
-            cardinality,
             resultsBufHolder,
             resultsBuf,
             aggregatorSizes,

--- a/processing/src/main/java/io/druid/query/topn/TimeExtractionTopNAlgorithm.java
+++ b/processing/src/main/java/io/druid/query/topn/TimeExtractionTopNAlgorithm.java
@@ -45,7 +45,6 @@ public class TimeExtractionTopNAlgorithm extends BaseTopNAlgorithm<int[], Map<St
     return new TopNParams(
         dimSelector,
         cursor,
-        dimSelector.getValueCardinality(),
         Integer.MAX_VALUE
     );
   }

--- a/processing/src/main/java/io/druid/query/topn/TopNParams.java
+++ b/processing/src/main/java/io/druid/query/topn/TopNParams.java
@@ -34,14 +34,17 @@ public class TopNParams
   protected TopNParams(
       DimensionSelector dimSelector,
       Cursor cursor,
-      int cardinality,
       int numValuesPerPass
   )
   {
     this.dimSelector = dimSelector;
     this.cursor = cursor;
-    this.cardinality = cardinality;
+    this.cardinality = dimSelector.getValueCardinality();
     this.numValuesPerPass = numValuesPerPass;
+
+    if (cardinality < 0) {
+      throw new UnsupportedOperationException("Cannot operate on a dimension without a dictionary");
+    }
   }
 
   public DimensionSelector getDimSelector()

--- a/processing/src/main/java/io/druid/segment/DimensionSelector.java
+++ b/processing/src/main/java/io/druid/segment/DimensionSelector.java
@@ -23,6 +23,8 @@ package io.druid.segment;import io.druid.segment.data.IndexedInts;
  */
 public interface DimensionSelector
 {
+  public static int CARDINALITY_UNKNOWN = -1;
+
   /**
    * Gets all values for the row inside of an IntBuffer.  I.e. one possible implementation could be
    *
@@ -42,7 +44,12 @@ public interface DimensionSelector
    *
    * Value cardinality would be 2.
    *
-   * @return the value cardinality
+   * Cardinality may be unknown (e.g. the selector used by IncrementalIndex while reading input rows),
+   * in which case this method will return -1. If cardinality is unknown, you should assume this
+   * dimension selector has no dictionary, and avoid storing ids, calling "lookupId", or calling "lookupName"
+   * outside of the context of operating on a single row.
+   *
+   * @return the value cardinality, or -1 if unknown.
    */
   public int getValueCardinality();
 

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -333,7 +333,7 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
           @Override
           public int getValueCardinality()
           {
-            throw new UnsupportedOperationException("value cardinality is unknown in incremental index");
+            return DimensionSelector.CARDINALITY_UNKNOWN;
           }
 
           @Override

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -4589,19 +4589,11 @@ public class GroupByQueryRunnerTest
         .setGranularity(QueryRunnerTestHelper.allGran)
         .build();
 
-    // v2 strategy would throw an exception for this because the dimension selector in GroupByRowProcessor is not
-    // dictionary encoded, but instead require the row to be set when doing lookup. Null Pointer Exception occurs
-    // when the filter aggregator is initialized with no row set.
-    if (config.getDefaultStrategy().equals(GroupByStrategySelector.STRATEGY_V2)) {
-      expectedException.expect(NullPointerException.class);
-      GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);
-    } else {
-      List<Row> expectedResults = Arrays.asList(
-          GroupByQueryRunnerTestHelper.createExpectedRow("1970-01-01", "rows", 837L)
-      );
-      Iterable<Row> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);
-      TestHelper.assertExpectedObjects(expectedResults, results, "");
-    }
+    List<Row> expectedResults = Arrays.asList(
+        GroupByQueryRunnerTestHelper.createExpectedRow("1970-01-01", "rows", 837L)
+    );
+    Iterable<Row> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);
+    TestHelper.assertExpectedObjects(expectedResults, results, "");
   }
 
   @Test

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
@@ -143,10 +143,10 @@ public class IncrementalIndexStorageAdapterTest
     Assert.assertEquals(2, results.size());
 
     MapBasedRow row = (MapBasedRow) results.get(0);
-    Assert.assertEquals(ImmutableMap.of("billy", "hi", "cnt", 1L), row.getEvent());
+    Assert.assertEquals(ImmutableMap.of("sally", "bo", "cnt", 1L), row.getEvent());
 
     row = (MapBasedRow) results.get(1);
-    Assert.assertEquals(ImmutableMap.of("sally", "bo", "cnt", 1L), row.getEvent());
+    Assert.assertEquals(ImmutableMap.of("billy", "hi", "cnt", 1L), row.getEvent());
   }
 
   @Test


### PR DESCRIPTION
The common theme between the two is they both create "fake" DimensionSelectors
that work on top of Rows. They both do it because there isn't really any
dictionary for the underlying Rows, they're just a stream of data. The fix for
both is to allow a DimensionSelector to tell callers that it has no dictionary
by returning CARDINALITY_UNKNOWN from getValueCardinality. The callers, in
turn, can avoid using it in ways that assume it has a dictionary.

Fixes #3311.