### PR TITLE
support atomic writes for local deep storage

### DIFF
--- a/api/src/main/java/io/druid/timeline/partition/NoneShardSpec.java
+++ b/api/src/main/java/io/druid/timeline/partition/NoneShardSpec.java
@@ -20,6 +20,7 @@
 package io.druid.timeline.partition;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Range;
 import io.druid.data.input.InputRow;
@@ -55,6 +56,7 @@ public class NoneShardSpec implements ShardSpec
   }
 
   @Override
+  @JsonIgnore
   public int getPartitionNum()
   {
     return 0;

--- a/api/src/test/java/io/druid/timeline/partition/NoneShardSpecTest.java
+++ b/api/src/test/java/io/druid/timeline/partition/NoneShardSpecTest.java
@@ -1,10 +1,11 @@
 package io.druid.timeline.partition;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.druid.TestObjectMapper;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.io.IOException;
 
 public class NoneShardSpecTest
 {
@@ -28,5 +29,14 @@ public class NoneShardSpecTest
     // Serde should return same object instead of creating new one every time.
     Assert.assertTrue(serde1 == serde2);
     Assert.assertTrue(one == serde1);
+  }
+
+  @Test
+  public void testPartitionFieldIgnored() throws IOException
+  {
+    final String jsonStr = "{\"type\": \"none\",\"partitionNum\": 2}";
+    ObjectMapper mapper = new TestObjectMapper();
+    final ShardSpec noneShardSpec = mapper.readValue(jsonStr, ShardSpec.class);
+    noneShardSpec.equals(NoneShardSpec.instance());
   }
 }

--- a/server/src/main/java/io/druid/segment/loading/LocalDataSegmentPusher.java
+++ b/server/src/main/java/io/druid/segment/loading/LocalDataSegmentPusher.java
@@ -74,7 +74,7 @@ public class LocalDataSegmentPusher implements DataSegmentPusher
   {
     final String storageDir = DataSegmentPusherUtil.getStorageDir(segment);
     final File baseStorageDir = config.getStorageDirectory();
-    File outDir = new File(baseStorageDir, storageDir);
+    final File outDir = new File(baseStorageDir, storageDir);
 
     log.info("Copying segment[%s] to local filesystem at location[%s]", segment.getIdentifier(), outDir.toString());
 
@@ -92,10 +92,10 @@ public class LocalDataSegmentPusher implements DataSegmentPusher
       );
     }
 
-    File tmpOutDir = new File(baseStorageDir, storageDir + "." + UUID.randomUUID().toString());
-    long size = compressSegment(dataSegmentFile, tmpOutDir);
+    final File tmpOutDir = new File(baseStorageDir, storageDir + "." + UUID.randomUUID().toString());
+    final long size = compressSegment(dataSegmentFile, tmpOutDir);
 
-    DataSegment dataSegment = createDescriptorFile(
+    final DataSegment dataSegment = createDescriptorFile(
       segment.withLoadSpec(makeLoadSpec(new File(outDir, "index.zip")))
              .withSize(size)
              .withBinaryVersion(SegmentUtils.getVersionFromDir(dataSegmentFile)),
@@ -109,8 +109,8 @@ public class LocalDataSegmentPusher implements DataSegmentPusher
     }
     catch (FileAlreadyExistsException e) {
       log.warn("Push destination directory[%s] exists, ignore this message if replication is configured.");
-      dataSegment = jsonMapper.readValue(new File(outDir, "descriptor.json"), DataSegment.class);
       FileUtils.deleteDirectory(tmpOutDir);
+      return jsonMapper.readValue(new File(outDir, "descriptor.json"), DataSegment.class);
     }
     return dataSegment;
   }

--- a/server/src/main/java/io/druid/segment/loading/LocalDataSegmentPusher.java
+++ b/server/src/main/java/io/druid/segment/loading/LocalDataSegmentPusher.java
@@ -105,7 +105,7 @@ public class LocalDataSegmentPusher implements DataSegmentPusher
 
     // moving the temporary directory to the final destination, once success the potentially concurrent push operations
     // will be failed and will read the descriptor.json created by current push operation directly
-    createIfNotExists(outDir.getParentFile());
+    createDirectoryIfNotExists(outDir.getParentFile());
     try {
       java.nio.file.Files.move(tmpOutDir.toPath(), outDir.toPath());
     }
@@ -117,7 +117,7 @@ public class LocalDataSegmentPusher implements DataSegmentPusher
     return dataSegment;
   }
 
-  private void createIfNotExists(File directory) throws IOException
+  private void createDirectoryIfNotExists(File directory) throws IOException
   {
     if (!directory.mkdirs() && !directory.isDirectory()) {
       throw new IOException(String.format("Cannot create directory[%s]", directory.toString()));
@@ -131,7 +131,7 @@ public class LocalDataSegmentPusher implements DataSegmentPusher
 
   private long compressSegment(File dataSegmentFile, File outDir) throws IOException
   {
-    createIfNotExists(outDir);
+    createDirectoryIfNotExists(outDir);
     File outFile = new File(outDir, "index.zip");
     log.info("Compressing files from[%s] to [%s]", dataSegmentFile, outFile);
     return CompressionUtils.zip(dataSegmentFile, outFile);

--- a/server/src/main/java/io/druid/segment/loading/LocalDataSegmentPusher.java
+++ b/server/src/main/java/io/druid/segment/loading/LocalDataSegmentPusher.java
@@ -28,9 +28,12 @@ import com.metamx.common.CompressionUtils;
 import com.metamx.common.logger.Logger;
 import io.druid.segment.SegmentUtils;
 import io.druid.timeline.DataSegment;
+import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.util.UUID;
 
 /**
  */
@@ -69,7 +72,9 @@ public class LocalDataSegmentPusher implements DataSegmentPusher
   @Override
   public DataSegment push(File dataSegmentFile, DataSegment segment) throws IOException
   {
-    File outDir = new File(config.getStorageDirectory(), DataSegmentPusherUtil.getStorageDir(segment));
+    final String storageDir = DataSegmentPusherUtil.getStorageDir(segment);
+    final File baseStorageDir = config.getStorageDirectory();
+    File outDir = new File(baseStorageDir, storageDir);
 
     log.info("Copying segment[%s] to local filesystem at location[%s]", segment.getIdentifier(), outDir.toString());
 
@@ -87,19 +92,37 @@ public class LocalDataSegmentPusher implements DataSegmentPusher
       );
     }
 
+    File tmpOutDir = new File(baseStorageDir, storageDir + "." + UUID.randomUUID().toString());
+    long size = compressSegment(dataSegmentFile, tmpOutDir);
+
+    DataSegment dataSegment = createDescriptorFile(
+      segment.withLoadSpec(makeLoadSpec(new File(outDir, "index.zip")))
+             .withSize(size)
+             .withBinaryVersion(SegmentUtils.getVersionFromDir(dataSegmentFile)),
+      tmpOutDir
+    );
+
+    // moving the temporary directory to the final destination, once success the potentially concurrent push operations
+    // will be failed and will read the descriptor.json created by current push operation directly
+    try {
+      java.nio.file.Files.move(tmpOutDir.toPath(), outDir.toPath());
+    }
+    catch (FileAlreadyExistsException e) {
+      log.warn("Push destination directory[%s] exists, ignore this message if replication is configured.");
+      dataSegment = jsonMapper.readValue(new File(outDir, "descriptor.json"), DataSegment.class);
+      FileUtils.deleteDirectory(tmpOutDir);
+    }
+    return dataSegment;
+  }
+
+  private long compressSegment(File dataSegmentFile, File outDir) throws IOException
+  {
     if (!outDir.mkdirs() && !outDir.isDirectory()) {
       throw new IOException(String.format("Cannot create directory[%s]", outDir));
     }
     File outFile = new File(outDir, "index.zip");
     log.info("Compressing files from[%s] to [%s]", dataSegmentFile, outFile);
-    long size = CompressionUtils.zip(dataSegmentFile, outFile);
-
-    return createDescriptorFile(
-        segment.withLoadSpec(makeLoadSpec(outFile))
-               .withSize(size)
-               .withBinaryVersion(SegmentUtils.getVersionFromDir(dataSegmentFile)),
-        outDir
-    );
+    return CompressionUtils.zip(dataSegmentFile, outFile);
   }
 
   private DataSegment createDescriptorFile(DataSegment segment, File outDir) throws IOException

--- a/server/src/test/java/io/druid/segment/loading/LocalDataSegmentPusherTest.java
+++ b/server/src/test/java/io/druid/segment/loading/LocalDataSegmentPusherTest.java
@@ -20,14 +20,12 @@
 package io.druid.segment.loading;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.joda.JodaMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Files;
 import com.google.common.primitives.Ints;
+import io.druid.jackson.DefaultObjectMapper;
 import io.druid.timeline.DataSegment;
-import io.druid.timeline.partition.LinearShardSpec;
 import io.druid.timeline.partition.NoneShardSpec;
-import io.druid.timeline.partition.ShardSpec;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Before;
@@ -67,7 +65,7 @@ public class LocalDataSegmentPusherTest
   {
     config = new LocalDataSegmentPusherConfig();
     config.storageDirectory = temporaryFolder.newFolder();
-    localDataSegmentPusher = new LocalDataSegmentPusher(config, new JodaMapper());
+    localDataSegmentPusher = new LocalDataSegmentPusher(config, new DefaultObjectMapper());
     dataSegmentFiles = temporaryFolder.newFolder();
     Files.asByteSink(new File(dataSegmentFiles, "version.bin")).write(Ints.toByteArray(0x9));
   }


### PR DESCRIPTION
First completed push wins for concurrent pushes to local deep storage.
I also add a simple UT to test the scenario, hope it'll bring any help for review.
