### PR TITLE
max row limit is necessary if connector is setup for streaming

### DIFF
--- a/server/src/main/java/io/druid/metadata/SQLMetadataSegmentManager.java
+++ b/server/src/main/java/io/druid/metadata/SQLMetadataSegmentManager.java
@@ -559,6 +559,7 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
                     )
                 )
                 .setFetchSize(connector.getStreamingFetchSize())
+                .setMaxRows(limit)
                 .bind("dataSource", dataSource)
                 .bind("start", interval.getStart().toString())
                 .bind("end", interval.getEnd().toString())


### PR DESCRIPTION
follow up on #3043

i noticed that auto kill at coordinator wasn't working anymore and failing with following exception..

```
java.sql.SQLException: Streaming result set com.mysql.jdbc.RowDataDynamic@2d4c8b52 is still active. No statements may be issued when any streaming result sets are open and in use on a given connection. Ensure that you have called .close() on any active streaming result sets before attempting more queries.
        at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:868) ~[mysql-connector-java-5.1.38.jar:5.1.38]
        at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:864) ~[mysql-connector-java-5.1.38.jar:5.1.38]
        at com.mysql.jdbc.MysqlIO.checkForOutstandingStreamingData(MysqlIO.java:3142) ~[mysql-connector-java-5.1.38.jar:5.1.38]
        at com.mysql.jdbc.MysqlIO.sendCommand(MysqlIO.java:2397) ~[mysql-connector-java-5.1.38.jar:5.1.38]
        at com.mysql.jdbc.MysqlIO.sqlQueryDirect(MysqlIO.java:2625) ~[mysql-connector-java-5.1.38.jar:5.1.38]
        at com.mysql.jdbc.ConnectionImpl.execSQL(ConnectionImpl.java:2547) ~[mysql-connector-java-5.1.38.jar:5.1.38]
        at com.mysql.jdbc.ConnectionImpl.setReadOnlyInternal(ConnectionImpl.java:5017) ~[mysql-connector-java-5.1.38.jar:5.1.38]
        at com.mysql.jdbc.ConnectionImpl.setReadOnly(ConnectionImpl.java:5010) ~[mysql-connector-java-5.1.38.jar:5.1.38]
        at org.apache.commons.dbcp2.DelegatingConnection.setReadOnly(DelegatingConnection.java:558) ~[commons-dbcp2-2.0.1.jar:2.0.1]
        at org.apache.commons.dbcp2.DelegatingConnection.setReadOnly(DelegatingConnection.java:558) ~[commons-dbcp2-2.0.1.jar:2.0.1]
        at io.druid.metadata.SQLMetadataSegmentManager$2.withHandle(SQLMetadataSegmentManager.java:179) [druid-server-0.9.1-1477425516-c72e96e-312.jar:0.9.1-1477425516-c72e96e-312]

...
```


It appears, you need to read all the results from iterator , so setting maxRows is necessary. There is a unit test to cover this case but things work fine for derby and the unit test passes without any issues.