### PR TITLE
Add legacy constructor to CsvParseSpec and DelimitedParseSpec for backward compatibility

### DIFF
--- a/api/src/main/java/io/druid/data/input/impl/CSVParseSpec.java
+++ b/api/src/main/java/io/druid/data/input/impl/CSVParseSpec.java
@@ -70,10 +70,10 @@ public class CSVParseSpec extends ParseSpec
 
   @Deprecated
   public CSVParseSpec(
-      @JsonProperty("timestampSpec") TimestampSpec timestampSpec,
-      @JsonProperty("dimensionsSpec") DimensionsSpec dimensionsSpec,
-      @JsonProperty("listDelimiter") String listDelimiter,
-      @JsonProperty("columns") List<String> columns
+      TimestampSpec timestampSpec,
+      DimensionsSpec dimensionsSpec,
+      String listDelimiter,
+      List<String> columns
   )
   {
     this(timestampSpec, dimensionsSpec, listDelimiter, columns, false, 0);

--- a/api/src/main/java/io/druid/data/input/impl/CSVParseSpec.java
+++ b/api/src/main/java/io/druid/data/input/impl/CSVParseSpec.java
@@ -68,6 +68,17 @@ public class CSVParseSpec extends ParseSpec
     }
   }
 
+  @Deprecated
+  public CSVParseSpec(
+      @JsonProperty("timestampSpec") TimestampSpec timestampSpec,
+      @JsonProperty("dimensionsSpec") DimensionsSpec dimensionsSpec,
+      @JsonProperty("listDelimiter") String listDelimiter,
+      @JsonProperty("columns") List<String> columns
+  )
+  {
+    this(timestampSpec, dimensionsSpec, listDelimiter, columns, false, 0);
+  }
+
   @JsonProperty
   public String getListDelimiter()
   {

--- a/api/src/main/java/io/druid/data/input/impl/DelimitedParseSpec.java
+++ b/api/src/main/java/io/druid/data/input/impl/DelimitedParseSpec.java
@@ -71,6 +71,18 @@ public class DelimitedParseSpec extends ParseSpec
     }
   }
 
+  @Deprecated
+  public DelimitedParseSpec(
+      TimestampSpec timestampSpec,
+      DimensionsSpec dimensionsSpec,
+      String delimiter,
+      String listDelimiter,
+      List<String> columns
+  )
+  {
+    this(timestampSpec, dimensionsSpec, delimiter, listDelimiter, columns, false, 0);
+  }
+
   @JsonProperty("delimiter")
   public String getDelimiter()
   {


### PR DESCRIPTION
Some external users are using this API, so the legacy constructor is needed (https://github.com/druid-io/druid/pull/4254#discussion_r121013256).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/druid-io/druid/4388)
<!-- Reviewable:end -->
