### PR TITLE
ExpressionPostAggregator: Automatically finalize inputs.

### DIFF
--- a/processing/src/main/java/io/druid/query/aggregation/post/ExpressionPostAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/post/ExpressionPostAggregator.java
@@ -35,6 +35,7 @@ import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.PostAggregator;
 import io.druid.query.cache.CacheKeyBuilder;
 
+import javax.annotation.Nullable;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
@@ -75,7 +76,7 @@ public class ExpressionPostAggregator implements PostAggregator
       @JacksonInject ExprMacroTable macroTable
   )
   {
-    this(name, expression, ordering, macroTable, null);
+    this(name, expression, ordering, macroTable, ImmutableMap.of());
   }
 
   /**
@@ -84,7 +85,7 @@ public class ExpressionPostAggregator implements PostAggregator
   private ExpressionPostAggregator(
       final String name,
       final String expression,
-      final String ordering,
+      @Nullable final String ordering,
       final ExprMacroTable macroTable,
       final Map<String, Function<Object, Object>> finalizers
   )
@@ -96,7 +97,7 @@ public class ExpressionPostAggregator implements PostAggregator
     this.ordering = ordering;
     this.comparator = ordering == null ? DEFAULT_COMPARATOR : Ordering.valueOf(ordering);
     this.macroTable = macroTable;
-    this.finalizers = finalizers != null ? ImmutableMap.copyOf(finalizers) : ImmutableMap.of();
+    this.finalizers = ImmutableMap.copyOf(finalizers);
 
     this.parsed = Parser.parse(expression, macroTable);
     this.dependentFields = ImmutableSet.copyOf(Parser.findRequiredBindings(parsed));
@@ -140,7 +141,10 @@ public class ExpressionPostAggregator implements PostAggregator
   public ExpressionPostAggregator decorate(final Map<String, AggregatorFactory> aggregators)
   {
     return new ExpressionPostAggregator(
-        name, expression, ordering, macroTable,
+        name,
+        expression,
+        ordering,
+        macroTable,
         aggregators.entrySet().stream().collect(
             Collectors.toMap(
                 entry -> entry.getKey(),

--- a/processing/src/main/java/io/druid/query/aggregation/post/ExpressionPostAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/post/ExpressionPostAggregator.java
@@ -97,7 +97,7 @@ public class ExpressionPostAggregator implements PostAggregator
     this.ordering = ordering;
     this.comparator = ordering == null ? DEFAULT_COMPARATOR : Ordering.valueOf(ordering);
     this.macroTable = macroTable;
-    this.finalizers = ImmutableMap.copyOf(finalizers);
+    this.finalizers = finalizers;
 
     this.parsed = Parser.parse(expression, macroTable);
     this.dependentFields = ImmutableSet.copyOf(Parser.findRequiredBindings(parsed));

--- a/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerTest.java
@@ -641,6 +641,56 @@ public class TopNQueryRunnerTest
   }
 
   @Test
+  public void testTopNOverHyperUniqueExpression()
+  {
+    TopNQuery query = new TopNQueryBuilder()
+        .dataSource(QueryRunnerTestHelper.dataSource)
+        .granularity(QueryRunnerTestHelper.allGran)
+        .dimension(QueryRunnerTestHelper.marketDimension)
+        .metric(QueryRunnerTestHelper.hyperUniqueFinalizingPostAggMetric)
+        .threshold(3)
+        .intervals(QueryRunnerTestHelper.fullOnInterval)
+        .aggregators(
+            Arrays.<AggregatorFactory>asList(QueryRunnerTestHelper.qualityUniques)
+        )
+        .postAggregators(
+            Collections.singletonList(new ExpressionPostAggregator(
+                QueryRunnerTestHelper.hyperUniqueFinalizingPostAggMetric,
+                "uniques + 1",
+                null,
+                TestExprMacroTable.INSTANCE
+            ))
+        )
+        .build();
+
+    List<Result<TopNResultValue>> expectedResults = Arrays.asList(
+        new Result<>(
+            new DateTime("2011-01-12T00:00:00.000Z"),
+            new TopNResultValue(
+                Arrays.<Map<String, Object>>asList(
+                    ImmutableMap.<String, Object>builder()
+                        .put("market", "spot")
+                        .put(QueryRunnerTestHelper.uniqueMetric, QueryRunnerTestHelper.UNIQUES_9)
+                        .put(QueryRunnerTestHelper.hyperUniqueFinalizingPostAggMetric, QueryRunnerTestHelper.UNIQUES_9 + 1)
+                        .build(),
+                    ImmutableMap.<String, Object>builder()
+                        .put("market", "total_market")
+                        .put(QueryRunnerTestHelper.uniqueMetric, QueryRunnerTestHelper.UNIQUES_2)
+                        .put(QueryRunnerTestHelper.hyperUniqueFinalizingPostAggMetric, QueryRunnerTestHelper.UNIQUES_2 + 1)
+                        .build(),
+                    ImmutableMap.<String, Object>builder()
+                        .put("market", "upfront")
+                        .put(QueryRunnerTestHelper.uniqueMetric, QueryRunnerTestHelper.UNIQUES_2)
+                        .put(QueryRunnerTestHelper.hyperUniqueFinalizingPostAggMetric, QueryRunnerTestHelper.UNIQUES_2 + 1)
+                        .build()
+                )
+            )
+        )
+    );
+    assertExpectedResults(expectedResults, query);
+  }
+
+  @Test
   public void testTopNOverFirstLastAggregator()
   {
     TopNQuery query = new TopNQueryBuilder()

--- a/sql/src/main/java/io/druid/sql/calcite/expression/Expressions.java
+++ b/sql/src/main/java/io/druid/sql/calcite/expression/Expressions.java
@@ -210,7 +210,8 @@ public class Expressions
       final String name,
       final List<String> rowOrder,
       final List<PostAggregatorFactory> finalizingPostAggregatorFactories,
-      final RexNode expression
+      final RexNode expression,
+      final PlannerContext plannerContext
   )
   {
     final PostAggregator retVal;
@@ -226,7 +227,7 @@ public class Expressions
       // types internally and there isn't much we can do to respect
       // TODO(gianm): Probably not a good idea to ignore CAST like this.
       final RexNode operand = ((RexCall) expression).getOperands().get(0);
-      retVal = toPostAggregator(name, rowOrder, finalizingPostAggregatorFactories, operand);
+      retVal = toPostAggregator(name, rowOrder, finalizingPostAggregatorFactories, operand, plannerContext);
     } else if (expression.getKind() == SqlKind.LITERAL
                && SqlTypeName.NUMERIC_TYPES.contains(expression.getType().getSqlTypeName())) {
       retVal = new ConstantPostAggregator(name, (Number) RexLiteral.value(expression));
@@ -246,7 +247,8 @@ public class Expressions
             null,
             rowOrder,
             finalizingPostAggregatorFactories,
-            operand
+            operand,
+            plannerContext
         );
         if (translatedOperand == null) {
           return null;
@@ -260,7 +262,7 @@ public class Expressions
       if (mathExpression == null) {
         retVal = null;
       } else {
-        retVal = new ExpressionPostAggregator(name, mathExpression);
+        retVal = new ExpressionPostAggregator(name, mathExpression, null, plannerContext.getExprMacroTable());
       }
     }
 

--- a/sql/src/main/java/io/druid/sql/calcite/rule/GroupByRules.java
+++ b/sql/src/main/java/io/druid/sql/calcite/rule/GroupByRules.java
@@ -540,7 +540,8 @@ public class GroupByRules
             postAggregatorName,
             rowOrder,
             finalizingPostAggregatorFactories,
-            projectExpression
+            projectExpression,
+            druidRel.getPlannerContext()
         );
         if (postAggregator != null) {
           newAggregations.add(Aggregation.create(postAggregator));

--- a/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
@@ -1529,7 +1529,7 @@ public class CalciteQueryTest
                       new DoubleSumAggregatorFactory("a2", "m1", null, macroTable)
                   ))
                   .postAggregators(ImmutableList.of(
-                      new ExpressionPostAggregator("a3", "log((\"a1\" + \"a2\"))"),
+                      EXPRESSION_POST_AGG("a3", "log((\"a1\" + \"a2\"))"),
                       new ArithmeticPostAggregator("a4", "quotient", ImmutableList.of(
                           new FieldAccessPostAggregator(null, "a1"),
                           new ConstantPostAggregator(null, 0.25)
@@ -4415,5 +4415,10 @@ public class CalciteQueryTest
   private static List<AggregatorFactory> AGGS(final AggregatorFactory... aggregators)
   {
     return Arrays.asList(aggregators);
+  }
+
+  private static ExpressionPostAggregator EXPRESSION_POST_AGG(final String name, final String expression)
+  {
+    return new ExpressionPostAggregator(name, expression, null, CalciteTests.createExprMacroTable());
   }
 }


### PR DESCRIPTION
Raw HyperLogLogCollectors and such aren't very useful. When writing
expressions like `x / y` users will expect `x` and `y` to be finalized.