### PR TITLE
Remove deprecated Aggregator/AggregatorFactory methods

### DIFF
--- a/extensions-contrib/distinctcount/src/main/java/io/druid/query/aggregation/distinctcount/DistinctCountAggregator.java
+++ b/extensions-contrib/distinctcount/src/main/java/io/druid/query/aggregation/distinctcount/DistinctCountAggregator.java
@@ -65,12 +65,6 @@ public class DistinctCountAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    throw new UnsupportedOperationException("getName is deprecated");
-  }
-
-  @Override
   public void close()
   {
     mutableBitmap.clear();

--- a/extensions-contrib/distinctcount/src/main/java/io/druid/query/aggregation/distinctcount/EmptyDistinctCountAggregator.java
+++ b/extensions-contrib/distinctcount/src/main/java/io/druid/query/aggregation/distinctcount/EmptyDistinctCountAggregator.java
@@ -51,12 +51,6 @@ public class EmptyDistinctCountAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    throw new UnsupportedOperationException("getName is deprecated");
-  }
-
-  @Override
   public void close()
   {
   }

--- a/extensions-contrib/time-min-max/src/main/java/io/druid/query/aggregation/TimestampAggregator.java
+++ b/extensions-contrib/time-min-max/src/main/java/io/druid/query/aggregation/TimestampAggregator.java
@@ -86,12 +86,6 @@ public class TimestampAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    return name;
-  }
-
-  @Override
   public void close()
   {
     // no resource to cleanup

--- a/extensions-contrib/time-min-max/src/main/java/io/druid/query/aggregation/TimestampAggregatorFactory.java
+++ b/extensions-contrib/time-min-max/src/main/java/io/druid/query/aggregation/TimestampAggregatorFactory.java
@@ -167,12 +167,6 @@ public class TimestampAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public Object getAggregatorStartValue()
-  {
-    return initValue;
-  }
-
-  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/extensions-contrib/time-min-max/src/test/java/io/druid/query/aggregation/TimestampMinMaxAggregatorTest.java
+++ b/extensions-contrib/time-min-max/src/test/java/io/druid/query/aggregation/TimestampMinMaxAggregatorTest.java
@@ -133,8 +133,6 @@ public class TimestampMinMaxAggregatorTest
   {
     TimestampAggregator aggregator = (TimestampAggregator) aggregatorFactory.factorize(selectorFactory);
 
-    Assert.assertEquals(aggType, aggregator.getName());
-
     for (Timestamp value: values) {
       aggregate(selector, aggregator);
     }

--- a/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/EmptySketchAggregator.java
+++ b/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/EmptySketchAggregator.java
@@ -56,12 +56,6 @@ public class EmptySketchAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    throw new UnsupportedOperationException("getName is deprecated");
-  }
-
-  @Override
   public void close()
   {
   }

--- a/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchAggregator.java
+++ b/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchAggregator.java
@@ -81,12 +81,6 @@ public class SketchAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    throw new UnsupportedOperationException("getName is deprecated");
-  }
-
-  @Override
   public void close()
   {
     union = null;

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregator.java
@@ -93,12 +93,6 @@ public class ApproximateHistogramAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    throw new UnsupportedOperationException("getName is deprecated");
-  }
-
-  @Override
   public void close()
   {
     // no resources to cleanup

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregator.java
@@ -91,12 +91,6 @@ public class ApproximateHistogramFoldingAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    throw new UnsupportedOperationException("getName is deprecated");
-  }
-
-  @Override
   public void close()
   {
     // no resources to cleanup

--- a/extensions-core/stats/src/main/java/io/druid/query/aggregation/variance/VarianceAggregator.java
+++ b/extensions-core/stats/src/main/java/io/druid/query/aggregation/variance/VarianceAggregator.java
@@ -47,12 +47,6 @@ public abstract class VarianceAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    throw new UnsupportedOperationException("getName is deprecated");
-  }
-
-  @Override
   public void close()
   {
   }

--- a/processing/src/main/java/io/druid/query/aggregation/Aggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/Aggregator.java
@@ -38,10 +38,6 @@ public interface Aggregator {
   Object get();
   float getFloat();
 
-  /**
-   * Deprecated, to be removed in 0.10.0. See https://github.com/druid-io/druid/issues/3588.
-   */
-  @Deprecated String getName();
   void close();
 
   long getLong();

--- a/processing/src/main/java/io/druid/query/aggregation/AggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/AggregatorFactory.java
@@ -127,15 +127,6 @@ public abstract class AggregatorFactory
   public abstract int getMaxIntermediateSize();
 
   /**
-   * Deprecated, to be removed in 0.10.0. See https://github.com/druid-io/druid/issues/3588.
-   */
-  @Deprecated
-  public Object getAggregatorStartValue()
-  {
-    throw new UnsupportedOperationException("getAggregatorStartValue is deprecated");
-  }
-
-  /**
    * Merges the list of AggregatorFactory[] (presumable from metadata of some segments being merged) and
    * returns merged AggregatorFactory[] (for the metadata for merged segment).
    * Null is returned if it is not possible to do the merging for any of the following reason.

--- a/processing/src/main/java/io/druid/query/aggregation/Aggregators.java
+++ b/processing/src/main/java/io/druid/query/aggregation/Aggregators.java
@@ -54,12 +54,6 @@ public class Aggregators
       }
 
       @Override
-      public String getName()
-      {
-        throw new UnsupportedOperationException("getName is deprecated");
-      }
-
-      @Override
       public void close()
       {
 

--- a/processing/src/main/java/io/druid/query/aggregation/CountAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/CountAggregator.java
@@ -69,12 +69,6 @@ public class CountAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    throw new UnsupportedOperationException("getName is deprecated");
-  }
-
-  @Override
   public Aggregator clone()
   {
     return new CountAggregator();

--- a/processing/src/main/java/io/druid/query/aggregation/DoubleMaxAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/DoubleMaxAggregator.java
@@ -76,12 +76,6 @@ public class DoubleMaxAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    throw new UnsupportedOperationException("getName is deprecated");
-  }
-
-  @Override
   public Aggregator clone()
   {
     return new DoubleMaxAggregator(selector);

--- a/processing/src/main/java/io/druid/query/aggregation/DoubleMinAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/DoubleMinAggregator.java
@@ -76,12 +76,6 @@ public class DoubleMinAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    throw new UnsupportedOperationException("getName is deprecated");
-  }
-
-  @Override
   public Aggregator clone()
   {
     return new DoubleMinAggregator(selector);

--- a/processing/src/main/java/io/druid/query/aggregation/DoubleSumAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/DoubleSumAggregator.java
@@ -85,12 +85,6 @@ public class DoubleSumAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    throw new UnsupportedOperationException("getName is deprecated");
-  }
-
-  @Override
   public Aggregator clone()
   {
     return new DoubleSumAggregator(selector);

--- a/processing/src/main/java/io/druid/query/aggregation/FilteredAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/FilteredAggregator.java
@@ -65,12 +65,6 @@ public class FilteredAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    throw new UnsupportedOperationException("getName is deprecated");
-  }
-
-  @Override
   public void close()
   {
     delegate.close();

--- a/processing/src/main/java/io/druid/query/aggregation/HistogramAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/HistogramAggregator.java
@@ -81,12 +81,6 @@ public class HistogramAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    throw new UnsupportedOperationException("getName is deprecated");
-  }
-
-  @Override
   public void close()
   {
     // no resources to cleanup

--- a/processing/src/main/java/io/druid/query/aggregation/JavaScriptAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/JavaScriptAggregator.java
@@ -81,12 +81,6 @@ public class JavaScriptAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    throw new UnsupportedOperationException("getName is deprecated");
-  }
-
-  @Override
   public void close()
   {
     script.close();

--- a/processing/src/main/java/io/druid/query/aggregation/LongMaxAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/LongMaxAggregator.java
@@ -76,12 +76,6 @@ public class LongMaxAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    throw new UnsupportedOperationException("getName is deprecated");
-  }
-
-  @Override
   public Aggregator clone()
   {
     return new LongMaxAggregator(selector);

--- a/processing/src/main/java/io/druid/query/aggregation/LongMinAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/LongMinAggregator.java
@@ -76,12 +76,6 @@ public class LongMinAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    throw new UnsupportedOperationException("getName is deprecated");
-  }
-
-  @Override
   public Aggregator clone()
   {
     return new LongMinAggregator(selector);

--- a/processing/src/main/java/io/druid/query/aggregation/LongSumAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/LongSumAggregator.java
@@ -84,12 +84,6 @@ public class LongSumAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    throw new UnsupportedOperationException("getName is deprecated");
-  }
-
-  @Override
   public Aggregator clone()
   {
     return new LongSumAggregator(selector);

--- a/processing/src/main/java/io/druid/query/aggregation/cardinality/CardinalityAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/cardinality/CardinalityAggregator.java
@@ -113,12 +113,6 @@ public class CardinalityAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    throw new UnsupportedOperationException("getName is deprecated");
-  }
-
-  @Override
   public Aggregator clone()
   {
     return new CardinalityAggregator(name, selectorPlusList, byRow);

--- a/processing/src/main/java/io/druid/query/aggregation/first/DoubleFirstAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/first/DoubleFirstAggregator.java
@@ -77,12 +77,6 @@ public class DoubleFirstAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    return name;
-  }
-
-  @Override
   public void close()
   {
 

--- a/processing/src/main/java/io/druid/query/aggregation/first/DoubleFirstAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/first/DoubleFirstAggregatorFactory.java
@@ -226,12 +226,6 @@ public class DoubleFirstAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public Object getAggregatorStartValue()
-  {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/processing/src/main/java/io/druid/query/aggregation/first/LongFirstAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/first/LongFirstAggregator.java
@@ -76,12 +76,6 @@ public class LongFirstAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    return name;
-  }
-
-  @Override
   public void close()
   {
 

--- a/processing/src/main/java/io/druid/query/aggregation/first/LongFirstAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/first/LongFirstAggregatorFactory.java
@@ -216,12 +216,6 @@ public class LongFirstAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public Object getAggregatorStartValue()
-  {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/processing/src/main/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregator.java
@@ -71,12 +71,6 @@ public class HyperUniquesAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    throw new UnsupportedOperationException("getName is deprecated");
-  }
-
-  @Override
   public Aggregator clone()
   {
     return new HyperUniquesAggregator(selector);

--- a/processing/src/main/java/io/druid/query/aggregation/last/DoubleLastAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/last/DoubleLastAggregator.java
@@ -77,12 +77,6 @@ public class DoubleLastAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    return name;
-  }
-
-  @Override
   public void close()
   {
 

--- a/processing/src/main/java/io/druid/query/aggregation/last/DoubleLastAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/last/DoubleLastAggregatorFactory.java
@@ -209,12 +209,6 @@ public class DoubleLastAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public Object getAggregatorStartValue()
-  {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/processing/src/main/java/io/druid/query/aggregation/last/LongLastAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/last/LongLastAggregator.java
@@ -75,12 +75,6 @@ public class LongLastAggregator implements Aggregator
   }
 
   @Override
-  public String getName()
-  {
-    return name;
-  }
-
-  @Override
   public void close()
   {
 

--- a/processing/src/main/java/io/druid/query/aggregation/last/LongLastAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/last/LongLastAggregatorFactory.java
@@ -209,12 +209,6 @@ public class LongLastAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public Object getAggregatorStartValue()
-  {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/processing/src/test/java/io/druid/query/aggregation/first/DoubleFirstAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/first/DoubleFirstAggregationTest.java
@@ -73,8 +73,6 @@ public class DoubleFirstAggregationTest
   {
     DoubleFirstAggregator agg = (DoubleFirstAggregator) doubleFirstAggFactory.factorize(colSelectorFactory);
 
-    Assert.assertEquals("billy", agg.getName());
-
     aggregate(agg);
     aggregate(agg);
     aggregate(agg);
@@ -125,8 +123,6 @@ public class DoubleFirstAggregationTest
   public void testDoubleFirstCombiningAggregator()
   {
     DoubleFirstAggregator agg = (DoubleFirstAggregator) combiningAggFactory.factorize(colSelectorFactory);
-
-    Assert.assertEquals("billy", agg.getName());
 
     aggregate(agg);
     aggregate(agg);

--- a/processing/src/test/java/io/druid/query/aggregation/first/LongFirstAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/first/LongFirstAggregationTest.java
@@ -72,8 +72,6 @@ public class LongFirstAggregationTest
   {
     LongFirstAggregator agg = (LongFirstAggregator) longFirstAggFactory.factorize(colSelectorFactory);
 
-    Assert.assertEquals("billy", agg.getName());
-
     aggregate(agg);
     aggregate(agg);
     aggregate(agg);
@@ -124,8 +122,6 @@ public class LongFirstAggregationTest
   public void testLongFirstCombiningAggregator()
   {
     LongFirstAggregator agg = (LongFirstAggregator) combiningAggFactory.factorize(colSelectorFactory);
-
-    Assert.assertEquals("billy", agg.getName());
 
     aggregate(agg);
     aggregate(agg);

--- a/processing/src/test/java/io/druid/query/aggregation/last/DoubleLastAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/last/DoubleLastAggregationTest.java
@@ -73,8 +73,6 @@ public class DoubleLastAggregationTest
   {
     DoubleLastAggregator agg = (DoubleLastAggregator) doubleLastAggFactory.factorize(colSelectorFactory);
 
-    Assert.assertEquals("billy", agg.getName());
-
     aggregate(agg);
     aggregate(agg);
     aggregate(agg);
@@ -125,8 +123,6 @@ public class DoubleLastAggregationTest
   public void testDoubleLastCombiningAggregator()
   {
     DoubleLastAggregator agg = (DoubleLastAggregator) combiningAggFactory.factorize(colSelectorFactory);
-
-    Assert.assertEquals("billy", agg.getName());
 
     aggregate(agg);
     aggregate(agg);

--- a/processing/src/test/java/io/druid/query/aggregation/last/LongLastAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/last/LongLastAggregationTest.java
@@ -72,8 +72,6 @@ public class LongLastAggregationTest
   {
     LongLastAggregator agg = (LongLastAggregator) longLastAggFactory.factorize(colSelectorFactory);
 
-    Assert.assertEquals("billy", agg.getName());
-
     aggregate(agg);
     aggregate(agg);
     aggregate(agg);
@@ -124,8 +122,6 @@ public class LongLastAggregationTest
   public void testLongLastCombiningAggregator()
   {
     LongLastAggregator agg = (LongLastAggregator) combiningAggFactory.factorize(colSelectorFactory);
-
-    Assert.assertEquals("billy", agg.getName());
 
     aggregate(agg);
     aggregate(agg);


### PR DESCRIPTION
Removes deprecated methods `Aggregator.getName` and `AggregatorFactory.getAggregatorStartValue`

Fixes https://github.com/druid-io/druid/issues/3588
