### PR TITLE
SQL: Support for coercing to DECIMAL.

### DIFF
--- a/sql/src/main/java/io/druid/sql/calcite/rel/QueryMaker.java
+++ b/sql/src/main/java/io/druid/sql/calcite/rel/QueryMaker.java
@@ -366,7 +366,7 @@ public class QueryMaker
       return ColumnMetaData.Rep.of(Integer.class);
     } else if (sqlType == SqlTypeName.BIGINT) {
       return ColumnMetaData.Rep.of(Long.class);
-    } else if (sqlType == SqlTypeName.FLOAT || sqlType == SqlTypeName.DOUBLE) {
+    } else if (sqlType == SqlTypeName.FLOAT || sqlType == SqlTypeName.DOUBLE || sqlType == SqlTypeName.DECIMAL) {
       return ColumnMetaData.Rep.of(Double.class);
     } else if (sqlType == SqlTypeName.OTHER) {
       return ColumnMetaData.Rep.of(Object.class);
@@ -435,7 +435,7 @@ public class QueryMaker
       } else {
         throw new ISE("Cannot coerce[%s] to %s", value.getClass().getName(), sqlType);
       }
-    } else if (sqlType == SqlTypeName.FLOAT || sqlType == SqlTypeName.DOUBLE) {
+    } else if (sqlType == SqlTypeName.FLOAT || sqlType == SqlTypeName.DOUBLE || sqlType == SqlTypeName.DECIMAL) {
       if (value instanceof String) {
         coercedValue = Doubles.tryParse((String) value);
       } else if (value instanceof Number) {

--- a/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
@@ -1350,7 +1350,7 @@ public class CalciteQueryTest
   public void testExpressionAggregations() throws Exception
   {
     testQuery(
-        "SELECT SUM(cnt * 3), LN(SUM(cnt) + SUM(m1)) FROM druid.foo",
+        "SELECT SUM(cnt * 3), LN(SUM(cnt) + SUM(m1)), SUM(cnt) / 0.25 FROM druid.foo",
         ImmutableList.<Query>of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -1361,14 +1361,18 @@ public class CalciteQueryTest
                       new LongSumAggregatorFactory("a1", "cnt", null),
                       new DoubleSumAggregatorFactory("a2", "m1", null)
                   ))
-                  .postAggregators(ImmutableList.<PostAggregator>of(
-                      new ExpressionPostAggregator("a3", "log((\"a1\" + \"a2\"))")
+                  .postAggregators(ImmutableList.of(
+                      new ExpressionPostAggregator("a3", "log((\"a1\" + \"a2\"))"),
+                      new ArithmeticPostAggregator("a4", "quotient", ImmutableList.of(
+                          new FieldAccessPostAggregator(null, "a1"),
+                          new ConstantPostAggregator(null, 0.25)
+                      ))
                   ))
                   .context(TIMESERIES_CONTEXT_DEFAULT)
                   .build()
         ),
         ImmutableList.of(
-            new Object[]{18L, 3.295836866004329}
+            new Object[]{18L, 3.295836866004329, 24.0}
         )
     );
   }


### PR DESCRIPTION
Useful for running queries that involve math of ints and floats, which
Calcite types as decimal. (see the test for an example)