### PR TITLE
[Backport] Add druid-lookups-cached-single to default distribution build

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -90,6 +90,8 @@
                                 <argument>-c</argument>
                                 <argument>io.druid.extensions:druid-lookups-cached-global</argument>
                                 <argument>-c</argument>
+                                <argument>io.druid.extensions:druid-lookups-cached-single</argument>
+                                <argument>-c</argument>
                                 <argument>io.druid.extensions:druid-s3-extensions</argument>
                                 <argument>-c</argument>
                                 <argument>io.druid.extensions:druid-stats</argument>


### PR DESCRIPTION
Backport of #3550 to 0.9.2.