### PR TITLE
Fix a bug in DruidCluster.getAllServers()

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/DruidCluster.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCluster.java
@@ -29,8 +29,10 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Contains a representation of the current state of the cluster by tier.
@@ -113,9 +115,11 @@ public class DruidCluster
 
   public Collection<ServerHolder> getAllServers()
   {
-    return historicals.values().stream()
-                      .flatMap(Collection::stream)
-                      .collect(() -> realtimes, Set::add, Set::addAll);
+    final List<ServerHolder> allServers = historicals.values().stream()
+                                                     .flatMap(Collection::stream)
+                                                     .collect(Collectors.toList());
+    allServers.addAll(realtimes);
+    return allServers;
   }
 
   public Iterable<MinMaxPriorityQueue<ServerHolder>> getSortedHistoricalsByTier()

--- a/server/src/test/java/io/druid/server/coordinator/DruidClusterTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidClusterTest.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class DruidClusterTest
@@ -184,6 +185,9 @@ public class DruidClusterTest
   {
     cluster.add(newRealtime);
     cluster.add(newHistorical);
+    final Set<ServerHolder> expectedRealtimes = cluster.getRealtimes();
+    final Map<String, MinMaxPriorityQueue<ServerHolder>> expectedHistoricals = cluster.getHistoricals();
+
     final Collection<ServerHolder> allServers = cluster.getAllServers();
     Assert.assertEquals(4, allServers.size());
     Assert.assertTrue(allServers.containsAll(cluster.getRealtimes()));
@@ -192,6 +196,9 @@ public class DruidClusterTest
             cluster.getHistoricals().values().stream().flatMap(Collection::stream).collect(Collectors.toList())
         )
     );
+
+    Assert.assertEquals(expectedHistoricals, cluster.getHistoricals());
+    Assert.assertEquals(expectedRealtimes, cluster.getRealtimes());
   }
 
   @Test


### PR DESCRIPTION
```realtimes``` is accidentally changed after calling getAllServers(), but must not.