### PR TITLE
fix MetadataStorage binding so that it is always Noop except for coordinator iff derby is configured

### DIFF
--- a/server/src/main/java/io/druid/guice/SQLMetadataStorageDruidModule.java
+++ b/server/src/main/java/io/druid/guice/SQLMetadataStorageDruidModule.java
@@ -33,7 +33,6 @@ import io.druid.metadata.MetadataSegmentManager;
 import io.druid.metadata.MetadataSegmentManagerProvider;
 import io.druid.metadata.MetadataSegmentPublisher;
 import io.druid.metadata.MetadataSegmentPublisherProvider;
-import io.druid.metadata.MetadataStorage;
 import io.druid.metadata.MetadataStorageActionHandlerFactory;
 import io.druid.metadata.MetadataStorageConnector;
 import io.druid.metadata.MetadataStorageProvider;
@@ -171,8 +170,6 @@ public class SQLMetadataStorageDruidModule implements Module
   @Override
   public void configure(Binder binder)
   {
-    binder.bind(MetadataStorage.class).toProvider(NoopMetadataStorageProvider.class);
-
     PolyBind.optionBinder(binder, Key.get(MetadataSegmentManager.class))
             .addBinding(type)
             .to(SQLMetadataSegmentManager.class)

--- a/server/src/main/java/io/druid/metadata/storage/derby/DerbyConnector.java
+++ b/server/src/main/java/io/druid/metadata/storage/derby/DerbyConnector.java
@@ -56,7 +56,7 @@ public class DerbyConnector extends SQLMetadataConnector
 
     this.dbi = new DBI(datasource);
     this.storage = storage;
-    log.info("Configured Derby as metadata storage");
+    log.info("Derby connector instantiated with metadata storage [%s].", this.storage.getClass().getName());
   }
 
   public DerbyConnector(
@@ -102,12 +102,14 @@ public class DerbyConnector extends SQLMetadataConnector
   @LifecycleStart
   public void start()
   {
+    log.info("Starting DerbyConnector...");
     storage.start();
   }
 
   @LifecycleStop
   public void stop()
   {
+    log.info("Stopping DerbyConnector...");
     storage.stop();
   }
 }

--- a/server/src/main/java/io/druid/metadata/storage/derby/DerbyMetadataStorageDruidModule.java
+++ b/server/src/main/java/io/druid/metadata/storage/derby/DerbyMetadataStorageDruidModule.java
@@ -24,8 +24,10 @@ import com.google.inject.Key;
 import io.druid.guice.LazySingleton;
 import io.druid.guice.PolyBind;
 import io.druid.guice.SQLMetadataStorageDruidModule;
+import io.druid.metadata.MetadataStorage;
 import io.druid.metadata.MetadataStorageConnector;
 import io.druid.metadata.MetadataStorageProvider;
+import io.druid.metadata.NoopMetadataStorageProvider;
 import io.druid.metadata.SQLMetadataConnector;
 
 public class DerbyMetadataStorageDruidModule extends SQLMetadataStorageDruidModule
@@ -42,6 +44,8 @@ public class DerbyMetadataStorageDruidModule extends SQLMetadataStorageDruidModu
   {
     createBindingChoices(binder, TYPE);
     super.configure(binder);
+
+    binder.bind(MetadataStorage.class).toProvider(NoopMetadataStorageProvider.class);
 
     PolyBind.optionBinder(binder, Key.get(MetadataStorageProvider.class))
             .addBinding(TYPE)


### PR DESCRIPTION
a regression from #3700

currently derby works fine as long as other metadata storage modules (mysql, postgres etc) are not loaded which always bind the MetadataStorage to Noop implementation even when derby is configured in the properties. this patch fixes that.

After this patch, DerbyStorage module binds MetadataStorage to Noop which is only overridden by CliCoordinator to bind to configured metadata storage.