### PR TITLE
Split travis jobs for parallel test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,23 @@ cache:
 
 matrix:
   include:
+      # strict compilation
     - sudo: false
       install: true
-      script:
-        # The script execution consists of 4 steps:
-        # 1) Increase the jvm max heap size. Strict compilation in 2) requires more than 2 GB.
-        # 2) Strict compilation using error-prone
-        # 3) Reset the maven options. Parallel testing in 4) launches 2 processes, each requires 1 GB of memory. Increasing the maximum memory may cause OutOfMemory error because the instance of Travis has 4 GB of memory space.
-        # 4) Parallel unit testing
-        # Using && instead of independent script steps to make Travis build fail faster, if each step is not successful
-        - echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn clean -Pstrict -pl '!benchmarks' compile test-compile -B && rm ~/.mavenrc && mvn test -B -Pparallel-test -Dmaven.fork.count=2
+      # Strict compilation requires more than 2 GB
+      script: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn clean -Pstrict -pl '!benchmarks' compile test-compile -B
+
+      # processing module test
+    - sudo: false
+      install: mvn install -q -ff -DskipTests -B
+      script: mvn test -B -Pparallel-test -Dmaven.fork.count=2 -pl processing
+
+      # non-processing modules test
+    - sudo: false
+      install: mvn install -q -ff -DskipTests -B
+      script: mvn test -B -Pparallel-test -Dmaven.fork.count=2 -pl '!processing'
+
+      # run integration tests
     - sudo: required
       services:
         - docker
@@ -26,6 +33,6 @@ matrix:
         - DOCKER_IP=172.17.0.1
       install:
         # Only errors will be shown with the -q option. This is to avoid generating too many logs which make travis build failed.
-        - mvn clean install -q -ff -DskipTests -B
+        - mvn install -q -ff -DskipTests -B
       script:
         - $TRAVIS_BUILD_DIR/ci/travis_script_integration.sh


### PR DESCRIPTION
Fixes https://github.com/druid-io/druid/issues/4402. 

This patch further splits the travis test into 4 jobs each of which is for running strict compilation, processing module tests, non-processing modules test, and integration tests, respectively. Tests for processing module takes about 10 mins on travis which is about 25% of the total testing time. Strict compilation also takes more than 5 mins on travis.

With this patch, we cannot exploit the advantage of fail fast strategy, but our tests will be safer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/druid-io/druid/4468)
<!-- Reviewable:end -->
