### PR TITLE
Fix integer overflow in BufferGrouper.

### DIFF
--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/BufferGrouper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/BufferGrouper.java
@@ -411,7 +411,7 @@ public class BufferGrouper<KeyType> implements Grouper<KeyType>
     final int newMaxSize;
     final int newTableStart;
 
-    if ((tableStart + buckets * 3 * bucketSize) > tableArenaSize) {
+    if ((long) buckets * 3 * bucketSize > (long) tableArenaSize - tableStart) {
       // Not enough space to grow upwards, start back from zero
       newTableStart = 0;
       newBuckets = tableStart / bucketSize;


### PR DESCRIPTION
Would have led to out of bounds buffer access with large buffers.
Also added tests using large buffers.

Fixes issue reported on the mailing list at https://groups.google.com/d/msg/druid-user/JOp9oTVOqEQ/_Tqk97paAQAJ.