### PR TITLE
Fix S3 deep storage push and s3 insert-segment-to-db

### DIFF
--- a/extensions-core/s3-extensions/src/main/java/io/druid/storage/s3/S3DataSegmentFinder.java
+++ b/extensions-core/s3-extensions/src/main/java/io/druid/storage/s3/S3DataSegmentFinder.java
@@ -87,9 +87,9 @@ public class S3DataSegmentFinder implements DataSegmentFinder
               log.info("Found segment [%s] located at [%s]", dataSegment.getIdentifier(), indexZip);
 
               final Map<String, Object> loadSpec = dataSegment.getLoadSpec();
-              if ((!loadSpec.containsKey("type") || !loadSpec.get("type").equals(S3StorageDruidModule.SCHEME)) ||
-                  (!loadSpec.containsKey("key") || !loadSpec.get("key").equals(indexZip)) ||
-                  (!loadSpec.containsKey("bucket") || !loadSpec.get("bucket").equals(config.getBucket()))) {
+              if (!S3StorageDruidModule.SCHEME.equals(loadSpec.get("type")) ||
+                  !indexZip.equals(loadSpec.get("key")) ||
+                  !config.getBucket().equals(loadSpec.get("bucket"))) {
                 loadSpec.put("type", S3StorageDruidModule.SCHEME);
                 loadSpec.put("key", indexZip);
                 loadSpec.put("bucket", config.getBucket());

--- a/extensions-core/s3-extensions/src/main/java/io/druid/storage/s3/S3DataSegmentFinder.java
+++ b/extensions-core/s3-extensions/src/main/java/io/druid/storage/s3/S3DataSegmentFinder.java
@@ -87,9 +87,12 @@ public class S3DataSegmentFinder implements DataSegmentFinder
               log.info("Found segment [%s] located at [%s]", dataSegment.getIdentifier(), indexZip);
 
               final Map<String, Object> loadSpec = dataSegment.getLoadSpec();
-              if (!loadSpec.get("type").equals(S3StorageDruidModule.SCHEME) || !loadSpec.get("key").equals(indexZip)) {
+              if ((!loadSpec.containsKey("type") || !loadSpec.get("type").equals(S3StorageDruidModule.SCHEME)) ||
+                  (!loadSpec.containsKey("key") || !loadSpec.get("key").equals(indexZip)) ||
+                  (!loadSpec.containsKey("bucket") || !loadSpec.get("bucket").equals(config.getBucket()))) {
                 loadSpec.put("type", S3StorageDruidModule.SCHEME);
                 loadSpec.put("key", indexZip);
+                loadSpec.put("bucket", config.getBucket());
                 if (updateDescriptor) {
                   log.info(
                       "Updating loadSpec in descriptor.json at [%s] with new path [%s]",

--- a/extensions-core/s3-extensions/src/main/java/io/druid/storage/s3/S3DataSegmentPusher.java
+++ b/extensions-core/s3-extensions/src/main/java/io/druid/storage/s3/S3DataSegmentPusher.java
@@ -120,7 +120,7 @@ public class S3DataSegmentPusher implements DataSegmentPusher
                                                       .withBinaryVersion(SegmentUtils.getVersionFromDir(indexFilesDir));
 
               File descriptorFile = File.createTempFile("druid", "descriptor.json");
-              Files.copy(ByteStreams.newInputStreamSupplier(jsonMapper.writeValueAsBytes(inSegment)), descriptorFile);
+              Files.copy(ByteStreams.newInputStreamSupplier(jsonMapper.writeValueAsBytes(outSegment)), descriptorFile);
               S3Object descriptorObject = new S3Object(descriptorFile);
               descriptorObject.setBucketName(outputBucket);
               descriptorObject.setKey(s3DescriptorPath);

--- a/extensions-core/s3-extensions/src/test/java/io/druid/storage/s3/S3DataSegmentPusherTest.java
+++ b/extensions-core/s3-extensions/src/test/java/io/druid/storage/s3/S3DataSegmentPusherTest.java
@@ -19,13 +19,17 @@
 
 package io.druid.storage.s3;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.timeline.DataSegment;
 import io.druid.timeline.partition.NoneShardSpec;
+import org.apache.commons.io.IOUtils;
+import org.easymock.Capture;
 import org.easymock.EasyMock;
+import org.easymock.IAnswer;
 import org.jets3t.service.impl.rest.httpclient.RestS3Service;
 import org.jets3t.service.model.S3Object;
 import org.joda.time.Interval;
@@ -40,6 +44,18 @@ import java.io.File;
  */
 public class S3DataSegmentPusherTest
 {
+  private class ValueContainer<T> {
+    private T value;
+
+    public T getValue() {
+      return value;
+    }
+
+    public void setValue(T value) {
+      this.value = value;
+    }
+  }
+
   @Rule
   public final TemporaryFolder tempFolder = new TemporaryFolder();
 
@@ -47,8 +63,21 @@ public class S3DataSegmentPusherTest
   public void testPush() throws Exception
   {
     RestS3Service s3Client = EasyMock.createStrictMock(RestS3Service.class);
-    EasyMock.expect(s3Client.putObject(EasyMock.anyString(), EasyMock.<S3Object>anyObject()))
-            .andReturn(null)
+
+    Capture<S3Object> capturedS3Object = Capture.newInstance();
+    ValueContainer<String> capturedS3SegmentJson = new ValueContainer<>();
+    EasyMock.expect(s3Client.putObject(EasyMock.anyString(), EasyMock.capture(capturedS3Object)))
+            .andAnswer(
+                new IAnswer<S3Object>() {
+                  @Override
+                  public S3Object answer() throws Throwable {
+                    capturedS3SegmentJson.setValue(
+                        IOUtils.toString(capturedS3Object.getValue().getDataInputStream(), "utf-8")
+                    );
+                    return null;
+                  }
+                }
+            )
             .atLeastOnce();
     EasyMock.replay(s3Client);
 
@@ -57,7 +86,8 @@ public class S3DataSegmentPusherTest
     config.setBucket("bucket");
     config.setBaseKey("key");
 
-    S3DataSegmentPusher pusher = new S3DataSegmentPusher(s3Client, config, new DefaultObjectMapper());
+    ObjectMapper objectMapper = new DefaultObjectMapper();
+    S3DataSegmentPusher pusher = new S3DataSegmentPusher(s3Client, config, objectMapper);
 
     // Create a mock segment on disk
     File tmp = tempFolder.newFile("version.bin");
@@ -81,6 +111,16 @@ public class S3DataSegmentPusherTest
     DataSegment segment = pusher.push(tempFolder.getRoot(), segmentToPush);
 
     Assert.assertEquals(segmentToPush.getSize(), segment.getSize());
+    Assert.assertEquals(1, (int) segment.getBinaryVersion());
+    Assert.assertEquals("bucket", segment.getLoadSpec().get("bucket"));
+    Assert.assertEquals(
+        "key/foo/2015-01-01T00:00:00.000Z_2016-01-01T00:00:00.000Z/0/0/index.zip",
+        segment.getLoadSpec().get("key"));
+    Assert.assertEquals("s3_zip", segment.getLoadSpec().get("type"));
+
+    // Verify that the pushed S3Object contains the correct data
+    String segmentJson = objectMapper.writeValueAsString(segment);
+    Assert.assertEquals(segmentJson, capturedS3SegmentJson.getValue());
 
     EasyMock.verify(s3Client);
   }


### PR DESCRIPTION
Addresses this issue: https://github.com/druid-io/druid/issues/4170

Also changes the insert-segment-to-db tool to not fail with a `NullPointerException` when trying to read `descriptor.json` files with a blank loadSpec.