### PR TITLE
Speed up sketch tests by merging fewer indexes.

### DIFF
--- a/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/theta/SketchAggregationTest.java
+++ b/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/theta/SketchAggregationTest.java
@@ -98,7 +98,7 @@ public class SketchAggregationTest
         readFileFromClasspathAsString("sketch_test_data_aggregators.json"),
         0,
         Granularities.NONE,
-        5,
+        1000,
         readFileFromClasspathAsString("sketch_test_data_group_by_query.json")
     );
 
@@ -139,7 +139,7 @@ public class SketchAggregationTest
         + "]",
         0,
         Granularities.NONE,
-        5,
+        1000,
         readFileFromClasspathAsString("simple_test_data_group_by_query.json")
     );
 

--- a/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/theta/oldapi/OldApiSketchAggregationTest.java
+++ b/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/theta/oldapi/OldApiSketchAggregationTest.java
@@ -92,7 +92,7 @@ public class OldApiSketchAggregationTest
         readFileFromClasspathAsString("oldapi/old_simple_test_data_aggregators.json"),
         0,
         Granularities.NONE,
-        5,
+        1000,
         readFileFromClasspathAsString("oldapi/old_simple_test_data_group_by_query.json")
     );
 
@@ -124,7 +124,7 @@ public class OldApiSketchAggregationTest
         readFileFromClasspathAsString("oldapi/old_sketch_test_data_aggregators.json"),
         0,
         Granularities.NONE,
-        5,
+        1000,
         readFileFromClasspathAsString("oldapi/old_sketch_test_data_group_by_query.json")
     );
 


### PR DESCRIPTION
The tests go from 5 minutes to about 10 seconds. 1000 maxRowCount is still
low enough to get a few merges, so we're still exercising that functionality.

See also #4402.