### PR TITLE
groupBy: Short-circuit identity preCompute manipulators.

### DIFF
--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryQueryToolChest.java
@@ -21,6 +21,7 @@ package io.druid.query.groupby;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Function;
+import com.google.common.base.Functions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Collections2;
@@ -51,6 +52,7 @@ import io.druid.query.QueryToolChest;
 import io.druid.query.SubqueryQueryRunner;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.MetricManipulationFn;
+import io.druid.query.aggregation.MetricManipulatorFns;
 import io.druid.query.dimension.DefaultDimensionSpec;
 import io.druid.query.dimension.DimensionSpec;
 import io.druid.query.extraction.ExtractionFn;
@@ -180,6 +182,10 @@ public class GroupByQueryQueryToolChest extends QueryToolChest<Row, GroupByQuery
       final MetricManipulationFn fn
   )
   {
+    if (MetricManipulatorFns.identity().equals(fn)) {
+      return Functions.identity();
+    }
+
     return new Function<Row, Row>()
     {
       @Override


### PR DESCRIPTION
This will short-circuit preComputeManipulatorFn into an identity function on the historical-level mergeResults (only the broker uses nonidentity manipulator fns).

Benchmarks:

```
master

Benchmark                                     (defaultStrategy)  (initialBuckets)  (numProcessingThreads)  (numSegments)  (rowsPerSegment)  (schemaAndQuery)  Mode  Cnt       Score       Error  Units
GroupByBenchmark.queryMultiQueryableIndex                    v2                -1                       4              4            100000           basic.A  avgt   25  351910.616 ± 11965.406  us/op
GroupByBenchmark.querySingleIncrementalIndex                 v2                -1                       4              4            100000           basic.A  avgt   25   78357.095 ±  1234.124  us/op
GroupByBenchmark.querySingleQueryableIndex                   v2                -1                       4              4            100000           basic.A  avgt   25   43284.222 ±   909.340  us/op

branch

Benchmark                                     (defaultStrategy)  (initialBuckets)  (numProcessingThreads)  (numSegments)  (rowsPerSegment)  (schemaAndQuery)  Mode  Cnt       Score      Error  Units
GroupByBenchmark.queryMultiQueryableIndex                    v2                -1                       4              4            100000           basic.A  avgt   25  343197.253 ± 8582.040  us/op
GroupByBenchmark.querySingleIncrementalIndex                 v2                -1                       4              4            100000           basic.A  avgt   25   74534.618 ±  593.965  us/op
GroupByBenchmark.querySingleQueryableIndex                   v2                -1                       4              4            100000           basic.A  avgt   25   37731.253 ±  434.930  us/op
```