### PR TITLE
Ignore DimFilterHavingSpec testConcurrentUsage.

### DIFF
--- a/processing/src/test/java/io/druid/query/groupby/having/DimFilterHavingSpecTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/having/DimFilterHavingSpecTest.java
@@ -27,6 +27,7 @@ import io.druid.query.filter.SelectorDimFilter;
 import io.druid.segment.column.ValueType;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.internal.matchers.ThrowableMessageMatcher;
@@ -65,6 +66,7 @@ public class DimFilterHavingSpecTest
   }
 
   @Test(timeout = 60_000L)
+  @Ignore // Doesn't always pass. The check in "eval" is best effort and not guaranteed to detect concurrent usage.
   public void testConcurrentUsage() throws Exception
   {
     final ExecutorService exec = Executors.newFixedThreadPool(2);


### PR DESCRIPTION
#3797 added a new test that doesn't always pass, presumably because it's testing best-effort behavior that doesn't always occur. This patch disables the test.

Meant to fix travis failures like https://travis-ci.org/druid-io/druid/jobs/188683957.