### PR TITLE
Revert some usages of Ints.asList to Arrays.asList.

### DIFF
--- a/processing/src/test/java/io/druid/segment/data/CompressedIntsIndexedSupplierTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedIntsIndexedSupplierTest.java
@@ -34,6 +34,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
 import java.nio.channels.Channels;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
@@ -330,7 +331,7 @@ public class CompressedIntsIndexedSupplierTest extends CompressionStrategyTest
       indices[i] = i;
     }
 
-    Collections.shuffle(Ints.asList(indices));
+    Collections.shuffle(Arrays.asList(indices));
     // random access
     for (int i = 0; i < indexed.size(); ++i) {
       int k = indices[i];

--- a/processing/src/test/java/io/druid/segment/data/CompressedLongsSerdeTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedLongsSerdeTest.java
@@ -21,7 +21,6 @@ package io.druid.segment.data;
 
 import com.google.common.base.Supplier;
 import com.google.common.io.ByteSink;
-import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import io.druid.java.util.common.guava.CloseQuietly;
 import org.junit.Assert;
@@ -36,6 +35,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.Channels;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -189,7 +189,7 @@ public class CompressedLongsSerdeTest
       indices[i] = i;
     }
 
-    Collections.shuffle(Ints.asList(indices));
+    Collections.shuffle(Arrays.asList(indices));
     // random access
     for (int i = 0; i < indexed.size(); ++i) {
       int k = indices[i];

--- a/processing/src/test/java/io/druid/segment/data/CompressedVSizeIntsIndexedSupplierTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedVSizeIntsIndexedSupplierTest.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.Channels;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
@@ -360,7 +361,7 @@ public class CompressedVSizeIntsIndexedSupplierTest extends CompressionStrategyT
       indices[i] = i;
     }
 
-    Collections.shuffle(Ints.asList(indices));
+    Collections.shuffle(Arrays.asList(indices));
     // random access
     for (int i = 0; i < indexed.size(); ++i) {
       int k = indices[i];


### PR DESCRIPTION
For some reason, Arrays.asList was much faster, so the change in #4252 slowed some tests down substantially. This speeds them up again.

We might also want to look into other usages of Ints.asList, but this patch doesn't do that.