### PR TITLE
fix zero period in PeriodGranularity causing infinite loop then OOM

### DIFF
--- a/processing/src/main/java/io/druid/granularity/DurationGranularity.java
+++ b/processing/src/main/java/io/druid/granularity/DurationGranularity.java
@@ -21,6 +21,7 @@ package io.druid.granularity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import com.google.common.primitives.Longs;
 import org.joda.time.DateTime;
 
@@ -42,6 +43,7 @@ public class DurationGranularity extends BaseQueryGranularity
 
   public DurationGranularity(long millis, long origin)
   {
+    Preconditions.checkArgument(millis > 0, "duration should be greater than 0!");
     this.length = millis;
     this.origin = origin % length;
   }

--- a/processing/src/main/java/io/druid/granularity/PeriodGranularity.java
+++ b/processing/src/main/java/io/druid/granularity/PeriodGranularity.java
@@ -21,6 +21,7 @@ package io.druid.granularity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import io.druid.java.util.common.StringUtils;
 import org.joda.time.Chronology;
 import org.joda.time.DateTime;
@@ -44,7 +45,8 @@ public class  PeriodGranularity extends BaseQueryGranularity
       @JsonProperty("timeZone") DateTimeZone tz
   )
   {
-    this.period = period;
+    this.period = Preconditions.checkNotNull(period, "period can't be null!");
+    Preconditions.checkArgument(!Period.ZERO.equals(period), "zero period is not acceptable in QueryGranularity!");
     this.chronology = tz == null ? ISOChronology.getInstanceUTC() : ISOChronology.getInstance(tz);
     if(origin == null)
     {

--- a/processing/src/test/java/io/druid/granularity/QueryGranularityTest.java
+++ b/processing/src/test/java/io/druid/granularity/QueryGranularityTest.java
@@ -19,6 +19,7 @@
 
 package io.druid.granularity;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -642,6 +643,13 @@ public class QueryGranularityTest
     String jsonOut = mapper.writeValueAsString(expected);
     Assert.assertEquals(expected, mapper.readValue(jsonOut, QueryGranularity.class));
 
+    String illegalJson = "{ \"type\": \"period\", \"period\": \"P0D\" }";
+    try {
+      mapper.readValue(illegalJson, QueryGranularity.class);
+      Assert.fail();
+    }
+    catch (JsonMappingException e) {
+    }
   }
 
   @Test
@@ -659,6 +667,14 @@ public class QueryGranularityTest
 
     DurationGranularity expected = new DurationGranularity(5, 2);
     Assert.assertEquals(expected, mapper.readValue(mapper.writeValueAsString(expected), QueryGranularity.class));
+
+    String illegalJson = "{ \"type\": \"duration\", \"duration\": \"0\" }";
+    try {
+      mapper.readValue(illegalJson, QueryGranularity.class);
+      Assert.fail();
+    }
+    catch (JsonMappingException e) {
+    }
   }
 
   @Test


### PR DESCRIPTION
when construct PeriodGranularity with ZERO period like P0D, P0M, P0S... will cause infinite loop when calling gran.iterable(start, end), because the PeriodGranularity.next(long t) never move forward.
Finally, this issue will cause "out of heap space" error when makeCursors(...) and bring down the historical/realtime.