### PR TITLE
skip rows which are added after cursor created

### DIFF
--- a/processing/src/main/java/io/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/StringDimensionIndexer.java
@@ -41,7 +41,6 @@ import io.druid.segment.data.IndexedIterable;
 import io.druid.segment.filter.BooleanValueMatcher;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexStorageAdapter;
-import it.unimi.dsi.fastutil.ints.IntArrays;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -394,7 +393,6 @@ public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], 
     final ExtractionFn extractionFn = spec.getExtractionFn();
 
     final int dimIndex = desc.getIndex();
-    final int maxId = getCardinality();
 
     class IndexerDimensionSelector implements DimensionSelector, IdLookup
     {
@@ -415,23 +413,15 @@ public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], 
         if (indices == null || indices.length == 0) {
           final int nullId = getEncodedValue(null, false);
           if (nullId > -1) {
-            if (nullId < maxId) {
-              row = new int[] {nullId};
-              rowSize = 1;
-            } else {
-              // Choose to use ArrayBasedIndexedInts later, instead of EmptyIndexedInts, for monomorphism
-              row = IntArrays.EMPTY_ARRAY;
-              rowSize = 0;
-            }
+            row = new int[] {nullId};
+            rowSize = 1;
           }
         }
 
         if (row == null && indices != null && indices.length > 0) {
           row = new int[indices.length];
           for (int id : indices) {
-            if (id < maxId) {
-              row[rowSize++] = id;
-            }
+            row[rowSize++] = id;
           }
         }
 
@@ -509,7 +499,7 @@ public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], 
       @Override
       public int getValueCardinality()
       {
-        return maxId;
+        return getCardinality();
       }
 
       @Override

--- a/processing/src/main/java/io/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/StringDimensionIndexer.java
@@ -415,7 +415,8 @@ public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], 
 
         int[] row = null;
         int rowSize = 0;
-        // typically, currEntry's rowIndex is smaller than the row's rowIndex in which this dim first appears
+
+        // usually due to currEntry's rowIndex is smaller than the row's rowIndex in which this dim first appears
         if (indices == null || indices.length == 0) {
           final int nullId = getEncodedValue(null, false);
           if (nullId > -1) {

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -316,6 +316,8 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
       Supplier<InputRow> rowSupplier
   ) throws IndexSizeExceededException;
 
+  public abstract int getLastRowIndex();
+
   protected abstract AggregatorType[] getAggsForRow(int rowOffset);
 
   protected abstract Object getAggVal(AggregatorType agg, int rowOffset, int aggPosition);

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
@@ -279,9 +279,6 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
                   BaseQuery.checkInterrupted();
 
                   Map.Entry<IncrementalIndex.TimeAndDims, Integer> entry = baseIter.next();
-                  // ignore rows whose rowIndex is beyond the maxRowIndex
-                  // rows are order by timestamp, not rowIndex,
-                  // so we need to go through all rows here to skip rows added after cursor created
                   if (beyondMaxRowIndex(entry.getValue())) {
                     continue;
                   }
@@ -312,9 +309,6 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
                   }
 
                   Map.Entry<IncrementalIndex.TimeAndDims, Integer> entry = baseIter.next();
-                  // ignore rows whose rowIndex is beyond the maxRowIndex
-                  // rows are order by timestamp, not rowIndex,
-                  // so we need to go through all rows here to skip rows added after cursor created
                   if (beyondMaxRowIndex(entry.getValue())) {
                     continue;
                   }
@@ -369,9 +363,6 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
                 boolean foundMatched = false;
                 while (baseIter.hasNext()) {
                   Map.Entry<IncrementalIndex.TimeAndDims, Integer> entry = baseIter.next();
-                  // ignore rows whose rowIndex is beyond the maxRowIndex
-                  // rows are order by timestamp, not rowIndex,
-                  // so we need to go through all rows here to skip rows added after cursor created
                   if (beyondMaxRowIndex(entry.getValue())) {
                     continue;
                   }
@@ -388,6 +379,9 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
               }
 
               private boolean beyondMaxRowIndex(Integer rowIndex) {
+                // ignore rows whose rowIndex is beyond the maxRowIndex
+                // rows are order by timestamp, not rowIndex,
+                // so we still need to go through all rows to skip rows added after cursor created
                 return rowIndex.compareTo(maxRowIndex) > 0;
               }
 

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
@@ -290,9 +290,7 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
                   }
                 }
 
-                if (!filterMatcher.matches()) {
-                  done = true;
-                }
+                done = true;
               }
 
               @Override
@@ -320,9 +318,7 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
                   }
                 }
 
-                if (!filterMatcher.matches()) {
-                  done = true;
-                }
+                done = true;
               }
 
               @Override
@@ -364,6 +360,7 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
                 while (baseIter.hasNext()) {
                   Map.Entry<IncrementalIndex.TimeAndDims, Integer> entry = baseIter.next();
                   if (beyondMaxRowIndex(entry.getValue())) {
+                    numAdvanced++;
                     continue;
                   }
                   currEntry.set(entry);
@@ -378,11 +375,11 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
                 done = !foundMatched && (emptyRange || !baseIter.hasNext());
               }
 
-              private boolean beyondMaxRowIndex(Integer rowIndex) {
+              private boolean beyondMaxRowIndex(int rowIndex) {
                 // ignore rows whose rowIndex is beyond the maxRowIndex
                 // rows are order by timestamp, not rowIndex,
                 // so we still need to go through all rows to skip rows added after cursor created
-                return rowIndex.compareTo(maxRowIndex) > 0;
+                return rowIndex > maxRowIndex;
               }
 
               @Override

--- a/processing/src/main/java/io/druid/segment/incremental/OffheapIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OffheapIncrementalIndex.java
@@ -277,6 +277,12 @@ public class OffheapIncrementalIndex extends IncrementalIndex<BufferAggregator>
   }
 
   @Override
+  public int getLastRowIndex()
+  {
+    return indexIncrement.get() - 1;
+  }
+
+  @Override
   public boolean canAppendRow()
   {
     final boolean canAdd = size() < maxRowCount;

--- a/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -215,6 +215,12 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
     return numEntries.get();
   }
 
+  @Override
+  public int getLastRowIndex()
+  {
+    return indexIncrement.get() - 1;
+  }
+
   private void factorizeAggs(
       AggregatorFactory[] metrics,
       Aggregator[] aggs,

--- a/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
+++ b/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
@@ -205,6 +205,12 @@ public class OnheapIncrementalIndexBenchmark extends AbstractBenchmark
 
       return numEntries.get();
     }
+
+    @Override
+    public int getLastRowIndex()
+    {
+      return indexIncrement.get() - 1;
+    }
   }
 
   @Parameterized.Parameters


### PR DESCRIPTION
The checking maxId behavior is weird, We can get dims array from cursor's currEntry in IndexerDimensionSelector, but choosing to ignore the dims if dims are beyond maxId which is actually too old if data arrives after the cursor is made and cursor can retrieve really new data when the new data is inside the cursor's interval.
But think about this case, a group by query may produces aggregator values with empty string dimensions, while actually these aggregator values should bound to some non-empty dimensions.

--update
the reason why maxId check is needed is explained here https://github.com/druid-io/druid/pull/4052#issuecomment-286779784
but still we can do it in a better way as described at https://github.com/druid-io/druid/pull/4052#issuecomment-288976998

The behavior test is already in IncrementalIndexStorageAdapterTest.testCursoringAndIndexUpdationInterleaving()