### PR TITLE
IndexTask: Raise default maxTotalRows.

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
@@ -890,10 +890,9 @@ public class IndexTask extends AbstractTask
   public static class IndexTuningConfig implements TuningConfig, AppenderatorConfig
   {
     private static final int DEFAULT_MAX_ROWS_IN_MEMORY = 75_000;
-    private static final int DEFAULT_MAX_TOTAL_ROWS = 150_000;
+    private static final int DEFAULT_MAX_TOTAL_ROWS = 20_000_000;
     private static final IndexSpec DEFAULT_INDEX_SPEC = new IndexSpec();
     private static final int DEFAULT_MAX_PENDING_PERSISTS = 0;
-    private static final boolean DEFAULT_BUILD_V9_DIRECTLY = true;
     private static final boolean DEFAULT_FORCE_EXTENDABLE_SHARD_SPECS = false;
     private static final boolean DEFAULT_GUARANTEE_ROLLUP = false;
     private static final boolean DEFAULT_REPORT_PARSE_EXCEPTIONS = false;


### PR DESCRIPTION
150k is very low, given that it should only be limited by disk space
rather than JVM heap.