### PR TITLE
Kafka generated shards incorrectly marked as overshadowed

### DIFF
--- a/server/src/main/java/io/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/io/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -315,7 +315,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
     // Find which segments are used (i.e. not overshadowed).
     final Set<DataSegment> usedSegments = Sets.newHashSet();
     for (TimelineObjectHolder<String, DataSegment> holder : VersionedIntervalTimeline.forSegments(segments)
-                                                                                     .lookup(JodaUtils.ETERNITY)) {
+                                                                                     .lookupWithIncompletePartitions(JodaUtils.ETERNITY)) {
       for (PartitionChunk<DataSegment> chunk : holder.getObject()) {
         usedSegments.add(chunk.getObject());
       }


### PR DESCRIPTION
If the shards generated by the KafkaIndexTask extended a NumberedShardSpec with a non-zero number of total shards (e.g. shards generated by an indexing task), these segments were incorrectly being marked as unused. This patch fixes this by changing announceHistoricalSegments to not expect to form a complete timeline from the segments being announced by the indexing task.