### PR TITLE
Drop travis fork count to 1 experiment (Don't merge)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,12 @@ matrix:
       # processing module test
     - sudo: false
       install: mvn install -q -ff -DskipTests -B
-      script: mvn test -B -Pparallel-test -Dmaven.fork.count=2 -pl processing
+      script: mvn test -B -Pparallel-test -Dmaven.fork.count=1 -pl processing
 
       # non-processing modules test
     - sudo: false
       install: mvn install -q -ff -DskipTests -B
-      script: mvn test -B -Pparallel-test -Dmaven.fork.count=2 -pl '!processing'
+      script: mvn test -B -Pparallel-test -Dmaven.fork.count=1 -pl '!processing'
 
       # run integration tests
     - sudo: required


### PR DESCRIPTION
Travis tests are having issues right now, dropping parallel test count to 1 to see if that helps:
https://docs.travis-ci.com/user/common-build-problems/#My-build-script-is-killed-without-any-error

Please don't merge this

