### PR TITLE
hadoop configurations using runtime properties.

### DIFF
--- a/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsStorageDruidModule.java
+++ b/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsStorageDruidModule.java
@@ -118,9 +118,9 @@ public class HdfsStorageDruidModule implements DruidModule
     }
 
     if (props != null) {
-      for (String propName : System.getProperties().stringPropertyNames()) {
+      for (String propName : props.stringPropertyNames()) {
         if (propName.startsWith("hadoop.")) {
-          conf.set(propName.substring("hadoop.".length()), System.getProperty(propName));
+          conf.set(propName.substring("hadoop.".length()), props.getProperty(propName));
         }
       }
     }


### PR DESCRIPTION
`HdfsStorageDruidModule` uses system properties to set Hadoop configurations, it would be nice to allow setting Hadoop configurations using `runtime.properties`.
 