### PR TITLE
groupBy v2: Always merge queries.

### DIFF
--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryQueryToolChest.java
@@ -108,9 +108,10 @@ public class GroupByQueryQueryToolChest extends QueryToolChest<Row, GroupByQuery
           return runner.run(query, responseContext);
         }
 
-        if (query.getContextBoolean(GROUP_BY_MERGE_KEY, true)) {
+        final GroupByQuery groupByQuery = (GroupByQuery) query;
+        if (strategySelector.strategize(groupByQuery).doMergeResults(groupByQuery)) {
           return initAndMergeGroupByResults(
-              (GroupByQuery) query,
+              groupByQuery,
               runner,
               responseContext
           );
@@ -181,7 +182,7 @@ public class GroupByQueryQueryToolChest extends QueryToolChest<Row, GroupByQuery
           subquery.withOverriddenContext(
               ImmutableMap.<String, Object>of(
                   //setting sort to false avoids unnecessary sorting while merging results. we only need to sort
-                  //in the end when returning results to user.
+                  //in the end when returning results to user. (note this is only respected by groupBy v1)
                   GroupByQueryHelper.CTX_KEY_SORT_RESULTS,
                   false
               )

--- a/processing/src/main/java/io/druid/query/groupby/strategy/GroupByStrategy.java
+++ b/processing/src/main/java/io/druid/query/groupby/strategy/GroupByStrategy.java
@@ -54,6 +54,11 @@ public interface GroupByStrategy
   boolean isCacheable(boolean willMergeRunners);
 
   /**
+   * Indicates if this query should undergo "mergeResults" or not.
+   */
+  boolean doMergeResults(final GroupByQuery query);
+
+  /**
    * Decorate a runner with an interval chunking decorator.
    */
   QueryRunner<Row> createIntervalChunkingRunner(

--- a/processing/src/main/java/io/druid/query/groupby/strategy/GroupByStrategyV1.java
+++ b/processing/src/main/java/io/druid/query/groupby/strategy/GroupByStrategyV1.java
@@ -102,6 +102,12 @@ public class GroupByStrategyV1 implements GroupByStrategy
   }
 
   @Override
+  public boolean doMergeResults(final GroupByQuery query)
+  {
+    return query.getContextBoolean(GroupByQueryQueryToolChest.GROUP_BY_MERGE_KEY, true);
+  }
+
+  @Override
   public Sequence<Row> mergeResults(
       final QueryRunner<Row> baseRunner,
       final GroupByQuery query,
@@ -131,10 +137,10 @@ public class GroupByStrategyV1 implements GroupByStrategy
                 ImmutableMap.<String, Object>of(
                     "finalize", false,
                     //setting sort to false avoids unnecessary sorting while merging results. we only need to sort
-                    //in the end when returning results to user.
+                    //in the end when returning results to user. (note this is only respected by groupBy v1)
                     GroupByQueryHelper.CTX_KEY_SORT_RESULTS, false,
                     //no merging needed at historicals because GroupByQueryRunnerFactory.mergeRunners(..) would return
-                    //merged results
+                    //merged results. (note this is only respected by groupBy v1)
                     GroupByQueryQueryToolChest.GROUP_BY_MERGE_KEY, false,
                     GroupByQueryConfig.CTX_KEY_STRATEGY, GroupByStrategySelector.STRATEGY_V1
                 )

--- a/processing/src/main/java/io/druid/query/groupby/strategy/GroupByStrategyV2.java
+++ b/processing/src/main/java/io/druid/query/groupby/strategy/GroupByStrategyV2.java
@@ -180,6 +180,12 @@ public class GroupByStrategyV2 implements GroupByStrategy
   }
 
   @Override
+  public boolean doMergeResults(final GroupByQuery query)
+  {
+    return true;
+  }
+
+  @Override
   public QueryRunner<Row> createIntervalChunkingRunner(
       final IntervalChunkingQueryRunnerDecorator decorator,
       final QueryRunner<Row> runner,


### PR DESCRIPTION
This fixes #4020 because it means the timestamp will always be included for outermost
queries. Historicals receiving queries from older brokers will think they're
outermost (because CTX_KEY_OUTERMOST isn't set to "false"), so they'll include a
timestamp, so the older brokers will be OK.

I tested this using 0.9.0, 0.9.1.1, and 0.9.2 brokers against new historicals.