### PR TITLE
DimensionSelector-related bug fixes and optimizations (fixes #3799, part of #3798)

### DIFF
--- a/processing/src/main/java/io/druid/query/dimension/BaseFilteredDimensionSpec.java
+++ b/processing/src/main/java/io/druid/query/dimension/BaseFilteredDimensionSpec.java
@@ -22,13 +22,6 @@ package io.druid.query.dimension;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import io.druid.query.extraction.ExtractionFn;
-import io.druid.segment.DimensionSelector;
-import io.druid.segment.data.IndexedInts;
-import io.druid.segment.data.ListBasedIndexedInts;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 /**
  */
@@ -71,52 +64,5 @@ public abstract class BaseFilteredDimensionSpec implements DimensionSpec
   public boolean preservesOrdering()
   {
     return delegate.preservesOrdering();
-  }
-
-  protected static DimensionSelector decorate(
-      final DimensionSelector selector,
-      final Map<Integer, Integer> forwardMapping,
-      final int[] reverseMapping
-  )
-  {
-    if (selector == null) {
-      return selector;
-    }
-
-    return new DimensionSelector()
-    {
-      @Override
-      public IndexedInts getRow()
-      {
-        IndexedInts baseRow = selector.getRow();
-        List<Integer> result = new ArrayList<>(baseRow.size());
-
-        for (int i : baseRow) {
-          if (forwardMapping.containsKey(i)) {
-            result.add(forwardMapping.get(i));
-          }
-        }
-
-        return new ListBasedIndexedInts(result);
-      }
-
-      @Override
-      public int getValueCardinality()
-      {
-        return forwardMapping.size();
-      }
-
-      @Override
-      public String lookupName(int id)
-      {
-        return selector.lookupName(reverseMapping[id]);
-      }
-
-      @Override
-      public int lookupId(String name)
-      {
-        return forwardMapping.get(selector.lookupId(name));
-      }
-    };
   }
 }

--- a/processing/src/main/java/io/druid/query/dimension/ForwardingFilteredDimensionSelector.java
+++ b/processing/src/main/java/io/druid/query/dimension/ForwardingFilteredDimensionSelector.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.dimension;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import io.druid.java.util.common.IAE;
+import io.druid.query.filter.ValueMatcher;
+import io.druid.segment.DimensionSelector;
+import io.druid.segment.DimensionSelectorUtils;
+import io.druid.segment.IdLookup;
+import io.druid.segment.data.ArrayBasedIndexedInts;
+import io.druid.segment.data.IndexedInts;
+import io.druid.segment.filter.BooleanValueMatcher;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+
+import javax.annotation.Nullable;
+import java.util.BitSet;
+import java.util.Objects;
+
+final class ForwardingFilteredDimensionSelector implements DimensionSelector, IdLookup
+{
+  private final DimensionSelector selector;
+  private final Int2IntMap forwardMapping;
+  private final int[] reverseMapping;
+
+  /**
+   * @param selector must return true from {@link DimensionSelector#nameLookupPossibleInAdvance()}
+   * @param forwardMapping must have {@link Int2IntMap#defaultReturnValue(int)} configured to -1.
+   */
+  ForwardingFilteredDimensionSelector(DimensionSelector selector, Int2IntMap forwardMapping, int[] reverseMapping)
+  {
+    this.selector = Preconditions.checkNotNull(selector);
+    if (!selector.nameLookupPossibleInAdvance()) {
+      throw new IAE("selector.nameLookupPossibleInAdvance() should return true");
+    }
+    this.forwardMapping = Preconditions.checkNotNull(forwardMapping);
+    if (forwardMapping.defaultReturnValue() != -1) {
+      throw new IAE("forwardMapping.defaultReturnValue() should be -1");
+    }
+    this.reverseMapping = Preconditions.checkNotNull(reverseMapping);
+  }
+
+  @Override
+  public IndexedInts getRow()
+  {
+    IndexedInts baseRow = selector.getRow();
+    int baseRowSize = baseRow.size();
+    int[] result = new int[baseRowSize];
+    int resultSize = 0;
+    for (int i = 0; i < baseRowSize; i++) {
+      int forwardedValue = forwardMapping.get(baseRow.get(i));
+      if (forwardedValue >= 0) {
+        result[resultSize++] = forwardedValue;
+      }
+    }
+    return new ArrayBasedIndexedInts(result, resultSize);
+  }
+
+  @Override
+  public ValueMatcher makeValueMatcher(final String value, final boolean matchNull)
+  {
+    IdLookup idLookup = idLookup();
+    if (idLookup != null) {
+      final int valueId = idLookup.lookupId(value);
+      if (valueId >= 0 || matchNull) {
+        return new ValueMatcher()
+        {
+          @Override
+          public boolean matches()
+          {
+            final IndexedInts baseRow = selector.getRow();
+            final int baseRowSize = baseRow.size();
+            boolean nullRow = true;
+            for (int i = 0; i < baseRowSize; i++) {
+              int forwardedValue = forwardMapping.get(baseRow.get(i));
+              if (forwardedValue >= 0) {
+                // Make the following check after the `forwardedValue >= 0` check, because if forwardedValue is -1 and
+                // valueId is -1, we don't want to return true from matches().
+                if (forwardedValue == valueId) {
+                  return true;
+                }
+                nullRow = false;
+              }
+            }
+            // null should match empty rows in multi-value columns
+            return nullRow && matchNull;
+          }
+        };
+      } else {
+        return BooleanValueMatcher.of(false);
+      }
+    } else {
+      return new ValueMatcher()
+      {
+        @Override
+        public boolean matches()
+        {
+          final IndexedInts baseRow = selector.getRow();
+          final int baseRowSize = baseRow.size();
+          boolean nullRow = true;
+          for (int i = 0; i < baseRowSize; i++) {
+            int rowValueId = baseRow.get(i);
+            int forwardedValue = forwardMapping.get(rowValueId);
+            if (forwardedValue >= 0) {
+              if (Objects.equals(selector.lookupName(rowValueId), value)) {
+                return true;
+              }
+              nullRow = false;
+            }
+          }
+          // null should match empty rows in multi-value columns
+          return nullRow && matchNull;
+        }
+      };
+    }
+  }
+
+  @Override
+  public ValueMatcher makeValueMatcher(Predicate<String> predicate, final boolean matchNull)
+  {
+    final BitSet valueIds = DimensionSelectorUtils.makePredicateMatchingSet(this, predicate);
+    return new ValueMatcher()
+    {
+      @Override
+      public boolean matches()
+      {
+        final IndexedInts baseRow = selector.getRow();
+        final int baseRowSize = baseRow.size();
+        boolean nullRow = true;
+        for (int i = 0; i < baseRowSize; ++i) {
+          int forwardedValue = forwardMapping.get(baseRow.get(i));
+          if (forwardedValue >= 0) {
+            if (valueIds.get(forwardedValue)) {
+              return true;
+            }
+            nullRow = false;
+          }
+        }
+        // null should match empty rows in multi-value columns
+        return nullRow && matchNull;
+      }
+    };
+  }
+
+  @Override
+  public int getValueCardinality()
+  {
+    return forwardMapping.size();
+  }
+
+  @Override
+  public String lookupName(int id)
+  {
+    return selector.lookupName(reverseMapping[id]);
+  }
+
+  @Override
+  public boolean nameLookupPossibleInAdvance()
+  {
+    return true;
+  }
+
+  @Nullable
+  @Override
+  public IdLookup idLookup()
+  {
+    final IdLookup baseIdLookup = selector.idLookup();
+    if (baseIdLookup != null) {
+      return this;
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public int lookupId(String name)
+  {
+    // Don't cache selector.idLookup(), because it is likely implemented as `return this`, in this case caching only
+    // makes access slower.
+    return forwardMapping.get(selector.idLookup().lookupId(name));
+  }
+}

--- a/processing/src/main/java/io/druid/query/dimension/ForwardingFilteredDimensionSelector.java
+++ b/processing/src/main/java/io/druid/query/dimension/ForwardingFilteredDimensionSelector.java
@@ -38,6 +38,7 @@ import java.util.Objects;
 final class ForwardingFilteredDimensionSelector implements DimensionSelector, IdLookup
 {
   private final DimensionSelector selector;
+  private final IdLookup baseIdLookup;
   private final Int2IntMap forwardMapping;
   private final int[] reverseMapping;
 
@@ -51,6 +52,7 @@ final class ForwardingFilteredDimensionSelector implements DimensionSelector, Id
     if (!selector.nameLookupPossibleInAdvance()) {
       throw new IAE("selector.nameLookupPossibleInAdvance() should return true");
     }
+    this.baseIdLookup = selector.idLookup();
     this.forwardMapping = Preconditions.checkNotNull(forwardMapping);
     if (forwardMapping.defaultReturnValue() != -1) {
       throw new IAE("forwardMapping.defaultReturnValue() should be -1");
@@ -182,19 +184,12 @@ final class ForwardingFilteredDimensionSelector implements DimensionSelector, Id
   @Override
   public IdLookup idLookup()
   {
-    final IdLookup baseIdLookup = selector.idLookup();
-    if (baseIdLookup != null) {
-      return this;
-    } else {
-      return null;
-    }
+    return baseIdLookup != null ? this : null;
   }
 
   @Override
   public int lookupId(String name)
   {
-    // Don't cache selector.idLookup(), because it is likely implemented as `return this`, in this case caching only
-    // makes access slower.
-    return forwardMapping.get(selector.idLookup().lookupId(name));
+    return forwardMapping.get(baseIdLookup.lookupId(name));
   }
 }

--- a/processing/src/main/java/io/druid/query/dimension/ForwardingFilteredDimensionSelector.java
+++ b/processing/src/main/java/io/druid/query/dimension/ForwardingFilteredDimensionSelector.java
@@ -71,7 +71,7 @@ final class ForwardingFilteredDimensionSelector implements DimensionSelector, Id
         result[resultSize++] = forwardedValue;
       }
     }
-    return new ArrayBasedIndexedInts(result, resultSize);
+    return ArrayBasedIndexedInts.of(result, resultSize);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/dimension/ForwardingFilteredDimensionSelector.java
+++ b/processing/src/main/java/io/druid/query/dimension/ForwardingFilteredDimensionSelector.java
@@ -77,12 +77,12 @@ final class ForwardingFilteredDimensionSelector implements DimensionSelector, Id
   }
 
   @Override
-  public ValueMatcher makeValueMatcher(final String value, final boolean matchNull)
+  public ValueMatcher makeValueMatcher(final String value)
   {
     IdLookup idLookup = idLookup();
     if (idLookup != null) {
       final int valueId = idLookup.lookupId(value);
-      if (valueId >= 0 || matchNull) {
+      if (valueId >= 0 || value == null) {
         return new ValueMatcher()
         {
           @Override
@@ -103,7 +103,7 @@ final class ForwardingFilteredDimensionSelector implements DimensionSelector, Id
               }
             }
             // null should match empty rows in multi-value columns
-            return nullRow && matchNull;
+            return nullRow && value == null;
           }
         };
       } else {
@@ -111,14 +111,15 @@ final class ForwardingFilteredDimensionSelector implements DimensionSelector, Id
       }
     } else {
       // Employ precomputed BitSet optimization
-      return makeValueMatcher(Predicates.equalTo(value), matchNull);
+      return makeValueMatcher(Predicates.equalTo(value));
     }
   }
 
   @Override
-  public ValueMatcher makeValueMatcher(Predicate<String> predicate, final boolean matchNull)
+  public ValueMatcher makeValueMatcher(Predicate<String> predicate)
   {
     final BitSet valueIds = DimensionSelectorUtils.makePredicateMatchingSet(this, predicate);
+    final boolean matchNull = predicate.apply(null);
     return new ValueMatcher()
     {
       @Override

--- a/processing/src/main/java/io/druid/query/dimension/ListFilteredDimensionSpec.java
+++ b/processing/src/main/java/io/druid/query/dimension/ListFilteredDimensionSpec.java
@@ -21,14 +21,18 @@ package io.druid.query.dimension;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import com.google.common.base.Strings;
 import io.druid.java.util.common.StringUtils;
 import io.druid.query.filter.DimFilterUtils;
 import io.druid.segment.DimensionSelector;
+import io.druid.segment.IdLookup;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 
+import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -71,24 +75,31 @@ public class ListFilteredDimensionSpec extends BaseFilteredDimensionSpec
   public DimensionSelector decorate(final DimensionSelector selector)
   {
     if (selector == null) {
-      return selector;
+      return null;
     }
-
-    final int selectorCardinality = selector.getValueCardinality();
-    if (selectorCardinality < 0) {
-      throw new UnsupportedOperationException("Cannot decorate a selector with no dictionary");
-    }
-
-    // Upper bound on cardinality of the filtered spec.
-    final int cardinality = isWhitelist ? values.size() : selectorCardinality;
-
-    int count = 0;
-    final Map<Integer,Integer> forwardMapping = new HashMap<>(cardinality);
-    final int[] reverseMapping = new int[cardinality];
 
     if (isWhitelist) {
+      return filterWhiteList(selector);
+    } else {
+      return filterBlackList(selector);
+    }
+  }
+
+  private DimensionSelector filterWhiteList(DimensionSelector selector)
+  {
+    final int selectorCardinality = selector.getValueCardinality();
+    if (selectorCardinality < 0 || (selector.idLookup() == null && !selector.nameLookupPossibleInAdvance())) {
+      return new PredicateFilteredDimensionSelector(selector, Predicates.in(values));
+    }
+    final int maxPossibleFilteredCardinality = values.size();
+    int count = 0;
+    final Int2IntMap forwardMapping = new Int2IntOpenHashMap(maxPossibleFilteredCardinality);
+    forwardMapping.defaultReturnValue(-1);
+    final int[] reverseMapping = new int[maxPossibleFilteredCardinality];
+    IdLookup idLookup = selector.idLookup();
+    if (idLookup != null) {
       for (String value : values) {
-        int i = selector.lookupId(value);
+        int i = idLookup.lookupId(value);
         if (i >= 0) {
           forwardMapping.put(i, count);
           reverseMapping[count++] = i;
@@ -96,14 +107,43 @@ public class ListFilteredDimensionSpec extends BaseFilteredDimensionSpec
       }
     } else {
       for (int i = 0; i < selectorCardinality; i++) {
-        if (!values.contains(Strings.nullToEmpty(selector.lookupName(i)))) {
+        if (values.contains(Strings.nullToEmpty(selector.lookupName(i)))) {
           forwardMapping.put(i, count);
           reverseMapping[count++] = i;
         }
       }
     }
+    return new ForwardingFilteredDimensionSelector(selector, forwardMapping, reverseMapping);
+  }
 
-    return BaseFilteredDimensionSpec.decorate(selector, forwardMapping, reverseMapping);
+  private DimensionSelector filterBlackList(DimensionSelector selector)
+  {
+    final int selectorCardinality = selector.getValueCardinality();
+    if (selectorCardinality < 0 || !selector.nameLookupPossibleInAdvance()) {
+      return new PredicateFilteredDimensionSelector(
+          selector,
+          new Predicate<String>()
+          {
+            @Override
+            public boolean apply(@Nullable String input)
+            {
+              return !values.contains(input);
+            }
+          }
+      );
+    }
+    final int maxPossibleFilteredCardinality = selectorCardinality;
+    int count = 0;
+    final Int2IntMap forwardMapping = new Int2IntOpenHashMap(maxPossibleFilteredCardinality);
+    forwardMapping.defaultReturnValue(-1);
+    final int[] reverseMapping = new int[maxPossibleFilteredCardinality];
+    for (int i = 0; i < selectorCardinality; i++) {
+      if (!values.contains(Strings.nullToEmpty(selector.lookupName(i)))) {
+        forwardMapping.put(i, count);
+        reverseMapping[count++] = i;
+      }
+    }
+    return new ForwardingFilteredDimensionSelector(selector, forwardMapping, reverseMapping);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/dimension/PredicateFilteredDimensionSelector.java
+++ b/processing/src/main/java/io/druid/query/dimension/PredicateFilteredDimensionSelector.java
@@ -52,7 +52,7 @@ final class PredicateFilteredDimensionSelector implements DimensionSelector
         result[resultSize++] = i;
       }
     }
-    return new ArrayBasedIndexedInts(result, resultSize);
+    return ArrayBasedIndexedInts.of(result, resultSize);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/dimension/PredicateFilteredDimensionSelector.java
+++ b/processing/src/main/java/io/druid/query/dimension/PredicateFilteredDimensionSelector.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.dimension;
+
+import com.google.common.base.Predicate;
+import io.druid.query.filter.ValueMatcher;
+import io.druid.segment.DimensionSelector;
+import io.druid.segment.IdLookup;
+import io.druid.segment.data.ArrayBasedIndexedInts;
+import io.druid.segment.data.IndexedInts;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+final class PredicateFilteredDimensionSelector implements DimensionSelector
+{
+  private final DimensionSelector selector;
+  private final Predicate<String> predicate;
+
+  PredicateFilteredDimensionSelector(DimensionSelector selector, Predicate<String> predicate)
+  {
+    this.selector = selector;
+    this.predicate = predicate;
+  }
+
+  @Override
+  public IndexedInts getRow()
+  {
+    IndexedInts baseRow = selector.getRow();
+    int baseRowSize = baseRow.size();
+    int[] result = new int[baseRowSize];
+    int resultSize = 0;
+    for (int i = 0; i < baseRowSize; i++) {
+      if (predicate.apply(selector.lookupName(baseRow.get(i)))) {
+        result[resultSize++] = i;
+      }
+    }
+    return new ArrayBasedIndexedInts(result, resultSize);
+  }
+
+  @Override
+  public ValueMatcher makeValueMatcher(final String value, final boolean matchNull)
+  {
+    return new ValueMatcher()
+    {
+      @Override
+      public boolean matches()
+      {
+        final IndexedInts baseRow = selector.getRow();
+        final int baseRowSize = baseRow.size();
+        boolean nullRow = true;
+        for (int i = 0; i < baseRowSize; i++) {
+          String rowValue = lookupName(baseRow.get(i));
+          if (predicate.apply(rowValue)) {
+            if (Objects.equals(rowValue, value)) {
+              return true;
+            }
+            nullRow = false;
+          }
+        }
+        // null should match empty rows in multi-value columns
+        return nullRow && matchNull;
+      }
+    };
+  }
+
+  @Override
+  public ValueMatcher makeValueMatcher(final Predicate<String> matcherPredicate, final boolean matchNull)
+  {
+    return new ValueMatcher()
+    {
+      @Override
+      public boolean matches()
+      {
+        final IndexedInts baseRow = selector.getRow();
+        final int baseRowSize = baseRow.size();
+        boolean nullRow = true;
+        for (int i = 0; i < baseRowSize; ++i) {
+          String rowValue = lookupName(baseRow.get(i));
+          if (predicate.apply(rowValue)) {
+            if (matcherPredicate.apply(rowValue)) {
+              return true;
+            }
+            nullRow = false;
+          }
+        }
+        // null should match empty rows in multi-value columns
+        return nullRow && matchNull;
+      }
+    };
+  }
+
+  @Override
+  public int getValueCardinality()
+  {
+    return selector.getValueCardinality();
+  }
+
+  @Override
+  public String lookupName(int id)
+  {
+    return selector.lookupName(id);
+  }
+
+  @Override
+  public boolean nameLookupPossibleInAdvance()
+  {
+    return selector.nameLookupPossibleInAdvance();
+  }
+
+  @Nullable
+  @Override
+  public IdLookup idLookup()
+  {
+    return selector.idLookup();
+  }
+}

--- a/processing/src/main/java/io/druid/query/dimension/PredicateFilteredDimensionSelector.java
+++ b/processing/src/main/java/io/druid/query/dimension/PredicateFilteredDimensionSelector.java
@@ -56,7 +56,7 @@ final class PredicateFilteredDimensionSelector implements DimensionSelector
   }
 
   @Override
-  public ValueMatcher makeValueMatcher(final String value, final boolean matchNull)
+  public ValueMatcher makeValueMatcher(final String value)
   {
     return new ValueMatcher()
     {
@@ -76,14 +76,15 @@ final class PredicateFilteredDimensionSelector implements DimensionSelector
           }
         }
         // null should match empty rows in multi-value columns
-        return nullRow && matchNull;
+        return nullRow && value == null;
       }
     };
   }
 
   @Override
-  public ValueMatcher makeValueMatcher(final Predicate<String> matcherPredicate, final boolean matchNull)
+  public ValueMatcher makeValueMatcher(final Predicate<String> matcherPredicate)
   {
+    final boolean matchNull = predicate.apply(null);
     return new ValueMatcher()
     {
       @Override

--- a/processing/src/main/java/io/druid/query/filter/StringValueMatcherColumnSelectorStrategy.java
+++ b/processing/src/main/java/io/druid/query/filter/StringValueMatcherColumnSelectorStrategy.java
@@ -22,11 +22,7 @@ package io.druid.query.filter;
 import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
 import io.druid.segment.DimensionSelector;
-import io.druid.segment.data.IndexedInts;
 import io.druid.segment.filter.BooleanValueMatcher;
-
-import java.util.BitSet;
-import java.util.Objects;
 
 public class StringValueMatcherColumnSelectorStrategy implements ValueMatcherColumnSelectorStrategy<DimensionSelector>
 {
@@ -42,53 +38,9 @@ public class StringValueMatcherColumnSelectorStrategy implements ValueMatcherCol
 
     if (cardinality == 0 || (cardinality == 1 && selector.lookupName(0) == null)) {
       // All values are null or empty rows (which match nulls anyway). No need to check each row.
-      return new BooleanValueMatcher(matchNull);
-    } else if (cardinality >= 0) {
-      // Dictionary-encoded dimension. Compare by id instead of by value to save time.
-      final int valueId = selector.lookupId(valueStr);
-
-      return new ValueMatcher()
-      {
-        @Override
-        public boolean matches()
-        {
-          final IndexedInts row = selector.getRow();
-          final int size = row.size();
-          if (size == 0) {
-            // null should match empty rows in multi-value columns
-            return matchNull;
-          } else {
-            for (int i = 0; i < size; ++i) {
-              if (row.get(i) == valueId) {
-                return true;
-              }
-            }
-            return false;
-          }
-        }
-      };
+      return BooleanValueMatcher.of(matchNull);
     } else {
-      // Not dictionary-encoded. Skip the optimization.
-      return new ValueMatcher()
-      {
-        @Override
-        public boolean matches()
-        {
-          final IndexedInts row = selector.getRow();
-          final int size = row.size();
-          if (size == 0) {
-            // null should match empty rows in multi-value columns
-            return matchNull;
-          } else {
-            for (int i = 0; i < size; ++i) {
-              if (Objects.equals(selector.lookupName(row.get(i)), valueStr)) {
-                return true;
-              }
-            }
-            return false;
-          }
-        }
-      };
+      return selector.makeValueMatcher(valueStr, matchNull);
     }
   }
 
@@ -104,58 +56,10 @@ public class StringValueMatcherColumnSelectorStrategy implements ValueMatcherCol
 
     if (cardinality == 0 || (cardinality == 1 && selector.lookupName(0) == null)) {
       // All values are null or empty rows (which match nulls anyway). No need to check each row.
-      return new BooleanValueMatcher(matchNull);
-    } else if (cardinality >= 0) {
-      // Dictionary-encoded dimension. Check every value; build a bitset of matching ids.
-      final BitSet valueIds = new BitSet(cardinality);
-      for (int i = 0; i < cardinality; i++) {
-        if (predicate.apply(selector.lookupName(i))) {
-          valueIds.set(i);
-        }
-      }
-
-      return new ValueMatcher()
-      {
-        @Override
-        public boolean matches()
-        {
-          final IndexedInts row = selector.getRow();
-          final int size = row.size();
-          if (size == 0) {
-            // null should match empty rows in multi-value columns
-            return matchNull;
-          } else {
-            for (int i = 0; i < size; ++i) {
-              if (valueIds.get(row.get(i))) {
-                return true;
-              }
-            }
-            return false;
-          }
-        }
-      };
+      return BooleanValueMatcher.of(matchNull);
     } else {
-      // Not dictionary-encoded. Skip the optimization.
-      return new ValueMatcher()
-      {
-        @Override
-        public boolean matches()
-        {
-          final IndexedInts row = selector.getRow();
-          final int size = row.size();
-          if (size == 0) {
-            // null should match empty rows in multi-value columns
-            return matchNull;
-          } else {
-            for (int i = 0; i < size; ++i) {
-              if (predicate.apply(selector.lookupName(row.get(i)))) {
-                return true;
-              }
-            }
-            return false;
-          }
-        }
-      };
+      return selector.makeValueMatcher(predicate, matchNull);
     }
   }
+
 }

--- a/processing/src/main/java/io/druid/query/filter/StringValueMatcherColumnSelectorStrategy.java
+++ b/processing/src/main/java/io/druid/query/filter/StringValueMatcherColumnSelectorStrategy.java
@@ -27,20 +27,13 @@ import io.druid.segment.filter.BooleanValueMatcher;
 public class StringValueMatcherColumnSelectorStrategy implements ValueMatcherColumnSelectorStrategy<DimensionSelector>
 {
   @Override
-  public ValueMatcher makeValueMatcher(final DimensionSelector selector, final String value)
+  public ValueMatcher makeValueMatcher(final DimensionSelector selector, String value)
   {
-    final String valueStr = Strings.emptyToNull(value);
-
-    // if matching against null, rows with size 0 should also match
-    final boolean matchNull = Strings.isNullOrEmpty(valueStr);
-
-    final int cardinality = selector.getValueCardinality();
-
-    if (cardinality == 0 || (cardinality == 1 && selector.lookupName(0) == null)) {
-      // All values are null or empty rows (which match nulls anyway). No need to check each row.
-      return BooleanValueMatcher.of(matchNull);
+    value = Strings.emptyToNull(value);
+    if (selector.getValueCardinality() == 0) {
+      return BooleanValueMatcher.of(value == null);
     } else {
-      return selector.makeValueMatcher(valueStr, matchNull);
+      return selector.makeValueMatcher(value);
     }
   }
 
@@ -51,14 +44,10 @@ public class StringValueMatcherColumnSelectorStrategy implements ValueMatcherCol
   )
   {
     final Predicate<String> predicate = predicateFactory.makeStringPredicate();
-    final int cardinality = selector.getValueCardinality();
-    final boolean matchNull = predicate.apply(null);
-
-    if (cardinality == 0 || (cardinality == 1 && selector.lookupName(0) == null)) {
-      // All values are null or empty rows (which match nulls anyway). No need to check each row.
-      return BooleanValueMatcher.of(matchNull);
+    if (selector.getValueCardinality() == 0) {
+      return BooleanValueMatcher.of(predicate.apply(null));
     } else {
-      return selector.makeValueMatcher(predicate, matchNull);
+      return selector.makeValueMatcher(predicate);
     }
   }
 

--- a/processing/src/main/java/io/druid/query/groupby/RowBasedColumnSelectorFactory.java
+++ b/processing/src/main/java/io/druid/query/groupby/RowBasedColumnSelectorFactory.java
@@ -113,7 +113,7 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
         }
 
         @Override
-        public ValueMatcher makeValueMatcher(final String value, boolean matchNull)
+        public ValueMatcher makeValueMatcher(final String value)
         {
           return new ValueMatcher()
           {
@@ -127,9 +127,7 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
         }
 
         @Override
-        public ValueMatcher makeValueMatcher(
-            final Predicate<String> predicate, boolean matchNull
-        )
+        public ValueMatcher makeValueMatcher(final Predicate<String> predicate)
         {
           return new ValueMatcher()
           {
@@ -178,7 +176,7 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
         }
 
         @Override
-        public ValueMatcher makeValueMatcher(final String value, final boolean matchNull)
+        public ValueMatcher makeValueMatcher(final String value)
         {
           if (extractionFn == null) {
             return new ValueMatcher()
@@ -188,7 +186,7 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
               {
                 final List<String> dimensionValues = row.get().getDimension(dimension);
                 if (dimensionValues == null || dimensionValues.isEmpty()) {
-                  return matchNull;
+                  return value == null;
                 }
 
                 for (String dimensionValue : dimensionValues) {
@@ -207,7 +205,7 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
               {
                 final List<String> dimensionValues = row.get().getDimension(dimension);
                 if (dimensionValues == null || dimensionValues.isEmpty()) {
-                  return matchNull;
+                  return value == null;
                 }
 
                 for (String dimensionValue : dimensionValues) {
@@ -222,8 +220,9 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
         }
 
         @Override
-        public ValueMatcher makeValueMatcher(final Predicate<String> predicate, final boolean matchNull)
+        public ValueMatcher makeValueMatcher(final Predicate<String> predicate)
         {
+          final boolean matchNull = predicate.apply(null);
           if (extractionFn == null) {
             return new ValueMatcher()
             {

--- a/processing/src/main/java/io/druid/query/groupby/RowBasedColumnSelectorFactory.java
+++ b/processing/src/main/java/io/druid/query/groupby/RowBasedColumnSelectorFactory.java
@@ -19,15 +19,18 @@
 
 package io.druid.query.groupby;
 
+import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMap;
 import io.druid.data.input.Row;
 import io.druid.query.dimension.DimensionSpec;
 import io.druid.query.extraction.ExtractionFn;
+import io.druid.query.filter.ValueMatcher;
 import io.druid.segment.ColumnSelectorFactory;
 import io.druid.segment.DimensionSelector;
 import io.druid.segment.FloatColumnSelector;
+import io.druid.segment.IdLookup;
 import io.druid.segment.LongColumnSelector;
 import io.druid.segment.ObjectColumnSelector;
 import io.druid.segment.column.Column;
@@ -41,6 +44,7 @@ import io.druid.segment.data.ZeroIndexedInts;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
 {
@@ -109,6 +113,36 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
         }
 
         @Override
+        public ValueMatcher makeValueMatcher(final String value, boolean matchNull)
+        {
+          return new ValueMatcher()
+          {
+            @Override
+            public boolean matches()
+            {
+              String rowValue = extractionFn.apply(row.get().getTimestampFromEpoch());
+              return Objects.equals(rowValue, value);
+            }
+          };
+        }
+
+        @Override
+        public ValueMatcher makeValueMatcher(
+            final Predicate<String> predicate, boolean matchNull
+        )
+        {
+          return new ValueMatcher()
+          {
+            @Override
+            public boolean matches()
+            {
+              String rowValue = extractionFn.apply(row.get().getTimestampFromEpoch());
+              return predicate.apply(rowValue);
+            }
+          };
+        }
+
+        @Override
         public int getValueCardinality()
         {
           return DimensionSelector.CARDINALITY_UNKNOWN;
@@ -121,9 +155,16 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
         }
 
         @Override
-        public int lookupId(String name)
+        public boolean nameLookupPossibleInAdvance()
         {
-          throw new UnsupportedOperationException("lookupId");
+          return false;
+        }
+
+        @Nullable
+        @Override
+        public IdLookup idLookup()
+        {
+          return null;
         }
       };
     } else {
@@ -134,6 +175,94 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
         {
           final List<String> dimensionValues = row.get().getDimension(dimension);
           return RangeIndexedInts.create(dimensionValues != null ? dimensionValues.size() : 0);
+        }
+
+        @Override
+        public ValueMatcher makeValueMatcher(final String value, final boolean matchNull)
+        {
+          if (extractionFn == null) {
+            return new ValueMatcher()
+            {
+              @Override
+              public boolean matches()
+              {
+                final List<String> dimensionValues = row.get().getDimension(dimension);
+                if (dimensionValues == null || dimensionValues.isEmpty()) {
+                  return matchNull;
+                }
+
+                for (String dimensionValue : dimensionValues) {
+                  if (Objects.equals(Strings.emptyToNull(dimensionValue), value)) {
+                    return true;
+                  }
+                }
+                return false;
+              }
+            };
+          } else {
+            return new ValueMatcher()
+            {
+              @Override
+              public boolean matches()
+              {
+                final List<String> dimensionValues = row.get().getDimension(dimension);
+                if (dimensionValues == null || dimensionValues.isEmpty()) {
+                  return matchNull;
+                }
+
+                for (String dimensionValue : dimensionValues) {
+                  if (Objects.equals(extractionFn.apply(Strings.emptyToNull(dimensionValue)), value)) {
+                    return true;
+                  }
+                }
+                return false;
+              }
+            };
+          }
+        }
+
+        @Override
+        public ValueMatcher makeValueMatcher(final Predicate<String> predicate, final boolean matchNull)
+        {
+          if (extractionFn == null) {
+            return new ValueMatcher()
+            {
+              @Override
+              public boolean matches()
+              {
+                final List<String> dimensionValues = row.get().getDimension(dimension);
+                if (dimensionValues == null || dimensionValues.isEmpty()) {
+                  return matchNull;
+                }
+
+                for (String dimensionValue : dimensionValues) {
+                  if (predicate.apply(Strings.emptyToNull(dimensionValue))) {
+                    return true;
+                  }
+                }
+                return false;
+              }
+            };
+          } else {
+            return new ValueMatcher()
+            {
+              @Override
+              public boolean matches()
+              {
+                final List<String> dimensionValues = row.get().getDimension(dimension);
+                if (dimensionValues == null || dimensionValues.isEmpty()) {
+                  return matchNull;
+                }
+
+                for (String dimensionValue : dimensionValues) {
+                  if (predicate.apply(extractionFn.apply(Strings.emptyToNull(dimensionValue)))) {
+                    return true;
+                  }
+                }
+                return false;
+              }
+            };
+          }
         }
 
         @Override
@@ -150,9 +279,16 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
         }
 
         @Override
-        public int lookupId(String name)
+        public boolean nameLookupPossibleInAdvance()
         {
-          throw new UnsupportedOperationException("lookupId");
+          return false;
+        }
+
+        @Nullable
+        @Override
+        public IdLookup idLookup()
+        {
+          return null;
         }
       };
     }

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByRowProcessor.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByRowProcessor.java
@@ -97,7 +97,7 @@ public class GroupByRowProcessor
         rowSignature
     );
     final ValueMatcher filterMatcher = filter == null
-                                       ? new BooleanValueMatcher(true)
+                                       ? BooleanValueMatcher.of(true)
                                        : filter.makeMatcher(columnSelectorFactory);
 
     final FilteredSequence<Row> filteredSequence = new FilteredSequence<>(

--- a/processing/src/main/java/io/druid/query/topn/BaseTopNAlgorithm.java
+++ b/processing/src/main/java/io/druid/query/topn/BaseTopNAlgorithm.java
@@ -238,7 +238,7 @@ public abstract class BaseTopNAlgorithm<DimValSelector, DimValAggregateStore, Pa
 
       if (previousStop != null) {
         if (idLookup == null) {
-          throw new IAE("Only DimensionSelectors which support idLookup() are supported yet");
+          throw new UnsupportedOperationException("Only DimensionSelectors which support idLookup() are supported yet");
         }
         int lookupId = idLookup.lookupId(previousStop) + 1;
         if (lookupId < 0) {

--- a/processing/src/main/java/io/druid/query/topn/BaseTopNAlgorithm.java
+++ b/processing/src/main/java/io/druid/query/topn/BaseTopNAlgorithm.java
@@ -26,6 +26,7 @@ import io.druid.query.aggregation.BufferAggregator;
 import io.druid.segment.Capabilities;
 import io.druid.segment.Cursor;
 import io.druid.segment.DimensionSelector;
+import io.druid.segment.IdLookup;
 
 import java.util.Arrays;
 import java.util.Comparator;
@@ -179,6 +180,7 @@ public abstract class BaseTopNAlgorithm<DimValSelector, DimValAggregateStore, Pa
     private volatile int keepOnlyN;
 
     private final DimensionSelector dimSelector;
+    private final IdLookup idLookup;
     private final TopNQuery query;
     private final Capabilities capabilities;
 
@@ -189,6 +191,7 @@ public abstract class BaseTopNAlgorithm<DimValSelector, DimValAggregateStore, Pa
     )
     {
       this.dimSelector = dimSelector;
+      this.idLookup = dimSelector.idLookup();
       this.query = query;
       this.capabilities = capabilities;
 
@@ -232,8 +235,8 @@ public abstract class BaseTopNAlgorithm<DimValSelector, DimValAggregateStore, Pa
     {
       int startIndex = ignoreFirstN;
 
-      if (previousStop != null) {
-        int lookupId = dimSelector.lookupId(previousStop) + 1;
+      if (previousStop != null && idLookup != null) {
+        int lookupId = idLookup.lookupId(previousStop) + 1;
         if (lookupId < 0) {
           lookupId *= -1;
         }

--- a/processing/src/main/java/io/druid/query/topn/BaseTopNAlgorithm.java
+++ b/processing/src/main/java/io/druid/query/topn/BaseTopNAlgorithm.java
@@ -193,9 +193,6 @@ public abstract class BaseTopNAlgorithm<DimValSelector, DimValAggregateStore, Pa
     {
       this.dimSelector = dimSelector;
       this.idLookup = dimSelector.idLookup();
-      if (idLookup == null && capabilities.dimensionValuesSorted()) {
-        throw new IAE("Only DimensionSelectors which support idLookup() are supported yet");
-      }
       this.query = query;
       this.capabilities = capabilities;
 
@@ -240,6 +237,9 @@ public abstract class BaseTopNAlgorithm<DimValSelector, DimValAggregateStore, Pa
       int startIndex = ignoreFirstN;
 
       if (previousStop != null) {
+        if (idLookup == null) {
+          throw new IAE("Only DimensionSelectors which support idLookup() are supported yet");
+        }
         int lookupId = idLookup.lookupId(previousStop) + 1;
         if (lookupId < 0) {
           lookupId *= -1;

--- a/processing/src/main/java/io/druid/query/topn/BaseTopNAlgorithm.java
+++ b/processing/src/main/java/io/druid/query/topn/BaseTopNAlgorithm.java
@@ -193,7 +193,7 @@ public abstract class BaseTopNAlgorithm<DimValSelector, DimValAggregateStore, Pa
     {
       this.dimSelector = dimSelector;
       this.idLookup = dimSelector.idLookup();
-      if (idLookup == null) {
+      if (idLookup == null && capabilities.dimensionValuesSorted()) {
         throw new IAE("Only DimensionSelectors which support idLookup() are supported yet");
       }
       this.query = query;

--- a/processing/src/main/java/io/druid/query/topn/BaseTopNAlgorithm.java
+++ b/processing/src/main/java/io/druid/query/topn/BaseTopNAlgorithm.java
@@ -19,6 +19,7 @@
 
 package io.druid.query.topn;
 
+import io.druid.java.util.common.IAE;
 import io.druid.java.util.common.Pair;
 import io.druid.query.aggregation.Aggregator;
 import io.druid.query.aggregation.AggregatorFactory;
@@ -192,6 +193,9 @@ public abstract class BaseTopNAlgorithm<DimValSelector, DimValAggregateStore, Pa
     {
       this.dimSelector = dimSelector;
       this.idLookup = dimSelector.idLookup();
+      if (idLookup == null) {
+        throw new IAE("Only DimensionSelectors which support idLookup() are supported yet");
+      }
       this.query = query;
       this.capabilities = capabilities;
 
@@ -201,7 +205,7 @@ public abstract class BaseTopNAlgorithm<DimValSelector, DimValAggregateStore, Pa
       keepOnlyN = dimSelector.getValueCardinality();
 
       if (keepOnlyN < 0) {
-        throw new UnsupportedOperationException("Cannot operate on a dimension with no dictionary");
+        throw new IAE("Cannot operate on a dimension with no dictionary");
       }
     }
 
@@ -235,7 +239,7 @@ public abstract class BaseTopNAlgorithm<DimValSelector, DimValAggregateStore, Pa
     {
       int startIndex = ignoreFirstN;
 
-      if (previousStop != null && idLookup != null) {
+      if (previousStop != null) {
         int lookupId = idLookup.lookupId(previousStop) + 1;
         if (lookupId < 0) {
           lookupId *= -1;

--- a/processing/src/main/java/io/druid/segment/DimensionSelector.java
+++ b/processing/src/main/java/io/druid/segment/DimensionSelector.java
@@ -96,10 +96,15 @@ public interface DimensionSelector extends ColumnValueSelector
    * Returns true if it is possible to {@link #lookupName(int)} by ids from 0 to {@link #getValueCardinality()}
    * before the rows with those ids are returned.
    *
-   * <p>Returns false if {@link #lookupName(int)} could be called only with ids, returned from the most recent call of
-   * {@link #getRow()} on this DimensionSelector, but not earlier and not later. If {@link #lookupName(int)} is called
-   * with an id, which is not present in the most recent {@link IndexedInts}, returned from {@link #getRow()}, result is
-   * undefined: exception could be thrown, or null returned, or some other random value.
+   * <p>Returns false if {@link #lookupName(int)} could be called with ids, returned from the most recent call of {@link
+   * #getRow()} on this DimensionSelector, but not earlier. If {@link #getValueCardinality()} of this DimensionSelector
+   * additionally returns {@link #CARDINALITY_UNKNOWN}, {@code lookupName()} couldn't be called with ids, returned by
+   * not the most recent call of {@link #getRow()}, i. e. names for ids couldn't be looked up "later". If {@link
+   * #getValueCardinality()} returns a non-negative number, {@code lookupName()} could be called with any ids, returned
+   * from {@code #getRow()} since the creation of this DimensionSelector.
+   *
+   * <p>If {@link #lookupName(int)} is called with an ineligible id, result is undefined: exception could be thrown, or
+   * null returned, or some other random value.
    */
   boolean nameLookupPossibleInAdvance();
 

--- a/processing/src/main/java/io/druid/segment/DimensionSelector.java
+++ b/processing/src/main/java/io/druid/segment/DimensionSelector.java
@@ -40,9 +40,12 @@ public interface DimensionSelector extends ColumnValueSelector
    */
   public IndexedInts getRow();
 
-  ValueMatcher makeValueMatcher(String value, boolean matchNull);
+  /**
+   * @param value nullable dimension value
+   */
+  ValueMatcher makeValueMatcher(String value);
 
-  ValueMatcher makeValueMatcher(Predicate<String> predicate, boolean matchNull);
+  ValueMatcher makeValueMatcher(Predicate<String> predicate);
 
   /**
    * Value cardinality is the cardinality of the different occurring values.  If there were 4 rows:

--- a/processing/src/main/java/io/druid/segment/DimensionSelector.java
+++ b/processing/src/main/java/io/druid/segment/DimensionSelector.java
@@ -17,7 +17,13 @@
  * under the License.
  */
 
-package io.druid.segment;import io.druid.segment.data.IndexedInts;
+package io.druid.segment;
+
+import com.google.common.base.Predicate;
+import io.druid.query.filter.ValueMatcher;
+import io.druid.segment.data.IndexedInts;
+
+import javax.annotation.Nullable;
 
 /**
  */
@@ -33,6 +39,10 @@ public interface DimensionSelector extends ColumnValueSelector
    * @return all values for the row as an IntBuffer
    */
   public IndexedInts getRow();
+
+  ValueMatcher makeValueMatcher(String value, boolean matchNull);
+
+  ValueMatcher makeValueMatcher(Predicate<String> predicate, boolean matchNull);
 
   /**
    * Value cardinality is the cardinality of the different occurring values.  If there were 4 rows:
@@ -80,10 +90,19 @@ public interface DimensionSelector extends ColumnValueSelector
   public String lookupName(int id);
 
   /**
-   * The ID is the int id value of the field.
+   * Returns true if it is possible to {@link #lookupName(int)} by ids from 0 to {@link #getValueCardinality()}
+   * Before the rows with those ids are returns.
    *
-   * @param name field name to look up the id for
-   * @return the id for the given field name
+   * <p>Returns false if {@link #lookupName(int)} could be called only with ids, returned from the last call of {@link
+   * #getRow()} on this DimensionSelector, but not earlier and not later. If {@link #lookupName(int)} is called with an
+   * id, which is not present in the last {@link IndexedInts}, returned from {@link #getRow()}, result is undefined:
+   * exception could be thrown, or null returned, or some other random value.
    */
-  public int lookupId(String name);
+  boolean nameLookupPossibleInAdvance();
+
+  /**
+   * Returns {@link IdLookup} if available for this DimensionSelector, or null.
+   */
+  @Nullable
+  IdLookup idLookup();
 }

--- a/processing/src/main/java/io/druid/segment/DimensionSelector.java
+++ b/processing/src/main/java/io/druid/segment/DimensionSelector.java
@@ -91,12 +91,12 @@ public interface DimensionSelector extends ColumnValueSelector
 
   /**
    * Returns true if it is possible to {@link #lookupName(int)} by ids from 0 to {@link #getValueCardinality()}
-   * Before the rows with those ids are returns.
+   * before the rows with those ids are returned.
    *
-   * <p>Returns false if {@link #lookupName(int)} could be called only with ids, returned from the last call of {@link
-   * #getRow()} on this DimensionSelector, but not earlier and not later. If {@link #lookupName(int)} is called with an
-   * id, which is not present in the last {@link IndexedInts}, returned from {@link #getRow()}, result is undefined:
-   * exception could be thrown, or null returned, or some other random value.
+   * <p>Returns false if {@link #lookupName(int)} could be called only with ids, returned from the most recent call of
+   * {@link #getRow()} on this DimensionSelector, but not earlier and not later. If {@link #lookupName(int)} is called
+   * with an id, which is not present in the most recent {@link IndexedInts}, returned from {@link #getRow()}, result is
+   * undefined: exception could be thrown, or null returned, or some other random value.
    */
   boolean nameLookupPossibleInAdvance();
 

--- a/processing/src/main/java/io/druid/segment/DimensionSelectorUtils.java
+++ b/processing/src/main/java/io/druid/segment/DimensionSelectorUtils.java
@@ -20,6 +20,7 @@
 package io.druid.segment;
 
 import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import io.druid.java.util.common.IAE;
 import io.druid.query.filter.ValueMatcher;
 import io.druid.segment.data.IndexedInts;
@@ -44,6 +45,9 @@ public final class DimensionSelectorUtils
     IdLookup idLookup = selector.idLookup();
     if (idLookup != null) {
       return makeDictionaryEncodedRowBasedValueMatcher(selector, idLookup.lookupId(value), matchNull);
+    } else if (selector.getValueCardinality() >= 0 && selector.nameLookupPossibleInAdvance()) {
+      // Employ precomputed BitSet optimization
+      return makeRowBasedValueMatcher(selector, Predicates.equalTo(value), matchNull);
     } else {
       return makeNonDictionaryEncodedRowBasedValueMatcher(selector, value, matchNull);
     }

--- a/processing/src/main/java/io/druid/segment/DimensionSelectorUtils.java
+++ b/processing/src/main/java/io/druid/segment/DimensionSelectorUtils.java
@@ -129,7 +129,7 @@ public final class DimensionSelectorUtils
   )
   {
     int cardinality = selector.getValueCardinality();
-    if (cardinality >= 0) {
+    if (cardinality >= 0 && selector.nameLookupPossibleInAdvance()) {
       return makeDictionaryEncodedRowBasedValueMatcher(selector, predicate, matchNull);
     } else {
       return makeNonDictionaryEncodedRowBasedValueMatcher(selector, predicate, matchNull);

--- a/processing/src/main/java/io/druid/segment/DimensionSelectorUtils.java
+++ b/processing/src/main/java/io/druid/segment/DimensionSelectorUtils.java
@@ -45,7 +45,7 @@ public final class DimensionSelectorUtils
     if (idLookup != null) {
       return makeDictionaryEncodedRowBasedValueMatcher(selector, idLookup.lookupId(value), matchNull);
     } else {
-      return makeNonDictionaryEncodedIndexedIntsBasedValueMatcher(selector, value, matchNull);
+      return makeNonDictionaryEncodedRowBasedValueMatcher(selector, value, matchNull);
     }
   }
 
@@ -94,7 +94,7 @@ public final class DimensionSelectorUtils
     }
   }
 
-  private static ValueMatcher makeNonDictionaryEncodedIndexedIntsBasedValueMatcher(
+  private static ValueMatcher makeNonDictionaryEncodedRowBasedValueMatcher(
       final DimensionSelector selector,
       final String value,
       final boolean matchNull

--- a/processing/src/main/java/io/druid/segment/DimensionSelectorUtils.java
+++ b/processing/src/main/java/io/druid/segment/DimensionSelectorUtils.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment;
+
+import com.google.common.base.Predicate;
+import io.druid.java.util.common.IAE;
+import io.druid.query.filter.ValueMatcher;
+import io.druid.segment.data.IndexedInts;
+import io.druid.segment.filter.BooleanValueMatcher;
+
+import java.util.BitSet;
+import java.util.Objects;
+
+public final class DimensionSelectorUtils
+{
+
+  private DimensionSelectorUtils()
+  {
+  }
+
+  public static ValueMatcher makeRowBasedValueMatcher(
+      DimensionSelector selector,
+      String value,
+      boolean matchNull
+  )
+  {
+    IdLookup idLookup = selector.idLookup();
+    if (idLookup != null) {
+      return makeDictionaryEncodedRowBasedValueMatcher(selector, idLookup.lookupId(value), matchNull);
+    } else {
+      return makeNonDictionaryEncodedIndexedIntsBasedValueMatcher(selector, value, matchNull);
+    }
+  }
+
+  private static ValueMatcher makeDictionaryEncodedRowBasedValueMatcher(
+      final DimensionSelector selector,
+      final int valueId,
+      final boolean matchNull
+  )
+  {
+    if (valueId >= 0) {
+      return new ValueMatcher()
+      {
+        @Override
+        public boolean matches()
+        {
+          final IndexedInts row = selector.getRow();
+          final int size = row.size();
+          if (size == 0) {
+            // null should match empty rows in multi-value columns
+            return matchNull;
+          } else {
+            for (int i = 0; i < size; ++i) {
+              if (row.get(i) == valueId) {
+                return true;
+              }
+            }
+            return false;
+          }
+        }
+      };
+    } else {
+      if (matchNull) {
+        return new ValueMatcher()
+        {
+          @Override
+          public boolean matches()
+          {
+            final IndexedInts row = selector.getRow();
+            final int size = row.size();
+            return size == 0;
+          }
+        };
+      } else {
+        return BooleanValueMatcher.of(false);
+      }
+    }
+  }
+
+  private static ValueMatcher makeNonDictionaryEncodedIndexedIntsBasedValueMatcher(
+      final DimensionSelector selector,
+      final String value,
+      final boolean matchNull
+  )
+  {
+    return new ValueMatcher()
+    {
+      @Override
+      public boolean matches()
+      {
+        final IndexedInts row = selector.getRow();
+        final int size = row.size();
+        if (size == 0) {
+          // null should match empty rows in multi-value columns
+          return matchNull;
+        } else {
+          for (int i = 0; i < size; ++i) {
+            if (Objects.equals(selector.lookupName(row.get(i)), value)) {
+              return true;
+            }
+          }
+          return false;
+        }
+      }
+    };
+  }
+
+  public static ValueMatcher makeRowBasedValueMatcher(
+      final DimensionSelector selector,
+      final Predicate<String> predicate,
+      final boolean matchNull
+  )
+  {
+    int cardinality = selector.getValueCardinality();
+    if (cardinality >= 0) {
+      return makeDictionaryEncodedRowBasedValueMatcher(selector, predicate, matchNull);
+    } else {
+      return makeNonDictionaryEncodedRowBasedValueMatcher(selector, predicate, matchNull);
+    }
+  }
+
+  private static ValueMatcher makeDictionaryEncodedRowBasedValueMatcher(
+      final DimensionSelector selector,
+      Predicate<String> predicate,
+      final boolean matchNull
+  )
+  {
+    final BitSet predicateMatchingValueIds = makePredicateMatchingSet(selector, predicate);
+    return new ValueMatcher()
+    {
+      @Override
+      public boolean matches()
+      {
+        final IndexedInts row = selector.getRow();
+        final int size = row.size();
+        if (size == 0) {
+          // null should match empty rows in multi-value columns
+          return matchNull;
+        } else {
+          for (int i = 0; i < size; ++i) {
+            if (predicateMatchingValueIds.get(row.get(i))) {
+              return true;
+            }
+          }
+          return false;
+        }
+      }
+    };
+  }
+
+  private static ValueMatcher makeNonDictionaryEncodedRowBasedValueMatcher(
+      final DimensionSelector selector,
+      final Predicate<String> predicate,
+      final boolean matchNull
+  )
+  {
+    return new ValueMatcher()
+    {
+      @Override
+      public boolean matches()
+      {
+        final IndexedInts row = selector.getRow();
+        final int size = row.size();
+        if (size == 0) {
+          // null should match empty rows in multi-value columns
+          return matchNull;
+        } else {
+          for (int i = 0; i < size; ++i) {
+            if (predicate.apply(selector.lookupName(row.get(i)))) {
+              return true;
+            }
+          }
+          return false;
+        }
+      }
+    };
+  }
+
+  public static BitSet makePredicateMatchingSet(DimensionSelector selector, Predicate<String> predicate)
+  {
+    if (!selector.nameLookupPossibleInAdvance()) {
+      throw new IAE("selector.nameLookupPossibleInAdvance() should return true");
+    }
+    int cardinality = selector.getValueCardinality();
+    BitSet valueIds = new BitSet(cardinality);
+    for (int i = 0; i < cardinality; i++) {
+      if (predicate.apply(selector.lookupName(i))) {
+        valueIds.set(i);
+      }
+    }
+    return valueIds;
+  }
+}

--- a/processing/src/main/java/io/druid/segment/IdLookup.java
+++ b/processing/src/main/java/io/druid/segment/IdLookup.java
@@ -17,20 +17,15 @@
  * under the License.
  */
 
-package io.druid.segment.filter;
-
-import io.druid.query.filter.ValueMatcher;
+package io.druid.segment;
 
 /**
-*/
-public final class BooleanValueMatcher
+ * "Mixin" for {@link DimensionSelector}.
+ */
+public interface IdLookup
 {
-  public static ValueMatcher of(boolean matches)
-  {
-    return matches ? TrueValueMatcher.instance() : FalseValueMatcher.instance();
-  }
-
-  private BooleanValueMatcher()
-  {
-  }
+  /**
+   * Inverse of {@link DimensionSelector#lookupName(int)}.
+   */
+  int lookupId(String name);
 }

--- a/processing/src/main/java/io/druid/segment/NullDimensionSelector.java
+++ b/processing/src/main/java/io/druid/segment/NullDimensionSelector.java
@@ -37,13 +37,13 @@ public class NullDimensionSelector implements DimensionSelector, IdLookup
   }
 
   @Override
-  public ValueMatcher makeValueMatcher(String value, boolean matchNull)
+  public ValueMatcher makeValueMatcher(String value)
   {
     return BooleanValueMatcher.of(value == null);
   }
 
   @Override
-  public ValueMatcher makeValueMatcher(Predicate<String> predicate, boolean matchNull)
+  public ValueMatcher makeValueMatcher(Predicate<String> predicate)
   {
     return BooleanValueMatcher.of(predicate.apply(null));
   }

--- a/processing/src/main/java/io/druid/segment/NullDimensionSelector.java
+++ b/processing/src/main/java/io/druid/segment/NullDimensionSelector.java
@@ -19,16 +19,33 @@
 
 package io.druid.segment;
 
+import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
+import io.druid.query.filter.ValueMatcher;
 import io.druid.segment.data.IndexedInts;
 import io.druid.segment.data.ZeroIndexedInts;
+import io.druid.segment.filter.BooleanValueMatcher;
 
-public class NullDimensionSelector implements DimensionSelector
+import javax.annotation.Nullable;
+
+public class NullDimensionSelector implements DimensionSelector, IdLookup
 {
   @Override
   public IndexedInts getRow()
   {
     return ZeroIndexedInts.instance();
+  }
+
+  @Override
+  public ValueMatcher makeValueMatcher(String value, boolean matchNull)
+  {
+    return BooleanValueMatcher.of(value == null);
+  }
+
+  @Override
+  public ValueMatcher makeValueMatcher(Predicate<String> predicate, boolean matchNull)
+  {
+    return BooleanValueMatcher.of(predicate.apply(null));
   }
 
   @Override
@@ -40,7 +57,21 @@ public class NullDimensionSelector implements DimensionSelector
   @Override
   public String lookupName(int id)
   {
+    assert id == 0 : "id = " + id;
     return null;
+  }
+
+  @Override
+  public boolean nameLookupPossibleInAdvance()
+  {
+    return true;
+  }
+
+  @Nullable
+  @Override
+  public IdLookup idLookup()
+  {
+    return this;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/NullStringObjectColumnSelector.java
+++ b/processing/src/main/java/io/druid/segment/NullStringObjectColumnSelector.java
@@ -17,20 +17,30 @@
  * under the License.
  */
 
-package io.druid.segment.filter;
+package io.druid.segment;
 
-import io.druid.query.filter.ValueMatcher;
-
-/**
-*/
-public final class BooleanValueMatcher
+public final class NullStringObjectColumnSelector implements ObjectColumnSelector<String>
 {
-  public static ValueMatcher of(boolean matches)
+  private static final NullStringObjectColumnSelector INSTANCE = new NullStringObjectColumnSelector();
+
+  public static NullStringObjectColumnSelector instance()
   {
-    return matches ? TrueValueMatcher.instance() : FalseValueMatcher.instance();
+    return INSTANCE;
   }
 
-  private BooleanValueMatcher()
+  private NullStringObjectColumnSelector()
   {
+  }
+
+  @Override
+  public Class<String> classOfObject()
+  {
+    return String.class;
+  }
+
+  @Override
+  public String get()
+  {
+    return null;
   }
 }

--- a/processing/src/main/java/io/druid/segment/QueryableIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/QueryableIndexStorageAdapter.java
@@ -63,7 +63,6 @@ import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  */
@@ -585,15 +584,8 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
                                 return BooleanValueMatcher.of(false);
                               }
                             } else {
-                              return new ValueMatcher()
-                              {
-                                @Override
-                                public boolean matches()
-                                {
-                                  String rowValue = lookupName(column.getSingleValueRow(cursorOffset.getOffset()));
-                                  return Objects.equals(rowValue, value);
-                                }
-                              };
+                              // Employ precomputed BitSet optimization
+                              return makeValueMatcher(Predicates.equalTo(value), matchNull);
                             }
                           }
 

--- a/processing/src/main/java/io/druid/segment/QueryableIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/QueryableIndexStorageAdapter.java
@@ -474,15 +474,15 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
                           }
 
                           @Override
-                          public ValueMatcher makeValueMatcher(String value, boolean matchNull)
+                          public ValueMatcher makeValueMatcher(String value)
                           {
-                            return DimensionSelectorUtils.makeRowBasedValueMatcher(this, value, matchNull);
+                            return DimensionSelectorUtils.makeValueMatcherGeneric(this, value);
                           }
 
                           @Override
-                          public ValueMatcher makeValueMatcher(Predicate<String> predicate, boolean matchNull)
+                          public ValueMatcher makeValueMatcher(Predicate<String> predicate)
                           {
-                            return DimensionSelectorUtils.makeRowBasedValueMatcher(this, predicate, matchNull);
+                            return DimensionSelectorUtils.makeValueMatcherGeneric(this, predicate);
                           }
 
                           @Override
@@ -567,7 +567,7 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
                           }
 
                           @Override
-                          public ValueMatcher makeValueMatcher(final String value, boolean matchNull)
+                          public ValueMatcher makeValueMatcher(final String value)
                           {
                             if (extractionFn == null) {
                               final int valueId = lookupId(value);
@@ -585,12 +585,12 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
                               }
                             } else {
                               // Employ precomputed BitSet optimization
-                              return makeValueMatcher(Predicates.equalTo(value), matchNull);
+                              return makeValueMatcher(Predicates.equalTo(value));
                             }
                           }
 
                           @Override
-                          public ValueMatcher makeValueMatcher(final Predicate<String> predicate, boolean matchNull)
+                          public ValueMatcher makeValueMatcher(final Predicate<String> predicate)
                           {
                             final BitSet predicateMatchingValueIds = DimensionSelectorUtils.makePredicateMatchingSet(
                                 this,

--- a/processing/src/main/java/io/druid/segment/SingleScanTimeDimSelector.java
+++ b/processing/src/main/java/io/druid/segment/SingleScanTimeDimSelector.java
@@ -19,14 +19,15 @@
 
 package io.druid.segment;
 
-import com.google.common.collect.Maps;
+import com.google.common.base.Predicate;
 import io.druid.query.extraction.ExtractionFn;
+import io.druid.query.filter.ValueMatcher;
 import io.druid.segment.data.IndexedInts;
-import it.unimi.dsi.fastutil.ints.IntIterator;
-import it.unimi.dsi.fastutil.ints.IntIterators;
+import io.druid.segment.data.SingleIndexedInt;
 
-import java.io.IOException;
-import java.util.Map;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 public class SingleScanTimeDimSelector implements DimensionSelector
@@ -35,7 +36,7 @@ public class SingleScanTimeDimSelector implements DimensionSelector
   private final LongColumnSelector selector;
   private final boolean descending;
 
-  private final Map<Integer, String> timeValues = Maps.newHashMap();
+  private final List<String> timeValues = new ArrayList<>();
   private String currentValue = null;
   private long currentTimestamp = Long.MIN_VALUE;
   private int index = -1;
@@ -59,13 +60,44 @@ public class SingleScanTimeDimSelector implements DimensionSelector
   @Override
   public IndexedInts getRow()
   {
+    return new SingleIndexedInt(getDimensionValueIndex());
+  }
+
+  @Override
+  public ValueMatcher makeValueMatcher(final String value, boolean matchNull)
+  {
+    return new ValueMatcher()
+    {
+      @Override
+      public boolean matches()
+      {
+        return Objects.equals(lookupName(getDimensionValueIndex()), value);
+      }
+    };
+  }
+
+  @Override
+  public ValueMatcher makeValueMatcher(final Predicate<String> predicate, boolean matchNull)
+  {
+    return new ValueMatcher()
+    {
+      @Override
+      public boolean matches()
+      {
+        return predicate.apply(lookupName(getDimensionValueIndex()));
+      }
+    };
+  }
+
+  private int getDimensionValueIndex()
+  {
     // if this the first timestamp, apply and cache extraction function result
     final long timestamp = selector.get();
     if (index < 0) {
       currentTimestamp = timestamp;
       currentValue = extractionFn.apply(timestamp);
       ++index;
-      timeValues.put(index, currentValue);
+      timeValues.add(currentValue);
     }
     // if this is a new timestamp, apply and cache extraction function result
     // since timestamps are assumed grouped and scanned once, we only need to
@@ -85,7 +117,7 @@ public class SingleScanTimeDimSelector implements DimensionSelector
       if (!Objects.equals(value, currentValue)) {
         currentValue = value;
         ++index;
-        timeValues.put(index, currentValue);
+        timeValues.add(currentValue);
       }
       // Note: this could be further optimized by checking if the new value is one we have
       // previously seen, but would require keeping track of both the current and the maximum index
@@ -93,39 +125,7 @@ public class SingleScanTimeDimSelector implements DimensionSelector
     // otherwise, if the current timestamp is the same as the previous timestamp,
     // keep using the same dimension value index
 
-    final int dimensionValueIndex = index;
-    return new IndexedInts()
-    {
-      @Override
-      public int size()
-      {
-        return 1;
-      }
-
-      @Override
-      public int get(int i)
-      {
-        return dimensionValueIndex;
-      }
-
-      @Override
-      public IntIterator iterator()
-      {
-        return IntIterators.singleton(dimensionValueIndex);
-      }
-
-      @Override
-      public void fill(int index, int[] toFill)
-      {
-        throw new UnsupportedOperationException("fill not supported");
-      }
-
-      @Override
-      public void close() throws IOException
-      {
-
-      }
-    };
+    return index;
   }
 
   @Override
@@ -145,8 +145,15 @@ public class SingleScanTimeDimSelector implements DimensionSelector
   }
 
   @Override
-  public int lookupId(String name)
+  public boolean nameLookupPossibleInAdvance()
   {
-    throw new UnsupportedOperationException("time column does not support lookups");
+    return false;
+  }
+
+  @Nullable
+  @Override
+  public IdLookup idLookup()
+  {
+    return null;
   }
 }

--- a/processing/src/main/java/io/druid/segment/SingleScanTimeDimSelector.java
+++ b/processing/src/main/java/io/druid/segment/SingleScanTimeDimSelector.java
@@ -64,7 +64,7 @@ public class SingleScanTimeDimSelector implements DimensionSelector
   }
 
   @Override
-  public ValueMatcher makeValueMatcher(final String value, boolean matchNull)
+  public ValueMatcher makeValueMatcher(final String value)
   {
     return new ValueMatcher()
     {
@@ -77,7 +77,7 @@ public class SingleScanTimeDimSelector implements DimensionSelector
   }
 
   @Override
-  public ValueMatcher makeValueMatcher(final Predicate<String> predicate, boolean matchNull)
+  public ValueMatcher makeValueMatcher(final Predicate<String> predicate)
   {
     return new ValueMatcher()
     {

--- a/processing/src/main/java/io/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/StringDimensionIndexer.java
@@ -21,6 +21,7 @@ package io.druid.segment;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -48,7 +49,6 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], String>
 {
@@ -463,29 +463,8 @@ public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], 
             return BooleanValueMatcher.of(false);
           }
         } else {
-          return new ValueMatcher()
-          {
-            @Override
-            public boolean matches()
-            {
-              Object[] dims = currEntry.getKey().getDims();
-              if (dimIndex >= dims.length) {
-                return matchNull;
-              }
-
-              int[] dimsInt = (int[]) dims[dimIndex];
-              if (dimsInt == null || dimsInt.length == 0) {
-                return matchNull;
-              }
-
-              for (int id : dimsInt) {
-                if (Objects.equals(extractionFn.apply(getActualValue(id, false)), value)) {
-                  return true;
-                }
-              }
-              return false;
-            }
-          };
+          // Employ precomputed BitSet optimization
+          return makeValueMatcher(Predicates.equalTo(value), matchNull);
         }
       }
 

--- a/processing/src/main/java/io/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/StringDimensionIndexer.java
@@ -427,7 +427,7 @@ public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], 
           }
         }
 
-        return rowSize > 0 ? new ArrayBasedIndexedInts(row, rowSize) : ArrayBasedIndexedInts.empty();
+        return ArrayBasedIndexedInts.of(row, rowSize);
       }
 
       @Override

--- a/processing/src/main/java/io/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/StringDimensionIndexer.java
@@ -431,11 +431,11 @@ public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], 
       }
 
       @Override
-      public ValueMatcher makeValueMatcher(final String value, final boolean matchNull)
+      public ValueMatcher makeValueMatcher(final String value)
       {
         if (extractionFn == null) {
           final int valueId = lookupId(value);
-          if (valueId >= 0 || matchNull) {
+          if (valueId >= 0 || value == null) {
             return new ValueMatcher()
             {
               @Override
@@ -443,12 +443,12 @@ public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], 
               {
                 Object[] dims = currEntry.getKey().getDims();
                 if (dimIndex >= dims.length) {
-                  return matchNull;
+                  return value == null;
                 }
 
                 int[] dimsInt = (int[]) dims[dimIndex];
                 if (dimsInt == null || dimsInt.length == 0) {
-                  return matchNull;
+                  return value == null;
                 }
 
                 for (int id : dimsInt) {
@@ -464,14 +464,15 @@ public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], 
           }
         } else {
           // Employ precomputed BitSet optimization
-          return makeValueMatcher(Predicates.equalTo(value), matchNull);
+          return makeValueMatcher(Predicates.equalTo(value));
         }
       }
 
       @Override
-      public ValueMatcher makeValueMatcher(final Predicate<String> predicate, final boolean matchNull)
+      public ValueMatcher makeValueMatcher(final Predicate<String> predicate)
       {
         final BitSet predicateMatchingValueIds = DimensionSelectorUtils.makePredicateMatchingSet(this, predicate);
+        final boolean matchNull = predicate.apply(null);
         return new ValueMatcher()
         {
           @Override

--- a/processing/src/main/java/io/druid/segment/data/ArrayBasedIndexedInts.java
+++ b/processing/src/main/java/io/druid/segment/data/ArrayBasedIndexedInts.java
@@ -30,32 +30,33 @@ import java.io.IOException;
  */
 public final class ArrayBasedIndexedInts implements IndexedInts
 {
-  private static final ArrayBasedIndexedInts EMPTY = new ArrayBasedIndexedInts(IntArrays.EMPTY_ARRAY);
+  private static final ArrayBasedIndexedInts EMPTY = new ArrayBasedIndexedInts(IntArrays.EMPTY_ARRAY, 0);
 
-  /**
-   * Returns empty ArrayBasedIndexedInts, size = 0. This is useful instead of {@link EmptyIndexedInts} where
-   * monomorphism is a concern.
-   */
-  public static ArrayBasedIndexedInts empty()
+  public static ArrayBasedIndexedInts of(int[] expansion)
   {
-    return EMPTY;
+    if (expansion.length == 0) {
+      return EMPTY;
+    }
+    return new ArrayBasedIndexedInts(expansion, expansion.length);
+  }
+
+  public static ArrayBasedIndexedInts of(int[] expansion, int size)
+  {
+    if (size == 0) {
+      return EMPTY;
+    }
+    if (size < 0 || size > expansion.length) {
+      throw new IAE("Size[%s] should be between 0 and %s", size, expansion.length);
+    }
+    return new ArrayBasedIndexedInts(expansion, size);
   }
 
   private final int[] expansion;
   private final int size;
 
-  public ArrayBasedIndexedInts(int[] expansion)
+  private ArrayBasedIndexedInts(int[] expansion, int size)
   {
     this.expansion = expansion;
-    this.size = expansion.length;
-  }
-
-  public ArrayBasedIndexedInts(int[] expansion, int size)
-  {
-    this.expansion = expansion;
-    if (size < 0 || size > expansion.length) {
-      throw new IAE("Size[%s] should be between 0 and %s", size, expansion.length);
-    }
     this.size = size;
   }
 

--- a/processing/src/main/java/io/druid/segment/data/SingleIndexedInt.java
+++ b/processing/src/main/java/io/druid/segment/data/SingleIndexedInt.java
@@ -19,65 +19,39 @@
 
 package io.druid.segment.data;
 
-import io.druid.java.util.common.IAE;
-import it.unimi.dsi.fastutil.ints.IntArrays;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntIterators;
 
 import java.io.IOException;
 
-/**
- */
-public final class ArrayBasedIndexedInts implements IndexedInts
+public final class SingleIndexedInt implements IndexedInts
 {
-  private static final ArrayBasedIndexedInts EMPTY = new ArrayBasedIndexedInts(IntArrays.EMPTY_ARRAY);
+  private final int value;
 
-  /**
-   * Returns empty ArrayBasedIndexedInts, size = 0. This is useful instead of {@link EmptyIndexedInts} where
-   * monomorphism is a concern.
-   */
-  public static ArrayBasedIndexedInts empty()
+  public SingleIndexedInt(int value)
   {
-    return EMPTY;
-  }
-
-  private final int[] expansion;
-  private final int size;
-
-  public ArrayBasedIndexedInts(int[] expansion)
-  {
-    this.expansion = expansion;
-    this.size = expansion.length;
-  }
-
-  public ArrayBasedIndexedInts(int[] expansion, int size)
-  {
-    this.expansion = expansion;
-    if (size < 0 || size > expansion.length) {
-      throw new IAE("Size[%s] should be between 0 and %s", size, expansion.length);
-    }
-    this.size = size;
+    this.value = value;
   }
 
   @Override
   public int size()
   {
-    return size;
+    return 1;
   }
 
   @Override
-  public int get(int index)
+  public int get(int i)
   {
-    if (index >= size) {
-      throw new IndexOutOfBoundsException("index: " + index + ", size: " + size);
+    if (i != 0) {
+      throw new IllegalArgumentException(i + " != 0");
     }
-    return expansion[index];
+    return value;
   }
 
   @Override
   public IntIterator iterator()
   {
-    return IntIterators.wrap(expansion, 0, size);
+    return IntIterators.singleton(value);
   }
 
   @Override
@@ -89,6 +63,5 @@ public final class ArrayBasedIndexedInts implements IndexedInts
   @Override
   public void close() throws IOException
   {
-
   }
 }

--- a/processing/src/main/java/io/druid/segment/filter/AndFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/AndFilter.java
@@ -80,7 +80,7 @@ public class AndFilter implements BooleanFilter
   public ValueMatcher makeMatcher(ColumnSelectorFactory factory)
   {
     if (filters.size() == 0) {
-      return new BooleanValueMatcher(false);
+      return BooleanValueMatcher.of(false);
     }
 
     final ValueMatcher[] matchers = new ValueMatcher[filters.size()];

--- a/processing/src/main/java/io/druid/segment/filter/FalseValueMatcher.java
+++ b/processing/src/main/java/io/druid/segment/filter/FalseValueMatcher.java
@@ -21,16 +21,22 @@ package io.druid.segment.filter;
 
 import io.druid.query.filter.ValueMatcher;
 
-/**
-*/
-public final class BooleanValueMatcher
+final class FalseValueMatcher implements ValueMatcher
 {
-  public static ValueMatcher of(boolean matches)
+  private static final FalseValueMatcher INSTANCE = new FalseValueMatcher();
+
+  public static FalseValueMatcher instance()
   {
-    return matches ? TrueValueMatcher.instance() : FalseValueMatcher.instance();
+    return INSTANCE;
   }
 
-  private BooleanValueMatcher()
+  private FalseValueMatcher()
   {
+  }
+
+  @Override
+  public boolean matches()
+  {
+    return false;
   }
 }

--- a/processing/src/main/java/io/druid/segment/filter/Filters.java
+++ b/processing/src/main/java/io/druid/segment/filter/Filters.java
@@ -283,12 +283,12 @@ public class Filters
   )
   {
     if (Strings.isNullOrEmpty(value)) {
-      return new BooleanValueMatcher(false);
+      return BooleanValueMatcher.of(false);
     }
 
     final Long longValue = GuavaUtils.tryParseLong(value);
     if (longValue == null) {
-      return new BooleanValueMatcher(false);
+      return BooleanValueMatcher.of(false);
     }
 
     return new ValueMatcher()

--- a/processing/src/main/java/io/druid/segment/filter/TrueValueMatcher.java
+++ b/processing/src/main/java/io/druid/segment/filter/TrueValueMatcher.java
@@ -21,16 +21,22 @@ package io.druid.segment.filter;
 
 import io.druid.query.filter.ValueMatcher;
 
-/**
-*/
-public final class BooleanValueMatcher
+final class TrueValueMatcher implements ValueMatcher
 {
-  public static ValueMatcher of(boolean matches)
+  private static final TrueValueMatcher INSTANCE = new TrueValueMatcher();
+
+  public static TrueValueMatcher instance()
   {
-    return matches ? TrueValueMatcher.instance() : FalseValueMatcher.instance();
+    return INSTANCE;
   }
 
-  private BooleanValueMatcher()
+  private TrueValueMatcher()
   {
+  }
+
+  @Override
+  public boolean matches()
+  {
+    return true;
   }
 }

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
@@ -558,7 +558,7 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
   private ValueMatcher makeFilterMatcher(final Filter filter, final Cursor cursor)
   {
     return filter == null
-           ? new BooleanValueMatcher(true)
+           ? BooleanValueMatcher.of(true)
            : filter.makeMatcher(cursor);
   }
 

--- a/processing/src/test/java/io/druid/query/aggregation/FilteredAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/FilteredAggregatorTest.java
@@ -104,9 +104,9 @@ public class FilteredAggregatorTest
                 public IndexedInts getRow()
                 {
                   if (selector.getIndex() % 3 == 2) {
-                    return new ArrayBasedIndexedInts(new int[]{1});
+                    return ArrayBasedIndexedInts.of(new int[]{1});
                   } else {
-                    return new ArrayBasedIndexedInts(new int[]{0});
+                    return ArrayBasedIndexedInts.of(new int[]{0});
                   }
                 }
 

--- a/processing/src/test/java/io/druid/query/aggregation/FilteredAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/FilteredAggregatorTest.java
@@ -111,15 +111,15 @@ public class FilteredAggregatorTest
                 }
 
                 @Override
-                public ValueMatcher makeValueMatcher(String value, boolean matchNull)
+                public ValueMatcher makeValueMatcher(String value)
                 {
-                  return DimensionSelectorUtils.makeRowBasedValueMatcher(this, value, matchNull);
+                  return DimensionSelectorUtils.makeValueMatcherGeneric(this, value);
                 }
 
                 @Override
-                public ValueMatcher makeValueMatcher(Predicate<String> predicate, boolean matchNull)
+                public ValueMatcher makeValueMatcher(Predicate<String> predicate)
                 {
-                  return DimensionSelectorUtils.makeRowBasedValueMatcher(this, predicate, matchNull);
+                  return DimensionSelectorUtils.makeValueMatcherGeneric(this, predicate);
                 }
 
                 @Override

--- a/processing/src/test/java/io/druid/query/aggregation/FilteredAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/FilteredAggregatorTest.java
@@ -19,6 +19,7 @@
 
 package io.druid.query.aggregation;
 
+import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import io.druid.js.JavaScriptConfig;
 import io.druid.query.dimension.DimensionSpec;
@@ -34,11 +35,14 @@ import io.druid.query.filter.OrDimFilter;
 import io.druid.query.filter.RegexDimFilter;
 import io.druid.query.filter.SearchQueryDimFilter;
 import io.druid.query.filter.SelectorDimFilter;
+import io.druid.query.filter.ValueMatcher;
 import io.druid.query.ordering.StringComparators;
 import io.druid.query.search.search.ContainsSearchQuerySpec;
 import io.druid.segment.ColumnSelectorFactory;
 import io.druid.segment.DimensionSelector;
+import io.druid.segment.DimensionSelectorUtils;
 import io.druid.segment.FloatColumnSelector;
+import io.druid.segment.IdLookup;
 import io.druid.segment.LongColumnSelector;
 import io.druid.segment.ObjectColumnSelector;
 import io.druid.segment.column.ColumnCapabilities;
@@ -49,6 +53,7 @@ import io.druid.segment.data.IndexedInts;
 import org.junit.Assert;
 import org.junit.Test;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 
 public class FilteredAggregatorTest
@@ -106,6 +111,18 @@ public class FilteredAggregatorTest
                 }
 
                 @Override
+                public ValueMatcher makeValueMatcher(String value, boolean matchNull)
+                {
+                  return DimensionSelectorUtils.makeRowBasedValueMatcher(this, value, matchNull);
+                }
+
+                @Override
+                public ValueMatcher makeValueMatcher(Predicate<String> predicate, boolean matchNull)
+                {
+                  return DimensionSelectorUtils.makeRowBasedValueMatcher(this, predicate, matchNull);
+                }
+
+                @Override
                 public int getValueCardinality()
                 {
                   return 2;
@@ -125,16 +142,30 @@ public class FilteredAggregatorTest
                 }
 
                 @Override
-                public int lookupId(String name)
+                public boolean nameLookupPossibleInAdvance()
                 {
-                  switch (name) {
-                    case "a":
-                      return 0;
-                    case "b":
-                      return 1;
-                    default:
-                      throw new IllegalArgumentException();
-                  }
+                  return true;
+                }
+
+                @Nullable
+                @Override
+                public IdLookup idLookup()
+                {
+                  return new IdLookup()
+                  {
+                    @Override
+                    public int lookupId(String name)
+                    {
+                      switch (name) {
+                        case "a":
+                          return 0;
+                        case "b":
+                          return 1;
+                        default:
+                          throw new IllegalArgumentException();
+                      }
+                    }
+                  };
                 }
               }
           );

--- a/processing/src/test/java/io/druid/query/aggregation/cardinality/CardinalityAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/cardinality/CardinalityAggregatorTest.java
@@ -21,6 +21,7 @@ package io.druid.query.aggregation.cardinality;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
@@ -41,7 +42,10 @@ import io.druid.query.dimension.RegexFilteredDimensionSpec;
 import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.extraction.JavaScriptExtractionFn;
 import io.druid.query.extraction.RegexDimExtractionFn;
+import io.druid.query.filter.ValueMatcher;
 import io.druid.segment.DimensionSelector;
+import io.druid.segment.DimensionSelectorUtils;
+import io.druid.segment.IdLookup;
 import io.druid.segment.data.IndexedInts;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntIterators;
@@ -158,6 +162,18 @@ public class CardinalityAggregatorTest
     }
 
     @Override
+    public ValueMatcher makeValueMatcher(String value, boolean matchNull)
+    {
+      return DimensionSelectorUtils.makeRowBasedValueMatcher(this, value, matchNull);
+    }
+
+    @Override
+    public ValueMatcher makeValueMatcher(Predicate<String> predicate, boolean matchNull)
+    {
+      return DimensionSelectorUtils.makeRowBasedValueMatcher(this, predicate, matchNull);
+    }
+
+    @Override
     public int getValueCardinality()
     {
       return 1;
@@ -171,9 +187,23 @@ public class CardinalityAggregatorTest
     }
 
     @Override
-    public int lookupId(String s)
+    public boolean nameLookupPossibleInAdvance()
     {
-      return ids.get(s);
+      return true;
+    }
+
+    @Nullable
+    @Override
+    public IdLookup idLookup()
+    {
+      return new IdLookup()
+      {
+        @Override
+        public int lookupId(String s)
+        {
+          return ids.get(s);
+        }
+      };
     }
   }
 

--- a/processing/src/test/java/io/druid/query/aggregation/cardinality/CardinalityAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/cardinality/CardinalityAggregatorTest.java
@@ -162,15 +162,15 @@ public class CardinalityAggregatorTest
     }
 
     @Override
-    public ValueMatcher makeValueMatcher(String value, boolean matchNull)
+    public ValueMatcher makeValueMatcher(String value)
     {
-      return DimensionSelectorUtils.makeRowBasedValueMatcher(this, value, matchNull);
+      return DimensionSelectorUtils.makeValueMatcherGeneric(this, value);
     }
 
     @Override
-    public ValueMatcher makeValueMatcher(Predicate<String> predicate, boolean matchNull)
+    public ValueMatcher makeValueMatcher(Predicate<String> predicate)
     {
-      return DimensionSelectorUtils.makeRowBasedValueMatcher(this, predicate, matchNull);
+      return DimensionSelectorUtils.makeValueMatcherGeneric(this, predicate);
     }
 
     @Override

--- a/processing/src/test/java/io/druid/query/dimension/ListFilteredDimensionSpecTest.java
+++ b/processing/src/test/java/io/druid/query/dimension/ListFilteredDimensionSpecTest.java
@@ -134,8 +134,8 @@ public class ListFilteredDimensionSpecTest
     Assert.assertEquals("c", selector.lookupName(0));
     Assert.assertEquals("g", selector.lookupName(1));
 
-    Assert.assertEquals(0, selector.lookupId("c"));
-    Assert.assertEquals(1, selector.lookupId("g"));
+    Assert.assertEquals(0, selector.idLookup().lookupId("c"));
+    Assert.assertEquals(1, selector.idLookup().lookupId("g"));
   }
 
   @Test
@@ -158,8 +158,8 @@ public class ListFilteredDimensionSpecTest
     Assert.assertEquals("a", selector.lookupName(0));
     Assert.assertEquals("z", selector.lookupName(23));
 
-    Assert.assertEquals(0, selector.lookupId("a"));
-    Assert.assertEquals(23, selector.lookupId("z"));
+    Assert.assertEquals(0, selector.idLookup().lookupId("a"));
+    Assert.assertEquals(23, selector.idLookup().lookupId("z"));
   }
 
   @Test
@@ -186,7 +186,7 @@ public class ListFilteredDimensionSpecTest
     Assert.assertEquals("a", selector.lookupName(0));
     Assert.assertEquals("z", selector.lookupName(24));
 
-    Assert.assertEquals(0, selector.lookupId("a"));
-    Assert.assertEquals(24, selector.lookupId("z"));
+    Assert.assertEquals(0, selector.idLookup().lookupId("a"));
+    Assert.assertEquals(24, selector.idLookup().lookupId("z"));
   }
 }

--- a/processing/src/test/java/io/druid/query/dimension/RegexFilteredDimensionSpecTest.java
+++ b/processing/src/test/java/io/druid/query/dimension/RegexFilteredDimensionSpecTest.java
@@ -96,7 +96,7 @@ public class RegexFilteredDimensionSpecTest
     Assert.assertEquals("c", selector.lookupName(0));
     Assert.assertEquals("g", selector.lookupName(1));
 
-    Assert.assertEquals(0, selector.lookupId("c"));
-    Assert.assertEquals(1, selector.lookupId("g"));
+    Assert.assertEquals(0, selector.idLookup().lookupId("c"));
+    Assert.assertEquals(1, selector.idLookup().lookupId("g"));
   }
 }

--- a/processing/src/test/java/io/druid/query/dimension/TestDimensionSelector.java
+++ b/processing/src/test/java/io/druid/query/dimension/TestDimensionSelector.java
@@ -19,9 +19,15 @@
 
 package io.druid.query.dimension;
 
+import com.google.common.base.Predicate;
+import io.druid.query.filter.ValueMatcher;
 import io.druid.segment.DimensionSelector;
+import io.druid.segment.DimensionSelectorUtils;
+import io.druid.segment.IdLookup;
 import io.druid.segment.data.ArrayBasedIndexedInts;
 import io.druid.segment.data.IndexedInts;
+
+import javax.annotation.Nullable;
 
 /**
  * Test dimension selector that has cardinality=26
@@ -44,6 +50,18 @@ class TestDimensionSelector implements DimensionSelector
   }
 
   @Override
+  public ValueMatcher makeValueMatcher(String value, boolean matchNull)
+  {
+    return DimensionSelectorUtils.makeRowBasedValueMatcher(this, value, matchNull);
+  }
+
+  @Override
+  public ValueMatcher makeValueMatcher(Predicate<String> predicate, boolean matchNull)
+  {
+    return DimensionSelectorUtils.makeRowBasedValueMatcher(this, predicate, matchNull);
+  }
+
+  @Override
   public int getValueCardinality()
   {
     return 26;
@@ -56,9 +74,22 @@ class TestDimensionSelector implements DimensionSelector
   }
 
   @Override
-  public int lookupId(String name)
+  public boolean nameLookupPossibleInAdvance()
   {
-    return name.charAt(0) - 'a';
+    return true;
   }
 
+  @Nullable
+  @Override
+  public IdLookup idLookup()
+  {
+    return new IdLookup()
+    {
+      @Override
+      public int lookupId(String name)
+      {
+        return name.charAt(0) - 'a';
+      }
+    };
+  }
 }

--- a/processing/src/test/java/io/druid/query/dimension/TestDimensionSelector.java
+++ b/processing/src/test/java/io/druid/query/dimension/TestDimensionSelector.java
@@ -46,7 +46,7 @@ class TestDimensionSelector implements DimensionSelector
   @Override
   public IndexedInts getRow()
   {
-    return new ArrayBasedIndexedInts(new int[]{2, 4, 6});
+    return ArrayBasedIndexedInts.of(new int[]{2, 4, 6});
   }
 
   @Override

--- a/processing/src/test/java/io/druid/query/dimension/TestDimensionSelector.java
+++ b/processing/src/test/java/io/druid/query/dimension/TestDimensionSelector.java
@@ -50,15 +50,15 @@ class TestDimensionSelector implements DimensionSelector
   }
 
   @Override
-  public ValueMatcher makeValueMatcher(String value, boolean matchNull)
+  public ValueMatcher makeValueMatcher(String value)
   {
-    return DimensionSelectorUtils.makeRowBasedValueMatcher(this, value, matchNull);
+    return DimensionSelectorUtils.makeValueMatcherGeneric(this, value);
   }
 
   @Override
-  public ValueMatcher makeValueMatcher(Predicate<String> predicate, boolean matchNull)
+  public ValueMatcher makeValueMatcher(Predicate<String> predicate)
   {
-    return DimensionSelectorUtils.makeRowBasedValueMatcher(this, predicate, matchNull);
+    return DimensionSelectorUtils.makeValueMatcherGeneric(this, predicate);
   }
 
   @Override

--- a/processing/src/test/java/io/druid/segment/NullDimensionSelectorTest.java
+++ b/processing/src/test/java/io/druid/segment/NullDimensionSelectorTest.java
@@ -53,8 +53,8 @@ public class NullDimensionSelectorTest {
 
   @Test
   public void testLookupId() throws Exception {
-    Assert.assertEquals(0, selector.lookupId(null));
-    Assert.assertEquals(0, selector.lookupId(""));
-    Assert.assertEquals(-1, selector.lookupId("billy"));
+    Assert.assertEquals(0, selector.idLookup().lookupId(null));
+    Assert.assertEquals(0, selector.idLookup().lookupId(""));
+    Assert.assertEquals(-1, selector.idLookup().lookupId("billy"));
   }
 }

--- a/processing/src/test/java/io/druid/segment/data/CompressedVSizeIndexedV3WriterTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedVSizeIndexedV3WriterTest.java
@@ -123,7 +123,7 @@ public class CompressedVSizeIndexedV3WriterTest
               @Override
               public IndexedInts apply(@Nullable final int[] input)
               {
-                return new ArrayBasedIndexedInts(input);
+                return ArrayBasedIndexedInts.of(input);
               }
             }
         ), offsetChunkFactor, maxValue, byteOrder, compressionStrategy


### PR DESCRIPTION
Fixes #3799, part of #3798

 * Add `DimensionSelector.idLookup()` and `nameLookupPossibleInAdvance()` to allow better inspection of features `DimensionSelector`s supports, it enables safer/more correct code working with `DimensionSelector`s in `BaseTopNAlgorithm`, `BaseFilteredDimensionSpec`, `DimensionSelectorUtils`.
 * Add `PredicateFilteringDimensionSelector`, to make `BaseFilteredDimensionSpec` to be able to decorate `DimensionSelector`s with unknown cardinality.
 * Add `DimensionSelector.makeValueMatcher()` (two kinds) for `DimensionSelector`-side specifics-aware optimizations of `ValueMatcher`s. Somewhere optimization goes beyond the level we had prior to #3797.
 * Optimize `getRow()` in `BaseFilteredDimensionSpec`'s `DimensionSelector` (which is refactored as `ForwardingFilteredDimensionSelector`), `StringDimensionIndexer`'s `DimensionSelector` and `SingleScanTimeDimSelector`.
 * Use two singletons, `TrueValueMatcher` and `FalseValueMatcher`, instead of `BooleanValueMatcher`.
 * Add `NullStringObjectColumnSelector` singleton and use it in `MapVirtualColumn`