### PR TITLE
fix can't get latest offset in KafkaEightSimpleConsumerFirehoseFactory

### DIFF
--- a/extensions-contrib/kafka-eight-simpleConsumer/src/main/java/io/druid/firehose/kafka/KafkaEightSimpleConsumerFirehoseFactory.java
+++ b/extensions-contrib/kafka-eight-simpleConsumer/src/main/java/io/druid/firehose/kafka/KafkaEightSimpleConsumerFirehoseFactory.java
@@ -153,7 +153,7 @@ public class KafkaEightSimpleConsumerFirehoseFactory implements
       );
       Long startOffset = lastOffsets.get(partition);
       PartitionConsumerWorker worker = new PartitionConsumerWorker(
-          feed, kafkaSimpleConsumer, partition, startOffset == null ? 0 : startOffset
+          feed, kafkaSimpleConsumer, partition, startOffset == null ? -1 : startOffset
       );
       consumerWorkers.add(worker);
     }

--- a/extensions-contrib/kafka-eight-simpleConsumer/src/main/java/io/druid/firehose/kafka/KafkaSimpleConsumer.java
+++ b/extensions-contrib/kafka-eight-simpleConsumer/src/main/java/io/druid/firehose/kafka/KafkaSimpleConsumer.java
@@ -238,7 +238,7 @@ public class KafkaSimpleConsumer
       }
       catch (Exception e) {
         ensureNotInterrupted(e);
-        log.warn(e, "caughte exception in fetch {} - {}", topic, partitionId);
+        log.warn(e, "caught exception in fetch {} - {}", topic, partitionId);
         response = null;
       }
 


### PR DESCRIPTION
when startOffset is null which means the first time coming in, the offset is set to 0
```
      PartitionConsumerWorker worker = new PartitionConsumerWorker(
          feed, kafkaSimpleConsumer, partition, startOffset == null ? 0 : startOffset
      );
```
This will cause the kafka fetch to start from 0 offset, which is a valid offset meaning earliest.
```
      FetchRequest request = new FetchRequestBuilder()
          .clientId(clientId)
          .addFetch(topic, partitionId, offset, FETCH_SIZE)
          .maxWait(timeoutMs)
          .minBytes(1)
          .build();

      log.debug("fetch offset %s", offset);

      try {
        response = consumer.fetch(request);
      }
      catch (Exception e) {
        ensureNotInterrupted(e);
        log.warn(e, "caught exception in fetch {} - {}", topic, partitionId);
        response = null;
      }
```
The offset can only be reset to latest by calling "getOffset(earliest)" when reponse is null
```
      if (response == null || response.hasError()) {
        short errorCode = response != null ? response.errorCode(topic, partitionId) : ErrorMapping.UnknownCode();
        log.warn("fetch %s - %s with offset %s encounters error: [%s]", topic, partitionId, offset, errorCode);

        boolean needNewLeader = false;
        if (errorCode == ErrorMapping.RequestTimedOutCode()) {
          log.info("kafka request timed out, response[%s]", response);
        } else if (errorCode == ErrorMapping.OffsetOutOfRangeCode()) {
          long newOffset = getOffset(earliest);
```

To fix this, we can just set startOffset to -1 if it is null to make the "response" to null to force calling getOffset()