### PR TITLE
Checkstyle checks for AvoidStaticImport, UnusedImports.

### DIFF
--- a/api/src/main/java/io/druid/guice/LazySingleton.java
+++ b/api/src/main/java/io/druid/guice/LazySingleton.java
@@ -23,14 +23,13 @@ import com.google.inject.ScopeAnnotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  */
-@Target({ ElementType.TYPE, ElementType.METHOD })
-@Retention(RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
 @ScopeAnnotation
 public @interface LazySingleton
 {

--- a/api/src/main/java/io/druid/guice/ManageLifecycle.java
+++ b/api/src/main/java/io/druid/guice/ManageLifecycle.java
@@ -23,9 +23,8 @@ import com.google.inject.ScopeAnnotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Marks the object to be managed by {@link io.druid.java.util.common.lifecycle.Lifecycle}
@@ -33,7 +32,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * This Scope gets defined by {@link io.druid.guice.LifecycleModule}
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
-@Retention(RUNTIME)
+@Retention(RetentionPolicy.RUNTIME)
 @ScopeAnnotation
 public @interface ManageLifecycle
 {

--- a/api/src/main/java/io/druid/guice/ManageLifecycleLast.java
+++ b/api/src/main/java/io/druid/guice/ManageLifecycleLast.java
@@ -23,9 +23,8 @@ import com.google.inject.ScopeAnnotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Marks the object to be managed by {@link io.druid.java.util.common.lifecycle.Lifecycle} and set to be on Stage.LAST
@@ -33,7 +32,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * This Scope gets defined by {@link io.druid.guice.LifecycleModule}
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
-@Retention(RUNTIME)
+@Retention(RetentionPolicy.RUNTIME)
 @ScopeAnnotation
 public @interface ManageLifecycleLast
 {

--- a/codestyle/checkstyle-suppressions.xml
+++ b/codestyle/checkstyle-suppressions.xml
@@ -25,4 +25,10 @@
 
 <suppressions>
   <!-- See http://checkstyle.sourceforge.net/config_filters.html#SuppressionFilter for examples -->
+
+  <!-- Code copied from TestNG to apply a bugfix -->
+  <suppress checks="AvoidStaticImport" files="[\\/]org[\\/]testng[\\/]" />
+
+  <!-- Our tests have many legacy usages of static imports; enforcement is impratical until those are removed. -->
+  <suppress checks="AvoidStaticImport" files="[\\/]src[\\/]test[\\/]" />
 </suppressions>

--- a/codestyle/checkstyle.xml
+++ b/codestyle/checkstyle.xml
@@ -33,7 +33,9 @@
       <!--<property name="max" value="120"/>-->
     <!--</module>-->
     <module name="AvoidStarImport"/>
+    <module name="AvoidStaticImport"/>
     <module name="RedundantImport"/>
+    <module name="UnusedImports" />
     <module name="NeedBraces"/>
   </module>
 </module>

--- a/common/src/main/java/io/druid/math/expr/Expr.java
+++ b/common/src/main/java/io/druid/math/expr/Expr.java
@@ -19,7 +19,6 @@
 
 package io.druid.math.expr;
 
-import com.google.common.base.Strings;
 import com.google.common.math.LongMath;
 import io.druid.java.util.common.IAE;
 

--- a/examples/src/main/java/io/druid/examples/twitter/TwitterSpritzerFirehoseFactory.java
+++ b/examples/src/main/java/io/druid/examples/twitter/TwitterSpritzerFirehoseFactory.java
@@ -55,8 +55,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static java.lang.Thread.sleep;
-
 /**
  * Twitter "spritzer" Firehose Factory named "twitzer".
  * Builds a Firehose that emits a stream of
@@ -263,7 +261,7 @@ public class TwitterSpritzerFirehoseFactory implements FirehoseFactory<InputRowP
             // sleep a long time instead of terminating
             try {
               log.info("reached limit, sleeping a long time...");
-              sleep(2000000000L);
+              Thread.sleep(2000000000L);
             }
             catch (InterruptedException e) {
               throw new RuntimeException("InterruptedException", e);

--- a/extensions-core/lookups-cached-single/src/main/java/io/druid/server/lookup/cache/loading/LookupCacheStats.java
+++ b/extensions-core/lookups-cached-single/src/main/java/io/druid/server/lookup/cache/loading/LookupCacheStats.java
@@ -19,8 +19,7 @@
 
 package io.druid.server.lookup.cache.loading;
 
-
-import static com.google.common.base.Preconditions.checkArgument;
+import com.google.common.base.Preconditions;
 
 /**
  * Statistics about the performance of a {@link LoadingCache}. Instances of this class are immutable.
@@ -45,9 +44,9 @@ public class LookupCacheStats
       long evictionCount
   )
   {
-    checkArgument(hitCount >= 0);
-    checkArgument(missCount >= 0);
-    checkArgument(evictionCount >= 0);
+    Preconditions.checkArgument(hitCount >= 0);
+    Preconditions.checkArgument(missCount >= 0);
+    Preconditions.checkArgument(evictionCount >= 0);
 
     this.hitCount = hitCount;
     this.missCount = missCount;

--- a/integration-tests/src/main/java/org/testng/DruidTestRunnerFactory.java
+++ b/integration-tests/src/main/java/org/testng/DruidTestRunnerFactory.java
@@ -27,7 +27,6 @@ import com.metamx.http.client.HttpClient;
 import com.metamx.http.client.Request;
 import com.metamx.http.client.response.StatusResponseHandler;
 import com.metamx.http.client.response.StatusResponseHolder;
-import io.druid.guice.annotations.Global;
 import io.druid.java.util.common.lifecycle.Lifecycle;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.testing.IntegrationTestingConfig;

--- a/integration-tests/src/test/java/io/druid/tests/indexer/ITUnionQueryTest.java
+++ b/integration-tests/src/test/java/io/druid/tests/indexer/ITUnionQueryTest.java
@@ -25,7 +25,6 @@ import com.google.inject.Inject;
 import com.metamx.http.client.HttpClient;
 import io.druid.curator.discovery.ServerDiscoveryFactory;
 import io.druid.curator.discovery.ServerDiscoverySelector;
-import io.druid.guice.annotations.Global;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.testing.IntegrationTestingConfig;
 import io.druid.testing.clients.EventReceiverFirehoseTestClient;

--- a/java-util/src/main/java/io/druid/java/util/common/MappedByteBufferHandler.java
+++ b/java-util/src/main/java/io/druid/java/util/common/MappedByteBufferHandler.java
@@ -19,14 +19,14 @@
 
 package io.druid.java.util.common;
 
-import java.io.File;
 import java.nio.MappedByteBuffer;
 
 /**
  * Facilitates using try-with-resources with {@link MappedByteBuffer}s which don't implement {@link AutoCloseable}.
  *
  * <p>This interface is a specialization of {@code io.druid.collections.ResourceHandler}.
- * @see FileUtils#map(File)
+ *
+ * @see FileUtils#map
  */
 public final class MappedByteBufferHandler implements AutoCloseable
 {

--- a/java-util/src/main/java/io/druid/java/util/common/StringUtils.java
+++ b/java-util/src/main/java/io/druid/java/util/common/StringUtils.java
@@ -21,7 +21,6 @@ package io.druid.java.util.common;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
-import io.druid.java.util.common.logger.Logger;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/CSVParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/CSVParser.java
@@ -25,7 +25,6 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import io.druid.java.util.common.collect.Utils;
-import io.druid.java.util.common.logger.Logger;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/DelimitedParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/DelimitedParser.java
@@ -27,7 +27,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import io.druid.java.util.common.collect.Utils;
-import io.druid.java.util.common.logger.Logger;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/TimestampParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/TimestampParser.java
@@ -22,7 +22,6 @@ package io.druid.java.util.common.parsers;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import io.druid.java.util.common.IAE;
-import io.druid.java.util.common.logger.Logger;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;

--- a/pom.xml
+++ b/pom.xml
@@ -684,6 +684,13 @@
                     <consoleOutput>true</consoleOutput>
                     <failsOnError>true</failsOnError>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>6.19</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <id>validate</id>

--- a/processing/src/main/java/io/druid/data/input/ProtoBufInputRowParser.java
+++ b/processing/src/main/java/io/druid/data/input/ProtoBufInputRowParser.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -35,10 +36,6 @@ import io.druid.java.util.common.logger.Logger;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.Map;
-
-import static com.google.protobuf.DescriptorProtos.FileDescriptorSet;
-import static com.google.protobuf.Descriptors.Descriptor;
-import static com.google.protobuf.Descriptors.FileDescriptor;
 
 @JsonTypeName("protobuf")
 public class ProtoBufInputRowParser implements ByteBufferInputRowParser
@@ -84,7 +81,7 @@ public class ProtoBufInputRowParser implements ByteBufferInputRowParser
 
   private Map<String, Object> buildStringKeyMap(ByteBuffer input)
   {
-    final Descriptor descriptor = getDescriptor(descriptorFileInClasspath);
+    final Descriptors.Descriptor descriptor = getDescriptor(descriptorFileInClasspath);
     final Map<String, Object> theMap = Maps.newHashMap();
 
     try {
@@ -114,13 +111,13 @@ public class ProtoBufInputRowParser implements ByteBufferInputRowParser
     return theMap;
   }
 
-  private Descriptor getDescriptor(String descriptorFileInClassPath)
+  private Descriptors.Descriptor getDescriptor(String descriptorFileInClassPath)
   {
     try {
       InputStream fin = this.getClass().getClassLoader().getResourceAsStream(descriptorFileInClassPath);
-      FileDescriptorSet set = FileDescriptorSet.parseFrom(fin);
-      FileDescriptor file = FileDescriptor.buildFrom(
-          set.getFile(0), new FileDescriptor[]
+      DescriptorProtos.FileDescriptorSet set = DescriptorProtos.FileDescriptorSet.parseFrom(fin);
+      Descriptors.FileDescriptor file = Descriptors.FileDescriptor.buildFrom(
+          set.getFile(0), new Descriptors.FileDescriptor[]
           {}
       );
       return file.getMessageTypes().get(0);

--- a/processing/src/main/java/io/druid/query/QueryRunnerHelper.java
+++ b/processing/src/main/java/io/druid/query/QueryRunnerHelper.java
@@ -27,8 +27,6 @@ import io.druid.java.util.common.guava.ResourceClosingSequence;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.logger.Logger;
-import io.druid.query.aggregation.Aggregator;
-import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.filter.Filter;
 import io.druid.segment.Cursor;
 import io.druid.segment.StorageAdapter;

--- a/processing/src/main/java/io/druid/query/filter/BoundDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/BoundDimFilter.java
@@ -22,7 +22,6 @@ package io.druid.query.filter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.google.common.base.Supplier;
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Range;

--- a/processing/src/main/java/io/druid/query/search/search/SearchHit.java
+++ b/processing/src/main/java/io/druid/query/search/search/SearchHit.java
@@ -21,8 +21,7 @@ package io.druid.query.search.search;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import com.google.common.base.Preconditions;
 
 /**
  */
@@ -39,8 +38,8 @@ public class SearchHit implements Comparable<SearchHit>
       @JsonProperty("count") Integer count
   )
   {
-    this.dimension = checkNotNull(dimension);
-    this.value = checkNotNull(value);
+    this.dimension = Preconditions.checkNotNull(dimension);
+    this.value = Preconditions.checkNotNull(value);
     this.count = count;
   }
 

--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesResultBuilder.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesResultBuilder.java
@@ -21,7 +21,6 @@ package io.druid.query.timeseries;
 
 import io.druid.query.Result;
 import io.druid.query.aggregation.Aggregator;
-import io.druid.query.aggregation.PostAggregator;
 import org.joda.time.DateTime;
 
 import java.util.HashMap;

--- a/processing/src/main/java/io/druid/segment/ColumnSelectorBitmapIndexSelector.java
+++ b/processing/src/main/java/io/druid/segment/ColumnSelectorBitmapIndexSelector.java
@@ -23,7 +23,6 @@ import com.google.common.base.Strings;
 import com.metamx.collections.bitmap.BitmapFactory;
 import com.metamx.collections.bitmap.ImmutableBitmap;
 import com.metamx.collections.spatial.ImmutableRTree;
-import io.druid.java.util.common.guava.CloseQuietly;
 import io.druid.query.filter.BitmapIndexSelector;
 import io.druid.segment.column.BitmapIndex;
 import io.druid.segment.column.Column;

--- a/processing/src/main/java/io/druid/segment/IndexSpec.java
+++ b/processing/src/main/java/io/druid/segment/IndexSpec.java
@@ -76,7 +76,7 @@ public class IndexSpec
    *
    * @param bitmapSerdeFactory type of bitmap to use (e.g. roaring or concise), null to use the default.
    *                           Defaults to the bitmap type specified by the (deprecated) "druid.processing.bitmap.type"
-   *                           setting, or, if none was set, uses the default {@link BitmapSerde.DefaultBitmapSerdeFactory}
+   *                           setting, or, if none was set, uses the default defined in {@link BitmapSerde}
    *
    * @param dimensionCompression compression format for dimension columns, null to use the default.
    *                             Defaults to {@link CompressedObjectStrategy#DEFAULT_COMPRESSION_STRATEGY}

--- a/processing/src/main/java/io/druid/segment/column/IndexedComplexColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/IndexedComplexColumn.java
@@ -21,8 +21,6 @@ package io.druid.segment.column;
 
 import io.druid.segment.data.Indexed;
 
-import java.io.IOException;
-
 /**
 */
 public class IndexedComplexColumn implements ComplexColumn

--- a/server/src/main/java/io/druid/guice/http/HttpClientModule.java
+++ b/server/src/main/java/io/druid/guice/http/HttpClientModule.java
@@ -19,7 +19,6 @@
 
 package io.druid.guice.http;
 
-import com.google.common.base.Throwables;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.metamx.http.client.HttpClient;
@@ -28,7 +27,6 @@ import com.metamx.http.client.HttpClientInit;
 import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.LazySingleton;
 import io.druid.guice.annotations.Global;
-import io.druid.java.util.common.lifecycle.Lifecycle;
 
 import java.lang.annotation.Annotation;
 


### PR DESCRIPTION
Many times I see comments like "unused import" and "avoid static imports" in PRs,
this will automate that kinds of review. I also removed the small number of those we
already had in production code.

This excludes tests from AvoidStaticImport, since those are used often there and
I didn't want to make this changeset too large.