### PR TITLE
fix: QueryResource thread name includes whole inner query string for nested query

### DIFF
--- a/server/src/main/java/io/druid/server/QueryResource.java
+++ b/server/src/main/java/io/druid/server/QueryResource.java
@@ -188,7 +188,7 @@ public class QueryResource
       toolChest = warehouse.getToolChest(query);
 
       Thread.currentThread()
-            .setName(String.format("%s[%s_%s_%s]", currThreadName, query.getType(), query.getDataSource(), queryId));
+            .setName(String.format("%s[%s_%s_%s]", currThreadName, query.getType(), query.getDataSource().getNames(), queryId));
       if (log.isDebugEnabled()) {
         log.debug("Got query [%s]", query);
       }

--- a/server/src/main/java/io/druid/server/QueryResource.java
+++ b/server/src/main/java/io/druid/server/QueryResource.java
@@ -307,7 +307,7 @@ public class QueryResource
     }
     catch (QueryInterruptedException e) {
       try {
-        log.info("%s [%s]", e.getMessage(), queryId);
+        log.warn(e, "Exception while processing queryId [%s]", queryId);
         final long queryTime = System.currentTimeMillis() - start;
         emitter.emit(
             DruidMetrics.makeQueryTimeMetric(toolChest, jsonMapper, query, req.getRemoteAddr())


### PR DESCRIPTION
..instead of just the dataSource name.

another log message update to print exception stack trace and not just the message to understand problem from the logs.