### PR TITLE
Fix mvn javadoc:jar failure due to HadoopFsWrapper.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -945,6 +945,9 @@
                     <configuration>
                         <!-- jdk8 started linting javadocs by default; ours are not fully compliant -->
                         <additionalparam>-Xdoclint:none</additionalparam>
+
+                        <!-- HadoopFsWrapper javadocs cannot be generated due to missing annotations -->
+                        <excludePackageNames>org.apache.hadoop.fs</excludePackageNames>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Fixes #3730 by forward-porting #3729.