### PR TITLE
Deduplication of loadList property

### DIFF
--- a/processing/src/main/java/io/druid/guice/ExtensionsConfig.java
+++ b/processing/src/main/java/io/druid/guice/ExtensionsConfig.java
@@ -22,7 +22,7 @@ package io.druid.guice;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.validation.constraints.NotNull;
-import java.util.List;
+import java.util.LinkedHashSet;
 
 /**
  */
@@ -46,7 +46,7 @@ public class ExtensionsConfig
   private boolean addExtensionsToHadoopContainer = false;
 
   @JsonProperty
-  private List<String> loadList;
+  private LinkedHashSet<String> loadList;
 
   public boolean searchCurrentClassloader()
   {
@@ -73,7 +73,7 @@ public class ExtensionsConfig
     return addExtensionsToHadoopContainer;
   }
 
-  public List<String> getLoadList()
+  public LinkedHashSet<String> getLoadList()
   {
     return loadList;
   }

--- a/processing/src/test/java/io/druid/guice/ExtensionsConfigTest.java
+++ b/processing/src/test/java/io/druid/guice/ExtensionsConfigTest.java
@@ -25,6 +25,8 @@ import io.druid.segment.TestHelper;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
+
 /**
  */
 public class ExtensionsConfigTest
@@ -57,7 +59,7 @@ public class ExtensionsConfigTest
                   + "  \"directory\": \"testExtensions\",\n"
                   + "  \"hadoopDependenciesDir\": \"testHadoopDependenciesDir\",\n"
                   + "  \"hadoopContainerDruidClasspath\": \"testHadoopContainerClasspath\",\n"
-                  + "  \"loadList\": [\"a\",\"b\"]\n"
+                  + "  \"loadList\": [\"b\",\"a\"]\n"
                   + "}";
     ObjectMapper mapper = TestHelper.getJsonMapper();
 
@@ -74,9 +76,34 @@ public class ExtensionsConfigTest
     Assert.assertEquals("testHadoopContainerClasspath", config.getHadoopContainerDruidClasspath());
     Assert.assertEquals(
         ImmutableList.of(
-            "a", "b"
+            "b", "a"
         ),
-        config.getLoadList()
+            new ArrayList<>(config.getLoadList())
+    );
+  }
+  @Test
+  public void testLoadList() throws Exception
+  {
+    String json = "{\n"
+            + "  \"searchCurrentClassloader\": false,\n"
+            + "  \"directory\": \"testExtensions\",\n"
+            + "  \"hadoopDependenciesDir\": \"testHadoopDependenciesDir\",\n"
+            + "  \"hadoopContainerDruidClasspath\": \"testHadoopContainerClasspath\",\n"
+            + "  \"loadList\": [\"b\",\"b\",\"a\",\"c\",\"d\",\"a\"]\n"
+            + "}";
+    ObjectMapper mapper = TestHelper.getJsonMapper();
+
+    ExtensionsConfig config = mapper.readValue(
+            mapper.writeValueAsString(
+                    mapper.readValue(json, ExtensionsConfig.class)
+            ),
+            ExtensionsConfig.class
+    );
+
+    Assert.assertEquals(
+            ImmutableList.of("b","a","c","d"),
+            new ArrayList<>(config.getLoadList())
     );
   }
 }
+

--- a/server/src/main/java/io/druid/initialization/Initialization.java
+++ b/server/src/main/java/io/druid/initialization/Initialization.java
@@ -76,6 +76,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -219,7 +220,7 @@ public class Initialization
       throw new ISE("Root extensions directory [%s] is not a directory!?", rootExtensionsDir);
     }
     File[] extensionsToLoad;
-    final List<String> toLoad = config.getLoadList();
+    final LinkedHashSet<String> toLoad = config.getLoadList();
     if (toLoad == null) {
       extensionsToLoad = rootExtensionsDir.listFiles();
     } else {

--- a/server/src/test/java/io/druid/initialization/InitializationTest.java
+++ b/server/src/test/java/io/druid/initialization/InitializationTest.java
@@ -51,6 +51,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -287,9 +288,9 @@ public class InitializationTest
     final ExtensionsConfig config = new ExtensionsConfig()
     {
       @Override
-      public List<String> getLoadList()
+      public LinkedHashSet<String> getLoadList()
       {
-        return Arrays.asList("mysql-metadata-storage", "druid-kafka-eight", absolutePathExtension.getAbsolutePath());
+        return Sets.newLinkedHashSet(Arrays.asList("mysql-metadata-storage", "druid-kafka-eight", absolutePathExtension.getAbsolutePath()));
       }
 
       @Override
@@ -322,9 +323,9 @@ public class InitializationTest
     final ExtensionsConfig config = new ExtensionsConfig()
     {
       @Override
-      public List<String> getLoadList()
+      public LinkedHashSet<String> getLoadList()
       {
-        return Arrays.asList("mysql-metadata-storage", "druid-kafka-eight");
+        return Sets.newLinkedHashSet(Arrays.asList("mysql-metadata-storage", "druid-kafka-eight"));
       }
 
       @Override


### PR DESCRIPTION
Ensure deduplication of extensions loadList property. This is to avoid redundant dependency loads as well as maintain the order in which they are loaded.
