### PR TITLE
Create/close yielder in same thread for JDBC queries

### DIFF
--- a/sql/src/main/java/io/druid/sql/avatica/DruidStatement.java
+++ b/sql/src/main/java/io/druid/sql/avatica/DruidStatement.java
@@ -102,7 +102,9 @@ public class DruidStatement implements Closeable
     this.statementId = statementId;
     this.queryContext = queryContext == null ? ImmutableMap.of() : queryContext;
     this.onClose = Preconditions.checkNotNull(onClose, "onClose");
-    this.yielderOpenCloseExecutor = Execs.singleThreaded(String.format("JDBCYielderOpenCloseExecutor-statement-%d", statementId));
+    this.yielderOpenCloseExecutor = Execs.singleThreaded(
+        String.format("JDBCYielderOpenCloseExecutor-connection-%s-statement-%d", connectionId, statementId)
+    );
   }
 
   public static List<ColumnMetaData> createColumnMetaData(final RelDataType rowType)


### PR DESCRIPTION
Fixes #4403 

Query metrics should only be used within a single thread. Because results for JDBC queries can be paginated into multiple JDBC frames (each frame being processed by a potentially different thread), the final frame thread that closes the yielder (which results in a QueryMetrics emit() call) may not be the same as the first frame thread that created the yielder (which initializes QueryMetrics with the current thread as the owner). 

This PR creates and closes the yielder for JDBC results with a single-thread executor to prevent this from happening.