### PR TITLE
enforce compile scope

### DIFF
--- a/extensions-contrib/orc-extensions/pom.xml
+++ b/extensions-contrib/orc-extensions/pom.xml
@@ -47,6 +47,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
+            <scope>compile</scope>
             <exclusions>
                 <exclusion>
                     <groupId>commons-cli</groupId>


### PR DESCRIPTION
For some bogus reason when compiling with a different (in-house) hadoop version the scope of this dependency becomes runtime which fails the build.
This PR enforce the default compile scope.
