### PR TITLE
verify no duplicate aggregator names in DataSchema

### DIFF
--- a/server/src/main/java/io/druid/segment/indexing/DataSchema.java
+++ b/server/src/main/java/io/druid/segment/indexing/DataSchema.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
-
 import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.data.input.impl.InputRowParser;
 import io.druid.data.input.impl.TimestampSpec;
@@ -37,6 +36,7 @@ import io.druid.segment.indexing.granularity.GranularitySpec;
 import io.druid.segment.indexing.granularity.UniformGranularitySpec;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -66,9 +66,18 @@ public class DataSchema
     this.dataSource = Preconditions.checkNotNull(dataSource, "dataSource cannot be null. Please provide a dataSource.");
     this.parser = parser;
 
-    if (aggregators.length == 0) {
+    if (aggregators == null || aggregators.length == 0) {
       log.warn("No metricsSpec has been specified. Are you sure this is what you want?");
+    } else {
+      //validate for no duplication
+      Set<String> names = new HashSet<>();
+      for (AggregatorFactory factory : aggregators) {
+        if (!names.add(factory.getName())) {
+          throw new IAE("duplicate aggregators found with name [%s].", factory.getName());
+        }
+      }
     }
+
     this.aggregators = aggregators;
 
     if (granularitySpec == null) {

--- a/server/src/test/java/io/druid/segment/indexing/DataSchemaTest.java
+++ b/server/src/test/java/io/druid/segment/indexing/DataSchemaTest.java
@@ -144,6 +144,35 @@ public class DataSchemaTest
     schema.getParser();
   }
 
+  @Test(expected = IAE.class)
+  public void testDuplicateAggregators() throws Exception
+  {
+    Map<String, Object> parser = jsonMapper.convertValue(
+        new StringInputRowParser(
+            new JSONParseSpec(
+                new TimestampSpec("time", "auto", null),
+                new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("time")), ImmutableList.of("dimC"), null),
+                null,
+                null
+            ),
+            null
+        ), new TypeReference<Map<String, Object>>() {}
+    );
+
+    DataSchema schema = new DataSchema(
+        "test",
+        parser,
+        new AggregatorFactory[]{
+            new DoubleSumAggregatorFactory("metric1", "col1"),
+            new DoubleSumAggregatorFactory("metric2", "col2"),
+            new DoubleSumAggregatorFactory("metric1", "col3"),
+        },
+        new ArbitraryGranularitySpec(QueryGranularities.DAY, ImmutableList.of(Interval.parse("2014/2015"))),
+        jsonMapper
+    );
+    schema.getParser();
+  }
+
   @Test
   public void testSerdeWithInvalidParserMap() throws Exception
   {


### PR DESCRIPTION
this will make a task fail very early with a decent error messages.

currently, some users made this mistake in a hadoop indexing task and job failed in the very end while persisting the segments to disk with following scary looking message...


```
2017-02-08T16:02:47,925 INFO [task-runner-0-priority-0] org.apache.hadoop.mapreduce.Job - Task Id : attempt_1485812078711_1459763_r_000000_1, Status : FAILED
Error: java.lang.ArrayIndexOutOfBoundsException: 5
	at io.druid.segment.IndexMerger$12.apply(IndexMerger.java:1097)
	at io.druid.segment.IndexMerger$12.apply(IndexMerger.java:1078)
	at com.google.common.collect.Iterators$8.next(Iterators.java:812)
	at com.google.common.collect.Iterators$8.next(Iterators.java:811)
	at com.google.common.collect.Iterators$PeekingImpl.next(Iterators.java:1169)
	at com.metamx.common.guava.MergeIterator.next(MergeIterator.java:75)
	at com.google.common.collect.Iterators$PeekingImpl.next(Iterators.java:1169)
	at io.druid.collections.CombiningIterator.next(CombiningIterator.java:75)
	at io.druid.segment.IndexMergerV9.mergeIndexesAndWriteColumns(IndexMergerV9.java:680)
	at io.druid.segment.IndexMergerV9.makeIndexFiles(IndexMergerV9.java:222)
	at io.druid.segment.IndexMerger.merge(IndexMerger.java:423)
	at io.druid.segment.IndexMerger.persist(IndexMerger.java:195)
	at io.druid.indexer.IndexGeneratorJob$IndexGeneratorReducer.persist(IndexGeneratorJob.java:497)
	at io.druid.indexer.IndexGeneratorJob$IndexGeneratorReducer.reduce(IndexGeneratorJob.java:672)
	at io.druid.indexer.IndexGeneratorJob$IndexGeneratorReducer.reduce(IndexGeneratorJob.java:469)
	at org.apache.hadoop.mapreduce.Reducer.run(Reducer.java:171)
	at org.apache.hadoop.mapred.ReduceTask.runNewReducer(ReduceTask.java:627)
	at org.apache.hadoop.mapred.ReduceTask.run(ReduceTask.java:389)
	at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:164)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:422)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1738)
	at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:158)
```

and I had to spend an hour debugging that :)