### PR TITLE
Run GroupByV2 queries in compatibility mode on Historicals

### DIFF
--- a/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceGroupByQueryTest.java
+++ b/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceGroupByQueryTest.java
@@ -61,6 +61,7 @@ public class VarianceGroupByQueryTest
   private final QueryRunner<Row> runner;
   private final GroupByQueryRunnerFactory factory;
   private final String testName;
+  private final boolean compatibilityMode;
 
   @Parameterized.Parameters(name="{0}")
   public static Collection<?> constructorFeeder() throws IOException
@@ -68,12 +69,18 @@ public class VarianceGroupByQueryTest
     return GroupByQueryRunnerTest.constructorFeeder();
   }
 
-  public VarianceGroupByQueryTest(String testName, GroupByQueryConfig config, GroupByQueryRunnerFactory factory, QueryRunner runner)
+  public VarianceGroupByQueryTest(
+      String testName,
+      GroupByQueryConfig config,
+      GroupByQueryRunnerFactory factory,
+      QueryRunner runner,
+      boolean compatibilityMode)
   {
     this.testName = testName;
     this.config = config;
     this.factory = factory;
     this.runner = factory.mergeRunners(MoreExecutors.sameThreadExecutor(), ImmutableList.<QueryRunner<Row>>of(runner));
+    this.compatibilityMode = compatibilityMode;
   }
 
   @Test

--- a/processing/src/main/java/io/druid/query/groupby/strategy/GroupByStrategy.java
+++ b/processing/src/main/java/io/druid/query/groupby/strategy/GroupByStrategy.java
@@ -54,6 +54,14 @@ public interface GroupByStrategy
   boolean isCacheable(boolean willMergeRunners);
 
   /**
+   * Indicates this strategy is compatible with GroupByStrategyV1 or not.
+   *
+   * @param compatibilityMode indicates whether to operate in compatibility mode or not
+   * @return true if this strategy is compatible with GroupByStrategyV1, otherwise false.
+   */
+  boolean isInCompatibilityMode(boolean compatibilityMode);
+
+  /**
    * Decorate a runner with an interval chunking decorator.
    */
   QueryRunner<Row> createIntervalChunkingRunner(

--- a/processing/src/main/java/io/druid/query/groupby/strategy/GroupByStrategyV1.java
+++ b/processing/src/main/java/io/druid/query/groupby/strategy/GroupByStrategyV1.java
@@ -92,6 +92,12 @@ public class GroupByStrategyV1 implements GroupByStrategy
   }
 
   @Override
+  public boolean isInCompatibilityMode(boolean compatibilityMode)
+  {
+    return false;
+  }
+
+  @Override
   public QueryRunner<Row> createIntervalChunkingRunner(
       final IntervalChunkingQueryRunnerDecorator decorator,
       final QueryRunner<Row> runner,

--- a/processing/src/main/java/io/druid/query/groupby/strategy/GroupByStrategyV2.java
+++ b/processing/src/main/java/io/druid/query/groupby/strategy/GroupByStrategyV2.java
@@ -180,6 +180,12 @@ public class GroupByStrategyV2 implements GroupByStrategy
   }
 
   @Override
+  public boolean isInCompatibilityMode(boolean compatibilityMode)
+  {
+    return compatibilityMode;
+  }
+
+  @Override
   public QueryRunner<Row> createIntervalChunkingRunner(
       final IntervalChunkingQueryRunnerDecorator decorator,
       final QueryRunner<Row> runner,
@@ -209,7 +215,8 @@ public class GroupByStrategyV2 implements GroupByStrategy
       @Override
       protected Ordering<Row> makeOrdering(Query<Row> queryParam)
       {
-        return ((GroupByQuery) queryParam).getRowOrdering(true);
+        return ((GroupByQuery) queryParam).getRowOrdering(true,
+            isInCompatibilityMode(query.getContextValue(GroupByQueryConfig.CTX_KEY_STRATEGY) == null ? true : false));
       }
 
       @Override

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -151,6 +151,7 @@ import static org.junit.Assert.assertEquals;
 public class GroupByQueryRunnerTest
 {
   public static final ObjectMapper DEFAULT_MAPPER = new DefaultObjectMapper(new SmileFactory());
+  public static final List<Boolean> COMPATIBILITY_MODES = ImmutableList.of(true, false);
   public static final DruidProcessingConfig DEFAULT_PROCESSING_CONFIG = new DruidProcessingConfig()
   {
     @Override
@@ -183,6 +184,7 @@ public class GroupByQueryRunnerTest
   private GroupByQueryRunnerFactory factory;
   private GroupByQueryConfig config;
   private final String testName;
+  private final boolean compatibilityMode;
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
@@ -380,12 +382,15 @@ public class GroupByQueryRunnerTest
     for (GroupByQueryConfig config : testConfigs()) {
       final GroupByQueryRunnerFactory factory = makeQueryRunnerFactory(config);
       for (QueryRunner<Row> runner : QueryRunnerTestHelper.makeQueryRunners(factory)) {
-        final String testName = String.format(
-            "config=%s, runner=%s",
-            config.toString(),
-            runner.toString()
-        );
-        constructors.add(new Object[]{testName, config, factory, runner});
+        for (boolean compatibilityMode : COMPATIBILITY_MODES) {
+          final String testName = String.format(
+              "config=%s, runner=%s, compatibilityMode=%s",
+              config.toString(),
+              runner.toString(),
+              compatibilityMode
+          );
+          constructors.add(new Object[] { testName, config, factory, runner, compatibilityMode });
+        }
       }
     }
 
@@ -393,13 +398,18 @@ public class GroupByQueryRunnerTest
   }
 
   public GroupByQueryRunnerTest(
-      String testName, GroupByQueryConfig config, GroupByQueryRunnerFactory factory, QueryRunner runner
+      String testName,
+      GroupByQueryConfig config,
+      GroupByQueryRunnerFactory factory,
+      QueryRunner runner,
+      boolean compatibilityMode
   )
   {
     this.testName = testName;
     this.config = config;
     this.factory = factory;
     this.runner = factory.mergeRunners(MoreExecutors.sameThreadExecutor(), ImmutableList.<QueryRunner<Row>>of(runner));
+    this.compatibilityMode = compatibilityMode;
   }
 
   @Test


### PR DESCRIPTION
Run GroupByV2 queries in compatibility mode on Historicals. If the broker doesn't send "groupByStrategy" in the context