### PR TITLE
don't do postAgg in TimeseriesQueryQueryToolChest when not necessary

### DIFF
--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesQuery.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesQuery.java
@@ -190,6 +190,21 @@ public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
     );
   }
 
+  public TimeseriesQuery withPostAggregatorSpecs(final List<PostAggregator> postAggregatorSpecs)
+  {
+    return new TimeseriesQuery(
+        getDataSource(),
+        getQuerySegmentSpec(),
+        isDescending(),
+        virtualColumns,
+        dimFilter,
+        granularity,
+        aggregatorSpecs,
+        postAggregatorSpecs,
+        getContext()
+    );
+  }
+
   @Override
   public String toString()
   {

--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
@@ -40,6 +40,7 @@ import io.druid.query.ResultGranularTimestampComparator;
 import io.druid.query.ResultMergeQueryRunner;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.MetricManipulationFn;
+import io.druid.query.aggregation.MetricManipulatorFns;
 import io.druid.query.aggregation.PostAggregator;
 import io.druid.query.cache.CacheKeyBuilder;
 import org.joda.time.DateTime;
@@ -239,7 +240,8 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
       TimeseriesQuery query, MetricManipulationFn fn
   )
   {
-    return makeComputeManipulatorFn(query, fn, true);
+    boolean shouldFinalize = MetricManipulatorFns.finalizing().equals(fn);
+    return makeComputeManipulatorFn(query, fn, shouldFinalize);
   }
 
   private Function<Result<TimeseriesResultValue>, Result<TimeseriesResultValue>> makeComputeManipulatorFn(

--- a/processing/src/test/java/io/druid/query/groupby/GroupByTimeseriesQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByTimeseriesQueryRunnerTest.java
@@ -99,6 +99,7 @@ public class GroupByTimeseriesQueryRunnerTest extends TimeseriesQueryRunnerTest
                                         .setAggregatorSpecs(tsQuery.getAggregatorSpecs())
                                         .setPostAggregatorSpecs(tsQuery.getPostAggregatorSpecs())
                                         .setVirtualColumns(tsQuery.getVirtualColumns())
+                                        .setContext(tsQuery.getContext())
                                         .build(),
                             responseContext
                         ),

--- a/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerTest.java
@@ -2562,7 +2562,31 @@ public class TimeseriesQueryRunnerTest
         optimizedRunner.run(query, CONTEXT),
         Lists.<Result<TimeseriesResultValue>>newArrayList()
     );
-    TestHelper.assertExpectedResults(expectedResults, results2);
+    // post aggs are calculated in FinalizeResultsQueryRunner.run()
+    // toolChest.mergeResults doesn't do post aggs, so addRowsIndexConstant is not included in expectedResults2
+    List<Result<TimeseriesResultValue>> expectedResults2 = Arrays.asList(
+        new Result<>(
+            new DateTime("2011-04-01"),
+            new TimeseriesResultValue(
+                ImmutableMap.<String, Object>of(
+                    "rows", 11L,
+                    "index", 3783L,
+                    "uniques", QueryRunnerTestHelper.UNIQUES_9
+                )
+            )
+        ),
+        new Result<>(
+            new DateTime("2011-04-02"),
+            new TimeseriesResultValue(
+                ImmutableMap.<String, Object>of(
+                    "rows", 11L,
+                    "index", 3313L,
+                    "uniques", QueryRunnerTestHelper.UNIQUES_9
+                )
+            )
+        )
+    );
+    TestHelper.assertExpectedResults(expectedResults2, results2);
 
   }
 }

--- a/server/src/test/java/io/druid/client/CachingClusteredClientTest.java
+++ b/server/src/test/java/io/druid/client/CachingClusteredClientTest.java
@@ -442,8 +442,6 @@ public class CachingClusteredClientTest
       }
     };
 
-    Map<String, Object> queryContext = new HashMap<>(CONTEXT);
-    queryContext.put("finalize", true);
     final Druids.TimeseriesQueryBuilder builder = Druids.newTimeseriesQueryBuilder()
                                                         .dataSource(DATA_SOURCE)
                                                         .intervals(SEG_SPEC)
@@ -451,7 +449,7 @@ public class CachingClusteredClientTest
                                                         .granularity(GRANULARITY)
                                                         .aggregators(AGGS)
                                                         .postAggregators(POST_AGGS)
-                                                        .context(queryContext);
+                                                        .context(CONTEXT);
 
     QueryRunner runner = new FinalizeResultsQueryRunner(
         client, new TimeseriesQueryQueryToolChest(
@@ -483,8 +481,6 @@ public class CachingClusteredClientTest
   @SuppressWarnings("unchecked")
   public void testTimeseriesCaching() throws Exception
   {
-    Map<String, Object> queryContext = new HashMap<>(CONTEXT);
-    queryContext.put("finalize", true);
     final Druids.TimeseriesQueryBuilder builder = Druids.newTimeseriesQueryBuilder()
                                                         .dataSource(DATA_SOURCE)
                                                         .intervals(SEG_SPEC)
@@ -492,7 +488,7 @@ public class CachingClusteredClientTest
                                                         .granularity(GRANULARITY)
                                                         .aggregators(AGGS)
                                                         .postAggregators(POST_AGGS)
-                                                        .context(queryContext);
+                                                        .context(CONTEXT);
 
     QueryRunner runner = new FinalizeResultsQueryRunner(
         client, new TimeseriesQueryQueryToolChest(
@@ -614,8 +610,6 @@ public class CachingClusteredClientTest
   @Test
   public void testTimeseriesMergingOutOfOrderPartitions() throws Exception
   {
-    Map<String, Object> queryContext = new HashMap<>(CONTEXT);
-    queryContext.put("finalize", true);
     final Druids.TimeseriesQueryBuilder builder = Druids.newTimeseriesQueryBuilder()
                                                         .dataSource(DATA_SOURCE)
                                                         .intervals(SEG_SPEC)
@@ -623,7 +617,7 @@ public class CachingClusteredClientTest
                                                         .granularity(GRANULARITY)
                                                         .aggregators(AGGS)
                                                         .postAggregators(POST_AGGS)
-                                                        .context(queryContext);
+                                                        .context(CONTEXT);
 
     QueryRunner runner = new FinalizeResultsQueryRunner(
         client, new TimeseriesQueryQueryToolChest(
@@ -679,8 +673,6 @@ public class CachingClusteredClientTest
   @SuppressWarnings("unchecked")
   public void testTimeseriesCachingTimeZone() throws Exception
   {
-    Map<String, Object> queryContext = new HashMap<>(CONTEXT);
-    queryContext.put("finalize", true);
     final Druids.TimeseriesQueryBuilder builder = Druids.newTimeseriesQueryBuilder()
                                                         .dataSource(DATA_SOURCE)
                                                         .intervals(SEG_SPEC)
@@ -688,7 +680,7 @@ public class CachingClusteredClientTest
                                                         .granularity(PT1H_TZ_GRANULARITY)
                                                         .aggregators(AGGS)
                                                         .postAggregators(POST_AGGS)
-                                                        .context(queryContext);
+                                                        .context(CONTEXT);
 
     QueryRunner runner = new FinalizeResultsQueryRunner(
         client, new TimeseriesQueryQueryToolChest(
@@ -1673,8 +1665,6 @@ public class CachingClusteredClientTest
                              )
                              .build();
 
-    Map<String, Object> queryContext = new HashMap<>(CONTEXT);
-    queryContext.put("finalize", true);
     final Druids.TimeseriesQueryBuilder builder = Druids.newTimeseriesQueryBuilder()
                                                         .dataSource(DATA_SOURCE)
                                                         .intervals(SEG_SPEC)
@@ -1682,7 +1672,7 @@ public class CachingClusteredClientTest
                                                         .granularity(GRANULARITY)
                                                         .aggregators(AGGS)
                                                         .postAggregators(POST_AGGS)
-                                                        .context(queryContext);
+                                                        .context(CONTEXT);
 
     QueryRunner runner = new FinalizeResultsQueryRunner(
         client, new TimeseriesQueryQueryToolChest(

--- a/server/src/test/java/io/druid/client/CachingClusteredClientTest.java
+++ b/server/src/test/java/io/druid/client/CachingClusteredClientTest.java
@@ -442,6 +442,8 @@ public class CachingClusteredClientTest
       }
     };
 
+    Map<String, Object> queryContext = new HashMap<>(CONTEXT);
+    queryContext.put("finalize", true);
     final Druids.TimeseriesQueryBuilder builder = Druids.newTimeseriesQueryBuilder()
                                                         .dataSource(DATA_SOURCE)
                                                         .intervals(SEG_SPEC)
@@ -449,7 +451,7 @@ public class CachingClusteredClientTest
                                                         .granularity(GRANULARITY)
                                                         .aggregators(AGGS)
                                                         .postAggregators(POST_AGGS)
-                                                        .context(CONTEXT);
+                                                        .context(queryContext);
 
     QueryRunner runner = new FinalizeResultsQueryRunner(
         client, new TimeseriesQueryQueryToolChest(
@@ -481,6 +483,8 @@ public class CachingClusteredClientTest
   @SuppressWarnings("unchecked")
   public void testTimeseriesCaching() throws Exception
   {
+    Map<String, Object> queryContext = new HashMap<>(CONTEXT);
+    queryContext.put("finalize", true);
     final Druids.TimeseriesQueryBuilder builder = Druids.newTimeseriesQueryBuilder()
                                                         .dataSource(DATA_SOURCE)
                                                         .intervals(SEG_SPEC)
@@ -488,7 +492,7 @@ public class CachingClusteredClientTest
                                                         .granularity(GRANULARITY)
                                                         .aggregators(AGGS)
                                                         .postAggregators(POST_AGGS)
-                                                        .context(CONTEXT);
+                                                        .context(queryContext);
 
     QueryRunner runner = new FinalizeResultsQueryRunner(
         client, new TimeseriesQueryQueryToolChest(
@@ -610,6 +614,8 @@ public class CachingClusteredClientTest
   @Test
   public void testTimeseriesMergingOutOfOrderPartitions() throws Exception
   {
+    Map<String, Object> queryContext = new HashMap<>(CONTEXT);
+    queryContext.put("finalize", true);
     final Druids.TimeseriesQueryBuilder builder = Druids.newTimeseriesQueryBuilder()
                                                         .dataSource(DATA_SOURCE)
                                                         .intervals(SEG_SPEC)
@@ -617,7 +623,7 @@ public class CachingClusteredClientTest
                                                         .granularity(GRANULARITY)
                                                         .aggregators(AGGS)
                                                         .postAggregators(POST_AGGS)
-                                                        .context(CONTEXT);
+                                                        .context(queryContext);
 
     QueryRunner runner = new FinalizeResultsQueryRunner(
         client, new TimeseriesQueryQueryToolChest(
@@ -673,6 +679,8 @@ public class CachingClusteredClientTest
   @SuppressWarnings("unchecked")
   public void testTimeseriesCachingTimeZone() throws Exception
   {
+    Map<String, Object> queryContext = new HashMap<>(CONTEXT);
+    queryContext.put("finalize", true);
     final Druids.TimeseriesQueryBuilder builder = Druids.newTimeseriesQueryBuilder()
                                                         .dataSource(DATA_SOURCE)
                                                         .intervals(SEG_SPEC)
@@ -680,7 +688,7 @@ public class CachingClusteredClientTest
                                                         .granularity(PT1H_TZ_GRANULARITY)
                                                         .aggregators(AGGS)
                                                         .postAggregators(POST_AGGS)
-                                                        .context(CONTEXT);
+                                                        .context(queryContext);
 
     QueryRunner runner = new FinalizeResultsQueryRunner(
         client, new TimeseriesQueryQueryToolChest(
@@ -1665,6 +1673,8 @@ public class CachingClusteredClientTest
                              )
                              .build();
 
+    Map<String, Object> queryContext = new HashMap<>(CONTEXT);
+    queryContext.put("finalize", true);
     final Druids.TimeseriesQueryBuilder builder = Druids.newTimeseriesQueryBuilder()
                                                         .dataSource(DATA_SOURCE)
                                                         .intervals(SEG_SPEC)
@@ -1672,7 +1682,7 @@ public class CachingClusteredClientTest
                                                         .granularity(GRANULARITY)
                                                         .aggregators(AGGS)
                                                         .postAggregators(POST_AGGS)
-                                                        .context(CONTEXT);
+                                                        .context(queryContext);
 
     QueryRunner runner = new FinalizeResultsQueryRunner(
         client, new TimeseriesQueryQueryToolChest(


### PR DESCRIPTION
I found postAgg is computed in compute node. After comparing with groupby query, I get to the conclusion that this computation shouldn't happen in realtime/historical node. Please correct me if I miss-understood it.

The root cause of this is like this:
1. makePostComputeManipulatorFn() is called in FinalizeResultsQueryRunner
2. makePostComputeManipulatorFn always passes calculatePostAggs=true to makeComputeManipulatorFn()
3. postAgg is computed if calculatePostAggs==true even when MetricManipulationFn is not finalzing fn, this is not necessary when it is on realtime/historical node.

by removing this computation, it should slightly improve the query performance if post aggs contains complex post aggs like histogram/sketch