### PR TITLE
Allow use of non-threadsafe ObjectCachingColumnSelectorFactory

### DIFF
--- a/api/src/main/java/io/druid/data/input/impl/DimensionsSpec.java
+++ b/api/src/main/java/io/druid/data/input/impl/DimensionsSpec.java
@@ -44,10 +44,7 @@ public class DimensionsSpec
   private final Set<String> dimensionExclusions;
   private final Map<String, DimensionSchema> dimensionSchemaMap;
 
-  public static DimensionsSpec ofEmpty()
-  {
-    return new DimensionsSpec(null, null, null);
-  }
+  public static final DimensionsSpec EMPTY = new DimensionsSpec(null, null, null);
 
   public static List<DimensionSchema> getDefaultSchemas(List<String> dimNames)
   {

--- a/benchmarks/src/main/java/io/druid/benchmark/FilterPartitionBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/FilterPartitionBenchmark.java
@@ -29,7 +29,6 @@ import io.druid.benchmark.datagen.BenchmarkDataGenerator;
 import io.druid.benchmark.datagen.BenchmarkSchemaInfo;
 import io.druid.benchmark.datagen.BenchmarkSchemas;
 import io.druid.data.input.InputRow;
-import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.hll.HyperLogLogHash;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.granularity.Granularities;
@@ -73,7 +72,6 @@ import io.druid.segment.filter.OrFilter;
 import io.druid.segment.filter.SelectorFilter;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
 import org.apache.commons.io.FileUtils;
 import org.joda.time.Interval;
@@ -228,17 +226,15 @@ public class FilterPartitionBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex.Builder()
+    return new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-                .withQueryGranularity(Granularities.NONE)
                 .withMetrics(schemaInfo.getAggsArray())
-                .withDimensionsSpec(DimensionsSpec.ofEmpty())
                 .build()
         )
         .setReportParseExceptions(false)
         .setMaxRowCount(rowsPerSegment)
-        .build();
+        .buildOnheap();
   }
 
   @Benchmark

--- a/benchmarks/src/main/java/io/druid/benchmark/FilterPartitionBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/FilterPartitionBenchmark.java
@@ -228,17 +228,17 @@ public class FilterPartitionBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex(
-        new IncrementalIndexSchema.Builder()
-            .withQueryGranularity(Granularities.NONE)
-            .withMetrics(schemaInfo.getAggsArray())
-            .withDimensionsSpec(new DimensionsSpec(null, null, null))
-            .build(),
-        true,
-        false,
-        true,
-        rowsPerSegment
-    );
+    return new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withQueryGranularity(Granularities.NONE)
+                .withMetrics(schemaInfo.getAggsArray())
+                .withDimensionsSpec(DimensionsSpec.ofEmpty())
+                .build()
+        )
+        .setReportParseExceptions(false)
+        .setMaxRowCount(rowsPerSegment)
+        .build();
   }
 
   @Benchmark

--- a/benchmarks/src/main/java/io/druid/benchmark/FilterPartitionBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/FilterPartitionBenchmark.java
@@ -71,7 +71,6 @@ import io.druid.segment.filter.Filters;
 import io.druid.segment.filter.OrFilter;
 import io.druid.segment.filter.SelectorFilter;
 import io.druid.segment.incremental.IncrementalIndex;
-import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.serde.ComplexMetrics;
 import org.apache.commons.io.FileUtils;
 import org.joda.time.Interval;
@@ -227,11 +226,7 @@ public class FilterPartitionBenchmark
   private IncrementalIndex makeIncIndex()
   {
     return new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
-            new IncrementalIndexSchema.Builder()
-                .withMetrics(schemaInfo.getAggsArray())
-                .build()
-        )
+        .setSimpleTestingIndexSchema(schemaInfo.getAggsArray())
         .setReportParseExceptions(false)
         .setMaxRowCount(rowsPerSegment)
         .buildOnheap();

--- a/benchmarks/src/main/java/io/druid/benchmark/FilteredAggregatorBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/FilteredAggregatorBenchmark.java
@@ -239,17 +239,17 @@ public class FilteredAggregatorBenchmark
 
   private IncrementalIndex makeIncIndex(AggregatorFactory[] metrics)
   {
-    return new OnheapIncrementalIndex(
-        new IncrementalIndexSchema.Builder()
-            .withQueryGranularity(Granularities.NONE)
-            .withMetrics(metrics)
-            .withDimensionsSpec(new DimensionsSpec(null, null, null))
-            .build(),
-        true,
-        false,
-        true,
-        rowsPerSegment
-    );
+    return new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withQueryGranularity(Granularities.NONE)
+                .withMetrics(metrics)
+                .withDimensionsSpec(DimensionsSpec.ofEmpty())
+                .build()
+        )
+        .setReportParseExceptions(false)
+        .setMaxRowCount(rowsPerSegment)
+        .build();
   }
 
   private static <T> List<T> runQuery(QueryRunnerFactory factory, QueryRunner runner, Query<T> query)

--- a/benchmarks/src/main/java/io/druid/benchmark/FilteredAggregatorBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/FilteredAggregatorBenchmark.java
@@ -72,7 +72,6 @@ import io.druid.segment.QueryableIndex;
 import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
-import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.serde.ComplexMetrics;
 import org.apache.commons.io.FileUtils;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -238,11 +237,7 @@ public class FilteredAggregatorBenchmark
   private IncrementalIndex makeIncIndex(AggregatorFactory[] metrics)
   {
     return new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
-            new IncrementalIndexSchema.Builder()
-                .withMetrics(metrics)
-                .build()
-        )
+        .setSimpleTestingIndexSchema(metrics)
         .setReportParseExceptions(false)
         .setMaxRowCount(rowsPerSegment)
         .buildOnheap();

--- a/benchmarks/src/main/java/io/druid/benchmark/FilteredAggregatorBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/FilteredAggregatorBenchmark.java
@@ -28,7 +28,6 @@ import io.druid.benchmark.datagen.BenchmarkSchemaInfo;
 import io.druid.benchmark.datagen.BenchmarkSchemas;
 import io.druid.benchmark.query.QueryBenchmarkUtil;
 import io.druid.data.input.InputRow;
-import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.hll.HyperLogLogHash;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.granularity.Granularities;
@@ -74,7 +73,6 @@ import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
 import org.apache.commons.io.FileUtils;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -239,17 +237,15 @@ public class FilteredAggregatorBenchmark
 
   private IncrementalIndex makeIncIndex(AggregatorFactory[] metrics)
   {
-    return new OnheapIncrementalIndex.Builder()
+    return new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-                .withQueryGranularity(Granularities.NONE)
                 .withMetrics(metrics)
-                .withDimensionsSpec(DimensionsSpec.ofEmpty())
                 .build()
         )
         .setReportParseExceptions(false)
         .setMaxRowCount(rowsPerSegment)
-        .build();
+        .buildOnheap();
   }
 
   private static <T> List<T> runQuery(QueryRunnerFactory factory, QueryRunner runner, Query<T> query)

--- a/benchmarks/src/main/java/io/druid/benchmark/GroupByTypeInterfaceBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/GroupByTypeInterfaceBenchmark.java
@@ -433,18 +433,18 @@ public class GroupByTypeInterfaceBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex(
-        new IncrementalIndexSchema.Builder()
+    return new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
             .withQueryGranularity(Granularities.NONE)
             .withMetrics(schemaInfo.getAggsArray())
-            .withDimensionsSpec(new DimensionsSpec(null, null, null))
-            .build(),
-        true,
-        false,
-        true,
-        true,
-        rowsPerSegment
-    );
+            .withDimensionsSpec(DimensionsSpec.ofEmpty())
+            .build()
+        )
+        .setReportParseExceptions(false)
+        .setConcurrentEventAdd(true)
+        .setMaxRowCount(rowsPerSegment)
+        .build();
   }
 
   @TearDown(Level.Trial)

--- a/benchmarks/src/main/java/io/druid/benchmark/GroupByTypeInterfaceBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/GroupByTypeInterfaceBenchmark.java
@@ -72,7 +72,6 @@ import io.druid.segment.QueryableIndex;
 import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
-import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.serde.ComplexMetrics;
 import org.apache.commons.io.FileUtils;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -432,11 +431,7 @@ public class GroupByTypeInterfaceBenchmark
   private IncrementalIndex makeIncIndex()
   {
     return new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
-            new IncrementalIndexSchema.Builder()
-            .withMetrics(schemaInfo.getAggsArray())
-            .build()
-        )
+        .setSimpleTestingIndexSchema(schemaInfo.getAggsArray())
         .setReportParseExceptions(false)
         .setConcurrentEventAdd(true)
         .setMaxRowCount(rowsPerSegment)

--- a/benchmarks/src/main/java/io/druid/benchmark/GroupByTypeInterfaceBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/GroupByTypeInterfaceBenchmark.java
@@ -442,6 +442,7 @@ public class GroupByTypeInterfaceBenchmark
         true,
         false,
         true,
+        true,
         rowsPerSegment
     );
   }

--- a/benchmarks/src/main/java/io/druid/benchmark/GroupByTypeInterfaceBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/GroupByTypeInterfaceBenchmark.java
@@ -36,7 +36,6 @@ import io.druid.collections.StupidPool;
 import io.druid.concurrent.Execs;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.Row;
-import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.hll.HyperLogLogHash;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.granularity.Granularities;
@@ -74,7 +73,6 @@ import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
 import org.apache.commons.io.FileUtils;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -433,18 +431,16 @@ public class GroupByTypeInterfaceBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex.Builder()
+    return new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-            .withQueryGranularity(Granularities.NONE)
             .withMetrics(schemaInfo.getAggsArray())
-            .withDimensionsSpec(DimensionsSpec.ofEmpty())
             .build()
         )
         .setReportParseExceptions(false)
         .setConcurrentEventAdd(true)
         .setMaxRowCount(rowsPerSegment)
-        .build();
+        .buildOnheap();
   }
 
   @TearDown(Level.Trial)

--- a/benchmarks/src/main/java/io/druid/benchmark/IncrementalIndexRowTypeBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/IncrementalIndexRowTypeBenchmark.java
@@ -27,7 +27,6 @@ import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.query.aggregation.DoubleSumAggregatorFactory;
 import io.druid.query.aggregation.LongSumAggregatorFactory;
 import io.druid.segment.incremental.IncrementalIndex;
-import io.druid.segment.incremental.IncrementalIndexSchema;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Level;
@@ -120,11 +119,7 @@ public class IncrementalIndexRowTypeBenchmark
   private IncrementalIndex makeIncIndex()
   {
     return new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
-            new IncrementalIndexSchema.Builder()
-                .withMetrics(aggs)
-                .build()
-        )
+        .setSimpleTestingIndexSchema(aggs)
         .setDeserializeComplexMetrics(false)
         .setReportParseExceptions(false)
         .setMaxRowCount(maxRows)

--- a/benchmarks/src/main/java/io/druid/benchmark/IncrementalIndexRowTypeBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/IncrementalIndexRowTypeBenchmark.java
@@ -28,6 +28,7 @@ import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.query.aggregation.DoubleSumAggregatorFactory;
 import io.druid.query.aggregation.LongSumAggregatorFactory;
 import io.druid.segment.incremental.IncrementalIndex;
+import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -120,15 +121,19 @@ public class IncrementalIndexRowTypeBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex(
-        0,
-        Granularities.NONE,
-        aggs,
-        false,
-        false,
-        true,
-        maxRows
-    );
+    return new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withMinTimestamp(0)
+                .withQueryGranularity(Granularities.NONE)
+                .withMetrics(aggs)
+                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .build()
+        )
+        .setDeserializeComplexMetrics(false)
+        .setReportParseExceptions(false)
+        .setMaxRowCount(maxRows)
+        .build();
   }
 
   @Setup

--- a/benchmarks/src/main/java/io/druid/benchmark/IncrementalIndexRowTypeBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/IncrementalIndexRowTypeBenchmark.java
@@ -22,14 +22,12 @@ package io.druid.benchmark;
 import com.google.common.collect.ImmutableMap;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.MapBasedInputRow;
-import io.druid.java.util.common.granularity.Granularities;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.query.aggregation.DoubleSumAggregatorFactory;
 import io.druid.query.aggregation.LongSumAggregatorFactory;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Level;
@@ -121,19 +119,16 @@ public class IncrementalIndexRowTypeBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex.Builder()
+    return new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-                .withMinTimestamp(0)
-                .withQueryGranularity(Granularities.NONE)
                 .withMetrics(aggs)
-                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
                 .build()
         )
         .setDeserializeComplexMetrics(false)
         .setReportParseExceptions(false)
         .setMaxRowCount(maxRows)
-        .build();
+        .buildOnheap();
   }
 
   @Setup

--- a/benchmarks/src/main/java/io/druid/benchmark/TopNTypeInterfaceBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/TopNTypeInterfaceBenchmark.java
@@ -314,17 +314,17 @@ public class TopNTypeInterfaceBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex(
-        new IncrementalIndexSchema.Builder()
-            .withQueryGranularity(Granularities.NONE)
-            .withMetrics(schemaInfo.getAggsArray())
-            .withDimensionsSpec(new DimensionsSpec(null, null, null))
-            .build(),
-        true,
-        false,
-        true,
-        rowsPerSegment
-    );
+    return new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withQueryGranularity(Granularities.NONE)
+                .withMetrics(schemaInfo.getAggsArray())
+                .withDimensionsSpec(DimensionsSpec.ofEmpty())
+                .build()
+        )
+        .setReportParseExceptions(false)
+        .setMaxRowCount(rowsPerSegment)
+        .build();
   }
 
   private static <T> List<T> runQuery(QueryRunnerFactory factory, QueryRunner runner, Query<T> query)

--- a/benchmarks/src/main/java/io/druid/benchmark/TopNTypeInterfaceBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/TopNTypeInterfaceBenchmark.java
@@ -69,7 +69,6 @@ import io.druid.segment.QueryableIndex;
 import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
-import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.serde.ComplexMetrics;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -313,11 +312,7 @@ public class TopNTypeInterfaceBenchmark
   private IncrementalIndex makeIncIndex()
   {
     return new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
-            new IncrementalIndexSchema.Builder()
-                .withMetrics(schemaInfo.getAggsArray())
-                .build()
-        )
+        .setSimpleTestingIndexSchema(schemaInfo.getAggsArray())
         .setReportParseExceptions(false)
         .setMaxRowCount(rowsPerSegment)
         .buildOnheap();

--- a/benchmarks/src/main/java/io/druid/benchmark/TopNTypeInterfaceBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/TopNTypeInterfaceBenchmark.java
@@ -30,7 +30,6 @@ import io.druid.benchmark.query.QueryBenchmarkUtil;
 import io.druid.collections.StupidPool;
 import io.druid.concurrent.Execs;
 import io.druid.data.input.InputRow;
-import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.hll.HyperLogLogHash;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.granularity.Granularities;
@@ -71,7 +70,6 @@ import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -314,17 +312,15 @@ public class TopNTypeInterfaceBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex.Builder()
+    return new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-                .withQueryGranularity(Granularities.NONE)
                 .withMetrics(schemaInfo.getAggsArray())
-                .withDimensionsSpec(DimensionsSpec.ofEmpty())
                 .build()
         )
         .setReportParseExceptions(false)
         .setMaxRowCount(rowsPerSegment)
-        .build();
+        .buildOnheap();
   }
 
   private static <T> List<T> runQuery(QueryRunnerFactory factory, QueryRunner runner, Query<T> query)

--- a/benchmarks/src/main/java/io/druid/benchmark/indexing/IncrementalIndexReadBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/indexing/IncrementalIndexReadBenchmark.java
@@ -24,7 +24,6 @@ import io.druid.benchmark.datagen.BenchmarkDataGenerator;
 import io.druid.benchmark.datagen.BenchmarkSchemaInfo;
 import io.druid.benchmark.datagen.BenchmarkSchemas;
 import io.druid.data.input.InputRow;
-import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.hll.HyperLogLogHash;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
@@ -49,7 +48,6 @@ import io.druid.segment.data.IndexedInts;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.IncrementalIndexStorageAdapter;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -124,18 +122,16 @@ public class IncrementalIndexReadBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex.Builder()
+    return new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-                .withQueryGranularity(Granularities.NONE)
                 .withMetrics(schemaInfo.getAggsArray())
-                .withDimensionsSpec(DimensionsSpec.ofEmpty())
                 .withRollup(rollup)
                 .build()
         )
         .setReportParseExceptions(false)
         .setMaxRowCount(rowsPerSegment)
-        .build();
+        .buildOnheap();
   }
 
   @Benchmark

--- a/benchmarks/src/main/java/io/druid/benchmark/indexing/IncrementalIndexReadBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/indexing/IncrementalIndexReadBenchmark.java
@@ -124,18 +124,18 @@ public class IncrementalIndexReadBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex(
-        new IncrementalIndexSchema.Builder()
-            .withQueryGranularity(Granularities.NONE)
-            .withMetrics(schemaInfo.getAggsArray())
-            .withDimensionsSpec(new DimensionsSpec(null, null, null))
-            .withRollup(rollup)
-            .build(),
-        true,
-        false,
-        true,
-        rowsPerSegment
-    );
+    return new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withQueryGranularity(Granularities.NONE)
+                .withMetrics(schemaInfo.getAggsArray())
+                .withDimensionsSpec(DimensionsSpec.ofEmpty())
+                .withRollup(rollup)
+                .build()
+        )
+        .setReportParseExceptions(false)
+        .setMaxRowCount(rowsPerSegment)
+        .build();
   }
 
   @Benchmark

--- a/benchmarks/src/main/java/io/druid/benchmark/indexing/IncrementalIndexReadBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/indexing/IncrementalIndexReadBenchmark.java
@@ -123,7 +123,7 @@ public class IncrementalIndexReadBenchmark
   private IncrementalIndex makeIncIndex()
   {
     return new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
+        .setIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withMetrics(schemaInfo.getAggsArray())
                 .withRollup(rollup)

--- a/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexIngestionBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexIngestionBenchmark.java
@@ -104,18 +104,18 @@ public class IndexIngestionBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex(
-        new IncrementalIndexSchema.Builder()
-            .withQueryGranularity(Granularities.NONE)
-            .withMetrics(schemaInfo.getAggsArray())
-            .withDimensionsSpec(new DimensionsSpec(null, null, null))
-            .withRollup(rollup)
-            .build(),
-        true,
-        false,
-        true,
-        rowsPerSegment * 2
-    );
+    return new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withQueryGranularity(Granularities.NONE)
+                .withMetrics(schemaInfo.getAggsArray())
+                .withDimensionsSpec(DimensionsSpec.ofEmpty())
+                .withRollup(rollup)
+                .build()
+        )
+        .setReportParseExceptions(false)
+        .setMaxRowCount(rowsPerSegment * 2)
+        .build();
   }
 
   @Benchmark

--- a/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexIngestionBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexIngestionBenchmark.java
@@ -23,14 +23,11 @@ import io.druid.benchmark.datagen.BenchmarkDataGenerator;
 import io.druid.benchmark.datagen.BenchmarkSchemaInfo;
 import io.druid.benchmark.datagen.BenchmarkSchemas;
 import io.druid.data.input.InputRow;
-import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.hll.HyperLogLogHash;
-import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.query.aggregation.hyperloglog.HyperUniquesSerde;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -104,18 +101,16 @@ public class IndexIngestionBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex.Builder()
+    return new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-                .withQueryGranularity(Granularities.NONE)
                 .withMetrics(schemaInfo.getAggsArray())
-                .withDimensionsSpec(DimensionsSpec.ofEmpty())
                 .withRollup(rollup)
                 .build()
         )
         .setReportParseExceptions(false)
         .setMaxRowCount(rowsPerSegment * 2)
-        .build();
+        .buildOnheap();
   }
 
   @Benchmark

--- a/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexIngestionBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexIngestionBenchmark.java
@@ -102,7 +102,7 @@ public class IndexIngestionBenchmark
   private IncrementalIndex makeIncIndex()
   {
     return new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
+        .setIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withMetrics(schemaInfo.getAggsArray())
                 .withRollup(rollup)

--- a/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexMergeBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexMergeBenchmark.java
@@ -159,7 +159,7 @@ public class IndexMergeBenchmark
   private IncrementalIndex makeIncIndex()
   {
     return new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
+        .setIndexSchema(
             new IncrementalIndexSchema.Builder()
             .withMetrics(schemaInfo.getAggsArray())
             .withRollup(rollup)

--- a/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexMergeBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexMergeBenchmark.java
@@ -161,18 +161,18 @@ public class IndexMergeBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex(
-        new IncrementalIndexSchema.Builder()
+    return new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
             .withQueryGranularity(Granularities.NONE)
             .withMetrics(schemaInfo.getAggsArray())
-            .withDimensionsSpec(new DimensionsSpec(null, null, null))
+            .withDimensionsSpec(DimensionsSpec.ofEmpty())
             .withRollup(rollup)
-            .build(),
-        true,
-        false,
-        true,
-        rowsPerSegment
-    );
+            .build()
+        )
+        .setReportParseExceptions(false)
+        .setMaxRowCount(rowsPerSegment)
+        .build();
   }
 
   @Benchmark

--- a/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexMergeBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexMergeBenchmark.java
@@ -25,10 +25,8 @@ import io.druid.benchmark.datagen.BenchmarkDataGenerator;
 import io.druid.benchmark.datagen.BenchmarkSchemaInfo;
 import io.druid.benchmark.datagen.BenchmarkSchemas;
 import io.druid.data.input.InputRow;
-import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.hll.HyperLogLogHash;
 import io.druid.jackson.DefaultObjectMapper;
-import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.query.aggregation.hyperloglog.HyperUniquesSerde;
 import io.druid.segment.IndexIO;
@@ -39,7 +37,6 @@ import io.druid.segment.QueryableIndex;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
 import org.apache.commons.io.FileUtils;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -161,18 +158,16 @@ public class IndexMergeBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex.Builder()
+    return new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-            .withQueryGranularity(Granularities.NONE)
             .withMetrics(schemaInfo.getAggsArray())
-            .withDimensionsSpec(DimensionsSpec.ofEmpty())
             .withRollup(rollup)
             .build()
         )
         .setReportParseExceptions(false)
         .setMaxRowCount(rowsPerSegment)
-        .build();
+        .buildOnheap();
   }
 
   @Benchmark

--- a/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexPersistBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexPersistBenchmark.java
@@ -25,10 +25,8 @@ import io.druid.benchmark.datagen.BenchmarkDataGenerator;
 import io.druid.benchmark.datagen.BenchmarkSchemaInfo;
 import io.druid.benchmark.datagen.BenchmarkSchemas;
 import io.druid.data.input.InputRow;
-import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.hll.HyperLogLogHash;
 import io.druid.jackson.DefaultObjectMapper;
-import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.query.aggregation.hyperloglog.HyperUniquesSerde;
 import io.druid.segment.IndexIO;
@@ -38,7 +36,6 @@ import io.druid.segment.IndexSpec;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
 import org.apache.commons.io.FileUtils;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -155,18 +152,16 @@ public class IndexPersistBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex.Builder()
+    return new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-            .withQueryGranularity(Granularities.NONE)
             .withMetrics(schemaInfo.getAggsArray())
-            .withDimensionsSpec(DimensionsSpec.ofEmpty())
             .withRollup(rollup)
             .build()
         )
         .setReportParseExceptions(false)
         .setMaxRowCount(rowsPerSegment)
-        .build();
+        .buildOnheap();
   }
 
   @Benchmark

--- a/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexPersistBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexPersistBenchmark.java
@@ -155,18 +155,18 @@ public class IndexPersistBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex(
-        new IncrementalIndexSchema.Builder()
+    return new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
             .withQueryGranularity(Granularities.NONE)
             .withMetrics(schemaInfo.getAggsArray())
-            .withDimensionsSpec(new DimensionsSpec(null, null, null))
+            .withDimensionsSpec(DimensionsSpec.ofEmpty())
             .withRollup(rollup)
-            .build(),
-        true,
-        false,
-        true,
-        rowsPerSegment
-    );
+            .build()
+        )
+        .setReportParseExceptions(false)
+        .setMaxRowCount(rowsPerSegment)
+        .build();
   }
 
   @Benchmark

--- a/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexPersistBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexPersistBenchmark.java
@@ -153,7 +153,7 @@ public class IndexPersistBenchmark
   private IncrementalIndex makeIncIndex()
   {
     return new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
+        .setIndexSchema(
             new IncrementalIndexSchema.Builder()
             .withMetrics(schemaInfo.getAggsArray())
             .withRollup(rollup)

--- a/benchmarks/src/main/java/io/druid/benchmark/query/GroupByBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/GroupByBenchmark.java
@@ -36,7 +36,6 @@ import io.druid.collections.StupidPool;
 import io.druid.concurrent.Execs;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.Row;
-import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.hll.HyperLogLogHash;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.granularity.Granularities;
@@ -76,7 +75,6 @@ import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.column.ValueType;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
 import org.apache.commons.io.FileUtils;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -476,19 +474,17 @@ public class GroupByBenchmark
 
   private IncrementalIndex makeIncIndex(boolean withRollup)
   {
-    return new OnheapIncrementalIndex.Builder()
+    return new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-            .withQueryGranularity(Granularities.NONE)
             .withMetrics(schemaInfo.getAggsArray())
-            .withDimensionsSpec(DimensionsSpec.ofEmpty())
             .withRollup(withRollup)
             .build()
         )
         .setReportParseExceptions(false)
         .setConcurrentEventAdd(true)
         .setMaxRowCount(rowsPerSegment)
-        .build();
+        .buildOnheap();
   }
 
   @TearDown(Level.Trial)

--- a/benchmarks/src/main/java/io/druid/benchmark/query/GroupByBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/GroupByBenchmark.java
@@ -486,6 +486,7 @@ public class GroupByBenchmark
         true,
         false,
         true,
+        true,
         rowsPerSegment
     );
   }

--- a/benchmarks/src/main/java/io/druid/benchmark/query/GroupByBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/GroupByBenchmark.java
@@ -475,7 +475,7 @@ public class GroupByBenchmark
   private IncrementalIndex makeIncIndex(boolean withRollup)
   {
     return new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
+        .setIndexSchema(
             new IncrementalIndexSchema.Builder()
             .withMetrics(schemaInfo.getAggsArray())
             .withRollup(withRollup)

--- a/benchmarks/src/main/java/io/druid/benchmark/query/GroupByBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/GroupByBenchmark.java
@@ -476,19 +476,19 @@ public class GroupByBenchmark
 
   private IncrementalIndex makeIncIndex(boolean withRollup)
   {
-    return new OnheapIncrementalIndex(
-        new IncrementalIndexSchema.Builder()
+    return new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
             .withQueryGranularity(Granularities.NONE)
             .withMetrics(schemaInfo.getAggsArray())
-            .withDimensionsSpec(new DimensionsSpec(null, null, null))
+            .withDimensionsSpec(DimensionsSpec.ofEmpty())
             .withRollup(withRollup)
-            .build(),
-        true,
-        false,
-        true,
-        true,
-        rowsPerSegment
-    );
+            .build()
+        )
+        .setReportParseExceptions(false)
+        .setConcurrentEventAdd(true)
+        .setMaxRowCount(rowsPerSegment)
+        .build();
   }
 
   @TearDown(Level.Trial)

--- a/benchmarks/src/main/java/io/druid/benchmark/query/SearchBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/SearchBenchmark.java
@@ -388,17 +388,17 @@ public class SearchBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex(
-        new IncrementalIndexSchema.Builder()
+    return new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
             .withQueryGranularity(Granularities.NONE)
             .withMetrics(schemaInfo.getAggsArray())
-            .withDimensionsSpec(new DimensionsSpec(null, null, null))
-            .build(),
-        true,
-        false,
-        true,
-        rowsPerSegment
-    );
+            .withDimensionsSpec(DimensionsSpec.ofEmpty())
+            .build()
+        )
+        .setReportParseExceptions(false)
+        .setMaxRowCount(rowsPerSegment)
+        .build();
   }
 
   private static <T> List<T> runQuery(QueryRunnerFactory factory, QueryRunner runner, Query<T> query)

--- a/benchmarks/src/main/java/io/druid/benchmark/query/SearchBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/SearchBenchmark.java
@@ -32,7 +32,6 @@ import io.druid.benchmark.datagen.BenchmarkSchemas;
 import io.druid.concurrent.Execs;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.Row;
-import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.hll.HyperLogLogHash;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.granularity.Granularities;
@@ -77,7 +76,6 @@ import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
 import org.apache.commons.io.FileUtils;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -388,17 +386,15 @@ public class SearchBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex.Builder()
+    return new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-            .withQueryGranularity(Granularities.NONE)
             .withMetrics(schemaInfo.getAggsArray())
-            .withDimensionsSpec(DimensionsSpec.ofEmpty())
             .build()
         )
         .setReportParseExceptions(false)
         .setMaxRowCount(rowsPerSegment)
-        .build();
+        .buildOnheap();
   }
 
   private static <T> List<T> runQuery(QueryRunnerFactory factory, QueryRunner runner, Query<T> query)

--- a/benchmarks/src/main/java/io/druid/benchmark/query/SearchBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/SearchBenchmark.java
@@ -75,7 +75,6 @@ import io.druid.segment.QueryableIndex;
 import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
-import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.serde.ComplexMetrics;
 import org.apache.commons.io.FileUtils;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -387,11 +386,7 @@ public class SearchBenchmark
   private IncrementalIndex makeIncIndex()
   {
     return new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
-            new IncrementalIndexSchema.Builder()
-            .withMetrics(schemaInfo.getAggsArray())
-            .build()
-        )
+        .setSimpleTestingIndexSchema(schemaInfo.getAggsArray())
         .setReportParseExceptions(false)
         .setMaxRowCount(rowsPerSegment)
         .buildOnheap();

--- a/benchmarks/src/main/java/io/druid/benchmark/query/SelectBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/SelectBenchmark.java
@@ -65,7 +65,6 @@ import io.druid.segment.QueryableIndex;
 import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
-import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.serde.ComplexMetrics;
 import org.apache.commons.io.FileUtils;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -251,11 +250,7 @@ public class SelectBenchmark
   private IncrementalIndex makeIncIndex()
   {
     return new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
-            new IncrementalIndexSchema.Builder()
-            .withMetrics(schemaInfo.getAggsArray())
-            .build()
-        )
+        .setSimpleTestingIndexSchema(schemaInfo.getAggsArray())
         .setReportParseExceptions(false)
         .setMaxRowCount(rowsPerSegment)
         .buildOnheap();

--- a/benchmarks/src/main/java/io/druid/benchmark/query/SelectBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/SelectBenchmark.java
@@ -252,17 +252,17 @@ public class SelectBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex(
-        new IncrementalIndexSchema.Builder()
+    return new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
             .withQueryGranularity(Granularities.NONE)
             .withMetrics(schemaInfo.getAggsArray())
-            .withDimensionsSpec(new DimensionsSpec(null, null, null))
-            .build(),
-        true,
-        false,
-        true,
-        rowsPerSegment
-    );
+            .withDimensionsSpec(DimensionsSpec.ofEmpty())
+            .build()
+        )
+        .setReportParseExceptions(false)
+        .setMaxRowCount(rowsPerSegment)
+        .build();
   }
 
   private static <T> List<T> runQuery(QueryRunnerFactory factory, QueryRunner runner, Query<T> query)

--- a/benchmarks/src/main/java/io/druid/benchmark/query/SelectBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/SelectBenchmark.java
@@ -31,7 +31,6 @@ import io.druid.benchmark.datagen.BenchmarkSchemas;
 import io.druid.concurrent.Execs;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.Row;
-import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.hll.HyperLogLogHash;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.granularity.Granularities;
@@ -67,7 +66,6 @@ import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
 import org.apache.commons.io.FileUtils;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -252,17 +250,15 @@ public class SelectBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex.Builder()
+    return new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-            .withQueryGranularity(Granularities.NONE)
             .withMetrics(schemaInfo.getAggsArray())
-            .withDimensionsSpec(DimensionsSpec.ofEmpty())
             .build()
         )
         .setReportParseExceptions(false)
         .setMaxRowCount(rowsPerSegment)
-        .build();
+        .buildOnheap();
   }
 
   private static <T> List<T> runQuery(QueryRunnerFactory factory, QueryRunner runner, Query<T> query)

--- a/benchmarks/src/main/java/io/druid/benchmark/query/TimeseriesBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/TimeseriesBenchmark.java
@@ -69,7 +69,6 @@ import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.column.Column;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
-import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.serde.ComplexMetrics;
 import org.apache.commons.io.FileUtils;
 import org.joda.time.Interval;
@@ -311,11 +310,7 @@ public class TimeseriesBenchmark
   private IncrementalIndex makeIncIndex()
   {
     return new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
-            new IncrementalIndexSchema.Builder()
-            .withMetrics(schemaInfo.getAggsArray())
-            .build()
-        )
+        .setSimpleTestingIndexSchema(schemaInfo.getAggsArray())
         .setReportParseExceptions(false)
         .setMaxRowCount(rowsPerSegment)
         .buildOnheap();

--- a/benchmarks/src/main/java/io/druid/benchmark/query/TimeseriesBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/TimeseriesBenchmark.java
@@ -28,7 +28,6 @@ import io.druid.benchmark.datagen.BenchmarkSchemaInfo;
 import io.druid.benchmark.datagen.BenchmarkSchemas;
 import io.druid.concurrent.Execs;
 import io.druid.data.input.InputRow;
-import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.hll.HyperLogLogHash;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.granularity.Granularities;
@@ -71,7 +70,6 @@ import io.druid.segment.column.Column;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
 import org.apache.commons.io.FileUtils;
 import org.joda.time.Interval;
@@ -312,17 +310,15 @@ public class TimeseriesBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex.Builder()
+    return new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-            .withQueryGranularity(Granularities.NONE)
             .withMetrics(schemaInfo.getAggsArray())
-            .withDimensionsSpec(DimensionsSpec.ofEmpty())
             .build()
         )
         .setReportParseExceptions(false)
         .setMaxRowCount(rowsPerSegment)
-        .build();
+        .buildOnheap();
   }
 
   private static <T> List<T> runQuery(QueryRunnerFactory factory, QueryRunner runner, Query<T> query)

--- a/benchmarks/src/main/java/io/druid/benchmark/query/TimeseriesBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/TimeseriesBenchmark.java
@@ -312,17 +312,17 @@ public class TimeseriesBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex(
-        new IncrementalIndexSchema.Builder()
+    return new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
             .withQueryGranularity(Granularities.NONE)
             .withMetrics(schemaInfo.getAggsArray())
-            .withDimensionsSpec(new DimensionsSpec(null, null, null))
-            .build(),
-        true,
-        false,
-        true,
-        rowsPerSegment
-    );
+            .withDimensionsSpec(DimensionsSpec.ofEmpty())
+            .build()
+        )
+        .setReportParseExceptions(false)
+        .setMaxRowCount(rowsPerSegment)
+        .build();
   }
 
   private static <T> List<T> runQuery(QueryRunnerFactory factory, QueryRunner runner, Query<T> query)

--- a/benchmarks/src/main/java/io/druid/benchmark/query/TopNBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/TopNBenchmark.java
@@ -29,7 +29,6 @@ import io.druid.benchmark.datagen.BenchmarkSchemas;
 import io.druid.collections.StupidPool;
 import io.druid.concurrent.Execs;
 import io.druid.data.input.InputRow;
-import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.hll.HyperLogLogHash;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.granularity.Granularities;
@@ -69,7 +68,6 @@ import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
 import org.apache.commons.io.FileUtils;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -292,17 +290,15 @@ public class TopNBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex.Builder()
+    return new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-            .withQueryGranularity(Granularities.NONE)
             .withMetrics(schemaInfo.getAggsArray())
-            .withDimensionsSpec(DimensionsSpec.ofEmpty())
             .build()
         )
         .setReportParseExceptions(false)
         .setMaxRowCount(rowsPerSegment)
-        .build();
+        .buildOnheap();
   }
 
   private static <T> List<T> runQuery(QueryRunnerFactory factory, QueryRunner runner, Query<T> query)

--- a/benchmarks/src/main/java/io/druid/benchmark/query/TopNBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/TopNBenchmark.java
@@ -67,7 +67,6 @@ import io.druid.segment.QueryableIndex;
 import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
-import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.serde.ComplexMetrics;
 import org.apache.commons.io.FileUtils;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -291,11 +290,7 @@ public class TopNBenchmark
   private IncrementalIndex makeIncIndex()
   {
     return new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
-            new IncrementalIndexSchema.Builder()
-            .withMetrics(schemaInfo.getAggsArray())
-            .build()
-        )
+        .setSimpleTestingIndexSchema(schemaInfo.getAggsArray())
         .setReportParseExceptions(false)
         .setMaxRowCount(rowsPerSegment)
         .buildOnheap();

--- a/benchmarks/src/main/java/io/druid/benchmark/query/TopNBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/TopNBenchmark.java
@@ -292,17 +292,17 @@ public class TopNBenchmark
 
   private IncrementalIndex makeIncIndex()
   {
-    return new OnheapIncrementalIndex(
-        new IncrementalIndexSchema.Builder()
+    return new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
             .withQueryGranularity(Granularities.NONE)
             .withMetrics(schemaInfo.getAggsArray())
-            .withDimensionsSpec(new DimensionsSpec(null, null, null))
-            .build(),
-        true,
-        false,
-        true,
-        rowsPerSegment
-    );
+            .withDimensionsSpec(DimensionsSpec.ofEmpty())
+            .build()
+        )
+        .setReportParseExceptions(false)
+        .setMaxRowCount(rowsPerSegment)
+        .build();
   }
 
   private static <T> List<T> runQuery(QueryRunnerFactory factory, QueryRunner runner, Query<T> query)

--- a/extensions-contrib/distinctcount/src/test/java/io/druid/query/aggregation/distinctcount/DistinctCountGroupByQueryTest.java
+++ b/extensions-contrib/distinctcount/src/test/java/io/druid/query/aggregation/distinctcount/DistinctCountGroupByQueryTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.druid.data.input.MapBasedInputRow;
 import io.druid.data.input.Row;
+import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.query.QueryRunnerTestHelper;
 import io.druid.query.aggregation.AggregatorFactory;
@@ -40,6 +41,7 @@ import io.druid.segment.IncrementalIndexSegment;
 import io.druid.segment.Segment;
 import io.druid.segment.TestHelper;
 import io.druid.segment.incremental.IncrementalIndex;
+import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.junit.Test;
 
@@ -56,9 +58,19 @@ public class DistinctCountGroupByQueryTest
     config.setMaxIntermediateRows(10000);
     final GroupByQueryRunnerFactory factory = GroupByQueryRunnerTest.makeQueryRunnerFactory(config);
 
-    IncrementalIndex index = new OnheapIncrementalIndex(
-        0, Granularities.SECOND, new AggregatorFactory[]{new CountAggregatorFactory("cnt")}, 1000
-    );
+    IncrementalIndex index = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withMinTimestamp(0)
+                .withQueryGranularity(Granularities.SECOND)
+                .withDimensionsSpec(DimensionsSpec.ofEmpty())
+                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("cnt")})
+                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .build()
+        )
+        .setMaxRowCount(1000)
+        .build();
+
     String visitor_id = "visitor_id";
     String client_type = "client_type";
     long timestamp = System.currentTimeMillis();

--- a/extensions-contrib/distinctcount/src/test/java/io/druid/query/aggregation/distinctcount/DistinctCountGroupByQueryTest.java
+++ b/extensions-contrib/distinctcount/src/test/java/io/druid/query/aggregation/distinctcount/DistinctCountGroupByQueryTest.java
@@ -56,7 +56,7 @@ public class DistinctCountGroupByQueryTest
     final GroupByQueryRunnerFactory factory = GroupByQueryRunnerTest.makeQueryRunnerFactory(config);
 
     IncrementalIndex index = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
+        .setIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withQueryGranularity(Granularities.SECOND)
                 .withMetrics(new CountAggregatorFactory("cnt"))

--- a/extensions-contrib/distinctcount/src/test/java/io/druid/query/aggregation/distinctcount/DistinctCountGroupByQueryTest.java
+++ b/extensions-contrib/distinctcount/src/test/java/io/druid/query/aggregation/distinctcount/DistinctCountGroupByQueryTest.java
@@ -23,10 +23,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.druid.data.input.MapBasedInputRow;
 import io.druid.data.input.Row;
-import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.query.QueryRunnerTestHelper;
-import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.query.dimension.DefaultDimensionSpec;
 import io.druid.query.dimension.DimensionSpec;
@@ -42,7 +40,6 @@ import io.druid.segment.Segment;
 import io.druid.segment.TestHelper;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -58,18 +55,16 @@ public class DistinctCountGroupByQueryTest
     config.setMaxIntermediateRows(10000);
     final GroupByQueryRunnerFactory factory = GroupByQueryRunnerTest.makeQueryRunnerFactory(config);
 
-    IncrementalIndex index = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex index = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-                .withMinTimestamp(0)
                 .withQueryGranularity(Granularities.SECOND)
-                .withDimensionsSpec(DimensionsSpec.ofEmpty())
-                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("cnt")})
-                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .withMetrics(new CountAggregatorFactory("cnt"))
                 .build()
         )
+        .setConcurrentEventAdd(true)
         .setMaxRowCount(1000)
-        .build();
+        .buildOnheap();
 
     String visitor_id = "visitor_id";
     String client_type = "client_type";

--- a/extensions-contrib/distinctcount/src/test/java/io/druid/query/aggregation/distinctcount/DistinctCountTimeseriesQueryTest.java
+++ b/extensions-contrib/distinctcount/src/test/java/io/druid/query/aggregation/distinctcount/DistinctCountTimeseriesQueryTest.java
@@ -22,13 +22,11 @@ package io.druid.query.aggregation.distinctcount;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.druid.data.input.MapBasedInputRow;
-import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.Druids;
 import io.druid.query.QueryRunnerTestHelper;
 import io.druid.query.Result;
-import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.query.timeseries.TimeseriesQuery;
 import io.druid.query.timeseries.TimeseriesQueryEngine;
@@ -37,7 +35,6 @@ import io.druid.segment.TestHelper;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.IncrementalIndexStorageAdapter;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
@@ -52,18 +49,15 @@ public class DistinctCountTimeseriesQueryTest
   {
     TimeseriesQueryEngine engine =  new TimeseriesQueryEngine();
 
-    IncrementalIndex index = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex index = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-                .withMinTimestamp(0)
                 .withQueryGranularity(Granularities.SECOND)
-                .withDimensionsSpec(DimensionsSpec.ofEmpty())
-                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("cnt")})
-                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .withMetrics(new CountAggregatorFactory("cnt"))
                 .build()
         )
         .setMaxRowCount(1000)
-        .build();
+        .buildOnheap();
 
     String visitor_id = "visitor_id";
     String client_type = "client_type";

--- a/extensions-contrib/distinctcount/src/test/java/io/druid/query/aggregation/distinctcount/DistinctCountTimeseriesQueryTest.java
+++ b/extensions-contrib/distinctcount/src/test/java/io/druid/query/aggregation/distinctcount/DistinctCountTimeseriesQueryTest.java
@@ -22,6 +22,7 @@ package io.druid.query.aggregation.distinctcount;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.druid.data.input.MapBasedInputRow;
+import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.Druids;
@@ -34,6 +35,7 @@ import io.druid.query.timeseries.TimeseriesQueryEngine;
 import io.druid.query.timeseries.TimeseriesResultValue;
 import io.druid.segment.TestHelper;
 import io.druid.segment.incremental.IncrementalIndex;
+import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.IncrementalIndexStorageAdapter;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.joda.time.DateTime;
@@ -50,9 +52,19 @@ public class DistinctCountTimeseriesQueryTest
   {
     TimeseriesQueryEngine engine =  new TimeseriesQueryEngine();
 
-    IncrementalIndex index = new OnheapIncrementalIndex(
-        0, Granularities.SECOND, new AggregatorFactory[]{new CountAggregatorFactory("cnt")}, 1000
-    );
+    IncrementalIndex index = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withMinTimestamp(0)
+                .withQueryGranularity(Granularities.SECOND)
+                .withDimensionsSpec(DimensionsSpec.ofEmpty())
+                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("cnt")})
+                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .build()
+        )
+        .setMaxRowCount(1000)
+        .build();
+
     String visitor_id = "visitor_id";
     String client_type = "client_type";
     DateTime time = new DateTime("2016-03-04T00:00:00.000Z");

--- a/extensions-contrib/distinctcount/src/test/java/io/druid/query/aggregation/distinctcount/DistinctCountTimeseriesQueryTest.java
+++ b/extensions-contrib/distinctcount/src/test/java/io/druid/query/aggregation/distinctcount/DistinctCountTimeseriesQueryTest.java
@@ -50,7 +50,7 @@ public class DistinctCountTimeseriesQueryTest
     TimeseriesQueryEngine engine =  new TimeseriesQueryEngine();
 
     IncrementalIndex index = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
+        .setIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withQueryGranularity(Granularities.SECOND)
                 .withMetrics(new CountAggregatorFactory("cnt"))

--- a/extensions-contrib/distinctcount/src/test/java/io/druid/query/aggregation/distinctcount/DistinctCountTopNQueryTest.java
+++ b/extensions-contrib/distinctcount/src/test/java/io/druid/query/aggregation/distinctcount/DistinctCountTopNQueryTest.java
@@ -68,7 +68,7 @@ public class DistinctCountTopNQueryTest
     );
 
     IncrementalIndex index = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
+        .setIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withQueryGranularity(Granularities.SECOND)
                 .withMetrics(new CountAggregatorFactory("cnt"))

--- a/extensions-contrib/distinctcount/src/test/java/io/druid/query/aggregation/distinctcount/DistinctCountTopNQueryTest.java
+++ b/extensions-contrib/distinctcount/src/test/java/io/druid/query/aggregation/distinctcount/DistinctCountTopNQueryTest.java
@@ -25,12 +25,10 @@ import com.google.common.collect.Lists;
 
 import io.druid.collections.StupidPool;
 import io.druid.data.input.MapBasedInputRow;
-import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.QueryRunnerTestHelper;
 import io.druid.query.Result;
-import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.query.topn.TopNQuery;
 import io.druid.query.topn.TopNQueryBuilder;
@@ -40,7 +38,6 @@ import io.druid.segment.TestHelper;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.IncrementalIndexStorageAdapter;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
@@ -70,18 +67,15 @@ public class DistinctCountTopNQueryTest
         )
     );
 
-    IncrementalIndex index = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex index = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-                .withMinTimestamp(0)
                 .withQueryGranularity(Granularities.SECOND)
-                .withDimensionsSpec(DimensionsSpec.ofEmpty())
-                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("cnt")})
-                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .withMetrics(new CountAggregatorFactory("cnt"))
                 .build()
         )
         .setMaxRowCount(1000)
-        .build();
+        .buildOnheap();
 
     String visitor_id = "visitor_id";
     String client_type = "client_type";

--- a/extensions-contrib/distinctcount/src/test/java/io/druid/query/aggregation/distinctcount/DistinctCountTopNQueryTest.java
+++ b/extensions-contrib/distinctcount/src/test/java/io/druid/query/aggregation/distinctcount/DistinctCountTopNQueryTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Lists;
 
 import io.druid.collections.StupidPool;
 import io.druid.data.input.MapBasedInputRow;
+import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.QueryRunnerTestHelper;
@@ -37,6 +38,7 @@ import io.druid.query.topn.TopNQueryEngine;
 import io.druid.query.topn.TopNResultValue;
 import io.druid.segment.TestHelper;
 import io.druid.segment.incremental.IncrementalIndex;
+import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.IncrementalIndexStorageAdapter;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.joda.time.DateTime;
@@ -68,9 +70,19 @@ public class DistinctCountTopNQueryTest
         )
     );
 
-    IncrementalIndex index = new OnheapIncrementalIndex(
-        0, Granularities.SECOND, new AggregatorFactory[]{new CountAggregatorFactory("cnt")}, 1000
-    );
+    IncrementalIndex index = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withMinTimestamp(0)
+                .withQueryGranularity(Granularities.SECOND)
+                .withDimensionsSpec(DimensionsSpec.ofEmpty())
+                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("cnt")})
+                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .build()
+        )
+        .setMaxRowCount(1000)
+        .build();
+
     String visitor_id = "visitor_id";
     String client_type = "client_type";
     DateTime time = new DateTime("2016-03-04T00:00:00.000Z");

--- a/extensions-contrib/scan-query/src/test/java/io/druid/query/scan/MultiSegmentScanQueryTest.java
+++ b/extensions-contrib/scan-query/src/test/java/io/druid/query/scan/MultiSegmentScanQueryTest.java
@@ -150,7 +150,7 @@ public class MultiSegmentScanQueryTest
         .withMetrics(TestIndex.METRIC_AGGS)
         .build();
     return new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(schema)
+        .setIndexSchema(schema)
         .setMaxRowCount(maxRowCount)
         .buildOnheap();
   }

--- a/extensions-contrib/scan-query/src/test/java/io/druid/query/scan/MultiSegmentScanQueryTest.java
+++ b/extensions-contrib/scan-query/src/test/java/io/druid/query/scan/MultiSegmentScanQueryTest.java
@@ -39,7 +39,6 @@ import io.druid.segment.Segment;
 import io.druid.segment.TestIndex;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.timeline.DataSegment;
 import io.druid.timeline.partition.NoneShardSpec;
 import org.apache.commons.io.IOUtils;
@@ -150,10 +149,10 @@ public class MultiSegmentScanQueryTest
         .withQueryGranularity(Granularities.HOUR)
         .withMetrics(TestIndex.METRIC_AGGS)
         .build();
-    return new OnheapIncrementalIndex.Builder()
+    return new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(schema)
         .setMaxRowCount(maxRowCount)
-        .build();
+        .buildOnheap();
   }
 
   @AfterClass

--- a/extensions-contrib/scan-query/src/test/java/io/druid/query/scan/MultiSegmentScanQueryTest.java
+++ b/extensions-contrib/scan-query/src/test/java/io/druid/query/scan/MultiSegmentScanQueryTest.java
@@ -150,7 +150,10 @@ public class MultiSegmentScanQueryTest
         .withQueryGranularity(Granularities.HOUR)
         .withMetrics(TestIndex.METRIC_AGGS)
         .build();
-    return new OnheapIncrementalIndex(schema, true, maxRowCount);
+    return new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(schema)
+        .setMaxRowCount(maxRowCount)
+        .build();
   }
 
   @AfterClass

--- a/extensions-contrib/virtual-columns/src/test/java/io/druid/segment/MapVirtualColumnTest.java
+++ b/extensions-contrib/virtual-columns/src/test/java/io/druid/segment/MapVirtualColumnTest.java
@@ -89,7 +89,10 @@ public class MapVirtualColumnTest
         .withMinTimestamp(new DateTime("2011-01-12T00:00:00.000Z").getMillis())
         .withQueryGranularity(Granularities.NONE)
         .build();
-    final IncrementalIndex index = new OnheapIncrementalIndex(schema, true, 10000);
+    final IncrementalIndex index = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(schema)
+        .setMaxRowCount(10000)
+        .build();
 
     final StringInputRowParser parser = new StringInputRowParser(
         new DelimitedParseSpec(

--- a/extensions-contrib/virtual-columns/src/test/java/io/druid/segment/MapVirtualColumnTest.java
+++ b/extensions-contrib/virtual-columns/src/test/java/io/druid/segment/MapVirtualColumnTest.java
@@ -87,7 +87,7 @@ public class MapVirtualColumnTest
         .withMinTimestamp(new DateTime("2011-01-12T00:00:00.000Z").getMillis())
         .build();
     final IncrementalIndex index = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(schema)
+        .setIndexSchema(schema)
         .setMaxRowCount(10000)
         .buildOnheap();
 

--- a/extensions-contrib/virtual-columns/src/test/java/io/druid/segment/MapVirtualColumnTest.java
+++ b/extensions-contrib/virtual-columns/src/test/java/io/druid/segment/MapVirtualColumnTest.java
@@ -30,7 +30,6 @@ import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.data.input.impl.StringInputRowParser;
 import io.druid.data.input.impl.TimestampSpec;
 import io.druid.jackson.DefaultObjectMapper;
-import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.Druids;
 import io.druid.query.QueryRunner;
@@ -46,7 +45,6 @@ import io.druid.query.select.SelectQueryRunnerFactory;
 import io.druid.query.select.SelectResultValue;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Test;
@@ -87,12 +85,11 @@ public class MapVirtualColumnTest
 
     final IncrementalIndexSchema schema = new IncrementalIndexSchema.Builder()
         .withMinTimestamp(new DateTime("2011-01-12T00:00:00.000Z").getMillis())
-        .withQueryGranularity(Granularities.NONE)
         .build();
-    final IncrementalIndex index = new OnheapIncrementalIndex.Builder()
+    final IncrementalIndex index = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(schema)
         .setMaxRowCount(10000)
-        .build();
+        .buildOnheap();
 
     final StringInputRowParser parser = new StringInputRowParser(
         new DelimitedParseSpec(

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/sql/QuantileSqlAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/sql/QuantileSqlAggregatorTest.java
@@ -27,7 +27,6 @@ import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.Druids;
 import io.druid.query.QueryContexts;
-import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.query.aggregation.DoubleSumAggregatorFactory;
 import io.druid.query.aggregation.FilteredAggregatorFactory;

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/sql/QuantileSqlAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/sql/QuantileSqlAggregatorTest.java
@@ -96,18 +96,16 @@ public class QuantileSqlAggregatorTest
                                              .schema(
                                                  new IncrementalIndexSchema.Builder()
                                                      .withMetrics(
-                                                         new AggregatorFactory[]{
-                                                             new CountAggregatorFactory("cnt"),
-                                                             new DoubleSumAggregatorFactory("m1", "m1"),
-                                                             new ApproximateHistogramAggregatorFactory(
-                                                                 "hist_m1",
-                                                                 "m1",
-                                                                 null,
-                                                                 null,
-                                                                 null,
-                                                                 null
-                                                             )
-                                                         }
+                                                         new CountAggregatorFactory("cnt"),
+                                                         new DoubleSumAggregatorFactory("m1", "m1"),
+                                                         new ApproximateHistogramAggregatorFactory(
+                                                             "hist_m1",
+                                                             "m1",
+                                                             null,
+                                                             null,
+                                                             null,
+                                                             null
+                                                         )
                                                      )
                                                      .withRollup(false)
                                                      .build()

--- a/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
@@ -237,7 +237,7 @@ public class IndexGeneratorJob implements Jobby
         .build();
 
     IncrementalIndex newIndex = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(indexSchema)
+        .setIndexSchema(indexSchema)
         .setReportParseExceptions(!tuningConfig.isIgnoreInvalidRows())
         .setMaxRowCount(tuningConfig.getRowFlushBoundary())
         .buildOnheap();

--- a/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
@@ -49,7 +49,6 @@ import io.druid.segment.QueryableIndex;
 import io.druid.segment.column.ColumnCapabilitiesImpl;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.timeline.DataSegment;
 import io.druid.timeline.partition.NumberedShardSpec;
 import io.druid.timeline.partition.ShardSpec;
@@ -237,11 +236,11 @@ public class IndexGeneratorJob implements Jobby
         .withRollup(config.getSchema().getDataSchema().getGranularitySpec().isRollup())
         .build();
 
-    OnheapIncrementalIndex newIndex = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex newIndex = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(indexSchema)
         .setReportParseExceptions(!tuningConfig.isIgnoreInvalidRows())
         .setMaxRowCount(tuningConfig.getRowFlushBoundary())
-        .build();
+        .buildOnheap();
 
     if (oldDimOrder != null && !indexSchema.getDimensionsSpec().hasCustomDimensions()) {
       newIndex.loadDimensionIterable(oldDimOrder, oldCapabilities);

--- a/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
@@ -237,11 +237,11 @@ public class IndexGeneratorJob implements Jobby
         .withRollup(config.getSchema().getDataSchema().getGranularitySpec().isRollup())
         .build();
 
-    OnheapIncrementalIndex newIndex = new OnheapIncrementalIndex(
-        indexSchema,
-        !tuningConfig.isIgnoreInvalidRows(),
-        tuningConfig.getRowFlushBoundary()
-    );
+    OnheapIncrementalIndex newIndex = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(indexSchema)
+        .setReportParseExceptions(!tuningConfig.isIgnoreInvalidRows())
+        .setMaxRowCount(tuningConfig.getRowFlushBoundary())
+        .build();
 
     if (oldDimOrder != null && !indexSchema.getDimensionsSpec().hasCustomDimensions()) {
       newIndex.loadDimensionIterable(oldDimOrder, oldCapabilities);

--- a/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
@@ -139,7 +139,7 @@ public class IngestSegmentFirehoseFactoryTest
         )
         .build();
     final IncrementalIndex index = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(schema)
+        .setIndexSchema(schema)
         .setMaxRowCount(MAX_ROWS * MAX_SHARD_NUMBER)
         .buildOnheap();
 

--- a/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
@@ -143,11 +143,10 @@ public class IngestSegmentFirehoseFactoryTest
             }
         )
         .build();
-    final OnheapIncrementalIndex index = new OnheapIncrementalIndex(
-        schema,
-        true,
-        MAX_ROWS * MAX_SHARD_NUMBER
-    );
+    final OnheapIncrementalIndex index = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(schema)
+        .setMaxRowCount(MAX_ROWS * MAX_SHARD_NUMBER)
+        .build();
 
     for (Integer i = 0; i < MAX_ROWS; ++i) {
       index.add(ROW_PARSER.parse(buildRow(i.longValue())));

--- a/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTimelineTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTimelineTest.java
@@ -214,7 +214,7 @@ public class IngestSegmentFirehoseFactoryTimelineTest
         .withMetrics(new LongSumAggregatorFactory(METRICS[0], METRICS[0]))
         .build();
     final IncrementalIndex index = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(schema)
+        .setIndexSchema(schema)
         .setMaxRowCount(rows.length)
         .buildOnheap();
 

--- a/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTimelineTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTimelineTest.java
@@ -49,17 +49,15 @@ import io.druid.indexing.common.actions.TaskActionClient;
 import io.druid.indexing.common.actions.TaskActionClientFactory;
 import io.druid.indexing.common.config.TaskConfig;
 import io.druid.indexing.common.task.Task;
-import io.druid.java.util.common.granularity.Granularities;
-import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.LongSumAggregatorFactory;
 import io.druid.query.filter.NoopDimFilter;
 import io.druid.segment.IndexIO;
 import io.druid.segment.IndexMerger;
 import io.druid.segment.IndexMergerV9;
 import io.druid.segment.IndexSpec;
+import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.IndexSizeExceededException;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.segment.loading.SegmentLoaderConfig;
 import io.druid.segment.loading.SegmentLoaderLocalCacheManager;
 import io.druid.segment.loading.StorageLocationConfig;
@@ -211,19 +209,14 @@ public class IngestSegmentFirehoseFactoryTimelineTest
   {
     final File persistDir = new File(tmpDir, UUID.randomUUID().toString());
     final IncrementalIndexSchema schema = new IncrementalIndexSchema.Builder()
-        .withQueryGranularity(Granularities.NONE)
         .withMinTimestamp(JodaUtils.MIN_INSTANT)
         .withDimensionsSpec(ROW_PARSER)
-        .withMetrics(
-            new AggregatorFactory[]{
-                new LongSumAggregatorFactory(METRICS[0], METRICS[0])
-            }
-        )
+        .withMetrics(new LongSumAggregatorFactory(METRICS[0], METRICS[0]))
         .build();
-    final OnheapIncrementalIndex index = new OnheapIncrementalIndex.Builder()
+    final IncrementalIndex index = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(schema)
         .setMaxRowCount(rows.length)
-        .build();
+        .buildOnheap();
 
     for (InputRow row : rows) {
       try {

--- a/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTimelineTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTimelineTest.java
@@ -220,7 +220,10 @@ public class IngestSegmentFirehoseFactoryTimelineTest
             }
         )
         .build();
-    final OnheapIncrementalIndex index = new OnheapIncrementalIndex(schema, true, rows.length);
+    final OnheapIncrementalIndex index = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(schema)
+        .setMaxRowCount(rows.length)
+        .build();
 
     for (InputRow row : rows) {
       try {

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryHelper.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryHelper.java
@@ -44,8 +44,6 @@ import io.druid.segment.column.ValueType;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.IndexSizeExceededException;
-import io.druid.segment.incremental.OffheapIncrementalIndex;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.joda.time.DateTime;
 
 import java.nio.ByteBuffer;
@@ -120,22 +118,21 @@ public class GroupByQueryHelper
         .build();
 
     if (query.getContextValue("useOffheap", false)) {
-      index = new OffheapIncrementalIndex.Builder()
+      index = new IncrementalIndex.Builder()
           .setIncrementalIndexSchema(indexSchema)
           .setDeserializeComplexMetrics(false)
           .setConcurrentEventAdd(true)
           .setSortFacts(sortResults)
           .setMaxRowCount(querySpecificConfig.getMaxResults())
-          .setBufferPool(bufferPool)
-          .build();
+          .buildOffheap(bufferPool);
     } else {
-      index = new OnheapIncrementalIndex.Builder()
+      index = new IncrementalIndex.Builder()
           .setIncrementalIndexSchema(indexSchema)
           .setDeserializeComplexMetrics(false)
           .setConcurrentEventAdd(true)
           .setSortFacts(sortResults)
           .setMaxRowCount(querySpecificConfig.getMaxResults())
-          .build();
+          .buildOnheap();
     }
 
     Accumulator<IncrementalIndex, T> accumulator = new Accumulator<IncrementalIndex, T>()

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryHelper.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryHelper.java
@@ -124,6 +124,7 @@ public class GroupByQueryHelper
           indexSchema,
           false,
           true,
+          true,
           sortResults,
           querySpecificConfig.getMaxResults(),
           bufferPool
@@ -132,6 +133,7 @@ public class GroupByQueryHelper
       index = new OnheapIncrementalIndex(
           indexSchema,
           false,
+          true,
           true,
           sortResults,
           querySpecificConfig.getMaxResults()

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryHelper.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryHelper.java
@@ -120,24 +120,22 @@ public class GroupByQueryHelper
         .build();
 
     if (query.getContextValue("useOffheap", false)) {
-      index = new OffheapIncrementalIndex(
-          indexSchema,
-          false,
-          true,
-          true,
-          sortResults,
-          querySpecificConfig.getMaxResults(),
-          bufferPool
-      );
+      index = new OffheapIncrementalIndex.Builder()
+          .setIncrementalIndexSchema(indexSchema)
+          .setDeserializeComplexMetrics(false)
+          .setConcurrentEventAdd(true)
+          .setSortFacts(sortResults)
+          .setMaxRowCount(querySpecificConfig.getMaxResults())
+          .setBufferPool(bufferPool)
+          .build();
     } else {
-      index = new OnheapIncrementalIndex(
-          indexSchema,
-          false,
-          true,
-          true,
-          sortResults,
-          querySpecificConfig.getMaxResults()
-      );
+      index = new OnheapIncrementalIndex.Builder()
+          .setIncrementalIndexSchema(indexSchema)
+          .setDeserializeComplexMetrics(false)
+          .setConcurrentEventAdd(true)
+          .setSortFacts(sortResults)
+          .setMaxRowCount(querySpecificConfig.getMaxResults())
+          .build();
     }
 
     Accumulator<IncrementalIndex, T> accumulator = new Accumulator<IncrementalIndex, T>()

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryHelper.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryHelper.java
@@ -119,7 +119,7 @@ public class GroupByQueryHelper
 
     if (query.getContextValue("useOffheap", false)) {
       index = new IncrementalIndex.Builder()
-          .setIncrementalIndexSchema(indexSchema)
+          .setIndexSchema(indexSchema)
           .setDeserializeComplexMetrics(false)
           .setConcurrentEventAdd(true)
           .setSortFacts(sortResults)
@@ -127,7 +127,7 @@ public class GroupByQueryHelper
           .buildOffheap(bufferPool);
     } else {
       index = new IncrementalIndex.Builder()
-          .setIncrementalIndexSchema(indexSchema)
+          .setIndexSchema(indexSchema)
           .setDeserializeComplexMetrics(false)
           .setConcurrentEventAdd(true)
           .setSortFacts(sortResults)

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -313,15 +313,13 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
       return this;
     }
 
-    // A helper method to set a simple index schema with only metrics and default values for the other parameters. Note
-    // that this method is normally used for testing and benchmarking; it is unlikely that you would use it in
-    // production settings.
-
-    /** A helper method to set a simple index schema with only metrics and default values for the other parameters. Note
+    /**
+     * A helper method to set a simple index schema with only metrics and default values for the other parameters. Note
      * that this method is normally used for testing and benchmarking; it is unlikely that you would use it in
      * production settings.
      *
      * @param metrics variable array of {@link AggregatorFactory} metrics
+     *
      * @return this
      */
     @VisibleForTesting

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -307,9 +307,29 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
       maxRowCount = 0;
     }
 
-    public Builder setIncrementalIndexSchema(final IncrementalIndexSchema incrementalIndexSchema)
+    public Builder setIndexSchema(final IncrementalIndexSchema incrementalIndexSchema)
     {
       this.incrementalIndexSchema = incrementalIndexSchema;
+      return this;
+    }
+
+    // A helper method to set a simple index schema with only metrics and default values for the other parameters. Note
+    // that this method is normally used for testing and benchmarking; it is unlikely that you would use it in
+    // production settings.
+
+    /** A helper method to set a simple index schema with only metrics and default values for the other parameters. Note
+     * that this method is normally used for testing and benchmarking; it is unlikely that you would use it in
+     * production settings.
+     *
+     * @param metrics variable array of {@link AggregatorFactory} metrics
+     * @return this
+     */
+    @VisibleForTesting
+    public Builder setSimpleTestingIndexSchema(final AggregatorFactory... metrics)
+    {
+      this.incrementalIndexSchema = new IncrementalIndexSchema.Builder()
+          .withMetrics(metrics)
+          .build();
       return this;
     }
 

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -219,7 +219,8 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
   public IncrementalIndex(
       final IncrementalIndexSchema incrementalIndexSchema,
       final boolean deserializeComplexMetrics,
-      final boolean reportParseExceptions
+      final boolean reportParseExceptions,
+      final boolean concurrentEventAdd
   )
   {
     this.minTimestamp = incrementalIndexSchema.getMinTimestamp();
@@ -238,7 +239,7 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
         .setQueryGranularity(this.gran)
         .setRollup(this.rollup);
 
-    this.aggs = initAggs(metrics, rowSupplier, deserializeComplexMetrics);
+    this.aggs = initAggs(metrics, rowSupplier, deserializeComplexMetrics, concurrentEventAdd);
 
     this.metricDescs = Maps.newLinkedHashMap();
     for (AggregatorFactory metric : metrics) {
@@ -294,7 +295,8 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
   protected abstract AggregatorType[] initAggs(
       AggregatorFactory[] metrics,
       Supplier<InputRow> rowSupplier,
-      boolean deserializeComplexMetrics
+      boolean deserializeComplexMetrics,
+      boolean concurrentEventAdd
   );
 
   // Note: This method needs to be thread safe.

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -210,11 +210,15 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
    * Setting deserializeComplexMetrics to false is necessary for intermediate aggregation such as groupBy that
    * should not deserialize input columns using ComplexMetricSerde for aggregators that return complex metrics.
    *
+   * Set concurrentEventAdd to true to indicate that adding of input row should be thread-safe (for example, groupBy
+   * where the multiple threads can add concurrently to the IncrementalIndex).
+   *
    * @param incrementalIndexSchema    the schema to use for incremental index
    * @param deserializeComplexMetrics flag whether or not to call ComplexMetricExtractor.extractValue() on the input
    *                                  value for aggregators that return metrics other than float.
    * @param reportParseExceptions     flag whether or not to report ParseExceptions that occur while extracting values
    *                                  from input rows
+   * @param concurrentEventAdd        flag whether ot not adding of input rows should be thread-safe
    */
   public IncrementalIndex(
       final IncrementalIndexSchema incrementalIndexSchema,

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexSchema.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexSchema.java
@@ -109,7 +109,7 @@ public class IncrementalIndexSchema
       this.minTimestamp = 0L;
       this.gran = Granularities.NONE;
       this.virtualColumns = VirtualColumns.EMPTY;
-      this.dimensionsSpec = new DimensionsSpec(null, null, null);
+      this.dimensionsSpec = DimensionsSpec.EMPTY;
       this.metrics = new AggregatorFactory[]{};
       this.rollup = true;
     }
@@ -152,7 +152,7 @@ public class IncrementalIndexSchema
 
     public Builder withDimensionsSpec(DimensionsSpec dimensionsSpec)
     {
-      this.dimensionsSpec = dimensionsSpec == null ? DimensionsSpec.ofEmpty() : dimensionsSpec;
+      this.dimensionsSpec = dimensionsSpec == null ? DimensionsSpec.EMPTY : dimensionsSpec;
       return this;
     }
 
@@ -169,7 +169,7 @@ public class IncrementalIndexSchema
       return this;
     }
 
-    public Builder withMetrics(AggregatorFactory[] metrics)
+    public Builder withMetrics(AggregatorFactory... metrics)
     {
       this.metrics = metrics;
       return this;

--- a/processing/src/main/java/io/druid/segment/incremental/OffheapIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OffheapIncrementalIndex.java
@@ -36,7 +36,6 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -66,7 +65,7 @@ public class OffheapIncrementalIndex extends IncrementalIndex<BufferAggregator>
 
   private String outOfRowsReason = null;
 
-  public OffheapIncrementalIndex(
+  OffheapIncrementalIndex(
       IncrementalIndexSchema incrementalIndexSchema,
       boolean deserializeComplexMetrics,
       boolean reportParseExceptions,
@@ -90,87 +89,6 @@ public class OffheapIncrementalIndex extends IncrementalIndex<BufferAggregator>
       throw new IAE("bufferPool buffers capacity must be >= [%s]", aggsTotalSize);
     }
     aggBuffers.add(bb);
-  }
-
-  public static class Builder
-  {
-    private IncrementalIndexSchema incrementalIndexSchema;
-    private boolean deserializeComplexMetrics;
-    private boolean reportParseExceptions;
-    private boolean concurrentEventAdd;
-    private boolean sortFacts;
-    private int maxRowCount;
-    private StupidPool<ByteBuffer> bufferPool;
-
-    public Builder()
-    {
-      incrementalIndexSchema = null;
-      deserializeComplexMetrics = true;
-      reportParseExceptions = true;
-      concurrentEventAdd = false;
-      sortFacts = true;
-      maxRowCount = 0;
-      bufferPool = null;
-    }
-
-    public Builder setIncrementalIndexSchema(final IncrementalIndexSchema incrementalIndexSchema)
-    {
-      this.incrementalIndexSchema = incrementalIndexSchema;
-      return this;
-    }
-
-    public Builder setDeserializeComplexMetrics(final boolean deserializeComplexMetrics)
-    {
-      this.deserializeComplexMetrics = deserializeComplexMetrics;
-      return this;
-    }
-
-    public Builder setReportParseExceptions(final boolean reportParseExceptions)
-    {
-      this.reportParseExceptions = reportParseExceptions;
-      return this;
-    }
-
-    public Builder setConcurrentEventAdd(final boolean concurrentEventAdd)
-    {
-      this.concurrentEventAdd = concurrentEventAdd;
-      return this;
-    }
-
-    public Builder setSortFacts(final boolean sortFacts)
-    {
-      this.sortFacts = sortFacts;
-      return this;
-    }
-
-    public Builder setMaxRowCount(final int maxRowCount)
-    {
-      this.maxRowCount = maxRowCount;
-      return this;
-    }
-
-    public Builder setBufferPool(final StupidPool<ByteBuffer> bufferPool)
-    {
-      this.bufferPool = bufferPool;
-      return this;
-    }
-
-    public OffheapIncrementalIndex build()
-    {
-      if (maxRowCount <= 0) {
-        throw new IllegalArgumentException("Invalid max row count: " + maxRowCount);
-      }
-
-      return new OffheapIncrementalIndex(
-          Objects.requireNonNull(incrementalIndexSchema, "incrementalIndexSchema is null"),
-          deserializeComplexMetrics,
-          reportParseExceptions,
-          concurrentEventAdd,
-          sortFacts,
-          maxRowCount,
-          Objects.requireNonNull(bufferPool, "bufferPool is null")
-      );
-    }
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -40,7 +40,6 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -58,7 +57,7 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
 
   private String outOfRowsReason = null;
 
-  protected OnheapIncrementalIndex(
+  OnheapIncrementalIndex(
       IncrementalIndexSchema incrementalIndexSchema,
       boolean deserializeComplexMetrics,
       boolean reportParseExceptions,
@@ -72,78 +71,6 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
 
     this.facts = incrementalIndexSchema.isRollup() ? new RollupFactsHolder(sortFacts, dimsComparator(), getDimensions())
                                                    : new PlainFactsHolder(sortFacts);
-  }
-
-  public static class Builder
-  {
-    private IncrementalIndexSchema incrementalIndexSchema;
-    private boolean deserializeComplexMetrics;
-    private boolean reportParseExceptions;
-    private boolean concurrentEventAdd;
-    private boolean sortFacts;
-    private int maxRowCount;
-
-    public Builder()
-    {
-      incrementalIndexSchema = null;
-      deserializeComplexMetrics = true;
-      reportParseExceptions = true;
-      concurrentEventAdd = false;
-      sortFacts = true;
-      maxRowCount = 0;
-    }
-
-    public Builder setIncrementalIndexSchema(final IncrementalIndexSchema incrementalIndexSchema)
-    {
-      this.incrementalIndexSchema = incrementalIndexSchema;
-      return this;
-    }
-
-    public Builder setDeserializeComplexMetrics(final boolean deserializeComplexMetrics)
-    {
-      this.deserializeComplexMetrics = deserializeComplexMetrics;
-      return this;
-    }
-
-    public Builder setReportParseExceptions(final boolean reportParseExceptions)
-    {
-      this.reportParseExceptions = reportParseExceptions;
-      return this;
-    }
-
-    public Builder setConcurrentEventAdd(final boolean concurrentEventAdd)
-    {
-      this.concurrentEventAdd = concurrentEventAdd;
-      return this;
-    }
-
-    public Builder setSortFacts(final boolean sortFacts)
-    {
-      this.sortFacts = sortFacts;
-      return this;
-    }
-
-    public Builder setMaxRowCount(final int maxRowCount)
-    {
-      this.maxRowCount = maxRowCount;
-      return this;
-    }
-
-    public OnheapIncrementalIndex build()
-    {
-      if (maxRowCount <= 0) {
-        throw new IllegalArgumentException("Invalid max row count: " + maxRowCount);
-      }
-
-      return new OnheapIncrementalIndex(
-          Objects.requireNonNull(incrementalIndexSchema, "incrementIndexSchema is null"),
-          deserializeComplexMetrics,
-          reportParseExceptions,
-          concurrentEventAdd,
-          sortFacts,
-          maxRowCount
-      );
-    }
   }
 
   @Override
@@ -402,18 +329,30 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
     @Override
     public FloatColumnSelector makeFloatColumnSelector(String columnName)
     {
+      final FloatColumnSelector existing = floatColumnSelectorMap.get(columnName);
+      if (existing != null) {
+        return existing;
+      }
       return floatColumnSelectorMap.computeIfAbsent(columnName, delegate::makeFloatColumnSelector);
     }
 
     @Override
     public LongColumnSelector makeLongColumnSelector(String columnName)
     {
+      final LongColumnSelector existing = longColumnSelectorMap.get(columnName);
+      if (existing != null) {
+        return existing;
+      }
       return longColumnSelectorMap.computeIfAbsent(columnName, delegate::makeLongColumnSelector);
     }
 
     @Override
     public ObjectColumnSelector makeObjectColumnSelector(String columnName)
     {
+      final ObjectColumnSelector existing = objectColumnSelectorMap.get(columnName);
+      if (existing != null) {
+        return existing;
+      }
       return objectColumnSelectorMap.computeIfAbsent(columnName, delegate::makeObjectColumnSelector);
     }
 

--- a/processing/src/test/java/io/druid/query/MultiValuedDimensionTest.java
+++ b/processing/src/test/java/io/druid/query/MultiValuedDimensionTest.java
@@ -61,7 +61,6 @@ import io.druid.segment.Segment;
 import io.druid.segment.TestHelper;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.commons.io.FileUtils;
 import org.joda.time.DateTime;
 import org.junit.AfterClass;
@@ -114,17 +113,14 @@ public class MultiValuedDimensionTest
   @BeforeClass
   public static void setupClass() throws Exception
   {
-    incrementalIndex = new OnheapIncrementalIndex.Builder()
+    incrementalIndex = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-                .withMinTimestamp(0)
-                .withQueryGranularity(Granularities.NONE)
-                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
-                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .withMetrics(new CountAggregatorFactory("count"))
                 .build()
         )
         .setMaxRowCount(5000)
-        .build();
+        .buildOnheap();
 
     StringInputRowParser parser = new StringInputRowParser(
         new CSVParseSpec(

--- a/processing/src/test/java/io/druid/query/MultiValuedDimensionTest.java
+++ b/processing/src/test/java/io/druid/query/MultiValuedDimensionTest.java
@@ -60,6 +60,7 @@ import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.Segment;
 import io.druid.segment.TestHelper;
 import io.druid.segment.incremental.IncrementalIndex;
+import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.commons.io.FileUtils;
 import org.joda.time.DateTime;
@@ -113,17 +114,17 @@ public class MultiValuedDimensionTest
   @BeforeClass
   public static void setupClass() throws Exception
   {
-    incrementalIndex = new OnheapIncrementalIndex(
-        0,
-        Granularities.NONE,
-        new AggregatorFactory[]{
-            new CountAggregatorFactory("count")
-        },
-        true,
-        true,
-        true,
-        5000
-    );
+    incrementalIndex = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withMinTimestamp(0)
+                .withQueryGranularity(Granularities.NONE)
+                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
+                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .build()
+        )
+        .setMaxRowCount(5000)
+        .build();
 
     StringInputRowParser parser = new StringInputRowParser(
         new CSVParseSpec(

--- a/processing/src/test/java/io/druid/query/MultiValuedDimensionTest.java
+++ b/processing/src/test/java/io/druid/query/MultiValuedDimensionTest.java
@@ -60,7 +60,6 @@ import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.Segment;
 import io.druid.segment.TestHelper;
 import io.druid.segment.incremental.IncrementalIndex;
-import io.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.commons.io.FileUtils;
 import org.joda.time.DateTime;
 import org.junit.AfterClass;
@@ -114,11 +113,7 @@ public class MultiValuedDimensionTest
   public static void setupClass() throws Exception
   {
     incrementalIndex = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
-            new IncrementalIndexSchema.Builder()
-                .withMetrics(new CountAggregatorFactory("count"))
-                .build()
-        )
+        .setSimpleTestingIndexSchema(new CountAggregatorFactory("count"))
         .setMaxRowCount(5000)
         .buildOnheap();
 

--- a/processing/src/test/java/io/druid/query/SchemaEvolutionTest.java
+++ b/processing/src/test/java/io/druid/query/SchemaEvolutionTest.java
@@ -150,7 +150,7 @@ public class SchemaEvolutionTest
                          .tmpDir(temporaryFolder.newFolder())
                          .schema(
                              new IncrementalIndexSchema.Builder()
-                                 .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("cnt")})
+                                 .withMetrics(new CountAggregatorFactory("cnt"))
                                  .withRollup(false)
                                  .build()
                          )
@@ -162,11 +162,11 @@ public class SchemaEvolutionTest
                          .tmpDir(temporaryFolder.newFolder())
                          .schema(
                              new IncrementalIndexSchema.Builder()
-                                 .withMetrics(new AggregatorFactory[]{
+                                 .withMetrics(
                                      new CountAggregatorFactory("cnt"),
                                      new LongSumAggregatorFactory("c1", "c1"),
                                      new HyperUniquesAggregatorFactory("uniques", "c2")
-                                 })
+                                 )
                                  .withRollup(false)
                                  .build()
                          )
@@ -178,11 +178,11 @@ public class SchemaEvolutionTest
                          .tmpDir(temporaryFolder.newFolder())
                          .schema(
                              new IncrementalIndexSchema.Builder()
-                                 .withMetrics(new AggregatorFactory[]{
+                                 .withMetrics(
                                      new CountAggregatorFactory("cnt"),
                                      new DoubleSumAggregatorFactory("c1", "c1"),
                                      new HyperUniquesAggregatorFactory("uniques", "c2")
-                                 })
+                                 )
                                  .withRollup(false)
                                  .build()
                          )
@@ -194,9 +194,7 @@ public class SchemaEvolutionTest
                          .tmpDir(temporaryFolder.newFolder())
                          .schema(
                              new IncrementalIndexSchema.Builder()
-                                 .withMetrics(new AggregatorFactory[]{
-                                     new HyperUniquesAggregatorFactory("c2", "c2")
-                                 })
+                                 .withMetrics(new HyperUniquesAggregatorFactory("c2", "c2"))
                                  .withRollup(false)
                                  .build()
                          )

--- a/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
@@ -78,7 +78,6 @@ import io.druid.segment.TestHelper;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
 import org.junit.rules.TemporaryFolder;
@@ -414,18 +413,17 @@ public class AggregationTestHelper
     List<File> toMerge = new ArrayList<>();
 
     try {
-      index = new OnheapIncrementalIndex.Builder()
+      index = new IncrementalIndex.Builder()
           .setIncrementalIndexSchema(
               new IncrementalIndexSchema.Builder()
                   .withMinTimestamp(minTimestamp)
                   .withQueryGranularity(gran)
                   .withMetrics(metrics)
-                  .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
                   .build()
           )
           .setDeserializeComplexMetrics(deserializeComplexMetrics)
           .setMaxRowCount(maxRowCount)
-          .build();
+          .buildOnheap();
 
       while (rows.hasNext()) {
         Object row = rows.next();
@@ -434,18 +432,17 @@ public class AggregationTestHelper
           toMerge.add(tmp);
           indexMerger.persist(index, tmp, new IndexSpec());
           index.close();
-          index = new OnheapIncrementalIndex.Builder()
+          index = new IncrementalIndex.Builder()
               .setIncrementalIndexSchema(
                   new IncrementalIndexSchema.Builder()
                       .withMinTimestamp(minTimestamp)
                       .withQueryGranularity(gran)
                       .withMetrics(metrics)
-                      .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
                       .build()
               )
               .setDeserializeComplexMetrics(deserializeComplexMetrics)
               .setMaxRowCount(maxRowCount)
-              .build();
+              .buildOnheap();
         }
         if (row instanceof String && parser instanceof StringInputRowParser) {
           //Note: this is required because StringInputRowParser is InputRowParser<ByteBuffer> as opposed to

--- a/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
@@ -414,7 +414,7 @@ public class AggregationTestHelper
 
     try {
       index = new IncrementalIndex.Builder()
-          .setIncrementalIndexSchema(
+          .setIndexSchema(
               new IncrementalIndexSchema.Builder()
                   .withMinTimestamp(minTimestamp)
                   .withQueryGranularity(gran)
@@ -433,7 +433,7 @@ public class AggregationTestHelper
           indexMerger.persist(index, tmp, new IndexSpec());
           index.close();
           index = new IncrementalIndex.Builder()
-              .setIncrementalIndexSchema(
+              .setIndexSchema(
                   new IncrementalIndexSchema.Builder()
                       .withMinTimestamp(minTimestamp)
                       .withQueryGranularity(gran)

--- a/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
@@ -77,6 +77,7 @@ import io.druid.segment.Segment;
 import io.druid.segment.TestHelper;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
+import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
@@ -413,7 +414,19 @@ public class AggregationTestHelper
     List<File> toMerge = new ArrayList<>();
 
     try {
-      index = new OnheapIncrementalIndex(minTimestamp, gran, metrics, deserializeComplexMetrics, true, true, maxRowCount);
+      index = new OnheapIncrementalIndex.Builder()
+          .setIncrementalIndexSchema(
+              new IncrementalIndexSchema.Builder()
+                  .withMinTimestamp(minTimestamp)
+                  .withQueryGranularity(gran)
+                  .withMetrics(metrics)
+                  .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                  .build()
+          )
+          .setDeserializeComplexMetrics(deserializeComplexMetrics)
+          .setMaxRowCount(maxRowCount)
+          .build();
+
       while (rows.hasNext()) {
         Object row = rows.next();
         if (!index.canAppendRow()) {
@@ -421,7 +434,18 @@ public class AggregationTestHelper
           toMerge.add(tmp);
           indexMerger.persist(index, tmp, new IndexSpec());
           index.close();
-          index = new OnheapIncrementalIndex(minTimestamp, gran, metrics, deserializeComplexMetrics, true, true, maxRowCount);
+          index = new OnheapIncrementalIndex.Builder()
+              .setIncrementalIndexSchema(
+                  new IncrementalIndexSchema.Builder()
+                      .withMinTimestamp(minTimestamp)
+                      .withQueryGranularity(gran)
+                      .withMetrics(metrics)
+                      .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                      .build()
+              )
+              .setDeserializeComplexMetrics(deserializeComplexMetrics)
+              .setMaxRowCount(maxRowCount)
+              .build();
         }
         if (row instanceof String && parser instanceof StringInputRowParser) {
           //Note: this is required because StringInputRowParser is InputRowParser<ByteBuffer> as opposed to

--- a/processing/src/test/java/io/druid/query/datasourcemetadata/DataSourceMetadataQueryTest.java
+++ b/processing/src/test/java/io/druid/query/datasourcemetadata/DataSourceMetadataQueryTest.java
@@ -26,9 +26,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.MapMaker;
 import io.druid.data.input.MapBasedInputRow;
-import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.jackson.DefaultObjectMapper;
-import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.DefaultGenericQueryMetricsFactory;
 import io.druid.query.Druids;
@@ -39,12 +37,10 @@ import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerFactory;
 import io.druid.query.QueryRunnerTestHelper;
 import io.druid.query.Result;
-import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.segment.IncrementalIndexSegment;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.timeline.LogicalSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -116,18 +112,14 @@ public class DataSourceMetadataQueryTest
   @Test
   public void testMaxIngestedEventTime() throws Exception
   {
-    final IncrementalIndex rtIndex = new OnheapIncrementalIndex.Builder()
+    final IncrementalIndex rtIndex = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-                .withMinTimestamp(0L)
-                .withQueryGranularity(Granularities.NONE)
-                .withDimensionsSpec(DimensionsSpec.ofEmpty())
-                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
-                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .withMetrics(new CountAggregatorFactory("count"))
                 .build()
         )
         .setMaxRowCount(1000)
-        .build();
+        .buildOnheap();
 
     final QueryRunner runner = QueryRunnerTestHelper.makeQueryRunner(
         (QueryRunnerFactory) new DataSourceMetadataQueryRunnerFactory(

--- a/processing/src/test/java/io/druid/query/datasourcemetadata/DataSourceMetadataQueryTest.java
+++ b/processing/src/test/java/io/druid/query/datasourcemetadata/DataSourceMetadataQueryTest.java
@@ -40,7 +40,6 @@ import io.druid.query.Result;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.segment.IncrementalIndexSegment;
 import io.druid.segment.incremental.IncrementalIndex;
-import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.timeline.LogicalSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -113,11 +112,7 @@ public class DataSourceMetadataQueryTest
   public void testMaxIngestedEventTime() throws Exception
   {
     final IncrementalIndex rtIndex = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
-            new IncrementalIndexSchema.Builder()
-                .withMetrics(new CountAggregatorFactory("count"))
-                .build()
-        )
+        .setSimpleTestingIndexSchema(new CountAggregatorFactory("count"))
         .setMaxRowCount(1000)
         .buildOnheap();
 

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerFactoryTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerFactoryTest.java
@@ -46,7 +46,6 @@ import io.druid.segment.IncrementalIndexSegment;
 import io.druid.segment.Segment;
 import io.druid.segment.TestHelper;
 import io.druid.segment.incremental.IncrementalIndex;
-import io.druid.segment.incremental.IncrementalIndexSchema;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -130,11 +129,7 @@ public class GroupByQueryRunnerFactoryTest
   private Segment createSegment() throws Exception
   {
     IncrementalIndex incrementalIndex = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
-            new IncrementalIndexSchema.Builder()
-                .withMetrics(new CountAggregatorFactory("count"))
-                .build()
-        )
+        .setSimpleTestingIndexSchema(new CountAggregatorFactory("count"))
         .setConcurrentEventAdd(true)
         .setMaxRowCount(5000)
         .buildOnheap();

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerFactoryTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerFactoryTest.java
@@ -47,7 +47,6 @@ import io.druid.segment.Segment;
 import io.druid.segment.TestHelper;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -130,18 +129,15 @@ public class GroupByQueryRunnerFactoryTest
 
   private Segment createSegment() throws Exception
   {
-    IncrementalIndex incrementalIndex = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex incrementalIndex = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-                .withMinTimestamp(0)
-                .withQueryGranularity(Granularities.NONE)
-                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
-                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .withMetrics(new CountAggregatorFactory("count"))
                 .build()
         )
         .setConcurrentEventAdd(true)
         .setMaxRowCount(5000)
-        .build();
+        .buildOnheap();
 
     StringInputRowParser parser = new StringInputRowParser(
         new CSVParseSpec(

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerFactoryTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerFactoryTest.java
@@ -46,6 +46,7 @@ import io.druid.segment.IncrementalIndexSegment;
 import io.druid.segment.Segment;
 import io.druid.segment.TestHelper;
 import io.druid.segment.incremental.IncrementalIndex;
+import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.junit.Rule;
 import org.junit.Test;
@@ -129,17 +130,18 @@ public class GroupByQueryRunnerFactoryTest
 
   private Segment createSegment() throws Exception
   {
-    IncrementalIndex incrementalIndex = new OnheapIncrementalIndex(
-        0,
-        Granularities.NONE,
-        new AggregatorFactory[]{
-            new CountAggregatorFactory("count")
-        },
-        true,
-        true,
-        true,
-        5000
-    );
+    IncrementalIndex incrementalIndex = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withMinTimestamp(0)
+                .withQueryGranularity(Granularities.NONE)
+                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
+                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .build()
+        )
+        .setConcurrentEventAdd(true)
+        .setMaxRowCount(5000)
+        .build();
 
     StringInputRowParser parser = new StringInputRowParser(
         new CSVParseSpec(

--- a/processing/src/test/java/io/druid/query/search/SearchQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/search/SearchQueryRunnerTest.java
@@ -23,7 +23,6 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.druid.data.input.MapBasedInputRow;
-import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.logger.Logger;
@@ -61,7 +60,6 @@ import io.druid.segment.column.Column;
 import io.druid.segment.column.ValueType;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.junit.Assert;
@@ -745,16 +743,14 @@ public class SearchQueryRunnerTest
   @Test
   public void testSearchWithNullValueInDimension() throws Exception
   {
-    IncrementalIndex<Aggregator> index = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex<Aggregator> index = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-                .withQueryGranularity(Granularities.NONE)
                 .withMinTimestamp(new DateTime("2011-01-12T00:00:00.000Z").getMillis())
                 .build()
         )
-        .setReportParseExceptions(true)
         .setMaxRowCount(10)
-        .build();
+        .buildOnheap();
 
     index.add(
         new MapBasedInputRow(

--- a/processing/src/test/java/io/druid/query/search/SearchQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/search/SearchQueryRunnerTest.java
@@ -745,13 +745,17 @@ public class SearchQueryRunnerTest
   @Test
   public void testSearchWithNullValueInDimension() throws Exception
   {
-    IncrementalIndex<Aggregator> index = new OnheapIncrementalIndex(
-        new IncrementalIndexSchema.Builder()
-            .withQueryGranularity(Granularities.NONE)
-            .withMinTimestamp(new DateTime("2011-01-12T00:00:00.000Z").getMillis()).build(),
-        true,
-        10
-    );
+    IncrementalIndex<Aggregator> index = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withQueryGranularity(Granularities.NONE)
+                .withMinTimestamp(new DateTime("2011-01-12T00:00:00.000Z").getMillis())
+                .build()
+        )
+        .setReportParseExceptions(true)
+        .setMaxRowCount(10)
+        .build();
+
     index.add(
         new MapBasedInputRow(
             1481871600000L,

--- a/processing/src/test/java/io/druid/query/search/SearchQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/search/SearchQueryRunnerTest.java
@@ -744,7 +744,7 @@ public class SearchQueryRunnerTest
   public void testSearchWithNullValueInDimension() throws Exception
   {
     IncrementalIndex<Aggregator> index = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
+        .setIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withMinTimestamp(new DateTime("2011-01-12T00:00:00.000Z").getMillis())
                 .build()

--- a/processing/src/test/java/io/druid/query/select/MultiSegmentSelectQueryTest.java
+++ b/processing/src/test/java/io/druid/query/select/MultiSegmentSelectQueryTest.java
@@ -43,7 +43,6 @@ import io.druid.segment.Segment;
 import io.druid.segment.TestIndex;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.timeline.DataSegment;
 import io.druid.timeline.TimelineObjectHolder;
 import io.druid.timeline.VersionedIntervalTimeline;

--- a/processing/src/test/java/io/druid/query/select/MultiSegmentSelectQueryTest.java
+++ b/processing/src/test/java/io/druid/query/select/MultiSegmentSelectQueryTest.java
@@ -188,10 +188,10 @@ public class MultiSegmentSelectQueryTest
         .withQueryGranularity(Granularities.HOUR)
         .withMetrics(TestIndex.METRIC_AGGS)
         .build();
-    return new OnheapIncrementalIndex.Builder()
+    return new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(schema)
         .setMaxRowCount(maxRowCount)
-        .build();
+        .buildOnheap();
   }
 
   @AfterClass

--- a/processing/src/test/java/io/druid/query/select/MultiSegmentSelectQueryTest.java
+++ b/processing/src/test/java/io/druid/query/select/MultiSegmentSelectQueryTest.java
@@ -188,7 +188,7 @@ public class MultiSegmentSelectQueryTest
         .withMetrics(TestIndex.METRIC_AGGS)
         .build();
     return new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(schema)
+        .setIndexSchema(schema)
         .setMaxRowCount(maxRowCount)
         .buildOnheap();
   }

--- a/processing/src/test/java/io/druid/query/select/MultiSegmentSelectQueryTest.java
+++ b/processing/src/test/java/io/druid/query/select/MultiSegmentSelectQueryTest.java
@@ -188,7 +188,10 @@ public class MultiSegmentSelectQueryTest
         .withQueryGranularity(Granularities.HOUR)
         .withMetrics(TestIndex.METRIC_AGGS)
         .build();
-    return new OnheapIncrementalIndex(schema, true, maxRowCount);
+    return new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(schema)
+        .setMaxRowCount(maxRowCount)
+        .build();
   }
 
   @AfterClass

--- a/processing/src/test/java/io/druid/query/timeboundary/TimeBoundaryQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/timeboundary/TimeBoundaryQueryRunnerTest.java
@@ -119,7 +119,10 @@ public class TimeBoundaryQueryRunnerTest
         .withQueryGranularity(Granularities.HOUR)
         .withMetrics(TestIndex.METRIC_AGGS)
         .build();
-    return new OnheapIncrementalIndex(schema, true, maxRowCount);
+    return new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(schema)
+        .setMaxRowCount(maxRowCount)
+        .build();
   }
 
   private static String makeIdentifier(IncrementalIndex index, String version)

--- a/processing/src/test/java/io/druid/query/timeboundary/TimeBoundaryQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/timeboundary/TimeBoundaryQueryRunnerTest.java
@@ -38,7 +38,6 @@ import io.druid.segment.Segment;
 import io.druid.segment.TestIndex;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.timeline.DataSegment;
 import io.druid.timeline.TimelineObjectHolder;
 import io.druid.timeline.VersionedIntervalTimeline;
@@ -119,10 +118,10 @@ public class TimeBoundaryQueryRunnerTest
         .withQueryGranularity(Granularities.HOUR)
         .withMetrics(TestIndex.METRIC_AGGS)
         .build();
-    return new OnheapIncrementalIndex.Builder()
+    return new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(schema)
         .setMaxRowCount(maxRowCount)
-        .build();
+        .buildOnheap();
   }
 
   private static String makeIdentifier(IncrementalIndex index, String version)

--- a/processing/src/test/java/io/druid/query/timeboundary/TimeBoundaryQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/timeboundary/TimeBoundaryQueryRunnerTest.java
@@ -119,7 +119,7 @@ public class TimeBoundaryQueryRunnerTest
         .withMetrics(TestIndex.METRIC_AGGS)
         .build();
     return new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(schema)
+        .setIndexSchema(schema)
         .setMaxRowCount(maxRowCount)
         .buildOnheap();
   }

--- a/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerBonusTest.java
+++ b/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerBonusTest.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.druid.data.input.MapBasedInputRow;
-import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.Druids;
@@ -39,7 +38,6 @@ import io.druid.segment.IncrementalIndexSegment;
 import io.druid.segment.Segment;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.junit.Assert;
@@ -71,18 +69,14 @@ public class TimeseriesQueryRunnerBonusTest
   @Test
   public void testOneRowAtATime() throws Exception
   {
-    final IncrementalIndex oneRowIndex = new OnheapIncrementalIndex.Builder()
+    final IncrementalIndex oneRowIndex = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withMinTimestamp(new DateTime("2012-01-01T00:00:00Z").getMillis())
-                .withQueryGranularity(Granularities.NONE)
-                .withDimensionsSpec(DimensionsSpec.ofEmpty())
-                .withMetrics(new AggregatorFactory[]{})
-                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
                 .build()
         )
         .setMaxRowCount(1000)
-        .build();
+        .buildOnheap();
 
     List<Result<TimeseriesResultValue>> results;
 

--- a/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerBonusTest.java
+++ b/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerBonusTest.java
@@ -70,7 +70,7 @@ public class TimeseriesQueryRunnerBonusTest
   public void testOneRowAtATime() throws Exception
   {
     final IncrementalIndex oneRowIndex = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
+        .setIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withMinTimestamp(new DateTime("2012-01-01T00:00:00Z").getMillis())
                 .build()

--- a/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerBonusTest.java
+++ b/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerBonusTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.druid.data.input.MapBasedInputRow;
+import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.Druids;
@@ -37,6 +38,7 @@ import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.segment.IncrementalIndexSegment;
 import io.druid.segment.Segment;
 import io.druid.segment.incremental.IncrementalIndex;
+import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -69,9 +71,18 @@ public class TimeseriesQueryRunnerBonusTest
   @Test
   public void testOneRowAtATime() throws Exception
   {
-    final IncrementalIndex oneRowIndex = new OnheapIncrementalIndex(
-        new DateTime("2012-01-01T00:00:00Z").getMillis(), Granularities.NONE, new AggregatorFactory[]{}, 1000
-    );
+    final IncrementalIndex oneRowIndex = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withMinTimestamp(new DateTime("2012-01-01T00:00:00Z").getMillis())
+                .withQueryGranularity(Granularities.NONE)
+                .withDimensionsSpec(DimensionsSpec.ofEmpty())
+                .withMetrics(new AggregatorFactory[]{})
+                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .build()
+        )
+        .setMaxRowCount(1000)
+        .build();
 
     List<Result<TimeseriesResultValue>> results;
 

--- a/processing/src/test/java/io/druid/segment/EmptyIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/EmptyIndexTest.java
@@ -22,14 +22,11 @@ package io.druid.segment;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import io.druid.collections.bitmap.ConciseBitmapFactory;
-import io.druid.data.input.impl.DimensionsSpec;
-import io.druid.java.util.common.granularity.Granularities;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.segment.column.Column;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexAdapter;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.commons.io.FileUtils;
 import org.joda.time.Interval;
 import org.junit.Assert;
@@ -51,18 +48,10 @@ public class EmptyIndexTest
     }
 
     try {
-      IncrementalIndex emptyIndex = new OnheapIncrementalIndex.Builder()
-          .setIncrementalIndexSchema(
-              new IncrementalIndexSchema.Builder()
-                  .withMinTimestamp(0)
-                  .withQueryGranularity(Granularities.NONE)
-                  .withDimensionsSpec(DimensionsSpec.ofEmpty())
-                  .withMetrics(new AggregatorFactory[0])
-                  .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
-                  .build()
-          )
+      IncrementalIndex emptyIndex = new IncrementalIndex.Builder()
+          .setIncrementalIndexSchema(new IncrementalIndexSchema.Builder().build())
           .setMaxRowCount(1000)
-          .build();
+          .buildOnheap();
 
       IncrementalIndexAdapter emptyIndexAdapter = new IncrementalIndexAdapter(
           new Interval("2012-08-01/P3D"),

--- a/processing/src/test/java/io/druid/segment/EmptyIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/EmptyIndexTest.java
@@ -22,11 +22,13 @@ package io.druid.segment;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import io.druid.collections.bitmap.ConciseBitmapFactory;
+import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.segment.column.Column;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexAdapter;
+import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.commons.io.FileUtils;
 import org.joda.time.Interval;
@@ -49,12 +51,19 @@ public class EmptyIndexTest
     }
 
     try {
-      IncrementalIndex emptyIndex = new OnheapIncrementalIndex(
-          0,
-          Granularities.NONE,
-          new AggregatorFactory[0],
-          1000
-      );
+      IncrementalIndex emptyIndex = new OnheapIncrementalIndex.Builder()
+          .setIncrementalIndexSchema(
+              new IncrementalIndexSchema.Builder()
+                  .withMinTimestamp(0)
+                  .withQueryGranularity(Granularities.NONE)
+                  .withDimensionsSpec(DimensionsSpec.ofEmpty())
+                  .withMetrics(new AggregatorFactory[0])
+                  .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                  .build()
+          )
+          .setMaxRowCount(1000)
+          .build();
+
       IncrementalIndexAdapter emptyIndexAdapter = new IncrementalIndexAdapter(
           new Interval("2012-08-01/P3D"),
           emptyIndex,

--- a/processing/src/test/java/io/druid/segment/EmptyIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/EmptyIndexTest.java
@@ -26,7 +26,6 @@ import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.segment.column.Column;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexAdapter;
-import io.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.commons.io.FileUtils;
 import org.joda.time.Interval;
 import org.junit.Assert;
@@ -49,7 +48,7 @@ public class EmptyIndexTest
 
     try {
       IncrementalIndex emptyIndex = new IncrementalIndex.Builder()
-          .setIncrementalIndexSchema(new IncrementalIndexSchema.Builder().build())
+          .setSimpleTestingIndexSchema(/* empty */)
           .setMaxRowCount(1000)
           .buildOnheap();
 

--- a/processing/src/test/java/io/druid/segment/IndexBuilder.java
+++ b/processing/src/test/java/io/druid/segment/IndexBuilder.java
@@ -203,7 +203,7 @@ public class IndexBuilder
   {
     Preconditions.checkNotNull(schema, "schema");
     final IncrementalIndex incrementalIndex = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(schema)
+        .setIndexSchema(schema)
         .setMaxRowCount(maxRows)
         .buildOnheap();
 

--- a/processing/src/test/java/io/druid/segment/IndexBuilder.java
+++ b/processing/src/test/java/io/druid/segment/IndexBuilder.java
@@ -30,7 +30,6 @@ import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.IndexSizeExceededException;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 
 import java.io.File;
 import java.io.IOException;
@@ -47,9 +46,9 @@ public class IndexBuilder
   private static final int ROWS_PER_INDEX_FOR_MERGING = 1;
   private static final int DEFAULT_MAX_ROWS = Integer.MAX_VALUE;
 
-  private IncrementalIndexSchema schema = new IncrementalIndexSchema.Builder().withMetrics(new AggregatorFactory[]{
-      new CountAggregatorFactory("count")
-  }).build();
+  private IncrementalIndexSchema schema = new IncrementalIndexSchema.Builder()
+      .withMetrics(new CountAggregatorFactory("count"))
+      .build();
   private IndexMerger indexMerger = TestHelper.getTestIndexMerger();
   private File tmpDir;
   private IndexSpec indexSpec = new IndexSpec();
@@ -203,10 +202,10 @@ public class IndexBuilder
   )
   {
     Preconditions.checkNotNull(schema, "schema");
-    final IncrementalIndex incrementalIndex = new OnheapIncrementalIndex.Builder()
+    final IncrementalIndex incrementalIndex = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(schema)
         .setMaxRowCount(maxRows)
-        .build();
+        .buildOnheap();
 
     for (InputRow row : rows) {
       try {

--- a/processing/src/test/java/io/druid/segment/IndexBuilder.java
+++ b/processing/src/test/java/io/druid/segment/IndexBuilder.java
@@ -203,11 +203,11 @@ public class IndexBuilder
   )
   {
     Preconditions.checkNotNull(schema, "schema");
-    final IncrementalIndex incrementalIndex = new OnheapIncrementalIndex(
-        schema,
-        true,
-        maxRows
-    );
+    final IncrementalIndex incrementalIndex = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(schema)
+        .setMaxRowCount(maxRows)
+        .build();
+
     for (InputRow row : rows) {
       try {
         incrementalIndex.add(row);

--- a/processing/src/test/java/io/druid/segment/IndexIOTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexIOTest.java
@@ -263,49 +263,53 @@ public class IndexIOTest
     this.exception = exception;
   }
 
-  final IncrementalIndex<Aggregator> incrementalIndex1 = new OnheapIncrementalIndex(
-      new IncrementalIndexSchema.Builder().withMinTimestamp(DEFAULT_INTERVAL.getStart().getMillis())
-                                          .withQueryGranularity(Granularities.NONE)
-                                          .withMetrics(
-                                              new AggregatorFactory[]{
-                                                  new CountAggregatorFactory(
-                                                      "count"
-                                                  )
-                                              }
-                                          )
-                                          .withDimensionsSpec(
-                                              new DimensionsSpec(
-                                                  DimensionsSpec.getDefaultSchemas(Arrays.asList("dim0", "dim1")),
-                                                  null,
-                                                  null
-                                              )
-                                          )
-                                          .build(),
-      true,
-      1000000
-  );
+  final IncrementalIndex<Aggregator> incrementalIndex1 = new OnheapIncrementalIndex.Builder()
+      .setIncrementalIndexSchema(
+          new IncrementalIndexSchema.Builder()
+              .withMinTimestamp(DEFAULT_INTERVAL.getStart().getMillis())
+              .withQueryGranularity(Granularities.NONE)
+              .withMetrics(
+                  new AggregatorFactory[]{
+                      new CountAggregatorFactory(
+                          "count"
+                      )
+                  }
+              )
+              .withDimensionsSpec(
+                  new DimensionsSpec(
+                      DimensionsSpec.getDefaultSchemas(Arrays.asList("dim0", "dim1")),
+                      null,
+                      null
+                  )
+              )
+              .build()
+      )
+      .setMaxRowCount(1000000)
+      .build();
 
-  final IncrementalIndex<Aggregator> incrementalIndex2 = new OnheapIncrementalIndex(
-      new IncrementalIndexSchema.Builder().withMinTimestamp(DEFAULT_INTERVAL.getStart().getMillis())
-                                          .withQueryGranularity(Granularities.NONE)
-                                          .withMetrics(
-                                              new AggregatorFactory[]{
-                                                  new CountAggregatorFactory(
-                                                      "count"
-                                                  )
-                                              }
-                                          )
-                                          .withDimensionsSpec(
-                                              new DimensionsSpec(
-                                                  DimensionsSpec.getDefaultSchemas(Arrays.asList("dim0", "dim1")),
-                                                  null,
-                                                  null
-                                              )
-                                          )
-                                          .build(),
-      true,
-      1000000
-  );
+  final IncrementalIndex<Aggregator> incrementalIndex2 = new OnheapIncrementalIndex.Builder()
+      .setIncrementalIndexSchema(
+          new IncrementalIndexSchema.Builder()
+              .withMinTimestamp(DEFAULT_INTERVAL.getStart().getMillis())
+              .withQueryGranularity(Granularities.NONE)
+              .withMetrics(
+                  new AggregatorFactory[]{
+                      new CountAggregatorFactory(
+                          "count"
+                      )
+                  }
+              )
+              .withDimensionsSpec(
+                  new DimensionsSpec(
+                      DimensionsSpec.getDefaultSchemas(Arrays.asList("dim0", "dim1")),
+                      null,
+                      null
+                  )
+              )
+              .build()
+      )
+      .setMaxRowCount(1000000)
+      .build();
 
   IndexableAdapter adapter1;
   IndexableAdapter adapter2;

--- a/processing/src/test/java/io/druid/segment/IndexIOTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexIOTest.java
@@ -30,9 +30,7 @@ import com.google.common.collect.Maps;
 import io.druid.data.input.MapBasedInputRow;
 import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.java.util.common.UOE;
-import io.druid.java.util.common.granularity.Granularities;
 import io.druid.query.aggregation.Aggregator;
-import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.segment.data.CompressedObjectStrategy;
 import io.druid.segment.data.CompressionFactory;
@@ -41,7 +39,6 @@ import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexAdapter;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.IndexSizeExceededException;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Before;
@@ -263,18 +260,11 @@ public class IndexIOTest
     this.exception = exception;
   }
 
-  final IncrementalIndex<Aggregator> incrementalIndex1 = new OnheapIncrementalIndex.Builder()
+  final IncrementalIndex<Aggregator> incrementalIndex1 = new IncrementalIndex.Builder()
       .setIncrementalIndexSchema(
           new IncrementalIndexSchema.Builder()
               .withMinTimestamp(DEFAULT_INTERVAL.getStart().getMillis())
-              .withQueryGranularity(Granularities.NONE)
-              .withMetrics(
-                  new AggregatorFactory[]{
-                      new CountAggregatorFactory(
-                          "count"
-                      )
-                  }
-              )
+              .withMetrics(new CountAggregatorFactory("count"))
               .withDimensionsSpec(
                   new DimensionsSpec(
                       DimensionsSpec.getDefaultSchemas(Arrays.asList("dim0", "dim1")),
@@ -285,20 +275,13 @@ public class IndexIOTest
               .build()
       )
       .setMaxRowCount(1000000)
-      .build();
+      .buildOnheap();
 
-  final IncrementalIndex<Aggregator> incrementalIndex2 = new OnheapIncrementalIndex.Builder()
+  final IncrementalIndex<Aggregator> incrementalIndex2 = new IncrementalIndex.Builder()
       .setIncrementalIndexSchema(
           new IncrementalIndexSchema.Builder()
               .withMinTimestamp(DEFAULT_INTERVAL.getStart().getMillis())
-              .withQueryGranularity(Granularities.NONE)
-              .withMetrics(
-                  new AggregatorFactory[]{
-                      new CountAggregatorFactory(
-                          "count"
-                      )
-                  }
-              )
+              .withMetrics(new CountAggregatorFactory("count"))
               .withDimensionsSpec(
                   new DimensionsSpec(
                       DimensionsSpec.getDefaultSchemas(Arrays.asList("dim0", "dim1")),
@@ -309,7 +292,7 @@ public class IndexIOTest
               .build()
       )
       .setMaxRowCount(1000000)
-      .build();
+      .buildOnheap();
 
   IndexableAdapter adapter1;
   IndexableAdapter adapter2;

--- a/processing/src/test/java/io/druid/segment/IndexIOTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexIOTest.java
@@ -261,7 +261,7 @@ public class IndexIOTest
   }
 
   final IncrementalIndex<Aggregator> incrementalIndex1 = new IncrementalIndex.Builder()
-      .setIncrementalIndexSchema(
+      .setIndexSchema(
           new IncrementalIndexSchema.Builder()
               .withMinTimestamp(DEFAULT_INTERVAL.getStart().getMillis())
               .withMetrics(new CountAggregatorFactory("count"))
@@ -278,7 +278,7 @@ public class IndexIOTest
       .buildOnheap();
 
   final IncrementalIndex<Aggregator> incrementalIndex2 = new IncrementalIndex.Builder()
-      .setIncrementalIndexSchema(
+      .setIndexSchema(
           new IncrementalIndexSchema.Builder()
               .withMinTimestamp(DEFAULT_INTERVAL.getStart().getMillis())
               .withMetrics(new CountAggregatorFactory("count"))

--- a/processing/src/test/java/io/druid/segment/IndexMergerTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerTest.java
@@ -58,7 +58,6 @@ import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexAdapter;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.IndexSizeExceededException;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.junit.Assert;
@@ -293,18 +292,14 @@ public class IndexMergerTest
     IncrementalIndex toPersist1 = IncrementalIndexTest.createIndex(null);
     IncrementalIndexTest.populateIndex(timestamp, toPersist1);
 
-    IncrementalIndex toPersist2 = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex toPersist2 = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-            .withMinTimestamp(0)
-            .withQueryGranularity(Granularities.NONE)
-            .withDimensionsSpec(DimensionsSpec.ofEmpty())
-            .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
-            .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+            .withMetrics(new CountAggregatorFactory("count"))
             .build()
         )
         .setMaxRowCount(1000)
-        .build();
+        .buildOnheap();
 
     toPersist2.add(
         new MapBasedInputRow(
@@ -385,31 +380,15 @@ public class IndexMergerTest
   @Test
   public void testPersistEmptyColumn() throws Exception
   {
-    final IncrementalIndex toPersist1 = new OnheapIncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
-            new IncrementalIndexSchema.Builder()
-                .withMinTimestamp(0)
-                .withQueryGranularity(Granularities.NONE)
-                .withDimensionsSpec(DimensionsSpec.ofEmpty())
-                .withMetrics(new AggregatorFactory[]{})
-                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
-                .build()
-        )
+    final IncrementalIndex toPersist1 = new IncrementalIndex.Builder()
+        .setIncrementalIndexSchema(new IncrementalIndexSchema.Builder().build())
         .setMaxRowCount(10)
-        .build();
+        .buildOnheap();
 
-    final IncrementalIndex toPersist2 = new OnheapIncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
-            new IncrementalIndexSchema.Builder()
-                .withMinTimestamp(0)
-                .withQueryGranularity(Granularities.NONE)
-                .withDimensionsSpec(DimensionsSpec.ofEmpty())
-                .withMetrics(new AggregatorFactory[]{})
-                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
-                .build()
-        )
+    final IncrementalIndex toPersist2 = new IncrementalIndex.Builder()
+        .setIncrementalIndexSchema(new IncrementalIndexSchema.Builder().build())
         .setMaxRowCount(10)
-        .build();
+        .buildOnheap();
 
     final File tmpDir1 = temporaryFolder.newFolder();
     final File tmpDir2 = temporaryFolder.newFolder();
@@ -944,24 +923,22 @@ public class IndexMergerTest
             null,
             null
         ))
-        .withMinTimestamp(0L)
-        .withQueryGranularity(Granularities.NONE)
-        .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
+        .withMetrics(new CountAggregatorFactory("count"))
         .build();
 
 
-    IncrementalIndex toPersist1 = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex toPersist1 = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(schema)
         .setMaxRowCount(1000)
-        .build();
-    IncrementalIndex toPersist2 = new OnheapIncrementalIndex.Builder()
+        .buildOnheap();
+    IncrementalIndex toPersist2 = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(schema)
         .setMaxRowCount(1000)
-        .build();
-    IncrementalIndex toPersist3 = new OnheapIncrementalIndex.Builder()
+        .buildOnheap();
+    IncrementalIndex toPersist3 = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(schema)
         .setMaxRowCount(1000)
-        .build();
+        .buildOnheap();
 
     addDimValuesToIndex(toPersist1, "dimA", Arrays.asList("1", "2"));
     addDimValuesToIndex(toPersist2, "dimA", Arrays.asList("1", "2"));
@@ -1171,18 +1148,14 @@ public class IndexMergerTest
     // d8: 'has null' join 'no null'
     // d9: 'no null' join 'no null'
 
-    IncrementalIndex toPersistA = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex toPersistA = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-                .withMinTimestamp(0)
-                .withQueryGranularity(Granularities.NONE)
-                .withDimensionsSpec(DimensionsSpec.ofEmpty())
-                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
-                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .withMetrics(new CountAggregatorFactory("count"))
                 .build()
         )
         .setMaxRowCount(1000)
-        .build();
+        .buildOnheap();
 
     toPersistA.add(
         new MapBasedInputRow(
@@ -1203,18 +1176,14 @@ public class IndexMergerTest
         )
     );
 
-    IncrementalIndex toPersistB = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex toPersistB = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-                .withMinTimestamp(0)
-                .withQueryGranularity(Granularities.NONE)
-                .withDimensionsSpec(DimensionsSpec.ofEmpty())
-                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
-                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .withMetrics(new CountAggregatorFactory("count"))
                 .build()
         )
         .setMaxRowCount(1000)
-        .build();
+        .buildOnheap();
 
     toPersistB.add(
         new MapBasedInputRow(
@@ -1326,15 +1295,13 @@ public class IndexMergerTest
     // d9: 'no null' join 'no null'
 
     IncrementalIndexSchema indexSchema = new IncrementalIndexSchema.Builder()
-        .withMinTimestamp(0L)
-        .withQueryGranularity(Granularities.NONE)
-        .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
+        .withMetrics(new CountAggregatorFactory("count"))
         .withRollup(false)
         .build();
-    IncrementalIndex toPersistA = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex toPersistA = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(indexSchema)
         .setMaxRowCount(1000)
-        .build();
+        .buildOnheap();
 
     toPersistA.add(
         new MapBasedInputRow(
@@ -1355,10 +1322,10 @@ public class IndexMergerTest
         )
     );
 
-    IncrementalIndex toPersistB = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex toPersistB = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(indexSchema)
         .setMaxRowCount(1000)
-        .build();
+        .buildOnheap();
 
     toPersistB.add(
         new MapBasedInputRow(
@@ -1469,15 +1436,13 @@ public class IndexMergerTest
     // 3. merge 2 indexes with duplicate rows
 
     IncrementalIndexSchema indexSchema = new IncrementalIndexSchema.Builder()
-        .withMinTimestamp(0L)
-        .withQueryGranularity(Granularities.NONE)
-        .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
+        .withMetrics(new CountAggregatorFactory("count"))
         .withRollup(false)
         .build();
-    IncrementalIndex toPersistA = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex toPersistA = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(indexSchema)
         .setMaxRowCount(1000)
-        .build();
+        .buildOnheap();
 
     toPersistA.add(
         new MapBasedInputRow(
@@ -1498,10 +1463,10 @@ public class IndexMergerTest
         )
     );
 
-    IncrementalIndex toPersistB = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex toPersistB = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(indexSchema)
         .setMaxRowCount(1000)
-        .build();
+        .buildOnheap();
 
     toPersistB.add(
         new MapBasedInputRow(
@@ -1602,18 +1567,14 @@ public class IndexMergerTest
     IncrementalIndex toPersistBA = getSingleDimIndex("dimB", Arrays.asList("1", "2", "3"));
     addDimValuesToIndex(toPersistBA, "dimA", Arrays.asList("1", "2"));
 
-    IncrementalIndex toPersistBA2 = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex toPersistBA2 = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-                .withMinTimestamp(0)
-                .withQueryGranularity(Granularities.NONE)
-                .withDimensionsSpec(DimensionsSpec.ofEmpty())
-                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
-                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .withMetrics(new CountAggregatorFactory("count"))
                 .build()
         )
         .setMaxRowCount(1000)
-        .build();
+        .buildOnheap();
 
     toPersistBA2.add(
         new MapBasedInputRow(
@@ -2182,17 +2143,14 @@ public class IndexMergerTest
   private IncrementalIndex getIndexWithDimsFromSchemata(List<DimensionSchema> dims)
   {
     IncrementalIndexSchema schema = new IncrementalIndexSchema.Builder()
-        .withMinTimestamp(0L)
-        .withQueryGranularity(Granularities.NONE)
         .withDimensionsSpec(new DimensionsSpec(dims, null, null))
-        .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
-        .withRollup(true)
+        .withMetrics(new CountAggregatorFactory("count"))
         .build();
 
-    return new OnheapIncrementalIndex.Builder()
+    return new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(schema)
         .setMaxRowCount(1000)
-        .build();
+        .buildOnheap();
   }
 
 
@@ -2242,18 +2200,14 @@ public class IndexMergerTest
 
   private IncrementalIndex getIndexD3() throws Exception
   {
-    IncrementalIndex toPersist1 = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex toPersist1 = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-            .withMinTimestamp(0)
-            .withQueryGranularity(Granularities.NONE)
-            .withDimensionsSpec(DimensionsSpec.ofEmpty())
-            .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
-            .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+            .withMetrics(new CountAggregatorFactory("count"))
             .build()
         )
         .setMaxRowCount(1000)
-        .build();
+        .buildOnheap();
 
     toPersist1.add(
         new MapBasedInputRow(
@@ -2284,18 +2238,14 @@ public class IndexMergerTest
 
   private IncrementalIndex getSingleDimIndex(String dimName, List<String> values) throws Exception
   {
-    IncrementalIndex toPersist1 = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex toPersist1 = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-                .withMinTimestamp(0)
-                .withQueryGranularity(Granularities.NONE)
-                .withDimensionsSpec(DimensionsSpec.ofEmpty())
-                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
-                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .withMetrics(new CountAggregatorFactory("count"))
                 .build()
         )
         .setMaxRowCount(1000)
-        .build();
+        .buildOnheap();
 
     addDimValuesToIndex(toPersist1, dimName, values);
     return toPersist1;
@@ -2317,17 +2267,14 @@ public class IndexMergerTest
   private IncrementalIndex getIndexWithDims(List<String> dims)
   {
     IncrementalIndexSchema schema = new IncrementalIndexSchema.Builder()
-        .withMinTimestamp(0L)
-        .withQueryGranularity(Granularities.NONE)
         .withDimensionsSpec(new DimensionsSpec(DimensionsSpec.getDefaultSchemas(dims), null, null))
-        .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
-        .withRollup(true)
+        .withMetrics(new CountAggregatorFactory("count"))
         .build();
 
-    return new OnheapIncrementalIndex.Builder()
+    return new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(schema)
         .setMaxRowCount(1000)
-        .build();
+        .buildOnheap();
   }
 
   private AggregatorFactory[] getCombiningAggregators(AggregatorFactory[] aggregators)

--- a/processing/src/test/java/io/druid/segment/IndexMergerTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerTest.java
@@ -293,11 +293,7 @@ public class IndexMergerTest
     IncrementalIndexTest.populateIndex(timestamp, toPersist1);
 
     IncrementalIndex toPersist2 = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
-            new IncrementalIndexSchema.Builder()
-            .withMetrics(new CountAggregatorFactory("count"))
-            .build()
-        )
+        .setSimpleTestingIndexSchema(new CountAggregatorFactory("count"))
         .setMaxRowCount(1000)
         .buildOnheap();
 
@@ -381,12 +377,12 @@ public class IndexMergerTest
   public void testPersistEmptyColumn() throws Exception
   {
     final IncrementalIndex toPersist1 = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(new IncrementalIndexSchema.Builder().build())
+        .setSimpleTestingIndexSchema(/* empty */)
         .setMaxRowCount(10)
         .buildOnheap();
 
     final IncrementalIndex toPersist2 = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(new IncrementalIndexSchema.Builder().build())
+        .setSimpleTestingIndexSchema(/* empty */)
         .setMaxRowCount(10)
         .buildOnheap();
 
@@ -928,15 +924,15 @@ public class IndexMergerTest
 
 
     IncrementalIndex toPersist1 = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(schema)
+        .setIndexSchema(schema)
         .setMaxRowCount(1000)
         .buildOnheap();
     IncrementalIndex toPersist2 = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(schema)
+        .setIndexSchema(schema)
         .setMaxRowCount(1000)
         .buildOnheap();
     IncrementalIndex toPersist3 = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(schema)
+        .setIndexSchema(schema)
         .setMaxRowCount(1000)
         .buildOnheap();
 
@@ -1149,11 +1145,7 @@ public class IndexMergerTest
     // d9: 'no null' join 'no null'
 
     IncrementalIndex toPersistA = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
-            new IncrementalIndexSchema.Builder()
-                .withMetrics(new CountAggregatorFactory("count"))
-                .build()
-        )
+        .setSimpleTestingIndexSchema(new CountAggregatorFactory("count"))
         .setMaxRowCount(1000)
         .buildOnheap();
 
@@ -1177,11 +1169,7 @@ public class IndexMergerTest
     );
 
     IncrementalIndex toPersistB = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
-            new IncrementalIndexSchema.Builder()
-                .withMetrics(new CountAggregatorFactory("count"))
-                .build()
-        )
+        .setSimpleTestingIndexSchema(new CountAggregatorFactory("count"))
         .setMaxRowCount(1000)
         .buildOnheap();
 
@@ -1299,7 +1287,7 @@ public class IndexMergerTest
         .withRollup(false)
         .build();
     IncrementalIndex toPersistA = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(indexSchema)
+        .setIndexSchema(indexSchema)
         .setMaxRowCount(1000)
         .buildOnheap();
 
@@ -1323,7 +1311,7 @@ public class IndexMergerTest
     );
 
     IncrementalIndex toPersistB = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(indexSchema)
+        .setIndexSchema(indexSchema)
         .setMaxRowCount(1000)
         .buildOnheap();
 
@@ -1440,7 +1428,7 @@ public class IndexMergerTest
         .withRollup(false)
         .build();
     IncrementalIndex toPersistA = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(indexSchema)
+        .setIndexSchema(indexSchema)
         .setMaxRowCount(1000)
         .buildOnheap();
 
@@ -1464,7 +1452,7 @@ public class IndexMergerTest
     );
 
     IncrementalIndex toPersistB = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(indexSchema)
+        .setIndexSchema(indexSchema)
         .setMaxRowCount(1000)
         .buildOnheap();
 
@@ -1568,11 +1556,7 @@ public class IndexMergerTest
     addDimValuesToIndex(toPersistBA, "dimA", Arrays.asList("1", "2"));
 
     IncrementalIndex toPersistBA2 = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
-            new IncrementalIndexSchema.Builder()
-                .withMetrics(new CountAggregatorFactory("count"))
-                .build()
-        )
+        .setSimpleTestingIndexSchema(new CountAggregatorFactory("count"))
         .setMaxRowCount(1000)
         .buildOnheap();
 
@@ -2148,7 +2132,7 @@ public class IndexMergerTest
         .build();
 
     return new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(schema)
+        .setIndexSchema(schema)
         .setMaxRowCount(1000)
         .buildOnheap();
   }
@@ -2201,11 +2185,7 @@ public class IndexMergerTest
   private IncrementalIndex getIndexD3() throws Exception
   {
     IncrementalIndex toPersist1 = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
-            new IncrementalIndexSchema.Builder()
-            .withMetrics(new CountAggregatorFactory("count"))
-            .build()
-        )
+        .setSimpleTestingIndexSchema(new CountAggregatorFactory("count"))
         .setMaxRowCount(1000)
         .buildOnheap();
 
@@ -2239,11 +2219,7 @@ public class IndexMergerTest
   private IncrementalIndex getSingleDimIndex(String dimName, List<String> values) throws Exception
   {
     IncrementalIndex toPersist1 = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
-            new IncrementalIndexSchema.Builder()
-                .withMetrics(new CountAggregatorFactory("count"))
-                .build()
-        )
+        .setSimpleTestingIndexSchema(new CountAggregatorFactory("count"))
         .setMaxRowCount(1000)
         .buildOnheap();
 
@@ -2272,7 +2248,7 @@ public class IndexMergerTest
         .build();
 
     return new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(schema)
+        .setIndexSchema(schema)
         .setMaxRowCount(1000)
         .buildOnheap();
   }

--- a/processing/src/test/java/io/druid/segment/IndexMergerTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerTest.java
@@ -293,12 +293,18 @@ public class IndexMergerTest
     IncrementalIndex toPersist1 = IncrementalIndexTest.createIndex(null);
     IncrementalIndexTest.populateIndex(timestamp, toPersist1);
 
-    IncrementalIndex toPersist2 = new OnheapIncrementalIndex(
-        0L,
-        Granularities.NONE,
-        new AggregatorFactory[]{new CountAggregatorFactory("count")},
-        1000
-    );
+    IncrementalIndex toPersist2 = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+            .withMinTimestamp(0)
+            .withQueryGranularity(Granularities.NONE)
+            .withDimensionsSpec(DimensionsSpec.ofEmpty())
+            .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
+            .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+            .build()
+        )
+        .setMaxRowCount(1000)
+        .build();
 
     toPersist2.add(
         new MapBasedInputRow(
@@ -379,18 +385,32 @@ public class IndexMergerTest
   @Test
   public void testPersistEmptyColumn() throws Exception
   {
-    final IncrementalIndex toPersist1 = new OnheapIncrementalIndex(
-        0L,
-        Granularities.NONE,
-        new AggregatorFactory[]{},
-        10
-    );
-    final IncrementalIndex toPersist2 = new OnheapIncrementalIndex(
-        0L,
-        Granularities.NONE,
-        new AggregatorFactory[]{},
-        10
-    );
+    final IncrementalIndex toPersist1 = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withMinTimestamp(0)
+                .withQueryGranularity(Granularities.NONE)
+                .withDimensionsSpec(DimensionsSpec.ofEmpty())
+                .withMetrics(new AggregatorFactory[]{})
+                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .build()
+        )
+        .setMaxRowCount(10)
+        .build();
+
+    final IncrementalIndex toPersist2 = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withMinTimestamp(0)
+                .withQueryGranularity(Granularities.NONE)
+                .withDimensionsSpec(DimensionsSpec.ofEmpty())
+                .withMetrics(new AggregatorFactory[]{})
+                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .build()
+        )
+        .setMaxRowCount(10)
+        .build();
+
     final File tmpDir1 = temporaryFolder.newFolder();
     final File tmpDir2 = temporaryFolder.newFolder();
     final File tmpDir3 = temporaryFolder.newFolder();
@@ -930,9 +950,18 @@ public class IndexMergerTest
         .build();
 
 
-    IncrementalIndex toPersist1 = new OnheapIncrementalIndex(schema, true, 1000);
-    IncrementalIndex toPersist2 = new OnheapIncrementalIndex(schema, true, 1000);
-    IncrementalIndex toPersist3 = new OnheapIncrementalIndex(schema, true, 1000);
+    IncrementalIndex toPersist1 = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(schema)
+        .setMaxRowCount(1000)
+        .build();
+    IncrementalIndex toPersist2 = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(schema)
+        .setMaxRowCount(1000)
+        .build();
+    IncrementalIndex toPersist3 = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(schema)
+        .setMaxRowCount(1000)
+        .build();
 
     addDimValuesToIndex(toPersist1, "dimA", Arrays.asList("1", "2"));
     addDimValuesToIndex(toPersist2, "dimA", Arrays.asList("1", "2"));
@@ -1142,12 +1171,19 @@ public class IndexMergerTest
     // d8: 'has null' join 'no null'
     // d9: 'no null' join 'no null'
 
-    IncrementalIndex toPersistA = new OnheapIncrementalIndex(
-        0L,
-        Granularities.NONE,
-        new AggregatorFactory[]{new CountAggregatorFactory("count")},
-        1000
-    );
+    IncrementalIndex toPersistA = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withMinTimestamp(0)
+                .withQueryGranularity(Granularities.NONE)
+                .withDimensionsSpec(DimensionsSpec.ofEmpty())
+                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
+                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .build()
+        )
+        .setMaxRowCount(1000)
+        .build();
+
     toPersistA.add(
         new MapBasedInputRow(
             1,
@@ -1167,12 +1203,19 @@ public class IndexMergerTest
         )
     );
 
-    IncrementalIndex toPersistB = new OnheapIncrementalIndex(
-        0L,
-        Granularities.NONE,
-        new AggregatorFactory[]{new CountAggregatorFactory("count")},
-        1000
-    );
+    IncrementalIndex toPersistB = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withMinTimestamp(0)
+                .withQueryGranularity(Granularities.NONE)
+                .withDimensionsSpec(DimensionsSpec.ofEmpty())
+                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
+                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .build()
+        )
+        .setMaxRowCount(1000)
+        .build();
+
     toPersistB.add(
         new MapBasedInputRow(
             3,
@@ -1288,7 +1331,11 @@ public class IndexMergerTest
         .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
         .withRollup(false)
         .build();
-    IncrementalIndex toPersistA = new OnheapIncrementalIndex(indexSchema, true, 1000);
+    IncrementalIndex toPersistA = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(indexSchema)
+        .setMaxRowCount(1000)
+        .build();
+
     toPersistA.add(
         new MapBasedInputRow(
             1,
@@ -1308,7 +1355,11 @@ public class IndexMergerTest
         )
     );
 
-    IncrementalIndex toPersistB = new OnheapIncrementalIndex(indexSchema, true, 1000);
+    IncrementalIndex toPersistB = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(indexSchema)
+        .setMaxRowCount(1000)
+        .build();
+
     toPersistB.add(
         new MapBasedInputRow(
             3,
@@ -1423,7 +1474,11 @@ public class IndexMergerTest
         .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
         .withRollup(false)
         .build();
-    IncrementalIndex toPersistA = new OnheapIncrementalIndex(indexSchema, true, 1000);
+    IncrementalIndex toPersistA = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(indexSchema)
+        .setMaxRowCount(1000)
+        .build();
+
     toPersistA.add(
         new MapBasedInputRow(
             1,
@@ -1443,7 +1498,11 @@ public class IndexMergerTest
         )
     );
 
-    IncrementalIndex toPersistB = new OnheapIncrementalIndex(indexSchema, true, 1000);
+    IncrementalIndex toPersistB = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(indexSchema)
+        .setMaxRowCount(1000)
+        .build();
+
     toPersistB.add(
         new MapBasedInputRow(
             1,
@@ -1543,12 +1602,18 @@ public class IndexMergerTest
     IncrementalIndex toPersistBA = getSingleDimIndex("dimB", Arrays.asList("1", "2", "3"));
     addDimValuesToIndex(toPersistBA, "dimA", Arrays.asList("1", "2"));
 
-    IncrementalIndex toPersistBA2 = new OnheapIncrementalIndex(
-        0L,
-        Granularities.NONE,
-        new AggregatorFactory[]{new CountAggregatorFactory("count")},
-        1000
-    );
+    IncrementalIndex toPersistBA2 = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withMinTimestamp(0)
+                .withQueryGranularity(Granularities.NONE)
+                .withDimensionsSpec(DimensionsSpec.ofEmpty())
+                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
+                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .build()
+        )
+        .setMaxRowCount(1000)
+        .build();
 
     toPersistBA2.add(
         new MapBasedInputRow(
@@ -2124,7 +2189,10 @@ public class IndexMergerTest
         .withRollup(true)
         .build();
 
-    return new OnheapIncrementalIndex(schema, true, 1000);
+    return new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(schema)
+        .setMaxRowCount(1000)
+        .build();
   }
 
 
@@ -2174,12 +2242,18 @@ public class IndexMergerTest
 
   private IncrementalIndex getIndexD3() throws Exception
   {
-    IncrementalIndex toPersist1 = new OnheapIncrementalIndex(
-        0L,
-        Granularities.NONE,
-        new AggregatorFactory[]{new CountAggregatorFactory("count")},
-        1000
-    );
+    IncrementalIndex toPersist1 = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+            .withMinTimestamp(0)
+            .withQueryGranularity(Granularities.NONE)
+            .withDimensionsSpec(DimensionsSpec.ofEmpty())
+            .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
+            .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+            .build()
+        )
+        .setMaxRowCount(1000)
+        .build();
 
     toPersist1.add(
         new MapBasedInputRow(
@@ -2210,12 +2284,18 @@ public class IndexMergerTest
 
   private IncrementalIndex getSingleDimIndex(String dimName, List<String> values) throws Exception
   {
-    IncrementalIndex toPersist1 = new OnheapIncrementalIndex(
-        0L,
-        Granularities.NONE,
-        new AggregatorFactory[]{new CountAggregatorFactory("count")},
-        1000
-    );
+    IncrementalIndex toPersist1 = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withMinTimestamp(0)
+                .withQueryGranularity(Granularities.NONE)
+                .withDimensionsSpec(DimensionsSpec.ofEmpty())
+                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
+                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .build()
+        )
+        .setMaxRowCount(1000)
+        .build();
 
     addDimValuesToIndex(toPersist1, dimName, values);
     return toPersist1;
@@ -2244,7 +2324,10 @@ public class IndexMergerTest
         .withRollup(true)
         .build();
 
-    return new OnheapIncrementalIndex(schema, true, 1000);
+    return new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(schema)
+        .setMaxRowCount(1000)
+        .build();
   }
 
   private AggregatorFactory[] getCombiningAggregators(AggregatorFactory[] aggregators)

--- a/processing/src/test/java/io/druid/segment/IndexMergerV9CompatibilityTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerV9CompatibilityTest.java
@@ -166,7 +166,7 @@ public class IndexMergerV9CompatibilityTest
   public void setUp() throws IOException
   {
     toPersist = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
+        .setIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withMinTimestamp(JodaUtils.MIN_INSTANT)
                 .withMetrics(DEFAULT_AGG_FACTORIES)

--- a/processing/src/test/java/io/druid/segment/IndexMergerV9CompatibilityTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerV9CompatibilityTest.java
@@ -28,8 +28,6 @@ import com.google.common.io.Files;
 import io.druid.common.utils.JodaUtils;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.MapBasedInputRow;
-import io.druid.data.input.impl.DimensionsSpec;
-import io.druid.java.util.common.granularity.Granularities;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.segment.data.CompressedObjectStrategy;
@@ -37,7 +35,6 @@ import io.druid.segment.data.CompressionFactory;
 import io.druid.segment.data.ConciseBitmapSerdeFactory;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.commons.io.FileUtils;
 import org.joda.time.DateTime;
 import org.junit.After;
@@ -168,18 +165,15 @@ public class IndexMergerV9CompatibilityTest
   @Before
   public void setUp() throws IOException
   {
-    toPersist = new OnheapIncrementalIndex.Builder()
+    toPersist = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withMinTimestamp(JodaUtils.MIN_INSTANT)
-                .withQueryGranularity(Granularities.NONE)
-                .withDimensionsSpec(DimensionsSpec.ofEmpty())
                 .withMetrics(DEFAULT_AGG_FACTORIES)
-                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
                 .build()
         )
     .setMaxRowCount(1000000)
-    .build();
+    .buildOnheap();
 
     toPersist.getMetadata().put("key", "value");
     for (InputRow event : events) {

--- a/processing/src/test/java/io/druid/segment/IndexMergerV9WithSpatialIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerV9WithSpatialIndexTest.java
@@ -102,7 +102,7 @@ public class IndexMergerV9WithSpatialIndexTest
   private static IncrementalIndex makeIncrementalIndex() throws IOException
   {
     IncrementalIndex theIndex = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
+        .setIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withMinTimestamp(DATA_INTERVAL.getStartMillis())
                 .withQueryGranularity(Granularities.DAY)
@@ -273,7 +273,7 @@ public class IndexMergerV9WithSpatialIndexTest
   {
     try {
       IncrementalIndex first = new IncrementalIndex.Builder()
-          .setIncrementalIndexSchema(
+          .setIndexSchema(
               new IncrementalIndexSchema.Builder()
                   .withMinTimestamp(DATA_INTERVAL.getStartMillis())
                   .withQueryGranularity(Granularities.DAY)
@@ -301,7 +301,7 @@ public class IndexMergerV9WithSpatialIndexTest
           .buildOnheap();
 
       IncrementalIndex second = new IncrementalIndex.Builder()
-          .setIncrementalIndexSchema(
+          .setIndexSchema(
               new IncrementalIndexSchema.Builder()
                   .withMinTimestamp(DATA_INTERVAL.getStartMillis())
                   .withQueryGranularity(Granularities.DAY)
@@ -329,7 +329,7 @@ public class IndexMergerV9WithSpatialIndexTest
           .buildOnheap();
 
       IncrementalIndex third = new IncrementalIndex.Builder()
-          .setIncrementalIndexSchema(
+          .setIndexSchema(
               new IncrementalIndexSchema.Builder()
                   .withMinTimestamp(DATA_INTERVAL.getStartMillis())
                   .withQueryGranularity(Granularities.DAY)

--- a/processing/src/test/java/io/druid/segment/IndexMergerV9WithSpatialIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerV9WithSpatialIndexTest.java
@@ -45,7 +45,6 @@ import io.druid.query.timeseries.TimeseriesQueryRunnerFactory;
 import io.druid.query.timeseries.TimeseriesResultValue;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.commons.io.FileUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -102,7 +101,7 @@ public class IndexMergerV9WithSpatialIndexTest
 
   private static IncrementalIndex makeIncrementalIndex() throws IOException
   {
-    IncrementalIndex theIndex = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex theIndex = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withMinTimestamp(DATA_INTERVAL.getStartMillis())
@@ -126,8 +125,9 @@ public class IndexMergerV9WithSpatialIndexTest
                     )
                 ).build()
         )
+        .setReportParseExceptions(false)
         .setMaxRowCount(NUM_POINTS)
-        .build();
+        .buildOnheap();
 
     theIndex.add(
         new MapBasedInputRow(
@@ -272,7 +272,7 @@ public class IndexMergerV9WithSpatialIndexTest
   private static QueryableIndex makeMergedQueryableIndex(IndexSpec indexSpec)
   {
     try {
-      IncrementalIndex first = new OnheapIncrementalIndex.Builder()
+      IncrementalIndex first = new IncrementalIndex.Builder()
           .setIncrementalIndexSchema(
               new IncrementalIndexSchema.Builder()
                   .withMinTimestamp(DATA_INTERVAL.getStartMillis())
@@ -298,9 +298,9 @@ public class IndexMergerV9WithSpatialIndexTest
           )
           .setReportParseExceptions(false)
           .setMaxRowCount(1000)
-          .build();
+          .buildOnheap();
 
-      IncrementalIndex second = new OnheapIncrementalIndex.Builder()
+      IncrementalIndex second = new IncrementalIndex.Builder()
           .setIncrementalIndexSchema(
               new IncrementalIndexSchema.Builder()
                   .withMinTimestamp(DATA_INTERVAL.getStartMillis())
@@ -326,9 +326,9 @@ public class IndexMergerV9WithSpatialIndexTest
           )
           .setReportParseExceptions(false)
           .setMaxRowCount(1000)
-          .build();
+          .buildOnheap();
 
-      IncrementalIndex third = new OnheapIncrementalIndex.Builder()
+      IncrementalIndex third = new IncrementalIndex.Builder()
           .setIncrementalIndexSchema(
               new IncrementalIndexSchema.Builder()
                   .withMinTimestamp(DATA_INTERVAL.getStartMillis())
@@ -354,7 +354,7 @@ public class IndexMergerV9WithSpatialIndexTest
           )
           .setReportParseExceptions(false)
           .setMaxRowCount(NUM_POINTS)
-          .build();
+          .buildOnheap();
 
       first.add(
           new MapBasedInputRow(

--- a/processing/src/test/java/io/druid/segment/IndexMergerV9WithSpatialIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerV9WithSpatialIndexTest.java
@@ -102,30 +102,32 @@ public class IndexMergerV9WithSpatialIndexTest
 
   private static IncrementalIndex makeIncrementalIndex() throws IOException
   {
-    IncrementalIndex theIndex = new OnheapIncrementalIndex(
-        new IncrementalIndexSchema.Builder().withMinTimestamp(DATA_INTERVAL.getStartMillis())
-                                            .withQueryGranularity(Granularities.DAY)
-                                            .withMetrics(METRIC_AGGS)
-                                            .withDimensionsSpec(
-                                                new DimensionsSpec(
-                                                    null,
-                                                    null,
-                                                    Arrays.asList(
-                                                        new SpatialDimensionSchema(
-                                                            "dim.geo",
-                                                            Arrays.asList("lat", "long")
-                                                        ),
-                                                        new SpatialDimensionSchema(
-                                                            "spatialIsRad",
-                                                            Arrays.asList("lat2", "long2")
-                                                        )
+    IncrementalIndex theIndex = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withMinTimestamp(DATA_INTERVAL.getStartMillis())
+                .withQueryGranularity(Granularities.DAY)
+                .withMetrics(METRIC_AGGS)
+                .withDimensionsSpec(
+                    new DimensionsSpec(
+                        null,
+                        null,
+                        Arrays.asList(
+                            new SpatialDimensionSchema(
+                                "dim.geo",
+                                Arrays.asList("lat", "long")
+                            ),
+                            new SpatialDimensionSchema(
+                                "spatialIsRad",
+                                Arrays.asList("lat2", "long2")
+                            )
 
-                                                    )
-                                                )
-                                            ).build(),
-        false,
-        NUM_POINTS
-    );
+                        )
+                    )
+                ).build()
+        )
+        .setMaxRowCount(NUM_POINTS)
+        .build();
 
     theIndex.add(
         new MapBasedInputRow(
@@ -270,79 +272,89 @@ public class IndexMergerV9WithSpatialIndexTest
   private static QueryableIndex makeMergedQueryableIndex(IndexSpec indexSpec)
   {
     try {
-      IncrementalIndex first = new OnheapIncrementalIndex(
-          new IncrementalIndexSchema.Builder().withMinTimestamp(DATA_INTERVAL.getStartMillis())
-                                              .withQueryGranularity(Granularities.DAY)
-                                              .withMetrics(METRIC_AGGS)
-                                              .withDimensionsSpec(
-                                                  new DimensionsSpec(
-                                                      null,
-                                                      null,
-                                                      Arrays.asList(
-                                                          new SpatialDimensionSchema(
-                                                              "dim.geo",
-                                                              Arrays.asList("lat", "long")
-                                                          ),
-                                                          new SpatialDimensionSchema(
-                                                              "spatialIsRad",
-                                                              Arrays.asList("lat2", "long2")
-                                                          )
+      IncrementalIndex first = new OnheapIncrementalIndex.Builder()
+          .setIncrementalIndexSchema(
+              new IncrementalIndexSchema.Builder()
+                  .withMinTimestamp(DATA_INTERVAL.getStartMillis())
+                  .withQueryGranularity(Granularities.DAY)
+                  .withMetrics(METRIC_AGGS)
+                  .withDimensionsSpec(
+                      new DimensionsSpec(
+                          null,
+                          null,
+                          Arrays.asList(
+                              new SpatialDimensionSchema(
+                                  "dim.geo",
+                                  Arrays.asList("lat", "long")
+                              ),
+                              new SpatialDimensionSchema(
+                                  "spatialIsRad",
+                                  Arrays.asList("lat2", "long2")
+                              )
 
-                                                      )
-                                                  )
-                                              ).build(),
-          false,
-          1000
-      );
-      IncrementalIndex second = new OnheapIncrementalIndex(
-          new IncrementalIndexSchema.Builder().withMinTimestamp(DATA_INTERVAL.getStartMillis())
-                                              .withQueryGranularity(Granularities.DAY)
-                                              .withMetrics(METRIC_AGGS)
-                                              .withDimensionsSpec(
-                                                  new DimensionsSpec(
-                                                      null,
-                                                      null,
-                                                      Arrays.asList(
-                                                          new SpatialDimensionSchema(
-                                                              "dim.geo",
-                                                              Arrays.asList("lat", "long")
-                                                          ),
-                                                          new SpatialDimensionSchema(
-                                                              "spatialIsRad",
-                                                              Arrays.asList("lat2", "long2")
-                                                          )
+                          )
+                      )
+                  ).build()
+          )
+          .setReportParseExceptions(false)
+          .setMaxRowCount(1000)
+          .build();
 
-                                                      )
-                                                  )
-                                              ).build(),
-          false,
-          1000
-      );
-      IncrementalIndex third = new OnheapIncrementalIndex(
-          new IncrementalIndexSchema.Builder().withMinTimestamp(DATA_INTERVAL.getStartMillis())
-                                              .withQueryGranularity(Granularities.DAY)
-                                              .withMetrics(METRIC_AGGS)
-                                              .withDimensionsSpec(
-                                                  new DimensionsSpec(
-                                                      null,
-                                                      null,
-                                                      Arrays.asList(
-                                                          new SpatialDimensionSchema(
-                                                              "dim.geo",
-                                                              Arrays.asList("lat", "long")
-                                                          ),
-                                                          new SpatialDimensionSchema(
-                                                              "spatialIsRad",
-                                                              Arrays.asList("lat2", "long2")
-                                                          )
+      IncrementalIndex second = new OnheapIncrementalIndex.Builder()
+          .setIncrementalIndexSchema(
+              new IncrementalIndexSchema.Builder()
+                  .withMinTimestamp(DATA_INTERVAL.getStartMillis())
+                  .withQueryGranularity(Granularities.DAY)
+                  .withMetrics(METRIC_AGGS)
+                  .withDimensionsSpec(
+                      new DimensionsSpec(
+                          null,
+                          null,
+                          Arrays.asList(
+                              new SpatialDimensionSchema(
+                                  "dim.geo",
+                                  Arrays.asList("lat", "long")
+                              ),
+                              new SpatialDimensionSchema(
+                                  "spatialIsRad",
+                                  Arrays.asList("lat2", "long2")
+                              )
 
-                                                      )
-                                                  )
-                                              ).build(),
-          false,
-          NUM_POINTS
-      );
+                          )
+                      )
+                  ).build()
+          )
+          .setReportParseExceptions(false)
+          .setMaxRowCount(1000)
+          .build();
 
+      IncrementalIndex third = new OnheapIncrementalIndex.Builder()
+          .setIncrementalIndexSchema(
+              new IncrementalIndexSchema.Builder()
+                  .withMinTimestamp(DATA_INTERVAL.getStartMillis())
+                  .withQueryGranularity(Granularities.DAY)
+                  .withMetrics(METRIC_AGGS)
+                  .withDimensionsSpec(
+                      new DimensionsSpec(
+                          null,
+                          null,
+                          Arrays.asList(
+                              new SpatialDimensionSchema(
+                                  "dim.geo",
+                                  Arrays.asList("lat", "long")
+                              ),
+                              new SpatialDimensionSchema(
+                                  "spatialIsRad",
+                                  Arrays.asList("lat2", "long2")
+                              )
+
+                          )
+                      )
+                  ).build()
+          )
+          .setReportParseExceptions(false)
+          .setMaxRowCount(NUM_POINTS)
+          .build();
 
       first.add(
           new MapBasedInputRow(

--- a/processing/src/test/java/io/druid/segment/SchemalessIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/SchemalessIndexTest.java
@@ -142,7 +142,7 @@ public class SchemalessIndexTest
 
         if (theIndex == null) {
           theIndex = new IncrementalIndex.Builder()
-              .setIncrementalIndexSchema(
+              .setIndexSchema(
                   new IncrementalIndexSchema.Builder()
                       .withMinTimestamp(timestamp)
                       .withQueryGranularity(Granularities.MINUTE)
@@ -360,7 +360,7 @@ public class SchemalessIndexTest
           }
 
           final IncrementalIndex rowIndex = new IncrementalIndex.Builder()
-              .setIncrementalIndexSchema(
+              .setIndexSchema(
                   new IncrementalIndexSchema.Builder()
                       .withMinTimestamp(timestamp)
                       .withQueryGranularity(Granularities.MINUTE)
@@ -397,7 +397,7 @@ public class SchemalessIndexTest
     log.info("Realtime loading index file[%s]", filename);
 
     final IncrementalIndex retVal = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
+        .setIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withMinTimestamp(new DateTime("2011-01-12T00:00:00.000Z").getMillis())
                 .withQueryGranularity(Granularities.MINUTE)

--- a/processing/src/test/java/io/druid/segment/SchemalessIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/SchemalessIndexTest.java
@@ -27,7 +27,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.druid.data.input.MapBasedInputRow;
-import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.hll.HyperLogLogHash;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.Pair;
@@ -42,7 +41,6 @@ import io.druid.query.aggregation.hyperloglog.HyperUniquesSerde;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.IndexSizeExceededException;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
 import io.druid.timeline.TimelineObjectHolder;
 import io.druid.timeline.VersionedIntervalTimeline;
@@ -143,18 +141,16 @@ public class SchemalessIndexTest
         final long timestamp = new DateTime(event.get(TIMESTAMP)).getMillis();
 
         if (theIndex == null) {
-          theIndex = new OnheapIncrementalIndex.Builder()
+          theIndex = new IncrementalIndex.Builder()
               .setIncrementalIndexSchema(
                   new IncrementalIndexSchema.Builder()
                       .withMinTimestamp(timestamp)
                       .withQueryGranularity(Granularities.MINUTE)
-                      .withDimensionsSpec(DimensionsSpec.ofEmpty())
                       .withMetrics(METRIC_AGGS)
-                      .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
                       .build()
               )
               .setMaxRowCount(1000)
-              .build();
+              .buildOnheap();
         }
 
         final List<String> dims = Lists.newArrayList();
@@ -363,18 +359,16 @@ public class SchemalessIndexTest
             }
           }
 
-          final IncrementalIndex rowIndex = new OnheapIncrementalIndex.Builder()
+          final IncrementalIndex rowIndex = new IncrementalIndex.Builder()
               .setIncrementalIndexSchema(
                   new IncrementalIndexSchema.Builder()
                       .withMinTimestamp(timestamp)
                       .withQueryGranularity(Granularities.MINUTE)
-                      .withDimensionsSpec(DimensionsSpec.ofEmpty())
                       .withMetrics(METRIC_AGGS)
-                      .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
                       .build()
               )
               .setMaxRowCount(1000)
-              .build();
+              .buildOnheap();
 
           rowIndex.add(
               new MapBasedInputRow(timestamp, dims, event)
@@ -402,18 +396,16 @@ public class SchemalessIndexTest
     String filename = resource.getFile();
     log.info("Realtime loading index file[%s]", filename);
 
-    final IncrementalIndex retVal = new OnheapIncrementalIndex.Builder()
+    final IncrementalIndex retVal = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withMinTimestamp(new DateTime("2011-01-12T00:00:00.000Z").getMillis())
                 .withQueryGranularity(Granularities.MINUTE)
-                .withDimensionsSpec(DimensionsSpec.ofEmpty())
                 .withMetrics(aggs)
-                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
                 .build()
         )
         .setMaxRowCount(1000)
-        .build();
+        .buildOnheap();
 
     try {
       final List<Object> events = jsonMapper.readValue(new File(filename), List.class);

--- a/processing/src/test/java/io/druid/segment/StringDimensionHandlerTest.java
+++ b/processing/src/test/java/io/druid/segment/StringDimensionHandlerTest.java
@@ -62,7 +62,7 @@ public class StringDimensionHandlerTest
       Map<String, Object> event2
   ) throws Exception {
     IncrementalIndex incrementalIndex1 = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
+        .setIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withMinTimestamp(TEST_INTERVAL.getStartMillis())
                 .withDimensionsSpec(new DimensionsSpec(DimensionsSpec.getDefaultSchemas(dims), null, null))
@@ -73,7 +73,7 @@ public class StringDimensionHandlerTest
         .buildOnheap();
 
     IncrementalIndex incrementalIndex2 = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
+        .setIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withMinTimestamp(TEST_INTERVAL.getStartMillis())
                 .withDimensionsSpec(new DimensionsSpec(DimensionsSpec.getDefaultSchemas(dims), null, null))

--- a/processing/src/test/java/io/druid/segment/StringDimensionHandlerTest.java
+++ b/processing/src/test/java/io/druid/segment/StringDimensionHandlerTest.java
@@ -32,6 +32,7 @@ import io.druid.segment.data.ConciseBitmapSerdeFactory;
 import io.druid.segment.data.Indexed;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexAdapter;
+import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.joda.time.Interval;
 import org.junit.Rule;
@@ -63,31 +64,31 @@ public class StringDimensionHandlerTest
       Map<String, Object> event1,
       Map<String, Object> event2
   ) throws Exception {
-    IncrementalIndex incrementalIndex1 = new OnheapIncrementalIndex(
-        TEST_INTERVAL.getStartMillis(),
-        Granularities.NONE,
-        true,
-        new DimensionsSpec(DimensionsSpec.getDefaultSchemas(dims), null, null),
-        new AggregatorFactory[]{
-            new CountAggregatorFactory(
-                "count"
-            )
-        },
-        1000
-    );
+    IncrementalIndex incrementalIndex1 = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withMinTimestamp(TEST_INTERVAL.getStartMillis())
+                .withQueryGranularity(Granularities.NONE)
+                .withDimensionsSpec(new DimensionsSpec(DimensionsSpec.getDefaultSchemas(dims), null, null))
+                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
+                .withRollup(true)
+                .build()
+        )
+        .setMaxRowCount(1000)
+        .build();
 
-    IncrementalIndex incrementalIndex2 = new OnheapIncrementalIndex(
-        TEST_INTERVAL.getStartMillis(),
-        Granularities.NONE,
-        true,
-        new DimensionsSpec(DimensionsSpec.getDefaultSchemas(dims), null, null),
-        new AggregatorFactory[]{
-            new CountAggregatorFactory(
-                "count"
-            )
-        },
-        1000
-    );
+    IncrementalIndex incrementalIndex2 = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withMinTimestamp(TEST_INTERVAL.getStartMillis())
+                .withQueryGranularity(Granularities.NONE)
+                .withDimensionsSpec(new DimensionsSpec(DimensionsSpec.getDefaultSchemas(dims), null, null))
+                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
+                .withRollup(true)
+                .build()
+        )
+        .setMaxRowCount(1000)
+        .build();
 
     incrementalIndex1.add(new MapBasedInputRow(TEST_INTERVAL.getStartMillis(), dims, event1));
     incrementalIndex2.add(new MapBasedInputRow(TEST_INTERVAL.getStartMillis() + 3, dims, event2));

--- a/processing/src/test/java/io/druid/segment/StringDimensionHandlerTest.java
+++ b/processing/src/test/java/io/druid/segment/StringDimensionHandlerTest.java
@@ -23,8 +23,6 @@ import com.google.common.collect.ImmutableMap;
 import io.druid.data.input.MapBasedInputRow;
 import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.java.util.common.Pair;
-import io.druid.java.util.common.granularity.Granularities;
-import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.segment.data.CompressedObjectStrategy;
 import io.druid.segment.data.CompressionFactory;
@@ -33,7 +31,6 @@ import io.druid.segment.data.Indexed;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexAdapter;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.joda.time.Interval;
 import org.junit.Rule;
 import org.junit.Test;
@@ -64,31 +61,27 @@ public class StringDimensionHandlerTest
       Map<String, Object> event1,
       Map<String, Object> event2
   ) throws Exception {
-    IncrementalIndex incrementalIndex1 = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex incrementalIndex1 = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withMinTimestamp(TEST_INTERVAL.getStartMillis())
-                .withQueryGranularity(Granularities.NONE)
                 .withDimensionsSpec(new DimensionsSpec(DimensionsSpec.getDefaultSchemas(dims), null, null))
-                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
-                .withRollup(true)
+                .withMetrics(new CountAggregatorFactory("count"))
                 .build()
         )
         .setMaxRowCount(1000)
-        .build();
+        .buildOnheap();
 
-    IncrementalIndex incrementalIndex2 = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex incrementalIndex2 = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withMinTimestamp(TEST_INTERVAL.getStartMillis())
-                .withQueryGranularity(Granularities.NONE)
                 .withDimensionsSpec(new DimensionsSpec(DimensionsSpec.getDefaultSchemas(dims), null, null))
-                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
-                .withRollup(true)
+                .withMetrics(new CountAggregatorFactory("count"))
                 .build()
         )
         .setMaxRowCount(1000)
-        .build();
+        .buildOnheap();
 
     incrementalIndex1.add(new MapBasedInputRow(TEST_INTERVAL.getStartMillis(), dims, event1));
     incrementalIndex2.add(new MapBasedInputRow(TEST_INTERVAL.getStartMillis() + 3, dims, event2));

--- a/processing/src/test/java/io/druid/segment/TestIndex.java
+++ b/processing/src/test/java/io/druid/segment/TestIndex.java
@@ -265,7 +265,7 @@ public class TestIndex
         .withRollup(rollup)
         .build();
     final IncrementalIndex retVal = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(schema)
+        .setIndexSchema(schema)
         .setMaxRowCount(10000)
         .buildOnheap();
 

--- a/processing/src/test/java/io/druid/segment/TestIndex.java
+++ b/processing/src/test/java/io/druid/segment/TestIndex.java
@@ -33,7 +33,6 @@ import io.druid.data.input.impl.StringDimensionSchema;
 import io.druid.data.input.impl.StringInputRowParser;
 import io.druid.data.input.impl.TimestampSpec;
 import io.druid.hll.HyperLogLogHash;
-import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.DoubleMaxAggregatorFactory;
@@ -44,7 +43,6 @@ import io.druid.query.aggregation.hyperloglog.HyperUniquesSerde;
 import io.druid.query.expression.TestExprMacroTable;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
 import io.druid.segment.virtual.ExpressionVirtualColumn;
 import org.joda.time.DateTime;
@@ -261,16 +259,15 @@ public class TestIndex
     final IncrementalIndexSchema schema = new IncrementalIndexSchema.Builder()
         .withMinTimestamp(new DateTime("2011-01-12T00:00:00.000Z").getMillis())
         .withTimestampSpec(new TimestampSpec("ds", "auto", null))
-        .withQueryGranularity(Granularities.NONE)
         .withDimensionsSpec(DIMENSIONS_SPEC)
         .withVirtualColumns(VIRTUAL_COLUMNS)
         .withMetrics(METRIC_AGGS)
         .withRollup(rollup)
         .build();
-    final IncrementalIndex retVal = new OnheapIncrementalIndex.Builder()
+    final IncrementalIndex retVal = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(schema)
         .setMaxRowCount(10000)
-        .build();
+        .buildOnheap();
 
     try {
       return loadIncrementalIndex(retVal, source);

--- a/processing/src/test/java/io/druid/segment/TestIndex.java
+++ b/processing/src/test/java/io/druid/segment/TestIndex.java
@@ -267,7 +267,10 @@ public class TestIndex
         .withMetrics(METRIC_AGGS)
         .withRollup(rollup)
         .build();
-    final IncrementalIndex retVal = new OnheapIncrementalIndex(schema, true, 10000);
+    final IncrementalIndex retVal = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(schema)
+        .setMaxRowCount(10000)
+        .build();
 
     try {
       return loadIncrementalIndex(retVal, source);

--- a/processing/src/test/java/io/druid/segment/data/IncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/data/IncrementalIndexTest.java
@@ -132,11 +132,7 @@ public class IncrementalIndexTest
                   public IncrementalIndex createIndex(AggregatorFactory[] factories)
                   {
                     return new IncrementalIndex.Builder()
-                        .setIncrementalIndexSchema(
-                            new IncrementalIndexSchema.Builder()
-                                .withMetrics(factories)
-                                .build()
-                        )
+                        .setSimpleTestingIndexSchema(factories)
                         .setMaxRowCount(1000000)
                         .buildOffheap(
                             new StupidPool<ByteBuffer>(
@@ -171,7 +167,7 @@ public class IncrementalIndexTest
                   public IncrementalIndex createIndex(AggregatorFactory[] factories)
                   {
                     return new IncrementalIndex.Builder()
-                        .setIncrementalIndexSchema(
+                        .setIndexSchema(
                             new IncrementalIndexSchema.Builder()
                                 .withMetrics(factories)
                                 .withRollup(false)
@@ -219,7 +215,7 @@ public class IncrementalIndexTest
     }
 
     return new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
+        .setIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withDimensionsSpec(dimensionsSpec)
                 .withMetrics(aggregatorFactories)
@@ -236,11 +232,7 @@ public class IncrementalIndexTest
     }
 
     return new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
-            new IncrementalIndexSchema.Builder()
-                .withMetrics(aggregatorFactories)
-                .build()
-        )
+        .setSimpleTestingIndexSchema(aggregatorFactories)
         .setMaxRowCount(1000000)
         .buildOnheap();
   }
@@ -252,11 +244,7 @@ public class IncrementalIndexTest
     }
 
     return new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
-            new IncrementalIndexSchema.Builder()
-                .withMetrics(aggregatorFactories)
-                .build()
-        )
+        .setSimpleTestingIndexSchema(aggregatorFactories)
         .setMaxRowCount(1000000)
         .buildOnheap();
   }
@@ -786,7 +774,7 @@ public class IncrementalIndexTest
   public void testgetDimensions()
   {
     final IncrementalIndex<Aggregator> incrementalIndex = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
+        .setIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withMetrics(new CountAggregatorFactory("count"))
                 .withDimensionsSpec(
@@ -809,7 +797,7 @@ public class IncrementalIndexTest
   public void testDynamicSchemaRollup() throws IndexSizeExceededException
   {
     IncrementalIndex<Aggregator> index = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(new IncrementalIndexSchema.Builder().build())
+        .setSimpleTestingIndexSchema(/* empty */)
         .setMaxRowCount(10)
         .buildOnheap();
     closer.closeLater(index);

--- a/processing/src/test/java/io/druid/segment/filter/FloatFilteringTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/FloatFilteringTest.java
@@ -108,11 +108,8 @@ public class FloatFilteringTest extends BaseFilterTest
         ROWS,
         indexBuilder.schema(
             new IncrementalIndexSchema.Builder()
-                .withMetrics(
-                    new AggregatorFactory[]{
-                        new DoubleSumAggregatorFactory(FLOAT_COLUMN, FLOAT_COLUMN)
-                    }
-                ).build()
+                .withMetrics(new DoubleSumAggregatorFactory(FLOAT_COLUMN, FLOAT_COLUMN))
+                .build()
         ),
         finisher,
         cnf,

--- a/processing/src/test/java/io/druid/segment/filter/FloatFilteringTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/FloatFilteringTest.java
@@ -34,7 +34,6 @@ import io.druid.data.input.impl.TimeAndDimsParseSpec;
 import io.druid.data.input.impl.TimestampSpec;
 import io.druid.java.util.common.Pair;
 import io.druid.js.JavaScriptConfig;
-import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.DoubleSumAggregatorFactory;
 import io.druid.query.extraction.MapLookupExtractor;
 import io.druid.query.filter.BoundDimFilter;

--- a/processing/src/test/java/io/druid/segment/filter/InvalidFilteringTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/InvalidFilteringTest.java
@@ -95,11 +95,12 @@ public class InvalidFilteringTest extends BaseFilterTest
 
   private static IndexBuilder overrideIndexBuilderSchema(IndexBuilder indexBuilder)
   {
-    IncrementalIndexSchema schema = new IncrementalIndexSchema.Builder().withMetrics(new AggregatorFactory[]{
-        new CountAggregatorFactory("count"),
-        new HyperUniquesAggregatorFactory("hyperion", "dim1"),
-        new DoubleMaxAggregatorFactory("dmax", "dim0")
-    }).build();
+    IncrementalIndexSchema schema = new IncrementalIndexSchema.Builder()
+        .withMetrics(
+            new CountAggregatorFactory("count"),
+            new HyperUniquesAggregatorFactory("hyperion", "dim1"),
+            new DoubleMaxAggregatorFactory("dmax", "dim0")
+        ).build();
 
     return indexBuilder.schema(schema);
   }

--- a/processing/src/test/java/io/druid/segment/filter/InvalidFilteringTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/InvalidFilteringTest.java
@@ -29,7 +29,6 @@ import io.druid.data.input.impl.MapInputRowParser;
 import io.druid.data.input.impl.TimeAndDimsParseSpec;
 import io.druid.data.input.impl.TimestampSpec;
 import io.druid.java.util.common.Pair;
-import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.query.aggregation.DoubleMaxAggregatorFactory;
 import io.druid.query.aggregation.hyperloglog.HyperUniquesAggregatorFactory;

--- a/processing/src/test/java/io/druid/segment/filter/LongFilteringTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/LongFilteringTest.java
@@ -112,11 +112,8 @@ public class LongFilteringTest extends BaseFilterTest
         ROWS,
         indexBuilder.schema(
             new IncrementalIndexSchema.Builder()
-                .withMetrics(
-                    new AggregatorFactory[]{
-                        new LongSumAggregatorFactory(LONG_COLUMN, LONG_COLUMN)
-                    }
-                ).build()
+                .withMetrics(new LongSumAggregatorFactory(LONG_COLUMN, LONG_COLUMN))
+                .build()
         ),
         finisher,
         cnf,

--- a/processing/src/test/java/io/druid/segment/filter/LongFilteringTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/LongFilteringTest.java
@@ -34,7 +34,6 @@ import io.druid.data.input.impl.TimeAndDimsParseSpec;
 import io.druid.data.input.impl.TimestampSpec;
 import io.druid.java.util.common.Pair;
 import io.druid.js.JavaScriptConfig;
-import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.LongSumAggregatorFactory;
 import io.druid.query.extraction.MapLookupExtractor;
 import io.druid.query.filter.BoundDimFilter;

--- a/processing/src/test/java/io/druid/segment/filter/SpatialFilterBonusTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/SpatialFilterBonusTest.java
@@ -116,25 +116,29 @@ public class SpatialFilterBonusTest
 
   private static IncrementalIndex makeIncrementalIndex() throws IOException
   {
-    IncrementalIndex theIndex = new OnheapIncrementalIndex(
-        new IncrementalIndexSchema.Builder().withMinTimestamp(DATA_INTERVAL.getStartMillis())
-                                            .withQueryGranularity(Granularities.DAY)
-                                            .withMetrics(METRIC_AGGS)
-                                            .withDimensionsSpec(
-                                                new DimensionsSpec(
-                                                    null,
-                                                    null,
-                                                    Arrays.asList(
-                                                        new SpatialDimensionSchema(
-                                                            "dim.geo",
-                                                            Lists.<String>newArrayList()
-                                                        )
-                                                    )
-                                                )
-                                            ).build(),
-        false,
-        NUM_POINTS
-    );
+    IncrementalIndex theIndex = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withMinTimestamp(DATA_INTERVAL.getStartMillis())
+                .withQueryGranularity(Granularities.DAY)
+                .withMetrics(METRIC_AGGS)
+                .withDimensionsSpec(
+                    new DimensionsSpec(
+                        null,
+                        null,
+                        Arrays.asList(
+                            new SpatialDimensionSchema(
+                                "dim.geo",
+                                Lists.<String>newArrayList()
+                            )
+                        )
+                    )
+                ).build()
+        )
+        .setReportParseExceptions(false)
+        .setMaxRowCount(NUM_POINTS)
+        .build();
+
     theIndex.add(
         new MapBasedInputRow(
             new DateTime("2013-01-01").getMillis(),
@@ -255,66 +259,76 @@ public class SpatialFilterBonusTest
   private static QueryableIndex makeMergedQueryableIndex(final IndexSpec indexSpec)
   {
     try {
-      IncrementalIndex first = new OnheapIncrementalIndex(
-          new IncrementalIndexSchema.Builder().withMinTimestamp(DATA_INTERVAL.getStartMillis())
-                                              .withQueryGranularity(Granularities.DAY)
-                                              .withMetrics(METRIC_AGGS)
-                                              .withDimensionsSpec(
-                                                  new DimensionsSpec(
-                                                      null,
-                                                      null,
-                                                      Arrays.asList(
-                                                          new SpatialDimensionSchema(
-                                                              "dim.geo",
-                                                              Lists.<String>newArrayList()
-                                                          )
-                                                      )
-                                                  )
+      IncrementalIndex first = new OnheapIncrementalIndex.Builder()
+          .setIncrementalIndexSchema(
+              new IncrementalIndexSchema.Builder()
+                  .withMinTimestamp(DATA_INTERVAL.getStartMillis())
+                  .withQueryGranularity(Granularities.DAY)
+                  .withMetrics(METRIC_AGGS)
+                  .withDimensionsSpec(
+                      new DimensionsSpec(
+                          null,
+                          null,
+                          Arrays.asList(
+                              new SpatialDimensionSchema(
+                                  "dim.geo",
+                                  Lists.<String>newArrayList()
+                              )
+                          )
+                      )
 
-                                              ).build(),
-          false,
-          NUM_POINTS
-      );
-      IncrementalIndex second = new OnheapIncrementalIndex(
-          new IncrementalIndexSchema.Builder().withMinTimestamp(DATA_INTERVAL.getStartMillis())
-                                              .withQueryGranularity(Granularities.DAY)
-                                              .withMetrics(METRIC_AGGS)
-                                              .withDimensionsSpec(
-                                                  new DimensionsSpec(
-                                                      null,
-                                                      null,
-                                                      Arrays.asList(
-                                                          new SpatialDimensionSchema(
-                                                              "dim.geo",
-                                                              Lists.<String>newArrayList()
-                                                          )
-                                                      )
-                                                  )
-                                              ).build(),
-          false,
-          NUM_POINTS
-      );
-      IncrementalIndex third = new OnheapIncrementalIndex(
-          new IncrementalIndexSchema.Builder().withMinTimestamp(DATA_INTERVAL.getStartMillis())
-                                              .withQueryGranularity(Granularities.DAY)
-                                              .withMetrics(METRIC_AGGS)
-                                              .withDimensionsSpec(
-                                                  new DimensionsSpec(
-                                                      null,
-                                                      null,
-                                                      Arrays.asList(
-                                                          new SpatialDimensionSchema(
-                                                              "dim.geo",
-                                                              Lists.<String>newArrayList()
-                                                          )
-                                                      )
-                                                  )
+                  ).build()
+          )
+          .setReportParseExceptions(false)
+          .setMaxRowCount(NUM_POINTS)
+          .build();
 
-                                              ).build(),
-          false,
-          NUM_POINTS
-      );
+      IncrementalIndex second = new OnheapIncrementalIndex.Builder()
+          .setIncrementalIndexSchema(
+              new IncrementalIndexSchema.Builder()
+                  .withMinTimestamp(DATA_INTERVAL.getStartMillis())
+                  .withQueryGranularity(Granularities.DAY)
+                  .withMetrics(METRIC_AGGS)
+                  .withDimensionsSpec(
+                      new DimensionsSpec(
+                          null,
+                          null,
+                          Arrays.asList(
+                              new SpatialDimensionSchema(
+                                  "dim.geo",
+                                  Lists.<String>newArrayList()
+                              )
+                          )
+                      )
+                  ).build()
+          )
+          .setReportParseExceptions(false)
+          .setMaxRowCount(NUM_POINTS)
+          .build();
 
+      IncrementalIndex third = new OnheapIncrementalIndex.Builder()
+          .setIncrementalIndexSchema(
+              new IncrementalIndexSchema.Builder()
+                  .withMinTimestamp(DATA_INTERVAL.getStartMillis())
+                  .withQueryGranularity(Granularities.DAY)
+                  .withMetrics(METRIC_AGGS)
+                  .withDimensionsSpec(
+                      new DimensionsSpec(
+                          null,
+                          null,
+                          Arrays.asList(
+                              new SpatialDimensionSchema(
+                                  "dim.geo",
+                                  Lists.<String>newArrayList()
+                              )
+                          )
+                      )
+
+                  ).build()
+          )
+          .setReportParseExceptions(false)
+          .setMaxRowCount(NUM_POINTS)
+          .build();
 
       first.add(
           new MapBasedInputRow(

--- a/processing/src/test/java/io/druid/segment/filter/SpatialFilterBonusTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/SpatialFilterBonusTest.java
@@ -116,7 +116,7 @@ public class SpatialFilterBonusTest
   private static IncrementalIndex makeIncrementalIndex() throws IOException
   {
     IncrementalIndex theIndex = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
+        .setIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withMinTimestamp(DATA_INTERVAL.getStartMillis())
                 .withQueryGranularity(Granularities.DAY)
@@ -259,7 +259,7 @@ public class SpatialFilterBonusTest
   {
     try {
       IncrementalIndex first = new IncrementalIndex.Builder()
-          .setIncrementalIndexSchema(
+          .setIndexSchema(
               new IncrementalIndexSchema.Builder()
                   .withMinTimestamp(DATA_INTERVAL.getStartMillis())
                   .withQueryGranularity(Granularities.DAY)
@@ -283,7 +283,7 @@ public class SpatialFilterBonusTest
           .buildOnheap();
 
       IncrementalIndex second = new IncrementalIndex.Builder()
-          .setIncrementalIndexSchema(
+          .setIndexSchema(
               new IncrementalIndexSchema.Builder()
                   .withMinTimestamp(DATA_INTERVAL.getStartMillis())
                   .withQueryGranularity(Granularities.DAY)
@@ -306,7 +306,7 @@ public class SpatialFilterBonusTest
           .buildOnheap();
 
       IncrementalIndex third = new IncrementalIndex.Builder()
-          .setIncrementalIndexSchema(
+          .setIndexSchema(
               new IncrementalIndexSchema.Builder()
                   .withMinTimestamp(DATA_INTERVAL.getStartMillis())
                   .withQueryGranularity(Granularities.DAY)

--- a/processing/src/test/java/io/druid/segment/filter/SpatialFilterBonusTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/SpatialFilterBonusTest.java
@@ -54,7 +54,6 @@ import io.druid.segment.Segment;
 import io.druid.segment.TestHelper;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.junit.Test;
@@ -116,7 +115,7 @@ public class SpatialFilterBonusTest
 
   private static IncrementalIndex makeIncrementalIndex() throws IOException
   {
-    IncrementalIndex theIndex = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex theIndex = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withMinTimestamp(DATA_INTERVAL.getStartMillis())
@@ -137,7 +136,7 @@ public class SpatialFilterBonusTest
         )
         .setReportParseExceptions(false)
         .setMaxRowCount(NUM_POINTS)
-        .build();
+        .buildOnheap();
 
     theIndex.add(
         new MapBasedInputRow(
@@ -259,7 +258,7 @@ public class SpatialFilterBonusTest
   private static QueryableIndex makeMergedQueryableIndex(final IndexSpec indexSpec)
   {
     try {
-      IncrementalIndex first = new OnheapIncrementalIndex.Builder()
+      IncrementalIndex first = new IncrementalIndex.Builder()
           .setIncrementalIndexSchema(
               new IncrementalIndexSchema.Builder()
                   .withMinTimestamp(DATA_INTERVAL.getStartMillis())
@@ -281,9 +280,9 @@ public class SpatialFilterBonusTest
           )
           .setReportParseExceptions(false)
           .setMaxRowCount(NUM_POINTS)
-          .build();
+          .buildOnheap();
 
-      IncrementalIndex second = new OnheapIncrementalIndex.Builder()
+      IncrementalIndex second = new IncrementalIndex.Builder()
           .setIncrementalIndexSchema(
               new IncrementalIndexSchema.Builder()
                   .withMinTimestamp(DATA_INTERVAL.getStartMillis())
@@ -304,9 +303,9 @@ public class SpatialFilterBonusTest
           )
           .setReportParseExceptions(false)
           .setMaxRowCount(NUM_POINTS)
-          .build();
+          .buildOnheap();
 
-      IncrementalIndex third = new OnheapIncrementalIndex.Builder()
+      IncrementalIndex third = new IncrementalIndex.Builder()
           .setIncrementalIndexSchema(
               new IncrementalIndexSchema.Builder()
                   .withMinTimestamp(DATA_INTERVAL.getStartMillis())
@@ -328,7 +327,7 @@ public class SpatialFilterBonusTest
           )
           .setReportParseExceptions(false)
           .setMaxRowCount(NUM_POINTS)
-          .build();
+          .buildOnheap();
 
       first.add(
           new MapBasedInputRow(

--- a/processing/src/test/java/io/druid/segment/filter/SpatialFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/SpatialFilterTest.java
@@ -53,7 +53,6 @@ import io.druid.segment.Segment;
 import io.druid.segment.TestHelper;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.junit.Test;
@@ -109,7 +108,7 @@ public class SpatialFilterTest
 
   private static IncrementalIndex makeIncrementalIndex() throws IOException
   {
-    IncrementalIndex theIndex = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex theIndex = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withMinTimestamp(DATA_INTERVAL.getStartMillis())
@@ -135,7 +134,7 @@ public class SpatialFilterTest
         )
         .setReportParseExceptions(false)
         .setMaxRowCount(NUM_POINTS)
-        .build();
+        .buildOnheap();
 
     theIndex.add(
         new MapBasedInputRow(
@@ -276,7 +275,7 @@ public class SpatialFilterTest
   private static QueryableIndex makeMergedQueryableIndex(IndexSpec indexSpec)
   {
     try {
-      IncrementalIndex first = new OnheapIncrementalIndex.Builder()
+      IncrementalIndex first = new IncrementalIndex.Builder()
           .setIncrementalIndexSchema(
               new IncrementalIndexSchema.Builder()
                   .withMinTimestamp(DATA_INTERVAL.getStartMillis())
@@ -301,9 +300,9 @@ public class SpatialFilterTest
           )
           .setReportParseExceptions(false)
           .setMaxRowCount(1000)
-          .build();
+          .buildOnheap();
 
-      IncrementalIndex second = new OnheapIncrementalIndex.Builder()
+      IncrementalIndex second = new IncrementalIndex.Builder()
           .setIncrementalIndexSchema(
               new IncrementalIndexSchema.Builder()
                   .withMinTimestamp(DATA_INTERVAL.getStartMillis())
@@ -328,9 +327,9 @@ public class SpatialFilterTest
           )
           .setReportParseExceptions(false)
           .setMaxRowCount(1000)
-          .build();
+          .buildOnheap();
 
-      IncrementalIndex third = new OnheapIncrementalIndex.Builder()
+      IncrementalIndex third = new IncrementalIndex.Builder()
           .setIncrementalIndexSchema(
               new IncrementalIndexSchema.Builder()
                   .withMinTimestamp(DATA_INTERVAL.getStartMillis())
@@ -355,7 +354,7 @@ public class SpatialFilterTest
           )
           .setReportParseExceptions(false)
           .setMaxRowCount(NUM_POINTS)
-          .build();
+          .buildOnheap();
 
       first.add(
           new MapBasedInputRow(

--- a/processing/src/test/java/io/druid/segment/filter/SpatialFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/SpatialFilterTest.java
@@ -109,7 +109,7 @@ public class SpatialFilterTest
   private static IncrementalIndex makeIncrementalIndex() throws IOException
   {
     IncrementalIndex theIndex = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
+        .setIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withMinTimestamp(DATA_INTERVAL.getStartMillis())
                 .withQueryGranularity(Granularities.DAY)
@@ -276,7 +276,7 @@ public class SpatialFilterTest
   {
     try {
       IncrementalIndex first = new IncrementalIndex.Builder()
-          .setIncrementalIndexSchema(
+          .setIndexSchema(
               new IncrementalIndexSchema.Builder()
                   .withMinTimestamp(DATA_INTERVAL.getStartMillis())
                   .withQueryGranularity(Granularities.DAY)
@@ -303,7 +303,7 @@ public class SpatialFilterTest
           .buildOnheap();
 
       IncrementalIndex second = new IncrementalIndex.Builder()
-          .setIncrementalIndexSchema(
+          .setIndexSchema(
               new IncrementalIndexSchema.Builder()
                   .withMinTimestamp(DATA_INTERVAL.getStartMillis())
                   .withQueryGranularity(Granularities.DAY)
@@ -330,7 +330,7 @@ public class SpatialFilterTest
           .buildOnheap();
 
       IncrementalIndex third = new IncrementalIndex.Builder()
-          .setIncrementalIndexSchema(
+          .setIndexSchema(
               new IncrementalIndexSchema.Builder()
                   .withMinTimestamp(DATA_INTERVAL.getStartMillis())
                   .withQueryGranularity(Granularities.DAY)

--- a/processing/src/test/java/io/druid/segment/filter/SpatialFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/SpatialFilterTest.java
@@ -109,30 +109,33 @@ public class SpatialFilterTest
 
   private static IncrementalIndex makeIncrementalIndex() throws IOException
   {
-    IncrementalIndex theIndex = new OnheapIncrementalIndex(
-        new IncrementalIndexSchema.Builder().withMinTimestamp(DATA_INTERVAL.getStartMillis())
-                                            .withQueryGranularity(Granularities.DAY)
-                                            .withMetrics(METRIC_AGGS)
-                                            .withDimensionsSpec(
-                                                new DimensionsSpec(
-                                                    null,
-                                                    null,
-                                                    Arrays.asList(
-                                                        new SpatialDimensionSchema(
-                                                            "dim.geo",
-                                                            Arrays.asList("lat", "long")
-                                                        ),
-                                                        new SpatialDimensionSchema(
-                                                            "spatialIsRad",
-                                                            Arrays.asList("lat2", "long2")
-                                                        )
+    IncrementalIndex theIndex = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withMinTimestamp(DATA_INTERVAL.getStartMillis())
+                .withQueryGranularity(Granularities.DAY)
+                .withMetrics(METRIC_AGGS)
+                .withDimensionsSpec(
+                    new DimensionsSpec(
+                        null,
+                        null,
+                        Arrays.asList(
+                            new SpatialDimensionSchema(
+                                "dim.geo",
+                                Arrays.asList("lat", "long")
+                            ),
+                            new SpatialDimensionSchema(
+                                "spatialIsRad",
+                                Arrays.asList("lat2", "long2")
+                            )
 
-                                                    )
-                                                )
-                                            ).build(),
-        false,
-        NUM_POINTS
-    );
+                        )
+                    )
+                ).build()
+        )
+        .setReportParseExceptions(false)
+        .setMaxRowCount(NUM_POINTS)
+        .build();
 
     theIndex.add(
         new MapBasedInputRow(
@@ -273,79 +276,86 @@ public class SpatialFilterTest
   private static QueryableIndex makeMergedQueryableIndex(IndexSpec indexSpec)
   {
     try {
-      IncrementalIndex first = new OnheapIncrementalIndex(
-          new IncrementalIndexSchema.Builder().withMinTimestamp(DATA_INTERVAL.getStartMillis())
-                                              .withQueryGranularity(Granularities.DAY)
-                                              .withMetrics(METRIC_AGGS)
-                                              .withDimensionsSpec(
-                                                  new DimensionsSpec(
-                                                      null,
-                                                      null,
-                                                      Arrays.asList(
-                                                          new SpatialDimensionSchema(
-                                                              "dim.geo",
-                                                              Arrays.asList("lat", "long")
-                                                          ),
-                                                          new SpatialDimensionSchema(
-                                                              "spatialIsRad",
-                                                              Arrays.asList("lat2", "long2")
-                                                          )
+      IncrementalIndex first = new OnheapIncrementalIndex.Builder()
+          .setIncrementalIndexSchema(
+              new IncrementalIndexSchema.Builder()
+                  .withMinTimestamp(DATA_INTERVAL.getStartMillis())
+                  .withQueryGranularity(Granularities.DAY)
+                  .withMetrics(METRIC_AGGS)
+                  .withDimensionsSpec(
+                      new DimensionsSpec(
+                          null,
+                          null,
+                          Arrays.asList(
+                              new SpatialDimensionSchema(
+                                  "dim.geo",
+                                  Arrays.asList("lat", "long")
+                              ),
+                              new SpatialDimensionSchema(
+                                  "spatialIsRad",
+                                  Arrays.asList("lat2", "long2")
+                              )
+                          )
+                      )
+                  ).build()
+          )
+          .setReportParseExceptions(false)
+          .setMaxRowCount(1000)
+          .build();
 
-                                                      )
-                                                  )
-                                              ).build(),
-          false,
-          1000
-      );
-      IncrementalIndex second = new OnheapIncrementalIndex(
-          new IncrementalIndexSchema.Builder().withMinTimestamp(DATA_INTERVAL.getStartMillis())
-                                              .withQueryGranularity(Granularities.DAY)
-                                              .withMetrics(METRIC_AGGS)
-                                              .withDimensionsSpec(
-                                                  new DimensionsSpec(
-                                                      null,
-                                                      null,
-                                                      Arrays.asList(
-                                                          new SpatialDimensionSchema(
-                                                              "dim.geo",
-                                                              Arrays.asList("lat", "long")
-                                                          ),
-                                                          new SpatialDimensionSchema(
-                                                              "spatialIsRad",
-                                                              Arrays.asList("lat2", "long2")
-                                                          )
+      IncrementalIndex second = new OnheapIncrementalIndex.Builder()
+          .setIncrementalIndexSchema(
+              new IncrementalIndexSchema.Builder()
+                  .withMinTimestamp(DATA_INTERVAL.getStartMillis())
+                  .withQueryGranularity(Granularities.DAY)
+                  .withMetrics(METRIC_AGGS)
+                  .withDimensionsSpec(
+                      new DimensionsSpec(
+                          null,
+                          null,
+                          Arrays.asList(
+                              new SpatialDimensionSchema(
+                                  "dim.geo",
+                                  Arrays.asList("lat", "long")
+                              ),
+                              new SpatialDimensionSchema(
+                                  "spatialIsRad",
+                                  Arrays.asList("lat2", "long2")
+                              )
+                          )
+                      )
+                  ).build()
+          )
+          .setReportParseExceptions(false)
+          .setMaxRowCount(1000)
+          .build();
 
-                                                      )
-                                                  )
-                                              ).build(),
-          false,
-          1000
-      );
-      IncrementalIndex third = new OnheapIncrementalIndex(
-          new IncrementalIndexSchema.Builder().withMinTimestamp(DATA_INTERVAL.getStartMillis())
-                                              .withQueryGranularity(Granularities.DAY)
-                                              .withMetrics(METRIC_AGGS)
-                                              .withDimensionsSpec(
-                                                  new DimensionsSpec(
-                                                      null,
-                                                      null,
-                                                      Arrays.asList(
-                                                          new SpatialDimensionSchema(
-                                                              "dim.geo",
-                                                              Arrays.asList("lat", "long")
-                                                          ),
-                                                          new SpatialDimensionSchema(
-                                                              "spatialIsRad",
-                                                              Arrays.asList("lat2", "long2")
-                                                          )
-
-                                                      )
-                                                  )
-                                              ).build(),
-          false,
-          NUM_POINTS
-      );
-
+      IncrementalIndex third = new OnheapIncrementalIndex.Builder()
+          .setIncrementalIndexSchema(
+              new IncrementalIndexSchema.Builder()
+                  .withMinTimestamp(DATA_INTERVAL.getStartMillis())
+                  .withQueryGranularity(Granularities.DAY)
+                  .withMetrics(METRIC_AGGS)
+                  .withDimensionsSpec(
+                      new DimensionsSpec(
+                          null,
+                          null,
+                          Arrays.asList(
+                              new SpatialDimensionSchema(
+                                  "dim.geo",
+                                  Arrays.asList("lat", "long")
+                              ),
+                              new SpatialDimensionSchema(
+                                  "spatialIsRad",
+                                  Arrays.asList("lat2", "long2")
+                              )
+                          )
+                      )
+                  ).build()
+          )
+          .setReportParseExceptions(false)
+          .setMaxRowCount(NUM_POINTS)
+          .build();
 
       first.add(
           new MapBasedInputRow(

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexMultiValueSpecTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexMultiValueSpecTest.java
@@ -78,7 +78,7 @@ public class IncrementalIndexMultiValueSpecTest
       }
     };
     IncrementalIndex<?> index = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(schema)
+        .setIndexSchema(schema)
         .setMaxRowCount(10000)
         .buildOnheap();
     index.add(

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexMultiValueSpecTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexMultiValueSpecTest.java
@@ -77,10 +77,10 @@ public class IncrementalIndexMultiValueSpecTest
         return null;
       }
     };
-    IncrementalIndex<?> index = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex<?> index = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(schema)
         .setMaxRowCount(10000)
-        .build();
+        .buildOnheap();
     index.add(
         new MapBasedInputRow(
             0, Arrays.asList(

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexMultiValueSpecTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexMultiValueSpecTest.java
@@ -77,7 +77,10 @@ public class IncrementalIndexMultiValueSpecTest
         return null;
       }
     };
-    IncrementalIndex<?> index = new OnheapIncrementalIndex(schema, true, 10000);
+    IncrementalIndex<?> index = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(schema)
+        .setMaxRowCount(10000)
+        .build();
     index.add(
         new MapBasedInputRow(
             0, Arrays.asList(

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
@@ -29,6 +29,7 @@ import io.druid.collections.StupidPool;
 import io.druid.data.input.MapBasedInputRow;
 import io.druid.data.input.MapBasedRow;
 import io.druid.data.input.Row;
+import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.guava.Sequences;
@@ -97,9 +98,18 @@ public class IncrementalIndexStorageAdapterTest
                   @Override
                   public IncrementalIndex createIndex()
                   {
-                    return new OnheapIncrementalIndex(
-                        0, Granularities.MINUTE, new AggregatorFactory[]{new CountAggregatorFactory("cnt")}, 1000
-                    );
+                    return new OnheapIncrementalIndex.Builder()
+                        .setIncrementalIndexSchema(
+                            new IncrementalIndexSchema.Builder()
+                                .withMinTimestamp(0)
+                                .withQueryGranularity(Granularities.NONE)
+                                .withDimensionsSpec(DimensionsSpec.ofEmpty())
+                                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("cnt")})
+                                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                                .build()
+                        )
+                        .setMaxRowCount(1000)
+                        .build();
                   }
                 }
             }

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
@@ -29,7 +29,6 @@ import io.druid.collections.StupidPool;
 import io.druid.data.input.MapBasedInputRow;
 import io.druid.data.input.MapBasedRow;
 import io.druid.data.input.Row;
-import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.guava.Sequences;
@@ -98,18 +97,14 @@ public class IncrementalIndexStorageAdapterTest
                   @Override
                   public IncrementalIndex createIndex()
                   {
-                    return new OnheapIncrementalIndex.Builder()
+                    return new IncrementalIndex.Builder()
                         .setIncrementalIndexSchema(
                             new IncrementalIndexSchema.Builder()
-                                .withMinTimestamp(0)
-                                .withQueryGranularity(Granularities.NONE)
-                                .withDimensionsSpec(DimensionsSpec.ofEmpty())
-                                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("cnt")})
-                                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                                .withMetrics(new CountAggregatorFactory("cnt"))
                                 .build()
                         )
                         .setMaxRowCount(1000)
-                        .build();
+                        .buildOnheap();
                   }
                 }
             }

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
@@ -98,11 +98,7 @@ public class IncrementalIndexStorageAdapterTest
                   public IncrementalIndex createIndex()
                   {
                     return new IncrementalIndex.Builder()
-                        .setIncrementalIndexSchema(
-                            new IncrementalIndexSchema.Builder()
-                                .withMetrics(new CountAggregatorFactory("cnt"))
-                                .build()
-                        )
+                        .setSimpleTestingIndexSchema(new CountAggregatorFactory("cnt"))
                         .setMaxRowCount(1000)
                         .buildOnheap();
                   }

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexTest.java
@@ -102,7 +102,7 @@ public class IncrementalIndexTest
                 public IncrementalIndex createIndex()
                 {
                   return new IncrementalIndex.Builder()
-                      .setIncrementalIndexSchema(schema)
+                      .setIndexSchema(schema)
                       .setDeserializeComplexMetrics(false)
                       .setSortFacts(sortFacts)
                       .setMaxRowCount(1000)
@@ -119,7 +119,7 @@ public class IncrementalIndexTest
                 public IncrementalIndex createIndex()
                 {
                   return new IncrementalIndex.Builder()
-                      .setIncrementalIndexSchema(schema)
+                      .setIndexSchema(schema)
                       .setSortFacts(sortFacts)
                       .setMaxRowCount(1000000)
                       .buildOffheap(

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexTest.java
@@ -87,11 +87,9 @@ public class IncrementalIndexTest
         )
     };
     final IncrementalIndexSchema schema = new IncrementalIndexSchema.Builder()
-        .withMinTimestamp(0)
         .withQueryGranularity(Granularities.MINUTE)
         .withDimensionsSpec(dimensions)
         .withMetrics(metrics)
-        .withRollup(true)
         .build();
 
     final List<Object[]> constructors = Lists.newArrayList();
@@ -103,12 +101,12 @@ public class IncrementalIndexTest
                 @Override
                 public IncrementalIndex createIndex()
                 {
-                  return new OnheapIncrementalIndex.Builder()
+                  return new IncrementalIndex.Builder()
                       .setIncrementalIndexSchema(schema)
                       .setDeserializeComplexMetrics(false)
                       .setSortFacts(sortFacts)
                       .setMaxRowCount(1000)
-                      .build();
+                      .buildOnheap();
                 }
               }
           }
@@ -120,11 +118,11 @@ public class IncrementalIndexTest
                 @Override
                 public IncrementalIndex createIndex()
                 {
-                  return new OffheapIncrementalIndex.Builder()
+                  return new IncrementalIndex.Builder()
                       .setIncrementalIndexSchema(schema)
                       .setSortFacts(sortFacts)
                       .setMaxRowCount(1000000)
-                      .setBufferPool(
+                      .buildOffheap(
                           new StupidPool<ByteBuffer>(
                               "OffheapIncrementalIndex-bufferPool",
                               new Supplier<ByteBuffer>()
@@ -136,8 +134,7 @@ public class IncrementalIndexTest
                                 }
                               }
                           )
-                      )
-                      .build();
+                      );
                 }
               }
           }

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexTest.java
@@ -103,7 +103,12 @@ public class IncrementalIndexTest
                 @Override
                 public IncrementalIndex createIndex()
                 {
-                  return new OnheapIncrementalIndex(schema, false, true, sortFacts, 1000);
+                  return new OnheapIncrementalIndex.Builder()
+                      .setIncrementalIndexSchema(schema)
+                      .setDeserializeComplexMetrics(false)
+                      .setSortFacts(sortFacts)
+                      .setMaxRowCount(1000)
+                      .build();
                 }
               }
           }
@@ -115,24 +120,24 @@ public class IncrementalIndexTest
                 @Override
                 public IncrementalIndex createIndex()
                 {
-                  return new OffheapIncrementalIndex(
-                      schema,
-                      true,
-                      true,
-                      sortFacts,
-                      1000000,
-                      new StupidPool<ByteBuffer>(
-                          "OffheapIncrementalIndex-bufferPool",
-                          new Supplier<ByteBuffer>()
-                          {
-                            @Override
-                            public ByteBuffer get()
-                            {
-                              return ByteBuffer.allocate(256 * 1024);
-                            }
-                          }
+                  return new OffheapIncrementalIndex.Builder()
+                      .setIncrementalIndexSchema(schema)
+                      .setSortFacts(sortFacts)
+                      .setMaxRowCount(1000000)
+                      .setBufferPool(
+                          new StupidPool<ByteBuffer>(
+                              "OffheapIncrementalIndex-bufferPool",
+                              new Supplier<ByteBuffer>()
+                              {
+                                @Override
+                                public ByteBuffer get()
+                                {
+                                  return ByteBuffer.allocate(256 * 1024);
+                                }
+                              }
+                          )
                       )
-                  );
+                      .build();
                 }
               }
           }

--- a/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
+++ b/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
@@ -33,6 +33,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.MapBasedInputRow;
+import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.granularity.Granularity;
 import io.druid.java.util.common.guava.Sequences;
@@ -117,7 +118,20 @@ public class OnheapIncrementalIndexBenchmark extends AbstractBenchmark
         int maxRowCount
     )
     {
-      super(minTimestamp, gran, metrics, maxRowCount);
+      super(
+          new IncrementalIndexSchema.Builder()
+            .withMinTimestamp(minTimestamp)
+            .withQueryGranularity(gran)
+            .withDimensionsSpec(DimensionsSpec.ofEmpty())
+            .withMetrics(metrics)
+            .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+            .build(),
+        true,
+        true,
+        false,
+        true,
+        maxRowCount
+      );
     }
 
     @Override

--- a/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexTest.java
@@ -42,7 +42,7 @@ public class OnheapIncrementalIndexTest
   public void testMultithreadAddFacts() throws Exception
   {
     final IncrementalIndex index = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
+        .setIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withQueryGranularity(Granularities.MINUTE)
                 .withMetrics(new LongMaxAggregatorFactory("max", "max"))
@@ -111,7 +111,7 @@ public class OnheapIncrementalIndexTest
     EasyMock.expectLastCall().times(1);
 
     final OnheapIncrementalIndex index = (OnheapIncrementalIndex) new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
+        .setIndexSchema(
             new IncrementalIndexSchema.Builder()
                 .withQueryGranularity(Granularities.MINUTE)
                 .withMetrics(new LongMaxAggregatorFactory("max", "max"))

--- a/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexTest.java
@@ -22,10 +22,8 @@ package io.druid.segment.incremental;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.druid.data.input.MapBasedInputRow;
-import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.query.aggregation.Aggregator;
-import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.LongMaxAggregator;
 import io.druid.query.aggregation.LongMaxAggregatorFactory;
 import org.easymock.EasyMock;
@@ -43,18 +41,15 @@ public class OnheapIncrementalIndexTest
   @Test
   public void testMultithreadAddFacts() throws Exception
   {
-    final OnheapIncrementalIndex index = new OnheapIncrementalIndex.Builder()
+    final IncrementalIndex index = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-                .withMinTimestamp(0)
                 .withQueryGranularity(Granularities.MINUTE)
-                .withDimensionsSpec(DimensionsSpec.ofEmpty())
-                .withMetrics(new AggregatorFactory[]{new LongMaxAggregatorFactory("max", "max")})
-                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .withMetrics(new LongMaxAggregatorFactory("max", "max"))
                 .build()
         )
         .setMaxRowCount(MAX_ROWS)
-        .build();
+        .buildOnheap();
 
     final Random random = new Random();
     final int addThreadCount = 2;
@@ -115,18 +110,15 @@ public class OnheapIncrementalIndexTest
     mockedAggregator.close();
     EasyMock.expectLastCall().times(1);
 
-    final OnheapIncrementalIndex index = new OnheapIncrementalIndex.Builder()
+    final OnheapIncrementalIndex index = (OnheapIncrementalIndex) new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-                .withMinTimestamp(0)
                 .withQueryGranularity(Granularities.MINUTE)
-                .withDimensionsSpec(DimensionsSpec.ofEmpty())
-                .withMetrics(new AggregatorFactory[]{new LongMaxAggregatorFactory("max", "max")})
-                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .withMetrics(new LongMaxAggregatorFactory("max", "max"))
                 .build()
         )
         .setMaxRowCount(MAX_ROWS)
-        .build();
+        .buildOnheap();
 
     index.add(new MapBasedInputRow(
             0,

--- a/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexTest.java
@@ -22,6 +22,7 @@ package io.druid.segment.incremental;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.druid.data.input.MapBasedInputRow;
+import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.query.aggregation.Aggregator;
 import io.druid.query.aggregation.AggregatorFactory;
@@ -42,12 +43,18 @@ public class OnheapIncrementalIndexTest
   @Test
   public void testMultithreadAddFacts() throws Exception
   {
-    final OnheapIncrementalIndex index = new OnheapIncrementalIndex(
-        0,
-        Granularities.MINUTE,
-        new AggregatorFactory[]{new LongMaxAggregatorFactory("max", "max")},
-        MAX_ROWS
-    );
+    final OnheapIncrementalIndex index = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withMinTimestamp(0)
+                .withQueryGranularity(Granularities.MINUTE)
+                .withDimensionsSpec(DimensionsSpec.ofEmpty())
+                .withMetrics(new AggregatorFactory[]{new LongMaxAggregatorFactory("max", "max")})
+                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .build()
+        )
+        .setMaxRowCount(MAX_ROWS)
+        .build();
 
     final Random random = new Random();
     final int addThreadCount = 2;
@@ -108,12 +115,18 @@ public class OnheapIncrementalIndexTest
     mockedAggregator.close();
     EasyMock.expectLastCall().times(1);
 
-    final OnheapIncrementalIndex index = new OnheapIncrementalIndex(
-            0,
-            Granularities.MINUTE,
-            new AggregatorFactory[]{new LongMaxAggregatorFactory("max", "max")},
-            MAX_ROWS
-    );
+    final OnheapIncrementalIndex index = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withMinTimestamp(0)
+                .withQueryGranularity(Granularities.MINUTE)
+                .withDimensionsSpec(DimensionsSpec.ofEmpty())
+                .withMetrics(new AggregatorFactory[]{new LongMaxAggregatorFactory("max", "max")})
+                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .build()
+        )
+        .setMaxRowCount(MAX_ROWS)
+        .build();
 
     index.add(new MapBasedInputRow(
             0,

--- a/processing/src/test/java/io/druid/segment/incremental/TimeAndDimsCompTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/TimeAndDimsCompTest.java
@@ -22,9 +22,6 @@ package io.druid.segment.incremental;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.druid.data.input.MapBasedInputRow;
-import io.druid.data.input.impl.DimensionsSpec;
-import io.druid.java.util.common.granularity.Granularities;
-import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import org.junit.Assert;
 import org.junit.Test;
@@ -42,18 +39,14 @@ public class TimeAndDimsCompTest
   @Test
   public void testBasic() throws IndexSizeExceededException
   {
-    IncrementalIndex index = new OnheapIncrementalIndex.Builder()
+    IncrementalIndex index = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(
             new IncrementalIndexSchema.Builder()
-                .withMinTimestamp(0)
-                .withQueryGranularity(Granularities.NONE)
-                .withDimensionsSpec(DimensionsSpec.ofEmpty())
-                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("cnt")})
-                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .withMetrics(new CountAggregatorFactory("cnt"))
                 .build()
         )
         .setMaxRowCount(1000)
-        .build();
+        .buildOnheap();
 
     long time = System.currentTimeMillis();
     TimeAndDims td1 = index.toTimeAndDims(toMapRow(time, "billy", "A", "joe", "B"));

--- a/processing/src/test/java/io/druid/segment/incremental/TimeAndDimsCompTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/TimeAndDimsCompTest.java
@@ -40,11 +40,7 @@ public class TimeAndDimsCompTest
   public void testBasic() throws IndexSizeExceededException
   {
     IncrementalIndex index = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(
-            new IncrementalIndexSchema.Builder()
-                .withMetrics(new CountAggregatorFactory("cnt"))
-                .build()
-        )
+        .setSimpleTestingIndexSchema(new CountAggregatorFactory("cnt"))
         .setMaxRowCount(1000)
         .buildOnheap();
 

--- a/processing/src/test/java/io/druid/segment/incremental/TimeAndDimsCompTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/TimeAndDimsCompTest.java
@@ -22,6 +22,7 @@ package io.druid.segment.incremental;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.druid.data.input.MapBasedInputRow;
+import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
@@ -41,9 +42,18 @@ public class TimeAndDimsCompTest
   @Test
   public void testBasic() throws IndexSizeExceededException
   {
-    IncrementalIndex index = new OnheapIncrementalIndex(
-        0, Granularities.NONE, new AggregatorFactory[]{new CountAggregatorFactory("cnt")}, 1000
-    );
+    IncrementalIndex index = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withMinTimestamp(0)
+                .withQueryGranularity(Granularities.NONE)
+                .withDimensionsSpec(DimensionsSpec.ofEmpty())
+                .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("cnt")})
+                .withRollup(IncrementalIndexSchema.DEFAULT_ROLLUP)
+                .build()
+        )
+        .setMaxRowCount(1000)
+        .build();
 
     long time = System.currentTimeMillis();
     TimeAndDims td1 = index.toTimeAndDims(toMapRow(time, "billy", "A", "joe", "B"));

--- a/server/src/main/java/io/druid/segment/realtime/plumber/Sink.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/Sink.java
@@ -36,7 +36,6 @@ import io.druid.segment.column.ColumnCapabilitiesImpl;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.IndexSizeExceededException;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import io.druid.segment.indexing.DataSchema;
 import io.druid.segment.realtime.FireHydrant;
 import io.druid.timeline.DataSegment;
@@ -254,11 +253,11 @@ public class Sink implements Iterable<FireHydrant>
         .withMetrics(schema.getAggregators())
         .withRollup(schema.getGranularitySpec().isRollup())
         .build();
-    final IncrementalIndex newIndex = new OnheapIncrementalIndex.Builder()
+    final IncrementalIndex newIndex = new IncrementalIndex.Builder()
         .setIncrementalIndexSchema(indexSchema)
         .setReportParseExceptions(reportParseExceptions)
         .setMaxRowCount(maxRowsInMemory)
-        .build();
+        .buildOnheap();
 
     final FireHydrant old;
     synchronized (hydrantLock) {

--- a/server/src/main/java/io/druid/segment/realtime/plumber/Sink.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/Sink.java
@@ -254,7 +254,7 @@ public class Sink implements Iterable<FireHydrant>
         .withRollup(schema.getGranularitySpec().isRollup())
         .build();
     final IncrementalIndex newIndex = new IncrementalIndex.Builder()
-        .setIncrementalIndexSchema(indexSchema)
+        .setIndexSchema(indexSchema)
         .setReportParseExceptions(reportParseExceptions)
         .setMaxRowCount(maxRowsInMemory)
         .buildOnheap();

--- a/server/src/main/java/io/druid/segment/realtime/plumber/Sink.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/Sink.java
@@ -254,7 +254,11 @@ public class Sink implements Iterable<FireHydrant>
         .withMetrics(schema.getAggregators())
         .withRollup(schema.getGranularitySpec().isRollup())
         .build();
-    final IncrementalIndex newIndex = new OnheapIncrementalIndex(indexSchema, reportParseExceptions, maxRowsInMemory);
+    final IncrementalIndex newIndex = new OnheapIncrementalIndex.Builder()
+        .setIncrementalIndexSchema(indexSchema)
+        .setReportParseExceptions(reportParseExceptions)
+        .setMaxRowCount(maxRowsInMemory)
+        .build();
 
     final FireHydrant old;
     synchronized (hydrantLock) {

--- a/server/src/test/java/io/druid/segment/realtime/firehose/IngestSegmentFirehoseTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/firehose/IngestSegmentFirehoseTest.java
@@ -31,7 +31,6 @@ import io.druid.data.input.impl.StringDimensionSchema;
 import io.druid.data.input.impl.StringInputRowParser;
 import io.druid.data.input.impl.TimestampSpec;
 import io.druid.hll.HyperLogLogCollector;
-import io.druid.java.util.common.granularity.Granularities;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.LongSumAggregatorFactory;
 import io.druid.query.aggregation.hyperloglog.HyperUniquesAggregatorFactory;
@@ -46,7 +45,6 @@ import io.druid.segment.TestHelper;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.IncrementalIndexStorageAdapter;
-import io.druid.segment.incremental.OnheapIncrementalIndex;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.junit.Assert;
@@ -105,16 +103,15 @@ public class IngestSegmentFirehoseTest
 
     try (
         final QueryableIndex qi = indexIO.loadIndex(segmentDir);
-        final IncrementalIndex index = new OnheapIncrementalIndex.Builder()
+        final IncrementalIndex index = new IncrementalIndex.Builder()
             .setIncrementalIndexSchema(
                 new IncrementalIndexSchema.Builder()
                     .withDimensionsSpec(DIMENSIONS_SPEC_REINDEX)
-                    .withQueryGranularity(Granularities.NONE)
                     .withMetrics(AGGREGATORS_REINDEX.toArray(new AggregatorFactory[]{}))
                     .build()
             )
         .setMaxRowCount(5000)
-        .build();
+        .buildOnheap();
     ) {
       final StorageAdapter sa = new QueryableIndexStorageAdapter(qi);
       final WindowedStorageAdapter wsa = new WindowedStorageAdapter(sa, sa.getInterval());
@@ -194,16 +191,15 @@ public class IngestSegmentFirehoseTest
     );
 
     try (
-        final IncrementalIndex index = new OnheapIncrementalIndex.Builder()
+        final IncrementalIndex index = new IncrementalIndex.Builder()
             .setIncrementalIndexSchema(
                 new IncrementalIndexSchema.Builder()
                     .withDimensionsSpec(parser.getParseSpec().getDimensionsSpec())
-                    .withQueryGranularity(Granularities.NONE)
                     .withMetrics(AGGREGATORS.toArray(new AggregatorFactory[]{}))
                     .build()
             )
         .setMaxRowCount(5000)
-        .build();
+        .buildOnheap();
     ) {
       for (String line : rows) {
         index.add(parser.parse(line));

--- a/server/src/test/java/io/druid/segment/realtime/firehose/IngestSegmentFirehoseTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/firehose/IngestSegmentFirehoseTest.java
@@ -105,15 +105,16 @@ public class IngestSegmentFirehoseTest
 
     try (
         final QueryableIndex qi = indexIO.loadIndex(segmentDir);
-        final IncrementalIndex index = new OnheapIncrementalIndex(
-            new IncrementalIndexSchema.Builder()
-                .withDimensionsSpec(DIMENSIONS_SPEC_REINDEX)
-                .withQueryGranularity(Granularities.NONE)
-                .withMetrics(AGGREGATORS_REINDEX.toArray(new AggregatorFactory[]{}))
-                .build(),
-            true,
-            5000
-        )
+        final IncrementalIndex index = new OnheapIncrementalIndex.Builder()
+            .setIncrementalIndexSchema(
+                new IncrementalIndexSchema.Builder()
+                    .withDimensionsSpec(DIMENSIONS_SPEC_REINDEX)
+                    .withQueryGranularity(Granularities.NONE)
+                    .withMetrics(AGGREGATORS_REINDEX.toArray(new AggregatorFactory[]{}))
+                    .build()
+            )
+        .setMaxRowCount(5000)
+        .build();
     ) {
       final StorageAdapter sa = new QueryableIndexStorageAdapter(qi);
       final WindowedStorageAdapter wsa = new WindowedStorageAdapter(sa, sa.getInterval());
@@ -193,15 +194,16 @@ public class IngestSegmentFirehoseTest
     );
 
     try (
-        final IncrementalIndex index = new OnheapIncrementalIndex(
-            new IncrementalIndexSchema.Builder()
-                .withDimensionsSpec(parser.getParseSpec().getDimensionsSpec())
-                .withQueryGranularity(Granularities.NONE)
-                .withMetrics(AGGREGATORS.toArray(new AggregatorFactory[]{}))
-                .build(),
-            true,
-            5000
-        )
+        final IncrementalIndex index = new OnheapIncrementalIndex.Builder()
+            .setIncrementalIndexSchema(
+                new IncrementalIndexSchema.Builder()
+                    .withDimensionsSpec(parser.getParseSpec().getDimensionsSpec())
+                    .withQueryGranularity(Granularities.NONE)
+                    .withMetrics(AGGREGATORS.toArray(new AggregatorFactory[]{}))
+                    .build()
+            )
+        .setMaxRowCount(5000)
+        .build();
     ) {
       for (String line : rows) {
         index.add(parser.parse(line));

--- a/server/src/test/java/io/druid/segment/realtime/firehose/IngestSegmentFirehoseTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/firehose/IngestSegmentFirehoseTest.java
@@ -104,7 +104,7 @@ public class IngestSegmentFirehoseTest
     try (
         final QueryableIndex qi = indexIO.loadIndex(segmentDir);
         final IncrementalIndex index = new IncrementalIndex.Builder()
-            .setIncrementalIndexSchema(
+            .setIndexSchema(
                 new IncrementalIndexSchema.Builder()
                     .withDimensionsSpec(DIMENSIONS_SPEC_REINDEX)
                     .withMetrics(AGGREGATORS_REINDEX.toArray(new AggregatorFactory[]{}))
@@ -192,7 +192,7 @@ public class IngestSegmentFirehoseTest
 
     try (
         final IncrementalIndex index = new IncrementalIndex.Builder()
-            .setIncrementalIndexSchema(
+            .setIndexSchema(
                 new IncrementalIndexSchema.Builder()
                     .withDimensionsSpec(parser.getParseSpec().getDimensionsSpec())
                     .withMetrics(AGGREGATORS.toArray(new AggregatorFactory[]{}))

--- a/sql/src/test/java/io/druid/sql/calcite/schema/DruidSchemaTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/schema/DruidSchemaTest.java
@@ -93,11 +93,9 @@ public class DruidSchemaTest
                                               .schema(
                                                   new IncrementalIndexSchema.Builder()
                                                       .withMetrics(
-                                                          new AggregatorFactory[]{
-                                                              new CountAggregatorFactory("cnt"),
-                                                              new DoubleSumAggregatorFactory("m1", "m1"),
-                                                              new HyperUniquesAggregatorFactory("unique_dim1", "dim1")
-                                                          }
+                                                          new CountAggregatorFactory("cnt"),
+                                                          new DoubleSumAggregatorFactory("m1", "m1"),
+                                                          new HyperUniquesAggregatorFactory("unique_dim1", "dim1")
                                                       )
                                                       .withRollup(false)
                                                       .build()
@@ -111,10 +109,7 @@ public class DruidSchemaTest
                                               .schema(
                                                   new IncrementalIndexSchema.Builder()
                                                       .withMetrics(
-                                                          new AggregatorFactory[]{
-                                                              new LongSumAggregatorFactory("m1", "m1")
-                                                          }
-                                                      )
+                                                          new LongSumAggregatorFactory("m1", "m1"))
                                                       .withRollup(false)
                                                       .build()
                                               )

--- a/sql/src/test/java/io/druid/sql/calcite/schema/DruidSchemaTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/schema/DruidSchemaTest.java
@@ -107,8 +107,7 @@ public class DruidSchemaTest
                                               .indexMerger(TestHelper.getTestIndexMergerV9())
                                               .schema(
                                                   new IncrementalIndexSchema.Builder()
-                                                      .withMetrics(
-                                                          new LongSumAggregatorFactory("m1", "m1"))
+                                                      .withMetrics(new LongSumAggregatorFactory("m1", "m1"))
                                                       .withRollup(false)
                                                       .build()
                                               )

--- a/sql/src/test/java/io/druid/sql/calcite/schema/DruidSchemaTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/schema/DruidSchemaTest.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.druid.data.input.InputRow;
-import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.query.aggregation.DoubleSumAggregatorFactory;
 import io.druid.query.aggregation.LongSumAggregatorFactory;

--- a/sql/src/test/java/io/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/io/druid/sql/calcite/util/CalciteTests.java
@@ -46,7 +46,6 @@ import io.druid.query.Query;
 import io.druid.query.QueryRunnerFactory;
 import io.druid.query.QueryRunnerFactoryConglomerate;
 import io.druid.query.QueryRunnerTestHelper;
-import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.query.aggregation.DoubleSumAggregatorFactory;
 import io.druid.query.aggregation.hyperloglog.HyperUniquesAggregatorFactory;

--- a/sql/src/test/java/io/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/io/druid/sql/calcite/util/CalciteTests.java
@@ -281,11 +281,9 @@ public class CalciteTests
 
   private static final IncrementalIndexSchema INDEX_SCHEMA = new IncrementalIndexSchema.Builder()
       .withMetrics(
-          new AggregatorFactory[]{
-              new CountAggregatorFactory("cnt"),
-              new DoubleSumAggregatorFactory("m1", "m1"),
-              new HyperUniquesAggregatorFactory("unique_dim1", "dim1")
-          }
+          new CountAggregatorFactory("cnt"),
+          new DoubleSumAggregatorFactory("m1", "m1"),
+          new HyperUniquesAggregatorFactory("unique_dim1", "dim1")
       )
       .withRollup(false)
       .build();


### PR DESCRIPTION
Added am additional boolean parameter in `IncrementalIndex` constructor (and subsequently the constructors for its subclasses `OnheapIncrementalIndex` and `OffheapIncrementalIndex`) and the protected function `initAggs` to indicate if `ConcurrentMap` should be used.