### PR TITLE
fix misusage of dimension as string instead of dimensionSchema in DataSchema

### DIFF
--- a/server/src/main/java/io/druid/segment/indexing/DataSchema.java
+++ b/server/src/main/java/io/druid/segment/indexing/DataSchema.java
@@ -113,7 +113,7 @@ public class DataSchema
       // exclude timestamp from dimensions by default, unless explicitly included in the list of dimensions
       if (timestampSpec != null) {
         final String timestampColumn = timestampSpec.getTimestampColumn();
-        if (!(dimensionsSpec.hasCustomDimensions() && dimensionsSpec.getDimensions().contains(timestampColumn))) {
+        if (!(dimensionsSpec.hasCustomDimensions() && dimensionsSpec.getDimensionNames().contains(timestampColumn))) {
           dimensionExclusions.add(timestampColumn);
         }
       }


### PR DESCRIPTION
The return type of dimensionsSpec.getDimensions() is DImensionSchema, timestampColumn is String, so `dimensionsSpec.getDimensions().contains(timestampColumn)`
 always return false