### PR TITLE
Don't eagerly allocate intermediate results buffers on brokers and routers

### DIFF
--- a/server/src/main/java/io/druid/guice/BrokerIntermediateResultsPoolProvider.java
+++ b/server/src/main/java/io/druid/guice/BrokerIntermediateResultsPoolProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.guice;
+
+import io.druid.java.util.common.ISE;
+import io.druid.query.DruidProcessingConfig;
+import io.druid.query.groupby.GroupByQueryConfig;
+import io.druid.query.groupby.strategy.GroupByStrategySelector;
+
+import javax.inject.Inject;
+
+@LazySingleton
+public class BrokerIntermediateResultsPoolProvider extends IntermediateResultsPoolProvider
+{
+  @Inject
+  public BrokerIntermediateResultsPoolProvider(
+      DruidProcessingConfig processingConfig,
+      GroupByQueryConfig groupByQueryConfig
+  )
+  {
+    super(choosePoolSize(processingConfig, groupByQueryConfig), processingConfig);
+  }
+
+  private static int choosePoolSize(DruidProcessingConfig processingConfig, GroupByQueryConfig groupByQueryConfig)
+  {
+    switch (groupByQueryConfig.getDefaultStrategy()) {
+      case GroupByStrategySelector.STRATEGY_V1:
+        return processingConfig.getNumThreads();
+      case GroupByStrategySelector.STRATEGY_V2:
+        return 0;
+      default:
+        throw new ISE("Unknown default groupBy strategy[%s]", groupByQueryConfig.getDefaultStrategy());
+    }
+  }
+}

--- a/server/src/main/java/io/druid/guice/DruidProcessingModule.java
+++ b/server/src/main/java/io/druid/guice/DruidProcessingModule.java
@@ -105,46 +105,49 @@ public class DruidProcessingModule implements Module
   @Provides
   @LazySingleton
   @Global
-  public StupidPool<ByteBuffer> getIntermediateResultsPool(DruidProcessingConfig config)
+  public StupidPool<ByteBuffer> getIntermediateResultsPool(
+      DruidProcessingConfig config,
+      IntermediateResultsPoolProvider provider
+  )
   {
-    verifyDirectMemory(config);
-    return new StupidPool<>(
-        "intermediate processing pool",
-        new OffheapBufferGenerator("intermediate processing", config.intermediateComputeSizeBytes()),
-        config.getNumThreads(),
-        config.poolCacheMaxCount()
-    );
+    verifyDirectMemory(config, provider.getPoolSize());
+    return provider.getIntermediateResultsPool();
   }
 
   @Provides
   @LazySingleton
   @Merging
-  public BlockingPool<ByteBuffer> getMergeBufferPool(DruidProcessingConfig config)
+  public BlockingPool<ByteBuffer> getMergeBufferPool(
+      DruidProcessingConfig config,
+      IntermediateResultsPoolProvider intermediateResultsPoolProvider
+  )
   {
-    verifyDirectMemory(config);
+    verifyDirectMemory(config, intermediateResultsPoolProvider.getPoolSize());
     return new BlockingPool<>(
         new OffheapBufferGenerator("result merging", config.intermediateComputeSizeBytes()),
         config.getNumMergeBuffers()
     );
   }
 
-  private void verifyDirectMemory(DruidProcessingConfig config)
+  private static void verifyDirectMemory(DruidProcessingConfig config, int intermediateResultsPoolSize)
   {
     try {
       final long maxDirectMemory = VMUtils.getMaxDirectMemory();
-      final long memoryNeeded = (long) config.intermediateComputeSizeBytes() *
-                                (config.getNumMergeBuffers() + config.getNumThreads() + 1);
+      int numBuffers = config.getNumMergeBuffers() + intermediateResultsPoolSize + 1;
+      final long memoryNeeded = (long) config.intermediateComputeSizeBytes() * numBuffers;
 
       if (maxDirectMemory < memoryNeeded) {
         throw new ProvisionException(
             String.format(
-                "Not enough direct memory.  Please adjust -XX:MaxDirectMemorySize, druid.processing.buffer.sizeBytes, druid.processing.numThreads, or druid.processing.numMergeBuffers: "
-                + "maxDirectMemory[%,d], memoryNeeded[%,d] = druid.processing.buffer.sizeBytes[%,d] * (druid.processing.numMergeBuffers[%,d] + druid.processing.numThreads[%,d] + 1)",
+                "Not enough direct memory.  Please adjust -XX:MaxDirectMemorySize, druid.processing.buffer.sizeBytes, "
+                + "druid.processing.numThreads, or druid.processing.numMergeBuffers: "
+                + "maxDirectMemory[%,d], memoryNeeded[%,d] = druid.processing.buffer.sizeBytes[%,d] * "
+                + "(druid.processing.numMergeBuffers[%,d] + intermediateResultsPoolSize[%,d] + 1)",
                 maxDirectMemory,
                 memoryNeeded,
                 config.intermediateComputeSizeBytes(),
                 config.getNumMergeBuffers(),
-                config.getNumThreads()
+                intermediateResultsPoolSize
             )
         );
       }

--- a/server/src/main/java/io/druid/guice/HistoricalIntermediateResultsPoolProvider.java
+++ b/server/src/main/java/io/druid/guice/HistoricalIntermediateResultsPoolProvider.java
@@ -19,31 +19,16 @@
 
 package io.druid.guice;
 
-import com.google.inject.ProvisionException;
 import io.druid.query.DruidProcessingConfig;
-import org.junit.Test;
 
-public class DruidProcessingModuleTest
+import javax.inject.Inject;
+
+@LazySingleton
+public class HistoricalIntermediateResultsPoolProvider extends IntermediateResultsPoolProvider
 {
-
-  @Test(expected=ProvisionException.class)
-  public void testMemoryCheckThrowsException() {
-    DruidProcessingModule module = new DruidProcessingModule();
-    DruidProcessingConfig config = new DruidProcessingConfig()
-    {
-      @Override
-      public String getFormatString()
-      {
-        return "test";
-      }
-
-      @Override
-      public int intermediateComputeSizeBytes()
-      {
-        return Integer.MAX_VALUE;
-      }
-    };
-    module.getIntermediateResultsPool(config, new HistoricalIntermediateResultsPoolProvider(config));
+  @Inject
+  public HistoricalIntermediateResultsPoolProvider(DruidProcessingConfig config)
+  {
+    super(config.getNumThreads(), config);
   }
-
 }

--- a/server/src/main/java/io/druid/guice/IntermediateResultsPoolProvider.java
+++ b/server/src/main/java/io/druid/guice/IntermediateResultsPoolProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.guice;
+
+import com.google.inject.ImplementedBy;
+import io.druid.collections.StupidPool;
+import io.druid.offheap.OffheapBufferGenerator;
+import io.druid.query.DruidProcessingConfig;
+
+import java.nio.ByteBuffer;
+
+@ImplementedBy(HistoricalIntermediateResultsPoolProvider.class)
+public abstract class IntermediateResultsPoolProvider
+{
+  private final int poolSize;
+  private final DruidProcessingConfig processingConfig;
+
+  IntermediateResultsPoolProvider(int poolSize, DruidProcessingConfig processingConfig)
+  {
+    this.poolSize = poolSize;
+    this.processingConfig = processingConfig;
+  }
+
+  public StupidPool<ByteBuffer> getIntermediateResultsPool()
+  {
+    return new StupidPool<>(
+        "intermediate processing pool",
+        new OffheapBufferGenerator("intermediate processing", processingConfig.intermediateComputeSizeBytes()),
+        poolSize,
+        processingConfig.poolCacheMaxCount()
+    );
+  }
+
+  public int getPoolSize()
+  {
+    return poolSize;
+  }
+}

--- a/services/src/main/java/io/druid/cli/CliBroker.java
+++ b/services/src/main/java/io/druid/cli/CliBroker.java
@@ -33,7 +33,9 @@ import io.druid.client.cache.CacheMonitor;
 import io.druid.client.selector.CustomTierSelectorStrategyConfig;
 import io.druid.client.selector.ServerSelectorStrategy;
 import io.druid.client.selector.TierSelectorStrategy;
+import io.druid.guice.BrokerIntermediateResultsPoolProvider;
 import io.druid.guice.CacheModule;
+import io.druid.guice.IntermediateResultsPoolProvider;
 import io.druid.guice.Jerseys;
 import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.LazySingleton;
@@ -84,6 +86,8 @@ public class CliBroker extends ServerRunnable
                 TieredBrokerConfig.DEFAULT_BROKER_SERVICE_NAME
             );
             binder.bindConstant().annotatedWith(Names.named("servicePort")).to(8082);
+
+            binder.bind(IntermediateResultsPoolProvider.class).to(BrokerIntermediateResultsPoolProvider.class);
 
             binder.bind(CachingClusteredClient.class).in(LazySingleton.class);
             binder.bind(BrokerServerView.class).in(LazySingleton.class);

--- a/services/src/main/java/io/druid/cli/CliRouter.java
+++ b/services/src/main/java/io/druid/cli/CliRouter.java
@@ -29,6 +29,8 @@ import io.airlift.airline.Command;
 import io.druid.curator.discovery.DiscoveryModule;
 import io.druid.curator.discovery.ServerDiscoveryFactory;
 import io.druid.curator.discovery.ServerDiscoverySelector;
+import io.druid.guice.BrokerIntermediateResultsPoolProvider;
+import io.druid.guice.IntermediateResultsPoolProvider;
 import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.LazySingleton;
 import io.druid.guice.LifecycleModule;
@@ -83,6 +85,8 @@ public class CliRouter extends ServerRunnable
 
             binder.bind(CoordinatorRuleManager.class);
             LifecycleModule.register(binder, CoordinatorRuleManager.class);
+
+            binder.bind(IntermediateResultsPoolProvider.class).to(BrokerIntermediateResultsPoolProvider.class);
 
             binder.bind(TieredBrokerHostSelector.class).in(ManageLifecycle.class);
             binder.bind(QueryHostFinder.class).in(LazySingleton.class);


### PR DESCRIPTION
After #3628 intermediate result buffers are eagerly allocated on broker and router nodes, where they could be used only on groupBy strategy v1 queries, as far as I can understand. It makes problematic to configure a lot of processing threads (to mitigate blocking nature of them) and not to hit maxDirectMemorySize limit.

This PR abstracts allocation of intermediate result buffer pool in `IntermediateResultsPoolProvider`, which eagerly allocates
 - Zero buffers on broker and router nodes, if the default groupBy strategy = v2.
 - `druid.processing.numThreads` buffers (as before this PR) in all other cases.