### PR TITLE
Use Ubuntu Precise for Travis unit test jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 
+dist: precise
+
 jdk:
   - oraclejdk8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
 
       # run integration tests
     - sudo: required
+      dist: trusty
       services:
         - docker
       env:


### PR DESCRIPTION
Travis CI seems to have updated its default base image to use Ubuntu Trusty today, the Druid tests are failing with what might be memory usage errors:

https://docs.travis-ci.com/user/common-build-problems/#My-build-script-is-killed-without-any-error

This PR reverts the two unit test Travis jobs to use Ubuntu Precise.

The integration test still runs with Trusty (required for docker support).