### PR TITLE
Adding SegmentInputRow.getDelegate().

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/SegmentInputRow.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/SegmentInputRow.java
@@ -87,6 +87,11 @@ public class SegmentInputRow implements InputRow
     return delegate.compareTo(row);
   }
 
+  public InputRow getDelegate()
+  {
+    return delegate;
+  }
+
   @Override
   public String toString()
   {


### PR DESCRIPTION
We are working on hive SerDe and using DatasourceRecordReader. Having ` InputRow SegmentInputRow.getDelegate()` method gives us direct access to  `Map<String, Object>  MapBasedRow.getEvent()` which can be directly used during hive deserialization.