### PR TITLE
JavaScript docs: Fix links and typos, add to TOC.

### DIFF
--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -351,3 +351,8 @@ the following properties.
 |Property|Description|Default|
 |--------|-----------|-------|
 |`druid.javascript.disabled`|Set to "true" to disable JavaScript functionality. This affects the JavaScript parser, filter, extractionFn, aggregator, and post-aggregator.|false|
+
+<div class="note info">
+Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines
+about using Druid's JavaScript functionality.
+</div>

--- a/docs/content/configuration/indexing-service.md
+++ b/docs/content/configuration/indexing-service.md
@@ -233,8 +233,8 @@ Example: a function that sends batch_index_task to workers 10.0.0.1 and 10.0.0.2
 ```
 
 <div class="note info">
-Please refer to the Druid [JavaScript programming guide](../development/javascript.html) for guidelines about using
-Druid's JavaScript functionality.
+Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines
+about using Druid's JavaScript functionality.
 </div>
 
 #### Autoscaler

--- a/docs/content/development/javascript.md
+++ b/docs/content/development/javascript.md
@@ -14,7 +14,8 @@ JavaScript can be used to extend Druid in a variety of ways:
 - [Filters](../querying/aggregations.html#javascript-filter)
 - [Post-aggregators](../querying/aggregations.html#javascript-post-aggregator)
 - [Input parsers](../ingestion/data-formats.html#javascript)
-- [Query routing](../development/router.html#javascript)
+- [Router strategy](../development/router.html#javascript)
+- [Worker select strategy](../configuration/indexing-service.html#javascript)
 
 JavaScript can be injected dynamically at runtime, making it convenient to rapidly prototype new functionality
 without needing to write and deploy Druid extensions.
@@ -28,7 +29,7 @@ unpredictable results if global variables are used.
 
 ## Performance
 
-Simple JavaScript functions typically perform a slight performance penalty to native speed. More complex JavaScript
+Simple JavaScript functions typically have a slight performance penalty to native speed. More complex JavaScript
 functions can have steeper performance penalties. Druid compiles JavaScript functions once per node per query.
 
 You may need to pay special attention to garbage collection when making heavy use of JavaScript functions, especially

--- a/docs/content/development/router.md
+++ b/docs/content/development/router.md
@@ -117,8 +117,8 @@ Allows defining arbitrary routing rules using a JavaScript function. The functio
 ```
 
 <div class="note info">
-Please refer to the Druid [JavaScript programming guide](../development/javascript.html) for guidelines about using
-Druid's JavaScript functionality.
+Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines
+about using Druid's JavaScript functionality.
 </div>
 
 HTTP Endpoints

--- a/docs/content/ingestion/data-formats.md
+++ b/docs/content/ingestion/data-formats.md
@@ -147,8 +147,8 @@ Note with the JavaScript parser that data must be fully parsed and returned as a
 This means any flattening or parsing multi-dimensional values must be done here.
 
 <div class="note info">
-Please refer to the Druid [JavaScript programming guide](../development/javascript.html) for guidelines about using
-Druid's JavaScript functionality.
+Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines
+about using Druid's JavaScript functionality.
 </div>
 
 ### Multi-value dimensions

--- a/docs/content/querying/aggregations.md
+++ b/docs/content/querying/aggregations.md
@@ -108,8 +108,8 @@ JavaScript functions are expected to return floating-point values.
 ```
 
 <div class="note info">
-Please refer to the Druid [JavaScript programming guide](../development/javascript.html) for guidelines about using
-Druid's JavaScript functionality.
+Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines
+about using Druid's JavaScript functionality.
 </div>
 
 ## Approximate Aggregations

--- a/docs/content/querying/dimensionspecs.md
+++ b/docs/content/querying/dimensionspecs.md
@@ -197,8 +197,8 @@ Example for the `__time` dimension:
 ```
 
 <div class="note info">
-Please refer to the Druid [JavaScript programming guide](../development/javascript.html) for guidelines about using
-Druid's JavaScript functionality.
+Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines
+about using Druid's JavaScript functionality.
 </div>
 
 ### Lookup extraction function

--- a/docs/content/querying/filters.md
+++ b/docs/content/querying/filters.md
@@ -89,8 +89,8 @@ The following matches any dimension values for the dimension `name` between `'ba
 The JavaScript filter supports the use of extraction functions, see [Filtering with Extraction Functions](#filtering-with-extraction-functions) for details.
 
 <div class="note info">
-Please refer to the Druid [JavaScript programming guide](../development/javascript.html) for guidelines about using
-Druid's JavaScript functionality.
+Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines
+about using Druid's JavaScript functionality.
 </div>
 
 ### Extraction filter

--- a/docs/content/querying/post-aggregations.md
+++ b/docs/content/querying/post-aggregations.md
@@ -79,8 +79,8 @@ Example JavaScript aggregator:
 ```
 
 <div class="note info">
-Please refer to the Druid [JavaScript programming guide](../development/javascript.html) for guidelines about using
-Druid's JavaScript functionality.
+Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines
+about using Druid's JavaScript functionality.
 </div>
 
 ### HyperUnique Cardinality post-aggregator

--- a/docs/content/toc.md
+++ b/docs/content/toc.md
@@ -87,6 +87,7 @@ layout: toc
   * [Overview](/docs/VERSION/development/overview.html)
   * [Libraries](/docs/VERSION/development/libraries.html)
   * [Extensions](/docs/VERSION/development/extensions.html)
+  * [JavaScript](/docs/VERSION/development/javascript.html)
   * [Build From Source](/docs/VERSION/development/build.html)
   * [Versioning](/docs/VERSION/development/versioning.html)
   * [Integration](/docs/VERSION/development/integrating-druid-with-other-technologies.html)


### PR DESCRIPTION
Fixes links; the `[foo](bar)` style doesn't work inside div blocks.