### PR TITLE
Mask properties from logging

### DIFF
--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -82,7 +82,7 @@ All nodes can log debugging information on startup.
 |Property|Description|Default|
 |--------|-----------|-------|
 |`druid.startup.logging.logProperties`|Log all properties on startup (from common.runtime.properties, runtime.properties, and the JVM command line).|false|
-|`druid.startup.logging.maskProperties`|Masks sensitive properties (passwords, for example) containing theses words.|[]|
+|`druid.startup.logging.maskProperties`|Masks sensitive properties (passwords, for example) containing theses words.|["password"]|
 
 Note that some sensitive information may be logged if these settings are enabled.
 

--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -82,6 +82,7 @@ All nodes can log debugging information on startup.
 |Property|Description|Default|
 |--------|-----------|-------|
 |`druid.startup.logging.logProperties`|Log all properties on startup (from common.runtime.properties, runtime.properties, and the JVM command line).|false|
+|`druid.startup.logging.maskProperties`|Masks sensitive properties (passwords, for example) containing theses words.|[]|
 
 Note that some sensitive information may be logged if these settings are enabled.
 

--- a/server/src/main/java/io/druid/server/log/StartupLoggingConfig.java
+++ b/server/src/main/java/io/druid/server/log/StartupLoggingConfig.java
@@ -20,14 +20,25 @@
 package io.druid.server.log;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
 
 public class StartupLoggingConfig
 {
   @JsonProperty
   private boolean logProperties = false;
 
+  @JsonProperty
+  private List<String> maskProperties = ImmutableList.of();
+
   public boolean isLogProperties()
   {
     return logProperties;
+  }
+
+  public List<String> getMaskProperties()
+  {
+    return maskProperties;
   }
 }

--- a/server/src/main/java/io/druid/server/log/StartupLoggingConfig.java
+++ b/server/src/main/java/io/druid/server/log/StartupLoggingConfig.java
@@ -30,7 +30,7 @@ public class StartupLoggingConfig
   private boolean logProperties = false;
 
   @JsonProperty
-  private List<String> maskProperties = ImmutableList.of();
+  private List<String> maskProperties = ImmutableList.of("password");
 
   public boolean isLogProperties()
   {

--- a/services/src/main/java/io/druid/cli/GuiceRunnable.java
+++ b/services/src/main/java/io/druid/cli/GuiceRunnable.java
@@ -21,6 +21,7 @@ package io.druid.cli;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.Ordering;
+import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Module;
@@ -32,6 +33,7 @@ import io.druid.server.log.StartupLoggingConfig;
 
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 
 /**
  */
@@ -80,10 +82,18 @@ public abstract class GuiceRunnable implements Runnable
       );
 
       if (startupLoggingConfig.isLogProperties()) {
+        final Set<String> maskProperties = Sets.newHashSet(startupLoggingConfig.getMaskProperties());
         final Properties props = injector.getInstance(Properties.class);
 
         for (String propertyName : Ordering.natural().sortedCopy(props.stringPropertyNames())) {
-          log.info("* %s: %s", propertyName, props.getProperty(propertyName));
+          String property = props.getProperty(propertyName);
+          for (String masked : maskProperties) {
+            if (propertyName.contains(masked)) {
+              property = "<masked>";
+              break;
+            }
+          }
+          log.info("* %s: %s", propertyName, property);
         }
       }
 


### PR DESCRIPTION
For masking some properties, https://groups.google.com/forum/m/#!topic/druid-user/nAj6PPXMNdU

```
druid.startup.logging.maskProperties=["user", "password", "URI"]
```