### PR TITLE
rolling upgrade order change to bring coordinator and overlord together

### DIFF
--- a/docs/content/operations/rolling-updates.md
+++ b/docs/content/operations/rolling-updates.md
@@ -9,11 +9,11 @@ For rolling Druid cluster updates with no downtime, we recommend updating Druid 
 following order:
 
 1. Historical
-2. Middle Manager (if any)
-3. Standalone Real-time (if any)
-4. Broker
-5. Overlord (if any)
-6. Coordinator
+2. Overlord (if any)
+3. Middle Manager (if any)
+4. Standalone Real-time (if any)
+5. Broker
+6. Coordinator ( or merged Coordinator+Overlord )
 
 ## Historical
 

--- a/docs/content/operations/rolling-updates.md
+++ b/docs/content/operations/rolling-updates.md
@@ -59,9 +59,12 @@ to `<MiddleManager_IP:PORT>/druid/worker/v1/enable`.
 
 ### Autoscaling-based replacement
 
-If autoscaling is enabled on your Overlord, then Overlord nodes can launch new Middle Manager nodes en masse and then gracefully terminate old ones as their tasks finish. This process is configured by setting druid.indexer.runner.minWorkerVersion=#{VERSION}. Each time you update your overlord node, the VERSION value should be increased, which will trigger a mass launch of new Middle Managers.
+If autoscaling is enabled on your Overlord, then Overlord nodes can launch new Middle Manager nodes
+en masse and then gracefully terminate old ones as their tasks finish. This process is configured by
+setting `druid.indexer.runner.minWorkerVersion=#{VERSION}`. Each time you update your overlord node,
+the `VERSION` value should be increased, which will trigger a mass launch of new Middle Managers.
 
-The config druid.indexer.autoscale.workerVersion=#{VERSION} also needs to be set.
+The config `druid.indexer.autoscale.workerVersion=#{VERSION}` also needs to be set.
 
 ## Standalone Real-time
 

--- a/docs/content/operations/rolling-updates.md
+++ b/docs/content/operations/rolling-updates.md
@@ -59,13 +59,9 @@ to `<MiddleManager_IP:PORT>/druid/worker/v1/enable`.
 
 ### Autoscaling-based replacement
 
-If autoscaling is enabled on your Overlord, then Overlord nodes can launch new Middle Manager nodes
-en masse and then gracefully terminate old ones as their tasks finish. This process is configured by
-setting `druid.indexer.runner.minWorkerVersion=#{VERSION}`.
-So, first you increase `VERSION` value on the overlord, which will trigger mass launch of new Middle Managers.
-Once all Middle Managers are updated, then update the Overlord to new version.
+If autoscaling is enabled on your Overlord, then Overlord nodes can launch new Middle Manager nodes en masse and then gracefully terminate old ones as their tasks finish. This process is configured by setting druid.indexer.runner.minWorkerVersion=#{VERSION}. Each time you update your overlord node, the VERSION value should be increased, which will trigger a mass launch of new Middle Managers.
 
-The config `druid.indexer.autoscale.workerVersion=#{VERSION}` also needs to be set.
+The config druid.indexer.autoscale.workerVersion=#{VERSION} also needs to be set.
 
 ## Standalone Real-time
 

--- a/docs/content/operations/rolling-updates.md
+++ b/docs/content/operations/rolling-updates.md
@@ -9,10 +9,10 @@ For rolling Druid cluster updates with no downtime, we recommend updating Druid 
 following order:
 
 1. Historical
-2. Overlord (if any)
-3. Middle Manager (if any)
-4. Standalone Real-time (if any)
-5. Broker
+2. Middle Manager (if any)
+3. Standalone Real-time (if any)
+4. Broker
+5. Overlord (if any)
 6. Coordinator
 
 ## Historical
@@ -61,8 +61,9 @@ to `<MiddleManager_IP:PORT>/druid/worker/v1/enable`.
 
 If autoscaling is enabled on your Overlord, then Overlord nodes can launch new Middle Manager nodes
 en masse and then gracefully terminate old ones as their tasks finish. This process is configured by
-setting `druid.indexer.runner.minWorkerVersion=#{VERSION}`. Each time you update your overlord node,
-the `VERSION` value should be increased, which will trigger a mass launch of new Middle Managers.
+setting `druid.indexer.runner.minWorkerVersion=#{VERSION}`.
+So, first you increase `VERSION` value on the overlord, which will trigger mass launch of new Middle Managers.
+Once all Middle Managers are updated, then update the Overlord to new version.
 
 The config `druid.indexer.autoscale.workerVersion=#{VERSION}` also needs to be set.
 


### PR DESCRIPTION
With Druid-0.10.0, there is an option to run Coordinator and Overlord in single process. With that option, it might not possible to update overlord and coordinator separately.

So, doc is rolling upgrade contract is augmented and further releases should  support overlord upgrade before or after the MMs .