### PR TITLE
fix cache populate incorrect content when numBackgroundThreads>1

### DIFF
--- a/server/src/main/java/io/druid/client/CachingQueryRunner.java
+++ b/server/src/main/java/io/druid/client/CachingQueryRunner.java
@@ -23,9 +23,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.base.Throwables;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -188,22 +188,7 @@ public class CachingQueryRunner<T> implements QueryRunner<T>
             public void run()
             {
               try {
-                CacheUtil.populate(cache, mapper, key, Iterables.transform(
-                    cacheFutures,
-                    new Function<ListenableFuture<?>, Object>()
-                    {
-                      @Override
-                      public Object apply(ListenableFuture<?> input)
-                      {
-                        try {
-                          return input.get();
-                        }
-                        catch (Exception e) {
-                          throw Throwables.propagate(e);
-                        }
-                      }
-                    }
-                ));
+                CacheUtil.populate(cache, mapper, key, Futures.allAsList(cacheFutures).get());
               }
               catch (Exception e) {
                 log.error(e, "Error while getting future for cache task");

--- a/server/src/test/java/io/druid/client/CachingQueryRunnerTest.java
+++ b/server/src/test/java/io/druid/client/CachingQueryRunnerTest.java
@@ -78,7 +78,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @RunWith(Parameterized.class)
 public class CachingQueryRunnerTest
 {
-  @Parameterized.Parameters(name="numBackgroundThreads={0}")
+  @Parameterized.Parameters(name = "numBackgroundThreads={0}")
   public static Iterable<Object[]> constructorFeeder() throws IOException
   {
     return QueryRunnerTestHelper.cartesian(Arrays.asList(5, 1, 0));
@@ -99,6 +99,7 @@ public class CachingQueryRunnerTest
   };
 
   private ExecutorService backgroundExecutorService;
+
   public CachingQueryRunnerTest(int numBackgroundThreads)
   {
     if (numBackgroundThreads > 0) {
@@ -209,7 +210,8 @@ public class CachingQueryRunnerTest
     );
 
     final CountDownLatch cacheMustBePutOnce = new CountDownLatch(1);
-    Cache cache = new Cache() {
+    Cache cache = new Cache()
+    {
       private final Map<NamedKey, byte[]> baseMap = new ConcurrentHashMap<>();
 
       @Override
@@ -308,7 +310,7 @@ public class CachingQueryRunnerTest
 
     // wait for background caching finish
     // wait at most 10 seconds to fail the test to avoid block overall tests
-    cacheMustBePutOnce.await(10, TimeUnit.SECONDS);
+    Assert.assertTrue("cache must be populated", cacheMustBePutOnce.await(10, TimeUnit.SECONDS));
     byte[] cacheValue = cache.get(cacheKey);
     Assert.assertNotNull(cacheValue);
 


### PR DESCRIPTION
The origin code can cause: 
1. concurrency issue
2. sequence order and cacheResults order maybe different, eg: for timeSeries query, 
the sequence order is 
```
[{
  "timestamp" : "2017-02-16T09:00:48.000+08:00",
  "result" : {
    "__result" : 1.0
  }
}, {
  "timestamp" : "2017-02-16T09:01:04.000+08:00",
  "result" : {
    "__result" : 1.0
  }
}, {
  "timestamp" : "2017-02-16T09:01:20.000+08:00",
  "result" : {
    "__result" : 1.0
  }
}]
```
but the cacheResults order can be
```
[{
  "timestamp" : "2017-02-16T09:00:48.000+08:00",
  "result" : {
    "__result" : 1.0
  }
}, {
  "timestamp" : "2017-02-16T09:01:20.000+08:00",
  "result" : {
    "__result" : 1.0
  }
}, {
  "timestamp" : "2017-02-16T09:01:04.000+08:00",
  "result" : {
    "__result" : 1.0
  }
}]
```

Basically, this issue is caused by the cacheResults.add() called order is not promised as same as backgroundExecutorService.submit() called order when numBackgroundThreads>1

This difference can cause incorrect merge sort result on broker.