### PR TITLE
increase kill timeout

### DIFF
--- a/indexing-service/src/main/resources/indexer_static/js/console-0.0.1.js
+++ b/indexing-service/src/main/resources/indexer_static/js/console-0.0.1.js
@@ -9,7 +9,7 @@ var killTask = function(taskId) {
       url: '/druid/indexer/v1/task/'+ taskId +'/shutdown',
       data: ''
     }).done(function(data) {
-      setTimeout(function() { location.reload(true) }, 75);
+      setTimeout(function() { location.reload(true) }, 750);
     }).fail(function(data) {
       alert('Kill request failed with status: '+data.status+' please check overlord logs');
     })


### PR DESCRIPTION
after https://github.com/druid-io/druid/pull/3974 some users have complained that even after refresh task status is not updated. So increase the timeout, if the status is not updated even after this then it is ok and users should refresh manually. 