### PR TITLE
fix auto reset - pause task instead of putting thread to sleep

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIndexTask.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIndexTask.java
@@ -1063,10 +1063,10 @@ public class KafkaIndexTask extends AbstractTask implements ChatHandler
          .emit();
       // wait for being killed by supervisor
       try {
-        Thread.sleep(Long.MAX_VALUE);
+        pause(-1);
       }
       catch (InterruptedException e) {
-        throw new RuntimeException("Got interrupted while waiting to be killed");
+        throw new RuntimeException("Got interrupted while pausing task");
       }
     } else {
       log.makeAlert("Failed to send reset request for partitions [%s]", partitionOffsetMap.keySet()).emit();


### PR DESCRIPTION
If the task sends a Reset action to the Supervisor and its main thread goes to sleep however for some reason Supervisor does not respond to Reset Notice from the task. Now lets say, if the Supervisor is restarted and it decides that the running tasks should be stopped it cannot do that as the tasks will not respond to the stopGracefully call as the main thread is sleeping.

TL;DR `pause(-1)` is better than `Thread.sleep(Long.MAX_VALUE)`