### PR TITLE
Fix two lgtm.com alerts: comparing Integers using '!=' tests object identity, not value

### DIFF
--- a/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchEstimatePostAggregator.java
+++ b/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchEstimatePostAggregator.java
@@ -141,9 +141,18 @@ public class SketchEstimatePostAggregator implements PostAggregator
     if (!name.equals(that.name)) {
       return false;
     }
-    if (errorBoundsStdDev != that.errorBoundsStdDev) {
+    
+    if (errorBoundsStdDev == null ^ that.errorBoundsStdDev == null) {
+      // one of the two stddevs (not both) are null
       return false;
     }
+    
+    if (errorBoundsStdDev != null && that.errorBoundsStdDev != null && 
+        errorBoundsStdDev.intValue() != that.errorBoundsStdDev.intValue()) {
+      // neither stddevs are null, Integer values don't match
+      return false;
+    }
+
     return field.equals(that.field);
 
   }

--- a/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchMergeAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchMergeAggregatorFactory.java
@@ -161,11 +161,19 @@ public class SketchMergeAggregatorFactory extends SketchAggregatorFactory
     if (shouldFinalize != that.shouldFinalize) {
       return false;
     }
-    if (errorBoundsStdDev != that.errorBoundsStdDev) {
+    
+    if (errorBoundsStdDev == null ^ that.errorBoundsStdDev == null) {
+      // one of the two stddevs (not both) are null
       return false;
     }
-    return isInputThetaSketch == that.isInputThetaSketch;
 
+    if (errorBoundsStdDev != null && that.errorBoundsStdDev != null && 
+        errorBoundsStdDev.intValue() != that.errorBoundsStdDev.intValue()) {
+      // neither stddevs are null, Integer values don't match
+      return false;
+    }
+    
+    return isInputThetaSketch == that.isInputThetaSketch;
   }
 
   @Override


### PR DESCRIPTION
This small PR fixes two alerts from lgtm.com. Comparing two boxed primitive values using the == or != operator compares object identity, which is not what's intended here.

There are a total of 63 alerts reported by lgtm.com (including some resource leaks), more details here: https://lgtm.com/projects/g/druid-io/druid/alerts/. The fixes proposed in this PR are easy to make for someone without knowledge of the Druid code base, most of the other alerts require a little bit more experience.

Tip: enable pull request integration to get automated code reviews! https://lgtm.com/projects/g/druid-io/druid/ci/

Alert details:
https://lgtm.com/projects/g/druid-io/druid/snapshot/013566ade941151eb37d55a9c7efa4a9c28a3493/files/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchEstimatePostAggregator.java#V144
https://lgtm.com/projects/g/druid-io/druid/snapshot/013566ade941151eb37d55a9c7efa4a9c28a3493/files/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchMergeAggregatorFactory.java#V164