### PR TITLE
Reduce log spam from Avro decoders.

### DIFF
--- a/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/InlineSchemaAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/InlineSchemaAvroBytesDecoder.java
@@ -61,7 +61,7 @@ public class InlineSchemaAvroBytesDecoder implements AvroBytesDecoder
     this.schema = schema;
     String schemaStr = mapper.writeValueAsString(schema);
 
-    LOGGER.info("Schema string [%s]", schemaStr);
+    LOGGER.debug("Schema string [%s]", schemaStr);
     this.schemaObj = new Schema.Parser().parse(schemaStr);
     this.reader = new GenericDatumReader<>(this.schemaObj);
   }

--- a/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/InlineSchemasAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/InlineSchemasAvroBytesDecoder.java
@@ -73,7 +73,7 @@ public class InlineSchemasAvroBytesDecoder implements AvroBytesDecoder
       Map<String, Object> schema = e.getValue();
       String schemaStr = mapper.writeValueAsString(schema);
 
-      LOGGER.info("Schema string [%s] = [%s]", id, schemaStr);
+      LOGGER.debug("Schema string [%s] = [%s]", id, schemaStr);
       schemaObjs.put(id, new Schema.Parser().parse(schemaStr));
     }
   }


### PR DESCRIPTION
These objects get constructed semi-frequently (any time a parser is
deserialized) and so info logs are spammy. They'll still appear in
task logs at least once, since they're part of the task definition and
will get logged due to that.