### PR TITLE
log sizes of created smoosh files

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
@@ -695,8 +695,15 @@ public class IndexGeneratorJob implements Jobby
           for (File file : toMerge) {
             indexes.add(HadoopDruidIndexerConfig.INDEX_IO.loadIndex(file));
           }
+
+          log.info("starting merge of intermediate persisted segments.");
+          long mergeStartTime = System.currentTimeMillis();
           mergedBase = mergeQueryableIndex(
               indexes, aggregators, new File(baseFlushFile, "merged"), progressIndicator
+          );
+          log.info(
+              "finished merge of intermediate persisted segments. time taken [%d] ms.",
+              (System.currentTimeMillis() - mergeStartTime)
           );
         }
         final FileSystem outputFS = new Path(config.getSchema().getIOConfig().getSegmentOutputPath())


### PR DESCRIPTION
just adding logs to primarily understand impact of changing maxRowsInMemory setting during batch ingestion on size of intermediate segments created.