### PR TITLE
flattenSpec: Document that "expr" is ignored for type "root".

### DIFF
--- a/api/src/main/java/io/druid/data/input/impl/JSONPathFieldSpec.java
+++ b/api/src/main/java/io/druid/data/input/impl/JSONPathFieldSpec.java
@@ -71,6 +71,6 @@ public class JSONPathFieldSpec
 
   public static JSONPathFieldSpec createRootField(String name)
   {
-    return new JSONPathFieldSpec(JSONPathFieldType.ROOT, name, name);
+    return new JSONPathFieldSpec(JSONPathFieldType.ROOT, name, null);
   }
 }

--- a/api/src/test/java/io/druid/data/input/impl/InputRowParserSerdeTest.java
+++ b/api/src/test/java/io/druid/data/input/impl/InputRowParserSerdeTest.java
@@ -27,8 +27,8 @@ import com.google.common.collect.Lists;
 import io.druid.TestObjectMapper;
 import io.druid.data.input.ByteBufferInputRowParser;
 import io.druid.data.input.InputRow;
-import junit.framework.Assert;
 import org.joda.time.DateTime;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
@@ -143,11 +143,11 @@ public class InputRowParserSerdeTest
         ImmutableList.of("1412705931123", "123.456", "1.23E47", "hello"),
         parsed.getDimension("values")
     );
-    Assert.assertEquals(Float.POSITIVE_INFINITY, parsed.getFloatMetric("toobig"));
+    Assert.assertEquals(Float.POSITIVE_INFINITY, parsed.getFloatMetric("toobig"), 0.0);
     Assert.assertEquals(123E64, parsed.getRaw("toobig"));
-    Assert.assertEquals(123.456f, parsed.getFloatMetric("value"));
+    Assert.assertEquals(123.456f, parsed.getFloatMetric("value"), 0.0f);
     Assert.assertEquals(123456789000L, parsed.getRaw("long"));
-    Assert.assertEquals(1.23456791E11f, parsed.getFloatMetric("long"));
+    Assert.assertEquals(1.23456791E11f, parsed.getFloatMetric("long"), 0.0f);
     Assert.assertEquals(1412705931123L, parsed.getTimestampFromEpoch());
   }
 
@@ -227,7 +227,7 @@ public class InputRowParserSerdeTest
     List<JSONPathFieldSpec> fieldSpecs = parsedSpec.getFields();
     Assert.assertEquals(JSONPathFieldType.ROOT, fieldSpecs.get(0).getType());
     Assert.assertEquals("parseThisRootField", fieldSpecs.get(0).getName());
-    Assert.assertEquals("parseThisRootField", fieldSpecs.get(0).getExpr());
+    Assert.assertEquals(null, fieldSpecs.get(0).getExpr());
   }
 
 }

--- a/api/src/test/java/io/druid/data/input/impl/JSONPathSpecTest.java
+++ b/api/src/test/java/io/druid/data/input/impl/JSONPathSpecTest.java
@@ -70,10 +70,10 @@ public class JSONPathSpecTest
 
     Assert.assertEquals(JSONPathFieldType.ROOT, timestamp.getType());
     Assert.assertEquals("timestamp", timestamp.getName());
-    Assert.assertEquals("timestamp", timestamp.getExpr());
+    Assert.assertEquals(null, timestamp.getExpr());
 
     Assert.assertEquals(JSONPathFieldType.ROOT, foodotbar1.getType());
     Assert.assertEquals("foo.bar1", foodotbar1.getName());
-    Assert.assertEquals("foo.bar1", foodotbar1.getExpr());
+    Assert.assertEquals(null, foodotbar1.getExpr());
   }
 }

--- a/docs/content/ingestion/flatten-json.md
+++ b/docs/content/ingestion/flatten-json.md
@@ -19,7 +19,7 @@ Defining the JSON Flatten Spec allows nested JSON fields to be flattened during 
 |-------|------|-------------|----------|
 | type | String | Type of the field, "root" or "path". | yes |
 | name | String | This string will be used as the column name when the data has been ingested.  | yes |
-| expr | String | Defines an expression for accessing the field within the JSON object, using [JsonPath](https://github.com/jayway/JsonPath) notation. | yes |
+| expr | String | Defines an expression for accessing the field within the JSON object, using [JsonPath](https://github.com/jayway/JsonPath) notation. Only used for type "path", otherwise ignored. | only for type "path" |
 
 Suppose the event JSON has the following form:
 
@@ -53,8 +53,7 @@ To flatten this JSON, the parseSpec could be defined as follows:
     "fields": [
       {
         "type": "root",
-        "name": "dim1",
-        "expr": "dim1"
+        "name": "dim1"
       },
       "dim2",
       {
@@ -64,8 +63,7 @@ To flatten this JSON, the parseSpec could be defined as follows:
       },
       {
         "type": "root",
-        "name": "root-foo.bar",
-        "expr": "foo.bar"
+        "name": "foo.bar"
       },
       {
         "type": "path",

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/JSONPathParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/JSONPathParser.java
@@ -134,7 +134,7 @@ public class JSONPathParser implements Parser<String, Object>
       if (map.get(fieldName) != null) {
         throw new IllegalArgumentException("Cannot have duplicate field definition: " + fieldName);
       }
-      JsonPath path = JsonPath.compile(fieldSpec.getExpr());
+      JsonPath path = fieldSpec.getType() == FieldType.PATH ? JsonPath.compile(fieldSpec.getExpr()) : null;
       Pair<FieldType, JsonPath> pair = new Pair<>(fieldSpec.getType(), path);
       map.put(fieldName, pair);
     }


### PR DESCRIPTION
The current docs are a little ambiguous.