### PR TITLE
Fix mvn javadoc:jar failure due to HadoopFsWrapper.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -786,6 +786,9 @@
                     <configuration>
                         <!-- jdk8 started linting javadocs by default; ours are not fully compliant -->
                         <additionalparam>-Xdoclint:none</additionalparam>
+
+                        <!-- HadoopFsWrapper javadocs cannot be generated due to missing annotations -->
+                        <excludePackageNames>org.apache.hadoop.fs</excludePackageNames>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Fixes a failure I ran into while doing the 0.9.2 release:

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] io.druid:druid ..................................... SUCCESS [  0.523 s]
[INFO] druid-api .......................................... SUCCESS [  2.053 s]
[INFO] druid-common ....................................... SUCCESS [  1.799 s]
[INFO] druid-processing ................................... SUCCESS [  5.038 s]
[INFO] druid-aws-common ................................... SUCCESS [  0.911 s]
[INFO] druid-server ....................................... SUCCESS [  5.139 s]
[INFO] druid-examples ..................................... SUCCESS [  1.176 s]
[INFO] druid-indexing-hadoop .............................. SUCCESS [  2.315 s]
[INFO] druid-indexing-service ............................. SUCCESS [  3.027 s]
[INFO] druid-services ..................................... SUCCESS [  1.704 s]
[INFO] druid-s3-extensions ................................ SUCCESS [  1.314 s]
[INFO] druid-datasketches ................................. SUCCESS [  1.399 s]
[INFO] druid-kafka-eight .................................. SUCCESS [  0.895 s]
[INFO] druid-histogram .................................... SUCCESS [  1.332 s]
[INFO] mysql-metadata-storage ............................. SUCCESS [  1.097 s]
[INFO] druid-kafka-indexing-service ....................... SUCCESS [  1.631 s]
[INFO] druid-integration-tests ............................ SUCCESS [  1.987 s]
[INFO] druid-benchmarks ................................... SUCCESS [  4.354 s]
[INFO] druid-avro-extensions .............................. SUCCESS [  1.729 s]
[INFO] druid-hdfs-storage ................................. FAILURE [  1.814 s]
[INFO] druid-stats ........................................ SKIPPED
[INFO] druid-lookups-cached-global ........................ SKIPPED
[INFO] druid-kafka-extraction-namespace ................... SKIPPED
[INFO] postgresql-metadata-storage ........................ SKIPPED
[INFO] druid-lookups-cached-single ........................ SKIPPED
[INFO] druid-azure-extensions ............................. SKIPPED
[INFO] druid-cassandra-storage ............................ SKIPPED
[INFO] druid-rocketmq ..................................... SKIPPED
[INFO] druid-cloudfiles-extensions ........................ SKIPPED
[INFO] graphite-emitter ................................... SKIPPED
[INFO] druid-kafka-eight-simple-consumer .................. SKIPPED
[INFO] druid-rabbitmq ..................................... SKIPPED
[INFO] druid-distinctcount ................................ SKIPPED
[INFO] druid-parquet-extensions ........................... SKIPPED
[INFO] statsd-emitter ..................................... SKIPPED
[INFO] druid-orc-extensions ............................... SKIPPED
[INFO] druid-caffeine-cache ............................... SKIPPED
[INFO] distribution ....................................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 41.785 s
[INFO] Finished at: 2016-12-01T11:09:42-08:00
[INFO] Final Memory: 42M/638M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.10.4:jar (default-cli) on project druid-hdfs-storage: MavenReportException: Error while generating Javadoc:
[ERROR] Exit code: 1 - /Users/gian/Documents/imply/src/druid/extensions-core/hdfs-storage/src/main/java/org/apache/hadoop/fs/HadoopFsWrapper.java:48: warning - @return tag has no arguments.
[ERROR] javadoc: error - com.sun.tools.doclets.internal.toolkit.util.DocletAbortException: com.sun.tools.doclets.internal.toolkit.util.DocletAbortException: com.sun.tools.doclets.internal.toolkit.util.DocletAbortException: com.sun.tools.doclets.internal.toolkit.util.DocletAbortException: com.sun.tools.doclets.internal.toolkit.util.DocletAbortException: com.sun.tools.javac.code.Symbol$CompletionFailure: class file for org.apache.hadoop.classification.InterfaceAudience$Public not found
[ERROR]
[ERROR] Command line was: /Library/Java/JavaVirtualMachines/jdk1.8.0_101.jdk/Contents/Home/jre/../bin/javadoc @options @packages
[ERROR]
[ERROR] Refer to the generated Javadoc files in '/Users/gian/Documents/imply/src/druid/extensions-core/hdfs-storage/target/apidocs' dir.
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :druid-hdfs-storage
```

I believe the issue is that HadoopFsWrapper accepts "FileSystem" as a parameter in a public method, so javadoc tries to generate javadocs for it, but then it bombs out when it tries to figure out what a FileSystem is. The error refers to a `InterfaceAudience$Public` class, which is an annotation. We probably could fix this by including hadoop-annotations jar. But, I don't want to do a patch that includes new jars so close to a release, so instead I suggest this patch which just disables javadoc generation for that class. This is against the 0.9.2 branch so we could potentially do a different approach in master.

This was not caught in the RC phase because we run "mvn javadoc:aggregate" there rather than "mvn javadoc:jar", and the aggregate command worked fine.

I tested "mvn javadoc:jar" and it works after this patch.