### PR TITLE
Disable flush after every DefaultObjectMapper write

### DIFF
--- a/processing/src/main/java/io/druid/jackson/DefaultObjectMapper.java
+++ b/processing/src/main/java/io/druid/jackson/DefaultObjectMapper.java
@@ -58,6 +58,7 @@ public class DefaultObjectMapper extends ObjectMapper
     configure(MapperFeature.AUTO_DETECT_SETTERS, false);
     configure(MapperFeature.ALLOW_FINAL_FIELDS_AS_MUTATORS, false);
     configure(SerializationFeature.INDENT_OUTPUT, false);
+    configure(SerializationFeature.FLUSH_AFTER_WRITE_VALUE, false);
   }
 
   @Override


### PR DESCRIPTION
This PR disables the FLUSH_AFTER_WRITE_VALUE setting on DefaultObjectMapper:

http://wiki.fasterxml.com/JacksonFeaturesSerialization
https://fasterxml.github.io/jackson-databind/javadoc/2.3.0/com/fasterxml/jackson/databind/SerializationFeature.html#FLUSH_AFTER_WRITE_VALUE

Disabling this setting resulted in better network performance between the historical and broker when transferring query results. When serializing results from a yielder, a flush was occurring for every yielder result. This had significant impact on a test groupby query with compression disabled at the HttpClient level. 

Using `iftop`, a transfer rate of ~350Mb/s was observed between the historical (i2.8xlarge node) and broker (r3.8xlarge node) with flush after write disabled, compared to a rate of ~170Mb/s with the setting enabled.