### PR TITLE
Fixed info message

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/DetermineHashedPartitionsJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/DetermineHashedPartitionsJob.java
@@ -146,7 +146,7 @@ public class DetermineHashedPartitionsJob implements Jobby
                 intervals
             )
         );
-        log.info("Determined Intervals for Job [%s]" + config.getSegmentGranularIntervals());
+        log.info("Determined Intervals for Job [%s].", config.getSegmentGranularIntervals());
       }
       Map<DateTime, List<HadoopyShardSpec>> shardSpecs = Maps.newTreeMap(DateTimeComparator.getInstance());
       int shardCount = 0;
@@ -416,6 +416,3 @@ public class DetermineHashedPartitionsJob implements Jobby
   }
 
 }
-
-
-


### PR DESCRIPTION
Hi guys,

Found this messy looking info message in the logs:
```
2016-09-21T16:20:53,686 INFO [task-runner-0-priority-0] io.druid.indexer.DetermineHashedPartitionsJob - Determined Intervals for Job [%s]Optional.of([2011-10-31T00:00:00.000Z/2011-11-01T00:00:00.000Z, 2011-11-01 ...
```
Therefore decided to fixed it. Keep up the good work.

Cheers, Fokko