### PR TITLE
Allow float parameters for Bound/Selector/In filters on long columns

### DIFF
--- a/processing/src/main/java/io/druid/query/filter/BoundDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/BoundDimFilter.java
@@ -352,9 +352,15 @@ public class BoundDimFilter implements DimFilter
           if (hasLowerBound()) {
             final Long lowerLong = GuavaUtils.tryParseLong(lower);
             if (lowerLong == null) {
-              // Unparseable values fall before all actual numbers, so all numbers will match the lower bound.
-              hasLowerLongBound = false;
-              lowerLongBound = 0L;
+              final Float lowerFloat = Floats.tryParse(lower);
+              if (lowerFloat != null) {
+                hasLowerLongBound = true;
+                lowerLongBound = getLongLowerBoundFromFloat(lowerFloat);
+              } else {
+                // Unparseable values fall before all actual numbers, so all numbers will match the lower bound.
+                hasLowerLongBound = false;
+                lowerLongBound = 0L;
+              }
             } else {
               hasLowerLongBound = true;
               lowerLongBound = lowerLong;
@@ -367,10 +373,16 @@ public class BoundDimFilter implements DimFilter
           if (hasUpperBound()) {
             Long upperLong = GuavaUtils.tryParseLong(upper);
             if (upperLong == null) {
-              // Unparseable values fall before all actual numbers, so no numbers can match the upper bound.
-              matchesNothing = true;
-              hasUpperLongBound = false;
-              upperLongBound = 0L;
+              Float upperFloat = Floats.tryParse(upper);
+              if (upperFloat != null) {
+                hasUpperLongBound = true;
+                upperLongBound = getLongUpperBoundFromFloat(upperFloat);
+              } else {
+                // Unparseable values fall before all actual numbers, so no numbers can match the upper bound.
+                matchesNothing = true;
+                hasUpperLongBound = false;
+                upperLongBound = 0L;
+              }
             } else {
               hasUpperLongBound = true;
               upperLongBound = upperLong;
@@ -396,6 +408,24 @@ public class BoundDimFilter implements DimFilter
       }
     }
     return new BoundLongPredicateSupplier();
+  }
+
+  private long getLongLowerBoundFromFloat(float floatBound)
+  {
+    if (lowerStrict) {
+      return (long) Math.floor(floatBound);
+    } else {
+      return (long) Math.ceil(floatBound);
+    }
+  }
+
+  private long getLongUpperBoundFromFloat(float floatBound)
+  {
+    if (upperStrict) {
+      return (long) Math.ceil(floatBound);
+    } else {
+      return (long) Math.floor(floatBound);
+    }
   }
 
   private Supplier<DruidFloatPredicate> makeFloatPredicateSupplier()

--- a/processing/src/main/java/io/druid/query/filter/BoundDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/BoundDimFilter.java
@@ -35,6 +35,7 @@ import io.druid.query.ordering.StringComparator;
 import io.druid.query.ordering.StringComparators;
 import io.druid.segment.filter.BoundFilter;
 
+import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.ByteBuffer;
@@ -430,6 +431,7 @@ public class BoundDimFilter implements DimFilter
     return new BoundLongPredicateSupplier();
   }
 
+  @Nullable
   private BigDecimal getBigDecimalLowerBoundFromFloatString(String floatStr)
   {
     BigDecimal convertedBD;
@@ -440,14 +442,13 @@ public class BoundDimFilter implements DimFilter
     }
 
     if (lowerStrict) {
-      convertedBD = convertedBD.setScale(0, RoundingMode.FLOOR);
+      return convertedBD.setScale(0, RoundingMode.FLOOR);
     } else {
-      convertedBD = convertedBD.setScale(0, RoundingMode.CEILING);
+      return convertedBD.setScale(0, RoundingMode.CEILING);
     }
-
-    return convertedBD;
   }
 
+  @Nullable
   private BigDecimal getBigDecimalUpperBoundFromFloatString(String floatStr)
   {
     BigDecimal convertedBD;
@@ -458,12 +459,10 @@ public class BoundDimFilter implements DimFilter
     }
 
     if (upperStrict) {
-      convertedBD = convertedBD.setScale(0, RoundingMode.CEILING);
+      return convertedBD.setScale(0, RoundingMode.CEILING);
     } else {
-      convertedBD = convertedBD.setScale(0, RoundingMode.FLOOR);
+      return convertedBD.setScale(0, RoundingMode.FLOOR);
     }
-
-    return convertedBD;
   }
 
   private Supplier<DruidFloatPredicate> makeFloatPredicateSupplier()

--- a/processing/src/main/java/io/druid/query/filter/InDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/InDimFilter.java
@@ -32,7 +32,6 @@ import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.TreeRangeSet;
 import com.google.common.primitives.Floats;
-import io.druid.common.guava.GuavaUtils;
 import io.druid.java.util.common.StringUtils;
 import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.lookup.LookupExtractionFn;
@@ -281,10 +280,7 @@ public class InDimFilter implements DimFilter
 
           LongArrayList longs = new LongArrayList(values.size());
           for (String value : values) {
-            Long longValue = GuavaUtils.tryParseLong(value);
-            if (longValue == null) {
-              longValue = DimensionHandlerUtils.getIntegralFromFloatString(value);
-            }
+            final Long longValue = DimensionHandlerUtils.getExactLongFromDecimalString(value);
             if (longValue != null) {
               longs.add(longValue);
             }

--- a/processing/src/main/java/io/druid/query/filter/InDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/InDimFilter.java
@@ -37,6 +37,7 @@ import io.druid.java.util.common.StringUtils;
 import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.lookup.LookupExtractionFn;
 import io.druid.query.lookup.LookupExtractor;
+import io.druid.segment.DimensionHandlerUtils;
 import io.druid.segment.filter.InFilter;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
@@ -281,6 +282,9 @@ public class InDimFilter implements DimFilter
           LongArrayList longs = new LongArrayList(values.size());
           for (String value : values) {
             Long longValue = GuavaUtils.tryParseLong(value);
+            if (longValue == null) {
+              longValue = DimensionHandlerUtils.getIntegralFromFloatString(value);
+            }
             if (longValue != null) {
               longs.add(longValue);
             }

--- a/processing/src/main/java/io/druid/query/filter/LongValueMatcherColumnSelectorStrategy.java
+++ b/processing/src/main/java/io/druid/query/filter/LongValueMatcherColumnSelectorStrategy.java
@@ -28,7 +28,10 @@ public class LongValueMatcherColumnSelectorStrategy implements ValueMatcherColum
   @Override
   public ValueMatcher makeValueMatcher(final LongColumnSelector selector, final String value)
   {
-    final Long matchVal = DimensionHandlerUtils.convertObjectToLong(value);
+    Long matchVal = DimensionHandlerUtils.convertObjectToLong(value);
+    if (matchVal == null) {
+      matchVal = DimensionHandlerUtils.getIntegralFromFloatString(value);
+    }
     if (matchVal == null) {
       return BooleanValueMatcher.of(false);
     }

--- a/processing/src/main/java/io/druid/query/filter/LongValueMatcherColumnSelectorStrategy.java
+++ b/processing/src/main/java/io/druid/query/filter/LongValueMatcherColumnSelectorStrategy.java
@@ -30,9 +30,6 @@ public class LongValueMatcherColumnSelectorStrategy implements ValueMatcherColum
   {
     Long matchVal = DimensionHandlerUtils.convertObjectToLong(value);
     if (matchVal == null) {
-      matchVal = DimensionHandlerUtils.getIntegralFromFloatString(value);
-    }
-    if (matchVal == null) {
       return BooleanValueMatcher.of(false);
     }
     final long matchValLong = matchVal;

--- a/processing/src/main/java/io/druid/query/filter/LongValueMatcherColumnSelectorStrategy.java
+++ b/processing/src/main/java/io/druid/query/filter/LongValueMatcherColumnSelectorStrategy.java
@@ -28,7 +28,7 @@ public class LongValueMatcherColumnSelectorStrategy implements ValueMatcherColum
   @Override
   public ValueMatcher makeValueMatcher(final LongColumnSelector selector, final String value)
   {
-    Long matchVal = DimensionHandlerUtils.convertObjectToLong(value);
+    final Long matchVal = DimensionHandlerUtils.convertObjectToLong(value);
     if (matchVal == null) {
       return BooleanValueMatcher.of(false);
     }

--- a/processing/src/main/java/io/druid/segment/DimensionHandlerUtils.java
+++ b/processing/src/main/java/io/druid/segment/DimensionHandlerUtils.java
@@ -263,4 +263,20 @@ public final class DimensionHandlerUtils
       throw new ParseException("Unknown type[%s]", valObj.getClass());
     }
   }
+
+  public static Long getIntegralFromFloatString(String floatStr)
+  {
+    Float f = Floats.tryParse(floatStr);
+    if (f == null) {
+      return null;
+    }
+
+    float asFloat = f;
+    long asLong = (long) asFloat;
+    if (asFloat == asLong) {
+      return asLong;
+    } else {
+      return null;
+    }
+  }
 }

--- a/processing/src/main/java/io/druid/segment/DimensionHandlerUtils.java
+++ b/processing/src/main/java/io/druid/segment/DimensionHandlerUtils.java
@@ -233,11 +233,7 @@ public final class DimensionHandlerUtils
     } else if (valObj instanceof Number) {
       return ((Number) valObj).longValue();
     } else if (valObj instanceof String) {
-      Long val = GuavaUtils.tryParseLong((String) valObj);
-      if (val == null) {
-        val = DimensionHandlerUtils.getIntegralFromFloatString((String) valObj);
-      }
-      return val;
+      return DimensionHandlerUtils.getExactLongFromDecimalString((String) valObj);
     } else {
       throw new ParseException("Unknown type[%s]", valObj.getClass());
     }
@@ -261,28 +257,36 @@ public final class DimensionHandlerUtils
   }
 
   /**
-   * Convert a string representing a floating point value to a long.
+   * Convert a string representing a decimal value to a long.
    *
-   * If the floating point value is not an exact integral value (e.g. 42.0), or if the floating point value
+   * If the decimal value is not an exact integral value (e.g. 42.0), or if the decimal value
    * is too large to be contained within a long, this function returns null.
    *
-   * @param floatStr string representing a floating point value
-   * @return long integral equivalent of floatStr, returns  null for non-integral floats and floats outside
-   *         of the values representable by longs
+   * @param decimalStr string representing a decimal value
+   *
+   * @return long equivalent of decimalStr, returns null for non-integral decimals and integral decimal values outside
+   * of the values representable by longs
    */
   @Nullable
-  public static Long getIntegralFromFloatString(String floatStr)
+  public static Long getExactLongFromDecimalString(String decimalStr)
   {
+    final Long val = GuavaUtils.tryParseLong(decimalStr);
+    if (val != null) {
+      return val;
+    }
+
     BigDecimal convertedBD;
     try {
-      convertedBD = new BigDecimal(floatStr);
-    } catch (NumberFormatException nfe) {
+      convertedBD = new BigDecimal(decimalStr);
+    }
+    catch (NumberFormatException nfe) {
       return null;
     }
 
     try {
       return convertedBD.longValueExact();
-    } catch (ArithmeticException ae) {
+    }
+    catch (ArithmeticException ae) {
       // indicates there was a non-integral part, or the BigDecimal was too big for a long
       return null;
     }

--- a/processing/src/main/java/io/druid/segment/DimensionHandlerUtils.java
+++ b/processing/src/main/java/io/druid/segment/DimensionHandlerUtils.java
@@ -33,6 +33,7 @@ import io.druid.segment.column.ColumnCapabilities;
 import io.druid.segment.column.ColumnCapabilitiesImpl;
 import io.druid.segment.column.ValueType;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -266,17 +267,21 @@ public final class DimensionHandlerUtils
 
   public static Long getIntegralFromFloatString(String floatStr)
   {
-    Float f = Floats.tryParse(floatStr);
-    if (f == null) {
+    BigDecimal convertedBD;
+    try {
+      convertedBD = new BigDecimal(floatStr);
+    } catch (NumberFormatException nfe) {
       return null;
     }
 
-    float asFloat = f;
-    long asLong = (long) asFloat;
-    if (asFloat == asLong) {
-      return asLong;
-    } else {
+    long asLong;
+    try {
+      asLong = convertedBD.longValueExact();
+    } catch (ArithmeticException ae) {
+      // indicates there was a non-integral part, or the BigDecimal was too big for a long
       return null;
     }
+
+    return asLong;
   }
 }

--- a/processing/src/test/java/io/druid/segment/filter/LongFilteringTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/LongFilteringTest.java
@@ -94,7 +94,9 @@ public class LongFilteringTest extends BaseFilterTest
       PARSER.parse(ImmutableMap.<String, Object>of("ts", 5L, "dim0", "5", "lng", 5L, "dim1", "def", "dim2", ImmutableList.of("c"))),
       PARSER.parse(ImmutableMap.<String, Object>of("ts", 6L, "dim0", "6", "lng", 6L, "dim1", "abc")),
       PARSER.parse(ImmutableMap.<String, Object>of("ts", 7L, "dim0", "7", "lng", 100000000L, "dim1", "xyz")),
-      PARSER.parse(ImmutableMap.<String, Object>of("ts", 8L, "dim0", "8", "lng", 100000001L, "dim1", "xyz"))
+      PARSER.parse(ImmutableMap.<String, Object>of("ts", 8L, "dim0", "8", "lng", 100000001L, "dim1", "xyz")),
+      PARSER.parse(ImmutableMap.<String, Object>of("ts", 9L, "dim0", "9", "lng", -25L, "dim1", "ghi")),
+      PARSER.parse(ImmutableMap.<String, Object>of("ts", 10L, "dim0", "10", "lng", -100000001L, "dim1", "qqq"))
   );
 
   public LongFilteringTest(
@@ -157,6 +159,11 @@ public class LongFilteringTest extends BaseFilterTest
     );
 
     assertFilterMatches(
+        new SelectorDimFilter(LONG_COLUMN, "-100000001.0", null),
+        ImmutableList.<String>of("10")
+    );
+
+    assertFilterMatches(
         new SelectorDimFilter(LONG_COLUMN, "111119223372036854775807.674398674398", null),
         ImmutableList.<String>of()
     );
@@ -198,7 +205,7 @@ public class LongFilteringTest extends BaseFilterTest
 
     assertFilterMatches(
         new BoundDimFilter(LONG_COLUMN, "-111119223372036854775807.67", "5.9", false, false, null, null, StringComparators.NUMERIC),
-        ImmutableList.<String>of("1", "2", "3", "4", "5")
+        ImmutableList.<String>of("1", "2", "3", "4", "5", "9", "10")
     );
 
     assertFilterMatches(
@@ -236,6 +243,11 @@ public class LongFilteringTest extends BaseFilterTest
         ImmutableList.<String>of("8")
     );
 
+    assertFilterMatches(
+        new InDimFilter(LONG_COLUMN, Arrays.asList("-25.0", "-99999999.999999999"), null),
+        ImmutableList.<String>of("9")
+    );
+
     // cross the hashing threshold to test hashset implementation, filter on even values
     List<String> infilterValues = new ArrayList<>(InDimFilter.NUMERIC_HASHING_THRESHOLD * 2);
     for (int i = 0; i < InDimFilter.NUMERIC_HASHING_THRESHOLD * 2; i++) {
@@ -259,7 +271,7 @@ public class LongFilteringTest extends BaseFilterTest
 
     assertFilterMatches(
         new SearchQueryDimFilter(LONG_COLUMN, new ContainsSearchQuerySpec("2", true), null),
-        ImmutableList.<String>of("2")
+        ImmutableList.<String>of("2", "9")
     );
   }
 
@@ -288,12 +300,12 @@ public class LongFilteringTest extends BaseFilterTest
 
     assertFilterMatches(
         new BoundDimFilter(LONG_COLUMN, " ", "4", false, false, null, null, StringComparators.NUMERIC),
-        ImmutableList.<String>of("1", "2", "3", "4")
+        ImmutableList.<String>of("1", "2", "3", "4", "9", "10")
     );
 
     assertFilterMatches(
         new BoundDimFilter(LONG_COLUMN, " ", "4", false, false, null, null, StringComparators.LEXICOGRAPHIC),
-        ImmutableList.<String>of("1", "2", "3", "4", "7", "8")
+        ImmutableList.<String>of("1", "2", "3", "4", "7", "8", "9", "10")
     );
 
     assertFilterMatches(
@@ -303,7 +315,7 @@ public class LongFilteringTest extends BaseFilterTest
 
     assertFilterMatches(
         new BoundDimFilter(LONG_COLUMN, " ", "A", false, false, null, null, StringComparators.LEXICOGRAPHIC),
-        ImmutableList.<String>of("1", "2", "3", "4", "5", "6", "7", "8")
+        ImmutableList.<String>of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10")
     );
   }
 

--- a/processing/src/test/java/io/druid/segment/filter/LongFilteringTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/LongFilteringTest.java
@@ -140,6 +140,21 @@ public class LongFilteringTest extends BaseFilterTest
     );
 
     assertFilterMatches(
+        new SelectorDimFilter(LONG_COLUMN, "3.0", null),
+        ImmutableList.<String>of("3")
+    );
+
+    assertFilterMatches(
+        new SelectorDimFilter(LONG_COLUMN, "3.000001", null),
+        ImmutableList.<String>of()
+    );
+
+    assertFilterMatches(
+        new SelectorDimFilter(LONG_COLUMN, "3.0000001", null),
+        ImmutableList.<String>of("3")
+    );
+
+    assertFilterMatches(
         new BoundDimFilter(LONG_COLUMN, "2", "5", false, false, null, null, StringComparators.NUMERIC),
         ImmutableList.<String>of("2", "3", "4", "5")
     );
@@ -150,7 +165,37 @@ public class LongFilteringTest extends BaseFilterTest
     );
 
     assertFilterMatches(
+        new BoundDimFilter(LONG_COLUMN, "2.0", "5.0", false, false, null, null, StringComparators.NUMERIC),
+        ImmutableList.<String>of("2", "3", "4", "5")
+    );
+
+    assertFilterMatches(
+        new BoundDimFilter(LONG_COLUMN, "2.0", "5.0", true, true, null, null, StringComparators.NUMERIC),
+        ImmutableList.<String>of("3", "4")
+    );
+
+    assertFilterMatches(
+        new BoundDimFilter(LONG_COLUMN, "1.9", "5.9", true, true, null, null, StringComparators.NUMERIC),
+        ImmutableList.<String>of("2", "3", "4", "5")
+    );
+
+    assertFilterMatches(
+        new BoundDimFilter(LONG_COLUMN, "2.1", "5.9", false, false, null, null, StringComparators.NUMERIC),
+        ImmutableList.<String>of("3", "4", "5")
+    );
+
+    assertFilterMatches(
         new InDimFilter(LONG_COLUMN, Arrays.asList("2", "4", "8"), null),
+        ImmutableList.<String>of("2", "4")
+    );
+
+    assertFilterMatches(
+        new InDimFilter(LONG_COLUMN, Arrays.asList("2.000001", "4.000001"), null),
+        ImmutableList.<String>of()
+    );
+
+    assertFilterMatches(
+        new InDimFilter(LONG_COLUMN, Arrays.asList("2.0000001", "4.0000001"), null),
         ImmutableList.<String>of("2", "4")
     );
 

--- a/processing/src/test/java/io/druid/segment/filter/LongFilteringTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/LongFilteringTest.java
@@ -92,7 +92,9 @@ public class LongFilteringTest extends BaseFilterTest
       PARSER.parse(ImmutableMap.<String, Object>of("ts", 3L, "dim0", "3", "lng", 3L, "dim1", "2", "dim2", ImmutableList.of(""))),
       PARSER.parse(ImmutableMap.<String, Object>of("ts", 4L, "dim0", "4", "lng", 4L, "dim1", "1", "dim2", ImmutableList.of("a"))),
       PARSER.parse(ImmutableMap.<String, Object>of("ts", 5L, "dim0", "5", "lng", 5L, "dim1", "def", "dim2", ImmutableList.of("c"))),
-      PARSER.parse(ImmutableMap.<String, Object>of("ts", 6L, "dim0", "6", "lng", 6L, "dim1", "abc"))
+      PARSER.parse(ImmutableMap.<String, Object>of("ts", 6L, "dim0", "6", "lng", 6L, "dim1", "abc")),
+      PARSER.parse(ImmutableMap.<String, Object>of("ts", 7L, "dim0", "7", "lng", 100000000L, "dim1", "xyz")),
+      PARSER.parse(ImmutableMap.<String, Object>of("ts", 8L, "dim0", "8", "lng", 100000001L, "dim1", "xyz"))
   );
 
   public LongFilteringTest(
@@ -145,13 +147,18 @@ public class LongFilteringTest extends BaseFilterTest
     );
 
     assertFilterMatches(
-        new SelectorDimFilter(LONG_COLUMN, "3.000001", null),
+        new SelectorDimFilter(LONG_COLUMN, "3.00000000000000000000001", null),
         ImmutableList.<String>of()
     );
 
     assertFilterMatches(
-        new SelectorDimFilter(LONG_COLUMN, "3.0000001", null),
-        ImmutableList.<String>of("3")
+        new SelectorDimFilter(LONG_COLUMN, "100000001.0", null),
+        ImmutableList.<String>of("8")
+    );
+
+    assertFilterMatches(
+        new SelectorDimFilter(LONG_COLUMN, "111119223372036854775807.674398674398", null),
+        ImmutableList.<String>of()
     );
 
     assertFilterMatches(
@@ -185,18 +192,48 @@ public class LongFilteringTest extends BaseFilterTest
     );
 
     assertFilterMatches(
+        new BoundDimFilter(LONG_COLUMN, "111119223372036854775807.67", "5.9", false, false, null, null, StringComparators.NUMERIC),
+        ImmutableList.<String>of()
+    );
+
+    assertFilterMatches(
+        new BoundDimFilter(LONG_COLUMN, "-111119223372036854775807.67", "5.9", false, false, null, null, StringComparators.NUMERIC),
+        ImmutableList.<String>of("1", "2", "3", "4", "5")
+    );
+
+    assertFilterMatches(
+        new BoundDimFilter(LONG_COLUMN, "2.1", "111119223372036854775807.67", false, false, null, null, StringComparators.NUMERIC),
+        ImmutableList.<String>of("3", "4", "5", "6", "7", "8")
+    );
+
+    assertFilterMatches(
+        new BoundDimFilter(LONG_COLUMN, "2.1", "-111119223372036854775807.67", false, false, null, null, StringComparators.NUMERIC),
+        ImmutableList.<String>of()
+    );
+
+    assertFilterMatches(
+        new BoundDimFilter(LONG_COLUMN, "100000000.0", "100000001.0", true, true, null, null, StringComparators.NUMERIC),
+        ImmutableList.<String>of()
+    );
+
+    assertFilterMatches(
+        new BoundDimFilter(LONG_COLUMN, "100000000.0", "100000001.0", false, false, null, null, StringComparators.NUMERIC),
+        ImmutableList.<String>of("7", "8")
+    );
+
+    assertFilterMatches(
         new InDimFilter(LONG_COLUMN, Arrays.asList("2", "4", "8"), null),
         ImmutableList.<String>of("2", "4")
     );
 
     assertFilterMatches(
-        new InDimFilter(LONG_COLUMN, Arrays.asList("2.000001", "4.000001"), null),
+        new InDimFilter(LONG_COLUMN, Arrays.asList("1.999999999999999999", "4.00000000000000000000001"), null),
         ImmutableList.<String>of()
     );
 
     assertFilterMatches(
-        new InDimFilter(LONG_COLUMN, Arrays.asList("2.0000001", "4.0000001"), null),
-        ImmutableList.<String>of("2", "4")
+        new InDimFilter(LONG_COLUMN, Arrays.asList("100000001.0", "99999999.999999999"), null),
+        ImmutableList.<String>of("8")
     );
 
     // cross the hashing threshold to test hashset implementation, filter on even values
@@ -256,7 +293,7 @@ public class LongFilteringTest extends BaseFilterTest
 
     assertFilterMatches(
         new BoundDimFilter(LONG_COLUMN, " ", "4", false, false, null, null, StringComparators.LEXICOGRAPHIC),
-        ImmutableList.<String>of("1", "2", "3", "4")
+        ImmutableList.<String>of("1", "2", "3", "4", "7", "8")
     );
 
     assertFilterMatches(
@@ -266,7 +303,7 @@ public class LongFilteringTest extends BaseFilterTest
 
     assertFilterMatches(
         new BoundDimFilter(LONG_COLUMN, " ", "A", false, false, null, null, StringComparators.LEXICOGRAPHIC),
-        ImmutableList.<String>of("1", "2", "3", "4", "5", "6")
+        ImmutableList.<String>of("1", "2", "3", "4", "5", "6", "7", "8")
     );
   }
 

--- a/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
@@ -1023,6 +1023,65 @@ public class CalciteQueryTest
   }
 
   @Test
+  public void testCountStarWithLongColumnFiltersOnFloatLiterals() throws Exception
+  {
+    testQuery(
+        "SELECT COUNT(*) FROM druid.foo WHERE cnt > 1.1",
+        ImmutableList.<Query>of(
+            Druids.newTimeseriesQueryBuilder()
+                  .dataSource(CalciteTests.DATASOURCE1)
+                  .intervals(QSS(Filtration.eternity()))
+                  .granularity(Granularities.ALL)
+                  .filters(
+                      BOUND("cnt", "1.1", null, true, false, null, StringComparators.NUMERIC)
+                  )
+                  .aggregators(AGGS(new CountAggregatorFactory("a0")))
+                  .context(TIMESERIES_CONTEXT_DEFAULT)
+                  .build()
+        ),
+        ImmutableList.of()
+    );
+
+    testQuery(
+        "SELECT COUNT(*) FROM druid.foo WHERE cnt = 1.0",
+        ImmutableList.<Query>of(
+            Druids.newTimeseriesQueryBuilder()
+                  .dataSource(CalciteTests.DATASOURCE1)
+                  .intervals(QSS(Filtration.eternity()))
+                  .granularity(Granularities.ALL)
+                  .filters(
+                      SELECTOR("cnt", "1.0", null)
+                  )
+                  .aggregators(AGGS(new CountAggregatorFactory("a0")))
+                  .context(TIMESERIES_CONTEXT_DEFAULT)
+                  .build()
+        ),
+        ImmutableList.of(
+            new Object[]{6L}
+        )
+    );
+
+    testQuery(
+        "SELECT COUNT(*) FROM druid.foo WHERE cnt = 1.0 or cnt = 2.0",
+        ImmutableList.<Query>of(
+            Druids.newTimeseriesQueryBuilder()
+                  .dataSource(CalciteTests.DATASOURCE1)
+                  .intervals(QSS(Filtration.eternity()))
+                  .granularity(Granularities.ALL)
+                  .filters(
+                      IN("cnt", ImmutableList.of("1.0", "2.0"), null)
+                  )
+                  .aggregators(AGGS(new CountAggregatorFactory("a0")))
+                  .context(TIMESERIES_CONTEXT_DEFAULT)
+                  .build()
+        ),
+        ImmutableList.of(
+            new Object[]{6L}
+        )
+    );
+  }
+
+  @Test
   public void testCountStarWithLongColumnFiltersOnTwoPoints() throws Exception
   {
     testQuery(

--- a/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
@@ -1026,14 +1026,14 @@ public class CalciteQueryTest
   public void testCountStarWithLongColumnFiltersOnFloatLiterals() throws Exception
   {
     testQuery(
-        "SELECT COUNT(*) FROM druid.foo WHERE cnt > 1.1",
+        "SELECT COUNT(*) FROM druid.foo WHERE cnt > 1.1 and cnt < 100000001.0",
         ImmutableList.<Query>of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
                   .intervals(QSS(Filtration.eternity()))
                   .granularity(Granularities.ALL)
                   .filters(
-                      BOUND("cnt", "1.1", null, true, false, null, StringComparators.NUMERIC)
+                      BOUND("cnt", "1.1", "100000001.0", true, true, null, StringComparators.NUMERIC)
                   )
                   .aggregators(AGGS(new CountAggregatorFactory("a0")))
                   .context(TIMESERIES_CONTEXT_DEFAULT)
@@ -1062,14 +1062,31 @@ public class CalciteQueryTest
     );
 
     testQuery(
-        "SELECT COUNT(*) FROM druid.foo WHERE cnt = 1.0 or cnt = 2.0",
+        "SELECT COUNT(*) FROM druid.foo WHERE cnt = 100000001.0",
         ImmutableList.<Query>of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
                   .intervals(QSS(Filtration.eternity()))
                   .granularity(Granularities.ALL)
                   .filters(
-                      IN("cnt", ImmutableList.of("1.0", "2.0"), null)
+                      SELECTOR("cnt", "100000001.0", null)
+                  )
+                  .aggregators(AGGS(new CountAggregatorFactory("a0")))
+                  .context(TIMESERIES_CONTEXT_DEFAULT)
+                  .build()
+        ),
+        ImmutableList.of()
+    );
+
+    testQuery(
+        "SELECT COUNT(*) FROM druid.foo WHERE cnt = 1.0 or cnt = 100000001.0",
+        ImmutableList.<Query>of(
+            Druids.newTimeseriesQueryBuilder()
+                  .dataSource(CalciteTests.DATASOURCE1)
+                  .intervals(QSS(Filtration.eternity()))
+                  .granularity(Granularities.ALL)
+                  .filters(
+                      IN("cnt", ImmutableList.of("1.0", "100000001.0"), null)
                   )
                   .aggregators(AGGS(new CountAggregatorFactory("a0")))
                   .context(TIMESERIES_CONTEXT_DEFAULT)


### PR DESCRIPTION
This PR allows the Bound/Selector/In filters to accept strings that represent floating point values as the filter value parameters when applying the filters to long columns.