### PR TITLE
Timeout and maxScatterGatherBytes handling for queries run by Druid SQL

### DIFF
--- a/benchmarks/src/main/java/io/druid/benchmark/query/SqlBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/SqlBenchmark.java
@@ -47,6 +47,7 @@ import io.druid.segment.QueryableIndex;
 import io.druid.segment.TestHelper;
 import io.druid.segment.column.ValueType;
 import io.druid.segment.serde.ComplexMetrics;
+import io.druid.server.initialization.ServerConfig;
 import io.druid.sql.calcite.planner.Calcites;
 import io.druid.sql.calcite.planner.DruidPlanner;
 import io.druid.sql.calcite.planner.PlannerConfig;
@@ -177,7 +178,8 @@ public class SqlBenchmark
         Calcites.createRootSchema(druidSchema),
         walker,
         CalciteTests.createOperatorTable(),
-        plannerConfig
+        plannerConfig,
+        new ServerConfig()
     );
     groupByQuery = GroupByQuery
         .builder()

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/sql/QuantileSqlAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/sql/QuantileSqlAggregatorTest.java
@@ -42,6 +42,7 @@ import io.druid.segment.IndexBuilder;
 import io.druid.segment.QueryableIndex;
 import io.druid.segment.TestHelper;
 import io.druid.segment.incremental.IncrementalIndexSchema;
+import io.druid.server.initialization.ServerConfig;
 import io.druid.sql.calcite.aggregation.SqlAggregator;
 import io.druid.sql.calcite.expression.SqlExtractionOperator;
 import io.druid.sql.calcite.filtration.Filtration;
@@ -134,7 +135,7 @@ public class QuantileSqlAggregatorTest
         ImmutableSet.<SqlAggregator>of(new QuantileSqlAggregator()),
         ImmutableSet.<SqlExtractionOperator>of()
     );
-    plannerFactory = new PlannerFactory(rootSchema, walker, operatorTable, plannerConfig);
+    plannerFactory = new PlannerFactory(rootSchema, walker, operatorTable, plannerConfig, new ServerConfig());
   }
 
   @After

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/sql/QuantileSqlAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/sql/QuantileSqlAggregatorTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Iterables;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.Druids;
+import io.druid.query.QueryContexts;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.query.aggregation.DoubleSumAggregatorFactory;
@@ -201,7 +202,11 @@ public class QuantileSqlAggregatorTest
                     new QuantilePostAggregator("a6", "a4:agg", 0.999f),
                     new QuantilePostAggregator("a7", "a7:agg", 0.50f)
                 ))
-                .context(ImmutableMap.<String, Object>of("skipEmptyBuckets", true))
+                .context(ImmutableMap.<String, Object>of(
+                    "skipEmptyBuckets", true,
+                    QueryContexts.DEFAULT_TIMEOUT_KEY, QueryContexts.DEFAULT_TIMEOUT_MILLIS,
+                    QueryContexts.MAX_SCATTER_GATHER_BYTES_KEY, Long.MAX_VALUE
+                ))
                 .build(),
           Iterables.getOnlyElement(queryLogHook.getRecordedQueries())
       );
@@ -261,7 +266,11 @@ public class QuantileSqlAggregatorTest
                     new QuantilePostAggregator("a5", "a5:agg", 0.999f),
                     new QuantilePostAggregator("a6", "a4:agg", 0.999f)
                 ))
-                .context(ImmutableMap.<String, Object>of("skipEmptyBuckets", true))
+                .context(ImmutableMap.<String, Object>of(
+                    "skipEmptyBuckets", true,
+                    QueryContexts.DEFAULT_TIMEOUT_KEY, QueryContexts.DEFAULT_TIMEOUT_MILLIS,
+                    QueryContexts.MAX_SCATTER_GATHER_BYTES_KEY, Long.MAX_VALUE
+                ))
                 .build(),
           Iterables.getOnlyElement(queryLogHook.getRecordedQueries())
       );

--- a/server/src/main/java/io/druid/server/QueryResource.java
+++ b/server/src/main/java/io/druid/server/QueryResource.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.jaxrs.smile.SmileMediaTypes;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.MapMaker;
 import com.google.common.io.CountingOutputStream;
 import com.google.inject.Inject;
 import com.metamx.emitter.EmittingLogger;
@@ -41,7 +40,6 @@ import io.druid.java.util.common.guava.Yielders;
 import io.druid.query.DruidMetrics;
 import io.druid.query.GenericQueryMetricsFactory;
 import io.druid.query.Query;
-import io.druid.query.QueryContexts;
 import io.druid.query.QueryInterruptedException;
 import io.druid.query.QueryMetrics;
 import io.druid.query.QueryPlus;
@@ -187,7 +185,6 @@ public class QueryResource implements QueryCountStatsProvider
 
     final String currThreadName = Thread.currentThread().getName();
     try {
-      final Map<String, Object> responseContext = new MapMaker().makeMap();
 
       query = context.getObjectMapper().readValue(in, Query.class);
       queryId = query.getId();
@@ -195,14 +192,12 @@ public class QueryResource implements QueryCountStatsProvider
         queryId = UUID.randomUUID().toString();
         query = query.withId(queryId);
       }
-      query = QueryContexts.withDefaultTimeout(query, config.getDefaultQueryTimeout());
-      query = QueryContexts.withMaxScatterGatherBytes(query, config.getMaxScatterGatherBytes());
 
-      responseContext.put(
-          DirectDruidClient.QUERY_FAIL_TIME,
-          System.currentTimeMillis() + QueryContexts.getTimeout(query)
+      query = DirectDruidClient.withDefaultTimeoutAndMaxScatterGatherBytes(query, config);
+      final Map<String, Object> responseContext = DirectDruidClient.makeResponseContextForQuery(
+          query,
+          System.currentTimeMillis()
       );
-      responseContext.put(DirectDruidClient.QUERY_TOTAL_BYTES_GATHERED, new AtomicLong());
 
       toolChest = warehouse.getToolChest(query);
 

--- a/sql/src/main/java/io/druid/sql/calcite/planner/PlannerContext.java
+++ b/sql/src/main/java/io/druid/sql/calcite/planner/PlannerContext.java
@@ -42,6 +42,7 @@ public class PlannerContext
 
   private final PlannerConfig plannerConfig;
   private final DateTime localNow;
+  private final long queryStartTimeMillis;
   private final Map<String, Object> queryContext;
 
   private PlannerContext(
@@ -53,6 +54,7 @@ public class PlannerContext
     this.plannerConfig = Preconditions.checkNotNull(plannerConfig, "plannerConfig");
     this.queryContext = queryContext != null ? ImmutableMap.copyOf(queryContext) : ImmutableMap.<String, Object>of();
     this.localNow = Preconditions.checkNotNull(localNow, "localNow");
+    this.queryStartTimeMillis = System.currentTimeMillis();
   }
 
   public static PlannerContext create(
@@ -104,6 +106,11 @@ public class PlannerContext
   public Map<String, Object> getQueryContext()
   {
     return queryContext;
+  }
+
+  public long getQueryStartTimeMillis()
+  {
+    return queryStartTimeMillis;
   }
 
   public DataContext createDataContext(final JavaTypeFactory typeFactory)

--- a/sql/src/main/java/io/druid/sql/calcite/planner/PlannerFactory.java
+++ b/sql/src/main/java/io/druid/sql/calcite/planner/PlannerFactory.java
@@ -21,6 +21,7 @@ package io.druid.sql.calcite.planner;
 
 import com.google.inject.Inject;
 import io.druid.query.QuerySegmentWalker;
+import io.druid.server.initialization.ServerConfig;
 import io.druid.sql.calcite.rel.QueryMaker;
 import io.druid.sql.calcite.schema.DruidSchema;
 import org.apache.calcite.avatica.util.Casing;
@@ -44,25 +45,28 @@ public class PlannerFactory
   private final QuerySegmentWalker walker;
   private final DruidOperatorTable operatorTable;
   private final PlannerConfig plannerConfig;
+  private final ServerConfig serverConfig;
 
   @Inject
   public PlannerFactory(
       final SchemaPlus rootSchema,
       final QuerySegmentWalker walker,
       final DruidOperatorTable operatorTable,
-      final PlannerConfig plannerConfig
+      final PlannerConfig plannerConfig,
+      final ServerConfig serverConfig
   )
   {
     this.rootSchema = rootSchema;
     this.walker = walker;
     this.operatorTable = operatorTable;
     this.plannerConfig = plannerConfig;
+    this.serverConfig = serverConfig;
   }
 
   public DruidPlanner createPlanner(final Map<String, Object> queryContext)
   {
     final PlannerContext plannerContext = PlannerContext.create(plannerConfig, queryContext);
-    final QueryMaker queryMaker = new QueryMaker(walker, plannerContext);
+    final QueryMaker queryMaker = new QueryMaker(walker, plannerContext, serverConfig);
     final FrameworkConfig frameworkConfig = Frameworks
         .newConfigBuilder()
         .parserConfig(

--- a/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
+++ b/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
@@ -32,6 +32,7 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.druid.java.util.common.Pair;
 import io.druid.server.DruidNode;
+import io.druid.server.initialization.ServerConfig;
 import io.druid.sql.calcite.planner.Calcites;
 import io.druid.sql.calcite.planner.DruidOperatorTable;
 import io.druid.sql.calcite.planner.PlannerConfig;
@@ -116,7 +117,10 @@ public class DruidAvaticaHandlerTest
     );
     final DruidOperatorTable operatorTable = CalciteTests.createOperatorTable();
     final DruidAvaticaHandler handler = new DruidAvaticaHandler(
-        new DruidMeta(new PlannerFactory(rootSchema, walker, operatorTable, plannerConfig), AVATICA_CONFIG),
+        new DruidMeta(
+            new PlannerFactory(rootSchema, walker, operatorTable, plannerConfig, new ServerConfig()),
+            AVATICA_CONFIG
+        ),
         new DruidNode("dummy", "dummy", 1),
         new AvaticaMonitor()
     );

--- a/sql/src/test/java/io/druid/sql/avatica/DruidStatementTest.java
+++ b/sql/src/test/java/io/druid/sql/avatica/DruidStatementTest.java
@@ -21,6 +21,7 @@ package io.druid.sql.avatica;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
+import io.druid.server.initialization.ServerConfig;
 import io.druid.sql.calcite.planner.Calcites;
 import io.druid.sql.calcite.planner.DruidOperatorTable;
 import io.druid.sql.calcite.planner.PlannerConfig;
@@ -65,7 +66,7 @@ public class DruidStatementTest
         )
     );
     final DruidOperatorTable operatorTable = CalciteTests.createOperatorTable();
-    plannerFactory = new PlannerFactory(rootSchema, walker, operatorTable, plannerConfig);
+    plannerFactory = new PlannerFactory(rootSchema, walker, operatorTable, plannerConfig, new ServerConfig());
   }
 
   @After

--- a/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
@@ -29,6 +29,7 @@ import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.query.Druids;
 import io.druid.query.Query;
+import io.druid.query.QueryContexts;
 import io.druid.query.QueryDataSource;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
@@ -170,35 +171,47 @@ public class CalciteQueryTest
   private static final String LOS_ANGELES = "America/Los_Angeles";
 
   private static final Map<String, Object> QUERY_CONTEXT_DEFAULT = ImmutableMap.<String, Object>of(
-      PlannerContext.CTX_SQL_CURRENT_TIMESTAMP, "2000-01-01T00:00:00Z"
+      PlannerContext.CTX_SQL_CURRENT_TIMESTAMP, "2000-01-01T00:00:00Z",
+      QueryContexts.DEFAULT_TIMEOUT_KEY, QueryContexts.DEFAULT_TIMEOUT_MILLIS,
+      QueryContexts.MAX_SCATTER_GATHER_BYTES_KEY, Long.MAX_VALUE
   );
 
   private static final Map<String, Object> QUERY_CONTEXT_DONT_SKIP_EMPTY_BUCKETS = ImmutableMap.<String, Object>of(
       PlannerContext.CTX_SQL_CURRENT_TIMESTAMP, "2000-01-01T00:00:00Z",
-      "skipEmptyBuckets", false
+      "skipEmptyBuckets", false,
+      QueryContexts.DEFAULT_TIMEOUT_KEY, QueryContexts.DEFAULT_TIMEOUT_MILLIS,
+      QueryContexts.MAX_SCATTER_GATHER_BYTES_KEY, Long.MAX_VALUE
   );
 
   private static final Map<String, Object> QUERY_CONTEXT_NO_TOPN = ImmutableMap.<String, Object>of(
       PlannerContext.CTX_SQL_CURRENT_TIMESTAMP, "2000-01-01T00:00:00Z",
-      PlannerConfig.CTX_KEY_USE_APPROXIMATE_TOPN, "false"
+      PlannerConfig.CTX_KEY_USE_APPROXIMATE_TOPN, "false",
+      QueryContexts.DEFAULT_TIMEOUT_KEY, QueryContexts.DEFAULT_TIMEOUT_MILLIS,
+      QueryContexts.MAX_SCATTER_GATHER_BYTES_KEY, Long.MAX_VALUE
   );
 
   private static final Map<String, Object> QUERY_CONTEXT_LOS_ANGELES = ImmutableMap.<String, Object>of(
       PlannerContext.CTX_SQL_CURRENT_TIMESTAMP, "2000-01-01T00:00:00Z",
-      PlannerContext.CTX_SQL_TIME_ZONE, LOS_ANGELES
+      PlannerContext.CTX_SQL_TIME_ZONE, LOS_ANGELES,
+      QueryContexts.DEFAULT_TIMEOUT_KEY, QueryContexts.DEFAULT_TIMEOUT_MILLIS,
+      QueryContexts.MAX_SCATTER_GATHER_BYTES_KEY, Long.MAX_VALUE
   );
 
   // Matches QUERY_CONTEXT_DEFAULT
   public static final Map<String, Object> TIMESERIES_CONTEXT_DEFAULT = ImmutableMap.<String, Object>of(
       PlannerContext.CTX_SQL_CURRENT_TIMESTAMP, "2000-01-01T00:00:00Z",
-      "skipEmptyBuckets", true
+      "skipEmptyBuckets", true,
+      QueryContexts.DEFAULT_TIMEOUT_KEY, QueryContexts.DEFAULT_TIMEOUT_MILLIS,
+      QueryContexts.MAX_SCATTER_GATHER_BYTES_KEY, Long.MAX_VALUE
   );
 
   // Matches QUERY_CONTEXT_LOS_ANGELES
   public static final Map<String, Object> TIMESERIES_CONTEXT_LOS_ANGELES = ImmutableMap.<String, Object>of(
       PlannerContext.CTX_SQL_CURRENT_TIMESTAMP, "2000-01-01T00:00:00Z",
       PlannerContext.CTX_SQL_TIME_ZONE, LOS_ANGELES,
-      "skipEmptyBuckets", true
+      "skipEmptyBuckets", true,
+      QueryContexts.DEFAULT_TIMEOUT_KEY, QueryContexts.DEFAULT_TIMEOUT_MILLIS,
+      QueryContexts.MAX_SCATTER_GATHER_BYTES_KEY, Long.MAX_VALUE
   );
   private static final PagingSpec FIRST_PAGING_SPEC = new PagingSpec(null, 1000, true);
 

--- a/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
@@ -81,6 +81,7 @@ import io.druid.query.topn.NumericTopNMetricSpec;
 import io.druid.query.topn.TopNQueryBuilder;
 import io.druid.segment.column.Column;
 import io.druid.segment.column.ValueType;
+import io.druid.server.initialization.ServerConfig;
 import io.druid.sql.calcite.filtration.Filtration;
 import io.druid.sql.calcite.planner.Calcites;
 import io.druid.sql.calcite.planner.DruidOperatorTable;
@@ -4223,7 +4224,13 @@ public class CalciteQueryTest
     final SchemaPlus rootSchema = Calcites.createRootSchema(druidSchema);
     final DruidOperatorTable operatorTable = CalciteTests.createOperatorTable();
 
-    final PlannerFactory plannerFactory = new PlannerFactory(rootSchema, walker, operatorTable, plannerConfig);
+    final PlannerFactory plannerFactory = new PlannerFactory(
+        rootSchema,
+        walker,
+        operatorTable,
+        plannerConfig,
+        new ServerConfig()
+    );
 
     viewManager.createView(
         plannerFactory,

--- a/sql/src/test/java/io/druid/sql/calcite/http/SqlResourceTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/http/SqlResourceTest.java
@@ -28,6 +28,7 @@ import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.Pair;
 import io.druid.query.QueryInterruptedException;
 import io.druid.query.ResourceLimitExceededException;
+import io.druid.server.initialization.ServerConfig;
 import io.druid.sql.calcite.planner.Calcites;
 import io.druid.sql.calcite.planner.DruidOperatorTable;
 import io.druid.sql.calcite.planner.PlannerConfig;
@@ -77,7 +78,10 @@ public class SqlResourceTest
         CalciteTests.createMockSchema(walker, plannerConfig)
     );
     final DruidOperatorTable operatorTable = CalciteTests.createOperatorTable();
-    resource = new SqlResource(JSON_MAPPER, new PlannerFactory(rootSchema, walker, operatorTable, plannerConfig));
+    resource = new SqlResource(
+        JSON_MAPPER,
+        new PlannerFactory(rootSchema, walker, operatorTable, plannerConfig, new ServerConfig())
+    );
   }
 
   @After

--- a/sql/src/test/java/io/druid/sql/calcite/schema/DruidSchemaTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/schema/DruidSchemaTest.java
@@ -32,6 +32,7 @@ import io.druid.segment.IndexBuilder;
 import io.druid.segment.QueryableIndex;
 import io.druid.segment.TestHelper;
 import io.druid.segment.incremental.IncrementalIndexSchema;
+import io.druid.server.initialization.ServerConfig;
 import io.druid.sql.calcite.planner.Calcites;
 import io.druid.sql.calcite.planner.PlannerConfig;
 import io.druid.sql.calcite.table.DruidTable;
@@ -150,7 +151,8 @@ public class DruidSchemaTest
         walker,
         new TestServerInventoryView(walker.getSegments()),
         PLANNER_CONFIG_DEFAULT,
-        new NoopViewManager()
+        new NoopViewManager(),
+        new ServerConfig()
     );
 
     schema.start();

--- a/sql/src/test/java/io/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/io/druid/sql/calcite/util/CalciteTests.java
@@ -76,6 +76,7 @@ import io.druid.segment.IndexBuilder;
 import io.druid.segment.QueryableIndex;
 import io.druid.segment.TestHelper;
 import io.druid.segment.incremental.IncrementalIndexSchema;
+import io.druid.server.initialization.ServerConfig;
 import io.druid.sql.calcite.aggregation.SqlAggregator;
 import io.druid.sql.calcite.expression.SqlExtractionOperator;
 import io.druid.sql.calcite.planner.DruidOperatorTable;
@@ -380,7 +381,8 @@ public class CalciteTests
         walker,
         new TestServerInventoryView(walker.getSegments()),
         plannerConfig,
-        viewManager
+        viewManager,
+        new ServerConfig()
     );
 
     schema.start();


### PR DESCRIPTION
This PR sets timeout and maxScatterGatherBytes parameters (https://github.com/druid-io/druid/pull/4229) in the query context/responseContext for SQL-originated queries.

Without this, SQL queries fail with a NullPointerException at this line in DirectDruidClient.run():
```
      long timeoutAt = ((Long) context.get(QUERY_FAIL_TIME)).longValue();
```
