### PR TITLE
exclude aws-java-sdk from hadoop-aws dep in hdfs-storage module

### DIFF
--- a/extensions-core/hdfs-storage/pom.xml
+++ b/extensions-core/hdfs-storage/pom.xml
@@ -140,11 +140,21 @@
             <artifactId>emitter</artifactId>
             <scope>provided</scope>
         </dependency>
-      <dependency>
-        <groupId>org.apache.hadoop</groupId>
-        <artifactId>hadoop-aws</artifactId>
-        <version>${hadoop.compile.version}</version>
-      </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-aws</artifactId>
+          <version>${hadoop.compile.version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>com.amazonaws</groupId>
+              <artifactId>aws-java-sdk</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>com.amazonaws</groupId>
+          <artifactId>aws-java-sdk-s3</artifactId>
+        </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
         <hadoop.compile.version>2.7.3</hadoop.compile.version>
         <hive.version>2.0.0</hive.version>
         <powermock.version>1.6.6</powermock.version>
+        <aws.sdk.version>1.10.77</aws.sdk.version>
     </properties>
 
     <modules>
@@ -189,7 +190,7 @@
                 <artifactId>aws-java-sdk-ec2</artifactId>
                 <!-- Cannot update to AWS SDK 1.11+ because of Jackson incompatibility.
                      Need to update Druid to use Jackson 2.6+ -->
-                <version>1.10.77</version>
+                <version>${aws.sdk.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>javax.mail</groupId>
@@ -208,6 +209,11 @@
                         <artifactId>commons-codec</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-s3</artifactId>
+                <version>${aws.sdk.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.ning</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,8 @@
         <hadoop.compile.version>2.7.3</hadoop.compile.version>
         <hive.version>2.0.0</hive.version>
         <powermock.version>1.6.6</powermock.version>
+        <!-- Cannot update to AWS SDK 1.11+ because of Jackson incompatibility.
+        Need to update Druid to use Jackson 2.6+ -->
         <aws.sdk.version>1.10.77</aws.sdk.version>
     </properties>
 
@@ -188,8 +190,6 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-ec2</artifactId>
-                <!-- Cannot update to AWS SDK 1.11+ because of Jackson incompatibility.
-                     Need to update Druid to use Jackson 2.6+ -->
                 <version>${aws.sdk.version}</version>
                 <exclusions>
                     <exclusion>
@@ -214,6 +214,24 @@
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-s3</artifactId>
                 <version>${aws.sdk.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.mail</groupId>
+                        <artifactId>mail</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-codec</groupId>
+                        <artifactId>commons-codec</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.ning</groupId>


### PR DESCRIPTION
instead make it use `aws-java-sdk-s3`.

Fix for the issue discussed in https://github.com/druid-io/druid/pull/4313#issuecomment-309854006 about aws always requiring credentials directory. i verified the this patch to ensure that said issue is fixed.


