### PR TITLE
LimitedTemporaryStorage: Fix perf bug.

### DIFF
--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/LimitedTemporaryStorage.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/LimitedTemporaryStorage.java
@@ -110,6 +110,11 @@ public class LimitedTemporaryStorage implements Closeable
     }
   }
 
+  public long maxSize()
+  {
+    return maxBytesUsed;
+  }
+
   @Override
   public void close()
   {
@@ -128,35 +133,48 @@ public class LimitedTemporaryStorage implements Closeable
     }
   }
 
-  public class LimitedOutputStream extends FilterOutputStream
+  public class LimitedOutputStream extends OutputStream
   {
     private final File file;
+    private final OutputStream out;
 
     private LimitedOutputStream(File file, OutputStream out)
     {
-      super(out);
       this.file = file;
+      this.out = out;
     }
 
     @Override
     public void write(int b) throws IOException
     {
       grab(1);
-      super.write(b);
+      out.write(b);
     }
 
     @Override
     public void write(byte[] b) throws IOException
     {
       grab(b.length);
-      super.write(b);
+      out.write(b);
     }
 
     @Override
     public void write(byte[] b, int off, int len) throws IOException
     {
       grab(len);
-      super.write(b, off, len);
+      out.write(b, off, len);
+    }
+
+    @Override
+    public void flush() throws IOException
+    {
+      out.flush();
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+      out.close();
     }
 
     public File getFile()


### PR DESCRIPTION
FilterOutputStream has an inefficient implementation of write(byte[], int, int).
So let's extend OutputStream directly and use efficient implementations of all
methods.

Benchmarks, with a buffer size reduction (1MB instead of 250MB) to force spilling
to disk:

```
master

Benchmark                                  (defaultStrategy)  (initialBuckets)  (numProcessingThreads)  (numSegments)  (rowsPerSegment)  (schemaAndQuery)  Mode  Cnt        Score       Error  Units
GroupByBenchmark.queryMultiQueryableIndex                 v2                -1                       4              4            100000           basic.A  avgt   25  1868621.242 ± 26624.772  us/op

lts-fix

Benchmark                                  (defaultStrategy)  (initialBuckets)  (numProcessingThreads)  (numSegments)  (rowsPerSegment)  (schemaAndQuery)  Mode  Cnt       Score      Error  Units
GroupByBenchmark.queryMultiQueryableIndex                 v2                -1                       4              4            100000           basic.A  avgt   25  475432.057 ± 8282.411  us/op
```