### PR TITLE
Add configs to enable running integration tests for cluster running behind proxy

### DIFF
--- a/integration-tests/src/main/java/io/druid/testing/ConfigFileConfigProvider.java
+++ b/integration-tests/src/main/java/io/druid/testing/ConfigFileConfigProvider.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.druid.java.util.common.logger.Logger;
 
 import java.io.File;
@@ -33,18 +32,21 @@ import java.util.Map;
 public class ConfigFileConfigProvider implements IntegrationTestingConfigProvider
 {
   private final static Logger LOG = new Logger(ConfigFileConfigProvider.class);
-  private String routerHost = "";
-  private String brokerHost = "";
-  private String historicalHost = "";
-  private String coordinatorHost = "";
-  private String indexerHost = "";
-  private String middleManagerHost = "";
-  private String zookeeperHosts = "";        // comma-separated list of host:port
-  private String kafkaHost = "";
+  private String routerUrl;
+  private String brokerUrl;
+  private String historicalUrl;
+  private String coordinatorUrl;
+  private String indexerUrl;
+  private String middleManagerHost;
+  private String zookeeperHosts;        // comma-separated list of host:port
+  private String kafkaHost;
   private Map<String, String> props = null;
+  private String username;
+  private String password;
 
   @JsonCreator
-  ConfigFileConfigProvider(@JsonProperty("configFile") String configFile){
+  ConfigFileConfigProvider(@JsonProperty("configFile") String configFile)
+  {
     loadProperties(configFile);
   }
 
@@ -53,34 +55,59 @@ public class ConfigFileConfigProvider implements IntegrationTestingConfigProvide
     ObjectMapper jsonMapper = new ObjectMapper();
     try {
       props = jsonMapper.readValue(
-          new File(configFile), new TypeReference<Map<String, String>>()
-      {
-      }
+        new File(configFile), new TypeReference<Map<String, String>>()
+        {
+        }
       );
     }
     catch (IOException ex) {
       throw new RuntimeException(ex);
     }
     // there might not be a router; we want routerHost to be null in that case
-    routerHost = props.get("router_host");
-    if (null != routerHost) {
-	routerHost += ":" + props.get("router_port");
+    routerUrl = props.get("router_url");
+    if (routerUrl == null) {
+      String routerHost = props.get("router_host");
+      if (null != routerHost) {
+        routerUrl = String.format("http://%s:%s", routerHost, props.get("router_port"));
+      }
     }
-    brokerHost = props.get("broker_host") + ":" + props.get("broker_port");
-    historicalHost = props.get("historical_host") + ":" + props.get("historical_port");
-    coordinatorHost = props.get("coordinator_host") + ":" + props.get("coordinator_port");
-    indexerHost = props.get("indexer_host") + ":" + props.get("indexer_port");
-    middleManagerHost = props.get("middlemanager_host");
-    zookeeperHosts = props.get("zookeeper_hosts");
-    kafkaHost = props.get("kafka_host") + ":" + props.get ("kafka_port");
+    brokerUrl = props.get("broker_url");
+    if (brokerUrl == null) {
+      brokerUrl = String.format("http://%s:%s", props.get("broker_host"), props.get("broker_port"));
+    }
 
-    LOG.info ("router: [%s]", routerHost);
-    LOG.info ("broker: [%s]", brokerHost);
-    LOG.info ("coordinator: [%s]", coordinatorHost);
-    LOG.info ("overlord: [%s]", indexerHost);
-    LOG.info ("middle manager: [%s]", middleManagerHost);
-    LOG.info ("zookeepers: [%s]", zookeeperHosts);
-    LOG.info ("kafka: [%s]", kafkaHost);
+    historicalUrl = props.get("historical_url");
+    if (historicalUrl == null) {
+      historicalUrl = String.format("http://%s:%s", props.get("historical_host"), props.get("historical_port"));
+    }
+
+    coordinatorUrl = props.get("coordinator_url");
+    if (coordinatorUrl == null) {
+      coordinatorUrl = String.format("http://%s:%s", props.get("coordinator_host"), props.get("coordinator_port"));
+    }
+
+    indexerUrl = props.get("indexer_url");
+    if (indexerUrl == null) {
+      indexerUrl = String.format("http://%s:%s", props.get("indexer_host"), props.get("indexer_port"));
+    }
+    middleManagerHost = props.get("middlemanager_host");
+
+    zookeeperHosts = props.get("zookeeper_hosts");
+    kafkaHost = props.get("kafka_host") + ":" + props.get("kafka_port");
+
+    username = props.get("username");
+
+    password = props.get("password");
+
+    LOG.info("router: [%s]", routerUrl);
+    LOG.info("broker: [%s]", brokerUrl);
+    LOG.info("coordinator: [%s]", coordinatorUrl);
+    LOG.info("overlord: [%s]", indexerUrl);
+    LOG.info("middle manager: [%s]", middleManagerHost);
+    LOG.info("zookeepers: [%s]", zookeeperHosts);
+    LOG.info("kafka: [%s]", kafkaHost);
+    LOG.info("Username: [%s]", username);
+    LOG.info("Password: [%s]", password);
   }
 
   @Override
@@ -88,34 +115,35 @@ public class ConfigFileConfigProvider implements IntegrationTestingConfigProvide
   {
     return new IntegrationTestingConfig()
     {
+
       @Override
-      public String getCoordinatorHost()
+      public String getCoordinatorUrl()
       {
-        return coordinatorHost;
+        return coordinatorUrl;
       }
 
       @Override
-      public String getIndexerHost()
+      public String getIndexerUrl()
       {
-        return indexerHost;
+        return indexerUrl;
       }
 
       @Override
-      public String getRouterHost()
+      public String getRouterUrl()
       {
-        return routerHost;
+        return routerUrl;
       }
 
       @Override
-      public String getBrokerHost()
+      public String getBrokerUrl()
       {
-        return brokerHost;
+        return brokerUrl;
       }
 
       @Override
-      public String getHistoricalHost()
+      public String getHistoricalUrl()
       {
-        return historicalHost;
+        return historicalUrl;
       }
 
       @Override
@@ -140,6 +168,18 @@ public class ConfigFileConfigProvider implements IntegrationTestingConfigProvide
       public String getProperty(String keyword)
       {
         return props.get(keyword);
+      }
+
+      @Override
+      public String getUsername()
+      {
+        return username;
+      }
+
+      @Override
+      public String getPassword()
+      {
+        return password;
       }
     };
   }

--- a/integration-tests/src/main/java/io/druid/testing/ConfigFileConfigProvider.java
+++ b/integration-tests/src/main/java/io/druid/testing/ConfigFileConfigProvider.java
@@ -107,7 +107,6 @@ public class ConfigFileConfigProvider implements IntegrationTestingConfigProvide
     LOG.info("zookeepers: [%s]", zookeeperHosts);
     LOG.info("kafka: [%s]", kafkaHost);
     LOG.info("Username: [%s]", username);
-    LOG.info("Password: [%s]", password);
   }
 
   @Override

--- a/integration-tests/src/main/java/io/druid/testing/DockerConfigProvider.java
+++ b/integration-tests/src/main/java/io/druid/testing/DockerConfigProvider.java
@@ -79,13 +79,13 @@ public class DockerConfigProvider implements IntegrationTestingConfigProvider
       @Override
       public String getZookeeperHosts()
       {
-        return "http://" + dockerIp + ":2181";
+        return dockerIp + ":2181";
       }
 
       @Override
       public String getKafkaHost()
       {
-        return "http://" + dockerIp + ":9092";
+        return dockerIp + ":9092";
       }
 
 

--- a/integration-tests/src/main/java/io/druid/testing/DockerConfigProvider.java
+++ b/integration-tests/src/main/java/io/druid/testing/DockerConfigProvider.java
@@ -41,33 +41,33 @@ public class DockerConfigProvider implements IntegrationTestingConfigProvider
     return new IntegrationTestingConfig()
     {
       @Override
-      public String getCoordinatorHost()
+      public String getCoordinatorUrl()
       {
-        return dockerIp+":8081";
+        return "http://" + dockerIp + ":8081";
       }
 
       @Override
-      public String getIndexerHost()
+      public String getIndexerUrl()
       {
-        return dockerIp+":8090";
+        return "http://" + dockerIp + ":8090";
       }
 
       @Override
-      public String getRouterHost()
+      public String getRouterUrl()
       {
-        return dockerIp+ ":8888";
+        return "http://" + dockerIp + ":8888";
       }
 
       @Override
-      public String getBrokerHost()
+      public String getBrokerUrl()
       {
-        return dockerIp + ":8082";
+        return "http://" + dockerIp + ":8082";
       }
 
       @Override
-      public String getHistoricalHost()
+      public String getHistoricalUrl()
       {
-        return dockerIp + ":8083";
+        return "http://" + dockerIp + ":8083";
       }
 
       @Override
@@ -79,22 +79,35 @@ public class DockerConfigProvider implements IntegrationTestingConfigProvider
       @Override
       public String getZookeeperHosts()
       {
-        return dockerIp + ":2181";
+        return "http://" + dockerIp + ":2181";
       }
 
       @Override
       public String getKafkaHost()
       {
-        return dockerIp + ":9092";
+        return "http://" + dockerIp + ":9092";
       }
+
 
       @Override
       public String getProperty(String prop)
       {
         if (prop.equals("hadoopTestDir")) {
-	   return hadoopDir;
-	}
+          return hadoopDir;
+        }
         throw new UnsupportedOperationException("DockerConfigProvider does not support property " + prop);
+      }
+
+      @Override
+      public String getUsername()
+      {
+        return null;
+      }
+
+      @Override
+      public String getPassword()
+      {
+        return null;
       }
     };
   }

--- a/integration-tests/src/main/java/io/druid/testing/IntegrationTestingConfig.java
+++ b/integration-tests/src/main/java/io/druid/testing/IntegrationTestingConfig.java
@@ -23,15 +23,15 @@ package io.druid.testing;
  */
 public interface IntegrationTestingConfig
 {
-  public String getCoordinatorHost();
+  public String getCoordinatorUrl();
 
-  public String getIndexerHost();
+  public String getIndexerUrl();
 
-  public String getRouterHost();
+  public String getRouterUrl();
 
-  public String getBrokerHost();
+  public String getBrokerUrl();
 
-  public String getHistoricalHost();
+  public String getHistoricalUrl();
 
   public String getMiddleManagerHost();
 
@@ -40,4 +40,8 @@ public interface IntegrationTestingConfig
   public String getKafkaHost();
 
   public String getProperty(String prop);
+
+  String getUsername();
+
+  String getPassword();
 }

--- a/integration-tests/src/main/java/io/druid/testing/clients/ClientInfoResourceTestClient.java
+++ b/integration-tests/src/main/java/io/druid/testing/clients/ClientInfoResourceTestClient.java
@@ -28,9 +28,9 @@ import com.metamx.http.client.HttpClient;
 import com.metamx.http.client.Request;
 import com.metamx.http.client.response.StatusResponseHandler;
 import com.metamx.http.client.response.StatusResponseHolder;
-import io.druid.guice.annotations.Global;
 import io.druid.java.util.common.ISE;
 import io.druid.testing.IntegrationTestingConfig;
+import io.druid.testing.guice.TestClient;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
@@ -47,20 +47,20 @@ public class ClientInfoResourceTestClient
   @Inject
   ClientInfoResourceTestClient(
       ObjectMapper jsonMapper,
-      @Global HttpClient httpClient,
+      @TestClient HttpClient httpClient,
       IntegrationTestingConfig config
   )
   {
     this.jsonMapper = jsonMapper;
     this.httpClient = httpClient;
-    this.broker = config.getBrokerHost();
+    this.broker = config.getBrokerUrl();
     this.responseHandler = new StatusResponseHandler(Charsets.UTF_8);
   }
 
   private String getBrokerURL()
   {
     return String.format(
-        "http://%s/druid/v2/datasources",
+        "%s/druid/v2/datasources",
         broker
     );
   }

--- a/integration-tests/src/main/java/io/druid/testing/clients/ClientInfoResourceTestClient.java
+++ b/integration-tests/src/main/java/io/druid/testing/clients/ClientInfoResourceTestClient.java
@@ -41,7 +41,7 @@ public class ClientInfoResourceTestClient
 {
   private final ObjectMapper jsonMapper;
   private final HttpClient httpClient;
-  private final String broker;
+  private final String brokerUrl;
   private final StatusResponseHandler responseHandler;
 
   @Inject
@@ -53,7 +53,7 @@ public class ClientInfoResourceTestClient
   {
     this.jsonMapper = jsonMapper;
     this.httpClient = httpClient;
-    this.broker = config.getBrokerUrl();
+    this.brokerUrl = config.getBrokerUrl();
     this.responseHandler = new StatusResponseHandler(Charsets.UTF_8);
   }
 
@@ -61,7 +61,7 @@ public class ClientInfoResourceTestClient
   {
     return String.format(
         "%s/druid/v2/datasources",
-        broker
+        brokerUrl
     );
   }
 

--- a/integration-tests/src/main/java/io/druid/testing/clients/CoordinatorResourceTestClient.java
+++ b/integration-tests/src/main/java/io/druid/testing/clients/CoordinatorResourceTestClient.java
@@ -28,9 +28,9 @@ import com.metamx.http.client.HttpClient;
 import com.metamx.http.client.Request;
 import com.metamx.http.client.response.StatusResponseHandler;
 import com.metamx.http.client.response.StatusResponseHolder;
-import io.druid.guice.annotations.Global;
 import io.druid.java.util.common.ISE;
 import io.druid.testing.IntegrationTestingConfig;
+import io.druid.testing.guice.TestClient;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.joda.time.Interval;
@@ -48,20 +48,20 @@ public class CoordinatorResourceTestClient
 
   @Inject
   CoordinatorResourceTestClient(
-      ObjectMapper jsonMapper,
-      @Global HttpClient httpClient, IntegrationTestingConfig config
+    ObjectMapper jsonMapper,
+    @TestClient HttpClient httpClient, IntegrationTestingConfig config
   )
   {
     this.jsonMapper = jsonMapper;
     this.httpClient = httpClient;
-    this.coordinator = config.getCoordinatorHost();
+    this.coordinator = config.getCoordinatorUrl();
     this.responseHandler = new StatusResponseHandler(Charsets.UTF_8);
   }
 
   private String getCoordinatorURL()
   {
     return String.format(
-        "http://%s/druid/coordinator/v1/",
+        "%s/druid/coordinator/v1/",
         coordinator
     );
   }

--- a/integration-tests/src/main/java/io/druid/testing/clients/EventReceiverFirehoseTestClient.java
+++ b/integration-tests/src/main/java/io/druid/testing/clients/EventReceiverFirehoseTestClient.java
@@ -28,9 +28,8 @@ import com.metamx.http.client.HttpClient;
 import com.metamx.http.client.Request;
 import com.metamx.http.client.response.StatusResponseHandler;
 import com.metamx.http.client.response.StatusResponseHolder;
-
 import io.druid.java.util.common.ISE;
-
+import io.druid.testing.guice.TestClient;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
@@ -55,7 +54,7 @@ public class EventReceiverFirehoseTestClient
       String host,
       String chatID,
       ObjectMapper jsonMapper,
-      HttpClient httpClient,
+      @TestClient HttpClient httpClient,
       ObjectMapper smileMapper
   )
   {

--- a/integration-tests/src/main/java/io/druid/testing/clients/OverlordResourceTestClient.java
+++ b/integration-tests/src/main/java/io/druid/testing/clients/OverlordResourceTestClient.java
@@ -28,12 +28,12 @@ import com.metamx.http.client.HttpClient;
 import com.metamx.http.client.Request;
 import com.metamx.http.client.response.StatusResponseHandler;
 import com.metamx.http.client.response.StatusResponseHolder;
-import io.druid.guice.annotations.Global;
 import io.druid.indexing.common.TaskStatus;
 import io.druid.indexing.common.task.Task;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.testing.IntegrationTestingConfig;
+import io.druid.testing.guice.TestClient;
 import io.druid.testing.utils.RetryUtil;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
@@ -54,20 +54,21 @@ public class OverlordResourceTestClient
 
   @Inject
   OverlordResourceTestClient(
-      ObjectMapper jsonMapper,
-      @Global HttpClient httpClient, IntegrationTestingConfig config
+    ObjectMapper jsonMapper,
+    @TestClient HttpClient httpClient,
+    IntegrationTestingConfig config
   )
   {
     this.jsonMapper = jsonMapper;
     this.httpClient = httpClient;
-    this.indexer = config.getIndexerHost();
+    this.indexer = config.getIndexerUrl();
     this.responseHandler = new StatusResponseHandler(Charsets.UTF_8);
   }
 
   private String getIndexerURL()
   {
     return String.format(
-        "http://%s/druid/indexer/v1/",
+        "%s/druid/indexer/v1/",
         indexer
     );
   }

--- a/integration-tests/src/main/java/io/druid/testing/clients/QueryResourceTestClient.java
+++ b/integration-tests/src/main/java/io/druid/testing/clients/QueryResourceTestClient.java
@@ -29,10 +29,10 @@ import com.metamx.http.client.HttpClient;
 import com.metamx.http.client.Request;
 import com.metamx.http.client.response.StatusResponseHandler;
 import com.metamx.http.client.response.StatusResponseHolder;
-import io.druid.guice.annotations.Global;
 import io.druid.java.util.common.ISE;
 import io.druid.query.Query;
 import io.druid.testing.IntegrationTestingConfig;
+import io.druid.testing.guice.TestClient;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
@@ -50,20 +50,20 @@ public class QueryResourceTestClient
   @Inject
   QueryResourceTestClient(
       ObjectMapper jsonMapper,
-      @Global HttpClient httpClient,
+      @TestClient HttpClient httpClient,
       IntegrationTestingConfig config
   )
   {
     this.jsonMapper = jsonMapper;
     this.httpClient = httpClient;
-    this.router = config.getRouterHost();
+    this.router = config.getRouterUrl();
     this.responseHandler = new StatusResponseHandler(Charsets.UTF_8);
   }
 
   private String getBrokerURL()
   {
     return String.format(
-        "http://%s/druid/v2/",
+        "%s/druid/v2/",
         router
     );
   }

--- a/integration-tests/src/main/java/io/druid/testing/clients/QueryResourceTestClient.java
+++ b/integration-tests/src/main/java/io/druid/testing/clients/QueryResourceTestClient.java
@@ -44,7 +44,7 @@ public class QueryResourceTestClient
 {
   private final ObjectMapper jsonMapper;
   private final HttpClient httpClient;
-  private final String router;
+  private final String routerUrl;
   private final StatusResponseHandler responseHandler;
 
   @Inject
@@ -56,7 +56,7 @@ public class QueryResourceTestClient
   {
     this.jsonMapper = jsonMapper;
     this.httpClient = httpClient;
-    this.router = config.getRouterUrl();
+    this.routerUrl = config.getRouterUrl();
     this.responseHandler = new StatusResponseHandler(Charsets.UTF_8);
   }
 
@@ -64,7 +64,7 @@ public class QueryResourceTestClient
   {
     return String.format(
         "%s/druid/v2/",
-        router
+        routerUrl
     );
   }
 

--- a/integration-tests/src/main/java/io/druid/testing/guice/DruidTestModule.java
+++ b/integration-tests/src/main/java/io/druid/testing/guice/DruidTestModule.java
@@ -24,16 +24,25 @@ import com.google.common.base.Supplier;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
+import com.metamx.common.lifecycle.Lifecycle;
 import com.metamx.emitter.core.LoggingEmitter;
 import com.metamx.emitter.core.LoggingEmitterConfig;
 import com.metamx.emitter.service.ServiceEmitter;
+import com.metamx.http.client.CredentialedHttpClient;
+import com.metamx.http.client.HttpClient;
+import com.metamx.http.client.HttpClientConfig;
+import com.metamx.http.client.HttpClientInit;
+import com.metamx.http.client.auth.BasicCredentials;
 import io.druid.curator.CuratorConfig;
 import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.LazySingleton;
 import io.druid.guice.ManageLifecycle;
+import io.druid.guice.http.DruidHttpClientConfig;
 import io.druid.testing.IntegrationTestingConfig;
 import io.druid.testing.IntegrationTestingConfigProvider;
 import io.druid.testing.IntegrationTestingCuratorConfig;
+
+import javax.net.ssl.SSLContext;
 
 /**
  */
@@ -42,10 +51,36 @@ public class DruidTestModule implements Module
   @Override
   public void configure(Binder binder)
   {
-    binder.bind(IntegrationTestingConfig.class).toProvider(IntegrationTestingConfigProvider.class).in(ManageLifecycle.class);
+    binder.bind(IntegrationTestingConfig.class)
+          .toProvider(IntegrationTestingConfigProvider.class)
+          .in(ManageLifecycle.class);
     JsonConfigProvider.bind(binder, "druid.test.config", IntegrationTestingConfigProvider.class);
 
     binder.bind(CuratorConfig.class).to(IntegrationTestingCuratorConfig.class);
+  }
+
+  @Provides
+  @TestClient
+  public HttpClient getHttpClient(
+    IntegrationTestingConfig config,
+    DruidHttpClientConfig httpClientConfig,
+    Lifecycle lifecycle
+  )
+    throws Exception
+  {
+
+    final HttpClientConfig.Builder builder = HttpClientConfig
+      .builder()
+      .withNumConnections(httpClientConfig.getNumConnections())
+      .withReadTimeout(httpClientConfig.getReadTimeout())
+      .withWorkerCount(httpClientConfig.getNumMaxThreads());
+
+    builder.withSslContext(SSLContext.getDefault());
+    HttpClient delegate = HttpClientInit.createClient(builder.build(), lifecycle);
+    if (config.getUsername() != null) {
+      return new CredentialedHttpClient(new BasicCredentials(config.getUsername(), config.getPassword()), delegate);
+    }
+    return delegate;
   }
 
   @Provides

--- a/integration-tests/src/main/java/io/druid/testing/guice/TestClient.java
+++ b/integration-tests/src/main/java/io/druid/testing/guice/TestClient.java
@@ -1,0 +1,36 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.testing.guice;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ */
+@BindingAnnotation
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestClient
+{
+}

--- a/integration-tests/src/main/java/io/druid/testing/utils/TestQueryHelper.java
+++ b/integration-tests/src/main/java/io/druid/testing/utils/TestQueryHelper.java
@@ -47,7 +47,7 @@ public class TestQueryHelper
   {
     this.jsonMapper = jsonMapper;
     this.queryClient = queryClient;
-    this.broker = config.getBrokerHost();
+    this.broker = config.getBrokerUrl();
   }
 
   public void testQueriesFromFile(String filePath, int timesToRun) throws Exception
@@ -116,6 +116,6 @@ public class TestQueryHelper
 
   private String getBrokerURL()
   {
-    return String.format("http://%s/druid/v2?pretty", broker);
+    return String.format("%s/druid/v2?pretty", broker);
   }
 }

--- a/integration-tests/src/test/java/io/druid/tests/indexer/ITRealtimeIndexTaskTest.java
+++ b/integration-tests/src/test/java/io/druid/tests/indexer/ITRealtimeIndexTaskTest.java
@@ -25,12 +25,12 @@ import com.google.inject.Inject;
 import com.metamx.http.client.HttpClient;
 import io.druid.curator.discovery.ServerDiscoveryFactory;
 import io.druid.curator.discovery.ServerDiscoverySelector;
-import io.druid.guice.annotations.Global;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.testing.IntegrationTestingConfig;
 import io.druid.testing.clients.EventReceiverFirehoseTestClient;
 import io.druid.testing.guice.DruidTestModuleFactory;
+import io.druid.testing.guice.TestClient;
 import io.druid.testing.utils.RetryUtil;
 import io.druid.testing.utils.ServerDiscoveryUtil;
 import org.apache.commons.io.IOUtils;
@@ -86,7 +86,7 @@ public class ITRealtimeIndexTaskTest extends AbstractIndexerTest
   @Inject
   ServerDiscoveryFactory factory;
   @Inject
-  @Global
+  @TestClient
   HttpClient httpClient;
 
   @Inject
@@ -255,8 +255,8 @@ public class ITRealtimeIndexTaskTest extends AbstractIndexerTest
   private String getRouterURL()
   {
     return String.format(
-        "http://%s/druid/v2?pretty",
-        config.getRouterHost()
+        "%s/druid/v2?pretty",
+        config.getRouterUrl()
     );
   }
 

--- a/integration-tests/src/test/java/io/druid/tests/indexer/ITUnionQueryTest.java
+++ b/integration-tests/src/test/java/io/druid/tests/indexer/ITUnionQueryTest.java
@@ -30,6 +30,7 @@ import io.druid.java.util.common.logger.Logger;
 import io.druid.testing.IntegrationTestingConfig;
 import io.druid.testing.clients.EventReceiverFirehoseTestClient;
 import io.druid.testing.guice.DruidTestModuleFactory;
+import io.druid.testing.guice.TestClient;
 import io.druid.testing.utils.RetryUtil;
 import io.druid.testing.utils.ServerDiscoveryUtil;
 import org.joda.time.DateTime;
@@ -54,7 +55,7 @@ public class ITUnionQueryTest extends AbstractIndexerTest
   ServerDiscoveryFactory factory;
 
   @Inject
-  @Global
+  @TestClient
   HttpClient httpClient;
 
   @Inject


### PR DESCRIPTION
As part of https://issues.apache.org/jira/browse/KNOX-758
I am working on adding support for proxying druid queries & UIs using
Apache KNOX gateway.
This PR adds support for integration-tests to be run using the proxy
gateway.
Changes Include -
1) Instead of hostName and port, ability to specify url in the config
file.
2) tests now use HTTPClient defined in DruidTestModule that can pass in
the request.

Note - the config changes are backwards compatible and existing configs
should work fine.