### PR TITLE
Fix TimeFormatExtractionFn getCacheKey when tz, locale are not provided.

### DIFF
--- a/docs/content/querying/dimensionspecs.md
+++ b/docs/content/querying/dimensionspecs.md
@@ -229,9 +229,9 @@ For a regular dimension, it assumes the string is formatted in
 ```json
 { "type" : "timeFormat",
   "format" : <output_format> (optional),
-  "timeZone" : <time_zone> (optional),
-  "locale" : <locale> (optional),
-  "granularity" : <granularity> (optional) },
+  "timeZone" : <time_zone> (optional, default UTC),
+  "locale" : <locale> (optional, default current locale),
+  "granularity" : <granularity> (optional, default none) },
   "asMillis" : <true or false> (optional) }
 ```
 

--- a/processing/src/main/java/io/druid/query/extraction/TimeFormatExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/TimeFormatExtractionFn.java
@@ -106,7 +106,9 @@ public class TimeFormatExtractionFn implements ExtractionFn
   @Override
   public byte[] getCacheKey()
   {
-    final byte[] exprBytes = StringUtils.toUtf8(format + "\u0001" + tz.getID() + "\u0001" + locale.toLanguageTag());
+    final String tzId = tz == null ? "" : tz.getID();
+    final String localeTag = locale == null ? "" : locale.toLanguageTag();
+    final byte[] exprBytes = StringUtils.toUtf8(format + "\u0001" + tzId + "\u0001" + localeTag);
     final byte[] granularityCacheKey = granularity.getCacheKey();
     return ByteBuffer.allocate(4 + exprBytes.length + granularityCacheKey.length)
                      .put(ExtractionCacheHelper.CACHE_TYPE_ID_TIME_FORMAT)

--- a/processing/src/main/java/io/druid/query/extraction/TimeFormatExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/TimeFormatExtractionFn.java
@@ -106,8 +106,8 @@ public class TimeFormatExtractionFn implements ExtractionFn
   @Override
   public byte[] getCacheKey()
   {
-    final String tzId = tz == null ? "" : tz.getID();
-    final String localeTag = locale == null ? "" : locale.toLanguageTag();
+    final String tzId = (tz == null ? DateTimeZone.UTC : tz).getID();
+    final String localeTag = (locale == null ? Locale.getDefault() : locale).toLanguageTag();
     final byte[] exprBytes = StringUtils.toUtf8(format + "\u0001" + tzId + "\u0001" + localeTag);
     final byte[] granularityCacheKey = granularity.getCacheKey();
     return ByteBuffer.allocate(4 + exprBytes.length + granularityCacheKey.length)

--- a/processing/src/test/java/io/druid/query/extraction/TimeFormatExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/TimeFormatExtractionFnTest.java
@@ -29,6 +29,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Locale;
 
 public class TimeFormatExtractionFnTest
 {
@@ -171,7 +172,16 @@ public class TimeFormatExtractionFnTest
         true
     );
 
+    TimeFormatExtractionFn fn4 = new TimeFormatExtractionFn(
+        null,
+        null,
+        null,
+        null,
+        false
+    );
+
     Assert.assertFalse(Arrays.equals(fn.getCacheKey(), fn2.getCacheKey()));
+    Assert.assertFalse(Arrays.equals(fn.getCacheKey(), fn4.getCacheKey()));
     Assert.assertTrue(Arrays.equals(fn2.getCacheKey(), fn3.getCacheKey()));
   }
 }

--- a/processing/src/test/java/io/druid/query/extraction/TimeFormatExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/TimeFormatExtractionFnTest.java
@@ -29,7 +29,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.Locale;
 
 public class TimeFormatExtractionFnTest
 {


### PR DESCRIPTION
The docs claim tz, locale are optional but getCacheKey threw NPE when either was null.

This also prevents some Druid SQL queries from working when cache is enabled, since it uses TimeFormatExtractionFn for some features.