### PR TITLE
Limit random access in compressed column tests.

### DIFF
--- a/processing/src/test/java/io/druid/segment/data/CompressedFloatsSerdeTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedFloatsSerdeTest.java
@@ -22,8 +22,8 @@ package io.druid.segment.data;
 import com.google.common.base.Supplier;
 import com.google.common.io.ByteSink;
 import com.google.common.primitives.Floats;
-import com.google.common.primitives.Ints;
 import io.druid.java.util.common.guava.CloseQuietly;
+import it.unimi.dsi.fastutil.ints.IntArrays;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,8 +36,8 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.Channels;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -167,9 +167,10 @@ public class CompressedFloatsSerdeTest
       indices[i] = i;
     }
 
-    Collections.shuffle(Ints.asList(indices));
-    // random access
-    for (int i = 0; i < indexed.size(); ++i) {
+    // random access, limited to 1000 elements for large lists (every element would take too long)
+    IntArrays.shuffle(indices, new Random());
+    final int limit = Math.min(indexed.size(), 1000);
+    for (int i = 0; i < limit; ++i) {
       int k = indices[i];
       Assert.assertEquals(vals[k], indexed.get(k), DELTA);
     }

--- a/processing/src/test/java/io/druid/segment/data/CompressedFloatsSerdeTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedFloatsSerdeTest.java
@@ -37,8 +37,8 @@ import java.nio.ByteOrder;
 import java.nio.channels.Channels;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -168,7 +168,7 @@ public class CompressedFloatsSerdeTest
     }
 
     // random access, limited to 1000 elements for large lists (every element would take too long)
-    IntArrays.shuffle(indices, new Random());
+    IntArrays.shuffle(indices, ThreadLocalRandom.current());
     final int limit = Math.min(indexed.size(), 1000);
     for (int i = 0; i < limit; ++i) {
       int k = indices[i];

--- a/processing/src/test/java/io/druid/segment/data/CompressedIntsIndexedSupplierTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedIntsIndexedSupplierTest.java
@@ -23,6 +23,7 @@ import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import io.druid.java.util.common.guava.CloseQuietly;
 import io.druid.segment.CompressedPools;
+import it.unimi.dsi.fastutil.ints.IntArrays;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -34,7 +35,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
 import java.nio.channels.Channels;
-import java.util.Collections;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -330,9 +330,10 @@ public class CompressedIntsIndexedSupplierTest extends CompressionStrategyTest
       indices[i] = i;
     }
 
-    Collections.shuffle(Ints.asList(indices));
-    // random access
-    for (int i = 0; i < indexed.size(); ++i) {
+    // random access, limited to 1000 elements for large lists (every element would take too long)
+    IntArrays.shuffle(indices, new Random());
+    final int limit = Math.min(indexed.size(), 1000);
+    for (int i = 0; i < limit; ++i) {
       int k = indices[i];
       Assert.assertEquals(vals[k], indexed.get(k), 0.0);
     }

--- a/processing/src/test/java/io/druid/segment/data/CompressedIntsIndexedSupplierTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedIntsIndexedSupplierTest.java
@@ -37,6 +37,7 @@ import java.nio.IntBuffer;
 import java.nio.channels.Channels;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -331,7 +332,7 @@ public class CompressedIntsIndexedSupplierTest extends CompressionStrategyTest
     }
 
     // random access, limited to 1000 elements for large lists (every element would take too long)
-    IntArrays.shuffle(indices, new Random());
+    IntArrays.shuffle(indices, ThreadLocalRandom.current());
     final int limit = Math.min(indexed.size(), 1000);
     for (int i = 0; i < limit; ++i) {
       int k = indices[i];

--- a/processing/src/test/java/io/druid/segment/data/CompressedLongsSerdeTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedLongsSerdeTest.java
@@ -37,8 +37,8 @@ import java.nio.ByteOrder;
 import java.nio.channels.Channels;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -190,7 +190,7 @@ public class CompressedLongsSerdeTest
     }
 
     // random access, limited to 1000 elements for large lists (every element would take too long)
-    IntArrays.shuffle(indices, new Random());
+    IntArrays.shuffle(indices, ThreadLocalRandom.current());
     final int limit = Math.min(indexed.size(), 1000);
     for (int i = 0; i < limit; ++i) {
       int k = indices[i];

--- a/processing/src/test/java/io/druid/segment/data/CompressedLongsSerdeTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedLongsSerdeTest.java
@@ -21,9 +21,9 @@ package io.druid.segment.data;
 
 import com.google.common.base.Supplier;
 import com.google.common.io.ByteSink;
-import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import io.druid.java.util.common.guava.CloseQuietly;
+import it.unimi.dsi.fastutil.ints.IntArrays;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,8 +36,8 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.Channels;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -189,9 +189,10 @@ public class CompressedLongsSerdeTest
       indices[i] = i;
     }
 
-    Collections.shuffle(Ints.asList(indices));
-    // random access
-    for (int i = 0; i < indexed.size(); ++i) {
+    // random access, limited to 1000 elements for large lists (every element would take too long)
+    IntArrays.shuffle(indices, new Random());
+    final int limit = Math.min(indexed.size(), 1000);
+    for (int i = 0; i < limit; ++i) {
       int k = indices[i];
       Assert.assertEquals(vals[k], indexed.get(k));
     }

--- a/processing/src/test/java/io/druid/segment/data/CompressedVSizeIntsIndexedSupplierTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedVSizeIntsIndexedSupplierTest.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -361,7 +362,7 @@ public class CompressedVSizeIntsIndexedSupplierTest extends CompressionStrategyT
     }
 
     // random access, limited to 1000 elements for large lists (every element would take too long)
-    IntArrays.shuffle(indices, new Random());
+    IntArrays.shuffle(indices, ThreadLocalRandom.current());
     final int limit = Math.min(indexed.size(), 1000);
     for (int i = 0; i < limit; ++i) {
       int k = indices[i];

--- a/processing/src/test/java/io/druid/segment/data/CompressedVSizeIntsIndexedSupplierTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedVSizeIntsIndexedSupplierTest.java
@@ -26,6 +26,7 @@ import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import io.druid.java.util.common.guava.CloseQuietly;
 import io.druid.segment.CompressedPools;
+import it.unimi.dsi.fastutil.ints.IntArrays;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -38,7 +39,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.Channels;
-import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
@@ -351,7 +351,7 @@ public class CompressedVSizeIntsIndexedSupplierTest extends CompressionStrategyT
   {
     Assert.assertEquals(vals.length, indexed.size());
 
-    // sequential access
+    // sequential access of every element
     int[] indices = new int[vals.length];
     for (int i = 0; i < indexed.size(); ++i) {
       final int expected = vals[i];
@@ -360,9 +360,10 @@ public class CompressedVSizeIntsIndexedSupplierTest extends CompressionStrategyT
       indices[i] = i;
     }
 
-    Collections.shuffle(Ints.asList(indices));
-    // random access
-    for (int i = 0; i < indexed.size(); ++i) {
+    // random access, limited to 1000 elements for large lists (every element would take too long)
+    IntArrays.shuffle(indices, new Random());
+    final int limit = Math.min(indexed.size(), 1000);
+    for (int i = 0; i < limit; ++i) {
       int k = indices[i];
       Assert.assertEquals(vals[k], indexed.get(k));
     }


### PR DESCRIPTION
Random access leads to lots of block decompressions for reading single elements,
which is time prohibitive for the large column tests. For those tests, limit the
number of randomly accessed elements to 1000.