### PR TITLE
report message gap, source gap and sink count in RealtimePlumber

### DIFF
--- a/docs/content/operations/metrics.md
+++ b/docs/content/operations/metrics.md
@@ -109,6 +109,8 @@ These metrics are only available if the RealtimeMetricsMonitor is included in th
 |`ingest/merge/time`|Milliseconds spent merging intermediate segments|dataSource.|Depends on configuration. Generally a few minutes at most.|
 |`ingest/merge/cpu`|Cpu time in Nanoseconds spent on merging intermediate segments.|dataSource.|Depends on configuration. Generally a few minutes at most.|
 |`ingest/handoff/count`|Number of handoffs that happened.|dataSource.|Varies. Generally greater than 0 once every segment granular period if cluster operating normally|
+|`ingest/sink/count`|Number of sinks not handoffed.|dataSource.|1~3|
+|`ingest/events/messageGap`|Time gap between the data time in event and current system time.|dataSource.|Greater than 0, depends on the time carried in event |
 
 Note: If the JVM does not support CPU time measurement for the current thread, ingest/merge/cpu and ingest/persists/cpu will be 0. 
 

--- a/docs/content/operations/metrics.md
+++ b/docs/content/operations/metrics.md
@@ -111,6 +111,7 @@ These metrics are only available if the RealtimeMetricsMonitor is included in th
 |`ingest/handoff/count`|Number of handoffs that happened.|dataSource.|Varies. Generally greater than 0 once every segment granular period if cluster operating normally|
 |`ingest/sink/count`|Number of sinks not handoffed.|dataSource.|1~3|
 |`ingest/events/messageGap`|Time gap between the data time in event and current system time.|dataSource.|Greater than 0, depends on the time carried in event |
+|`ingest/events/sourceGap`|Time gap between the time when the event written into source(like kafka 0.10 https://issues.apache.org/jira/browse/KAFKA-2511) and current system time.|dataSource.|Greater than 0, depends on the time when the event written into source|
 
 Note: If the JVM does not support CPU time measurement for the current thread, ingest/merge/cpu and ingest/persists/cpu will be 0. 
 

--- a/docs/content/operations/metrics.md
+++ b/docs/content/operations/metrics.md
@@ -111,7 +111,6 @@ These metrics are only available if the RealtimeMetricsMonitor is included in th
 |`ingest/handoff/count`|Number of handoffs that happened.|dataSource.|Varies. Generally greater than 0 once every segment granular period if cluster operating normally|
 |`ingest/sink/count`|Number of sinks not handoffed.|dataSource.|1~3|
 |`ingest/events/messageGap`|Time gap between the data time in event and current system time.|dataSource.|Greater than 0, depends on the time carried in event |
-|`ingest/events/sourceGap`|Time gap between the time when the event written into source(like kafka 0.10 https://issues.apache.org/jira/browse/KAFKA-2511) and current system time.|dataSource.|Greater than 0, depends on the time when the event written into source|
 
 Note: If the JVM does not support CPU time measurement for the current thread, ingest/merge/cpu and ingest/persists/cpu will be 0. 
 

--- a/server/src/main/java/io/druid/segment/realtime/FireDepartmentMetrics.java
+++ b/server/src/main/java/io/druid/segment/realtime/FireDepartmentMetrics.java
@@ -40,6 +40,11 @@ public class FireDepartmentMetrics
   private final AtomicLong mergeCpuTime = new AtomicLong(0);
   private final AtomicLong persistCpuTime = new AtomicLong(0);
   private final AtomicLong handOffCount = new AtomicLong(0);
+  private final AtomicLong sinkCount = new AtomicLong(0);
+  private final AtomicLong messageMaxTimestamp = new AtomicLong(0);
+  private final AtomicLong sourceMaxTimestamp = new AtomicLong(0);
+  private final AtomicLong messageGap = new AtomicLong(0);
+  private final AtomicLong sourceGap = new AtomicLong(0);
 
   public void incrementProcessed()
   {
@@ -101,6 +106,18 @@ public class FireDepartmentMetrics
 
   public void incrementHandOffCount(){
     handOffCount.incrementAndGet();
+  }
+
+  public void setSinkCount(long sinkCount){
+    this.sinkCount.set(sinkCount);
+  }
+
+  public void reportMessageMaxTimestamp(long messageMaxTimestamp){
+    this.messageMaxTimestamp.set(Math.max(messageMaxTimestamp, this.messageMaxTimestamp.get()));
+  }
+
+  public void reportSourceMaxTimestamp(long sourceMaxTimestamp){
+    this.sourceMaxTimestamp.set(Math.max(sourceMaxTimestamp, this.sourceMaxTimestamp.get()));
   }
 
   public long processed()
@@ -168,6 +185,31 @@ public class FireDepartmentMetrics
     return handOffCount.get();
   }
 
+  public long sinkCount()
+  {
+    return sinkCount.get();
+  }
+
+  public long getMessageMaxTimestamp()
+  {
+    return messageMaxTimestamp.get();
+  }
+
+  public long getSourceMaxTimestamp()
+  {
+    return sourceMaxTimestamp.get();
+  }
+
+  public long messageGap()
+  {
+    return messageGap.get();
+  }
+
+  public long sourceGap()
+  {
+    return sourceGap.get();
+  }
+
 
   public FireDepartmentMetrics snapshot()
   {
@@ -185,6 +227,11 @@ public class FireDepartmentMetrics
     retVal.mergeCpuTime.set(mergeCpuTime.get());
     retVal.persistCpuTime.set(persistCpuTime.get());
     retVal.handOffCount.set(handOffCount.get());
+    retVal.sinkCount.set(sinkCount.get());
+    retVal.messageMaxTimestamp.set(messageMaxTimestamp.get());
+    retVal.sourceMaxTimestamp.set(sourceMaxTimestamp.get());
+    retVal.messageGap.set(System.currentTimeMillis() - messageMaxTimestamp.get());
+    retVal.sourceGap.set(System.currentTimeMillis() - sourceMaxTimestamp.get());
     return retVal;
   }
 
@@ -210,6 +257,11 @@ public class FireDepartmentMetrics
     mergeCpuTime.addAndGet(otherSnapshot.mergeCpuTime());
     persistCpuTime.addAndGet(otherSnapshot.persistCpuTime());
     handOffCount.addAndGet(otherSnapshot.handOffCount());
+    sinkCount.addAndGet(otherSnapshot.sinkCount());
+    messageMaxTimestamp.set(Math.max(getMessageMaxTimestamp(), otherSnapshot.getMessageMaxTimestamp()));
+    sourceMaxTimestamp.set(Math.max(getSourceMaxTimestamp(), otherSnapshot.getSourceMaxTimestamp()));
+    messageGap.set(Math.max(messageGap(), otherSnapshot.messageGap()));
+    sourceGap.set(Math.max(sourceGap(), otherSnapshot.sourceGap()));
     return this;
   }
 

--- a/server/src/main/java/io/druid/segment/realtime/FireDepartmentMetrics.java
+++ b/server/src/main/java/io/druid/segment/realtime/FireDepartmentMetrics.java
@@ -190,12 +190,12 @@ public class FireDepartmentMetrics
     return sinkCount.get();
   }
 
-  public long getMessageMaxTimestamp()
+  public long messageMaxTimestamp()
   {
     return messageMaxTimestamp.get();
   }
 
-  public long getSourceMaxTimestamp()
+  public long sourceMaxTimestamp()
   {
     return sourceMaxTimestamp.get();
   }
@@ -258,8 +258,8 @@ public class FireDepartmentMetrics
     persistCpuTime.addAndGet(otherSnapshot.persistCpuTime());
     handOffCount.addAndGet(otherSnapshot.handOffCount());
     sinkCount.addAndGet(otherSnapshot.sinkCount());
-    messageMaxTimestamp.set(Math.max(getMessageMaxTimestamp(), otherSnapshot.getMessageMaxTimestamp()));
-    sourceMaxTimestamp.set(Math.max(getSourceMaxTimestamp(), otherSnapshot.getSourceMaxTimestamp()));
+    messageMaxTimestamp.set(Math.max(messageMaxTimestamp(), otherSnapshot.messageMaxTimestamp()));
+    sourceMaxTimestamp.set(Math.max(sourceMaxTimestamp(), otherSnapshot.sourceMaxTimestamp()));
     messageGap.set(Math.max(messageGap(), otherSnapshot.messageGap()));
     sourceGap.set(Math.max(sourceGap(), otherSnapshot.sourceGap()));
     return this;

--- a/server/src/main/java/io/druid/segment/realtime/FireDepartmentMetrics.java
+++ b/server/src/main/java/io/druid/segment/realtime/FireDepartmentMetrics.java
@@ -42,9 +42,7 @@ public class FireDepartmentMetrics
   private final AtomicLong handOffCount = new AtomicLong(0);
   private final AtomicLong sinkCount = new AtomicLong(0);
   private final AtomicLong messageMaxTimestamp = new AtomicLong(0);
-  private final AtomicLong sourceMaxTimestamp = new AtomicLong(0);
   private final AtomicLong messageGap = new AtomicLong(0);
-  private final AtomicLong sourceGap = new AtomicLong(0);
 
   public void incrementProcessed()
   {
@@ -114,10 +112,6 @@ public class FireDepartmentMetrics
 
   public void reportMessageMaxTimestamp(long messageMaxTimestamp){
     this.messageMaxTimestamp.set(Math.max(messageMaxTimestamp, this.messageMaxTimestamp.get()));
-  }
-
-  public void reportSourceMaxTimestamp(long sourceMaxTimestamp){
-    this.sourceMaxTimestamp.set(Math.max(sourceMaxTimestamp, this.sourceMaxTimestamp.get()));
   }
 
   public long processed()
@@ -195,21 +189,10 @@ public class FireDepartmentMetrics
     return messageMaxTimestamp.get();
   }
 
-  public long sourceMaxTimestamp()
-  {
-    return sourceMaxTimestamp.get();
-  }
-
   public long messageGap()
   {
     return messageGap.get();
   }
-
-  public long sourceGap()
-  {
-    return sourceGap.get();
-  }
-
 
   public FireDepartmentMetrics snapshot()
   {
@@ -229,9 +212,7 @@ public class FireDepartmentMetrics
     retVal.handOffCount.set(handOffCount.get());
     retVal.sinkCount.set(sinkCount.get());
     retVal.messageMaxTimestamp.set(messageMaxTimestamp.get());
-    retVal.sourceMaxTimestamp.set(sourceMaxTimestamp.get());
     retVal.messageGap.set(System.currentTimeMillis() - messageMaxTimestamp.get());
-    retVal.sourceGap.set(System.currentTimeMillis() - sourceMaxTimestamp.get());
     return retVal;
   }
 
@@ -259,9 +240,7 @@ public class FireDepartmentMetrics
     handOffCount.addAndGet(otherSnapshot.handOffCount());
     sinkCount.addAndGet(otherSnapshot.sinkCount());
     messageMaxTimestamp.set(Math.max(messageMaxTimestamp(), otherSnapshot.messageMaxTimestamp()));
-    sourceMaxTimestamp.set(Math.max(sourceMaxTimestamp(), otherSnapshot.sourceMaxTimestamp()));
     messageGap.set(Math.max(messageGap(), otherSnapshot.messageGap()));
-    sourceGap.set(Math.max(sourceGap(), otherSnapshot.sourceGap()));
     return this;
   }
 

--- a/server/src/main/java/io/druid/segment/realtime/RealtimeMetricsMonitor.java
+++ b/server/src/main/java/io/druid/segment/realtime/RealtimeMetricsMonitor.java
@@ -98,7 +98,6 @@ public class RealtimeMetricsMonitor extends AbstractMonitor
       emitter.emit(builder.build("ingest/handoff/count", metrics.handOffCount() - previous.handOffCount()));
       emitter.emit(builder.build("ingest/sink/count", metrics.sinkCount()));
       emitter.emit(builder.build("ingest/events/messageGap", metrics.messageGap()));
-      emitter.emit(builder.build("ingest/events/sourceGap", metrics.sourceGap()));
       previousValues.put(fireDepartment, metrics);
     }
 

--- a/server/src/main/java/io/druid/segment/realtime/RealtimeMetricsMonitor.java
+++ b/server/src/main/java/io/druid/segment/realtime/RealtimeMetricsMonitor.java
@@ -96,6 +96,9 @@ public class RealtimeMetricsMonitor extends AbstractMonitor
       emitter.emit(builder.build("ingest/merge/time", metrics.mergeTimeMillis() - previous.mergeTimeMillis()));
       emitter.emit(builder.build("ingest/merge/cpu", metrics.mergeCpuTime() - previous.mergeCpuTime()));
       emitter.emit(builder.build("ingest/handoff/count", metrics.handOffCount() - previous.handOffCount()));
+      emitter.emit(builder.build("ingest/sink/count", metrics.sinkCount()));
+      emitter.emit(builder.build("ingest/events/messageGap", metrics.messageGap()));
+      emitter.emit(builder.build("ingest/events/sourceGap", metrics.sourceGap()));
       previousValues.put(fireDepartment, metrics);
     }
 

--- a/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -191,6 +191,7 @@ public class AppenderatorImpl implements Appenderator
     }
 
     final Sink sink = getOrCreateSink(identifier);
+    metrics.reportMessageMaxTimestamp(row.getTimestampFromEpoch());
     final int sinkRowsInMemoryBeforeAdd = sink.getNumRowsInMemory();
     final int sinkRowsInMemoryAfterAdd;
 
@@ -269,6 +270,7 @@ public class AppenderatorImpl implements Appenderator
       }
 
       sinks.put(identifier, retVal);
+      metrics.setSinkCount(sinks.size());
       sinkTimeline.add(retVal.getInterval(), retVal.getVersion(), identifier.getShardSpec().createChunk(retVal));
     }
 
@@ -905,6 +907,7 @@ public class AppenderatorImpl implements Appenderator
 
             log.info("Removing sink for segment[%s].", identifier);
             sinks.remove(identifier);
+            metrics.setSinkCount(sinks.size());
             droppingSinks.remove(identifier);
             sinkTimeline.remove(
                 sink.getInterval(),

--- a/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -205,6 +205,7 @@ public class RealtimePlumber implements Plumber
   public int add(InputRow row, Supplier<Committer> committerSupplier) throws IndexSizeExceededException
   {
     final Sink sink = getSink(row.getTimestampFromEpoch());
+    metrics.reportMessageMaxTimestamp(rejectionPolicy.getCurrMaxTime().getMillis());
     if (sink == null) {
       return -1;
     }
@@ -716,6 +717,7 @@ public class RealtimePlumber implements Plumber
   private void addSink(final Sink sink)
   {
     sinks.put(sink.getInterval().getStartMillis(), sink);
+    metrics.setSinkCount(sinks.size());
     sinkTimeline.add(
         sink.getInterval(),
         sink.getVersion(),
@@ -850,6 +852,7 @@ public class RealtimePlumber implements Plumber
         removeSegment(sink, computePersistDir(schema, sink.getInterval()));
         log.info("Removing sinkKey %d for segment %s", truncatedTime, sink.getSegment().getIdentifier());
         sinks.remove(truncatedTime);
+        metrics.setSinkCount(sinks.size());
         sinkTimeline.remove(
             sink.getInterval(),
             sink.getVersion(),

--- a/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -204,8 +204,9 @@ public class RealtimePlumber implements Plumber
   @Override
   public int add(InputRow row, Supplier<Committer> committerSupplier) throws IndexSizeExceededException
   {
-    final Sink sink = getSink(row.getTimestampFromEpoch());
-    metrics.reportMessageMaxTimestamp(rejectionPolicy.getCurrMaxTime().getMillis());
+    long messageTimestamp = row.getTimestampFromEpoch();
+    final Sink sink = getSink(messageTimestamp);
+    metrics.reportMessageMaxTimestamp(messageTimestamp);
     if (sink == null) {
       return -1;
     }


### PR DESCRIPTION
report message gap, source gap and sink count in RealtimePlumber for better view of ingestion status and progress. It is useful to tell a realtime task is abnormal or not.

message gap is the gap between the data time carried in the event and current system time.
source gap is the gap between the time when the message written in source(like kafka 0.10) and current system time, this gap can be reported by a customized task, like a customized kafka task (kafka 0.10 supports event time, can be retrieved from message, https://issues.apache.org/jira/browse/KAFKA-2511)
sink count means the sinks not handoffed