### PR TITLE
Update Apache curator to a non-leaky version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     </scm>
 
     <properties>
-        <apache.curator.version>2.11.0</apache.curator.version>
+        <apache.curator.version>2.11.1</apache.curator.version>
         <guava.version>16.0.1</guava.version>
         <guice.version>4.1.0</guice.version>
         <jetty.version>9.2.5.v20141112</jetty.version>


### PR DESCRIPTION
Apache Curator before 2.11.1 suffers from a native memory leak in `GzipCompressionProvider` that is used by `io.druid.curator.PotentiallyGzippedCompressionProvider`.

When a lot of segments are loaded and uncompressed at once, this may lead to exhausting all the physical memory on the machine and crashing the JVM running the druid node or triggering the OOM killer.

See also:
* https://issues.apache.org/jira/browse/CURATOR-354
* https://github.com/apache/curator/pull/168