### PR TITLE
[Bugfix] null string in map/reduce jvm opts

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
@@ -308,8 +308,8 @@ public class JobHelper
 
   public static void injectDruidProperties(Configuration configuration, List<String> listOfAllowedPrefix)
   {
-    String mapJavaOpts = configuration.get(MRJobConfig.MAP_JAVA_OPTS);
-    String reduceJavaOpts = configuration.get(MRJobConfig.REDUCE_JAVA_OPTS);
+    String mapJavaOpts = Strings.nullToEmpty(configuration.get(MRJobConfig.MAP_JAVA_OPTS));
+    String reduceJavaOpts = Strings.nullToEmpty(configuration.get(MRJobConfig.REDUCE_JAVA_OPTS));
 
     for (String propName : System.getProperties().stringPropertyNames()) {
       for (String prefix : listOfAllowedPrefix) {


### PR DESCRIPTION
fix a bug when the cluster don't configure mapreduce.map.java.opts or mapreduce.map.java.opts
This is the same bug in #4585.
The original pull request comment is:

> This is to fix a bug when the cluster don't configure mapreduce.map.java.opts or mapreduce.map.java.opts. 
I encountered this bug when trying hdfs batch indexing. Our remote cluster don't set the two configs, and I got "Error: Could not find or load main class null" message in the failing mapper.
I asked this question in the druid-user group:
[Error when running Hadoop indexing Quickstart demo](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/druid-user/INBzP53tGVo/4JqAChnaAQAJ)

I have changed with comment of @leventov & @b-slim 
@leventov I am using String.nullToEmpty.
@b-slim I rebase this commit on master, it seems it doesn't support change base branch of pull request.