### PR TITLE
Add Checkstyle check to prohibit IntelliJ-style commented code lines

### DIFF
--- a/codestyle/checkstyle.xml
+++ b/codestyle/checkstyle.xml
@@ -48,5 +48,10 @@
       <property name="format" value="com\.google\.common\.io\.Closer"/>
       <property name="illegalPattern" value="true"/>
     </module>
+    <module name="Regexp">
+      <!-- Prohibit IntelliJ-style commented code lines from being committed -->
+      <property name="format" value="^// {2}"/>
+      <property name="illegalPattern" value="true"/>
+    </module>
   </module>
 </module>

--- a/integration-tests/src/main/java/org/testng/TestNG.java
+++ b/integration-tests/src/main/java/org/testng/TestNG.java
@@ -384,7 +384,6 @@ public class TestNG
         while (t.getCause() != null) {
           t = t.getCause();
         }
-//        t.printStackTrace();
         if (t instanceof TestNGException) {
           throw (TestNGException) t;
         } else {
@@ -421,7 +420,6 @@ public class TestNG
       Utils.log("TestNG", 2, "Trying to open jar file:" + jarFile);
 
       JarFile jf = new JarFile(jarFile);
-//      System.out.println("   result: " + jf);
       Enumeration<JarEntry> entries = jf.entries();
       List<String> classes = Lists.newArrayList();
       boolean foundTestngXml = false;
@@ -1055,10 +1053,6 @@ public class TestNG
       }
       Iterable<ITestNGListener> loader =
           (Iterable<ITestNGListener>) loadMethod.invoke(c, parameters.toArray());
-//      Object loader = c.
-//      ServiceLoader<ITestNGListener> loader = m_serviceLoaderClassLoader != null
-//      ? ServiceLoader.load(ITestNGListener.class, m_serviceLoaderClassLoader)
-//          : ServiceLoader.load(ITestNGListener.class);
       for (ITestNGListener l : loader) {
         Utils.log("[TestNG]", 2, "Adding ServiceLoader listener:" + l);
         addListener(l);
@@ -1551,11 +1545,6 @@ public class TestNG
     if (cla.testNames != null) {
       setTestNames(Arrays.asList(cla.testNames.split(",")));
     }
-
-//    List<String> testNgXml = (List<String>) cmdLineArgs.get(CommandLineArgs.SUITE_DEF);
-//    if (null != testNgXml) {
-//      setTestSuites(testNgXml);
-//    }
 
     // Note: can't use a Boolean field here because we are allowing a boolean
     // parameter with an arity of 1 ("-usedefaultlisteners false")

--- a/integration-tests/src/main/java/org/testng/remote/RemoteTestNG.java
+++ b/integration-tests/src/main/java/org/testng/remote/RemoteTestNG.java
@@ -97,9 +97,7 @@ public class RemoteTestNG extends TestNG
     m_debug = cla.debug;
     m_ack = ra.ack;
     if (m_debug) {
-//      while (true) {
       initAndRun(args, cla, ra);
-//      }
     } else {
       initAndRun(args, cla, ra);
     }
@@ -128,22 +126,9 @@ public class RemoteTestNG extends TestNG
         sb.append(s).append(" ");
       }
       p(sb.toString());
-//      remoteTestNg.setVerbose(1);
-//    } else {
-//      remoteTestNg.setVerbose(0);
     }
     validateCommandLineParameters(cla);
     remoteTestNg.run();
-//    if (m_debug) {
-//      // Run in a loop if in debug mode so it is possible to run several launches
-//      // without having to relauch RemoteTestNG.
-//      while (true) {
-//        remoteTestNg.run();
-//        remoteTestNg.configure(cla);
-//      }
-//    } else {
-//      remoteTestNg.run();
-//    }
   }
 
   private static void p(String s)
@@ -168,7 +153,6 @@ public class RemoteTestNG extends TestNG
   {
     for (XmlSuite s : suites) {
       outSuites.add(s);
-//      calculateAllSuites(s.getChildSuites(), outSuites);
     }
   }
 
@@ -189,8 +173,6 @@ public class RemoteTestNG extends TestNG
 
       List<XmlSuite> suites = Lists.newArrayList();
       calculateAllSuites(m_suites, suites);
-//      System.out.println("Suites: " + m_suites.get(0).getChildSuites().size()
-//          + " and:" + suites.get(0).getChildSuites().size());
       if (suites.size() > 0) {
 
         int testCount = 0;
@@ -207,7 +189,6 @@ public class RemoteTestNG extends TestNG
         addListener(new RemoteSuiteListener(msh));
         setTestRunnerFactory(new DelegatingTestRunnerFactory(buildTestRunnerFactory(), msh));
 
-//        System.out.println("RemoteTestNG starting");
         super.run();
       } else {
         System.err.println("No test suite found. Nothing to run");
@@ -217,7 +198,6 @@ public class RemoteTestNG extends TestNG
       cause.printStackTrace(System.err);
     }
     finally {
-//      System.out.println("RemoteTestNG finishing: " + (getEnd() - getStart()) + " ms");
       msh.shutDown();
       if (!m_debug && !m_dontExit) {
         System.exit(0);

--- a/processing/src/main/java/io/druid/jackson/DefaultObjectMapper.java
+++ b/processing/src/main/java/io/druid/jackson/DefaultObjectMapper.java
@@ -53,7 +53,7 @@ public class DefaultObjectMapper extends ObjectMapper
 
     configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     configure(MapperFeature.AUTO_DETECT_GETTERS, false);
-    configure(MapperFeature.AUTO_DETECT_CREATORS, false);
+    // configure(MapperFeature.AUTO_DETECT_CREATORS, false);
     configure(MapperFeature.AUTO_DETECT_FIELDS, false);
     configure(MapperFeature.AUTO_DETECT_IS_GETTERS, false);
     configure(MapperFeature.AUTO_DETECT_SETTERS, false);

--- a/processing/src/main/java/io/druid/jackson/DefaultObjectMapper.java
+++ b/processing/src/main/java/io/druid/jackson/DefaultObjectMapper.java
@@ -53,6 +53,7 @@ public class DefaultObjectMapper extends ObjectMapper
 
     configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     configure(MapperFeature.AUTO_DETECT_GETTERS, false);
+    // See https://github.com/FasterXML/jackson-databind/issues/170
     // configure(MapperFeature.AUTO_DETECT_CREATORS, false);
     configure(MapperFeature.AUTO_DETECT_FIELDS, false);
     configure(MapperFeature.AUTO_DETECT_IS_GETTERS, false);

--- a/processing/src/main/java/io/druid/jackson/DefaultObjectMapper.java
+++ b/processing/src/main/java/io/druid/jackson/DefaultObjectMapper.java
@@ -53,7 +53,7 @@ public class DefaultObjectMapper extends ObjectMapper
 
     configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     configure(MapperFeature.AUTO_DETECT_GETTERS, false);
-//    configure(MapperFeature.AUTO_DETECT_CREATORS, false); https://github.com/FasterXML/jackson-databind/issues/170
+    configure(MapperFeature.AUTO_DETECT_CREATORS, false);
     configure(MapperFeature.AUTO_DETECT_FIELDS, false);
     configure(MapperFeature.AUTO_DETECT_IS_GETTERS, false);
     configure(MapperFeature.AUTO_DETECT_SETTERS, false);


### PR DESCRIPTION
Also restore change that was made as a workaround for FasterXML/jackson-databind#170, it was fixed in Jackson 2.1, now we use 2.4. FYI @cheddar.