### PR TITLE
Actually allow to create new kafka lookups

### DIFF
--- a/extensions-core/kafka-extraction-namespace/src/main/java/io/druid/query/lookup/KafkaLookupExtractorFactory.java
+++ b/extensions-core/kafka-extraction-namespace/src/main/java/io/druid/query/lookup/KafkaLookupExtractorFactory.java
@@ -321,11 +321,7 @@ public class KafkaLookupExtractorFactory implements LookupExtractorFactory
       return false;
     }
 
-    if (other == null) {
-      return false;
-    }
-
-    if (getClass() != other.getClass()) {
+    if (other == null || getClass() != other.getClass()) {
       return true;
     }
 

--- a/extensions-core/kafka-extraction-namespace/src/test/java/io/druid/query/lookup/KafkaLookupExtractorFactoryTest.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/io/druid/query/lookup/KafkaLookupExtractorFactoryTest.java
@@ -195,6 +195,9 @@ public class KafkaLookupExtractorFactoryTest
         TOPIC,
         DEFAULT_PROPERTIES
     );
+
+    Assert.assertTrue(factory.replaces(null));
+
     Assert.assertTrue(factory.replaces(new MapLookupExtractorFactory(ImmutableMap.<String, String>of(), false)));
     Assert.assertFalse(factory.replaces(factory));
     Assert.assertFalse(factory.replaces(new KafkaLookupExtractorFactory(


### PR DESCRIPTION
The problem was that attempting to add a new Kafka-based lookup via API would return `202 ACCEPTED`, but the lookups would not actually appear in subsequent queries.

A quick investigation showed that all the other (`map` and `cachedNamespace`)  `LookupExtractorFactory.replaces()` implementations return `true` for `null`, but for Kafka it returns `false`.

With this change, adding a new lookup works fine.