### PR TITLE
Include loadqueuepeon size to compute disknormalized cost

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/DiskNormalizedCostBalancerStrategy.java
+++ b/server/src/main/java/io/druid/server/coordinator/DiskNormalizedCostBalancerStrategy.java
@@ -51,7 +51,7 @@ public class DiskNormalizedCostBalancerStrategy extends CostBalancerStrategy
     }
 
     double normalizedCost = cost/nSegments;
-    double usageRatio = (double)server.getServer().getCurrSize()/(double)server.getServer().getMaxSize();
+    double usageRatio = (double) server.getSizeUsed() / (double) server.getServer().getMaxSize();
 
     return normalizedCost*usageRatio;
   }


### PR DESCRIPTION
**getCurrSize()** uses the size of the server and doesn't include the size of the segments that have been assigned to it. A more accurate representation is to use **server.getSizeUsed()** while computing the Disk normalized cost.

`getSizeUsed() = getCurrSize() + getLoadQueueSize();`