### PR TITLE
Do not flush closed stream in indexing-hadoop

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
@@ -399,7 +399,6 @@ public class JobHelper
                 progressable
             )) {
               size.set(zipAndCopyDir(mergedBase, outputStream, progressable));
-              outputStream.flush();
             }
             catch (IOException | RuntimeException exception) {
               log.error(exception, "Exception in retry loop");


### PR DESCRIPTION
Removing a flush on closed stream as this prevent using Hadoop indexing task with hdfs encrypted zones

https://groups.google.com/d/msg/druid-development/M5QKd8sg-eY/AETM5uE4BAAJ