### PR TITLE
Update Error prone configuration; Fix bugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ language: java
 jdk:
   - oraclejdk8
 
-script:
-  - mvn clean test -B -Pparallel-test -Dmaven.fork.count=2
+env:
+  - MAVEN_OPTS="-Xmx3000m"
+
+install: mvn clean test -B -Pparallel-test -Dmaven.fork.count=2
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ jdk:
   - oraclejdk8
 
 script:
-  - mvn test -B -Pparallel-test -Dmaven.fork.count=2
   - mvn clean -Pstrict -pl '!benchmarks' compile test-compile -B
+  - mvn test -B -Pparallel-test -Dmaven.fork.count=2
 
 install: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
   - oraclejdk8
 
 script:
-  - mvn test -B -Pparallel-test -Dmaven.fork.count=2 && mvn clean -Pstrict compile test-compile -B
+  - mvn clean test -B -Pparallel-test -Dmaven.fork.count=2
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,11 @@ language: java
 jdk:
   - oraclejdk8
 
-install: mvn test -B -Pparallel-test -Dmaven.fork.count=2 && mvn clean -Pstrict -pl '!benchmarks' compile test-compile -B
+script:
+  - mvn test -B -Pparallel-test -Dmaven.fork.count=2
+  - mvn clean -Pstrict -pl '!benchmarks' compile test-compile -B
+
+install: true
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
 env:
   - MAVEN_OPTS="-Xmx3000m"
 
-install: mvn clean test -B -Pparallel-test -Dmaven.fork.count=2
+install: mvn test -B -Pparallel-test -Dmaven.fork.count=2 && mvn clean -Pstrict compile test-compile -B
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 jdk:
   - oraclejdk8
 
-install: mvn test -B -Pparallel-test -Dmaven.fork.count=2 && mvn clean -Pstrict compile test-compile -B
+install: mvn test -B -Pparallel-test -Dmaven.fork.count=2 && mvn clean -Pstrict -pl '!benchmarks' compile test-compile -B
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: java
 jdk:
   - oraclejdk8
 
-env:
-  - MAVEN_OPTS="-Xmx3000m"
-
 install: mvn test -B -Pparallel-test -Dmaven.fork.count=2 && mvn clean -Pstrict compile test-compile -B
 
 sudo: false

--- a/benchmarks/src/main/java/io/druid/benchmark/FilterPartitionBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/FilterPartitionBenchmark.java
@@ -560,7 +560,7 @@ public class FilterPartitionBenchmark
     );
   }
 
-  private class NoBitmapSelectorFilter extends SelectorFilter
+  private static class NoBitmapSelectorFilter extends SelectorFilter
   {
     public NoBitmapSelectorFilter(
         String dimension,
@@ -577,7 +577,7 @@ public class FilterPartitionBenchmark
     }
   }
 
-  private class NoBitmapDimensionPredicateFilter extends DimensionPredicateFilter
+  private static class NoBitmapDimensionPredicateFilter extends DimensionPredicateFilter
   {
     public NoBitmapDimensionPredicateFilter(
         final String dimension,
@@ -595,7 +595,7 @@ public class FilterPartitionBenchmark
     }
   }
 
-  private class NoBitmapSelectorDimFilter extends SelectorDimFilter
+  private static class NoBitmapSelectorDimFilter extends SelectorDimFilter
   {
     public NoBitmapSelectorDimFilter(
         String dimension,

--- a/benchmarks/src/main/java/io/druid/benchmark/FlattenJSONBenchmarkUtil.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/FlattenJSONBenchmarkUtil.java
@@ -285,7 +285,7 @@ public class FlattenJSONBenchmarkUtil
     return mapper.writeValueAsString(wrapper);
   }
 
-  public class BenchmarkEvent
+  public static class BenchmarkEvent
   {
 
     public String ts;

--- a/benchmarks/src/test/java/io/druid/benchmark/BenchmarkDataGeneratorTest.java
+++ b/benchmarks/src/test/java/io/druid/benchmark/BenchmarkDataGeneratorTest.java
@@ -384,7 +384,7 @@ public class BenchmarkDataGeneratorTest
   }
 
 
-  private class RowValueTracker
+  private static class RowValueTracker
   {
     private Map<String, Map<Object, Integer>> dimensionMap;
 

--- a/bytebuffer-collections/src/main/java/io/druid/collections/spatial/ImmutableNode.java
+++ b/bytebuffer-collections/src/main/java/io/druid/collections/spatial/ImmutableNode.java
@@ -160,6 +160,7 @@ public class ImmutableNode
     return bitmapFactory.mapImmutableBitmap(tmpBuffer.asReadOnlyBuffer());
   }
 
+  @SuppressWarnings("ArgumentParameterSwap")
   public Iterable<ImmutableNode> getChildren()
   {
     return new Iterable<ImmutableNode>()

--- a/common/src/test/java/io/druid/collections/CountingMapTest.java
+++ b/common/src/test/java/io/druid/collections/CountingMapTest.java
@@ -50,7 +50,7 @@ public class CountingMapTest
     String defaultKey = "defaultKey";
     long actual;
     actual = mapObject.add(defaultKey,defaultValue);
-    Assert.assertEquals("Values does not match", actual, defaultValue);
+    Assert.assertEquals("Values does not match", defaultValue, actual);
   }
 
   @Test
@@ -63,7 +63,6 @@ public class CountingMapTest
     Assert.assertEquals("Maps size does not match",mapObject.size(),snapShotMap.size());
     long expected = (long) snapShotMap.get(defaultKey);
     AtomicLong actual = (AtomicLong) mapObject.get(defaultKey);
-    Assert.assertEquals("Values for key = " + defaultKey + " does not match",
-        actual.longValue(),expected);
+    Assert.assertEquals("Values for key = " + defaultKey + " does not match", expected, actual.longValue());
   }
 }

--- a/extensions-contrib/druid-rocketmq/src/main/java/io/druid/firehose/rocketmq/RocketMQFirehoseFactory.java
+++ b/extensions-contrib/druid-rocketmq/src/main/java/io/druid/firehose/rocketmq/RocketMQFirehoseFactory.java
@@ -308,7 +308,7 @@ public class RocketMQFirehoseFactory implements FirehoseFactory<ByteBufferInputR
   /**
    * Pull request.
    */
-  final class DruidPullRequest
+  static final class DruidPullRequest
   {
     private final MessageQueue messageQueue;
     private final String tag;

--- a/extensions-contrib/orc-extensions/src/main/java/io/druid/data/input/orc/OrcHadoopInputRowParser.java
+++ b/extensions-contrib/orc-extensions/src/main/java/io/druid/data/input/orc/OrcHadoopInputRowParser.java
@@ -70,6 +70,7 @@ public class OrcHadoopInputRowParser implements InputRowParser<OrcStruct>
     initialize();
   }
 
+  @SuppressWarnings("ArgumentParameterSwap")
   @Override
   public InputRow parse(OrcStruct input)
   {

--- a/extensions-contrib/scan-query/src/main/java/io/druid/query/scan/ScanQueryRunnerFactory.java
+++ b/extensions-contrib/scan-query/src/main/java/io/druid/query/scan/ScanQueryRunnerFactory.java
@@ -100,7 +100,7 @@ public class ScanQueryRunnerFactory implements QueryRunnerFactory<ScanResultValu
     return toolChest;
   }
 
-  private class ScanQueryRunner implements QueryRunner<ScanResultValue>
+  private static class ScanQueryRunner implements QueryRunner<ScanResultValue>
   {
     private final ScanQueryEngine engine;
     private final Segment segment;

--- a/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchEstimateWithErrorBounds.java
+++ b/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchEstimateWithErrorBounds.java
@@ -105,7 +105,7 @@ public class SketchEstimateWithErrorBounds
     if (estimate != that.estimate ||
         highBound != that.highBound ||
         lowBound != that.lowBound ||
-        numStdDev != numStdDev) {
+        numStdDev != that.numStdDev) {
       return false;
     }
     return true;

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogram.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogram.java
@@ -548,19 +548,19 @@ public class ApproximateHistogram
     } else {
       Preconditions.checkArgument(
           mergedPositions.length >= maxSize,
-          "temp buffer [mergedPositions] too small: length must be at least [%d], got [%d]",
+          "temp buffer [mergedPositions] too small: length must be at least [%s], got [%s]",
           maxSize,
           mergedPositions.length
       );
       Preconditions.checkArgument(
           mergedBins.length >= maxSize,
-          "temp buffer [mergedBins] too small: length must be at least [%d], got [%d]",
+          "temp buffer [mergedBins] too small: length must be at least [%s], got [%s]",
           maxSize,
           mergedPositions.length
       );
       Preconditions.checkArgument(
           deltas.length >= maxSize,
-          "temp buffer [deltas] too small: length must be at least [%d], got [%d]",
+          "temp buffer [deltas] too small: length must be at least [%s], got [%s]",
           maxSize,
           mergedPositions.length
       );

--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIOConfig.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIOConfig.java
@@ -74,7 +74,7 @@ public class KafkaIOConfig implements IOConfig
       Preconditions.checkArgument(
           endPartitions.getPartitionOffsetMap().get(partition) >= startPartitions.getPartitionOffsetMap()
                                                                                  .get(partition),
-          "end offset must be >= start offset for partition[%d]",
+          "end offset must be >= start offset for partition[%s]",
           partition
       );
     }

--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIndexTaskClient.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIndexTaskClient.java
@@ -60,7 +60,7 @@ import java.util.concurrent.Callable;
 
 public class KafkaIndexTaskClient
 {
-  public class NoTaskLocationException extends RuntimeException
+  public static class NoTaskLocationException extends RuntimeException
   {
     public NoTaskLocationException(String message)
     {
@@ -68,7 +68,7 @@ public class KafkaIndexTaskClient
     }
   }
 
-  public class TaskNotRunnableException extends RuntimeException
+  public static class TaskNotRunnableException extends RuntimeException
   {
     public TaskNotRunnableException(String message)
     {

--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisor.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisor.java
@@ -125,7 +125,7 @@ public class KafkaSupervisor implements Supervisor
    * time, there should only be up to a maximum of [taskCount] actively-reading task groups (tracked in the [taskGroups]
    * map) + zero or more pending-completion task groups (tracked in [pendingCompletionTaskGroups]).
    */
-  private class TaskGroup
+  private static class TaskGroup
   {
     // This specifies the partitions and starting offsets for this task group. It is set on group creation from the data
     // in [partitionGroups] and never changes during the lifetime of this task group, which will live until a task in
@@ -150,7 +150,7 @@ public class KafkaSupervisor implements Supervisor
     }
   }
 
-  private class TaskData
+  private static class TaskData
   {
     TaskStatus status;
     DateTime startTime;

--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorReport.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorReport.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 public class KafkaSupervisorReport extends SupervisorReport
 {
-  public class KafkaSupervisorReportPayload
+  public static class KafkaSupervisorReportPayload
   {
     private final String dataSource;
     private final String topic;

--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -1789,7 +1789,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     );
   }
 
-  private class TestTaskRunnerWorkItem extends TaskRunnerWorkItem
+  private static class TestTaskRunnerWorkItem extends TaskRunnerWorkItem
   {
 
     private TaskLocation location;
@@ -1807,7 +1807,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     }
   }
 
-  private class TestableKafkaSupervisor extends KafkaSupervisor
+  private static class TestableKafkaSupervisor extends KafkaSupervisor
   {
     public TestableKafkaSupervisor(
         TaskStorage taskStorage,

--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -416,7 +416,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     KafkaIndexTask task = captured.getValue();
     KafkaIOConfig taskConfig = task.getIOConfig();
-    Assert.assertEquals(String.format("sequenceName-0", DATASOURCE), taskConfig.getBaseSequenceName());
+    Assert.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
     Assert.assertEquals(10L, (long) taskConfig.getStartPartitions().getPartitionOffsetMap().get(0));
     Assert.assertEquals(20L, (long) taskConfig.getStartPartitions().getPartitionOffsetMap().get(1));
     Assert.assertEquals(30L, (long) taskConfig.getStartPartitions().getPartitionOffsetMap().get(2));

--- a/extensions-core/s3-extensions/src/test/java/io/druid/storage/s3/S3DataSegmentMoverTest.java
+++ b/extensions-core/s3-extensions/src/test/java/io/druid/storage/s3/S3DataSegmentMoverTest.java
@@ -158,7 +158,7 @@ public class S3DataSegmentMoverTest
     ), ImmutableMap.<String, Object>of("bucket", "DOES NOT EXIST", "baseKey", "baseKey2"));
   }
 
-  private class MockStorageService extends RestS3Service {
+  private static class MockStorageService extends RestS3Service {
     Map<String, Set<String>> storage = Maps.newHashMap();
     boolean moved = false;
 

--- a/extensions-core/s3-extensions/src/test/java/io/druid/storage/s3/S3DataSegmentPusherTest.java
+++ b/extensions-core/s3-extensions/src/test/java/io/druid/storage/s3/S3DataSegmentPusherTest.java
@@ -44,7 +44,7 @@ import java.io.File;
  */
 public class S3DataSegmentPusherTest
 {
-  private class ValueContainer<T> {
+  private static class ValueContainer<T> {
     private T value;
 
     public T getValue() {

--- a/indexing-hadoop/src/main/java/io/druid/indexer/path/GranularUnprocessedPathSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/path/GranularUnprocessedPathSpec.java
@@ -75,7 +75,7 @@ public class GranularUnprocessedPathSpec extends GranularityPathSpec
     final FileSystem fs = betaInput.getFileSystem(job.getConfiguration());
     final Granularity segmentGranularity = config.getGranularitySpec().getSegmentGranularity();
 
-    Map<Long, Long> inputModifiedTimes = new TreeMap<>(Ordering.natural());
+    Map<Long, Long> inputModifiedTimes = new TreeMap<>(Ordering.natural().reverse());
 
     for (FileStatus status : FSSpideringIterator.spiderIterable(fs, betaInput)) {
       final DateTime key = segmentGranularity.toDate(status.getPath().toString());

--- a/indexing-hadoop/src/main/java/io/druid/indexer/path/GranularUnprocessedPathSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/path/GranularUnprocessedPathSpec.java
@@ -22,6 +22,7 @@ package io.druid.indexer.path;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 import io.druid.java.util.common.granularity.Granularity;
 import io.druid.indexer.HadoopDruidIndexerConfig;
@@ -74,13 +75,11 @@ public class GranularUnprocessedPathSpec extends GranularityPathSpec
     final FileSystem fs = betaInput.getFileSystem(job.getConfiguration());
     final Granularity segmentGranularity = config.getGranularitySpec().getSegmentGranularity();
 
-    Map<Long, Long> inputModifiedTimes = new TreeMap<>(
-        Comparators.inverse(Comparators.comparable())
-    );
+    Map<Long, Long> inputModifiedTimes = new TreeMap<>(Ordering.natural());
 
     for (FileStatus status : FSSpideringIterator.spiderIterable(fs, betaInput)) {
       final DateTime key = segmentGranularity.toDate(status.getPath().toString());
-      final Long currVal = inputModifiedTimes.get(key);
+      final Long currVal = inputModifiedTimes.get(key.getMillis());
       final long mTime = status.getModificationTime();
 
       inputModifiedTimes.put(key.getMillis(), currVal == null ? mTime : Math.max(currVal, mTime));

--- a/indexing-hadoop/src/test/java/io/druid/indexer/DetermineHashedPartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/DetermineHashedPartitionsJobTest.java
@@ -67,7 +67,7 @@ public class DetermineHashedPartitionsJobTest
     return Arrays.asList(
         new Object[][]{
             {
-                DetermineHashedPartitionsJobTest.class.getClass().getResource("/druid.test.data.with.duplicate.rows.tsv").getPath(),
+                DetermineHashedPartitionsJobTest.class.getResource("/druid.test.data.with.duplicate.rows.tsv").getPath(),
                 1L,
                 "2011-04-10T00:00:00.000Z/2011-04-11T00:00:00.000Z",
                 0,
@@ -75,7 +75,7 @@ public class DetermineHashedPartitionsJobTest
                 first
             },
             {
-                DetermineHashedPartitionsJobTest.class.getClass().getResource("/druid.test.data.with.duplicate.rows.tsv").getPath(),
+                DetermineHashedPartitionsJobTest.class.getResource("/druid.test.data.with.duplicate.rows.tsv").getPath(),
                 100L,
                 "2011-04-10T00:00:00.000Z/2011-04-16T00:00:00.000Z",
                 0,
@@ -83,7 +83,7 @@ public class DetermineHashedPartitionsJobTest
                 second
             },
             {
-                DetermineHashedPartitionsJobTest.class.getClass().getResource("/druid.test.data.with.duplicate.rows.tsv").getPath(),
+                DetermineHashedPartitionsJobTest.class.getResource("/druid.test.data.with.duplicate.rows.tsv").getPath(),
                 1L,
                 "2011-04-10T00:00:00.000Z/2011-04-16T00:00:00.000Z",
                 0,

--- a/indexing-hadoop/src/test/java/io/druid/indexer/UtilsTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/UtilsTest.java
@@ -65,7 +65,7 @@ public class UtilsTest
   @Rule
   public TemporaryFolder tmpFolder = new TemporaryFolder();
 
-  private class CreateValueFromKey implements Function
+  private static class CreateValueFromKey implements Function
   {
     @Override public Object apply(Object input)
     {

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunner.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunner.java
@@ -310,8 +310,11 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
                     waitingFor.decrement();
                     waitingForMonitor.notifyAll();
                   }
-                default:
                   break;
+                case CONNECTION_SUSPENDED:
+                case CONNECTION_RECONNECTED:
+                case CONNECTION_LOST:
+                  // do nothing
               }
             }
           }
@@ -1001,6 +1004,11 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
                         retVal.setException(new IllegalStateException(message));
                       }
                       runPendingTasks();
+                      break;
+                    case CONNECTION_SUSPENDED:
+                    case CONNECTION_RECONNECTED:
+                    case CONNECTION_LOST:
+                      // do nothing
                   }
                 }
                 catch (Exception e) {

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
@@ -269,7 +269,7 @@ public class SupervisorManagerTest extends EasyMockSupport
     verifyAll();
   }
 
-  private class TestSupervisorSpec implements SupervisorSpec
+  private static class TestSupervisorSpec implements SupervisorSpec
   {
     private final String id;
     private final Supervisor supervisor;

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
@@ -307,7 +307,7 @@ public class SupervisorResourceTest extends EasyMockSupport
     verifyAll();
   }
 
-  private class TestSupervisorSpec implements SupervisorSpec
+  private static class TestSupervisorSpec implements SupervisorSpec
   {
     private final String id;
     private final Supervisor supervisor;

--- a/integration-tests/src/main/java/org/testng/TestNG.java
+++ b/integration-tests/src/main/java/org/testng/TestNG.java
@@ -954,10 +954,10 @@ public class TestNG
     }
   }
 
-  private void addReporter(Class<? extends IReporter> r)
+  private void addReporter(Class<? extends IReporter> reporterClass)
   {
-    if (!m_reporters.contains(r)) {
-      m_reporters.add(ClassHelper.newInstance(r));
+    if (m_reporters.stream().noneMatch(reporterClass::isInstance)) {
+      m_reporters.add(ClassHelper.newInstance(reporterClass));
     }
   }
 

--- a/java-util/src/test/java/io/druid/java/util/common/GranularityTest.java
+++ b/java-util/src/test/java/io/druid/java/util/common/GranularityTest.java
@@ -422,7 +422,7 @@ public class GranularityTest {
         }
     }
 
-    private class PathDate
+    private static class PathDate
     {
         public final String path;
         public final DateTime date;

--- a/pom.xml
+++ b/pom.xml
@@ -995,6 +995,9 @@
                     <configuration>
                         <compilerId>javac-with-errorprone</compilerId>
                         <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                        <fork>true</fork>
+                        <meminitial>2048m</meminitial>
+                        <maxmem>2048m</maxmem>
                         <source>1.8</source>
                         <target>1.8</target>
                         <showWarnings>true</showWarnings>

--- a/pom.xml
+++ b/pom.xml
@@ -1000,6 +1000,7 @@
                         <showWarnings>true</showWarnings>
                         <compilerArgs>
                             <arg>-XepDisableWarningsInGeneratedCode</arg>
+                            <arg>-Xep:ClassCanBeStatic:ERROR</arg>
                             <arg>-Xep:ArgumentParameterSwap</arg>
                             <arg>-Xep:AssistedInjectAndInjectOnSameConstructor</arg>
                             <arg>-Xep:AutoFactoryAtInject</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -1001,6 +1001,7 @@
                         <compilerArgs>
                             <arg>-XepDisableWarningsInGeneratedCode</arg>
                             <arg>-Xep:ClassCanBeStatic:ERROR</arg>
+                            <arg>-Xep:PreconditionsInvalidPlaceholder:ERROR</arg>
                             <arg>-Xep:ArgumentParameterSwap</arg>
                             <arg>-Xep:AssistedInjectAndInjectOnSameConstructor</arg>
                             <arg>-Xep:AutoFactoryAtInject</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,8 @@
         <module>extensions-contrib/scan-query</module>
         <module>extensions-contrib/sqlserver-metadata-storage</module>
         <module>extensions-contrib/kafka-emitter</module>
+        <!-- distribution packaging -->
+        <module>distribution</module>
     </modules>
 
     <dependencyManagement>
@@ -1052,17 +1054,6 @@
     </build>
 
     <profiles>
-        <profile>
-            <id>java8</id>
-            <activation>
-                <jdk>1.8</jdk>
-            </activation>
-            <modules>
-                <!-- distribution packaging -->
-                <module>distribution</module>
-            </modules>
-        </profile>
-
         <profile>
             <id>parallel-test</id>
             <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -1014,6 +1014,9 @@
                         <configuration>
                             <compilerId>javac-with-errorprone</compilerId>
                             <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                            <fork>true</fork>
+                            <meminitial>1024m</meminitial>
+                            <maxmem>2048m</maxmem>
                             <source>1.8</source>
                             <target>1.8</target>
                             <showWarnings>false</showWarnings>

--- a/pom.xml
+++ b/pom.xml
@@ -1016,7 +1016,7 @@
                             <forceJavacCompilerUse>true</forceJavacCompilerUse>
                             <fork>true</fork>
                             <meminitial>1024m</meminitial>
-                            <maxmem>2048m</maxmem>
+                            <maxmem>4000m</maxmem>
                             <source>1.8</source>
                             <target>1.8</target>
                             <showWarnings>false</showWarnings>

--- a/pom.xml
+++ b/pom.xml
@@ -995,65 +995,77 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
-                        <compilerId>javac-with-errorprone</compilerId>
-                        <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                        <fork>true</fork>
-                        <meminitial>1024m</meminitial>
-                        <maxmem>2048m</maxmem>
                         <source>1.8</source>
                         <target>1.8</target>
-                        <showWarnings>false</showWarnings>
-                        <compilerArgs>
-                            <arg>-XepDisableWarningsInGeneratedCode</arg>
-                            <arg>-Xep:ClassCanBeStatic:ERROR</arg>
-                            <arg>-Xep:PreconditionsInvalidPlaceholder:ERROR</arg>
-                            <arg>-Xep:ArgumentParameterSwap</arg>
-                            <arg>-Xep:AssistedInjectAndInjectOnSameConstructor</arg>
-                            <arg>-Xep:AutoFactoryAtInject</arg>
-                            <arg>-Xep:ClassName</arg>
-                            <arg>-Xep:ComparisonContractViolated</arg>
-                            <arg>-Xep:DepAnn</arg>
-                            <arg>-Xep:DivZero</arg>
-                            <arg>-Xep:EmptyIf</arg>
-                            <arg>-Xep:InjectInvalidTargetingOnScopingAnnotation</arg>
-                            <arg>-Xep:InjectMoreThanOneQualifier</arg>
-                            <arg>-Xep:InjectScopeAnnotationOnInterfaceOrAbstractClass</arg>
-                            <arg>-Xep:InjectScopeOrQualifierAnnotationRetention</arg>
-                            <arg>-Xep:InjectedConstructorAnnotations</arg>
-                            <arg>-Xep:InsecureCryptoUsage</arg>
-                            <arg>-Xep:JMockTestWithoutRunWithOrRuleAnnotation</arg>
-                            <arg>-Xep:JavaxInjectOnFinalField</arg>
-                            <arg>-Xep:LockMethodChecker</arg>
-                            <arg>-Xep:LongLiteralLowerCaseSuffix</arg>
-                            <arg>-Xep:NoAllocation</arg>
-                            <arg>-Xep:NonRuntimeAnnotation</arg>
-                            <arg>-Xep:NumericEquality</arg>
-                            <arg>-Xep:ParameterPackage</arg>
-                            <arg>-Xep:ProtoStringFieldReferenceEquality</arg>
-                            <arg>-Xep:QualifierOnMethodWithoutProvides</arg>
-                            <arg>-Xep:UnlockMethod</arg>
-                        </compilerArgs>
                     </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.codehaus.plexus</groupId>
-                            <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                            <version>2.8.1</version>
-                        </dependency>
-                        <!-- override plexus-compiler-javac-errorprone's dependency on
-                             Error Prone with the latest version -->
-                        <dependency>
-                            <groupId>com.google.errorprone</groupId>
-                            <artifactId>error_prone_core</artifactId>
-                            <version>2.0.19</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>
     </build>
 
     <profiles>
+        <profile>
+            <id>strict</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <compilerId>javac-with-errorprone</compilerId>
+                            <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                            <source>1.8</source>
+                            <target>1.8</target>
+                            <showWarnings>false</showWarnings>
+                            <compilerArgs>
+                                <arg>-XepDisableWarningsInGeneratedCode</arg>
+                                <arg>-Xep:ClassCanBeStatic:ERROR</arg>
+                                <arg>-Xep:PreconditionsInvalidPlaceholder:ERROR</arg>
+                                <arg>-Xep:ArgumentParameterSwap</arg>
+                                <arg>-Xep:AssistedInjectAndInjectOnSameConstructor</arg>
+                                <arg>-Xep:AutoFactoryAtInject</arg>
+                                <arg>-Xep:ClassName</arg>
+                                <arg>-Xep:ComparisonContractViolated</arg>
+                                <arg>-Xep:DepAnn</arg>
+                                <arg>-Xep:DivZero</arg>
+                                <arg>-Xep:EmptyIf</arg>
+                                <arg>-Xep:InjectInvalidTargetingOnScopingAnnotation</arg>
+                                <arg>-Xep:InjectMoreThanOneQualifier</arg>
+                                <arg>-Xep:InjectScopeAnnotationOnInterfaceOrAbstractClass</arg>
+                                <arg>-Xep:InjectScopeOrQualifierAnnotationRetention</arg>
+                                <arg>-Xep:InjectedConstructorAnnotations</arg>
+                                <arg>-Xep:InsecureCryptoUsage</arg>
+                                <arg>-Xep:JMockTestWithoutRunWithOrRuleAnnotation</arg>
+                                <arg>-Xep:JavaxInjectOnFinalField</arg>
+                                <arg>-Xep:LockMethodChecker</arg>
+                                <arg>-Xep:LongLiteralLowerCaseSuffix</arg>
+                                <arg>-Xep:NoAllocation</arg>
+                                <arg>-Xep:NonRuntimeAnnotation</arg>
+                                <arg>-Xep:NumericEquality</arg>
+                                <arg>-Xep:ParameterPackage</arg>
+                                <arg>-Xep:ProtoStringFieldReferenceEquality</arg>
+                                <arg>-Xep:QualifierOnMethodWithoutProvides</arg>
+                                <arg>-Xep:UnlockMethod</arg>
+                            </compilerArgs>
+                        </configuration>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.codehaus.plexus</groupId>
+                                <artifactId>plexus-compiler-javac-errorprone</artifactId>
+                                <version>2.8.1</version>
+                            </dependency>
+                            <!-- override plexus-compiler-javac-errorprone's dependency on
+                                 Error Prone with the latest version -->
+                            <dependency>
+                                <groupId>com.google.errorprone</groupId>
+                                <artifactId>error_prone_core</artifactId>
+                                <version>2.0.19</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>parallel-test</id>
             <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -998,11 +998,11 @@
                         <compilerId>javac-with-errorprone</compilerId>
                         <forceJavacCompilerUse>true</forceJavacCompilerUse>
                         <fork>true</fork>
-                        <meminitial>2048m</meminitial>
+                        <meminitial>1024m</meminitial>
                         <maxmem>2048m</maxmem>
                         <source>1.8</source>
                         <target>1.8</target>
-                        <showWarnings>true</showWarnings>
+                        <showWarnings>false</showWarnings>
                         <compilerArgs>
                             <arg>-XepDisableWarningsInGeneratedCode</arg>
                             <arg>-Xep:ClassCanBeStatic:ERROR</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -993,39 +993,60 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
-                          <source>1.8</source>
-                          <target>1.8</target>
+                        <compilerId>javac-with-errorprone</compilerId>
+                        <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                        <showWarnings>true</showWarnings>
+                        <compilerArgs>
+                            <arg>-XepDisableWarningsInGeneratedCode</arg>
+                            <arg>-Xep:ArgumentParameterSwap</arg>
+                            <arg>-Xep:AssistedInjectAndInjectOnSameConstructor</arg>
+                            <arg>-Xep:AutoFactoryAtInject</arg>
+                            <arg>-Xep:ClassName</arg>
+                            <arg>-Xep:ComparisonContractViolated</arg>
+                            <arg>-Xep:DepAnn</arg>
+                            <arg>-Xep:DivZero</arg>
+                            <arg>-Xep:EmptyIf</arg>
+                            <arg>-Xep:InjectInvalidTargetingOnScopingAnnotation</arg>
+                            <arg>-Xep:InjectMoreThanOneQualifier</arg>
+                            <arg>-Xep:InjectScopeAnnotationOnInterfaceOrAbstractClass</arg>
+                            <arg>-Xep:InjectScopeOrQualifierAnnotationRetention</arg>
+                            <arg>-Xep:InjectedConstructorAnnotations</arg>
+                            <arg>-Xep:InsecureCryptoUsage</arg>
+                            <arg>-Xep:JMockTestWithoutRunWithOrRuleAnnotation</arg>
+                            <arg>-Xep:JavaxInjectOnFinalField</arg>
+                            <arg>-Xep:LockMethodChecker</arg>
+                            <arg>-Xep:LongLiteralLowerCaseSuffix</arg>
+                            <arg>-Xep:NoAllocation</arg>
+                            <arg>-Xep:NonRuntimeAnnotation</arg>
+                            <arg>-Xep:NumericEquality</arg>
+                            <arg>-Xep:ParameterPackage</arg>
+                            <arg>-Xep:ProtoStringFieldReferenceEquality</arg>
+                            <arg>-Xep:QualifierOnMethodWithoutProvides</arg>
+                            <arg>-Xep:UnlockMethod</arg>
+                        </compilerArgs>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.codehaus.plexus</groupId>
+                            <artifactId>plexus-compiler-javac-errorprone</artifactId>
+                            <version>2.8.1</version>
+                        </dependency>
+                        <!-- override plexus-compiler-javac-errorprone's dependency on
+                             Error Prone with the latest version -->
+                        <dependency>
+                            <groupId>com.google.errorprone</groupId>
+                            <artifactId>error_prone_core</artifactId>
+                            <version>2.0.19</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>
     </build>
 
     <profiles>
-        <profile>
-            <id>strict</id>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-compiler-plugin</artifactId>
-                            <configuration>
-                                <compilerId>javac-with-errorprone</compilerId>
-                                <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                            </configuration>
-                            <dependencies>
-                                <dependency>
-                                    <groupId>org.codehaus.plexus</groupId>
-                                    <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                                    <version>2.5</version>
-                                </dependency>
-                            </dependencies>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
         <profile>
             <id>java8</id>
             <activation>

--- a/processing/src/main/java/io/druid/query/MetricsEmittingExecutorService.java
+++ b/processing/src/main/java/io/druid/query/MetricsEmittingExecutorService.java
@@ -48,6 +48,7 @@ public class MetricsEmittingExecutorService extends ForwardingListeningExecutorS
     return delegate;
   }
 
+  @SuppressWarnings("ParameterPackage")
   @Override
   public <T> ListenableFuture<T> submit(Callable<T> tCallable)
   {

--- a/processing/src/main/java/io/druid/query/QueryContexts.java
+++ b/processing/src/main/java/io/druid/query/QueryContexts.java
@@ -111,7 +111,7 @@ public class QueryContexts
   public static <T> long getTimeout(Query<T> query, long defaultTimeout)
   {
     final long timeout = parseLong(query, TIMEOUT_KEY, defaultTimeout);
-    Preconditions.checkState(timeout >= 0, "Timeout must be a non negative value, but was [%d]", timeout);
+    Preconditions.checkState(timeout >= 0, "Timeout must be a non negative value, but was [%s]", timeout);
     return timeout;
   }
 
@@ -123,7 +123,7 @@ public class QueryContexts
   static <T> long getDefaultTimeout(Query<T> query)
   {
     final long defaultTimeout = parseLong(query, DEFAULT_TIMEOUT_KEY, DEFAULT_TIMEOUT_MILLIS);
-    Preconditions.checkState(defaultTimeout >= 0, "Timeout must be a non negative value, but was [%d]", defaultTimeout);
+    Preconditions.checkState(defaultTimeout >= 0, "Timeout must be a non negative value, but was [%s]", defaultTimeout);
     return defaultTimeout;
   }
 

--- a/processing/src/main/java/io/druid/query/extraction/CascadeExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/CascadeExtractionFn.java
@@ -171,7 +171,7 @@ public class CascadeExtractionFn implements ExtractionFn
            "extractionFns=[" + chainedExtractionFn.toString() + "]}";
   }
 
-  private class ChainedExtractionFn
+  private static class ChainedExtractionFn
   {
     private final ExtractionFn fn;
     private final ChainedExtractionFn child;

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -528,20 +528,6 @@ public class RowBasedGrouperHelper
 
   @SuppressWarnings("unchecked")
   private static Function<Comparable, Comparable>[] makeValueConvertFunctions(
-      final Map<String, ValueType> rawInputRowSignature,
-      final List<DimensionSpec> dimensions
-  )
-  {
-    final List<ValueType> valueTypes = Lists.newArrayListWithCapacity(dimensions.size());
-    for (DimensionSpec dimensionSpec : dimensions) {
-      final ValueType valueType = rawInputRowSignature.get(dimensionSpec);
-      valueTypes.add(valueType == null ? ValueType.STRING : valueType);
-    }
-    return makeValueConvertFunctions(valueTypes);
-  }
-
-  @SuppressWarnings("unchecked")
-  private static Function<Comparable, Comparable>[] makeValueConvertFunctions(
       final List<ValueType> valueTypes
   )
   {

--- a/processing/src/main/java/io/druid/query/groupby/orderby/DefaultLimitSpec.java
+++ b/processing/src/main/java/io/druid/query/groupby/orderby/DefaultLimitSpec.java
@@ -208,9 +208,8 @@ public class DefaultLimitSpec implements LimitSpec
         throw new ISE("Unknown column in order clause[%s]", columnSpec);
       }
 
-      switch (columnSpec.getDirection()) {
-        case DESCENDING:
-          nextOrdering = nextOrdering.reverse();
+      if (columnSpec.getDirection() == OrderByColumnSpec.Direction.DESCENDING) {
+        nextOrdering = nextOrdering.reverse();
       }
 
       ordering = ordering.compound(nextOrdering);

--- a/processing/src/main/java/io/druid/query/lookup/LookupReferencesManager.java
+++ b/processing/src/main/java/io/druid/query/lookup/LookupReferencesManager.java
@@ -163,6 +163,7 @@ public class LookupReferencesManager
       return;
     }
 
+    @SuppressWarnings("ArgumentParameterSwap")
     LookupUpdateState swappedState = atomicallyUpdateStateRef(
         oldState -> new LookupUpdateState(oldState.lookupMap, ImmutableList.of(), oldState.pendingNotices)
     );

--- a/processing/src/main/java/io/druid/query/lookup/LookupReferencesManager.java
+++ b/processing/src/main/java/io/druid/query/lookup/LookupReferencesManager.java
@@ -346,7 +346,7 @@ public class LookupReferencesManager
     void handle(Map<String, LookupExtractorFactoryContainer> lookupMap);
   }
 
-  private class LoadNotice implements Notice
+  private static class LoadNotice implements Notice
   {
     private final String lookupName;
     private final LookupExtractorFactoryContainer lookupExtractorFactoryContainer;
@@ -399,7 +399,7 @@ public class LookupReferencesManager
     }
   }
 
-  private class DropNotice implements Notice
+  private static class DropNotice implements Notice
   {
     private final String lookupName;
 
@@ -435,7 +435,7 @@ public class LookupReferencesManager
     }
   }
 
-  private class LookupUpdateState
+  private static class LookupUpdateState
   {
     private final ImmutableMap<String, LookupExtractorFactoryContainer> lookupMap;
     private final ImmutableList<Notice> pendingNotices;

--- a/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQueryRunnerFactory.java
+++ b/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQueryRunnerFactory.java
@@ -94,6 +94,7 @@ public class TimeBoundaryQueryRunnerFactory
       this.adapter = segment.asStorageAdapter();
       this.skipToFirstMatching = new Function<Cursor, Result<DateTime>>()
       {
+        @SuppressWarnings("ArgumentParameterSwap")
         @Override
         public Result<DateTime> apply(Cursor cursor)
         {

--- a/processing/src/main/java/io/druid/query/topn/PooledTopNAlgorithm.java
+++ b/processing/src/main/java/io/druid/query/topn/PooledTopNAlgorithm.java
@@ -314,6 +314,7 @@ public class PooledTopNAlgorithm
               dimValues.get(6),
               currentPosition
           );
+          // fall through
         case 6:
           currentPosition = aggregateDimValue(
               positions,
@@ -326,6 +327,7 @@ public class PooledTopNAlgorithm
               dimValues.get(5),
               currentPosition
           );
+          // fall through
         case 5:
           currentPosition = aggregateDimValue(
               positions,
@@ -338,6 +340,7 @@ public class PooledTopNAlgorithm
               dimValues.get(4),
               currentPosition
           );
+          // fall through
         case 4:
           currentPosition = aggregateDimValue(
               positions,
@@ -350,6 +353,7 @@ public class PooledTopNAlgorithm
               dimValues.get(3),
               currentPosition
           );
+          // fall through
         case 3:
           currentPosition = aggregateDimValue(
               positions,
@@ -362,6 +366,7 @@ public class PooledTopNAlgorithm
               dimValues.get(2),
               currentPosition
           );
+          // fall through
         case 2:
           currentPosition = aggregateDimValue(
               positions,
@@ -374,6 +379,7 @@ public class PooledTopNAlgorithm
               dimValues.get(1),
               currentPosition
           );
+          // fall through
         case 1:
           currentPosition = aggregateDimValue(
               positions,
@@ -513,16 +519,22 @@ public class PooledTopNAlgorithm
     switch(aggExtra) {
       case 7:
         theAggregators[6].aggregate(resultsBuf, position + aggregatorOffsets[6]);
+        // fall through
       case 6:
         theAggregators[5].aggregate(resultsBuf, position + aggregatorOffsets[5]);
+        // fall through
       case 5:
         theAggregators[4].aggregate(resultsBuf, position + aggregatorOffsets[4]);
+        // fall through
       case 4:
         theAggregators[3].aggregate(resultsBuf, position + aggregatorOffsets[3]);
+        // fall through
       case 3:
         theAggregators[2].aggregate(resultsBuf, position + aggregatorOffsets[2]);
+        // fall through
       case 2:
         theAggregators[1].aggregate(resultsBuf, position + aggregatorOffsets[1]);
+        // fall through
       case 1:
         theAggregators[0].aggregate(resultsBuf, position + aggregatorOffsets[0]);
     }

--- a/processing/src/main/java/io/druid/query/topn/TopNLexicographicResultBuilder.java
+++ b/processing/src/main/java/io/druid/query/topn/TopNLexicographicResultBuilder.java
@@ -96,16 +96,22 @@ public class TopNLexicographicResultBuilder implements TopNResultBuilder
       switch (extra) {
         case 7:
           metricValues.put(aggFactoryNames[6], metricVals[6]);
+          // fall through
         case 6:
           metricValues.put(aggFactoryNames[5], metricVals[5]);
+          // fall through
         case 5:
           metricValues.put(aggFactoryNames[4], metricVals[4]);
+          // fall through
         case 4:
           metricValues.put(aggFactoryNames[3], metricVals[3]);
+          // fall through
         case 3:
           metricValues.put(aggFactoryNames[2], metricVals[2]);
+          // fall through
         case 2:
           metricValues.put(aggFactoryNames[1], metricVals[1]);
+          // fall through
         case 1:
           metricValues.put(aggFactoryNames[0], metricVals[0]);
       }

--- a/processing/src/main/java/io/druid/query/topn/TopNNumericResultBuilder.java
+++ b/processing/src/main/java/io/druid/query/topn/TopNNumericResultBuilder.java
@@ -133,16 +133,22 @@ public class TopNNumericResultBuilder implements TopNResultBuilder
     switch (extra) {
       case 7:
         metricValues.put(aggFactoryNames[6], metricVals[6]);
+        // fall through
       case 6:
         metricValues.put(aggFactoryNames[5], metricVals[5]);
+        // fall through
       case 5:
         metricValues.put(aggFactoryNames[4], metricVals[4]);
+        // fall through
       case 4:
         metricValues.put(aggFactoryNames[3], metricVals[3]);
+        // fall through
       case 3:
         metricValues.put(aggFactoryNames[2], metricVals[2]);
+        // fall through
       case 2:
         metricValues.put(aggFactoryNames[1], metricVals[1]);
+        // fall through
       case 1:
         metricValues.put(aggFactoryNames[0], metricVals[0]);
     }

--- a/processing/src/main/java/io/druid/segment/MetricHolder.java
+++ b/processing/src/main/java/io/druid/segment/MetricHolder.java
@@ -113,6 +113,9 @@ public class MetricHolder
       case FLOAT:
         holder.floatType.writeToChannel(out);
         break;
+      case LONG:
+        holder.longType.writeToChannel(out);
+        break;
       case COMPLEX:
         if (holder.complexType instanceof GenericIndexed) {
           ((GenericIndexed) holder.complexType).writeToChannel(out);

--- a/processing/src/main/java/io/druid/segment/MetricHolder.java
+++ b/processing/src/main/java/io/druid/segment/MetricHolder.java
@@ -45,7 +45,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.channels.WritableByteChannel;
 
 /**
  */
@@ -101,29 +100,6 @@ public class MetricHolder
     serializerUtils.writeString(toOutputSupplier(outSupplier), name);
     serializerUtils.writeString(toOutputSupplier(outSupplier), "long");
     column.closeAndConsolidate(outSupplier);
-  }
-
-  public static void writeToChannel(MetricHolder holder, WritableByteChannel out) throws IOException
-  {
-    out.write(ByteBuffer.wrap(version));
-    serializerUtils.writeString(out, holder.name);
-    serializerUtils.writeString(out, holder.typeName);
-
-    switch (holder.type) {
-      case FLOAT:
-        holder.floatType.writeToChannel(out);
-        break;
-      case LONG:
-        holder.longType.writeToChannel(out);
-        break;
-      case COMPLEX:
-        if (holder.complexType instanceof GenericIndexed) {
-          ((GenericIndexed) holder.complexType).writeToChannel(out);
-        } else {
-          throw new IAE("Cannot serialize out MetricHolder for complex type that is not a GenericIndexed");
-        }
-        break;
-    }
   }
 
   public static MetricHolder fromByteBuffer(ByteBuffer buf, SmooshedFileMapper mapper) throws IOException

--- a/processing/src/main/java/io/druid/segment/StringDimensionMergerV9.java
+++ b/processing/src/main/java/io/druid/segment/StringDimensionMergerV9.java
@@ -462,7 +462,7 @@ public class StringDimensionMergerV9 implements DimensionMergerV9<int[]>
     int seek(int dictId);
   }
 
-  protected class IndexSeekerWithoutConversion implements IndexSeeker
+  protected static class IndexSeekerWithoutConversion implements IndexSeeker
   {
     private final int limit;
 
@@ -481,7 +481,7 @@ public class StringDimensionMergerV9 implements DimensionMergerV9<int[]>
   /**
    * Get old dictId from new dictId, and only support access in order
    */
-  protected class IndexSeekerWithConversion implements IndexSeeker
+  protected static class IndexSeekerWithConversion implements IndexSeeker
   {
     private final IntBuffer dimConversions;
     private int currIndex;

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexAdapter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexAdapter.java
@@ -53,7 +53,7 @@ public class IncrementalIndexAdapter implements IndexableAdapter
   private final IncrementalIndex<?> index;
   private final Map<String, DimensionAccessor> accessors;
 
-  private class DimensionAccessor
+  private static class DimensionAccessor
   {
     private final IncrementalIndex.DimensionDesc dimensionDesc;
     private final MutableBitmap[] invertedIndexes;

--- a/processing/src/main/java/io/druid/segment/serde/DictionaryEncodedColumnPartSerde.java
+++ b/processing/src/main/java/io/druid/segment/serde/DictionaryEncodedColumnPartSerde.java
@@ -447,7 +447,7 @@ public class DictionaryEncodedColumnPartSerde implements ColumnPartSerde
         final WritableSupplier<IndexedMultivalue<IndexedInts>> rMultiValuedColumn;
 
         if (hasMultipleValues) {
-          rMultiValuedColumn = readMultiValuedColum(rVersion, buffer, rFlags, builder.getFileMapper());
+          rMultiValuedColumn = readMultiValuedColumn(rVersion, buffer, rFlags, builder.getFileMapper());
           rSingleValuedColumn = null;
         } else {
           rSingleValuedColumn = readSingleValuedColumn(rVersion, buffer, builder.getFileMapper());
@@ -495,12 +495,13 @@ public class DictionaryEncodedColumnPartSerde implements ColumnPartSerde
           case UNCOMPRESSED_SINGLE_VALUE:
             return VSizeIndexedInts.readFromByteBuffer(buffer).asWritableSupplier();
           case COMPRESSED:
-          return CompressedVSizeIntsIndexedSupplier.fromByteBuffer(buffer, byteOrder, fileMapper);
+            return CompressedVSizeIntsIndexedSupplier.fromByteBuffer(buffer, byteOrder, fileMapper);
+          default:
+            throw new IAE("Unsupported single-value version[%s]", version);
         }
-        throw new IAE("Unsupported single-value version[%s]", version);
       }
 
-      private WritableSupplier<IndexedMultivalue<IndexedInts>> readMultiValuedColum(
+      private WritableSupplier<IndexedMultivalue<IndexedInts>> readMultiValuedColumn(
           VERSION version, ByteBuffer buffer, int flags, SmooshedFileMapper fileMapper
       )
       {
@@ -515,8 +516,9 @@ public class DictionaryEncodedColumnPartSerde implements ColumnPartSerde
             } else {
               throw new IAE("Unrecognized multi-value flag[%d]", flags);
             }
+          default:
+            throw new IAE("Unsupported multi-value version[%s]", version);
         }
-        throw new IAE("Unsupported multi-value version[%s]", version);
       }
     };
   }

--- a/processing/src/test/java/io/druid/data/input/ProtoTestEventWrapper.java
+++ b/processing/src/test/java/io/druid/data/input/ProtoTestEventWrapper.java
@@ -23,6 +23,7 @@
 package io.druid.data.input;
 
 import com.google.protobuf.AbstractMessage;
+import com.google.protobuf.GeneratedMessage;
 import com.google.protobuf.UnknownFieldSet;
 
 public final class ProtoTestEventWrapper {
@@ -70,7 +71,7 @@ public final class ProtoTestEventWrapper {
     long getSomeLongColumn();
   }
   public static final class ProtoTestEvent extends
-      com.google.protobuf.GeneratedMessage
+      GeneratedMessage
       implements ProtoTestEventOrBuilder {
     // Use ProtoTestEvent.newBuilder() to construct.
     private ProtoTestEvent(Builder builder) {
@@ -506,8 +507,9 @@ public final class ProtoTestEventWrapper {
       return newBuilder().mergeFrom(prototype);
     }
     public Builder toBuilder() { return newBuilder(this); }
-    
-    @java.lang.Override
+
+    @SuppressWarnings("ParameterPackage")
+    @Override
     protected Builder newBuilderForType(
         com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);

--- a/processing/src/test/java/io/druid/guice/GuiceInjectorsTest.java
+++ b/processing/src/test/java/io/druid/guice/GuiceInjectorsTest.java
@@ -63,7 +63,7 @@ public class GuiceInjectorsTest
     }
   }
 
-  private class CustomEmitterFactory implements Provider<CustomEmitter> {
+  private static class CustomEmitterFactory implements Provider<CustomEmitter> {
 
     private Emitter emitter;
     private Injector injector;

--- a/processing/src/test/java/io/druid/query/aggregation/JavaScriptAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/JavaScriptAggregatorTest.java
@@ -357,7 +357,7 @@ public class JavaScriptAggregatorTest
       ++i;
     }
     long t1 = System.currentTimeMillis() - t;
-    System.out.println(String.format("JavaScript aggregator == %,f: %d ms", aggRhino.get(), t1));
+    System.out.println(String.format("JavaScript aggregator == %,f: %d ms", aggRhino.getFloat(), t1));
 
     t = System.currentTimeMillis();
     i = 0;
@@ -366,7 +366,7 @@ public class JavaScriptAggregatorTest
       ++i;
     }
     long t2 = System.currentTimeMillis() - t;
-    System.out.println(String.format("DoubleSum  aggregator == %,f: %d ms", doubleAgg.get(), t2));
+    System.out.println(String.format("DoubleSum  aggregator == %,f: %d ms", doubleAgg.getFloat(), t2));
 
     System.out.println(String.format("JavaScript is %2.1fx slower", (double) t1 / t2));
   }

--- a/processing/src/test/java/io/druid/query/groupby/having/DimensionSelectorHavingSpecTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/having/DimensionSelectorHavingSpecTest.java
@@ -108,14 +108,14 @@ public class DimensionSelectorHavingSpecTest
                                  "dimension='gender'," +
                                  " value='m'," +
                                  " extractionFunction='regex(/^([^,]*),/, 1)'}";
-    Assert.assertEquals(new DimensionSelectorHavingSpec("gender", "m", extractionFn).toString(), expected);
+    Assert.assertEquals(expected, new DimensionSelectorHavingSpec("gender", "m", extractionFn).toString());
     
     expected = "DimensionSelectorHavingSpec{" +
                                  "dimension='gender'," +
                                  " value='m'," +
                                  " extractionFunction='Identity'}";
     
-    Assert.assertEquals(new DimensionSelectorHavingSpec("gender", "m", null).toString(), expected);
+    Assert.assertEquals(expected, new DimensionSelectorHavingSpec("gender", "m", null).toString());
   }
 
   @Test(expected = NullPointerException.class)

--- a/processing/src/test/java/io/druid/query/lookup/LookupExtractorTest.java
+++ b/processing/src/test/java/io/druid/query/lookup/LookupExtractorTest.java
@@ -86,9 +86,9 @@ public class LookupExtractorTest
   @Test
   public void testApplyAllWithNotExisting()
   {
-    Map<String, String> actual = new HashMap<>();
-    actual.put("not there", null);
-    Assert.assertEquals(actual, lookupExtractor.applyAll(Lists.newArrayList("not there")));
+    Map<String, String> expected = new HashMap<>();
+    expected.put("not there", null);
+    Assert.assertEquals(expected, lookupExtractor.applyAll(Lists.newArrayList("not there")));
   }
 
   @Test

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
@@ -273,6 +273,7 @@ public class SegmentMetadataQueryQueryToolChestTest
     );
   }
 
+  @SuppressWarnings("ArgumentParameterSwap")
   @Test
   public void testMergeRollup()
   {

--- a/processing/src/test/java/io/druid/segment/SchemalessTestFullTest.java
+++ b/processing/src/test/java/io/druid/segment/SchemalessTestFullTest.java
@@ -1352,6 +1352,7 @@ public class SchemalessTestFullTest
     );
   }
 
+  @SuppressWarnings("ArgumentParameterSwap")
   private List<Pair<QueryableIndex, String>> getIndexes(int index1, int index2)
   {
     return Arrays.asList(

--- a/processing/src/test/java/io/druid/segment/data/CompressedFloatsSerdeTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedFloatsSerdeTest.java
@@ -22,6 +22,7 @@ package io.druid.segment.data;
 import com.google.common.base.Supplier;
 import com.google.common.io.ByteSink;
 import com.google.common.primitives.Floats;
+import com.google.common.primitives.Ints;
 import io.druid.java.util.common.guava.CloseQuietly;
 import org.junit.Assert;
 import org.junit.Test;
@@ -35,7 +36,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.Channels;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -167,7 +167,7 @@ public class CompressedFloatsSerdeTest
       indices[i] = i;
     }
 
-    Collections.shuffle(Arrays.asList(indices));
+    Collections.shuffle(Ints.asList(indices));
     // random access
     for (int i = 0; i < indexed.size(); ++i) {
       int k = indices[i];
@@ -224,7 +224,7 @@ public class CompressedFloatsSerdeTest
               final float indexedVal = indexed.get(j);
               if (Floats.compare(val, indexedVal) != 0) {
                 failureHappened.set(true);
-                reason.set(String.format("Thread1[%d]: %d != %d", j, val, indexedVal));
+                reason.set(String.format("Thread1[%d]: %f != %f", j, val, indexedVal));
                 stopLatch.countDown();
                 return;
               }
@@ -263,7 +263,7 @@ public class CompressedFloatsSerdeTest
                 final float indexedVal = indexed2.get(j);
                 if (Floats.compare(val, indexedVal) != 0) {
                   failureHappened.set(true);
-                  reason.set(String.format("Thread2[%d]: %d != %d", j, val, indexedVal));
+                  reason.set(String.format("Thread2[%d]: %f != %f", j, val, indexedVal));
                   stopLatch.countDown();
                   return;
                 }

--- a/processing/src/test/java/io/druid/segment/data/CompressedIntsIndexedSupplierTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedIntsIndexedSupplierTest.java
@@ -34,7 +34,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
 import java.nio.channels.Channels;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
@@ -331,7 +330,7 @@ public class CompressedIntsIndexedSupplierTest extends CompressionStrategyTest
       indices[i] = i;
     }
 
-    Collections.shuffle(Arrays.asList(indices));
+    Collections.shuffle(Ints.asList(indices));
     // random access
     for (int i = 0; i < indexed.size(); ++i) {
       int k = indices[i];

--- a/processing/src/test/java/io/druid/segment/data/CompressedLongsSerdeTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedLongsSerdeTest.java
@@ -21,6 +21,7 @@ package io.druid.segment.data;
 
 import com.google.common.base.Supplier;
 import com.google.common.io.ByteSink;
+import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import io.druid.java.util.common.guava.CloseQuietly;
 import org.junit.Assert;
@@ -35,7 +36,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.Channels;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -189,7 +189,7 @@ public class CompressedLongsSerdeTest
       indices[i] = i;
     }
 
-    Collections.shuffle(Arrays.asList(indices));
+    Collections.shuffle(Ints.asList(indices));
     // random access
     for (int i = 0; i < indexed.size(); ++i) {
       int k = indices[i];

--- a/processing/src/test/java/io/druid/segment/data/CompressedVSizeIntsIndexedSupplierTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedVSizeIntsIndexedSupplierTest.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.Channels;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
@@ -361,7 +360,7 @@ public class CompressedVSizeIntsIndexedSupplierTest extends CompressionStrategyT
       indices[i] = i;
     }
 
-    Collections.shuffle(Arrays.asList(indices));
+    Collections.shuffle(Ints.asList(indices));
     // random access
     for (int i = 0; i < indexed.size(); ++i) {
       int k = indices[i];

--- a/processing/src/test/java/io/druid/segment/filter/FilterPartitionTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/FilterPartitionTest.java
@@ -61,7 +61,7 @@ import java.util.Objects;
 @RunWith(Parameterized.class)
 public class FilterPartitionTest extends BaseFilterTest
 {
-  private class NoBitmapSelectorFilter extends SelectorFilter
+  private static class NoBitmapSelectorFilter extends SelectorFilter
   {
     public NoBitmapSelectorFilter(
         String dimension,
@@ -78,7 +78,7 @@ public class FilterPartitionTest extends BaseFilterTest
     }
   }
 
-  private class NoBitmapDimensionPredicateFilter extends DimensionPredicateFilter
+  private static class NoBitmapDimensionPredicateFilter extends DimensionPredicateFilter
   {
     public NoBitmapDimensionPredicateFilter(
         final String dimension,
@@ -96,7 +96,7 @@ public class FilterPartitionTest extends BaseFilterTest
     }
   }
 
-  private class NoBitmapSelectorDimFilter extends SelectorDimFilter
+  private static class NoBitmapSelectorDimFilter extends SelectorDimFilter
   {
     public NoBitmapSelectorDimFilter(
         String dimension,

--- a/server/src/main/java/io/druid/client/cache/MemcachedCache.java
+++ b/server/src/main/java/io/druid/client/cache/MemcachedCache.java
@@ -409,7 +409,7 @@ public class MemcachedCache implements Cache
   {
     Preconditions.checkArgument(
         config.getMemcachedPrefix().length() <= MAX_PREFIX_LENGTH,
-        "memcachedPrefix length [%d] exceeds maximum length [%d]",
+        "memcachedPrefix length [%s] exceeds maximum length [%s]",
         config.getMemcachedPrefix().length(),
         MAX_PREFIX_LENGTH
     );

--- a/server/src/main/java/io/druid/curator/CuratorModule.java
+++ b/server/src/main/java/io/druid/curator/CuratorModule.java
@@ -22,7 +22,10 @@ package io.druid.curator;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
-
+import io.druid.guice.JsonConfigProvider;
+import io.druid.guice.LazySingleton;
+import io.druid.java.util.common.lifecycle.Lifecycle;
+import io.druid.java.util.common.logger.Logger;
 import org.apache.curator.ensemble.EnsembleProvider;
 import org.apache.curator.ensemble.exhibitor.DefaultExhibitorRestClient;
 import org.apache.curator.ensemble.exhibitor.ExhibitorEnsembleProvider;
@@ -38,11 +41,6 @@ import org.apache.zookeeper.data.ACL;
 
 import java.io.IOException;
 import java.util.List;
-
-import io.druid.guice.JsonConfigProvider;
-import io.druid.guice.LazySingleton;
-import io.druid.java.util.common.lifecycle.Lifecycle;
-import io.druid.java.util.common.logger.Logger;
 
 /**
  */
@@ -147,7 +145,7 @@ public class CuratorModule implements Module
     };
   }
 
-  class SecuredACLProvider implements ACLProvider
+  static class SecuredACLProvider implements ACLProvider
   {
     @Override
     public List<ACL> getDefaultAcl()

--- a/server/src/main/java/io/druid/curator/announcement/Announcer.java
+++ b/server/src/main/java/io/druid/curator/announcement/Announcer.java
@@ -259,6 +259,11 @@ public class Announcer
                         }
                       }
                       break;
+                    case INITIALIZED:
+                    case CHILD_ADDED:
+                    case CHILD_UPDATED:
+                    case CONNECTION_SUSPENDED:
+                      // do nothing
                   }
                 }
               }

--- a/server/src/main/java/io/druid/curator/inventory/CuratorInventoryManager.java
+++ b/server/src/main/java/io/druid/curator/inventory/CuratorInventoryManager.java
@@ -256,9 +256,8 @@ public class CuratorInventoryManager<ContainerClass, InventoryClass>
               inventoryCache.start(PathChildrenCache.StartMode.POST_INITIALIZED_EVENT);
               strategy.newContainer(container);
             }
-
-            break;
           }
+          break;
         case CHILD_REMOVED:
           synchronized (lock) {
             final ChildData child = event.getData();
@@ -281,9 +280,8 @@ public class CuratorInventoryManager<ContainerClass, InventoryClass>
             synchronized (removed) {
               markInventoryInitialized(removed);
             }
-
-            break;
           }
+          break;
         case CHILD_UPDATED:
           synchronized (lock) {
             final ChildData child = event.getData();
@@ -310,9 +308,8 @@ public class CuratorInventoryManager<ContainerClass, InventoryClass>
                 holder.setContainer(strategy.updateContainer(holder.getContainer(), container));
               }
             }
-
-            break;
           }
+          break;
         case INITIALIZED:
           synchronized (lock) {
             // must await initialized of all containerholders
@@ -325,8 +322,12 @@ public class CuratorInventoryManager<ContainerClass, InventoryClass>
             }
             containersInitialized = true;
             maybeDoneInitializing();
-            break;
           }
+          break;
+        case CONNECTION_SUSPENDED:
+        case CONNECTION_RECONNECTED:
+        case CONNECTION_LOST:
+          // do nothing
       }
     }
 
@@ -431,7 +432,7 @@ public class CuratorInventoryManager<ContainerClass, InventoryClass>
 
             break;
           }
-          case INITIALIZED:
+          case INITIALIZED: {
             // make sure to acquire locks in (lock -> holder) order
             synchronized (lock) {
               synchronized (holder) {
@@ -440,6 +441,11 @@ public class CuratorInventoryManager<ContainerClass, InventoryClass>
             }
 
             break;
+          }
+          case CONNECTION_SUSPENDED:
+          case CONNECTION_RECONNECTED:
+          case CONNECTION_LOST:
+            // do nothing
         }
       }
     }

--- a/server/src/main/java/io/druid/server/coordinator/LoadQueuePeon.java
+++ b/server/src/main/java/io/druid/server/coordinator/LoadQueuePeon.java
@@ -243,6 +243,9 @@ public class LoadQueuePeon
                     switch (watchedEvent.getType()) {
                       case NodeDeleted:
                         entryRemoved(watchedEvent.getPath());
+                        break;
+                      default:
+                        // do nothing
                     }
                   }
                 }

--- a/server/src/main/java/io/druid/server/initialization/jetty/ResponseHeaderFilterHolder.java
+++ b/server/src/main/java/io/druid/server/initialization/jetty/ResponseHeaderFilterHolder.java
@@ -75,7 +75,7 @@ public class ResponseHeaderFilterHolder implements ServletFilterHolder
     return null;
   }
 
-  private class ResponseHeaderFilter implements Filter
+  private static class ResponseHeaderFilter implements Filter
   {
     private volatile FilterConfig config;
 

--- a/server/src/main/java/io/druid/server/log/FileRequestLogger.java
+++ b/server/src/main/java/io/druid/server/log/FileRequestLogger.java
@@ -73,11 +73,11 @@ public class FileRequestLogger implements RequestLogger
         fileWriter = getFileWriter();
       }
       long nextDay = currentDay.plusDays(1).getMillis();
-      Duration delay = new Duration(nextDay - new DateTime().getMillis());
+      Duration initialDelay = new Duration(nextDay - new DateTime().getMillis());
 
       ScheduledExecutors.scheduleWithFixedDelay(
           exec,
-          delay,
+          initialDelay,
           Duration.standardDays(1),
           new Callable<ScheduledExecutors.Signal>()
           {

--- a/server/src/test/java/io/druid/client/CachingClusteredClientTest.java
+++ b/server/src/test/java/io/druid/client/CachingClusteredClientTest.java
@@ -398,6 +398,7 @@ public class CachingClusteredClientTest
                (ListenableFuture<T>) delegate.submit((Runnable) task);
       }
 
+      @SuppressWarnings("ParameterPackage")
       @Override
       public <T> ListenableFuture<T> submit(Callable<T> task)
       {

--- a/server/src/test/java/io/druid/client/client/BatchServerInventoryViewTest.java
+++ b/server/src/test/java/io/druid/client/client/BatchServerInventoryViewTest.java
@@ -39,6 +39,7 @@ import io.druid.curator.announcement.Announcer;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.Pair;
+import io.druid.java.util.common.guava.Comparators;
 import io.druid.server.coordination.BatchDataSegmentAnnouncer;
 import io.druid.server.coordination.DruidServerMetadata;
 import io.druid.server.initialization.BatchDataSegmentAnnouncerConfig;
@@ -285,16 +286,8 @@ public class BatchServerInventoryViewTest
     Assert.assertEquals(testSegments, segments);
 
     ServerView.SegmentCallback callback = EasyMock.createStrictMock(ServerView.SegmentCallback.class);
-    Comparator<DataSegment> dataSegmentComparator = new Comparator<DataSegment>()
-    {
-      @Override
-      public int compare(DataSegment o1, DataSegment o2)
-      {
-        Interval i1 = o1.getInterval();
-        Interval i2 = o2.getInterval();
-        return Long.compare(i1.getStartMillis(), i2.getStartMillis());
-      }
-    };
+    Comparator<DataSegment> dataSegmentComparator =
+        Comparator.comparing(DataSegment::getInterval, Comparators.intervalsByStartThenEnd());
 
     EasyMock
         .expect(

--- a/server/src/test/java/io/druid/client/client/BatchServerInventoryViewTest.java
+++ b/server/src/test/java/io/druid/client/client/BatchServerInventoryViewTest.java
@@ -290,7 +290,9 @@ public class BatchServerInventoryViewTest
       @Override
       public int compare(DataSegment o1, DataSegment o2)
       {
-        return o1.getInterval().equals(o2.getInterval()) ? 0 : -1;
+        Interval i1 = o1.getInterval();
+        Interval i2 = o2.getInterval();
+        return Long.compare(i1.getStartMillis(), i2.getStartMillis());
       }
     };
 

--- a/server/src/test/java/io/druid/realtime/firehose/ReplayableFirehoseFactoryTest.java
+++ b/server/src/test/java/io/druid/realtime/firehose/ReplayableFirehoseFactoryTest.java
@@ -438,7 +438,7 @@ public class ReplayableFirehoseFactoryTest extends EasyMockSupport
     verifyAll();
   }
 
-  private class TestReadingException extends RuntimeException
+  private static class TestReadingException extends RuntimeException
   {
   }
 }

--- a/server/src/test/java/io/druid/segment/realtime/appenderator/FiniteAppenderatorDriverTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/appenderator/FiniteAppenderatorDriverTest.java
@@ -199,7 +199,7 @@ public class FiniteAppenderatorDriverTest
     };
   }
 
-  private class TestCommitterSupplier<T> implements Supplier<Committer>
+  private static class TestCommitterSupplier<T> implements Supplier<Committer>
   {
     private final AtomicReference<T> metadata = new AtomicReference<>();
 
@@ -229,7 +229,7 @@ public class FiniteAppenderatorDriverTest
     }
   }
 
-  private class TestSegmentAllocator implements SegmentAllocator
+  private static class TestSegmentAllocator implements SegmentAllocator
   {
     private final String dataSource;
     private final Granularity granularity;
@@ -264,7 +264,7 @@ public class FiniteAppenderatorDriverTest
     }
   }
 
-  private class TestSegmentHandoffNotifierFactory implements SegmentHandoffNotifierFactory
+  private static class TestSegmentHandoffNotifierFactory implements SegmentHandoffNotifierFactory
   {
     @Override
     public SegmentHandoffNotifier createSegmentHandoffNotifier(String dataSource)

--- a/server/src/test/java/io/druid/segment/realtime/firehose/ServiceAnnouncingChatHandlerProviderTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/firehose/ServiceAnnouncingChatHandlerProviderTest.java
@@ -36,7 +36,7 @@ import java.io.IOException;
 @RunWith(EasyMockRunner.class)
 public class ServiceAnnouncingChatHandlerProviderTest extends EasyMockSupport
 {
-  private class TestChatHandler implements ChatHandler {}
+  private static class TestChatHandler implements ChatHandler {}
 
   private static final String TEST_SERVICE_NAME = "test-service-name";
   private static final String TEST_HOST = "test-host";

--- a/server/src/test/java/io/druid/server/coordination/coordination/BatchDataSegmentAnnouncerTest.java
+++ b/server/src/test/java/io/druid/server/coordination/coordination/BatchDataSegmentAnnouncerTest.java
@@ -315,7 +315,7 @@ public class BatchDataSegmentAnnouncerTest
                       .build();
   }
 
-  private class SegmentReader
+  private static class SegmentReader
   {
     private final CuratorFramework cf;
     private final ObjectMapper jsonMapper;

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTester.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTester.java
@@ -46,7 +46,6 @@ public class DruidCoordinatorBalancerTester extends DruidCoordinatorBalancer
 
     if (!toPeon.getSegmentsToLoad().contains(segmentToMove) &&
         !currentlyMovingSegments.get("normal").containsKey(segmentName) &&
-        !toServer.getSegments().containsKey(segmentName) &&
         new ServerHolder(toServer, toPeon).getAvailableSize() > segmentToMove.getSize()) {
       log.info(
           "Moving [%s] from [%s] to [%s]",

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTester.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTester.java
@@ -71,7 +71,7 @@ public class DruidCoordinatorBalancerTester extends DruidCoordinatorBalancer
         log.info(e, String.format("[%s] : Moving exception", segmentName));
       }
     } else {
-      currentlyMovingSegments.get("normal").remove(segment);
+      currentlyMovingSegments.get("normal").remove(segmentName);
     }
   }
 }

--- a/server/src/test/java/io/druid/server/metrics/HistoricalMetricsMonitorTest.java
+++ b/server/src/test/java/io/druid/server/metrics/HistoricalMetricsMonitorTest.java
@@ -119,7 +119,7 @@ public class HistoricalMetricsMonitorTest extends EasyMockSupport
               @Nullable ServiceEventBuilder<ServiceMetricEvent> input
           )
           {
-            final HashMap<String, Object> map = new HashMap<>(input.build(host, service).toMap());
+            final HashMap<String, Object> map = new HashMap<>(input.build(service, host).toMap());
             Assert.assertNotNull(map.remove("feed"));
             Assert.assertNotNull(map.remove("timestamp"));
             Assert.assertNotNull(map.remove("service"));

--- a/services/src/main/java/io/druid/cli/Log4JShutdownPropertyChecker.java
+++ b/services/src/main/java/io/druid/cli/Log4JShutdownPropertyChecker.java
@@ -26,10 +26,10 @@ public class Log4JShutdownPropertyChecker implements PropertyChecker
   @Override
   public void checkProperties(Properties properties)
   {
-    if (!properties.contains("log4j.shutdownCallbackRegistry")) {
+    if (!properties.containsKey("log4j.shutdownCallbackRegistry")) {
       properties.setProperty("log4j.shutdownCallbackRegistry", "io.druid.common.config.Log4jShutdown");
     }
-    if (!properties.contains("log4j.shutdownHookEnabled")) {
+    if (!properties.containsKey("log4j.shutdownHookEnabled")) {
       properties.setProperty("log4j.shutdownHookEnabled", "true");
     }
   }


### PR DESCRIPTION
Fixed three bugs in production code:
 - In `SketchEstimateWithErrorBounds`, `datasketches` module
 - In `GranularUnprocessedPathSpec`, `indexing-hadoop` module
 - In `Log4JShutdownPropertyChecker`, `services` module

+ More bugs in test code.

@drcrallen [commented](https://github.com/druid-io/druid/pull/1271#issuecomment-93563584) in 2015:

> Since there is some uncertainty about the behavior of the compiler vs what is really being used currently, and if it modifies byte code at all, I have modified the PR to have a separate POM which contains the error checking stuff.

<s>[Error Prone is a javac plugin, for a version of javac that corresponds roughly to JDK 9 EA Build 159](https://github.com/google/error-prone/issues/620#issuecomment-299320588). It's bytecode output shouldn't be more risky to use than the default `javac` output. Maybe even safer, because JDK 9's javac [fixes some bugs from JDK 8's javac](https://groups.google.com/d/msg/error-prone-discuss/B2aOPzx11lo/ZEdmkR5ZAgAJ).</s> The stability and safety of this compiler is yet questionable, according to https://github.com/druid-io/druid/pull/4252#issuecomment-300046036. However it turned out unnecessary to make Error prone the default compiler; It's configuration was just updated, keeping it in an optional profile, enabled in travis via `mvn -Pstrict compile test-compile`.