### PR TITLE
Add jq expression support in flattenSpec

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -87,7 +87,11 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>net.thisptr</groupId>
+            <artifactId>jackson-jq</artifactId>
+            <version>0.0.7</version>
+        </dependency>
         <!-- Tests -->
         <dependency>
             <groupId>junit</groupId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -90,7 +90,6 @@
         <dependency>
             <groupId>net.thisptr</groupId>
             <artifactId>jackson-jq</artifactId>
-            <version>0.0.7</version>
         </dependency>
         <!-- Tests -->
         <dependency>

--- a/api/src/main/java/io/druid/data/input/impl/JSONParseSpec.java
+++ b/api/src/main/java/io/druid/data/input/impl/JSONParseSpec.java
@@ -115,6 +115,9 @@ public class JSONParseSpec extends ParseSpec
         case PATH:
           type = JSONPathParser.FieldType.PATH;
           break;
+        case JQ:
+          type = JSONPathParser.FieldType.JQ;
+          break;
         default:
           throw new IllegalArgumentException("Invalid type for field " + druidSpec.getName());
       }

--- a/api/src/main/java/io/druid/data/input/impl/JSONPathFieldSpec.java
+++ b/api/src/main/java/io/druid/data/input/impl/JSONPathFieldSpec.java
@@ -69,6 +69,11 @@ public class JSONPathFieldSpec
     return new JSONPathFieldSpec(JSONPathFieldType.PATH, name, expr);
   }
 
+  public static JSONPathFieldSpec createJqField(String name, String expr)
+  {
+    return new JSONPathFieldSpec(JSONPathFieldType.JQ, name, expr);
+  }
+
   public static JSONPathFieldSpec createRootField(String name)
   {
     return new JSONPathFieldSpec(JSONPathFieldType.ROOT, name, null);

--- a/api/src/main/java/io/druid/data/input/impl/JSONPathFieldType.java
+++ b/api/src/main/java/io/druid/data/input/impl/JSONPathFieldType.java
@@ -25,7 +25,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum JSONPathFieldType
 {
   ROOT,
-  PATH;
+  PATH,
+  JQ;
 
   @JsonValue
   @Override

--- a/api/src/test/java/io/druid/data/input/impl/JSONPathSpecTest.java
+++ b/api/src/test/java/io/druid/data/input/impl/JSONPathSpecTest.java
@@ -41,6 +41,9 @@ public class JSONPathSpecTest
     fields.add(JSONPathFieldSpec.createNestedField("hey0barx", "$.hey[0].barx"));
     fields.add(JSONPathFieldSpec.createRootField("timestamp"));
     fields.add(JSONPathFieldSpec.createRootField("foo.bar1"));
+    fields.add(JSONPathFieldSpec.createJqField("foobar1", ".foo.bar1"));
+    fields.add(JSONPathFieldSpec.createJqField("baz0", ".baz[0]"));
+    fields.add(JSONPathFieldSpec.createJqField("hey0barx", ".hey[0].barx"));
 
     JSONPathSpec flattenSpec = new JSONPathSpec(true, fields);
 
@@ -55,6 +58,9 @@ public class JSONPathSpecTest
     JSONPathFieldSpec hey0barx = serdeFields.get(2);
     JSONPathFieldSpec timestamp = serdeFields.get(3);
     JSONPathFieldSpec foodotbar1 = serdeFields.get(4);
+    JSONPathFieldSpec jqFoobar1 = serdeFields.get(5);
+    JSONPathFieldSpec jqBaz0 = serdeFields.get(6);
+    JSONPathFieldSpec jqHey0barx = serdeFields.get(7);
 
     Assert.assertEquals(JSONPathFieldType.PATH, foobar1.getType());
     Assert.assertEquals("foobar1", foobar1.getName());
@@ -67,6 +73,18 @@ public class JSONPathSpecTest
     Assert.assertEquals(JSONPathFieldType.PATH, hey0barx.getType());
     Assert.assertEquals("hey0barx", hey0barx.getName());
     Assert.assertEquals("$.hey[0].barx", hey0barx.getExpr());
+
+    Assert.assertEquals(JSONPathFieldType.JQ, jqFoobar1.getType());
+    Assert.assertEquals("foobar1", jqFoobar1.getName());
+    Assert.assertEquals(".foo.bar1", jqFoobar1.getExpr());
+
+    Assert.assertEquals(JSONPathFieldType.JQ, jqBaz0.getType());
+    Assert.assertEquals("baz0", jqBaz0.getName());
+    Assert.assertEquals(".baz[0]", jqBaz0.getExpr());
+
+    Assert.assertEquals(JSONPathFieldType.JQ, jqHey0barx.getType());
+    Assert.assertEquals("hey0barx", jqHey0barx.getName());
+    Assert.assertEquals(".hey[0].barx", jqHey0barx.getExpr());
 
     Assert.assertEquals(JSONPathFieldType.ROOT, timestamp.getType());
     Assert.assertEquals("timestamp", timestamp.getName());

--- a/benchmarks/src/main/java/io/druid/benchmark/FlattenJSONBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/FlattenJSONBenchmark.java
@@ -45,12 +45,15 @@ public class FlattenJSONBenchmark
 
   List<String> flatInputs;
   List<String> nestedInputs;
+  List<String> jqInputs;
   Parser flatParser;
   Parser nestedParser;
+  Parser jqParser;
   Parser fieldDiscoveryParser;
   Parser forcedPathParser;
   int flatCounter = 0;
   int nestedCounter = 0;
+  int jqCounter = 0;
 
   @Setup
   public void prepare() throws Exception
@@ -64,9 +67,14 @@ public class FlattenJSONBenchmark
     for (int i = 0; i < numEvents; i++) {
       nestedInputs.add(gen.generateNestedEvent());
     }
+    jqInputs = new ArrayList<String>();
+    for (int i = 0; i < numEvents; i++) {
+      jqInputs.add(gen.generateNestedEvent()); // reuse the same event as "nested"
+    }
 
     flatParser = gen.getFlatParser();
     nestedParser = gen.getNestedParser();
+    jqParser = gen.getJqParser();
     fieldDiscoveryParser = gen.getFieldDiscoveryParser();
     forcedPathParser = gen.getForcedPathParser();
   }
@@ -88,6 +96,16 @@ public class FlattenJSONBenchmark
   {
     Map<String, Object> parsed = nestedParser.parse(nestedInputs.get(nestedCounter));
     nestedCounter = (nestedCounter + 1) % numEvents;
+    return parsed;
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public Map<String, Object> jqflatten()
+  {
+    Map<String, Object> parsed = jqParser.parse(jqInputs.get(jqCounter));
+    jqCounter = (jqCounter + 1) % numEvents;
     return parsed;
   }
 

--- a/benchmarks/src/main/java/io/druid/benchmark/FlattenJSONBenchmarkUtil.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/FlattenJSONBenchmarkUtil.java
@@ -164,6 +164,48 @@ public class FlattenJSONBenchmarkUtil
     return spec.makeParser();
   }
 
+  public Parser getJqParser()
+  {
+    List<JSONPathFieldSpec> fields = new ArrayList<>();
+    fields.add(JSONPathFieldSpec.createRootField("ts"));
+
+    fields.add(JSONPathFieldSpec.createRootField("d1"));
+    //fields.add(JSONPathFieldSpec.createRootField("d2"));
+    fields.add(JSONPathFieldSpec.createJqField("e1.d1", ".e1.d1"));
+    fields.add(JSONPathFieldSpec.createJqField("e1.d2", ".e1.d2"));
+    fields.add(JSONPathFieldSpec.createJqField("e2.d3", ".e2.d3"));
+    fields.add(JSONPathFieldSpec.createJqField("e2.d4", ".e2.d4"));
+    fields.add(JSONPathFieldSpec.createJqField("e2.d5", ".e2.d5"));
+    fields.add(JSONPathFieldSpec.createJqField("e2.d6", ".e2.d6"));
+    fields.add(JSONPathFieldSpec.createJqField("e2.ad1[0]", ".e2.ad1[0]"));
+    fields.add(JSONPathFieldSpec.createJqField("e2.ad1[1]", ".e2.ad1[1]"));
+    fields.add(JSONPathFieldSpec.createJqField("e2.ad1[2]", ".e2.ad1[2]"));
+    fields.add(JSONPathFieldSpec.createJqField("ae1[0].d1", ".ae1[0].d1"));
+    fields.add(JSONPathFieldSpec.createJqField("ae1[1].d1", ".ae1[1].d1"));
+    fields.add(JSONPathFieldSpec.createJqField("ae1[2].e1.d2", ".ae1[2].e1.d2"));
+
+    fields.add(JSONPathFieldSpec.createRootField("m3"));
+    //fields.add(JSONPathFieldSpec.createRootField("m4"));
+    fields.add(JSONPathFieldSpec.createJqField("e3.m1", ".e3.m1"));
+    fields.add(JSONPathFieldSpec.createJqField("e3.m2", ".e3.m2"));
+    fields.add(JSONPathFieldSpec.createJqField("e3.m3", ".e3.m3"));
+    fields.add(JSONPathFieldSpec.createJqField("e3.m4", ".e3.m4"));
+    fields.add(JSONPathFieldSpec.createJqField("e3.am1[0]", ".e3.am1[0]"));
+    fields.add(JSONPathFieldSpec.createJqField("e3.am1[1]", ".e3.am1[1]"));
+    fields.add(JSONPathFieldSpec.createJqField("e3.am1[2]", ".e3.am1[2]"));
+    fields.add(JSONPathFieldSpec.createJqField("e3.am1[3]", ".e3.am1[3]"));
+    fields.add(JSONPathFieldSpec.createJqField("e4.e4.m4", ".e4.e4.m4"));
+
+    JSONPathSpec flattenSpec = new JSONPathSpec(true, fields);
+    JSONParseSpec spec = new JSONParseSpec(
+        new TimestampSpec("ts", "iso", null),
+        new DimensionsSpec(null, null, null),
+        flattenSpec,
+        null
+    );
+
+    return spec.makeParser();
+  }
 
   public String generateFlatEvent() throws Exception
   {

--- a/benchmarks/src/main/java/io/druid/benchmark/FlattenJSONBenchmarkUtil.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/FlattenJSONBenchmarkUtil.java
@@ -170,7 +170,6 @@ public class FlattenJSONBenchmarkUtil
     fields.add(JSONPathFieldSpec.createRootField("ts"));
 
     fields.add(JSONPathFieldSpec.createRootField("d1"));
-    //fields.add(JSONPathFieldSpec.createRootField("d2"));
     fields.add(JSONPathFieldSpec.createJqField("e1.d1", ".e1.d1"));
     fields.add(JSONPathFieldSpec.createJqField("e1.d2", ".e1.d2"));
     fields.add(JSONPathFieldSpec.createJqField("e2.d3", ".e2.d3"));
@@ -185,7 +184,6 @@ public class FlattenJSONBenchmarkUtil
     fields.add(JSONPathFieldSpec.createJqField("ae1[2].e1.d2", ".ae1[2].e1.d2"));
 
     fields.add(JSONPathFieldSpec.createRootField("m3"));
-    //fields.add(JSONPathFieldSpec.createRootField("m4"));
     fields.add(JSONPathFieldSpec.createJqField("e3.m1", ".e3.m1"));
     fields.add(JSONPathFieldSpec.createJqField("e3.m2", ".e3.m2"));
     fields.add(JSONPathFieldSpec.createJqField("e3.m3", ".e3.m3"));

--- a/benchmarks/src/test/java/io/druid/benchmark/FlattenJSONBenchmarkUtilTest.java
+++ b/benchmarks/src/test/java/io/druid/benchmark/FlattenJSONBenchmarkUtilTest.java
@@ -37,12 +37,15 @@ public class FlattenJSONBenchmarkUtilTest
 
     Parser flatParser = eventGen.getFlatParser();
     Parser nestedParser = eventGen.getNestedParser();
+    Parser jqParser = eventGen.getJqParser();
 
     Map<String, Object> event = flatParser.parse(newEvent);
     Map<String, Object> event2 = nestedParser.parse(newEvent2);
+    Map<String, Object> event3 = jqParser.parse(newEvent2);  // reuse the same event as "nested"
 
     checkEvent1(event);
     checkEvent2(event2);
+    checkEvent2(event3); // make sure JQ parser output matches with JSONPath parser output
   }
 
   public void checkEvent1(Map<String, Object> event) {

--- a/docs/content/ingestion/flatten-json.md
+++ b/docs/content/ingestion/flatten-json.md
@@ -17,9 +17,9 @@ Defining the JSON Flatten Spec allows nested JSON fields to be flattened during 
 
 | Field | Type | Description | Required |
 |-------|------|-------------|----------|
-| type | String | Type of the field, "root" or "path". | yes |
+| type | String | Type of the field, "root", "path" or "jq". | yes |
 | name | String | This string will be used as the column name when the data has been ingested.  | yes |
-| expr | String | Defines an expression for accessing the field within the JSON object, using [JsonPath](https://github.com/jayway/JsonPath) notation. Only used for type "path", otherwise ignored. | only for type "path" |
+| expr | String | Defines an expression for accessing the field within the JSON object, using [JsonPath](https://github.com/jayway/JsonPath) notation for type "path", and [jackson-jq](https://github.com/eiiches/jackson-jq) for type "jq". This field is only used for type "path" and "jq", otherwise ignored. | only for type "path" or "jq" |
 
 Suppose the event JSON has the following form:
 
@@ -99,6 +99,16 @@ To flatten this JSON, the parseSpec could be defined as follows:
         "type": "path",
         "name": "second-food",
         "expr": "$.thing.food[1]"
+      },
+      {
+        "type": "jq",
+        "name": "first-food-by-jq",
+        "expr": ".thing.food[1]"
+      },
+      {
+        "type": "jq",
+        "name": "hello-total",
+        "expr": ".hello | sum"
       }
     ]
   },
@@ -147,3 +157,4 @@ Note that:
 * If auto field discovery is enabled, any discovered field with the same name as one already defined in the field specs will be skipped and not added twice.
 * The JSON input must be a JSON object at the root, not an array. e.g., {"valid": "true"} and {"valid":[1,2,3]} are supported but [{"invalid": "true"}] and [1,2,3] are not.
 * [http://jsonpath.herokuapp.com/](http://jsonpath.herokuapp.com/) is useful for testing the path expressions.
+* jackson-jq supports subset of [./jq](https://stedolan.github.io/jq/) syntax.  Please refer jackson-jq document.

--- a/java-util/pom.xml
+++ b/java-util/pom.xml
@@ -110,7 +110,6 @@
       <dependency>
         <groupId>net.thisptr</groupId>
         <artifactId>jackson-jq</artifactId>
-        <version>RELEASE</version>
       </dependency>
     </dependencies>
 

--- a/java-util/pom.xml
+++ b/java-util/pom.xml
@@ -107,6 +107,11 @@
             <scope>test</scope>
             <optional>true</optional>
         </dependency>
+      <dependency>
+        <groupId>net.thisptr</groupId>
+        <artifactId>jackson-jq</artifactId>
+        <version>RELEASE</version>
+      </dependency>
     </dependencies>
 
     <build>

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/FlattenExpr.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/FlattenExpr.java
@@ -25,7 +25,9 @@ import com.jayway.jsonpath.JsonPath;
 import net.thisptr.jackson.jq.JsonQuery;
 import net.thisptr.jackson.jq.exception.JsonQueryException;
 
-
+/*
+ *  Flatten expr adapter class
+ */
 public class FlattenExpr
 {
   private JsonPath jsonPathExpr;
@@ -42,12 +44,12 @@ public class FlattenExpr
     this.jsonQueryExpr = jsonQueryExpr;
   }
 
-  public JsonNode read(JsonNode document, Configuration jsonConfig)
+  public JsonNode readPath(JsonNode document, Configuration jsonConfig)
   {
     return this.jsonPathExpr.read(document, jsonConfig);
   }
 
-  public JsonNode read(JsonNode document)
+  public JsonNode readJq(JsonNode document)
   {
     try {
       return this.jsonQueryExpr.apply(document).get(0);

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/FlattenExpr.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/FlattenExpr.java
@@ -53,7 +53,7 @@ public class FlattenExpr
       return this.jsonQueryExpr.apply(document).get(0);
     }
     catch (JsonQueryException e) {
-      e.printStackTrace();
+      // ignore errors
     }
     return null;
   }

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/FlattenExpr.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/FlattenExpr.java
@@ -53,7 +53,7 @@ public class FlattenExpr
       return this.jsonQueryExpr.apply(document).get(0);
     }
     catch (JsonQueryException e) {
-      // ignore errors
+      // ignore errors.
     }
     return null;
   }

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/FlattenExpr.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/FlattenExpr.java
@@ -34,19 +34,23 @@ public class FlattenExpr
   private JsonQuery jsonQueryExpr;
 
 
-  FlattenExpr(JsonPath jsonPathExpr) {
+  FlattenExpr(JsonPath jsonPathExpr)
+  {
     this.jsonPathExpr = jsonPathExpr;
   }
 
-  FlattenExpr(JsonQuery jsonQueryExpr) {
+  FlattenExpr(JsonQuery jsonQueryExpr)
+  {
     this.jsonQueryExpr = jsonQueryExpr;
   }
 
-  public Object read(Map<String, Object> document, Configuration jsonConfig) {
+  public Object read(Map<String, Object> document, Configuration jsonConfig)
+  {
     return this.jsonPathExpr.read(document, jsonConfig);
   }
 
-  public JsonNode read(JsonNode document) {
+  public JsonNode read(JsonNode document)
+  {
     try {
       return this.jsonQueryExpr.apply(document).get(0);
     }
@@ -55,6 +59,4 @@ public class FlattenExpr
     }
     return null;
   }
-
-
 }

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/FlattenExpr.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/FlattenExpr.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.java.util.common.parsers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import net.thisptr.jackson.jq.JsonQuery;
+import net.thisptr.jackson.jq.exception.JsonQueryException;
+
+import java.util.Map;
+
+
+public class FlattenExpr
+{
+  private JsonPath jsonPathExpr;
+  private JsonQuery jsonQueryExpr;
+
+
+  FlattenExpr(JsonPath jsonPathExpr) {
+    this.jsonPathExpr = jsonPathExpr;
+  }
+
+  FlattenExpr(JsonQuery jsonQueryExpr) {
+    this.jsonQueryExpr = jsonQueryExpr;
+  }
+
+  public Object read(Map<String, Object> document, Configuration jsonConfig) {
+    return this.jsonPathExpr.read(document, jsonConfig);
+  }
+
+  public JsonNode read(JsonNode document) {
+    try {
+      return this.jsonQueryExpr.apply(document).get(0);
+    }
+    catch (JsonQueryException e) {
+      e.printStackTrace();
+    }
+    return null;
+  }
+
+
+}

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/FlattenExpr.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/FlattenExpr.java
@@ -25,9 +25,7 @@ import com.jayway.jsonpath.JsonPath;
 import net.thisptr.jackson.jq.JsonQuery;
 import net.thisptr.jackson.jq.exception.JsonQueryException;
 
-/*
- *  Flatten expr adapter class
- */
+
 public class FlattenExpr
 {
   private JsonPath jsonPathExpr;

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/FlattenExpr.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/FlattenExpr.java
@@ -25,8 +25,6 @@ import com.jayway.jsonpath.JsonPath;
 import net.thisptr.jackson.jq.JsonQuery;
 import net.thisptr.jackson.jq.exception.JsonQueryException;
 
-import java.util.Map;
-
 
 public class FlattenExpr
 {
@@ -44,7 +42,7 @@ public class FlattenExpr
     this.jsonQueryExpr = jsonQueryExpr;
   }
 
-  public Object read(Map<String, Object> document, Configuration jsonConfig)
+  public JsonNode read(JsonNode document, Configuration jsonConfig)
   {
     return this.jsonPathExpr.read(document, jsonConfig);
   }

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/JSONPathParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/JSONPathParser.java
@@ -143,7 +143,7 @@ public class JSONPathParser implements Parser<String, Object>
           path = new FlattenExpr(JsonQuery.compile(fieldSpec.getExpr()));
         }
         catch (JsonQueryException e) {
-          throw new ParseException(e, "Unable to compile JQ expression [%s]", fieldSpec.getExpr());
+          throw new IllegalArgumentException("Unable to compile JQ expression: " + fieldSpec.getExpr());
         }
       }
       Pair<FieldType, FlattenExpr> pair = new Pair<>(fieldSpec.getType(), path);

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/JSONPathParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/JSONPathParser.java
@@ -106,9 +106,9 @@ public class JSONPathParser implements Parser<String, Object>
         if (pair.lhs == FieldType.ROOT) {
           parsedVal = valueConversionFunction(document.get(fieldName));
         } else if (pair.lhs == FieldType.PATH) {
-          parsedVal = valueConversionFunction(path.read(document, jsonPathConfig));
+          parsedVal = valueConversionFunction(path.readPath(document, jsonPathConfig));
         } else if (pair.lhs == FieldType.JQ) {
-          parsedVal = valueConversionFunction(path.read(document));
+          parsedVal = valueConversionFunction(path.readJq(document));
         } else {
           throw new ParseException("Unknown FieldType", pair.lhs);
         }
@@ -143,7 +143,7 @@ public class JSONPathParser implements Parser<String, Object>
           path = new FlattenExpr(JsonQuery.compile(fieldSpec.getExpr()));
         }
         catch (JsonQueryException e) {
-          throw new ParseException(e, "Unable to flatten expression row [%s]", fieldSpec.getExpr());
+          throw new ParseException(e, "Unable to compile JQ expression [%s]", fieldSpec.getExpr());
         }
       }
       Pair<FieldType, FlattenExpr> pair = new Pair<>(fieldSpec.getType(), path);
@@ -170,8 +170,7 @@ public class JSONPathParser implements Parser<String, Object>
             continue;
           }
         }
-        Object val2 = valueConversionFunction(val);
-        map.put(field, val2);
+        map.put(field, valueConversionFunction(val));
       }
     }
   }

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/JSONPathParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/JSONPathParser.java
@@ -110,7 +110,7 @@ public class JSONPathParser implements Parser<String, Object>
         } else if (pair.lhs == FieldType.JQ) {
           parsedVal = path.readJq(document);
         } else {
-          throw new IllegalArgumentException("Unknown FieldType: " + pair.lhs);
+          throw new ParseException("Unknown FieldType", pair.lhs);
         }
         if (parsedVal == null) {
           continue;

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/JSONPathParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/JSONPathParser.java
@@ -110,7 +110,7 @@ public class JSONPathParser implements Parser<String, Object>
         } else if (pair.lhs == FieldType.JQ) {
           parsedVal = path.readJq(document);
         } else {
-          throw new ParseException("Unknown FieldType", pair.lhs);
+          throw new IllegalArgumentException("Unknown FieldType: " + pair.lhs);
         }
         if (parsedVal == null) {
           continue;

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/JSONPathParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/JSONPathParser.java
@@ -102,20 +102,20 @@ public class JSONPathParser implements Parser<String, Object>
         String fieldName = entry.getKey();
         Pair<FieldType, FlattenExpr> pair = entry.getValue();
         FlattenExpr path = pair.rhs;
-        Object parsedVal;
+        JsonNode parsedVal;
         if (pair.lhs == FieldType.ROOT) {
-          parsedVal = valueConversionFunction(document.get(fieldName));
+          parsedVal = document.get(fieldName);
         } else if (pair.lhs == FieldType.PATH) {
-          parsedVal = valueConversionFunction(path.readPath(document, jsonPathConfig));
+          parsedVal = path.readPath(document, jsonPathConfig);
         } else if (pair.lhs == FieldType.JQ) {
-          parsedVal = valueConversionFunction(path.readJq(document));
+          parsedVal = path.readJq(document);
         } else {
           throw new ParseException("Unknown FieldType", pair.lhs);
         }
         if (parsedVal == null) {
           continue;
         }
-        map.put(fieldName, parsedVal);
+        map.put(fieldName, valueConversionFunction(parsedVal));
       }
       if (useFieldDiscovery) {
         discoverFields(map, document);

--- a/java-util/src/test/java/io/druid/java/util/common/parsers/JSONPathParserTest.java
+++ b/java-util/src/test/java/io/druid/java/util/common/parsers/JSONPathParserTest.java
@@ -169,6 +169,9 @@ public class JSONPathParserTest
     fields.add(new JSONPathParser.FieldSpec(JSONPathParser.FieldType.PATH, "nested-foo.bar2", "$.foo.bar2"));
     fields.add(new JSONPathParser.FieldSpec(JSONPathParser.FieldType.PATH, "heybarx0", "$.hey[0].barx"));
     fields.add(new JSONPathParser.FieldSpec(JSONPathParser.FieldType.PATH, "met-array", "$.met.a"));
+    fields.add(new JSONPathParser.FieldSpec(JSONPathParser.FieldType.JQ, "jq-nested-foo.bar2", ".foo.bar2"));
+    fields.add(new JSONPathParser.FieldSpec(JSONPathParser.FieldType.JQ, "jq-heybarx0", ".hey[0].barx"));
+    fields.add(new JSONPathParser.FieldSpec(JSONPathParser.FieldType.JQ, "jq-met-array", ".met.a"));
 
     final Parser<String, Object> jsonParser = new JSONPathParser(fields, false, null);
     final Map<String, Object> jsonMap = jsonParser.parse(nestedJson);
@@ -181,6 +184,9 @@ public class JSONPathParserTest
     Assert.assertEquals("bbb", jsonMap.get("nested-foo.bar2"));
     Assert.assertEquals("asdf", jsonMap.get("heybarx0"));
     Assert.assertEquals(ImmutableList.of(7L, 8L, 9L), jsonMap.get("met-array"));
+    Assert.assertEquals("bbb", jsonMap.get("jq-nested-foo.bar2"));
+    Assert.assertEquals("asdf", jsonMap.get("jq-heybarx0"));
+    Assert.assertEquals(ImmutableList.of(7L, 8L, 9L), jsonMap.get("jq-met-array"));
 
     // Fields that should not be discovered
     Assert.assertNull(jsonMap.get("newmet"));
@@ -200,6 +206,20 @@ public class JSONPathParserTest
     List<JSONPathParser.FieldSpec> fields = new ArrayList<>();
     fields.add(new JSONPathParser.FieldSpec(JSONPathParser.FieldType.PATH, "met-array", "$.met.a"));
     fields.add(new JSONPathParser.FieldSpec(JSONPathParser.FieldType.PATH, "met-array", "$.met.a"));
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Cannot have duplicate field definition: met-array");
+
+    final Parser<String, Object> jsonParser = new JSONPathParser(fields, false, null);
+    final Map<String, Object> jsonMap = jsonParser.parse(nestedJson);
+  }
+
+  @Test
+  public void testRejectDuplicates2()
+  {
+    List<JSONPathParser.FieldSpec> fields = new ArrayList<>();
+    fields.add(new JSONPathParser.FieldSpec(JSONPathParser.FieldType.PATH, "met-array", "$.met.a"));
+    fields.add(new JSONPathParser.FieldSpec(JSONPathParser.FieldType.JQ, "met-array", ".met.a"));
 
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Cannot have duplicate field definition: met-array");

--- a/java-util/src/test/java/io/druid/java/util/common/parsers/JSONPathParserTest.java
+++ b/java-util/src/test/java/io/druid/java/util/common/parsers/JSONPathParserTest.java
@@ -106,6 +106,11 @@ public class JSONPathParserTest
     fields.add(new JSONPathParser.FieldSpec(JSONPathParser.FieldType.ROOT, "INVALID_ROOT", "INVALID_ROOT_EXPR"));
     fields.add(new JSONPathParser.FieldSpec(JSONPathParser.FieldType.PATH, "INVALID_PATH", "INVALID_PATH_EXPR"));
 
+    fields.add(new JSONPathParser.FieldSpec(JSONPathParser.FieldType.JQ, "jq-nested-foo.bar1", ".foo.bar1"));
+    fields.add(new JSONPathParser.FieldSpec(JSONPathParser.FieldType.JQ, "jq-nested-foo.bar2", ".foo.bar2"));
+    fields.add(new JSONPathParser.FieldSpec(JSONPathParser.FieldType.JQ, "jq-heybarx0", ".hey[0].barx"));
+    fields.add(new JSONPathParser.FieldSpec(JSONPathParser.FieldType.JQ, "jq-met-array", ".met.a"));
+
 
     final Parser<String, Object> jsonParser = new JSONPathParser(fields, true, null);
     final Map<String, Object> jsonMap = jsonParser.parse(nestedJson);
@@ -138,6 +143,11 @@ public class JSONPathParserTest
     Assert.assertEquals("bbb", jsonMap.get("nested-foo.bar2"));
     Assert.assertEquals("asdf", jsonMap.get("heybarx0"));
     Assert.assertEquals(ImmutableList.of(7L, 8L, 9L), jsonMap.get("met-array"));
+
+    Assert.assertEquals("aaa", jsonMap.get("jq-nested-foo.bar1"));
+    Assert.assertEquals("bbb", jsonMap.get("jq-nested-foo.bar2"));
+    Assert.assertEquals("asdf", jsonMap.get("jq-heybarx0"));
+    Assert.assertEquals(ImmutableList.of(7L, 8L, 9L), jsonMap.get("jq-met-array"));
 
     // Fields that should not be discovered
     Assert.assertNull(jsonMap.get("hey"));

--- a/java-util/src/test/java/io/druid/java/util/common/parsers/JSONPathParserTest.java
+++ b/java-util/src/test/java/io/druid/java/util/common/parsers/JSONPathParserTest.java
@@ -123,11 +123,11 @@ public class JSONPathParserTest
     Assert.assertEquals("2999", jsonMap.get("timestamp"));
     Assert.assertEquals("Hello world!", jsonMap.get("foo.bar1"));
 
-    List<Object> testListConvert = (List)jsonMap.get("testListConvert");
+    List<Object> testListConvert = (List) jsonMap.get("testListConvert");
     Assert.assertEquals(1.23456789E21, testListConvert.get(0));
     Assert.assertEquals("foo?", testListConvert.get(1));
 
-    List<Object> testListConvert2 = (List)jsonMap.get("testListConvert2");
+    List<Object> testListConvert2 = (List) jsonMap.get("testListConvert2");
     Assert.assertEquals(1.23456789E21, testListConvert2.get(0));
     Assert.assertEquals("foo?", testListConvert2.get(1));
     Assert.assertEquals(1.23456789E21, ((List) testListConvert2.get(2)).get(0));

--- a/pom.xml
+++ b/pom.xml
@@ -630,6 +630,11 @@
                 <version>2.1.0</version>
             </dependency>
             <dependency>
+                <groupId>net.thisptr</groupId>
+                <artifactId>jackson-jq</artifactId>
+                <version>0.0.7</version>
+            </dependency>
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>1.6.4</version>


### PR DESCRIPTION
This PR adds a new expression type "jq" to the flattenSpec.  "jq" is a well known JSON manipulation tool.   JSONPath is ok for extracting values out of the nested data structure but it lacks value translation capability.   jq is pretty good at it and it can be used as ETL tool, effectively.

Example:  a JSON has `secondField` and `nanosecField` fields where integer values are stored, and you want to extract the sum of the two fields, and get the derived field `totalSecond`.  Another example is to apply regex on URL and get directory name.  The flattenSpec can be written like this.

```
"flattenSpec": {
    "fields": [
      {
         "type": "jq",
         "name": "totalSecond",
         "expr": ".secondField + .nanosecField / 1000000000"
      },
      {
        "type": "jq",
        "name": "directory",
        "expr": ".url | capture(\"(?<dir>\/[^\/]+/\", \"\") | .dir)"
      } 
   ]
}
```

The benchmark that accesses nested fields shows no significant difference than JSONPath.

JsonPath related code has been modified to use `JacksonJsonNodeJsonProvide`r and `JsonNode` instead of `JacksonJsonProvider` and `Map<String, Object>` so that both JsonPath and Jackson-JQ use the same JsonNode document.

The only ugly part is the newly added `FlattenExpr` adapter that wraps JsonPath and JsonQuery classes.  I'm not sure the best way to create a common interface for the 3rd party classes.  Please enlighten me if there is a better way.

Lastly, please note,  the jq library used in this PR is [jackson-jq](https://github.com/eiiches/jackson-jq) that is a Java port, not the [original jq](https://stedolan.github.io/jq/) nor [libjq wrapper](https://github.com/bskaggs/jjq).

