### PR TITLE
Use GenericIndexed v2 supported read() method

### DIFF
--- a/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchMergeComplexMetricSerde.java
+++ b/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchMergeComplexMetricSerde.java
@@ -69,7 +69,7 @@ public class SketchMergeComplexMetricSerde extends ComplexMetricSerde
   @Override
   public void deserializeColumn(ByteBuffer buffer, ColumnBuilder builder)
   {
-    GenericIndexed<Sketch> ge = GenericIndexed.read(buffer, strategy);
+    GenericIndexed<Sketch> ge = GenericIndexed.read(buffer, strategy, builder.getFileMapper());
     builder.setComplexColumn(new ComplexColumnPartSupplier(getTypeName(), ge));
   }
 

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingSerde.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingSerde.java
@@ -97,7 +97,7 @@ public class ApproximateHistogramFoldingSerde extends ComplexMetricSerde
       ByteBuffer byteBuffer, ColumnBuilder columnBuilder
   )
   {
-    final GenericIndexed column = GenericIndexed.read(byteBuffer, getObjectStrategy());
+    final GenericIndexed column = GenericIndexed.read(byteBuffer, getObjectStrategy(), columnBuilder.getFileMapper());
     columnBuilder.setComplexColumn(new ComplexColumnPartSupplier(getTypeName(), column));
   }
 

--- a/extensions-core/stats/src/main/java/io/druid/query/aggregation/variance/VarianceSerde.java
+++ b/extensions-core/stats/src/main/java/io/druid/query/aggregation/variance/VarianceSerde.java
@@ -85,7 +85,7 @@ public class VarianceSerde extends ComplexMetricSerde
       ByteBuffer byteBuffer, ColumnBuilder columnBuilder
   )
   {
-    final GenericIndexed column = GenericIndexed.read(byteBuffer, getObjectStrategy());
+    final GenericIndexed column = GenericIndexed.read(byteBuffer, getObjectStrategy(), columnBuilder.getFileMapper());
     columnBuilder.setComplexColumn(new ComplexColumnPartSupplier(getTypeName(), column));
   }
 

--- a/processing/src/main/java/io/druid/query/aggregation/hyperloglog/HyperUniquesSerde.java
+++ b/processing/src/main/java/io/druid/query/aggregation/hyperloglog/HyperUniquesSerde.java
@@ -102,7 +102,7 @@ public class HyperUniquesSerde extends ComplexMetricSerde
       ByteBuffer byteBuffer, ColumnBuilder columnBuilder
   )
   {
-    final GenericIndexed column = GenericIndexed.read(byteBuffer, getObjectStrategy());
+    final GenericIndexed column = GenericIndexed.read(byteBuffer, getObjectStrategy(), columnBuilder.getFileMapper());
     columnBuilder.setComplexColumn(new ComplexColumnPartSupplier(getTypeName(), column));
   }
 


### PR DESCRIPTION
Use GenericIndexed v2 supported `read(ByteBuffer buffer, ObjectStrategy<T> strategy, SmooshedFileMapper fileMapper)` instead of `read(ByteBuffer buffer, ObjectStrategy<T> strategy)`.