### PR TITLE
Router misc fixes

### DIFF
--- a/server/src/main/java/io/druid/guice/http/DruidHttpClientConfig.java
+++ b/server/src/main/java/io/druid/guice/http/DruidHttpClientConfig.java
@@ -44,6 +44,10 @@ public class DruidHttpClientConfig
   private int numMaxThreads = Math.max(10, (Runtime.getRuntime().availableProcessors() * 17) / 16 + 2) + 30;
 
   @JsonProperty
+  @Min(1)
+  private int numRequestsQueued = 1024;
+
+  @JsonProperty
   private String compressionCodec = DEFAULT_COMPRESSION_CODEC;
 
   public int getNumConnections()
@@ -64,5 +68,10 @@ public class DruidHttpClientConfig
   public String getCompressionCodec()
   {
     return compressionCodec;
+  }
+
+  public int getNumRequestsQueued()
+  {
+    return numRequestsQueued;
   }
 }

--- a/server/src/main/java/io/druid/guice/http/JettyHttpClientModule.java
+++ b/server/src/main/java/io/druid/guice/http/JettyHttpClientModule.java
@@ -38,6 +38,8 @@ import java.lang.annotation.Annotation;
  */
 public class JettyHttpClientModule implements Module
 {
+  private static final long CLIENT_CONNECT_TIMEOUT = 500;
+
   public static JettyHttpClientModule global()
   {
     return new JettyHttpClientModule("druid.global.http", Global.class);
@@ -120,7 +122,7 @@ public class JettyHttpClientModule implements Module
       httpClient.setIdleTimeout(config.getReadTimeout().getMillis());
       httpClient.setMaxConnectionsPerDestination(config.getNumConnections());
       httpClient.setMaxRequestsQueuedPerDestination(config.getNumRequestsQueued());
-      httpClient.setConnectTimeout(500);
+      httpClient.setConnectTimeout(CLIENT_CONNECT_TIMEOUT);
       final QueuedThreadPool pool = new QueuedThreadPool(config.getNumMaxThreads());
       pool.setName(JettyHttpClientModule.class.getSimpleName() + "-threadPool-" + pool.hashCode());
       httpClient.setExecutor(pool);

--- a/server/src/main/java/io/druid/guice/http/JettyHttpClientModule.java
+++ b/server/src/main/java/io/druid/guice/http/JettyHttpClientModule.java
@@ -119,6 +119,7 @@ public class JettyHttpClientModule implements Module
 
       httpClient.setIdleTimeout(config.getReadTimeout().getMillis());
       httpClient.setMaxConnectionsPerDestination(config.getNumConnections());
+      httpClient.setMaxRequestsQueuedPerDestination(config.getNumRequestsQueued());
       final QueuedThreadPool pool = new QueuedThreadPool(config.getNumMaxThreads());
       pool.setName(JettyHttpClientModule.class.getSimpleName() + "-threadPool-" + pool.hashCode());
       httpClient.setExecutor(pool);

--- a/server/src/main/java/io/druid/guice/http/JettyHttpClientModule.java
+++ b/server/src/main/java/io/druid/guice/http/JettyHttpClientModule.java
@@ -120,6 +120,7 @@ public class JettyHttpClientModule implements Module
       httpClient.setIdleTimeout(config.getReadTimeout().getMillis());
       httpClient.setMaxConnectionsPerDestination(config.getNumConnections());
       httpClient.setMaxRequestsQueuedPerDestination(config.getNumRequestsQueued());
+      httpClient.setConnectTimeout(500);
       final QueuedThreadPool pool = new QueuedThreadPool(config.getNumMaxThreads());
       pool.setName(JettyHttpClientModule.class.getSimpleName() + "-threadPool-" + pool.hashCode());
       httpClient.setExecutor(pool);

--- a/server/src/main/java/io/druid/server/AsyncQueryForwardingServlet.java
+++ b/server/src/main/java/io/druid/server/AsyncQueryForwardingServlet.java
@@ -138,7 +138,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
   {
     super.init();
 
-    // Note that httpClinetProvider is setup to return same HttpClient instance on each get() so
+    // Note that httpClientProvider is setup to return same HttpClient instance on each get() so
     // it is same http client as that is used by parent ProxyServlet.
     broadcastClient = httpClientProvider.get();
     try {

--- a/server/src/main/java/io/druid/server/AsyncQueryForwardingServlet.java
+++ b/server/src/main/java/io/druid/server/AsyncQueryForwardingServlet.java
@@ -76,7 +76,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
   private static final String OBJECTMAPPER_ATTRIBUTE = "io.druid.proxy.objectMapper";
 
   private static final int CANCELLATION_TIMEOUT_MILLIS = 500;
-  private static final int MAX_QUEUED_CANCELLATIONS = 64;
+
   private final AtomicLong successfulQueryCount = new AtomicLong();
   private final AtomicLong failedQueryCount = new AtomicLong();
   private final AtomicLong interruptedQueryCount = new AtomicLong();
@@ -116,7 +116,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       @Smile ObjectMapper smileMapper,
       QueryHostFinder hostFinder,
       @Router Provider<HttpClient> httpClientProvider,
-      DruidHttpClientConfig httpClientConfig,
+      @Router DruidHttpClientConfig httpClientConfig,
       ServiceEmitter emitter,
       RequestLogger requestLogger,
       GenericQueryMetricsFactory queryMetricsFactory
@@ -138,12 +138,9 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
   {
     super.init();
 
-    // separate client with more aggressive connection timeouts
-    // to prevent cancellations requests from blocking queries
+    // Note that httpClinetProvider is setup to return same HttpClient instance on each get() so
+    // it is same http client as that is used by parent ProxyServlet.
     broadcastClient = httpClientProvider.get();
-    broadcastClient.setConnectTimeout(CANCELLATION_TIMEOUT_MILLIS);
-    broadcastClient.setMaxRequestsQueuedPerDestination(MAX_QUEUED_CANCELLATIONS);
-
     try {
       broadcastClient.start();
     }

--- a/services/src/main/java/io/druid/cli/CliBroker.java
+++ b/services/src/main/java/io/druid/cli/CliBroker.java
@@ -108,6 +108,7 @@ public class CliBroker extends ServerRunnable
 
             binder.bind(JettyServerInitializer.class).to(QueryJettyServerInitializer.class).in(LazySingleton.class);
 
+            binder.bind(BrokerQueryResource.class).in(LazySingleton.class);
             Jerseys.addResource(binder, BrokerQueryResource.class);
             binder.bind(QueryCountStatsProvider.class).to(BrokerQueryResource.class).in(LazySingleton.class);
             Jerseys.addResource(binder, BrokerResource.class);


### PR DESCRIPTION
- Various fixes to honor druid.router.http.* properties, @Router annotation wasn't used to get 
 config instance causing them to be not used at all.
- Makes maxRequestsQueued on jetty http client configurable which
- broadcastClient in AsyncQueryForwardingServlet was accidentally setting maxRequestsQueued to 64 from default 1024 assuming it would be a different instance of HttpClient but provider is singleton so it was using same instance all along.

unrelated to router but very minor, makes BrokerQueryResource singleton.