### PR TITLE
fix over counting of bytes in ByteCountingLRUMap

### DIFF
--- a/server/src/main/java/io/druid/client/cache/ByteCountingLRUMap.java
+++ b/server/src/main/java/io/druid/client/cache/ByteCountingLRUMap.java
@@ -19,6 +19,8 @@
 
 package io.druid.client.cache;
 
+import io.druid.java.util.common.logger.Logger;
+
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -28,8 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
-
-import io.druid.java.util.common.logger.Logger;
 
 /**
 */
@@ -104,7 +104,11 @@ class ByteCountingLRUMap extends LinkedHashMap<ByteBuffer, byte[]>
       remove(keyToRemove);
     }
 
-    return super.put(key, value);
+    byte[] old = super.put(key, value);
+    if (old != null) {
+      numBytes.addAndGet(-key.remaining() - old.length);
+    }
+    return old;
   }
 
   @Override

--- a/server/src/test/java/io/druid/client/cache/ByteCountingLRUMapTest.java
+++ b/server/src/test/java/io/druid/client/cache/ByteCountingLRUMapTest.java
@@ -86,6 +86,19 @@ public class ByteCountingLRUMapTest
     assertMapValues(0, 0, 3);
   }
 
+  @Test
+  public void testSameKeyUpdate() throws Exception
+  {
+    final ByteBuffer k = ByteBuffer.allocate(1);
+
+    assertMapValues(0, 0, 0);
+    map.put(k, new byte[1]);
+    map.put(k, new byte[2]);
+    map.put(k, new byte[5]);
+    map.put(k, new byte[3]);
+    assertMapValues(1, 4, 0);
+  }
+
   private void assertMapValues(final int size, final int numBytes, final int evictionCount)
   {
     Assert.assertEquals(size, map.size());


### PR DESCRIPTION
a user reporting `query/cache/total/sizeBytes` about 5G whereas the cache is configured to be a maximum of 2G .
it looks like current impl over counts the bytes in case of updates. this patch fixes that.