### PR TITLE
File.deleteOnExit()

### DIFF
--- a/benchmarks/src/main/java/io/druid/benchmark/FilterPartitionBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/FilterPartitionBenchmark.java
@@ -26,7 +26,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.hash.Hashing;
 import com.google.common.io.Files;
-
 import io.druid.benchmark.datagen.BenchmarkDataGenerator;
 import io.druid.benchmark.datagen.BenchmarkSchemaInfo;
 import io.druid.benchmark.datagen.BenchmarkSchemas;
@@ -76,6 +75,7 @@ import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
+import org.apache.commons.io.FileUtils;
 import org.joda.time.Interval;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -87,6 +87,7 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
@@ -118,6 +119,7 @@ public class FilterPartitionBenchmark
   private IncrementalIndex incIndex;
   private QueryableIndex qIndex;
   private File indexFile;
+  private File tmpDir;
 
   private Filter timeFilterNone;
   private Filter timeFilterHalf;
@@ -172,13 +174,12 @@ public class FilterPartitionBenchmark
       incIndex.add(row);
     }
 
-    File tmpFile = Files.createTempDir();
-    log.info("Using temp dir: " + tmpFile.getAbsolutePath());
-    tmpFile.deleteOnExit();
+    tmpDir = Files.createTempDir();
+    log.info("Using temp dir: " + tmpDir.getAbsolutePath());
 
     indexFile = INDEX_MERGER_V9.persist(
         incIndex,
-        tmpFile,
+        tmpDir,
         new IndexSpec()
     );
     qIndex = INDEX_IO.loadIndex(indexFile);
@@ -217,6 +218,12 @@ public class FilterPartitionBenchmark
         null,
         StringComparators.ALPHANUMERIC
     ));
+  }
+
+  @TearDown
+  public void tearDown() throws IOException
+  {
+    FileUtils.deleteDirectory(tmpDir);
   }
 
   private IncrementalIndex makeIncIndex()

--- a/benchmarks/src/main/java/io/druid/benchmark/FloatCompressionBenchmarkFileGenerator.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/FloatCompressionBenchmarkFileGenerator.java
@@ -184,7 +184,7 @@ public class FloatCompressionBenchmarkFileGenerator
           output.write(ByteBuffer.wrap(baos.toByteArray()));
         }
         finally {
-          iopeon.cleanup();
+          iopeon.close();
           br.close();
         }
         System.out.print(compFile.length() / 1024 + "\n");

--- a/benchmarks/src/main/java/io/druid/benchmark/LongCompressionBenchmarkFileGenerator.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/LongCompressionBenchmarkFileGenerator.java
@@ -177,7 +177,7 @@ public class LongCompressionBenchmarkFileGenerator
             output.write(ByteBuffer.wrap(baos.toByteArray()));
           }
           finally {
-            iopeon.cleanup();
+            iopeon.close();
             br.close();
           }
           System.out.print(compFile.length() / 1024 + "\n");

--- a/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexMergeBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexMergeBenchmark.java
@@ -22,7 +22,6 @@ package io.druid.benchmark.indexing;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.hash.Hashing;
 import com.google.common.io.Files;
-
 import io.druid.benchmark.datagen.BenchmarkDataGenerator;
 import io.druid.benchmark.datagen.BenchmarkSchemaInfo;
 import io.druid.benchmark.datagen.BenchmarkSchemas;
@@ -42,6 +41,7 @@ import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
+import org.apache.commons.io.FileUtils;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -52,6 +52,7 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
@@ -88,6 +89,7 @@ public class IndexMergeBenchmark
 
   private List<QueryableIndex> indexesToMerge;
   private BenchmarkSchemaInfo schemaInfo;
+  private File tmpDir;
 
   static {
     JSON_MAPPER = new DefaultObjectMapper();
@@ -137,19 +139,24 @@ public class IndexMergeBenchmark
         incIndex.add(row);
       }
 
-      File tmpFile = Files.createTempDir();
-      log.info("Using temp dir: " + tmpFile.getAbsolutePath());
-      tmpFile.deleteOnExit();
+      tmpDir = Files.createTempDir();
+      log.info("Using temp dir: " + tmpDir.getAbsolutePath());
 
       File indexFile = INDEX_MERGER_V9.persist(
           incIndex,
-          tmpFile,
+          tmpDir,
           new IndexSpec()
       );
 
       QueryableIndex qIndex = INDEX_IO.loadIndex(indexFile);
       indexesToMerge.add(qIndex);
     }
+  }
+
+  @TearDown
+  public void tearDown() throws IOException
+  {
+    FileUtils.deleteDirectory(tmpDir);
   }
 
   private IncrementalIndex makeIncIndex()
@@ -176,14 +183,23 @@ public class IndexMergeBenchmark
     File tmpFile = File.createTempFile("IndexMergeBenchmark-MERGEDFILE-" + System.currentTimeMillis(), ".TEMPFILE");
     tmpFile.delete();
     tmpFile.mkdirs();
-    log.info(tmpFile.getAbsolutePath() + " isFile: " + tmpFile.isFile() + " isDir:" + tmpFile.isDirectory());
-    tmpFile.deleteOnExit();
+    try {
+      log.info(tmpFile.getAbsolutePath() + " isFile: " + tmpFile.isFile() + " isDir:" + tmpFile.isDirectory());
 
-    File mergedFile = INDEX_MERGER.mergeQueryableIndex(indexesToMerge, rollup, schemaInfo.getAggsArray(), tmpFile, new IndexSpec());
+      File mergedFile = INDEX_MERGER.mergeQueryableIndex(
+          indexesToMerge,
+          rollup,
+          schemaInfo.getAggsArray(),
+          tmpFile,
+          new IndexSpec()
+      );
 
-    blackhole.consume(mergedFile);
+      blackhole.consume(mergedFile);
+    }
+    finally {
+      tmpFile.delete();
+    }
 
-    tmpFile.delete();
   }
 
   @Benchmark
@@ -194,13 +210,23 @@ public class IndexMergeBenchmark
     File tmpFile = File.createTempFile("IndexMergeBenchmark-MERGEDFILE-V9-" + System.currentTimeMillis(), ".TEMPFILE");
     tmpFile.delete();
     tmpFile.mkdirs();
-    log.info(tmpFile.getAbsolutePath() + " isFile: " + tmpFile.isFile() + " isDir:" + tmpFile.isDirectory());
-    tmpFile.deleteOnExit();
+    try {
+      log.info(tmpFile.getAbsolutePath() + " isFile: " + tmpFile.isFile() + " isDir:" + tmpFile.isDirectory());
 
-    File mergedFile = INDEX_MERGER_V9.mergeQueryableIndex(indexesToMerge, rollup, schemaInfo.getAggsArray(), tmpFile, new IndexSpec());
+      File mergedFile = INDEX_MERGER_V9.mergeQueryableIndex(
+          indexesToMerge,
+          rollup,
+          schemaInfo.getAggsArray(),
+          tmpFile,
+          new IndexSpec()
+      );
 
-    blackhole.consume(mergedFile);
+      blackhole.consume(mergedFile);
+    }
+    finally {
+      tmpFile.delete();
 
-    tmpFile.delete();
+    }
+
   }
 }

--- a/benchmarks/src/main/java/io/druid/benchmark/query/SearchBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/SearchBenchmark.java
@@ -79,6 +79,7 @@ import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
+import org.apache.commons.io.FileUtils;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -89,6 +90,7 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
@@ -132,6 +134,7 @@ public class SearchBenchmark
   private BenchmarkSchemaInfo schemaInfo;
   private Druids.SearchQueryBuilder queryBuilder;
   private SearchQuery query;
+  private File tmpDir;
 
   private ExecutorService executorService;
 
@@ -351,15 +354,14 @@ public class SearchBenchmark
       incIndexes.add(incIndex);
     }
 
-    File tmpFile = Files.createTempDir();
-    log.info("Using temp dir: " + tmpFile.getAbsolutePath());
-    tmpFile.deleteOnExit();
+    tmpDir = Files.createTempDir();
+    log.info("Using temp dir: " + tmpDir.getAbsolutePath());
 
     qIndexes = new ArrayList<>();
     for (int i = 0; i < numSegments; i++) {
       File indexFile = INDEX_MERGER_V9.persist(
           incIndexes.get(i),
-          tmpFile,
+          tmpDir,
           new IndexSpec()
       );
 
@@ -376,6 +378,12 @@ public class SearchBenchmark
         ),
         QueryBenchmarkUtil.NOOP_QUERYWATCHER
     );
+  }
+
+  @TearDown
+  public void tearDown() throws IOException
+  {
+    FileUtils.deleteDirectory(tmpDir);
   }
 
   private IncrementalIndex makeIncIndex()

--- a/benchmarks/src/main/java/io/druid/benchmark/query/TimeseriesBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/TimeseriesBenchmark.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.hash.Hashing;
 import com.google.common.io.Files;
-
 import io.druid.benchmark.datagen.BenchmarkDataGenerator;
 import io.druid.benchmark.datagen.BenchmarkSchemaInfo;
 import io.druid.benchmark.datagen.BenchmarkSchemas;
@@ -74,6 +73,7 @@ import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
+import org.apache.commons.io.FileUtils;
 import org.joda.time.Interval;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -85,6 +85,7 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
@@ -121,6 +122,7 @@ public class TimeseriesBenchmark
 
   private List<IncrementalIndex> incIndexes;
   private List<QueryableIndex> qIndexes;
+  private File tmpDir;
 
   private QueryRunnerFactory factory;
   private BenchmarkSchemaInfo schemaInfo;
@@ -278,15 +280,14 @@ public class TimeseriesBenchmark
       incIndexes.add(incIndex);
     }
 
-    File tmpFile = Files.createTempDir();
-    log.info("Using temp dir: " + tmpFile.getAbsolutePath());
-    tmpFile.deleteOnExit();
+    tmpDir = Files.createTempDir();
+    log.info("Using temp dir: " + tmpDir.getAbsolutePath());
 
     qIndexes = new ArrayList<>();
     for (int i = 0; i < numSegments; i++) {
       File indexFile = INDEX_MERGER_V9.persist(
           incIndexes.get(i),
-          tmpFile,
+          tmpDir,
           new IndexSpec()
       );
 
@@ -301,6 +302,12 @@ public class TimeseriesBenchmark
         new TimeseriesQueryEngine(),
         QueryBenchmarkUtil.NOOP_QUERYWATCHER
     );
+  }
+
+  @TearDown
+  public void tearDown() throws IOException
+  {
+    FileUtils.deleteDirectory(tmpDir);
   }
 
   private IncrementalIndex makeIncIndex()

--- a/benchmarks/src/main/java/io/druid/benchmark/query/TopNBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/TopNBenchmark.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.hash.Hashing;
 import com.google.common.io.Files;
-
 import io.druid.benchmark.datagen.BenchmarkDataGenerator;
 import io.druid.benchmark.datagen.BenchmarkSchemaInfo;
 import io.druid.benchmark.datagen.BenchmarkSchemas;
@@ -72,6 +71,7 @@ import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
+import org.apache.commons.io.FileUtils;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -82,6 +82,7 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
@@ -126,6 +127,7 @@ public class TopNBenchmark
   private BenchmarkSchemaInfo schemaInfo;
   private TopNQueryBuilder queryBuilder;
   private TopNQuery query;
+  private File tmpDir;
 
   private ExecutorService executorService;
 
@@ -255,15 +257,14 @@ public class TopNBenchmark
       incIndexes.add(incIndex);
     }
 
-    File tmpFile = Files.createTempDir();
-    log.info("Using temp dir: " + tmpFile.getAbsolutePath());
-    tmpFile.deleteOnExit();
+    tmpDir = Files.createTempDir();
+    log.info("Using temp dir: " + tmpDir.getAbsolutePath());
 
     qIndexes = new ArrayList<>();
     for (int i = 0; i < numSegments; i++) {
       File indexFile = INDEX_MERGER_V9.persist(
           incIndexes.get(i),
-          tmpFile,
+          tmpDir,
           new IndexSpec()
       );
 
@@ -281,6 +282,12 @@ public class TopNBenchmark
         new TopNQueryQueryToolChest(new TopNQueryConfig(), QueryBenchmarkUtil.NoopIntervalChunkingQueryRunnerDecorator()),
         QueryBenchmarkUtil.NOOP_QUERYWATCHER
     );
+  }
+
+  @TearDown
+  public void tearDown() throws IOException
+  {
+    FileUtils.deleteDirectory(tmpDir);
   }
 
   private IncrementalIndex makeIncIndex()

--- a/extensions-contrib/azure-extensions/src/test/java/io/druid/storage/azure/AzureDataSegmentPullerTest.java
+++ b/extensions-contrib/azure-extensions/src/test/java/io/druid/storage/azure/AzureDataSegmentPullerTest.java
@@ -21,7 +21,6 @@ package io.druid.storage.azure;
 
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.azure.storage.StorageException;
-
 import io.druid.java.util.common.FileUtils;
 import io.druid.segment.loading.SegmentLoadingException;
 import io.druid.timeline.DataSegment;
@@ -46,7 +45,6 @@ import static org.junit.Assert.assertTrue;
 public class AzureDataSegmentPullerTest extends EasyMockSupport
 {
 
-  private AzureStorage azureStorage;
   private static final String SEGMENT_FILE_NAME = "segment";
   private static final String containerName = "container";
   private static final String blobPath = "/path/to/storage/index.zip";
@@ -61,6 +59,7 @@ public class AzureDataSegmentPullerTest extends EasyMockSupport
       0,
       1
   );
+  private AzureStorage azureStorage;
 
   @Before
   public void before()
@@ -91,7 +90,8 @@ public class AzureDataSegmentPullerTest extends EasyMockSupport
       assertEquals(value.length(), expected.length());
 
       verifyAll();
-    } finally {
+    }
+    finally {
       pulledFile.delete();
       org.apache.commons.io.FileUtils.deleteDirectory(toDir);
     }
@@ -123,8 +123,9 @@ public class AzureDataSegmentPullerTest extends EasyMockSupport
       assertFalse(outDir.exists());
 
       verifyAll();
-    } finally {
-      outDir.delete();
+    }
+    finally {
+      org.apache.commons.io.FileUtils.deleteDirectory(outDir);
     }
 
   }
@@ -146,7 +147,8 @@ public class AzureDataSegmentPullerTest extends EasyMockSupport
       puller.getSegmentFiles(dataSegment, outDir);
 
       verifyAll();
-    } finally {
+    }
+    finally {
       outDir.delete();
     }
 

--- a/extensions-contrib/google-extensions/src/test/java/io/druid/storage/google/GoogleDataSegmentPullerTest.java
+++ b/extensions-contrib/google-extensions/src/test/java/io/druid/storage/google/GoogleDataSegmentPullerTest.java
@@ -57,38 +57,45 @@ public class GoogleDataSegmentPullerTest extends EasyMockSupport
       throws IOException, SegmentLoadingException
   {
     final File outDir = Files.createTempDirectory("druid").toFile();
-    outDir.deleteOnExit();
-    GoogleStorage storage = createMock(GoogleStorage.class);
+    try {
+      GoogleStorage storage = createMock(GoogleStorage.class);
 
-    expect(storage.get(bucket, path)).andThrow(new IOException(""));
+      expect(storage.get(bucket, path)).andThrow(new IOException(""));
 
-    replayAll();
+      replayAll();
 
-    GoogleDataSegmentPuller puller = new GoogleDataSegmentPuller(storage);
-    puller.getSegmentFiles(bucket, path, outDir);
+      GoogleDataSegmentPuller puller = new GoogleDataSegmentPuller(storage);
+      puller.getSegmentFiles(bucket, path, outDir);
 
-    assertFalse(outDir.exists());
+      assertFalse(outDir.exists());
 
-    verifyAll();
+      verifyAll();
+    } finally {
+      org.apache.commons.io.FileUtils.deleteDirectory(outDir);
+    }
   }
 
   @Test
-  public void getSegmentFilesTest() throws SegmentLoadingException
+  public void getSegmentFilesTest() throws SegmentLoadingException, IOException
   {
     final File outDir = new File("");
-    final FileUtils.FileCopyResult result = createMock(FileUtils.FileCopyResult.class);
-    GoogleStorage storage = createMock(GoogleStorage.class);
-    GoogleDataSegmentPuller puller = createMockBuilder(GoogleDataSegmentPuller.class).withConstructor(
-        storage
-    ).addMockedMethod("getSegmentFiles", String.class, String.class, File.class).createMock();
+    try {
+      final FileUtils.FileCopyResult result = createMock(FileUtils.FileCopyResult.class);
+      GoogleStorage storage = createMock(GoogleStorage.class);
+      GoogleDataSegmentPuller puller = createMockBuilder(GoogleDataSegmentPuller.class).withConstructor(
+          storage
+      ).addMockedMethod("getSegmentFiles", String.class, String.class, File.class).createMock();
 
-    expect(puller.getSegmentFiles(bucket, path, outDir)).andReturn(result);
+      expect(puller.getSegmentFiles(bucket, path, outDir)).andReturn(result);
 
-    replayAll();
+      replayAll();
 
-    puller.getSegmentFiles(dataSegment, outDir);
+      puller.getSegmentFiles(dataSegment, outDir);
 
-    verifyAll();
+      verifyAll();
+    } finally {
+      org.apache.commons.io.FileUtils.deleteDirectory(outDir);
+    }
   }
 
   @Test
@@ -104,7 +111,7 @@ public class GoogleDataSegmentPullerTest extends EasyMockSupport
       assertTrue(outDir.exists());
     }
     finally {
-      outDir.delete();
+      org.apache.commons.io.FileUtils.deleteDirectory(outDir);
     }
   }
 }

--- a/extensions-contrib/google-extensions/src/test/java/io/druid/storage/google/GoogleDataSegmentPullerTest.java
+++ b/extensions-contrib/google-extensions/src/test/java/io/druid/storage/google/GoogleDataSegmentPullerTest.java
@@ -70,7 +70,8 @@ public class GoogleDataSegmentPullerTest extends EasyMockSupport
       assertFalse(outDir.exists());
 
       verifyAll();
-    } finally {
+    }
+    finally {
       org.apache.commons.io.FileUtils.deleteDirectory(outDir);
     }
   }
@@ -93,7 +94,8 @@ public class GoogleDataSegmentPullerTest extends EasyMockSupport
       puller.getSegmentFiles(dataSegment, outDir);
 
       verifyAll();
-    } finally {
+    }
+    finally {
       org.apache.commons.io.FileUtils.deleteDirectory(outDir);
     }
   }

--- a/extensions-core/hdfs-storage/src/test/java/io/druid/segment/loading/HdfsDataSegmentFinderTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/io/druid/segment/loading/HdfsDataSegmentFinderTest.java
@@ -27,6 +27,7 @@ import io.druid.jackson.DefaultObjectMapper;
 import io.druid.storage.hdfs.HdfsDataSegmentFinder;
 import io.druid.timeline.DataSegment;
 import io.druid.timeline.partition.NumberedShardSpec;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -133,7 +134,6 @@ public class HdfsDataSegmentFinderTest
     mapper.registerSubtypes(new NamedType(NumberedShardSpec.class, "numbered"));
 
     hdfsTmpDir = File.createTempFile("hdfsDataSource", "dir");
-    hdfsTmpDir.deleteOnExit();
     if (!hdfsTmpDir.delete()) {
       throw new IOException(String.format("Unable to delete hdfsTmpDir [%s]", hdfsTmpDir.getAbsolutePath()));
     }
@@ -145,11 +145,12 @@ public class HdfsDataSegmentFinderTest
   }
 
   @AfterClass
-  public static void tearDownStatic()
+  public static void tearDownStatic() throws IOException
   {
     if (miniCluster != null) {
       miniCluster.shutdown(true);
     }
+    FileUtils.deleteDirectory(hdfsTmpDir);
   }
 
   @Before

--- a/extensions-core/hdfs-storage/src/test/java/io/druid/segment/loading/HdfsDataSegmentPullerTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/io/druid/segment/loading/HdfsDataSegmentPullerTest.java
@@ -24,6 +24,7 @@ import com.google.common.io.ByteStreams;
 import io.druid.java.util.common.CompressionUtils;
 import io.druid.java.util.common.StringUtils;
 import io.druid.storage.hdfs.HdfsDataSegmentPuller;
+import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
@@ -62,7 +63,6 @@ public class HdfsDataSegmentPullerTest
   public static void setupStatic() throws IOException, ClassNotFoundException
   {
     hdfsTmpDir = File.createTempFile("hdfsHandlerTest", "dir");
-    hdfsTmpDir.deleteOnExit();
     if (!hdfsTmpDir.delete()) {
       throw new IOException(String.format("Unable to delete hdfsTmpDir [%s]", hdfsTmpDir.getAbsolutePath()));
     }
@@ -74,7 +74,6 @@ public class HdfsDataSegmentPullerTest
     final File tmpFile = File.createTempFile("hdfsHandlerTest", ".data");
     tmpFile.delete();
     try {
-      tmpFile.deleteOnExit();
       Files.copy(new ByteArrayInputStream(pathByteContents), tmpFile.toPath());
       try (OutputStream stream = miniCluster.getFileSystem().create(filePath)) {
         Files.copy(tmpFile.toPath(), stream);
@@ -91,6 +90,7 @@ public class HdfsDataSegmentPullerTest
     if (miniCluster != null) {
       miniCluster.shutdown(true);
     }
+    FileUtils.deleteDirectory(hdfsTmpDir);
   }
 
 
@@ -112,18 +112,14 @@ public class HdfsDataSegmentPullerTest
   public void testZip() throws IOException, SegmentLoadingException
   {
     final File tmpDir = com.google.common.io.Files.createTempDir();
-    tmpDir.deleteOnExit();
     final File tmpFile = File.createTempFile("zipContents", ".txt", tmpDir);
-    tmpFile.deleteOnExit();
 
     final Path zipPath = new Path("/tmp/testZip.zip");
 
     final File outTmpDir = com.google.common.io.Files.createTempDir();
-    outTmpDir.deleteOnExit();
 
     final URI uri = URI.create(uriBase.toString() + zipPath.toString());
 
-    tmpFile.deleteOnExit();
     try (final OutputStream stream = new FileOutputStream(tmpFile)) {
       ByteStreams.copy(new ByteArrayInputStream(pathByteContents), stream);
     }
@@ -164,7 +160,6 @@ public class HdfsDataSegmentPullerTest
     final Path zipPath = new Path("/tmp/testZip.gz");
 
     final File outTmpDir = com.google.common.io.Files.createTempDir();
-    outTmpDir.deleteOnExit();
     final File outFile = new File(outTmpDir, "testZip");
     outFile.delete();
 
@@ -201,7 +196,6 @@ public class HdfsDataSegmentPullerTest
     final Path zipPath = new Path(perTestPath, "test.txt");
 
     final File outTmpDir = com.google.common.io.Files.createTempDir();
-    outTmpDir.deleteOnExit();
     final File outFile = new File(outTmpDir, "test.txt");
     outFile.delete();
 

--- a/extensions-core/hdfs-storage/src/test/java/io/druid/segment/loading/HdfsFileTimestampVersionFinderTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/io/druid/segment/loading/HdfsFileTimestampVersionFinderTest.java
@@ -23,6 +23,7 @@ import com.google.common.io.ByteStreams;
 
 import io.druid.java.util.common.StringUtils;
 import io.druid.storage.hdfs.HdfsFileTimestampVersionFinder;
+import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
@@ -58,7 +59,6 @@ public class HdfsFileTimestampVersionFinderTest
   public static void setupStatic() throws IOException, ClassNotFoundException
   {
     hdfsTmpDir = File.createTempFile("hdfsHandlerTest", "dir");
-    hdfsTmpDir.deleteOnExit();
     if (!hdfsTmpDir.delete()) {
       throw new IOException(String.format("Unable to delete hdfsTmpDir [%s]", hdfsTmpDir.getAbsolutePath()));
     }
@@ -70,7 +70,6 @@ public class HdfsFileTimestampVersionFinderTest
     final File tmpFile = File.createTempFile("hdfsHandlerTest", ".data");
     tmpFile.delete();
     try {
-      tmpFile.deleteOnExit();
       Files.copy(new ByteArrayInputStream(pathByteContents), tmpFile.toPath());
       try (OutputStream stream = miniCluster.getFileSystem().create(filePath)) {
         Files.copy(tmpFile.toPath(), stream);
@@ -87,6 +86,7 @@ public class HdfsFileTimestampVersionFinderTest
     if (miniCluster != null) {
       miniCluster.shutdown(true);
     }
+    FileUtils.deleteDirectory(hdfsTmpDir);
   }
 
 

--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopIOPeon.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopIOPeon.java
@@ -55,14 +55,8 @@ class HadoopIOPeon implements IOPeon
   }
 
   @Override
-  public void cleanup() throws IOException
-  {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public void close() throws IOException
   {
-    cleanup();
+    throw new UnsupportedOperationException();
   }
 }

--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopIOPeon.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopIOPeon.java
@@ -59,4 +59,10 @@ class HadoopIOPeon implements IOPeon
   {
     throw new UnsupportedOperationException();
   }
+
+  @Override
+  public void close() throws IOException
+  {
+    cleanup();
+  }
 }

--- a/indexing-hadoop/src/test/java/io/druid/indexer/DetermineHashedPartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/DetermineHashedPartitionsJobTest.java
@@ -33,6 +33,7 @@ import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.DoubleSumAggregatorFactory;
 import io.druid.segment.indexing.DataSchema;
 import io.druid.segment.indexing.granularity.UniformGranularitySpec;
+import org.apache.commons.io.FileUtils;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Test;
@@ -95,79 +96,96 @@ public class DetermineHashedPartitionsJobTest
     );
   }
 
-  public DetermineHashedPartitionsJobTest(String dataFilePath, long targetPartitionSize, String interval, int errorMargin, int expectedNumTimeBuckets, int[] expectedNumOfShards) throws IOException
+  public DetermineHashedPartitionsJobTest(
+      String dataFilePath,
+      long targetPartitionSize,
+      String interval,
+      int errorMargin,
+      int expectedNumTimeBuckets,
+      int[] expectedNumOfShards
+  ) throws IOException
   {
     this.expectedNumOfShards = expectedNumOfShards;
     this.expectedNumTimeBuckets = expectedNumTimeBuckets;
     this.errorMargin = errorMargin;
     File tmpDir = Files.createTempDir();
-    tmpDir.deleteOnExit();
 
-    HadoopIngestionSpec ingestionSpec = new HadoopIngestionSpec(
-        new DataSchema(
-            "test_schema",
-            HadoopDruidIndexerConfig.JSON_MAPPER.convertValue(
-                new StringInputRowParser(
-                    new DelimitedParseSpec(
-                        new TimestampSpec("ts", null, null),
-                        new DimensionsSpec(
-                            DimensionsSpec.getDefaultSchemas(ImmutableList.of("market", "quality", "placement", "placementish")),
-                            null,
-                            null
-                        ),
-                        "\t",
-                        null,
-                        Arrays.asList(
-                            "ts",
-                            "market",
-                            "quality",
-                            "placement",
-                            "placementish",
-                            "index"
-                        )
-                    ),
-                    null
-                ),
-                Map.class
-            ),
-            new AggregatorFactory[]{new DoubleSumAggregatorFactory("index", "index")},
-            new UniformGranularitySpec(
-                Granularity.DAY,
-                QueryGranularities.NONE,
-                ImmutableList.of(new Interval(interval))
-            ),
-            HadoopDruidIndexerConfig.JSON_MAPPER
-        ),
-        new HadoopIOConfig(
-            ImmutableMap.<String, Object>of(
-                "paths",
-                dataFilePath,
-                "type",
-                "static"
-            ), null, tmpDir.getAbsolutePath()
-        ),
-        new HadoopTuningConfig(
-            tmpDir.getAbsolutePath(),
-            null,
-            new HashedPartitionsSpec(targetPartitionSize, null, true, null, null),
-            null,
-            null,
-            null,
-            false,
-            false,
-            false,
-            false,
-            null,
-            false,
-            false,
-            null,
-            null,
-            null,
-            false,
-            false
-        )
-    );
-    this.indexerConfig = new HadoopDruidIndexerConfig(ingestionSpec);
+    try {
+
+      HadoopIngestionSpec ingestionSpec = new HadoopIngestionSpec(
+          new DataSchema(
+              "test_schema",
+              HadoopDruidIndexerConfig.JSON_MAPPER.convertValue(
+                  new StringInputRowParser(
+                      new DelimitedParseSpec(
+                          new TimestampSpec("ts", null, null),
+                          new DimensionsSpec(
+                              DimensionsSpec.getDefaultSchemas(ImmutableList.of(
+                                  "market",
+                                  "quality",
+                                  "placement",
+                                  "placementish"
+                              )),
+                              null,
+                              null
+                          ),
+                          "\t",
+                          null,
+                          Arrays.asList(
+                              "ts",
+                              "market",
+                              "quality",
+                              "placement",
+                              "placementish",
+                              "index"
+                          )
+                      ),
+                      null
+                  ),
+                  Map.class
+              ),
+              new AggregatorFactory[]{new DoubleSumAggregatorFactory("index", "index")},
+              new UniformGranularitySpec(
+                  Granularity.DAY,
+                  QueryGranularities.NONE,
+                  ImmutableList.of(new Interval(interval))
+              ),
+              HadoopDruidIndexerConfig.JSON_MAPPER
+          ),
+          new HadoopIOConfig(
+              ImmutableMap.<String, Object>of(
+                  "paths",
+                  dataFilePath,
+                  "type",
+                  "static"
+              ), null, tmpDir.getAbsolutePath()
+          ),
+          new HadoopTuningConfig(
+              tmpDir.getAbsolutePath(),
+              null,
+              new HashedPartitionsSpec(targetPartitionSize, null, true, null, null),
+              null,
+              null,
+              null,
+              false,
+              false,
+              false,
+              false,
+              null,
+              false,
+              false,
+              null,
+              null,
+              null,
+              false,
+              false
+          )
+      );
+      this.indexerConfig = new HadoopDruidIndexerConfig(ingestionSpec);
+    }
+    finally {
+      FileUtils.deleteDirectory(tmpDir);
+    }
   }
 
   @Test

--- a/indexing-hadoop/src/test/java/io/druid/indexer/DeterminePartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/DeterminePartitionsJobTest.java
@@ -212,66 +212,74 @@ public class DeterminePartitionsJobTest
     this.expectedStartEndForEachShard = expectedStartEndForEachShard;
 
     dataFile = File.createTempFile("test_website_data", "tmp");
-    dataFile.deleteOnExit();
     tmpDir = Files.createTempDir();
-    tmpDir.deleteOnExit();
 
-    FileUtils.writeLines(dataFile, data);
+    try {
+      FileUtils.writeLines(dataFile, data);
 
-    config = new HadoopDruidIndexerConfig(
-        new HadoopIngestionSpec(
-            new DataSchema(
-                "website",
-                HadoopDruidIndexerConfig.JSON_MAPPER.convertValue(
-                    new StringInputRowParser(
-                        new CSVParseSpec(
-                            new TimestampSpec("timestamp", "yyyyMMddHH", null),
-                            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("host", "country")), null, null),
-                            null,
-                            ImmutableList.of("timestamp", "host", "country", "visited_num")
-                        ),
-                        null
-                    ),
-                    Map.class
-                ),
-                new AggregatorFactory[]{new LongSumAggregatorFactory("visited_num", "visited_num")},
-                new UniformGranularitySpec(
-                    Granularity.DAY, QueryGranularities.NONE, ImmutableList.of(new Interval(interval))
-                ),
-                HadoopDruidIndexerConfig.JSON_MAPPER
-            ),
-            new HadoopIOConfig(
-                ImmutableMap.<String, Object>of(
-                    "paths",
-                    dataFile.getCanonicalPath(),
-                    "type",
-                    "static"
-                ),
-                null,
-                tmpDir.getCanonicalPath()
-            ),
-            new HadoopTuningConfig(
-                tmpDir.getCanonicalPath(),
-                null,
-                new SingleDimensionPartitionsSpec(null, targetPartitionSize, null, assumeGrouped),
-                null,
-                null,
-                null,
-                false,
-                false,
-                false,
-                false,
-                null,
-                false,
-                false,
-                null,
-                null,
-                null,
-                false,
-                false
-            )
-        )
-    );
+      config = new HadoopDruidIndexerConfig(
+          new HadoopIngestionSpec(
+              new DataSchema(
+                  "website",
+                  HadoopDruidIndexerConfig.JSON_MAPPER.convertValue(
+                      new StringInputRowParser(
+                          new CSVParseSpec(
+                              new TimestampSpec("timestamp", "yyyyMMddHH", null),
+                              new DimensionsSpec(
+                                  DimensionsSpec.getDefaultSchemas(ImmutableList.of("host", "country")),
+                                  null,
+                                  null
+                              ),
+                              null,
+                              ImmutableList.of("timestamp", "host", "country", "visited_num")
+                          ),
+                          null
+                      ),
+                      Map.class
+                  ),
+                  new AggregatorFactory[]{new LongSumAggregatorFactory("visited_num", "visited_num")},
+                  new UniformGranularitySpec(
+                      Granularity.DAY, QueryGranularities.NONE, ImmutableList.of(new Interval(interval))
+                  ),
+                  HadoopDruidIndexerConfig.JSON_MAPPER
+              ),
+              new HadoopIOConfig(
+                  ImmutableMap.<String, Object>of(
+                      "paths",
+                      dataFile.getCanonicalPath(),
+                      "type",
+                      "static"
+                  ),
+                  null,
+                  tmpDir.getCanonicalPath()
+              ),
+              new HadoopTuningConfig(
+                  tmpDir.getCanonicalPath(),
+                  null,
+                  new SingleDimensionPartitionsSpec(null, targetPartitionSize, null, assumeGrouped),
+                  null,
+                  null,
+                  null,
+                  false,
+                  false,
+                  false,
+                  false,
+                  null,
+                  false,
+                  false,
+                  null,
+                  null,
+                  null,
+                  false,
+                  false
+              )
+          )
+      );
+    }
+    finally {
+      FileUtils.deleteDirectory(tmpDir);
+      FileUtils.forceDelete(dataFile);
+    }
   }
 
   @Test

--- a/indexing-hadoop/src/test/java/io/druid/indexer/DeterminePartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/DeterminePartitionsJobTest.java
@@ -212,74 +212,66 @@ public class DeterminePartitionsJobTest
     this.expectedStartEndForEachShard = expectedStartEndForEachShard;
 
     dataFile = File.createTempFile("test_website_data", "tmp");
+    dataFile.deleteOnExit();
     tmpDir = Files.createTempDir();
+    tmpDir.deleteOnExit();
 
-    try {
-      FileUtils.writeLines(dataFile, data);
+    FileUtils.writeLines(dataFile, data);
 
-      config = new HadoopDruidIndexerConfig(
-          new HadoopIngestionSpec(
-              new DataSchema(
-                  "website",
-                  HadoopDruidIndexerConfig.JSON_MAPPER.convertValue(
-                      new StringInputRowParser(
-                          new CSVParseSpec(
-                              new TimestampSpec("timestamp", "yyyyMMddHH", null),
-                              new DimensionsSpec(
-                                  DimensionsSpec.getDefaultSchemas(ImmutableList.of("host", "country")),
-                                  null,
-                                  null
-                              ),
-                              null,
-                              ImmutableList.of("timestamp", "host", "country", "visited_num")
-                          ),
-                          null
-                      ),
-                      Map.class
-                  ),
-                  new AggregatorFactory[]{new LongSumAggregatorFactory("visited_num", "visited_num")},
-                  new UniformGranularitySpec(
-                      Granularity.DAY, QueryGranularities.NONE, ImmutableList.of(new Interval(interval))
-                  ),
-                  HadoopDruidIndexerConfig.JSON_MAPPER
-              ),
-              new HadoopIOConfig(
-                  ImmutableMap.<String, Object>of(
-                      "paths",
-                      dataFile.getCanonicalPath(),
-                      "type",
-                      "static"
-                  ),
-                  null,
-                  tmpDir.getCanonicalPath()
-              ),
-              new HadoopTuningConfig(
-                  tmpDir.getCanonicalPath(),
-                  null,
-                  new SingleDimensionPartitionsSpec(null, targetPartitionSize, null, assumeGrouped),
-                  null,
-                  null,
-                  null,
-                  false,
-                  false,
-                  false,
-                  false,
-                  null,
-                  false,
-                  false,
-                  null,
-                  null,
-                  null,
-                  false,
-                  false
-              )
-          )
-      );
-    }
-    finally {
-      FileUtils.deleteDirectory(tmpDir);
-      FileUtils.forceDelete(dataFile);
-    }
+    config = new HadoopDruidIndexerConfig(
+        new HadoopIngestionSpec(
+            new DataSchema(
+                "website",
+                HadoopDruidIndexerConfig.JSON_MAPPER.convertValue(
+                    new StringInputRowParser(
+                        new CSVParseSpec(
+                            new TimestampSpec("timestamp", "yyyyMMddHH", null),
+                            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("host", "country")), null, null),
+                            null,
+                            ImmutableList.of("timestamp", "host", "country", "visited_num")
+                        ),
+                        null
+                    ),
+                    Map.class
+                ),
+                new AggregatorFactory[]{new LongSumAggregatorFactory("visited_num", "visited_num")},
+                new UniformGranularitySpec(
+                    Granularity.DAY, QueryGranularities.NONE, ImmutableList.of(new Interval(interval))
+                ),
+                HadoopDruidIndexerConfig.JSON_MAPPER
+            ),
+            new HadoopIOConfig(
+                ImmutableMap.<String, Object>of(
+                    "paths",
+                    dataFile.getCanonicalPath(),
+                    "type",
+                    "static"
+                ),
+                null,
+                tmpDir.getCanonicalPath()
+            ),
+            new HadoopTuningConfig(
+                tmpDir.getCanonicalPath(),
+                null,
+                new SingleDimensionPartitionsSpec(null, targetPartitionSize, null, assumeGrouped),
+                null,
+                null,
+                null,
+                false,
+                false,
+                false,
+                false,
+                null,
+                false,
+                false,
+                null,
+                null,
+                null,
+                false,
+                false
+            )
+        )
+    );
   }
 
   @Test

--- a/indexing-hadoop/src/test/java/io/druid/indexer/HadoopIOPeonTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/HadoopIOPeonTest.java
@@ -73,4 +73,8 @@ public class HadoopIOPeonTest
   {
     ioPeon.cleanup();
   }
+  @Test(expected = UnsupportedOperationException.class) public void testClose() throws IOException
+  {
+    ioPeon.close();
+  }
 }

--- a/indexing-hadoop/src/test/java/io/druid/indexer/HadoopIOPeonTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/HadoopIOPeonTest.java
@@ -69,10 +69,6 @@ public class HadoopIOPeonTest
     Assert.assertNotNull(ioPeon.makeInputStream(tmpFolder.newFile(TMP_FILE_NAME).getName()));
   }
 
-  @Test(expected = UnsupportedOperationException.class) public void testCleanup() throws IOException
-  {
-    ioPeon.cleanup();
-  }
   @Test(expected = UnsupportedOperationException.class) public void testClose() throws IOException
   {
     ioPeon.close();

--- a/indexing-hadoop/src/test/java/io/druid/indexer/HdfsClasspathSetupTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/HdfsClasspathSetupTest.java
@@ -26,6 +26,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import io.druid.common.utils.UUIDUtils;
 import io.druid.java.util.common.StringUtils;
 import junit.framework.Assert;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -71,7 +72,6 @@ public class HdfsClasspathSetupTest
   public static void setupStatic() throws IOException, ClassNotFoundException
   {
     hdfsTmpDir = File.createTempFile("hdfsClasspathSetupTest", "dir");
-    hdfsTmpDir.deleteOnExit();
     if (!hdfsTmpDir.delete()) {
       throw new IOException(String.format("Unable to delete hdfsTmpDir [%s]", hdfsTmpDir.getAbsolutePath()));
     }
@@ -100,6 +100,7 @@ public class HdfsClasspathSetupTest
     if (miniCluster != null) {
       miniCluster.shutdown(true);
     }
+    FileUtils.deleteDirectory(hdfsTmpDir);
   }
 
   @After

--- a/java-util/src/test/java/io/druid/java/util/common/CompressionUtilsTest.java
+++ b/java-util/src/test/java/io/druid/java/util/common/CompressionUtilsTest.java
@@ -131,15 +131,25 @@ public class CompressionUtilsTest
   {
     final File tmpDir = temporaryFolder.newFolder("testGoodZipCompressUncompress");
     final File zipFile = new File(tmpDir, "compressionUtilTest.zip");
-    zipFile.deleteOnExit();
-    CompressionUtils.zip(testDir, zipFile);
-    final File newDir = new File(tmpDir, "newDir");
-    newDir.mkdir();
-    CompressionUtils.unzip(zipFile, newDir);
-    final Path newPath = Paths.get(newDir.getAbsolutePath(), testFile.getName());
-    Assert.assertTrue(newPath.toFile().exists());
-    try (final FileInputStream inputStream = new FileInputStream(newPath.toFile())) {
-      assertGoodDataStream(inputStream);
+    try {
+      CompressionUtils.zip(testDir, zipFile);
+      final File newDir = new File(tmpDir, "newDir");
+      newDir.mkdir();
+      CompressionUtils.unzip(zipFile, newDir);
+      final Path newPath = Paths.get(newDir.getAbsolutePath(), testFile.getName());
+      Assert.assertTrue(newPath.toFile().exists());
+      try (final FileInputStream inputStream = new FileInputStream(newPath.toFile())) {
+        assertGoodDataStream(inputStream);
+      }
+    }
+    finally {
+      if (zipFile.exists()) {
+        zipFile.delete();
+      }
+
+      if (tmpDir.exists()) {
+        tmpDir.delete();
+      }
     }
   }
 

--- a/processing/src/main/java/io/druid/segment/IndexMerger.java
+++ b/processing/src/main/java/io/druid/segment/IndexMerger.java
@@ -642,7 +642,7 @@ public class IndexMerger
       @Override
       public void close() throws IOException
       {
-        ioPeon.cleanup();
+        ioPeon.close();
       }
     });
     try {

--- a/processing/src/main/java/io/druid/segment/IndexMergerV9.java
+++ b/processing/src/main/java/io/druid/segment/IndexMergerV9.java
@@ -135,7 +135,7 @@ public class IndexMergerV9 extends IndexMerger
       @Override
       public void close() throws IOException
       {
-        ioPeon.cleanup();
+        ioPeon.close();
       }
     });
     final FileSmoosher v9Smoosher = new FileSmoosher(outDir);

--- a/processing/src/main/java/io/druid/segment/StringDimensionMergerLegacy.java
+++ b/processing/src/main/java/io/druid/segment/StringDimensionMergerLegacy.java
@@ -210,7 +210,7 @@ public class StringDimensionMergerLegacy extends StringDimensionMergerV9 impleme
       spatialWriter.close();
       serializerUtils.writeString(spatialIndexFile, dimensionName);
       ByteStreams.copy(spatialWriter.combineStreams(), spatialIndexFile);
-      spatialIoPeon.cleanup();
+      spatialIoPeon.close();
     }
   }
 

--- a/processing/src/main/java/io/druid/segment/data/IOPeon.java
+++ b/processing/src/main/java/io/druid/segment/data/IOPeon.java
@@ -30,6 +30,4 @@ public interface IOPeon extends Closeable
 {
   public OutputStream makeOutputStream(String filename) throws IOException;
   public InputStream makeInputStream(String filename) throws IOException;
-  @Deprecated
-  public void cleanup() throws IOException;
 }

--- a/processing/src/main/java/io/druid/segment/data/IOPeon.java
+++ b/processing/src/main/java/io/druid/segment/data/IOPeon.java
@@ -19,15 +19,17 @@
 
 package io.druid.segment.data;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
 /**
  */
-public interface IOPeon
+public interface IOPeon extends Closeable
 {
   public OutputStream makeOutputStream(String filename) throws IOException;
   public InputStream makeInputStream(String filename) throws IOException;
+  @Deprecated
   public void cleanup() throws IOException;
 }

--- a/processing/src/main/java/io/druid/segment/data/TmpFileIOPeon.java
+++ b/processing/src/main/java/io/druid/segment/data/TmpFileIOPeon.java
@@ -53,7 +53,6 @@ public class TmpFileIOPeon implements IOPeon
     File retFile = createdFiles.get(filename);
     if (retFile == null) {
       retFile = File.createTempFile("filePeon", filename);
-      retFile.deleteOnExit();
       createdFiles.put(filename, retFile);
       return new BufferedOutputStream(new FileOutputStream(retFile));
     } else if (allowOverwrite) {
@@ -83,5 +82,11 @@ public class TmpFileIOPeon implements IOPeon
   public boolean isOverwriteAllowed()
   {
     return allowOverwrite;
+  }
+
+  @Override
+  public void close() throws IOException
+  {
+    cleanup();
   }
 }

--- a/processing/src/main/java/io/druid/segment/data/TmpFileIOPeon.java
+++ b/processing/src/main/java/io/druid/segment/data/TmpFileIOPeon.java
@@ -71,7 +71,7 @@ public class TmpFileIOPeon implements IOPeon
   }
 
   @Override
-  public void cleanup() throws IOException
+  public void close() throws IOException
   {
     for (File file : createdFiles.values()) {
       file.delete();
@@ -82,11 +82,5 @@ public class TmpFileIOPeon implements IOPeon
   public boolean isOverwriteAllowed()
   {
     return allowOverwrite;
-  }
-
-  @Override
-  public void close() throws IOException
-  {
-    cleanup();
   }
 }

--- a/processing/src/test/java/io/druid/segment/EmptyIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/EmptyIndexTest.java
@@ -28,6 +28,7 @@ import io.druid.segment.column.Column;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexAdapter;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
+import org.apache.commons.io.FileUtils;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Test;
@@ -46,32 +47,40 @@ public class EmptyIndexTest
     if (!tmpDir.mkdir()) {
       throw new IllegalStateException("tmp mkdir failed");
     }
-    tmpDir.deleteOnExit();
 
-    IncrementalIndex emptyIndex = new OnheapIncrementalIndex(
-        0,
-        QueryGranularities.NONE,
-        new AggregatorFactory[0],
-        1000
-    );
-    IncrementalIndexAdapter emptyIndexAdapter = new IncrementalIndexAdapter(
-        new Interval("2012-08-01/P3D"),
-        emptyIndex,
-        new ConciseBitmapFactory()
-    );
-    TestHelper.getTestIndexMerger().merge(
-        Lists.<IndexableAdapter>newArrayList(emptyIndexAdapter),
-        true,
-        new AggregatorFactory[0],
-        tmpDir,
-        new IndexSpec()
-    );
+    try {
+      IncrementalIndex emptyIndex = new OnheapIncrementalIndex(
+          0,
+          QueryGranularities.NONE,
+          new AggregatorFactory[0],
+          1000
+      );
+      IncrementalIndexAdapter emptyIndexAdapter = new IncrementalIndexAdapter(
+          new Interval("2012-08-01/P3D"),
+          emptyIndex,
+          new ConciseBitmapFactory()
+      );
+      TestHelper.getTestIndexMerger().merge(
+          Lists.<IndexableAdapter>newArrayList(emptyIndexAdapter),
+          true,
+          new AggregatorFactory[0],
+          tmpDir,
+          new IndexSpec()
+      );
 
-    QueryableIndex emptyQueryableIndex = TestHelper.getTestIndexIO().loadIndex(tmpDir);
+      QueryableIndex emptyQueryableIndex = TestHelper.getTestIndexIO().loadIndex(tmpDir);
 
-    Assert.assertEquals("getDimensionNames", 0, Iterables.size(emptyQueryableIndex.getAvailableDimensions()));
-    Assert.assertEquals("getMetricNames", 0, Iterables.size(emptyQueryableIndex.getColumnNames()));
-    Assert.assertEquals("getDataInterval", new Interval("2012-08-01/P3D"), emptyQueryableIndex.getDataInterval());
-    Assert.assertEquals("getReadOnlyTimestamps", 0, emptyQueryableIndex.getColumn(Column.TIME_COLUMN_NAME).getLength());
+      Assert.assertEquals("getDimensionNames", 0, Iterables.size(emptyQueryableIndex.getAvailableDimensions()));
+      Assert.assertEquals("getMetricNames", 0, Iterables.size(emptyQueryableIndex.getColumnNames()));
+      Assert.assertEquals("getDataInterval", new Interval("2012-08-01/P3D"), emptyQueryableIndex.getDataInterval());
+      Assert.assertEquals(
+          "getReadOnlyTimestamps",
+          0,
+          emptyQueryableIndex.getColumn(Column.TIME_COLUMN_NAME).getLength()
+      );
+    }
+    finally {
+      FileUtils.deleteDirectory(tmpDir);
+    }
   }
 }

--- a/processing/src/test/java/io/druid/segment/IndexMergerV9WithSpatialIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerV9WithSpatialIndexTest.java
@@ -46,6 +46,7 @@ import io.druid.query.timeseries.TimeseriesResultValue;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
+import org.apache.commons.io.FileUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.junit.Test;
@@ -256,10 +257,14 @@ public class IndexMergerV9WithSpatialIndexTest
     File tmpFile = File.createTempFile("billy", "yay");
     tmpFile.delete();
     tmpFile.mkdirs();
-    tmpFile.deleteOnExit();
 
-    INDEX_MERGER_V9.persist(theIndex, tmpFile, indexSpec);
-    return INDEX_IO.loadIndex(tmpFile);
+    try {
+      INDEX_MERGER_V9.persist(theIndex, tmpFile, indexSpec);
+      return INDEX_IO.loadIndex(tmpFile);
+    }
+    finally {
+      FileUtils.deleteDirectory(tmpFile);
+    }
   }
 
   private static QueryableIndex makeMergedQueryableIndex(IndexSpec indexSpec)
@@ -470,33 +475,38 @@ public class IndexMergerV9WithSpatialIndexTest
       File mergedFile = new File(tmpFile, "merged");
 
       firstFile.mkdirs();
-      firstFile.deleteOnExit();
       secondFile.mkdirs();
-      secondFile.deleteOnExit();
       thirdFile.mkdirs();
-      thirdFile.deleteOnExit();
       mergedFile.mkdirs();
-      mergedFile.deleteOnExit();
 
       INDEX_MERGER_V9.persist(first, DATA_INTERVAL, firstFile, indexSpec);
       INDEX_MERGER_V9.persist(second, DATA_INTERVAL, secondFile, indexSpec);
       INDEX_MERGER_V9.persist(third, DATA_INTERVAL, thirdFile, indexSpec);
 
-      QueryableIndex mergedRealtime = INDEX_IO.loadIndex(
-          INDEX_MERGER_V9.mergeQueryableIndex(
-              Arrays.asList(
-                  INDEX_IO.loadIndex(firstFile),
-                  INDEX_IO.loadIndex(secondFile),
-                  INDEX_IO.loadIndex(thirdFile)
-              ),
-              true,
-              METRIC_AGGS,
-              mergedFile,
-              indexSpec
-          )
-      );
+      try {
+        QueryableIndex mergedRealtime = INDEX_IO.loadIndex(
+            INDEX_MERGER_V9.mergeQueryableIndex(
+                Arrays.asList(
+                    INDEX_IO.loadIndex(firstFile),
+                    INDEX_IO.loadIndex(secondFile),
+                    INDEX_IO.loadIndex(thirdFile)
+                ),
+                true,
+                METRIC_AGGS,
+                mergedFile,
+                indexSpec
+            )
+        );
+        return mergedRealtime;
 
-      return mergedRealtime;
+      }
+      finally {
+        FileUtils.deleteDirectory(firstFile);
+        FileUtils.deleteDirectory(secondFile);
+        FileUtils.deleteDirectory(thirdFile);
+        FileUtils.deleteDirectory(mergedFile);
+      }
+
     }
     catch (IOException e) {
       throw Throwables.propagate(e);

--- a/processing/src/test/java/io/druid/segment/data/CompressedIntsIndexedWriterTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedIntsIndexedWriterTest.java
@@ -92,7 +92,7 @@ public class CompressedIntsIndexedWriterTest
   @After
   public void tearDown() throws Exception
   {
-    ioPeon.cleanup();
+    ioPeon.close();
   }
 
   private void generateVals(final int totalSize, final int maxValue) throws IOException

--- a/processing/src/test/java/io/druid/segment/data/CompressedVSizeIndexedV3WriterTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedVSizeIndexedV3WriterTest.java
@@ -182,7 +182,7 @@ public class CompressedVSizeIndexedV3WriterTest
   @After
   public void tearDown() throws Exception
   {
-    ioPeon.cleanup();
+    ioPeon.close();
   }
 
   @Test

--- a/processing/src/test/java/io/druid/segment/data/CompressedVSizeIntsIndexedWriterTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedVSizeIntsIndexedWriterTest.java
@@ -91,7 +91,7 @@ public class CompressedVSizeIntsIndexedWriterTest
   @After
   public void tearDown() throws Exception
   {
-    ioPeon.cleanup();
+    ioPeon.close();
   }
 
   private void generateVals(final int totalSize, final int maxValue) throws IOException

--- a/processing/src/test/java/io/druid/segment/data/IOPeonForTesting.java
+++ b/processing/src/test/java/io/druid/segment/data/IOPeonForTesting.java
@@ -61,14 +61,8 @@ class IOPeonForTesting implements IOPeon
   }
 
   @Override
-  public void cleanup() throws IOException
-  {
-    outStreams.clear();
-  }
-
-  @Override
   public void close() throws IOException
   {
-    cleanup();
+    outStreams.clear();
   }
 }

--- a/processing/src/test/java/io/druid/segment/data/IOPeonForTesting.java
+++ b/processing/src/test/java/io/druid/segment/data/IOPeonForTesting.java
@@ -65,4 +65,10 @@ class IOPeonForTesting implements IOPeon
   {
     outStreams.clear();
   }
+
+  @Override
+  public void close() throws IOException
+  {
+    cleanup();
+  }
 }

--- a/processing/src/test/java/io/druid/segment/data/VSizeIndexedIntsWriterTest.java
+++ b/processing/src/test/java/io/druid/segment/data/VSizeIndexedIntsWriterTest.java
@@ -50,7 +50,7 @@ public class VSizeIndexedIntsWriterTest
   @After
   public void tearDown() throws Exception
   {
-    ioPeon.cleanup();
+    ioPeon.close();
   }
 
   private void generateVals(final int totalSize, final int maxValue) throws IOException

--- a/server/src/test/java/io/druid/segment/loading/LocalDataSegmentPullerTest.java
+++ b/server/src/test/java/io/druid/segment/loading/LocalDataSegmentPullerTest.java
@@ -20,9 +20,9 @@
 package io.druid.segment.loading;
 
 import com.google.common.io.Files;
-
 import io.druid.java.util.common.CompressionUtils;
-
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -49,8 +49,13 @@ public class LocalDataSegmentPullerTest
   public void setup() throws IOException
   {
     tmpDir = temporaryFolder.newFolder();
-    tmpDir.deleteOnExit();
     puller = new LocalDataSegmentPuller();
+  }
+
+  @After
+  public void after() throws IOException
+  {
+    FileUtils.deleteDirectory(tmpDir);
   }
 
   @Test

--- a/server/src/test/java/io/druid/segment/realtime/plumber/RealtimePlumberSchoolTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/plumber/RealtimePlumberSchoolTest.java
@@ -96,6 +96,7 @@ public class RealtimePlumberSchoolTest
   private DataSchema schema;
   private DataSchema schema2;
   private FireDepartmentMetrics metrics;
+  private File tmpDir;
 
   public RealtimePlumberSchoolTest(RejectionPolicyFactory rejectionPolicy, boolean buildV9Directly)
   {
@@ -124,8 +125,7 @@ public class RealtimePlumberSchoolTest
   @Before
   public void setUp() throws Exception
   {
-    final File tmpDir = Files.createTempDir();
-    tmpDir.deleteOnExit();
+    tmpDir = Files.createTempDir();
 
     ObjectMapper jsonMapper = new DefaultObjectMapper();
 
@@ -237,6 +237,7 @@ public class RealtimePlumberSchoolTest
             schema.getDataSource()
         )
     );
+    FileUtils.deleteDirectory(tmpDir);
   }
 
   @Test(timeout = 60000)


### PR DESCRIPTION
Addresses https://github.com/druid-io/druid/issues/3885

 * Removed deleteOnExit() from most of the classes except few(classes which heavily depend on this method).
-> ReplayableFirehose
-> SchemalessIndexTest
-> SpatialFilterBonusTest
-> SpatialFilterTest
-> DeterminePartitionsJobTest.java

 * Made IOpeon closable

