### PR TITLE
[Bugfix] return null for the null list in OrcStruct

### DIFF
--- a/extensions-contrib/orc-extensions/src/main/java/io/druid/data/input/orc/OrcHadoopInputRowParser.java
+++ b/extensions-contrib/orc-extensions/src/main/java/io/druid/data/input/orc/OrcHadoopInputRowParser.java
@@ -131,6 +131,9 @@ public class OrcHadoopInputRowParser implements InputRowParser<OrcStruct>
 
   private List getListObject(ListObjectInspector listObjectInspector, Object listObject)
   {
+    if (listObjectInspector.getListLength(listObject) < 0) {
+      return null;
+    }
     List objectList = listObjectInspector.getList(listObject);
     List list = null;
     ObjectInspector child = listObjectInspector.getListElementObjectInspector();

--- a/extensions-contrib/orc-extensions/src/test/java/io/druid/data/input/orc/OrcHadoopInputRowParserTest.java
+++ b/extensions-contrib/orc-extensions/src/test/java/io/druid/data/input/orc/OrcHadoopInputRowParserTest.java
@@ -144,7 +144,7 @@ public class OrcHadoopInputRowParserTest
   @Test
   public void testParse()
   {
-    final String typeString = "struct<timestamp:string,col1:string,col2:array<string>,col3:float,col4:bigint,col5:decimal>";
+    final String typeString = "struct<timestamp:string,col1:string,col2:array<string>,col3:float,col4:bigint,col5:decimal,col6:array<string>>";
     final OrcHadoopInputRowParser parser = new OrcHadoopInputRowParser(
         new TimeAndDimsParseSpec(
             new TimestampSpec("timestamp", "auto", null),
@@ -157,13 +157,14 @@ public class OrcHadoopInputRowParserTest
         TypeInfoUtils.getTypeInfoFromTypeString(typeString)
     );
     final OrcStruct struct = (OrcStruct) oi.create();
-    struct.setNumFields(6);
+    struct.setNumFields(7);
     oi.setStructFieldData(struct, oi.getStructFieldRef("timestamp"), new Text("2000-01-01"));
     oi.setStructFieldData(struct, oi.getStructFieldRef("col1"), new Text("foo"));
     oi.setStructFieldData(struct, oi.getStructFieldRef("col2"), ImmutableList.of(new Text("foo"), new Text("bar")));
     oi.setStructFieldData(struct, oi.getStructFieldRef("col3"), new FloatWritable(1));
     oi.setStructFieldData(struct, oi.getStructFieldRef("col4"), new LongWritable(2));
     oi.setStructFieldData(struct, oi.getStructFieldRef("col5"), new HiveDecimalWritable(3));
+    oi.setStructFieldData(struct, oi.getStructFieldRef("col6"), null);
 
     final InputRow row = parser.parse(struct);
     Assert.assertEquals("timestamp", new DateTime("2000-01-01"), row.getTimestamp());
@@ -172,5 +173,6 @@ public class OrcHadoopInputRowParserTest
     Assert.assertEquals("col3", 1.0f, row.getRaw("col3"));
     Assert.assertEquals("col4", 2L, row.getRaw("col4"));
     Assert.assertEquals("col5", 3.0d, row.getRaw("col5"));
+    Assert.assertNull("col6", row.getRaw("col6"));
   }
 }


### PR DESCRIPTION
Using with druid-orc-extensions, I tried to ingest orc-formatted data to Druid 0.10.0 cluster. The ingestion task is failed, because following error occurred.

```
Error: io.druid.java.util.common.RE: Failure on row[{1499154693, col1, null}]
	at io.druid.indexer.HadoopDruidIndexerMapper.map(HadoopDruidIndexerMapper.java:91)
	at org.apache.hadoop.mapreduce.Mapper.run(Mapper.java:146)
	at org.apache.hadoop.mapred.MapTask.runNewMapper(MapTask.java:787)
	at org.apache.hadoop.mapred.MapTask.run(MapTask.java:341)
	at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:168)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:422)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1709)
	at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:162)
Caused by: java.lang.NullPointerException
	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:213)
	at com.google.common.collect.Lists$TransformingSequentialList.<init>(Lists.java:525)
	at com.google.common.collect.Lists.transform(Lists.java:508)
	at io.druid.data.input.orc.OrcHadoopInputRowParser.getListObject(OrcHadoopInputRowParser.java:127)
	at io.druid.data.input.orc.OrcHadoopInputRowParser.parse(OrcHadoopInputRowParser.java:89)
	at io.druid.data.input.orc.OrcHadoopInputRowParser.parse(OrcHadoopInputRowParser.java:52)
	at io.druid.indexer.HadoopDruidIndexerMapper.parseInputRow(HadoopDruidIndexerMapper.java:105)
	at io.druid.indexer.HadoopDruidIndexerMapper.map(HadoopDruidIndexerMapper.java:72)
	... 8 more
```

My index spec is as follows.

```javascript
"parser": {
  "type": "orc",
  "typeString": "struct<timestamp:bigint,col1:string,col2:array<string>>",
  "parseSpec": {
    "format": "timeAndDims",
    "timestampSpec": {
      "column": "timestamp",
      "format": "posix"
    },
    "dimensionsSpec": {
      "dimensions": [ "col1", "col2" ]
    }
  }
}
```

My `col2` dimension contains null. The cause of this NullPointerException is that null-list are passed to `Lists.transform`.

https://github.com/druid-io/druid/blob/druid-0.10.0/extensions-contrib/orc-extensions/src/main/java/io/druid/data/input/orc/OrcHadoopInputRowParser.java#L127

This patch provides the validation for null-list using with `ListObjectInspector#getListLength(Object)`.


```java
/**
 * returns -1 for data = null.
 */
int getListLength(Object data);
```

https://github.com/apache/hive/blob/release-2.0.0/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ListObjectInspector.java#L37-L40

Please check this PR. Thanks.