### PR TITLE
DruidCoordinator: Leave the ServerInventoryView running when we lose leadership.

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
@@ -553,7 +553,6 @@ public class DruidCoordinator
         leader = true;
         metadataSegmentManager.start();
         metadataRuleManager.start();
-        serverInventoryView.start();
         serviceAnnouncer.announce(self);
         final int startingLeaderCounter = leaderCounter;
 
@@ -635,7 +634,6 @@ public class DruidCoordinator
         loadManagementPeons.clear();
 
         serviceAnnouncer.unannounce(self);
-        serverInventoryView.stop();
         metadataRuleManager.stop();
         metadataSegmentManager.stop();
         leader = false;

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
@@ -304,13 +304,7 @@ public class DruidCoordinatorTest extends CuratorTestBase
     EasyMock.expect(serverInventoryView.getInventory()).andReturn(
         ImmutableList.of(druidServer)
     ).atLeastOnce();
-    serverInventoryView.start();
-    EasyMock.expectLastCall().atLeastOnce();
     EasyMock.expect(serverInventoryView.isStarted()).andReturn(true).anyTimes();
-
-    serverInventoryView.stop();
-    EasyMock.expectLastCall().once();
-
     EasyMock.replay(serverInventoryView);
 
     coordinator.start();


### PR DESCRIPTION
Fixes regression from #3726 that prevents the coordinator from gaining leadership once it has lost it. Since that patch, CuratorInventoryManager calls shutdownNow on its PathChildrenCache's executor when stopped, meaning it can't be re-started.

Rather than undo that change, this patch just leaves the ServerInventoryView running when a coordinator loses leadership. It's part of the global lifecycle anyway so there's no need to micro-manage it.

Stack trace when the coordinator tries to regain leadership was:

```
2017-01-07T22:21:22,622 ERROR [CoordinatorLeader-0] io.druid.server.coordinator.DruidCoordinator - Unable to become leader: {class=io.druid.server.coordinator.DruidCoordinator, exceptionType=class java.
util.concurrent.RejectedExecutionException, exceptionMessage=Task org.apache.curator.utils.CloseableExecutorService$InternalFutureTask@38ff7859 rejected from java.util.concurrent.ThreadPoolExecutor@41f4
7d6[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 17]}
java.util.concurrent.RejectedExecutionException: Task org.apache.curator.utils.CloseableExecutorService$InternalFutureTask@38ff7859 rejected from java.util.concurrent.ThreadPoolExecutor@41f47d6[Terminat
ed, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 17]
        at java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2047) ~[?:1.8.0_101]
        at java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:823) ~[?:1.8.0_101]
        at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1369) ~[?:1.8.0_101]
        at java.util.concurrent.Executors$DelegatedExecutorService.execute(Executors.java:668) ~[?:1.8.0_101]
        at org.apache.curator.utils.CloseableExecutorService.submit(CloseableExecutorService.java:191) ~[curator-client-2.11.1.jar:?]
        at org.apache.curator.framework.recipes.cache.PathChildrenCache.submitToExecutor(PathChildrenCache.java:813) ~[curator-recipes-2.11.1.jar:?]
        at org.apache.curator.framework.recipes.cache.PathChildrenCache.offerOperation(PathChildrenCache.java:764) ~[curator-recipes-2.11.1.jar:?]
        at org.apache.curator.framework.recipes.cache.PathChildrenCache.start(PathChildrenCache.java:310) ~[curator-recipes-2.11.1.jar:?]
        at io.druid.curator.inventory.CuratorInventoryManager.start(CuratorInventoryManager.java:111) ~[druid-server-0.9.3-SNAPSHOT.jar:0.9.3-SNAPSHOT]
        at io.druid.client.ServerInventoryView.start(ServerInventoryView.java:180) ~[druid-server-0.9.3-SNAPSHOT.jar:0.9.3-SNAPSHOT]
        at io.druid.server.coordinator.DruidCoordinator.becomeLeader(DruidCoordinator.java:556) [druid-server-0.9.3-SNAPSHOT.jar:0.9.3-SNAPSHOT]
        at io.druid.server.coordinator.DruidCoordinator.access$100(DruidCoordinator.java:96) [druid-server-0.9.3-SNAPSHOT.jar:0.9.3-SNAPSHOT]
        at io.druid.server.coordinator.DruidCoordinator$4.isLeader(DruidCoordinator.java:504) [druid-server-0.9.3-SNAPSHOT.jar:0.9.3-SNAPSHOT]
        at org.apache.curator.framework.recipes.leader.LeaderLatch$9.apply(LeaderLatch.java:652) [curator-recipes-2.11.1.jar:?]
        at org.apache.curator.framework.recipes.leader.LeaderLatch$9.apply(LeaderLatch.java:648) [curator-recipes-2.11.1.jar:?]
        at org.apache.curator.framework.listen.ListenerContainer$1.run(ListenerContainer.java:93) [curator-framework-2.11.1.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_101]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_101]
        at java.lang.Thread.run(Thread.java:745) [?:1.8.0_101]
```