### PR TITLE
add mvn profile to bundle contrib extensions if/when needed

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -79,8 +79,6 @@
                                 <argument>-c</argument>
                                 <argument>io.druid.extensions:druid-avro-extensions</argument>
                                 <argument>-c</argument>
-                                <argument>io.druid.extensions:druid-examples</argument>
-                                <argument>-c</argument>
                                 <argument>io.druid.extensions:druid-datasketches</argument>
                                 <argument>-c</argument>
                                 <argument>io.druid.extensions:druid-hdfs-storage</argument>
@@ -97,17 +95,17 @@
                                 <argument>-c</argument>
                                 <argument>io.druid.extensions:druid-lookups-cached-single</argument>
                                 <argument>-c</argument>
+                                <argument>io.druid.extensions:mysql-metadata-storage</argument>
+                                <argument>-c</argument>
+                                <argument>io.druid.extensions:postgresql-metadata-storage</argument>
+				                        <argument>-c</argument>
+                                <argument>io.druid.extensions:druid-kerberos</argument>
+                                <argument>-c</argument>
                                 <argument>io.druid.extensions:druid-s3-extensions</argument>
                                 <argument>-c</argument>
                                 <argument>io.druid.extensions:druid-stats</argument>
                                 <argument>-c</argument>
-                                <argument>io.druid.extensions:mysql-metadata-storage</argument>
-                                <argument>-c</argument>
-                                <argument>io.druid.extensions:postgresql-metadata-storage</argument>
-                                <argument>-c</argument>
-                                <argument>io.druid.extensions.contrib:scan-query</argument>
-				                        <argument>-c</argument>
-                                <argument>io.druid.extensions:druid-kerberos</argument>
+                                <argument>io.druid.extensions:druid-examples</argument>
                                 <argument>${druid.distribution.pulldeps.opts}</argument>
                             </arguments>
                         </configuration>
@@ -207,6 +205,84 @@
                                         <argument>--no-default-hadoop</argument>
                                         <argument>-c</argument>
                                         <argument>io.druid.extensions:druid-caffeine-cache</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>bundle-contrib-exts</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>pull-deps-contrib-exts</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>java</executable>
+                                    <arguments>
+                                        <argument>-classpath</argument>
+                                        <classpath/>
+                                        <argument>-Ddruid.extensions.loadList=[]</argument>
+                                        <argument>-Ddruid.extensions.directory=${project.build.directory}/extensions
+                                        </argument>
+                                        <argument>
+                                            -Ddruid.extensions.hadoopDependenciesDir=${project.build.directory}/hadoop-dependencies
+                                        </argument>
+                                        <argument>io.druid.cli.Main</argument>
+                                        <argument>tools</argument>
+                                        <argument>pull-deps</argument>
+                                        <argument>--defaultVersion</argument>
+                                        <argument>${project.parent.version}</argument>
+                                        <argument>-l</argument>
+                                        <argument>${settings.localRepository}</argument>
+                                        <argument>--no-default-hadoop</argument>
+                                        <argument>${druid.distribution.pulldeps.opts}</argument>
+                                        <argument>-c</argument>
+                                        <argument>io.druid.extensions.contrib:ambari-metrics-emitter</argument>
+                                        <argument>-c</argument>
+                                        <argument>io.druid.extensions.contrib:druid-azure-extensions</argument>
+                                        <argument>-c</argument>
+                                        <argument>io.druid.extensions.contrib:druid-cassandra-storage</argument>
+                                        <argument>-c</argument>
+                                        <argument>io.druid.extensions.contrib:druid-cloudfiles-extensions</argument>
+                                        <argument>-c</argument>
+                                        <argument>io.druid.extensions.contrib:druid-distinctcount</argument>
+                                        <argument>-c</argument>
+                                        <argument>io.druid.extensions.contrib:druid-rocketmq</argument>
+                                        <argument>-c</argument>
+                                        <argument>io.druid.extensions.contrib:druid-google-extensions</argument>
+                                        <argument>-c</argument>
+                                        <argument>io.druid.extensions.contrib:druid-kafka-eight-simple-consumer</argument>
+                                        <argument>-c</argument>
+                                        <argument>io.druid.extensions.contrib:graphite-emitter</argument>
+                                        <argument>-c</argument>
+                                        <argument>io.druid.extensions.contrib:druid-orc-extensions</argument>
+                                        <argument>-c</argument>
+                                        <argument>io.druid.extensions.contrib:druid-parquet-extensions</argument>
+                                        <argument>-c</argument>
+                                        <argument>io.druid.extensions.contrib:druid-rabbitmq</argument>
+                                        <argument>-c</argument>
+                                        <argument>io.druid.extensions.contrib:scan-query</argument>
+                                        <argument>-c</argument>
+                                        <argument>io.druid.extensions.contrib:sqlserver-metadata-storage</argument>
+                                        <argument>-c</argument>
+                                        <argument>io.druid.extensions.contrib:statsd-emitter</argument>
+                                        <argument>-c</argument>
+                                        <argument>io.druid.extensions.contrib:druid-thrift-extensions</argument>
+                                        <argument>-c</argument>
+                                        <argument>io.druid.extensions.contrib:druid-time-min-max</argument>
+                                        <argument>-c</argument>
+                                        <argument>io.druid.extensions.contrib:druid-virtual-columns</argument>
                                     </arguments>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
this depends on https://github.com/druid-io/druid/pull/3871 which should be merged first.


[Old Description] --
I don't remember if we explicitly decided to not package the contrib extensions. But, it gives user pain to use contrib extensions because they are not bundled.

I think distinction of expectations for core vs contrib extensions is well explained in the doc and also present in package names. but, it should be possible to use any extension without much effort.

that said, if community believes they should not be packaged by default then I can change this patch to add an extra profile that packages everything and can be used by users wanting that.

this patch also adds "sqlserver-metadata-storage" to top level pom so that it is built/tested like other extensions. it was probably missed earlier.