### PR TITLE
 relocate method in BufferAggregator.

### DIFF
--- a/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchBufferAggregator.java
+++ b/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchBufferAggregator.java
@@ -40,7 +40,7 @@ public class SketchBufferAggregator implements BufferAggregator
   private final int size;
   private final int maxIntermediateSize;
   private final Map<Integer, Union> unions = new HashMap<>(); //position in BB -> Union Object
-  private IdentityHashMap<ByteBuffer, NativeMemory> nmCache = new IdentityHashMap<>();
+  private final IdentityHashMap<ByteBuffer, NativeMemory> nmCache = new IdentityHashMap<>();
 
   public SketchBufferAggregator(ObjectColumnSelector selector, int size, int maxIntermediateSize)
   {
@@ -126,12 +126,8 @@ public class SketchBufferAggregator implements BufferAggregator
     Union newUnion = (Union) SetOperation.wrap(mem);
 
     Union union = unions.get(oldPosition);
-    if (union != null) {
-      unions.remove(oldPosition);
-      unions.put(newPosition, newUnion);
-    } else {
-      unions.put(newPosition, newUnion);
-    }
+    unions.remove(oldPosition);
+    unions.put(newPosition, newUnion);
 
   }
 

--- a/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchBufferAggregator.java
+++ b/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchBufferAggregator.java
@@ -99,9 +99,9 @@ public class SketchBufferAggregator implements BufferAggregator
     Int2ObjectMap<Union> unionMap = unions.get(buf);
     if (unionMap == null) {
       unionMap = new Int2ObjectOpenHashMap<>();
+      unions.put(buf, unionMap);
     }
     unionMap.put(position, union);
-    unions.put(buf, unionMap);
     return union;
   }
 

--- a/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchBufferAggregator.java
+++ b/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchBufferAggregator.java
@@ -28,18 +28,18 @@ import com.yahoo.sketches.theta.Union;
 import io.druid.query.aggregation.BufferAggregator;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.ObjectColumnSelector;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
 import java.nio.ByteBuffer;
-import java.util.HashMap;
 import java.util.IdentityHashMap;
-import java.util.Map;
 
 public class SketchBufferAggregator implements BufferAggregator
 {
   private final ObjectColumnSelector selector;
   private final int size;
   private final int maxIntermediateSize;
-  private final Map<Integer, Union> unions = new HashMap<>(); //position in BB -> Union Object
+  private final Int2ObjectMap<Union> unions = new Int2ObjectOpenHashMap<>();
   private final IdentityHashMap<ByteBuffer, NativeMemory> nmCache = new IdentityHashMap<>();
 
   public SketchBufferAggregator(ObjectColumnSelector selector, int size, int maxIntermediateSize)
@@ -125,7 +125,6 @@ public class SketchBufferAggregator implements BufferAggregator
     Memory mem = new MemoryRegion(nm, newPosition, maxIntermediateSize);
     Union newUnion = (Union) SetOperation.wrap(mem);
 
-    Union union = unions.get(oldPosition);
     unions.remove(oldPosition);
     unions.put(newPosition, newUnion);
 

--- a/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchHolder.java
+++ b/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchHolder.java
@@ -290,4 +290,16 @@ public class SketchHolder
         throw new IllegalArgumentException("Unknown sketch operation " + func);
     }
   }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return this.getSketch().equals(((SketchHolder) o).getSketch());
+  }
 }

--- a/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/theta/BufferGrouperTestForSketchAggregation.java
+++ b/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/theta/BufferGrouperTestForSketchAggregation.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.aggregation.datasketches.theta;
+
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.yahoo.sketches.theta.Sketches;
+import com.yahoo.sketches.theta.UpdateSketch;
+import io.druid.data.input.MapBasedRow;
+import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.query.aggregation.CountAggregatorFactory;
+import io.druid.query.groupby.epinephelinae.BufferGrouper;
+import io.druid.query.groupby.epinephelinae.Grouper;
+import io.druid.query.groupby.epinephelinae.GrouperTestUtil;
+import io.druid.query.groupby.epinephelinae.TestColumnSelectorFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+public class BufferGrouperTestForSketchAggregation
+{
+  private static BufferGrouper<Integer> makeGrouper(
+      TestColumnSelectorFactory columnSelectorFactory,
+      int bufferSize,
+      int initialBuckets
+  )
+  {
+    final BufferGrouper<Integer> grouper = new BufferGrouper<>(
+        Suppliers.ofInstance(ByteBuffer.allocate(bufferSize)),
+        GrouperTestUtil.intKeySerde(),
+        columnSelectorFactory,
+        new AggregatorFactory[]{
+            new SketchMergeAggregatorFactory("sketch", "sketch", 16, false, true, 2),
+            new CountAggregatorFactory("count")
+        },
+        Integer.MAX_VALUE,
+        0.75f,
+        initialBuckets
+    );
+    grouper.init();
+    return grouper;
+  }
+
+  @Test
+  public void testGrowingBufferGrouper()
+  {
+    final TestColumnSelectorFactory columnSelectorFactory = GrouperTestUtil.newColumnSelectorFactory();
+    final Grouper<Integer> grouper = makeGrouper(columnSelectorFactory, 100000, 2);
+    final int expectedMaxSize = 5;
+
+    SketchHolder sketchHolder = SketchHolder.of(Sketches.updateSketchBuilder().build(16));
+    UpdateSketch updateSketch = (UpdateSketch) sketchHolder.getSketch();
+    updateSketch.update(1);
+
+    columnSelectorFactory.setRow(new MapBasedRow(0, ImmutableMap.<String, Object>of("sketch", sketchHolder)));
+
+    for (int i = 0; i < expectedMaxSize; i++) {
+      Assert.assertTrue(String.valueOf(i), grouper.aggregate(i));
+    }
+
+    updateSketch.update(3);
+    columnSelectorFactory.setRow(new MapBasedRow(0, ImmutableMap.<String, Object>of("sketch", sketchHolder)));
+
+    for (int i = 0; i < expectedMaxSize; i++) {
+      Assert.assertTrue(String.valueOf(i), grouper.aggregate(i));
+    }
+
+    Object[] holders = Lists.newArrayList(grouper.iterator(true)).get(0).getValues();
+
+    Assert.assertEquals(2.0d, ((SketchHolder) holders[0]).getEstimate(), 0);
+  }
+}

--- a/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/theta/BufferGrouperUsingSketchMergeAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/theta/BufferGrouperUsingSketchMergeAggregatorFactoryTest.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 
 import java.nio.ByteBuffer;
 
-public class BufferGrouperTestForSketchAggregation
+public class BufferGrouperUsingSketchMergeAggregatorFactoryTest
 {
   private static BufferGrouper<Integer> makeGrouper(
       TestColumnSelectorFactory columnSelectorFactory,

--- a/processing/src/main/java/io/druid/query/aggregation/BufferAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/BufferAggregator.java
@@ -24,6 +24,7 @@ import io.druid.query.monomorphicprocessing.HotLoopCallee;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 
 import java.nio.ByteBuffer;
+import java.util.Map;
 
 /**
  * A BufferAggregator is an object that can aggregate metrics into a ByteBuffer.  Its aggregation-related methods
@@ -136,13 +137,17 @@ public interface BufferAggregator extends HotLoopCallee
    *
    * Only used if there is any positional caches/objects in the BufferAggregator implementation.
    *
+   * If relocate happens to be across multiple new ByteBuffers (say n ByteBuffers), this method should be called
+   * multiple times(n times) given all the new positions/old positions should exist in newBuffer/OldBuffer.
+   *
    * <b>Implementations must not change the position, limit or mark of the given buffer</b>
    *
-   * @param oldPosition old position of a cached object before aggregation buffer relocates to a new ByteBuffer.
-   * @param newPosition  new position of a cached object after aggregation buffer relocates to a new ByteBuffer.
+   * @param oldToNewPositionMap old position of a cached object to new Position of a cached object before and after
+   * aggregation buffer relocates to a new ByteBuffer.
+   * @param newBuffer    new aggregation buffer.
    * @param newBuffer    new aggregation buffer.
    */
-  default void relocate(int oldPosition, int newPosition, ByteBuffer newBuffer)
+  default void relocate(Map<Integer, Integer> oldToNewPositionMap, ByteBuffer newBuffer, ByteBuffer oldBuffer)
   {
   }
 

--- a/processing/src/main/java/io/druid/query/aggregation/BufferAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/BufferAggregator.java
@@ -126,4 +126,17 @@ public interface BufferAggregator extends HotLoopCallee
   default void inspectRuntimeShape(RuntimeShapeInspector inspector)
   {
   }
+
+  /*
+   * Relocates any cached objects.
+   * <b>Implementations must not change the position, limit or mark of the given buffer</b>
+   *
+   * @param oldPostition old position of an item in old ByteBuffer.
+   * @param newPosition  new position of an item in new ByteBuffer.
+   * @param newBuffer    ByteBuffer to be used.
+   */
+  default void relocate(int oldPostition, int newPosition, ByteBuffer newBuffer)
+  {
+  }
+
 }

--- a/processing/src/main/java/io/druid/query/aggregation/BufferAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/BufferAggregator.java
@@ -129,11 +129,18 @@ public interface BufferAggregator extends HotLoopCallee
 
   /*
    * Relocates any cached objects.
+   * If underlying ByteBuffer used for aggregation buffer relocates to a new ByteBuffer, positional caches(if any)
+   * built on top of old ByteBuffer can not be used for further {@link BufferAggregator#aggregate(ByteBuffer, int)}
+   * calls. This method tells the BufferAggregator that the cached objects at a certain location has been relocated to
+   * a different location.
+   *
+   * Only used if there is any positional caches/objects in the BufferAggregator implementation.
+   *
    * <b>Implementations must not change the position, limit or mark of the given buffer</b>
    *
-   * @param oldPostition old position of an item in old ByteBuffer.
-   * @param newPosition  new position of an item in new ByteBuffer.
-   * @param newBuffer    ByteBuffer to be used.
+   * @param oldPostition old position of a cached object before aggregation buffer relocates to a new ByteBuffer.
+   * @param newPosition  new position of a cached object after aggregation buffer relocates to a new ByteBuffer.
+   * @param newBuffer    new aggregation buffer.
    */
   default void relocate(int oldPostition, int newPosition, ByteBuffer newBuffer)
   {

--- a/processing/src/main/java/io/druid/query/aggregation/BufferAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/BufferAggregator.java
@@ -138,11 +138,11 @@ public interface BufferAggregator extends HotLoopCallee
    *
    * <b>Implementations must not change the position, limit or mark of the given buffer</b>
    *
-   * @param oldPostition old position of a cached object before aggregation buffer relocates to a new ByteBuffer.
+   * @param oldPosition old position of a cached object before aggregation buffer relocates to a new ByteBuffer.
    * @param newPosition  new position of a cached object after aggregation buffer relocates to a new ByteBuffer.
    * @param newBuffer    new aggregation buffer.
    */
-  default void relocate(int oldPostition, int newPosition, ByteBuffer newBuffer)
+  default void relocate(int oldPosition, int newPosition, ByteBuffer newBuffer)
   {
   }
 

--- a/processing/src/main/java/io/druid/query/aggregation/BufferAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/BufferAggregator.java
@@ -142,12 +142,12 @@ public interface BufferAggregator extends HotLoopCallee
    *
    * <b>Implementations must not change the position, limit or mark of the given buffer</b>
    *
-   * @param oldToNewPositionMap old position of a cached object to new Position of a cached object before and after
-   * aggregation buffer relocates to a new ByteBuffer.
+   * @param oldPosition old position of a cached object before aggregation buffer relocates to a new ByteBuffer.
+   * @param newPosition  new position of a cached object after aggregation buffer relocates to a new ByteBuffer.
    * @param newBuffer    new aggregation buffer.
    * @param newBuffer    new aggregation buffer.
    */
-  default void relocate(Map<Integer, Integer> oldToNewPositionMap, ByteBuffer newBuffer, ByteBuffer oldBuffer)
+  default void relocate(int oldPosition, int newPosition, ByteBuffer newBuffer, ByteBuffer oldBuffer)
   {
   }
 

--- a/processing/src/main/java/io/druid/query/aggregation/BufferAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/BufferAggregator.java
@@ -24,7 +24,6 @@ import io.druid.query.monomorphicprocessing.HotLoopCallee;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 
 import java.nio.ByteBuffer;
-import java.util.Map;
 
 /**
  * A BufferAggregator is an object that can aggregate metrics into a ByteBuffer.  Its aggregation-related methods
@@ -143,11 +142,11 @@ public interface BufferAggregator extends HotLoopCallee
    * <b>Implementations must not change the position, limit or mark of the given buffer</b>
    *
    * @param oldPosition old position of a cached object before aggregation buffer relocates to a new ByteBuffer.
-   * @param newPosition  new position of a cached object after aggregation buffer relocates to a new ByteBuffer.
-   * @param newBuffer    new aggregation buffer.
-   * @param newBuffer    new aggregation buffer.
+   * @param newPosition new position of a cached object after aggregation buffer relocates to a new ByteBuffer.
+   * @param oldBuffer old aggregation buffer.
+   * @param newBuffer new aggregation buffer.
    */
-  default void relocate(int oldPosition, int newPosition, ByteBuffer newBuffer, ByteBuffer oldBuffer)
+  default void relocate(int oldPosition, int newPosition, ByteBuffer oldBuffer, ByteBuffer newBuffer)
   {
   }
 

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/BufferGrouper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/BufferGrouper.java
@@ -430,8 +430,9 @@ public class BufferGrouper<KeyType> implements Grouper<KeyType>
 
     for (int oldBucket = 0; oldBucket < buckets; oldBucket++) {
       if (isUsed(oldBucket)) {
+        int oldPosition = oldBucket * bucketSize;
         entryBuffer.limit((oldBucket + 1) * bucketSize);
-        entryBuffer.position(oldBucket * bucketSize);
+        entryBuffer.position(oldPosition);
         keyBuffer.limit(entryBuffer.position() + HASH_SIZE + keySize);
         keyBuffer.position(entryBuffer.position() + HASH_SIZE);
 
@@ -442,8 +443,13 @@ public class BufferGrouper<KeyType> implements Grouper<KeyType>
           throw new ISE("WTF?! Couldn't find a bucket while resizing?!");
         }
 
-        newTableBuffer.position(newBucket * bucketSize);
+        int newPostition = newBucket * bucketSize;
+        newTableBuffer.position(newPostition);
         newTableBuffer.put(entryBuffer);
+
+        for (int i = 0; i < aggregators.length; i++) {
+          aggregators[i].relocate(oldPosition + aggregatorOffsets[i], newPostition + aggregatorOffsets[i], newTableBuffer);
+        }
 
         buffer.putInt(tableArenaSize + newSize * Ints.BYTES, newBucket * bucketSize);
         newSize++;

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/BufferGrouper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/BufferGrouper.java
@@ -30,10 +30,13 @@ import io.druid.segment.ColumnSelectorFactory;
 
 import java.nio.ByteBuffer;
 import java.util.AbstractList;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Grouper based around a hash table and companion array in a single ByteBuffer. Not thread-safe.
@@ -428,6 +431,12 @@ public class BufferGrouper<KeyType> implements Grouper<KeyType>
     final ByteBuffer entryBuffer = tableBuffer.duplicate();
     final ByteBuffer keyBuffer = tableBuffer.duplicate();
 
+    List<Map<Integer, Integer>> reloationMaps = new ArrayList<>(aggregators.length);
+    for (int i = 0; i < aggregators.length ; i++)
+    {
+      reloationMaps.add(new HashMap<Integer, Integer>(buckets));
+    }
+
     for (int oldBucket = 0; oldBucket < buckets; oldBucket++) {
       if (isUsed(oldBucket)) {
         int oldPosition = oldBucket * bucketSize;
@@ -448,16 +457,20 @@ public class BufferGrouper<KeyType> implements Grouper<KeyType>
         newTableBuffer.put(entryBuffer);
 
         for (int i = 0; i < aggregators.length; i++) {
-          aggregators[i].relocate(
+          reloationMaps.get(i).put(
               oldPosition + aggregatorOffsets[i],
-              newPosition + aggregatorOffsets[i],
-              newTableBuffer
+              newPosition + aggregatorOffsets[i]
           );
         }
 
         buffer.putInt(tableArenaSize + newSize * Ints.BYTES, newBucket * bucketSize);
         newSize++;
       }
+    }
+
+    for (int i = 0; i < aggregators.length ; i++)
+    {
+      aggregators[i].relocate(reloationMaps.get(i), newTableBuffer, tableBuffer);
     }
 
     buckets = newBuckets;

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/BufferGrouper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/BufferGrouper.java
@@ -451,8 +451,8 @@ public class BufferGrouper<KeyType> implements Grouper<KeyType>
           aggregators[i].relocate(
               oldPosition + aggregatorOffsets[i],
               newPosition + aggregatorOffsets[i],
-              newTableBuffer,
-              tableBuffer
+              tableBuffer,
+              newTableBuffer
           );
         }
 

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/BufferGrouper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/BufferGrouper.java
@@ -443,12 +443,16 @@ public class BufferGrouper<KeyType> implements Grouper<KeyType>
           throw new ISE("WTF?! Couldn't find a bucket while resizing?!");
         }
 
-        int newPostition = newBucket * bucketSize;
-        newTableBuffer.position(newPostition);
+        int newPosition = newBucket * bucketSize;
+        newTableBuffer.position(newPosition);
         newTableBuffer.put(entryBuffer);
 
         for (int i = 0; i < aggregators.length; i++) {
-          aggregators[i].relocate(oldPosition + aggregatorOffsets[i], newPostition + aggregatorOffsets[i], newTableBuffer);
+          aggregators[i].relocate(
+              oldPosition + aggregatorOffsets[i],
+              newPosition + aggregatorOffsets[i],
+              newTableBuffer
+          );
         }
 
         buffer.putInt(tableArenaSize + newSize * Ints.BYTES, newBucket * bucketSize);

--- a/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
@@ -615,9 +615,7 @@ public class AggregationTestHelper
     newBuf.position(7574);
     newBuf.put(theBytes);
     newBuf.position(0);
-    Map<Integer, Integer> oldToNewPositions = new HashMap<>();
-    oldToNewPositions.put(0, 7574);
-    agg.relocate(oldToNewPositions, newBuf, myBuf);
+    agg.relocate(0, 7574, newBuf, myBuf);
     results[1] = (T) agg.get(newBuf, 7574);
     return results;
   }

--- a/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
@@ -614,7 +614,7 @@ public class AggregationTestHelper
     newBuf.position(7574);
     newBuf.put(theBytes);
     newBuf.position(0);
-    agg.relocate(0, 7574, newBuf, myBuf);
+    agg.relocate(0, 7574, myBuf, newBuf);
     results[1] = (T) agg.get(newBuf, 7574);
     return results;
   }

--- a/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
@@ -79,7 +79,6 @@ import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
-import org.junit.Assert;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;

--- a/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
@@ -88,6 +88,7 @@ import java.io.InputStream;
 import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -614,8 +615,9 @@ public class AggregationTestHelper
     newBuf.position(7574);
     newBuf.put(theBytes);
     newBuf.position(0);
-
-    agg.relocate(0, 7574, newBuf);
+    Map<Integer, Integer> oldToNewPositions = new HashMap<>();
+    oldToNewPositions.put(0, 7574);
+    agg.relocate(oldToNewPositions, newBuf, myBuf);
     results[1] = (T) agg.get(newBuf, 7574);
     return results;
   }

--- a/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
@@ -67,6 +67,7 @@ import io.druid.query.timeseries.TimeseriesQueryRunnerFactory;
 import io.druid.query.topn.TopNQueryConfig;
 import io.druid.query.topn.TopNQueryQueryToolChest;
 import io.druid.query.topn.TopNQueryRunnerFactory;
+import io.druid.segment.ColumnSelectorFactory;
 import io.druid.segment.IndexIO;
 import io.druid.segment.IndexMerger;
 import io.druid.segment.IndexSpec;
@@ -78,12 +79,14 @@ import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
+import org.junit.Assert;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -590,6 +593,32 @@ public class AggregationTestHelper
   public ObjectMapper getObjectMapper()
   {
     return mapper;
+  }
+
+  public <T> T[] runRelocateVerificationTest(
+      AggregatorFactory factory,
+      ColumnSelectorFactory selector,
+      Class<T> clazz
+  )
+  {
+    T[] results = (T[]) Array.newInstance(clazz, 2);
+    BufferAggregator agg = factory.factorizeBuffered(selector);
+    ByteBuffer myBuf = ByteBuffer.allocate(10040902);
+    agg.init(myBuf, 0);
+    agg.aggregate(myBuf, 0);
+    results[0] = (T) agg.get(myBuf, 0);
+
+    byte[] theBytes = new byte[factory.getMaxIntermediateSize()];
+    myBuf.get(theBytes);
+
+    ByteBuffer newBuf = ByteBuffer.allocate(941209);
+    newBuf.position(7574);
+    newBuf.put(theBytes);
+    newBuf.position(0);
+
+    agg.relocate(0, 7574, newBuf);
+    results[1] = (T) agg.get(newBuf, 7574);
+    return results;
   }
 }
 

--- a/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
@@ -88,7 +88,6 @@ import java.io.InputStream;
 import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
Fixes https://github.com/druid-io/druid/issues/4026.
This pr introduces a new method `relocate` in BufferAggregator to allow relocation of any cached object.

@gianm @cheddar @himanshug 