### PR TITLE
fix a bug when the cluster don't configure mapreduce.map.java.opts or…

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
@@ -313,7 +313,14 @@ public class JobHelper
   public static void injectDruidProperties(Configuration configuration, List<String> listOfAllowedPrefix)
   {
     String mapJavaOpts = configuration.get(MRJobConfig.MAP_JAVA_OPTS);
+    if (mapJavaOpts == null) {
+      mapJavaOpts = "";
+    }
+
     String reduceJavaOpts = configuration.get(MRJobConfig.REDUCE_JAVA_OPTS);
+    if (reduceJavaOpts == null) {
+      reduceJavaOpts = "";
+    }
 
     for (String propName : System.getProperties().stringPropertyNames()) {
       for (String prefix : listOfAllowedPrefix) {


### PR DESCRIPTION
This is to fix a bug when the cluster don't configure mapreduce.map.java.opts or mapreduce.map.java.opts. 
I encountered this bug when trying hdfs batch indexing. Our remote cluster don't set the two configs, and I got "Error: Could not find or load main class null" message in the failing mapper.
I asked this question in the druid-user group:
[Error when running Hadoop indexing Quickstart demo](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/druid-user/INBzP53tGVo/4JqAChnaAQAJ)