### PR TITLE
Support metric filters

### DIFF
--- a/processing/src/main/java/io/druid/query/aggregation/AggregatorUtil.java
+++ b/processing/src/main/java/io/druid/query/aggregation/AggregatorUtil.java
@@ -19,6 +19,7 @@
 
 package io.druid.query.aggregation;
 
+import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;
 import io.druid.segment.ColumnSelectorFactory;
 import io.druid.segment.FloatColumnSelector;
@@ -100,7 +101,7 @@ public class AggregatorUtil
       return metricFactory.makeFloatColumnSelector(fieldName);
     }
     if (fieldName == null && fieldExpression != null) {
-      final NumericColumnSelector numeric = metricFactory.makeMathExpressionSelector(fieldExpression);
+      final NumericColumnSelector numeric = metricFactory.makeExpressionSelector(fieldExpression);
       return new FloatColumnSelector()
       {
         @Override
@@ -125,7 +126,7 @@ public class AggregatorUtil
       return metricFactory.makeLongColumnSelector(fieldName);
     }
     if (fieldName == null && fieldExpression != null) {
-      final NumericColumnSelector numeric = metricFactory.makeMathExpressionSelector(fieldExpression);
+      final NumericColumnSelector numeric = metricFactory.makeExpressionSelector(fieldExpression);
       return new LongColumnSelector()
       {
         @Override
@@ -137,5 +138,29 @@ public class AggregatorUtil
       };
     }
     throw new IllegalArgumentException("Must have a valid, non-null fieldName or expression");
+  }
+
+  public static Supplier<Number> asSupplier(final FloatColumnSelector selector)
+  {
+    return new Supplier<Number>()
+    {
+      @Override
+      public Number get()
+      {
+        return selector.get();
+      }
+    };
+  }
+
+  public static Supplier<Number> asSupplier(final LongColumnSelector selector)
+  {
+    return new Supplier<Number>()
+    {
+      @Override
+      public Number get()
+      {
+        return selector.get();
+      }
+    };
   }
 }

--- a/processing/src/main/java/io/druid/query/aggregation/FilteredAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/FilteredAggregatorFactory.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
+import io.druid.math.expr.Evals;
 import io.druid.query.dimension.DefaultDimensionSpec;
 import io.druid.query.filter.DimFilter;
 import io.druid.query.filter.DruidLongPredicate;
@@ -34,6 +35,7 @@ import io.druid.segment.DimensionSelector;
 import io.druid.segment.column.Column;
 import io.druid.segment.column.ColumnCapabilities;
 import io.druid.segment.column.ValueType;
+import io.druid.segment.NumericColumnSelector;
 import io.druid.segment.data.IndexedInts;
 import io.druid.segment.filter.BooleanValueMatcher;
 import io.druid.segment.filter.Filters;
@@ -390,6 +392,20 @@ public class FilteredAggregatorFactory extends AggregatorFactory
       }
       ColumnCapabilities capabilities = columnSelectorFactory.getColumnCapabilities(dimension);
       return capabilities == null ? ValueType.STRING : capabilities.getType();
+    }
+
+    @Override
+    public ValueMatcher makeExpressionMatcher(String expression)
+    {
+      final NumericColumnSelector selector = columnSelectorFactory.makeExpressionSelector(expression);
+      return new ValueMatcher()
+      {
+        @Override
+        public boolean matches()
+        {
+          return Evals.asBoolean(selector.get());
+        }
+      };
     }
   }
 }

--- a/processing/src/main/java/io/druid/query/filter/DimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/DimFilter.java
@@ -25,7 +25,7 @@ import com.google.common.collect.RangeSet;
 
 /**
  */
-@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, property="type")
+@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, property="type",defaultImpl = ExpressionFilter.class)
 @JsonSubTypes(value={
     @JsonSubTypes.Type(name="and", value=AndDimFilter.class),
     @JsonSubTypes.Type(name="or", value=OrDimFilter.class),
@@ -39,7 +39,8 @@ import com.google.common.collect.RangeSet;
     @JsonSubTypes.Type(name="in", value=InDimFilter.class),
     @JsonSubTypes.Type(name="bound", value=BoundDimFilter.class),
     @JsonSubTypes.Type(name="interval", value=IntervalDimFilter.class),
-    @JsonSubTypes.Type(name="like", value=LikeDimFilter.class)
+    @JsonSubTypes.Type(name="like", value=LikeDimFilter.class),
+    @JsonSubTypes.Type(name="expression", value=ExpressionFilter.class)
 })
 public interface DimFilter
 {

--- a/processing/src/main/java/io/druid/query/filter/DimFilterUtils.java
+++ b/processing/src/main/java/io/druid/query/filter/DimFilterUtils.java
@@ -50,6 +50,8 @@ public class DimFilterUtils
   static final byte BOUND_CACHE_ID = 0xA;
   static final byte INTERVAL_CACHE_ID = 0xB;
   static final byte LIKE_CACHE_ID = 0xC;
+  static final byte EXPR_CACHE_ID = 0xD;
+
   public static final byte STRING_SEPARATOR = (byte) 0xFF;
 
   static byte[] computeCacheKey(byte cacheIdKey, List<DimFilter> filters)

--- a/processing/src/main/java/io/druid/query/filter/ExpressionFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/ExpressionFilter.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.filter;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.RangeSet;
+import io.druid.collections.bitmap.ImmutableBitmap;
+import io.druid.common.utils.StringUtils;
+
+import java.nio.ByteBuffer;
+
+/**
+ */
+public class ExpressionFilter implements DimFilter
+{
+  private final String expression;
+
+  @JsonCreator
+  public ExpressionFilter(
+      @JsonProperty("expression") String expression
+  )
+  {
+    this.expression = Preconditions.checkNotNull(expression, "expression can not be null");
+  }
+
+  @JsonProperty
+  public String getExpression()
+  {
+    return expression;
+  }
+
+  @Override
+  public byte[] getCacheKey()
+  {
+    byte[] expressionBytes = StringUtils.toUtf8(expression);
+    return ByteBuffer.allocate(1 + expressionBytes.length)
+                     .put(DimFilterUtils.EXPR_CACHE_ID)
+                     .put(expressionBytes)
+                     .array();
+  }
+
+  @Override
+  public DimFilter optimize()
+  {
+    return this;
+  }
+
+  @Override
+  public Filter toFilter()
+  {
+    return new Filter()
+    {
+      @Override
+      public ImmutableBitmap getBitmapIndex(BitmapIndexSelector selector)
+      {
+        throw new IllegalStateException("should not be called");
+      }
+
+      @Override
+      public ValueMatcher makeMatcher(ValueMatcherFactory factory)
+      {
+        return factory.makeExpressionMatcher(expression);
+      }
+
+      @Override
+      public boolean supportsBitmapIndex(BitmapIndexSelector selector)
+      {
+        return false;
+      }
+
+      @Override
+      public String toString()
+      {
+        return ExpressionFilter.this.toString();
+      }
+    };
+  }
+
+  @Override
+  public RangeSet<String> getDimensionRangeSet(String dimension)
+  {
+    return null;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "ExpressionFilter{" +
+           "expression='" + expression + '\'' +
+           '}';
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return expression.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ExpressionFilter that = (ExpressionFilter) o;
+
+    if (!expression.equals(that.expression)) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/processing/src/main/java/io/druid/query/filter/ValueMatcherFactory.java
+++ b/processing/src/main/java/io/druid/query/filter/ValueMatcherFactory.java
@@ -60,4 +60,14 @@ public interface ValueMatcherFactory
    * @return An object that applies a predicate to row values
    */
   public ValueMatcher makeValueMatcher(String dimension, DruidPredicateFactory predicateFactory);
+
+  /**
+   * Create a ValueMatcher that applies expression to row values.
+   *
+   * The matcher returned does not use any type of index to evaluate result.
+   *
+   * @param expression
+   * @return
+   */
+  public ValueMatcher makeExpressionMatcher(String expression);
 }

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -777,7 +777,7 @@ public class RowBasedGrouperHelper
     }
 
     @Override
-    public NumericColumnSelector makeMathExpressionSelector(String expression)
+    public NumericColumnSelector makeExpressionSelector(String expression)
     {
       final Expr parsed = Parser.parse(expression);
 

--- a/processing/src/main/java/io/druid/segment/ColumnSelectorFactory.java
+++ b/processing/src/main/java/io/druid/segment/ColumnSelectorFactory.java
@@ -31,6 +31,6 @@ public interface ColumnSelectorFactory
   public FloatColumnSelector makeFloatColumnSelector(String columnName);
   public LongColumnSelector makeLongColumnSelector(String columnName);
   public ObjectColumnSelector makeObjectColumnSelector(String columnName);
-  public NumericColumnSelector makeMathExpressionSelector(String expression);
+  public NumericColumnSelector makeExpressionSelector(String expression);
   public ColumnCapabilities getColumnCapabilities(String columnName);
 }

--- a/processing/src/main/java/io/druid/segment/DimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/DimensionIndexer.java
@@ -275,6 +275,9 @@ public interface DimensionIndexer<EncodedType extends Comparable<EncodedType>, E
    */
   public Object convertUnsortedEncodedArrayToActualArrayOrList(EncodedTypeArray key, boolean asList);
 
+  public ActualType convertUnsortedEncodedArrayToActualValue(EncodedTypeArray key, int index);
+
+  public int getLengthOfUnsortedEncodedArray(EncodedTypeArray key);
 
   /**
    * Given a row value array from a TimeAndDims key, as described in the documentation for compareUnsortedEncodedArrays(),

--- a/processing/src/main/java/io/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/StringDimensionIndexer.java
@@ -511,6 +511,21 @@ public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], 
   }
 
   @Override
+  public String convertUnsortedEncodedArrayToActualValue(int[] key, int index)
+  {
+    if (key == null || key.length <= index) {
+      return null;
+    }
+    return getActualValue(key[index], false);
+  }
+
+  @Override
+  public int getLengthOfUnsortedEncodedArray(int[] key)
+  {
+    return key.length;
+  }
+
+  @Override
   public int[] convertUnsortedEncodedArrayToSortedEncodedArray(int[] key)
   {
     int[] sortedDimVals = new int[key.length];

--- a/processing/src/main/java/io/druid/segment/column/ValueType.java
+++ b/processing/src/main/java/io/druid/segment/column/ValueType.java
@@ -19,14 +19,42 @@
 
 package io.druid.segment.column;
 
+import io.druid.data.input.impl.DimensionSchema;
+
 /**
-*/
+ */
 public enum ValueType
 {
-  FLOAT,
-  LONG,
-  STRING,
-  COMPLEX;
+  FLOAT {
+    @Override
+    public DimensionSchema.ValueType asDimensionType()
+    {
+      return DimensionSchema.ValueType.STRING;
+    }
+  },
+  LONG {
+    @Override
+    public DimensionSchema.ValueType asDimensionType()
+    {
+      return DimensionSchema.ValueType.LONG;
+    }
+  },
+  STRING {
+    @Override
+    public DimensionSchema.ValueType asDimensionType()
+    {
+      return DimensionSchema.ValueType.STRING;
+    }
+  },
+  COMPLEX {
+    @Override
+    public DimensionSchema.ValueType asDimensionType()
+    {
+      return DimensionSchema.ValueType.COMPLEX;
+    }
+  };
+
+  public abstract DimensionSchema.ValueType asDimensionType();
 
   public static ValueType typeFor(Class clazz)
   {

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -295,7 +295,7 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
       }
 
       @Override
-      public NumericColumnSelector makeMathExpressionSelector(String expression)
+      public NumericColumnSelector makeExpressionSelector(String expression)
       {
         final Expr parsed = Parser.parse(expression);
 
@@ -671,6 +671,11 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
     synchronized (dimensionDescs) {
       return dimensionDescs.get(dimension);
     }
+  }
+
+  public MetricDesc getMetric(String metric)
+  {
+    return metricDescs.get(metric);
   }
 
   public String getMetricType(String metric)

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
@@ -22,18 +22,22 @@ package io.druid.segment.incremental;
 import com.google.common.base.Function;
 import com.google.common.base.Strings;
 import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import io.druid.data.input.impl.DimensionSchema;
 import io.druid.granularity.QueryGranularity;
+import io.druid.math.expr.Evals;
 import io.druid.math.expr.Expr;
 import io.druid.math.expr.Parser;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.QueryInterruptedException;
 import io.druid.query.dimension.DefaultDimensionSpec;
+import io.druid.query.aggregation.AggregatorUtil;
 import io.druid.query.dimension.DimensionSpec;
 import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.filter.DruidLongPredicate;
@@ -562,7 +566,7 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
               }
 
               @Override
-              public NumericColumnSelector makeMathExpressionSelector(String expression)
+              public NumericColumnSelector makeExpressionSelector(String expression)
               {
                 final Expr parsed = Parser.parse(expression);
 
@@ -722,6 +726,77 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
     {
       ColumnCapabilities capabilities = index.getCapabilities(dimension);
       return capabilities == null ? ValueType.STRING : capabilities.getType();
+    }
+
+    @Override
+    public ValueMatcher makeExpressionMatcher(String expression)
+    {
+      final Expr parsed = Parser.parse(expression);
+
+      final Map<String, Supplier<Number>> values = Maps.newHashMap();
+      for (String column : Parser.findRequiredBindings(parsed)) {
+        IncrementalIndex.DimensionDesc dimensionDesc = index.getDimension(column);
+        if (dimensionDesc != null) {
+          if (dimensionDesc.getCapabilities().hasMultipleValues()) {
+            throw new IllegalArgumentException("multi-valued dimension");
+          }
+          final int dimIndex = dimensionDesc.getIndex();
+          final DimensionIndexer indexer = dimensionDesc.getIndexer();
+          final Supplier<Comparable> supplier = new Supplier<Comparable>()
+          {
+            @Override
+            public Comparable get()
+            {
+              final Object[] dims = holder.getKey().getDims();
+              if (dimIndex < dims.length && dims[dimIndex] != null &&
+                  indexer.getLengthOfUnsortedEncodedArray(dims[dimIndex]) == 1) {
+                return indexer.convertUnsortedEncodedArrayToActualValue(dims[dimIndex], 0);
+              }
+              return null;
+            }
+          };
+          DimensionSchema.ValueType type = dimensionDesc.getCapabilities().getType().asDimensionType();
+          values.put(column, Suppliers.compose(Evals.asNumberFunc(type), supplier));
+          continue;
+        }
+        IncrementalIndex.MetricDesc metricDesc = index.getMetric(column);
+        if (metricDesc != null) {
+          final int metricIndex = metricDesc.getIndex();
+          final ValueType type = ValueType.valueOf(metricDesc.getType().toUpperCase());
+          if (type == ValueType.FLOAT) {
+            final FloatColumnSelector selector = new FloatColumnSelector()
+            {
+              @Override
+              public float get()
+              {
+                return index.getMetricFloatValue(holder.getValue(), metricIndex);
+              }
+            };
+            values.put(column, AggregatorUtil.asSupplier(selector));
+          } else if (type == ValueType.LONG) {
+            final LongColumnSelector selector = new LongColumnSelector()
+            {
+              @Override
+              public long get()
+              {
+                return index.getMetricLongValue(holder.getValue(), metricIndex);
+              }
+            };
+            values.put(column, AggregatorUtil.asSupplier(selector));
+          } else {
+            throw new UnsupportedOperationException("Unsupported type " + type);
+          }
+        }
+      }
+
+      final Expr.ObjectBinding binding = Parser.withSuppliers(values);
+      return new ValueMatcher() {
+        @Override
+        public boolean matches()
+        {
+          return parsed.eval(binding).asBoolean();
+        }
+      };
     }
   }
 

--- a/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -410,9 +410,9 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
     }
 
     @Override
-    public NumericColumnSelector makeMathExpressionSelector(String expression)
+    public NumericColumnSelector makeExpressionSelector(String expression)
     {
-      return delegate.makeMathExpressionSelector(expression);
+      return delegate.makeExpressionSelector(expression);
     }
   }
 

--- a/processing/src/test/java/io/druid/query/aggregation/FilteredAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/FilteredAggregatorTest.java
@@ -185,7 +185,7 @@ public class FilteredAggregatorTest
       }
 
       @Override
-      public NumericColumnSelector makeMathExpressionSelector(String expression)
+      public NumericColumnSelector makeExpressionSelector(String expression)
       {
         throw new UnsupportedOperationException();
       }

--- a/processing/src/test/java/io/druid/query/aggregation/JavaScriptAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/JavaScriptAggregatorTest.java
@@ -79,7 +79,7 @@ public class JavaScriptAggregatorTest
     }
 
     @Override
-    public NumericColumnSelector makeMathExpressionSelector(String expression)
+    public NumericColumnSelector makeExpressionSelector(String expression)
     {
       return null;
     }

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -82,6 +82,7 @@ import io.druid.query.extraction.TimeFormatExtractionFn;
 import io.druid.query.filter.AndDimFilter;
 import io.druid.query.filter.BoundDimFilter;
 import io.druid.query.filter.DimFilter;
+import io.druid.query.filter.ExpressionFilter;
 import io.druid.query.filter.ExtractionDimFilter;
 import io.druid.query.filter.InDimFilter;
 import io.druid.query.filter.JavaScriptDimFilter;
@@ -3946,6 +3947,16 @@ public class GroupByQueryRunnerTest
     // Subqueries are handled by the ToolChest
     Iterable<Row> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);
     TestHelper.assertExpectedObjects(expectedResults, results, "");
+
+    expectedResults = Arrays.asList(
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-01", "alias", "a", "rows", 6L, "idx", 771L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "alias", "a", "rows", 6L, "idx", 778L)
+    );
+
+    query = query.withDimFilter(new ExpressionFilter("idx > 100 && idx < 200"));
+    TestHelper.assertExpectedObjects(
+        expectedResults, GroupByQueryRunnerTestHelper.runQuery(factory, runner, query), ""
+    );
   }
 
   @Test

--- a/processing/src/test/java/io/druid/query/groupby/epinephelinae/TestColumnSelectorFactory.java
+++ b/processing/src/test/java/io/druid/query/groupby/epinephelinae/TestColumnSelectorFactory.java
@@ -90,7 +90,7 @@ public class TestColumnSelectorFactory implements ColumnSelectorFactory
   }
 
   @Override
-  public NumericColumnSelector makeMathExpressionSelector(String expression)
+  public NumericColumnSelector makeExpressionSelector(String expression)
   {
     throw new UnsupportedOperationException("expression is not supported in current context");
   }

--- a/processing/src/test/java/io/druid/query/search/SearchQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/search/SearchQueryRunnerTest.java
@@ -33,6 +33,7 @@ import io.druid.query.dimension.ExtractionDimensionSpec;
 import io.druid.query.extraction.MapLookupExtractor;
 import io.druid.query.filter.AndDimFilter;
 import io.druid.query.filter.DimFilter;
+import io.druid.query.filter.ExpressionFilter;
 import io.druid.query.filter.ExtractionDimFilter;
 import io.druid.query.filter.SelectorDimFilter;
 import io.druid.query.lookup.LookupExtractionFn;
@@ -128,6 +129,17 @@ public class SearchQueryRunnerTest
     expectedHits.add(new SearchHit(QueryRunnerTestHelper.marketDimension, "total_market", 186));
     expectedHits.add(new SearchHit(QueryRunnerTestHelper.placementishDimension, "a", 93));
     expectedHits.add(new SearchHit(QueryRunnerTestHelper.partialNullDimension, "value", 186));
+
+    checkSearchQuery(searchQuery, expectedHits);
+
+    searchQuery = searchQuery.withDimFilter(new ExpressionFilter("index < 100"));
+
+    expectedHits = Lists.newLinkedList();
+    expectedHits.add(new SearchHit(QueryRunnerTestHelper.placementishDimension, "a", 14));
+    expectedHits.add(new SearchHit(QueryRunnerTestHelper.qualityDimension, "automotive", 14));
+    expectedHits.add(new SearchHit(QueryRunnerTestHelper.qualityDimension, "entertainment", 12));
+    expectedHits.add(new SearchHit(QueryRunnerTestHelper.qualityDimension, "health", 24));
+    expectedHits.add(new SearchHit(QueryRunnerTestHelper.qualityDimension, "mezzanine", 23));
 
     checkSearchQuery(searchQuery, expectedHits);
   }


### PR DESCRIPTION
Reopen of #3005 

This patch introduces `expression` type dimension filter, which can reference metrics (and calculations) to decide whether to include the row. Some query types like search query that requires bitmap index will be fall-back to cursor based processing.

If there is a metric `index` in a datasource and user want to query data of which `index` value is between 100 and 200,
`"filter" : {"expression": "index > 100 && index < 200"}`
will make it done.