### PR TITLE
fix 'No Such File' error when execute script out of druid installatio…

### DIFF
--- a/examples/bin/broker.sh
+++ b/examples/bin/broker.sh
@@ -7,4 +7,5 @@ if [ $# -lt 1 ]; then
   exit 1
 fi
 
+cd $(dirname $0)/../
 sh ./bin/node.sh broker $1

--- a/examples/bin/coordinator.sh
+++ b/examples/bin/coordinator.sh
@@ -7,4 +7,5 @@ if [ $# -lt 1 ]; then
   exit 1
 fi
 
+cd $(dirname $0)/../
 sh ./bin/node.sh coordinator $1

--- a/examples/bin/historical.sh
+++ b/examples/bin/historical.sh
@@ -7,4 +7,5 @@ if [ $# -lt 1 ]; then
   exit 1
 fi
 
+cd $(dirname $0)/../
 sh ./bin/node.sh historical $1

--- a/examples/bin/middleManager.sh
+++ b/examples/bin/middleManager.sh
@@ -7,4 +7,5 @@ if [ $# -lt 1 ]; then
   exit 1
 fi
 
+cd $(dirname $0)/../
 sh ./bin/node.sh middleManager $1

--- a/examples/bin/overlord.sh
+++ b/examples/bin/overlord.sh
@@ -7,4 +7,5 @@ if [ $# -lt 1 ]; then
   exit 1
 fi
 
+cd $(dirname $0)/../
 sh ./bin/node.sh overlord $1


### PR DESCRIPTION
…n directory

When execute shell `/home/user/druid-home/bin/broker.sh` out of  druid installation directory like `/home/user/`, the shell will throw 'No Such File' because can't find './bin/node.sh', should `cd` to druid installation directory first.
