### PR TITLE
Adding Kafka-emitter

### DIFF
--- a/docs/content/development/extensions-contrib/kafka-emitter.md
+++ b/docs/content/development/extensions-contrib/kafka-emitter.md
@@ -22,4 +22,14 @@ All the configuration parameters for the Kafka emitter are under `druid.emitter.
 |`druid.emitter.kafka.bootstrap.servers`|Comma-separated Kafka broker. (`[hostname:port],[hostname:port]...`)|yes|none|
 |`druid.emitter.kafka.metric.topic`|Kafka topic name for emitter's target to emit service metric.|yes|none|
 |`druid.emitter.kafka.alert.topic`|Kafka topic name for emitter's target to emit alert.|yes|none|
-|`druid.emitter.kafka.clusterName`|Optional value to specify name of your druid cluster. It can help make groups in your monitoring environment. |no|none|  
+|`druid.emitter.kafka.producer.config`|JSON formatted configuration which user want to set additional properties to Kafka producer.|no|none|
+|`druid.emitter.kafka.clusterName`|Optional value to specify name of your druid cluster. It can help make groups in your monitoring environment. |no|none|
+
+### Example
+
+```
+druid.emitter.kafka.bootstrap.servers=hostname1:9092,hotname2:9092
+druid.emitter.kafka.metric.topic=druid-metric
+druid.emitter.kafka.alert.topic=druid-alert
+druid.emitter.kafka.producer.config={"max.block.ms":10000}
+```

--- a/docs/content/development/extensions-contrib/kafka-emitter.md
+++ b/docs/content/development/extensions-contrib/kafka-emitter.md
@@ -20,5 +20,6 @@ All the configuration parameters for the Kafka emitter are under `druid.emitter.
 |property|description|required?|default|
 |--------|-----------|---------|-------|
 |`druid.emitter.kafka.bootstrap.servers`|Comma-separated Kafka broker. (`[hostname:port],[hostname:port]...`)|yes|none|
-|`druid.emitter.kafka.topic`|Kafka topic name for emitter's emitting target.|yes|none|
+|`druid.emitter.kafka.metric.topic`|Kafka topic name for emitter's target to emit service metric.|yes|none|
+|`druid.emitter.kafka.alert.topic`|Kafka topic name for emitter's target to emit alert.|yes|none|
 |`druid.emitter.kafka.clusterName`|Optional value to specify name of your druid cluster. It can help make groups in your monitoring environment. |no|none|  

--- a/docs/content/development/extensions-contrib/kafka-emitter.md
+++ b/docs/content/development/extensions-contrib/kafka-emitter.md
@@ -8,10 +8,10 @@ To use this extension, make sure to [include](../../operations/including-extensi
 
 ## Introduction
 
-This extension emits druid metrics to a Kafka(https://kafka.apache.org) directly with JSON format.<br>
+This extension emits Druid metrics to a [Kafka](https://kafka.apache.org) directly with JSON format.<br>
 Currently, Kafka has not only their nice ecosystem but also consumer API readily available. 
-So, If you currently use kafka, It's easy to integrate various tool or UI 
-to monitor the status of your druid cluster with this extension.
+So, If you currently use Kafka, It's easy to integrate various tool or UI 
+to monitor the status of your Druid cluster with this extension.
 
 ## Configuration
 
@@ -28,7 +28,7 @@ All the configuration parameters for the Kafka emitter are under `druid.emitter.
 ### Example
 
 ```
-druid.emitter.kafka.bootstrap.servers=hostname1:9092,hotname2:9092
+druid.emitter.kafka.bootstrap.servers=hostname1:9092,hostname2:9092
 druid.emitter.kafka.metric.topic=druid-metric
 druid.emitter.kafka.alert.topic=druid-alert
 druid.emitter.kafka.producer.config={"max.block.ms":10000}

--- a/docs/content/development/extensions-contrib/kafka-emitter.md
+++ b/docs/content/development/extensions-contrib/kafka-emitter.md
@@ -1,0 +1,24 @@
+---
+layout: doc_page
+---
+
+# Kafka Emitter
+
+To use this extension, make sure to [include](../../operations/including-extensions.html) `kafka-emitter` extension.
+
+## Introduction
+
+This extension emits druid metrics to a Kafka(https://kafka.apache.org) directly with JSON format.<br>
+Currently, Kafka has not only their nice ecosystem but also consumer API readily available. 
+So, If you currently use kafka, It's easy to integrate various tool or UI 
+to monitor the status of your druid cluster with this extension.
+
+## Configuration
+
+All the configuration parameters for the Kafka emitter are under `druid.emitter.kafka`.
+
+|property|description|required?|default|
+|--------|-----------|---------|-------|
+|`druid.emitter.kafka.bootstrap.servers`|Comma-separated Kafka broker. (`[hostname:port],[hostname:port]...`)|yes|none|
+|`druid.emitter.kafka.topic`|Kafka topic name for emitter's emitting target.|yes|none|
+|`druid.emitter.kafka.clusterName`|Optional value to specify name of your druid cluster. It can help make groups in your monitoring environment. |no|none|  

--- a/docs/content/development/extensions.md
+++ b/docs/content/development/extensions.md
@@ -65,6 +65,7 @@ All of these community extensions can be downloaded using *pull-deps* with the c
 |sqlserver-metadata-storage|Microsoft SqlServer deep storage.|[link](../development/extensions-contrib/sqlserver.html)|
 |graphite-emitter|Graphite metrics emitter|[link](../development/extensions-contrib/graphite.html)|
 |statsd-emitter|StatsD metrics emitter|[link](../development/extensions-contrib/statsd.html)|
+|kafka-emitter|Kafka metrics emitter|[link](../development/extensions-contrib/kafka-emitter.html)|
 |druid-thrift-extensions|Support thrift ingestion |[link](../development/extensions-contrib/thrift.html)|
 |scan-query|Scan query|[link](../development/extensions-contrib/scan-query.html)|
 

--- a/extensions-contrib/kafka-emitter/pom.xml
+++ b/extensions-contrib/kafka-emitter/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>0.10.1.0</version>
+      <version>0.10.1.1</version>
     </dependency>
     <dependency>
       <groupId>io.druid</groupId>

--- a/extensions-contrib/kafka-emitter/pom.xml
+++ b/extensions-contrib/kafka-emitter/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>0.10.1.1</version>
+      <version>0.10.2.0</version>
     </dependency>
     <dependency>
       <groupId>io.druid</groupId>

--- a/extensions-contrib/kafka-emitter/pom.xml
+++ b/extensions-contrib/kafka-emitter/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>io.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.9.3-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/kafka-emitter/pom.xml
+++ b/extensions-contrib/kafka-emitter/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ ~ or more contributor license agreements. See the NOTICE file
+ ~ distributed with this work for additional information
+ ~ regarding copyright ownership. Metamarkets licenses this file
+ ~ to you under the Apache License, Version 2.0 (the
+ ~ "License"); you may not use this file except in compliance
+ ~ with the License. You may obtain a copy of the License at
+ ~
+ ~ http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied. See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.druid</groupId>
+    <artifactId>druid</artifactId>
+    <version>0.9.3-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <groupId>io.druid.extensions.contrib</groupId>
+  <artifactId>kafka-emitter</artifactId>
+  <name>kafka-emitter</name>
+  <description>Druid emitter extension to support kafka</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>0.10.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.druid</groupId>
+      <artifactId>druid-common</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.druid</groupId>
+      <artifactId>druid-api</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.metamx</groupId>
+      <artifactId>emitter</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+      <version>1.0.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.druid</groupId>
+      <artifactId>druid-server</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.druid</groupId>
+      <artifactId>druid-processing</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitter.java
@@ -73,6 +73,7 @@ public class KafkaEmitter implements Emitter {
     props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, DEFAULT_KEY_SERIALIZER);
     props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, DEFAULT_VALUE_SERIALIZER);
     props.put(ProducerConfig.RETRIES_CONFIG, DEFAULT_RETRIES);
+    props.putAll(config.getKafkaProducerConfig());
 
     return new KafkaProducer<>(props);
   }

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitter.java
@@ -95,18 +95,23 @@ public class KafkaEmitter implements Emitter {
   }
 
   private Producer<String, String> setKafkaProducer() {
-    Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+    ClassLoader currCtxCl = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
 
-    Properties props = new Properties();
-    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.getBootstrapServers());
-    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-    props.put(ProducerConfig.RETRIES_CONFIG, DEFAULT_RETRIES);
-    props.putAll(config.getKafkaProducerConfig());
-    queueMemoryBound = (props.containsKey(ProducerConfig.BUFFER_MEMORY_CONFIG) ?
-        Long.parseLong(props.getProperty(ProducerConfig.BUFFER_MEMORY_CONFIG)) : queueMemoryBound);
+      Properties props = new Properties();
+      props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.getBootstrapServers());
+      props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+      props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+      props.put(ProducerConfig.RETRIES_CONFIG, DEFAULT_RETRIES);
+      props.putAll(config.getKafkaProducerConfig());
+      queueMemoryBound = (props.containsKey(ProducerConfig.BUFFER_MEMORY_CONFIG) ?
+                          Long.parseLong(props.getProperty(ProducerConfig.BUFFER_MEMORY_CONFIG)) : queueMemoryBound);
 
-    return new KafkaProducer<>(props);
+      return new KafkaProducer<>(props);
+    } finally {
+      Thread.currentThread().setContextClassLoader(currCtxCl);
+    }
   }
 
   @Override

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitter.java
@@ -45,6 +45,7 @@ public class KafkaEmitter implements Emitter {
 
   private final static String DEFAULT_KEY_SERIALIZER = "org.apache.kafka.common.serialization.StringSerializer";
   private final static String DEFAULT_VALUE_SERIALIZER = "org.apache.kafka.common.serialization.StringSerializer";
+  private final static int DEFAULT_RETRIES = 3;
 
   private final KafkaEmitterConfig config;
   private final Producer<String, String> producer;
@@ -61,6 +62,7 @@ public class KafkaEmitter implements Emitter {
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.getBootstrapServers());
     props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, DEFAULT_KEY_SERIALIZER);
     props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, DEFAULT_VALUE_SERIALIZER);
+    props.put(ProducerConfig.RETRIES_CONFIG, DEFAULT_RETRIES);
 
     return new KafkaProducer<>(props);
   }
@@ -88,7 +90,6 @@ public class KafkaEmitter implements Emitter {
         public void onCompletion(RecordMetadata metadata, Exception exception) {
           if(exception != null) {
             log.warn(exception, "Exception is occured! Retry.");
-            emit(event);
           }
         }
       });

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitter.java
@@ -86,10 +86,12 @@ public class KafkaEmitter implements Emitter {
   @Override
   public void emit(final Event event) {
     if(event != null) {
-      Map<String, Object> result = ImmutableMap.<String, Object>builder()
-          .putAll(event.toMap())
-          .put("clusterName", config.getClusterName())
-          .build();
+      ImmutableMap.Builder<String, Object> resultBuilder = ImmutableMap.<String, Object>builder().putAll(event.toMap());
+      if (config.getClusterName() != null) {
+        resultBuilder.put("clusterName", config.getClusterName());
+      }
+      Map<String, Object> result = resultBuilder.build();
+
       try {
         String resultJson = jsonMapper.writeValueAsString(result);
         if(event instanceof ServiceMetricEvent) {

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitter.java
@@ -81,7 +81,7 @@ public class KafkaEmitter implements Emitter {
     try {
       TypeReference<Map<String,String>> typeRef = new TypeReference<Map<String,String>>() {};
       HashMap<String, String> result = jsonMapper.readValue(jsonMapper.writeValueAsString(event), typeRef);
-      result.put("clustername", config.getClusterName());
+      result.put("clusterName", config.getClusterName());
       producer.send(new ProducerRecord<String, String>(config.getTopic(), jsonMapper.writeValueAsString(result)));
     } catch (Exception e) {
       log.warn(e, "Failed to generate json");

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitter.java
@@ -123,7 +123,7 @@ public class KafkaEmitter implements Emitter {
     scheduler.scheduleWithFixedDelay(new Runnable() {
       @Override
       public void run() {
-        log.info("Message lost counter: metricLost=[%d] / alertLost=[%d] / invalidLost=[%d]",
+        log.info("Message lost counter: metricLost=[%d], alertLost=[%d], invalidLost=[%d]",
                  metricLost.get(), alertLost.get(), invalidLost.get());
       }
     }, 5, 5, TimeUnit.MINUTES);

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitter.java
@@ -82,6 +82,7 @@ public class KafkaEmitter implements Emitter {
       @Override
       public void onCompletion(RecordMetadata recordMetadata, Exception e) {
         if(e != null) {
+          log.debug("Event send failed [%s]", e.getMessage());
           if(recordMetadata.topic().equals(config.getMetricTopic())) {
             metricLost.incrementAndGet();
           } else if (recordMetadata.topic().equals(config.getAlertTopic())) {

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitter.java
@@ -36,6 +36,7 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.serialization.StringSerializer;
 
 import java.io.IOException;
 import java.util.Map;
@@ -48,8 +49,6 @@ import java.util.concurrent.atomic.AtomicLong;
 public class KafkaEmitter implements Emitter {
   private static Logger log = new Logger(KafkaEmitter.class);
 
-  private final static String DEFAULT_KEY_SERIALIZER = "org.apache.kafka.common.serialization.StringSerializer";
-  private final static String DEFAULT_VALUE_SERIALIZER = "org.apache.kafka.common.serialization.StringSerializer";
   private final static int DEFAULT_RETRIES = 3;
   private long queueMemoryBound = 33554432L; // same with default value of kafka producer's buffer.memory
   private final AtomicLong metricLost;
@@ -96,10 +95,12 @@ public class KafkaEmitter implements Emitter {
   }
 
   private Producer<String, String> setKafkaProducer() {
+    Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+
     Properties props = new Properties();
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.getBootstrapServers());
-    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, DEFAULT_KEY_SERIALIZER);
-    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, DEFAULT_VALUE_SERIALIZER);
+    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
     props.put(ProducerConfig.RETRIES_CONFIG, DEFAULT_RETRIES);
     props.putAll(config.getKafkaProducerConfig());
     queueMemoryBound = (props.containsKey(ProducerConfig.BUFFER_MEMORY_CONFIG) ?

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitter.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.emitter.kafka;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.metamx.emitter.core.Emitter;
+import com.metamx.emitter.core.Event;
+
+import com.metamx.emitter.service.ServiceMetricEvent;
+import io.druid.java.util.common.lifecycle.LifecycleStart;
+import io.druid.java.util.common.lifecycle.LifecycleStop;
+import io.druid.java.util.common.logger.Logger;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+import java.io.IOException;
+import java.util.Properties;
+
+public class KafkaEmitter implements Emitter {
+  private static Logger log = new Logger(KafkaEmitter.class);
+
+  private final static String DEFAULT_KEY_SERIALIZER = "org.apache.kafka.common.serialization.StringSerializer";
+  private final static String DEFAULT_VALUE_SERIALIZER = "org.apache.kafka.common.serialization.StringSerializer";
+
+  private final KafkaEmitterConfig config;
+  private final Producer<String, String> producer;
+  private final ObjectMapper jsonMapper;
+
+
+  public KafkaEmitter(KafkaEmitterConfig config, ObjectMapper jsonMapper) {
+    this.config = config;
+    this.jsonMapper = jsonMapper;
+    this.producer = getKafkaProducer(config);
+
+  }
+
+  private Producer<String, String> getKafkaProducer(KafkaEmitterConfig config) {
+    Properties props = new Properties();
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.getBootstrapServers());
+    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, DEFAULT_KEY_SERIALIZER);
+    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, DEFAULT_VALUE_SERIALIZER);
+
+    return new KafkaProducer<>(props);
+  }
+
+  @Override
+  @LifecycleStart
+  public void start() {
+    log.info("Starting Kafka Emitter.");
+  }
+
+  @Override
+  public void emit(Event event) {
+    if(event instanceof ServiceMetricEvent) {
+      if(event == null) {
+        return;
+      }
+    }
+    try {
+      producer.send(new ProducerRecord<String, String>(config.getTopic(), jsonMapper.writeValueAsString(event)));
+    } catch (JsonProcessingException e) {
+      log.warn(e, "Failed to generate json");
+    }
+  }
+
+  @Override
+  public void flush() throws IOException {
+    producer.flush();
+  }
+
+  @Override
+  @LifecycleStop
+  public void close() throws IOException {
+    producer.close();
+  }
+}

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitter.java
@@ -79,8 +79,8 @@ public class KafkaEmitter implements Emitter {
       }
     }
     try {
-      TypeReference<Map<String,String>> typeRef = new TypeReference<Map<String,String>>() {};
-      HashMap<String, String> result = jsonMapper.readValue(jsonMapper.writeValueAsString(event), typeRef);
+      TypeReference<Map<String, Object>> typeRef = new TypeReference<Map<String, Object>>() {};
+      HashMap<String, Object> result = jsonMapper.readValue(jsonMapper.writeValueAsString(event), typeRef);
       result.put("clusterName", config.getClusterName());
       producer.send(new ProducerRecord<String, String>(config.getTopic(), jsonMapper.writeValueAsString(result)));
     } catch (Exception e) {

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
@@ -130,11 +130,11 @@ public class KafkaEmitterConfig
   public String toString()
   {
     return "KafkaEmitterConfig{" +
-           "bootstrapServers='" + bootstrapServers + '\'' +
-           ", metricTopic='" + metricTopic + '\'' +
-           ", alertTopic='" + alertTopic + '\'' +
+           "bootstrap.servers='" + bootstrapServers + '\'' +
+           ", metric.topic='" + metricTopic + '\'' +
+           ", alert.topic='" + alertTopic + '\'' +
            ", clusterName='" + clusterName + '\'' +
-           ", kafkaProducerConfig=" + kafkaProducerConfig +
+           ", Producer.config=" + kafkaProducerConfig +
            '}';
   }
 }

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import org.apache.kafka.clients.producer.ProducerConfig;
 
+import java.util.Map;
+
 public class KafkaEmitterConfig {
 
   @JsonProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
@@ -34,6 +36,8 @@ public class KafkaEmitterConfig {
   final private String alertTopic;
   @JsonProperty
   final private String clusterName;
+  @JsonProperty("producer.config")
+  private Map<String, String> kafkaProducerConfig;
 
   @Override
   public boolean equals(Object o) {
@@ -59,11 +63,13 @@ public class KafkaEmitterConfig {
   public KafkaEmitterConfig(@JsonProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG) String bootstrapServers,
                             @JsonProperty("metric.topic") String metricTopic,
                             @JsonProperty("alert.topic") String alertTopic,
-                            @JsonProperty("clusterName") String clusterName) {
+                            @JsonProperty("clusterName") String clusterName,
+                            @JsonProperty("producer.config") Map<String, String> kafkaProducerConfig) {
     this.bootstrapServers = Preconditions.checkNotNull(bootstrapServers, "bootstrap.servers can not be null");
     this.metricTopic = Preconditions.checkNotNull(metricTopic, "metric.topic can not be null");
     this.alertTopic = Preconditions.checkNotNull(alertTopic, "alert.topic can not be null");
-    this.clusterName = (clusterName == null || clusterName.isEmpty()) ? null : clusterName;
+    this.clusterName = clusterName;
+    this.kafkaProducerConfig = kafkaProducerConfig;
   }
 
   @JsonProperty
@@ -78,6 +84,9 @@ public class KafkaEmitterConfig {
   @JsonProperty
   public String getClusterName() { return clusterName; }
 
+  @JsonProperty
+  public Map<String, String> getKafkaProducerConfig() { return kafkaProducerConfig; }
+
   @Override
   public String toString()
   {
@@ -86,6 +95,7 @@ public class KafkaEmitterConfig {
         ", metric.topic=" + metricTopic +
         ", alert.topic=" + alertTopic +
         ", clusterName=" + clusterName +
+        ", producer.config=" + kafkaProducerConfig.toString() +
         '}';
   }
 }

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.emitter.kafka;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import org.apache.kafka.clients.producer.ProducerConfig;
+
+public class KafkaEmitterConfig {
+
+  @JsonProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
+  final private String bootstrapServers;
+  @JsonProperty
+  final private String topic;
+
+  @Override
+  public boolean equals(Object o) {
+    if(this == o) {
+      return true;
+    }
+    if(!(o instanceof KafkaEmitterConfig)) {
+      return false;
+    }
+
+    KafkaEmitterConfig that = (KafkaEmitterConfig) o;
+
+    if(!getBootstrapServers().equals(that.getBootstrapServers())) {
+      return false;
+    }
+    return getTopic().equals(that.getTopic());
+  }
+  @JsonCreator
+  public KafkaEmitterConfig(@JsonProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG) String bootstrapServers,
+                            @JsonProperty("topic") String topic) {
+    this.bootstrapServers = Preconditions.checkNotNull(bootstrapServers, "bootstrap.servers can not be null");
+    this.topic = Preconditions.checkNotNull(topic, "topic can not be null");
+  }
+
+  @JsonProperty
+  public String getBootstrapServers() { return bootstrapServers; }
+
+  @JsonProperty
+  public String getTopic() { return topic; }
+}

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
@@ -26,7 +26,8 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 
 import java.util.Map;
 
-public class KafkaEmitterConfig {
+public class KafkaEmitterConfig
+{
 
   @JsonProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
   final private String bootstrapServers;
@@ -39,32 +40,15 @@ public class KafkaEmitterConfig {
   @JsonProperty("producer.config")
   private Map<String, String> kafkaProducerConfig;
 
-  @Override
-  public boolean equals(Object o) {
-    if(this == o) {
-      return true;
-    }
-    if(!(o instanceof KafkaEmitterConfig)) {
-      return false;
-    }
-
-    KafkaEmitterConfig that = (KafkaEmitterConfig) o;
-
-    if(!getBootstrapServers().equals(that.getBootstrapServers())
-        || !getMetricTopic().equals(that.getMetricTopic())
-        || !getAlertTopic().equals(that.getAlertTopic())
-        || !getClusterName().equals(that.getClusterName())) {
-      return false;
-    } else {
-      return true;
-    }
-  }
   @JsonCreator
-  public KafkaEmitterConfig(@JsonProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG) String bootstrapServers,
-                            @JsonProperty("metric.topic") String metricTopic,
-                            @JsonProperty("alert.topic") String alertTopic,
-                            @JsonProperty("clusterName") String clusterName,
-                            @JsonProperty("producer.config") Map<String, String> kafkaProducerConfig) {
+  public KafkaEmitterConfig(
+      @JsonProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG) String bootstrapServers,
+      @JsonProperty("metric.topic") String metricTopic,
+      @JsonProperty("alert.topic") String alertTopic,
+      @JsonProperty("clusterName") String clusterName,
+      @JsonProperty("producer.config") Map<String, String> kafkaProducerConfig
+  )
+  {
     this.bootstrapServers = Preconditions.checkNotNull(bootstrapServers, "bootstrap.servers can not be null");
     this.metricTopic = Preconditions.checkNotNull(metricTopic, "metric.topic can not be null");
     this.alertTopic = Preconditions.checkNotNull(alertTopic, "alert.topic can not be null");
@@ -73,38 +57,84 @@ public class KafkaEmitterConfig {
   }
 
   @JsonProperty
-  public String getBootstrapServers() {
+  public String getBootstrapServers()
+  {
     return bootstrapServers;
   }
 
   @JsonProperty
-  public String getMetricTopic() {
+  public String getMetricTopic()
+  {
     return metricTopic;
   }
 
   @JsonProperty
-  public String getAlertTopic() {
+  public String getAlertTopic()
+  {
     return alertTopic;
   }
 
   @JsonProperty
-  public String getClusterName() {
+  public String getClusterName()
+  {
     return clusterName;
   }
 
   @JsonProperty
-  public Map<String, String> getKafkaProducerConfig() {
+  public Map<String, String> getKafkaProducerConfig()
+  {
     return kafkaProducerConfig;
   }
 
   @Override
-  public String toString() {
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    KafkaEmitterConfig that = (KafkaEmitterConfig) o;
+
+    if (!getBootstrapServers().equals(that.getBootstrapServers())) {
+      return false;
+    }
+    if (!getMetricTopic().equals(that.getMetricTopic())) {
+      return false;
+    }
+    if (!getAlertTopic().equals(that.getAlertTopic())) {
+      return false;
+    }
+    if (getClusterName() != null ? !getClusterName().equals(that.getClusterName()) : that.getClusterName() != null) {
+      return false;
+    }
+    return getKafkaProducerConfig() != null
+           ? getKafkaProducerConfig().equals(that.getKafkaProducerConfig())
+           : that.getKafkaProducerConfig() == null;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = getBootstrapServers().hashCode();
+    result = 31 * result + getMetricTopic().hashCode();
+    result = 31 * result + getAlertTopic().hashCode();
+    result = 31 * result + (getClusterName() != null ? getClusterName().hashCode() : 0);
+    result = 31 * result + (getKafkaProducerConfig() != null ? getKafkaProducerConfig().hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString()
+  {
     return "KafkaEmitterConfig{" +
-        "bootstrap.servers='" + bootstrapServers +
-        ", metric.topic=" + metricTopic +
-        ", alert.topic=" + alertTopic +
-        ", clusterName=" + clusterName +
-        ", producer.config={" + kafkaProducerConfig.toString() +
-        "}}";
+           "bootstrapServers='" + bootstrapServers + '\'' +
+           ", metricTopic='" + metricTopic + '\'' +
+           ", alertTopic='" + alertTopic + '\'' +
+           ", clusterName='" + clusterName + '\'' +
+           ", kafkaProducerConfig=" + kafkaProducerConfig +
+           '}';
   }
 }

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
@@ -73,23 +73,32 @@ public class KafkaEmitterConfig {
   }
 
   @JsonProperty
-  public String getBootstrapServers() { return bootstrapServers; }
+  public String getBootstrapServers() {
+    return bootstrapServers;
+  }
 
   @JsonProperty
-  public String getMetricTopic() { return metricTopic; }
+  public String getMetricTopic() {
+    return metricTopic;
+  }
 
   @JsonProperty
-  public String getAlertTopic() { return alertTopic; }
+  public String getAlertTopic() {
+    return alertTopic;
+  }
 
   @JsonProperty
-  public String getClusterName() { return clusterName; }
+  public String getClusterName() {
+    return clusterName;
+  }
 
   @JsonProperty
-  public Map<String, String> getKafkaProducerConfig() { return kafkaProducerConfig; }
+  public Map<String, String> getKafkaProducerConfig() {
+    return kafkaProducerConfig;
+  }
 
   @Override
-  public String toString()
-  {
+  public String toString() {
     return "KafkaEmitterConfig{" +
         "bootstrap.servers='" + bootstrapServers +
         ", metric.topic=" + metricTopic +

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
@@ -95,7 +95,7 @@ public class KafkaEmitterConfig {
         ", metric.topic=" + metricTopic +
         ", alert.topic=" + alertTopic +
         ", clusterName=" + clusterName +
-        ", producer.config=" + kafkaProducerConfig.toString() +
-        '}';
+        ", producer.config={" + kafkaProducerConfig.toString() +
+        "}}";
   }
 }

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
@@ -63,7 +63,7 @@ public class KafkaEmitterConfig {
     this.bootstrapServers = Preconditions.checkNotNull(bootstrapServers, "bootstrap.servers can not be null");
     this.metricTopic = Preconditions.checkNotNull(metricTopic, "metric.topic can not be null");
     this.alertTopic = Preconditions.checkNotNull(alertTopic, "alert.topic can not be null");
-    this.clusterName = (clusterName == null || clusterName.isEmpty()) ? "NONAME" : clusterName;
+    this.clusterName = (clusterName == null || clusterName.isEmpty()) ? null : clusterName;
   }
 
   @JsonProperty

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
@@ -77,4 +77,15 @@ public class KafkaEmitterConfig {
 
   @JsonProperty
   public String getClusterName() { return clusterName; }
+
+  @Override
+  public String toString()
+  {
+    return "KafkaEmitterConfig{" +
+        "bootstrap.servers='" + bootstrapServers +
+        ", metric.topic=" + metricTopic +
+        ", alert.topic=" + alertTopic +
+        ", clusterName=" + clusterName +
+        '}';
+  }
 }

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
@@ -28,8 +28,10 @@ public class KafkaEmitterConfig {
 
   @JsonProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
   final private String bootstrapServers;
-  @JsonProperty
-  final private String topic;
+  @JsonProperty("metric.topic")
+  final private String metricTopic;
+  @JsonProperty("alert.topic")
+  final private String alertTopic;
   @JsonProperty
   final private String clusterName;
 
@@ -45,7 +47,8 @@ public class KafkaEmitterConfig {
     KafkaEmitterConfig that = (KafkaEmitterConfig) o;
 
     if(!getBootstrapServers().equals(that.getBootstrapServers())
-        || !getTopic().equals(that.getTopic())
+        || !getMetricTopic().equals(that.getMetricTopic())
+        || !getAlertTopic().equals(that.getAlertTopic())
         || !getClusterName().equals(that.getClusterName())) {
       return false;
     } else {
@@ -54,9 +57,12 @@ public class KafkaEmitterConfig {
   }
   @JsonCreator
   public KafkaEmitterConfig(@JsonProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG) String bootstrapServers,
-                            @JsonProperty("topic") String topic, @JsonProperty("clusterName") String clusterName) {
+                            @JsonProperty("metric.topic") String metricTopic,
+                            @JsonProperty("alert.topic") String alertTopic,
+                            @JsonProperty("clusterName") String clusterName) {
     this.bootstrapServers = Preconditions.checkNotNull(bootstrapServers, "bootstrap.servers can not be null");
-    this.topic = Preconditions.checkNotNull(topic, "topic can not be null");
+    this.metricTopic = Preconditions.checkNotNull(metricTopic, "metric.topic can not be null");
+    this.alertTopic = Preconditions.checkNotNull(alertTopic, "alert.topic can not be null");
     this.clusterName = (clusterName == null || clusterName.isEmpty()) ? "NONAME" : clusterName;
   }
 
@@ -64,7 +70,10 @@ public class KafkaEmitterConfig {
   public String getBootstrapServers() { return bootstrapServers; }
 
   @JsonProperty
-  public String getTopic() { return topic; }
+  public String getMetricTopic() { return metricTopic; }
+
+  @JsonProperty
+  public String getAlertTopic() { return alertTopic; }
 
   @JsonProperty
   public String getClusterName() { return clusterName; }

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
@@ -30,7 +30,7 @@ public class KafkaEmitterConfig {
   final private String bootstrapServers;
   @JsonProperty
   final private String topic;
-  @JsonProperty("clustername")
+  @JsonProperty
   final private String clusterName;
 
   @Override
@@ -54,7 +54,7 @@ public class KafkaEmitterConfig {
   }
   @JsonCreator
   public KafkaEmitterConfig(@JsonProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG) String bootstrapServers,
-                            @JsonProperty("topic") String topic, @JsonProperty("clustername") String clusterName) {
+                            @JsonProperty("topic") String topic, @JsonProperty("clusterName") String clusterName) {
     this.bootstrapServers = Preconditions.checkNotNull(bootstrapServers, "bootstrap.servers can not be null");
     this.topic = Preconditions.checkNotNull(topic, "topic can not be null");
     this.clusterName = (clusterName == null || clusterName.isEmpty()) ? "NONAME" : clusterName;

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
@@ -30,6 +30,8 @@ public class KafkaEmitterConfig {
   final private String bootstrapServers;
   @JsonProperty
   final private String topic;
+  @JsonProperty("clustername")
+  final private String clusterName;
 
   @Override
   public boolean equals(Object o) {
@@ -42,16 +44,20 @@ public class KafkaEmitterConfig {
 
     KafkaEmitterConfig that = (KafkaEmitterConfig) o;
 
-    if(!getBootstrapServers().equals(that.getBootstrapServers())) {
+    if(!getBootstrapServers().equals(that.getBootstrapServers())
+        || !getTopic().equals(that.getTopic())
+        || !getClusterName().equals(that.getClusterName())) {
       return false;
+    } else {
+      return true;
     }
-    return getTopic().equals(that.getTopic());
   }
   @JsonCreator
   public KafkaEmitterConfig(@JsonProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG) String bootstrapServers,
-                            @JsonProperty("topic") String topic) {
+                            @JsonProperty("topic") String topic, @JsonProperty("clustername") String clusterName) {
     this.bootstrapServers = Preconditions.checkNotNull(bootstrapServers, "bootstrap.servers can not be null");
     this.topic = Preconditions.checkNotNull(topic, "topic can not be null");
+    this.clusterName = (clusterName == null || clusterName.isEmpty()) ? "NONAME" : clusterName;
   }
 
   @JsonProperty
@@ -59,4 +65,7 @@ public class KafkaEmitterConfig {
 
   @JsonProperty
   public String getTopic() { return topic; }
+
+  @JsonProperty
+  public String getClusterName() { return clusterName; }
 }

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterModule.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterModule.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.emitter.kafka;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Binder;
+import com.google.inject.Provides;
+import com.google.inject.name.Named;
+import com.metamx.emitter.core.Emitter;
+import io.druid.guice.JsonConfigProvider;
+import io.druid.guice.ManageLifecycle;
+import io.druid.initialization.DruidModule;
+
+import java.util.Collections;
+import java.util.List;
+
+public class KafkaEmitterModule implements DruidModule {
+  private static final String EMITTER_TYPE = "kafka";
+
+  @Override
+  public List<? extends Module> getJacksonModules() {
+    return Collections.EMPTY_LIST;
+  }
+
+  @Override
+  public void configure(Binder binder) {
+    JsonConfigProvider.bind(binder, "druid.emitter." + EMITTER_TYPE, KafkaEmitterConfig.class);
+  }
+
+  @Provides
+  @ManageLifecycle
+  @Named(EMITTER_TYPE)
+  public Emitter getEmitter(KafkaEmitterConfig kafkaEmitterConfig, ObjectMapper mapper) {
+    return new KafkaEmitter(kafkaEmitterConfig, mapper);
+  }
+}

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterModule.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterModule.java
@@ -32,23 +32,27 @@ import io.druid.initialization.DruidModule;
 import java.util.Collections;
 import java.util.List;
 
-public class KafkaEmitterModule implements DruidModule {
+public class KafkaEmitterModule implements DruidModule
+{
   private static final String EMITTER_TYPE = "kafka";
 
   @Override
-  public List<? extends Module> getJacksonModules() {
+  public List<? extends Module> getJacksonModules()
+  {
     return Collections.EMPTY_LIST;
   }
 
   @Override
-  public void configure(Binder binder) {
+  public void configure(Binder binder)
+  {
     JsonConfigProvider.bind(binder, "druid.emitter." + EMITTER_TYPE, KafkaEmitterConfig.class);
   }
 
   @Provides
   @ManageLifecycle
   @Named(EMITTER_TYPE)
-  public Emitter getEmitter(KafkaEmitterConfig kafkaEmitterConfig, ObjectMapper mapper) {
+  public Emitter getEmitter(KafkaEmitterConfig kafkaEmitterConfig, ObjectMapper mapper)
+  {
     return new KafkaEmitter(kafkaEmitterConfig, mapper);
   }
 }

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/MemoryBoundLinkedBlockingQueue.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/MemoryBoundLinkedBlockingQueue.java
@@ -29,8 +29,8 @@ import java.util.concurrent.atomic.AtomicLong;
 public class MemoryBoundLinkedBlockingQueue<T>
 {
   private final long memoryBound;
-  private AtomicLong currentMemory;
-  private LinkedBlockingQueue<ObjectContainer<T>> queue;
+  private final AtomicLong currentMemory;
+  private final LinkedBlockingQueue<ObjectContainer<T>> queue;
 
   public MemoryBoundLinkedBlockingQueue(long memoryBound)
   {

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/MemoryBoundLinkedBlockingQueue.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/MemoryBoundLinkedBlockingQueue.java
@@ -26,19 +26,22 @@ import java.util.concurrent.atomic.AtomicLong;
  * Similar to LinkedBlockingQueue but can be bounded by the total byte size of the items present in the queue
  * rather than number of items.
  */
-public class MemoryBoundLinkedBlockingQueue<T> {
+public class MemoryBoundLinkedBlockingQueue<T>
+{
   private final long memoryBound;
   private AtomicLong currentMemory;
   private LinkedBlockingQueue<ObjectContainer<T>> queue;
 
-  public MemoryBoundLinkedBlockingQueue(long memoryBound) {
+  public MemoryBoundLinkedBlockingQueue(long memoryBound)
+  {
     this.memoryBound = memoryBound;
     this.currentMemory = new AtomicLong(0L);
     this.queue = new LinkedBlockingQueue<>();
   }
 
   // returns true/false depending on whether item was added or not
-  public boolean offer(ObjectContainer<T> item) {
+  public boolean offer(ObjectContainer<T> item)
+  {
     final long itemLength = item.getSize();
 
     if (currentMemory.addAndGet(itemLength) <= memoryBound) {
@@ -51,34 +54,41 @@ public class MemoryBoundLinkedBlockingQueue<T> {
   }
 
   // blocks until at least one item is available to take
-  public ObjectContainer<T> take() throws InterruptedException {
+  public ObjectContainer<T> take() throws InterruptedException
+  {
     final ObjectContainer<T> ret = queue.take();
     currentMemory.addAndGet(-ret.getSize());
     return ret;
   }
 
-  public long getAvailableBuffer() {
+  public long getAvailableBuffer()
+  {
     return memoryBound - currentMemory.get();
   }
 
-  public int size() {
+  public int size()
+  {
     return queue.size();
   }
 
-  public static class ObjectContainer<T> {
+  public static class ObjectContainer<T>
+  {
     private T data;
     private long size;
 
-    ObjectContainer(T data, long size) {
+    ObjectContainer(T data, long size)
+    {
       this.data = data;
       this.size = size;
     }
 
-    public T getData() {
+    public T getData()
+    {
       return data;
     }
 
-    public long getSize() {
+    public long getSize()
+    {
       return size;
     }
   }

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/MemoryBoundLinkedBlockingQueue.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/MemoryBoundLinkedBlockingQueue.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.emitter.kafka;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Similar to LinkedBlockingQueue but can be bounded by the total byte size of the items present in the queue
+ * rather than number of items.
+ */
+public class MemoryBoundLinkedBlockingQueue<T> {
+  private final long memoryBound;
+  private AtomicLong currentMemory;
+  private LinkedBlockingQueue<ObjectContainer<T>> queue;
+
+  public MemoryBoundLinkedBlockingQueue(long memoryBound) {
+    this.memoryBound = memoryBound;
+    this.currentMemory = new AtomicLong(0L);
+    this.queue = new LinkedBlockingQueue<>();
+  }
+
+  // returns true/false depending on whether item was added or not
+  public boolean offer(ObjectContainer<T> item) {
+    final long itemLength = item.getSize();
+
+    if (currentMemory.addAndGet(itemLength) <= memoryBound) {
+      if (queue.offer(item)) {
+        return true;
+      }
+    }
+    currentMemory.addAndGet(-itemLength);
+    return false;
+  }
+
+  // blocks until at least one item is available to take
+  public ObjectContainer<T> take() throws InterruptedException {
+    final ObjectContainer<T> ret = queue.take();
+    currentMemory.addAndGet(-ret.getSize());
+    return ret;
+  }
+
+  public long getAvailableBuffer() {
+    return memoryBound - currentMemory.get();
+  }
+
+  public int size() {
+    return queue.size();
+  }
+
+  public static class ObjectContainer<T> {
+    private T data;
+    private long size;
+
+    ObjectContainer(T data, long size) {
+      this.data = data;
+      this.size = size;
+    }
+
+    public T getData()
+    {
+      return data;
+    }
+
+    public long getSize()
+    {
+      return size;
+    }
+  }
+}

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/MemoryBoundLinkedBlockingQueue.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/MemoryBoundLinkedBlockingQueue.java
@@ -74,13 +74,11 @@ public class MemoryBoundLinkedBlockingQueue<T> {
       this.size = size;
     }
 
-    public T getData()
-    {
+    public T getData() {
       return data;
     }
 
-    public long getSize()
-    {
+    public long getSize() {
       return size;
     }
   }

--- a/extensions-contrib/kafka-emitter/src/main/resources/META-INF/services/io.druid.initialization.DruidModule
+++ b/extensions-contrib/kafka-emitter/src/main/resources/META-INF/services/io.druid.initialization.DruidModule
@@ -1,0 +1,1 @@
+io.druid.emitter.kafka.KafkaEmitterModule

--- a/extensions-contrib/kafka-emitter/src/test/java/io/druid/emitter/kafka/KafkaEmitterConfigTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/io/druid/emitter/kafka/KafkaEmitterConfigTest.java
@@ -21,6 +21,7 @@ package io.druid.emitter.kafka;
 
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import io.druid.jackson.DefaultObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
@@ -39,7 +40,9 @@ public class KafkaEmitterConfigTest {
   @Test
   public void testSerDeserKafkaEmitterConfig() throws IOException {
     KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", "metricTest",
-                                                                   "alertTest", "clusterNameTest");
+                                                                   "alertTest", "clusterNameTest",
+                                                                    ImmutableMap.<String, String>builder()
+                                                                        .put("testKey", "testValue").build());
     String kafkaEmitterConfigString = mapper.writeValueAsString(kafkaEmitterConfig);
     KafkaEmitterConfig kafkaEmitterConfigExpected = mapper.reader(KafkaEmitterConfig.class)
                                                           .readValue(kafkaEmitterConfigString);

--- a/extensions-contrib/kafka-emitter/src/test/java/io/druid/emitter/kafka/KafkaEmitterConfigTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/io/druid/emitter/kafka/KafkaEmitterConfigTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.emitter.kafka;
+
+import com.fasterxml.jackson.databind.InjectableValues;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.druid.jackson.DefaultObjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class KafkaEmitterConfigTest {
+  private ObjectMapper mapper = new DefaultObjectMapper();
+
+  @Before
+  public void setUp() {
+    mapper.setInjectableValues(new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper()));
+  }
+
+  @Test
+  public void testSerDeserKafkaEmitterConfig() throws IOException {
+    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", "test");
+    String kafkaEmitterConfigString = mapper.writeValueAsString(kafkaEmitterConfig);
+    KafkaEmitterConfig kafkaEmitterConfigExpected = mapper.reader(KafkaEmitterConfig.class)
+                                                          .readValue(kafkaEmitterConfigString);
+    Assert.assertEquals(kafkaEmitterConfigExpected, kafkaEmitterConfig);
+  }
+}

--- a/extensions-contrib/kafka-emitter/src/test/java/io/druid/emitter/kafka/KafkaEmitterConfigTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/io/druid/emitter/kafka/KafkaEmitterConfigTest.java
@@ -38,7 +38,8 @@ public class KafkaEmitterConfigTest {
 
   @Test
   public void testSerDeserKafkaEmitterConfig() throws IOException {
-    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", "test", "test");
+    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", "metricTest",
+                                                                   "alertTest", "clusterNameTest");
     String kafkaEmitterConfigString = mapper.writeValueAsString(kafkaEmitterConfig);
     KafkaEmitterConfig kafkaEmitterConfigExpected = mapper.reader(KafkaEmitterConfig.class)
                                                           .readValue(kafkaEmitterConfigString);

--- a/extensions-contrib/kafka-emitter/src/test/java/io/druid/emitter/kafka/KafkaEmitterConfigTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/io/druid/emitter/kafka/KafkaEmitterConfigTest.java
@@ -38,7 +38,7 @@ public class KafkaEmitterConfigTest {
 
   @Test
   public void testSerDeserKafkaEmitterConfig() throws IOException {
-    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", "test");
+    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", "test", "test");
     String kafkaEmitterConfigString = mapper.writeValueAsString(kafkaEmitterConfig);
     KafkaEmitterConfig kafkaEmitterConfigExpected = mapper.reader(KafkaEmitterConfig.class)
                                                           .readValue(kafkaEmitterConfigString);

--- a/extensions-contrib/kafka-emitter/src/test/java/io/druid/emitter/kafka/KafkaEmitterConfigTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/io/druid/emitter/kafka/KafkaEmitterConfigTest.java
@@ -29,20 +29,24 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-public class KafkaEmitterConfigTest {
+public class KafkaEmitterConfigTest
+{
   private ObjectMapper mapper = new DefaultObjectMapper();
 
   @Before
-  public void setUp() {
+  public void setUp()
+  {
     mapper.setInjectableValues(new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper()));
   }
 
   @Test
-  public void testSerDeserKafkaEmitterConfig() throws IOException {
+  public void testSerDeserKafkaEmitterConfig() throws IOException
+  {
     KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", "metricTest",
                                                                    "alertTest", "clusterNameTest",
-                                                                    ImmutableMap.<String, String>builder()
-                                                                        .put("testKey", "testValue").build());
+                                                                   ImmutableMap.<String, String>builder()
+                                                                       .put("testKey", "testValue").build()
+    );
     String kafkaEmitterConfigString = mapper.writeValueAsString(kafkaEmitterConfig);
     KafkaEmitterConfig kafkaEmitterConfigExpected = mapper.reader(KafkaEmitterConfig.class)
                                                           .readValue(kafkaEmitterConfigString);

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,7 @@
         <module>extensions-contrib/ambari-metrics-emitter</module>
         <module>extensions-contrib/scan-query</module>
         <module>extensions-contrib/sqlserver-metadata-storage</module>
+        <module>extensions-contrib/kafka-emitter</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
This PR is about adding new extensions-contrib. 

Currently, Druid has various emitter module and also has HttpPostEmitter for general purpose. But, Many user currently using Apache Kafka platform and I assume that If druid has another extension emitting their metrics to kafka directly, many user feel comfort and convenience using various monitoring dashboard UI or another eco. 

Please feel free for commenting this PR.