### PR TITLE
Fix race in KafkaIndexTaskTest

### DIFF
--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -1247,7 +1247,9 @@ public class KafkaIndexTaskTest
 
     task.pause(0);
 
-    Assert.assertEquals(KafkaIndexTask.Status.PAUSED, task.getStatus());
+    while (!task.getStatus().equals(KafkaIndexTask.Status.PAUSED)) {
+      Thread.sleep(25);
+    }
   }
 
   @Test(timeout = 30_000L)


### PR DESCRIPTION
task.pause(0) can return before the task is actually paused.
Exception for failure -
```
java.lang.AssertionError: expected:<PAUSED> but was:<READING>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:743)
	at org.junit.Assert.assertEquals(Assert.java:118)
	at org.junit.Assert.assertEquals(Assert.java:144)
	at
io.druid.indexing.kafka.KafkaIndexTaskTest.testRunWithOffsetOutOfRangeEx
ceptionAndPause(KafkaIndexTaskTest.java:1229)
```
To reproduce add Thread.sleep(10000) in beginning of
KafkaIndexTask.possiblypause method.