### PR TITLE
FIX: HadoopFsWrapper not compatible with hadoop 2.7.1 if compile with hadoop 2.3.0

### DIFF
--- a/extensions-core/hdfs-storage/src/main/java/org/apache/hadoop/fs/HadoopFsWrapper.java
+++ b/extensions-core/hdfs-storage/src/main/java/org/apache/hadoop/fs/HadoopFsWrapper.java
@@ -22,6 +22,7 @@ package org.apache.hadoop.fs;
 import io.druid.java.util.common.logger.Logger;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 
 /**
  * This wrapper class is created to be able to access some of the the "protected" methods inside Hadoop's
@@ -48,10 +49,11 @@ public class HadoopFsWrapper
   public static boolean rename(FileSystem fs, Path from, Path to) throws IOException
   {
     try {
-      fs.rename(from, to, Options.Rename.NONE);
+      Method renameMethod = fs.getClass().getMethod("rename", Path.class, Path.class, Options.Rename[].class);
+      renameMethod.invoke(fs, from, to, new Options.Rename[]{Options.Rename.NONE});
       return true;
     }
-    catch (IOException ex) {
+    catch (Exception ex) {
       log.warn(ex, "Failed to rename [%s] to [%s].", from, to);
       return false;
     }


### PR DESCRIPTION
I worked around #3786 this problem by invoking `rename` by reflection.
Its a temporary way, and I am not sure, if this way suitable to be merged into druid/master.