### PR TITLE
Exclude the transitive dependency LGPL jar since it is not needed

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -56,6 +56,7 @@
             <artifactId>airline</artifactId>
             <exclusions>
                 <exclusion>
+                    <!--GPL licenced library-->
                     <groupId>com.google.code.findbugs</groupId>
                     <artifactId>annotations</artifactId>
                 </exclusion>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -54,6 +54,12 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>airline</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -82,6 +88,10 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
         </dependency>
 
         <!-- Tests -->

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -54,13 +54,6 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>airline</artifactId>
-            <exclusions>
-                <exclusion>
-                    <!--GPL licenced library-->
-                    <groupId>com.google.code.findbugs</groupId>
-                    <artifactId>annotations</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
                 <version>0.7</version>
                 <exclusions>
                     <exclusion>
-                        <!--GPL licenced library-->
+                        <!--LGPL licenced library-->
                         <groupId>com.google.code.findbugs</groupId>
                         <artifactId>annotations</artifactId>
                     </exclusion>
@@ -810,6 +810,30 @@
                                 <ignore>sun.nio.ch.DirectBuffer</ignore>
                                 <ignore>sun.misc.Cleaner</ignore>
                             </ignores>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.4.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-banned-dependencies</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <!--LGPL licenced library-->
+                                        <exclude>com.google.code.findbugs:annotations</exclude>
+                                    </excludes>
+                                </bannedDependencies>
+                            </rules>
+                            <fail>true</fail>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,13 @@
                 <groupId>io.airlift</groupId>
                 <artifactId>airline</artifactId>
                 <version>0.7</version>
+                <exclusions>
+                    <exclusion>
+                        <!--GPL licenced library-->
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>annotations</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.skife.config</groupId>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -59,13 +59,6 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>airline</artifactId>
-            <exclusions>
-                <exclusion>
-                    <!--GPL licenced library-->
-                    <groupId>com.google.code.findbugs</groupId>
-                    <artifactId>annotations</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -59,6 +59,12 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>airline</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -61,6 +61,7 @@
             <artifactId>airline</artifactId>
             <exclusions>
                 <exclusion>
+                    <!--GPL licenced library-->
                     <groupId>com.google.code.findbugs</groupId>
                     <artifactId>annotations</artifactId>
                 </exclusion>


### PR DESCRIPTION
One of druid transitive [dependency](https://mvnrepository.com/artifact/com.google.code.findbugs/annotations/2.0.3)  is a LGPL. This Pr exclude it and replace it with an existing Apache version.
