### PR TITLE
Add druid-lookups-cached-single to default distribution build

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -91,6 +91,8 @@
                                 <argument>-c</argument>
                                 <argument>io.druid.extensions:druid-lookups-cached-global</argument>
                                 <argument>-c</argument>
+                                <argument>io.druid.extensions:druid-lookups-cached-single</argument>
+                                <argument>-c</argument>
                                 <argument>io.druid.extensions:druid-s3-extensions</argument>
                                 <argument>-c</argument>
                                 <argument>io.druid.extensions:druid-stats</argument>


### PR DESCRIPTION
Fixes #3527 

Note: #3548