### PR TITLE
Changes statsd-emitter error print to a debug print

### DIFF
--- a/extensions-contrib/statsd-emitter/src/main/java/io/druid/emitter/statsd/StatsDEmitter.java
+++ b/extensions-contrib/statsd-emitter/src/main/java/io/druid/emitter/statsd/StatsDEmitter.java
@@ -120,7 +120,7 @@ public class StatsDEmitter implements Emitter
             break;
         }
       } else {
-        log.error("Metric=[%s] has no StatsD type mapping", statsDMetric);
+        log.debug("Metric=[%s] has no StatsD type mapping", statsDMetric);
       }
     }
   }


### PR DESCRIPTION
This was mentioned in the original pull for the statsd-emitter (https://github.com/druid-io/druid/pull/2410) by @sascha-coenen, and the original author (@michaelschiff) agreed that it seemed reasonable

This commit fixes issue https://github.com/druid-io/druid/issues/3960