### PR TITLE
Fix over-optimistic log message.

### DIFF
--- a/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/tasklog/HdfsTaskLogs.java
+++ b/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/tasklog/HdfsTaskLogs.java
@@ -66,8 +66,9 @@ public class HdfsTaskLogs implements TaskLogs
         final OutputStream out = fs.create(path, true)
     ) {
       ByteStreams.copy(in, out);
-      log.info("Wrote task log to: %s", path);
     }
+
+    log.info("Wrote task log to: %s", path);
   }
 
   @Override


### PR DESCRIPTION
"Wrote task log" could be logged before the output stream is flushed and
closed, which could generate an error and not actually write the log.