### PR TITLE
Allow users to specify additional command line args for creating druid package

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -39,6 +39,9 @@
             <version>${project.parent.version}</version>
         </dependency>
     </dependencies>
+    <properties>
+        <druid.distribution.pulldeps.opts></druid.distribution.pulldeps.opts>
+    </properties>
 
     <build>
         <plugins>
@@ -100,6 +103,7 @@
                                 <argument>io.druid.extensions:mysql-metadata-storage</argument>
                                 <argument>-c</argument>
                                 <argument>io.druid.extensions:postgresql-metadata-storage</argument>
+                                <argument>${druid.distribution.pulldeps.opts}</argument>
                             </arguments>
                         </configuration>
                     </execution>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -40,7 +40,8 @@
         </dependency>
     </dependencies>
     <properties>
-        <druid.distribution.pulldeps.opts></druid.distribution.pulldeps.opts>
+        <!-- the default value is a repeated flag from the command line, since blank value is not allowed -->
+        <druid.distribution.pulldeps.opts>--clean</druid.distribution.pulldeps.opts>
     </properties>
 
     <build>

--- a/services/src/main/java/io/druid/cli/PullDependencies.java
+++ b/services/src/main/java/io/druid/cli/PullDependencies.java
@@ -241,7 +241,8 @@ public class PullDependencies implements Runnable
 
     try {
       log.info("Start downloading dependencies for extension coordinates: [%s]", coordinates);
-      for (final String coordinate : coordinates) {
+      for (String coordinate : coordinates) {
+        coordinate = coordinate.trim();
         final Artifact versionedArtifact = getArtifact(coordinate);
 
         File currExtensionDir = new File(extensionsDir, versionedArtifact.getArtifactId());


### PR DESCRIPTION
This PR allows users to specify additional command line options to the
pull deps command while creating druid distribution.
e.g. To also package graphite-emitter in druid tarball one can run -
```
mvn package -Ddruid.distribution.pulldeps.opts='-c io.druid.extensions.contrib:graphite-emitter'
```

This also trims any additional whitespace in the coordinate string if any.  