### PR TITLE
Configurable row limit for JDBC frames

### DIFF
--- a/docs/content/querying/sql.md
+++ b/docs/content/querying/sql.md
@@ -200,6 +200,7 @@ The broker's [built-in SQL server](../querying/sql.html) can be configured throu
 |`druid.sql.avatica.connectionIdleTimeout`|Avatica client connection idle timeout.|PT30M|
 |`druid.sql.avatica.maxConnections`|Maximum number of open connections for the Avatica server. These are not HTTP connections, but are logical client connections that may span multiple HTTP connections.|25|
 |`druid.sql.avatica.maxStatementsPerConnection`|Maximum number of simultaneous open statements per Avatica client connection.|4|
+|`druid.sql.avatica.maxRowsPerFrame`|Maximum number of rows to return in a single JDBC frame. Setting this property to -1 indicates that no row limit should be applied. Clients can optionally specify a row limit in their requests; if a client specifies a row limit, the lesser value of the client-provided limit and `maxRowsPerFrame` will be used.|100,000|
 |`druid.sql.http.enable`|Whether to enable a simple JSON over HTTP route at `/druid/v2/sql/`.|true|
 
 #### SQL Planner Configuration

--- a/sql/src/main/java/io/druid/sql/avatica/AvaticaServerConfig.java
+++ b/sql/src/main/java/io/druid/sql/avatica/AvaticaServerConfig.java
@@ -33,6 +33,9 @@ public class AvaticaServerConfig
   @JsonProperty
   public Period connectionIdleTimeout = new Period("PT5M");
 
+  @JsonProperty
+  public int maxRowsPerFrame = 100_000;
+
   public int getMaxConnections()
   {
     return maxConnections;
@@ -46,5 +49,10 @@ public class AvaticaServerConfig
   public Period getConnectionIdleTimeout()
   {
     return connectionIdleTimeout;
+  }
+
+  public int getMaxRowsPerFrame()
+  {
+    return maxRowsPerFrame;
   }
 }


### PR DESCRIPTION
Adds a configuration for setting the maximum size of single JDBC frames for Druid SQL query results.