### PR TITLE
Make UpdateCounter proof to update count overflow

### DIFF
--- a/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/cache/UpdateCounter.java
+++ b/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/cache/UpdateCounter.java
@@ -42,10 +42,19 @@ final class UpdateCounter
     totalUpdates &= MAX_PHASE;
     int currentUpdates = phaser.getPhase();
     checkNotTerminated(currentUpdates);
-    while (((totalUpdates - currentUpdates) & MAX_PHASE) < MAX_PHASE / 2) { // overflow-aware
+    while (comparePhases(totalUpdates, currentUpdates) > 0) {
       currentUpdates = phaser.awaitAdvanceInterruptibly(currentUpdates);
       checkNotTerminated(currentUpdates);
     }
+  }
+
+  private static int comparePhases(int phase1, int phase2)
+  {
+    int diff = (phase1 - phase2) & MAX_PHASE;
+    if (diff == 0) {
+      return 0;
+    }
+    return diff < MAX_PHASE / 2 ? 1 : -1;
   }
 
   private void checkNotTerminated(int phase)


### PR DESCRIPTION
This is a part of query-time lookup subsystem, introduced in #3697. The fixed functionality is used only in tests (yet), so no need to backport to 0.10.0.