### PR TITLE
Randomly choose a server when multiple best servers are available

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/CostBalancerStrategy.java
+++ b/server/src/main/java/io/druid/server/coordinator/CostBalancerStrategy.java
@@ -32,6 +32,7 @@ import io.druid.timeline.DataSegment;
 import org.apache.commons.math3.util.FastMath;
 import org.joda.time.Interval;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -348,13 +349,21 @@ public class CostBalancerStrategy implements BalancerStrategy
     }
 
     final ListenableFuture<List<Pair<Double, ServerHolder>>> resultsFuture = Futures.allAsList(futures);
-
+    final List<Pair<Double, ServerHolder>> bestServers = new ArrayList<>();
     try {
       for (Pair<Double, ServerHolder> server : resultsFuture.get()) {
         if (server.lhs < bestServer.lhs) {
           bestServer = server;
         }
       }
+
+      // Find All best servers and choose one randomly
+      for (Pair<Double, ServerHolder> server : resultsFuture.get()) {
+        if (server.lhs == bestServer.lhs) {
+          bestServers.add(server);
+        }
+      }
+      bestServer = (bestServers.size() > 0) ? bestServers.get((int)Math.random()*bestServers.size()): bestServer;
     }
     catch (Exception e) {
       log.makeAlert(e, "Cost Balancer Multithread strategy wasn't able to complete cost computation.").emit();

--- a/server/src/main/java/io/druid/server/coordinator/CostBalancerStrategy.java
+++ b/server/src/main/java/io/druid/server/coordinator/CostBalancerStrategy.java
@@ -350,20 +350,19 @@ public class CostBalancerStrategy implements BalancerStrategy
 
     final ListenableFuture<List<Pair<Double, ServerHolder>>> resultsFuture = Futures.allAsList(futures);
     final List<Pair<Double, ServerHolder>> bestServers = new ArrayList<>();
+    bestServers.add(bestServer);
     try {
       for (Pair<Double, ServerHolder> server : resultsFuture.get()) {
-        if (server.lhs < bestServer.lhs) {
-          bestServer = server;
-        }
-      }
-
-      // Find All best servers and choose one randomly
-      for (Pair<Double, ServerHolder> server : resultsFuture.get()) {
-        if (server.lhs == bestServer.lhs) {
+        if (server.lhs <= bestServers.get(0).lhs) {
+          if(server.lhs < bestServers.get(0).lhs){
+            bestServers.clear();
+          }
           bestServers.add(server);
         }
       }
-      bestServer = (bestServers.size() > 0) ? bestServers.get((int)Math.random()*bestServers.size()): bestServer;
+
+      // Randomly choose a server from the best servers
+      bestServer = bestServers.get((int)Math.random()*bestServers.size());
     }
     catch (Exception e) {
       log.makeAlert(e, "Cost Balancer Multithread strategy wasn't able to complete cost computation.").emit();

--- a/server/src/main/java/io/druid/server/coordinator/CostBalancerStrategy.java
+++ b/server/src/main/java/io/druid/server/coordinator/CostBalancerStrategy.java
@@ -354,7 +354,7 @@ public class CostBalancerStrategy implements BalancerStrategy
     try {
       for (Pair<Double, ServerHolder> server : resultsFuture.get()) {
         if (server.lhs <= bestServers.get(0).lhs) {
-          if(server.lhs < bestServers.get(0).lhs){
+          if (server.lhs < bestServers.get(0).lhs) {
             bestServers.clear();
           }
           bestServers.add(server);
@@ -362,7 +362,7 @@ public class CostBalancerStrategy implements BalancerStrategy
       }
 
       // Randomly choose a server from the best servers
-      bestServer = bestServers.get((int)Math.random()*bestServers.size());
+      bestServer = bestServers.get((int) Math.random() * bestServers.size());
     }
     catch (Exception e) {
       log.makeAlert(e, "Cost Balancer Multithread strategy wasn't able to complete cost computation.").emit();


### PR DESCRIPTION
We found an issue when we added new hosts to our cluster. We found that all the segments were getting assigned to the same host for a run of the coordinator "moveSegments".

Solution: Choose a server randomly when multiple best servers are available. This ensures that all the segments aren't assigned to the same host for a particular run of the coordinator. 