### PR TITLE
More documentation on expected interval format for coordinator endpoints

### DIFF
--- a/docs/content/design/coordinator.md
+++ b/docs/content/design/coordinator.md
@@ -160,7 +160,7 @@ Returns a map of an interval to a map of segment metadata to a set of server nam
 
 * `/druid/coordinator/v1/datasources/{dataSourceName}/intervals/{interval}`
 
-Returns a set of segment ids for an ISO8601 interval. Note that the interval is delimited by a `_` instead of a `/`
+Returns a set of segment ids for an ISO8601 interval. Note that {interval} parameters are delimited by a `_` instead of a `/` (e.g., 2016-06-27_2016-06-28).
 
 * `/druid/coordinator/v1/datasources/{dataSourceName}/intervals/{interval}?simple`
 
@@ -223,6 +223,8 @@ Returns all rules for a specified datasource and includes default datasource.
 
 #### Intervals
 
+Note that {interval} parameters are delimited by a `_` instead of a `/` (e.g., 2016-06-27_2016-06-28).
+
 * `/druid/coordinator/v1/intervals`
 
 Returns all intervals for all datasources with total size and count.
@@ -277,6 +279,8 @@ Disables a datasource.
 * `@Deprecated. /druid/coordinator/v1/datasources/{dataSourceName}?kill=true&interval={myISO8601Interval}`
 
 Runs a [Kill task](../ingestion/tasks.html) for a given interval and datasource.
+
+Note that {interval} parameters are delimited by a `_` instead of a `/` (e.g., 2016-06-27_2016-06-28).
 
 * `/druid/coordinator/v1/datasources/{dataSourceName}/segments/{segmentId}`
 


### PR DESCRIPTION
Updates the coordinator docs to clarify the expected format for {interval}, putting a note in all places where such a parameter appears.