### PR TITLE
Remove dropwizard-jdbc dependency from lookups-cached-single.

### DIFF
--- a/extensions-core/lookups-cached-single/pom.xml
+++ b/extensions-core/lookups-cached-single/pom.xml
@@ -57,11 +57,6 @@
       <artifactId>mapdb</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.dropwizard</groupId>
-      <artifactId>dropwizard-jdbi</artifactId>
-      <version>0.9.2</version>
-    </dependency>
-    <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>stringtemplate</artifactId>
       <version>3.2</version>


### PR DESCRIPTION
Fixes #3548. Only one class from dropwizard-jdbc was used, and it wasn't doing anything overly special.