### PR TITLE
Fix a bug of CSV/TSV parsers when extracting columns from header

### DIFF
--- a/indexing-service/src/test/java/io/druid/indexing/common/task/IndexTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/IndexTaskTest.java
@@ -482,7 +482,7 @@ public class IndexTaskTest
 
     Assert.assertEquals(1, segments.size());
 
-    Assert.assertEquals(Arrays.asList("dim"), segments.get(0).getDimensions());
+    Assert.assertEquals(Arrays.asList("d"), segments.get(0).getDimensions());
     Assert.assertEquals(Arrays.asList("val"), segments.get(0).getMetrics());
     Assert.assertEquals(new Interval("2014/P1D"), segments.get(0).getInterval());
   }

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/CSVParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/CSVParser.java
@@ -113,7 +113,9 @@ public class CSVParser implements Parser<String, Object>
   @Override
   public void startFileFromBeginning()
   {
-    fieldNames = null;
+    if (hasHeaderRow) {
+      fieldNames = null;
+    }
     hasParsedHeader = false;
     skippedHeaderRows = 0;
     supportSkipHeaderRows = true;

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/CSVParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/CSVParser.java
@@ -113,9 +113,10 @@ public class CSVParser implements Parser<String, Object>
   @Override
   public void startFileFromBeginning()
   {
-    supportSkipHeaderRows = true;
+    fieldNames = null;
     hasParsedHeader = false;
     skippedHeaderRows = 0;
+    supportSkipHeaderRows = true;
   }
 
   @Override

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/DelimitedParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/DelimitedParser.java
@@ -126,9 +126,10 @@ public class DelimitedParser implements Parser<String, Object>
   @Override
   public void startFileFromBeginning()
   {
-    supportSkipHeaderRows = true;
+    fieldNames = null;
     hasParsedHeader = false;
     skippedHeaderRows = 0;
+    supportSkipHeaderRows = true;
   }
 
   @Override

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/DelimitedParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/DelimitedParser.java
@@ -126,7 +126,9 @@ public class DelimitedParser implements Parser<String, Object>
   @Override
   public void startFileFromBeginning()
   {
-    fieldNames = null;
+    if (hasHeaderRow) {
+      fieldNames = null;
+    }
     hasParsedHeader = false;
     skippedHeaderRows = 0;
     supportSkipHeaderRows = true;

--- a/java-util/src/test/java/io/druid/java/util/common/parsers/CSVParserTest.java
+++ b/java-util/src/test/java/io/druid/java/util/common/parsers/CSVParserTest.java
@@ -22,12 +22,16 @@ package io.druid.java.util.common.parsers;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.Map;
 
 public class CSVParserTest
 {
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testValidHeader()
@@ -117,9 +121,71 @@ public class CSVParserTest
     );
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
+  public void testCSVParserWithHeaderRow()
+  {
+    final Parser<String, Object> csvParser = new CSVParser(
+        Optional.absent(),
+        true,
+        0
+    );
+    csvParser.startFileFromBeginning();
+    final String[] body = new String[] {
+        "time,value1,value2",
+        "hello,world,foo"
+    };
+    Assert.assertNull(csvParser.parse(body[0]));
+    final Map<String, Object> jsonMap = csvParser.parse(body[1]);
+    Assert.assertEquals(
+        "jsonMap",
+        ImmutableMap.of("time", "hello", "value1", "world", "value2", "foo"),
+        jsonMap
+    );
+  }
+
+  @Test
+  public void testCSVParserWithDifferentHeaderRows()
+  {
+    final Parser<String, Object> csvParser = new CSVParser(
+        Optional.absent(),
+        true,
+        0
+    );
+    csvParser.startFileFromBeginning();
+    final String[] body = new String[] {
+        "time,value1,value2",
+        "hello,world,foo"
+    };
+    Assert.assertNull(csvParser.parse(body[0]));
+    Map<String, Object> jsonMap = csvParser.parse(body[1]);
+    Assert.assertEquals(
+        "jsonMap",
+        ImmutableMap.of("time", "hello", "value1", "world", "value2", "foo"),
+        jsonMap
+    );
+
+    csvParser.startFileFromBeginning();
+    final String[] body2 = new String[] {
+        "time,value1,value2,value3",
+        "hello,world,foo,bar"
+    };
+    Assert.assertNull(csvParser.parse(body2[0]));
+    jsonMap = csvParser.parse(body2[1]);
+    Assert.assertEquals(
+        "jsonMap",
+        ImmutableMap.of("time", "hello", "value1", "world", "value2", "foo", "value3", "bar"),
+        jsonMap
+    );
+  }
+
+  @Test
   public void testCSVParserWithoutStartFileFromBeginning()
   {
+    expectedException.expect(UnsupportedOperationException.class);
+    expectedException.expectMessage(
+        "hasHeaderRow or maxSkipHeaderRows is not supported. Please check the indexTask supports these options."
+    );
+
     final int skipHeaderRows = 2;
     final Parser<String, Object> csvParser = new CSVParser(
         Optional.absent(),
@@ -127,9 +193,9 @@ public class CSVParserTest
         skipHeaderRows
     );
     final String[] body = new String[] {
-        "header\tline\t1",
-        "header\tline\t2",
-        "hello\tworld\tfoo"
+        "header,line,1",
+        "header,line,2",
+        "hello,world,foo"
     };
     csvParser.parse(body[0]);
   }


### PR DESCRIPTION
Since each file can have different columns, ```fieldNames``` of CSV/TSV parsers should be reset when a new file begins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/druid-io/druid/4443)
<!-- Reviewable:end -->
