### PR TITLE
Update java-util to 0.27.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     </scm>
 
     <properties>
-        <metamx.java-util.version>0.27.10</metamx.java-util.version>
+        <metamx.java-util.version>0.27.11</metamx.java-util.version>
         <apache.curator.version>2.11.0</apache.curator.version>
         <guice.version>4.1.0</guice.version>
         <jetty.version>9.2.5.v20141112</jetty.version>


### PR DESCRIPTION
* More deterministic unmapping (https://github.com/metamx/java-util/pull/51)
* GzipInputStream attempts to use `super.available()` first (https://github.com/metamx/java-util/pull/53)
* Remove reflection from ByteBufferUtils (https://github.com/metamx/java-util/pull/52)
* Add syntactic sugar for catching bad ordering of log messages (https://github.com/metamx/java-util/pull/44)