### PR TITLE
Delete a duplicate "Bucket Extraction Function" section

### DIFF
--- a/docs/content/querying/dimensionspecs.md
+++ b/docs/content/querying/dimensionspecs.md
@@ -529,20 +529,3 @@ The following extraction function creates buckets of 5 starting from 2. In this 
   "offset" : 2
 }
 ```
-
-### Bucket Extraction Function
-
-Bucket extraction function is used to bucket numerical values in each range of the given size by converting them to the same base value. Non numeric values are converted to null.
-
-* `size` : the size of the buckets (optional, default 1)
-* `offset` : the offset for the buckets (optional, default 0)
-
-The following extraction function creates buckets of 5 starting from 2. In this case, values in the range of [2, 7) will be converted to 2, values in [7, 12) will be converted to 7, etc.
-
-```json
-{
-  "type" : "bucket",
-  "size" : 5,
-  "offset" : 2
-}
-```


### PR DESCRIPTION
at the bottom of "Querying"-"DimensionSpec" page