### PR TITLE
Move off-heap QTL global cache delete lock outside of subclass lock (#3597)

### DIFF
--- a/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/cache/OnHeapNamespaceExtractionCacheManager.java
+++ b/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/cache/OnHeapNamespaceExtractionCacheManager.java
@@ -92,10 +92,14 @@ public class OnHeapNamespaceExtractionCacheManager extends NamespaceExtractionCa
   @Override
   public boolean delete(final String namespaceKey)
   {
+    // `super.delete` has a synchronization in it, don't call it in the lock.
+    if (!super.delete(namespaceKey)) {
+      return false;
+    }
     final Lock lock = nsLocks.get(namespaceKey);
     lock.lock();
     try {
-      return super.delete(namespaceKey) && mapMap.remove(namespaceKey) != null;
+      return mapMap.remove(namespaceKey) != null;
     }
     finally {
       lock.unlock();

--- a/extensions-core/lookups-cached-global/src/test/java/io/druid/server/lookup/namespace/cache/NamespaceExtractionCacheManagerExecutorsTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/io/druid/server/lookup/namespace/cache/NamespaceExtractionCacheManagerExecutorsTest.java
@@ -122,14 +122,12 @@ public class NamespaceExtractionCacheManagerExecutorsTest
     )
     {
       @Override
-      protected <T extends ExtractionNamespace> Runnable getPostRunnable(
+      protected Runnable getPostRunnable(
           final String id,
-          final T namespace,
-          final ExtractionNamespaceCacheFactory<T> factory,
           final String cacheId
       )
       {
-        final Runnable runnable = super.getPostRunnable(id, namespace, factory, cacheId);
+        final Runnable runnable = super.getPostRunnable(id, cacheId);
         cacheUpdateAlerts.putIfAbsent(id, new Object());
         final Object cacheUpdateAlerter = cacheUpdateAlerts.get(id);
         return new Runnable()


### PR DESCRIPTION
* Move off-heap QTL global cache delete lock outside of subclass lock

* Make `delete` thread safe