### PR TITLE
optionally dump list of segment-ids used to process the query

### DIFF
--- a/api/src/main/java/io/druid/query/SegmentDescriptor.java
+++ b/api/src/main/java/io/druid/query/SegmentDescriptor.java
@@ -21,6 +21,7 @@ package io.druid.query;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.druid.timeline.DataSegment;
 import org.joda.time.Interval;
 
 /**
@@ -84,6 +85,16 @@ public class SegmentDescriptor
     }
 
     return true;
+  }
+
+  public String getSegmentIdWithoutDataSource()
+  {
+    return DataSegment.makeDataSegmentIdentifierWithoutDataSource(
+        interval.getStart(),
+        interval.getEnd(),
+        version,
+        partitionNumber
+    );
   }
 
   @Override

--- a/api/src/main/java/io/druid/timeline/DataSegment.java
+++ b/api/src/main/java/io/druid/timeline/DataSegment.java
@@ -48,7 +48,7 @@ import java.util.Map;
  */
 public class DataSegment implements Comparable<DataSegment>
 {
-  public static String delimiter = "_";
+  public final static String DELIMITER = "_";
   private final Integer binaryVersion;
   private static final Interner<String> interner = Interners.newWeakInterner();
   private static final Function<String, String> internFun = new Function<String, String>()
@@ -70,18 +70,43 @@ public class DataSegment implements Comparable<DataSegment>
   {
     StringBuilder sb = new StringBuilder();
 
-    sb.append(dataSource).append(delimiter)
-      .append(start).append(delimiter)
-      .append(end).append(delimiter)
-      .append(version);
-
-    if (shardSpec.getPartitionNum() != 0) {
-      sb.append(delimiter).append(shardSpec.getPartitionNum());
-    }
+    sb.append(dataSource).append(DELIMITER);
+    updateBuilderWithSegmentIdWithoutDataSource(sb, start, end, version, shardSpec.getPartitionNum());
 
     return sb.toString();
   }
 
+  private static void updateBuilderWithSegmentIdWithoutDataSource(
+      StringBuilder sb,
+      DateTime start,
+      DateTime end,
+      String version,
+      int partitionNum
+  )
+  {
+    sb.append(start).append(DELIMITER)
+      .append(end).append(DELIMITER)
+      .append(version);
+
+    if (partitionNum != 0) {
+      sb.append(DELIMITER).append(partitionNum);
+    }
+  }
+
+  public static String makeDataSegmentIdentifierWithoutDataSource(
+      DateTime start,
+      DateTime end,
+      String version,
+      int partitionNum
+  )
+  {
+    StringBuilder sb = new StringBuilder();
+
+    updateBuilderWithSegmentIdWithoutDataSource(sb, start, end, version, partitionNum);
+
+    return sb.toString();
+  }
+  
   private final String dataSource;
   private final Interval interval;
   private final String version;

--- a/api/src/main/java/io/druid/timeline/DataSegmentUtils.java
+++ b/api/src/main/java/io/druid/timeline/DataSegmentUtils.java
@@ -64,7 +64,7 @@ public class DataSegmentUtils
       return null;
     }
     String remaining = identifier.substring(dataSource.length() + 1);
-    String[] splits = remaining.split(DataSegment.delimiter);
+    String[] splits = remaining.split(DataSegment.DELIMITER);
     if (splits.length < 3) {
       LOGGER.info("Invalid identifier %s", identifier);
       return null;
@@ -74,7 +74,7 @@ public class DataSegmentUtils
     DateTime start = formatter.parseDateTime(splits[0]);
     DateTime end = formatter.parseDateTime(splits[1]);
     String version = splits[2];
-    String trail = splits.length > 3 ? join(splits, DataSegment.delimiter, 3, splits.length) : null;
+    String trail = splits.length > 3 ? join(splits, DataSegment.DELIMITER, 3, splits.length) : null;
 
     return new SegmentIdentifierParts(
         dataSource,
@@ -169,7 +169,7 @@ public class DataSegmentUtils
     {
       return join(
           new Object[]{dataSource, interval.getStart(), interval.getEnd(), version, trail},
-          DataSegment.delimiter, 0, version == null ? 3 : trail == null ? 4 : 5
+          DataSegment.DELIMITER, 0, version == null ? 3 : trail == null ? 4 : 5
       );
     }
   }

--- a/processing/src/main/java/io/druid/query/BaseQuery.java
+++ b/processing/src/main/java/io/druid/query/BaseQuery.java
@@ -67,6 +67,11 @@ public abstract class BaseQuery<T extends Comparable<T>> implements Query<T>
     return parseInt(query, "uncoveredIntervalsLimit", defaultValue);
   }
 
+  public static <T> boolean getContextDumpSegmentList(Query<T> query, boolean defaultValue)
+  {
+    return parseBoolean(query, "dumpSegmentList", defaultValue);
+  }
+
   private static <T> int parseInt(Query<T> query, String key, int defaultValue)
   {
     Object val = query.getContextValue(key);

--- a/server/src/main/java/io/druid/client/CachingClusteredClient.java
+++ b/server/src/main/java/io/druid/client/CachingClusteredClient.java
@@ -248,6 +248,15 @@ public class CachingClusteredClient<T> implements QueryRunner<T>
       }
     }
 
+    // Optionally dump all used segmentIds in processing this query
+    if (BaseQuery.getContextDumpSegmentList(query, false)) {
+      List<String> segmentIds = new ArrayList<>(segments.size());
+      for (Pair<ServerSelector, SegmentDescriptor> segment : segments) {
+        segmentIds.add(segment.rhs.getSegmentIdWithoutDataSource());
+      }
+      responseContext.put("segments", segmentIds);
+    }
+
     final byte[] queryCacheKey;
 
     if ((populateCache || useCache) // implies strategy != null


### PR DESCRIPTION
"/druid/v3" introduced in #3319 can handle larger context objects.

enabled by "dumpSegmentList" flag in the query context.

having the list of all segment-ids returned to user has 2 primary use-cases.

1. user can see exactly what timelines were found and not found, accordingly user can choose to use the result or error out or appropriately adjust the visualization.
2. some users have caches on top of druid that cache whole query results, they can use a hash of segments used in the cache key. users typically get the list of loaded segments from coordinator HTTP endpoints (or segment metadata query) and based on that they can check whether to use cached result or not.

i'm leaving this option undocumented intentionally for now as it should only be used with "/druid/v3" really.