### PR TITLE
Initialize ApproximateHistogram Module in ApproximateHistogramGroupByQueryTest

### DIFF
--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
@@ -123,6 +123,9 @@ public class ApproximateHistogramGroupByQueryTest
     this.testName = testName;
     this.factory = factory;
     this.runner = runner;
+
+    //Note: this is needed in order to properly register the serde for Histogram.
+    new ApproximateHistogramDruidModule().configure(null);
   }
 
   @Test


### PR DESCRIPTION
or else the test fails if ran independently.