### PR TITLE
Fix duplicated locks after sync from storage

### DIFF
--- a/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLockboxTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLockboxTest.java
@@ -54,13 +54,7 @@ public class TaskLockboxTest
   public void setup()
   {
     final TestDerbyConnector derbyConnector = derby.getConnector();
-    derbyConnector.createDataSourceTable();
-    derbyConnector.createPendingSegmentsTable();
-    derbyConnector.createSegmentTable();
-    derbyConnector.createRulesTable();
-    derbyConnector.createConfigTable();
     derbyConnector.createTaskTables();
-    derbyConnector.createAuditTable();
     taskStorage = new MetadataTaskStorage(
         derbyConnector,
         new TaskStorageConfig(null),


### PR DESCRIPTION
Fixed that same locks were added to ```taskStorage``` in ```TaskLockBox.syncFromStorage()```.
Also ```TaskLockBoxTest``` is changed to use ```MetadataTaskStorage``` because this problem is found only with ```MetadataTaskStorage``` and ```HeapMemoryTaskStorage``` is not used in production.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/druid-io/druid/4521)
<!-- Reviewable:end -->
