### PR TITLE
log exceptions while trying to pause task

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIndexTaskClient.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIndexTaskClient.java
@@ -176,6 +176,7 @@ public class KafkaIndexTaskClient
       );
 
       if (response.getStatus().equals(HttpResponseStatus.OK)) {
+        log.info("Task [%s] paused successfully", id);
         return jsonMapper.readValue(response.getContent(), new TypeReference<Map<Integer, Long>>() {});
       }
 
@@ -187,6 +188,7 @@ public class KafkaIndexTaskClient
 
         final Duration delay = retryPolicy.getAndIncrementRetryDelay();
         if (delay == null) {
+          log.error("Task [%s] failed to pause, aborting", id);
           throw new ISE("Task [%s] failed to pause, aborting", id);
         } else {
           final long sleepTime = delay.getMillis();
@@ -200,9 +202,11 @@ public class KafkaIndexTaskClient
       }
     }
     catch (NoTaskLocationException e) {
+      log.error("Exception [%s] while pausing Task [%s]", e.getMessage(), id);
       return ImmutableMap.of();
     }
     catch (IOException | InterruptedException e) {
+      log.error("Exception [%s] while pausing Task [%s]", e.getMessage(), id);
       throw Throwables.propagate(e);
     }
   }


### PR DESCRIPTION
`Futures.successfulAsList(Future...)` returns null as the Future result even if some runtime exception was thrown in the callable, thus effectively there is no information about what went wrong. Therefore, log exceptions explicitly as `Futures.successfulAsList()` is used to get result of Callables to pause tasks here - https://github.com/druid-io/druid/blob/master/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisor.java#L998