### PR TITLE
Fix a transient failure of IndexTaskTest

### DIFF
--- a/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorDriverTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorDriverTest.java
@@ -138,6 +138,8 @@ public class AppenderatorDriverTest
         committerSupplier.get(),
         ImmutableList.of("dummy")
     ).get(PUBLISH_TIMEOUT, TimeUnit.MILLISECONDS);
+    Assert.assertFalse(driver.getActiveSegments().containsKey("dummy"));
+    Assert.assertFalse(driver.getPublishPendingSegments().containsKey("dummy"));
     final SegmentsAndMetadata segmentsAndMetadata = driver.registerHandoff(published)
                                                           .get(HANDOFF_CONDITION_TIMEOUT, TimeUnit.MILLISECONDS);
 
@@ -183,6 +185,8 @@ public class AppenderatorDriverTest
         committerSupplier.get(),
         ImmutableList.of("dummy")
     ).get(PUBLISH_TIMEOUT, TimeUnit.MILLISECONDS);
+    Assert.assertFalse(driver.getActiveSegments().containsKey("dummy"));
+    Assert.assertFalse(driver.getPublishPendingSegments().containsKey("dummy"));
     final SegmentsAndMetadata segmentsAndMetadata = driver.registerHandoff(published)
                                                           .get(HANDOFF_CONDITION_TIMEOUT, TimeUnit.MILLISECONDS);
     Assert.assertEquals(numSegments, segmentsAndMetadata.getSegments().size());
@@ -207,6 +211,8 @@ public class AppenderatorDriverTest
         committerSupplier.get(),
         ImmutableList.of("dummy")
     ).get(PUBLISH_TIMEOUT, TimeUnit.MILLISECONDS);
+    Assert.assertFalse(driver.getActiveSegments().containsKey("dummy"));
+    Assert.assertFalse(driver.getPublishPendingSegments().containsKey("dummy"));
     driver.registerHandoff(published).get(HANDOFF_CONDITION_TIMEOUT, TimeUnit.MILLISECONDS);
   }
 


### PR DESCRIPTION
See https://travis-ci.org/druid-io/druid/jobs/252299428.
Segments should be removed immediately from ```AppenderatorDriver.publishPendingSegments``` when ```AppenderatorDriver.publish()``` is called rather than waiting for those segments to be published.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/druid-io/druid/4530)
<!-- Reviewable:end -->
