### PR TITLE
Remove slf4j-log4j12 as dependency

### DIFF
--- a/extensions-core/avro-extensions/pom.xml
+++ b/extensions-core/avro-extensions/pom.xml
@@ -79,6 +79,12 @@
       <groupId>io.confluent</groupId>
       <artifactId>kafka-schema-registry-client</artifactId>
       <version>${confluent.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
Dear committers,

From the kafka-schema-registry-client in the avro extension slf4j will be packaged into the distribution. We don't want this as it will conflict and throw a slf4j multiple bindings warning. This will cause slf4j to fall back to no-operation (NOP) binding:

```
Log Upload Time:Fri Apr 28 21:48:42 +0200 2017
LogLength:828
Log Contents:
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/hdata/1/yarn/local/usercache/druid/filecache/1201/slf4j-log4j12-1.7.6.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/hdata/3/yarn/local/usercache/druid/filecache/1138/log4j-slf4j-impl-2.5.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/hdata/2/yarn/local/filecache/45/mapreduce.tar.gz/hadoop/share/hadoop/common/lib/slf4j-log4j12-1.7.10.jar!/org/slf4j/impl/S
taticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.

End of LogType:stderr
:Write failed: Broken pipe
```

The mvn dependancy tree:
```
[INFO] ------------------------------------------------------------------------
[INFO] Building druid-avro-extensions 0.10.0
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ druid-avro-extensions ---
[INFO] io.druid.extensions:druid-avro-extensions:jar:0.10.0
[INFO] +- org.apache.avro:avro-mapred:jar:hadoop2:1.7.7:compile
[INFO] |  +- org.apache.avro:avro-ipc:jar:1.7.7:compile
[INFO] |  |  +- io.netty:netty:jar:3.4.0.Final:compile
[INFO] |  |  +- org.apache.velocity:velocity:jar:1.7:compile
[INFO] |  |  \- org.mortbay.jetty:servlet-api:jar:2.5-20081211:compile
[INFO] |  +- org.apache.avro:avro-ipc:jar:tests:1.7.7:compile
[INFO] |  +- org.codehaus.jackson:jackson-core-asl:jar:1.9.13:compile
[INFO] |  +- org.codehaus.jackson:jackson-mapper-asl:jar:1.9.13:compile
[INFO] |  \- org.slf4j:slf4j-api:jar:1.6.4:compile
[INFO] +- io.druid:druid-api:jar:0.10.0:provided
[INFO] |  +- io.druid:java-util:jar:0.10.0:provided
[INFO] |  |  +- net.sf.opencsv:opencsv:jar:2.3:provided
[INFO] |  |  \- com.jayway.jsonpath:json-path:jar:2.1.0:provided
[INFO] |  +- com.google.inject:guice:jar:4.1.0:provided
[INFO] |  |  +- javax.inject:javax.inject:jar:1:provided
[INFO] |  |  \- aopalliance:aopalliance:jar:1.0:provided
[INFO] |  +- com.google.inject.extensions:guice-multibindings:jar:4.1.0:provided
[INFO] |  +- io.airlift:airline:jar:0.7:provided
[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.4.6:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.4.6:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.4.6:compile
[INFO] |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:jar:2.4.6:provided
[INFO] |  +- org.hibernate:hibernate-validator:jar:5.1.3.Final:provided
[INFO] |  |  +- org.jboss.logging:jboss-logging:jar:3.1.3.GA:provided
[INFO] |  |  \- com.fasterxml:classmate:jar:1.0.0:provided
[INFO] |  +- javax.validation:validation-api:jar:1.1.0.Final:provided
[INFO] |  +- commons-io:commons-io:jar:2.4:provided
[INFO] |  \- com.google.code.findbugs:jsr305:jar:2.0.1:provided
[INFO] +- org.schemarepo:schema-repo-api:jar:0.1.3:compile
[INFO] |  +- org.schemarepo:schema-repo-common:jar:0.1.3:compile
[INFO] |  |  \- com.google.code.gson:gson:jar:2.3.1:compile
[INFO] |  \- com.google.guava:guava:jar:16.0.1:compile
[INFO] +- org.schemarepo:schema-repo-client:jar:0.1.3:compile
[INFO] |  \- com.sun.jersey:jersey-client:jar:1.15:compile
[INFO] |     \- com.sun.jersey:jersey-core:jar:1.19:compile
[INFO] |        \- javax.ws.rs:jsr311-api:jar:1.1.1:compile
[INFO] +- org.schemarepo:schema-repo-avro:jar:0.1.3:compile
[INFO] |  \- org.apache.avro:avro:jar:1.7.7:compile
[INFO] |     +- com.thoughtworks.paranamer:paranamer:jar:2.3:compile
[INFO] |     +- org.xerial.snappy:snappy-java:jar:1.0.5:compile
[INFO] |     \- org.apache.commons:commons-compress:jar:1.4.1:compile
[INFO] |        \- org.tukaani:xz:jar:1.0:compile
[INFO] +- io.confluent:kafka-schema-registry-client:jar:3.0.1:compile
[INFO] |  \- org.slf4j:slf4j-log4j12:jar:1.7.6:compile
[INFO] +- org.apache.hadoop:hadoop-client:jar:2.7.3:provided
[INFO] |  +- org.apache.hadoop:hadoop-common:jar:2.7.3:provided
[INFO] |  |  +- org.apache.commons:commons-math3:jar:3.6.1:provided
[INFO] |  |  +- commons-collections:commons-collections:jar:3.2.2:compile
[INFO] |  |  +- javax.servlet.jsp:jsp-api:jar:2.1:provided
[INFO] |  |  +- commons-configuration:commons-configuration:jar:1.6:provided
[INFO] |  |  |  +- commons-digester:commons-digester:jar:1.8:provided
[INFO] |  |  |  |  \- commons-beanutils:commons-beanutils:jar:1.7.0:provided
[INFO] |  |  |  \- commons-beanutils:commons-beanutils-core:jar:1.8.0:provided
[INFO] |  |  +- org.apache.hadoop:hadoop-auth:jar:2.7.3:provided
[INFO] |  |  |  +- org.apache.httpcomponents:httpclient:jar:4.5.1:provided
[INFO] |  |  |  |  \- org.apache.httpcomponents:httpcore:jar:4.4.3:provided
[INFO] |  |  |  +- org.apache.directory.server:apacheds-kerberos-codec:jar:2.0.0-M15:provided
[INFO] |  |  |  |  +- org.apache.directory.server:apacheds-i18n:jar:2.0.0-M15:provided
[INFO] |  |  |  |  +- org.apache.directory.api:api-asn1-api:jar:1.0.0-M20:provided
[INFO] |  |  |  |  \- org.apache.directory.api:api-util:jar:1.0.0-M20:provided
[INFO] |  |  |  \- org.apache.curator:curator-framework:jar:2.11.0:provided
[INFO] |  |  +- org.apache.curator:curator-client:jar:2.11.0:provided
[INFO] |  |  +- org.apache.curator:curator-recipes:jar:2.11.0:provided
[INFO] |  |  +- org.apache.htrace:htrace-core:jar:3.1.0-incubating:provided
[INFO] |  |  \- org.apache.zookeeper:zookeeper:jar:3.4.9:provided
[INFO] |  +- org.apache.hadoop:hadoop-hdfs:jar:2.7.3:provided
[INFO] |  |  +- io.netty:netty-all:jar:4.1.6.Final:provided
[INFO] |  |  +- xerces:xercesImpl:jar:2.9.1:provided
[INFO] |  |  |  \- xml-apis:xml-apis:jar:1.3.04:provided
[INFO] |  |  \- org.fusesource.leveldbjni:leveldbjni-all:jar:1.8:provided
[INFO] |  +- org.apache.hadoop:hadoop-mapreduce-client-app:jar:2.7.3:provided
[INFO] |  |  +- org.apache.hadoop:hadoop-mapreduce-client-common:jar:2.7.3:provided
[INFO] |  |  |  +- org.apache.hadoop:hadoop-yarn-client:jar:2.7.3:provided
[INFO] |  |  |  \- org.apache.hadoop:hadoop-yarn-server-common:jar:2.7.3:provided
[INFO] |  |  \- org.apache.hadoop:hadoop-mapreduce-client-shuffle:jar:2.7.3:provided
[INFO] |  +- org.apache.hadoop:hadoop-yarn-api:jar:2.7.3:provided
[INFO] |  +- org.apache.hadoop:hadoop-mapreduce-client-core:jar:2.7.3:provided
[INFO] |  |  \- org.apache.hadoop:hadoop-yarn-common:jar:2.7.3:provided
[INFO] |  |     +- javax.xml.bind:jaxb-api:jar:2.2.2:provided
[INFO] |  |     |  \- javax.xml.stream:stax-api:jar:1.0-2:provided
[INFO] |  |     +- javax.servlet:servlet-api:jar:2.5:provided
[INFO] |  |     +- org.codehaus.jackson:jackson-jaxrs:jar:1.9.13:provided
[INFO] |  |     \- org.codehaus.jackson:jackson-xc:jar:1.9.13:provided
[INFO] |  +- org.apache.hadoop:hadoop-mapreduce-client-jobclient:jar:2.7.3:provided
[INFO] |  \- org.apache.hadoop:hadoop-annotations:jar:2.7.3:provided
[INFO] +- junit:junit:jar:4.11:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] +- org.mockito:mockito-core:jar:2.2.10:test
[INFO] |  +- net.bytebuddy:byte-buddy:jar:1.5.3:test
[INFO] |  +- net.bytebuddy:byte-buddy-agent:jar:1.5.3:test
[INFO] |  \- org.objenesis:objenesis:jar:2.4:test
[INFO] +- org.apache.pig:pig:jar:h2:0.15.0:test
[INFO] |  +- commons-cli:commons-cli:jar:1.2:provided
[INFO] |  +- xmlenc:xmlenc:jar:0.52:provided
[INFO] |  +- commons-httpclient:commons-httpclient:jar:3.1:provided
[INFO] |  +- commons-codec:commons-codec:jar:1.7:provided
[INFO] |  +- commons-net:commons-net:jar:1.4.1:provided
[INFO] |  +- org.mortbay.jetty:jetty:jar:6.1.26:compile
[INFO] |  +- org.mortbay.jetty:jetty-util:jar:6.1.26:compile
[INFO] |  +- tomcat:jasper-runtime:jar:5.5.12:test
[INFO] |  +- tomcat:jasper-compiler:jar:5.5.12:test
[INFO] |  +- org.mortbay.jetty:jsp-api-2.1:jar:6.1.14:test
[INFO] |  +- org.mortbay.jetty:jsp-2.1:jar:6.1.14:test
[INFO] |  |  +- org.eclipse.jdt:core:jar:3.1.1:test
[INFO] |  |  \- ant:ant:jar:1.6.5:test
[INFO] |  +- commons-el:commons-el:jar:1.0:test
[INFO] |  +- net.java.dev.jets3t:jets3t:jar:0.9.4:test
[INFO] |  |  +- javax.activation:activation:jar:1.1.1:provided
[INFO] |  |  +- org.bouncycastle:bcprov-jdk15on:jar:1.52:test
[INFO] |  |  \- com.jamesmurty.utils:java-xmlbuilder:jar:1.1:test
[INFO] |  |     \- net.iharder:base64:jar:2.3.8:test
[INFO] |  +- org.mortbay.jetty:servlet-api-2.5:jar:6.1.14:test
[INFO] |  +- net.sf.kosmosfs:kfs:jar:0.3:test
[INFO] |  +- hsqldb:hsqldb:jar:1.8.0.10:test
[INFO] |  +- oro:oro:jar:2.0.8:provided
[INFO] |  +- jline:jline:jar:1.0:test
[INFO] |  +- org.antlr:ST4:jar:4.0.4:test
[INFO] |  +- org.antlr:antlr-runtime:jar:3.4:test
[INFO] |  |  +- org.antlr:stringtemplate:jar:3.2.1:test
[INFO] |  |  \- antlr:antlr:jar:2.7.7:test
[INFO] |  +- dk.brics.automaton:automaton:jar:1.11-8:test
[INFO] |  \- joda-time:joda-time:jar:2.8.2:provided
[INFO] +- org.apache.pig:piggybank:jar:0.15.0:test
[INFO] |  +- commons-lang:commons-lang:jar:2.6:compile
[INFO] |  +- log4j:log4j:jar:1.2.16:compile
[INFO] |  +- commons-logging:commons-logging:jar:1.1.1:provided
[INFO] |  +- com.googlecode.json-simple:json-simple:jar:1.1:test
[INFO] |  \- org.apache.pig:pig:jar:0.15.0:test
[INFO] \- io.druid:druid-processing:jar:0.10.0:test
[INFO]    +- io.druid:druid-common:jar:0.10.0:test
[INFO]    |  +- org.apache.commons:commons-dbcp2:jar:2.0.1:test
[INFO]    |  |  \- org.apache.commons:commons-pool2:jar:2.2:test
[INFO]    |  +- commons-pool:commons-pool:jar:1.6:test
[INFO]    |  +- javax.el:javax.el-api:jar:3.0.0:test
[INFO]    |  +- com.fasterxml.jackson.datatype:jackson-datatype-guava:jar:2.4.6:test
[INFO]    |  +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.4.6:test
[INFO]    |  +- org.jdbi:jdbi:jar:2.63.1:test
[INFO]    |  +- org.apache.logging.log4j:log4j-api:jar:2.5:test
[INFO]    |  +- org.apache.logging.log4j:log4j-core:jar:2.5:test
[INFO]    |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.5:test
[INFO]    |  +- org.apache.logging.log4j:log4j-jul:jar:2.5:test
[INFO]    |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.5:test
[INFO]    |  +- org.slf4j:jcl-over-slf4j:jar:1.7.12:test
[INFO]    |  +- com.lmax:disruptor:jar:3.3.0:test
[INFO]    |  \- org.antlr:antlr4-runtime:jar:4.5.1:test
[INFO]    +- io.druid:druid-hll:jar:0.10.0:test
[INFO]    +- io.druid:bytebuffer-collections:jar:0.10.0:test
[INFO]    |  +- io.druid:extendedset:jar:0.10.0:test
[INFO]    |  \- org.roaringbitmap:RoaringBitmap:jar:0.5.18:test
[INFO]    +- it.unimi.dsi:fastutil:jar:7.0.13:test
[INFO]    +- com.metamx:emitter:jar:0.4.1:test
[INFO]    |  +- com.metamx:java-util:jar:0.27.12:test
[INFO]    |  \- com.metamx:http-client:jar:1.0.6:test
[INFO]    +- com.metamx:server-metrics:jar:0.2.8:test
[INFO]    +- com.ning:compress-lzf:jar:1.0.3:test
[INFO]    +- org.skife.config:config-magic:jar:0.9:provided
[INFO]    +- com.google.protobuf:protobuf-java:jar:3.1.0:provided
[INFO]    +- com.ibm.icu:icu4j:jar:4.8.1:test
[INFO]    +- org.mozilla:rhino:jar:1.7R5:provided
[INFO]    +- net.jpountz.lz4:lz4:jar:1.3.0:test
[INFO]    \- org.mapdb:mapdb:jar:1.0.8:test
```