### PR TITLE
Kafka Index Task that supports Incremental handoffs

### DIFF
--- a/common/src/main/java/io/druid/metadata/MetadataStorageConnector.java
+++ b/common/src/main/java/io/druid/metadata/MetadataStorageConnector.java
@@ -54,5 +54,7 @@ public interface MetadataStorageConnector
 
   void createSupervisorsTable();
 
+  void createTaskCheckPointsTable();
+
   void deleteAllRecords(String tableName);
 }

--- a/common/src/main/java/io/druid/metadata/MetadataStorageTablesConfig.java
+++ b/common/src/main/java/io/druid/metadata/MetadataStorageTablesConfig.java
@@ -31,7 +31,7 @@ public class MetadataStorageTablesConfig
 {
   public static MetadataStorageTablesConfig fromBase(String base)
   {
-    return new MetadataStorageTablesConfig(base, null, null, null, null, null, null, null, null, null, null);
+    return new MetadataStorageTablesConfig(base, null, null, null, null, null, null, null, null, null, null, null);
   }
 
   public static final String TASK_ENTRY_TYPE = "task";
@@ -75,6 +75,9 @@ public class MetadataStorageTablesConfig
   @JsonProperty("supervisors")
   private final String supervisorTable;
 
+  @JsonProperty("taskCheckPoints")
+  private final String taskCheckPointsTable;
+
   @JsonCreator
   public MetadataStorageTablesConfig(
       @JsonProperty("base") String base,
@@ -87,7 +90,8 @@ public class MetadataStorageTablesConfig
       @JsonProperty("taskLog") String taskLogTable,
       @JsonProperty("taskLock") String taskLockTable,
       @JsonProperty("audit") String auditTable,
-      @JsonProperty("supervisors") String supervisorTable
+      @JsonProperty("supervisors") String supervisorTable,
+      @JsonProperty("taskCheckPoints") String taskCheckPointsTable
   )
   {
     this.base = (base == null) ? DEFAULT_BASE : base;
@@ -105,6 +109,7 @@ public class MetadataStorageTablesConfig
     lockTables.put(TASK_ENTRY_TYPE, this.taskLockTable);
     this.auditTable = makeTableName(auditTable, "audit");
     this.supervisorTable = makeTableName(supervisorTable, "supervisors");
+    this.taskCheckPointsTable = makeTableName(taskCheckPointsTable, "taskCheckPoints");
   }
 
   private String makeTableName(String explicitTableName, String defaultSuffix)
@@ -192,5 +197,10 @@ public class MetadataStorageTablesConfig
   public String getTaskLockTable()
   {
     return taskLockTable;
+  }
+
+  public String getTaskCheckPointsTable()
+  {
+    return taskCheckPointsTable;
   }
 }

--- a/extensions-contrib/sqlserver-metadata-storage/src/test/java/io/druid/metadata/storage/sqlserver/SQLServerConnectorTest.java
+++ b/extensions-contrib/sqlserver-metadata-storage/src/test/java/io/druid/metadata/storage/sqlserver/SQLServerConnectorTest.java
@@ -18,15 +18,13 @@
  */
 package io.druid.metadata.storage.sqlserver;
 
-import java.sql.SQLException;
-
+import com.google.common.base.Suppliers;
+import io.druid.metadata.MetadataStorageConnectorConfig;
+import io.druid.metadata.MetadataStorageTablesConfig;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.google.common.base.Suppliers;
-
-import io.druid.metadata.MetadataStorageConnectorConfig;
-import io.druid.metadata.MetadataStorageTablesConfig;
+import java.sql.SQLException;
 
 @SuppressWarnings("nls")
 public class SQLServerConnectorTest
@@ -39,6 +37,7 @@ public class SQLServerConnectorTest
         Suppliers.ofInstance(new MetadataStorageConnectorConfig()),
         Suppliers.ofInstance(
             new MetadataStorageTablesConfig(
+                null,
                 null,
                 null,
                 null,

--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/DriverHolder.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/DriverHolder.java
@@ -1,0 +1,671 @@
+package io.druid.indexing.kafka;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.metamx.emitter.EmittingLogger;
+import io.druid.data.input.Committer;
+import io.druid.data.input.InputRow;
+import io.druid.indexing.common.TaskToolbox;
+import io.druid.indexing.common.actions.SegmentTransactionalInsertAction;
+import io.druid.java.util.common.IAE;
+import io.druid.java.util.common.ISE;
+import io.druid.segment.realtime.FireDepartmentMetrics;
+import io.druid.segment.realtime.appenderator.FiniteAppenderatorDriver;
+import io.druid.segment.realtime.appenderator.SegmentIdentifier;
+import io.druid.segment.realtime.appenderator.SegmentsAndMetadata;
+import io.druid.segment.realtime.appenderator.TransactionalSegmentPublisher;
+import io.druid.timeline.DataSegment;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.RejectedExecutionException;
+
+public class DriverHolder implements Closeable
+{
+  public enum DriverStatus
+  {
+    NOT_OPEN,
+    OPEN,
+    COMPLETE,
+    PERSISTING,
+    PERSISTED,
+    PUBLISHING,
+    PUBLISHED,
+    CLOSED
+  }
+
+  volatile DriverStatus driverStatus = DriverStatus.NOT_OPEN;
+
+  private static final EmittingLogger log = new EmittingLogger(DriverHolder.class);
+
+  private final FiniteAppenderatorDriver driver;
+  private final Set<Integer> assignment;
+  private Supplier<Committer> committerSupplier;
+
+  private final Map<Integer, Long> nextPartitionOffsets = Maps.newHashMap();
+
+  /*********** Driver Metadata **********/
+  private final String topic;
+  private final Map<Integer, Long> startOffsets;
+  private final Map<Integer, Long> endOffsets;
+  private final String sequenceName;
+  // this uniquely identifies the persist dir for this driver
+  private final int driverIndex;
+  // whether this is the last driver for the task
+  private volatile boolean last;
+  // whether the end offsets for this driver is set
+  private volatile boolean checkPointed;
+  private boolean maxRowsPerSegmentLimitReached;
+
+  /***************************************/
+
+  private DriverHolder(
+      String topic,
+      FiniteAppenderatorDriver driver,
+      Map<Integer, Long> startOffsets,
+      Map<Integer, Long> endOffsets,
+      int driverIndex,
+      String sequenceName,
+      boolean last,
+      boolean checkPointed,
+      boolean maxRowsPerSegmentLimitReached
+  )
+  {
+    this.topic = topic;
+    this.driver = driver;
+    this.startOffsets = startOffsets;
+    // endOffsets will change when a check point is set so make a local copy of it
+    this.endOffsets = Maps.newHashMap(endOffsets);
+    this.driverIndex = driverIndex;
+    this.sequenceName = sequenceName;
+    this.assignment = Sets.newHashSet(endOffsets.keySet());
+    this.last = last;
+    this.checkPointed = checkPointed;
+    this.maxRowsPerSegmentLimitReached = maxRowsPerSegmentLimitReached;
+  }
+
+  Map<Integer, Long> startJob(final ObjectMapper mapper)
+  {
+    final Object restored = driver.startJob();
+    Preconditions.checkState(
+        driverStatus == DriverStatus.NOT_OPEN,
+        "WTH?! Cannot change driver status to [%s] from [%s]",
+        DriverStatus.OPEN,
+        driverStatus
+    );
+    driverStatus = DriverStatus.OPEN;
+    if (restored == null) {
+      nextPartitionOffsets.putAll(startOffsets);
+    } else {
+      Map<String, Object> restoredMetadataMap = (Map) restored;
+      final KafkaPartitions restoredNextPartitions = mapper.convertValue(
+          restoredMetadataMap.get(KafkaIndexTask.METADATA_NEXT_PARTITIONS),
+          KafkaPartitions.class
+      );
+      nextPartitionOffsets.putAll(restoredNextPartitions.getPartitionOffsetMap());
+
+      // Sanity checks.
+      if (!restoredNextPartitions.getTopic().equals(topic)) {
+        throw new ISE(
+            "WTF?! Restored topic[%s] but expected topic[%s]",
+            restoredNextPartitions.getTopic(),
+            topic
+        );
+      }
+
+      if (!nextPartitionOffsets.keySet().equals(startOffsets.keySet())) {
+        throw new ISE(
+            "WTF?! Restored partitions[%s] but expected partitions[%s]",
+            nextPartitionOffsets.keySet(),
+            startOffsets.keySet()
+        );
+      }
+    }
+    committerSupplier = new Supplier<Committer>()
+    {
+      @Override
+      public Committer get()
+      {
+        final Map<Integer, Long> snapshot = ImmutableMap.copyOf(nextPartitionOffsets);
+
+        return new Committer()
+        {
+          @Override
+          public Object getMetadata()
+          {
+            return ImmutableMap.of(
+                KafkaIndexTask.METADATA_NEXT_PARTITIONS, new KafkaPartitions(
+                    topic,
+                    snapshot
+                )
+            );
+          }
+
+          @Override
+          public void run()
+          {
+            // Do nothing
+          }
+        };
+      }
+    };
+
+    // remove partition for which offsets have been consumed fully
+    for (Map.Entry<Integer, Long> partitionOffset : nextPartitionOffsets.entrySet()) {
+      if (endOffsets.get(partitionOffset.getKey()).equals(partitionOffset.getValue())) {
+        logInfo("[Start-Job] read partition [%d]", partitionOffset.getKey());
+        assignment.remove(partitionOffset.getKey());
+      }
+    }
+    if (assignment.isEmpty()) {
+      // finish the driver
+      logInfo("[Start-Job] read all partitions");
+      Preconditions.checkState(
+          driverStatus == DriverStatus.OPEN,
+          "WTH?! Cannot change driver status to [%s] from [%s]",
+          DriverStatus.COMPLETE,
+          driverStatus
+      );
+      driverStatus = DriverStatus.COMPLETE;
+    }
+
+    return nextPartitionOffsets;
+  }
+
+  boolean canHandle(ConsumerRecord<byte[], byte[]> record)
+  {
+    return driverStatus == DriverStatus.OPEN
+           && endOffsets.get(record.partition()) != null
+           && record.offset() >= startOffsets.get(record.partition())
+           && record.offset() < endOffsets.get(record.partition());
+  }
+
+  public SegmentIdentifier add(InputRow row) throws IOException
+  {
+    Preconditions.checkState(driverStatus == DriverStatus.OPEN, "Cannot add to driver which is not open!");
+
+    SegmentIdentifier identifier = driver.add(row, sequenceName, committerSupplier, false);
+
+    if (identifier == null) {
+      // Failure to allocate segment puts determinism at risk, bail out to be safe.
+      // May want configurable behavior here at some point.
+      // If we allow continuing, then consider blacklisting the interval for a while to avoid constant checks.
+      throw new ISE("Could not allocate segment for row with timestamp[%s]", row.getTimestamp());
+    }
+
+    // remember to call incrementNextOffsets before using any other method
+    // which relies on updated value of nextPartitionOffsets
+    if (driver.numRowsInSegment(identifier) >= driver.getMaxRowPerSegment()) {
+      maxRowsPerSegmentLimitReached = true;
+    }
+    return identifier;
+  }
+
+  void incrementNextOffsets(ConsumerRecord<byte[], byte[]> record)
+  {
+    // we do not automatically increment next offset with add call
+    // as in case record cannot be parsed add method will not be called
+    // however we still need to increment next offsets irrespective
+
+    // update local nextOffset to be used by committer at some point
+    nextPartitionOffsets.put(record.partition(), nextPartitionOffsets.get(record.partition()) + 1);
+
+    if (nextPartitionOffsets.get(record.partition()).equals(endOffsets.get(record.partition()))) {
+      logInfo("[Increment-Offsets] read partition [%d]", record.partition());
+      // done with this partition, remove it from end offsets
+      assignment.remove(record.partition());
+      if (assignment.isEmpty()) {
+        logInfo("[Increment-Offsets] read all partitions");
+        Preconditions.checkState(
+            driverStatus == DriverStatus.OPEN,
+            "WTH?! Cannot change driver status to [%s] from [%s]",
+            DriverStatus.COMPLETE,
+            driverStatus
+        );
+        driverStatus = DriverStatus.COMPLETE;
+      }
+    }
+  }
+
+  boolean isCheckPointingRequired()
+  {
+    return maxRowsPerSegmentLimitReached && !checkPointed;
+  }
+
+  boolean isComplete()
+  {
+    return driverStatus == DriverStatus.COMPLETE;
+  }
+
+  void setEndOffsets(Map<Integer, Long> offsets)
+  {
+    // sanity check again with driver's local offsets
+    if (!endOffsets.keySet().containsAll(offsets.keySet())) {
+      throw new IAE(
+          "Got request to set some offsets not handled by driver [%d], handling [%s] partitions",
+          endOffsets.keySet()
+      );
+    }
+    for (Map.Entry<Integer, Long> entry : offsets.entrySet()) {
+      if (entry.getValue().compareTo(nextPartitionOffsets.get(entry.getKey())) < 0) {
+        throw new IAE(
+            "End offset must be >= current offset for driver [%d] for partition [%s] (current: %s)",
+            driverIndex,
+            entry.getKey(),
+            nextPartitionOffsets.get(entry.getKey())
+        );
+      }
+    }
+    endOffsets.putAll(offsets);
+    // check if any or all partitions have been consumed
+    for (Map.Entry<Integer, Long> entry : endOffsets.entrySet()) {
+      if (entry.getValue().compareTo(nextPartitionOffsets.get(entry.getKey())) == 0) {
+        assignment.remove(entry.getKey());
+        logInfo("[Set-End-Offsets] read partition [%d]", entry.getKey());
+      }
+    }
+    logInfo("endOffsets changed to [%s]", endOffsets);
+    if (assignment.isEmpty()) {
+      logInfo("[Set-End-Offsets] read all partitions");
+      Preconditions.checkState(
+          driverStatus == DriverStatus.OPEN,
+          "WTH?! Cannot change driver status to [%s] from [%s]",
+          DriverStatus.COMPLETE,
+          driverStatus
+      );
+      driverStatus = DriverStatus.COMPLETE;
+    }
+    checkPointed = true;
+    logInfo("check-pointed");
+  }
+
+  SegmentsAndMetadata finish(final TaskToolbox toolbox, final boolean isUseTransaction)
+      throws InterruptedException
+  {
+    try {
+      final TransactionalSegmentPublisher publisher = new TransactionalSegmentPublisher()
+      {
+        @Override
+        public boolean publishSegments(Set<DataSegment> segments, Object commitMetadata) throws IOException
+        {
+          final KafkaPartitions finalPartitions = toolbox.getObjectMapper().convertValue(
+              ((Map) commitMetadata).get(KafkaIndexTask.METADATA_NEXT_PARTITIONS),
+              KafkaPartitions.class
+          );
+
+          // Sanity check, we should only be publishing things that match our desired end state.
+          if (!endOffsets.equals(finalPartitions.getPartitionOffsetMap())) {
+            throw new ISE("WTF?! Driver attempted to publish invalid metadata[%s].", commitMetadata);
+          }
+
+          final SegmentTransactionalInsertAction action;
+
+          if (isUseTransaction) {
+            action = new SegmentTransactionalInsertAction(
+                segments,
+                new KafkaDataSourceMetadata(new KafkaPartitions(topic, startOffsets)),
+                new KafkaDataSourceMetadata(finalPartitions)
+            );
+          } else {
+            action = new SegmentTransactionalInsertAction(segments, null, null);
+          }
+
+          logInfo("Publishing with isTransaction[%s].", isUseTransaction);
+
+          return toolbox.getTaskActionClient().submit(action).isSuccess();
+        }
+      };
+
+      return driver.finish(publisher, committerSupplier.get());
+    }
+    catch (InterruptedException | RejectedExecutionException e) {
+      logError("Interrupted in finish");
+      throw e;
+    }
+  }
+
+  void waitForHandOff() throws InterruptedException
+  {
+    driver.waitForHandOff();
+  }
+
+  Object persist() throws InterruptedException
+  {
+    return driver.persist(committerSupplier.get());
+  }
+
+  public DriverMetadata getMetadata()
+  {
+    return new DriverMetadata(
+        topic,
+        startOffsets,
+        endOffsets,
+        driverIndex,
+        sequenceName,
+        last,
+        checkPointed,
+        maxRowsPerSegmentLimitReached
+    );
+  }
+
+  @Override
+  public void close() throws IOException
+  {
+    if (driverStatus == DriverStatus.CLOSED) {
+      logWarn("already closed");
+    } else {
+      synchronized (this) {
+        if (driverStatus == DriverStatus.CLOSED) {
+          logWarn("already closed");
+          return;
+        }
+        driverStatus = DriverStatus.CLOSED;
+      }
+      driver.getAppenderator().close();
+      driver.close();
+    }
+  }
+
+  void setLast() {
+    last = true;
+  }
+
+  FiniteAppenderatorDriver getDriver()
+  {
+    return driver;
+  }
+
+  Map<Integer, Long> getStartOffsets()
+  {
+    return startOffsets;
+  }
+
+  Map<Integer, Long> getEndOffsets()
+  {
+    return endOffsets;
+  }
+
+  int getDriverIndex()
+  {
+    return driverIndex;
+  }
+
+  boolean isLast()
+  {
+    return last;
+  }
+
+  boolean isCheckPointed()
+  {
+    return checkPointed;
+  }
+
+  private void logInfo(String msg, Object... formatArgs)
+  {
+    log.info("Driver [%d], status [%s]: [%s]", driverIndex, driverStatus, String.format(msg, formatArgs));
+  }
+
+  private void logWarn(String msg, Object... formatArgs)
+  {
+    log.warn("Driver [%d], status [%s]: [%s]", driverIndex, driverStatus, String.format(msg, formatArgs));
+  }
+
+  private void logError(String msg, Object... formatArgs)
+  {
+    log.error("Driver [%d], status [%s]: [%s]", driverIndex, driverStatus, String.format(msg, formatArgs));
+  }
+
+  @Override
+  public String toString()
+  {
+    return "DriverHolder{" +
+           "driverStatus=" + driverStatus +
+           ", driver=" + driver +
+           ", assignment=" + assignment +
+           ", committerSupplier=" + committerSupplier +
+           ", nextPartitionOffsets=" + nextPartitionOffsets +
+           ", topic='" + topic + '\'' +
+           ", startOffsets=" + startOffsets +
+           ", endOffsets=" + endOffsets +
+           ", sequenceName='" + sequenceName + '\'' +
+           ", driverIndex=" + driverIndex +
+           ", last=" + last +
+           ", checkPointed=" + checkPointed +
+           ", maxRowsPerSegmentLimitReached=" + maxRowsPerSegmentLimitReached +
+           '}';
+  }
+
+  static DriverHolder getNextDriverHolder(
+      KafkaIndexTask taskContext,
+      Map<Integer, Long> startOffsets,
+      Map<Integer, Long> endOffsets,
+      String baseSequenceName,
+      FireDepartmentMetrics fireDepartmentMetrics,
+      TaskToolbox taskToolbox
+  )
+  {
+    return createDriverHolder(
+        taskContext,
+        startOffsets,
+        endOffsets,
+        taskContext.nextDriverIndex++,
+        baseSequenceName,
+        fireDepartmentMetrics,
+        taskToolbox,
+        false,
+        false,
+        false
+    );
+  }
+
+  static DriverHolder getNextDriverHolder(
+      KafkaIndexTask taskContext,
+      Map<Integer, Long> startOffsets,
+      Map<Integer, Long> endOffsets,
+      String baseSequenceName,
+      FireDepartmentMetrics fireDepartmentMetrics,
+      TaskToolbox taskToolbox,
+      boolean checkPointed
+  )
+  {
+    return createDriverHolder(
+        taskContext,
+        startOffsets,
+        endOffsets,
+        taskContext.nextDriverIndex++,
+        baseSequenceName,
+        fireDepartmentMetrics,
+        taskToolbox,
+        false,
+        checkPointed,
+        false
+    );
+  }
+
+  static DriverHolder createDriverHolder(
+      KafkaIndexTask taskContext,
+      Map<Integer, Long> startOffsets,
+      Map<Integer, Long> endOffsets,
+      int basePersistDirectoryIndex,
+      String baseSequenceName,
+      FireDepartmentMetrics fireDepartmentMetrics,
+      TaskToolbox taskToolbox,
+      boolean last,
+      boolean checkPointed,
+      boolean maxRowsPerSegmentLimitReached
+  )
+  {
+    final File basePersistDir = new File(
+        taskToolbox.getTaskWorkDir(),
+        String.format("%s%s", "persist", basePersistDirectoryIndex > 0 ? basePersistDirectoryIndex : "")
+    );
+    DriverHolder holder = new DriverHolder(
+        taskContext.getIOConfig().getStartPartitions().getTopic(),
+        taskContext.newDriver(taskContext.newAppenderator(
+            fireDepartmentMetrics,
+            taskToolbox,
+            basePersistDir
+        ), taskToolbox, fireDepartmentMetrics),
+        startOffsets,
+        endOffsets,
+        basePersistDirectoryIndex,
+        String.format("%s_%d", baseSequenceName, basePersistDirectoryIndex),
+        last,
+        checkPointed,
+        maxRowsPerSegmentLimitReached
+    );
+    log.info("Created new Driver with metadata [%s]", holder.getMetadata());
+    return holder;
+  }
+
+  public static class DriverMetadata implements Comparable<DriverMetadata>
+  {
+    private final String topic;
+    private final Map<Integer, Long> startOffsets;
+    private final Map<Integer, Long> endOffsets;
+    private final int driverIndex;
+    private final String sequenceName;
+    private final boolean last;
+    private final boolean checkPointed;
+    private final boolean maxRowsPerSegmentLimitReached;
+
+    @JsonCreator
+    public DriverMetadata(
+        @JsonProperty("topic") String topic,
+        @JsonProperty("startOffsets") Map<Integer, Long> startOffsets,
+        @JsonProperty("endOffsets") Map<Integer, Long> endOffsets,
+        @JsonProperty("driverIndex") int driverIndex,
+        @JsonProperty("sequenceName") String sequenceName,
+        @JsonProperty("last") boolean last,
+        @JsonProperty("checkPointed") boolean checkPointed,
+        @JsonProperty("maxRowsPerSegmentLimitReached") boolean maxRowsPerSegmentLimitReached
+    )
+    {
+      this.topic = topic;
+      this.startOffsets = startOffsets;
+      this.endOffsets = endOffsets;
+      this.driverIndex = driverIndex;
+      this.sequenceName = sequenceName;
+      this.last = last;
+      this.checkPointed = checkPointed;
+      this.maxRowsPerSegmentLimitReached = maxRowsPerSegmentLimitReached;
+    }
+
+    @JsonProperty
+    public int getDriverIndex()
+    {
+      return driverIndex;
+    }
+
+    @JsonProperty
+    public String getSequenceName()
+    {
+      return sequenceName;
+    }
+
+    @JsonProperty
+    public Map<Integer, Long> getEndOffsets()
+    {
+      return endOffsets;
+    }
+
+    @JsonProperty
+    public Map<Integer, Long> getStartOffsets()
+    {
+      return startOffsets;
+    }
+
+    @JsonProperty
+    public String getTopic()
+    {
+      return topic;
+    }
+
+    @JsonProperty
+    public boolean isLast()
+    {
+      return last;
+    }
+
+    @JsonProperty
+    public boolean isCheckPointed()
+    {
+      return checkPointed;
+    }
+
+    @JsonProperty
+    public boolean isMaxRowsPerSegmentLimitReached()
+    {
+      return maxRowsPerSegmentLimitReached;
+    }
+
+    @Override
+    public String toString()
+    {
+      return "DriverMetadata{" +
+             "topic='" + topic + '\'' +
+             ", startOffsets=" + startOffsets +
+             ", endOffsets=" + endOffsets +
+             ", driverIndex=" + driverIndex +
+             ", sequenceName='" + sequenceName + '\'' +
+             ", last=" + last +
+             ", checkPointed=" + checkPointed +
+             ", maxRowsPerSegmentLimitReached=" + maxRowsPerSegmentLimitReached +
+             '}';
+    }
+
+    @Override
+    public int compareTo(DriverMetadata o)
+    {
+      return driverIndex - o.driverIndex;
+    }
+  }
+
+  static class SentinelDriverHolder extends DriverHolder
+  {
+    final CountDownLatch persistLatch;
+    final CountDownLatch handOffLatch;
+
+    SentinelDriverHolder(
+        CountDownLatch persistLatch,
+        CountDownLatch handOffLatch
+    )
+    {
+      super(null, null, ImmutableMap.<Integer, Long>of(), ImmutableMap.<Integer, Long>of(), -1, null, true, true, true);
+      super.driverStatus = DriverStatus.COMPLETE;
+      this.persistLatch = persistLatch;
+      this.handOffLatch = handOffLatch;
+    }
+
+    @Override
+    Object persist() throws InterruptedException
+    {
+      persistLatch.countDown();
+      return null;
+    }
+
+    @Override
+    SegmentsAndMetadata finish(TaskToolbox toolbox, boolean isUseTransaction) throws InterruptedException
+    {
+      // Do nothing
+      return null;
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+      handOffLatch.countDown();
+    }
+  }
+}

--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/DriverHolder.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/DriverHolder.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.druid.indexing.kafka;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIndexTask.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIndexTask.java
@@ -918,7 +918,7 @@ public class KafkaIndexTask extends AbstractTask implements ChatHandler
                 true
             )
         );
-        driverHolders.get(0).startJob(toolbox.getObjectMapper());
+        nextOffsets.putAll(driverHolders.get(0).startJob(toolbox.getObjectMapper()));
         if (driverHolders.get(0).isComplete()) {
           persistAndPossiblyPublish(driverHolders.get(0));
         }

--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaIndexTaskClientTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaIndexTaskClientTest.java
@@ -138,8 +138,8 @@ public class KafkaIndexTaskClientTest extends EasyMockSupport
     Assert.assertEquals(null, client.getStartTime(TEST_ID));
     Assert.assertEquals(ImmutableMap.of(), client.getCurrentOffsets(TEST_ID, true));
     Assert.assertEquals(ImmutableMap.of(), client.getEndOffsets(TEST_ID));
-    Assert.assertEquals(false, client.setEndOffsets(TEST_ID, ImmutableMap.<Integer, Long>of()));
-    Assert.assertEquals(false, client.setEndOffsets(TEST_ID, ImmutableMap.<Integer, Long>of(), true));
+    Assert.assertEquals(false, client.setEndOffsets(TEST_ID, ImmutableMap.<Integer, Long>of(), false, true));
+    Assert.assertEquals(false, client.setEndOffsets(TEST_ID, ImmutableMap.<Integer, Long>of(), true, true));
 
     verifyAll();
   }
@@ -537,13 +537,13 @@ public class KafkaIndexTaskClientTest extends EasyMockSupport
     );
     replayAll();
 
-    client.setEndOffsets(TEST_ID, endOffsets);
+    client.setEndOffsets(TEST_ID, endOffsets, false, true);
     verifyAll();
 
     Request request = captured.getValue();
     Assert.assertEquals(HttpMethod.POST, request.getMethod());
     Assert.assertEquals(
-        new URL("http://test-host:1234/druid/worker/v1/chat/test-id/offsets/end"),
+        new URL("http://test-host:1234/druid/worker/v1/chat/test-id/offsets/end?resume=false&finish=true"),
         request.getUrl()
     );
     Assert.assertTrue(request.getHeaders().get("X-Druid-Task-Id").contains("test-id"));
@@ -562,13 +562,13 @@ public class KafkaIndexTaskClientTest extends EasyMockSupport
     );
     replayAll();
 
-    client.setEndOffsets(TEST_ID, endOffsets, true);
+    client.setEndOffsets(TEST_ID, endOffsets, true, true);
     verifyAll();
 
     Request request = captured.getValue();
     Assert.assertEquals(HttpMethod.POST, request.getMethod());
     Assert.assertEquals(
-        new URL("http://test-host:1234/druid/worker/v1/chat/test-id/offsets/end?resume=true"),
+        new URL("http://test-host:1234/druid/worker/v1/chat/test-id/offsets/end?resume=true&finish=true"),
         request.getUrl()
     );
     Assert.assertTrue(request.getHeaders().get("X-Druid-Task-Id").contains("test-id"));
@@ -897,8 +897,8 @@ public class KafkaIndexTaskClientTest extends EasyMockSupport
     List<URL> expectedUrls = Lists.newArrayList();
     List<ListenableFuture<Boolean>> futures = Lists.newArrayList();
     for (int i = 0; i < numRequests; i++) {
-      expectedUrls.add(new URL(String.format(URL_FORMATTER, TEST_HOST, TEST_PORT, TEST_IDS.get(i), "offsets/end")));
-      futures.add(client.setEndOffsetsAsync(TEST_IDS.get(i), endOffsets));
+      expectedUrls.add(new URL(String.format(URL_FORMATTER, TEST_HOST, TEST_PORT, TEST_IDS.get(i), "offsets/end?resume=false&finish=true")));
+      futures.add(client.setEndOffsetsAsync(TEST_IDS.get(i), endOffsets, false, true));
     }
 
     List<Boolean> responses = Futures.allAsList(futures).get();
@@ -937,11 +937,11 @@ public class KafkaIndexTaskClientTest extends EasyMockSupport
                   TEST_HOST,
                   TEST_PORT,
                   TEST_IDS.get(i),
-                  "offsets/end?resume=true"
+                  "offsets/end?resume=true&finish=true"
               )
           )
       );
-      futures.add(client.setEndOffsetsAsync(TEST_IDS.get(i), endOffsets, true));
+      futures.add(client.setEndOffsetsAsync(TEST_IDS.get(i), endOffsets, true, true));
     }
 
     List<Boolean> responses = Futures.allAsList(futures).get();

--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -161,7 +161,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
         zkServer.getConnectString(),
         tempFolder.newFolder(),
         1,
-        ImmutableMap.of("num.partitions", String.valueOf(NUM_PARTITIONS))
+        ImmutableMap.of("num.partitions", String.valueOf(NUM_PARTITIONS), "advertised.host.name", "localhost")
     );
     kafkaServer.start();
     kafkaHost = String.format("localhost:%d", kafkaServer.getPort());
@@ -213,6 +213,10 @@ public class KafkaSupervisorTest extends EasyMockSupport
             null
         )
     ).anyTimes();
+    expect(indexerMetadataStorageCoordinator.getCheckPointsForSequence(EasyMock.anyString())).andReturn(
+        ImmutableList.<DataSourceMetadata>of()
+    ).anyTimes();
+
     expect(taskQueue.add(capture(captured))).andReturn(true);
     taskRunner.registerListener(anyObject(TaskRunnerListener.class), anyObject(Executor.class));
     replayAll();
@@ -259,6 +263,10 @@ public class KafkaSupervisorTest extends EasyMockSupport
             null
         )
     ).anyTimes();
+    expect(indexerMetadataStorageCoordinator.getCheckPointsForSequence(EasyMock.anyString())).andReturn(
+        ImmutableList.<DataSourceMetadata>of()
+    ).anyTimes();
+
     expect(taskQueue.add(capture(captured))).andReturn(true).times(2);
     replayAll();
 
@@ -296,6 +304,10 @@ public class KafkaSupervisorTest extends EasyMockSupport
             null
         )
     ).anyTimes();
+    expect(indexerMetadataStorageCoordinator.getCheckPointsForSequence(EasyMock.anyString())).andReturn(
+        ImmutableList.<DataSourceMetadata>of()
+    ).anyTimes();
+
     expect(taskQueue.add(capture(captured))).andReturn(true).times(2);
     replayAll();
 
@@ -333,6 +345,10 @@ public class KafkaSupervisorTest extends EasyMockSupport
             null
         )
     ).anyTimes();
+    expect(indexerMetadataStorageCoordinator.getCheckPointsForSequence(EasyMock.anyString())).andReturn(
+        ImmutableList.<DataSourceMetadata>of()
+    ).anyTimes();
+
     expect(taskQueue.add(capture(captured))).andReturn(true).times(2);
     replayAll();
 
@@ -375,6 +391,10 @@ public class KafkaSupervisorTest extends EasyMockSupport
             null
         )
     ).anyTimes();
+    expect(indexerMetadataStorageCoordinator.getCheckPointsForSequence(EasyMock.anyString())).andReturn(
+        ImmutableList.<DataSourceMetadata>of()
+    ).anyTimes();
+
     expect(taskQueue.add(capture(captured))).andReturn(true);
     replayAll();
 
@@ -407,6 +427,10 @@ public class KafkaSupervisorTest extends EasyMockSupport
             new KafkaPartitions(KAFKA_TOPIC, ImmutableMap.of(0, 10L, 1, 20L, 2, 30L))
         )
     ).anyTimes();
+    expect(indexerMetadataStorageCoordinator.getCheckPointsForSequence(EasyMock.anyString())).andReturn(
+        ImmutableList.<DataSourceMetadata>of()
+    ).anyTimes();
+
     expect(taskQueue.add(capture(captured))).andReturn(true);
     replayAll();
 
@@ -435,6 +459,10 @@ public class KafkaSupervisorTest extends EasyMockSupport
             new KafkaPartitions(KAFKA_TOPIC, ImmutableMap.of(0, 10L, 1, 20L, 2, 30L))
         )
     ).anyTimes();
+    expect(indexerMetadataStorageCoordinator.getCheckPointsForSequence(EasyMock.anyString())).andReturn(
+        ImmutableList.<DataSourceMetadata>of()
+    ).anyTimes();
+
     replayAll();
 
     supervisor.start();
@@ -514,6 +542,10 @@ public class KafkaSupervisorTest extends EasyMockSupport
             null
         )
     ).anyTimes();
+    expect(indexerMetadataStorageCoordinator.getCheckPointsForSequence(EasyMock.anyString())).andReturn(
+        ImmutableList.<DataSourceMetadata>of()
+    ).anyTimes();
+
     expect(taskClient.stopAsync("id1", false)).andReturn(Futures.immediateFuture(true));
     expect(taskClient.stopAsync("id3", false)).andReturn(Futures.immediateFuture(false));
     taskRunner.registerListener(anyObject(TaskRunnerListener.class), anyObject(Executor.class));
@@ -630,6 +662,10 @@ public class KafkaSupervisorTest extends EasyMockSupport
             null
         )
     ).anyTimes();
+    expect(indexerMetadataStorageCoordinator.getCheckPointsForSequence(EasyMock.anyString())).andReturn(
+        ImmutableList.<DataSourceMetadata>of()
+    ).anyTimes();
+
     expect(taskQueue.add(capture(captured))).andReturn(true).times(4);
     taskRunner.registerListener(anyObject(TaskRunnerListener.class), anyObject(Executor.class));
     replayAll();
@@ -713,6 +749,10 @@ public class KafkaSupervisorTest extends EasyMockSupport
             null
         )
     ).anyTimes();
+    expect(indexerMetadataStorageCoordinator.getCheckPointsForSequence(EasyMock.anyString())).andReturn(
+        ImmutableList.<DataSourceMetadata>of()
+    ).anyTimes();
+
     taskRunner.registerListener(anyObject(TaskRunnerListener.class), anyObject(Executor.class));
     replayAll();
 
@@ -775,6 +815,10 @@ public class KafkaSupervisorTest extends EasyMockSupport
             null
         )
     ).anyTimes();
+    expect(indexerMetadataStorageCoordinator.getCheckPointsForSequence(EasyMock.anyString())).andReturn(
+        ImmutableList.<DataSourceMetadata>of()
+    ).anyTimes();
+
     expect(taskQueue.add(capture(captured))).andReturn(true).times(4);
     taskRunner.registerListener(anyObject(TaskRunnerListener.class), anyObject(Executor.class));
     replayAll();
@@ -843,6 +887,14 @@ public class KafkaSupervisorTest extends EasyMockSupport
             null
         )
     ).anyTimes();
+    expect(indexerMetadataStorageCoordinator.getCheckPointsForSequence(EasyMock.anyString())).andReturn(
+        ImmutableList.<DataSourceMetadata>of()
+    ).anyTimes();
+    expect(indexerMetadataStorageCoordinator.addNewCheckPointForSequence(
+        EasyMock.anyString(),
+        EasyMock.anyObject(DataSourceMetadata.class)
+    )).andReturn(true).anyTimes();
+
     expect(taskQueue.add(capture(captured))).andReturn(true).times(4);
     taskRunner.registerListener(anyObject(TaskRunnerListener.class), anyObject(Executor.class));
     replayAll();
@@ -881,6 +933,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
         taskClient.setEndOffsetsAsync(
             EasyMock.contains("sequenceName-0"),
             EasyMock.eq(ImmutableMap.of(0, 10L, 1, 20L, 2, 35L)),
+            EasyMock.eq(true),
             EasyMock.eq(true)
         )
     ).andReturn(Futures.immediateFuture(true)).times(2);
@@ -940,6 +993,10 @@ public class KafkaSupervisorTest extends EasyMockSupport
             null
         )
     ).anyTimes();
+    expect(indexerMetadataStorageCoordinator.getCheckPointsForSequence(EasyMock.anyString())).andReturn(
+        ImmutableList.<DataSourceMetadata>of()
+    ).anyTimes();
+
     expect(taskClient.getStatusAsync("id1")).andReturn(Futures.immediateFuture(KafkaIndexTask.Status.PUBLISHING));
     expect(taskClient.getCurrentOffsetsAsync("id1", false))
         .andReturn(Futures.immediateFuture((Map<Integer, Long>) ImmutableMap.of(0, 10L, 1, 20L, 2, 30L)));
@@ -1029,6 +1086,10 @@ public class KafkaSupervisorTest extends EasyMockSupport
             null
         )
     ).anyTimes();
+    expect(indexerMetadataStorageCoordinator.getCheckPointsForSequence(EasyMock.anyString())).andReturn(
+        ImmutableList.<DataSourceMetadata>of()
+    ).anyTimes();
+
     expect(taskClient.getStatusAsync("id1")).andReturn(Futures.immediateFuture(KafkaIndexTask.Status.PUBLISHING));
     expect(taskClient.getCurrentOffsetsAsync("id1", false))
         .andReturn(Futures.immediateFuture((Map<Integer, Long>) ImmutableMap.of(0, 10L, 2, 30L)));
@@ -1131,6 +1192,10 @@ public class KafkaSupervisorTest extends EasyMockSupport
             null
         )
     ).anyTimes();
+    expect(indexerMetadataStorageCoordinator.getCheckPointsForSequence(EasyMock.anyString())).andReturn(
+        ImmutableList.<DataSourceMetadata>of()
+    ).anyTimes();
+
     expect(taskClient.getStatusAsync("id1")).andReturn(Futures.immediateFuture(KafkaIndexTask.Status.PUBLISHING));
     expect(taskClient.getStatusAsync("id2")).andReturn(Futures.immediateFuture(KafkaIndexTask.Status.READING));
     expect(taskClient.getStartTimeAsync("id2")).andReturn(Futures.immediateFuture(startTime));
@@ -1191,6 +1256,10 @@ public class KafkaSupervisorTest extends EasyMockSupport
             null
         )
     ).anyTimes();
+    expect(indexerMetadataStorageCoordinator.getCheckPointsForSequence(EasyMock.anyString())).andReturn(
+        ImmutableList.<DataSourceMetadata>of()
+    ).anyTimes();
+
     expect(taskQueue.add(capture(captured))).andReturn(true).times(4);
     taskRunner.registerListener(anyObject(TaskRunnerListener.class), anyObject(Executor.class));
     replayAll();
@@ -1236,6 +1305,10 @@ public class KafkaSupervisorTest extends EasyMockSupport
             null
         )
     ).anyTimes();
+    expect(indexerMetadataStorageCoordinator.getCheckPointsForSequence(EasyMock.anyString())).andReturn(
+        ImmutableList.<DataSourceMetadata>of()
+    ).anyTimes();
+
     expect(taskQueue.add(capture(captured))).andReturn(true).times(4);
     taskRunner.registerListener(anyObject(TaskRunnerListener.class), anyObject(Executor.class));
     replayAll();
@@ -1303,6 +1376,14 @@ public class KafkaSupervisorTest extends EasyMockSupport
             null
         )
     ).anyTimes();
+    expect(indexerMetadataStorageCoordinator.getCheckPointsForSequence(EasyMock.anyString())).andReturn(
+        ImmutableList.<DataSourceMetadata>of()
+    ).anyTimes();
+    expect(indexerMetadataStorageCoordinator.addNewCheckPointForSequence(
+        EasyMock.anyString(),
+        EasyMock.anyObject(DataSourceMetadata.class)
+    )).andReturn(true).anyTimes();
+
     expect(taskQueue.add(capture(captured))).andReturn(true).times(4);
     taskRunner.registerListener(anyObject(TaskRunnerListener.class), anyObject(Executor.class));
     replayAll();
@@ -1341,6 +1422,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
         taskClient.setEndOffsetsAsync(
             EasyMock.contains("sequenceName-0"),
             EasyMock.eq(ImmutableMap.of(0, 10L, 1, 20L, 2, 35L)),
+            EasyMock.eq(true),
             EasyMock.eq(true)
         )
     ).andReturn(Futures.<Boolean>immediateFailedFuture(new RuntimeException())).times(2);
@@ -1438,6 +1520,14 @@ public class KafkaSupervisorTest extends EasyMockSupport
             null
         )
     ).anyTimes();
+    expect(indexerMetadataStorageCoordinator.getCheckPointsForSequence(EasyMock.anyString())).andReturn(
+        ImmutableList.<DataSourceMetadata>of()
+    ).anyTimes();
+    expect(indexerMetadataStorageCoordinator.addNewCheckPointForSequence(
+        EasyMock.anyString(),
+        EasyMock.anyObject(DataSourceMetadata.class)
+    )).andReturn(true).anyTimes();
+
     expect(taskClient.getStatusAsync("id1")).andReturn(Futures.immediateFuture(KafkaIndexTask.Status.PUBLISHING));
     expect(taskClient.getStatusAsync("id2")).andReturn(Futures.immediateFuture(KafkaIndexTask.Status.READING));
     expect(taskClient.getStatusAsync("id3")).andReturn(Futures.immediateFuture(KafkaIndexTask.Status.READING));
@@ -1456,7 +1546,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     expect(taskRunner.getRunningTasks()).andReturn(workItems).anyTimes();
     expect(taskClient.pauseAsync("id2"))
         .andReturn(Futures.immediateFuture((Map<Integer, Long>) ImmutableMap.of(0, 15L, 1, 25L, 2, 30L)));
-    expect(taskClient.setEndOffsetsAsync("id2", ImmutableMap.of(0, 15L, 1, 25L, 2, 30L), true))
+    expect(taskClient.setEndOffsetsAsync("id2", ImmutableMap.of(0, 15L, 1, 25L, 2, 30L), true, true))
         .andReturn(Futures.immediateFuture(true));
     taskQueue.shutdown("id3");
     expectLastCall().times(2);

--- a/extensions-core/postgresql-metadata-storage/src/test/java/io/druid/metadata/storage/postgresql/PostgreSQLConnectorTest.java
+++ b/extensions-core/postgresql-metadata-storage/src/test/java/io/druid/metadata/storage/postgresql/PostgreSQLConnectorTest.java
@@ -47,6 +47,7 @@ public class PostgreSQLConnectorTest
                 null,
                 null,
                 null,
+                null,
                 null
             )
         )

--- a/indexing-hadoop/src/main/java/io/druid/indexer/updater/MetadataStorageUpdaterJobSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/updater/MetadataStorageUpdaterJobSpec.java
@@ -97,6 +97,7 @@ public class MetadataStorageUpdaterJobSpec implements Supplier<MetadataStorageCo
         null,
         null,
         null,
+        null,
         null
     );
   }

--- a/indexing-service/src/main/java/io/druid/indexing/common/actions/CheckPointDataSourceMetadataAction.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/actions/CheckPointDataSourceMetadataAction.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.indexing.common.actions;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.druid.indexing.common.task.Task;
+import io.druid.indexing.overlord.DataSourceMetadata;
+
+import java.io.IOException;
+
+public class CheckPointDataSourceMetadataAction implements TaskAction<Boolean>
+{
+  private final String supervisorId;
+  private final String sequenceName;
+  private final DataSourceMetadata previousCheckPoint;
+  private final DataSourceMetadata currentCheckPoint;
+
+  public CheckPointDataSourceMetadataAction(
+      @JsonProperty("supervisorId") String supervisorId,
+      @JsonProperty("sequenceName") String sequenceName,
+      @JsonProperty("previousCheckPoint") DataSourceMetadata previousCheckPoint,
+      @JsonProperty("currentCheckPoint") DataSourceMetadata currentCheckPoint
+  )
+  {
+    this.supervisorId = supervisorId;
+    this.sequenceName = sequenceName;
+    this.previousCheckPoint = previousCheckPoint;
+    this.currentCheckPoint = currentCheckPoint;
+  }
+
+  @JsonProperty
+  public String getSupervisorId()
+  {
+    return supervisorId;
+  }
+
+  @JsonProperty
+  public String getSequenceName()
+  {
+    return sequenceName;
+  }
+
+  @JsonProperty
+  public DataSourceMetadata getPreviousCheckPoint()
+  {
+    return previousCheckPoint;
+  }
+
+  @JsonProperty
+  public DataSourceMetadata getCurrentCheckPoint()
+  {
+    return currentCheckPoint;
+  }
+
+  @Override
+  public TypeReference<Boolean> getReturnTypeReference()
+  {
+    return new TypeReference<Boolean>()
+    {
+    };
+  }
+
+  @Override
+  public Boolean perform(
+      Task task, TaskActionToolbox toolbox
+  ) throws IOException
+  {
+    return toolbox.getSupervisorManager()
+                  .checkPointDataSourceMetadata(supervisorId, sequenceName, previousCheckPoint, currentCheckPoint);
+  }
+
+  @Override
+  public boolean isAudited()
+  {
+    return true;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "CheckPointDataSourceMetadataAction{" +
+           "supervisorId='" + supervisorId + '\'' +
+           ", sequenceName='" + sequenceName + '\'' +
+           ", previousCheckPoint=" + previousCheckPoint +
+           ", currentCheckPoint=" + currentCheckPoint +
+           '}';
+  }
+}

--- a/indexing-service/src/main/java/io/druid/indexing/common/actions/TaskAction.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/actions/TaskAction.java
@@ -39,7 +39,8 @@ import java.io.IOException;
     @JsonSubTypes.Type(name = "segmentNuke", value = SegmentNukeAction.class),
     @JsonSubTypes.Type(name = "segmentMetadataUpdate", value = SegmentMetadataUpdateAction.class),
     @JsonSubTypes.Type(name = "segmentAllocate", value = SegmentAllocateAction.class),
-    @JsonSubTypes.Type(name = "resetDataSourceMetadata", value = ResetDataSourceMetadataAction.class)
+    @JsonSubTypes.Type(name = "resetDataSourceMetadata", value = ResetDataSourceMetadataAction.class),
+    @JsonSubTypes.Type(name = "checkPointDataSourceMetadata", value = CheckPointDataSourceMetadataAction.class)
 })
 public interface TaskAction<RetType>
 {

--- a/indexing-service/src/main/java/io/druid/indexing/common/config/TaskConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/config/TaskConfig.java
@@ -162,4 +162,19 @@ public class TaskConfig
 
     return configParameter;
   }
+
+  @Override
+  public String toString()
+  {
+    return "TaskConfig{" +
+           "baseDir='" + baseDir + '\'' +
+           ", baseTaskDir=" + baseTaskDir +
+           ", hadoopWorkingPath='" + hadoopWorkingPath + '\'' +
+           ", defaultRowFlushBoundary=" + defaultRowFlushBoundary +
+           ", defaultHadoopCoordinates=" + defaultHadoopCoordinates +
+           ", restoreTasksOnRestart=" + restoreTasksOnRestart +
+           ", gracefulShutdownTimeout=" + gracefulShutdownTimeout +
+           ", directoryLockTimeout=" + directoryLockTimeout +
+           '}';
+  }
 }

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
@@ -483,6 +483,7 @@ public class IndexTask extends AbstractTask
         log.error("Failed to publish segments, aborting!");
         return false;
       } else {
+        driver.waitForHandOff();
         log.info(
             "Published segments[%s]", Joiner.on(", ").join(
                 Iterables.transform(

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/supervisor/SupervisorManager.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/supervisor/SupervisorManager.java
@@ -24,7 +24,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import com.metamx.emitter.EmittingLogger;
-
 import io.druid.indexing.overlord.DataSourceMetadata;
 import io.druid.java.util.common.Pair;
 import io.druid.java.util.common.collect.JavaCompatUtils;
@@ -155,6 +154,24 @@ public class SupervisorManager
     }
 
     supervisor.lhs.reset(dataSourceMetadata);
+    return true;
+  }
+
+  public boolean checkPointDataSourceMetadata(
+      String supervisorId,
+      String sequenceName,
+      @Nullable DataSourceMetadata previousDataSourceMetadata,
+      @Nullable DataSourceMetadata currentDataSourceMetadata
+  )
+  {
+    Preconditions.checkState(started, "SupervisorManager not started");
+    Preconditions.checkNotNull(supervisorId, "supervisorId cannot be null");
+
+    Pair<Supervisor, SupervisorSpec> supervisor = supervisors.get(supervisorId);
+
+    Preconditions.checkNotNull(supervisor, "supervisor could not be found");
+
+    supervisor.lhs.checkPoint(sequenceName, previousDataSourceMetadata, currentDataSourceMetadata);
     return true;
   }
 

--- a/indexing-service/src/test/java/io/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
+++ b/indexing-service/src/test/java/io/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
@@ -88,6 +88,20 @@ public class TestIndexerMetadataStorageCoordinator implements IndexerMetadataSto
   }
 
   @Override
+  public List<DataSourceMetadata> getCheckPointsForSequence(String sequenceName) throws IOException
+  {
+    return ImmutableList.of();
+  }
+
+  @Override
+  public boolean addNewCheckPointForSequence(
+      String sequenceName, DataSourceMetadata dataSourceMetadata
+  ) throws IOException
+  {
+    return false;
+  }
+
+  @Override
   public Set<DataSegment> announceHistoricalSegments(Set<DataSegment> segments)
   {
     Set<DataSegment> added = Sets.newHashSet();

--- a/server/src/main/java/io/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
+++ b/server/src/main/java/io/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
@@ -150,4 +150,8 @@ public interface IndexerMetadataStorageCoordinator
    * @return DataSegments which include ONLY data within the requested interval and are not flagged as used. Data segments NOT returned here may include data in the interval
    */
   List<DataSegment> getUnusedSegmentsForInterval(String dataSource, Interval interval);
+
+  List<DataSourceMetadata> getCheckPointsForSequence(String sequenceName) throws IOException;
+
+  boolean addNewCheckPointForSequence(String sequenceName, DataSourceMetadata dataSourceMetadata) throws IOException;
 }

--- a/server/src/main/java/io/druid/indexing/overlord/supervisor/NoopSupervisorSpec.java
+++ b/server/src/main/java/io/druid/indexing/overlord/supervisor/NoopSupervisorSpec.java
@@ -52,6 +52,12 @@ public class NoopSupervisorSpec implements SupervisorSpec
 
       @Override
       public void reset(DataSourceMetadata dataSourceMetadata) {}
+
+      @Override
+      public void checkPoint(String sequenceName, DataSourceMetadata prev, DataSourceMetadata curr)
+      {
+
+      }
     };
   }
 

--- a/server/src/main/java/io/druid/indexing/overlord/supervisor/Supervisor.java
+++ b/server/src/main/java/io/druid/indexing/overlord/supervisor/Supervisor.java
@@ -21,6 +21,8 @@ package io.druid.indexing.overlord.supervisor;
 
 import io.druid.indexing.overlord.DataSourceMetadata;
 
+import javax.annotation.Nullable;
+
 public interface Supervisor
 {
   void start();
@@ -36,4 +38,20 @@ public interface Supervisor
   SupervisorReport getStatus();
 
   void reset(DataSourceMetadata dataSourceMetadata);
+
+  /**
+   * The definition of checkpoint is not very strict as currently it does not affect data or control path
+   * On this call Supervisor can potentially checkpoint data processed so far to some durable storage
+   * for example - Kafka Supervisor uses this to merge and handoff segments containing at least the data
+   * represented by dataSourceMetadata
+   *
+   * @param sequenceName       unique Identifier to figure out for which sequence to do check pointing
+   * @param previousCheckPoint DataSourceMetadata check pointed in previous call
+   * @param currentCheckPoint  current DataSourceMetadata to be check pointed
+   */
+  void checkPoint(
+      @Nullable String sequenceName,
+      @Nullable DataSourceMetadata previousCheckPoint,
+      @Nullable DataSourceMetadata currentCheckPoint
+  );
 }

--- a/server/src/main/java/io/druid/metadata/SQLMetadataConnector.java
+++ b/server/src/main/java/io/druid/metadata/SQLMetadataConnector.java
@@ -393,6 +393,24 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
     );
   }
 
+  public void createTaskCheckPointsTable(final String tableName)
+  {
+    createTable(
+        tableName,
+        ImmutableList.of(
+            String.format(
+                "CREATE TABLE %1$s (\n"
+                + "  sequence_name VARCHAR(255) NOT NULL,\n"
+                + "  payload %2$s NOT NULL,\n"
+                + "  PRIMARY KEY (sequence_name)\n"
+                + ")",
+                tableName, getPayloadType()
+            ),
+            String.format("CREATE INDEX idx_%1$s_sequence_name ON %1$s(sequence_name)", tableName)
+        )
+    );
+  }
+
   @Override
   public Void insertOrUpdate(
       final String tableName,
@@ -500,6 +518,14 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
   {
     if (config.get().isCreateTables()) {
       createSupervisorsTable(tablesConfigSupplier.get().getSupervisorTable());
+    }
+  }
+
+  @Override
+  public void createTaskCheckPointsTable()
+  {
+    if (config.get().isCreateTables()) {
+      createTaskCheckPointsTable(tablesConfigSupplier.get().getTaskCheckPointsTable());
     }
   }
 

--- a/server/src/main/java/io/druid/segment/loading/LocalDataSegmentPusher.java
+++ b/server/src/main/java/io/druid/segment/loading/LocalDataSegmentPusher.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;
 import com.google.inject.Inject;
-
 import io.druid.java.util.common.CompressionUtils;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.segment.SegmentUtils;

--- a/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -684,6 +684,7 @@ public class AppenderatorImpl implements Appenderator
 
   private void shutdownExecutors()
   {
+    log.info("Shutting down persist and push executor");
     persistExecutor.shutdownNow();
     pushExecutor.shutdownNow();
   }

--- a/server/src/test/java/io/druid/segment/realtime/appenderator/FiniteAppenderatorDriverTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/appenderator/FiniteAppenderatorDriverTest.java
@@ -140,7 +140,7 @@ public class FiniteAppenderatorDriverTest
         asIdentifiers(segmentsAndMetadata.getSegments())
     );
 
-    Assert.assertEquals(3, segmentsAndMetadata.getCommitMetadata());
+    Assert.assertEquals(3, ((FiniteAppenderatorDriverMetadata)segmentsAndMetadata.getCommitMetadata()).getCallerMetadata());
   }
 
   @Test
@@ -167,7 +167,7 @@ public class FiniteAppenderatorDriverTest
 
     final SegmentsAndMetadata segmentsAndMetadata = driver.finish(makeOkPublisher(), committerSupplier.get());
     Assert.assertEquals(numSegments, segmentsAndMetadata.getSegments().size());
-    Assert.assertEquals(numSegments * MAX_ROWS_PER_SEGMENT, segmentsAndMetadata.getCommitMetadata());
+    Assert.assertEquals(numSegments * MAX_ROWS_PER_SEGMENT, ((FiniteAppenderatorDriverMetadata)segmentsAndMetadata.getCommitMetadata()).getCallerMetadata());
   }
 
   private Set<SegmentIdentifier> asIdentifiers(Iterable<DataSegment> segments)


### PR DESCRIPTION
Fixes https://github.com/druid-io/druid/issues/4016 and https://github.com/druid-io/druid/issues/4177
- Incrementally handoff segments when they hit maxRowsPerSegment limit
- Decouple segment partitioning from Kafka partitioning, all records from consumed partitions go to a single druid segment
- Decouple publishing of segments from waiting for handoff
- Support for restoring task on middle manager restarts by check pointing end offsets for segments

Design - 
- Introduce `DriverHolder` that has start and end offsets and thus represents the Kafka records that the `FiniteAppenderatorDriver` it wraps should consume. Each `DriverHolder` has a unique sequence name which is concatenation of the baseSequenceName of the task and a suffix of linearly increasing `DriverHolder` index. Similarly, the persist directory for each holder is concatenation of basePersistDir of the task and the holder index.
- When a new task starts, a new `DriverHolder` is created with start and end offsets of the task.
- All records consumed from assigned partitions are given to a `DriverHolder` that can handle it.
- As soon as the number of records consumed hit the `maxRowsInSegment` limit the task pauses and Supervisor is sent `CheckPointDataSourceMetadataAction` which pauses all replica tasks, gets the highest offset for all partitions, store these partition offsets as a check point in the metadata store for the baseSequenceName of the task. Then sends the check point to all replica tasks using `setEndOffset` call with `finish` query param as `false` indicating that these are not the final end offsets for the task. The latest `DriverHolder` in the task updates its local end offsets to the check point and a new `DriverHolder` is created to handle records beyond this check point.
- When a `DriverHolder` has consumed till its end offsets, it is submitted to a `persistExecService` which persists the driver and then adds the driver to a `publishQueue`. Another, executor service named `publishExecService` takes the driver from the `publishQueue` and tries to push and publish the segments to deep storage and metadata store. After a successful publish the driver is added to `handOffQueue` and `handOffExecService` keeps on waiting for completion of hand off of the driver.
- After ingestion loop is finished a `SentinelDriverHolder` is submitted to be persisted and published. When this `SentinelDriverHolder`  is done, the task ends.
- For supporting restore on restart, the `DriverHolder` list is persisted every time a critical action happens like - a new holder is created, end offsets for a holder is set and a holder is removed from a list.
- Each new task is sent a list of checkpoints for its baseSequenceName if one exists in the metadata store. This way if some task failed after check-pointing some holders and a new task is created in its place, it can get the same checkpoints. 
- At start of each task the persisted drivers list and checkpoints information is used to restore its state by creating `DriverHolder`s if necessary.

This code is currently running on our metrics cluster for few days without any issues. 
Note - ~~We do not run replicas on our metrics cluster.~~ Now running with 2 replicas since last few days.

TODO
- Add tests
~~- Possibly test with replicas on real cluster~~