### PR TITLE
RemoteTaskRunnerConfig: Fix Guice error on startup.

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
@@ -72,7 +72,6 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
     return taskAssignmentTimeout;
   }
 
-  @JsonProperty
   public Period getTaskCleanupTimeout(){
     return taskCleanupTimeout;
   }
@@ -105,7 +104,7 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
     return workerBlackListBackoffTime;
   }
 
-  public void setTaskBlackListBackoffTimeMillis(Period taskBlackListBackoffTime) {
+  public void setWorkerBlackListBackoffTime(Period taskBlackListBackoffTime) {
     this.workerBlackListBackoffTime = taskBlackListBackoffTime;
   }
 

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfigTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfigTest.java
@@ -20,6 +20,7 @@
 package io.druid.indexing.overlord.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.druid.guice.JsonConfigurator;
 import io.druid.jackson.DefaultObjectMapper;
 import org.joda.time.Period;
 import org.junit.Assert;
@@ -39,6 +40,12 @@ public class RemoteTaskRunnerConfigTest
   private static final int DEFAULT_MAX_RETRIES_BEFORE_BLACKLIST = 5;
   private static final Period DEFAULT_TASK_BACKOFF = new Period("PT10M");
   private static final Period DEFAULT_BLACKLIST_CLEANUP_PERIOD = new Period("PT5M");
+
+  @Test
+  public void testIsJsonConfiguratable()
+  {
+    JsonConfigurator.verifyClazzIsConfigurable(mapper, RemoteTaskRunnerConfig.class);
+  }
 
   @Test
   public void testGetTaskAssignmentTimeout() throws Exception


### PR DESCRIPTION
The name mismatch on "setTaskBlackListBackoffTimeMillis" prevents the overlord from starting up, since it fails JsonConfigurator's validation. Regression from #3643.