### PR TITLE
additional lookup status discovery http endpoints at coordinator

### DIFF
--- a/common/src/main/java/io/druid/common/utils/ServletResourceUtils.java
+++ b/common/src/main/java/io/druid/common/utils/ServletResourceUtils.java
@@ -40,4 +40,12 @@ public class ServletResourceUtils
         t == null ? "null" : (t.getMessage() == null ? t.toString() : t.getMessage())
     );
   }
+
+  /**
+   * Converts String errorMsg into a Map so that it produces valid json on serialization into response.
+   */
+  public static Map<String, String> jsonize(String msgFormat, Object... args)
+  {
+    return ImmutableMap.of("error", StringUtils.safeFormat(msgFormat, args));
+  }
 }

--- a/docs/content/querying/lookups.md
+++ b/docs/content/querying/lookups.md
@@ -67,6 +67,7 @@ The configuration is propagated to the query serving nodes (broker / router / pe
 The query serving nodes have an internal API for managing lookups on the node and those are used by the coordinator.
 The coordinator periodically checks if any of the nodes need to load/drop lookups and updates them appropriately.
 
+# API for configuring lookups
 
 ## Bulk update
 Lookups can be updated in bulk by posting a JSON object to `/druid/coordinator/v1/lookups`. The format of the json object is as follows:
@@ -231,6 +232,27 @@ To discover a list of tiers currently active in the cluster **instead of** ones 
 
 ## List lookup names
 A `GET` to `/druid/coordinator/v1/lookups/{tier}` will return a list of known lookup names for that tier.
+
+# Additional API related to status of configured lookups
+These end points can be used to get the propagation status of configured lookups to lookup nodes such as historicals.
+
+## List load status of all lookups
+`GET /druid/coordinator/v1/lookups/status` with optional query parameter `detailed`.
+
+## List load status of lookups in a tier
+`GET /druid/coordinator/v1/lookups/status/{tier}` with optional query parameter `detailed`.
+
+## List load status of single lookup
+`GET /druid/coordinator/v1/lookups/status/{tier}/{lookup}` with optional query parameter `detailed`.
+
+## List lookup state of all nodes
+`GET /druid/coordinator/v1/lookups/nodeStatus` with optional query parameter `discover` to discover tiers from zookeeper or configured lookup tiers are listed.
+
+## List lookup state of nodes in a tier
+`GET /druid/coordinator/v1/lookups/nodeStatus/{tier}`
+
+## List lookup state of single node
+`GET /druid/coordinator/v1/lookups/nodeStatus/{tier}/{host:port}`
 
 # Internal API
 

--- a/server/src/main/java/io/druid/server/http/LookupCoordinatorResource.java
+++ b/server/src/main/java/io/druid/server/http/LookupCoordinatorResource.java
@@ -351,12 +351,6 @@ public class LookupCoordinatorResource
   )
   {
     try {
-      if (Strings.isNullOrEmpty(tier)) {
-        return Response.status(Response.Status.BAD_REQUEST)
-                       .entity("`tier` required")
-                       .build();
-      }
-
       Map<String, Map<String, LookupExtractorFactoryMapContainer>> configuredLookups = lookupCoordinatorManager.getKnownLookups();
       if (configuredLookups == null) {
         return Response.status(Response.Status.NOT_FOUND)
@@ -401,18 +395,6 @@ public class LookupCoordinatorResource
   )
   {
     try {
-      if (Strings.isNullOrEmpty(tier)) {
-        return Response.status(Response.Status.BAD_REQUEST)
-                       .entity("`tier` required")
-                       .build();
-      }
-
-      if (Strings.isNullOrEmpty(lookup)) {
-        return Response.status(Response.Status.BAD_REQUEST)
-                       .entity("`lookup` required")
-                       .build();
-      }
-
       Map<String, Map<String, LookupExtractorFactoryMapContainer>> configuredLookups = lookupCoordinatorManager.getKnownLookups();
       if (configuredLookups == null) {
         return Response.status(Response.Status.NOT_FOUND)
@@ -535,12 +517,6 @@ public class LookupCoordinatorResource
   )
   {
     try {
-      if (Strings.isNullOrEmpty(tier)) {
-        return Response.status(Response.Status.BAD_REQUEST)
-                       .entity("`tier` required")
-                       .build();
-      }
-
       Map<HostAndPort, LookupsState<LookupExtractorFactoryMapContainer>> lookupsStateOnHosts = lookupCoordinatorManager.getLastKnownLookupsStateOnNodes();
 
       Map<HostAndPort, LookupsState<LookupExtractorFactoryMapContainer>> tierNodesStatus = new HashMap<>();
@@ -568,25 +544,13 @@ public class LookupCoordinatorResource
   @Path("/nodeStatus/{tier}/{hostAndPort}")
   public Response getSpecificNodeStatus(
       @PathParam("tier") String tier,
-      @PathParam("hostAndPort") String hostAndPort
+      @PathParam("hostAndPort") HostAndPort hostAndPort
   )
   {
     try {
-      if (Strings.isNullOrEmpty(tier)) {
-        return Response.status(Response.Status.BAD_REQUEST)
-                       .entity("`tier` required")
-                       .build();
-      }
-
-      if (Strings.isNullOrEmpty(hostAndPort)) {
-        return Response.status(Response.Status.BAD_REQUEST)
-                       .entity("`hostAndPort` required")
-                       .build();
-      }
-
       Map<HostAndPort, LookupsState<LookupExtractorFactoryMapContainer>> lookupsStateOnHosts = lookupCoordinatorManager.getLastKnownLookupsStateOnNodes();
 
-      LookupsState<LookupExtractorFactoryMapContainer> lookupsState = lookupsStateOnHosts.get(HostAndPort.fromString(hostAndPort));
+      LookupsState<LookupExtractorFactoryMapContainer> lookupsState = lookupsStateOnHosts.get(hostAndPort);
       if (lookupsState == null) {
         return Response.status(Response.Status.NOT_FOUND)
                        .entity(ServletResourceUtils.sanitizeException(new RE("Node [%s] status is unknown.", hostAndPort)))
@@ -609,12 +573,12 @@ public class LookupCoordinatorResource
 
     @JsonProperty
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private List<HostAndPort> pendingHosts;
+    private List<HostAndPort> pendingNodes;
 
     public LookupStatus(boolean loaded, List<HostAndPort> pendingHosts)
     {
       this.loaded = loaded;
-      this.pendingHosts = pendingHosts;
+      this.pendingNodes = pendingHosts;
     }
 
     @Override
@@ -628,13 +592,13 @@ public class LookupCoordinatorResource
       }
       LookupStatus that = (LookupStatus) o;
       return Objects.equals(loaded, that.loaded) &&
-             Objects.equals(pendingHosts, that.pendingHosts);
+             Objects.equals(pendingNodes, that.pendingNodes);
     }
 
     @Override
     public int hashCode()
     {
-      return Objects.hash(loaded, pendingHosts);
+      return Objects.hash(loaded, pendingNodes);
     }
   }
 }

--- a/server/src/main/java/io/druid/server/http/LookupCoordinatorResource.java
+++ b/server/src/main/java/io/druid/server/http/LookupCoordinatorResource.java
@@ -31,7 +31,6 @@ import com.google.inject.Inject;
 import io.druid.audit.AuditInfo;
 import io.druid.audit.AuditManager;
 import io.druid.common.utils.ServletResourceUtils;
-import io.druid.common.utils.StringUtils;
 import io.druid.guice.annotations.Json;
 import io.druid.guice.annotations.Smile;
 import io.druid.java.util.common.IAE;
@@ -307,7 +306,7 @@ public class LookupCoordinatorResource
       Map<String, Map<String, LookupExtractorFactoryMapContainer>> configuredLookups = lookupCoordinatorManager.getKnownLookups();
       if (configuredLookups == null) {
         return Response.status(Response.Status.NOT_FOUND)
-                       .entity("No lookups found")
+                       .entity(ServletResourceUtils.jsonize("No lookups found"))
                        .build();
       }
 
@@ -354,14 +353,14 @@ public class LookupCoordinatorResource
       Map<String, Map<String, LookupExtractorFactoryMapContainer>> configuredLookups = lookupCoordinatorManager.getKnownLookups();
       if (configuredLookups == null) {
         return Response.status(Response.Status.NOT_FOUND)
-                       .entity("No lookups found")
+                       .entity(ServletResourceUtils.jsonize("No lookups found"))
                        .build();
       }
 
       Map<String, LookupExtractorFactoryMapContainer> tierLookups = configuredLookups.get(tier);
       if (tierLookups == null) {
         return Response.status(Response.Status.NOT_FOUND)
-                       .entity(StringUtils.safeFormat("No lookups found for tier [%s].", tier))
+                       .entity(ServletResourceUtils.jsonize("No lookups found for tier [%s].", tier))
                        .build();
       }
 
@@ -398,21 +397,21 @@ public class LookupCoordinatorResource
       Map<String, Map<String, LookupExtractorFactoryMapContainer>> configuredLookups = lookupCoordinatorManager.getKnownLookups();
       if (configuredLookups == null) {
         return Response.status(Response.Status.NOT_FOUND)
-                       .entity("No lookups found")
+                       .entity(ServletResourceUtils.jsonize("No lookups found"))
                        .build();
       }
 
       Map<String, LookupExtractorFactoryMapContainer> tierLookups = configuredLookups.get(tier);
       if (tierLookups == null) {
         return Response.status(Response.Status.NOT_FOUND)
-                       .entity(StringUtils.safeFormat("No lookups found for tier [%s].", tier))
+                       .entity(ServletResourceUtils.jsonize("No lookups found for tier [%s].", tier))
                        .build();
       }
 
       LookupExtractorFactoryMapContainer lookupDef = tierLookups.get(lookup);
       if (lookupDef == null) {
         return Response.status(Response.Status.NOT_FOUND)
-                       .entity(StringUtils.safeFormat("Lookup [%s] not found for tier [%s].", lookup, tier))
+                       .entity(ServletResourceUtils.jsonize("Lookup [%s] not found for tier [%s].", lookup, tier))
                        .build();
       }
 
@@ -476,7 +475,7 @@ public class LookupCoordinatorResource
         Map<String, Map<String, LookupExtractorFactoryMapContainer>> configuredLookups = lookupCoordinatorManager.getKnownLookups();
         if (configuredLookups == null) {
           return Response.status(Response.Status.NOT_FOUND)
-                         .entity("No lookups configured.")
+                         .entity(ServletResourceUtils.jsonize("No lookups configured."))
                          .build();
         }
         tiers = configuredLookups.keySet();
@@ -553,7 +552,7 @@ public class LookupCoordinatorResource
       LookupsState<LookupExtractorFactoryMapContainer> lookupsState = lookupsStateOnHosts.get(hostAndPort);
       if (lookupsState == null) {
         return Response.status(Response.Status.NOT_FOUND)
-                       .entity(ServletResourceUtils.sanitizeException(new RE("Node [%s] status is unknown.", hostAndPort)))
+                       .entity(ServletResourceUtils.jsonize("Node [%s] status is unknown.", hostAndPort))
                        .build();
       } else {
         return Response.ok(lookupsState).build();

--- a/server/src/test/java/io/druid/server/http/LookupCoordinatorResourceTest.java
+++ b/server/src/test/java/io/druid/server/http/LookupCoordinatorResourceTest.java
@@ -1055,7 +1055,7 @@ public class LookupCoordinatorResourceTest
         mapper
     );
 
-    final Response response = lookupCoordinatorResource.getSpecificNodeStatus(LOOKUP_TIER, LOOKUP_NODE.toString());
+    final Response response = lookupCoordinatorResource.getSpecificNodeStatus(LOOKUP_TIER, LOOKUP_NODE);
     Assert.assertEquals(200, response.getStatus());
     Assert.assertEquals(
         LOOKUP_STATE, response.getEntity()

--- a/server/src/test/java/io/druid/server/lookup/cache/LookupCoordinatorManagerTest.java
+++ b/server/src/test/java/io/druid/server/lookup/cache/LookupCoordinatorManagerTest.java
@@ -1135,7 +1135,7 @@ public class LookupCoordinatorManagerTest
         lookupsCommunicator
     );
 
-    Assert.assertNull(manager.knownOldState.get());
+    Assert.assertTrue(manager.knownOldState.get().isEmpty());
 
     manager.start();
 
@@ -1335,6 +1335,7 @@ public class LookupCoordinatorManagerTest
         configManager,
         lookupCoordinatorManagerConfig
     );
+    manager.start();
     Assert.assertEquals(fakeChildren, manager.discoverTiers());
     EasyMock.verify(discoverer);
   }
@@ -1371,12 +1372,10 @@ public class LookupCoordinatorManagerTest
         configManager,
         lookupCoordinatorManagerConfig
     );
-    try {
-      manager.discoverTiers();
-    }
-    finally {
-      EasyMock.verify(discoverer);
-    }
+
+    manager.start();
+    manager.discoverTiers();
+    EasyMock.verify(discoverer);
   }
 
   //tests that lookups stored in db from 0.10.0 are converted and restored.


### PR DESCRIPTION
part of #3821

this allows users to find whether a given lookup has been loaded on all the lookup nodes and lookup node status endpoints for further investigation.

see updates to lookups.md .