### PR TITLE
make the timeout publishing as a failure

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIndexTask.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIndexTask.java
@@ -279,6 +279,7 @@ public class KafkaIndexTask extends AbstractTask implements ChatHandler
         )
     );
 
+    boolean publishedSuccessfully = false;
     try (
         final Appenderator appenderator0 = newAppenderator(fireDepartmentMetrics, toolbox);
         final FiniteAppenderatorDriver driver = newDriver(appenderator0, toolbox, fireDepartmentMetrics);
@@ -516,6 +517,7 @@ public class KafkaIndexTask extends AbstractTask implements ChatHandler
       if (published == null) {
         throw new ISE("Transaction failure publishing segments, aborting");
       } else {
+        publishedSuccessfully = true;
         log.info(
             "Published segments[%s] with metadata[%s].",
             Joiner.on(", ").join(
@@ -545,6 +547,11 @@ public class KafkaIndexTask extends AbstractTask implements ChatHandler
       // if we were interrupted because we were asked to stop, handle the exception and return success, else rethrow
       if (!stopRequested) {
         Thread.currentThread().interrupt();
+        throw e;
+      }
+
+      if (!publishedSuccessfully){
+        log.error("The task did NOT publish the segments successfully, check the value of [completionTimeout]");
         throw e;
       }
 


### PR DESCRIPTION
In one kafka ingestion task , if there is too much data(e.g. reset offset for a data source), it probably would NOT finish the publishing within the time of `completionTimeout(default:30Mins)`.
In this case, I found that it did put the data into HDFS(deep storage), but it lost the meta-data because the KafkaIndexTask thread was interrupted, it's caught by line538(540), in this catch block, it does NOT rethrow exception if it's the publishing timeout case, and finally, it finishes as a SUCCESSFUL task, but in fact, it lose the meta-data for these segments created by this task.
In this PR, It determines whether the task really publish these meta-data successfully , and throw the exception if it does NOT.
