### PR TITLE
groupBy sort results by (dimensions,timestamp) instead of (timestamp,dimension)

### DIFF
--- a/docs/content/querying/groupbyquery.md
+++ b/docs/content/querying/groupbyquery.md
@@ -207,3 +207,4 @@ When using the "v2" strategy, the following query context parameters apply:
 |`bufferGrouperMaxLoadFactor`|Overrides the value of `druid.query.groupBy.bufferGrouperMaxLoadFactor` for this query.|
 |`maxMergingDictionarySize`|Can be used to lower the value of `druid.query.groupBy.maxMergingDictionarySize` for this query.|
 |`maxOnDiskStorage`|Can be used to lower the value of `druid.query.groupBy.maxOnDiskStorage` for this query.|
+|`sortByDimsFirst`||Sort the results first by dimension values and then by timestamp.|

--- a/docs/content/querying/groupbyquery.md
+++ b/docs/content/querying/groupbyquery.md
@@ -207,4 +207,4 @@ When using the "v2" strategy, the following query context parameters apply:
 |`bufferGrouperMaxLoadFactor`|Overrides the value of `druid.query.groupBy.bufferGrouperMaxLoadFactor` for this query.|
 |`maxMergingDictionarySize`|Can be used to lower the value of `druid.query.groupBy.maxMergingDictionarySize` for this query.|
 |`maxOnDiskStorage`|Can be used to lower the value of `druid.query.groupBy.maxOnDiskStorage` for this query.|
-|`sortByDimsFirst`||Sort the results first by dimension values and then by timestamp.|
+|`sortByDimsFirst`|Sort the results first by dimension values and then by timestamp.|

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQuery.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQuery.java
@@ -260,7 +260,6 @@ public class GroupByQuery extends BaseQuery<Row>
   @Override
   public Ordering getResultOrdering()
   {
-    final Comparator naturalNullsFirst = Ordering.natural().nullsFirst();
     final Ordering<Row> rowOrdering = getRowOrdering(false);
 
     return Ordering.from(
@@ -273,7 +272,7 @@ public class GroupByQuery extends BaseQuery<Row>
               return rowOrdering.compare((Row) lhs, (Row) rhs);
             } else {
               // Probably bySegment queries
-              return naturalNullsFirst.compare(lhs, rhs);
+              return NATURAL_NULLS_FIRST.compare(lhs, rhs);
             }
           }
         }
@@ -293,7 +292,7 @@ public class GroupByQuery extends BaseQuery<Row>
             @Override
             public int compare(Row lhs, Row rhs)
             {
-              final int cmp = compareDims(NATURAL_NULLS_FIRST, dimensions, lhs, rhs);
+              final int cmp = compareDims(dimensions, lhs, rhs);
               if (cmp != 0) {
                 return cmp;
               }
@@ -315,7 +314,7 @@ public class GroupByQuery extends BaseQuery<Row>
                 return timeCompare;
               }
 
-              return compareDims(NATURAL_NULLS_FIRST, dimensions, lhs, rhs);
+              return compareDims(dimensions, lhs, rhs);
             }
           }
       );
@@ -341,10 +340,10 @@ public class GroupByQuery extends BaseQuery<Row>
     }
   }
 
-  private static int compareDims(Comparator naturalNullsFirst, List<DimensionSpec> dimensions, Row lhs, Row rhs)
+  private static int compareDims(List<DimensionSpec> dimensions, Row lhs, Row rhs)
   {
     for (DimensionSpec dimension : dimensions) {
-      final int dimCompare = naturalNullsFirst.compare(
+      final int dimCompare = NATURAL_NULLS_FIRST.compare(
           lhs.getRaw(dimension.getOutputName()),
           rhs.getRaw(dimension.getOutputName())
       );

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryQueryToolChest.java
@@ -153,6 +153,7 @@ public class GroupByQueryQueryToolChest extends QueryToolChest<Row, GroupByQuery
         if (((QueryDataSource) dataSource).getQuery().getContext() != null) {
           subqueryContext.putAll(((QueryDataSource) dataSource).getQuery().getContext());
         }
+        subqueryContext.put(GroupByQuery.CTX_KEY_SORT_BY_DIMS_FIRST, false);
         subquery = (GroupByQuery) ((QueryDataSource) dataSource).getQuery().withOverriddenContext(subqueryContext);
       }
       catch (ClassCastException e) {

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/BufferGrouper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/BufferGrouper.java
@@ -265,7 +265,7 @@ public class BufferGrouper<KeyType> implements Grouper<KeyType>
         }
       };
 
-      final KeyComparator comparator = keySerde.comparator();
+      final KeyComparator comparator = keySerde.bufferComparator();
 
       // Sort offsets in-place.
       Collections.sort(

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/BufferGrouper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/BufferGrouper.java
@@ -56,7 +56,7 @@ import java.util.List;
  * of pointers) it still helps significantly on initialization times. Otherwise, we'd need to clear the used bits of
  * each bucket in the entire buffer, which is a lot of writes if the buckets are small.
  */
-public class BufferGrouper<KeyType extends Comparable<KeyType>> implements Grouper<KeyType>
+public class BufferGrouper<KeyType> implements Grouper<KeyType>
 {
   private static final Logger log = new Logger(BufferGrouper.class);
 

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/CloseableGrouperIterator.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/CloseableGrouperIterator.java
@@ -26,7 +26,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
 
-public class CloseableGrouperIterator<KeyType extends Comparable<KeyType>, T> implements Iterator<T>, Closeable
+public class CloseableGrouperIterator<KeyType, T> implements Iterator<T>, Closeable
 {
   private final Function<Grouper.Entry<KeyType>, T> transformer;
   private final Closeable closer;

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/ConcurrentGrouper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/ConcurrentGrouper.java
@@ -48,7 +48,7 @@ public class ConcurrentGrouper<KeyType> implements Grouper<KeyType>
   private final AtomicInteger threadNumber = new AtomicInteger();
   private volatile boolean spilling = false;
   private volatile boolean closed = false;
-  private final Comparator<Entry<KeyType>> entryComparator;
+  private final Comparator<KeyType> keyObjComparator;
 
   public ConcurrentGrouper(
       final ByteBuffer buffer,
@@ -97,7 +97,7 @@ public class ConcurrentGrouper<KeyType> implements Grouper<KeyType>
       );
     }
 
-    this.entryComparator = keySerdeFactory.factorize().entryComparator();
+    this.keyObjComparator = keySerdeFactory.objectComparator();
   }
 
   @Override
@@ -165,7 +165,7 @@ public class ConcurrentGrouper<KeyType> implements Grouper<KeyType>
       }
     }
 
-    return Groupers.mergeIterators(iterators, sorted ? entryComparator : null);
+    return Groupers.mergeIterators(iterators, sorted ? keyObjComparator : null);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/ConcurrentGrouper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/ConcurrentGrouper.java
@@ -27,6 +27,7 @@ import io.druid.segment.ColumnSelectorFactory;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -40,13 +41,14 @@ import java.util.concurrent.atomic.AtomicInteger;
  * it becomes clear that the result set does not fit in memory, the table switches to a mode where each thread
  * gets its own buffer and its own spill files on disk.
  */
-public class ConcurrentGrouper<KeyType extends Comparable<KeyType>> implements Grouper<KeyType>
+public class ConcurrentGrouper<KeyType> implements Grouper<KeyType>
 {
   private final List<SpillingGrouper<KeyType>> groupers;
   private final ThreadLocal<SpillingGrouper<KeyType>> threadLocalGrouper;
   private final AtomicInteger threadNumber = new AtomicInteger();
   private volatile boolean spilling = false;
   private volatile boolean closed = false;
+  private final Comparator<Entry<KeyType>> entryComparator;
 
   public ConcurrentGrouper(
       final ByteBuffer buffer,
@@ -94,6 +96,8 @@ public class ConcurrentGrouper<KeyType extends Comparable<KeyType>> implements G
           )
       );
     }
+
+    this.entryComparator = keySerdeFactory.factorize().entryComparator();
   }
 
   @Override
@@ -161,7 +165,7 @@ public class ConcurrentGrouper<KeyType extends Comparable<KeyType>> implements G
       }
     }
 
-    return Groupers.mergeIterators(iterators, sorted);
+    return Groupers.mergeIterators(iterators, sorted ? entryComparator : null);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
@@ -50,6 +50,7 @@ import org.joda.time.Interval;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -387,6 +388,13 @@ outer:
 
     @Override
     public Grouper.KeyComparator comparator()
+    {
+      // No sorting, let mergeRunners handle that
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Comparator<Grouper.Entry<ByteBuffer>> entryComparator()
     {
       // No sorting, let mergeRunners handle that
       throw new UnsupportedOperationException();

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
@@ -50,7 +50,6 @@ import org.joda.time.Interval;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -387,14 +386,7 @@ outer:
     }
 
     @Override
-    public Grouper.KeyComparator comparator()
-    {
-      // No sorting, let mergeRunners handle that
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Comparator<Grouper.Entry<ByteBuffer>> entryComparator()
+    public Grouper.KeyComparator bufferComparator()
     {
       // No sorting, let mergeRunners handle that
       throw new UnsupportedOperationException();

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/Grouper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/Grouper.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Closeable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Iterator;
 
 /**
@@ -37,7 +38,7 @@ import java.util.Iterator;
  *
  * @param <KeyType> type of the key that will be passed in
  */
-public interface Grouper<KeyType extends Comparable<KeyType>> extends Closeable
+public interface Grouper<KeyType> extends Closeable
 {
   /**
    * Aggregate the current row with the provided key. Some implementations are thread-safe and
@@ -207,6 +208,12 @@ public interface Grouper<KeyType extends Comparable<KeyType>> extends Closeable
      * @return comparator for keys
      */
     KeyComparator comparator();
+
+    /**
+     *
+     * @return
+     */
+    Comparator<Entry<T>> entryComparator();
 
     /**
      * Reset the keySerde to its initial state. After this method is called, {@link #fromByteBuffer(ByteBuffer, int)}

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/Grouper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/Grouper.java
@@ -160,6 +160,14 @@ public interface Grouper<KeyType> extends Closeable
      * Create a new KeySerde, which may be stateful.
      */
     KeySerde<T> factorize();
+
+    /**
+     * Return an object that knows how to compare two serialized key instances. Will be called by the
+     * {@link #iterator(boolean)} method if sorting is enabled.
+     *
+     * @return comparator for keys
+     */
+    Comparator<T> objectComparator();
   }
 
   /**
@@ -207,17 +215,11 @@ public interface Grouper<KeyType> extends Closeable
      *
      * @return comparator for keys
      */
-    KeyComparator comparator();
-
-    /**
-     *
-     * @return
-     */
-    Comparator<Entry<T>> entryComparator();
+    KeyComparator bufferComparator();
 
     /**
      * Reset the keySerde to its initial state. After this method is called, {@link #fromByteBuffer(ByteBuffer, int)}
-     * and {@link #comparator()} may no longer work properly on previously-serialized keys.
+     * and {@link #bufferComparator()} may no longer work properly on previously-serialized keys.
      */
     void reset();
   }

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/Grouper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/Grouper.java
@@ -165,7 +165,7 @@ public interface Grouper<KeyType> extends Closeable
      * Return an object that knows how to compare two serialized key instances. Will be called by the
      * {@link #iterator(boolean)} method if sorting is enabled.
      *
-     * @return comparator for keys
+     * @return comparator for key objects.
      */
     Comparator<T> objectComparator();
   }

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/Groupers.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/Groupers.java
@@ -41,11 +41,21 @@ public class Groupers
 
   public static <KeyType> Iterator<Grouper.Entry<KeyType>> mergeIterators(
       final Iterable<Iterator<Grouper.Entry<KeyType>>> iterators,
-      final Comparator<Grouper.Entry<KeyType>> comparator
+      final Comparator<KeyType> keyTypeComparator
   )
   {
-    if (comparator != null) {
-      return Iterators.mergeSorted(iterators, comparator);
+    if (keyTypeComparator != null) {
+      return Iterators.mergeSorted(
+          iterators,
+          new Comparator<Grouper.Entry<KeyType>>()
+          {
+            @Override
+            public int compare(Grouper.Entry<KeyType> lhs, Grouper.Entry<KeyType> rhs)
+            {
+              return keyTypeComparator.compare(lhs.getKey(), rhs.getKey());
+            }
+          }
+      );
     } else {
       return Iterators.concat(iterators.iterator());
     }

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/Groupers.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/Groupers.java
@@ -26,18 +26,6 @@ import java.util.Iterator;
 
 public class Groupers
 {
-  private static final Comparator<Grouper.Entry<? extends Comparable>> ENTRY_COMPARATOR = new Comparator<Grouper.Entry<? extends Comparable>>()
-  {
-    @Override
-    public int compare(
-        final Grouper.Entry<? extends Comparable> lhs,
-        final Grouper.Entry<? extends Comparable> rhs
-    )
-    {
-      return lhs.getKey().compareTo(rhs.getKey());
-    }
-  };
-
   private Groupers()
   {
     // No instantiation
@@ -51,13 +39,13 @@ public class Groupers
     return (code ^ (code >>> 16)) & 0x7fffffff;
   }
 
-  public static <KeyType extends Comparable<KeyType>> Iterator<Grouper.Entry<KeyType>> mergeIterators(
+  public static <KeyType> Iterator<Grouper.Entry<KeyType>> mergeIterators(
       final Iterable<Iterator<Grouper.Entry<KeyType>>> iterators,
-      final boolean sorted
+      final Comparator<Grouper.Entry<KeyType>> comparator
   )
   {
-    if (sorted) {
-      return Iterators.mergeSorted(iterators, ENTRY_COMPARATOR);
+    if (comparator != null) {
+      return Iterators.mergeSorted(iterators, comparator);
     } else {
       return Iterators.concat(iterators.iterator());
     }

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/SpillingGrouper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/SpillingGrouper.java
@@ -40,6 +40,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
@@ -57,6 +58,7 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
   private final LimitedTemporaryStorage temporaryStorage;
   private final ObjectMapper spillMapper;
   private final AggregatorFactory[] aggregatorFactories;
+  private final Comparator<KeyType> keyObjComparator;
 
   private final List<File> files = Lists.newArrayList();
   private final List<Closeable> closeables = Lists.newArrayList();
@@ -77,6 +79,7 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
   )
   {
     this.keySerde = keySerdeFactory.factorize();
+    this.keyObjComparator = keySerdeFactory.objectComparator();
     this.grouper = new BufferGrouper<>(
         buffer,
         keySerde,
@@ -172,7 +175,7 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
       closeables.add(fileIterator);
     }
 
-    return Groupers.mergeIterators(iterators, sorted ? keySerde.entryComparator() : null);
+    return Groupers.mergeIterators(iterators, sorted ? keyObjComparator : null);
   }
 
   private void spill() throws IOException

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/SpillingGrouper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/SpillingGrouper.java
@@ -48,7 +48,7 @@ import java.util.List;
  *
  * When the underlying grouper is full, its contents are sorted and written to temporary files using "spillMapper".
  */
-public class SpillingGrouper<KeyType extends Comparable<KeyType>> implements Grouper<KeyType>
+public class SpillingGrouper<KeyType> implements Grouper<KeyType>
 {
   private static final Logger log = new Logger(SpillingGrouper.class);
 
@@ -172,7 +172,7 @@ public class SpillingGrouper<KeyType extends Comparable<KeyType>> implements Gro
       closeables.add(fileIterator);
     }
 
-    return Groupers.mergeIterators(iterators, sorted);
+    return Groupers.mergeIterators(iterators, sorted ? keySerde.entryComparator() : null);
   }
 
   private void spill() throws IOException

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -463,7 +463,6 @@ public class GroupByQueryRunnerTest
     );
 
     Iterable<Row> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);
-    System.out.println(results);
     TestHelper.assertExpectedObjects(expectedResults, results, "");
   }
 

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -416,6 +416,58 @@ public class GroupByQueryRunnerTest
   }
 
   @Test
+  public void testGroupByWithSortDimsFirst()
+  {
+    GroupByQuery query = GroupByQuery
+        .builder()
+        .setDataSource(QueryRunnerTestHelper.dataSource)
+        .setQuerySegmentSpec(QueryRunnerTestHelper.firstToThird)
+        .setDimensions(Lists.<DimensionSpec>newArrayList(new DefaultDimensionSpec("quality", "alias")))
+        .setAggregatorSpecs(
+            Arrays.asList(
+                QueryRunnerTestHelper.rowsCount,
+                new LongSumAggregatorFactory("idx", "index")
+            )
+        )
+        .setGranularity(QueryRunnerTestHelper.dayGran)
+        .setContext(ImmutableMap.<String, Object>of("sortByDimsFirst", true, "groupByStrategy", "v2"))
+        .build();
+
+    List<Row> expectedResults = Arrays.asList(
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-01", "alias", "automotive", "rows", 1L, "idx", 135L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "alias", "automotive", "rows", 1L, "idx", 147L),
+
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-01", "alias", "business", "rows", 1L, "idx", 118L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "alias", "business", "rows", 1L, "idx", 112L),
+
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-01", "alias", "entertainment", "rows", 1L, "idx", 158L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "alias", "entertainment", "rows", 1L, "idx", 166L),
+
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-01", "alias", "health", "rows", 1L, "idx", 120L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "alias", "health", "rows", 1L, "idx", 113L),
+
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-01", "alias", "mezzanine", "rows", 3L, "idx", 2870L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "alias", "mezzanine", "rows", 3L, "idx", 2447L),
+
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-01", "alias", "news", "rows", 1L, "idx", 121L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "alias", "news", "rows", 1L, "idx", 114L),
+
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-01", "alias", "premium", "rows", 3L, "idx", 2900L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "alias", "premium", "rows", 3L, "idx", 2505L),
+
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-01", "alias", "technology", "rows", 1L, "idx", 78L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "alias", "technology", "rows", 1L, "idx", 97L),
+
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-01", "alias", "travel", "rows", 1L, "idx", 119L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "alias", "travel", "rows", 1L, "idx", 126L)
+    );
+
+    Iterable<Row> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);
+    System.out.println(results);
+    TestHelper.assertExpectedObjects(expectedResults, results, "");
+  }
+
+  @Test
   public void testGroupByNoAggregators()
   {
     GroupByQuery query = GroupByQuery

--- a/processing/src/test/java/io/druid/query/groupby/epinephelinae/IntKeySerde.java
+++ b/processing/src/test/java/io/druid/query/groupby/epinephelinae/IntKeySerde.java
@@ -22,6 +22,7 @@ package io.druid.query.groupby.epinephelinae;
 import com.google.common.primitives.Ints;
 
 import java.nio.ByteBuffer;
+import java.util.Comparator;
 
 public class IntKeySerde implements Grouper.KeySerde<Integer>
 {
@@ -38,6 +39,15 @@ public class IntKeySerde implements Grouper.KeySerde<Integer>
     public int compare(ByteBuffer lhsBuffer, ByteBuffer rhsBuffer, int lhsPosition, int rhsPosition)
     {
       return Ints.compare(lhsBuffer.getInt(lhsPosition), rhsBuffer.getInt(rhsPosition));
+    }
+  };
+
+  private static final Comparator<Grouper.Entry<Integer>> ENTRY_COMPARATOR = new Comparator<Grouper.Entry<Integer>>()
+  {
+    @Override
+    public int compare(Grouper.Entry<Integer> o1, Grouper.Entry<Integer> o2)
+    {
+      return o1.getKey().intValue() - o2.getKey().intValue();
     }
   };
 
@@ -73,6 +83,12 @@ public class IntKeySerde implements Grouper.KeySerde<Integer>
   public Grouper.KeyComparator comparator()
   {
     return KEY_COMPARATOR;
+  }
+
+  @Override
+  public Comparator<Grouper.Entry<Integer>> entryComparator()
+  {
+    return ENTRY_COMPARATOR;
   }
 
   @Override

--- a/processing/src/test/java/io/druid/query/groupby/epinephelinae/IntKeySerde.java
+++ b/processing/src/test/java/io/druid/query/groupby/epinephelinae/IntKeySerde.java
@@ -80,15 +80,9 @@ public class IntKeySerde implements Grouper.KeySerde<Integer>
   }
 
   @Override
-  public Grouper.KeyComparator comparator()
+  public Grouper.KeyComparator bufferComparator()
   {
     return KEY_COMPARATOR;
-  }
-
-  @Override
-  public Comparator<Grouper.Entry<Integer>> entryComparator()
-  {
-    return ENTRY_COMPARATOR;
   }
 
   @Override


### PR DESCRIPTION
User can optionally supply the flag "sortByDimsFirst" to true in query context to change results sort order. This feature is only supported for new "v2" groupBy strategy.

This feature enables client applications and extensions to do "rolling averages", e.g. computing average of a metric for a window of last x days by iterating over the results returned from groupBy query. we are working on such an extension. This can enable other retention type computations as well.