### PR TITLE
Fix: Broker fails throws OOME with conf-quickstart

### DIFF
--- a/examples/conf-quickstart/druid/broker/jvm.config
+++ b/examples/conf-quickstart/druid/broker/jvm.config
@@ -1,7 +1,7 @@
 -server
 -Xms1g
 -Xmx1g
--XX:MaxDirectMemorySize=1280m
+-XX:MaxDirectMemorySize=1792m
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp


### PR DESCRIPTION
when running the the packaged conf-quickstart druid broker fails to
start and throws OOME. 
increasing the direct memory to get around this.