### PR TITLE
do not use --clean option when using bundle-contrib-exts profile

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -201,7 +201,6 @@
                                         <argument>-l</argument>
                                         <argument>${settings.localRepository}</argument>
                                         <argument>--no-default-hadoop</argument>
-                                        <argument>${druid.distribution.pulldeps.opts}</argument>
                                         <argument>-c</argument>
                                         <argument>io.druid.extensions.contrib:ambari-metrics-emitter</argument>
                                         <argument>-c</argument>


### PR DESCRIPTION
...so that core extensions are not wiped out

currently that profile is unusable as it bundles contrib extensions only whereas expected behavior is to have both core+contrib extensions bundled