### PR TITLE
Fix NPE when indexing unparseable/missing numeric values when sortFacts=false

### DIFF
--- a/processing/src/main/java/io/druid/segment/DimensionHandlerUtils.java
+++ b/processing/src/main/java/io/druid/segment/DimensionHandlerUtils.java
@@ -233,7 +233,8 @@ public final class DimensionHandlerUtils
     } else if (valObj instanceof Number) {
       return ((Number) valObj).longValue();
     } else if (valObj instanceof String) {
-      return DimensionHandlerUtils.getExactLongFromDecimalString((String) valObj);
+      Long parsedVal = DimensionHandlerUtils.getExactLongFromDecimalString((String) valObj);
+      return parsedVal == null ? 0L : parsedVal;
     } else {
       throw new ParseException("Unknown type[%s]", valObj.getClass());
     }
@@ -250,7 +251,8 @@ public final class DimensionHandlerUtils
     } else if (valObj instanceof Number) {
       return ((Number) valObj).floatValue();
     } else if (valObj instanceof String) {
-      return Floats.tryParse((String) valObj);
+      Float parsedVal = Floats.tryParse((String) valObj);
+      return parsedVal == null ? 0.0f : parsedVal;
     } else {
       throw new ParseException("Unknown type[%s]", valObj.getClass());
     }

--- a/processing/src/main/java/io/druid/segment/DimensionHandlerUtils.java
+++ b/processing/src/main/java/io/druid/segment/DimensionHandlerUtils.java
@@ -40,6 +40,11 @@ import java.util.List;
 
 public final class DimensionHandlerUtils
 {
+  // use these values to ensure that convertObjectToLong() and convertObjectToFloat() return the same
+  // boxed object when returning a constant zero
+  private final static Long LONG_ZERO = 0L;
+  private final static Float FLOAT_ZERO = 0.0f;
+
   private DimensionHandlerUtils() {}
 
   public final static ColumnCapabilities DEFAULT_STRING_CAPABILITIES =
@@ -225,7 +230,7 @@ public final class DimensionHandlerUtils
   public static Long convertObjectToLong(Object valObj)
   {
     if (valObj == null) {
-      return 0L;
+      return LONG_ZERO;
     }
 
     if (valObj instanceof Long) {
@@ -234,7 +239,7 @@ public final class DimensionHandlerUtils
       return ((Number) valObj).longValue();
     } else if (valObj instanceof String) {
       Long parsedVal = DimensionHandlerUtils.getExactLongFromDecimalString((String) valObj);
-      return parsedVal == null ? 0L : parsedVal;
+      return parsedVal == null ? LONG_ZERO : parsedVal;
     } else {
       throw new ParseException("Unknown type[%s]", valObj.getClass());
     }
@@ -243,7 +248,7 @@ public final class DimensionHandlerUtils
   public static Float convertObjectToFloat(Object valObj)
   {
     if (valObj == null) {
-      return 0.0f;
+      return FLOAT_ZERO;
     }
 
     if (valObj instanceof Float) {
@@ -252,7 +257,7 @@ public final class DimensionHandlerUtils
       return ((Number) valObj).floatValue();
     } else if (valObj instanceof String) {
       Float parsedVal = Floats.tryParse((String) valObj);
-      return parsedVal == null ? 0.0f : parsedVal;
+      return parsedVal == null ? FLOAT_ZERO : parsedVal;
     } else {
       throw new ParseException("Unknown type[%s]", valObj.getClass());
     }

--- a/processing/src/main/java/io/druid/segment/FloatDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/FloatDimensionIndexer.java
@@ -199,13 +199,16 @@ public class FloatDimensionIndexer implements DimensionIndexer<Float, Float, Flo
   @Override
   public boolean checkUnsortedEncodedKeyComponentsEqual(Float lhs, Float rhs)
   {
+    if (lhs == null) {
+      return rhs == null;
+    }
     return lhs.equals(rhs);
   }
 
   @Override
   public int getUnsortedEncodedKeyComponentHashCode(Float key)
   {
-    return key.hashCode();
+    return key == null ? 0 : key.hashCode();
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/LongDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/LongDimensionIndexer.java
@@ -199,13 +199,16 @@ public class LongDimensionIndexer implements DimensionIndexer<Long, Long, Long>
   @Override
   public boolean checkUnsortedEncodedKeyComponentsEqual(Long lhs, Long rhs)
   {
+    if (lhs == null) {
+      return rhs == null;
+    }
     return lhs.equals(rhs);
   }
 
   @Override
   public int getUnsortedEncodedKeyComponentHashCode(Long key)
   {
-    return key.hashCode();
+    return key == null ? 0 : key.hashCode();
   }
 
   @Override


### PR DESCRIPTION
Related to discussion in https://github.com/druid-io/druid/issues/4503

If a row with non-null unparseable values for a numeric dimension or a row with a numeric dimension missing is ingested, this would cause an NPE when sortFacts=false.