### PR TITLE
fix cleanup of hadoop ingestion intermediate path

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerConfig.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerConfig.java
@@ -487,7 +487,7 @@ public class HadoopDruidIndexerConfig
   {
     return new Path(
         String.format(
-            "%s/%s/%s/%s",
+            "%s/%s/%s_%s",
             getWorkingPath(),
             schema.getDataSchema().getDataSource(),
             schema.getTuningConfig().getVersion().replace(":", ""),


### PR DESCRIPTION
currently, intermediate path is like...

```
/global-work-dir/dataSource/version/uuid
```

so when task runs, then "intermediate path" creation leads to creation of following 2 directories on hdfs (instead of just 1 directory) ...


```
/global-work-dir/dataSource/version
/global-work-dir/dataSource/version/uuid
```
and the cleanup would clean intermediate path and leaves following empty directory behind

```
/global-work-dir/dataSource/version
```


this patch changes the intermediate path to

```
/global-work-dir/dataSource/version_uuid
```

so that only 1 directory is created and then deleted appropriately which was also the behavior before https://github.com/druid-io/druid/pull/2049