### PR TITLE
fix cleanup of tmp dir in HdfsDataSegmentPusher

### DIFF
--- a/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsDataSegmentPusher.java
+++ b/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsDataSegmentPusher.java
@@ -116,11 +116,7 @@ public class HdfsDataSegmentPusher implements DataSegmentPusher
 
       // Create parent if it does not exist, recreation is not an error
       fs.mkdirs(outDir.getParent());
-
       if (!fs.rename(tmpFile.getParent(), outDir)) {
-        if (!fs.delete(tmpFile.getParent(), true)) {
-          log.error("Failed to delete temp directory[%s]", tmpFile.getParent());
-        }
         if (fs.exists(outDir)) {
           log.info(
               "Unable to rename temp directory[%s] to segment directory[%s]. It is already pushed by a replica task.",
@@ -134,6 +130,14 @@ public class HdfsDataSegmentPusher implements DataSegmentPusher
               outDir
           ));
         }
+      }
+    } finally {
+      try {
+        if (fs.exists(tmpFile.getParent()) && !fs.delete(tmpFile.getParent(), true)) {
+          log.error("Failed to delete temp directory[%s]", tmpFile.getParent());
+        }
+      } catch(IOException ex) {
+        log.error(ex, "Failed to delete temp directory[%s]", tmpFile.getParent());
       }
     }
 


### PR DESCRIPTION
it has to be done in the finally block just in case there is any exception before renaming/deletion is attempted.

in our cluster, there was an exception on line
`CompressionUtils.zip(inDir,out)` because there was no space left (disk quota full but namespace quota was available allowing creation of new files) and that led to many orphaned tmp directories.