### PR TITLE
add truncated timestamp column to row

### DIFF
--- a/api/src/main/java/io/druid/data/input/impl/DimensionsSpec.java
+++ b/api/src/main/java/io/druid/data/input/impl/DimensionsSpec.java
@@ -39,6 +39,7 @@ public class DimensionsSpec
 {
   private final List<DimensionSchema> dimensions;
   private final Set<String> dimensionExclusions;
+  private final Boolean includeTruncatedTimestampColumnAsDimension;
   private final Map<String, DimensionSchema> dimensionSchemaMap;
 
   public static List<DimensionSchema> getDefaultSchemas(List<String> dimNames)
@@ -65,6 +66,7 @@ public class DimensionsSpec
   public DimensionsSpec(
       @JsonProperty("dimensions") List<DimensionSchema> dimensions,
       @JsonProperty("dimensionExclusions") List<String> dimensionExclusions,
+      @JsonProperty("includeTruncatedTimestampColumnAsDimension") Boolean includeTruncatedTimestampColumnAsDimension,
       @Deprecated @JsonProperty("spatialDimensions") List<SpatialDimensionSchema> spatialDimensions
   )
   {
@@ -75,6 +77,10 @@ public class DimensionsSpec
     this.dimensionExclusions = (dimensionExclusions == null)
                                ? Sets.<String>newHashSet()
                                : Sets.newHashSet(dimensionExclusions);
+
+    this.includeTruncatedTimestampColumnAsDimension = includeTruncatedTimestampColumnAsDimension == null
+                                                      ? false
+                                                      : includeTruncatedTimestampColumnAsDimension;
 
     List<SpatialDimensionSchema> spatialDims = (spatialDimensions == null)
                                                ? Lists.<SpatialDimensionSchema>newArrayList()
@@ -88,13 +94,21 @@ public class DimensionsSpec
       dimensionSchemaMap.put(schema.getName(), schema);
     }
 
-    for(SpatialDimensionSchema spatialSchema : spatialDims) {
+    for (SpatialDimensionSchema spatialSchema : spatialDims) {
       DimensionSchema newSchema = DimensionsSpec.convertSpatialSchema(spatialSchema);
       this.dimensions.add(newSchema);
       dimensionSchemaMap.put(newSchema.getName(), newSchema);
     }
   }
 
+  public DimensionsSpec(
+      List<DimensionSchema> dimensions,
+      List<String> dimensionExclusions,
+      List<SpatialDimensionSchema> spatialDimensions
+  )
+  {
+    this(dimensions, dimensionExclusions, false, spatialDimensions);
+  }
 
   @JsonProperty
   public List<DimensionSchema> getDimensions()
@@ -106,6 +120,12 @@ public class DimensionsSpec
   public Set<String> getDimensionExclusions()
   {
     return dimensionExclusions;
+  }
+
+  @JsonProperty
+  public Boolean isIncludeTruncatedTimestampColumnAsDimension()
+  {
+    return includeTruncatedTimestampColumnAsDimension;
   }
 
   @Deprecated @JsonIgnore
@@ -220,8 +240,10 @@ public class DimensionsSpec
     if (!dimensions.equals(that.dimensions)) {
       return false;
     }
-
-    return dimensionExclusions.equals(that.dimensionExclusions);
+    if (!dimensionExclusions.equals(that.dimensionExclusions)) {
+      return false;
+    }
+    return includeTruncatedTimestampColumnAsDimension.equals(that.includeTruncatedTimestampColumnAsDimension);
   }
 
   @Override
@@ -229,6 +251,7 @@ public class DimensionsSpec
   {
     int result = dimensions.hashCode();
     result = 31 * result + dimensionExclusions.hashCode();
+    result = 31 * result + includeTruncatedTimestampColumnAsDimension.hashCode();
     return result;
   }
 }

--- a/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
@@ -41,6 +41,7 @@ import io.druid.concurrent.Execs;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.Row;
 import io.druid.data.input.Rows;
+import io.druid.data.input.impl.InputRowParser;
 import io.druid.indexer.hadoop.SegmentInputRow;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.segment.BaseProgressIndicator;
@@ -220,13 +221,15 @@ public class IndexGeneratorJob implements Jobby
   )
   {
     final HadoopTuningConfig tuningConfig = config.getSchema().getTuningConfig();
+    InputRowParser parser = config.getSchema().getDataSchema().getParser();
     final IncrementalIndexSchema indexSchema = new IncrementalIndexSchema.Builder()
         .withMinTimestamp(theBucket.time.getMillis())
-        .withTimestampSpec(config.getSchema().getDataSchema().getParser().getParseSpec().getTimestampSpec())
-        .withDimensionsSpec(config.getSchema().getDataSchema().getParser())
+        .withTimestampSpec(parser)
+        .withDimensionsSpec(parser)
         .withQueryGranularity(config.getSchema().getDataSchema().getGranularitySpec().getQueryGranularity())
         .withMetrics(aggs)
         .withRollup(config.getSchema().getDataSchema().getGranularitySpec().isRollup())
+        .withIncludeTruncatedTimestampColumnAsDimension(parser)
         .build();
 
     OnheapIncrementalIndex newIndex = new OnheapIncrementalIndex(

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -455,6 +455,14 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
     if (!spatialDimensions.isEmpty()) {
       this.rowTransformers.add(new SpatialDimensionRowTransformer(spatialDimensions));
     }
+
+    if (incrementalIndexSchema.isIncludeTruncatedTimestampColumnAsDimension()
+        && metadata.getTimestampSpec() != null
+        && columnCapabilities.containsKey(metadata.getTimestampSpec().getTimestampColumn())) {
+      this.rowTransformers.add(
+          new TruncateTimestampColumnRowTransformer(gran, metadata)
+      );
+    }
   }
 
   private DimDim newDimDim(String dimension, ValueType type)

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexSchema.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexSchema.java
@@ -37,6 +37,7 @@ public class IncrementalIndexSchema
   private final DimensionsSpec dimensionsSpec;
   private final AggregatorFactory[] metrics;
   private final boolean rollup;
+  private final boolean includeTruncatedTimestampColumnAsDimension;
 
   public IncrementalIndexSchema(
       long minTimestamp,
@@ -44,7 +45,8 @@ public class IncrementalIndexSchema
       QueryGranularity gran,
       DimensionsSpec dimensionsSpec,
       AggregatorFactory[] metrics,
-      boolean rollup
+      boolean rollup,
+      boolean includeTruncatedTimestampColumnAsDimension
   )
   {
     this.minTimestamp = minTimestamp;
@@ -53,6 +55,7 @@ public class IncrementalIndexSchema
     this.dimensionsSpec = dimensionsSpec;
     this.metrics = metrics;
     this.rollup = rollup;
+    this.includeTruncatedTimestampColumnAsDimension = includeTruncatedTimestampColumnAsDimension;
   }
 
   public long getMinTimestamp()
@@ -85,6 +88,11 @@ public class IncrementalIndexSchema
     return rollup;
   }
 
+  public boolean isIncludeTruncatedTimestampColumnAsDimension()
+  {
+    return includeTruncatedTimestampColumnAsDimension;
+  }
+
   public static class Builder
   {
     private long minTimestamp;
@@ -93,6 +101,7 @@ public class IncrementalIndexSchema
     private DimensionsSpec dimensionsSpec;
     private AggregatorFactory[] metrics;
     private boolean rollup;
+    private boolean includeTruncatedTimestampColumnAsDimension;
 
     public Builder()
     {
@@ -101,11 +110,31 @@ public class IncrementalIndexSchema
       this.dimensionsSpec = new DimensionsSpec(null, null, null);
       this.metrics = new AggregatorFactory[]{};
       this.rollup = true;
+      this.includeTruncatedTimestampColumnAsDimension = false;
     }
 
     public Builder withMinTimestamp(long minTimestamp)
     {
       this.minTimestamp = minTimestamp;
+      return this;
+    }
+
+    public Builder withIncludeTruncatedTimestampColumnAsDimension(boolean includeTruncatedTimestampColumnAsDimension)
+    {
+      this.includeTruncatedTimestampColumnAsDimension = includeTruncatedTimestampColumnAsDimension;
+      return this;
+    }
+
+    public Builder withIncludeTruncatedTimestampColumnAsDimension(InputRowParser parser)
+    {
+      if (parser != null
+          && parser.getParseSpec() != null
+          && parser.getParseSpec().getDimensionsSpec() != null) {
+        this.includeTruncatedTimestampColumnAsDimension = parser.getParseSpec().getDimensionsSpec()
+                                                                .isIncludeTruncatedTimestampColumnAsDimension();
+      } else {
+        this.includeTruncatedTimestampColumnAsDimension = false;
+      }
       return this;
     }
 
@@ -167,7 +196,7 @@ public class IncrementalIndexSchema
     public IncrementalIndexSchema build()
     {
       return new IncrementalIndexSchema(
-          minTimestamp, timestampSpec, gran, dimensionsSpec, metrics, rollup
+          minTimestamp, timestampSpec, gran, dimensionsSpec, metrics, rollup, includeTruncatedTimestampColumnAsDimension
       );
     }
   }

--- a/processing/src/main/java/io/druid/segment/incremental/TimestampFormatter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/TimestampFormatter.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.incremental;
+
+import com.google.common.base.Function;
+import com.metamx.common.IAE;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+
+public class TimestampFormatter
+{
+  public static Function<Long, String> createTimestampFormatter(
+      final String format
+  )
+  {
+    if (format.equalsIgnoreCase("millis")) {
+      return new Function<Long, String>()
+      {
+        @Override
+        public String apply(Long input)
+        {
+          return "" + input;
+        }
+      };
+    } else if (format.equalsIgnoreCase("posix")) {
+      return new Function<Long, String>()
+      {
+        @Override
+        public String apply(Long input)
+        {
+          return "" + input / 1000;
+        }
+      };
+    } else if (format.equalsIgnoreCase("nano")) {
+      return new Function<Long, String>()
+      {
+        @Override
+        public String apply(Long input)
+        {
+          return "" + input * 1000000L;
+        }
+      };
+    } else if (format.equalsIgnoreCase("ruby")) {
+      return new Function<Long, String>()
+      {
+        @Override
+        public String apply(Long input)
+        {
+          return String.format("%d.%3d000", input / 1000, input % 1000);
+        }
+      };
+    } else if (format.equalsIgnoreCase("iso")) {
+      final DateTimeFormatter formatter = ISODateTimeFormat.dateTime();
+      return new Function<Long, String>()
+      {
+        @Override
+        public String apply(Long input)
+        {
+          return formatter.print((input));
+        }
+      };
+    } else {
+      try {
+        final DateTimeFormatter formatter = DateTimeFormat.forPattern(format);
+        return new Function<Long, String>()
+        {
+          @Override
+          public String apply(Long input)
+          {
+            return formatter.print(input);
+          }
+        };
+      }
+      catch (Exception e) {
+        throw new IAE(e, "Unable to format timestamps with format [%s]", format);
+      }
+    }
+  }
+}

--- a/processing/src/main/java/io/druid/segment/incremental/TruncateTimestampColumnRowTransformer.java
+++ b/processing/src/main/java/io/druid/segment/incremental/TruncateTimestampColumnRowTransformer.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.incremental;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import io.druid.data.input.InputRow;
+import io.druid.data.input.Row;
+import io.druid.data.input.impl.TimestampSpec;
+import io.druid.granularity.QueryGranularity;
+import io.druid.segment.Metadata;
+import org.joda.time.DateTime;
+
+import java.util.List;
+
+public class TruncateTimestampColumnRowTransformer implements Function<InputRow, InputRow>
+{
+  private QueryGranularity granularity;
+  private Metadata metadata;
+  private String timestampColumn;
+  private String timestampFormat;
+  private Function<Long, String> timestampFormatter;
+
+  public TruncateTimestampColumnRowTransformer(
+      QueryGranularity granularity,
+      Metadata metadata
+  )
+  {
+    this.granularity = granularity;
+    this.metadata = metadata;
+    timestampColumn = metadata.getTimestampSpec().getTimestampColumn();
+    timestampFormat = metadata.getTimestampSpec().getTimestampFormat();
+    timestampFormatter = !"auto".equals(timestampFormat)
+                         ? TimestampFormatter.createTimestampFormatter(timestampFormat) : null;
+  }
+
+  private boolean isMillis(String input)
+  {
+    for (int i = 0; i < input.length(); i++) {
+      if (input.charAt(i) < '0' || input.charAt(i) > '9') {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private String getTimeStr(long timestamp)
+  {
+    return timestampFormatter.apply(granularity.truncate(timestamp));
+  }
+
+  @Override
+  public InputRow apply(final InputRow row)
+  {
+    if ("auto".equals(timestampFormat)) {
+      timestampFormat = isMillis(row.getDimension(timestampColumn).get(0)) ? "millis" : "iso";
+      timestampFormatter = TimestampFormatter.createTimestampFormatter(timestampFormat);
+      metadata.setTimestampSpec(
+          new TimestampSpec(
+              metadata.getTimestampSpec().getTimestampColumn(),
+              timestampFormat,
+              metadata.getTimestampSpec().getMissingValue()
+          )
+      );
+    }
+
+    return new InputRow()
+    {
+      @Override
+      public List<String> getDimensions()
+      {
+        return row.getDimensions();
+      }
+
+      @Override
+      public long getTimestampFromEpoch()
+      {
+        return row.getTimestampFromEpoch();
+      }
+
+      @Override
+      public DateTime getTimestamp()
+      {
+        return row.getTimestamp();
+      }
+
+      @Override
+      public List<String> getDimension(String dimension)
+      {
+        if (timestampColumn.equals(dimension)) {
+          return ImmutableList.of(getTimeStr(row.getTimestampFromEpoch()));
+        }
+        return row.getDimension(dimension);
+      }
+
+      @Override
+      public Object getRaw(String dimension)
+      {
+        if (timestampColumn.equals(dimension)) {
+          return getTimeStr(row.getTimestampFromEpoch());
+        }
+        return row.getRaw(dimension);
+      }
+
+      @Override
+      public long getLongMetric(String metric)
+      {
+        return row.getLongMetric(metric);
+      }
+
+      @Override
+      public float getFloatMetric(String metric)
+      {
+        return row.getFloatMetric(metric);
+      }
+
+      @Override
+      public String toString()
+      {
+        return row.toString();
+      }
+
+      @Override
+      public int compareTo(Row o)
+      {
+        return getTimestamp().compareTo(o.getTimestamp());
+      }
+    };
+  }
+}

--- a/processing/src/test/java/io/druid/segment/incremental/TimestampFormatterTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/TimestampFormatterTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.incremental;
+
+import com.google.common.base.Function;
+import org.joda.time.format.ISODateTimeFormat;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TimestampFormatterTest
+{
+  @Test
+  public void testMillis() throws Exception
+  {
+    Function<Long, String> formatter = TimestampFormatter.createTimestampFormatter("millis");
+    Assert.assertEquals("1358347307435", formatter.apply(1358347307435L));
+  }
+
+  @Test
+  public void testRuby() throws Exception
+  {
+    Function<Long, String> formatter = TimestampFormatter.createTimestampFormatter("ruby");
+    Assert.assertEquals("1358347307.435000", formatter.apply(1358347307435L));
+  }
+
+  @Test
+  public void testNano() throws Exception
+  {
+    Function<Long, String> formatter = TimestampFormatter.createTimestampFormatter("nano");
+    assert formatter != null;
+    Assert.assertEquals("1358347307435000000", formatter.apply(1358347307435L));
+  }
+
+  @Test
+  public void testPosix() throws Exception
+  {
+    Function<Long, String> formatter = TimestampFormatter.createTimestampFormatter("posix");
+    assert formatter != null;
+    Assert.assertEquals("1358347307", formatter.apply(1358347307435L));
+  }
+
+  @Test
+  public void testIso() throws Exception
+  {
+    Function<Long, String> formatter = TimestampFormatter.createTimestampFormatter("iso");
+    assert formatter != null;
+    Assert.assertEquals(ISODateTimeFormat.dateTime().print(1358347307435L), formatter.apply(1358347307435L));
+  }
+
+  @Test
+  public void testOther() throws Exception
+  {
+    Function<Long, String> formatter = TimestampFormatter.createTimestampFormatter("yyyy-MM-dd");
+    assert formatter != null;
+    Assert.assertEquals(ISODateTimeFormat.date().print(1358347307435L), formatter.apply(1358347307435L));
+  }
+}

--- a/processing/src/test/java/io/druid/segment/incremental/TruncateTimestampColumnRowTransformerTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/TruncateTimestampColumnRowTransformerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.incremental;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.druid.data.input.InputRow;
+import io.druid.data.input.MapBasedInputRow;
+import io.druid.data.input.impl.TimestampSpec;
+import io.druid.granularity.QueryGranularities;
+import io.druid.granularity.QueryGranularity;
+import io.druid.segment.Metadata;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TruncateTimestampColumnRowTransformerTest
+{
+  @Test
+  public void testTruncate()
+  {
+    TimestampSpec timestampSpec = new TimestampSpec("ts", "auto", null);
+    QueryGranularity granularity = QueryGranularities.HOUR;
+    Metadata metadata = new Metadata()
+        .setTimestampSpec(timestampSpec);
+    TruncateTimestampColumnRowTransformer transformer = new TruncateTimestampColumnRowTransformer(
+        granularity, metadata
+    );
+    long timestamp = System.currentTimeMillis();
+    InputRow row = transformer.apply(new MapBasedInputRow(
+        timestamp,
+        ImmutableList.of("ts", "dimA"),
+        ImmutableMap.<String, Object>of(
+            "ts", timestamp, "dimA", "dima"
+        )
+    ));
+    assertEquals("" + granularity.truncate(timestamp), row.getDimension("ts").get(0));
+    assertEquals("millis", metadata.getTimestampSpec().getTimestampFormat());
+  }
+}

--- a/server/src/main/java/io/druid/segment/realtime/plumber/Sink.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/Sink.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Sets;
 import com.metamx.common.IAE;
 import com.metamx.common.ISE;
 import io.druid.data.input.InputRow;
+import io.druid.data.input.impl.InputRowParser;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.segment.QueryableIndex;
 import io.druid.segment.incremental.IncrementalIndex;
@@ -242,13 +243,15 @@ public class Sink implements Iterable<FireHydrant>
 
   private FireHydrant makeNewCurrIndex(long minTimestamp, DataSchema schema)
   {
+    InputRowParser parser = schema.getParser();
     final IncrementalIndexSchema indexSchema = new IncrementalIndexSchema.Builder()
         .withMinTimestamp(minTimestamp)
-        .withTimestampSpec(schema.getParser())
+        .withTimestampSpec(parser)
         .withQueryGranularity(schema.getGranularitySpec().getQueryGranularity())
-        .withDimensionsSpec(schema.getParser())
+        .withDimensionsSpec(parser)
         .withMetrics(schema.getAggregators())
         .withRollup(schema.getGranularitySpec().isRollup())
+        .withIncludeTruncatedTimestampColumnAsDimension(parser)
         .build();
     final IncrementalIndex newIndex = new OnheapIncrementalIndex(indexSchema, reportParseExceptions, maxRowsInMemory);
 


### PR DESCRIPTION
We're working on sql on druid, when we transform such sql
 `select * from someDataSource where (time > '20160801 010000' and time < '20160801 100000' and dimA='xxx') or (time > '20160801 110000 ' and time <= '20160801 160000' and dimA='yyy')` 
to a druid query, we need 2 things from druid:
1: the timestampSpec info (done in another PR): the timestamp column and format, then we can know the 'time' range can be transformed to 'intervals':['2016-08-01 01:00:00/2016-08-01 10:00:00', '2016-08-01 11:00:00/2016-08-01 16:00:00']

``` json
"timestampSpec": {
  "column": "time",
  "format": "yyyyMMdd HHmmss"
}
```

2: the ability to do complex filter on time.

When ingestion, the timestamp column defined in timestampSpec is explicit excluded in dimension list because of the need of rollup, this patch adds the timestamp column back, but with truncated value according to queryGranularity and in origin format, in other word, it is the dimension version of __time.

If queryGranularity is set to 'HOUR', the original value is '20160801 013556', the final value in row is '20160801 010000'.

This feature is very useful when filtering by complex time range which 'intervals' can't represent(but still can use intervals to narrow down to less segments), like the above example.

The above query can be transformed to BoundDimFilter on 'time' or IntervalDimFilter on __time within an OrDimFilter.
But for a sql like
`select * from someDataSource where time > '201608' and time < '201609'`, we can't use IntervalDimFilter due to the '201608' is not in pattern 'yyyyMMdd HHmmss' and we don't have another pattern to parse the '201608' string to a valid representation that the `Interval` class can understand.

To use this feature, just set the option includeTruncatedTimestampColumnAsDimension=true in dimensionsSpec in DataSchema:

```
"parser": {
  "type": "string",
  "parseSpec": {
    "timestampSpec": {
      "column": "time",
      "format": "iso"
    },
    "dimensionsSpec": {
      "includeTruncatedTimestampColumnAsDimension": true,
      "dimensions": [
        "appId",
        "containerId",
        "cluster"
      ]
    },
    "format": "json"
  }
}
```
