### PR TITLE
Make TaskLockbox's ReentrantLock fair

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/overlord/TaskLockbox.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/TaskLockbox.java
@@ -65,7 +65,7 @@ public class TaskLockbox
   // Datasource -> Interval -> Tasks + TaskLock
   private final Map<String, NavigableMap<Interval, TaskLockPosse>> running = Maps.newHashMap();
   private final TaskStorage taskStorage;
-  private final ReentrantLock giant = new ReentrantLock();
+  private final ReentrantLock giant = new ReentrantLock(true);
   private final Condition lockReleaseCondition = giant.newCondition();
 
   private static final EmittingLogger log = new EmittingLogger(TaskLockbox.class);


### PR DESCRIPTION
We had a scenario where the overlord had problems connecting with zookeeper, which caused a strange condition where some tasks ended up not having locks appropriately. This caused a scenario where lots of tasks were submitting task actions, and the ones that did not have locks set appropriately were causing massive load on the database and blocking up the CPU on the overlord.

This does not resolve the root cause, but does make sure that actions that come in are handled in a FIFO-ish manner.