### PR TITLE
Kafka Indexing - optionally reset dataSourceState when topic in state has gone stale 

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisor.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisor.java
@@ -497,6 +497,24 @@ public class KafkaSupervisor implements Supervisor
     }
   }
 
+  public void possiblyResetDataSourceState() {
+    // check that the dataSourceState match the current config, optionally reset it if resetOffsetAutomatically is set
+    DataSourceMetadata dataSourceMetadata = indexerMetadataStorageCoordinator.getDataSourceMetadata(dataSource);
+    if (dataSourceMetadata != null && dataSourceMetadata instanceof KafkaDataSourceMetadata) {
+      KafkaPartitions partitions = ((KafkaDataSourceMetadata) dataSourceMetadata).getKafkaPartitions();
+      if (partitions != null &&
+          !ioConfig.getTopic().equals(partitions.getTopic()) &&
+          tuningConfig.isResetOffsetAutomatically()) {
+        log.makeAlert(
+            "Topic in metadata storage [%s] doesn't match spec topic [%s], resetting dataSourceState",
+            partitions.getTopic(),
+            ioConfig.getTopic()
+        );
+        resetInternal(null);
+      }
+    }
+  }
+
   private interface Notice
   {
     void handle() throws ExecutionException, InterruptedException, TimeoutException;
@@ -675,6 +693,7 @@ public class KafkaSupervisor implements Supervisor
   void runInternal() throws ExecutionException, InterruptedException, TimeoutException
   {
     possiblyRegisterListener();
+    possiblyResetDataSourceState();
     updatePartitionDataFromKafka();
     discoverTasks();
     updateTaskStatus();
@@ -1499,10 +1518,6 @@ public class KafkaSupervisor implements Supervisor
               partitions.getTopic(),
               ioConfig.getTopic()
           );
-          if (tuningConfig.isResetOffsetAutomatically()) {
-            // reset the dataSourceMetadata to a clean state
-            reset(null);
-          }
           return ImmutableMap.of();
         } else if (partitions.getPartitionOffsetMap() != null) {
           return partitions.getPartitionOffsetMap();

--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisor.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisor.java
@@ -1499,6 +1499,10 @@ public class KafkaSupervisor implements Supervisor
               partitions.getTopic(),
               ioConfig.getTopic()
           );
+          if (tuningConfig.isResetOffsetAutomatically()) {
+            // reset the dataSourceMetadata to a clean state
+            reset(null);
+          }
           return ImmutableMap.of();
         } else if (partitions.getPartitionOffsetMap() != null) {
           return partitions.getPartitionOffsetMap();

--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -1778,7 +1778,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     }
   }
 
-  private KafkaSupervisorIOConfig getIOConfig(
+  private KafkaSupervisor getSupervisor(
       int replicas,
       int taskCount,
       boolean useEarliestOffset,
@@ -1787,7 +1787,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
       boolean skipOffsetGaps
   )
   {
-    return new KafkaSupervisorIOConfig(
+    KafkaSupervisorIOConfig kafkaSupervisorIOConfig = new KafkaSupervisorIOConfig(
         topic,
         replicas,
         taskCount,
@@ -1800,11 +1800,8 @@ public class KafkaSupervisorTest extends EasyMockSupport
         lateMessageRejectionPeriod,
         skipOffsetGaps
     );
-  }
 
-  private KafkaIndexTaskClientFactory getClientFactory()
-  {
-    return new KafkaIndexTaskClientFactory(null, null)
+    KafkaIndexTaskClientFactory taskClientFactory = new KafkaIndexTaskClientFactory(null, null)
     {
       @Override
       public KafkaIndexTaskClient build(
@@ -1821,26 +1818,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
         return taskClient;
       }
     };
-  }
-
-  private KafkaSupervisor getSupervisor(
-      int replicas,
-      int taskCount,
-      boolean useEarliestOffset,
-      String duration,
-      Period lateMessageRejectionPeriod,
-      boolean skipOffsetGaps
-  )
-  {
-    KafkaSupervisorIOConfig kafkaSupervisorIOConfig = getIOConfig(
-        replicas,
-        taskCount,
-        useEarliestOffset,
-        duration,
-        lateMessageRejectionPeriod,
-        skipOffsetGaps
-    );
-    KafkaIndexTaskClientFactory taskClientFactory = getClientFactory();
 
     return new TestableKafkaSupervisor(
         taskStorage,

--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -1557,6 +1557,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     expect(taskRunner.getRunningTasks()).andReturn(Collections.EMPTY_LIST).anyTimes();
     expect(taskStorage.getActiveTasks()).andReturn(ImmutableList.<Task>of()).anyTimes();
     taskRunner.registerListener(anyObject(TaskRunnerListener.class), anyObject(Executor.class));
+    expect(indexerMetadataStorageCoordinator.getDataSourceMetadata(DATASOURCE)).andReturn(null).anyTimes();
     replayAll();
 
     supervisor = getSupervisor(1, 1, true, "PT1H", null, false);
@@ -1582,6 +1583,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     expect(taskRunner.getRunningTasks()).andReturn(Collections.EMPTY_LIST).anyTimes();
     expect(taskStorage.getActiveTasks()).andReturn(ImmutableList.<Task>of()).anyTimes();
     taskRunner.registerListener(anyObject(TaskRunnerListener.class), anyObject(Executor.class));
+    expect(indexerMetadataStorageCoordinator.getDataSourceMetadata(DATASOURCE)).andReturn(null).anyTimes();
     replayAll();
 
     supervisor.start();
@@ -1629,6 +1631,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     expect(taskMaster.getTaskRunner()).andReturn(Optional.of(taskRunner)).anyTimes();
     expect(taskRunner.getRunningTasks()).andReturn(Collections.EMPTY_LIST).anyTimes();
     expect(taskStorage.getActiveTasks()).andReturn(ImmutableList.<Task>of()).anyTimes();
+    expect(indexerMetadataStorageCoordinator.getDataSourceMetadata(DATASOURCE)).andReturn(null).anyTimes();
     taskRunner.registerListener(anyObject(TaskRunnerListener.class), anyObject(Executor.class));
     replayAll();
 
@@ -1733,7 +1736,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
   @Test
   public void testResetStateTopicChange() throws Exception
   {
-    supervisor = getSupervisor(1, 1, true, "PT1H", null, false);
+    supervisor = getSupervisor(1, 2, true, "PT1H", null, false);
 
     Capture<KafkaIndexTask> captured = Capture.newInstance();
     addSomeEvents(1);
@@ -1743,13 +1746,12 @@ public class KafkaSupervisorTest extends EasyMockSupport
     expect(taskStorage.getActiveTasks()).andReturn(ImmutableList.<Task>of()).anyTimes();
     expect(indexerMetadataStorageCoordinator.getDataSourceMetadata(DATASOURCE)).andReturn(
         new KafkaDataSourceMetadata(
-            new KafkaPartitions("staleTopic", ImmutableMap.of(0, 10L))
-        )
+            new KafkaPartitions("staleTopic", ImmutableMap.of(0, 10L, 1, 20L, 3, 30L)))
     ).anyTimes();
-    expect(taskQueue.add(capture(captured))).andReturn(true);
-    expect(indexerMetadataStorageCoordinator.deleteDataSourceMetadata(DATASOURCE)).andReturn(true);
+    expect(taskQueue.add(capture(captured))).andReturn(true).anyTimes();
+    expect(indexerMetadataStorageCoordinator.deleteDataSourceMetadata(DATASOURCE)).andReturn(true).once();
     taskClient.close();
-    EasyMock.expectLastCall().once();
+    EasyMock.expectLastCall().anyTimes();
     taskRunner.registerListener(anyObject(TaskRunnerListener.class), anyObject(Executor.class));
     taskRunner.unregisterListener("KafkaSupervisor-testDS");
     replayAll();


### PR DESCRIPTION
The proposed change is to reset the datasourceMetadata when it is detected that the topic in the state doesn't match the one in the config, if and only if the supervisor is configured with the pre-existing flag **resetOffsetAutomatically** set to true.


Currently changing the topic of a datasource after a previous commit, cause subsequent task to fail when publishing, arguing that the datasource state doesn't match the config.

There is reset endpoint that can be called to solve the issue, but this require the supervisor to be started.
