### PR TITLE
[Backport] Incorrect use of Long.TYPE and Float.TYPE as return type of ObjectColumnSelector.classOfObject()

### DIFF
--- a/codestyle/checkstyle.xml
+++ b/codestyle/checkstyle.xml
@@ -71,5 +71,10 @@
       <property name="illegalPattern" value="true"/>
       <property name="message" value="Use Comparators.naturalNullsFirst() instead of Ordering.natural().nullsFirst()"/>
     </module>
+    <module name="Regexp">
+      <property name="format" value="(Byte|Character|Short|Integer|Long|Float|Double)\.TYPE"/>
+      <property name="illegalPattern" value="true"/>
+      <property name="message" value="Use primitive.class instead. But check twice that you don't actually need BoxedPrimitive.class instead of BoxedPrimitive.TYPE"/>
+    </module>
   </module>
 </module>

--- a/processing/src/main/java/io/druid/segment/QueryableIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/QueryableIndexStorageAdapter.java
@@ -669,7 +669,7 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
                             @Override
                             public Class classOfObject()
                             {
-                              return Float.TYPE;
+                              return Float.class;
                             }
 
                             @Override
@@ -685,7 +685,7 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
                             @Override
                             public Class classOfObject()
                             {
-                              return Long.TYPE;
+                              return Long.class;
                             }
 
                             @Override

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -658,9 +658,9 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
       case COMPLEX:
         return ComplexMetrics.getSerdeForType(metricDesc.getType()).getObjectStrategy().getClazz();
       case FLOAT:
-        return Float.TYPE;
+        return Float.class;
       case LONG:
-        return Long.TYPE;
+        return Long.class;
       case STRING:
         return String.class;
     }

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
@@ -547,7 +547,7 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
                     @Override
                     public Class classOfObject()
                     {
-                      return Long.TYPE;
+                      return Long.class;
                     }
 
                     @Override

--- a/processing/src/test/java/io/druid/query/aggregation/MetricSelectorUtils.java
+++ b/processing/src/test/java/io/druid/query/aggregation/MetricSelectorUtils.java
@@ -31,7 +31,7 @@ public class MetricSelectorUtils
       @Override
       public Class<Float> classOfObject()
       {
-        return Float.TYPE;
+        return Float.class;
       }
 
       @Override

--- a/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
+++ b/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
@@ -286,11 +286,11 @@ public class OnheapIncrementalIndexBenchmark extends AbstractBenchmark
 
     final IncrementalIndex incrementalIndex = this.incrementalIndex.getConstructor(
         IncrementalIndexSchema.class,
-        Boolean.TYPE,
-        Boolean.TYPE,
-        Boolean.TYPE,
-        Boolean.TYPE,
-        Integer.TYPE
+        boolean.class,
+        boolean.class,
+        boolean.class,
+        boolean.class,
+        int.class
     ).newInstance(
         new IncrementalIndexSchema.Builder().withMetrics(factories).build(),
         true,


### PR DESCRIPTION
Backport of #4501 to 0.10.1.