### PR TITLE
Upgrade to server-metrics 0.5.0

### DIFF
--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -182,9 +182,11 @@ The following monitors are available:
 |Name|Description|
 |----|-----------|
 |`io.druid.client.cache.CacheMonitor`|Emits metrics (to logs) about the segment results cache for Historical and Broker nodes. Reports typical cache statistics include hits, misses, rates, and size (bytes and number of entries), as well as timeouts and and errors.|
-|`com.metamx.metrics.SysMonitor`|This uses the [SIGAR library](http://www.hyperic.com/products/sigar) to report on various system activities and statuses. Make sure to add the [sigar library jar](https://repository.jboss.org/nexus/content/repositories/thirdparty-uploads/org/hyperic/sigar/1.6.5.132/sigar-1.6.5.132.jar) to your classpath if using this monitor.|
+|`com.metamx.metrics.SysMonitor`|This uses the [SIGAR library](http://www.hyperic.com/products/sigar) to report on various system activities and statuses.|
 |`io.druid.server.metrics.HistoricalMetricsMonitor`|Reports statistics on Historical nodes.|
-|`com.metamx.metrics.JvmMonitor`|Reports JVM-related statistics.|
+|`com.metamx.metrics.JvmMonitor`|Reports various JVM-related statistics.|
+|`com.metamx.metrics.JvmCpuMonitor`|Reports statistics of CPU consumption by the JVM.|
+|`com.metamx.metrics.JvmThreadsMonitor`|Reports Thread statistics in the JVM, like numbers of total, daemon, started, died threads.|
 |`io.druid.segment.realtime.RealtimeMetricsMonitor`|Reports statistics on Realtime nodes.|
 |`io.druid.server.metrics.EventReceiverFirehoseMonitor`|Reports how many events have been queued in the EventReceiverFirehose.|
 |`io.druid.server.metrics.QueryCountStatsMonitor`|Reports how many queries have been successful/failed/interrupted.|

--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -186,6 +186,7 @@ The following monitors are available:
 |`io.druid.server.metrics.HistoricalMetricsMonitor`|Reports statistics on Historical nodes.|
 |`com.metamx.metrics.JvmMonitor`|Reports various JVM-related statistics.|
 |`com.metamx.metrics.JvmCpuMonitor`|Reports statistics of CPU consumption by the JVM.|
+|`com.metamx.metrics.CpuAcctDeltaMonitor`|Reports consumed CPU as per the cpuacct cgroup.|
 |`com.metamx.metrics.JvmThreadsMonitor`|Reports Thread statistics in the JVM, like numbers of total, daemon, started, died threads.|
 |`io.druid.segment.realtime.RealtimeMetricsMonitor`|Reports statistics on Realtime nodes.|
 |`io.druid.server.metrics.EventReceiverFirehoseMonitor`|Reports how many events have been queued in the EventReceiverFirehose.|

--- a/examples/conf-quickstart/druid/_common/common.runtime.properties
+++ b/examples/conf-quickstart/druid/_common/common.runtime.properties
@@ -113,6 +113,6 @@ druid.selectors.coordinator.serviceName=druid/coordinator
 # Monitoring
 #
 
-druid.monitoring.monitors=["com.metamx.metrics.JvmMonitor"]
+druid.monitoring.monitors=["com.metamx.metrics.SysMonitor", "com.metamx.metrics.JvmMonitor", "com.metamx.metrics.JvmCpuMonitor"]
 druid.emitter=logging
 druid.emitter.logging.logLevel=info

--- a/examples/conf/druid/_common/common.runtime.properties
+++ b/examples/conf/druid/_common/common.runtime.properties
@@ -112,6 +112,6 @@ druid.selectors.coordinator.serviceName=druid/coordinator
 # Monitoring
 #
 
-druid.monitoring.monitors=["com.metamx.metrics.JvmMonitor"]
+druid.monitoring.monitors=["com.metamx.metrics.SysMonitor", "com.metamx.metrics.JvmMonitor", "com.metamx.metrics.JvmCpuMonitor"]
 druid.emitter=logging
 druid.emitter.logging.logLevel=info

--- a/pom.xml
+++ b/pom.xml
@@ -154,13 +154,7 @@
             <dependency>
                 <groupId>com.metamx</groupId>
                 <artifactId>server-metrics</artifactId>
-                <version>0.2.8</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.metamx</groupId>
-                        <artifactId>java-util</artifactId>
-                    </exclusion>
-                </exclusions>
+                <version>0.4.3</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
             <dependency>
                 <groupId>com.metamx</groupId>
                 <artifactId>server-metrics</artifactId>
-                <version>0.4.3</version>
+                <version>0.5.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>


### PR DESCRIPTION
Fixes #4083

The incompatible difference is explained here: https://github.com/metamx/server-metrics/releases/tag/server-metrics-0.3.0, `jvm/gc/cpu` is emitted instead of `jvm/gc/time`. `jvm/gc/time` didn't actually reflect "GC time" in any reasonable sense. The new `jvm/gc/cpu` is the amount of CPU time spend in all GC threads in the JVM, measured in nanoseconds.