### PR TITLE
Workaround for non-thread-safe use of CardinalityAggregator.

### DIFF
--- a/processing/src/main/java/io/druid/query/aggregation/cardinality/CardinalityAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/cardinality/CardinalityAggregator.java
@@ -109,7 +109,9 @@ public class CardinalityAggregator implements Aggregator
   @Override
   public Object get()
   {
-    return collector;
+    // Workaround for non-thread-safe use of HyperLogLogCollector.
+    // OnheapIncrementalIndex has a penchant for calling "aggregate" and "get" simultaneously.
+    return HyperLogLogCollector.makeCollectorSharingStorage(collector);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregator.java
@@ -55,7 +55,8 @@ public class HyperUniquesAggregator implements Aggregator
   @Override
   public Object get()
   {
-    // Workaround for OnheapIncrementalIndex's penchant for calling "aggregate" and "get" simultaneously.
+    // Workaround for non-thread-safe use of HyperLogLogCollector.
+    // OnheapIncrementalIndex has a penchant for calling "aggregate" and "get" simultaneously.
     return HyperLogLogCollector.makeCollectorSharingStorage(collector);
   }
 


### PR DESCRIPTION
Fix for #4296, probably.

Fixes #4296, #4199.