### PR TITLE
StringDimensionIndexer: Don't match values that exceed maxId.

### DIFF
--- a/processing/src/main/java/io/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/StringDimensionIndexer.java
@@ -442,7 +442,7 @@ public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], 
       {
         if (extractionFn == null) {
           final int valueId = lookupId(value);
-          if (valueId >= 0 || value == null) {
+          if (value == null || (valueId >= 0 && valueId < maxId)) {
             return new ValueMatcher()
             {
               @Override


### PR DESCRIPTION
For consistency, the selector is supposed to act as if ids >= maxId
don't exist.