### PR TITLE
Avoid exceptions for dataSource spec when using s3

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceInputFormat.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceInputFormat.java
@@ -34,6 +34,7 @@ import io.druid.data.input.InputRow;
 import io.druid.indexer.HadoopDruidIndexerConfig;
 import io.druid.indexer.JobHelper;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.NullWritable;
@@ -158,6 +159,18 @@ public class DatasourceInputFormat extends InputFormat<NullWritable, InputRow>
         @Override
         protected boolean isSplitable(FileSystem fs, Path file) {
           return false;
+        }
+
+        @Override
+        protected FileStatus[] listStatus(JobConf job) throws IOException
+        {
+          // to avoid globbing which needs input path should be hadoop-compatible (':' is not acceptable in path, etc.)
+          List<FileStatus> statusList = Lists.newArrayList();
+          for (Path path : FileInputFormat.getInputPaths(job)) {
+            // load spec in segment points specifically zip file itself
+            statusList.add(path.getFileSystem(job).getFileStatus(path));
+          }
+          return statusList.toArray(new FileStatus[statusList.size()]);
         }
       };
     }


### PR DESCRIPTION
This is for #3306. Default implementation of `listStatus()` in `TextInputFormat` uses globbing, which makes exceptions with paths containing non-hadoop-compatible characters like ':'.