### PR TITLE
Deprecate Aggregator#getName()

### DIFF
--- a/extensions-contrib/distinctcount/src/main/java/io/druid/query/aggregation/distinctcount/DistinctCountAggregator.java
+++ b/extensions-contrib/distinctcount/src/main/java/io/druid/query/aggregation/distinctcount/DistinctCountAggregator.java
@@ -26,17 +26,14 @@ import io.druid.segment.DimensionSelector;
 public class DistinctCountAggregator implements Aggregator
 {
 
-  private final String name;
   private final DimensionSelector selector;
   private final MutableBitmap mutableBitmap;
 
   public DistinctCountAggregator(
-      String name,
       DimensionSelector selector,
       MutableBitmap mutableBitmap
   )
   {
-    this.name = name;
     this.selector = selector;
     this.mutableBitmap = mutableBitmap;
   }
@@ -65,12 +62,6 @@ public class DistinctCountAggregator implements Aggregator
   public float getFloat()
   {
     return (float) mutableBitmap.size();
-  }
-
-  @Override
-  public String getName()
-  {
-    return name;
   }
 
   @Override

--- a/extensions-contrib/distinctcount/src/main/java/io/druid/query/aggregation/distinctcount/DistinctCountAggregatorFactory.java
+++ b/extensions-contrib/distinctcount/src/main/java/io/druid/query/aggregation/distinctcount/DistinctCountAggregatorFactory.java
@@ -68,10 +68,9 @@ public class DistinctCountAggregatorFactory extends AggregatorFactory
   {
     DimensionSelector selector = makeDimensionSelector(columnFactory);
     if (selector == null) {
-      return new EmptyDistinctCountAggregator(name);
+      return new EmptyDistinctCountAggregator();
     } else {
       return new DistinctCountAggregator(
-          name,
           selector,
           bitMapFactory.makeEmptyMutableBitmap()
       );

--- a/extensions-contrib/distinctcount/src/main/java/io/druid/query/aggregation/distinctcount/EmptyDistinctCountAggregator.java
+++ b/extensions-contrib/distinctcount/src/main/java/io/druid/query/aggregation/distinctcount/EmptyDistinctCountAggregator.java
@@ -23,14 +23,6 @@ import io.druid.query.aggregation.Aggregator;
 
 public class EmptyDistinctCountAggregator implements Aggregator
 {
-
-  private final String name;
-
-  public EmptyDistinctCountAggregator(String name)
-  {
-    this.name = name;
-  }
-
   @Override
   public void aggregate()
   {
@@ -51,12 +43,6 @@ public class EmptyDistinctCountAggregator implements Aggregator
   public float getFloat()
   {
     return (float) 0;
-  }
-
-  @Override
-  public String getName()
-  {
-    return name;
   }
 
   @Override

--- a/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/EmptySketchAggregator.java
+++ b/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/EmptySketchAggregator.java
@@ -23,13 +23,6 @@ import io.druid.query.aggregation.Aggregator;
 
 public class EmptySketchAggregator implements Aggregator
 {
-  private final String name;
-
-  public EmptySketchAggregator(String name)
-  {
-    this.name = name;
-  }
-
   @Override
   public void aggregate()
   {
@@ -56,12 +49,6 @@ public class EmptySketchAggregator implements Aggregator
   public long getLong()
   {
     throw new UnsupportedOperationException("Not implemented");
-  }
-
-  @Override
-  public String getName()
-  {
-    return name;
   }
 
   @Override

--- a/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchAggregator.java
+++ b/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchAggregator.java
@@ -36,16 +36,12 @@ public class SketchAggregator implements Aggregator
   private static final Logger logger = new Logger(SketchAggregator.class);
 
   private final ObjectColumnSelector selector;
-  private final String name;
-  private final int size;
 
   private Union union;
 
-  public SketchAggregator(String name, ObjectColumnSelector selector, int size)
+  public SketchAggregator(ObjectColumnSelector selector, int size)
   {
-    this.name = name;
     this.selector = selector;
-    this.size = size;
     union = new SynchronizedUnion((Union) SetOperation.builder().build(size, Family.UNION));
   }
 
@@ -87,12 +83,6 @@ public class SketchAggregator implements Aggregator
   public long getLong()
   {
     throw new UnsupportedOperationException("Not implemented");
-  }
-
-  @Override
-  public String getName()
-  {
-    return name;
   }
 
   @Override

--- a/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchAggregatorFactory.java
@@ -77,9 +77,9 @@ public abstract class SketchAggregatorFactory extends AggregatorFactory
   {
     ObjectColumnSelector selector = metricFactory.makeObjectColumnSelector(fieldName);
     if (selector == null) {
-      return new EmptySketchAggregator(name);
+      return new EmptySketchAggregator();
     } else {
-      return new SketchAggregator(name, selector, size);
+      return new SketchAggregator(selector, size);
     }
   }
 

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregator.java
@@ -41,7 +41,6 @@ public class ApproximateHistogramAggregator implements Aggregator
     return ((ApproximateHistogram) lhs).foldFast((ApproximateHistogram) rhs);
   }
 
-  private final String name;
   private final FloatColumnSelector selector;
   private final int resolution;
   private final float lowerLimit;
@@ -50,14 +49,12 @@ public class ApproximateHistogramAggregator implements Aggregator
   private ApproximateHistogram histogram;
 
   public ApproximateHistogramAggregator(
-      String name,
       FloatColumnSelector selector,
       int resolution,
       float lowerLimit,
       float upperLimit
   )
   {
-    this.name = name;
     this.selector = selector;
     this.resolution = resolution;
     this.lowerLimit = lowerLimit;
@@ -93,12 +90,6 @@ public class ApproximateHistogramAggregator implements Aggregator
   public long getLong()
   {
     throw new UnsupportedOperationException("ApproximateHistogramAggregator does not support getLong()");
-  }
-
-  @Override
-  public String getName()
-  {
-    return name;
   }
 
   @Override

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
@@ -80,7 +80,6 @@ public class ApproximateHistogramAggregatorFactory extends AggregatorFactory
   public Aggregator factorize(ColumnSelectorFactory metricFactory)
   {
     return new ApproximateHistogramAggregator(
-        name,
         metricFactory.makeFloatColumnSelector(fieldName),
         resolution,
         lowerLimit,

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregator.java
@@ -25,7 +25,6 @@ import io.druid.segment.ObjectColumnSelector;
 
 public class ApproximateHistogramFoldingAggregator implements Aggregator
 {
-  private final String name;
   private final ObjectColumnSelector<ApproximateHistogram> selector;
   private final int resolution;
   private final float lowerLimit;
@@ -36,14 +35,12 @@ public class ApproximateHistogramFoldingAggregator implements Aggregator
   private long[] tmpBufferB;
 
   public ApproximateHistogramFoldingAggregator(
-      String name,
       ObjectColumnSelector<ApproximateHistogram> selector,
       int resolution,
       float lowerLimit,
       float upperLimit
   )
   {
-    this.name = name;
     this.selector = selector;
     this.resolution = resolution;
     this.lowerLimit = lowerLimit;
@@ -91,12 +88,6 @@ public class ApproximateHistogramFoldingAggregator implements Aggregator
   public long getLong()
   {
     throw new UnsupportedOperationException("ApproximateHistogramFoldingAggregator does not support getLong()");
-  }
-
-  @Override
-  public String getName()
-  {
-    return name;
   }
 
   @Override

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregatorFactory.java
@@ -79,7 +79,6 @@ public class ApproximateHistogramFoldingAggregatorFactory extends ApproximateHis
     final Class cls = selector.classOfObject();
     if (cls.equals(Object.class) || ApproximateHistogram.class.isAssignableFrom(cls)) {
       return new ApproximateHistogramFoldingAggregator(
-          name,
           selector,
           resolution,
           lowerLimit,

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramPostAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramPostAggregatorTest.java
@@ -45,14 +45,14 @@ public class ApproximateHistogramPostAggregatorTest
     ApproximateHistogram ah = buildHistogram(10, VALUES);
     final TestFloatColumnSelector selector = new TestFloatColumnSelector(VALUES);
 
-    ApproximateHistogramAggregator agg = new ApproximateHistogramAggregator("price", selector, 10, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY);
+    ApproximateHistogramAggregator agg = new ApproximateHistogramAggregator(selector, 10, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY);
     for (int i = 0; i < VALUES.length; i++) {
       agg.aggregate();
       selector.increment();
     }
 
     Map<String, Object> metricValues = new HashMap<String, Object>();
-    metricValues.put(agg.getName(), agg.get());
+    metricValues.put("price", agg.get());
 
     ApproximateHistogramPostAggregator approximateHistogramPostAggregator = new EqualBucketsPostAggregator(
         "approxHist",

--- a/extensions-core/stats/src/main/java/io/druid/query/aggregation/variance/VarianceAggregator.java
+++ b/extensions-core/stats/src/main/java/io/druid/query/aggregation/variance/VarianceAggregator.java
@@ -28,14 +28,7 @@ import io.druid.segment.ObjectColumnSelector;
  */
 public abstract class VarianceAggregator implements Aggregator
 {
-  protected final String name;
-
   protected final VarianceAggregatorCollector holder = new VarianceAggregatorCollector();
-
-  public VarianceAggregator(String name)
-  {
-    this.name = name;
-  }
 
   @Override
   public void reset()
@@ -47,12 +40,6 @@ public abstract class VarianceAggregator implements Aggregator
   public Object get()
   {
     return holder;
-  }
-
-  @Override
-  public String getName()
-  {
-    return name;
   }
 
   @Override
@@ -76,9 +63,8 @@ public abstract class VarianceAggregator implements Aggregator
   {
     private final FloatColumnSelector selector;
 
-    public FloatVarianceAggregator(String name, FloatColumnSelector selector)
+    public FloatVarianceAggregator(FloatColumnSelector selector)
     {
-      super(name);
       this.selector = selector;
     }
 
@@ -93,9 +79,8 @@ public abstract class VarianceAggregator implements Aggregator
   {
     private final LongColumnSelector selector;
 
-    public LongVarianceAggregator(String name, LongColumnSelector selector)
+    public LongVarianceAggregator(LongColumnSelector selector)
     {
-      super(name);
       this.selector = selector;
     }
 
@@ -110,9 +95,8 @@ public abstract class VarianceAggregator implements Aggregator
   {
     private final ObjectColumnSelector selector;
 
-    public ObjectVarianceAggregator(String name, ObjectColumnSelector selector)
+    public ObjectVarianceAggregator(ObjectColumnSelector selector)
     {
-      super(name);
       this.selector = selector;
     }
 

--- a/extensions-core/stats/src/main/java/io/druid/query/aggregation/variance/VarianceAggregatorFactory.java
+++ b/extensions-core/stats/src/main/java/io/druid/query/aggregation/variance/VarianceAggregatorFactory.java
@@ -99,16 +99,14 @@ public class VarianceAggregatorFactory extends AggregatorFactory
 
     if ("float".equalsIgnoreCase(inputType)) {
       return new VarianceAggregator.FloatVarianceAggregator(
-          name,
           metricFactory.makeFloatColumnSelector(fieldName)
       );
     } else if ("long".equalsIgnoreCase(inputType)) {
       return new VarianceAggregator.LongVarianceAggregator(
-          name,
           metricFactory.makeLongColumnSelector(fieldName)
       );
     } else if ("variance".equalsIgnoreCase(inputType)) {
-      return new VarianceAggregator.ObjectVarianceAggregator(name, selector);
+      return new VarianceAggregator.ObjectVarianceAggregator(selector);
     }
     throw new IAE(
         "Incompatible type for metric[%s], expected a float, long or variance, got a %s", fieldName, inputType

--- a/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceAggregatorTest.java
+++ b/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceAggregatorTest.java
@@ -76,8 +76,6 @@ public class VarianceAggregatorTest
   {
     VarianceAggregator agg = (VarianceAggregator) aggFactory.factorize(colSelectorFactory);
 
-    Assert.assertEquals("billy", agg.getName());
-
     assertValues((VarianceAggregatorCollector) agg.get(), 0, 0d, 0d);
     aggregate(selector, agg);
     assertValues((VarianceAggregatorCollector) agg.get(), 1, 1.1d, 0d);

--- a/indexing-hadoop/src/main/java/io/druid/indexer/InputRowSerde.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/InputRowSerde.java
@@ -98,9 +98,9 @@ public class InputRowSerde
         catch (ParseException e) {
           // "aggregate" can throw ParseExceptions if a selector expects something but gets something else.
           if (reportParseExceptions) {
-            throw new ParseException(e, "Encountered parse error for aggregator[%s]", agg.getName());
+            throw new ParseException(e, "Encountered parse error for aggregator[%s]", k);
           }
-          log.debug(e, "Encountered parse error, skipping aggregator[%s].", agg.getName());
+          log.debug(e, "Encountered parse error, skipping aggregator[%s].", k);
         }
 
         String t = aggFactory.getTypeName();

--- a/processing/src/main/java/io/druid/query/QueryRunnerHelper.java
+++ b/processing/src/main/java/io/druid/query/QueryRunnerHelper.java
@@ -55,6 +55,16 @@ public class QueryRunnerHelper
     return aggregators;
   }
 
+  public static String[] makeAggregatorNames(List<AggregatorFactory> aggregatorSpecs)
+  {
+    String[] aggregators = new String[aggregatorSpecs.size()];
+    int aggregatorIndex = 0;
+    for (AggregatorFactory spec : aggregatorSpecs) {
+      aggregators[aggregatorIndex++] = spec.getName();
+    }
+    return aggregators;
+  }
+
   public static <T> Sequence<Result<T>> makeCursorBasedQuery(
       final StorageAdapter adapter,
       List<Interval> queryIntervals,

--- a/processing/src/main/java/io/druid/query/aggregation/Aggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/Aggregator.java
@@ -37,6 +37,7 @@ public interface Aggregator {
   void reset();
   Object get();
   float getFloat();
+  @Deprecated
   String getName();
   void close();
 

--- a/processing/src/main/java/io/druid/query/aggregation/Aggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/Aggregator.java
@@ -37,8 +37,6 @@ public interface Aggregator {
   void reset();
   Object get();
   float getFloat();
-  @Deprecated
-  String getName();
   void close();
 
   long getLong();

--- a/processing/src/main/java/io/druid/query/aggregation/Aggregators.java
+++ b/processing/src/main/java/io/druid/query/aggregation/Aggregators.java
@@ -53,11 +53,6 @@ public class Aggregators
         return 0;
       }
 
-      public String getName()
-      {
-        return null;
-      }
-
       @Override
       public void close()
       {

--- a/processing/src/main/java/io/druid/query/aggregation/Aggregators.java
+++ b/processing/src/main/java/io/druid/query/aggregation/Aggregators.java
@@ -53,7 +53,6 @@ public class Aggregators
         return 0;
       }
 
-      @Override
       public String getName()
       {
         return null;

--- a/processing/src/main/java/io/druid/query/aggregation/CountAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/CountAggregator.java
@@ -33,12 +33,6 @@ public class CountAggregator implements Aggregator
   }
 
   long count = 0;
-  private final String name;
-
-  public CountAggregator(String name)
-  {
-    this.name = name;
-  }
 
   @Override
   public void aggregate()
@@ -71,15 +65,9 @@ public class CountAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    return this.name;
-  }
-
-  @Override
   public Aggregator clone()
   {
-    return new CountAggregator(name);
+    return new CountAggregator();
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/CountAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/CountAggregatorFactory.java
@@ -50,7 +50,7 @@ public class CountAggregatorFactory extends AggregatorFactory
   @Override
   public Aggregator factorize(ColumnSelectorFactory metricFactory)
   {
-    return new CountAggregator(name);
+    return new CountAggregator();
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/DoubleMaxAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/DoubleMaxAggregator.java
@@ -35,13 +35,11 @@ public class DoubleMaxAggregator implements Aggregator
   }
 
   private final FloatColumnSelector selector;
-  private final String name;
 
   private double max;
 
-  public DoubleMaxAggregator(String name, FloatColumnSelector selector)
+  public DoubleMaxAggregator(FloatColumnSelector selector)
   {
-    this.name = name;
     this.selector = selector;
 
     reset();
@@ -78,15 +76,9 @@ public class DoubleMaxAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    return this.name;
-  }
-
-  @Override
   public Aggregator clone()
   {
-    return new DoubleMaxAggregator(name, selector);
+    return new DoubleMaxAggregator(selector);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/DoubleMaxAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/DoubleMaxAggregatorFactory.java
@@ -56,7 +56,7 @@ public class DoubleMaxAggregatorFactory extends AggregatorFactory
   @Override
   public Aggregator factorize(ColumnSelectorFactory metricFactory)
   {
-    return new DoubleMaxAggregator(name, metricFactory.makeFloatColumnSelector(fieldName));
+    return new DoubleMaxAggregator(metricFactory.makeFloatColumnSelector(fieldName));
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/DoubleMinAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/DoubleMinAggregator.java
@@ -35,13 +35,11 @@ public class DoubleMinAggregator implements Aggregator
   }
 
   private final FloatColumnSelector selector;
-  private final String name;
 
   private double min;
 
-  public DoubleMinAggregator(String name, FloatColumnSelector selector)
+  public DoubleMinAggregator(FloatColumnSelector selector)
   {
-    this.name = name;
     this.selector = selector;
 
     reset();
@@ -78,15 +76,9 @@ public class DoubleMinAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    return this.name;
-  }
-
-  @Override
   public Aggregator clone()
   {
-    return new DoubleMinAggregator(name, selector);
+    return new DoubleMinAggregator(selector);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/DoubleMinAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/DoubleMinAggregatorFactory.java
@@ -56,7 +56,7 @@ public class DoubleMinAggregatorFactory extends AggregatorFactory
   @Override
   public Aggregator factorize(ColumnSelectorFactory metricFactory)
   {
-    return new DoubleMinAggregator(name, metricFactory.makeFloatColumnSelector(fieldName));
+    return new DoubleMinAggregator(metricFactory.makeFloatColumnSelector(fieldName));
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/DoubleSumAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/DoubleSumAggregator.java
@@ -44,13 +44,11 @@ public class DoubleSumAggregator implements Aggregator
   }
 
   private final FloatColumnSelector selector;
-  private final String name;
 
   private double sum;
 
-  public DoubleSumAggregator(String name, FloatColumnSelector selector)
+  public DoubleSumAggregator(FloatColumnSelector selector)
   {
-    this.name = name;
     this.selector = selector;
 
     this.sum = 0;
@@ -87,15 +85,9 @@ public class DoubleSumAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    return this.name;
-  }
-
-  @Override
   public Aggregator clone()
   {
-    return new DoubleSumAggregator(name, selector);
+    return new DoubleSumAggregator(selector);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/DoubleSumAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/DoubleSumAggregatorFactory.java
@@ -57,7 +57,6 @@ public class DoubleSumAggregatorFactory extends AggregatorFactory
   public Aggregator factorize(ColumnSelectorFactory metricFactory)
   {
     return new DoubleSumAggregator(
-        name,
         metricFactory.makeFloatColumnSelector(fieldName)
     );
   }

--- a/processing/src/main/java/io/druid/query/aggregation/FilteredAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/FilteredAggregator.java
@@ -65,12 +65,6 @@ public class FilteredAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    return delegate.getName();
-  }
-
-  @Override
   public void close()
   {
     delegate.close();

--- a/processing/src/main/java/io/druid/query/aggregation/HistogramAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/HistogramAggregator.java
@@ -40,12 +40,10 @@ public class HistogramAggregator implements Aggregator
   }
 
   private final FloatColumnSelector selector;
-  private final String name;
 
   private Histogram histogram;
 
-  public HistogramAggregator(String name, FloatColumnSelector selector, float[] breaks) {
-    this.name = name;
+  public HistogramAggregator(FloatColumnSelector selector, float[] breaks) {
     this.selector = selector;
     this.histogram = new Histogram(breaks);
   }
@@ -78,12 +76,6 @@ public class HistogramAggregator implements Aggregator
   public long getLong()
   {
     throw new UnsupportedOperationException("HistogramAggregator does not support getLong()");
-  }
-
-  @Override
-  public String getName()
-  {
-    return name;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/HistogramAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/HistogramAggregatorFactory.java
@@ -67,7 +67,6 @@ public class HistogramAggregatorFactory extends AggregatorFactory
   public Aggregator factorize(ColumnSelectorFactory metricFactory)
   {
     return new HistogramAggregator(
-        name,
         metricFactory.makeFloatColumnSelector(fieldName),
         breaks
     );

--- a/processing/src/main/java/io/druid/query/aggregation/JavaScriptAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/JavaScriptAggregator.java
@@ -37,15 +37,13 @@ public class JavaScriptAggregator implements Aggregator
     public void close();
   }
 
-  private final String name;
   private final ObjectColumnSelector[] selectorList;
   private final ScriptAggregator script;
 
   private volatile double current;
 
-  public JavaScriptAggregator(String name, List<ObjectColumnSelector> selectorList, ScriptAggregator script)
+  public JavaScriptAggregator(List<ObjectColumnSelector> selectorList, ScriptAggregator script)
   {
-    this.name = name;
     this.selectorList = Lists.newArrayList(selectorList).toArray(new ObjectColumnSelector[]{});
     this.script = script;
 
@@ -80,12 +78,6 @@ public class JavaScriptAggregator implements Aggregator
   public long getLong()
   {
     return (long) current;
-  }
-
-  @Override
-  public String getName()
-  {
-    return name;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/JavaScriptAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/JavaScriptAggregatorFactory.java
@@ -96,7 +96,6 @@ public class JavaScriptAggregatorFactory extends AggregatorFactory
   public Aggregator factorize(final ColumnSelectorFactory columnFactory)
   {
     return new JavaScriptAggregator(
-        name,
         Lists.transform(
             fieldNames,
             new com.google.common.base.Function<String, ObjectColumnSelector>()

--- a/processing/src/main/java/io/druid/query/aggregation/LongMaxAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/LongMaxAggregator.java
@@ -35,13 +35,11 @@ public class LongMaxAggregator implements Aggregator
   }
 
   private final LongColumnSelector selector;
-  private final String name;
 
   private long max;
 
-  public LongMaxAggregator(String name, LongColumnSelector selector)
+  public LongMaxAggregator(LongColumnSelector selector)
   {
-    this.name = name;
     this.selector = selector;
 
     reset();
@@ -78,15 +76,9 @@ public class LongMaxAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    return this.name;
-  }
-
-  @Override
   public Aggregator clone()
   {
-    return new LongMaxAggregator(name, selector);
+    return new LongMaxAggregator(selector);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/LongMaxAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/LongMaxAggregatorFactory.java
@@ -56,7 +56,7 @@ public class LongMaxAggregatorFactory extends AggregatorFactory
   @Override
   public Aggregator factorize(ColumnSelectorFactory metricFactory)
   {
-    return new LongMaxAggregator(name, metricFactory.makeLongColumnSelector(fieldName));
+    return new LongMaxAggregator(metricFactory.makeLongColumnSelector(fieldName));
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/LongMinAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/LongMinAggregator.java
@@ -35,13 +35,11 @@ public class LongMinAggregator implements Aggregator
   }
 
   private final LongColumnSelector selector;
-  private final String name;
 
   private long min;
 
-  public LongMinAggregator(String name, LongColumnSelector selector)
+  public LongMinAggregator(LongColumnSelector selector)
   {
-    this.name = name;
     this.selector = selector;
 
     reset();
@@ -78,15 +76,9 @@ public class LongMinAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    return this.name;
-  }
-
-  @Override
   public Aggregator clone()
   {
-    return new LongMinAggregator(name, selector);
+    return new LongMinAggregator(selector);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/LongMinAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/LongMinAggregatorFactory.java
@@ -56,7 +56,7 @@ public class LongMinAggregatorFactory extends AggregatorFactory
   @Override
   public Aggregator factorize(ColumnSelectorFactory metricFactory)
   {
-    return new LongMinAggregator(name, metricFactory.makeLongColumnSelector(fieldName));
+    return new LongMinAggregator(metricFactory.makeLongColumnSelector(fieldName));
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/LongSumAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/LongSumAggregator.java
@@ -42,13 +42,11 @@ public class LongSumAggregator implements Aggregator
   }
 
   private final LongColumnSelector selector;
-  private final String name;
 
   private long sum;
 
-  public LongSumAggregator(String name, LongColumnSelector selector)
+  public LongSumAggregator(LongColumnSelector selector)
   {
-    this.name = name;
     this.selector = selector;
 
     this.sum = 0;
@@ -85,15 +83,9 @@ public class LongSumAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    return name;
-  }
-
-  @Override
   public Aggregator clone()
   {
-    return new LongSumAggregator(name, selector);
+    return new LongSumAggregator(selector);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/LongSumAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/LongSumAggregatorFactory.java
@@ -57,7 +57,6 @@ public class LongSumAggregatorFactory extends AggregatorFactory
   public Aggregator factorize(ColumnSelectorFactory metricFactory)
   {
     return new LongSumAggregator(
-        name,
         metricFactory.makeLongColumnSelector(fieldName)
     );
   }

--- a/processing/src/main/java/io/druid/query/aggregation/cardinality/CardinalityAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/cardinality/CardinalityAggregator.java
@@ -34,7 +34,6 @@ public class CardinalityAggregator implements Aggregator
 {
   private static final String NULL_STRING = "\u0000";
 
-  private final String name;
   private final List<DimensionSelector> selectorList;
   private final boolean byRow;
 
@@ -87,12 +86,10 @@ public class CardinalityAggregator implements Aggregator
   private HyperLogLogCollector collector;
 
   public CardinalityAggregator(
-      String name,
       List<DimensionSelector> selectorList,
       boolean byRow
   )
   {
-    this.name = name;
     this.selectorList = selectorList;
     this.collector = HyperLogLogCollector.makeLatestCollector();
     this.byRow = byRow;
@@ -133,15 +130,9 @@ public class CardinalityAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    return name;
-  }
-
-  @Override
   public Aggregator clone()
   {
-    return new CardinalityAggregator(name, selectorList, byRow);
+    return new CardinalityAggregator(selectorList, byRow);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/cardinality/CardinalityAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/cardinality/CardinalityAggregatorFactory.java
@@ -82,7 +82,7 @@ public class CardinalityAggregatorFactory extends AggregatorFactory
       return Aggregators.noopAggregator();
     }
 
-    return new CardinalityAggregator(name, selectors, byRow);
+    return new CardinalityAggregator(selectors, byRow);
   }
 
 

--- a/processing/src/main/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregator.java
@@ -26,17 +26,14 @@ import io.druid.segment.ObjectColumnSelector;
  */
 public class HyperUniquesAggregator implements Aggregator
 {
-  private final String name;
   private final ObjectColumnSelector selector;
 
   private HyperLogLogCollector collector;
 
   public HyperUniquesAggregator(
-      String name,
       ObjectColumnSelector selector
   )
   {
-    this.name = name;
     this.selector = selector;
 
     this.collector = HyperLogLogCollector.makeLatestCollector();
@@ -73,15 +70,9 @@ public class HyperUniquesAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    return name;
-  }
-
-  @Override
   public Aggregator clone()
   {
-    return new HyperUniquesAggregator(name, selector);
+    return new HyperUniquesAggregator(selector);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
@@ -77,7 +77,7 @@ public class HyperUniquesAggregatorFactory extends AggregatorFactory
 
     final Class classOfObject = selector.classOfObject();
     if (classOfObject.equals(Object.class) || HyperLogLogCollector.class.isAssignableFrom(classOfObject)) {
-      return new HyperUniquesAggregator(name, selector);
+      return new HyperUniquesAggregator(selector);
     }
 
     throw new IAE(

--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryEngine.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryEngine.java
@@ -61,6 +61,7 @@ public class TimeseriesQueryEngine
           @Override
           public Result<TimeseriesResultValue> apply(Cursor cursor)
           {
+            String[] aggregatorNames = QueryRunnerHelper.makeAggregatorNames(aggregatorSpecs);
             Aggregator[] aggregators = QueryRunnerHelper.makeAggregators(cursor, aggregatorSpecs);
 
             if (skipEmptyBuckets && cursor.isDone()) {
@@ -77,12 +78,11 @@ public class TimeseriesQueryEngine
 
               TimeseriesResultBuilder bob = new TimeseriesResultBuilder(cursor.getTime());
 
-              for (Aggregator aggregator : aggregators) {
-                bob.addMetric(aggregator);
+              for (int i = 0; i < aggregators.length; i++) {
+                bob.addMetric(aggregatorNames[i], aggregators[i]);
               }
 
-              Result<TimeseriesResultValue> retVal = bob.build();
-              return retVal;
+              return bob.build();
             }
             finally {
               // cleanup

--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesResultBuilder.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesResultBuilder.java
@@ -42,9 +42,9 @@ public class TimeseriesResultBuilder
     this.timestamp = timestamp;
   }
 
-  public TimeseriesResultBuilder addMetric(Aggregator aggregator)
+  public TimeseriesResultBuilder addMetric(String name, Aggregator aggregator)
   {
-    metricValues.put(aggregator.getName(), aggregator.get());
+    metricValues.put(name, aggregator.get());
     return this;
   }
 

--- a/processing/src/test/java/io/druid/query/aggregation/CountAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/CountAggregatorTest.java
@@ -33,8 +33,6 @@ public class CountAggregatorTest
   {
     CountAggregator agg = new CountAggregator("billy");
 
-    Assert.assertEquals("billy", agg.getName());
-
     Assert.assertEquals(0L, agg.get());
     Assert.assertEquals(0L, agg.get());
     Assert.assertEquals(0L, agg.get());

--- a/processing/src/test/java/io/druid/query/aggregation/CountAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/CountAggregatorTest.java
@@ -31,7 +31,7 @@ public class CountAggregatorTest
   @Test
   public void testAggregate()
   {
-    CountAggregator agg = new CountAggregator("billy");
+    CountAggregator agg = new CountAggregator();
 
     Assert.assertEquals(0L, agg.get());
     Assert.assertEquals(0L, agg.get());
@@ -49,7 +49,7 @@ public class CountAggregatorTest
   @Test
   public void testComparator()
   {
-    CountAggregator agg = new CountAggregator("billy");
+    CountAggregator agg = new CountAggregator();
 
     Object first = agg.get();
     agg.aggregate();

--- a/processing/src/test/java/io/druid/query/aggregation/DoubleMaxAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/DoubleMaxAggregationTest.java
@@ -59,8 +59,6 @@ public class DoubleMaxAggregationTest
   {
     DoubleMaxAggregator agg = (DoubleMaxAggregator) doubleMaxAggFactory.factorize(colSelectorFactory);
 
-    Assert.assertEquals("billy", agg.getName());
-
     aggregate(selector, agg);
     aggregate(selector, agg);
     aggregate(selector, agg);

--- a/processing/src/test/java/io/druid/query/aggregation/DoubleMinAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/DoubleMinAggregationTest.java
@@ -59,8 +59,6 @@ public class DoubleMinAggregationTest
   {
     DoubleMinAggregator agg = (DoubleMinAggregator) doubleMinAggFactory.factorize(colSelectorFactory);
 
-    Assert.assertEquals("billy", agg.getName());
-
     aggregate(selector, agg);
     aggregate(selector, agg);
     aggregate(selector, agg);

--- a/processing/src/test/java/io/druid/query/aggregation/DoubleSumAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/DoubleSumAggregatorTest.java
@@ -39,9 +39,7 @@ public class DoubleSumAggregatorTest
   {
     final float[] values = {0.15f, 0.27f};
     final TestFloatColumnSelector selector = new TestFloatColumnSelector(values);
-    DoubleSumAggregator agg = new DoubleSumAggregator("billy", selector);
-
-    Assert.assertEquals("billy", agg.getName());
+    DoubleSumAggregator agg = new DoubleSumAggregator(selector);
 
     double expectedFirst = new Float(values[0]).doubleValue();
     double expectedSecond = new Float(values[1]).doubleValue() + expectedFirst;
@@ -63,9 +61,7 @@ public class DoubleSumAggregatorTest
   public void testComparator()
   {
     final TestFloatColumnSelector selector = new TestFloatColumnSelector(new float[]{0.15f, 0.27f});
-    DoubleSumAggregator agg = new DoubleSumAggregator("billy", selector);
-
-    Assert.assertEquals("billy", agg.getName());
+    DoubleSumAggregator agg = new DoubleSumAggregator(selector);
 
     Object first = agg.get();
     agg.aggregate();

--- a/processing/src/test/java/io/druid/query/aggregation/FilteredAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/FilteredAggregatorTest.java
@@ -74,8 +74,6 @@ public class FilteredAggregatorTest
      makeColumnSelector(selector)
     );
 
-    Assert.assertEquals("billy", agg.getName());
-
     double expectedFirst = new Float(values[0]).doubleValue();
     double expectedSecond = new Float(values[1]).doubleValue() + expectedFirst;
     double expectedThird = expectedSecond;
@@ -228,8 +226,6 @@ public class FilteredAggregatorTest
         makeColumnSelector(selector)
     );
 
-    Assert.assertEquals("billy", agg.getName());
-
     double expectedFirst = new Float(values[0]).doubleValue();
     double expectedSecond = new Float(values[1]).doubleValue() + expectedFirst;
     double expectedThird = expectedSecond + new Float(values[2]).doubleValue();
@@ -351,8 +347,6 @@ public class FilteredAggregatorTest
     FilteredAggregator agg = (FilteredAggregator) factory.factorize(
         makeColumnSelector(selector)
     );
-
-    Assert.assertEquals("billy", agg.getName());
 
     double expectedFirst = new Float(values[0]).doubleValue();
     double expectedSecond = new Float(values[1]).doubleValue() + expectedFirst;

--- a/processing/src/test/java/io/druid/query/aggregation/HistogramAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/HistogramAggregatorTest.java
@@ -59,9 +59,7 @@ public class HistogramAggregatorTest
 
     final TestFloatColumnSelector selector = new TestFloatColumnSelector(values);
 
-    HistogramAggregator agg = new HistogramAggregator("billy", selector, breaks);
-
-    Assert.assertEquals("billy", agg.getName());
+    HistogramAggregator agg = new HistogramAggregator(selector, breaks);
 
     Assert.assertArrayEquals(new long[]{0,0,0,0,0,0}, ((Histogram)agg.get()).bins);
     Assert.assertArrayEquals(new long[]{0,0,0,0,0,0}, ((Histogram)agg.get()).bins);

--- a/processing/src/test/java/io/druid/query/aggregation/JavaScriptAggregatorBenchmark.java
+++ b/processing/src/test/java/io/druid/query/aggregation/JavaScriptAggregatorBenchmark.java
@@ -54,7 +54,6 @@ public class JavaScriptAggregatorBenchmark extends SimpleBenchmark
     Map<String, String> script = scriptDoubleSum;
 
     jsAggregator = new JavaScriptAggregator(
-        "billy",
         Lists.asList(MetricSelectorUtils.wrap(selector), new ObjectColumnSelector[]{}),
         JavaScriptAggregatorFactory.compileScript(
             script.get("fnAggregate"),
@@ -63,7 +62,7 @@ public class JavaScriptAggregatorBenchmark extends SimpleBenchmark
         )
     );
 
-    doubleAgg = new DoubleSumAggregator("billy", selector);
+    doubleAgg = new DoubleSumAggregator(selector);
   }
 
   public double timeJavaScriptDoubleSum(int reps)

--- a/processing/src/test/java/io/druid/query/aggregation/JavaScriptAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/JavaScriptAggregatorTest.java
@@ -131,7 +131,6 @@ public class JavaScriptAggregatorTest
     Map<String, String> script = sumLogATimesBPlusTen;
 
     JavaScriptAggregator agg = new JavaScriptAggregator(
-        "billy",
         Arrays.<ObjectColumnSelector>asList(MetricSelectorUtils.wrap(selector1), MetricSelectorUtils.wrap(selector2)),
         JavaScriptAggregatorFactory.compileScript(
             script.get("fnAggregate"),
@@ -141,8 +140,6 @@ public class JavaScriptAggregatorTest
     );
 
     agg.reset();
-
-    Assert.assertEquals("billy", agg.getName());
 
     double val = 10.;
     Assert.assertEquals(val, agg.get());
@@ -206,7 +203,6 @@ public class JavaScriptAggregatorTest
     Map<String, String> script = scriptDoubleSum;
 
     JavaScriptAggregator agg = new JavaScriptAggregator(
-        "billy",
         Collections.<ObjectColumnSelector>singletonList(null),
         JavaScriptAggregatorFactory.compileScript(
             script.get("fnAggregate"),
@@ -216,8 +212,6 @@ public class JavaScriptAggregatorTest
     );
 
     final double val = 0;
-
-    Assert.assertEquals("billy", agg.getName());
 
     agg.reset();
     Assert.assertEquals(val, agg.get());
@@ -240,7 +234,6 @@ public class JavaScriptAggregatorTest
   {
     final TestObjectColumnSelector ocs = new TestObjectColumnSelector("what", null, new String[]{"hey", "there"});
     final JavaScriptAggregator agg = new JavaScriptAggregator(
-        "billy",
         Collections.<ObjectColumnSelector>singletonList(ocs),
         JavaScriptAggregatorFactory.compileScript(
             "function aggregate(current, a) { if (Array.isArray(a)) { return current + a.length; } else if (typeof a === 'string') { return current + 1; } else { return current; } }",
@@ -250,8 +243,6 @@ public class JavaScriptAggregatorTest
     );
 
     agg.reset();
-
-    Assert.assertEquals("billy", agg.getName());
 
     double val = 0.;
     Assert.assertEquals(val, agg.get());
@@ -336,7 +327,6 @@ public class JavaScriptAggregatorTest
 
     Map<String, String> script = scriptDoubleSum;
     JavaScriptAggregator aggRhino = new JavaScriptAggregator(
-        "billy",
         Lists.asList(MetricSelectorUtils.wrap(selector), new ObjectColumnSelector[]{}),
         JavaScriptAggregatorFactory.compileScript(
             script.get("fnAggregate"),
@@ -345,7 +335,7 @@ public class JavaScriptAggregatorTest
         )
     );
 
-    DoubleSumAggregator doubleAgg = new DoubleSumAggregator("billy", selector);
+    DoubleSumAggregator doubleAgg = new DoubleSumAggregator(selector);
 
     // warmup
     int i = 0;

--- a/processing/src/test/java/io/druid/query/aggregation/LongMaxAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/LongMaxAggregationTest.java
@@ -59,8 +59,6 @@ public class LongMaxAggregationTest
   {
     LongMaxAggregator agg = (LongMaxAggregator)longMaxAggFactory.factorize(colSelectorFactory);
 
-    Assert.assertEquals("billy", agg.getName());
-
     aggregate(selector, agg);
     aggregate(selector, agg);
     aggregate(selector, agg);

--- a/processing/src/test/java/io/druid/query/aggregation/LongMinAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/LongMinAggregationTest.java
@@ -59,8 +59,6 @@ public class LongMinAggregationTest
   {
     LongMinAggregator agg = (LongMinAggregator)longMinAggFactory.factorize(colSelectorFactory);
 
-    Assert.assertEquals("billy", agg.getName());
-
     aggregate(selector, agg);
     aggregate(selector, agg);
     aggregate(selector, agg);

--- a/processing/src/test/java/io/druid/query/aggregation/LongSumAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/LongSumAggregatorTest.java
@@ -38,9 +38,7 @@ public class LongSumAggregatorTest
   public void testAggregate()
   {
     final TestLongColumnSelector selector = new TestLongColumnSelector(new long[]{24L, 20L});
-    LongSumAggregator agg = new LongSumAggregator("billy", selector);
-
-    Assert.assertEquals("billy", agg.getName());
+    LongSumAggregator agg = new LongSumAggregator(selector);
 
     Assert.assertEquals(0L, agg.get());
     Assert.assertEquals(0L, agg.get());
@@ -59,9 +57,7 @@ public class LongSumAggregatorTest
   public void testComparator()
   {
     final TestLongColumnSelector selector = new TestLongColumnSelector(new long[]{18293L});
-    LongSumAggregator agg = new LongSumAggregator("billy", selector);
-
-    Assert.assertEquals("billy", agg.getName());
+    LongSumAggregator agg = new LongSumAggregator(selector);
 
     Object first = agg.get();
     agg.aggregate();

--- a/processing/src/test/java/io/druid/query/aggregation/MetricManipulatorFnsTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/MetricManipulatorFnsTest.java
@@ -42,7 +42,7 @@ public class MetricManipulatorFnsTest
     final ArrayList<Object[]> constructorArrays = new ArrayList<>();
     final long longVal = 13789;
     LongMinAggregator longMinAggregator = new LongMinAggregator(
-        NAME, new LongColumnSelector()
+        new LongColumnSelector()
     {
       @Override
       public long get()
@@ -81,7 +81,7 @@ public class MetricManipulatorFnsTest
 
     LongSumAggregatorFactory longSumAggregatorFactory = new LongSumAggregatorFactory(NAME, FIELD);
     LongSumAggregator longSumAggregator = new LongSumAggregator(
-        NAME, new LongColumnSelector()
+        new LongColumnSelector()
     {
       @Override
       public long get()

--- a/processing/src/test/java/io/druid/query/aggregation/cardinality/CardinalityAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/cardinality/CardinalityAggregatorTest.java
@@ -265,7 +265,6 @@ public class CardinalityAggregatorTest
   public void testAggregateRows() throws Exception
   {
     CardinalityAggregator agg = new CardinalityAggregator(
-        "billy",
         selectorList,
         true
     );
@@ -281,7 +280,6 @@ public class CardinalityAggregatorTest
   public void testAggregateValues() throws Exception
   {
     CardinalityAggregator agg = new CardinalityAggregator(
-        "billy",
         selectorList,
         false
     );
@@ -340,8 +338,8 @@ public class CardinalityAggregatorTest
     List<DimensionSelector> selector1 = Lists.newArrayList((DimensionSelector) dim1);
     List<DimensionSelector> selector2 = Lists.newArrayList((DimensionSelector) dim2);
 
-    CardinalityAggregator agg1 = new CardinalityAggregator("billy", selector1, true);
-    CardinalityAggregator agg2 = new CardinalityAggregator("billy", selector2, true);
+    CardinalityAggregator agg1 = new CardinalityAggregator(selector1, true);
+    CardinalityAggregator agg2 = new CardinalityAggregator(selector2, true);
 
     for (int i = 0; i < values1.size(); ++i) {
       aggregate(selector1, agg1);
@@ -371,8 +369,8 @@ public class CardinalityAggregatorTest
     List<DimensionSelector> selector1 = Lists.newArrayList((DimensionSelector) dim1);
     List<DimensionSelector> selector2 = Lists.newArrayList((DimensionSelector) dim2);
 
-    CardinalityAggregator agg1 = new CardinalityAggregator("billy", selector1, false);
-    CardinalityAggregator agg2 = new CardinalityAggregator("billy", selector2, false);
+    CardinalityAggregator agg1 = new CardinalityAggregator(selector1, false);
+    CardinalityAggregator agg2 = new CardinalityAggregator(selector2, false);
 
     for (int i = 0; i < values1.size(); ++i) {
       aggregate(selector1, agg1);

--- a/processing/src/test/java/io/druid/query/aggregation/post/ArithmeticPostAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/post/ArithmeticPostAggregatorTest.java
@@ -40,12 +40,12 @@ public class ArithmeticPostAggregatorTest
   public void testCompute()
   {
     ArithmeticPostAggregator arithmeticPostAggregator;
-    CountAggregator agg = new CountAggregator("rows");
+    CountAggregator agg = new CountAggregator();
     agg.aggregate();
     agg.aggregate();
     agg.aggregate();
     Map<String, Object> metricValues = new HashMap<String, Object>();
-    metricValues.put(agg.getName(), agg.get());
+    metricValues.put("rows", agg.get());
 
     List<PostAggregator> postAggregatorList =
         Lists.newArrayList(
@@ -74,9 +74,9 @@ public class ArithmeticPostAggregatorTest
   public void testComparator()
   {
     ArithmeticPostAggregator arithmeticPostAggregator;
-    CountAggregator agg = new CountAggregator("rows");
+    CountAggregator agg = new CountAggregator();
     Map<String, Object> metricValues = new HashMap<String, Object>();
-    metricValues.put(agg.getName(), agg.get());
+    metricValues.put("rows", agg.get());
 
     List<PostAggregator> postAggregatorList =
         Lists.newArrayList(
@@ -94,7 +94,7 @@ public class ArithmeticPostAggregatorTest
     agg.aggregate();
     agg.aggregate();
     agg.aggregate();
-    metricValues.put(agg.getName(), agg.get());
+    metricValues.put("rows", agg.get());
     Object after = arithmeticPostAggregator.compute(metricValues);
 
     Assert.assertEquals(-1, comp.compare(before, after));

--- a/processing/src/test/java/io/druid/query/aggregation/post/FieldAccessPostAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/post/FieldAccessPostAggregatorTest.java
@@ -36,15 +36,15 @@ public class FieldAccessPostAggregatorTest
     FieldAccessPostAggregator fieldAccessPostAggregator;
 
     fieldAccessPostAggregator = new FieldAccessPostAggregator("To be, or not to be, that is the question:", "rows");
-    CountAggregator agg = new CountAggregator("rows");
+    CountAggregator agg = new CountAggregator();
     Map<String, Object> metricValues = new HashMap<String, Object>();
-    metricValues.put(agg.getName(), agg.get());
+    metricValues.put("rows", agg.get());
     Assert.assertEquals(new Long(0L), fieldAccessPostAggregator.compute(metricValues));
 
     agg.aggregate();
     agg.aggregate();
     agg.aggregate();
-    metricValues.put(agg.getName(), agg.get());
+    metricValues.put("rows", agg.get());
     Assert.assertEquals(new Long(3L), fieldAccessPostAggregator.compute(metricValues));
   }
 }

--- a/processing/src/test/java/io/druid/query/spec/SpecificSegmentQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/spec/SpecificSegmentQueryRunnerTest.java
@@ -141,7 +141,7 @@ public class SpecificSegmentQueryRunnerTest
     );
     CountAggregator rows = new CountAggregator("rows");
     rows.aggregate();
-    builder.addMetric(rows);
+    builder.addMetric(rows.getName(), rows);
     final Result<TimeseriesResultValue> value = builder.build();
 
     final SpecificSegmentQueryRunner queryRunner = new SpecificSegmentQueryRunner(

--- a/processing/src/test/java/io/druid/query/spec/SpecificSegmentQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/spec/SpecificSegmentQueryRunnerTest.java
@@ -139,9 +139,9 @@ public class SpecificSegmentQueryRunnerTest
     TimeseriesResultBuilder builder = new TimeseriesResultBuilder(
         new DateTime("2012-01-01T00:00:00Z")
     );
-    CountAggregator rows = new CountAggregator("rows");
+    CountAggregator rows = new CountAggregator();
     rows.aggregate();
-    builder.addMetric(rows.getName(), rows);
+    builder.addMetric("rows", rows);
     final Result<TimeseriesResultValue> value = builder.build();
 
     final SpecificSegmentQueryRunner queryRunner = new SpecificSegmentQueryRunner(


### PR DESCRIPTION
It's not necessary but occupies memory (a string reference, about 4~8 byte). This makes substantial difference on batch ingestion time (we are using 1000+ metric).