### PR TITLE
Support locking multiple-datasources if needed.

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/common/TaskLock.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/TaskLock.java
@@ -72,6 +72,11 @@ public class TaskLock
     return version;
   }
 
+  public boolean isShareable(String groupId, Interval interval)
+  {
+    return this.interval.contains(interval) && this.groupId.equals(groupId);
+  }
+
   @Override
   public boolean equals(Object o)
   {

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/AbstractTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/AbstractTask.java
@@ -124,6 +124,13 @@ public abstract class AbstractTask implements Task
     return dataSource;
   }
 
+  @JsonProperty
+  @Override
+  public String getRequiredLockName()
+  {
+    return getDataSource();
+  }
+
   @Override
   public <T> QueryRunner<T> getQueryRunner(Query<T> query)
   {

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/HadoopIndexTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/HadoopIndexTask.java
@@ -115,7 +115,7 @@ public class HadoopIndexTask extends HadoopTask
     );
 
     this.classpathPrefix = classpathPrefix;
-    this.jsonMapper = Preconditions.checkNotNull(jsonMapper, "null ObjectMappper");
+    this.jsonMapper = Preconditions.checkNotNull(jsonMapper, "null ObjectMapper");
   }
 
   @Override

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/NoopTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/NoopTask.java
@@ -85,6 +85,20 @@ public class NoopTask extends AbstractTask
     this.firehoseFactory = firehoseFactory;
   }
 
+  public NoopTask(String id, String groupId, String dataSource)
+  {
+    super(
+        id == null ? String.format("%s_%s_%s", dataSource, new DateTime(), UUID.randomUUID().toString()) : id,
+        groupId == null ? String.format("%s_%s_%s", dataSource, new DateTime(), UUID.randomUUID().toString()) : groupId,
+        dataSource,
+        null
+    );
+    runTime = defaultRunTime;
+    isReadyTime = defaultIsReadyTime;
+    isReadyResult = defaultIsReadyResult;
+    firehoseFactory = null;
+  }
+
   @Override
   public String getType()
   {

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/Task.java
@@ -106,6 +106,11 @@ public interface Task
   public String getDataSource();
 
   /**
+   * Returns the name of lock to be acquired for this task. Generally, it's the name of datasource.
+   */
+  public String getRequiredLockName();
+
+  /**
    * Returns query runners for this task. If this task is not meant to answer queries over its datasource, this method
    * should return null.
    *

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLockboxTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLockboxTest.java
@@ -30,8 +30,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.List;
-
 public class TaskLockboxTest
 {
   private TaskStorage taskStorage;
@@ -127,4 +125,24 @@ public class TaskLockboxTest
   }
 
 
+  @Test
+  public void testMultiLock() throws InterruptedException
+  {
+    Interval interval = new Interval("2015-01-01/2015-01-02");
+
+    Task task1 = new NoopTask("id1", "gp1", "navis;manse");
+    lockbox.add(task1);
+    Assert.assertTrue(lockbox.tryLock(task1, interval).isPresent());
+
+    Task task2 = new NoopTask("id2", "gp1", "navis;manmanse");
+    lockbox.add(task2);
+    Assert.assertTrue(lockbox.tryLock(task2, interval).isPresent());
+
+    Task task3 = new NoopTask("id3", "gp2", "manse");
+    lockbox.add(task3);
+    Assert.assertTrue(!lockbox.tryLock(task3, interval).isPresent());
+
+    lockbox.unlock(task1, interval);
+    Assert.assertTrue(lockbox.tryLock(task3, interval).isPresent());
+  }
 }


### PR DESCRIPTION
We have some task implementation which needs locking on multiple datasources. This is for that.

Task can return ';' separated names in newly added method getRequiredLockName()