### PR TITLE
Remove queryMetricsFactory from GroupByQueryConfig

### DIFF
--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryConfig.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryConfig.java
@@ -70,9 +70,6 @@ public class GroupByQueryConfig
   @JsonProperty
   private boolean forcePushDownLimit = false;
 
-  @JsonProperty
-  private Class<? extends GroupByQueryMetricsFactory> queryMetricsFactory;
-
   public String getDefaultStrategy()
   {
     return defaultStrategy;
@@ -136,16 +133,6 @@ public class GroupByQueryConfig
   public boolean isForcePushDownLimit()
   {
     return forcePushDownLimit;
-  }
-
-  public Class<? extends GroupByQueryMetricsFactory> getQueryMetricsFactory()
-  {
-    return queryMetricsFactory != null ? queryMetricsFactory : DefaultGroupByQueryMetricsFactory.class;
-  }
-
-  public void setQueryMetricsFactory(Class<? extends GroupByQueryMetricsFactory> queryMetricsFactory)
-  {
-    this.queryMetricsFactory = queryMetricsFactory;
   }
   
   public GroupByQueryConfig withOverrides(final GroupByQuery query)


### PR DESCRIPTION
PR #3873 erroneously re-included code that was removed in PR #4336:

https://github.com/druid-io/druid/pull/4336/files#diff-5e30ea112240e82f233099071bb3389e