### PR TITLE
Fix integration tests

### DIFF
--- a/extensions-core/kafka-indexing-service/pom.xml
+++ b/extensions-core/kafka-indexing-service/pom.xml
@@ -33,6 +33,10 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
+  <properties>
+    <apache.kafka.version>0.10.2.0</apache.kafka.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.druid</groupId>
@@ -55,7 +59,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>0.10.2.0</version>
+      <version>${apache.kafka.version}</version>
     </dependency>
 
     <!-- Tests -->
@@ -67,7 +71,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka_2.11</artifactId>
-      <version>0.10.2.0</version>
+      <version>${apache.kafka.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisor.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisor.java
@@ -1509,7 +1509,7 @@ public class KafkaSupervisor implements Supervisor
   {
     TopicPartition topicPartition = new TopicPartition(ioConfig.getTopic(), partition);
     if (!consumer.assignment().contains(topicPartition)) {
-      consumer.assign(Collections.singletonList(topicPartition));
+      consumer.assign(Lists.newArrayList(topicPartition));
     }
 
     if (useEarliestOffset) {

--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisor.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisor.java
@@ -1509,7 +1509,7 @@ public class KafkaSupervisor implements Supervisor
   {
     TopicPartition topicPartition = new TopicPartition(ioConfig.getTopic(), partition);
     if (!consumer.assignment().contains(topicPartition)) {
-      consumer.assign(Lists.newArrayList(topicPartition));
+      consumer.assign(Collections.singletonList(topicPartition));
     }
 
     if (useEarliestOffset) {

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -23,8 +23,9 @@ RUN wget -q -O - http://www.us.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeep
       && ln -s /usr/local/zookeeper-3.4.6 /usr/local/zookeeper
 
 # Kafka
-RUN wget -q -O - http://www.us.apache.org/dist/kafka/0.9.0.1/kafka_2.10-0.9.0.1.tgz | tar -xzf - -C /usr/local \
-      && ln -s /usr/local/kafka_2.10-0.9.0.1 /usr/local/kafka
+# Match the version to the Kafka client used by KafkaSupervisor
+RUN wget -q -O - http://www.us.apache.org/dist/kafka/0.10.2.0/kafka_2.11-0.10.2.0.tgz | tar -xzf - -C /usr/local \
+      && ln -s /usr/local/kafka_2.11-0.10.2.0 /usr/local/kafka
 
 # Druid system user
 RUN adduser --system --group --no-create-home druid \
@@ -62,7 +63,7 @@ ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 # unless advertised.host.name is set to docker host ip, publishing data fails
 # run this last to avoid rebuilding the image every time the ip changes
 ADD docker_ip docker_ip
-RUN perl -pi -e "s/#advertised.port=.*/advertised.port=9092/; s/#advertised.host.*/advertised.host.name=$(cat docker_ip)/" /usr/local/kafka/config/server.properties
+RUN perl -pi -e "s/#advertised.listeners=.*/advertised.listeners=PLAINTEXT:\/\/$(cat docker_ip):9092/" /usr/local/kafka/config/server.properties
 
 # Expose ports:
 # - 8081: HTTP (coordinator)

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -30,8 +30,7 @@
     </parent>
 
     <properties>
-        <apache.kafka.version>0.8.2.1</apache.kafka.version>
-        <zkclient.version>0.4</zkclient.version>
+        <apache.kafka.version>0.10.2.0</apache.kafka.version>
     </properties>
 
     <dependencies>
@@ -54,6 +53,12 @@
             <groupId>io.druid.extensions</groupId>
             <artifactId>druid-kafka-eight</artifactId>
             <version>${project.parent.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>kafka_2.10</artifactId>
+                    <groupId>org.apache.kafka</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.druid.extensions</groupId>
@@ -69,6 +74,12 @@
             <groupId>io.druid.extensions</groupId>
             <artifactId>druid-kafka-indexing-service</artifactId>
             <version>${project.parent.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.kafka</groupId>
+                    <artifactId>kafka-clients</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.druid</groupId>
@@ -92,32 +103,19 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.101tec</groupId>
-            <artifactId>zkclient</artifactId>
-            <version>${zkclient.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.zookeeper</groupId>
-                    <artifactId>zookeeper</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.10</artifactId>
+            <artifactId>kafka_2.11</artifactId>
             <version>${apache.kafka.version}</version>
-	    <!-- without this exclusion, there's interference that affects the log level -->
             <exclusions>
                 <exclusion>
-                    <groupId>org.slf4j</groupId>
+                    <artifactId>log4j</artifactId>
+                    <groupId>log4j</groupId>
+                </exclusion>
+                <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
+                    <groupId>org.slf4j</groupId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
-            <version>0.9.0.1</version>
         </dependency>
     </dependencies>
 

--- a/integration-tests/src/main/java/io/druid/testing/guice/DruidTestModule.java
+++ b/integration-tests/src/main/java/io/druid/testing/guice/DruidTestModule.java
@@ -33,7 +33,6 @@ import com.metamx.http.client.HttpClient;
 import com.metamx.http.client.auth.BasicCredentials;
 import io.druid.curator.CuratorConfig;
 import io.druid.guice.JsonConfigProvider;
-import io.druid.guice.LazySingleton;
 import io.druid.guice.ManageLifecycle;
 import io.druid.guice.annotations.Client;
 import io.druid.testing.IntegrationTestingConfig;
@@ -72,7 +71,7 @@ public class DruidTestModule implements Module
   }
 
   @Provides
-  @LazySingleton
+  @ManageLifecycle
   public ServiceEmitter getServiceEmitter(Supplier<LoggingEmitterConfig> config, ObjectMapper jsonMapper)
   {
     return new ServiceEmitter("", "", new LoggingEmitter(config.get(), jsonMapper));

--- a/integration-tests/src/test/java/io/druid/tests/indexer/ITKafkaTest.java
+++ b/integration-tests/src/test/java/io/druid/tests/indexer/ITKafkaTest.java
@@ -28,9 +28,11 @@ import io.druid.testing.guice.DruidTestModuleFactory;
 import io.druid.testing.utils.RetryUtil;
 import io.druid.testing.utils.TestQueryHelper;
 import kafka.admin.AdminUtils;
-import kafka.common.TopicExistsException;
+import kafka.admin.RackAwareMode;
 import kafka.utils.ZKStringSerializer$;
+import kafka.utils.ZkUtils;
 import org.I0Itec.zkclient.ZkClient;
+import org.I0Itec.zkclient.ZkConnection;
 import org.apache.commons.io.IOUtils;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -84,7 +86,8 @@ public class ITKafkaTest extends AbstractIndexerTest
 
   private String taskID;
   private ZkClient zkClient;
-  private Boolean segmentsExist;   // to tell if we should remove segments during teardown
+  private ZkUtils zkUtils;
+  private boolean segmentsExist;   // to tell if we should remove segments during teardown
 
   // format for the querying interval
   private final DateTimeFormatter INTERVAL_FMT = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:'00Z'");
@@ -112,13 +115,11 @@ public class ITKafkaTest extends AbstractIndexerTest
           zkHosts, sessionTimeoutMs, connectionTimeoutMs,
           ZKStringSerializer$.MODULE$
       );
+      zkUtils = new ZkUtils(zkClient, new ZkConnection(zkHosts, sessionTimeoutMs), false);
       int numPartitions = 1;
       int replicationFactor = 1;
       Properties topicConfig = new Properties();
-      AdminUtils.createTopic(zkClient, TOPIC_NAME, numPartitions, replicationFactor, topicConfig);
-    }
-    catch (TopicExistsException e) {
-      // it's ok if the topic already exists
+      AdminUtils.createTopic(zkUtils, TOPIC_NAME, numPartitions, replicationFactor, topicConfig, RackAwareMode.Disabled$.MODULE$);
     }
     catch (Exception e) {
       throw new ISE(e, "could not create kafka topic");
@@ -196,7 +197,7 @@ public class ITKafkaTest extends AbstractIndexerTest
     LOG.info("-------------SUBMITTED TASK");
 
     // wait for the task to finish
-    indexer.waitUntilTaskCompletes (taskID, 20000, 30);
+    indexer.waitUntilTaskCompletes(taskID, 20000, 30);
 
     // wait for segments to be handed off
     try {
@@ -263,7 +264,7 @@ public class ITKafkaTest extends AbstractIndexerTest
     LOG.info("teardown");
 
     // delete kafka topic
-    AdminUtils.deleteTopic(zkClient, TOPIC_NAME);
+    AdminUtils.deleteTopic(zkUtils, TOPIC_NAME);
 
     // remove segments
     if (segmentsExist) {


### PR DESCRIPTION
Mostly the problem relates to the version mismatch between the testing kafka cluster and kafka clients. Currently, the testing kafka cluster is using 0.9, while integration tests and KafkaSupervisor are using 0.8 and 0.10, respectively. Since kafka clients doesn't support backward compatibility, the testing cluster must use 0.10, too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/druid-io/druid/4337)
<!-- Reviewable:end -->
