### PR TITLE
Documented the need for hadoop config after insert-segment-to-db

### DIFF
--- a/docs/content/operations/insert-segment-to-db.md
+++ b/docs/content/operations/insert-segment-to-db.md
@@ -93,3 +93,4 @@ of them in a runtime.properites file and include it in the Druid classpath. Note
 and `druid-hdfs-storage` in the extension list.
 
 After running this command, the segments table in `mysql` should store the new location for each segment we just inserted.
+Note that for segments stored in HDFS, druid config must contain core-site.xml as described in [Druid Docs](http://druid.io/docs/latest/tutorials/cluster.html), as this new location is stored with relative path.


### PR DESCRIPTION
Default file-system in 'core-site.xml' is required after running insert-segment-to-db when segments are stored in HDFS, since it saves all segment paths as relative URLs.

While running insert-segment-to-db, class io.druid.storage.hdfs.HdfsDataSegmentFinder changes the absolute path to relative.

While loading the segments using relative path, io.druid.storage.hdfs.HdfsDataSegmentPuller.getSegmentFiles calls path.getFileSystem(config), which (in absence of "fs.defaultFS" in Hadoop conf, in org.apache.hadoop.fs.FileSystem) assumes it to be a file on local disc, even when type in segment metadata is set to hdfs.