### PR TITLE
Simplify LikeFilter implementation of getBitmapIndex, estimateSelectivity.

### DIFF
--- a/bytebuffer-collections/src/main/java/io/druid/collections/bitmap/ConciseBitmapFactory.java
+++ b/bytebuffer-collections/src/main/java/io/druid/collections/bitmap/ConciseBitmapFactory.java
@@ -20,7 +20,6 @@
 package io.druid.collections.bitmap;
 
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
 import io.druid.extendedset.intset.ImmutableConciseSet;
 
 import java.nio.ByteBuffer;

--- a/bytebuffer-collections/src/main/java/io/druid/collections/bitmap/ConciseBitmapFactory.java
+++ b/bytebuffer-collections/src/main/java/io/druid/collections/bitmap/ConciseBitmapFactory.java
@@ -19,10 +19,13 @@
 
 package io.druid.collections.bitmap;
 
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import io.druid.extendedset.intset.ImmutableConciseSet;
+
 import java.nio.ByteBuffer;
 import java.util.Iterator;
-
-import io.druid.extendedset.intset.ImmutableConciseSet;
+import java.util.List;
 
 /**
  * As the name suggests, this class instantiates bitmaps of the types
@@ -109,6 +112,15 @@ public class ConciseBitmapFactory implements BitmapFactory
   public ImmutableBitmap union(Iterable<ImmutableBitmap> b)
       throws ClassCastException
   {
+    if (b instanceof List) {
+      final List<ImmutableBitmap> bitmapList = (List<ImmutableBitmap>) b;
+      if (bitmapList.isEmpty()) {
+        return makeEmptyImmutableBitmap();
+      } else if (bitmapList.size() == 1) {
+        return Iterables.getOnlyElement(b);
+      }
+    }
+
     return new WrappedImmutableConciseBitmap(ImmutableConciseSet.union(unwrap(b)));
   }
 

--- a/bytebuffer-collections/src/main/java/io/druid/collections/bitmap/ConciseBitmapFactory.java
+++ b/bytebuffer-collections/src/main/java/io/druid/collections/bitmap/ConciseBitmapFactory.java
@@ -23,8 +23,8 @@ import com.google.common.collect.Iterables;
 import io.druid.extendedset.intset.ImmutableConciseSet;
 
 import java.nio.ByteBuffer;
+import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 
 /**
  * As the name suggests, this class instantiates bitmaps of the types
@@ -111,11 +111,12 @@ public class ConciseBitmapFactory implements BitmapFactory
   public ImmutableBitmap union(Iterable<ImmutableBitmap> b)
       throws ClassCastException
   {
-    if (b instanceof List) {
-      final List<ImmutableBitmap> bitmapList = (List<ImmutableBitmap>) b;
-      if (bitmapList.isEmpty()) {
+    if (b instanceof Collection) {
+      final Collection<ImmutableBitmap> bitmapList = (Collection<ImmutableBitmap>) b;
+      final int size = bitmapList.size();
+      if (size == 0) {
         return makeEmptyImmutableBitmap();
-      } else if (bitmapList.size() == 1) {
+      } else if (size == 1) {
         return Iterables.getOnlyElement(b);
       }
     }

--- a/bytebuffer-collections/src/main/java/io/druid/collections/bitmap/RoaringBitmapFactory.java
+++ b/bytebuffer-collections/src/main/java/io/druid/collections/bitmap/RoaringBitmapFactory.java
@@ -28,8 +28,8 @@ import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.nio.ByteBuffer;
+import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 
 /**
  * As the name suggests, this class instantiates bitmaps of the types
@@ -144,11 +144,12 @@ public class RoaringBitmapFactory implements BitmapFactory
   @Override
   public ImmutableBitmap union(Iterable<ImmutableBitmap> b)
   {
-    if (b instanceof List) {
-      final List<ImmutableBitmap> bitmapList = (List<ImmutableBitmap>) b;
-      if (bitmapList.isEmpty()) {
+    if (b instanceof Collection) {
+      final Collection<ImmutableBitmap> bitmapList = (Collection<ImmutableBitmap>) b;
+      final int size = bitmapList.size();
+      if (size == 0) {
         return makeEmptyImmutableBitmap();
-      } else if (bitmapList.size() == 1) {
+      } else if (size == 1) {
         return Iterables.getOnlyElement(b);
       }
     }

--- a/bytebuffer-collections/src/main/java/io/druid/collections/bitmap/RoaringBitmapFactory.java
+++ b/bytebuffer-collections/src/main/java/io/druid/collections/bitmap/RoaringBitmapFactory.java
@@ -20,6 +20,7 @@
 package io.druid.collections.bitmap;
 
 import com.google.common.base.Throwables;
+import com.google.common.collect.Iterables;
 import org.roaringbitmap.RoaringBitmap;
 import org.roaringbitmap.buffer.BufferFastAggregation;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
@@ -28,6 +29,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * As the name suggests, this class instantiates bitmaps of the types
@@ -142,6 +144,15 @@ public class RoaringBitmapFactory implements BitmapFactory
   @Override
   public ImmutableBitmap union(Iterable<ImmutableBitmap> b)
   {
+    if (b instanceof List) {
+      final List<ImmutableBitmap> bitmapList = (List<ImmutableBitmap>) b;
+      if (bitmapList.isEmpty()) {
+        return makeEmptyImmutableBitmap();
+      } else if (bitmapList.size() == 1) {
+        return Iterables.getOnlyElement(b);
+      }
+    }
+
     return new WrappedImmutableRoaringBitmap(ImmutableRoaringBitmap.or(unwrap(b).iterator()));
   }
 

--- a/processing/src/main/java/io/druid/segment/filter/BoundFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/BoundFilter.java
@@ -85,13 +85,13 @@ public class BoundFilter implements Filter
         return doesMatch(null) ? 1. : 0.;
       }
 
-      return Filters.estimatePredicateSelectivity(
+      return Filters.estimateSelectivity(
           bitmapIndex,
           getBitmapIndexList(boundDimFilter, bitmapIndex),
           indexSelector.getNumRows()
       );
     } else {
-      return Filters.estimatePredicateSelectivity(
+      return Filters.estimateSelectivity(
           boundDimFilter.getDimension(),
           indexSelector,
           getPredicateFactory().makeStringPredicate()

--- a/processing/src/main/java/io/druid/segment/filter/DimensionPredicateFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/DimensionPredicateFilter.java
@@ -116,7 +116,7 @@ public class DimensionPredicateFilter implements Filter
   @Override
   public double estimateSelectivity(BitmapIndexSelector indexSelector)
   {
-    return Filters.estimatePredicateSelectivity(
+    return Filters.estimateSelectivity(
         dimension,
         indexSelector,
         predicateFactory.makeStringPredicate()

--- a/processing/src/main/java/io/druid/segment/filter/InFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/InFilter.java
@@ -82,13 +82,13 @@ public class InFilter implements Filter
   {
     if (extractionFn == null) {
       final BitmapIndex bitmapIndex = indexSelector.getBitmapIndex(dimension);
-      return Filters.estimatePredicateSelectivity(
+      return Filters.estimateSelectivity(
           bitmapIndex,
           IntIteratorUtils.toIntList(getBitmapIndexIterable(bitmapIndex).iterator()),
           indexSelector.getNumRows()
       );
     } else {
-      return Filters.estimatePredicateSelectivity(
+      return Filters.estimateSelectivity(
           dimension,
           indexSelector,
           getPredicateFactory().makeStringPredicate()

--- a/processing/src/main/java/io/druid/segment/filter/JavaScriptFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/JavaScriptFilter.java
@@ -60,7 +60,7 @@ public class JavaScriptFilter implements Filter
   {
     final Context cx = Context.enter();
     try {
-      return Filters.estimatePredicateSelectivity(dimension, indexSelector, makeStringPredicate(cx));
+      return Filters.estimateSelectivity(dimension, indexSelector, makeStringPredicate(cx));
     }
     finally {
       Context.exit();

--- a/processing/src/main/java/io/druid/segment/filter/LikeFilter.java
+++ b/processing/src/main/java/io/druid/segment/filter/LikeFilter.java
@@ -57,7 +57,7 @@ public class LikeFilter implements Filter
   @Override
   public ImmutableBitmap getBitmapIndex(BitmapIndexSelector selector)
   {
-    return Filters.union(selector.getBitmapFactory(), getBitmapIterable(selector));
+    return selector.getBitmapFactory().union(getBitmapIterable(selector));
   }
 
   @Override
@@ -111,12 +111,10 @@ public class LikeFilter implements Filter
       );
     } else {
       // fallback
-      return ImmutableList.of(
-          Filters.matchPredicate(
-              dimension,
-              selector,
-              likeMatcher.predicateFactory(extractionFn).makeStringPredicate()
-          )
+      return Filters.matchPredicateNoUnion(
+          dimension,
+          selector,
+          likeMatcher.predicateFactory(extractionFn).makeStringPredicate()
       );
     }
   }

--- a/processing/src/test/java/io/druid/segment/filter/FiltersTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/FiltersTest.java
@@ -42,7 +42,7 @@ public class FiltersTest
     final List<ImmutableBitmap> bitmaps = Lists.newArrayListWithCapacity(bitmapNum);
     final BitmapIndex bitmapIndex = makeNonOverlappedBitmapIndexes(bitmapNum, bitmaps);
 
-    final double estimated = Filters.estimatePredicateSelectivity(
+    final double estimated = Filters.estimateSelectivity(
         bitmapIndex,
         IntIteratorUtils.toIntList(IntIterators.fromTo(0, bitmapNum)),
         10000


### PR DESCRIPTION
Follow up to #3848. I think the simplification is worth the extra box which should be cheap.

cc @jihoonson / @leventov -- what do you think? Similar changes could be made to BoundFilter and InFilter if this one looks good.

LikeFilter:
- Reduce code duplication, and simplify methods, at the cost of incurring an extra box
  of ImmutableBitmap into a SingletonImmutableList. I think this is fine, since this
  should be cheap and the code path is not hot (just once per filter).

Filters:
- Make estimateSelectivity public since it seems intended that they be used by Filter
  implementations, and Filters from extensions may want to use them too. Removed
  `@VisibleForTesting` for the same reason.
- Rename one of the estimatePredicateSelectivity overloads to estimateSelectivity, since
  predicates aren't involved.