### PR TITLE
fix dynamic schema data can't rollup correctly

### DIFF
--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -963,11 +963,26 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
       }
 
       if (retVal == 0) {
-        return Ints.compare(lhs.dims.length, rhs.dims.length);
+        int lengthDiff = Ints.compare(lhs.dims.length, rhs.dims.length);
+        if (lengthDiff == 0) {
+          return 0;
+        }
+        Object[] largerDims = lengthDiff > 0 ? lhs.dims : rhs.dims;
+        return allNull(largerDims, numComparisons) ? 0 : lengthDiff;
       }
 
       return retVal;
     }
+  }
+
+  private static boolean allNull(Object[] dims, int startPosition)
+  {
+    for (int i = startPosition; i < dims.length; i++) {
+      if (dims[i] != null) {
+        return false;
+      }
+    }
+    return true;
   }
 
   public static class FactsEntry implements Map.Entry<TimeAndDims, Integer>

--- a/processing/src/test/java/io/druid/segment/data/IncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/data/IncrementalIndexTest.java
@@ -781,4 +781,38 @@ public class IncrementalIndexTest
 
     Assert.assertEquals(Arrays.asList("dim0", "dim1"), incrementalIndex.getDimensionNames());
   }
+
+  @Test
+  public void testDynamicSchemaRollup() throws IndexSizeExceededException
+  {
+    IncrementalIndex<Aggregator> index = new OnheapIncrementalIndex(
+        new IncrementalIndexSchema.Builder().withQueryGranularity(QueryGranularities.NONE).build(),
+        true,
+        10
+    );
+    closer.closeLater(index);
+    index.add(
+        new MapBasedInputRow(
+            1481871600000L,
+            Arrays.asList("name", "host"),
+            ImmutableMap.<String, Object>of("name", "name1", "host", "host")
+        )
+    );
+    index.add(
+        new MapBasedInputRow(
+            1481871670000L,
+            Arrays.asList("name", "table"),
+            ImmutableMap.<String, Object>of("name", "name2", "table", "table")
+        )
+    );
+    index.add(
+        new MapBasedInputRow(
+            1481871600000L,
+            Arrays.asList("name", "host"),
+            ImmutableMap.<String, Object>of("name", "name1", "host", "host")
+        )
+    );
+
+    Assert.assertEquals(2, index.size());
+  }
 }


### PR DESCRIPTION
for dynamic schema data(schema can't be pre-defined, it is discovered) like this:
```
ts=1481871600000  name=query_latency       host=11.227.70.224
ts=1481871670000  name=table_update_gap    table=igraph_userclick
ts=1481871600000  name=query_latency       host=11.227.70.224
```
the first line and third line should be considered as same and should rollup
but for the current implement, the TimeAndDimsComp will consider them as different due to dims[].length is different.
```
the first line: dims={0,0}
the second line: dims={1,null,0}
the third line: dims={0,0,null}
```

we should consider them as same when the differences between the dims[] are all null