### PR TITLE
Enable parallel test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk:
   - oraclejdk8
 
 script:
-  - mvn test -B && mvn clean -Pstrict compile test-compile -B
+  - mvn test -B -Pparallel-test -Dmaven.fork.count=2 && mvn clean -Pstrict compile test-compile -B
 
 sudo: false
 

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -159,7 +159,6 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.17</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/bytebuffer-collections/pom.xml
+++ b/bytebuffer-collections/pom.xml
@@ -112,7 +112,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.18.1</version>
         <configuration>
           <excludedGroups>io.druid.test.annotation.Benchmark</excludedGroups>
         </configuration>

--- a/common/src/main/java/io/druid/common/utils/SocketUtil.java
+++ b/common/src/main/java/io/druid/common/utils/SocketUtil.java
@@ -21,6 +21,7 @@ package io.druid.common.utils;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.util.Random;
 
 import io.druid.java.util.common.ISE;
 
@@ -28,8 +29,12 @@ import io.druid.java.util.common.ISE;
  */
 public class SocketUtil
 {
-  public static int findOpenPort(int startPort)
+
+  private static final Random rnd = new Random(System.currentTimeMillis());
+
+  public static int findOpenPort(int basePort)
   {
+    final int startPort = rnd.nextInt(0xffff / 2) + basePort;
     int currPort = startPort;
 
     while (currPort < 0xffff) {
@@ -53,6 +58,6 @@ public class SocketUtil
       }
     }
 
-    throw new ISE("Unable to find open port between[%d] and [%d]", startPort, currPort);
+    throw new ISE("Unable to find open port between [%d] and [%d]", startPort, currPort);
   }
 }

--- a/common/src/main/java/io/druid/common/utils/SocketUtil.java
+++ b/common/src/main/java/io/druid/common/utils/SocketUtil.java
@@ -34,7 +34,11 @@ public class SocketUtil
 
   public static int findOpenPort(int basePort)
   {
-    final int startPort = rnd.nextInt(0xffff / 2) + basePort;
+    final int startPort = basePort == -1 ? -1 : rnd.nextInt(0x7fff) + basePort;
+    return findOpenPortFrom(startPort);
+  }
+
+  public static int findOpenPortFrom(int startPort) {
     int currPort = startPort;
 
     while (currPort < 0xffff) {

--- a/common/src/main/java/io/druid/common/utils/SocketUtil.java
+++ b/common/src/main/java/io/druid/common/utils/SocketUtil.java
@@ -34,7 +34,7 @@ public class SocketUtil
 
   public static int findOpenPort(int basePort)
   {
-    final int startPort = basePort == -1 ? -1 : rnd.nextInt(0x7fff) + basePort;
+    final int startPort = basePort < 0 ? -1 : rnd.nextInt(0x7fff) + basePort;
     return findOpenPortFrom(startPort);
   }
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -133,25 +133,25 @@
                 </configuration>
             </plugin>
             <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-jar-plugin</artifactId>
-              <configuration>
-		<archive>
-                  <manifest>
-                    <mainClass>org.testng.TestNG</mainClass>
-                  </manifest>
-		</archive>
-              </configuration>
-              <executions> 
-		<execution> 
-                  <id>test-jar</id>
-                  <phase>package</phase> 
-                  <goals> 
-                    <goal>test-jar</goal> 
-                  </goals>
-		</execution> 
-              </executions>
-	    </plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>org.testng.TestNG</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>test-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -729,11 +729,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.19.1</version>
                     <configuration>
                         <!-- locale settings must be set on the command line before startup -->
                         <!-- set heap size to work around https://github.com/travis-ci/travis-ci/issues/3396 -->
                         <argLine>-Xmx1024m -Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8
-                            -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
+                            -Duser.timezone=UTC -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
                         </argLine>
                         <!-- our tests are very verbose, let's keep the volume down -->
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
@@ -894,6 +895,41 @@
                 <!-- distribution packaging -->
                 <module>distribution</module>
             </modules>
+        </profile>
+
+        <profile>
+            <id>parallel-test</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration combine.self="override">
+                            <forkCount>${maven.fork.count}</forkCount>
+                            <reuseForks>true</reuseForks>
+                            <trimStackTrace>false</trimStackTrace>
+                            <!-- locale settings must be set on the command line before startup -->
+                            <!-- set heap size to work around https://github.com/travis-ci/travis-ci/issues/3396 -->
+                            <argLine>-Xmx1024m -Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8
+                                -Duser.timezone=UTC -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
+                            </argLine>
+                            <!-- our tests are very verbose, let's keep the volume down -->
+                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/server/src/test/java/io/druid/server/AsyncQueryForwardingServletTest.java
+++ b/server/src/test/java/io/druid/server/AsyncQueryForwardingServletTest.java
@@ -84,8 +84,8 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
     Injector injector = setupInjector();
     final DruidNode node = injector.getInstance(Key.get(DruidNode.class, Self.class));
     port = node.getPort();
-    port1 = SocketUtil.findOpenPort(port + 1);
-    port2 = SocketUtil.findOpenPort(port1 + 1);
+    port1 = SocketUtil.findOpenPortFrom(port + 1);
+    port2 = SocketUtil.findOpenPortFrom(port1 + 1);
 
     lifecycle = injector.getInstance(Lifecycle.class);
     lifecycle.start();

--- a/server/src/test/java/io/druid/server/initialization/JettyQosTest.java
+++ b/server/src/test/java/io/druid/server/initialization/JettyQosTest.java
@@ -43,7 +43,6 @@ import io.druid.initialization.Initialization;
 import io.druid.server.DruidNode;
 import io.druid.server.initialization.jetty.JettyBindings;
 import io.druid.server.initialization.jetty.JettyServerInitializer;
-import net.jcip.annotations.NotThreadSafe;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.jboss.netty.handler.codec.http.HttpMethod;
@@ -56,7 +55,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
 
-@NotThreadSafe
 public class JettyQosTest extends BaseJettyTest
 {
   @Override

--- a/server/src/test/java/io/druid/server/initialization/JettyQosTest.java
+++ b/server/src/test/java/io/druid/server/initialization/JettyQosTest.java
@@ -43,6 +43,7 @@ import io.druid.initialization.Initialization;
 import io.druid.server.DruidNode;
 import io.druid.server.initialization.jetty.JettyBindings;
 import io.druid.server.initialization.jetty.JettyServerInitializer;
+import net.jcip.annotations.NotThreadSafe;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.jboss.netty.handler.codec.http.HttpMethod;
@@ -55,6 +56,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
 
+@NotThreadSafe
 public class JettyQosTest extends BaseJettyTest
 {
   @Override


### PR DESCRIPTION
Here is the comparison of testing time.

*Sequential test*
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] io.druid:druid ..................................... SUCCESS [  4.468 s]
[INFO] java-util .......................................... SUCCESS [ 12.232 s]
[INFO] druid-api .......................................... SUCCESS [  4.750 s]
[INFO] druid-common ....................................... SUCCESS [  8.116 s]
[INFO] bytebuffer-collections ............................. SUCCESS [  3.654 s]
[INFO] druid-processing ................................... SUCCESS [05:36 min]
[INFO] druid-aws-common ................................... SUCCESS [  0.478 s]
[INFO] druid-server ....................................... SUCCESS [02:44 min]
[INFO] druid-examples ..................................... SUCCESS [  0.488 s]
[INFO] druid-indexing-hadoop .............................. SUCCESS [01:19 min]
[INFO] druid-indexing-service ............................. SUCCESS [01:40 min]
[INFO] druid-services ..................................... SUCCESS [  7.252 s]
[INFO] druid-s3-extensions ................................ SUCCESS [  3.767 s]
[INFO] druid-datasketches ................................. SUCCESS [03:12 min]
[INFO] druid-kafka-eight .................................. SUCCESS [  0.168 s]
[INFO] druid-histogram .................................... SUCCESS [  7.000 s]
[INFO] mysql-metadata-storage ............................. SUCCESS [  0.417 s]
[INFO] druid-kafka-indexing-service ....................... SUCCESS [07:31 min]
[INFO] druid-integration-tests ............................ SUCCESS [  1.922 s]
[INFO] druid-benchmarks ................................... SUCCESS [  5.773 s]
[INFO] druid-avro-extensions .............................. SUCCESS [  7.252 s]
[INFO] druid-hdfs-storage ................................. SUCCESS [  8.468 s]
[INFO] druid-stats ........................................ SUCCESS [  6.449 s]
[INFO] druid-lookups-cached-global ........................ SUCCESS [ 46.248 s]
[INFO] druid-kafka-extraction-namespace ................... SUCCESS [  8.839 s]
[INFO] postgresql-metadata-storage ........................ SUCCESS [  1.423 s]
[INFO] druid-lookups-cached-single ........................ SUCCESS [ 11.649 s]
[INFO] druid-azure-extensions ............................. SUCCESS [  2.771 s]
[INFO] druid-cassandra-storage ............................ SUCCESS [  0.312 s]
[INFO] druid-rocketmq ..................................... SUCCESS [  0.317 s]
[INFO] druid-cloudfiles-extensions ........................ SUCCESS [  2.487 s]
[INFO] graphite-emitter ................................... SUCCESS [  2.338 s]
[INFO] druid-kafka-eight-simple-consumer .................. SUCCESS [  0.199 s]
[INFO] druid-rabbitmq ..................................... SUCCESS [  3.102 s]
[INFO] druid-distinctcount ................................ SUCCESS [  2.392 s]
[INFO] druid-parquet-extensions ........................... SUCCESS [  6.997 s]
[INFO] statsd-emitter ..................................... SUCCESS [  2.025 s]
[INFO] druid-orc-extensions ............................... SUCCESS [ 12.209 s]
[INFO] druid-time-min-max ................................. SUCCESS [  8.253 s]
[INFO] druid-google-extensions ............................ SUCCESS [  2.269 s]
[INFO] druid-virtual-columns .............................. SUCCESS [  2.522 s]
[INFO] druid-caffeine-cache ............................... SUCCESS [  5.903 s]
[INFO] distribution ....................................... SUCCESS [  0.126 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 25:32 min
[INFO] Finished at: 2016-12-13T09:39:05+09:00
[INFO] Final Memory: 213M/1506M
[INFO] ------------------------------------------------------------------------
```

*Parallel test*
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] io.druid:druid ..................................... SUCCESS [  0.959 s]
[INFO] java-util .......................................... SUCCESS [  4.915 s]
[INFO] druid-api .......................................... SUCCESS [  2.312 s]
[INFO] druid-common ....................................... SUCCESS [  4.908 s]
[INFO] bytebuffer-collections ............................. SUCCESS [  1.739 s]
[INFO] druid-processing ................................... SUCCESS [02:33 min]
[INFO] druid-aws-common ................................... SUCCESS [  0.170 s]
[INFO] druid-server ....................................... SUCCESS [01:15 min]
[INFO] druid-examples ..................................... SUCCESS [  0.145 s]
[INFO] druid-indexing-hadoop .............................. SUCCESS [ 46.378 s]
[INFO] druid-indexing-service ............................. SUCCESS [ 51.878 s]
[INFO] druid-services ..................................... SUCCESS [  4.272 s]
[INFO] druid-s3-extensions ................................ SUCCESS [  2.834 s]
[INFO] druid-datasketches ................................. SUCCESS [01:36 min]
[INFO] druid-kafka-eight .................................. SUCCESS [  0.072 s]
[INFO] druid-histogram .................................... SUCCESS [  5.494 s]
[INFO] mysql-metadata-storage ............................. SUCCESS [  0.136 s]
[INFO] druid-kafka-indexing-service ....................... SUCCESS [03:33 min]
[INFO] druid-integration-tests ............................ SUCCESS [  3.199 s]
[INFO] druid-benchmarks ................................... SUCCESS [  2.160 s]
[INFO] druid-avro-extensions .............................. SUCCESS [  4.334 s]
[INFO] druid-hdfs-storage ................................. SUCCESS [  5.311 s]
[INFO] druid-stats ........................................ SUCCESS [  3.624 s]
[INFO] druid-lookups-cached-global ........................ SUCCESS [ 29.681 s]
[INFO] druid-kafka-extraction-namespace ................... SUCCESS [  6.016 s]
[INFO] postgresql-metadata-storage ........................ SUCCESS [  0.882 s]
[INFO] druid-lookups-cached-single ........................ SUCCESS [  6.526 s]
[INFO] druid-azure-extensions ............................. SUCCESS [  1.372 s]
[INFO] druid-cassandra-storage ............................ SUCCESS [  0.085 s]
[INFO] druid-rocketmq ..................................... SUCCESS [  0.064 s]
[INFO] druid-cloudfiles-extensions ........................ SUCCESS [  1.375 s]
[INFO] graphite-emitter ................................... SUCCESS [  1.318 s]
[INFO] druid-kafka-eight-simple-consumer .................. SUCCESS [  0.061 s]
[INFO] druid-rabbitmq ..................................... SUCCESS [  0.977 s]
[INFO] druid-distinctcount ................................ SUCCESS [  1.292 s]
[INFO] druid-parquet-extensions ........................... SUCCESS [  3.193 s]
[INFO] statsd-emitter ..................................... SUCCESS [  0.981 s]
[INFO] druid-orc-extensions ............................... SUCCESS [  6.955 s]
[INFO] druid-time-min-max ................................. SUCCESS [  3.774 s]
[INFO] druid-google-extensions ............................ SUCCESS [  1.357 s]
[INFO] druid-virtual-columns .............................. SUCCESS [  1.421 s]
[INFO] druid-caffeine-cache ............................... SUCCESS [  2.928 s]
[INFO] distribution ....................................... SUCCESS [  0.070 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 12:34 min
[INFO] Finished at: 2016-12-14T10:08:09+09:00
[INFO] Final Memory: 89M/1536M
[INFO] ------------------------------------------------------------------------
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/druid-io/druid/3774)
<!-- Reviewable:end -->
