### PR TITLE
Introduce SegmentizerFactory

### DIFF
--- a/processing/src/main/java/io/druid/jackson/DefaultObjectMapper.java
+++ b/processing/src/main/java/io/druid/jackson/DefaultObjectMapper.java
@@ -49,6 +49,7 @@ public class DefaultObjectMapper extends ObjectMapper
     registerModule(new AggregatorsModule());
     registerModule(new SegmentsModule());
     registerModule(new StringComparatorModule());
+    registerModule(new SegmentizerModule());
 
     configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     configure(MapperFeature.AUTO_DETECT_GETTERS, false);

--- a/processing/src/main/java/io/druid/jackson/SegmentizerModule.java
+++ b/processing/src/main/java/io/druid/jackson/SegmentizerModule.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.jackson;
+
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import io.druid.segment.loading.MMappedQueryableSegmentizerFactory;
+
+public class SegmentizerModule extends SimpleModule
+{
+  public SegmentizerModule() {
+    super("SegmentizerModule");
+    registerSubtypes(new NamedType(MMappedQueryableSegmentizerFactory.class, "mMapSegmentFactory"));
+  }
+}

--- a/processing/src/main/java/io/druid/segment/IndexMergerV9.java
+++ b/processing/src/main/java/io/druid/segment/IndexMergerV9.java
@@ -160,9 +160,9 @@ public class IndexMergerV9 extends IndexMerger
 
       progress.progress();
       startTime = System.currentTimeMillis();
-      FileOutputStream fos = new FileOutputStream(new File(outDir, "factory.json"));
-      mapper.writeValue(fos, new MMappedQueryableSegmentizerFactory(indexIO));
-      fos.close();
+      try (FileOutputStream fos = new FileOutputStream(new File(outDir, "factory.json"))) {
+        mapper.writeValue(fos, new MMappedQueryableSegmentizerFactory(indexIO));
+      }
       log.info("Completed factory.json in %,d millis", System.currentTimeMillis() - startTime);
 
       progress.progress();
@@ -215,7 +215,7 @@ public class IndexMergerV9 extends IndexMerger
       makeTimeColumn(v9Smoosher, progress, timeWriter);
       makeMetricsColumns(v9Smoosher, progress, mergedMetrics, metricsValueTypes, metricTypeNames, metWriters);
 
-      for(int i = 0; i < mergedDimensions.size(); i++) {
+      for (int i = 0; i < mergedDimensions.size(); i++) {
         DimensionMergerV9 merger = (DimensionMergerV9) mergers.get(i);
         merger.writeIndexes(rowNumConversions, closer);
         if (merger.canSkip()) {

--- a/processing/src/main/java/io/druid/segment/IndexMergerV9.java
+++ b/processing/src/main/java/io/druid/segment/IndexMergerV9.java
@@ -46,6 +46,7 @@ import io.druid.segment.data.CompressionFactory;
 import io.druid.segment.data.GenericIndexed;
 import io.druid.segment.data.IOPeon;
 import io.druid.segment.data.TmpFileIOPeon;
+import io.druid.segment.loading.MMappedQueryableSegmentizerFactory;
 import io.druid.segment.serde.ComplexColumnPartSerde;
 import io.druid.segment.serde.ComplexColumnSerializer;
 import io.druid.segment.serde.ComplexMetricSerde;
@@ -59,6 +60,7 @@ import org.joda.time.Interval;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
@@ -155,6 +157,13 @@ public class IndexMergerV9 extends IndexMerger
           Files.newOutputStreamSupplier(new File(outDir, "version.bin"))
       );
       log.info("Completed version.bin in %,d millis.", System.currentTimeMillis() - startTime);
+
+      progress.progress();
+      startTime = System.currentTimeMillis();
+      FileOutputStream fos = new FileOutputStream(new File(outDir, "factory.json"));
+      mapper.writeValue(fos, new MMappedQueryableSegmentizerFactory(indexIO));
+      fos.close();
+      log.info("Completed factory.json in %,d millis", System.currentTimeMillis() - startTime);
 
       progress.progress();
       final Map<String, ValueType> metricsValueTypes = Maps.newTreeMap(Ordering.<String>natural().nullsFirst());

--- a/processing/src/main/java/io/druid/segment/loading/MMappedQueryableSegmentizerFactory.java
+++ b/processing/src/main/java/io/druid/segment/loading/MMappedQueryableSegmentizerFactory.java
@@ -19,35 +19,35 @@
 
 package io.druid.segment.loading;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.google.common.base.Preconditions;
-import com.google.inject.Inject;
-
 import io.druid.java.util.common.logger.Logger;
 import io.druid.segment.IndexIO;
-import io.druid.segment.QueryableIndex;
+import io.druid.segment.QueryableIndexSegment;
+import io.druid.segment.Segment;
+import io.druid.timeline.DataSegment;
 
 import java.io.File;
 import java.io.IOException;
 
 /**
  */
-public class MMappedQueryableIndexFactory implements QueryableIndexFactory
+public class MMappedQueryableSegmentizerFactory implements SegmentizerFactory
 {
-  private static final Logger log = new Logger(MMappedQueryableIndexFactory.class);
+  private static final Logger log = new Logger(MMappedQueryableSegmentizerFactory.class);
 
   private final IndexIO indexIO;
 
-  @Inject
-  public MMappedQueryableIndexFactory(IndexIO indexIO)
+  public MMappedQueryableSegmentizerFactory(@JacksonInject IndexIO indexIO)
   {
     this.indexIO = Preconditions.checkNotNull(indexIO, "Null IndexIO");
   }
 
   @Override
-  public QueryableIndex factorize(File parentDir) throws SegmentLoadingException
+  public Segment factorize(DataSegment dataSegment, File parentDir) throws SegmentLoadingException
   {
     try {
-      return indexIO.loadIndex(parentDir);
+      return new QueryableIndexSegment(dataSegment.getIdentifier(), indexIO.loadIndex(parentDir));
     }
     catch (IOException e) {
       throw new SegmentLoadingException(e, "%s", e.getMessage());

--- a/processing/src/main/java/io/druid/segment/loading/SegmentizerFactory.java
+++ b/processing/src/main/java/io/druid/segment/loading/SegmentizerFactory.java
@@ -19,13 +19,17 @@
 
 package io.druid.segment.loading;
 
-import io.druid.segment.QueryableIndex;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.druid.segment.Segment;
+import io.druid.timeline.DataSegment;
 
 import java.io.File;
 
 /**
+ * Factory that loads segment files from the disk and creates {@link Segment} object
  */
-public interface QueryableIndexFactory
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = MMappedQueryableSegmentizerFactory.class)
+public interface SegmentizerFactory
 {
-  public QueryableIndex factorize(File parentDir) throws SegmentLoadingException;
+  public Segment factorize(DataSegment segment, File parentDir) throws SegmentLoadingException;
 }

--- a/processing/src/test/java/io/druid/segment/loading/SegmentizerFactoryTest.java
+++ b/processing/src/test/java/io/druid/segment/loading/SegmentizerFactoryTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.loading;
+
+import com.fasterxml.jackson.databind.InjectableValues;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.druid.jackson.DefaultObjectMapper;
+import io.druid.jackson.SegmentizerModule;
+import io.druid.segment.IndexIO;
+import io.druid.segment.column.ColumnConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+
+public class SegmentizerFactoryTest
+{
+  @Test
+  public void testFactory() throws IOException{
+    File factoryFile = Files.createTempFile("", "factory.json").toFile();
+    FileOutputStream fos = new FileOutputStream(factoryFile);
+    ObjectMapper mapper = new DefaultObjectMapper();
+    mapper.registerModule(new SegmentizerModule());
+    IndexIO indexIO = new IndexIO(mapper, new ColumnConfig()
+    {
+      @Override
+      public int columnCacheSizeBytes()
+      {
+        return 777;
+      }
+    });
+    mapper.setInjectableValues(
+        new InjectableValues.Std().addValue(
+            IndexIO.class,
+            indexIO
+        )
+    );
+    mapper.writeValue(fos, new MMappedQueryableSegmentizerFactory(indexIO));
+    fos.close();
+
+    SegmentizerFactory factory = mapper.readValue(factoryFile, SegmentizerFactory.class);
+    Assert.assertTrue(factory instanceof MMappedQueryableSegmentizerFactory);
+  }
+}

--- a/server/src/main/java/io/druid/guice/StorageNodeModule.java
+++ b/server/src/main/java/io/druid/guice/StorageNodeModule.java
@@ -30,8 +30,6 @@ import io.druid.query.DefaultQueryRunnerFactoryConglomerate;
 import io.druid.query.DruidProcessingConfig;
 import io.druid.query.QueryRunnerFactoryConglomerate;
 import io.druid.segment.column.ColumnConfig;
-import io.druid.segment.loading.MMappedQueryableIndexFactory;
-import io.druid.segment.loading.QueryableIndexFactory;
 import io.druid.segment.loading.SegmentLoaderConfig;
 import io.druid.server.DruidNode;
 import io.druid.server.coordination.DruidServerMetadata;
@@ -49,7 +47,6 @@ public class StorageNodeModule implements Module
     JsonConfigProvider.bind(binder, "druid.segmentCache", SegmentLoaderConfig.class);
 
     binder.bind(NodeTypeConfig.class).toProvider(Providers.<NodeTypeConfig>of(null));
-    binder.bind(QueryableIndexFactory.class).to(MMappedQueryableIndexFactory.class).in(LazySingleton.class);
     binder.bind(ColumnConfig.class).to(DruidProcessingConfig.class);
 
     binder.bind(QueryRunnerFactoryConglomerate.class)

--- a/server/src/test/java/io/druid/segment/loading/SegmentLoaderLocalCacheManagerTest.java
+++ b/server/src/test/java/io/druid/segment/loading/SegmentLoaderLocalCacheManagerTest.java
@@ -76,7 +76,7 @@ public class SegmentLoaderLocalCacheManagerTest
     locations.add(locationConfig);
 
     manager = new SegmentLoaderLocalCacheManager(
-        new MMappedQueryableIndexFactory(TestHelper.getTestIndexIO()),
+        TestHelper.getTestIndexIO(),
         new SegmentLoaderConfig().withLocations(locations),
         jsonMapper
     );
@@ -150,7 +150,7 @@ public class SegmentLoaderLocalCacheManagerTest
     locations.add(locationConfig2);
 
     manager = new SegmentLoaderLocalCacheManager(
-        new MMappedQueryableIndexFactory(TestHelper.getTestIndexIO()),
+        TestHelper.getTestIndexIO(),
         new SegmentLoaderConfig().withLocations(locations),
         jsonMapper
     );
@@ -203,7 +203,7 @@ public class SegmentLoaderLocalCacheManagerTest
     locations.add(locationConfig2);
 
     manager = new SegmentLoaderLocalCacheManager(
-        new MMappedQueryableIndexFactory(TestHelper.getTestIndexIO()),
+        TestHelper.getTestIndexIO(),
         new SegmentLoaderConfig().withLocations(locations),
         jsonMapper
     );
@@ -258,7 +258,7 @@ public class SegmentLoaderLocalCacheManagerTest
     locations.add(locationConfig2);
 
     manager = new SegmentLoaderLocalCacheManager(
-        new MMappedQueryableIndexFactory(TestHelper.getTestIndexIO()),
+        TestHelper.getTestIndexIO(),
         new SegmentLoaderConfig().withLocations(locations),
         jsonMapper
     );


### PR DESCRIPTION
- that knows how to deserialize specific type of segment
- Default implementation is MMappedQueryableSegmentizerFactory which creates QueryableIndexSegment
- Unit test for the default behavior

Part of https://github.com/druid-io/druid/issues/2965