### PR TITLE
Nicer handling for cancelled groupBy v2 queries.

### DIFF
--- a/common/src/main/java/io/druid/collections/ReferenceCountingResourceHolder.java
+++ b/common/src/main/java/io/druid/collections/ReferenceCountingResourceHolder.java
@@ -42,6 +42,11 @@ public class ReferenceCountingResourceHolder<T> implements ResourceHolder<T>
     this.closer = closer;
   }
 
+  public static <T extends Closeable> ReferenceCountingResourceHolder<T> fromCloseable(final T object)
+  {
+    return new ReferenceCountingResourceHolder<>(object, object);
+  }
+
   @Override
   public T get()
   {

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/CloseableGrouperIterator.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/CloseableGrouperIterator.java
@@ -28,7 +28,6 @@ import java.util.Iterator;
 
 public class CloseableGrouperIterator<KeyType extends Comparable<KeyType>, T> implements Iterator<T>, Closeable
 {
-  private final Grouper<KeyType> grouper;
   private final Function<Grouper.Entry<KeyType>, T> transformer;
   private final Closeable closer;
   private final Iterator<Grouper.Entry<KeyType>> iterator;
@@ -40,7 +39,6 @@ public class CloseableGrouperIterator<KeyType extends Comparable<KeyType>, T> im
       final Closeable closer
   )
   {
-    this.grouper = grouper;
     this.transformer = transformer;
     this.closer = closer;
     this.iterator = grouper.iterator(sorted);

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -35,6 +35,7 @@ import com.metamx.common.guava.Accumulator;
 import io.druid.data.input.MapBasedRow;
 import io.druid.data.input.Row;
 import io.druid.granularity.AllGranularity;
+import io.druid.query.QueryInterruptedException;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.dimension.DimensionSpec;
 import io.druid.query.extraction.ExtractionFn;
@@ -126,6 +127,10 @@ public class RowBasedGrouperHelper
           final Row row
       )
       {
+        if (Thread.interrupted()) {
+          throw new QueryInterruptedException(new InterruptedException());
+        }
+
         if (theGrouper == null) {
           // Pass-through null returns without doing more work.
           return null;


### PR DESCRIPTION
1. Wrap temporaryStorage in a resource holder, to avoid spurious "Closed" errors from already-running processing tasks.
2. Exit early from the merging accumulator if the query is cancelled.