### PR TITLE
More informative query unit test names

### DIFF
--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
@@ -51,17 +51,31 @@ public class ApproximateHistogramGroupByQueryTest
 {
   private final QueryRunner<Row> runner;
   private GroupByQueryRunnerFactory factory;
+  private String testName;
 
-  @Parameterized.Parameters
+  @Parameterized.Parameters(name="{0}")
   public static Iterable<Object[]> constructorFeeder() throws IOException
   {
-    final GroupByQueryConfig defaultConfig = new GroupByQueryConfig();
+    final GroupByQueryConfig defaultConfig = new GroupByQueryConfig()
+    {
+      @Override
+      public String toString()
+      {
+        return "default";
+      }
+    };
     final GroupByQueryConfig singleThreadedConfig = new GroupByQueryConfig()
     {
       @Override
       public boolean isSingleThreaded()
       {
         return true;
+      }
+
+      @Override
+      public String toString()
+      {
+        return "singleThreaded";
       }
     };
     final GroupByQueryConfig v2Config = new GroupByQueryConfig()
@@ -70,6 +84,12 @@ public class ApproximateHistogramGroupByQueryTest
       public String getDefaultStrategy()
       {
         return GroupByStrategySelector.STRATEGY_V2;
+      }
+
+      @Override
+      public String toString()
+      {
+        return "v2";
       }
     };
 
@@ -86,15 +106,21 @@ public class ApproximateHistogramGroupByQueryTest
     for (GroupByQueryConfig config : configs) {
       final GroupByQueryRunnerFactory factory = GroupByQueryRunnerTest.makeQueryRunnerFactory(config);
       for (QueryRunner<Row> runner : QueryRunnerTestHelper.makeQueryRunners(factory)) {
-        constructors.add(new Object[]{factory, runner});
+        final String testName = String.format(
+            "config=%s, runner=%s",
+            config.toString(),
+            runner.toString()
+        );
+        constructors.add(new Object[]{testName, factory, runner});
       }
     }
 
     return constructors;
   }
 
-  public ApproximateHistogramGroupByQueryTest(GroupByQueryRunnerFactory factory, QueryRunner runner)
+  public ApproximateHistogramGroupByQueryTest(String testName, GroupByQueryRunnerFactory factory, QueryRunner runner)
   {
+    this.testName = testName;
     this.factory = factory;
     this.runner = runner;
   }

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramTopNQueryTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramTopNQueryTest.java
@@ -54,7 +54,7 @@ import java.util.Map;
 @RunWith(Parameterized.class)
 public class ApproximateHistogramTopNQueryTest
 {
-  @Parameterized.Parameters
+  @Parameterized.Parameters(name="{0}")
   public static Iterable<Object[]> constructorFeeder() throws IOException
   {
     return QueryRunnerTestHelper.transformToConstructionFeeder(

--- a/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceGroupByQueryTest.java
+++ b/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceGroupByQueryTest.java
@@ -60,15 +60,17 @@ public class VarianceGroupByQueryTest
   private final GroupByQueryConfig config;
   private final QueryRunner<Row> runner;
   private final GroupByQueryRunnerFactory factory;
+  private final String testName;
 
-  @Parameterized.Parameters
+  @Parameterized.Parameters(name="{0}")
   public static Collection<?> constructorFeeder() throws IOException
   {
     return GroupByQueryRunnerTest.constructorFeeder();
   }
 
-  public VarianceGroupByQueryTest(GroupByQueryConfig config, GroupByQueryRunnerFactory factory, QueryRunner runner)
+  public VarianceGroupByQueryTest(String testName, GroupByQueryConfig config, GroupByQueryRunnerFactory factory, QueryRunner runner)
   {
+    this.testName = testName;
     this.config = config;
     this.factory = factory;
     this.runner = factory.mergeRunners(MoreExecutors.sameThreadExecutor(), ImmutableList.<QueryRunner<Row>>of(runner));

--- a/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceTopNQueryTest.java
+++ b/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceTopNQueryTest.java
@@ -50,7 +50,7 @@ import java.util.Map;
 @RunWith(Parameterized.class)
 public class VarianceTopNQueryTest
 {
-  @Parameterized.Parameters
+  @Parameterized.Parameters(name="{0}")
   public static Iterable<Object[]> constructorFeeder() throws IOException
   {
     return TopNQueryRunnerTest.constructorFeeder();

--- a/processing/src/test/java/io/druid/query/MultiValuedDimensionTest.java
+++ b/processing/src/test/java/io/druid/query/MultiValuedDimensionTest.java
@@ -299,7 +299,8 @@ public class MultiValuedDimensionTest
     );
     QueryRunner<Result<TopNResultValue>> runner = QueryRunnerTestHelper.makeQueryRunner(
         factory,
-        new QueryableIndexSegment("sid1", queryableIndex)
+        new QueryableIndexSegment("sid1", queryableIndex),
+        null
     );
     Map<String, Object> context = Maps.newHashMap();
     Sequence<Result<TopNResultValue>> result = runner.run(query, context);

--- a/processing/src/test/java/io/druid/query/datasourcemetadata/DataSourceMetadataQueryTest.java
+++ b/processing/src/test/java/io/druid/query/datasourcemetadata/DataSourceMetadataQueryTest.java
@@ -118,7 +118,8 @@ public class DataSourceMetadataQueryTest
     final QueryRunner runner = QueryRunnerTestHelper.makeQueryRunner(
         (QueryRunnerFactory) new DataSourceMetadataQueryRunnerFactory(
             QueryRunnerTestHelper.NOOP_QUERYWATCHER
-        ), new IncrementalIndexSegment(rtIndex, "test")
+        ), new IncrementalIndexSegment(rtIndex, "test"),
+        null
     );
     DateTime timestamp = new DateTime(System.currentTimeMillis());
     rtIndex.add(

--- a/processing/src/test/java/io/druid/query/groupby/GroupByTimeseriesQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByTimeseriesQueryRunnerTest.java
@@ -51,7 +51,7 @@ import java.util.Map;
 public class GroupByTimeseriesQueryRunnerTest extends TimeseriesQueryRunnerTest
 {
   @SuppressWarnings("unchecked")
-  @Parameterized.Parameters
+  @Parameterized.Parameters(name="{0}")
   public static Iterable<Object[]> constructorFeeder() throws IOException
   {
     GroupByQueryConfig config = new GroupByQueryConfig();
@@ -99,6 +99,12 @@ public class GroupByTimeseriesQueryRunnerTest extends TimeseriesQueryRunnerTest
                           }
                         }
                     );
+                  }
+
+                  @Override
+                  public String toString()
+                  {
+                    return input.toString();
                   }
                 };
               }

--- a/processing/src/test/java/io/druid/query/metadata/SegmentAnalyzerTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentAnalyzerTest.java
@@ -167,7 +167,9 @@ public class SegmentAnalyzerTest
         (QueryRunnerFactory) new SegmentMetadataQueryRunnerFactory(
             new SegmentMetadataQueryQueryToolChest(new SegmentMetadataQueryConfig()),
             QueryRunnerTestHelper.NOOP_QUERYWATCHER
-        ), index
+        ),
+        index,
+        null
     );
 
     final SegmentMetadataQuery query = new SegmentMetadataQuery(

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
@@ -88,7 +88,8 @@ public class SegmentMetadataQueryTest
     return QueryRunnerTestHelper.makeQueryRunner(
         factory,
         segmentId,
-        new QueryableIndexSegment(segmentId, index)
+        new QueryableIndexSegment(segmentId, index),
+        null
     );
   }
 
@@ -103,7 +104,8 @@ public class SegmentMetadataQueryTest
     return QueryRunnerTestHelper.makeQueryRunner(
         factory,
         segmentId,
-        new IncrementalIndexSegment(index, segmentId)
+        new IncrementalIndexSegment(index, segmentId),
+        null
     );
   }
 

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataUnionQueryTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataUnionQueryTest.java
@@ -74,8 +74,9 @@ public class SegmentMetadataUnionQueryTest
                 new QueryableIndexSegment(
                     QueryRunnerTestHelper.segmentId,
                     TestIndex.getMMappedTestIndex()
-                )
-            ), true
+                ),
+                null
+            ), true,
         },
         new Object[]{
             QueryRunnerTestHelper.makeUnionQueryRunner(
@@ -83,7 +84,8 @@ public class SegmentMetadataUnionQueryTest
                 new IncrementalIndexSegment(
                     TestIndex.getIncrementalTestIndex(),
                     QueryRunnerTestHelper.segmentId
-                )
+                ),
+                null
             ), false
         }
     );

--- a/processing/src/test/java/io/druid/query/search/SearchQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/search/SearchQueryRunnerTest.java
@@ -67,7 +67,7 @@ public class SearchQueryRunnerTest
       QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
   );
 
-  @Parameterized.Parameters
+  @Parameterized.Parameters(name="{0}")
   public static Iterable<Object[]> constructorFeeder() throws IOException
   {
     return QueryRunnerTestHelper.transformToConstructionFeeder(

--- a/processing/src/test/java/io/druid/query/search/SearchQueryRunnerWithCaseTest.java
+++ b/processing/src/test/java/io/druid/query/search/SearchQueryRunnerWithCaseTest.java
@@ -91,10 +91,10 @@ public class SearchQueryRunnerWithCaseTest
 
     return transformToConstructionFeeder(
         Arrays.asList(
-            makeQueryRunner(factory, "index1", new IncrementalIndexSegment(index1, "index1")),
-            makeQueryRunner(factory, "index2", new IncrementalIndexSegment(index2, "index2")),
-            makeQueryRunner(factory, "index3", new QueryableIndexSegment("index3", index3)),
-            makeQueryRunner(factory, "index4", new QueryableIndexSegment("index4", index4))
+            makeQueryRunner(factory, "index1", new IncrementalIndexSegment(index1, "index1"), "index1"),
+            makeQueryRunner(factory, "index2", new IncrementalIndexSegment(index2, "index2"), "index2"),
+            makeQueryRunner(factory, "index3", new QueryableIndexSegment("index3", index3), "index3"),
+            makeQueryRunner(factory, "index4", new QueryableIndexSegment("index4", index4), "index4")
         )
     );
   }

--- a/processing/src/test/java/io/druid/query/timeboundary/TimeBoundaryQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/timeboundary/TimeBoundaryQueryRunnerTest.java
@@ -45,7 +45,7 @@ import java.util.Map;
 @RunWith(Parameterized.class)
 public class TimeBoundaryQueryRunnerTest
 {
-  @Parameterized.Parameters
+  @Parameterized.Parameters(name="{0}")
   public static Iterable<Object[]> constructorFeeder() throws IOException
   {
     return QueryRunnerTestHelper.transformToConstructionFeeder(

--- a/processing/src/test/java/io/druid/query/topn/TopNQueryQueryToolChestTest.java
+++ b/processing/src/test/java/io/druid/query/topn/TopNQueryQueryToolChestTest.java
@@ -121,7 +121,8 @@ public class TopNQueryQueryToolChestTest
     );
     QueryRunner<Result<TopNResultValue>> runner = QueryRunnerTestHelper.makeQueryRunner(
         factory,
-        new IncrementalIndexSegment(TestIndex.getIncrementalTestIndex(), segmentId)
+        new IncrementalIndexSegment(TestIndex.getIncrementalTestIndex(), segmentId),
+        null
     );
 
     Map<String, Object> context = Maps.newHashMap();

--- a/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerBenchmark.java
+++ b/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerBenchmark.java
@@ -106,21 +106,24 @@ public class TopNQueryRunnerBenchmark extends AbstractBenchmark
         TestCases.rtIndex,
         QueryRunnerTestHelper.makeQueryRunner(
             factory,
-            new IncrementalIndexSegment(TestIndex.getIncrementalTestIndex(), segmentId)
+            new IncrementalIndexSegment(TestIndex.getIncrementalTestIndex(), segmentId),
+            null
         )
     );
     testCaseMap.put(
         TestCases.mMappedTestIndex,
         QueryRunnerTestHelper.makeQueryRunner(
             factory,
-            new QueryableIndexSegment(segmentId, TestIndex.getMMappedTestIndex())
+            new QueryableIndexSegment(segmentId, TestIndex.getMMappedTestIndex()),
+            null
         )
     );
     testCaseMap.put(
         TestCases.mergedRealtimeIndex,
         QueryRunnerTestHelper.makeQueryRunner(
             factory,
-            new QueryableIndexSegment(segmentId, TestIndex.mergedRealtimeIndex())
+            new QueryableIndexSegment(segmentId, TestIndex.mergedRealtimeIndex()),
+            null
         )
     );
     //Thread.sleep(10000);

--- a/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerTest.java
@@ -90,7 +90,7 @@ import java.util.Map;
 @RunWith(Parameterized.class)
 public class TopNQueryRunnerTest
 {
-  @Parameterized.Parameters
+  @Parameterized.Parameters(name="{0}")
   public static Iterable<Object[]> constructorFeeder() throws IOException
   {
     List<QueryRunner<Result<TopNResultValue>>> retVal = Lists.newArrayList();

--- a/processing/src/test/java/io/druid/query/topn/TopNUnionQueryTest.java
+++ b/processing/src/test/java/io/druid/query/topn/TopNUnionQueryTest.java
@@ -57,7 +57,7 @@ public class TopNUnionQueryTest
     this.runner = runner;
   }
 
-  @Parameterized.Parameters
+  @Parameterized.Parameters(name="{0}")
   public static Iterable<Object[]> constructorFeeder() throws IOException
   {
     return QueryRunnerTestHelper.cartesian(

--- a/server/src/test/java/io/druid/segment/realtime/RealtimeManagerTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/RealtimeManagerTest.java
@@ -606,13 +606,15 @@ public class RealtimeManagerTest
         interval_26_28,
         QueryRunnerTestHelper.makeQueryRunner(
             factory,
-            "druid.sample.tsv.top"
+            "druid.sample.tsv.top",
+            null
         )
         ,
         interval_28_29,
         QueryRunnerTestHelper.makeQueryRunner(
             factory,
-            "druid.sample.tsv.bottom"
+            "druid.sample.tsv.bottom",
+            null
         )
     );
     plumber.setRunners(runnerMap);


### PR DESCRIPTION
Changes the query tests to include parameters in their names, e.g.:

GroupBy:
```
config=default, runner=noRollupMMappedTestIndex
```
instead of
```
[2]
```


Timeseries:
```
mergedRealtimeIndex:descending=true
```
instead of 
```
io.druid.query.FinalizeResultsQueryRunner@1e8b7643:descending=false
```