### PR TITLE
retry loadsegment with all locations

### DIFF
--- a/server/src/main/java/io/druid/segment/loading/StorageLocation.java
+++ b/server/src/main/java/io/druid/segment/loading/StorageLocation.java
@@ -76,9 +76,4 @@ class StorageLocation
   {
     return maxSize - currSize;
   }
-
-  StorageLocation mostEmpty(StorageLocation other)
-  {
-    return available() > other.available() ? this : other;
-  }
 }


### PR DESCRIPTION
Currently, when the most empty location failed to load segment, it won't try other locations.
The better way is to try all locations ordered from empty to full, if all locations failed, then throw exception