### PR TITLE
Restore optimizations in BoundFilter.

### DIFF
--- a/benchmarks/src/main/java/io/druid/benchmark/query/TimeseriesBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/TimeseriesBenchmark.java
@@ -109,7 +109,7 @@ public class TimeseriesBenchmark
   @Param({"750000"})
   private int rowsPerSegment;
 
-  @Param({"basic.A", "basic.timeFilter", "basic.timeFilterAlphanumeric", "basic.timeFilterByInterval"})
+  @Param({"basic.A", "basic.timeFilterNumeric", "basic.timeFilterAlphanumeric", "basic.timeFilterByInterval"})
   private String schemaAndQuery;
 
   private static final Logger log = new Logger(TimeseriesBenchmark.class);
@@ -190,7 +190,7 @@ public class TimeseriesBenchmark
                 .descending(false)
                 .build();
 
-      basicQueries.put("timeFilter", timeFilterQuery);
+      basicQueries.put("timeFilterNumeric", timeFilterQuery);
     }
     {
       QuerySegmentSpec intervalSpec = new MultipleIntervalSegmentSpec(Arrays.asList(basicSchema.getDataInterval()));


### PR DESCRIPTION
Some of the rejiggering in #3270 inadvertently disabled the optimization from #2727.

one day #2823 would catch stuff like this automatically!