### PR TITLE
Increase timeout for QueryGranularityTest.testDeadLock()

### DIFF
--- a/processing/src/test/java/io/druid/granularity/QueryGranularityTest.java
+++ b/processing/src/test/java/io/druid/granularity/QueryGranularityTest.java
@@ -804,7 +804,7 @@ public class QueryGranularityTest
     Assert.assertFalse("expectedIter not exhausted!?", expectedIter.hasNext());
   }
 
-  @Test(timeout = 10_000L)
+  @Test(timeout = 60_000L)
   public void testDeadLock() throws Exception
   {
     final URL[] urls = ((URLClassLoader) Granularity.class.getClassLoader()).getURLs();


### PR DESCRIPTION
From stack traces, it seems that the reason for #4393, frequent failure of `QueryGranularityTest.testDeadLock()` is just that 10 seconds is not enough to perform this test, it runs for 5-6 seconds on average on my powerful dev machine with SSD, so it could easily be more than 10 seconds on Travis. Increasing timeout to 60 seconds.

