### PR TITLE
[WIP] Lessen coordinator burden

### DIFF
--- a/common/src/main/java/io/druid/common/utils/JodaUtils.java
+++ b/common/src/main/java/io/druid/common/utils/JodaUtils.java
@@ -23,13 +23,13 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-
+import com.google.common.primitives.Longs;
 import io.druid.java.util.common.guava.Comparators;
-
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.TreeSet;
 
@@ -42,11 +42,57 @@ public class JodaUtils
   public static final long MIN_INSTANT = Long.MIN_VALUE / 2;
   public static final Interval ETERNITY = new Interval(MIN_INSTANT, MAX_INSTANT);
 
+  private static final Comparator<Interval> INTERVAL_BY_START_THEN_END = new Comparator<Interval>()
+  {
+    private final Comparator<Interval> comparator = Comparators.intervalsByStartThenEnd();
+
+    @Override
+    public int compare(Interval lhs, Interval rhs)
+    {
+      if (lhs.getChronology().equals(rhs.getChronology())) {
+        int compare = Longs.compare(lhs.getStartMillis(), rhs.getStartMillis());
+        if (compare == 0) {
+          return Longs.compare(lhs.getEndMillis(), rhs.getEndMillis());
+        }
+        return compare;
+      }
+      return comparator.compare(lhs, rhs);
+    }
+  };
+
+  private static final Comparator<Interval> INTERVAL_BY_END_THEN_START = new Comparator<Interval>()
+  {
+    private final Comparator<Interval> comparator = Comparators.intervalsByEndThenStart();
+
+    @Override
+    public int compare(Interval lhs, Interval rhs)
+    {
+      if (lhs.getChronology().equals(rhs.getChronology())) {
+        int compare = Longs.compare(lhs.getEndMillis(), rhs.getEndMillis());
+        if (compare == 0) {
+          return Longs.compare(lhs.getStartMillis(), rhs.getStartMillis());
+        }
+        return compare;
+      }
+      return comparator.compare(lhs, rhs);
+    }
+  };
+
+  public static Comparator<Interval> intervalsByStartThenEnd()
+  {
+    return INTERVAL_BY_START_THEN_END;
+  }
+
+  public static Comparator<Interval> intervalsByEndThenStart()
+  {
+    return INTERVAL_BY_END_THEN_START;
+  }
+
   public static ArrayList<Interval> condenseIntervals(Iterable<Interval> intervals)
   {
     ArrayList<Interval> retVal = Lists.newArrayList();
 
-    TreeSet<Interval> sortedIntervals = Sets.newTreeSet(Comparators.intervalsByStartThenEnd());
+    TreeSet<Interval> sortedIntervals = Sets.newTreeSet(JodaUtils.intervalsByStartThenEnd());
     for (Interval interval : intervals) {
       sortedIntervals.add(interval);
     }
@@ -95,13 +141,13 @@ public class JodaUtils
   {
     return Iterables.any(
         intervals, new Predicate<Interval>()
-    {
-      @Override
-      public boolean apply(Interval input)
-      {
-        return input.overlaps(i);
-      }
-    }
+        {
+          @Override
+          public boolean apply(Interval input)
+          {
+            return input.overlaps(i);
+          }
+        }
     );
 
   }

--- a/common/src/main/java/io/druid/timeline/VersionedIntervalTimeline.java
+++ b/common/src/main/java/io/druid/timeline/VersionedIntervalTimeline.java
@@ -23,8 +23,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
-
-import io.druid.java.util.common.guava.Comparators;
+import io.druid.common.utils.JodaUtils;
 import io.druid.timeline.partition.ImmutablePartitionHolder;
 import io.druid.timeline.partition.PartitionChunk;
 import io.druid.timeline.partition.PartitionHolder;
@@ -63,10 +62,10 @@ public class VersionedIntervalTimeline<VersionType, ObjectType> implements Timel
   private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
 
   final NavigableMap<Interval, TimelineEntry> completePartitionsTimeline = new TreeMap<Interval, TimelineEntry>(
-      Comparators.intervalsByStartThenEnd()
+      JodaUtils.intervalsByStartThenEnd()
   );
   final NavigableMap<Interval, TimelineEntry> incompletePartitionsTimeline = new TreeMap<Interval, TimelineEntry>(
-      Comparators.intervalsByStartThenEnd()
+      JodaUtils.intervalsByStartThenEnd()
   );
   private final Map<Interval, TreeMap<VersionType, TimelineEntry>> allTimelineEntries = Maps.newHashMap();
 

--- a/docs/content/configuration/coordinator.md
+++ b/docs/content/configuration/coordinator.md
@@ -24,6 +24,7 @@ The coordinator node uses several of the global configs in [Configuration](../co
 |--------|-----------|-------|
 |`druid.coordinator.period`|The run period for the coordinator. The coordinator’s operates by maintaining the current state of the world in memory and periodically looking at the set of segments available and segments being served to make decisions about whether any changes need to be made to the data topology. This property sets the delay between each of these runs.|PT60S|
 |`druid.coordinator.period.indexingPeriod`|How often to send indexing tasks to the indexing service. Only applies if merge or conversion is turned on.|PT1800S (30 mins)|
+|`druid.coordinator.lazy.ticks`|Make non-urgent coordinator works (cleanup or balancing) to be executed every this times of `druid.coordinator.period`.|1|
 |`druid.coordinator.startDelay`|The operation of the Coordinator works on the assumption that it has an up-to-date view of the state of the world when it runs, the current ZK interaction code, however, is written in a way that doesn’t allow the Coordinator to know for a fact that it’s done loading the current state of the world. This delay is a hack to give it enough time to believe that it has all the data.|PT300S|
 |`druid.coordinator.merge.on`|Boolean flag for whether or not the coordinator should try and merge small segments into a more optimal segment size.|false|
 |`druid.coordinator.conversion.on`|Boolean flag for converting old segment indexing versions to the latest segment indexing version.|false|

--- a/indexing-hadoop/src/main/java/io/druid/indexer/path/GranularUnprocessedPathSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/path/GranularUnprocessedPathSpec.java
@@ -22,11 +22,12 @@ package io.druid.indexer.path;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
+import io.druid.common.utils.JodaUtils;
 import io.druid.indexer.HadoopDruidIndexerConfig;
 import io.druid.indexer.hadoop.FSSpideringIterator;
 import io.druid.java.util.common.Granularity;
-import io.druid.java.util.common.guava.Comparators;
 import io.druid.segment.indexing.granularity.UniformGranularitySpec;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -75,7 +76,7 @@ public class GranularUnprocessedPathSpec extends GranularityPathSpec
     final Granularity segmentGranularity = config.getGranularitySpec().getSegmentGranularity();
 
     Map<DateTime, Long> inputModifiedTimes = new TreeMap<>(
-        Comparators.inverse(Comparators.comparable())
+        Ordering.natural().reverse()
     );
 
     for (FileStatus status : FSSpideringIterator.spiderIterable(fs, betaInput)) {
@@ -86,7 +87,7 @@ public class GranularUnprocessedPathSpec extends GranularityPathSpec
       inputModifiedTimes.put(key, currVal == null ? mTime : Math.max(currVal, mTime));
     }
 
-    Set<Interval> bucketsToRun = Sets.newTreeSet(Comparators.intervals());
+    Set<Interval> bucketsToRun = Sets.newTreeSet(JodaUtils.intervalsByStartThenEnd());
     for (Map.Entry<DateTime, Long> entry : inputModifiedTimes.entrySet()) {
       DateTime timeBucket = entry.getKey();
       long mTime = entry.getValue();

--- a/indexing-hadoop/src/main/java/io/druid/indexer/path/GranularityPathSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/path/GranularityPathSpec.java
@@ -22,13 +22,11 @@ package io.druid.indexer.path;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
-
+import io.druid.common.utils.JodaUtils;
 import io.druid.indexer.HadoopDruidIndexerConfig;
 import io.druid.indexer.hadoop.FSSpideringIterator;
 import io.druid.java.util.common.Granularity;
-import io.druid.java.util.common.guava.Comparators;
 import io.druid.java.util.common.logger.Logger;
-
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -113,7 +111,7 @@ public class GranularityPathSpec implements PathSpec
   @Override
   public Job addInputPaths(HadoopDruidIndexerConfig config, Job job) throws IOException
   {
-    final Set<Interval> intervals = Sets.newTreeSet(Comparators.intervals());
+    final Set<Interval> intervals = Sets.newTreeSet(JodaUtils.intervalsByStartThenEnd());
     Optional<Set<Interval>> optionalIntervals = config.getSegmentGranularIntervals();
     if (optionalIntervals.isPresent()) {
       for (Interval segmentInterval : optionalIntervals.get()) {

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
@@ -34,7 +34,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
-
+import io.druid.common.utils.JodaUtils;
 import io.druid.data.input.Committer;
 import io.druid.data.input.Firehose;
 import io.druid.data.input.FirehoseFactory;
@@ -46,7 +46,6 @@ import io.druid.indexing.common.TaskStatus;
 import io.druid.indexing.common.TaskToolbox;
 import io.druid.indexing.common.index.YeOldePlumberSchool;
 import io.druid.java.util.common.ISE;
-import io.druid.java.util.common.guava.Comparators;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.query.aggregation.hyperloglog.HyperLogLogCollector;
 import io.druid.segment.IndexSpec;
@@ -251,8 +250,8 @@ public class IndexTask extends AbstractFixedIntervalTask
     final FirehoseFactory firehoseFactory = ingestionSchema.getIOConfig().getFirehoseFactory();
     final GranularitySpec granularitySpec = ingestionSchema.getDataSchema().getGranularitySpec();
 
-    SortedSet<Interval> retVal = Sets.newTreeSet(Comparators.intervalsByStartThenEnd());
     int unparsed = 0;
+    SortedSet<Interval> retVal = Sets.newTreeSet(JodaUtils.intervalsByStartThenEnd());
     try (Firehose firehose = firehoseFactory.connect(ingestionSchema.getDataSchema().getParser())) {
       while (firehose.hasMore()) {
         final InputRow inputRow = firehose.nextRow();

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/TaskLockbox.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/TaskLockbox.java
@@ -38,9 +38,7 @@ import io.druid.indexing.common.TaskLock;
 import io.druid.indexing.common.task.Task;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.Pair;
-import io.druid.java.util.common.guava.Comparators;
 import io.druid.java.util.common.guava.FunctionalIterable;
-
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
@@ -254,7 +252,7 @@ public class TaskLockbox
 
         // No existing locks. We can make a new one.
         if (!running.containsKey(dataSource)) {
-          running.put(dataSource, new TreeMap<Interval, TaskLockPosse>(Comparators.intervalsByStartThenEnd()));
+          running.put(dataSource, new TreeMap<Interval, TaskLockPosse>(JodaUtils.intervalsByStartThenEnd()));
         }
 
         // Create new TaskLock and assign it a version.

--- a/processing/src/main/java/io/druid/query/select/SelectQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/select/SelectQueryQueryToolChest.java
@@ -31,9 +31,9 @@ import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.metamx.emitter.service.ServiceMetricEvent;
+import io.druid.common.utils.JodaUtils;
 import io.druid.granularity.QueryGranularity;
 import io.druid.java.util.common.StringUtils;
-import io.druid.java.util.common.guava.Comparators;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.guava.nary.BinaryFn;
 import io.druid.query.CacheStrategy;
@@ -349,8 +349,8 @@ public class SelectQueryQueryToolChest extends QueryToolChest<Result<SelectResul
         Iterables.transform(paging.keySet(), DataSegmentUtils.INTERVAL_EXTRACTOR(dataSource))
     );
     Collections.sort(
-        intervals, query.isDescending() ? Comparators.intervalsByEndThenStart()
-                                        : Comparators.intervalsByStartThenEnd()
+        intervals, query.isDescending() ? JodaUtils.intervalsByEndThenStart()
+                                        : JodaUtils.intervalsByStartThenEnd()
     );
 
     TreeMap<Long, Long> granularThresholds = Maps.newTreeMap();

--- a/server/src/main/java/io/druid/segment/indexing/granularity/ArbitraryGranularitySpec.java
+++ b/server/src/main/java/io/druid/segment/indexing/granularity/ArbitraryGranularitySpec.java
@@ -26,12 +26,9 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.PeekingIterator;
 import com.google.common.collect.Sets;
-
 import io.druid.common.utils.JodaUtils;
 import io.druid.granularity.QueryGranularity;
 import io.druid.java.util.common.Granularity;
-import io.druid.java.util.common.guava.Comparators;
-
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Interval;
@@ -58,7 +55,7 @@ public class ArbitraryGranularitySpec implements GranularitySpec
   {
     this.queryGranularity = queryGranularity;
     this.rollup = rollup == null ? Boolean.TRUE : rollup;
-    this.intervals = Sets.newTreeSet(Comparators.intervalsByStartThenEnd());
+    this.intervals = Sets.newTreeSet(JodaUtils.intervalsByStartThenEnd());
     this.timezone = timezone;
     final DateTimeZone timeZone = DateTimeZone.forID(this.timezone);
 

--- a/server/src/main/java/io/druid/server/coordinator/CoordinatorStats.java
+++ b/server/src/main/java/io/druid/server/coordinator/CoordinatorStats.java
@@ -80,4 +80,10 @@ public class CoordinatorStats
     }
     return this;
   }
+
+  public void clear()
+  {
+    perTierStats.clear();
+    globalStats.clear();
+  }
 }

--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
@@ -39,6 +39,7 @@ import io.druid.client.ServerInventoryView;
 import io.druid.client.indexing.IndexingServiceClient;
 import io.druid.collections.CountingMap;
 import io.druid.common.config.JacksonConfigManager;
+import io.druid.common.utils.JodaUtils;
 import io.druid.concurrent.Execs;
 import io.druid.curator.discovery.ServiceAnnouncer;
 import io.druid.guice.ManageLifecycle;
@@ -49,7 +50,6 @@ import io.druid.java.util.common.Pair;
 import io.druid.java.util.common.concurrent.ScheduledExecutorFactory;
 import io.druid.java.util.common.concurrent.ScheduledExecutors;
 import io.druid.java.util.common.guava.CloseQuietly;
-import io.druid.java.util.common.guava.Comparators;
 import io.druid.java.util.common.guava.FunctionalIterable;
 import io.druid.java.util.common.lifecycle.LifecycleStart;
 import io.druid.java.util.common.lifecycle.LifecycleStop;
@@ -94,7 +94,7 @@ public class DruidCoordinator
 {
   public static final String COORDINATOR_OWNER_NODE = "_COORDINATOR";
 
-  public static Comparator<DataSegment> SEGMENT_COMPARATOR = Ordering.from(Comparators.intervalsByEndThenStart())
+  public static Comparator<DataSegment> SEGMENT_COMPARATOR = Ordering.from(JodaUtils.intervalsByEndThenStart())
                                                                      .onResultOf(
                                                                          new Function<DataSegment, Interval>()
                                                                          {
@@ -796,9 +796,9 @@ public class DruidCoordinator
                 }
               },
               new DruidCoordinatorRuleRunner(DruidCoordinator.this),
-              new DruidCoordinatorCleanupUnneeded(DruidCoordinator.this),
-              new DruidCoordinatorCleanupOvershadowed(DruidCoordinator.this),
-              new DruidCoordinatorBalancer(DruidCoordinator.this),
+              new DruidCoordinatorCleanupUnneeded(DruidCoordinator.this, config.getCoordinatorLazyTicks()),
+              new DruidCoordinatorCleanupOvershadowed(DruidCoordinator.this, config.getCoordinatorLazyTicks()),
+              new DruidCoordinatorBalancer(DruidCoordinator.this, config.getCoordinatorLazyTicks()),
               new DruidCoordinatorLogger(DruidCoordinator.this)
           ),
           startingLeaderCounter

--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
@@ -430,9 +430,12 @@ public class DruidCoordinator
 
   public Set<DataSegment> getOrderedAvailableDataSegments()
   {
-    Set<DataSegment> availableSegments = Sets.newTreeSet(SEGMENT_COMPARATOR);
+    return makeOrdered(getAvailableDataSegments());
+  }
 
-    Iterable<DataSegment> dataSegments = getAvailableDataSegments();
+  public static Set<DataSegment> makeOrdered(Iterable<DataSegment> dataSegments)
+  {
+    Set<DataSegment> availableSegments = Sets.newTreeSet(SEGMENT_COMPARATOR);
 
     for (DataSegment dataSegment : dataSegments) {
       if (dataSegment.getSize() < 0) {
@@ -795,7 +798,7 @@ public class DruidCoordinator
                                .build();
                 }
               },
-              new DruidCoordinatorRuleRunner(DruidCoordinator.this),
+              new DruidCoordinatorRuleRunner(DruidCoordinator.this, config.getCoordinatorLazyTicks()),
               new DruidCoordinatorCleanupUnneeded(DruidCoordinator.this, config.getCoordinatorLazyTicks()),
               new DruidCoordinatorCleanupOvershadowed(DruidCoordinator.this, config.getCoordinatorLazyTicks()),
               new DruidCoordinatorBalancer(DruidCoordinator.this, config.getCoordinatorLazyTicks()),

--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinatorConfig.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinatorConfig.java
@@ -35,6 +35,10 @@ public abstract class DruidCoordinatorConfig
   @Default("PT60s")
   public abstract Duration getCoordinatorPeriod();
 
+  @Config("druid.coordinator.lazy.ticks")
+  @Default("1")
+  public abstract int getCoordinatorLazyTicks();
+
   @Config("druid.coordinator.period.indexingPeriod")
   @Default("PT1800s")
   public abstract Duration getCoordinatorIndexingPeriod();

--- a/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorCleanupUnneeded.java
+++ b/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorCleanupUnneeded.java
@@ -41,18 +41,22 @@ public class DruidCoordinatorCleanupUnneeded implements DruidCoordinatorHelper
 {
   private static final Logger log = new Logger(DruidCoordinatorCleanupUnneeded.class);
 
-  private final DruidCoordinator coordinator;
+  private final int cleanupLazyTicks;
+  private int currentTick;
 
-  public DruidCoordinatorCleanupUnneeded(
-      DruidCoordinator coordinator
-  )
+  public DruidCoordinatorCleanupUnneeded(DruidCoordinator coordinator, int cleanupLazyTicks)
   {
-    this.coordinator = coordinator;
+    this.cleanupLazyTicks = cleanupLazyTicks;
   }
 
   @Override
   public DruidCoordinatorRuntimeParams run(DruidCoordinatorRuntimeParams params)
   {
+    if (++currentTick < cleanupLazyTicks) {
+      return params;
+    }
+    currentTick = 0;
+
     CoordinatorStats stats = new CoordinatorStats();
     Set<DataSegment> availableSegments = params.getAvailableSegments();
     DruidCluster cluster = params.getDruidCluster();

--- a/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorSegmentInfoLoader.java
+++ b/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorSegmentInfoLoader.java
@@ -19,11 +19,13 @@
 
 package io.druid.server.coordinator.helper;
 
+import com.google.common.base.Supplier;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.server.coordinator.DruidCoordinator;
 import io.druid.server.coordinator.DruidCoordinatorRuntimeParams;
 import io.druid.timeline.DataSegment;
 
+import java.util.Collections;
 import java.util.Set;
 
 public class DruidCoordinatorSegmentInfoLoader implements DruidCoordinatorHelper
@@ -43,18 +45,26 @@ public class DruidCoordinatorSegmentInfoLoader implements DruidCoordinatorHelper
     log.info("Starting coordination. Getting available segments.");
 
     // Display info about all available segments
-    final Set<DataSegment> availableSegments = coordinator.getOrderedAvailableDataSegments();
-    if (log.isDebugEnabled()) {
-      log.debug("Available DataSegments");
-      for (DataSegment dataSegment : availableSegments) {
-        log.debug("  %s", dataSegment);
-      }
-    }
+    Supplier<Set<DataSegment>> supplier = new Supplier<Set<DataSegment>>()
+    {
+      @Override
+      public Set<DataSegment> get()
+      {
+        final Set<DataSegment> availableSegments = coordinator.getOrderedAvailableDataSegments();
+        if (log.isDebugEnabled()) {
+          log.debug("Available DataSegments");
+          for (DataSegment dataSegment : availableSegments) {
+            log.debug("  %s", dataSegment);
+          }
+        }
 
-    log.info("Found [%,d] available segments.", availableSegments.size());
+        log.info("Found [%,d] available segments.", availableSegments.size());
+        return Collections.unmodifiableSet(availableSegments);
+      }
+    };
 
     return params.buildFromExisting()
-                 .withAvailableSegments(availableSegments)
+                 .withAvailableSegments(supplier)
                  .build();
   }
 }

--- a/server/src/main/java/io/druid/server/coordinator/rules/LoadRule.java
+++ b/server/src/main/java/io/druid/server/coordinator/rules/LoadRule.java
@@ -37,7 +37,6 @@ import org.joda.time.DateTime;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * LoadRules indicate the number of replicants a segment should have in a given tier.
@@ -52,7 +51,6 @@ public abstract class LoadRule implements Rule
   public CoordinatorStats run(DruidCoordinator coordinator, DruidCoordinatorRuntimeParams params, DataSegment segment)
   {
     final CoordinatorStats stats = new CoordinatorStats();
-    final Set<DataSegment> availableSegments = params.getAvailableSegments();
 
     final Map<String, Integer> loadStatus = Maps.newHashMap();
 
@@ -74,20 +72,18 @@ public abstract class LoadRule implements Rule
       final List<ServerHolder> serverHolderList = Lists.newArrayList(serverQueue);
       final DateTime referenceTimestamp = params.getBalancerReferenceTimestamp();
       final BalancerStrategy strategy = params.getBalancerStrategyFactory().createBalancerStrategy(referenceTimestamp);
-      if (availableSegments.contains(segment)) {
-        CoordinatorStats assignStats = assign(
-            params.getReplicationManager(),
-            tier,
-            totalReplicantsInCluster,
-            expectedReplicantsInTier,
-            totalReplicantsInTier,
-            strategy,
-            serverHolderList,
-            segment
-        );
-        stats.accumulate(assignStats);
-        totalReplicantsInCluster += assignStats.getPerTierStats().get(assignedCount).get(tier).get();
-      }
+      CoordinatorStats assignStats = assign(
+          params.getReplicationManager(),
+          tier,
+          totalReplicantsInCluster,
+          expectedReplicantsInTier,
+          totalReplicantsInTier,
+          strategy,
+          serverHolderList,
+          segment
+      );
+      stats.accumulate(assignStats);
+      totalReplicantsInCluster += assignStats.getPerTierStats().get(assignedCount).get(tier).get();
 
       loadStatus.put(tier, expectedReplicantsInTier - loadedReplicantsInTier);
     }

--- a/server/src/main/java/io/druid/server/http/DatasourcesResource.java
+++ b/server/src/main/java/io/druid/server/http/DatasourcesResource.java
@@ -33,6 +33,7 @@ import io.druid.client.DruidServer;
 import io.druid.client.ImmutableSegmentLoadInfo;
 import io.druid.client.SegmentLoadInfo;
 import io.druid.client.indexing.IndexingServiceClient;
+import io.druid.common.utils.JodaUtils;
 import io.druid.java.util.common.MapUtils;
 import io.druid.java.util.common.Pair;
 import io.druid.java.util.common.guava.Comparators;
@@ -286,7 +287,7 @@ public class DatasourcesResource
       return Response.noContent().build();
     }
 
-    final Comparator<Interval> comparator = Comparators.inverse(Comparators.intervalsByStartThenEnd());
+    final Comparator<Interval> comparator = Comparators.inverse(JodaUtils.intervalsByStartThenEnd());
 
     if (full != null) {
       final Map<Interval, Map<String, Object>> retVal = Maps.newTreeMap(comparator);
@@ -349,7 +350,7 @@ public class DatasourcesResource
       return Response.noContent().build();
     }
 
-    final Comparator<Interval> comparator = Comparators.inverse(Comparators.intervalsByStartThenEnd());
+    final Comparator<Interval> comparator = Comparators.inverse(JodaUtils.intervalsByStartThenEnd());
     if (full != null) {
       final Map<Interval, Map<String, Object>> retVal = Maps.newTreeMap(comparator);
       for (DataSegment dataSegment : dataSource.getSegments()) {

--- a/server/src/main/java/io/druid/server/http/IntervalsResource.java
+++ b/server/src/main/java/io/druid/server/http/IntervalsResource.java
@@ -21,9 +21,9 @@ package io.druid.server.http;
 
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
-
 import io.druid.client.DruidDataSource;
 import io.druid.client.InventoryView;
+import io.druid.common.utils.JodaUtils;
 import io.druid.java.util.common.MapUtils;
 import io.druid.java.util.common.guava.Comparators;
 import io.druid.server.security.AuthConfig;
@@ -66,7 +66,7 @@ public class IntervalsResource
   @Produces(MediaType.APPLICATION_JSON)
   public Response getIntervals(@Context final HttpServletRequest req)
   {
-    final Comparator<Interval> comparator = Comparators.inverse(Comparators.intervalsByStartThenEnd());
+    final Comparator<Interval> comparator = Comparators.inverse(JodaUtils.intervalsByStartThenEnd());
     final Set<DruidDataSource> datasources = authConfig.isEnabled() ?
                                              InventoryViewUtils.getSecuredDataSources(
                                                  serverInventoryView,
@@ -107,7 +107,7 @@ public class IntervalsResource
                                              ) :
                                              InventoryViewUtils.getDataSources(serverInventoryView);
 
-    final Comparator<Interval> comparator = Comparators.inverse(Comparators.intervalsByStartThenEnd());
+    final Comparator<Interval> comparator = Comparators.inverse(JodaUtils.intervalsByStartThenEnd());
 
     if (full != null) {
       final Map<Interval, Map<String, Map<String, Object>>> retVal = Maps.newTreeMap(comparator);

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerProfiler.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerProfiler.java
@@ -174,7 +174,7 @@ public class DruidCoordinatorBalancerProfiler
                                 .build();
 
     DruidCoordinatorBalancerTester tester = new DruidCoordinatorBalancerTester(coordinator);
-    DruidCoordinatorRuleRunner runner = new DruidCoordinatorRuleRunner(coordinator);
+    DruidCoordinatorRuleRunner runner = new DruidCoordinatorRuleRunner(coordinator, 1);
     watch.start();
     DruidCoordinatorRuntimeParams balanceParams = tester.run(params);
     DruidCoordinatorRuntimeParams assignParams = runner.run(params);

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTester.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTester.java
@@ -27,7 +27,7 @@ public class DruidCoordinatorBalancerTester extends DruidCoordinatorBalancer
 {
   public DruidCoordinatorBalancerTester(DruidCoordinator coordinator)
   {
-    super(coordinator);
+    super(coordinator, 1);
   }
 
   @Override

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorRuleRunnerTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorRuleRunnerTest.java
@@ -31,6 +31,7 @@ import com.metamx.emitter.service.ServiceEventBuilder;
 import io.druid.client.DruidServer;
 import io.druid.metadata.MetadataRuleManager;
 import io.druid.segment.IndexIO;
+import io.druid.server.coordinator.helper.DruidCoordinatorHelper;
 import io.druid.server.coordinator.helper.DruidCoordinatorRuleRunner;
 import io.druid.server.coordinator.rules.IntervalDropRule;
 import io.druid.server.coordinator.rules.IntervalLoadRule;
@@ -46,6 +47,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -55,7 +57,7 @@ public class DruidCoordinatorRuleRunnerTest
   private DruidCoordinator coordinator;
   private LoadQueuePeon mockPeon;
   private List<DataSegment> availableSegments;
-  private DruidCoordinatorRuleRunner ruleRunner;
+  private List<DataSegment> availableSegmentsShuffled;
   private ServiceEmitter emitter;
   private MetadataRuleManager databaseRuleManager;
 
@@ -86,8 +88,8 @@ public class DruidCoordinatorRuleRunnerTest
       );
       start = start.plusHours(1);
     }
-
-    ruleRunner = new DruidCoordinatorRuleRunner(new ReplicationThrottler(24, 1), coordinator);
+    availableSegmentsShuffled = Lists.newArrayList(availableSegments);
+    Collections.shuffle(availableSegmentsShuffled);
   }
 
   @After
@@ -187,6 +189,7 @@ public class DruidCoordinatorRuleRunnerTest
             .withDynamicConfigs(new CoordinatorDynamicConfig.Builder().withMaxSegmentsToMove(5).build())
             .build();
 
+    DruidCoordinatorHelper ruleRunner = new DruidCoordinatorRuleRunner(new ReplicationThrottler(24, 1), coordinator, 1);
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
@@ -283,6 +286,7 @@ public class DruidCoordinatorRuleRunnerTest
             .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
             .build();
 
+    DruidCoordinatorHelper ruleRunner = new DruidCoordinatorRuleRunner(new ReplicationThrottler(24, 1), coordinator, 1);
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
@@ -374,6 +378,7 @@ public class DruidCoordinatorRuleRunnerTest
             .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
             .build();
 
+    DruidCoordinatorHelper ruleRunner = new DruidCoordinatorRuleRunner(new ReplicationThrottler(24, 1), coordinator, 1);
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
@@ -440,6 +445,7 @@ public class DruidCoordinatorRuleRunnerTest
             .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
             .build();
 
+    DruidCoordinatorHelper ruleRunner = new DruidCoordinatorRuleRunner(new ReplicationThrottler(24, 1), coordinator, 1);
     ruleRunner.run(params);
 
     EasyMock.verify(emitter);
@@ -492,6 +498,7 @@ public class DruidCoordinatorRuleRunnerTest
             .withSegmentReplicantLookup(SegmentReplicantLookup.make(new DruidCluster()))
             .build();
 
+    DruidCoordinatorHelper ruleRunner = new DruidCoordinatorRuleRunner(new ReplicationThrottler(24, 1), coordinator, 1);
     ruleRunner.run(params);
 
     EasyMock.verify(emitter);
@@ -561,6 +568,7 @@ public class DruidCoordinatorRuleRunnerTest
         .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
         .build();
 
+    DruidCoordinatorHelper ruleRunner = new DruidCoordinatorRuleRunner(new ReplicationThrottler(24, 1), coordinator, 1);
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
@@ -640,6 +648,7 @@ public class DruidCoordinatorRuleRunnerTest
         .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
         .build();
 
+    DruidCoordinatorHelper ruleRunner = new DruidCoordinatorRuleRunner(new ReplicationThrottler(24, 1), coordinator, 1);
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
@@ -726,6 +735,7 @@ public class DruidCoordinatorRuleRunnerTest
         .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
         .build();
 
+    DruidCoordinatorHelper ruleRunner = new DruidCoordinatorRuleRunner(new ReplicationThrottler(24, 1), coordinator, 1);
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
@@ -808,6 +818,7 @@ public class DruidCoordinatorRuleRunnerTest
         .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
         .build();
 
+    DruidCoordinatorHelper ruleRunner = new DruidCoordinatorRuleRunner(new ReplicationThrottler(24, 1), coordinator, 1);
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
@@ -903,6 +914,7 @@ public class DruidCoordinatorRuleRunnerTest
         .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
         .build();
 
+    DruidCoordinatorHelper ruleRunner = new DruidCoordinatorRuleRunner(new ReplicationThrottler(24, 1), coordinator, 1);
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
@@ -978,6 +990,7 @@ public class DruidCoordinatorRuleRunnerTest
             .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
             .build();
 
+    DruidCoordinatorHelper ruleRunner = new DruidCoordinatorRuleRunner(new ReplicationThrottler(24, 1), coordinator, 1);
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
@@ -1200,10 +1213,89 @@ public class DruidCoordinatorRuleRunnerTest
         .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
         .build();
 
+    DruidCoordinatorHelper ruleRunner = new DruidCoordinatorRuleRunner(new ReplicationThrottler(24, 1), coordinator, 1);
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
     Assert.assertTrue(stats.getPerTierStats().get("droppedCount").get("normal").get() == 24);
+    EasyMock.verify(mockPeon);
+    params.getBalancerStrategyFactory().close();
+  }
+
+  @Test
+  public void testRunTwoTiersWithLazyTick() throws Exception
+  {
+    EasyMock.expect(coordinator.getDynamicConfigs()).andReturn(
+        new CoordinatorDynamicConfig(0, 0, 0, 0, 1, 24, 0, false, null, false)
+    ).anyTimes();
+    coordinator.removeSegment(EasyMock.<DataSegment>anyObject());
+    EasyMock.expectLastCall().anyTimes();
+    EasyMock.expect(coordinator.getAvailableDataSegments()).andReturn(availableSegmentsShuffled);
+    EasyMock.replay(coordinator);
+
+    DruidServer server1 = new DruidServer("serverHot", "hostHot", 1000, "historical", "hot", 0);
+    for (DataSegment segment : availableSegments.subList(0, 4)) {
+      server1.addDataSegment(segment.getIdentifier(), segment);
+    }
+    DruidServer server2 = new DruidServer("serverHot2", "hostHot2", 1000, "historical", "hot", 0);
+    for (DataSegment segment : availableSegments.subList(12, 18)) {
+      server2.addDataSegment(segment.getIdentifier(), segment);
+    }
+    DruidServer server3 = new DruidServer("serverCold", "hostCold", 1000, "historical", "cold", 0);
+    for (DataSegment segment : availableSegments.subList(20, 24)) {
+      server3.addDataSegment(segment.getIdentifier(), segment);
+    }
+
+    mockPeon.loadSegment(EasyMock.<DataSegment>anyObject(), EasyMock.<LoadPeonCallback>anyObject());
+    EasyMock.expectLastCall().atLeastOnce();
+    EasyMock.expect(mockPeon.getSegmentsToLoad()).andReturn(Sets.<DataSegment>newHashSet()).atLeastOnce();
+    EasyMock.expect(mockPeon.getLoadQueueSize()).andReturn(0L).atLeastOnce();
+    EasyMock.replay(mockPeon);
+
+    DruidCluster druidCluster = new DruidCluster(
+        ImmutableMap.of(
+            "hot",
+            MinMaxPriorityQueue.orderedBy(Ordering.natural().reverse()).create(
+                Arrays.asList(
+                    new ServerHolder(server1.toImmutableDruidServer(), mockPeon),
+                    new ServerHolder(server2.toImmutableDruidServer(), mockPeon)
+                )
+            ),
+            "cold",
+            MinMaxPriorityQueue.orderedBy(Ordering.natural().reverse()).create(
+                Arrays.asList(new ServerHolder(server3.toImmutableDruidServer(), mockPeon))
+            )
+        )
+    );
+
+    DruidCoordinatorRuntimeParams params =
+        new DruidCoordinatorRuntimeParams.Builder()
+            .withDruidCluster(druidCluster)
+            .withAvailableSegments(availableSegments)
+            .withDatabaseRuleManager(databaseRuleManager)
+            .withSegmentReplicantLookup(SegmentReplicantLookup.make(druidCluster))
+            .withBalancerStrategyFactory(new CostBalancerStrategyFactory(1))
+            .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
+            .build();
+
+    EasyMock.expect(databaseRuleManager.getRulesWithDefault(EasyMock.<String>anyObject())).andReturn(
+        Lists.<Rule>newArrayList(
+            new IntervalLoadRule(new Interval("2012-01-01T00:00:00.000Z/2012-01-01T06:00:00.000Z"), ImmutableMap.<String, Integer>of("hot", 2)),
+            new IntervalLoadRule(new Interval("2012-01-01T00:00:00.000Z/2012-01-02T00:00:00.000Z"), ImmutableMap.<String, Integer>of("cold", 2))
+        )
+    ).atLeastOnce();
+    EasyMock.replay(databaseRuleManager);
+
+    DruidCoordinatorHelper ruleRunner = new DruidCoordinatorRuleRunner(new ReplicationThrottler(24, 1), coordinator, 2);
+    CoordinatorStats stats = ruleRunner.run(params).getCoordinatorStats();
+
+    // 4-5
+    Assert.assertEquals(2 * 2, stats.getPerTierStats().get("assignedCount").get("hot").get());
+    // 6-12, 19-20
+    Assert.assertEquals(8 * 2, stats.getPerTierStats().get("assignedCount").get("cold").get());
+    Assert.assertTrue(stats.getPerTierStats().get("unassignedCount") == null);
+    Assert.assertTrue(stats.getPerTierStats().get("unassignedSize") == null);
+
     EasyMock.verify(mockPeon);
     params.getBalancerStrategyFactory().close();
   }

--- a/server/src/test/java/io/druid/server/coordinator/TestDruidCoordinatorConfig.java
+++ b/server/src/test/java/io/druid/server/coordinator/TestDruidCoordinatorConfig.java
@@ -75,6 +75,12 @@ public class TestDruidCoordinatorConfig extends DruidCoordinatorConfig
   }
 
   @Override
+  public int getCoordinatorLazyTicks()
+  {
+    return 1;
+  }
+
+  @Override
   public Duration getCoordinatorIndexingPeriod()
   {
     return coordinatorIndexingPeriod;


### PR DESCRIPTION
We've configured coordinator with rather small interval (druid.coordinator.period=PT5S) to make new segments loaded in a few seconds. That made coordinator very busy on sorting segments (we have 200K segments) to check unneeded/overshadowed segments, which seemed occur very intermittently.

This patch consists 4 parts,
1. Minor improvement of Comparator of Interval not to make DateTime for each compare when two interval has the same chronology
2. Makes some works (cleanups and balancing) not run every coordinator period
3. Cache immutable view of DruidServer when nothing is changed for the server
4. Related to 2. Use Supplier instead of Set of segments for DruidCoordinatorRuntimeParams to materialize segments only when needed
