### PR TITLE
SQL: Add resolution parameter, fix filtering bug with APPROX_QUANTILE

### DIFF
--- a/benchmarks/src/main/java/io/druid/benchmark/query/SqlBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/SqlBenchmark.java
@@ -53,6 +53,7 @@ import io.druid.sql.calcite.planner.PlannerFactory;
 import io.druid.sql.calcite.planner.PlannerResult;
 import io.druid.sql.calcite.rel.QueryMaker;
 import io.druid.sql.calcite.table.DruidTable;
+import io.druid.sql.calcite.table.RowSignature;
 import io.druid.sql.calcite.util.CalciteTests;
 import io.druid.sql.calcite.util.SpecificSegmentsQuerySegmentWalker;
 import io.druid.timeline.DataSegment;
@@ -158,12 +159,12 @@ public class SqlBenchmark
         new DruidTable(
             new QueryMaker(walker, plannerConfig),
             new TableDataSource("foo"),
-            ImmutableMap.of(
-                "__time", ValueType.LONG,
-                "dimSequential", ValueType.STRING,
-                "dimZipf", ValueType.STRING,
-                "dimUniform", ValueType.STRING
-            )
+            RowSignature.builder()
+                        .add("__time", ValueType.LONG)
+                        .add("dimSequential", ValueType.STRING)
+                        .add("dimZipf", ValueType.STRING)
+                        .add("dimUniform", ValueType.STRING)
+                        .build()
         )
     );
     final Schema druidSchema = new AbstractSchema()

--- a/docs/content/querying/sql.md
+++ b/docs/content/querying/sql.md
@@ -149,8 +149,10 @@ Some Druid extensions also include SQL language extensions.
 
 If the [approximate histogram extension](../development/extensions-core/approximate-histograms.html) is loaded:
 
-- `QUANTILE(column, probability)` on numeric or approximate histogram columns computes approximate quantiles. The
-"probability" should be between 0 and 1 (exclusive).
+- `APPROX_QUANTILE(column, probability)` or `APPROX_QUANTILE(column, probability, resolution)` on numeric or
+approximate histogram columns computes approximate quantiles. The "probability" should be between 0 and 1 (exclusive).
+The "resolution" is the number of centroids to use for the computation. Higher resolutions will be give more
+precise results but also have higher overhead. If not provided, the default resolution is 50.
 
 ### Unsupported features
 

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/sql/QuantileSqlAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/sql/QuantileSqlAggregator.java
@@ -21,7 +21,6 @@ package io.druid.query.aggregation.histogram.sql;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.histogram.ApproximateHistogram;
 import io.druid.query.aggregation.histogram.ApproximateHistogramAggregatorFactory;

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/sql/QuantileSqlAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/sql/QuantileSqlAggregatorTest.java
@@ -26,10 +26,22 @@ import io.druid.granularity.QueryGranularities;
 import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.Druids;
 import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.query.aggregation.CountAggregatorFactory;
+import io.druid.query.aggregation.DoubleSumAggregatorFactory;
+import io.druid.query.aggregation.FilteredAggregatorFactory;
 import io.druid.query.aggregation.PostAggregator;
 import io.druid.query.aggregation.histogram.ApproximateHistogramAggregatorFactory;
+import io.druid.query.aggregation.histogram.ApproximateHistogramDruidModule;
+import io.druid.query.aggregation.histogram.ApproximateHistogramFoldingAggregatorFactory;
 import io.druid.query.aggregation.histogram.QuantilePostAggregator;
+import io.druid.query.filter.NotDimFilter;
+import io.druid.query.filter.SelectorDimFilter;
 import io.druid.query.spec.MultipleIntervalSegmentSpec;
+import io.druid.segment.IndexBuilder;
+import io.druid.segment.QueryableIndex;
+import io.druid.segment.TestHelper;
+import io.druid.segment.incremental.IncrementalIndexSchema;
+import io.druid.sql.calcite.CalciteQueryTest;
 import io.druid.sql.calcite.aggregation.SqlAggregator;
 import io.druid.sql.calcite.filtration.Filtration;
 import io.druid.sql.calcite.planner.Calcites;
@@ -40,6 +52,8 @@ import io.druid.sql.calcite.planner.PlannerResult;
 import io.druid.sql.calcite.util.CalciteTests;
 import io.druid.sql.calcite.util.QueryLogHook;
 import io.druid.sql.calcite.util.SpecificSegmentsQuerySegmentWalker;
+import io.druid.timeline.DataSegment;
+import io.druid.timeline.partition.LinearShardSpec;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.tools.Planner;
 import org.junit.After;
@@ -52,10 +66,10 @@ import org.junit.rules.TemporaryFolder;
 import java.util.ArrayList;
 import java.util.List;
 
-import static io.druid.sql.calcite.CalciteQueryTest.TIMESERIES_CONTEXT;
-
 public class QuantileSqlAggregatorTest
 {
+  private static final String DATA_SOURCE = "foo";
+
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -69,7 +83,45 @@ public class QuantileSqlAggregatorTest
   public void setUp() throws Exception
   {
     Calcites.setSystemProperties();
-    walker = CalciteTests.createMockWalker(temporaryFolder.newFolder());
+
+    // Note: this is needed in order to properly register the serde for Histogram.
+    new ApproximateHistogramDruidModule().configure(null);
+
+    final QueryableIndex index = IndexBuilder.create()
+                                             .tmpDir(temporaryFolder.newFolder())
+                                             .indexMerger(TestHelper.getTestIndexMergerV9())
+                                             .schema(
+                                                 new IncrementalIndexSchema.Builder()
+                                                     .withMetrics(
+                                                         new AggregatorFactory[]{
+                                                             new CountAggregatorFactory("cnt"),
+                                                             new DoubleSumAggregatorFactory("m1", "m1"),
+                                                             new ApproximateHistogramAggregatorFactory(
+                                                                 "hist_m1",
+                                                                 "m1",
+                                                                 null,
+                                                                 null,
+                                                                 null,
+                                                                 null
+                                                             )
+                                                         }
+                                                     )
+                                                     .withRollup(false)
+                                                     .build()
+                                             )
+                                             .rows(CalciteTests.ROWS1)
+                                             .buildMMappedIndex();
+
+    walker = new SpecificSegmentsQuerySegmentWalker(CalciteTests.queryRunnerFactoryConglomerate()).add(
+        DataSegment.builder()
+                   .dataSource(DATA_SOURCE)
+                   .interval(index.getDataInterval())
+                   .version("1")
+                   .shardSpec(new LinearShardSpec(0))
+                   .build(),
+        index
+    );
+
     final PlannerConfig plannerConfig = new PlannerConfig();
     final SchemaPlus rootSchema = Calcites.createRootSchema(
         CalciteTests.createMockSchema(
@@ -101,6 +153,9 @@ public class QuantileSqlAggregatorTest
                          + "APPROX_QUANTILE(m1, 0.5, 50),\n"
                          + "APPROX_QUANTILE(m1, 0.98, 200),\n"
                          + "APPROX_QUANTILE(m1, 0.99),\n"
+                         + "APPROX_QUANTILE(m1, 0.99) FILTER(WHERE dim1 = 'abc'),\n"
+                         + "APPROX_QUANTILE(m1, 0.999) FILTER(WHERE dim1 <> 'abc'),\n"
+                         + "APPROX_QUANTILE(m1, 0.999) FILTER(WHERE dim1 = 'abc'),\n"
                          + "APPROX_QUANTILE(cnt, 0.5)\n"
                          + "FROM foo";
 
@@ -109,7 +164,7 @@ public class QuantileSqlAggregatorTest
       // Verify results
       final List<Object[]> results = Sequences.toList(plannerResult.run(), new ArrayList<Object[]>());
       final List<Object[]> expectedResults = ImmutableList.of(
-          new Object[]{1.0, 3.0, 5.880000114440918, 5.940000057220459, 1.0}
+          new Object[]{1.0, 3.0, 5.880000114440918, 5.940000057220459, 6.0, 4.994999885559082, 6.0, 1.0}
       );
       Assert.assertEquals(expectedResults.size(), results.size());
       for (int i = 0; i < expectedResults.size(); i++) {
@@ -122,19 +177,90 @@ public class QuantileSqlAggregatorTest
                 .dataSource(CalciteTests.DATASOURCE1)
                 .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Filtration.eternity())))
                 .granularity(QueryGranularities.ALL)
-                .aggregators(ImmutableList.<AggregatorFactory>of(
+                .aggregators(ImmutableList.of(
                     new ApproximateHistogramAggregatorFactory("a0:agg", "m1", null, null, null, null),
                     new ApproximateHistogramAggregatorFactory("a2:agg", "m1", 200, null, null, null),
-                    new ApproximateHistogramAggregatorFactory("a4:agg", "cnt", null, null, null, null)
+                    new FilteredAggregatorFactory(
+                        new ApproximateHistogramAggregatorFactory("a4:agg", "m1", null, null, null, null),
+                        new SelectorDimFilter("dim1", "abc", null)
+                    ),
+                    new FilteredAggregatorFactory(
+                        new ApproximateHistogramAggregatorFactory("a5:agg", "m1", null, null, null, null),
+                        new NotDimFilter(new SelectorDimFilter("dim1", "abc", null))
+                    ),
+                    new ApproximateHistogramAggregatorFactory("a7:agg", "cnt", null, null, null, null)
                 ))
                 .postAggregators(ImmutableList.<PostAggregator>of(
                     new QuantilePostAggregator("a0", "a0:agg", 0.01f),
                     new QuantilePostAggregator("a1", "a0:agg", 0.50f),
                     new QuantilePostAggregator("a2", "a2:agg", 0.98f),
                     new QuantilePostAggregator("a3", "a0:agg", 0.99f),
-                    new QuantilePostAggregator("a4", "a4:agg", 0.50f)
+                    new QuantilePostAggregator("a4", "a4:agg", 0.99f),
+                    new QuantilePostAggregator("a5", "a5:agg", 0.999f),
+                    new QuantilePostAggregator("a6", "a4:agg", 0.999f),
+                    new QuantilePostAggregator("a7", "a7:agg", 0.50f)
                 ))
-                .context(TIMESERIES_CONTEXT)
+                .context(CalciteQueryTest.TIMESERIES_CONTEXT)
+                .build(),
+          Iterables.getOnlyElement(queryLogHook.getRecordedQueries())
+      );
+    }
+  }
+
+  @Test
+  public void testQuantileOnComplexColumn() throws Exception
+  {
+    try (final Planner planner = plannerFactory.createPlanner()) {
+      final String sql = "SELECT\n"
+                         + "APPROX_QUANTILE(hist_m1, 0.01),\n"
+                         + "APPROX_QUANTILE(hist_m1, 0.5, 50),\n"
+                         + "APPROX_QUANTILE(hist_m1, 0.98, 200),\n"
+                         + "APPROX_QUANTILE(hist_m1, 0.99),\n"
+                         + "APPROX_QUANTILE(hist_m1, 0.99) FILTER(WHERE dim1 = 'abc'),\n"
+                         + "APPROX_QUANTILE(hist_m1, 0.999) FILTER(WHERE dim1 <> 'abc'),\n"
+                         + "APPROX_QUANTILE(hist_m1, 0.999) FILTER(WHERE dim1 = 'abc')\n"
+                         + "FROM foo";
+
+      final PlannerResult plannerResult = Calcites.plan(planner, sql);
+
+      // Verify results
+      final List<Object[]> results = Sequences.toList(plannerResult.run(), new ArrayList<Object[]>());
+      final List<Object[]> expectedResults = ImmutableList.of(
+          new Object[]{1.0, 3.0, 5.880000114440918, 5.940000057220459, 6.0, 4.994999885559082, 6.0}
+      );
+      Assert.assertEquals(expectedResults.size(), results.size());
+      for (int i = 0; i < expectedResults.size(); i++) {
+        Assert.assertArrayEquals(expectedResults.get(i), results.get(i));
+      }
+
+      // Verify query
+      Assert.assertEquals(
+          Druids.newTimeseriesQueryBuilder()
+                .dataSource(CalciteTests.DATASOURCE1)
+                .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Filtration.eternity())))
+                .granularity(QueryGranularities.ALL)
+                .aggregators(ImmutableList.of(
+                    new ApproximateHistogramFoldingAggregatorFactory("a0:agg", "hist_m1", null, null, null, null),
+                    new ApproximateHistogramFoldingAggregatorFactory("a2:agg", "hist_m1", 200, null, null, null),
+                    new FilteredAggregatorFactory(
+                        new ApproximateHistogramFoldingAggregatorFactory("a4:agg", "hist_m1", null, null, null, null),
+                        new SelectorDimFilter("dim1", "abc", null)
+                    ),
+                    new FilteredAggregatorFactory(
+                        new ApproximateHistogramFoldingAggregatorFactory("a5:agg", "hist_m1", null, null, null, null),
+                        new NotDimFilter(new SelectorDimFilter("dim1", "abc", null))
+                    )
+                ))
+                .postAggregators(ImmutableList.<PostAggregator>of(
+                    new QuantilePostAggregator("a0", "a0:agg", 0.01f),
+                    new QuantilePostAggregator("a1", "a0:agg", 0.50f),
+                    new QuantilePostAggregator("a2", "a2:agg", 0.98f),
+                    new QuantilePostAggregator("a3", "a0:agg", 0.99f),
+                    new QuantilePostAggregator("a4", "a4:agg", 0.99f),
+                    new QuantilePostAggregator("a5", "a5:agg", 0.999f),
+                    new QuantilePostAggregator("a6", "a4:agg", 0.999f)
+                ))
+                .context(CalciteQueryTest.TIMESERIES_CONTEXT)
                 .build(),
           Iterables.getOnlyElement(queryLogHook.getRecordedQueries())
       );

--- a/sql/src/main/java/io/druid/sql/calcite/aggregation/Aggregations.java
+++ b/sql/src/main/java/io/druid/sql/calcite/aggregation/Aggregations.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.sql.calcite.aggregation;
+
+import com.google.common.base.Predicate;
+import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.query.aggregation.FilteredAggregatorFactory;
+import io.druid.query.filter.DimFilter;
+
+public class Aggregations
+{
+  private Aggregations()
+  {
+    // No instantiation.
+  }
+
+  /**
+   * Returns true if "factory" is an aggregator factory that either matches "predicate" (if filter is null) or is
+   * a filtered aggregator factory whose filter is equal to "filter" and underlying aggregator matches "predicate".
+   *
+   * @param factory   factory to match
+   * @param filter    filter, may be null
+   * @param clazz     class of factory to match
+   * @param predicate predicate
+   *
+   * @return true if the aggregator matches filter + predicate
+   */
+  public static <T extends AggregatorFactory> boolean aggregatorMatches(
+      final AggregatorFactory factory,
+      final DimFilter filter,
+      final Class<T> clazz,
+      final Predicate<T> predicate
+  )
+  {
+    if (filter != null) {
+      return factory instanceof FilteredAggregatorFactory &&
+             ((FilteredAggregatorFactory) factory).getFilter().equals(filter)
+             && aggregatorMatches(((FilteredAggregatorFactory) factory).getAggregator(), null, clazz, predicate);
+    } else {
+      return clazz.isAssignableFrom(factory.getClass()) && predicate.apply(clazz.cast(factory));
+    }
+  }
+}

--- a/sql/src/main/java/io/druid/sql/calcite/aggregation/ApproxCountDistinctSqlAggregator.java
+++ b/sql/src/main/java/io/druid/sql/calcite/aggregation/ApproxCountDistinctSqlAggregator.java
@@ -27,6 +27,7 @@ import io.druid.query.aggregation.cardinality.CardinalityAggregatorFactory;
 import io.druid.query.aggregation.hyperloglog.HyperUniqueFinalizingPostAggregator;
 import io.druid.query.aggregation.hyperloglog.HyperUniquesAggregatorFactory;
 import io.druid.query.dimension.DimensionSpec;
+import io.druid.query.filter.DimFilter;
 import io.druid.segment.column.ValueType;
 import io.druid.sql.calcite.expression.Expressions;
 import io.druid.sql.calcite.expression.RowExtraction;
@@ -60,7 +61,8 @@ public class ApproxCountDistinctSqlAggregator implements SqlAggregator
       final RowSignature rowSignature,
       final List<Aggregation> existingAggregations,
       final Project project,
-      final AggregateCall aggregateCall
+      final AggregateCall aggregateCall,
+      final DimFilter filter
   )
   {
     final RowExtraction rex = Expressions.toRowExtraction(
@@ -99,7 +101,7 @@ public class ApproxCountDistinctSqlAggregator implements SqlAggregator
             return new HyperUniqueFinalizingPostAggregator(outputName, name);
           }
         }
-    );
+    ).filter(filter);
   }
 
   private static class ApproxCountDistinctSqlAggFunction extends SqlAggFunction

--- a/sql/src/main/java/io/druid/sql/calcite/aggregation/SqlAggregator.java
+++ b/sql/src/main/java/io/druid/sql/calcite/aggregation/SqlAggregator.java
@@ -19,6 +19,7 @@
 
 package io.druid.sql.calcite.aggregation;
 
+import io.druid.query.filter.DimFilter;
 import io.druid.sql.calcite.table.RowSignature;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.core.Project;
@@ -44,9 +45,11 @@ public interface SqlAggregator
    *
    * @param name                 desired output name of the aggregation
    * @param rowSignature         signature of the rows being aggregated
-   * @param existingAggregations existing aggregations for this query; useful for re-using aggregators
-   * @param project              SQL projection to apply before the aggregate call
+   * @param existingAggregations existing aggregations for this query; useful for re-using aggregations. May be safely
+   *                             ignored if you do not want to re-use existing aggregations.
+   * @param project              SQL projection to apply before the aggregate call, may be null
    * @param aggregateCall        SQL aggregate call
+   * @param filter               filter that should be applied to the aggregation, may be null
    *
    * @return aggregation, or null if the call cannot be translated
    */
@@ -56,6 +59,7 @@ public interface SqlAggregator
       final RowSignature rowSignature,
       final List<Aggregation> existingAggregations,
       final Project project,
-      final AggregateCall aggregateCall
+      final AggregateCall aggregateCall,
+      final DimFilter filter
   );
 }

--- a/sql/src/main/java/io/druid/sql/calcite/schema/DruidSchema.java
+++ b/sql/src/main/java/io/druid/sql/calcite/schema/DruidSchema.java
@@ -50,6 +50,7 @@ import io.druid.server.coordination.DruidServerMetadata;
 import io.druid.sql.calcite.planner.PlannerConfig;
 import io.druid.sql.calcite.rel.QueryMaker;
 import io.druid.sql.calcite.table.DruidTable;
+import io.druid.sql.calcite.table.RowSignature;
 import io.druid.timeline.DataSegment;
 import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.impl.AbstractSchema;
@@ -296,7 +297,7 @@ public class DruidSchema extends AbstractSchema
     }
 
     final Map<String, ColumnAnalysis> columnMetadata = Iterables.getOnlyElement(results).getColumns();
-    final Map<String, ValueType> columnValueTypes = Maps.newHashMap();
+    final RowSignature.Builder rowSignature = RowSignature.builder();
 
     for (Map.Entry<String, ColumnAnalysis> entry : columnMetadata.entrySet()) {
       if (entry.getValue().isError()) {
@@ -314,13 +315,13 @@ public class DruidSchema extends AbstractSchema
         valueType = ValueType.COMPLEX;
       }
 
-      columnValueTypes.put(entry.getKey(), valueType);
+      rowSignature.add(entry.getKey(), valueType);
     }
 
     return new DruidTable(
         queryMaker,
         new TableDataSource(dataSource),
-        columnValueTypes
+        rowSignature.build()
     );
   }
 }

--- a/sql/src/main/java/io/druid/sql/calcite/table/DruidTable.java
+++ b/sql/src/main/java/io/druid/sql/calcite/table/DruidTable.java
@@ -20,9 +20,7 @@
 package io.druid.sql.calcite.table;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSortedMap;
 import io.druid.query.DataSource;
-import io.druid.segment.column.ValueType;
 import io.druid.sql.calcite.rel.DruidQueryRel;
 import io.druid.sql.calcite.rel.QueryMaker;
 import org.apache.calcite.plan.RelOptCluster;
@@ -35,8 +33,6 @@ import org.apache.calcite.schema.Statistic;
 import org.apache.calcite.schema.Statistics;
 import org.apache.calcite.schema.TranslatableTable;
 
-import java.util.Map;
-
 public class DruidTable implements TranslatableTable
 {
   private final QueryMaker queryMaker;
@@ -46,17 +42,12 @@ public class DruidTable implements TranslatableTable
   public DruidTable(
       final QueryMaker queryMaker,
       final DataSource dataSource,
-      final Map<String, ValueType> columns
+      final RowSignature rowSignature
   )
   {
     this.queryMaker = Preconditions.checkNotNull(queryMaker, "queryMaker");
     this.dataSource = Preconditions.checkNotNull(dataSource, "dataSource");
-
-    final RowSignature.Builder rowSignatureBuilder = RowSignature.builder();
-    for (Map.Entry<String, ValueType> entry : ImmutableSortedMap.copyOf(columns).entrySet()) {
-      rowSignatureBuilder.add(entry.getKey(), entry.getValue());
-    }
-    this.rowSignature = rowSignatureBuilder.build();
+    this.rowSignature = Preconditions.checkNotNull(rowSignature, "rowSignature");
   }
 
   public QueryMaker getQueryMaker()

--- a/sql/src/main/java/io/druid/sql/calcite/table/RowSignature.java
+++ b/sql/src/main/java/io/druid/sql/calcite/table/RowSignature.java
@@ -51,7 +51,7 @@ public class RowSignature
   private final Map<String, ValueType> columnTypes;
   private final List<String> columnNames;
 
-  public RowSignature(final List<Pair<String, ValueType>> columnTypeList)
+  private RowSignature(final List<Pair<String, ValueType>> columnTypeList)
   {
     final Map<String, ValueType> columnTypes0 = Maps.newHashMap();
     final ImmutableList.Builder<String> columnNamesBuilder = ImmutableList.builder();


### PR DESCRIPTION
- Adds an optional resolution parameter to APPROX_QUANTILE.
- Fixes a bug where unfiltered approximate histogram aggregators could get reused improperly by filtered aggregators.
- Rename QUANTILE to APPROX_QUANTILE, which is probably a better name, in keeping with APPROX_COUNT_DISTINCT.
- Includes some slight refactoring to allow tests to make DruidTables that include complex columns.