### PR TITLE
fix kafka-indexing-service pom to not reference specific version 

### DIFF
--- a/extensions-core/kafka-indexing-service/pom.xml
+++ b/extensions-core/kafka-indexing-service/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>io.druid</groupId>
       <artifactId>druid-indexing-service</artifactId>
-      <version>0.9.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -73,14 +73,14 @@
     <dependency>
       <groupId>io.druid</groupId>
       <artifactId>druid-server</artifactId>
-      <version>0.9.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.druid</groupId>
       <artifactId>druid-indexing-service</artifactId>
-      <version>0.9.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
but parent version for druid core dependencies