### PR TITLE
disable javascript execution by default

### DIFF
--- a/api/src/main/java/io/druid/data/input/impl/JavaScriptParseSpec.java
+++ b/api/src/main/java/io/druid/data/input/impl/JavaScriptParseSpec.java
@@ -65,7 +65,7 @@ public class JavaScriptParseSpec extends ParseSpec
   @Override
   public Parser<String, Object> makeParser()
   {
-    if (config.isDisabled()) {
+    if (!config.isEnabled()) {
       throw new ISE("JavaScript is disabled");
     }
 

--- a/api/src/main/java/io/druid/js/JavaScriptConfig.java
+++ b/api/src/main/java/io/druid/js/JavaScriptConfig.java
@@ -19,31 +19,31 @@
 
 package io.druid.js;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import java.util.Objects;
 
 public class JavaScriptConfig
 {
   public static final int DEFAULT_OPTIMIZATION_LEVEL = 9;
 
-  private static final JavaScriptConfig DEFAULT = new JavaScriptConfig(false);
+  private static final JavaScriptConfig ENABLED_INSTANCE = new JavaScriptConfig(true);
 
   @JsonProperty
-  private boolean disabled = false;
+  private boolean enabled = false;
 
-  public JavaScriptConfig()
+  @JsonCreator
+  public JavaScriptConfig(
+      @JsonProperty("enabled") Boolean enabled
+  )
   {
+    if (enabled != null) {
+      this.enabled = enabled.booleanValue();
+    }
   }
 
-  public JavaScriptConfig(boolean disabled)
+  public boolean isEnabled()
   {
-    this.disabled = disabled;
-  }
-
-  public boolean isDisabled()
-  {
-    return disabled;
+    return enabled;
   }
 
   @Override
@@ -55,26 +55,29 @@ public class JavaScriptConfig
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    JavaScriptConfig config = (JavaScriptConfig) o;
-    return disabled == config.disabled;
+
+    JavaScriptConfig that = (JavaScriptConfig) o;
+
+    return enabled == that.enabled;
+
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(disabled);
+    return (enabled ? 1 : 0);
   }
 
   @Override
   public String toString()
   {
     return "JavaScriptConfig{" +
-           "disabled=" + disabled +
+           "enabled=" + enabled +
            '}';
   }
 
-  public static JavaScriptConfig getDefault()
+  public static JavaScriptConfig getEnabledInstance()
   {
-    return DEFAULT;
+    return ENABLED_INSTANCE;
   }
 }

--- a/api/src/test/java/io/druid/data/input/impl/JavaScriptParseSpecTest.java
+++ b/api/src/test/java/io/druid/data/input/impl/JavaScriptParseSpecTest.java
@@ -50,14 +50,14 @@ public class JavaScriptParseSpecTest
     jsonMapper.setInjectableValues(
         new InjectableValues.Std().addValue(
             JavaScriptConfig.class,
-            JavaScriptConfig.getDefault()
+            JavaScriptConfig.getEnabledInstance()
         )
     );
     JavaScriptParseSpec spec = new JavaScriptParseSpec(
         new TimestampSpec("abc", "iso", null),
         new DimensionsSpec(DimensionsSpec.getDefaultSchemas(Arrays.asList("abc")), null, null),
         "abc",
-        JavaScriptConfig.getDefault()
+        JavaScriptConfig.getEnabledInstance()
     );
     final JavaScriptParseSpec serde = jsonMapper.readValue(
         jsonMapper.writeValueAsString(spec),
@@ -73,7 +73,7 @@ public class JavaScriptParseSpecTest
   @Test
   public void testMakeParser()
   {
-    final JavaScriptConfig config = JavaScriptConfig.getDefault();
+    final JavaScriptConfig config = JavaScriptConfig.getEnabledInstance();
     JavaScriptParseSpec spec = new JavaScriptParseSpec(
         new TimestampSpec("abc", "iso", null),
         new DimensionsSpec(DimensionsSpec.getDefaultSchemas(Arrays.asList("abc")), null, null),
@@ -89,7 +89,7 @@ public class JavaScriptParseSpecTest
   @Test
   public void testMakeParserNotAllowed()
   {
-    final JavaScriptConfig config = new JavaScriptConfig(true);
+    final JavaScriptConfig config = new JavaScriptConfig(false);
     JavaScriptParseSpec spec = new JavaScriptParseSpec(
         new TimestampSpec("abc", "iso", null),
         new DimensionsSpec(DimensionsSpec.getDefaultSchemas(Arrays.asList("abc")), null, null),

--- a/api/src/test/java/io/druid/js/JavaScriptConfigTest.java
+++ b/api/src/test/java/io/druid/js/JavaScriptConfigTest.java
@@ -25,13 +25,39 @@ import org.junit.Test;
 
 public class JavaScriptConfigTest
 {
+  private static ObjectMapper mapper = new ObjectMapper();
+
   @Test
   public void testSerde() throws Exception
   {
-    final JavaScriptConfig config = new JavaScriptConfig(true);
-    final ObjectMapper mapper = new ObjectMapper();
-    final JavaScriptConfig config2 = mapper.readValue(mapper.writeValueAsBytes(config), JavaScriptConfig.class);
-    Assert.assertTrue(config2.isDisabled());
-    Assert.assertEquals(config, config2);
+    String json = "{\"enabled\":true}";
+
+    JavaScriptConfig config = mapper.readValue(
+        mapper.writeValueAsString(
+            mapper.readValue(
+                json,
+                JavaScriptConfig.class
+            )
+        ), JavaScriptConfig.class
+    );
+
+    Assert.assertTrue(config.isEnabled());
+  }
+
+  @Test
+  public void testSerdeWithDefaults() throws Exception
+  {
+    String json = "{}";
+
+    JavaScriptConfig config = mapper.readValue(
+        mapper.writeValueAsString(
+            mapper.readValue(
+                json,
+                JavaScriptConfig.class
+            )
+        ), JavaScriptConfig.class
+    );
+
+    Assert.assertFalse(config.isEnabled());
   }
 }

--- a/benchmarks/src/main/java/io/druid/benchmark/FilterPartitionBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/FilterPartitionBenchmark.java
@@ -126,7 +126,7 @@ public class FilterPartitionBenchmark
   private BenchmarkSchemaInfo schemaInfo;
 
   private static String JS_FN = "function(str) { return 'super-' + str; }";
-  private static ExtractionFn JS_EXTRACTION_FN = new JavaScriptExtractionFn(JS_FN, false, JavaScriptConfig.getDefault());
+  private static ExtractionFn JS_EXTRACTION_FN = new JavaScriptExtractionFn(JS_FN, false, JavaScriptConfig.getEnabledInstance());
 
   static {
     JSON_MAPPER = new DefaultObjectMapper();

--- a/benchmarks/src/main/java/io/druid/benchmark/FilteredAggregatorBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/FilteredAggregatorBenchmark.java
@@ -126,7 +126,7 @@ public class FilteredAggregatorBenchmark
   private TimeseriesQuery query;
 
   private static String JS_FN = "function(str) { return 'super-' + str; }";
-  private static ExtractionFn JS_EXTRACTION_FN = new JavaScriptExtractionFn(JS_FN, false, JavaScriptConfig.getDefault());
+  private static ExtractionFn JS_EXTRACTION_FN = new JavaScriptExtractionFn(JS_FN, false, JavaScriptConfig.getEnabledInstance());
 
   static {
     JSON_MAPPER = new DefaultObjectMapper();
@@ -167,7 +167,7 @@ public class FilteredAggregatorBenchmark
     filter = new OrDimFilter(
         Arrays.asList(
             new BoundDimFilter("dimSequential", "-1", "-1", true, true, null, null, StringComparators.ALPHANUMERIC),
-            new JavaScriptDimFilter("dimSequential", "function(x) { return false }", null, JavaScriptConfig.getDefault()),
+            new JavaScriptDimFilter("dimSequential", "function(x) { return false }", null, JavaScriptConfig.getEnabledInstance()),
             new RegexDimFilter("dimSequential", "X", null),
             new SearchQueryDimFilter("dimSequential", new ContainsSearchQuerySpec("X", false), null),
             new InDimFilter("dimSequential", Arrays.asList("X"), null)

--- a/benchmarks/src/main/java/io/druid/benchmark/indexing/IncrementalIndexReadBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/indexing/IncrementalIndexReadBenchmark.java
@@ -171,7 +171,7 @@ public class IncrementalIndexReadBenchmark
     DimFilter filter = new OrDimFilter(
         Arrays.asList(
             new BoundDimFilter("dimSequential", "-1", "-1", true, true, null, null, StringComparators.ALPHANUMERIC),
-            new JavaScriptDimFilter("dimSequential", "function(x) { return false }", null, JavaScriptConfig.getDefault()),
+            new JavaScriptDimFilter("dimSequential", "function(x) { return false }", null, JavaScriptConfig.getEnabledInstance()),
             new RegexDimFilter("dimSequential", "X", null),
             new SearchQueryDimFilter("dimSequential", new ContainsSearchQuerySpec("X", false), null),
             new InDimFilter("dimSequential", Arrays.asList("X"), null)

--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -384,9 +384,8 @@ the following properties.
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.javascript.disabled`|Set to "true" to disable JavaScript functionality. This affects the JavaScript parser, filter, extractionFn, aggregator, post-aggregator, router strategy, and worker selection strategy.|false|
+|`druid.javascript.enabled`|Set to "true" to enable JavaScript functionality. This affects the JavaScript parser, filter, extractionFn, aggregator, post-aggregator, router strategy, and worker selection strategy.|false|
 
 <div class="note info">
-Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines
-about using Druid's JavaScript functionality.
+JavaScript-based functionality is disabled by default. Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines about using Druid's JavaScript functionality, including instructions on how to enable it.
 </div>

--- a/docs/content/configuration/indexing-service.md
+++ b/docs/content/configuration/indexing-service.md
@@ -257,8 +257,7 @@ Example: a function that sends batch_index_task to workers 10.0.0.1 and 10.0.0.2
 ```
 
 <div class="note info">
-Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines
-about using Druid's JavaScript functionality.
+JavaScript-based functionality is disabled by default. Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines about using Druid's JavaScript functionality, including instructions on how to enable it.
 </div>
 
 #### Autoscaler

--- a/docs/content/development/javascript.md
+++ b/docs/content/development/javascript.md
@@ -22,6 +22,14 @@ without needing to write and deploy Druid extensions.
 
 Druid uses the Mozilla Rhino engine at optimization level 9 to compile and execute JavaScript.
 
+## Security
+
+Druid does not execute JavaScript functions in a sandbox, so they have full access to the machine. So Javascript
+functions allow users to execute arbutrary code inside druid process. So, by default, Javascript is disabled.
+However, on dev/staging environments or secured production environments you can enable those by setting
+the [configuration property](../configuration/index.html)
+`druid.javascript.enabled = true`.
+
 ## Global variables
 
 Avoid using global variables. Druid may share the global scope between multiple threads, which can lead to
@@ -35,13 +43,6 @@ functions can have steeper performance penalties. Druid compiles JavaScript func
 You may need to pay special attention to garbage collection when making heavy use of JavaScript functions, especially
 garbage collection of the compiled classes themselves. Be sure to use a garbage collector configuration that supports
 timely collection of unused classes (this is generally easier on JDK8 with the Metaspace than it is on JDK7).
-
-## Security
-
-Druid does not execute JavaScript functions in a sandbox, so they have full access to the machine. If you are running
-a cluster where users that can submit queries should not be allowed to execute arbitrary code, we recommend disabling
-JavaScript functionality by setting the [configuration property](../configuration/index.html)
-`druid.javascript.disabled = true`.
 
 ## JavaScript vs. Native Extensions
 

--- a/docs/content/development/router.md
+++ b/docs/content/development/router.md
@@ -117,8 +117,7 @@ Allows defining arbitrary routing rules using a JavaScript function. The functio
 ```
 
 <div class="note info">
-Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines
-about using Druid's JavaScript functionality.
+JavaScript-based functionality is disabled by default. Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines about using Druid's JavaScript functionality, including instructions on how to enable it.
 </div>
 
 HTTP Endpoints

--- a/docs/content/ingestion/data-formats.md
+++ b/docs/content/ingestion/data-formats.md
@@ -147,8 +147,7 @@ Note with the JavaScript parser that data must be fully parsed and returned as a
 This means any flattening or parsing multi-dimensional values must be done here.
 
 <div class="note info">
-Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines
-about using Druid's JavaScript functionality.
+JavaScript-based functionality is disabled by default. Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines about using Druid's JavaScript functionality, including instructions on how to enable it.
 </div>
 
 ### Multi-value dimensions

--- a/docs/content/querying/aggregations.md
+++ b/docs/content/querying/aggregations.md
@@ -162,8 +162,7 @@ JavaScript functions are expected to return floating-point values.
 ```
 
 <div class="note info">
-Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines
-about using Druid's JavaScript functionality.
+JavaScript-based functionality is disabled by default. Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines about using Druid's JavaScript functionality, including instructions on how to enable it.
 </div>
 
 ## Approximate Aggregations

--- a/docs/content/querying/dimensionspecs.md
+++ b/docs/content/querying/dimensionspecs.md
@@ -308,8 +308,7 @@ Example for the `__time` dimension:
 ```
 
 <div class="note info">
-Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines
-about using Druid's JavaScript functionality.
+JavaScript-based functionality is disabled by default. Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines about using Druid's JavaScript functionality, including instructions on how to enable it.
 </div>
 
 ### Lookup extraction function

--- a/docs/content/querying/filters.md
+++ b/docs/content/querying/filters.md
@@ -89,8 +89,7 @@ The following matches any dimension values for the dimension `name` between `'ba
 The JavaScript filter supports the use of extraction functions, see [Filtering with Extraction Functions](#filtering-with-extraction-functions) for details.
 
 <div class="note info">
-Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines
-about using Druid's JavaScript functionality.
+JavaScript-based functionality is disabled by default. Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines about using Druid's JavaScript functionality, including instructions on how to enable it.
 </div>
 
 ### Extraction filter

--- a/docs/content/querying/post-aggregations.md
+++ b/docs/content/querying/post-aggregations.md
@@ -99,8 +99,7 @@ Example JavaScript aggregator:
 ```
 
 <div class="note info">
-Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines
-about using Druid's JavaScript functionality.
+JavaScript-based functionality is disabled by default. Please refer to the Druid <a href="../development/javascript.html">JavaScript programming guide</a> for guidelines about using Druid's JavaScript functionality, including instructions on how to enable it.
 </div>
 
 ### HyperUnique Cardinality post-aggregator

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/setup/JavaScriptWorkerSelectStrategy.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/setup/JavaScriptWorkerSelectStrategy.java
@@ -57,7 +57,7 @@ public class JavaScriptWorkerSelectStrategy implements WorkerSelectStrategy
   {
     Preconditions.checkNotNull(fn, "function must not be null");
 
-    if (config.isDisabled()) {
+    if (!config.isEnabled()) {
       throw new ISE("JavaScript is disabled");
     }
 

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/setup/JavaScriptWorkerSelectStrategyTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/setup/JavaScriptWorkerSelectStrategyTest.java
@@ -69,7 +69,7 @@ public class JavaScriptWorkerSelectStrategyTest
       + "}\n"
       + "return null;\n"
       + "}",
-      JavaScriptConfig.getDefault()
+      JavaScriptConfig.getEnabledInstance()
   );
 
   @Test
@@ -79,7 +79,7 @@ public class JavaScriptWorkerSelectStrategyTest
     mapper.setInjectableValues(
         new InjectableValues.Std().addValue(
             JavaScriptConfig.class,
-            JavaScriptConfig.getDefault()
+            JavaScriptConfig.getEnabledInstance()
         )
     );
 
@@ -99,7 +99,7 @@ public class JavaScriptWorkerSelectStrategyTest
     mapper.setInjectableValues(
         new InjectableValues.Std().addValue(
             JavaScriptConfig.class,
-            new JavaScriptConfig(true)
+            new JavaScriptConfig(false)
         )
     );
 

--- a/processing/src/main/java/io/druid/query/aggregation/JavaScriptAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/JavaScriptAggregatorFactory.java
@@ -85,10 +85,10 @@ public class JavaScriptAggregatorFactory extends AggregatorFactory
     this.fnCombine = fnCombine;
     this.config = config;
 
-    if (config.isDisabled()) {
-      this.compiledScript = null;
-    } else {
+    if (config.isEnabled()) {
       this.compiledScript = compileScript(fnAggregate, fnReset, fnCombine);
+    } else {
+      this.compiledScript = null;
     }
   }
 

--- a/processing/src/main/java/io/druid/query/aggregation/post/JavaScriptPostAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/post/JavaScriptPostAggregator.java
@@ -97,7 +97,7 @@ public class JavaScriptPostAggregator implements PostAggregator
     Preconditions.checkNotNull(name, "Must have a valid, non-null post-aggregator name");
     Preconditions.checkNotNull(fieldNames, "Must have a valid, non-null fieldNames");
     Preconditions.checkNotNull(function, "Must have a valid, non-null function");
-    Preconditions.checkState(!config.isDisabled(), "JavaScript is disabled");
+    Preconditions.checkState(config.isEnabled(), "JavaScript is disabled.");
 
     this.name = name;
     this.fieldNames = fieldNames;

--- a/processing/src/main/java/io/druid/query/extraction/JavaScriptExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/JavaScriptExtractionFn.java
@@ -80,10 +80,10 @@ public class JavaScriptExtractionFn implements ExtractionFn
     this.function = function;
     this.injective = injective;
 
-    if (config.isDisabled()) {
-      this.fn = null;
-    } else {
+    if (config.isEnabled()) {
       this.fn = compile(function);
+    } else {
+      this.fn = null;
     }
   }
 

--- a/processing/src/main/java/io/druid/query/filter/JavaScriptDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/JavaScriptDimFilter.java
@@ -60,10 +60,10 @@ public class JavaScriptDimFilter implements DimFilter
     this.extractionFn = extractionFn;
     this.config = config;
 
-    if (config.isDisabled()) {
-      this.predicateFactory = null;
-    } else {
+    if (config.isEnabled()) {
       this.predicateFactory = new JavaScriptPredicateFactory(function, extractionFn);
+    } else {
+      this.predicateFactory = null;
     }
   }
 
@@ -111,7 +111,7 @@ public class JavaScriptDimFilter implements DimFilter
   @Override
   public Filter toFilter()
   {
-    if (config.isDisabled()) {
+    if (!config.isEnabled()) {
       throw new ISE("JavaScript is disabled");
     }
 

--- a/processing/src/test/java/io/druid/query/QueryRunnerTestHelper.java
+++ b/processing/src/test/java/io/druid/query/QueryRunnerTestHelper.java
@@ -139,7 +139,7 @@ public class QueryRunnerTestHelper
       "function aggregate(current, a, b) { if ((Array.isArray(a) && a.indexOf('a') > -1) || a === 'a') { return current + b; } else { return current; } }",
       JS_RESET_0,
       JS_COMBINE_A_PLUS_B,
-      JavaScriptConfig.getDefault()
+      JavaScriptConfig.getEnabledInstance()
   );
   public static final JavaScriptAggregatorFactory jsCountIfTimeGreaterThan = new JavaScriptAggregatorFactory(
       "ntimestamps",
@@ -149,7 +149,7 @@ public class QueryRunnerTestHelper
       ") { return current + 1; } else { return current; } }",
       JS_RESET_0,
       JS_COMBINE_A_PLUS_B,
-      JavaScriptConfig.getDefault()
+      JavaScriptConfig.getEnabledInstance()
   );
   public static final JavaScriptAggregatorFactory jsPlacementishCount = new JavaScriptAggregatorFactory(
       "pishcount",
@@ -157,7 +157,7 @@ public class QueryRunnerTestHelper
       "function aggregate(current, a) { if (Array.isArray(a)) { return current + a.length; } else if (typeof a === 'string') { return current + 1; } else { return current; } }",
       JS_RESET_0,
       JS_COMBINE_A_PLUS_B,
-      JavaScriptConfig.getDefault()
+      JavaScriptConfig.getEnabledInstance()
   );
   public static final HyperUniquesAggregatorFactory qualityUniques = new HyperUniquesAggregatorFactory(
       "uniques",

--- a/processing/src/test/java/io/druid/query/aggregation/FilteredAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/FilteredAggregatorTest.java
@@ -307,7 +307,7 @@ public class FilteredAggregatorTest
     String jsFn = "function(x) { return(x === 'a') }";
     factory = new FilteredAggregatorFactory(
         new DoubleSumAggregatorFactory("billy", "value"),
-        new JavaScriptDimFilter("dim", jsFn, null, JavaScriptConfig.getDefault())
+        new JavaScriptDimFilter("dim", jsFn, null, JavaScriptConfig.getEnabledInstance())
     );
     selector = new TestFloatColumnSelector(values);
     validateFilteredAggs(factory, values, selector);
@@ -321,7 +321,7 @@ public class FilteredAggregatorTest
     FilteredAggregatorFactory factory;
 
     String extractionJsFn = "function(str) { return str + 'AARDVARK'; }";
-    ExtractionFn extractionFn = new JavaScriptExtractionFn(extractionJsFn, false, JavaScriptConfig.getDefault());
+    ExtractionFn extractionFn = new JavaScriptExtractionFn(extractionJsFn, false, JavaScriptConfig.getEnabledInstance());
 
     factory = new FilteredAggregatorFactory(
         new DoubleSumAggregatorFactory("billy", "value"),
@@ -363,7 +363,7 @@ public class FilteredAggregatorTest
     String jsFn = "function(x) { return(x === 'aAARDVARK') }";
     factory = new FilteredAggregatorFactory(
         new DoubleSumAggregatorFactory("billy", "value"),
-        new JavaScriptDimFilter("dim", jsFn, extractionFn, JavaScriptConfig.getDefault())
+        new JavaScriptDimFilter("dim", jsFn, extractionFn, JavaScriptConfig.getEnabledInstance())
     );
     selector = new TestFloatColumnSelector(values);
     validateFilteredAggs(factory, values, selector);

--- a/processing/src/test/java/io/druid/query/aggregation/JavaScriptAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/JavaScriptAggregatorTest.java
@@ -276,7 +276,7 @@ public class JavaScriptAggregatorTest
         scriptDoubleSum.get("fnAggregate"),
         scriptDoubleSum.get("fnReset"),
         scriptDoubleSum.get("fnCombine"),
-        new JavaScriptConfig(true)
+        new JavaScriptConfig(false)
     );
 
     expectedException.expect(IllegalStateException.class);
@@ -294,7 +294,7 @@ public class JavaScriptAggregatorTest
         scriptDoubleSum.get("fnAggregate"),
         scriptDoubleSum.get("fnReset"),
         scriptDoubleSum.get("fnCombine"),
-        new JavaScriptConfig(true)
+        new JavaScriptConfig(false)
     );
 
     expectedException.expect(IllegalStateException.class);

--- a/processing/src/test/java/io/druid/query/aggregation/cardinality/CardinalityAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/cardinality/CardinalityAggregatorTest.java
@@ -340,7 +340,7 @@ public class CardinalityAggregatorTest
 
 
     String superJsFn = "function(str) { return 'super-' + str; }";
-    ExtractionFn superFn = new JavaScriptExtractionFn(superJsFn, false, JavaScriptConfig.getDefault());
+    ExtractionFn superFn = new JavaScriptExtractionFn(superJsFn, false, JavaScriptConfig.getEnabledInstance());
     dim1WithExtraction = new TestDimensionSelector(values1, superFn);
     dim2WithExtraction = new TestDimensionSelector(values2, superFn);
     selectorListWithExtraction = Lists.newArrayList(
@@ -361,7 +361,7 @@ public class CardinalityAggregatorTest
     );
 
     String helloJsFn = "function(str) { return 'hello' }";
-    ExtractionFn helloFn = new JavaScriptExtractionFn(helloJsFn, false, JavaScriptConfig.getDefault());
+    ExtractionFn helloFn = new JavaScriptExtractionFn(helloJsFn, false, JavaScriptConfig.getEnabledInstance());
     dim1ConstantVal = new TestDimensionSelector(values1, helloFn);
     dim2ConstantVal = new TestDimensionSelector(values2, helloFn);
     selectorListConstantVal = Lists.newArrayList(

--- a/processing/src/test/java/io/druid/query/aggregation/post/JavaScriptPostAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/post/JavaScriptPostAggregatorTest.java
@@ -49,7 +49,7 @@ public class JavaScriptPostAggregatorTest
         "absPercent",
         Lists.newArrayList("delta", "total"),
         absPercentFunction,
-        JavaScriptConfig.getDefault()
+        JavaScriptConfig.getEnabledInstance()
     );
 
     Assert.assertEquals(10.0, javaScriptPostAggregator.compute(metricValues));
@@ -65,7 +65,7 @@ public class JavaScriptPostAggregatorTest
         "absPercent",
         Lists.newArrayList("delta", "total"),
         absPercentFunction,
-        new JavaScriptConfig(true)
+        new JavaScriptConfig(false)
     );
   }
 }

--- a/processing/src/test/java/io/druid/query/extraction/CascadeExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/CascadeExtractionFnTest.java
@@ -50,7 +50,7 @@ public class CascadeExtractionFnTest
   private final JavaScriptExtractionFn javascriptExtractionFn = new JavaScriptExtractionFn(
       function,
       true,
-      JavaScriptConfig.getDefault()
+      JavaScriptConfig.getEnabledInstance()
   );
   private final SubstringDimExtractionFn substringDimExtractionFn = new SubstringDimExtractionFn(0, 7);
   private final String regexDimExtractionFnJson = "{ \"type\" : \"regex\", \"expr\" : \"/([^/]+)/\" , " +
@@ -172,7 +172,7 @@ public class CascadeExtractionFnTest
     objectMapper.setInjectableValues(
         new InjectableValues.Std().addValue(
             JavaScriptConfig.class,
-            JavaScriptConfig.getDefault()
+            JavaScriptConfig.getEnabledInstance()
         )
     );
     final String json = "{\"type\" : \"cascade\", \"extractionFns\": ["

--- a/processing/src/test/java/io/druid/query/extraction/JavaScriptExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/JavaScriptExtractionFnTest.java
@@ -53,7 +53,7 @@ public class JavaScriptExtractionFnTest
   public void testJavascriptSubstring()
   {
     String function = "function(str) { return str.substring(0,3); }";
-    ExtractionFn extractionFn = new JavaScriptExtractionFn(function, false, JavaScriptConfig.getDefault());
+    ExtractionFn extractionFn = new JavaScriptExtractionFn(function, false, JavaScriptConfig.getEnabledInstance());
 
     for (String str : testStrings) {
       String res = extractionFn.apply(str);
@@ -65,7 +65,7 @@ public class JavaScriptExtractionFnTest
   public void testJavascriptNotAllowed()
   {
     String function = "function(str) { return str.substring(0,3); }";
-    ExtractionFn extractionFn = new JavaScriptExtractionFn(function, false, new JavaScriptConfig(true));
+    ExtractionFn extractionFn = new JavaScriptExtractionFn(function, false, new JavaScriptConfig(false));
 
     expectedException.expect(IllegalStateException.class);
     expectedException.expectMessage("JavaScript is disabled");
@@ -78,28 +78,28 @@ public class JavaScriptExtractionFnTest
   {
     String utcHour = "function(t) {\nreturn 'Second ' + Math.floor((t % 60000) / 1000);\n}";
     final long millis = new DateTime("2015-01-02T13:00:59.999Z").getMillis();
-    Assert.assertEquals("Second 59" , new JavaScriptExtractionFn(utcHour, false, JavaScriptConfig.getDefault()).apply(millis));
+    Assert.assertEquals("Second 59" , new JavaScriptExtractionFn(utcHour, false, JavaScriptConfig.getEnabledInstance()).apply(millis));
   }
 
   @Test
   public void testLongs() throws Exception
   {
     String typeOf = "function(x) {\nreturn typeof x\n}";
-    Assert.assertEquals("number", new JavaScriptExtractionFn(typeOf, false, JavaScriptConfig.getDefault()).apply(1234L));
+    Assert.assertEquals("number", new JavaScriptExtractionFn(typeOf, false, JavaScriptConfig.getEnabledInstance()).apply(1234L));
   }
 
   @Test
   public void testFloats() throws Exception
   {
     String typeOf = "function(x) {\nreturn typeof x\n}";
-    Assert.assertEquals("number", new JavaScriptExtractionFn(typeOf, false, JavaScriptConfig.getDefault()).apply(1234.0));
+    Assert.assertEquals("number", new JavaScriptExtractionFn(typeOf, false, JavaScriptConfig.getEnabledInstance()).apply(1234.0));
   }
 
   @Test
   public void testCastingAndNull()
   {
     String function = "function(x) {\n  x = Number(x);\n  if(isNaN(x)) return null;\n  return Math.floor(x / 5) * 5;\n}";
-    ExtractionFn extractionFn = new JavaScriptExtractionFn(function, false, JavaScriptConfig.getDefault());
+    ExtractionFn extractionFn = new JavaScriptExtractionFn(function, false, JavaScriptConfig.getEnabledInstance());
 
     Iterator<String> it = Iterators.forArray("0", "5", "5", "10", null);
 
@@ -114,7 +114,7 @@ public class JavaScriptExtractionFnTest
   public void testJavascriptRegex()
   {
     String function = "function(str) { return str.replace(/[aeiou]/g, ''); }";
-    ExtractionFn extractionFn = new JavaScriptExtractionFn(function, false, JavaScriptConfig.getDefault());
+    ExtractionFn extractionFn = new JavaScriptExtractionFn(function, false, JavaScriptConfig.getEnabledInstance());
 
     Iterator it = Iterators.forArray("Qt", "Clgry", "Tky", "Stckhlm", "Vncvr", "Prtr", "Wllngtn", "Ontr");
     for (String str : testStrings) {
@@ -127,7 +127,7 @@ public class JavaScriptExtractionFnTest
   public void testJavascriptIsNull()
   {
     String function = "function(x) { if (x == null) { return 'yes'; } else { return 'no' } }";
-    ExtractionFn extractionFn = new JavaScriptExtractionFn(function, false, JavaScriptConfig.getDefault());
+    ExtractionFn extractionFn = new JavaScriptExtractionFn(function, false, JavaScriptConfig.getEnabledInstance());
 
     Assert.assertEquals("yes", extractionFn.apply((String) null));
     Assert.assertEquals("yes", extractionFn.apply((Object) null));
@@ -332,7 +332,7 @@ public class JavaScriptExtractionFnTest
                       + ""
                       + "}";
 
-    ExtractionFn extractionFn = new JavaScriptExtractionFn(function, false, JavaScriptConfig.getDefault());
+    ExtractionFn extractionFn = new JavaScriptExtractionFn(function, false, JavaScriptConfig.getEnabledInstance());
 
     Iterator<String> inputs = Iterators.forArray("introducing", "exploratory", "analytics", "on", "large", "datasets");
     Iterator<String> it = Iterators.forArray("introduc", "exploratori", "analyt", "on", "larg", "dataset");
@@ -350,7 +350,7 @@ public class JavaScriptExtractionFnTest
     objectMapper.setInjectableValues(
         new InjectableValues.Std().addValue(
             JavaScriptConfig.class,
-            JavaScriptConfig.getDefault()
+            JavaScriptConfig.getEnabledInstance()
         )
     );
 
@@ -372,7 +372,7 @@ public class JavaScriptExtractionFnTest
   @Test
   public void testInjective()
   {
-    Assert.assertEquals(ExtractionFn.ExtractionType.MANY_TO_ONE, new JavaScriptExtractionFn("function(str) { return str; }", false, JavaScriptConfig.getDefault()).getExtractionType());
-    Assert.assertEquals(ExtractionFn.ExtractionType.ONE_TO_ONE, new JavaScriptExtractionFn("function(str) { return str; }", true, JavaScriptConfig.getDefault()).getExtractionType());
+    Assert.assertEquals(ExtractionFn.ExtractionType.MANY_TO_ONE, new JavaScriptExtractionFn("function(str) { return str; }", false, JavaScriptConfig.getEnabledInstance()).getExtractionType());
+    Assert.assertEquals(ExtractionFn.ExtractionType.ONE_TO_ONE, new JavaScriptExtractionFn("function(str) { return str; }", true, JavaScriptConfig.getEnabledInstance()).getExtractionType());
   }
 }

--- a/processing/src/test/java/io/druid/query/filter/GetDimensionRangeSetTest.java
+++ b/processing/src/test/java/io/druid/query/filter/GetDimensionRangeSetTest.java
@@ -60,7 +60,7 @@ public class GetDimensionRangeSetTest
   );
   private final DimFilter other1 = new RegexDimFilter("someDim", "pattern", null);
   private final DimFilter other2 = new JavaScriptDimFilter("someOtherDim", "function(x) { return x }", null,
-                                                           JavaScriptConfig.getDefault());
+                                                           JavaScriptConfig.getEnabledInstance());
   private final DimFilter other3 = new SearchQueryDimFilter("dim", new ContainsSearchQuerySpec("a", true), null);
 
   private final DimFilter interval1 = new IntervalDimFilter(

--- a/processing/src/test/java/io/druid/query/filter/JavaScriptDimFilterTest.java
+++ b/processing/src/test/java/io/druid/query/filter/JavaScriptDimFilterTest.java
@@ -41,27 +41,27 @@ public class JavaScriptDimFilterTest
   @Test
   public void testGetCacheKey()
   {
-    JavaScriptDimFilter javaScriptDimFilter = new JavaScriptDimFilter("dim", FN1, null, JavaScriptConfig.getDefault());
-    JavaScriptDimFilter javaScriptDimFilter2 = new JavaScriptDimFilter("di", FN2, null, JavaScriptConfig.getDefault());
+    JavaScriptDimFilter javaScriptDimFilter = new JavaScriptDimFilter("dim", FN1, null, JavaScriptConfig.getEnabledInstance());
+    JavaScriptDimFilter javaScriptDimFilter2 = new JavaScriptDimFilter("di", FN2, null, JavaScriptConfig.getEnabledInstance());
     Assert.assertFalse(Arrays.equals(javaScriptDimFilter.getCacheKey(), javaScriptDimFilter2.getCacheKey()));
 
     RegexDimExtractionFn regexFn = new RegexDimExtractionFn(".*", false, null);
-    JavaScriptDimFilter javaScriptDimFilter3 = new JavaScriptDimFilter("dim", FN1, regexFn, JavaScriptConfig.getDefault());
+    JavaScriptDimFilter javaScriptDimFilter3 = new JavaScriptDimFilter("dim", FN1, regexFn, JavaScriptConfig.getEnabledInstance());
     Assert.assertFalse(Arrays.equals(javaScriptDimFilter.getCacheKey(), javaScriptDimFilter3.getCacheKey()));
   }
 
   @Test
   public void testEquals()
   {
-    JavaScriptDimFilter javaScriptDimFilter = new JavaScriptDimFilter("dim", FN1, null, JavaScriptConfig.getDefault());
-    JavaScriptDimFilter javaScriptDimFilter2 = new JavaScriptDimFilter("di", FN2, null, JavaScriptConfig.getDefault());
-    JavaScriptDimFilter javaScriptDimFilter3 = new JavaScriptDimFilter("di", FN2, null, JavaScriptConfig.getDefault());
+    JavaScriptDimFilter javaScriptDimFilter = new JavaScriptDimFilter("dim", FN1, null, JavaScriptConfig.getEnabledInstance());
+    JavaScriptDimFilter javaScriptDimFilter2 = new JavaScriptDimFilter("di", FN2, null, JavaScriptConfig.getEnabledInstance());
+    JavaScriptDimFilter javaScriptDimFilter3 = new JavaScriptDimFilter("di", FN2, null, JavaScriptConfig.getEnabledInstance());
     Assert.assertNotEquals(javaScriptDimFilter, javaScriptDimFilter2);
     Assert.assertEquals(javaScriptDimFilter2, javaScriptDimFilter3);
 
     RegexDimExtractionFn regexFn = new RegexDimExtractionFn(".*", false, null);
-    JavaScriptDimFilter javaScriptDimFilter4 = new JavaScriptDimFilter("dim", FN1, regexFn, JavaScriptConfig.getDefault());
-    JavaScriptDimFilter javaScriptDimFilter5 = new JavaScriptDimFilter("dim", FN1, regexFn, JavaScriptConfig.getDefault());
+    JavaScriptDimFilter javaScriptDimFilter4 = new JavaScriptDimFilter("dim", FN1, regexFn, JavaScriptConfig.getEnabledInstance());
+    JavaScriptDimFilter javaScriptDimFilter5 = new JavaScriptDimFilter("dim", FN1, regexFn, JavaScriptConfig.getEnabledInstance());
     Assert.assertNotEquals(javaScriptDimFilter, javaScriptDimFilter3);
     Assert.assertEquals(javaScriptDimFilter4, javaScriptDimFilter5);
   }
@@ -69,15 +69,15 @@ public class JavaScriptDimFilterTest
   @Test
   public void testHashcode()
   {
-    JavaScriptDimFilter javaScriptDimFilter = new JavaScriptDimFilter("dim", FN1, null, JavaScriptConfig.getDefault());
-    JavaScriptDimFilter javaScriptDimFilter2 = new JavaScriptDimFilter("di", FN2, null, JavaScriptConfig.getDefault());
-    JavaScriptDimFilter javaScriptDimFilter3 = new JavaScriptDimFilter("di", FN2, null, JavaScriptConfig.getDefault());
+    JavaScriptDimFilter javaScriptDimFilter = new JavaScriptDimFilter("dim", FN1, null, JavaScriptConfig.getEnabledInstance());
+    JavaScriptDimFilter javaScriptDimFilter2 = new JavaScriptDimFilter("di", FN2, null, JavaScriptConfig.getEnabledInstance());
+    JavaScriptDimFilter javaScriptDimFilter3 = new JavaScriptDimFilter("di", FN2, null, JavaScriptConfig.getEnabledInstance());
     Assert.assertNotEquals(javaScriptDimFilter.hashCode(), javaScriptDimFilter2.hashCode());
     Assert.assertEquals(javaScriptDimFilter2.hashCode(), javaScriptDimFilter3.hashCode());
 
     RegexDimExtractionFn regexFn = new RegexDimExtractionFn(".*", false, null);
-    JavaScriptDimFilter javaScriptDimFilter4 = new JavaScriptDimFilter("dim", FN1, regexFn, JavaScriptConfig.getDefault());
-    JavaScriptDimFilter javaScriptDimFilter5 = new JavaScriptDimFilter("dim", FN1, regexFn, JavaScriptConfig.getDefault());
+    JavaScriptDimFilter javaScriptDimFilter4 = new JavaScriptDimFilter("dim", FN1, regexFn, JavaScriptConfig.getEnabledInstance());
+    JavaScriptDimFilter javaScriptDimFilter5 = new JavaScriptDimFilter("dim", FN1, regexFn, JavaScriptConfig.getEnabledInstance());
     Assert.assertNotEquals(javaScriptDimFilter.hashCode(), javaScriptDimFilter3.hashCode());
     Assert.assertEquals(javaScriptDimFilter4.hashCode(), javaScriptDimFilter5.hashCode());
   }
@@ -89,7 +89,7 @@ public class JavaScriptDimFilterTest
         "dim",
         "function(x) { return true; }",
         null,
-        JavaScriptConfig.getDefault()
+        JavaScriptConfig.getEnabledInstance()
     );
     final Filter filter = javaScriptDimFilter.toFilter();
     Assert.assertThat(filter, CoreMatchers.instanceOf(JavaScriptFilter.class));
@@ -98,7 +98,7 @@ public class JavaScriptDimFilterTest
   @Test
   public void testToFilterNotAllowed()
   {
-    JavaScriptDimFilter javaScriptDimFilter = new JavaScriptDimFilter("dim", FN1, null, new JavaScriptConfig(true));
+    JavaScriptDimFilter javaScriptDimFilter = new JavaScriptDimFilter("dim", FN1, null, new JavaScriptConfig(false));
 
     expectedException.expect(IllegalStateException.class);
     expectedException.expectMessage("JavaScript is disabled");

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -3457,10 +3457,10 @@ public class GroupByQueryRunnerTest
   public void testDimFilterHavingSpecWithExtractionFns()
   {
     String extractionJsFn = "function(str) { return 'super-' + str; }";
-    ExtractionFn extractionFn = new JavaScriptExtractionFn(extractionJsFn, false, JavaScriptConfig.getDefault());
+    ExtractionFn extractionFn = new JavaScriptExtractionFn(extractionJsFn, false, JavaScriptConfig.getEnabledInstance());
 
     String extractionJsFn2 = "function(num) { return num + 10; }";
-    ExtractionFn extractionFn2 = new JavaScriptExtractionFn(extractionJsFn2, false, JavaScriptConfig.getDefault());
+    ExtractionFn extractionFn2 = new JavaScriptExtractionFn(extractionJsFn2, false, JavaScriptConfig.getEnabledInstance());
 
     List<Row> expectedResults = Arrays.asList(
         GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-01", "alias", "business", "rows", 2L, "idx", 217L),
@@ -3793,7 +3793,7 @@ public class GroupByQueryRunnerTest
             "quality",
             "function(dim){ return true; }",
             null,
-            JavaScriptConfig.getDefault()
+            JavaScriptConfig.getEnabledInstance()
         ))
         .setAggregatorSpecs(
             Arrays.asList(
@@ -3858,7 +3858,7 @@ public class GroupByQueryRunnerTest
             "quality",
             "function(dim){ return true; }",
             null,
-            JavaScriptConfig.getDefault()
+            JavaScriptConfig.getEnabledInstance()
         ))
         .setAggregatorSpecs(
             Arrays.asList(
@@ -3932,7 +3932,7 @@ public class GroupByQueryRunnerTest
             "quality",
             "function(dim){ return true; }",
             null,
-            JavaScriptConfig.getDefault()
+            JavaScriptConfig.getEnabledInstance()
         ))
         .setAggregatorSpecs(
             Arrays.asList(
@@ -4334,7 +4334,7 @@ public class GroupByQueryRunnerTest
             "quality",
             "function(dim){ return true; }",
             null,
-            JavaScriptConfig.getDefault()
+            JavaScriptConfig.getEnabledInstance()
         ))
         .setAggregatorSpecs(
             Arrays.asList(
@@ -4600,7 +4600,7 @@ public class GroupByQueryRunnerTest
             "quality",
             "function(dim){ return true; }",
             null,
-            JavaScriptConfig.getDefault()
+            JavaScriptConfig.getEnabledInstance()
         ))
         .setAggregatorSpecs(
             Arrays.asList(
@@ -4863,7 +4863,7 @@ public class GroupByQueryRunnerTest
             "market",
             "function(dim){ return true; }",
             null,
-            JavaScriptConfig.getDefault()
+            JavaScriptConfig.getEnabledInstance()
         ))
         .setAggregatorSpecs(
             Arrays.asList(
@@ -4875,7 +4875,7 @@ public class GroupByQueryRunnerTest
                     "function(current, index, dim){return current + index + dim.length;}",
                     "function(){return 0;}",
                     "function(a,b){return a + b;}",
-                    JavaScriptConfig.getDefault()
+                    JavaScriptConfig.getEnabledInstance()
                 )
             )
         )
@@ -5257,7 +5257,7 @@ public class GroupByQueryRunnerTest
                     "function(current, index, dim){return current + index + dim.length;}",
                     "function(){return 0;}",
                     "function(a,b){return a + b;}",
-                    JavaScriptConfig.getDefault()
+                    JavaScriptConfig.getEnabledInstance()
                 )
             )
         )
@@ -5320,7 +5320,7 @@ public class GroupByQueryRunnerTest
                     "function(current, index, rows){return current + index + rows;}",
                     "function(){return 0;}",
                     "function(a,b){return a + b;}",
-                    JavaScriptConfig.getDefault()
+                    JavaScriptConfig.getEnabledInstance()
                 )
             )
         )
@@ -6691,7 +6691,7 @@ public class GroupByQueryRunnerTest
 
     String extractionJsFn = "function(str) { return 'super-' + str; }";
     String jsFn = "function(x) { return(x === 'super-mezzanine') }";
-    ExtractionFn extractionFn = new JavaScriptExtractionFn(extractionJsFn, false, JavaScriptConfig.getDefault());
+    ExtractionFn extractionFn = new JavaScriptExtractionFn(extractionJsFn, false, JavaScriptConfig.getEnabledInstance());
 
     List<DimFilter> superFilterList = new ArrayList<>();
     superFilterList.add(new SelectorDimFilter("quality", "super-mezzanine", extractionFn));
@@ -6716,7 +6716,7 @@ public class GroupByQueryRunnerTest
         new ContainsSearchQuerySpec("super-mezzanine", true),
         extractionFn
     ));
-    superFilterList.add(new JavaScriptDimFilter("quality", jsFn, extractionFn, JavaScriptConfig.getDefault()));
+    superFilterList.add(new JavaScriptDimFilter("quality", jsFn, extractionFn, JavaScriptConfig.getEnabledInstance()));
     DimFilter superFilter = new AndDimFilter(superFilterList);
 
     GroupByQuery.Builder builder = GroupByQuery
@@ -6775,7 +6775,7 @@ public class GroupByQueryRunnerTest
         new ContainsSearchQuerySpec("EMPTY", true),
         extractionFn
     ));
-    superFilterList.add(new JavaScriptDimFilter("null_column", jsFn, extractionFn, JavaScriptConfig.getDefault()));
+    superFilterList.add(new JavaScriptDimFilter("null_column", jsFn, extractionFn, JavaScriptConfig.getEnabledInstance()));
     DimFilter superFilter = new AndDimFilter(superFilterList);
 
     GroupByQuery query = GroupByQuery.builder().setDataSource(QueryRunnerTestHelper.dataSource)
@@ -6806,7 +6806,7 @@ public class GroupByQueryRunnerTest
   public void testGroupByCardinalityAggWithExtractionFn()
   {
     String helloJsFn = "function(str) { return 'hello' }";
-    ExtractionFn helloFn = new JavaScriptExtractionFn(helloJsFn, false, JavaScriptConfig.getDefault());
+    ExtractionFn helloFn = new JavaScriptExtractionFn(helloJsFn, false, JavaScriptConfig.getEnabledInstance());
 
     GroupByQuery query = GroupByQuery
         .builder()
@@ -7011,7 +7011,7 @@ public class GroupByQueryRunnerTest
     }
 
     String jsFn = "function(str) { return 'super-' + str; }";
-    ExtractionFn jsExtractionFn = new JavaScriptExtractionFn(jsFn, false, JavaScriptConfig.getDefault());
+    ExtractionFn jsExtractionFn = new JavaScriptExtractionFn(jsFn, false, JavaScriptConfig.getEnabledInstance());
 
     GroupByQuery query = GroupByQuery
         .builder()
@@ -7103,7 +7103,7 @@ public class GroupByQueryRunnerTest
   public void testGroupByLongTimeColumnWithExFn()
   {
     String jsFn = "function(str) { return 'super-' + str; }";
-    ExtractionFn jsExtractionFn = new JavaScriptExtractionFn(jsFn, false, JavaScriptConfig.getDefault());
+    ExtractionFn jsExtractionFn = new JavaScriptExtractionFn(jsFn, false, JavaScriptConfig.getEnabledInstance());
 
     GroupByQuery query = GroupByQuery
         .builder()
@@ -7276,7 +7276,7 @@ public class GroupByQueryRunnerTest
     }
 
     String jsFn = "function(str) { return 'super-' + str; }";
-    ExtractionFn jsExtractionFn = new JavaScriptExtractionFn(jsFn, false, JavaScriptConfig.getDefault());
+    ExtractionFn jsExtractionFn = new JavaScriptExtractionFn(jsFn, false, JavaScriptConfig.getEnabledInstance());
 
     GroupByQuery query = GroupByQuery
         .builder()

--- a/processing/src/test/java/io/druid/query/search/SearchQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/search/SearchQueryRunnerTest.java
@@ -665,7 +665,7 @@ public class SearchQueryRunnerTest
   public void testSearchOnLongColumnWithExFn()
   {
     String jsFn = "function(str) { return 'super-' + str; }";
-    ExtractionFn jsExtractionFn = new JavaScriptExtractionFn(jsFn, false, JavaScriptConfig.getDefault());
+    ExtractionFn jsExtractionFn = new JavaScriptExtractionFn(jsFn, false, JavaScriptConfig.getEnabledInstance());
 
     SearchQuery searchQuery = Druids.newSearchQueryBuilder()
                                     .dimensions(
@@ -711,7 +711,7 @@ public class SearchQueryRunnerTest
   public void testSearchOnFloatColumnWithExFn()
   {
     String jsFn = "function(str) { return 'super-' + str; }";
-    ExtractionFn jsExtractionFn = new JavaScriptExtractionFn(jsFn, false, JavaScriptConfig.getDefault());
+    ExtractionFn jsExtractionFn = new JavaScriptExtractionFn(jsFn, false, JavaScriptConfig.getEnabledInstance());
 
     SearchQuery searchQuery = Druids.newSearchQueryBuilder()
                                     .dimensions(

--- a/processing/src/test/java/io/druid/query/select/SelectQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/select/SelectQueryRunnerTest.java
@@ -724,7 +724,7 @@ public class SelectQueryRunnerTest
   public void testFullOnSelectWithLongAndFloatWithExFn()
   {
     String jsFn = "function(str) { return 'super-' + str; }";
-    ExtractionFn jsExtractionFn = new JavaScriptExtractionFn(jsFn, false, JavaScriptConfig.getDefault());
+    ExtractionFn jsExtractionFn = new JavaScriptExtractionFn(jsFn, false, JavaScriptConfig.getEnabledInstance());
 
     List<DimensionSpec> dimSpecs = Arrays.<DimensionSpec>asList(
         new ExtractionDimensionSpec(QueryRunnerTestHelper.indexMetric, "floatIndex", jsExtractionFn),

--- a/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerTest.java
@@ -1705,7 +1705,7 @@ public class TopNQueryRunnerTest
             new ExtractionDimensionSpec(
                 QueryRunnerTestHelper.marketDimension,
                 QueryRunnerTestHelper.marketDimension,
-                new JavaScriptExtractionFn("function(f) { return \"POTATO\"; }", false, JavaScriptConfig.getDefault())
+                new JavaScriptExtractionFn("function(f) { return \"POTATO\"; }", false, JavaScriptConfig.getEnabledInstance())
             )
         )
         .metric("rows")
@@ -2923,7 +2923,7 @@ public class TopNQueryRunnerTest
   public void testTopNQueryCardinalityAggregatorWithExtractionFn()
   {
     String helloJsFn = "function(str) { return 'hello' }";
-    ExtractionFn helloFn = new JavaScriptExtractionFn(helloJsFn, false, JavaScriptConfig.getDefault());
+    ExtractionFn helloFn = new JavaScriptExtractionFn(helloJsFn, false, JavaScriptConfig.getEnabledInstance());
 
     DimensionSpec dimSpec = new ExtractionDimensionSpec(QueryRunnerTestHelper.marketDimension,
                                                         QueryRunnerTestHelper.marketDimension,
@@ -3747,7 +3747,7 @@ public class TopNQueryRunnerTest
   public void testFullOnTopNFloatColumnWithExFn()
   {
     String jsFn = "function(str) { return 'super-' + str; }";
-    ExtractionFn jsExtractionFn = new JavaScriptExtractionFn(jsFn, false, JavaScriptConfig.getDefault());
+    ExtractionFn jsExtractionFn = new JavaScriptExtractionFn(jsFn, false, JavaScriptConfig.getEnabledInstance());
 
     TopNQuery query = new TopNQueryBuilder()
         .dataSource(QueryRunnerTestHelper.dataSource)
@@ -3966,7 +3966,7 @@ public class TopNQueryRunnerTest
   public void testFullOnTopNLongColumnWithExFn()
   {
     String jsFn = "function(str) { return 'super-' + str; }";
-    ExtractionFn jsExtractionFn = new JavaScriptExtractionFn(jsFn, false, JavaScriptConfig.getDefault());
+    ExtractionFn jsExtractionFn = new JavaScriptExtractionFn(jsFn, false, JavaScriptConfig.getEnabledInstance());
 
     TopNQuery query = new TopNQueryBuilder()
         .dataSource(QueryRunnerTestHelper.dataSource)
@@ -4329,7 +4329,7 @@ public class TopNQueryRunnerTest
   public void testFullOnTopNLongTimeColumnWithExFn()
   {
     String jsFn = "function(str) { return 'super-' + str; }";
-    ExtractionFn jsExtractionFn = new JavaScriptExtractionFn(jsFn, false, JavaScriptConfig.getDefault());
+    ExtractionFn jsExtractionFn = new JavaScriptExtractionFn(jsFn, false, JavaScriptConfig.getEnabledInstance());
 
     TopNQuery query = new TopNQueryBuilder()
         .dataSource(QueryRunnerTestHelper.dataSource)
@@ -4404,7 +4404,7 @@ public class TopNQueryRunnerTest
   public void testFullOnTopNDimExtractionAllNulls()
   {
     String jsFn = "function(str) { return null; }";
-    ExtractionFn jsExtractionFn = new JavaScriptExtractionFn(jsFn, false, JavaScriptConfig.getDefault());
+    ExtractionFn jsExtractionFn = new JavaScriptExtractionFn(jsFn, false, JavaScriptConfig.getEnabledInstance());
 
     TopNQuery query = new TopNQueryBuilder()
         .dataSource(QueryRunnerTestHelper.dataSource)

--- a/processing/src/test/java/io/druid/segment/filter/BoundFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/BoundFilterTest.java
@@ -413,10 +413,10 @@ public class BoundFilterTest extends BaseFilterTest
   public void testMatchWithExtractionFn()
   {
     String extractionJsFn = "function(str) { return 'super-' + str; }";
-    ExtractionFn superFn = new JavaScriptExtractionFn(extractionJsFn, false, JavaScriptConfig.getDefault());
+    ExtractionFn superFn = new JavaScriptExtractionFn(extractionJsFn, false, JavaScriptConfig.getEnabledInstance());
 
     String nullJsFn = "function(str) { return null; }";
-    ExtractionFn makeNullFn = new JavaScriptExtractionFn(nullJsFn, false, JavaScriptConfig.getDefault());
+    ExtractionFn makeNullFn = new JavaScriptExtractionFn(nullJsFn, false, JavaScriptConfig.getEnabledInstance());
 
     assertFilterMatches(
         new BoundDimFilter("dim0", "", "", false, false, false, makeNullFn, StringComparators.LEXICOGRAPHIC),

--- a/processing/src/test/java/io/druid/segment/filter/FilterPartitionTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/FilterPartitionTest.java
@@ -165,7 +165,7 @@ public class FilterPartitionTest extends BaseFilterTest
   }
 
   private static String JS_FN = "function(str) { return 'super-' + str; }";
-  private static ExtractionFn JS_EXTRACTION_FN = new JavaScriptExtractionFn(JS_FN, false, JavaScriptConfig.getDefault());
+  private static ExtractionFn JS_EXTRACTION_FN = new JavaScriptExtractionFn(JS_FN, false, JavaScriptConfig.getEnabledInstance());
 
   private static final String TIMESTAMP_COLUMN = "timestamp";
 

--- a/processing/src/test/java/io/druid/segment/filter/FloatFilteringTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/FloatFilteringTest.java
@@ -192,13 +192,13 @@ public class FloatFilteringTest extends BaseFilterTest
 
     String jsFn = "function(x) { return(x === 3 || x === 5) }";
     assertFilterMatches(
-        new JavaScriptDimFilter(FLOAT_COLUMN, jsFn, null, JavaScriptConfig.getDefault()),
+        new JavaScriptDimFilter(FLOAT_COLUMN, jsFn, null, JavaScriptConfig.getEnabledInstance()),
         ImmutableList.<String>of("3", "5")
     );
 
     String jsFn2 = "function(x) { return(x === 3.0 || x === 5.0) }";
     assertFilterMatches(
-        new JavaScriptDimFilter(FLOAT_COLUMN, jsFn2, null, JavaScriptConfig.getDefault()),
+        new JavaScriptDimFilter(FLOAT_COLUMN, jsFn2, null, JavaScriptConfig.getEnabledInstance()),
         ImmutableList.<String>of("3", "5")
     );
 
@@ -321,7 +321,7 @@ public class FloatFilteringTest extends BaseFilterTest
 
     String jsFn = "function(x) { return(x === 'Wednesday' || x === 'Thursday') }";
     assertFilterMatches(
-        new JavaScriptDimFilter(FLOAT_COLUMN, jsFn, exfn, JavaScriptConfig.getDefault()),
+        new JavaScriptDimFilter(FLOAT_COLUMN, jsFn, exfn, JavaScriptConfig.getEnabledInstance()),
         ImmutableList.<String>of("3", "4")
     );
 

--- a/processing/src/test/java/io/druid/segment/filter/InFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/InFilterTest.java
@@ -210,10 +210,10 @@ public class InFilterTest extends BaseFilterTest
   public void testMatchWithExtractionFn()
   {
     String extractionJsFn = "function(str) { return 'super-' + str; }";
-    ExtractionFn superFn = new JavaScriptExtractionFn(extractionJsFn, false, JavaScriptConfig.getDefault());
+    ExtractionFn superFn = new JavaScriptExtractionFn(extractionJsFn, false, JavaScriptConfig.getEnabledInstance());
 
     String nullJsFn = "function(str) { if (str === null) { return 'YES'; } else { return 'NO';} }";
-    ExtractionFn yesNullFn = new JavaScriptExtractionFn(nullJsFn, false, JavaScriptConfig.getDefault());
+    ExtractionFn yesNullFn = new JavaScriptExtractionFn(nullJsFn, false, JavaScriptConfig.getEnabledInstance());
 
     assertFilterMatches(
         toInFilterWithFn("dim2", superFn, "super-null", "super-a", "super-b"),

--- a/processing/src/test/java/io/druid/segment/filter/JavaScriptFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/JavaScriptFilterTest.java
@@ -185,7 +185,7 @@ public class JavaScriptFilterTest extends BaseFilterTest
         dimension,
         function,
         extractionFn,
-        JavaScriptConfig.getDefault()
+        JavaScriptConfig.getEnabledInstance()
     );
   }
 }

--- a/processing/src/test/java/io/druid/segment/filter/LongFilteringTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/LongFilteringTest.java
@@ -166,7 +166,7 @@ public class LongFilteringTest extends BaseFilterTest
 
     String jsFn = "function(x) { return(x === 3 || x === 5) }";
     assertFilterMatches(
-        new JavaScriptDimFilter(LONG_COLUMN, jsFn, null, JavaScriptConfig.getDefault()),
+        new JavaScriptDimFilter(LONG_COLUMN, jsFn, null, JavaScriptConfig.getEnabledInstance()),
         ImmutableList.<String>of("3", "5")
     );
 
@@ -274,7 +274,7 @@ public class LongFilteringTest extends BaseFilterTest
 
     String jsFn = "function(x) { return(x === 'Wednesday' || x === 'Thursday') }";
     assertFilterMatches(
-        new JavaScriptDimFilter(LONG_COLUMN, jsFn, exfn, JavaScriptConfig.getDefault()),
+        new JavaScriptDimFilter(LONG_COLUMN, jsFn, exfn, JavaScriptConfig.getEnabledInstance()),
         ImmutableList.<String>of("3", "4")
     );
 

--- a/processing/src/test/java/io/druid/segment/filter/RegexFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/RegexFilterTest.java
@@ -140,7 +140,7 @@ public class RegexFilterTest extends BaseFilterTest
   public void testRegexWithExtractionFn()
   {
     String nullJsFn = "function(str) { if (str === null) { return 'NOT_NULL_ANYMORE'; } else { return str;} }";
-    ExtractionFn changeNullFn = new JavaScriptExtractionFn(nullJsFn, false, JavaScriptConfig.getDefault());
+    ExtractionFn changeNullFn = new JavaScriptExtractionFn(nullJsFn, false, JavaScriptConfig.getEnabledInstance());
 
     assertFilterMatches(new RegexDimFilter("dim1", ".*ANYMORE", changeNullFn), ImmutableList.of("0"));
     assertFilterMatches(new RegexDimFilter("dim1", "ab.*", changeNullFn), ImmutableList.<String>of("4", "5"));

--- a/processing/src/test/java/io/druid/segment/filter/SearchQueryFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/SearchQueryFilterTest.java
@@ -149,7 +149,7 @@ public class SearchQueryFilterTest extends BaseFilterTest
   public void testSearchQueryWithExtractionFn()
   {
     String nullJsFn = "function(str) { if (str === null) { return 'NOT_NULL_ANYMORE'; } else { return str;} }";
-    ExtractionFn changeNullFn = new JavaScriptExtractionFn(nullJsFn, false, JavaScriptConfig.getDefault());
+    ExtractionFn changeNullFn = new JavaScriptExtractionFn(nullJsFn, false, JavaScriptConfig.getEnabledInstance());
 
     assertFilterMatches(new SearchQueryDimFilter("dim1", specForValue("ANYMORE"), changeNullFn), ImmutableList.of("0"));
     assertFilterMatches(new SearchQueryDimFilter("dim1", specForValue("ab"), changeNullFn), ImmutableList.<String>of("4", "5"));

--- a/processing/src/test/java/io/druid/segment/filter/TimeFilteringTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/TimeFilteringTest.java
@@ -143,7 +143,7 @@ public class TimeFilteringTest extends BaseFilterTest
 
     String jsFn = "function(x) { return(x === 3 || x === 5) }";
     assertFilterMatches(
-        new JavaScriptDimFilter(Column.TIME_COLUMN_NAME, jsFn, null, JavaScriptConfig.getDefault()),
+        new JavaScriptDimFilter(Column.TIME_COLUMN_NAME, jsFn, null, JavaScriptConfig.getEnabledInstance()),
         ImmutableList.<String>of("3", "5")
     );
 
@@ -207,7 +207,7 @@ public class TimeFilteringTest extends BaseFilterTest
 
     String jsFn = "function(x) { return(x === 'Wednesday' || x === 'Thursday') }";
     assertFilterMatches(
-        new JavaScriptDimFilter(Column.TIME_COLUMN_NAME, jsFn, exfn, JavaScriptConfig.getDefault()),
+        new JavaScriptDimFilter(Column.TIME_COLUMN_NAME, jsFn, exfn, JavaScriptConfig.getEnabledInstance()),
         ImmutableList.<String>of("2", "3")
     );
 
@@ -271,7 +271,7 @@ public class TimeFilteringTest extends BaseFilterTest
 
     // increment timestamp by 2 hours
     String timeBoosterJsFn = "function(x) { return(x + 7200000) }";
-    ExtractionFn exFn = new JavaScriptExtractionFn(timeBoosterJsFn, true, JavaScriptConfig.getDefault());
+    ExtractionFn exFn = new JavaScriptExtractionFn(timeBoosterJsFn, true, JavaScriptConfig.getEnabledInstance());
     assertFilterMatches(
         new IntervalDimFilter(
             Column.TIME_COLUMN_NAME,
@@ -330,7 +330,7 @@ public class TimeFilteringTest extends BaseFilterTest
 
     // increment timestamp by 2 hours
     String timeBoosterJsFn = "function(x) { return(Number(x) + 7200000) }";
-    ExtractionFn exFn = new JavaScriptExtractionFn(timeBoosterJsFn, true, JavaScriptConfig.getDefault());
+    ExtractionFn exFn = new JavaScriptExtractionFn(timeBoosterJsFn, true, JavaScriptConfig.getEnabledInstance());
     assertFilterMatches(
         new IntervalDimFilter(
             "dim0",

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
@@ -191,7 +191,7 @@ public class IncrementalIndexStorageAdapterTest
                             "function(current, s, b) { return current + (s == null ? 0 : s.length) + (b == null ? 0 : b.length); }",
                             "function() { return 0; }",
                             "function(a,b) { return a + b; }",
-                            JavaScriptConfig.getDefault()
+                            JavaScriptConfig.getEnabledInstance()
                         )
                     )
                     .build(),

--- a/server/src/main/java/io/druid/server/router/JavaScriptTieredBrokerSelectorStrategy.java
+++ b/server/src/main/java/io/druid/server/router/JavaScriptTieredBrokerSelectorStrategy.java
@@ -54,7 +54,7 @@ public class JavaScriptTieredBrokerSelectorStrategy implements TieredBrokerSelec
   {
     Preconditions.checkNotNull(fn, "function must not be null");
 
-    if (config.isDisabled()) {
+    if (!config.isEnabled()) {
       throw new ISE("JavaScript is disabled");
     }
 

--- a/server/src/test/java/io/druid/guice/JavaScriptModuleTest.java
+++ b/server/src/test/java/io/druid/guice/JavaScriptModuleTest.java
@@ -38,16 +38,16 @@ public class JavaScriptModuleTest
   public void testInjectionDefault() throws Exception
   {
     JavaScriptConfig config = makeInjectorWithProperties(new Properties()).getInstance(JavaScriptConfig.class);
-    Assert.assertFalse(config.isDisabled());
+    Assert.assertFalse(config.isEnabled());
   }
 
   @Test
-  public void testInjectionDisabled() throws Exception
+  public void testInjectionEnabled() throws Exception
   {
     final Properties props = new Properties();
-    props.setProperty("druid.javascript.disabled", "true");
+    props.setProperty("druid.javascript.enabled", "true");
     JavaScriptConfig config = makeInjectorWithProperties(props).getInstance(JavaScriptConfig.class);
-    Assert.assertTrue(config.isDisabled());
+    Assert.assertTrue(config.isEnabled());
   }
 
   private Injector makeInjectorWithProperties(final Properties props)

--- a/server/src/test/java/io/druid/server/router/JavaScriptTieredBrokerSelectorStrategyTest.java
+++ b/server/src/test/java/io/druid/server/router/JavaScriptTieredBrokerSelectorStrategyTest.java
@@ -47,7 +47,7 @@ public class JavaScriptTieredBrokerSelectorStrategyTest
 
   private final TieredBrokerSelectorStrategy STRATEGY = new JavaScriptTieredBrokerSelectorStrategy(
       "function (config, query) { if (query.getAggregatorSpecs && query.getDimensionSpec && query.getDimensionSpec().getDimension() == 'bigdim' && query.getAggregatorSpecs().size() >= 3) { var size = config.getTierToBrokerMap().values().size(); if (size > 0) { return config.getTierToBrokerMap().values().toArray()[size-1] } else { return config.getDefaultBrokerServiceName() } } else { return null } }",
-      JavaScriptConfig.getDefault()
+      JavaScriptConfig.getEnabledInstance()
   );
 
   @Test
@@ -57,7 +57,7 @@ public class JavaScriptTieredBrokerSelectorStrategyTest
     mapper.setInjectableValues(
         new InjectableValues.Std().addValue(
             JavaScriptConfig.class,
-            JavaScriptConfig.getDefault()
+            JavaScriptConfig.getEnabledInstance()
         )
     );
 
@@ -77,7 +77,7 @@ public class JavaScriptTieredBrokerSelectorStrategyTest
     mapper.setInjectableValues(
         new InjectableValues.Std().addValue(
             JavaScriptConfig.class,
-            new JavaScriptConfig(true)
+            new JavaScriptConfig(false)
         )
     );
 

--- a/sql/src/main/java/io/druid/sql/calcite/filtration/Filtration.java
+++ b/sql/src/main/java/io/druid/sql/calcite/filtration/Filtration.java
@@ -37,10 +37,10 @@ public class Filtration
 {
   private static final Interval ETERNITY = new Interval(JodaUtils.MIN_INSTANT, JodaUtils.MAX_INSTANT);
   private static final DimFilter MATCH_NOTHING = new JavaScriptDimFilter(
-      "dummy", "function(x){return false;}", null, JavaScriptConfig.getDefault()
+      "dummy", "function(x){return false;}", null, JavaScriptConfig.getEnabledInstance()
   );
   private static final DimFilter MATCH_EVERYTHING = new JavaScriptDimFilter(
-      "dummy", "function(x){return true;}", null, JavaScriptConfig.getDefault()
+      "dummy", "function(x){return true;}", null, JavaScriptConfig.getEnabledInstance()
   );
 
   // 1) If "dimFilter" is null, it should be ignored and not affect filtration.


### PR DESCRIPTION
most users don't use javascript but still have it enabled because it happens to be default behavior and are surprised that it is enabled by default even with severe security threat.

with 0.10.0, we can disable javascript by default.