### PR TITLE
Update to Calcite 1.11.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
 
     <properties>
         <apache.curator.version>2.11.1</apache.curator.version>
-        <avatica.version>1.8.0</avatica.version>
-        <calcite.version>1.10.0</calcite.version>
+        <avatica.version>1.9.0</avatica.version>
+        <calcite.version>1.11.0</calcite.version>
         <guava.version>16.0.1</guava.version>
         <guice.version>4.1.0</guice.version>
         <jetty.version>9.2.5.v20141112</jetty.version>
@@ -261,6 +261,11 @@
                 <groupId>org.apache.calcite</groupId>
                 <artifactId>calcite-linq4j</artifactId>
                 <version>${calcite.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.calcite.avatica</groupId>
+                <artifactId>avatica-core</artifactId>
+                <version>${avatica.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.calcite.avatica</groupId>

--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -48,6 +48,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.calcite.avatica</groupId>
+      <artifactId>avatica-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.calcite.avatica</groupId>
       <artifactId>avatica-server</artifactId>
     </dependency>
     <dependency>

--- a/sql/src/main/java/io/druid/sql/calcite/planner/DruidPlannerImpl.java
+++ b/sql/src/main/java/io/druid/sql/calcite/planner/DruidPlannerImpl.java
@@ -27,6 +27,7 @@ import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.volcano.VolcanoPlanner;
 import org.apache.calcite.prepare.CalcitePrepareImpl;
 import org.apache.calcite.rel.RelCollationTraitDef;
+import org.apache.calcite.sql2rel.SqlRexConvertletTable;
 
 /**
  * Our very own subclass of CalcitePrepareImpl, used to alter behaviors of the JDBC driver as necessary.
@@ -64,5 +65,11 @@ public class DruidPlannerImpl extends CalcitePrepareImpl
     }
 
     return planner;
+  }
+
+  @Override
+  protected SqlRexConvertletTable createConvertletTable()
+  {
+    return DruidConvertletTable.instance();
   }
 }

--- a/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
@@ -106,9 +106,6 @@ public class CalciteQueryTest
 {
   private static final Logger log = new Logger(CalciteQueryTest.class);
 
-  // Used to mark tests that should pass once Calcite 1.11.0 is released.
-  private static final boolean CALCITE_1_11_0 = false;
-
   private static final PlannerConfig PLANNER_CONFIG_DEFAULT = new PlannerConfig();
   private static final PlannerConfig PLANNER_CONFIG_NO_TOPN = new PlannerConfig()
   {
@@ -588,11 +585,6 @@ public class CalciteQueryTest
   @Test
   public void testGroupByNothingWithLiterallyFalseFilter() throws Exception
   {
-    if (!CALCITE_1_11_0) {
-      // https://issues.apache.org/jira/browse/CALCITE-1488
-      return;
-    }
-
     testQuery(
         "SELECT COUNT(*), MAX(cnt) FROM druid.foo WHERE 1 = 0",
         ImmutableList.<Query>of(),
@@ -605,11 +597,6 @@ public class CalciteQueryTest
   @Test
   public void testGroupByOneColumnWithLiterallyFalseFilter() throws Exception
   {
-    if (!CALCITE_1_11_0) {
-      // https://issues.apache.org/jira/browse/CALCITE-1488
-      return;
-    }
-
     testQuery(
         "SELECT COUNT(*), MAX(cnt) FROM druid.foo WHERE 1 = 0 GROUP BY dim1",
         ImmutableList.<Query>of(),
@@ -2002,11 +1989,6 @@ public class CalciteQueryTest
   @Test
   public void testGroupByExtractYear() throws Exception
   {
-    if (!CALCITE_1_11_0) {
-      // https://issues.apache.org/jira/browse/CALCITE-1509
-      return;
-    }
-
     testQuery(
         "SELECT\n"
         + "  EXTRACT(YEAR FROM __time) AS \"year\",\n"
@@ -2053,11 +2035,6 @@ public class CalciteQueryTest
   @Test
   public void testExtractFloorTime() throws Exception
   {
-    if (!CALCITE_1_11_0) {
-      // https://issues.apache.org/jira/browse/CALCITE-1509
-      return;
-    }
-
     testQuery(
         "SELECT\n"
         + "EXTRACT(YEAR FROM FLOOR(__time TO YEAR)) AS \"year\", SUM(cnt)\n"
@@ -2272,11 +2249,6 @@ public class CalciteQueryTest
   @Test
   public void testUsingSubqueryAsFilterOnTwoColumns() throws Exception
   {
-    if (!CALCITE_1_11_0) {
-      // https://issues.apache.org/jira/browse/CALCITE-1479
-      return;
-    }
-
     testQuery(
         "SELECT __time, cnt, dim1, dim2 FROM druid.foo "
         + " WHERE (dim1, dim2) IN ("


### PR DESCRIPTION
Fixes #3800 and enables some new kinds of queries (see the tests that were previously disabled).