### PR TITLE
Removed Artifactory repo from the default repo list

### DIFF
--- a/services/src/main/java/io/druid/cli/PullDependencies.java
+++ b/services/src/main/java/io/druid/cli/PullDependencies.java
@@ -135,8 +135,7 @@ public class PullDependencies implements Runnable
   );
 
   private static final List<String> DEFAULT_REMOTE_REPOSITORIES = ImmutableList.of(
-      "https://repo1.maven.org/maven2/",
-      "https://metamx.artifactoryonline.com/metamx/pub-libs-releases-local"
+      "https://repo1.maven.org/maven2/"
   );
 
   private TeslaAether aether;
@@ -179,7 +178,7 @@ public class PullDependencies implements Runnable
 
   @Option(
       name = {"-r", "--remoteRepository"},
-      title = "Add a remote repository. Unless --no-default-remote-repositories is provided, these will be used after https://repo1.maven.org/maven2/ and https://metamx.artifactoryonline.com/metamx/pub-libs-releases-local",
+      title = "Add a remote repository. Unless --no-default-remote-repositories is provided, these will be used after https://repo1.maven.org/maven2/",
       required = false
   )
   List<String> remoteRepositories = Lists.newArrayList();


### PR DESCRIPTION
`artifactory.com` has been deprecated recently and is no longer working as of June 30, 2017. see https://www.jfrog.com/knowledge-base/deprecation-of-artifactoryonline-com-domain 

The alternative option is to use `jfrog.io`
