### PR TITLE
Increase the max heap size for maven for strict compilation step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,18 @@ language: java
 jdk:
   - oraclejdk8
 
-# Using && instead of two script steps to make Travis build fail faster, if "strict" compilation is not successful
-script: mvn clean -Pstrict -pl '!benchmarks' compile test-compile -B && mvn test -B -Pparallel-test -Dmaven.fork.count=2
-
 install: true
+
+# The script execution consists of 4 steps:
+# 1) Increase the jvm max heap size. Strict compilation in 2) requires more than 2 GB.
+# 2) Strict compilation using error-prone
+# 3) Reset the maven options. Parallel testing in 4) launches 2 processes, each requires 1 GB of memory. Increasing the maximum memory may cause OutOfMemory error because the instance of Travis has 4 GB of memory space.
+# 4) Parallel unit testing
+# Using && instead of independent script steps to make Travis build fail faster, if each step is not successful
+script: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn clean -Pstrict -pl '!benchmarks' compile test-compile -B && rm ~/.mavenrc && mvn test -B -Pparallel-test -Dmaven.fork.count=2
 
 sudo: false
 
 cache:
   directories:
-      - $HOME/.m2
-
+    - $HOME/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -875,7 +875,7 @@
                     <configuration>
                         <!-- locale settings must be set on the command line before startup -->
                         <!-- set heap size to work around https://github.com/travis-ci/travis-ci/issues/3396 -->
-                        <argLine>-Xmx1024m -Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8
+                        <argLine>-Xmx3000m -Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8
                             -Duser.timezone=UTC -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
                         </argLine>
                         <!-- our tests are very verbose, let's keep the volume down -->
@@ -1016,7 +1016,7 @@
                             <forceJavacCompilerUse>true</forceJavacCompilerUse>
                             <fork>true</fork>
                             <meminitial>1024m</meminitial>
-                            <maxmem>4000m</maxmem>
+                            <maxmem>3000m</maxmem>
                             <source>1.8</source>
                             <target>1.8</target>
                             <showWarnings>false</showWarnings>


### PR DESCRIPTION
This patch fixes the travis failure of #4298.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/druid-io/druid/4306)
<!-- Reviewable:end -->
