### PR TITLE
When inserting segments, mark unused if already overshadowed.

### DIFF
--- a/common/src/main/java/io/druid/common/utils/JodaUtils.java
+++ b/common/src/main/java/io/druid/common/utils/JodaUtils.java
@@ -38,6 +38,7 @@ public class JodaUtils
   // limit intervals such that duration millis fits in a long
   public static final long MAX_INSTANT = Long.MAX_VALUE / 2;
   public static final long MIN_INSTANT = Long.MIN_VALUE / 2;
+  public static final Interval ETERNITY = new Interval(MIN_INSTANT, MAX_INSTANT);
 
   public static ArrayList<Interval> condenseIntervals(Iterable<Interval> intervals)
   {


### PR DESCRIPTION
This is useful for the insert-segment-to-db tool, which would otherwise
potentially insert a lot of overshadowed segments as "used", causing
load and drop churn in the cluster.

Inspired by https://groups.google.com/d/topic/druid-user/Q0L4obz2jtc/discussion.