### PR TITLE
BucketExtractionFn: Implement hashCode, fix toString.

### DIFF
--- a/processing/src/main/java/io/druid/query/extraction/BucketExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/BucketExtractionFn.java
@@ -36,10 +36,8 @@ public class BucketExtractionFn implements ExtractionFn
 
   @JsonCreator
   public BucketExtractionFn(
-      @Nullable
-      @JsonProperty("size") Double size,
-      @Nullable
-      @JsonProperty("offset") Double offset
+      @Nullable @JsonProperty("size") Double size,
+      @Nullable @JsonProperty("offset") Double offset
   )
   {
     this.size = size == null ? 1 : size;
@@ -74,7 +72,8 @@ public class BucketExtractionFn implements ExtractionFn
   {
     try {
       return bucket(Double.parseDouble(value));
-    } catch (NumberFormatException | NullPointerException ex) {
+    }
+    catch (NumberFormatException | NullPointerException ex) {
       return null;
     }
   }
@@ -85,9 +84,10 @@ public class BucketExtractionFn implements ExtractionFn
     return bucket(value);
   }
 
-  private String bucket(double value) {
+  private String bucket(double value)
+  {
     double ret = Math.floor((value - offset) / size) * size + offset;
-    return ret == (long)ret ? String.valueOf((long)ret) : String.valueOf(ret);
+    return ret == (long) ret ? String.valueOf((long) ret) : String.valueOf(ret);
   }
 
   @Override
@@ -124,7 +124,28 @@ public class BucketExtractionFn implements ExtractionFn
 
     BucketExtractionFn that = (BucketExtractionFn) o;
 
-    return size == that.size && offset == that.offset;
+    if (Double.compare(that.size, size) != 0) {
+      return false;
+    }
+    return Double.compare(that.offset, offset) == 0;
 
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result;
+    long temp;
+    temp = Double.doubleToLongBits(size);
+    result = (int) (temp ^ (temp >>> 32));
+    temp = Double.doubleToLongBits(offset);
+    result = 31 * result + (int) (temp ^ (temp >>> 32));
+    return result;
+  }
+
+  @Override
+  public String toString()
+  {
+    return String.format("bucket(%f, %f)", size, offset);
   }
 }

--- a/processing/src/test/java/io/druid/query/extraction/BucketExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/BucketExtractionFnTest.java
@@ -53,6 +53,19 @@ public class BucketExtractionFnTest
   }
 
   @Test
+  public void testEqualsAndHashCode()
+  {
+    BucketExtractionFn extractionFn1 = new BucketExtractionFn(100.0, 0.5);
+    BucketExtractionFn extractionFn2 = new BucketExtractionFn(3.0, 2.0);
+    BucketExtractionFn extractionFn3 = new BucketExtractionFn(3.0, 2.0);
+
+    Assert.assertNotEquals(extractionFn1, extractionFn2);
+    Assert.assertNotEquals(extractionFn1.hashCode(), extractionFn2.hashCode());
+    Assert.assertEquals(extractionFn2, extractionFn3);
+    Assert.assertEquals(extractionFn2.hashCode(), extractionFn3.hashCode());
+  }
+
+  @Test
   public void testSerde() throws Exception
   {
     final ObjectMapper objectMapper = new DefaultObjectMapper();


### PR DESCRIPTION
BucketExtractionFn didn't have a proper hashCode or toString impl, as is expected of extractionFns.