### PR TITLE
Fix float, long dimension indexer object selectors.

### DIFF
--- a/processing/src/main/java/io/druid/segment/FloatDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/FloatDimensionIndexer.java
@@ -19,7 +19,6 @@
 
 package io.druid.segment;
 
-import com.google.common.collect.ImmutableList;
 import io.druid.collections.bitmap.BitmapFactory;
 import io.druid.collections.bitmap.MutableBitmap;
 import io.druid.query.dimension.DimensionSpec;
@@ -199,7 +198,7 @@ public class FloatDimensionIndexer implements DimensionIndexer<Float, Float, Flo
   @Override
   public Object convertUnsortedEncodedKeyComponentToActualArrayOrList(Float key, boolean asList)
   {
-    return ImmutableList.of(key);
+    return key;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/LongDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/LongDimensionIndexer.java
@@ -19,7 +19,6 @@
 
 package io.druid.segment;
 
-import com.google.common.collect.ImmutableList;
 import io.druid.collections.bitmap.BitmapFactory;
 import io.druid.collections.bitmap.MutableBitmap;
 import io.druid.query.dimension.DimensionSpec;
@@ -199,7 +198,7 @@ public class LongDimensionIndexer implements DimensionIndexer<Long, Long, Long>
   @Override
   public Object convertUnsortedEncodedKeyComponentToActualArrayOrList(Long key, boolean asList)
   {
-    return ImmutableList.of(key);
+    return key;
   }
 
   @Override

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -7975,8 +7975,24 @@ public class GroupByQueryRunnerTest
                 QueryRunnerTestHelper.rowsCount,
                 new LongSumAggregatorFactory("qlLong", "qualityLong"),
                 new DoubleSumAggregatorFactory("qlFloat", "qualityLong"),
+                new JavaScriptAggregatorFactory(
+                    "qlJs",
+                    ImmutableList.of("qualityLong"),
+                    "function(a,b) { return a + b; }",
+                    "function() { return 0; }",
+                    "function(a,b) { return a + b }",
+                    JavaScriptConfig.getEnabledInstance()
+                ),
                 new DoubleSumAggregatorFactory("qfFloat", "qualityFloat"),
-                new LongSumAggregatorFactory("qfLong", "qualityFloat")
+                new LongSumAggregatorFactory("qfLong", "qualityFloat"),
+                new JavaScriptAggregatorFactory(
+                    "qfJs",
+                    ImmutableList.of("qualityFloat"),
+                    "function(a,b) { return a + b; }",
+                    "function() { return 0; }",
+                    "function(a,b) { return a + b }",
+                    JavaScriptConfig.getEnabledInstance()
+                )
             )
         )
         .setGranularity(QueryRunnerTestHelper.dayGran)
@@ -7989,8 +8005,10 @@ public class GroupByQueryRunnerTest
             "rows", 1L,
             "qlLong", 1700L,
             "qlFloat", 1700.0,
+            "qlJs", 1700.0,
             "qfFloat", 17000.0,
-            "qfLong", 17000L
+            "qfLong", 17000L,
+            "qfJs", 17000.0
         ),
         GroupByQueryRunnerTestHelper.createExpectedRow(
             "2011-04-02",
@@ -7998,8 +8016,10 @@ public class GroupByQueryRunnerTest
             "rows", 1L,
             "qlLong", 1700L,
             "qlFloat", 1700.0,
+            "qlJs", 1700.0,
             "qfFloat", 17000.0,
-            "qfLong", 17000L
+            "qfLong", 17000L,
+            "qfJs", 17000.0
         )
     );
 


### PR DESCRIPTION
Their "convertUnsortedEncodedKeyComponentToActualArrayOrList" methods didn't respect the contract, which says they should return single values (not array/list) if there is only a single value to return. This affects the behavior of ObjectColumnSelectors on realtime segments.