### PR TITLE
Add HTTP/2 cleartext to the jetty server module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -437,6 +437,11 @@
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.eclipse.jetty.http2</groupId>
+                <artifactId>http2-server</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
                 <version>${netty.version}</version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -129,6 +129,10 @@
             <artifactId>jetty-proxy</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>http2-server</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>

--- a/server/src/main/java/io/druid/server/initialization/jetty/JettyServerModule.java
+++ b/server/src/main/java/io/druid/server/initialization/jetty/JettyServerModule.java
@@ -57,9 +57,12 @@ import io.druid.server.initialization.ServerConfig;
 import io.druid.server.metrics.DataSourceTaskIdHolder;
 import io.druid.server.metrics.MetricsModule;
 import io.druid.server.metrics.MonitorsConfig;
+import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
 import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
@@ -169,7 +172,14 @@ public class JettyServerModule extends JerseyServletModule
     // to fire on main exit. Related bug: https://github.com/druid-io/druid/pull/1627
     server.addBean(new ScheduledExecutorScheduler("JettyScheduler", true), true);
 
-    ServerConnector connector = new ServerConnector(server);
+    final HttpConfiguration httpConfiguration = new HttpConfiguration();
+    httpConfiguration.setSendXPoweredBy(false);
+
+    final ServerConnector connector = new ServerConnector(
+        server,
+        new HttpConnectionFactory(httpConfiguration),
+        new HTTP2CServerConnectionFactory(httpConfiguration)
+    );
     connector.setPort(node.getPort());
     connector.setIdleTimeout(Ints.checkedCast(config.getMaxIdleTime().toStandardDuration().getMillis()));
     // workaround suggested in -


### PR DESCRIPTION
This enables http1 --> http2 cleartext [upgrade](https://tools.ietf.org/html/rfc7230#section-6.7). where http/2 cleartext clients can use the procedure in RFC-7230 to promote a request to http/2 instead of http 1. This will be always on and should still allow clients to use http1 by simply not requesting an upgrade (the default behavior)

This does NOT support the secure version of http/2 because trying to document how to use [ALPN](https://www.eclipse.org/jetty/documentation/9.4.x/alpn-chapter.html) is not trivial.

This does not expose any new configuration options. The prior implementation used a default `HttpConnectionFactory` implicitly which uses a default `HttpConfiguration`, so there should be no loss or change in functionality there.

Initially only external clients can upgrade to http/2 since the included http client with druid does not support the upgrade. Future releases of https://github.com/metamx/http-client are expected to have an updated Netty and http/2 client support