### PR TITLE
fix kafka8 unparsable message halt job issue

### DIFF
--- a/extensions-contrib/kafka-eight-simpleConsumer/src/main/java/io/druid/firehose/kafka/KafkaEightSimpleConsumerFirehoseFactory.java
+++ b/extensions-contrib/kafka-eight-simpleConsumer/src/main/java/io/druid/firehose/kafka/KafkaEightSimpleConsumerFirehoseFactory.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.io.Closeables;
+import com.metamx.common.parsers.ParseException;
 import com.metamx.emitter.EmittingLogger;
 import io.druid.data.input.ByteBufferInputRowParser;
 import io.druid.data.input.Committer;
@@ -182,7 +183,6 @@ public class KafkaEightSimpleConsumerFirehoseFactory implements
       @Override
       public void start() throws Exception
       {
-        nextMessage();
       }
 
       @Override
@@ -223,6 +223,15 @@ public class KafkaEightSimpleConsumerFirehoseFactory implements
       {
         if (stopped) {
           return null;
+        }
+        // currRow will be called before the first advance
+        if (row == null) {
+          try {
+            nextMessage();
+          }
+          catch (ParseException e) {
+            return null;
+          }
         }
         return row;
       }


### PR DESCRIPTION
When I rewrite this extension to use kafka10 (I know there is kafka indexing service, but I'm not using it right now for some reason), I found if the first message is unparsable, then RealtimeManager will quit the job

```java
    private void runFirehoseV2(FirehoseV2 firehose)
    {
      try {
        firehose.start();
      }
      catch (Exception e) {
        log.error(e, "Failed to start firehoseV2");
        return;
      }
      ...
    }
```

so should avoid throw exception in the firehose.start() method if the first message is unparsable