### PR TITLE
Significantly improve LongEncodingStrategy.AUTO build performance

### DIFF
--- a/processing/src/main/java/io/druid/segment/data/IntermediateLongSupplierSerializer.java
+++ b/processing/src/main/java/io/druid/segment/data/IntermediateLongSupplierSerializer.java
@@ -131,8 +131,10 @@ public class IntermediateLongSupplierSerializer implements LongSupplierSerialize
 
     try (DataInputStream tempIn = new DataInputStream(new BufferedInputStream(ioPeon.makeInputStream(tempFile)))) {
       delegate.open();
-      while (tempIn.available() > 0) {
+      int available = tempIn.available();
+      while (available > 0) {
         delegate.add(tempIn.readLong());
+        available -= Longs.BYTES;
       }
     }
   }

--- a/processing/src/main/java/io/druid/segment/data/IntermediateLongSupplierSerializer.java
+++ b/processing/src/main/java/io/druid/segment/data/IntermediateLongSupplierSerializer.java
@@ -131,7 +131,7 @@ public class IntermediateLongSupplierSerializer implements LongSupplierSerialize
 
     try (DataInputStream tempIn = new DataInputStream(new BufferedInputStream(ioPeon.makeInputStream(tempFile)))) {
       delegate.open();
-      int available = tempIn.available();
+      int available = numInserted;
       while (available > 0) {
         delegate.add(tempIn.readLong());
         available -= Longs.BYTES;

--- a/processing/src/main/java/io/druid/segment/data/IntermediateLongSupplierSerializer.java
+++ b/processing/src/main/java/io/druid/segment/data/IntermediateLongSupplierSerializer.java
@@ -134,7 +134,7 @@ public class IntermediateLongSupplierSerializer implements LongSupplierSerialize
       int available = numInserted;
       while (available > 0) {
         delegate.add(tempIn.readLong());
-        available -= Longs.BYTES;
+        available--;
       }
     }
   }


### PR DESCRIPTION
IntermediateLongSupplierSerializer calls available() before every readLong() which is very inefficient
```
      while (tempIn.available() > 0) {
        delegate.add(tempIn.readLong());
      }
```
Here is the benchmark
```
    // prepare data
    File file = new File("/Users/kading/dev/long.out");
    OutputStream out = new FileOutputStream(file);
    DataOutputStream dataOutputStream = new DataOutputStream(out);
    int expectedCount = 1000000;
    for (int i = 0; i < expectedCount; i++) {
      dataOutputStream.writeLong(i);
    }
    dataOutputStream.close();
    out.close();

    // old code
    DataInputStream tempIn = new DataInputStream(new BufferedInputStream(new FileInputStream(file)));
    long count = 0;
    long start = System.currentTimeMillis();
    while (tempIn.available() > 0) {
      tempIn.readLong();
      count++;
    }
    System.out.println("time cost: " + (System.currentTimeMillis() - start));;
    System.out.println("finished: " + (count == expectedCount));
    tempIn.close();

    // new code
    tempIn = new DataInputStream(new BufferedInputStream(new FileInputStream(file)));
    count = 0;
    start = System.currentTimeMillis();
    int available = tempIn.available();
    while (available > 0) {
      tempIn.readLong();
      count++;
      available -= Longs.BYTES;
    }
    System.out.println("time cost: " + (System.currentTimeMillis() - start));
    System.out.println("finished: " + (count == expectedCount));
    tempIn.close();

    file.delete();
```
The result is:
time cost: 2748
finished: true
time cost: 33
finished: true