### PR TITLE
[WIP] Add initial size for histogram

### DIFF
--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregator.java
@@ -53,6 +53,7 @@ public class ApproximateHistogramAggregator implements Aggregator
       String name,
       FloatColumnSelector selector,
       int resolution,
+      int initialSize,
       float lowerLimit,
       float upperLimit
   )
@@ -62,7 +63,7 @@ public class ApproximateHistogramAggregator implements Aggregator
     this.resolution = resolution;
     this.lowerLimit = lowerLimit;
     this.upperLimit = upperLimit;
-    this.histogram = new ApproximateHistogram(resolution, lowerLimit, upperLimit);
+    this.histogram = new ApproximateHistogram(resolution, initialSize, lowerLimit, upperLimit);
   }
 
   @Override

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregatorFactory.java
@@ -44,12 +44,13 @@ public class ApproximateHistogramFoldingAggregatorFactory extends ApproximateHis
       @JsonProperty("name") String name,
       @JsonProperty("fieldName") String fieldName,
       @JsonProperty("resolution") Integer resolution,
+      @JsonProperty("initialSize") Integer initialSize,
       @JsonProperty("numBuckets") Integer numBuckets,
       @JsonProperty("lowerLimit") Float lowerLimit,
       @JsonProperty("upperLimit") Float upperLimit
   )
   {
-    super(name, fieldName, resolution, numBuckets, lowerLimit, upperLimit);
+    super(name, fieldName, resolution, initialSize, numBuckets, lowerLimit, upperLimit);
   }
 
   @Override
@@ -133,7 +134,15 @@ public class ApproximateHistogramFoldingAggregatorFactory extends ApproximateHis
   @Override
   public AggregatorFactory getCombiningFactory()
   {
-    return new ApproximateHistogramFoldingAggregatorFactory(name, name, resolution, numBuckets, lowerLimit, upperLimit);
+    return new ApproximateHistogramFoldingAggregatorFactory(
+        name,
+        name,
+        resolution,
+        initialSize,
+        numBuckets,
+        lowerLimit,
+        upperLimit
+    );
   }
 
   @Override
@@ -203,6 +212,7 @@ public class ApproximateHistogramFoldingAggregatorFactory extends ApproximateHis
            "name='" + name + '\'' +
            ", fieldName='" + fieldName + '\'' +
            ", resolution=" + resolution +
+           ", initialSize=" + initialSize +
            ", numBuckets=" + numBuckets +
            ", lowerLimit=" + lowerLimit +
            ", upperLimit=" + upperLimit +

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorTest.java
@@ -23,11 +23,29 @@ import io.druid.query.aggregation.BufferAggregator;
 import io.druid.query.aggregation.TestFloatColumnSelector;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
+@RunWith(Parameterized.class)
 public class ApproximateHistogramAggregatorTest
 {
+  @Parameterized.Parameters(name="initialSize={0}")
+  public static Iterable<Object[]> constructorFeeder() throws IOException
+  {
+    return Arrays.<Object[]>asList(new Object[] {-1}, new Object[] {1});
+  }
+
+  private final int initialSize;
+
+  public ApproximateHistogramAggregatorTest(int initialSize)
+  {
+    this.initialSize = initialSize;
+  }
+
   private void aggregateBuffer(TestFloatColumnSelector selector, BufferAggregator agg, ByteBuffer buf, int position)
   {
     agg.aggregate(buf, position);
@@ -44,7 +62,7 @@ public class ApproximateHistogramAggregatorTest
     final TestFloatColumnSelector selector = new TestFloatColumnSelector(values);
 
     ApproximateHistogramAggregatorFactory factory = new ApproximateHistogramAggregatorFactory(
-        "billy", "billy", resolution, numBuckets, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY
+        "billy", "billy", resolution, initialSize, numBuckets, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY
     );
     ApproximateHistogramBufferAggregator agg = new ApproximateHistogramBufferAggregator(selector, resolution, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY);
 

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
@@ -52,8 +52,9 @@ public class ApproximateHistogramGroupByQueryTest
   private final QueryRunner<Row> runner;
   private GroupByQueryRunnerFactory factory;
   private String testName;
+  private int initialSize;
 
-  @Parameterized.Parameters(name="{0}")
+  @Parameterized.Parameters(name="{0}, initialSize={3}")
   public static Iterable<Object[]> constructorFeeder() throws IOException
   {
     final GroupByQueryConfig defaultConfig = new GroupByQueryConfig()
@@ -111,18 +112,26 @@ public class ApproximateHistogramGroupByQueryTest
             config.toString(),
             runner.toString()
         );
-        constructors.add(new Object[]{testName, factory, runner});
+        for (int initialSize : new int[] {-1, 1}) {
+          constructors.add(new Object[]{testName, factory, runner, initialSize});
+        }
       }
     }
 
     return constructors;
   }
 
-  public ApproximateHistogramGroupByQueryTest(String testName, GroupByQueryRunnerFactory factory, QueryRunner runner)
+  public ApproximateHistogramGroupByQueryTest(
+      String testName,
+      GroupByQueryRunnerFactory factory,
+      QueryRunner runner,
+      int initialSize
+  )
   {
     this.testName = testName;
     this.factory = factory;
     this.runner = runner;
+    this.initialSize = initialSize;
 
     //Note: this is needed in order to properly register the serde for Histogram.
     new ApproximateHistogramDruidModule().configure(null);
@@ -135,6 +144,7 @@ public class ApproximateHistogramGroupByQueryTest
         "apphisto",
         "index",
         10,
+        initialSize,
         5,
         Float.NEGATIVE_INFINITY,
         Float.POSITIVE_INFINITY
@@ -209,6 +219,7 @@ public class ApproximateHistogramGroupByQueryTest
         "quantile",
         "index",
         10,
+        initialSize,
         5,
         Float.NEGATIVE_INFINITY,
         Float.POSITIVE_INFINITY

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramPostAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramPostAggregatorTest.java
@@ -45,7 +45,14 @@ public class ApproximateHistogramPostAggregatorTest
     ApproximateHistogram ah = buildHistogram(10, VALUES);
     final TestFloatColumnSelector selector = new TestFloatColumnSelector(VALUES);
 
-    ApproximateHistogramAggregator agg = new ApproximateHistogramAggregator("price", selector, 10, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY);
+    ApproximateHistogramAggregator agg = new ApproximateHistogramAggregator(
+        "price",
+        selector,
+        10,
+        10,
+        Float.NEGATIVE_INFINITY,
+        Float.POSITIVE_INFINITY
+    );
     for (int i = 0; i < VALUES.length; i++) {
       agg.aggregate();
       selector.increment();

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramTopNQueryTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramTopNQueryTest.java
@@ -54,10 +54,10 @@ import java.util.Map;
 @RunWith(Parameterized.class)
 public class ApproximateHistogramTopNQueryTest
 {
-  @Parameterized.Parameters(name="{0}")
+  @Parameterized.Parameters(name = "{0}")
   public static Iterable<Object[]> constructorFeeder() throws IOException
   {
-    return QueryRunnerTestHelper.transformToConstructionFeeder(
+    return QueryRunnerTestHelper.cartesian(
         Iterables.concat(
             QueryRunnerTestHelper.makeQueryRunners(
                 new TopNQueryRunnerFactory(
@@ -82,17 +82,21 @@ public class ApproximateHistogramTopNQueryTest
                     QueryRunnerTestHelper.NOOP_QUERYWATCHER
                 )
             )
-        )
+        ),
+        Arrays.asList(-1, 1)
     );
   }
 
   private final QueryRunner runner;
+  private final int initialSize;
 
   public ApproximateHistogramTopNQueryTest(
-      QueryRunner runner
+      QueryRunner runner,
+      int initialSize
   )
   {
     this.runner = runner;
+    this.initialSize = initialSize;
   }
 
   @Test
@@ -102,6 +106,7 @@ public class ApproximateHistogramTopNQueryTest
         "apphisto",
         "index",
         10,
+        initialSize,
         5,
         Float.NEGATIVE_INFINITY,
         Float.POSITIVE_INFINITY
@@ -237,7 +242,7 @@ public class ApproximateHistogramTopNQueryTest
             )
         )
     );
-    HashMap<String,Object> context = new HashMap<String, Object>();
+    HashMap<String, Object> context = new HashMap<String, Object>();
 
     TestHelper.assertExpectedResults(expectedResults, runner.run(query, context));
   }


### PR DESCRIPTION
Histogram aggregator allocates two array with provided resolution. If it's not aggregating many of values (or values with low cardinality), it will not be used occupying memory. We are using thousands of histogram in a row and that induces frequent spilling out of indices. This patch introduces new parameter `initialSize` for histogram aggregator.
