### PR TITLE
Fix GroupBy type cast when ChainedExecutionQueryRunner merges results

### DIFF
--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
@@ -362,25 +362,7 @@ outer:
               }
 
               // Convert dimension types to specified output types
-              for (DimensionSpec dimSpec : query.getDimensions()) {
-                Object baseVal = theMap.get(dimSpec.getOutputName());
-                switch (dimSpec.getOutputType()) {
-                  case STRING:
-                    baseVal = baseVal == null ? "" : baseVal.toString();
-                    break;
-                  case LONG:
-                    baseVal = DimensionHandlerUtils.convertObjectToLong(baseVal);
-                    baseVal = baseVal == null ? 0L : baseVal;
-                    break;
-                  case FLOAT:
-                    baseVal = DimensionHandlerUtils.convertObjectToFloat(baseVal);
-                    baseVal = baseVal == null ? 0.f : baseVal;
-                    break;
-                  default:
-                    throw new IAE("Unsupported type: " + dimSpec.getOutputType());
-                }
-                theMap.put(dimSpec.getOutputName(), baseVal);
-              }
+              convertRowTypesToOutputTypes(query.getDimensions(), theMap);
 
               // Add aggregations.
               for (int i = 0; i < entry.getValues().length; i++) {
@@ -421,6 +403,29 @@ outer:
       if (delegate != null) {
         delegate.close();
       }
+    }
+  }
+
+  private static void convertRowTypesToOutputTypes(List<DimensionSpec> dimensionSpecs, Map<String, Object> rowMap)
+  {
+    for (DimensionSpec dimSpec : dimensionSpecs) {
+      Object baseVal = rowMap.get(dimSpec.getOutputName());
+      switch (dimSpec.getOutputType()) {
+        case STRING:
+          baseVal = baseVal == null ? "" : baseVal.toString();
+          break;
+        case LONG:
+          baseVal = DimensionHandlerUtils.convertObjectToLong(baseVal);
+          baseVal = baseVal == null ? 0L : baseVal;
+          break;
+        case FLOAT:
+          baseVal = DimensionHandlerUtils.convertObjectToFloat(baseVal);
+          baseVal = baseVal == null ? 0.f : baseVal;
+          break;
+        default:
+          throw new IAE("Unsupported type: " + dimSpec.getOutputType());
+      }
+      rowMap.put(dimSpec.getOutputName(), baseVal);
     }
   }
 

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
@@ -408,23 +408,28 @@ outer:
   private static void convertRowTypesToOutputTypes(List<DimensionSpec> dimensionSpecs, Map<String, Object> rowMap)
   {
     for (DimensionSpec dimSpec : dimensionSpecs) {
-      Object baseVal = rowMap.get(dimSpec.getOutputName());
-      switch (dimSpec.getOutputType()) {
-        case STRING:
-          baseVal = baseVal == null ? "" : baseVal.toString();
-          break;
-        case LONG:
-          baseVal = DimensionHandlerUtils.convertObjectToLong(baseVal);
-          baseVal = baseVal == null ? 0L : baseVal;
-          break;
-        case FLOAT:
-          baseVal = DimensionHandlerUtils.convertObjectToFloat(baseVal);
-          baseVal = baseVal == null ? 0.f : baseVal;
-          break;
-        default:
-          throw new IAE("Unsupported type: " + dimSpec.getOutputType());
-      }
-      rowMap.put(dimSpec.getOutputName(), baseVal);
+      final ValueType outputType = dimSpec.getOutputType();
+      rowMap.compute(
+          dimSpec.getOutputName(),
+          (dimName, baseVal) -> {
+            switch (outputType) {
+              case STRING:
+                baseVal = baseVal == null ? "" : baseVal.toString();
+                break;
+              case LONG:
+                baseVal = DimensionHandlerUtils.convertObjectToLong(baseVal);
+                baseVal = baseVal == null ? 0L : baseVal;
+                break;
+              case FLOAT:
+                baseVal = DimensionHandlerUtils.convertObjectToFloat(baseVal);
+                baseVal = baseVal == null ? 0.f : baseVal;
+                break;
+              default:
+                throw new IAE("Unsupported type: " + outputType);
+            }
+            return baseVal;
+          }
+      );
     }
   }
 

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
@@ -361,7 +361,6 @@ outer:
                 );
               }
 
-              // Convert dimension types to specified output types
               convertRowTypesToOutputTypes(query.getDimensions(), theMap);
 
               // Add aggregations.

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.druid.collections.BlockingPool;
 import io.druid.collections.DefaultBlockingPool;
@@ -49,6 +50,7 @@ import io.druid.java.util.common.parsers.ParseException;
 import io.druid.js.JavaScriptConfig;
 import io.druid.query.BySegmentResultValue;
 import io.druid.query.BySegmentResultValueClass;
+import io.druid.query.ChainedExecutionQueryRunner;
 import io.druid.query.DruidProcessingConfig;
 import io.druid.query.Druids;
 import io.druid.query.FinalizeResultsQueryRunner;
@@ -59,6 +61,7 @@ import io.druid.query.QueryPlus;
 import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerTestHelper;
 import io.druid.query.QueryToolChest;
+import io.druid.query.QueryWatcher;
 import io.druid.query.ResourceLimitExceededException;
 import io.druid.query.Result;
 import io.druid.query.aggregation.AggregatorFactory;
@@ -9128,6 +9131,60 @@ public class GroupByQueryRunnerTest
 
     // Subqueries are handled by the ToolChest
     Iterable<Row> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);
+    TestHelper.assertExpectedObjects(expectedResults, results, "");
+  }
+
+  @Test
+  public void testTypeConversionWithMergingChainedExecutionRunner()
+  {
+    if (config.getDefaultStrategy().equals(GroupByStrategySelector.STRATEGY_V1)) {
+      expectedException.expect(UnsupportedOperationException.class);
+      expectedException.expectMessage("GroupBy v1 only supports dimensions with an outputType of STRING.");
+    }
+
+    GroupByQuery query = GroupByQuery
+        .builder()
+        .setDataSource(QueryRunnerTestHelper.dataSource)
+        .setQuerySegmentSpec(QueryRunnerTestHelper.firstToThird)
+        .setDimensions(Lists.<DimensionSpec>newArrayList(
+            new DefaultDimensionSpec("quality", "alias"),
+            new ExtractionDimensionSpec("quality", "qualityLen", ValueType.LONG, StrlenExtractionFn.instance())
+        ))
+        .setDimFilter(new SelectorDimFilter(
+            "quality",
+            "technology",
+            null
+        ))
+        .setAggregatorSpecs(
+            Arrays.asList(
+                QueryRunnerTestHelper.rowsCount,
+                new LongSumAggregatorFactory("idx", "index")
+            )
+        )
+        .setGranularity(QueryRunnerTestHelper.dayGran)
+        .build();
+
+    List<Row> expectedResults = Arrays.asList(
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-01", "alias", "technology", "qualityLen", 10L, "rows", 2L, "idx", 156L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "alias", "technology", "qualityLen", 10L, "rows", 2L, "idx", 194L)
+    );
+
+    ChainedExecutionQueryRunner ceqr = new ChainedExecutionQueryRunner(
+        MoreExecutors.sameThreadExecutor(),
+        new QueryWatcher()
+        {
+          @Override
+          public void registerQuery(Query query, ListenableFuture future)
+          {
+            return;
+          }
+        },
+        ImmutableList.<QueryRunner<Row>>of(runner, runner)
+    );
+
+    QueryRunner<Row> mergingRunner = factory.mergeRunners(MoreExecutors.sameThreadExecutor(), ImmutableList.<QueryRunner<Row>>of(ceqr));
+
+    Iterable<Row> results = GroupByQueryRunnerTestHelper.runQuery(factory, mergingRunner, query);
     TestHelper.assertExpectedObjects(expectedResults, results, "");
   }
 }


### PR DESCRIPTION
When using the "outputType" parameter of DimensionSpec to change the type of a dimension, a ClassCastException would occur when the ChainedExecutionQueryRunner merges results from multiple query runners:
```
java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Number

	at io.druid.query.groupby.GroupByQuery.compareDims(GroupByQuery.java:558)
	at io.druid.query.groupby.GroupByQuery.lambda$getRowOrdering$8(GroupByQuery.java:532)
	at io.druid.query.groupby.GroupByQuery$$Lambda$23/727666004.compare(Unknown Source)
	at com.google.common.collect.ComparatorOrdering.compare(ComparatorOrdering.java:38)
	at io.druid.query.groupby.GroupByQuery.lambda$getResultOrdering$5(GroupByQuery.java:328)
	at io.druid.query.groupby.GroupByQuery$$Lambda$24/1803093683.compare(Unknown Source)
	at com.google.common.collect.ComparatorOrdering.compare(ComparatorOrdering.java:38)
	at com.google.common.collect.NullsFirstOrdering.compare(NullsFirstOrdering.java:44)
	at io.druid.java.util.common.guava.MergeIterator$1.compare(MergeIterator.java:48)
	at io.druid.java.util.common.guava.MergeIterator$1.compare(MergeIterator.java:44)
	at java.util.PriorityQueue.siftUpUsingComparator(PriorityQueue.java:669)
	at java.util.PriorityQueue.siftUp(PriorityQueue.java:645)
	at java.util.PriorityQueue.offer(PriorityQueue.java:344)
	at java.util.PriorityQueue.add(PriorityQueue.java:321)
	at io.druid.java.util.common.guava.MergeIterator.<init>(MergeIterator.java:57)
	at io.druid.java.util.common.guava.MergeIterable.iterator(MergeIterable.java:52)
	at io.druid.query.ChainedExecutionQueryRunner$1.make(ChainedExecutionQueryRunner.java:159)
	at io.druid.java.util.common.guava.BaseSequence.accumulate(BaseSequence.java:43)
	at io.druid.query.groupby.epinephelinae.GroupByMergingQueryRunnerV2$1$1$1.call(GroupByMergingQueryRunnerV2.java:233)
	at io.druid.query.groupby.epinephelinae.GroupByMergingQueryRunnerV2$1$1$1.call(GroupByMergingQueryRunnerV2.java:224)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at com.google.common.util.concurrent.MoreExecutors$SameThreadExecutorService.execute(MoreExecutors.java:297)
	at java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:134)
	at com.google.common.util.concurrent.AbstractListeningExecutorService.submit(AbstractListeningExecutorService.java:58)
	at io.druid.query.groupby.epinephelinae.GroupByMergingQueryRunnerV2$1$1.apply(GroupByMergingQueryRunnerV2.java:222)
	at io.druid.query.groupby.epinephelinae.GroupByMergingQueryRunnerV2$1$1.apply(GroupByMergingQueryRunnerV2.java:212)
	at com.google.common.collect.Iterators$8.transform(Iterators.java:794)
	at com.google.common.collect.TransformedIterator.next(TransformedIterator.java:48)
	at com.google.common.collect.Iterators.addAll(Iterators.java:357)
	at com.google.common.collect.Lists.newArrayList(Lists.java:147)
	at com.google.common.collect.Lists.newArrayList(Lists.java:129)
	at io.druid.query.groupby.epinephelinae.GroupByMergingQueryRunnerV2$1.make(GroupByMergingQueryRunnerV2.java:208)
	at io.druid.query.groupby.epinephelinae.GroupByMergingQueryRunnerV2$1.make(GroupByMergingQueryRunnerV2.java:156)
	at io.druid.java.util.common.guava.BaseSequence.accumulate(BaseSequence.java:43)
	at io.druid.common.guava.CombiningSequence.accumulate(CombiningSequence.java:64)
	at io.druid.java.util.common.guava.MappedSequence.accumulate(MappedSequence.java:43)
	at io.druid.java.util.common.guava.WrappingSequence$1.get(WrappingSequence.java:50)
	at io.druid.java.util.common.guava.SequenceWrapper.wrap(SequenceWrapper.java:55)
	at io.druid.java.util.common.guava.WrappingSequence.accumulate(WrappingSequence.java:45)
	at io.druid.java.util.common.guava.MappedSequence.accumulate(MappedSequence.java:43)
	at io.druid.java.util.common.guava.Sequences.toList(Sequences.java:150)

```

The unit test provides an example that would trigger the error.

This patch adds a type conversion step to results generated by GroupByEngineV2 before they are merged by the ChainedExecutionQueryRunner.