### PR TITLE
LikeFilter: Read value lazily when doing a prefix-based match.

### DIFF
--- a/processing/src/main/java/io/druid/query/filter/LikeDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/LikeDimFilter.java
@@ -29,6 +29,7 @@ import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.Chars;
 import io.druid.java.util.common.StringUtils;
 import io.druid.query.extraction.ExtractionFn;
+import io.druid.segment.data.Indexed;
 import io.druid.segment.filter.LikeFilter;
 
 import javax.annotation.Nullable;
@@ -154,17 +155,20 @@ public class LikeDimFilter implements DimFilter
     }
 
     /**
-     * Checks if the suffix of "s" matches the suffix of this matcher. The first prefix.length characters
-     * of s are ignored. This method is useful if you've already independently verified the prefix.
+     * Checks if the suffix of strings.get(i) matches the suffix of this matcher. The first prefix.length characters
+     * of s are ignored. This method is useful if you've already independently verified the prefix. This method
+     * evalutes strings.get(i) lazily to save time when it isn't necessary to actually look at the string.
      */
-    public boolean matchesSuffixOnly(@Nullable final String s)
+    public boolean matchesSuffixOnly(final Indexed<String> strings, final int i)
     {
       if (suffixMatch == SuffixMatch.MATCH_ANY) {
         return true;
       } else if (suffixMatch == SuffixMatch.MATCH_EMPTY) {
+        final String s = strings.get(i);
         return (s == null ? 0 : s.length()) == prefix.length();
       } else {
         // suffixMatch is MATCH_PATTERN
+        final String s = strings.get(i);
         return matches(s);
       }
     }

--- a/processing/src/main/java/io/druid/segment/filter/LikeFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/LikeFilter.java
@@ -99,7 +99,7 @@ public class LikeFilter implements Filter
                 @Override
                 public ImmutableBitmap next()
                 {
-                  while (currIndex < endIndex && !likeMatcher.matchesSuffixOnly(dimValues.get(currIndex))) {
+                  while (currIndex < endIndex && !likeMatcher.matchesSuffixOnly(dimValues, currIndex)) {
                     currIndex++;
                   }
 


### PR DESCRIPTION
This speeds up cases where we don't actually need to read the value, such as `LIKE 'foo%'`.

Benchmarks:

```
master

Benchmark                            (cardinality)  Mode  Cnt      Score      Error  Units
LikeFilterBenchmark.matchLikePrefix           1000  avgt   10      6.034 ±    0.764  us/op
LikeFilterBenchmark.matchLikePrefix         100000  avgt   10   1212.425 ±  165.169  us/op
LikeFilterBenchmark.matchLikePrefix        1000000  avgt   10  13881.014 ± 1802.151  us/op

patch

Benchmark                            (cardinality)  Mode  Cnt      Score     Error  Units
LikeFilterBenchmark.matchLikePrefix           1000  avgt   10      4.176 ±   0.159  us/op
LikeFilterBenchmark.matchLikePrefix         100000  avgt   10    894.584 ±  41.895  us/op
LikeFilterBenchmark.matchLikePrefix        1000000  avgt   10  10665.437 ± 271.716  us/op
```