### PR TITLE
Blacklist workers if they fail for too many times

### DIFF
--- a/docs/content/configuration/indexing-service.md
+++ b/docs/content/configuration/indexing-service.md
@@ -84,7 +84,7 @@ The following configs only apply if the overlord is running in remote mode:
 |`druid.indexer.runner.taskShutdownLinkTimeout`|How long to wait on a shutdown request to a middle manager before timing out|PT1M|
 |`druid.indexer.runner.pendingTasksRunnerNumThreads`|Number of threads to allocate pending-tasks to workers, must be at least 1.|1|
 |`druid.indexer.runner.maxRetriesBeforeBlacklist`|Number of times the middle manager can fail a task,  before it gets blacklisted, must be at least 1|5|
-|`druid.indexer.runner.taskBlackListBackoffTimeMillis`|How long to wait before a task is whitelisted again, must be at least 60000. This value should be greater that the value set for taskBlackListCleanupPeriod.|900000|
+|`druid.indexer.runner.taskBlackListBackoffTime`|How long to wait before a task is whitelisted again. This value should be greater that the value set for taskBlackListCleanupPeriod.|PT15M|
 |`druid.indexer.runner.taskBlackListCleanupPeriod`|A duration after which the cleanup thread will startup to clean blacklisted workers.|PT5M|
 
 There are additional configs for autoscaling (if it is enabled):

--- a/docs/content/configuration/indexing-service.md
+++ b/docs/content/configuration/indexing-service.md
@@ -83,6 +83,9 @@ The following configs only apply if the overlord is running in remote mode:
 |`druid.indexer.runner.taskCleanupTimeout`|How long to wait before failing a task after a middle manager is disconnected from Zookeeper.|PT15M|
 |`druid.indexer.runner.taskShutdownLinkTimeout`|How long to wait on a shutdown request to a middle manager before timing out|PT1M|
 |`druid.indexer.runner.pendingTasksRunnerNumThreads`|Number of threads to allocate pending-tasks to workers, must be at least 1.|1|
+|`druid.indexer.runner.maxRetriesBeforeBlacklist`|Number of times the middle manager can fail a task,  before it gets blacklisted, must be at least 1|5|
+|`druid.indexer.runner.taskBlackListBackoffTimeMillis`|How long to wait before a task is whitelisted again, must be at least 60000. This value should be greater that the value set for taskBlackListCleanupPeriod.|900000|
+|`druid.indexer.runner.taskBlackListCleanupPeriod`|A duration after which the cleanup thread will startup to clean blacklisted workers.|PT5M|
 
 There are additional configs for autoscaling (if it is enabled):
 

--- a/docs/content/configuration/indexing-service.md
+++ b/docs/content/configuration/indexing-service.md
@@ -83,9 +83,10 @@ The following configs only apply if the overlord is running in remote mode:
 |`druid.indexer.runner.taskCleanupTimeout`|How long to wait before failing a task after a middle manager is disconnected from Zookeeper.|PT15M|
 |`druid.indexer.runner.taskShutdownLinkTimeout`|How long to wait on a shutdown request to a middle manager before timing out|PT1M|
 |`druid.indexer.runner.pendingTasksRunnerNumThreads`|Number of threads to allocate pending-tasks to workers, must be at least 1.|1|
-|`druid.indexer.runner.maxRetriesBeforeBlacklist`|Number of times the middle manager can fail a task,  before it gets blacklisted, must be at least 1|5|
-|`druid.indexer.runner.taskBlackListBackoffTime`|How long to wait before a task is whitelisted again. This value should be greater that the value set for taskBlackListCleanupPeriod.|PT15M|
-|`druid.indexer.runner.taskBlackListCleanupPeriod`|A duration after which the cleanup thread will startup to clean blacklisted workers.|PT5M|
+|`druid.indexer.runner.maxRetriesBeforeBlacklist`|Number of consecutive times the middle manager can fail tasks,  before the worker is blacklisted, must be at least 1|5|
+|`druid.indexer.runner.workerBlackListBackoffTime`|How long to wait before a task is whitelisted again. This value should be greater that the value set for taskBlackListCleanupPeriod.|PT15M|
+|`druid.indexer.runner.workerBlackListCleanupPeriod`|A duration after which the cleanup thread will startup to clean blacklisted workers.|PT5M|
+|`druid.indexer.runner.maxPercentageBlacklistWorkers`|The maximum percentage of workers to blacklist, this must be between 0 and 100.|20|
 
 There are additional configs for autoscaling (if it is enabled):
 

--- a/docs/content/design/indexing-service.md
+++ b/docs/content/design/indexing-service.md
@@ -75,8 +75,9 @@ The following vairables can be used to set the threshold and blacklist timeouts.
 
 ```
 druid.indexer.runner.maxRetriesBeforeBlacklist
-druid.indexer.runner.taskBlackListBackoffTime
-druid.indexer.runner.taskBlackListCleanupPeriod
+druid.indexer.runner.workerBlackListBackoffTime
+druid.indexer.runner.workerBlackListCleanupPeriod
+druid.indexer.runner.maxPercentageBlacklistWorkers
 ```
 
 #### Autoscaling

--- a/docs/content/design/indexing-service.md
+++ b/docs/content/design/indexing-service.md
@@ -68,6 +68,12 @@ The overlord console can be used to view pending tasks, running tasks, available
 http://<OVERLORD_IP>:<port>/console.html
 ```
 
+#### Blacklisted Workers
+If the workers fail tasks above a threshold, the overlord will blacklist these workers. No more than 20% of the nodes can be blacklisted.
+
+Blacklisted nodes will be periodically whitelisted.
+
+
 #### Autoscaling
 
 The Autoscaling mechanisms currently in place are tightly coupled with our deployment infrastructure but the framework should be in place for other implementations. We are highly open to new implementations or extensions of the existing mechanisms. In our own deployments, middle manager nodes are Amazon AWS EC2 nodes and they are provisioned to register themselves in a [galaxy](https://github.com/ning/galaxy) environment.

--- a/docs/content/design/indexing-service.md
+++ b/docs/content/design/indexing-service.md
@@ -69,10 +69,15 @@ http://<OVERLORD_IP>:<port>/console.html
 ```
 
 #### Blacklisted Workers
-If the workers fail tasks above a threshold, the overlord will blacklist these workers. No more than 20% of the nodes can be blacklisted.
+If the workers fail tasks above a threshold, the overlord will blacklist these workers. No more than 20% of the nodes can be blacklisted. Blacklisted nodes will be periodically whitelisted.
 
-Blacklisted nodes will be periodically whitelisted.
+The following vairables can be used to set the threshold and blacklist timeouts.
 
+```
+druid.indexer.runner.maxRetriesBeforeBlacklist
+druid.indexer.runner.taskBlackListBackoffTime
+druid.indexer.runner.taskBlackListCleanupPeriod
+```
 
 #### Autoscaling
 

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunner.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunner.java
@@ -1066,7 +1066,7 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
     ScheduledExecutors.scheduleAtFixedRate(
             cleanupExec,
             Period.ZERO.toStandardDuration(),
-            config.getTaskBlackListCleanupPeriod().toStandardDuration(),
+            config.getWorkerBlackListCleanupPeriod().toStandardDuration(),
             new Runnable()
             {
               @Override
@@ -1083,9 +1083,9 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
   {
     // Clean blacklisted workers if blacklisted time has elapsed
     if(System.currentTimeMillis() - zkWorker.getLastCompletedTaskTime().getMillis() >
-            config.getTaskBlackListBackoffTime().toStandardDuration().getMillis()){
+            config.getWorkerBlackListBackoffTime().toStandardDuration().getMillis()){
       // White listing node
-      log.debug( "Whitelisting worker [%s]. ", zkWorker);
+      log.info("Whitelisting worker [%s]. ", zkWorker);
       blackListedWorkers.remove(zkWorker);
     }
   }
@@ -1199,9 +1199,10 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
       zkWorker.incrementCountinouslyFailedTasksCount();
     }
 
-    // BlackList node if there are too many failures. Also ensure that at most 20% of zkWorkers can be blacklisted
+    // BlackList node if there are too many failures.
     if(zkWorker.getCountinouslyFailedTasksCount() > config.getMaxRetriesBeforeBlacklist() &&
-            blackListedWorkers.size() <= zkWorkers.size()/5){
+            blackListedWorkers.size() <=
+                    zkWorkers.size()*((double)config.getMaxPercentageBlacklistWorkers()/100)){
       blackListedWorkers.add(zkWorker);
     }
 

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunner.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunner.java
@@ -1083,7 +1083,7 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
   {
     // Clean blacklisted workers if blacklisted time has elapsed
     if(System.currentTimeMillis() - zkWorker.getLastCompletedTaskTime().getMillis() >
-            config.getTaskBlackListBackoffTimeMillis()){
+            config.getTaskBlackListBackoffTime().toStandardDuration().getMillis()){
       // White listing node
       log.debug( "Whitelisting worker [%s]. ", zkWorker);
       blackListedWorkers.remove(zkWorker);
@@ -1299,19 +1299,7 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
 
   public Collection<ImmutableWorkerInfo> getBlackListedWorkers()
   {
-    return ImmutableList.copyOf(
-            Collections2.transform(
-                    blackListedWorkers,
-                    new Function<ZkWorker, ImmutableWorkerInfo>()
-                    {
-                      @Override
-                      public ImmutableWorkerInfo apply(ZkWorker input)
-                      {
-                        return input.toImmutable();
-                      }
-                    }
-            )
-    );
+    return getImmutableWorkerFromZK(blackListedWorkers);
   }
 
   @VisibleForTesting

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunner.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunner.java
@@ -66,6 +66,7 @@ import io.druid.indexing.worker.Worker;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.Pair;
 import io.druid.java.util.common.RE;
+import io.druid.java.util.common.concurrent.ScheduledExecutors;
 import io.druid.java.util.common.lifecycle.LifecycleStart;
 import io.druid.java.util.common.lifecycle.LifecycleStop;
 import io.druid.server.initialization.IndexerZkConfig;
@@ -82,6 +83,7 @@ import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
+import org.joda.time.Period;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -90,9 +92,11 @@ import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -150,6 +154,9 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
 
   // Workers that have been marked as lazy. these workers are not running any tasks and can be terminated safely by the scaling policy.
   private final ConcurrentMap<String, ZkWorker> lazyWorkers = new ConcurrentHashMap<>();
+
+  // Workers that have been blacklisted.
+  private final Set<ZkWorker> blackListedWorkers = Collections.synchronizedSet(new HashSet<ZkWorker>());
 
   // task runner listeners
   private final CopyOnWriteArrayList<Pair<TaskRunnerListener, Executor>> listeners = new CopyOnWriteArrayList<>();
@@ -309,6 +316,7 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
           waitingForMonitor.wait();
         }
       }
+      scheduleBlackListedNodesCleanUp();
       resourceManagement.startManagement(this);
       started = true;
     }
@@ -735,7 +743,8 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
                             public boolean apply(Map.Entry<String, ZkWorker> input)
                             {
                               return !lazyWorkers.containsKey(input.getKey()) &&
-                                     !workersWithUnacknowledgedTask.containsKey(input.getKey());
+                                     !workersWithUnacknowledgedTask.containsKey(input.getKey()) &&
+                                     !blackListedWorkers.contains(input.getValue());
                             }
                           }
                       ),
@@ -1050,6 +1059,38 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
   }
 
   /**
+   * Schedule a task that will clean the blackListed ZK Workers periodically
+   */
+  private void scheduleBlackListedNodesCleanUp()
+  {
+    ScheduledExecutors.scheduleAtFixedRate(
+            cleanupExec,
+            Period.ZERO.toStandardDuration(),
+            config.getTaskBlackListCleanupPeriod().toStandardDuration(),
+            new Runnable()
+            {
+              @Override
+              public void run() {
+                for(ZkWorker zkWorker : blackListedWorkers){
+                  cleanBlackListedNode(zkWorker);
+                }
+              }
+            }
+    );
+  }
+
+  public void cleanBlackListedNode(ZkWorker zkWorker)
+  {
+    // Clean blacklisted workers if blacklisted time has elapsed
+    if(System.currentTimeMillis() - zkWorker.getLastCompletedTaskTime().getMillis() >
+            config.getTaskBlackListBackoffTimeMillis()){
+      // White listing node
+      log.debug( "Whitelisting worker [%s]. ", zkWorker);
+      blackListedWorkers.remove(zkWorker);
+    }
+  }
+
+  /**
    * Schedule a task that will, at some point in the future, clean up znodes and issue failures for "tasksToFail"
    * if they are being run by "worker".
    */
@@ -1151,6 +1192,19 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
     completeTasks.put(taskStatus.getId(), taskRunnerWorkItem);
     runningTasks.remove(taskStatus.getId());
 
+    // Update success/failure counters
+    if(taskStatus.isSuccess()){
+      zkWorker.resetCountinouslyFailedTasksCount();
+    } else if(taskStatus.isFailure()){
+      zkWorker.incrementCountinouslyFailedTasksCount();
+    }
+
+    // BlackList node if there are too many failures. Also ensure that at most 20% of zkWorkers can be blacklisted
+    if(zkWorker.getCountinouslyFailedTasksCount() > config.getMaxRetriesBeforeBlacklist() &&
+            blackListedWorkers.size() <= zkWorkers.size()/5){
+      blackListedWorkers.add(zkWorker);
+    }
+
     // Notify interested parties
     taskRunnerWorkItem.setResult(taskStatus);
     TaskRunnerUtils.notifyStatusChanged(listeners, taskStatus.getId(), taskStatus);
@@ -1240,6 +1294,23 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
             return input.getWorker();
           }
         }
+    );
+  }
+
+  public Collection<ImmutableWorkerInfo> getBlackListedWorkers()
+  {
+    return ImmutableList.copyOf(
+            Collections2.transform(
+                    blackListedWorkers,
+                    new Function<ZkWorker, ImmutableWorkerInfo>()
+                    {
+                      @Override
+                      public ImmutableWorkerInfo apply(ZkWorker input)
+                      {
+                        return input.toImmutable();
+                      }
+                    }
+            )
     );
   }
 

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunner.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunner.java
@@ -1071,18 +1071,19 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
             {
               @Override
               public void run() {
+                long currentTimeStamp = System.currentTimeMillis();
                 for(ZkWorker zkWorker : blackListedWorkers){
-                  cleanBlackListedNode(zkWorker);
+                  cleanBlackListedNode(zkWorker, currentTimeStamp);
                 }
               }
             }
     );
   }
 
-  public void cleanBlackListedNode(ZkWorker zkWorker)
+  public void cleanBlackListedNode(ZkWorker zkWorker, long currentTimeStamp)
   {
     // Clean blacklisted workers if blacklisted time has elapsed
-    if(System.currentTimeMillis() - zkWorker.getLastCompletedTaskTime().getMillis() >
+    if(currentTimeStamp - zkWorker.getLastCompletedTaskTime().getMillis() >
             config.getWorkerBlackListBackoffTime().toStandardDuration().getMillis()){
       // White listing node
       log.info("Whitelisting worker [%s]. ", zkWorker);
@@ -1202,7 +1203,7 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
     // BlackList node if there are too many failures.
     if(zkWorker.getCountinouslyFailedTasksCount() > config.getMaxRetriesBeforeBlacklist() &&
             blackListedWorkers.size() <=
-                    zkWorkers.size()*((double)config.getMaxPercentageBlacklistWorkers()/100)){
+                    zkWorkers.size()*(config.getMaxPercentageBlacklistWorkers()/100)){
       blackListedWorkers.add(zkWorker);
     }
 

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/ZkWorker.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/ZkWorker.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -51,6 +52,7 @@ public class ZkWorker implements Closeable
 
   private AtomicReference<Worker> worker;
   private AtomicReference<DateTime> lastCompletedTaskTime = new AtomicReference<DateTime>(new DateTime());
+  private AtomicInteger countinouslyFailedTasksCount = new AtomicInteger(0);
 
   public ZkWorker(Worker worker, PathChildrenCache statusCache, final ObjectMapper jsonMapper)
   {
@@ -166,6 +168,18 @@ public class ZkWorker implements Closeable
   public void close() throws IOException
   {
     statusCache.close();
+  }
+
+  public int getCountinouslyFailedTasksCount() {
+    return countinouslyFailedTasksCount.get();
+  }
+
+  public void resetCountinouslyFailedTasksCount() {
+    this.countinouslyFailedTasksCount.set(0);
+  }
+
+  public void incrementCountinouslyFailedTasksCount() {
+    this.countinouslyFailedTasksCount.incrementAndGet();
   }
 
   @Override

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
@@ -65,7 +65,7 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
   @JsonProperty
   @Max(100)
   @Min(0)
-  private int maxPercentageBlacklistWorkers = 20;
+  private double maxPercentageBlacklistWorkers = 20;
 
   public Period getTaskAssignmentTimeout()
   {
@@ -117,7 +117,7 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
     this.workerBlackListCleanupPeriod = workerBlackListCleanupPeriod;
   }
 
-  public int getMaxPercentageBlacklistWorkers() {
+  public double getMaxPercentageBlacklistWorkers() {
     return maxPercentageBlacklistWorkers;
   }
 
@@ -180,7 +180,7 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
     result = 31 * result + maxRetriesBeforeBlacklist;
     result = 31 * result + workerBlackListBackoffTime.hashCode();
     result = 31 * result + workerBlackListCleanupPeriod.hashCode();
-    result = 31 * result + maxPercentageBlacklistWorkers;
+    result = 31 * result + (int)maxPercentageBlacklistWorkers;
     return result;
   }
 

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.druid.curator.CuratorUtils;
 import org.joda.time.Period;
 
+import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
@@ -55,11 +56,16 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
 
   @JsonProperty
   @NotNull
-  private Period taskBlackListBackoffTime = new Period("PT15M");
+  private Period workerBlackListBackoffTime = new Period("PT15M");
 
   @JsonProperty
   @NotNull
-  private Period taskBlackListCleanupPeriod = new Period("PT5M");
+  private Period workerBlackListCleanupPeriod = new Period("PT5M");
+
+  @JsonProperty
+  @Max(100)
+  @Min(0)
+  private int maxPercentageBlacklistWorkers = 20;
 
   public Period getTaskAssignmentTimeout()
   {
@@ -95,20 +101,28 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
     this.maxRetriesBeforeBlacklist = maxRetriesBeforeBlacklist;
   }
 
-  public Period getTaskBlackListBackoffTime() {
-    return taskBlackListBackoffTime;
+  public Period getWorkerBlackListBackoffTime() {
+    return workerBlackListBackoffTime;
   }
 
   public void setTaskBlackListBackoffTimeMillis(Period taskBlackListBackoffTime) {
-    this.taskBlackListBackoffTime = taskBlackListBackoffTime;
+    this.workerBlackListBackoffTime = taskBlackListBackoffTime;
   }
 
-  public Period getTaskBlackListCleanupPeriod() {
-    return taskBlackListCleanupPeriod;
+  public Period getWorkerBlackListCleanupPeriod() {
+    return workerBlackListCleanupPeriod;
   }
 
-  public void setTaskBlackListCleanupPeriod(Period taskBlackListCleanupPeriod) {
-    this.taskBlackListCleanupPeriod = taskBlackListCleanupPeriod;
+  public void setWorkerBlackListCleanupPeriod(Period workerBlackListCleanupPeriod) {
+    this.workerBlackListCleanupPeriod = workerBlackListCleanupPeriod;
+  }
+
+  public int getMaxPercentageBlacklistWorkers() {
+    return maxPercentageBlacklistWorkers;
+  }
+
+  public void setMaxPercentageBlacklistWorkers(int maxPercentageBlacklistWorkers) {
+    this.maxPercentageBlacklistWorkers = maxPercentageBlacklistWorkers;
   }
 
   @Override
@@ -144,10 +158,13 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
     if (maxRetriesBeforeBlacklist != that.maxRetriesBeforeBlacklist) {
       return false;
     }
-    if (!taskBlackListBackoffTime.equals(that.getTaskBlackListBackoffTime())) {
+    if (!workerBlackListBackoffTime.equals(that.getWorkerBlackListBackoffTime())) {
       return false;
     }
-    return taskBlackListCleanupPeriod.equals(that.taskBlackListCleanupPeriod);
+    if (maxPercentageBlacklistWorkers != that.maxPercentageBlacklistWorkers) {
+      return false;
+    }
+    return workerBlackListCleanupPeriod.equals(that.workerBlackListCleanupPeriod);
 
   }
 
@@ -161,8 +178,9 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
     result = 31 * result + taskShutdownLinkTimeout.hashCode();
     result = 31 * result + pendingTasksRunnerNumThreads;
     result = 31 * result + maxRetriesBeforeBlacklist;
-    result = 31 * result + taskBlackListBackoffTime.hashCode();
-    result = 31 * result + taskBlackListCleanupPeriod.hashCode();
+    result = 31 * result + workerBlackListBackoffTime.hashCode();
+    result = 31 * result + workerBlackListCleanupPeriod.hashCode();
+    result = 31 * result + maxPercentageBlacklistWorkers;
     return result;
   }
 
@@ -177,8 +195,9 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
            ", taskShutdownLinkTimeout=" + taskShutdownLinkTimeout +
            ", pendingTasksRunnerNumThreads=" + pendingTasksRunnerNumThreads +
            ", maxRetriesBeforeBlacklist=" + maxRetriesBeforeBlacklist +
-           ", taskBlackListBackoffTimeMillis=" + taskBlackListBackoffTime +
-           ", taskBlackListCleanupPeriod=" + taskBlackListCleanupPeriod +
+           ", taskBlackListBackoffTimeMillis=" + workerBlackListBackoffTime +
+           ", taskBlackListCleanupPeriod=" + workerBlackListCleanupPeriod +
+           ", maxPercentageBlacklistWorkers= " + maxPercentageBlacklistWorkers +
            '}';
   }
 }

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
@@ -54,8 +54,8 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
   private int maxRetriesBeforeBlacklist = 5;
 
   @JsonProperty
-  @Min(60000)
-  private long taskBlackListBackoffTimeMillis = 900000;
+  @NotNull
+  private Period taskBlackListBackoffTime = new Period("PT15M");
 
   @JsonProperty
   @NotNull
@@ -95,12 +95,12 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
     this.maxRetriesBeforeBlacklist = maxRetriesBeforeBlacklist;
   }
 
-  public long getTaskBlackListBackoffTimeMillis() {
-    return taskBlackListBackoffTimeMillis;
+  public Period getTaskBlackListBackoffTime() {
+    return taskBlackListBackoffTime;
   }
 
-  public void setTaskBlackListBackoffTimeMillis(long taskBlackListBackoffTimeMillis) {
-    this.taskBlackListBackoffTimeMillis = taskBlackListBackoffTimeMillis;
+  public void setTaskBlackListBackoffTimeMillis(Period taskBlackListBackoffTime) {
+    this.taskBlackListBackoffTime = taskBlackListBackoffTime;
   }
 
   public Period getTaskBlackListCleanupPeriod() {
@@ -144,7 +144,7 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
     if (maxRetriesBeforeBlacklist != that.maxRetriesBeforeBlacklist) {
       return false;
     }
-    if (taskBlackListBackoffTimeMillis != that.taskBlackListBackoffTimeMillis) {
+    if (!taskBlackListBackoffTime.equals(that.getTaskBlackListBackoffTime())) {
       return false;
     }
     return taskBlackListCleanupPeriod.equals(that.taskBlackListCleanupPeriod);
@@ -161,7 +161,7 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
     result = 31 * result + taskShutdownLinkTimeout.hashCode();
     result = 31 * result + pendingTasksRunnerNumThreads;
     result = 31 * result + maxRetriesBeforeBlacklist;
-    result = 31 * result + (int)taskBlackListBackoffTimeMillis;
+    result = 31 * result + taskBlackListBackoffTime.hashCode();
     result = 31 * result + taskBlackListCleanupPeriod.hashCode();
     return result;
   }
@@ -177,7 +177,7 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
            ", taskShutdownLinkTimeout=" + taskShutdownLinkTimeout +
            ", pendingTasksRunnerNumThreads=" + pendingTasksRunnerNumThreads +
            ", maxRetriesBeforeBlacklist=" + maxRetriesBeforeBlacklist +
-           ", taskBlackListBackoffTimeMillis=" + taskBlackListBackoffTimeMillis +
+           ", taskBlackListBackoffTimeMillis=" + taskBlackListBackoffTime +
            ", taskBlackListCleanupPeriod=" + taskBlackListCleanupPeriod +
            '}';
   }

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
@@ -49,6 +49,18 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
   @Min(1)
   private int pendingTasksRunnerNumThreads = 1;
 
+  @JsonProperty
+  @Min(1)
+  private int maxRetriesBeforeBlacklist = 5;
+
+  @JsonProperty
+  @Min(60000)
+  private long taskBlackListBackoffTimeMillis = 900000;
+
+  @JsonProperty
+  @NotNull
+  private Period taskBlackListCleanupPeriod = new Period("PT5M");
+
   public Period getTaskAssignmentTimeout()
   {
     return taskAssignmentTimeout;
@@ -73,6 +85,30 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
   public int getPendingTasksRunnerNumThreads()
   {
     return pendingTasksRunnerNumThreads;
+  }
+
+  public int getMaxRetriesBeforeBlacklist() {
+    return maxRetriesBeforeBlacklist;
+  }
+
+  public void setMaxRetriesBeforeBlacklist(int maxRetriesBeforeBlacklist) {
+    this.maxRetriesBeforeBlacklist = maxRetriesBeforeBlacklist;
+  }
+
+  public long getTaskBlackListBackoffTimeMillis() {
+    return taskBlackListBackoffTimeMillis;
+  }
+
+  public void setTaskBlackListBackoffTimeMillis(long taskBlackListBackoffTimeMillis) {
+    this.taskBlackListBackoffTimeMillis = taskBlackListBackoffTimeMillis;
+  }
+
+  public Period getTaskBlackListCleanupPeriod() {
+    return taskBlackListCleanupPeriod;
+  }
+
+  public void setTaskBlackListCleanupPeriod(Period taskBlackListCleanupPeriod) {
+    this.taskBlackListCleanupPeriod = taskBlackListCleanupPeriod;
   }
 
   @Override
@@ -102,7 +138,16 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
     if (!getMinWorkerVersion().equals(that.getMinWorkerVersion())) {
       return false;
     }
-    return taskShutdownLinkTimeout.equals(that.taskShutdownLinkTimeout);
+    if (!taskShutdownLinkTimeout.equals(that.taskShutdownLinkTimeout)) {
+      return false;
+    }
+    if (maxRetriesBeforeBlacklist != that.maxRetriesBeforeBlacklist) {
+      return false;
+    }
+    if (taskBlackListBackoffTimeMillis != that.taskBlackListBackoffTimeMillis) {
+      return false;
+    }
+    return taskBlackListCleanupPeriod.equals(that.taskBlackListCleanupPeriod);
 
   }
 
@@ -115,6 +160,9 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
     result = 31 * result + maxZnodeBytes;
     result = 31 * result + taskShutdownLinkTimeout.hashCode();
     result = 31 * result + pendingTasksRunnerNumThreads;
+    result = 31 * result + maxRetriesBeforeBlacklist;
+    result = 31 * result + (int)taskBlackListBackoffTimeMillis;
+    result = 31 * result + taskBlackListCleanupPeriod.hashCode();
     return result;
   }
 
@@ -128,6 +176,9 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
            ", maxZnodeBytes=" + maxZnodeBytes +
            ", taskShutdownLinkTimeout=" + taskShutdownLinkTimeout +
            ", pendingTasksRunnerNumThreads=" + pendingTasksRunnerNumThreads +
+           ", maxRetriesBeforeBlacklist=" + maxRetriesBeforeBlacklist +
+           ", taskBlackListBackoffTimeMillis=" + taskBlackListBackoffTimeMillis +
+           ", taskBlackListCleanupPeriod=" + taskBlackListCleanupPeriod +
            '}';
   }
 }

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTest.java
@@ -617,15 +617,15 @@ public class RemoteTaskRunnerTest
   @Test
   public void testBlacklistZKWorkers() throws Exception
   {
-    Period timeoutPeriod = new Period("PT5S");
+    Period timeoutPeriod = Period.millis(1000);
     makeWorker();
     makeRemoteTaskRunner(new TestRemoteTaskRunnerConfig(timeoutPeriod));
 
     TestRealtimeTask task1 = new TestRealtimeTask(
-            "rt1",
-            new TaskResource("rt1", 1),
+            "realtime1",
+            new TaskResource("realtime1", 1),
             "foo",
-            TaskStatus.success("rt1"),
+            TaskStatus.success("realtime1"),
             jsonMapper
     );
     Future<TaskStatus> taskFuture1 = remoteTaskRunner.run(task1);
@@ -638,10 +638,10 @@ public class RemoteTaskRunnerTest
             remoteTaskRunner.findWorkerRunningTask(task1.getId()).getCountinouslyFailedTasksCount());
 
     TestRealtimeTask task2 = new TestRealtimeTask(
-            "rt2",
-            new TaskResource("rt2", 1),
+            "realtime2",
+            new TaskResource("realtime2", 1),
             "foo",
-            TaskStatus.running("rt2"),
+            TaskStatus.running("realtime2"),
             jsonMapper
     );
     Future<TaskStatus> taskFuture2 = remoteTaskRunner.run(task2);
@@ -656,16 +656,17 @@ public class RemoteTaskRunnerTest
     remoteTaskRunner.cleanBlackListedNode(remoteTaskRunner.findWorkerRunningTask(task2.getId()));
 
     // After backOffTime the nodes are whitelisted
-    Thread.sleep(timeoutPeriod.toStandardDuration().getMillis());
+    System.out.println("Sleeping for " + timeoutPeriod.toStandardDuration().getMillis());
+    Thread.sleep(2*timeoutPeriod.toStandardDuration().getMillis());
     Assert.assertEquals(0, remoteTaskRunner.getBlackListedWorkers().size());
     Assert.assertEquals(2,
             remoteTaskRunner.findWorkerRunningTask(task2.getId()).getCountinouslyFailedTasksCount());
 
     TestRealtimeTask task3 = new TestRealtimeTask(
-            "rt3",
-            new TaskResource("rt3", 1),
+            "realtime3",
+            new TaskResource("realtime3", 1),
             "foo",
-            TaskStatus.running("rt3"),
+            TaskStatus.running("realtime3"),
             jsonMapper
     );
     Future<TaskStatus> taskFuture3 = remoteTaskRunner.run(task3);

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTest.java
@@ -653,11 +653,10 @@ public class RemoteTaskRunnerTest
     Assert.assertEquals(2,
             remoteTaskRunner.findWorkerRunningTask(task2.getId()).getCountinouslyFailedTasksCount());
 
-    remoteTaskRunner.cleanBlackListedNode(remoteTaskRunner.findWorkerRunningTask(task2.getId()));
+    remoteTaskRunner.cleanBlackListedNode(remoteTaskRunner.findWorkerRunningTask(task2.getId()),
+            System.currentTimeMillis() + 2*timeoutPeriod.toStandardDuration().getMillis());
 
     // After backOffTime the nodes are whitelisted
-    System.out.println("Sleeping for " + timeoutPeriod.toStandardDuration().getMillis());
-    Thread.sleep(2*timeoutPeriod.toStandardDuration().getMillis());
     Assert.assertEquals(0, remoteTaskRunner.getBlackListedWorkers().size());
     Assert.assertEquals(2,
             remoteTaskRunner.findWorkerRunningTask(task2.getId()).getCountinouslyFailedTasksCount());

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTestUtils.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTestUtils.java
@@ -173,6 +173,12 @@ public class RemoteTaskRunnerTestUtils
     cf.setData().forPath(joiner.join(statusPath, workerId, task.getId()), jsonMapper.writeValueAsBytes(taskAnnouncement));
   }
 
+  void mockWorkerCompleteFailedTask(final String workerId, final Task task) throws Exception
+  {
+    TaskAnnouncement taskAnnouncement = TaskAnnouncement.create(task, TaskStatus.failure(task.getId()), DUMMY_LOCATION);
+    cf.setData().forPath(joiner.join(statusPath, workerId, task.getId()), jsonMapper.writeValueAsBytes(taskAnnouncement));
+  }
+
   boolean workerRunningTask(final String workerId, final String taskId)
   {
     return pathExists(joiner.join(statusPath, workerId, taskId));

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/TestRemoteTaskRunnerConfig.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/TestRemoteTaskRunnerConfig.java
@@ -71,9 +71,9 @@ public class TestRemoteTaskRunnerConfig extends RemoteTaskRunnerConfig
   }
 
   @Override
-  public long getTaskBlackListBackoffTimeMillis()
+  public Period getTaskBlackListBackoffTime()
   {
-    return timeout.getMillis();
+    return timeout;
   }
 
   @Override

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/TestRemoteTaskRunnerConfig.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/TestRemoteTaskRunnerConfig.java
@@ -63,4 +63,22 @@ public class TestRemoteTaskRunnerConfig extends RemoteTaskRunnerConfig
   {
     return "";
   }
+
+  @Override
+  public int getMaxRetriesBeforeBlacklist()
+  {
+    return 1;
+  }
+
+  @Override
+  public long getTaskBlackListBackoffTimeMillis()
+  {
+    return timeout.getMillis();
+  }
+
+  @Override
+  public Period getTaskBlackListCleanupPeriod()
+  {
+    return timeout;
+  }
 }

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/TestRemoteTaskRunnerConfig.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/TestRemoteTaskRunnerConfig.java
@@ -71,13 +71,13 @@ public class TestRemoteTaskRunnerConfig extends RemoteTaskRunnerConfig
   }
 
   @Override
-  public Period getTaskBlackListBackoffTime()
+  public Period getWorkerBlackListBackoffTime()
   {
     return timeout;
   }
 
   @Override
-  public Period getTaskBlackListCleanupPeriod()
+  public Period getWorkerBlackListCleanupPeriod()
   {
     return timeout;
   }

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfigTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfigTest.java
@@ -37,7 +37,7 @@ public class RemoteTaskRunnerConfigTest
   private static final long DEFAULT_MAX_ZNODE = 10 * 1024;
   private static final int DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS = 5;
   private static final int DEFAULT_MAX_RETRIES_BEFORE_BLACKLIST = 5;
-  private static final long DEFAULT_TASK_BACKOFF = 900000;
+  private static final Period DEFAULT_TASK_BACKOFF = new Period("PT10M");
   private static final Period DEFAULT_BLACKLIST_CLEANUP_PERIOD = new Period("PT5M");
 
   @Test
@@ -181,11 +181,11 @@ public class RemoteTaskRunnerConfigTest
   }
 
   @Test
-  public void testGetTaskBlackListBackoffTimeMillis() throws Exception
+  public void testGettaskBlackListBackoffTime() throws Exception
   {
-    final long taskBlackListBackoffTimeMillis = 200;
+    final Period taskBlackListBackoffTime = new Period("PT1M");
     Assert.assertEquals(
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             reflect(generateRemoteTaskRunnerConfig(
                     DEFAULT_TIMEOUT,
                     DEFAULT_TIMEOUT,
@@ -194,9 +194,9 @@ public class RemoteTaskRunnerConfigTest
                     DEFAULT_TIMEOUT,
                     DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS,
                     DEFAULT_MAX_RETRIES_BEFORE_BLACKLIST,
-                    taskBlackListBackoffTimeMillis,
+                    taskBlackListBackoffTime,
                     DEFAULT_BLACKLIST_CLEANUP_PERIOD
-            )).getTaskBlackListBackoffTimeMillis()
+            )).getTaskBlackListBackoffTime()
     );
   }
 
@@ -252,7 +252,7 @@ public class RemoteTaskRunnerConfigTest
     final long max = 20 * 1024;
     final int pendingTasksRunnerNumThreads = 20;
     final int maxRetriesBeforeBlacklist = 1;
-    final long taskBlackListBackoffTimeMillis = 1000;
+    final Period taskBlackListBackoffTime = new Period("PT1M");
     final Period taskBlackListCleanupPeriod = Period.years(10);
     Assert.assertEquals(
         reflect(generateRemoteTaskRunnerConfig(
@@ -263,7 +263,7 @@ public class RemoteTaskRunnerConfigTest
             timeout,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         )),
         reflect(generateRemoteTaskRunnerConfig(
@@ -274,7 +274,7 @@ public class RemoteTaskRunnerConfigTest
             timeout,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         ))
     );
@@ -287,7 +287,7 @@ public class RemoteTaskRunnerConfigTest
             timeout,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         )),
         reflect(generateRemoteTaskRunnerConfig(
@@ -298,7 +298,7 @@ public class RemoteTaskRunnerConfigTest
             timeout,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         ))
     );
@@ -311,7 +311,7 @@ public class RemoteTaskRunnerConfigTest
             timeout,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         )),
         reflect(generateRemoteTaskRunnerConfig(
@@ -322,7 +322,7 @@ public class RemoteTaskRunnerConfigTest
             timeout,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         ))
     );
@@ -335,7 +335,7 @@ public class RemoteTaskRunnerConfigTest
             timeout,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         )),
         reflect(generateRemoteTaskRunnerConfig(
@@ -346,7 +346,7 @@ public class RemoteTaskRunnerConfigTest
             timeout,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         ))
     );
@@ -360,7 +360,7 @@ public class RemoteTaskRunnerConfigTest
             timeout,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         )),
         reflect(generateRemoteTaskRunnerConfig(
@@ -371,7 +371,7 @@ public class RemoteTaskRunnerConfigTest
             timeout,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         ))
     );
@@ -386,7 +386,7 @@ public class RemoteTaskRunnerConfigTest
             timeout,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         )),
         reflect(generateRemoteTaskRunnerConfig(
@@ -397,7 +397,7 @@ public class RemoteTaskRunnerConfigTest
             DEFAULT_TIMEOUT,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         ))
     );
@@ -411,7 +411,7 @@ public class RemoteTaskRunnerConfigTest
                     timeout,
                     pendingTasksRunnerNumThreads,
                     maxRetriesBeforeBlacklist,
-                    taskBlackListBackoffTimeMillis,
+                    taskBlackListBackoffTime,
                     taskBlackListCleanupPeriod
                 )),
         reflect(generateRemoteTaskRunnerConfig(
@@ -422,7 +422,7 @@ public class RemoteTaskRunnerConfigTest
                     timeout,
                     DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS,
                     maxRetriesBeforeBlacklist,
-                    taskBlackListBackoffTimeMillis,
+                    taskBlackListBackoffTime,
                     taskBlackListCleanupPeriod
                 ))
     );
@@ -436,7 +436,7 @@ public class RemoteTaskRunnerConfigTest
                     timeout,
                     pendingTasksRunnerNumThreads,
                     maxRetriesBeforeBlacklist,
-                    taskBlackListBackoffTimeMillis,
+                    taskBlackListBackoffTime,
                     taskBlackListCleanupPeriod
             )),
             reflect(generateRemoteTaskRunnerConfig(
@@ -447,7 +447,7 @@ public class RemoteTaskRunnerConfigTest
                     timeout,
                     pendingTasksRunnerNumThreads,
                     DEFAULT_MAX_RETRIES_BEFORE_BLACKLIST,
-                    taskBlackListBackoffTimeMillis,
+                    taskBlackListBackoffTime,
                     taskBlackListCleanupPeriod
             ))
     );
@@ -461,7 +461,7 @@ public class RemoteTaskRunnerConfigTest
                     timeout,
                     pendingTasksRunnerNumThreads,
                     maxRetriesBeforeBlacklist,
-                    taskBlackListBackoffTimeMillis,
+                    taskBlackListBackoffTime,
                     taskBlackListCleanupPeriod
             )),
             reflect(generateRemoteTaskRunnerConfig(
@@ -486,7 +486,7 @@ public class RemoteTaskRunnerConfigTest
                     timeout,
                     pendingTasksRunnerNumThreads,
                     maxRetriesBeforeBlacklist,
-                    taskBlackListBackoffTimeMillis,
+                    taskBlackListBackoffTime,
                     taskBlackListCleanupPeriod
             )),
             reflect(generateRemoteTaskRunnerConfig(
@@ -497,7 +497,7 @@ public class RemoteTaskRunnerConfigTest
                     timeout,
                     pendingTasksRunnerNumThreads,
                     maxRetriesBeforeBlacklist,
-                    taskBlackListBackoffTimeMillis,
+                    taskBlackListBackoffTime,
                     DEFAULT_BLACKLIST_CLEANUP_PERIOD
             ))
     );
@@ -535,7 +535,7 @@ public class RemoteTaskRunnerConfigTest
     final long max = 20 * 1024;
     final int pendingTasksRunnerNumThreads = 20;
     final int maxRetriesBeforeBlacklist = 80;
-    final long taskBlackListBackoffTimeMillis = 10000;
+    final Period taskBlackListBackoffTime = new Period("PT1M");
     final Period taskBlackListCleanupPeriod = Period.years(10);
     Assert.assertEquals(
         reflect(generateRemoteTaskRunnerConfig(
@@ -546,7 +546,7 @@ public class RemoteTaskRunnerConfigTest
             timeout,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         )).hashCode(),
         reflect(generateRemoteTaskRunnerConfig(
@@ -557,7 +557,7 @@ public class RemoteTaskRunnerConfigTest
             timeout,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         )).hashCode()
     );
@@ -570,7 +570,7 @@ public class RemoteTaskRunnerConfigTest
             timeout,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         )).hashCode(),
         reflect(generateRemoteTaskRunnerConfig(
@@ -581,7 +581,7 @@ public class RemoteTaskRunnerConfigTest
             timeout,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         )).hashCode()
     );
@@ -594,7 +594,7 @@ public class RemoteTaskRunnerConfigTest
             timeout,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         )).hashCode(),
         reflect(generateRemoteTaskRunnerConfig(
@@ -605,7 +605,7 @@ public class RemoteTaskRunnerConfigTest
             timeout,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         )).hashCode()
     );
@@ -618,7 +618,7 @@ public class RemoteTaskRunnerConfigTest
             timeout,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         )).hashCode(),
         reflect(generateRemoteTaskRunnerConfig(
@@ -629,7 +629,7 @@ public class RemoteTaskRunnerConfigTest
             timeout,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         )).hashCode()
     );
@@ -643,7 +643,7 @@ public class RemoteTaskRunnerConfigTest
             timeout,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         )).hashCode(),
         reflect(generateRemoteTaskRunnerConfig(
@@ -654,7 +654,7 @@ public class RemoteTaskRunnerConfigTest
             timeout,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         )).hashCode()
     );
@@ -669,7 +669,7 @@ public class RemoteTaskRunnerConfigTest
             timeout,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         )).hashCode(),
         reflect(generateRemoteTaskRunnerConfig(
@@ -680,7 +680,7 @@ public class RemoteTaskRunnerConfigTest
             DEFAULT_TIMEOUT,
             pendingTasksRunnerNumThreads,
             maxRetriesBeforeBlacklist,
-            taskBlackListBackoffTimeMillis,
+            taskBlackListBackoffTime,
             taskBlackListCleanupPeriod
         )).hashCode()
     );
@@ -694,7 +694,7 @@ public class RemoteTaskRunnerConfigTest
                     timeout,
                     pendingTasksRunnerNumThreads,
                     maxRetriesBeforeBlacklist,
-                    taskBlackListBackoffTimeMillis,
+                    taskBlackListBackoffTime,
                     taskBlackListCleanupPeriod
                 )).hashCode(),
         reflect(generateRemoteTaskRunnerConfig(
@@ -705,7 +705,7 @@ public class RemoteTaskRunnerConfigTest
                     timeout,
                     DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS,
                     maxRetriesBeforeBlacklist,
-                    taskBlackListBackoffTimeMillis,
+                    taskBlackListBackoffTime,
                     taskBlackListCleanupPeriod
                 )).hashCode()
     );
@@ -719,7 +719,7 @@ public class RemoteTaskRunnerConfigTest
                     timeout,
                     pendingTasksRunnerNumThreads,
                     maxRetriesBeforeBlacklist,
-                    taskBlackListBackoffTimeMillis,
+                    taskBlackListBackoffTime,
                     taskBlackListCleanupPeriod
             )).hashCode(),
             reflect(generateRemoteTaskRunnerConfig(
@@ -730,7 +730,7 @@ public class RemoteTaskRunnerConfigTest
                     timeout,
                     pendingTasksRunnerNumThreads,
                     DEFAULT_MAX_RETRIES_BEFORE_BLACKLIST,
-                    taskBlackListBackoffTimeMillis,
+                    taskBlackListBackoffTime,
                     taskBlackListCleanupPeriod
             )).hashCode()
     );
@@ -744,7 +744,7 @@ public class RemoteTaskRunnerConfigTest
                     timeout,
                     pendingTasksRunnerNumThreads,
                     maxRetriesBeforeBlacklist,
-                    taskBlackListBackoffTimeMillis,
+                    taskBlackListBackoffTime,
                     taskBlackListCleanupPeriod
             )).hashCode(),
             reflect(generateRemoteTaskRunnerConfig(
@@ -769,7 +769,7 @@ public class RemoteTaskRunnerConfigTest
                     timeout,
                     pendingTasksRunnerNumThreads,
                     maxRetriesBeforeBlacklist,
-                    taskBlackListBackoffTimeMillis,
+                    taskBlackListBackoffTime,
                     taskBlackListCleanupPeriod
             )).hashCode(),
             reflect(generateRemoteTaskRunnerConfig(
@@ -780,7 +780,7 @@ public class RemoteTaskRunnerConfigTest
                     timeout,
                     pendingTasksRunnerNumThreads,
                     maxRetriesBeforeBlacklist,
-                    taskBlackListBackoffTimeMillis,
+                    taskBlackListBackoffTime,
                     DEFAULT_BLACKLIST_CLEANUP_PERIOD
             )).hashCode()
     );
@@ -799,7 +799,7 @@ public class RemoteTaskRunnerConfigTest
       Period taskShutdownLinkTimeout,
       int pendingTasksRunnerNumThreads,
       int maxRetriesBeforeBlacklist,
-      long taskBlackListBackoffTimeMillis,
+      Period taskBlackListBackoffTime,
       Period taskBlackListCleanupPeriod
   )
   {
@@ -811,7 +811,7 @@ public class RemoteTaskRunnerConfigTest
     objectMap.put("taskShutdownLinkTimeout", taskShutdownLinkTimeout);
     objectMap.put("pendingTasksRunnerNumThreads", pendingTasksRunnerNumThreads);
     objectMap.put("maxRetriesBeforeBlacklist", maxRetriesBeforeBlacklist);
-    objectMap.put("taskBlackListBackoffTimeMillis", taskBlackListBackoffTimeMillis);
+    objectMap.put("taskBlackListBackoffTime", taskBlackListBackoffTime);
     objectMap.put("taskBlackListCleanupPeriod", taskBlackListCleanupPeriod);
     return mapper.convertValue(objectMap, RemoteTaskRunnerConfig.class);
   }

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfigTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfigTest.java
@@ -36,6 +36,9 @@ public class RemoteTaskRunnerConfigTest
   private static final String DEFAULT_VERSION = "";
   private static final long DEFAULT_MAX_ZNODE = 10 * 1024;
   private static final int DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS = 5;
+  private static final int DEFAULT_MAX_RETRIES_BEFORE_BLACKLIST = 5;
+  private static final long DEFAULT_TASK_BACKOFF = 900000;
+  private static final Period DEFAULT_BLACKLIST_CLEANUP_PERIOD = new Period("PT5M");
 
   @Test
   public void testGetTaskAssignmentTimeout() throws Exception
@@ -49,7 +52,10 @@ public class RemoteTaskRunnerConfigTest
             DEFAULT_VERSION,
             DEFAULT_MAX_ZNODE,
             DEFAULT_TIMEOUT,
-            DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS
+            DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS,
+            DEFAULT_MAX_RETRIES_BEFORE_BLACKLIST,
+            DEFAULT_TASK_BACKOFF,
+            DEFAULT_BLACKLIST_CLEANUP_PERIOD
         )).getTaskAssignmentTimeout()
     );
   }
@@ -66,7 +72,10 @@ public class RemoteTaskRunnerConfigTest
             DEFAULT_VERSION,
             DEFAULT_MAX_ZNODE,
             DEFAULT_TIMEOUT,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            DEFAULT_MAX_RETRIES_BEFORE_BLACKLIST,
+            DEFAULT_TASK_BACKOFF,
+            DEFAULT_BLACKLIST_CLEANUP_PERIOD
         )).getPendingTasksRunnerNumThreads()
     );
   }
@@ -83,7 +92,10 @@ public class RemoteTaskRunnerConfigTest
             version,
             DEFAULT_MAX_ZNODE,
             DEFAULT_TIMEOUT,
-            DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS
+            DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS,
+            DEFAULT_MAX_RETRIES_BEFORE_BLACKLIST,
+            DEFAULT_TASK_BACKOFF,
+            DEFAULT_BLACKLIST_CLEANUP_PERIOD
         )).getMinWorkerVersion()
     );
   }
@@ -100,7 +112,10 @@ public class RemoteTaskRunnerConfigTest
             DEFAULT_VERSION,
             max,
             DEFAULT_TIMEOUT,
-            DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS
+            DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS,
+            DEFAULT_MAX_RETRIES_BEFORE_BLACKLIST,
+            DEFAULT_TASK_BACKOFF,
+            DEFAULT_BLACKLIST_CLEANUP_PERIOD
         )).getMaxZnodeBytes()
     );
   }
@@ -117,7 +132,10 @@ public class RemoteTaskRunnerConfigTest
             DEFAULT_VERSION,
             DEFAULT_MAX_ZNODE,
             timeout,
-            DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS
+            DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS,
+            DEFAULT_MAX_RETRIES_BEFORE_BLACKLIST,
+            DEFAULT_TASK_BACKOFF,
+            DEFAULT_BLACKLIST_CLEANUP_PERIOD
         )).getTaskShutdownLinkTimeout()
     );
   }
@@ -134,8 +152,71 @@ public class RemoteTaskRunnerConfigTest
                     DEFAULT_VERSION,
                     DEFAULT_MAX_ZNODE,
                     DEFAULT_TIMEOUT,
-                    DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS
+                    DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS,
+                    DEFAULT_MAX_RETRIES_BEFORE_BLACKLIST,
+                    DEFAULT_TASK_BACKOFF,
+                    DEFAULT_BLACKLIST_CLEANUP_PERIOD
                 )).getTaskCleanupTimeout()
+    );
+  }
+
+  @Test
+  public void testGetMaxRetriesBeforeBlacklist() throws Exception
+  {
+    final int maxRetriesBeforeBlacklist = 2;
+    Assert.assertEquals(
+            maxRetriesBeforeBlacklist,
+            reflect(generateRemoteTaskRunnerConfig(
+                    DEFAULT_TIMEOUT,
+                    DEFAULT_TIMEOUT,
+                    DEFAULT_VERSION,
+                    DEFAULT_MAX_ZNODE,
+                    DEFAULT_TIMEOUT,
+                    DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS,
+                    maxRetriesBeforeBlacklist,
+                    DEFAULT_TASK_BACKOFF,
+                    DEFAULT_BLACKLIST_CLEANUP_PERIOD
+            )).getMaxRetriesBeforeBlacklist()
+    );
+  }
+
+  @Test
+  public void testGetTaskBlackListBackoffTimeMillis() throws Exception
+  {
+    final long taskBlackListBackoffTimeMillis = 200;
+    Assert.assertEquals(
+            taskBlackListBackoffTimeMillis,
+            reflect(generateRemoteTaskRunnerConfig(
+                    DEFAULT_TIMEOUT,
+                    DEFAULT_TIMEOUT,
+                    DEFAULT_VERSION,
+                    DEFAULT_MAX_ZNODE,
+                    DEFAULT_TIMEOUT,
+                    DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS,
+                    DEFAULT_MAX_RETRIES_BEFORE_BLACKLIST,
+                    taskBlackListBackoffTimeMillis,
+                    DEFAULT_BLACKLIST_CLEANUP_PERIOD
+            )).getTaskBlackListBackoffTimeMillis()
+    );
+  }
+
+  @Test
+  public void testGetTaskBlackListCleanupPeriod() throws Exception
+  {
+    final Period taskBlackListCleanupPeriod = Period.years(100);
+    Assert.assertEquals(
+            taskBlackListCleanupPeriod,
+            reflect(generateRemoteTaskRunnerConfig(
+                    DEFAULT_TIMEOUT,
+                    DEFAULT_TIMEOUT,
+                    DEFAULT_VERSION,
+                    DEFAULT_MAX_ZNODE,
+                    DEFAULT_TIMEOUT,
+                    DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS,
+                    DEFAULT_MAX_RETRIES_BEFORE_BLACKLIST,
+                    DEFAULT_TASK_BACKOFF,
+                    taskBlackListCleanupPeriod
+            )).getTaskBlackListCleanupPeriod()
     );
   }
 
@@ -149,7 +230,10 @@ public class RemoteTaskRunnerConfigTest
             DEFAULT_VERSION,
             DEFAULT_MAX_ZNODE,
             DEFAULT_TIMEOUT,
-            DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS
+            DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS,
+            DEFAULT_MAX_RETRIES_BEFORE_BLACKLIST,
+            DEFAULT_TASK_BACKOFF,
+            DEFAULT_BLACKLIST_CLEANUP_PERIOD
         )),
         reflect(generateRemoteTaskRunnerConfig(
             DEFAULT_TIMEOUT,
@@ -157,13 +241,19 @@ public class RemoteTaskRunnerConfigTest
             DEFAULT_VERSION,
             DEFAULT_MAX_ZNODE,
             DEFAULT_TIMEOUT,
-            DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS
+            DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS,
+            DEFAULT_MAX_RETRIES_BEFORE_BLACKLIST,
+            DEFAULT_TASK_BACKOFF,
+            DEFAULT_BLACKLIST_CLEANUP_PERIOD
         ))
     );
     final Period timeout = Period.years(999);
     final String version = "someVersion";
     final long max = 20 * 1024;
     final int pendingTasksRunnerNumThreads = 20;
+    final int maxRetriesBeforeBlacklist = 1;
+    final long taskBlackListBackoffTimeMillis = 1000;
+    final Period taskBlackListCleanupPeriod = Period.years(10);
     Assert.assertEquals(
         reflect(generateRemoteTaskRunnerConfig(
             timeout,
@@ -171,7 +261,10 @@ public class RemoteTaskRunnerConfigTest
             version,
             max,
             timeout,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         )),
         reflect(generateRemoteTaskRunnerConfig(
             timeout,
@@ -179,7 +272,10 @@ public class RemoteTaskRunnerConfigTest
             version,
             max,
             timeout,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         ))
     );
     Assert.assertNotEquals(
@@ -189,7 +285,10 @@ public class RemoteTaskRunnerConfigTest
             version,
             max,
             timeout,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         )),
         reflect(generateRemoteTaskRunnerConfig(
             DEFAULT_TIMEOUT,
@@ -197,7 +296,10 @@ public class RemoteTaskRunnerConfigTest
             version,
             max,
             timeout,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         ))
     );
     Assert.assertNotEquals(
@@ -207,7 +309,10 @@ public class RemoteTaskRunnerConfigTest
             version,
             max,
             timeout,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         )),
         reflect(generateRemoteTaskRunnerConfig(
             timeout,
@@ -215,7 +320,10 @@ public class RemoteTaskRunnerConfigTest
             version,
             max,
             timeout,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         ))
     );
     Assert.assertNotEquals(
@@ -225,7 +333,10 @@ public class RemoteTaskRunnerConfigTest
             version,
             max,
             timeout,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         )),
         reflect(generateRemoteTaskRunnerConfig(
             timeout,
@@ -233,7 +344,10 @@ public class RemoteTaskRunnerConfigTest
             DEFAULT_VERSION,
             max,
             timeout,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         ))
     );
 
@@ -244,7 +358,10 @@ public class RemoteTaskRunnerConfigTest
             version,
             max,
             timeout,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         )),
         reflect(generateRemoteTaskRunnerConfig(
             timeout,
@@ -252,7 +369,10 @@ public class RemoteTaskRunnerConfigTest
             version,
             DEFAULT_MAX_ZNODE,
             timeout,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         ))
     );
 
@@ -264,7 +384,10 @@ public class RemoteTaskRunnerConfigTest
             version,
             max,
             timeout,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         )),
         reflect(generateRemoteTaskRunnerConfig(
             timeout,
@@ -272,7 +395,10 @@ public class RemoteTaskRunnerConfigTest
             version,
             max,
             DEFAULT_TIMEOUT,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         ))
     );
 
@@ -283,7 +409,10 @@ public class RemoteTaskRunnerConfigTest
                     version,
                     max,
                     timeout,
-                    pendingTasksRunnerNumThreads
+                    pendingTasksRunnerNumThreads,
+                    maxRetriesBeforeBlacklist,
+                    taskBlackListBackoffTimeMillis,
+                    taskBlackListCleanupPeriod
                 )),
         reflect(generateRemoteTaskRunnerConfig(
                     timeout,
@@ -291,8 +420,86 @@ public class RemoteTaskRunnerConfigTest
                     version,
                     max,
                     timeout,
-                    DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS
+                    DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS,
+                    maxRetriesBeforeBlacklist,
+                    taskBlackListBackoffTimeMillis,
+                    taskBlackListCleanupPeriod
                 ))
+    );
+
+    Assert.assertNotEquals(
+            reflect(generateRemoteTaskRunnerConfig(
+                    timeout,
+                    timeout,
+                    version,
+                    max,
+                    timeout,
+                    pendingTasksRunnerNumThreads,
+                    maxRetriesBeforeBlacklist,
+                    taskBlackListBackoffTimeMillis,
+                    taskBlackListCleanupPeriod
+            )),
+            reflect(generateRemoteTaskRunnerConfig(
+                    timeout,
+                    timeout,
+                    version,
+                    max,
+                    timeout,
+                    pendingTasksRunnerNumThreads,
+                    DEFAULT_MAX_RETRIES_BEFORE_BLACKLIST,
+                    taskBlackListBackoffTimeMillis,
+                    taskBlackListCleanupPeriod
+            ))
+    );
+
+    Assert.assertNotEquals(
+            reflect(generateRemoteTaskRunnerConfig(
+                    timeout,
+                    timeout,
+                    version,
+                    max,
+                    timeout,
+                    pendingTasksRunnerNumThreads,
+                    maxRetriesBeforeBlacklist,
+                    taskBlackListBackoffTimeMillis,
+                    taskBlackListCleanupPeriod
+            )),
+            reflect(generateRemoteTaskRunnerConfig(
+                    timeout,
+                    timeout,
+                    version,
+                    max,
+                    timeout,
+                    pendingTasksRunnerNumThreads,
+                    maxRetriesBeforeBlacklist,
+                    DEFAULT_TASK_BACKOFF,
+                    taskBlackListCleanupPeriod
+            ))
+    );
+
+    Assert.assertNotEquals(
+            reflect(generateRemoteTaskRunnerConfig(
+                    timeout,
+                    timeout,
+                    version,
+                    max,
+                    timeout,
+                    pendingTasksRunnerNumThreads,
+                    maxRetriesBeforeBlacklist,
+                    taskBlackListBackoffTimeMillis,
+                    taskBlackListCleanupPeriod
+            )),
+            reflect(generateRemoteTaskRunnerConfig(
+                    timeout,
+                    timeout,
+                    version,
+                    max,
+                    timeout,
+                    pendingTasksRunnerNumThreads,
+                    maxRetriesBeforeBlacklist,
+                    taskBlackListBackoffTimeMillis,
+                    DEFAULT_BLACKLIST_CLEANUP_PERIOD
+            ))
     );
   }
 
@@ -306,7 +513,10 @@ public class RemoteTaskRunnerConfigTest
             DEFAULT_VERSION,
             DEFAULT_MAX_ZNODE,
             DEFAULT_TIMEOUT,
-            DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS
+            DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS,
+            DEFAULT_MAX_RETRIES_BEFORE_BLACKLIST,
+            DEFAULT_TASK_BACKOFF,
+            DEFAULT_BLACKLIST_CLEANUP_PERIOD
         )).hashCode(),
         reflect(generateRemoteTaskRunnerConfig(
             DEFAULT_TIMEOUT,
@@ -314,13 +524,19 @@ public class RemoteTaskRunnerConfigTest
             DEFAULT_VERSION,
             DEFAULT_MAX_ZNODE,
             DEFAULT_TIMEOUT,
-            DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS
+            DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS,
+            DEFAULT_MAX_RETRIES_BEFORE_BLACKLIST,
+            DEFAULT_TASK_BACKOFF,
+            DEFAULT_BLACKLIST_CLEANUP_PERIOD
         )).hashCode()
     );
     final Period timeout = Period.years(999);
     final String version = "someVersion";
     final long max = 20 * 1024;
     final int pendingTasksRunnerNumThreads = 20;
+    final int maxRetriesBeforeBlacklist = 80;
+    final long taskBlackListBackoffTimeMillis = 10000;
+    final Period taskBlackListCleanupPeriod = Period.years(10);
     Assert.assertEquals(
         reflect(generateRemoteTaskRunnerConfig(
             timeout,
@@ -328,7 +544,10 @@ public class RemoteTaskRunnerConfigTest
             version,
             max,
             timeout,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         )).hashCode(),
         reflect(generateRemoteTaskRunnerConfig(
             timeout,
@@ -336,7 +555,10 @@ public class RemoteTaskRunnerConfigTest
             version,
             max,
             timeout,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         )).hashCode()
     );
     Assert.assertNotEquals(
@@ -346,7 +568,10 @@ public class RemoteTaskRunnerConfigTest
             version,
             max,
             timeout,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         )).hashCode(),
         reflect(generateRemoteTaskRunnerConfig(
             DEFAULT_TIMEOUT,
@@ -354,7 +579,10 @@ public class RemoteTaskRunnerConfigTest
             version,
             max,
             timeout,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         )).hashCode()
     );
     Assert.assertNotEquals(
@@ -364,7 +592,10 @@ public class RemoteTaskRunnerConfigTest
             version,
             max,
             timeout,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         )).hashCode(),
         reflect(generateRemoteTaskRunnerConfig(
             timeout,
@@ -372,7 +603,10 @@ public class RemoteTaskRunnerConfigTest
             version,
             max,
             timeout,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         )).hashCode()
     );
     Assert.assertNotEquals(
@@ -382,7 +616,10 @@ public class RemoteTaskRunnerConfigTest
             version,
             max,
             timeout,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         )).hashCode(),
         reflect(generateRemoteTaskRunnerConfig(
             timeout,
@@ -390,7 +627,10 @@ public class RemoteTaskRunnerConfigTest
             DEFAULT_VERSION,
             max,
             timeout,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         )).hashCode()
     );
 
@@ -401,7 +641,10 @@ public class RemoteTaskRunnerConfigTest
             version,
             max,
             timeout,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         )).hashCode(),
         reflect(generateRemoteTaskRunnerConfig(
             timeout,
@@ -409,7 +652,10 @@ public class RemoteTaskRunnerConfigTest
             version,
             DEFAULT_MAX_ZNODE,
             timeout,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         )).hashCode()
     );
 
@@ -421,7 +667,10 @@ public class RemoteTaskRunnerConfigTest
             version,
             max,
             timeout,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         )).hashCode(),
         reflect(generateRemoteTaskRunnerConfig(
             timeout,
@@ -429,7 +678,10 @@ public class RemoteTaskRunnerConfigTest
             version,
             max,
             DEFAULT_TIMEOUT,
-            pendingTasksRunnerNumThreads
+            pendingTasksRunnerNumThreads,
+            maxRetriesBeforeBlacklist,
+            taskBlackListBackoffTimeMillis,
+            taskBlackListCleanupPeriod
         )).hashCode()
     );
 
@@ -440,7 +692,10 @@ public class RemoteTaskRunnerConfigTest
                     version,
                     max,
                     timeout,
-                    pendingTasksRunnerNumThreads
+                    pendingTasksRunnerNumThreads,
+                    maxRetriesBeforeBlacklist,
+                    taskBlackListBackoffTimeMillis,
+                    taskBlackListCleanupPeriod
                 )).hashCode(),
         reflect(generateRemoteTaskRunnerConfig(
                     timeout,
@@ -448,8 +703,86 @@ public class RemoteTaskRunnerConfigTest
                     version,
                     max,
                     timeout,
-                    DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS
+                    DEFAULT_PENDING_TASKS_RUNNER_NUM_THREADS,
+                    maxRetriesBeforeBlacklist,
+                    taskBlackListBackoffTimeMillis,
+                    taskBlackListCleanupPeriod
                 )).hashCode()
+    );
+
+    Assert.assertNotEquals(
+            reflect(generateRemoteTaskRunnerConfig(
+                    timeout,
+                    timeout,
+                    version,
+                    max,
+                    timeout,
+                    pendingTasksRunnerNumThreads,
+                    maxRetriesBeforeBlacklist,
+                    taskBlackListBackoffTimeMillis,
+                    taskBlackListCleanupPeriod
+            )).hashCode(),
+            reflect(generateRemoteTaskRunnerConfig(
+                    timeout,
+                    timeout,
+                    version,
+                    max,
+                    timeout,
+                    pendingTasksRunnerNumThreads,
+                    DEFAULT_MAX_RETRIES_BEFORE_BLACKLIST,
+                    taskBlackListBackoffTimeMillis,
+                    taskBlackListCleanupPeriod
+            )).hashCode()
+    );
+
+    Assert.assertNotEquals(
+            reflect(generateRemoteTaskRunnerConfig(
+                    timeout,
+                    timeout,
+                    version,
+                    max,
+                    timeout,
+                    pendingTasksRunnerNumThreads,
+                    maxRetriesBeforeBlacklist,
+                    taskBlackListBackoffTimeMillis,
+                    taskBlackListCleanupPeriod
+            )).hashCode(),
+            reflect(generateRemoteTaskRunnerConfig(
+                    timeout,
+                    timeout,
+                    version,
+                    max,
+                    timeout,
+                    pendingTasksRunnerNumThreads,
+                    maxRetriesBeforeBlacklist,
+                    DEFAULT_TASK_BACKOFF,
+                    taskBlackListCleanupPeriod
+            )).hashCode()
+    );
+
+    Assert.assertNotEquals(
+            reflect(generateRemoteTaskRunnerConfig(
+                    timeout,
+                    timeout,
+                    version,
+                    max,
+                    timeout,
+                    pendingTasksRunnerNumThreads,
+                    maxRetriesBeforeBlacklist,
+                    taskBlackListBackoffTimeMillis,
+                    taskBlackListCleanupPeriod
+            )).hashCode(),
+            reflect(generateRemoteTaskRunnerConfig(
+                    timeout,
+                    timeout,
+                    version,
+                    max,
+                    timeout,
+                    pendingTasksRunnerNumThreads,
+                    maxRetriesBeforeBlacklist,
+                    taskBlackListBackoffTimeMillis,
+                    DEFAULT_BLACKLIST_CLEANUP_PERIOD
+            )).hashCode()
     );
   }
 
@@ -464,7 +797,10 @@ public class RemoteTaskRunnerConfigTest
       String minWorkerVersion,
       long maxZnodeBytes,
       Period taskShutdownLinkTimeout,
-      int pendingTasksRunnerNumThreads
+      int pendingTasksRunnerNumThreads,
+      int maxRetriesBeforeBlacklist,
+      long taskBlackListBackoffTimeMillis,
+      Period taskBlackListCleanupPeriod
   )
   {
     final Map<String, Object> objectMap = new HashMap<>();
@@ -474,6 +810,9 @@ public class RemoteTaskRunnerConfigTest
     objectMap.put("maxZnodeBytes", maxZnodeBytes);
     objectMap.put("taskShutdownLinkTimeout", taskShutdownLinkTimeout);
     objectMap.put("pendingTasksRunnerNumThreads", pendingTasksRunnerNumThreads);
+    objectMap.put("maxRetriesBeforeBlacklist", maxRetriesBeforeBlacklist);
+    objectMap.put("taskBlackListBackoffTimeMillis", taskBlackListBackoffTimeMillis);
+    objectMap.put("taskBlackListCleanupPeriod", taskBlackListCleanupPeriod);
     return mapper.convertValue(objectMap, RemoteTaskRunnerConfig.class);
   }
 }

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfigTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfigTest.java
@@ -181,7 +181,7 @@ public class RemoteTaskRunnerConfigTest
   }
 
   @Test
-  public void testGettaskBlackListBackoffTime() throws Exception
+  public void testGetWorkerBlackListBackoffTime() throws Exception
   {
     final Period taskBlackListBackoffTime = new Period("PT1M");
     Assert.assertEquals(
@@ -196,7 +196,7 @@ public class RemoteTaskRunnerConfigTest
                     DEFAULT_MAX_RETRIES_BEFORE_BLACKLIST,
                     taskBlackListBackoffTime,
                     DEFAULT_BLACKLIST_CLEANUP_PERIOD
-            )).getTaskBlackListBackoffTime()
+            )).getWorkerBlackListBackoffTime()
     );
   }
 
@@ -216,7 +216,7 @@ public class RemoteTaskRunnerConfigTest
                     DEFAULT_MAX_RETRIES_BEFORE_BLACKLIST,
                     DEFAULT_TASK_BACKOFF,
                     taskBlackListCleanupPeriod
-            )).getTaskBlackListCleanupPeriod()
+            )).getWorkerBlackListCleanupPeriod()
     );
   }
 
@@ -811,8 +811,8 @@ public class RemoteTaskRunnerConfigTest
     objectMap.put("taskShutdownLinkTimeout", taskShutdownLinkTimeout);
     objectMap.put("pendingTasksRunnerNumThreads", pendingTasksRunnerNumThreads);
     objectMap.put("maxRetriesBeforeBlacklist", maxRetriesBeforeBlacklist);
-    objectMap.put("taskBlackListBackoffTime", taskBlackListBackoffTime);
-    objectMap.put("taskBlackListCleanupPeriod", taskBlackListCleanupPeriod);
+    objectMap.put("workerBlackListBackoffTime", taskBlackListBackoffTime);
+    objectMap.put("workerBlackListCleanupPeriod", taskBlackListCleanupPeriod);
     return mapper.convertValue(objectMap, RemoteTaskRunnerConfig.class);
   }
 }


### PR DESCRIPTION
1. Blacklisting Workers if the tasks have failed continuously for the last 'n' times that can be specified by maxRetriesBeforeBlacklist
2. Added a cleanup period that will remove blacklisted nodes after a certain period taskBlackListCleanupPeriod
3. Once node is blacklisted it only remains blacklisted for a period taskBlackListBackoffTimeMillis
