### PR TITLE
Memoize last returned object in GenericIndexed

### DIFF
--- a/processing/src/main/java/io/druid/segment/data/GenericIndexed.java
+++ b/processing/src/main/java/io/druid/segment/data/GenericIndexed.java
@@ -124,7 +124,11 @@ public class GenericIndexed<T> implements Indexed<T>
   @Override
   public T get(int index)
   {
-    return bufferIndexed.get(index);
+    if (index != lastReadIndex) {
+      lastObject = bufferIndexed.get(index);
+      lastReadIndex = index;
+    }
+    return lastObject;
   }
 
   /**
@@ -154,6 +158,9 @@ public class GenericIndexed<T> implements Indexed<T>
 
   private final int valuesOffset;
   private final BufferIndexed bufferIndexed;
+
+  private int lastReadIndex = -1;
+  private T lastObject;
 
   GenericIndexed(
       ByteBuffer buffer,

--- a/processing/src/test/java/io/druid/segment/data/GenericIndexedTest.java
+++ b/processing/src/test/java/io/druid/segment/data/GenericIndexedTest.java
@@ -99,7 +99,9 @@ public class GenericIndexedTest
   {
     Assert.assertEquals(strings.length, index.size());
     for (int i = 0; i < strings.length; i++) {
-      Assert.assertEquals(strings[i], index.get(i));
+      String actual = index.get(i);
+      Assert.assertSame(actual, index.get(i));  // return memoized
+      Assert.assertEquals(strings[i], actual);
     }
 
     if (allowReverseLookup) {


### PR DESCRIPTION
Some columns can be accessed more than once. But for each access, GenericIndexed should parse the value again. This is for memorizing last object returned from GenericIndexed. It's effective especially for complex columns like HLL or histogram. 