### PR TITLE
use as() method of base segment in reference counting segment

### DIFF
--- a/processing/src/main/java/io/druid/segment/ReferenceCountingSegment.java
+++ b/processing/src/main/java/io/druid/segment/ReferenceCountingSegment.java
@@ -180,4 +180,9 @@ public class ReferenceCountingSegment extends AbstractSegment
       baseSegment.close();
     }
   }
+
+  public <T> T as(Class<T> clazz)
+  {
+    return getBaseSegment().as(clazz);
+  }
 }


### PR DESCRIPTION
Reference counting segment should override `as` method and use `as` method of base segment