### PR TITLE
Fix SingleScanTimeDimSelector when an extractionFn returns null for a timestamp.

### DIFF
--- a/processing/src/main/java/io/druid/segment/SingleScanTimeDimSelector.java
+++ b/processing/src/main/java/io/druid/segment/SingleScanTimeDimSelector.java
@@ -27,6 +27,7 @@ import it.unimi.dsi.fastutil.ints.IntIterators;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 
 public class SingleScanTimeDimSelector implements DimensionSelector
 {
@@ -81,7 +82,7 @@ public class SingleScanTimeDimSelector implements DimensionSelector
       }
       currentTimestamp = timestamp;
       final String value = extractionFn.apply(timestamp);
-      if (!value.equals(currentValue)) {
+      if (!Objects.equals(value, currentValue)) {
         currentValue = value;
         ++index;
         timeValues.put(index, currentValue);


### PR DESCRIPTION
It used to throw NPE.