### PR TITLE
Lookup cache bug fixes

### DIFF
--- a/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/JDBCExtractionNamespaceCacheFactory.java
+++ b/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/JDBCExtractionNamespaceCacheFactory.java
@@ -74,6 +74,7 @@ public class JDBCExtractionNamespaceCacheFactory
       @Override
       public String call()
       {
+        final long dbQueryStart = System.currentTimeMillis();
         final DBI dbi = ensureDBI(id, namespace);
         final String table = namespace.getTable();
         final String valueColumn = namespace.getValueColumn();
@@ -118,7 +119,11 @@ public class JDBCExtractionNamespaceCacheFactory
           cache.put(pair.lhs, pair.rhs);
         }
         LOG.info("Finished loading %d values for namespace[%s]", cache.size(), id);
-        return String.format("%d", System.currentTimeMillis());
+        if (lastDBUpdate != null) {
+          return lastDBUpdate.toString();
+        } else {
+          return String.format("%d", dbQueryStart);
+        }
       }
     };
   }

--- a/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/StaticMapExtractionNamespaceCacheFactory.java
+++ b/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/StaticMapExtractionNamespaceCacheFactory.java
@@ -39,21 +39,20 @@ public class StaticMapExtractionNamespaceCacheFactory
       final Map<String, String> swap
   )
   {
+    if (lastVersion != null) {
+      // Throwing AssertionError, because NamespaceExtractionCacheManager doesn't suppress Errors and will stop trying
+      // to update the cache periodically.
+      throw new AssertionError(
+          "StaticMapExtractionNamespaceCacheFactory could only be configured for a namespace which is scheduled " +
+          "to be updated once, not periodically. Last version: `" + lastVersion + "`");
+    }
     return new Callable<String>()
     {
       @Override
       public String call() throws Exception
       {
-        if (lastVersion != null) {
-          // Throwing AssertionError, because NamespaceExtractionCacheManager doesn't suppress Errors and will stop
-          // trying to update the cache periodically.
-          throw new AssertionError(
-              "StaticMapExtractionNamespaceCacheFactory could only be configured for a namespace which is scheduled " +
-              "to be updated once, not periodically. Last version: `" + lastVersion + "`");
-        } else {
-          swap.putAll(extractionNamespace.getMap());
-          return version;
-        }
+        swap.putAll(extractionNamespace.getMap());
+        return version;
       }
     };
   }

--- a/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/StaticMapExtractionNamespaceCacheFactory.java
+++ b/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/StaticMapExtractionNamespaceCacheFactory.java
@@ -44,8 +44,12 @@ public class StaticMapExtractionNamespaceCacheFactory
       @Override
       public String call() throws Exception
       {
-        if (version.equals(lastVersion)) {
-          return null;
+        if (lastVersion != null) {
+          // Throwing AssertionError, because NamespaceExtractionCacheManager doesn't suppress Errors and will stop
+          // trying to update the cache periodically.
+          throw new AssertionError(
+              "StaticMapExtractionNamespaceCacheFactory could only be configured for a namespace which is scheduled " +
+              "to be updated once, not periodically. Last version: `" + lastVersion + "`");
         } else {
           swap.putAll(extractionNamespace.getMap());
           return version;

--- a/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/URIExtractionNamespaceCacheFactory.java
+++ b/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/URIExtractionNamespaceCacheFactory.java
@@ -32,6 +32,7 @@ import io.druid.query.lookup.namespace.ExtractionNamespaceCacheFactory;
 import io.druid.query.lookup.namespace.URIExtractionNamespace;
 import io.druid.segment.loading.URIDataPuller;
 
+import javax.annotation.Nullable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -61,7 +62,7 @@ public class URIExtractionNamespaceCacheFactory implements ExtractionNamespaceCa
   public Callable<String> getCachePopulator(
       final String id,
       final URIExtractionNamespace extractionNamespace,
-      final String lastVersion,
+      @Nullable final String lastVersion,
       final Map<String, String> cache
   )
   {
@@ -129,6 +130,7 @@ public class URIExtractionNamespaceCacheFactory implements ExtractionNamespaceCa
                 {
                   final String version = puller.getVersion(uri);
                   try {
+                    // Important to call equals() against version because lastVersion could be null
                     if (version.equals(lastVersion)) {
                       log.debug(
                           "URI [%s] for namespace [%s] has the same last modified time [%s] as the last cached. " +

--- a/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/URIExtractionNamespaceCacheFactory.java
+++ b/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/URIExtractionNamespaceCacheFactory.java
@@ -22,8 +22,6 @@ package io.druid.server.lookup.namespace;
 import com.google.common.base.Throwables;
 import com.google.common.io.ByteSource;
 import com.google.inject.Inject;
-
-import io.druid.common.utils.JodaUtils;
 import io.druid.data.SearchableVersionedDataFinder;
 import io.druid.data.input.MapPopulator;
 import io.druid.java.util.common.CompressionUtils;
@@ -33,8 +31,6 @@ import io.druid.java.util.common.logger.Logger;
 import io.druid.query.lookup.namespace.ExtractionNamespaceCacheFactory;
 import io.druid.query.lookup.namespace.URIExtractionNamespace;
 import io.druid.segment.loading.URIDataPuller;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -69,7 +65,6 @@ public class URIExtractionNamespaceCacheFactory implements ExtractionNamespaceCa
       final Map<String, String> cache
   )
   {
-    final long lastCached = lastVersion == null ? JodaUtils.MIN_INSTANT : Long.parseLong(lastVersion);
     return new Callable<String>()
     {
       @Override
@@ -134,15 +129,13 @@ public class URIExtractionNamespaceCacheFactory implements ExtractionNamespaceCa
                 {
                   final String version = puller.getVersion(uri);
                   try {
-                    long lastModified = Long.parseLong(version);
-                    if (lastModified <= lastCached) {
-                      final DateTimeFormatter fmt = ISODateTimeFormat.dateTime();
+                    if (version.equals(lastVersion)) {
                       log.debug(
-                          "URI [%s] for namespace [%s] was las modified [%s] but was last cached [%s]. Skipping ",
+                          "URI [%s] for namespace [%s] has the same last modified time [%s] as the last cached. " +
+                          "Skipping ",
                           uri.toString(),
                           id,
-                          fmt.print(lastModified),
-                          fmt.print(lastCached)
+                          version
                       );
                       return lastVersion;
                     }

--- a/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/URIExtractionNamespaceCacheFactory.java
+++ b/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/URIExtractionNamespaceCacheFactory.java
@@ -144,7 +144,7 @@ public class URIExtractionNamespaceCacheFactory implements ExtractionNamespaceCa
                           fmt.print(lastModified),
                           fmt.print(lastCached)
                       );
-                      return version;
+                      return lastVersion;
                     }
                   }
                   catch (NumberFormatException ex) {

--- a/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/cache/NamespaceExtractionCacheManager.java
+++ b/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/cache/NamespaceExtractionCacheManager.java
@@ -289,10 +289,7 @@ public abstract class NamespaceExtractionCacheManager
           }
         }
     );
-    if (!future.isDone()
-        && !future.cancel(true)) { // Interrupt to make sure we don't pollute stuff after we've already cleaned up
-      throw new ISE("Future for namespace [%s] was not able to be canceled", implDatum.name);
-    }
+    future.cancel(true);
     try {
       latch.await();
     }

--- a/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/cache/NamespaceExtractionCacheManager.java
+++ b/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/cache/NamespaceExtractionCacheManager.java
@@ -372,7 +372,11 @@ public abstract class NamespaceExtractionCacheManager
         catch (Throwable t) {
           try {
             delete(cacheId);
-            log.error(t, "Failed update namespace [%s]", namespace);
+            if (t instanceof InterruptedException) {
+              log.debug(t, "Namespace [%s] cancelled", id);
+            } else {
+              log.error(t, "Failed update namespace [%s]", namespace);
+            }
           }
           catch (Exception e) {
             t.addSuppressed(e);

--- a/extensions-core/lookups-cached-global/src/test/java/io/druid/server/lookup/namespace/StaticMapExtractionNamespaceCacheFactoryTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/io/druid/server/lookup/namespace/StaticMapExtractionNamespaceCacheFactoryTest.java
@@ -39,6 +39,14 @@ public class StaticMapExtractionNamespaceCacheFactoryTest
     final Map<String, String> cache = new HashMap<>();
     Assert.assertEquals(factory.getVersion(), factory.getCachePopulator(null, namespace, null, cache).call());
     Assert.assertEquals(MAP, cache);
+  }
+
+  @Test(expected = AssertionError.class)
+  public void testNonNullLastVersionCausesAssertionError() throws Exception
+  {
+    final StaticMapExtractionNamespaceCacheFactory factory = new StaticMapExtractionNamespaceCacheFactory();
+    final StaticMapExtractionNamespace namespace = new StaticMapExtractionNamespace(MAP);
+    final Map<String, String> cache = new HashMap<>();
     Assert.assertNull(factory.getCachePopulator(null, namespace, factory.getVersion(), cache).call());
   }
 }

--- a/extensions-core/lookups-cached-global/src/test/java/io/druid/server/lookup/namespace/cache/NamespaceExtractionCacheManagerExecutorsTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/io/druid/server/lookup/namespace/cache/NamespaceExtractionCacheManagerExecutorsTest.java
@@ -123,30 +123,19 @@ public class NamespaceExtractionCacheManagerExecutorsTest
     )
     {
       @Override
-      protected Runnable getPostRunnable(
-          final String id,
-          final String cacheId
-      )
+      protected void updateNamespace(final String id, final String cacheId, final String newVersion)
       {
-        final Runnable runnable = super.getPostRunnable(id, cacheId);
         cacheUpdateAlerts.putIfAbsent(id, new Object());
         final Object cacheUpdateAlerter = cacheUpdateAlerts.get(id);
-        return new Runnable()
-        {
-          @Override
-          public void run()
-          {
-            synchronized (cacheUpdateAlerter) {
-              try {
-                runnable.run();
-                numRuns.incrementAndGet();
-              }
-              finally {
-                cacheUpdateAlerter.notifyAll();
-              }
-            }
+        synchronized (cacheUpdateAlerter) {
+          try {
+            super.updateNamespace(id, cacheId, newVersion);
+            numRuns.incrementAndGet();
           }
-        };
+          finally {
+            cacheUpdateAlerter.notifyAll();
+          }
+        }
       }
     };
     tmpFile = Files.createTempFile(tmpDir, "druidTestURIExtractionNS", ".dat").toFile();


### PR DESCRIPTION
- Return better lastVersion from `JDBCExtractionNamespaceCacheFactory`'s cache populator callable 
- Return the lastVersion if URI lookup last modified date is not later than the last cached, from `URIExtractionNamespaceCacheFactory`'s cache populator callable
- Fix a race condition in `NamespaceExtractionCacheManager.cancelFuture()`
- Don't delete cache from `NamespaceExtractionCacheManager` if the `ExtractionNamespaceCacheFactory` returned the same version as the last; Better exception treatment in the scheduled cache updater runnable in `NamespaceExtractionCacheManager` (in particular, don't consume Errors); throw `AssertionError` in `StaticMapExtractionNamespaceCacheFactory` if the `lastVersion != null`
