### PR TITLE
explicitly unmap hydrant files when abandonSegment to recycle mmap memory

### DIFF
--- a/extensions-core/kafka-extraction-namespace/src/test/java/io/druid/query/lookup/TestKafkaExtractionCluster.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/io/druid/query/lookup/TestKafkaExtractionCluster.java
@@ -59,6 +59,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Random;
 
 /**
  *
@@ -128,6 +129,7 @@ public class TestKafkaExtractionCluster
     serverProperties.put("zookeeper.connect", zkTestServer.getConnectString() + zkKafkaPath);
     serverProperties.put("zookeeper.session.timeout.ms", "10000");
     serverProperties.put("zookeeper.sync.time.ms", "200");
+    serverProperties.put("port", String.valueOf(new Random().nextInt(9999) + 10000));
 
     kafkaConfig = new KafkaConfig(serverProperties);
 

--- a/extensions-core/kafka-extraction-namespace/src/test/java/io/druid/query/lookup/TestKafkaExtractionCluster.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/io/druid/query/lookup/TestKafkaExtractionCluster.java
@@ -59,7 +59,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  *
@@ -129,7 +129,7 @@ public class TestKafkaExtractionCluster
     serverProperties.put("zookeeper.connect", zkTestServer.getConnectString() + zkKafkaPath);
     serverProperties.put("zookeeper.session.timeout.ms", "10000");
     serverProperties.put("zookeeper.sync.time.ms", "200");
-    serverProperties.put("port", String.valueOf(new Random().nextInt(9999) + 10000));
+    serverProperties.put("port", String.valueOf(ThreadLocalRandom.current().nextInt(9999) + 10000));
 
     kafkaConfig = new KafkaConfig(serverProperties);
 

--- a/processing/src/main/java/io/druid/segment/IndexMerger.java
+++ b/processing/src/main/java/io/druid/segment/IndexMerger.java
@@ -214,24 +214,8 @@ public class IndexMerger
       ProgressIndicator progress
   ) throws IOException
   {
-    // We are materializing the list for performance reasons. Lists.transform
-    // only creates a "view" of the original list, meaning the function gets
-    // applied every time you access an element.
-    List<IndexableAdapter> indexAdapteres = Lists.newArrayList(
-        Iterables.transform(
-            indexes,
-            new Function<QueryableIndex, IndexableAdapter>()
-            {
-              @Override
-              public IndexableAdapter apply(final QueryableIndex input)
-              {
-                return new QueryableIndexIndexableAdapter(input);
-              }
-            }
-        )
-    );
     return merge(
-        indexAdapteres,
+        toIndexableAdapters(indexes),
         rollup,
         metricAggs,
         outDir,
@@ -268,6 +252,24 @@ public class IndexMerger
     );
   }
 
+  private static List<IndexableAdapter> toIndexableAdapters(List<QueryableIndex> indexes)
+  {
+    // We are materializing the list for performance reasons. Lists.transform
+    // only creates a "view" of the original list, meaning the function gets
+    // applied every time you access an element.
+    return Lists.transform(
+        indexes,
+        new Function<QueryableIndex, IndexableAdapter>()
+        {
+          @Override
+          public IndexableAdapter apply(final QueryableIndex input)
+          {
+            return new QueryableIndexIndexableAdapter(input);
+          }
+        }
+    );
+  }
+
   private static List<String> getLongestSharedDimOrder(List<IndexableAdapter> indexes)
   {
     int maxSize = 0;
@@ -301,6 +303,11 @@ public class IndexMerger
       }
     }
     return ImmutableList.copyOf(orderingCandidate);
+  }
+
+  public static List<String> getMergedDimensionsFromQueryableIndexes(List<QueryableIndex> indexes)
+  {
+    return getMergedDimensions(toIndexableAdapters(indexes));
   }
 
   public static List<String> getMergedDimensions(List<IndexableAdapter> indexes)

--- a/processing/src/main/java/io/druid/segment/IndexMerger.java
+++ b/processing/src/main/java/io/druid/segment/IndexMerger.java
@@ -257,16 +257,18 @@ public class IndexMerger
     // We are materializing the list for performance reasons. Lists.transform
     // only creates a "view" of the original list, meaning the function gets
     // applied every time you access an element.
-    return Lists.transform(
-        indexes,
-        new Function<QueryableIndex, IndexableAdapter>()
-        {
-          @Override
-          public IndexableAdapter apply(final QueryableIndex input)
-          {
-            return new QueryableIndexIndexableAdapter(input);
-          }
-        }
+    return Lists.newArrayList(
+        Iterables.transform(
+            indexes,
+            new Function<QueryableIndex, IndexableAdapter>()
+            {
+              @Override
+              public IndexableAdapter apply(final QueryableIndex input)
+              {
+                return new QueryableIndexIndexableAdapter(input);
+              }
+            }
+        )
     );
   }
 

--- a/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -42,10 +42,10 @@ import io.druid.concurrent.Execs;
 import io.druid.concurrent.TaskThreadPriority;
 import io.druid.data.input.Committer;
 import io.druid.data.input.InputRow;
-import io.druid.java.util.common.granularity.Granularity;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.Pair;
 import io.druid.java.util.common.concurrent.ScheduledExecutors;
+import io.druid.java.util.common.granularity.Granularity;
 import io.druid.query.Query;
 import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerFactoryConglomerate;
@@ -424,14 +424,12 @@ public class RealtimePlumber implements Plumber
               metrics.incrementMergeCpuTime(VMUtils.safeGetThreadCpuTime() - mergeThreadCpuTime);
               metrics.incrementMergeTimeMillis(mergeStopwatch.elapsed(TimeUnit.MILLISECONDS));
 
-              QueryableIndex index = indexIO.loadIndex(mergedFile);
               log.info("Pushing [%s] to deep storage", sink.getSegment().getIdentifier());
 
               DataSegment segment = dataSegmentPusher.push(
                   mergedFile,
-                  sink.getSegment().withDimensions(Lists.newArrayList(index.getAvailableDimensions()))
+                  sink.getSegment().withDimensions(IndexMerger.getMergedDimensionsFromQueryableIndexes(indexes))
               );
-              index.close();
               log.info("Inserting [%s] to the metadata store", sink.getSegment().getIdentifier());
               segmentPublisher.publishSegment(segment);
 

--- a/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -431,6 +431,7 @@ public class RealtimePlumber implements Plumber
                   mergedFile,
                   sink.getSegment().withDimensions(Lists.newArrayList(index.getAvailableDimensions()))
               );
+              index.close();
               log.info("Inserting [%s] to the metadata store", sink.getSegment().getIdentifier());
               segmentPublisher.publishSegment(segment);
 
@@ -861,6 +862,7 @@ public class RealtimePlumber implements Plumber
         );
         for (FireHydrant hydrant : sink) {
           cache.close(SinkQuerySegmentWalker.makeHydrantCacheIdentifier(hydrant));
+          hydrant.getSegment().close();
         }
         synchronized (handoffCondition) {
           handoffCondition.notifyAll();


### PR DESCRIPTION
I noticed the RSS memory grown to extremely large number in realtime node in one of my environments. The memory usage grows after index merge and never goes down after handoff like it in other environments.
Usually the `FileUtils.deleteDirectory(target);` can recycle mmap memory, but it doesn't work in some environment.
We should explicitly unmap hydrant files when abandonSegment to recycle mmap memory.

Also a test fix in TestKafkaExtractionCluster to use random port like in KafkaSupervisorTest. This test failed if the kafka was already started in environment(my environment is not as clean as in Travis environment)