### PR TITLE
Avoid interrupting ZookeeperConsumerConnector.shutdown() #3346

### DIFF
--- a/extensions-core/kafka-extraction-namespace/src/test/java/io/druid/query/lookup/KafkaLookupExtractorFactoryTest.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/io/druid/query/lookup/KafkaLookupExtractorFactoryTest.java
@@ -34,6 +34,7 @@ import kafka.consumer.KafkaStream;
 import kafka.consumer.TopicFilter;
 import kafka.javaapi.consumer.ConsumerConnector;
 import org.easymock.EasyMock;
+import org.easymock.IAnswer;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -46,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static io.druid.query.lookup.KafkaLookupExtractorFactory.DEFAULT_STRING_DECODER;
@@ -271,8 +273,18 @@ public class KafkaLookupExtractorFactoryTest
             .andReturn(new ConcurrentHashMap<String, String>())
             .once();
     EasyMock.expect(cacheManager.delete(EasyMock.anyString())).andReturn(true).once();
+
+    final AtomicBoolean threadWasInterrupted = new AtomicBoolean(false);
     consumerConnector.shutdown();
-    EasyMock.expectLastCall().once();
+    EasyMock.expectLastCall().andAnswer(new IAnswer<Object>()
+    {
+      @Override
+      public Object answer() throws Throwable {
+        threadWasInterrupted.set(Thread.currentThread().isInterrupted());
+        return null;
+      }
+    }).once();
+
     EasyMock.replay(cacheManager, kafkaStream, consumerConnector, consumerIterator);
     final KafkaLookupExtractorFactory factory = new KafkaLookupExtractorFactory(
         cacheManager,
@@ -288,9 +300,12 @@ public class KafkaLookupExtractorFactoryTest
         return consumerConnector;
       }
     };
+
     Assert.assertTrue(factory.start());
     Assert.assertTrue(factory.close());
     Assert.assertTrue(factory.getFuture().isDone());
+    Assert.assertFalse(threadWasInterrupted.get());
+
     EasyMock.verify(cacheManager);
   }
 


### PR DESCRIPTION
This is a less intrusive version of PR https://github.com/druid-io/druid/pull/3351, fixing issue https://github.com/druid-io/druid/issues/3346

The problem is that if the thread that executes `ZookeeperConsumerConnector.shutdown()` is interrupted, then the shutdown may fail to actually terminate the `ConsumerFetcherThread`s.

To avoid this, the following changes were made:

1. When cancelling the futures, set `mayInterruptIfRunning` to `false`
2. Make sure to always softly `shutdown()` the executor (instead of aggressively doing `shutdownNow()`).

Also, redundant checks like `!future.cancel() && !future.isDone()` were removed, since the javadoc of `cancel()` says that:

> `After this method returns, subsequent calls to {@link #isDone} will always return {@code true}`

(regardless of what `cancel` returns)