### PR TITLE
log the exception on failure to send query response

### DIFF
--- a/server/src/main/java/io/druid/server/QueryResource.java
+++ b/server/src/main/java/io/druid/server/QueryResource.java
@@ -273,6 +273,7 @@ public class QueryResource implements QueryCountStatsProvider
                       success = true;
                     } catch (Exception ex) {
                       exceptionStr = ex.toString();
+                      log.error(ex, "Unable to send query response.");
                       throw Throwables.propagate(ex);
                     } finally {
                       try {


### PR DESCRIPTION
small follow up on #4169 to print exception to druid logs