### PR TITLE
SqlResource: Fix incorrect labeling of aliased columns.

### DIFF
--- a/sql/src/main/java/io/druid/sql/http/SqlResource.java
+++ b/sql/src/main/java/io/druid/sql/http/SqlResource.java
@@ -106,7 +106,7 @@ public class SqlResource
                       value = resultSet.getObject(i + 1);
                     }
 
-                    jsonGenerator.writeObjectField(metaData.getColumnName(i + 1), value);
+                    jsonGenerator.writeObjectField(metaData.getColumnLabel(i + 1), value);
                   }
                   jsonGenerator.writeEndObject();
                 }

--- a/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
+++ b/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
@@ -125,6 +125,21 @@ public class DruidAvaticaHandlerTest
   }
 
   @Test
+  public void testFieldAliasingSelect() throws Exception
+  {
+    final ResultSet resultSet = client.createStatement().executeQuery(
+        "SELECT dim2 AS \"x\", dim2 AS \"y\" FROM druid.foo LIMIT 1"
+    );
+    final List<Map<String, Object>> rows = getRows(resultSet);
+    Assert.assertEquals(
+        ImmutableList.of(
+            ImmutableMap.of("x", "a", "y", "a")
+        ),
+        rows
+    );
+  }
+
+  @Test
   public void testExplainSelectCount() throws Exception
   {
     final ResultSet resultSet = client.createStatement().executeQuery(
@@ -244,8 +259,8 @@ public class DruidAvaticaHandlerTest
       while (resultSet.next()) {
         final Map<String, Object> row = Maps.newHashMap();
         for (int i = 0; i < metaData.getColumnCount(); i++) {
-          if (returnKeys == null || returnKeys.contains(metaData.getColumnName(i + 1))) {
-            row.put(metaData.getColumnName(i + 1), resultSet.getObject(i + 1));
+          if (returnKeys == null || returnKeys.contains(metaData.getColumnLabel(i + 1))) {
+            row.put(metaData.getColumnLabel(i + 1), resultSet.getObject(i + 1));
           }
         }
         rows.add(row);

--- a/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
@@ -329,6 +329,31 @@ public class CalciteQueryTest
   }
 
   @Test
+  public void testSelectSingleColumnTwice() throws Exception
+  {
+    testQuery(
+        "SELECT dim2 x, dim2 y FROM druid.foo LIMIT 2",
+        ImmutableList.<Query>of(
+            Druids.newSelectQueryBuilder()
+                  .dataSource(CalciteTests.DATASOURCE)
+                  .intervals(QSS(Filtration.eternity()))
+                  .dimensionSpecs(DIMS(
+                      new DefaultDimensionSpec("dim2", "d1"),
+                      new DefaultDimensionSpec("dim2", "d2")
+                  ))
+                  .granularity(QueryGranularities.ALL)
+                  .descending(false)
+                  .pagingSpec(FIRST_PAGING_SPEC)
+                  .build()
+        ),
+        ImmutableList.of(
+            new Object[]{"a", "a"},
+            new Object[]{"", ""}
+        )
+    );
+  }
+
+  @Test
   public void testSelectSingleColumnWithLimitDescending() throws Exception
   {
     testQuery(

--- a/sql/src/test/java/io/druid/sql/calcite/http/SqlResourceTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/http/SqlResourceTest.java
@@ -110,6 +110,38 @@ public class SqlResourceTest
   }
 
   @Test
+  public void testFieldAliasingSelect() throws Exception
+  {
+    final List<Map<String, Object>> rows = doPost(
+        new SqlQuery("SELECT dim2 \"x\", dim2 \"y\" FROM druid.foo LIMIT 1")
+    );
+
+    Assert.assertEquals(
+        ImmutableList.of(
+            ImmutableMap.of("x", "a", "y", "a")
+        ),
+        rows
+    );
+  }
+
+  @Test
+  public void testFieldAliasingGroupBy() throws Exception
+  {
+    final List<Map<String, Object>> rows = doPost(
+        new SqlQuery("SELECT dim2 \"x\", dim2 \"y\" FROM druid.foo GROUP BY dim2")
+    );
+
+    Assert.assertEquals(
+        ImmutableList.of(
+            ImmutableMap.of("x", "", "y", ""),
+            ImmutableMap.of("x", "a", "y", "a"),
+            ImmutableMap.of("x", "abc", "y", "abc")
+        ),
+        rows
+    );
+  }
+
+  @Test
   public void testExplainCountStar() throws Exception
   {
     final List<Map<String, Object>> rows = doPost(


### PR DESCRIPTION
Should have been using getColumnLabel, not getColumnName.