### PR TITLE
SQL: More forgiving Avatica server.

### DIFF
--- a/sql/src/main/java/io/druid/sql/avatica/AvaticaServerConfig.java
+++ b/sql/src/main/java/io/druid/sql/avatica/AvaticaServerConfig.java
@@ -31,7 +31,7 @@ public class AvaticaServerConfig
   public int maxStatementsPerConnection = 4;
 
   @JsonProperty
-  public Period connectionIdleTimeout = new Period("PT30M");
+  public Period connectionIdleTimeout = new Period("PT5M");
 
   public int getMaxConnections()
   {

--- a/sql/src/main/java/io/druid/sql/avatica/DruidConnection.java
+++ b/sql/src/main/java/io/druid/sql/avatica/DruidConnection.java
@@ -19,43 +19,123 @@
 
 package io.druid.sql.avatica;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.druid.java.util.common.ISE;
+import io.druid.java.util.common.logger.Logger;
 
+import javax.annotation.concurrent.GuardedBy;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Connection tracking for {@link DruidMeta}. Not thread-safe.
+ * Connection tracking for {@link DruidMeta}. Thread-safe.
  */
 public class DruidConnection
 {
-  private final Map<String, Object> context;
-  private final Map<Integer, DruidStatement> statements;
-  private Future<?> timeoutFuture;
+  private static final Logger log = new Logger(DruidConnection.class);
 
-  public DruidConnection(final Map<String, Object> context)
+  private final String connectionId;
+  private final int maxStatements;
+  private final ImmutableMap<String, Object> context;
+  private final AtomicInteger statementCounter = new AtomicInteger();
+  private final AtomicReference<Future<?>> timeoutFuture = new AtomicReference<>();
+
+  @GuardedBy("statements")
+  private final Map<Integer, DruidStatement> statements;
+
+  @GuardedBy("statements")
+  private boolean open = true;
+
+  public DruidConnection(final String connectionId, final int maxStatements, final Map<String, Object> context)
   {
+    this.connectionId = Preconditions.checkNotNull(connectionId);
+    this.maxStatements = maxStatements;
     this.context = ImmutableMap.copyOf(context);
     this.statements = new HashMap<>();
   }
 
-  public Map<String, Object> context()
+  public DruidStatement createStatement()
   {
-    return context;
+    final int statementId = statementCounter.incrementAndGet();
+
+    synchronized (statements) {
+      if (statements.containsKey(statementId)) {
+        // Will only happen if statementCounter rolls over before old statements are cleaned up. If this
+        // ever happens then something fishy is going on, because we shouldn't have billions of statements.
+        throw new ISE("Uh oh, too many statements");
+      }
+
+      if (statements.size() >= maxStatements) {
+        throw new ISE("Too many open statements, limit is[%,d]", maxStatements);
+      }
+
+      final DruidStatement statement = new DruidStatement(connectionId, statementId, context, () -> {
+        // onClose function for the statement
+        synchronized (statements) {
+          log.debug("Connection[%s] closed statement[%s].", connectionId, statementId);
+          statements.remove(statementId);
+        }
+      });
+
+      statements.put(statementId, statement);
+      log.debug("Connection[%s] opened statement[%s].", connectionId, statementId);
+      return statement;
+    }
   }
 
-  public Map<Integer, DruidStatement> statements()
+  public DruidStatement getStatement(final int statementId)
   {
-    return statements;
+    synchronized (statements) {
+      return statements.get(statementId);
+    }
+  }
+
+  /**
+   * Closes this connection if it has no statements.
+   *
+   * @return true if closed
+   */
+  public boolean closeIfEmpty()
+  {
+    synchronized (statements) {
+      if (statements.isEmpty()) {
+        close();
+        return true;
+      } else {
+        return false;
+      }
+    }
+  }
+
+  public void close()
+  {
+    synchronized (statements) {
+      // Copy statements before iterating because statement.close() modifies it.
+      for (DruidStatement statement : ImmutableList.copyOf(statements.values())) {
+        try {
+          statement.close();
+        }
+        catch (Exception e) {
+          log.warn("Connection[%s] failed to close statement[%s]!", connectionId, statement.getStatementId());
+        }
+      }
+
+      log.debug("Connection[%s] closed.", connectionId);
+      open = false;
+    }
   }
 
   public DruidConnection sync(final Future<?> newTimeoutFuture)
   {
-    if (timeoutFuture != null) {
-      timeoutFuture.cancel(false);
+    final Future<?> oldFuture = timeoutFuture.getAndSet(newTimeoutFuture);
+    if (oldFuture != null) {
+      oldFuture.cancel(false);
     }
-    timeoutFuture = newTimeoutFuture;
     return this;
   }
 }

--- a/sql/src/main/java/io/druid/sql/avatica/DruidStatement.java
+++ b/sql/src/main/java/io/druid/sql/avatica/DruidStatement.java
@@ -21,6 +21,7 @@ package io.druid.sql.avatica;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.guava.Sequences;
@@ -80,7 +81,7 @@ public class DruidStatement implements Closeable
   {
     this.connectionId = Preconditions.checkNotNull(connectionId, "connectionId");
     this.statementId = statementId;
-    this.queryContext = Preconditions.checkNotNull(queryContext, "queryContext");
+    this.queryContext = queryContext == null ? ImmutableMap.of() : queryContext;
     this.onClose = Preconditions.checkNotNull(onClose, "onClose");
   }
 

--- a/sql/src/main/java/io/druid/sql/avatica/DruidStatement.java
+++ b/sql/src/main/java/io/druid/sql/avatica/DruidStatement.java
@@ -30,7 +30,6 @@ import io.druid.sql.calcite.planner.DruidPlanner;
 import io.druid.sql.calcite.planner.PlannerFactory;
 import io.druid.sql.calcite.planner.PlannerResult;
 import io.druid.sql.calcite.rel.QueryMaker;
-import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.ColumnMetaData;
 import org.apache.calcite.avatica.Meta;
 import org.apache.calcite.rel.type.RelDataType;
@@ -38,7 +37,6 @@ import org.apache.calcite.rel.type.RelDataTypeField;
 
 import javax.annotation.concurrent.GuardedBy;
 import java.io.Closeable;
-import java.io.IOException;
 import java.sql.DatabaseMetaData;
 import java.util.ArrayList;
 import java.util.List;
@@ -62,6 +60,7 @@ public class DruidStatement implements Closeable
   private final String connectionId;
   private final int statementId;
   private final Map<String, Object> queryContext;
+  private final Runnable onClose;
   private final Object lock = new Object();
 
   private State state = State.NEW;
@@ -72,11 +71,17 @@ public class DruidStatement implements Closeable
   private Yielder<Object[]> yielder;
   private int offset = 0;
 
-  public DruidStatement(final String connectionId, final int statementId, final Map<String, Object> queryContext)
+  public DruidStatement(
+      final String connectionId,
+      final int statementId,
+      final Map<String, Object> queryContext,
+      final Runnable onClose
+  )
   {
-    this.connectionId = connectionId;
+    this.connectionId = Preconditions.checkNotNull(connectionId, "connectionId");
     this.statementId = statementId;
-    this.queryContext = queryContext;
+    this.queryContext = Preconditions.checkNotNull(queryContext, "queryContext");
+    this.onClose = Preconditions.checkNotNull(onClose, "onClose");
   }
 
   public static List<ColumnMetaData> createColumnMetaData(final RelDataType rowType)
@@ -134,15 +139,21 @@ public class DruidStatement implements Closeable
         this.signature = Meta.Signature.create(
             createColumnMetaData(plannerResult.rowType()),
             query,
-            new ArrayList<AvaticaParameter>(),
+            new ArrayList<>(),
             Meta.CursorFactory.ARRAY,
             Meta.StatementType.SELECT // We only support SELECT
         );
         this.state = State.PREPARED;
       }
     }
-    catch (Exception e) {
-      throw Throwables.propagate(e);
+    catch (Throwable t) {
+      try {
+        close();
+      }
+      catch (Throwable t1) {
+        t.addSuppressed(t1);
+      }
+      throw Throwables.propagate(t);
     }
 
     return this;
@@ -153,16 +164,27 @@ public class DruidStatement implements Closeable
     synchronized (lock) {
       ensure(State.PREPARED);
 
-      final Sequence<Object[]> baseSequence = plannerResult.run();
+      try {
+        final Sequence<Object[]> baseSequence = plannerResult.run();
 
-      // We can't apply limits greater than Integer.MAX_VALUE, ignore them.
-      final Sequence<Object[]> retSequence =
-          maxRowCount >= 0 && maxRowCount <= Integer.MAX_VALUE
-          ? Sequences.limit(baseSequence, (int) maxRowCount)
-          : baseSequence;
+        // We can't apply limits greater than Integer.MAX_VALUE, ignore them.
+        final Sequence<Object[]> retSequence =
+            maxRowCount >= 0 && maxRowCount <= Integer.MAX_VALUE
+            ? Sequences.limit(baseSequence, (int) maxRowCount)
+            : baseSequence;
 
-      yielder = Yielders.each(retSequence);
-      state = State.RUNNING;
+        yielder = Yielders.each(retSequence);
+        state = State.RUNNING;
+      }
+      catch (Throwable t) {
+        try {
+          close();
+        }
+        catch (Throwable t1) {
+          t.addSuppressed(t1);
+        }
+        throw t;
+      }
 
       return this;
     }
@@ -254,18 +276,39 @@ public class DruidStatement implements Closeable
   public void close()
   {
     synchronized (lock) {
+      final State oldState = state;
       state = State.DONE;
 
-      if (yielder != null) {
-        Yielder<Object[]> theYielder = this.yielder;
-        this.yielder = null;
+      try {
+        if (yielder != null) {
+          Yielder<Object[]> theYielder = this.yielder;
+          this.yielder = null;
 
-        // Put the close last, so any exceptions it throws are after we did the other cleanup above.
-        try {
+          // Put the close last, so any exceptions it throws are after we did the other cleanup above.
           theYielder.close();
         }
-        catch (IOException e) {
-          throw Throwables.propagate(e);
+      }
+      catch (Throwable t) {
+        if (oldState != State.DONE) {
+          // First close. Run the onClose function.
+          try {
+            onClose.run();
+          }
+          catch (Throwable t1) {
+            t.addSuppressed(t1);
+          }
+        }
+
+        throw Throwables.propagate(t);
+      }
+
+      if (oldState != State.DONE) {
+        // First close. Run the onClose function.
+        try {
+          onClose.run();
+        }
+        catch (Throwable t) {
+          throw Throwables.propagate(t);
         }
       }
     }

--- a/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
+++ b/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
@@ -102,6 +102,8 @@ public class DruidAvaticaHandlerTest
   private Server server;
   private Connection client;
   private Connection clientLosAngeles;
+  private DruidMeta druidMeta;
+  private String url;
 
   @Before
   public void setUp() throws Exception
@@ -116,11 +118,12 @@ public class DruidAvaticaHandlerTest
         )
     );
     final DruidOperatorTable operatorTable = CalciteTests.createOperatorTable();
+    druidMeta = new DruidMeta(
+        new PlannerFactory(rootSchema, walker, operatorTable, plannerConfig, new ServerConfig()),
+        AVATICA_CONFIG
+    );
     final DruidAvaticaHandler handler = new DruidAvaticaHandler(
-        new DruidMeta(
-            new PlannerFactory(rootSchema, walker, operatorTable, plannerConfig, new ServerConfig()),
-            AVATICA_CONFIG
-        ),
+        druidMeta,
         new DruidNode("dummy", "dummy", 1),
         new AvaticaMonitor()
     );
@@ -128,7 +131,7 @@ public class DruidAvaticaHandlerTest
     server = new Server(new InetSocketAddress("127.0.0.1", port));
     server.setHandler(handler);
     server.start();
-    final String url = String.format(
+    url = String.format(
         "jdbc:avatica:remote:url=http://127.0.0.1:%d%s",
         port,
         DruidAvaticaHandler.AVATICA_PATH
@@ -423,6 +426,90 @@ public class DruidAvaticaHandlerTest
     client.createStatement().close();
     client.createStatement().close();
 
+    Assert.assertTrue(true);
+  }
+
+  @Test
+  public void testNotTooManyStatementsWhenYouFullyIterateThem() throws Exception
+  {
+    for (int i = 0; i < 50; i++) {
+      final ResultSet resultSet = client.createStatement().executeQuery(
+          "SELECT COUNT(*) AS cnt FROM druid.foo"
+      );
+      Assert.assertEquals(
+          ImmutableList.of(
+              ImmutableMap.of("cnt", 6L)
+          ),
+          getRows(resultSet)
+      );
+    }
+
+    Assert.assertTrue(true);
+  }
+
+  @Test
+  public void testNotTooManyStatementsWhenTheyThrowErrors() throws Exception
+  {
+    for (int i = 0; i < 50; i++) {
+      Exception thrown = null;
+      try {
+        client.createStatement().executeQuery("SELECT SUM(nonexistent) FROM druid.foo");
+      }
+      catch (Exception e) {
+        thrown = e;
+      }
+
+      Assert.assertNotNull(thrown);
+
+      final ResultSet resultSet = client.createStatement().executeQuery("SELECT COUNT(*) AS cnt FROM druid.foo");
+      Assert.assertEquals(
+          ImmutableList.of(ImmutableMap.of("cnt", 6L)),
+          getRows(resultSet)
+      );
+    }
+
+    Assert.assertTrue(true);
+  }
+
+  @Test
+  public void testAutoReconnectOnNoSuchConnection() throws Exception
+  {
+    for (int i = 0; i < 50; i++) {
+      final ResultSet resultSet = client.createStatement().executeQuery("SELECT COUNT(*) AS cnt FROM druid.foo");
+      Assert.assertEquals(
+          ImmutableList.of(ImmutableMap.of("cnt", 6L)),
+          getRows(resultSet)
+      );
+      druidMeta.closeAllConnections();
+    }
+
+    Assert.assertTrue(true);
+  }
+
+  @Test
+  public void testTooManyConnections() throws Exception
+  {
+    final Connection connection1 = DriverManager.getConnection(url);
+    final Statement statement1 = connection1.createStatement();
+
+    final Connection connection2 = DriverManager.getConnection(url);
+    final Statement statement2 = connection2.createStatement();
+
+    expectedException.expect(AvaticaClientRuntimeException.class);
+    expectedException.expectMessage("Too many connections, limit is[2]");
+    final Connection connection3 = DriverManager.getConnection(url);
+  }
+
+  @Test
+  public void testNotTooManyConnectionsWhenTheyAreEmpty() throws Exception
+  {
+    final Connection connection1 = DriverManager.getConnection(url);
+    connection1.createStatement().close();
+
+    final Connection connection2 = DriverManager.getConnection(url);
+    connection2.createStatement().close();
+
+    final Connection connection3 = DriverManager.getConnection(url);
     Assert.assertTrue(true);
   }
 

--- a/sql/src/test/java/io/druid/sql/avatica/DruidStatementTest.java
+++ b/sql/src/test/java/io/druid/sql/avatica/DruidStatementTest.java
@@ -80,7 +80,7 @@ public class DruidStatementTest
   public void testSignature() throws Exception
   {
     final String sql = "SELECT * FROM druid.foo";
-    final DruidStatement statement = new DruidStatement("", 0, null).prepare(plannerFactory, sql, -1);
+    final DruidStatement statement = new DruidStatement("", 0, null, () -> {}).prepare(plannerFactory, sql, -1);
 
     // Check signature.
     final Meta.Signature signature = statement.getSignature();
@@ -118,7 +118,7 @@ public class DruidStatementTest
   public void testSelectAllInFirstFrame() throws Exception
   {
     final String sql = "SELECT __time, cnt, dim1, dim2, m1 FROM druid.foo";
-    final DruidStatement statement = new DruidStatement("", 0, null).prepare(plannerFactory, sql, -1);
+    final DruidStatement statement = new DruidStatement("", 0, null, () -> {}).prepare(plannerFactory, sql, -1);
 
     // First frame, ask for all rows.
     Meta.Frame frame = statement.execute().nextFrame(DruidStatement.START_OFFSET, 6);
@@ -144,7 +144,7 @@ public class DruidStatementTest
   public void testSelectSplitOverTwoFrames() throws Exception
   {
     final String sql = "SELECT __time, cnt, dim1, dim2, m1 FROM druid.foo";
-    final DruidStatement statement = new DruidStatement("", 0, null).prepare(plannerFactory, sql, -1);
+    final DruidStatement statement = new DruidStatement("", 0, null, () -> {}).prepare(plannerFactory, sql, -1);
 
     // First frame, ask for 2 rows.
     Meta.Frame frame = statement.execute().nextFrame(DruidStatement.START_OFFSET, 2);


### PR DESCRIPTION
Some changes to make life easier for users that aren't being completely scrupulous 
with closing connections and statements. And also, for dealing with the realities that
 sometimes clients crash and we need to clean up stale connections promptly or else 
the server becomes unresponsive to new ones.

- Automatically close statements that are fully iterated or that have
  errors, to prevent dangling statements from causing clients to hit
  open statement limits.
- Empower client auto-reconnects by throwing NoSuchConnectionException
  when appropriate.
- Try to close empty connections when we hit the open connection limit,
  rather than failing the newly opened connection. Client
  auto-reconnections mean this shouldn't cause problems in practice.
- Improve concurrency of the server by making "connections" a
  concurrent map.
- Lower default connection timeout to PT5M from PT30M.