### PR TITLE
use correct joda-time

### DIFF
--- a/java-util/pom.xml
+++ b/java-util/pom.xml
@@ -77,7 +77,6 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>1.6</version>
         </dependency>
         <dependency>
             <groupId>org.mozilla</groupId>


### PR DESCRIPTION
Removed the version on joda-time in java-util, was causing an issue with building extensions