### PR TITLE
Bitset iteration optimization and improve safety

### DIFF
--- a/bytebuffer-collections/pom.xml
+++ b/bytebuffer-collections/pom.xml
@@ -88,6 +88,11 @@
       <version>1.4.182</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava-testlib</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/bytebuffer-collections/src/main/java/io/druid/collections/bitmap/WrappedImmutableBitSetBitmap.java
+++ b/bytebuffer-collections/src/main/java/io/druid/collections/bitmap/WrappedImmutableBitSetBitmap.java
@@ -23,6 +23,7 @@ import org.roaringbitmap.IntIterator;
 
 import java.nio.ByteBuffer;
 import java.util.BitSet;
+import java.util.NoSuchElementException;
 
 /**
  * WrappedImmutableBitSetBitmap implements ImmutableBitmap for java.util.BitSet
@@ -117,18 +118,27 @@ public class WrappedImmutableBitSetBitmap implements ImmutableBitmap
 
   private class BitSetIterator implements IntIterator
   {
-    private int pos = -1;
+    private int nextPos;
+
+    BitSetIterator()
+    {
+      nextPos = bitmap.nextSetBit(0);
+    }
 
     @Override
     public boolean hasNext()
     {
-      return bitmap.nextSetBit(pos + 1) >= 0;
+      return nextPos >= 0;
     }
 
     @Override
     public int next()
     {
-      pos = bitmap.nextSetBit(pos + 1);
+      int pos = nextPos;
+      if (pos < 0) {
+        throw new NoSuchElementException();
+      }
+      nextPos = bitmap.nextSetBit(pos + 1);
       return pos;
     }
 
@@ -136,7 +146,7 @@ public class WrappedImmutableBitSetBitmap implements ImmutableBitmap
     public IntIterator clone()
     {
       BitSetIterator newIt = new BitSetIterator();
-      newIt.pos = pos;
+      newIt.nextPos = nextPos;
       return newIt;
     }
   }

--- a/bytebuffer-collections/src/test/java/io/druid/collections/bitmap/BitmapIterationTest.java
+++ b/bytebuffer-collections/src/test/java/io/druid/collections/bitmap/BitmapIterationTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.collections.bitmap;
+
+import com.google.common.collect.UnmodifiableIterator;
+import com.google.common.collect.testing.CollectionTestSuiteBuilder;
+import com.google.common.collect.testing.SampleElements;
+import com.google.common.collect.testing.TestCollectionGenerator;
+import com.google.common.collect.testing.features.CollectionFeature;
+import com.google.common.collect.testing.features.CollectionSize;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+import org.roaringbitmap.IntIterator;
+
+import java.util.AbstractCollection;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class BitmapIterationTest extends TestCase
+{
+  public static Test suite()
+  {
+    List<BitmapFactory> factories = Arrays.asList(
+        new BitSetBitmapFactory(),
+        new ConciseBitmapFactory()
+        // Exclude Roaring because it fails yet!
+        //new RoaringBitmapFactory()
+    );
+
+    TestSuite suite = new TestSuite();
+    for (BitmapFactory factory : factories) {
+      suite.addTest(suiteForFactory(factory));
+    }
+    return suite;
+  }
+
+  private static Test suiteForFactory(BitmapFactory factory)
+  {
+    return CollectionTestSuiteBuilder
+        .using(new BitmapCollectionGenerator(factory))
+        .named("bitmap iteration tests of " + factory)
+        .withFeatures(CollectionFeature.KNOWN_ORDER)
+        .withFeatures(CollectionFeature.REJECTS_DUPLICATES_AT_CREATION)
+        .withFeatures(CollectionFeature.RESTRICTS_ELEMENTS)
+        .withFeatures(CollectionSize.ANY)
+        .createTestSuite();
+  }
+
+  private static class BitmapCollection extends AbstractCollection<Integer>
+  {
+    private final ImmutableBitmap bitmap;
+    private final int size;
+
+    private BitmapCollection(ImmutableBitmap bitmap, int size)
+    {
+      this.bitmap = bitmap;
+      this.size = size;
+    }
+
+    @Override
+    public UnmodifiableIterator<Integer> iterator()
+    {
+      final IntIterator iterator = bitmap.iterator();
+      return new UnmodifiableIterator<Integer>()
+      {
+        @Override
+        public boolean hasNext()
+        {
+          return iterator.hasNext();
+        }
+
+        @Override
+        public Integer next()
+        {
+          return iterator.next();
+        }
+      };
+    }
+
+    @Override
+    public int size()
+    {
+      return size;
+    }
+  }
+
+  private static class BitmapCollectionGenerator implements TestCollectionGenerator<Integer>
+  {
+    private final BitmapFactory factory;
+
+    private BitmapCollectionGenerator(BitmapFactory factory)
+    {
+      this.factory = factory;
+    }
+
+    @Override
+    public SampleElements<Integer> samples()
+    {
+      return new SampleElements.Ints();
+    }
+
+    @Override
+    public BitmapCollection create(Object... objects)
+    {
+      MutableBitmap mutableBitmap = factory.makeEmptyMutableBitmap();
+      for (Object element : objects) {
+        mutableBitmap.add(((Integer) element));
+      }
+      return new BitmapCollection(factory.makeImmutableBitmap(mutableBitmap), objects.length);
+    }
+
+    @Override
+    public Integer[] createArray(int n)
+    {
+      return new Integer[n];
+    }
+
+    @Override
+    public Iterable<Integer> order(List<Integer> list)
+    {
+      Collections.sort(list);
+      return list;
+    }
+  }
+}

--- a/bytebuffer-collections/src/test/java/io/druid/collections/bitmap/BitmapIterationTest.java
+++ b/bytebuffer-collections/src/test/java/io/druid/collections/bitmap/BitmapIterationTest.java
@@ -42,7 +42,16 @@ public class BitmapIterationTest extends TestCase
     List<BitmapFactory> factories = Arrays.asList(
         new BitSetBitmapFactory(),
         new ConciseBitmapFactory()
-        // Exclude Roaring because it fails yet!
+        // Roaring iteration fails because it doesn't throw NoSuchElementException on next() call when there are no more
+        // elements. Instead, it either throws NullPointerException or returns some unspecified value. If bitmap
+        // iterators are always used correctly in shouldn't be a problem, but if next() is occasionally called after
+        // hasNext() returned false and it returns some unspecified value, and everything continues to work without
+        // indication that there was a error, it would be a bug that is very hard to catch.
+        //
+        // This line should be uncommented when Druid updates RoaringBitmap dependency to a version which includes a fix
+        // for https://github.com/RoaringBitmap/RoaringBitmap/issues/129, or when RoaringBitmap is included into Druid
+        // as a module and the issue is fixed there.
+
         //new RoaringBitmapFactory()
     );
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
 
     <properties>
         <apache.curator.version>2.11.0</apache.curator.version>
+        <guava.version>16.0.1</guava.version>
         <guice.version>4.1.0</guice.version>
         <jetty.version>9.2.5.v20141112</jetty.version>
         <jersey.version>1.19</jersey.version>
@@ -252,7 +253,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>16.0.1</version>
+                <version>${guava.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.inject</groupId>
@@ -658,6 +659,12 @@
                 <groupId>pl.pragmatists</groupId>
                 <artifactId>JUnitParams</artifactId>
                 <version>1.0.4</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava-testlib</artifactId>
+                <version>${guava.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
 - Deduplicate looking for `bitset.nextSetBit()` in `BitSetIterator.next()` and `hasNext()`
 - Along the way it makes this iterator to follow `Iterator` contract, should throw `NoSuchElementException` on calling `next()` after `hasNext() = false`. Before it was returning -1, that is bug-prone.
 - Add `BitmapIterationTest` which verifies Bitmap iteration implementations. BTW it fails for Roaring right now, but immediate fix is not possible, because it's a library dependency.

It makes iteration over a bitset 20-30% faster (before-after, benchmarks from #3751):
```
Benchmark                      (bitmapAlgo)  (prob)   (size)  Mode  Cnt        Score        Error  Units
BitmapIterationBenchmark.iter        bitset     0.0  1000000  avgt    5        4.052 ±      0.137  ns/op
BitmapIterationBenchmark.iter        bitset   0.001  1000000  avgt    5    36647.927 ±   1738.782  ns/op
BitmapIterationBenchmark.iter        bitset     0.1  1000000  avgt    5   699019.477 ± 158638.803  ns/op
BitmapIterationBenchmark.iter        bitset     0.5  1000000  avgt    5  3395422.304 ± 158315.241  ns/op
BitmapIterationBenchmark.iter        bitset    0.99  1000000  avgt    5  5875929.154 ± 241268.439  ns/op
BitmapIterationBenchmark.iter        bitset     1.0  1000000  avgt    5  5626511.995 ± 759176.569  ns/op

Benchmark                      (bitmapAlgo)  (prob)   (size)  Mode  Cnt        Score        Error  Units
BitmapIterationBenchmark.iter        bitset     0.0  1000000  avgt    5        3.221 ±      0.362  ns/op
BitmapIterationBenchmark.iter        bitset   0.001  1000000  avgt    5    26713.522 ±   6375.378  ns/op
BitmapIterationBenchmark.iter        bitset     0.1  1000000  avgt    5   521381.301 ±  16891.222  ns/op
BitmapIterationBenchmark.iter        bitset     0.5  1000000  avgt    5  2053421.442 ±  34196.751  ns/op
BitmapIterationBenchmark.iter        bitset    0.99  1000000  avgt    5  3969497.718 ± 410796.782  ns/op
BitmapIterationBenchmark.iter        bitset     1.0  1000000  avgt    5  4040926.926 ± 139893.245  ns/op
```

This is a copy of metamx/bytebuffer-collections#37