### PR TITLE
Remove another google-http-client dependency from geoip2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -714,6 +714,10 @@
                         <artifactId>google-http-client-jackson2</artifactId>
                     </exclusion>
                     <exclusion>
+                        <groupId>com.google.http-client</groupId>
+                        <artifactId>google-http-client-jackson2</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>com.fasterxml.jackson.core</groupId>
                         <artifactId>jackson-databind</artifactId>
                     </exclusion>


### PR DESCRIPTION
This pulls in bad dependencies that can make GCP extensions have classloader problems.