### PR TITLE
Ignore misnamed segment cache info files.

### DIFF
--- a/server/src/main/java/io/druid/server/coordination/ZkCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordination/ZkCoordinator.java
@@ -252,6 +252,7 @@ public class ZkCoordinator implements DataSegmentChangeHandler
 
     List<DataSegment> cachedSegments = Lists.newArrayList();
     File[] segmentsToLoad = baseDir.listFiles();
+    int ignored = 0;
     for (int i = 0; i < segmentsToLoad.length; i++) {
       File file = segmentsToLoad[i];
       log.info("Loading segment cache file [%d/%d][%s].", i, segmentsToLoad.length, file);
@@ -259,10 +260,8 @@ public class ZkCoordinator implements DataSegmentChangeHandler
         final DataSegment segment = jsonMapper.readValue(file, DataSegment.class);
 
         if (!segment.getIdentifier().equals(file.getName())) {
-          log.makeAlert("Ignoring cache file for dataSource[%s].", segment.getDataSource())
-             .addData("cacheFile", file.getPath())
-             .addData("segmentIdentifier", segment.getIdentifier())
-             .emit();
+          log.warn("Ignoring cache file[%s] for segment[%s].", file.getPath(), segment.getIdentifier());
+          ignored++;
         } else if (serverManager.isSegmentCached(segment)) {
           cachedSegments.add(segment);
         } else {
@@ -279,6 +278,12 @@ public class ZkCoordinator implements DataSegmentChangeHandler
            .addData("file", file)
            .emit();
       }
+    }
+
+    if (ignored > 0) {
+      log.makeAlert("Ignored misnamed segment cache files on startup.")
+         .addData("numIgnored", ignored)
+         .emit();
     }
 
     addSegments(

--- a/server/src/main/java/io/druid/server/coordination/ZkCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordination/ZkCoordinator.java
@@ -256,8 +256,14 @@ public class ZkCoordinator implements DataSegmentChangeHandler
       File file = segmentsToLoad[i];
       log.info("Loading segment cache file [%d/%d][%s].", i, segmentsToLoad.length, file);
       try {
-        DataSegment segment = jsonMapper.readValue(file, DataSegment.class);
-        if (serverManager.isSegmentCached(segment)) {
+        final DataSegment segment = jsonMapper.readValue(file, DataSegment.class);
+
+        if (!segment.getIdentifier().equals(file.getName())) {
+          log.makeAlert("Ignoring cache file for dataSource[%s].", segment.getDataSource())
+             .addData("cacheFile", file.getPath())
+             .addData("segmentIdentifier", segment.getIdentifier())
+             .emit();
+        } else if (serverManager.isSegmentCached(segment)) {
           cachedSegments.add(segment);
         } else {
           log.warn("Unable to find cache file for %s. Deleting lookup entry", segment.getIdentifier());


### PR DESCRIPTION
Fixes a bug where historical nodes could announce the same segment twice,
ultimately leading to historicals and their watchers (like coordinators
and brokers) being out of sync about which segments are served.

This could be caused if Druid is switched from local time to UTC, because
that causes the same segment descriptors to lead to different identifiers
(an identifier with local time interval before the switch, and UTC interval
after the switch). In turn this causes that segment descriptor to be written
to multiple segment cache info files and then get announced twice after
the historical is restarted.

Later, if the historical receives a drop request, it drops the segment and
unannounces it once, but the other announcement would stick around in an
ephemeral znode forever, confusing coordinators and brokers.

And when it restarts, the cycle of violence continues anew.