### PR TITLE
Fix test fail of PollingLookupTest.testApplyAfterDataChange

### DIFF
--- a/extensions-core/lookups-cached-single/src/test/java/io/druid/server/lookup/PollingLookupTest.java
+++ b/extensions-core/lookups-cached-single/src/test/java/io/druid/server/lookup/PollingLookupTest.java
@@ -59,7 +59,7 @@ public class PollingLookupTest
       "new-bad", "new-bar"
   );
 
-  private static final long POLL_PERIOD = 100L;
+  private static final long POLL_PERIOD = 1000L;
 
   @JsonTypeName("mock")
   private static class MockDataFetcher implements DataFetcher


### PR DESCRIPTION
For fixing #3480

When using timeout in unit test, junit makes separate thread to run it. In this case, it seemed takes more time than current polling interval (100msec) in sometimes. If we make `PollingLookup` inside of the test method instead of `@Before`, it'll not happen I think. But just making the interval a little longer (1sec, in this patch) seemed enough.