### PR TITLE
use sync kafka producer for deterministic test

### DIFF
--- a/integration-tests/src/test/java/io/druid/tests/indexer/ITKafkaTest.java
+++ b/integration-tests/src/test/java/io/druid/tests/indexer/ITKafkaTest.java
@@ -158,7 +158,7 @@ public class ITKafkaTest extends AbstractIndexerTest
     LOG.info("kafka host: [%s]", config.getKafkaHost());
     properties.put("serializer.class", "kafka.serializer.StringEncoder");
     properties.put("request.required.acks", "1");
-    properties.put("producer.type", "async");
+    properties.put("producer.type", "sync"); // use sync producer for deterministic test
     ProducerConfig producerConfig = new ProducerConfig(properties);
     Producer<String, String> producer = new Producer<String, String>(producerConfig);
 


### PR DESCRIPTION
Integration test for kafka currently uses async producer which makes the integration test somewhat non-deterministic because as soon as all the `producer.send()` calls are done we do query tests which may not give the expected results as all the events may not have been sent because of async nature of the producer.