### PR TITLE
Fix ListFilteredDimensionSpec blacklisting on non-present values.

### DIFF
--- a/processing/src/main/java/io/druid/query/dimension/ListFilteredDimensionSpec.java
+++ b/processing/src/main/java/io/druid/query/dimension/ListFilteredDimensionSpec.java
@@ -78,7 +78,9 @@ public class ListFilteredDimensionSpec extends BaseFilteredDimensionSpec
     if (selectorCardinality < 0) {
       throw new UnsupportedOperationException("Cannot decorate a selector with no dictionary");
     }
-    int cardinality = isWhitelist ? values.size() : selectorCardinality - values.size();
+
+    // Upper bound on cardinality of the filtered spec.
+    final int cardinality = isWhitelist ? values.size() : selectorCardinality;
 
     int count = 0;
     final Map<Integer,Integer> forwardMapping = new HashMap<>(cardinality);

--- a/processing/src/test/java/io/druid/query/dimension/ListFilteredDimensionSpecTest.java
+++ b/processing/src/test/java/io/druid/query/dimension/ListFilteredDimensionSpecTest.java
@@ -161,4 +161,32 @@ public class ListFilteredDimensionSpecTest
     Assert.assertEquals(0, selector.lookupId("a"));
     Assert.assertEquals(23, selector.lookupId("z"));
   }
+
+  @Test
+  public void testDecoratorWithBlacklistUsingNonPresentValues()
+  {
+    ListFilteredDimensionSpec spec = new ListFilteredDimensionSpec(
+        new DefaultDimensionSpec("foo", "bar"),
+        ImmutableSet.of("c", "gx"),
+        false
+    );
+
+    DimensionSelector selector = spec.decorate(TestDimensionSelector.instance);
+
+    Assert.assertEquals(25, selector.getValueCardinality());
+
+    IndexedInts row = selector.getRow();
+    Assert.assertEquals(2, row.size());
+    Assert.assertEquals(3, row.get(0));
+    Assert.assertEquals(5, row.get(1));
+
+    Assert.assertEquals("e", selector.lookupName(row.get(0)));
+    Assert.assertEquals("g", selector.lookupName(row.get(1)));
+
+    Assert.assertEquals("a", selector.lookupName(0));
+    Assert.assertEquals("z", selector.lookupName(24));
+
+    Assert.assertEquals(0, selector.lookupId("a"));
+    Assert.assertEquals(24, selector.lookupId("z"));
+  }
 }


### PR DESCRIPTION
Bug reported in https://groups.google.com/d/topic/druid-user/6GuZfzzz6o0/discussion.

The bug is that `reverseMapping` was sized too small when one of the blacklisted values didn't actually appear in the column.