### PR TITLE
DataSegmentPusher: Add allowed hadoop property prefixes.

### DIFF
--- a/api/src/main/java/io/druid/segment/loading/DataSegmentPusher.java
+++ b/api/src/main/java/io/druid/segment/loading/DataSegmentPusher.java
@@ -26,6 +26,8 @@ import io.druid.timeline.DataSegment;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 public interface DataSegmentPusher
@@ -43,6 +45,15 @@ public interface DataSegmentPusher
   }
   default String makeIndexPathName(DataSegment dataSegment, String indexName) {
     return StringUtils.format("./%s/%s", getStorageDir(dataSegment), indexName);
+  }
+
+  /**
+   * Property prefixes that should be added to the "allowedHadoopPrefix" config for passing down to Hadoop jobs. These
+   * should be property prefixes like "druid.xxx", which means to include "druid.xxx" and "druid.xxx.*".
+   */
+  default List<String> getAllowedPropertyPrefixesForHadoop()
+  {
+    return Collections.emptyList();
   }
 
   // Note: storage directory structure format = .../dataSource/interval/version/partitionNumber/

--- a/extensions-contrib/azure-extensions/src/main/java/io/druid/storage/azure/AzureDataSegmentPusher.java
+++ b/extensions-contrib/azure-extensions/src/main/java/io/druid/storage/azure/AzureDataSegmentPusher.java
@@ -78,7 +78,7 @@ public class AzureDataSegmentPusher implements DataSegmentPusher
   @Override
   public List<String> getAllowedPropertyPrefixesForHadoop()
   {
-    return ImmutableList.of("druid.azure.");
+    return ImmutableList.of("druid.azure");
   }
 
   public File createSegmentDescriptorFile(final ObjectMapper jsonMapper, final DataSegment segment) throws

--- a/extensions-contrib/azure-extensions/src/main/java/io/druid/storage/azure/AzureDataSegmentPusher.java
+++ b/extensions-contrib/azure-extensions/src/main/java/io/druid/storage/azure/AzureDataSegmentPusher.java
@@ -21,6 +21,7 @@ package io.druid.storage.azure;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.microsoft.azure.storage.StorageException;
@@ -37,6 +38,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
@@ -71,6 +73,12 @@ public class AzureDataSegmentPusher implements DataSegmentPusher
   public String getPathForHadoop()
   {
     return null;
+  }
+
+  @Override
+  public List<String> getAllowedPropertyPrefixesForHadoop()
+  {
+    return ImmutableList.of("druid.azure.");
   }
 
   public File createSegmentDescriptorFile(final ObjectMapper jsonMapper, final DataSegment segment) throws

--- a/extensions-contrib/google-extensions/src/main/java/io/druid/storage/google/GoogleDataSegmentPusher.java
+++ b/extensions-contrib/google-extensions/src/main/java/io/druid/storage/google/GoogleDataSegmentPusher.java
@@ -80,7 +80,7 @@ public class GoogleDataSegmentPusher implements DataSegmentPusher
   @Override
   public List<String> getAllowedPropertyPrefixesForHadoop()
   {
-    return ImmutableList.of("druid.google.");
+    return ImmutableList.of("druid.google");
   }
 
   public File createDescriptorFile(final ObjectMapper jsonMapper, final DataSegment segment)

--- a/extensions-contrib/google-extensions/src/main/java/io/druid/storage/google/GoogleDataSegmentPusher.java
+++ b/extensions-contrib/google-extensions/src/main/java/io/druid/storage/google/GoogleDataSegmentPusher.java
@@ -24,6 +24,7 @@ import com.google.api.client.http.InputStreamContent;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.druid.java.util.common.CompressionUtils;
@@ -38,6 +39,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
+import java.util.List;
 import java.util.Map;
 
 public class GoogleDataSegmentPusher implements DataSegmentPusher
@@ -73,6 +75,12 @@ public class GoogleDataSegmentPusher implements DataSegmentPusher
   public String getPathForHadoop()
   {
     return StringUtils.format("gs://%s/%s", config.getBucket(), config.getPrefix());
+  }
+
+  @Override
+  public List<String> getAllowedPropertyPrefixesForHadoop()
+  {
+    return ImmutableList.of("druid.google.");
   }
 
   public File createDescriptorFile(final ObjectMapper jsonMapper, final DataSegment segment)

--- a/extensions-core/s3-extensions/src/main/java/io/druid/storage/s3/S3DataSegmentPusher.java
+++ b/extensions-core/s3-extensions/src/main/java/io/druid/storage/s3/S3DataSegmentPusher.java
@@ -84,7 +84,7 @@ public class S3DataSegmentPusher implements DataSegmentPusher
   @Override
   public List<String> getAllowedPropertyPrefixesForHadoop()
   {
-    return ImmutableList.of("druid.s3.");
+    return ImmutableList.of("druid.s3");
   }
 
   @Override

--- a/extensions-core/s3-extensions/src/main/java/io/druid/storage/s3/S3DataSegmentPusher.java
+++ b/extensions-core/s3-extensions/src/main/java/io/druid/storage/s3/S3DataSegmentPusher.java
@@ -21,6 +21,7 @@ package io.druid.storage.s3;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.metamx.emitter.EmittingLogger;
@@ -38,6 +39,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
@@ -77,6 +79,12 @@ public class S3DataSegmentPusher implements DataSegmentPusher
   public String getPathForHadoop(String dataSource)
   {
     return getPathForHadoop();
+  }
+
+  @Override
+  public List<String> getAllowedPropertyPrefixesForHadoop()
+  {
+    return ImmutableList.of("druid.s3.");
   }
 
   @Override

--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerConfig.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerConfig.java
@@ -74,6 +74,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -259,7 +260,13 @@ public class HadoopDruidIndexerConfig
 
     }
     this.rollupGran = spec.getDataSchema().getGranularitySpec().getQueryGranularity();
-    this.allowedHadoopPrefix = spec.getTuningConfig().getAllowedHadoopPrefix();
+
+    // User-specified list plus our additional bonus list.
+    this.allowedHadoopPrefix = new ArrayList<>();
+    this.allowedHadoopPrefix.add("druid.storage");
+    this.allowedHadoopPrefix.add("druid.javascript");
+    this.allowedHadoopPrefix.addAll(DATA_SEGMENT_PUSHER.getAllowedPropertyPrefixesForHadoop());
+    this.allowedHadoopPrefix.addAll(spec.getTuningConfig().getUserAllowedHadoopPrefix());
   }
 
   @JsonProperty(value = "spec")

--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopTuningConfig.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopTuningConfig.java
@@ -137,9 +137,7 @@ public class HadoopTuningConfig implements TuningConfig
     this.forceExtendableShardSpecs = forceExtendableShardSpecs;
     Preconditions.checkArgument(this.numBackgroundPersistThreads >= 0, "Not support persistBackgroundCount < 0");
     this.useExplicitVersion = useExplicitVersion;
-    this.allowedHadoopPrefix = allowedHadoopPrefix == null
-                               ? ImmutableList.of("druid.storage.", "druid.javascript.")
-                               : allowedHadoopPrefix;
+    this.allowedHadoopPrefix = allowedHadoopPrefix == null ? ImmutableList.of() : allowedHadoopPrefix;
   }
 
   @JsonProperty
@@ -323,9 +321,10 @@ public class HadoopTuningConfig implements TuningConfig
     );
   }
 
-  @JsonProperty
-  public List<String> getAllowedHadoopPrefix()
+  @JsonProperty("allowedHadoopPrefix")
+  public List<String> getUserAllowedHadoopPrefix()
   {
+    // Just the user-specified list. More are added in HadoopDruidIndexerConfig.
     return allowedHadoopPrefix;
   }
 }

--- a/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
@@ -313,7 +313,7 @@ public class JobHelper
 
     for (String propName : System.getProperties().stringPropertyNames()) {
       for (String prefix : listOfAllowedPrefix) {
-        if (propName.startsWith(prefix)) {
+        if (propName.equals(prefix) || propName.startsWith(prefix + ".")) {
           mapJavaOpts = StringUtils.format("%s -D%s=%s", mapJavaOpts, propName, System.getProperty(propName));
           reduceJavaOpts = StringUtils.format("%s -D%s=%s", reduceJavaOpts, propName, System.getProperty(propName));
           break;


### PR DESCRIPTION
Fixes #4536 by adding a method to DataSegmentPusher.

Also changes the built-in allowed property prefixes so they are always added. I think that makes more sense, otherwise a user-provided list might break something built-in (like a Pusher's list). Also changes the prefixes from looking like "druid.xxx." to looking like "druid.xxx". This is useful for stuff like "druid.emitter", where "druid.emitter" is a property but so is "druid.emitter.foo".

I think these behavior changes are all fine for a minor release since allowedHadoopPrefix wasn't documented yet.