### PR TITLE
Fix topNs with extractionFns but no aggregators.

### DIFF
--- a/processing/src/main/java/io/druid/query/topn/TimeExtractionTopNAlgorithm.java
+++ b/processing/src/main/java/io/druid/query/topn/TimeExtractionTopNAlgorithm.java
@@ -107,7 +107,7 @@ public class TimeExtractionTopNAlgorithm extends BaseTopNAlgorithm<int[], Map<St
   {
     for (Map.Entry<String, Aggregator[]> entry : aggregatesStore.entrySet()) {
       Aggregator[] aggs = entry.getValue();
-      if (aggs != null && aggs.length > 0) {
+      if (aggs != null) {
         Object[] vals = new Object[aggs.length];
         for (int i = 0; i < aggs.length; i++) {
           vals[i] = aggs[i].get();

--- a/processing/src/main/java/io/druid/query/topn/types/FloatTopNColumnSelectorStrategy.java
+++ b/processing/src/main/java/io/druid/query/topn/types/FloatTopNColumnSelectorStrategy.java
@@ -93,7 +93,7 @@ public class FloatTopNColumnSelectorStrategy
   {
     for (Int2ObjectMap.Entry<Aggregator[]> entry : aggregatesStore.int2ObjectEntrySet()) {
       Aggregator[] aggs = entry.getValue();
-      if (aggs != null && aggs.length > 0) {
+      if (aggs != null) {
         Object[] vals = new Object[aggs.length];
         for (int i = 0; i < aggs.length; i++) {
           vals[i] = aggs[i].get();

--- a/processing/src/main/java/io/druid/query/topn/types/LongTopNColumnSelectorStrategy.java
+++ b/processing/src/main/java/io/druid/query/topn/types/LongTopNColumnSelectorStrategy.java
@@ -93,7 +93,7 @@ public class LongTopNColumnSelectorStrategy
   {
     for (Long2ObjectMap.Entry<Aggregator[]> entry : aggregatesStore.long2ObjectEntrySet()) {
       Aggregator[] aggs = entry.getValue();
-      if (aggs != null && aggs.length > 0) {
+      if (aggs != null) {
         Object[] vals = new Object[aggs.length];
         for (int i = 0; i < aggs.length; i++) {
           vals[i] = aggs[i].get();

--- a/processing/src/main/java/io/druid/query/topn/types/StringTopNColumnSelectorStrategy.java
+++ b/processing/src/main/java/io/druid/query/topn/types/StringTopNColumnSelectorStrategy.java
@@ -101,7 +101,7 @@ public class StringTopNColumnSelectorStrategy
   {
     for (Map.Entry<String, Aggregator[]> entry : aggregatesStore.entrySet()) {
       Aggregator[] aggs = entry.getValue();
-      if (aggs != null && aggs.length > 0) {
+      if (aggs != null) {
         Object[] vals = new Object[aggs.length];
         for (int i = 0; i < aggs.length; i++) {
           vals[i] = aggs[i].get();

--- a/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerTest.java
@@ -1995,6 +1995,44 @@ public class TopNQueryRunnerTest
     assertExpectedResults(expectedResults, query);
   }
 
+  @Test
+  public void testTopNDimExtractionNoAggregators()
+  {
+    TopNQuery query = new TopNQueryBuilder()
+        .dataSource(QueryRunnerTestHelper.dataSource)
+        .granularity(QueryRunnerTestHelper.allGran)
+        .dimension(
+            new ExtractionDimensionSpec(
+                QueryRunnerTestHelper.marketDimension,
+                QueryRunnerTestHelper.marketDimension,
+                new RegexDimExtractionFn("(.)", false, null)
+            )
+        )
+        .metric(new LexicographicTopNMetricSpec(QueryRunnerTestHelper.marketDimension))
+        .threshold(4)
+        .intervals(QueryRunnerTestHelper.firstToThird)
+        .build();
+
+    List<Result<TopNResultValue>> expectedResults = Arrays.asList(
+        new Result<>(
+            new DateTime("2011-04-01T00:00:00.000Z"),
+            new TopNResultValue(
+                Arrays.<Map<String, Object>>asList(
+                    ImmutableMap.<String, Object>of(
+                        QueryRunnerTestHelper.marketDimension, "s"
+                    ),
+                    ImmutableMap.<String, Object>of(
+                        QueryRunnerTestHelper.marketDimension, "t"
+                    ),
+                    ImmutableMap.<String, Object>of(
+                        QueryRunnerTestHelper.marketDimension, "u"
+                    )
+                )
+            )
+        )
+    );
+    assertExpectedResults(expectedResults, query);
+  }
 
   @Test
   public void testTopNDimExtractionFastTopNOptimalWithReplaceMissing()


### PR DESCRIPTION
The result sets were empty because of an aggs.length > 0 check. I'm not
sure if it was there for any good reason, but there didn't seem to be one.