### PR TITLE
Fix rolling of request log files.

### DIFF
--- a/server/src/main/java/io/druid/server/log/FileRequestLogger.java
+++ b/server/src/main/java/io/druid/server/log/FileRequestLogger.java
@@ -32,6 +32,7 @@ import org.joda.time.Duration;
 import org.joda.time.MutableDateTime;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -69,10 +70,7 @@ public class FileRequestLogger implements RequestLogger
       synchronized (lock) {
         currentDay = mutableDateTime.toDateTime();
 
-        fileWriter = new OutputStreamWriter(
-            new FileOutputStream(new File(baseDir, currentDay.toString("yyyy-MM-dd'.log'")), true),
-            Charsets.UTF_8
-        );
+        fileWriter = getFileWriter();
       }
       long nextDay = currentDay.plusDays(1).getMillis();
       Duration delay = new Duration(nextDay - new DateTime().getMillis());
@@ -90,10 +88,7 @@ public class FileRequestLogger implements RequestLogger
                 synchronized (lock) {
                   currentDay = currentDay.plusDays(1);
                   CloseQuietly.close(fileWriter);
-                  fileWriter = new OutputStreamWriter(
-                      new FileOutputStream(new File(baseDir, currentDay.toString("yyyy-MM-dd'.log'")), true),
-                      Charsets.UTF_8
-                  );
+                  fileWriter = getFileWriter();
                 }
               }
               catch (Exception e) {
@@ -108,6 +103,13 @@ public class FileRequestLogger implements RequestLogger
     catch (IOException e) {
       Throwables.propagate(e);
     }
+  }
+
+  private OutputStreamWriter getFileWriter() throws FileNotFoundException {
+    return new OutputStreamWriter(
+            new FileOutputStream(new File(baseDir, currentDay.toString("yyyy-MM-dd'.log'")), true),
+            Charsets.UTF_8
+    );
   }
 
   @LifecycleStop

--- a/server/src/main/java/io/druid/server/log/FileRequestLogger.java
+++ b/server/src/main/java/io/druid/server/log/FileRequestLogger.java
@@ -91,7 +91,7 @@ public class FileRequestLogger implements RequestLogger
                   currentDay = currentDay.plusDays(1);
                   CloseQuietly.close(fileWriter);
                   fileWriter = new OutputStreamWriter(
-                      new FileOutputStream(new File(baseDir, currentDay.toString()), true),
+                      new FileOutputStream(new File(baseDir, currentDay.toString("yyyy-MM-dd'.log'")), true),
                       Charsets.UTF_8
                   );
                 }


### PR DESCRIPTION
There's a small bug in the naming of requests's log files. Files created at midnight roll have the `yyyy-MM-dd'T'HH:mm:..` DateFormat and files created on druid (re)start have the `yyyy-MM-dd` DateFormat.