### PR TITLE
fix NPE if queueBufferLength is null in KafkaEightSimpleConsumerFireh…

### DIFF
--- a/extensions-contrib/kafka-eight-simpleConsumer/src/main/java/io/druid/firehose/kafka/KafkaEightSimpleConsumerFirehoseFactory.java
+++ b/extensions-contrib/kafka-eight-simpleConsumer/src/main/java/io/druid/firehose/kafka/KafkaEightSimpleConsumerFirehoseFactory.java
@@ -106,7 +106,7 @@ public class KafkaEightSimpleConsumerFirehoseFactory implements
     );
 
     this.queueBufferLength = queueBufferLength == null ? DEFAULT_QUEUE_BUFFER_LENGTH : queueBufferLength;
-    Preconditions.checkArgument(queueBufferLength > 0, "queueBufferLength must be positive number");
+    Preconditions.checkArgument(this.queueBufferLength > 0, "queueBufferLength must be positive number");
     log.info("queueBufferLength loaded as[%s]", this.queueBufferLength);
 
     this.earliest = resetOffsetToEarliest == null ? true : resetOffsetToEarliest.booleanValue();


### PR DESCRIPTION
…oseFactory
`
Preconditions.checkArgument(queueBufferLength > 0, "queueBufferLength must be positive number");`

should be
`
Preconditions.checkArgument(this.queueBufferLength > 0, "queueBufferLength must be positive number");`