### PR TITLE
Use MetadataSegmentManager info during segment move.

### DIFF
--- a/server/src/main/java/io/druid/client/DruidDataSource.java
+++ b/server/src/main/java/io/druid/client/DruidDataSource.java
@@ -171,4 +171,9 @@ public class DruidDataSource
     result = 31 * result + (segmentsHolder != null ? segmentsHolder.hashCode() : 0);
     return result;
   }
+
+  public DataSegment getSegment(String identifier)
+  {
+    return partitionNames.get(identifier);
+  }
 }

--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
@@ -385,7 +385,13 @@ public class DruidCoordinator
         throw new IAE("Unable to find dataSource for segment [%s] in metadata", segmentName);
       }
 
+      // get segment information from MetadataSegmentManager instead of getting it from fromServer's.
+      // This is useful when MetadataSegmentManager and fromServer DataSegment's are different for same
+      // identifier (say loadSpec differs because of deep storage migration).
       final DataSegment segmentToLoad = dataSource.getSegment(segment.getIdentifier());
+      if (segmentToLoad == null) {
+        throw new IAE("No segment metadata found for segment Id [%s]", segment.getIdentifier());
+      }
       final LoadQueuePeon loadPeon = loadManagementPeons.get(toServer.getName());
       if (loadPeon == null) {
         throw new IAE("LoadQueuePeon hasn't been created yet for path [%s]", toServer.getName());

--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
@@ -376,7 +376,6 @@ public class DruidCoordinator
     }
     String segmentName = segment.getIdentifier();
     try {
-
       if (fromServer.getMetadata().equals(toServer.getMetadata())) {
         throw new IAE("Cannot move [%s] to and from the same server [%s]", segmentName, fromServer.getName());
       }
@@ -385,6 +384,7 @@ public class DruidCoordinator
       if (dataSource == null) {
         throw new IAE("Unable to find dataSource for segment [%s] in metadata", segmentName);
       }
+
       final DataSegment segmentToLoad = dataSource.getSegment(segment.getIdentifier());
       final LoadQueuePeon loadPeon = loadManagementPeons.get(toServer.getName());
       if (loadPeon == null) {

--- a/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorBalancer.java
+++ b/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorBalancer.java
@@ -188,7 +188,7 @@ public class DruidCoordinatorBalancer implements DruidCoordinatorHelper
         coordinator.moveSegment(
             fromServer,
             toServer,
-            segmentToMove.getIdentifier(),
+            segmentToMove,
             callback
         );
       }

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerProfiler.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerProfiler.java
@@ -82,7 +82,7 @@ public class DruidCoordinatorBalancerProfiler
     coordinator.moveSegment(
         EasyMock.<ImmutableDruidServer>anyObject(),
         EasyMock.<ImmutableDruidServer>anyObject(),
-        EasyMock.<String>anyObject(),
+        EasyMock.<DataSegment>anyObject(),
         EasyMock.<LoadPeonCallback>anyObject()
     );
     EasyMock.expectLastCall().anyTimes();
@@ -208,7 +208,7 @@ public class DruidCoordinatorBalancerProfiler
     coordinator.moveSegment(
         EasyMock.<ImmutableDruidServer>anyObject(),
         EasyMock.<ImmutableDruidServer>anyObject(),
-        EasyMock.<String>anyObject(),
+        EasyMock.<DataSegment>anyObject(),
         EasyMock.<LoadPeonCallback>anyObject()
     );
     EasyMock.expectLastCall().anyTimes();

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTest.java
@@ -162,7 +162,7 @@ public class DruidCoordinatorBalancerTest
     coordinator.moveSegment(
         EasyMock.<ImmutableDruidServer>anyObject(),
         EasyMock.<ImmutableDruidServer>anyObject(),
-        EasyMock.<String>anyObject(),
+        EasyMock.<DataSegment>anyObject(),
         EasyMock.<LoadPeonCallback>anyObject()
     );
     EasyMock.expectLastCall().anyTimes();
@@ -244,7 +244,7 @@ public class DruidCoordinatorBalancerTest
     coordinator.moveSegment(
         EasyMock.<ImmutableDruidServer>anyObject(),
         EasyMock.<ImmutableDruidServer>anyObject(),
-        EasyMock.<String>anyObject(),
+        EasyMock.<DataSegment>anyObject(),
         EasyMock.<LoadPeonCallback>anyObject()
     );
     EasyMock.expectLastCall().anyTimes();
@@ -336,7 +336,7 @@ public class DruidCoordinatorBalancerTest
     coordinator.moveSegment(
         EasyMock.<ImmutableDruidServer>anyObject(),
         EasyMock.<ImmutableDruidServer>anyObject(),
-        EasyMock.<String>anyObject(),
+        EasyMock.<DataSegment>anyObject(),
         EasyMock.<LoadPeonCallback>anyObject()
     );
     EasyMock.expectLastCall().anyTimes();

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
@@ -206,10 +206,17 @@ public class DruidCoordinatorTest extends CuratorTestBase
   public void testMoveSegment() throws Exception
   {
     loadQueuePeon = EasyMock.createNiceMock(LoadQueuePeon.class);
-    EasyMock.expect(loadQueuePeon.getLoadQueueSize()).andReturn(new Long(1));
-    EasyMock.replay(loadQueuePeon);
     segment = EasyMock.createNiceMock(DataSegment.class);
+    EasyMock.expect(segment.getIdentifier()).andReturn("dummySegment");
+    EasyMock.expect(segment.getDataSource()).andReturn("dummyDataSource");
     EasyMock.replay(segment);
+    EasyMock.expect(loadQueuePeon.getLoadQueueSize()).andReturn(new Long(1));
+    DruidDataSource druidDataSource= EasyMock.createNiceMock(DruidDataSource.class);
+    EasyMock.expect(druidDataSource.getSegment(EasyMock.anyString())).andReturn(segment);
+    EasyMock.replay(druidDataSource);
+    EasyMock.expect(databaseSegmentManager.getInventoryValue(EasyMock.anyString())).andReturn(druidDataSource);
+    EasyMock.replay(databaseSegmentManager);
+    EasyMock.replay(loadQueuePeon);
     scheduledExecutorFactory = EasyMock.createNiceMock(ScheduledExecutorFactory.class);
     EasyMock.replay(scheduledExecutorFactory);
     EasyMock.replay(metadataRuleManager);
@@ -242,7 +249,7 @@ public class DruidCoordinatorTest extends CuratorTestBase
     coordinator.moveSegment(
         druidServer.toImmutableDruidServer(),
         druidServer2.toImmutableDruidServer(),
-        "dummySegment", null
+        segment, null
     );
     EasyMock.verify(druidServer);
     EasyMock.verify(druidServer2);


### PR DESCRIPTION
PR to get segment information from `MetadataSegmentManager`  instead of getting it from`fromServer's`. This is useful when `MetadataSegmentManager` and `fromServer` DataSegment's are different for same identifier  (say loadSpec differs because of deep storage migration).