### PR TITLE
DruidAvaticaHandlerTest: Extend timeout.

### DIFF
--- a/server/src/test/java/io/druid/server/initialization/JettyQosTest.java
+++ b/server/src/test/java/io/druid/server/initialization/JettyQosTest.java
@@ -98,7 +98,7 @@ public class JettyQosTest extends BaseJettyTest
     );
   }
 
-  @Test(timeout = 60_000L)
+  @Test(timeout = 120_000L)
   public void testQoS() throws Exception
   {
     final int fastThreads = 20;

--- a/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
+++ b/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
@@ -370,7 +370,7 @@ public class DruidAvaticaHandlerTest
     );
   }
 
-  @Test(timeout = 30000)
+  @Test(timeout = 90000)
   public void testConcurrentQueries() throws Exception
   {
     final List<ListenableFuture<Integer>> futures = new ArrayList<>();


### PR DESCRIPTION
Fixes #4408, probably.