### PR TITLE
Close all aggregators when closing onHeapIncrementalIndex

### DIFF
--- a/processing/src/main/java/io/druid/query/aggregation/Aggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/Aggregator.java
@@ -19,6 +19,8 @@
 
 package io.druid.query.aggregation;
 
+import java.io.Closeable;
+
 /**
  * An Aggregator is an object that can aggregate metrics.  Its aggregation-related methods (namely, aggregate() and get())
  * do not take any arguments as the assumption is that the Aggregator was given something in its constructor that
@@ -32,7 +34,8 @@ package io.druid.query.aggregation;
  *
  * This interface is old and going away.  It is being replaced by BufferAggregator
  */
-public interface Aggregator {
+public interface Aggregator extends Closeable
+{
   void aggregate();
   void reset();
   Object get();

--- a/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -263,8 +263,8 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
   private void closeAggregators()
   {
     Closer closer = Closer.create();
-    for (Aggregator[] aggregators : aggregators.values()) {
-      for (Aggregator agg : aggregators) {
+    for (Aggregator[] aggs : aggregators.values()) {
+      for (Aggregator agg : aggs) {
         closer.register(agg);
       }
     }

--- a/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -257,6 +257,15 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
     rowContainer.set(null);
   }
 
+  private void closeAggregators(Map<Integer, Aggregator[]> intMap)
+  {
+    for (Aggregator[] aggregators : intMap.values()) {
+      for (Aggregator agg : aggregators) {
+        agg.close();
+      }
+    }
+  }
+
   protected Aggregator[] concurrentGet(int offset)
   {
     // All get operations should be fine
@@ -327,6 +336,7 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
   public void close()
   {
     super.close();
+    closeAggregators(aggregators);
     aggregators.clear();
     facts.clear();
     if (selectors != null) {

--- a/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexTest.java
@@ -104,19 +104,15 @@ public class OnheapIncrementalIndexTest
   @Test
   public void testOnHeapIncrementalIndexClose() throws Exception
   {
-    // Prepare the mocks
-    LongMaxAggregatorFactory aggFact = EasyMock.createMockBuilder(LongMaxAggregatorFactory.class)
-                                               .withConstructor("max", "max")
-                                               .createMock();
+    // Prepare the mocks & set close() call count expectation to 1
     Aggregator mockedAggregator = EasyMock.createMock(LongMaxAggregator.class);
-    // set close() call count expectation to 1
     mockedAggregator.close();
     EasyMock.expectLastCall().times(1);
 
     final OnheapIncrementalIndex index = new OnheapIncrementalIndex(
             0,
             QueryGranularities.MINUTE,
-            new AggregatorFactory[]{aggFact},
+            new AggregatorFactory[]{new LongMaxAggregatorFactory("max", "max")},
             MAX_ROWS
     );
 


### PR DESCRIPTION
following discussion on https://groups.google.com/forum/#!topic/druid-development/u4b-H-UD3Es

Aggregators close() method is not called when OnHeapIncrementalIndex tear down.
