### PR TITLE
Don't use QueryMetrics from multiple threads in DirectDruidClient (fixes #4308)

### DIFF
--- a/server/src/main/java/io/druid/client/DirectDruidClient.java
+++ b/server/src/main/java/io/druid/client/DirectDruidClient.java
@@ -173,20 +173,27 @@ public class DirectDruidClient<T> implements QueryRunner<T>
 
       final long requestStartTimeNs = System.nanoTime();
 
-      final QueryMetrics<? super Query<T>> queryMetrics = toolChest.makeMetrics(query);
-      queryMetrics.server(host);
-
       long timeoutAt = ((Long) context.get(QUERY_FAIL_TIME)).longValue();
       long maxScatterGatherBytes = QueryContexts.getMaxScatterGatherBytes(query);
       AtomicLong totalBytesGathered = (AtomicLong) context.get(QUERY_TOTAL_BYTES_GATHERED);
 
       final HttpResponseHandler<InputStream, InputStream> responseHandler = new HttpResponseHandler<InputStream, InputStream>()
       {
+        private QueryMetrics<? super Query<T>> queryMetrics;
         private long responseStartTimeNs;
         private final AtomicLong byteCount = new AtomicLong(0);
         private final BlockingQueue<InputStream> queue = new LinkedBlockingQueue<>();
         private final AtomicBoolean done = new AtomicBoolean(false);
         private final AtomicReference<String> fail = new AtomicReference<>();
+
+        QueryMetrics<? super Query<T>> acquireQueryMetrics()
+        {
+          if (queryMetrics == null) {
+            queryMetrics = toolChest.makeMetrics(query);
+            queryMetrics.server(host);
+          }
+          return queryMetrics;
+        }
 
         @Override
         public ClientResponse<InputStream> handleResponse(HttpResponse response)
@@ -196,7 +203,7 @@ public class DirectDruidClient<T> implements QueryRunner<T>
 
           log.debug("Initial response from url[%s] for queryId[%s]", url, query.getId());
           responseStartTimeNs = System.nanoTime();
-          queryMetrics.reportNodeTimeToFirstByte(responseStartTimeNs - requestStartTimeNs).emit(emitter);
+          acquireQueryMetrics().reportNodeTimeToFirstByte(responseStartTimeNs - requestStartTimeNs).emit(emitter);
 
           try {
             final String responseContext = response.headers().get("X-Druid-Response-Context");
@@ -315,6 +322,7 @@ public class DirectDruidClient<T> implements QueryRunner<T>
               nodeTimeMs,
               byteCount.get() / (0.001 * nodeTimeMs) // Floating math; division by zero will yield Inf, not exception
           );
+          QueryMetrics<? super Query<T>> queryMetrics = acquireQueryMetrics();
           queryMetrics.reportNodeTime(nodeTimeNs);
           queryMetrics.reportNodeBytes(byteCount.get());
           queryMetrics.emit(emitter);


### PR DESCRIPTION
See #4308