### PR TITLE
fix missing segments duplicate retried in RetryQueryRunner

### DIFF
--- a/processing/src/main/java/io/druid/query/RetryQueryRunner.java
+++ b/processing/src/main/java/io/druid/query/RetryQueryRunner.java
@@ -71,7 +71,7 @@ public class RetryQueryRunner<T> implements QueryRunner<T>
           OutType initValue, YieldingAccumulator<OutType, T> accumulator
       )
       {
-        final List<SegmentDescriptor> missingSegments = getMissingSegments(context);
+        List<SegmentDescriptor> missingSegments = getMissingSegments(context);
 
         if (!missingSegments.isEmpty()) {
           for (int i = 0; i < config.getNumTries(); i++) {
@@ -85,7 +85,8 @@ public class RetryQueryRunner<T> implements QueryRunner<T>
             );
             Sequence<T> retrySequence = baseRunner.run(retryQuery, context);
             listOfSequences.add(retrySequence);
-            if (getMissingSegments(context).isEmpty()) {
+            missingSegments = getMissingSegments(context);
+            if (missingSegments.isEmpty()) {
               break;
             }
           }


### PR DESCRIPTION
RetryQueryRunner will retry missing segments, but it always uses the origin missing segments among all retry attempts. 
This behaviors will cause incorrect query result because same segment is queried more than once.
It should use the latest missing segments for each retry attempt to avoid the duplication.

The log should look like this:
```
2016-08-26T05:08:03,834 INFO [main] io.druid.query.RetryQueryRunner - [2] missing segments found. Retry attempt [0]
2016-08-26T05:08:03,842 INFO [main] io.druid.query.RetryQueryRunner - [1] missing segments found. Retry attempt [1]
```