### PR TITLE
Fix a NPE using kafka emitter extension

### DIFF
--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
@@ -25,6 +25,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import org.apache.kafka.clients.producer.ProducerConfig;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
 public class KafkaEmitterConfig
@@ -47,7 +48,7 @@ public class KafkaEmitterConfig
       @JsonProperty("metric.topic") String metricTopic,
       @JsonProperty("alert.topic") String alertTopic,
       @JsonProperty("clusterName") String clusterName,
-      @JsonProperty("producer.config") Map<String, String> kafkaProducerConfig
+      @JsonProperty("producer.config") @Nullable Map<String, String> kafkaProducerConfig
   )
   {
     this.bootstrapServers = Preconditions.checkNotNull(bootstrapServers, "bootstrap.servers can not be null");

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
@@ -22,6 +22,7 @@ package io.druid.emitter.kafka;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import org.apache.kafka.clients.producer.ProducerConfig;
 
 import java.util.Map;
@@ -53,7 +54,7 @@ public class KafkaEmitterConfig
     this.metricTopic = Preconditions.checkNotNull(metricTopic, "metric.topic can not be null");
     this.alertTopic = Preconditions.checkNotNull(alertTopic, "alert.topic can not be null");
     this.clusterName = clusterName;
-    this.kafkaProducerConfig = kafkaProducerConfig;
+    this.kafkaProducerConfig = kafkaProducerConfig == null? ImmutableMap.<String,String>of() : kafkaProducerConfig;
   }
 
   @JsonProperty
@@ -110,9 +111,7 @@ public class KafkaEmitterConfig
     if (getClusterName() != null ? !getClusterName().equals(that.getClusterName()) : that.getClusterName() != null) {
       return false;
     }
-    return getKafkaProducerConfig() != null
-           ? getKafkaProducerConfig().equals(that.getKafkaProducerConfig())
-           : that.getKafkaProducerConfig() == null;
+    return getKafkaProducerConfig().equals(that.getKafkaProducerConfig());
   }
 
   @Override
@@ -122,7 +121,7 @@ public class KafkaEmitterConfig
     result = 31 * result + getMetricTopic().hashCode();
     result = 31 * result + getAlertTopic().hashCode();
     result = 31 * result + (getClusterName() != null ? getClusterName().hashCode() : 0);
-    result = 31 * result + (getKafkaProducerConfig() != null ? getKafkaProducerConfig().hashCode() : 0);
+    result = 31 * result + getKafkaProducerConfig().hashCode();
     return result;
   }
 

--- a/extensions-contrib/kafka-emitter/src/test/java/io/druid/emitter/kafka/KafkaEmitterConfigTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/io/druid/emitter/kafka/KafkaEmitterConfigTest.java
@@ -52,4 +52,18 @@ public class KafkaEmitterConfigTest
                                                           .readValue(kafkaEmitterConfigString);
     Assert.assertEquals(kafkaEmitterConfigExpected, kafkaEmitterConfig);
   }
+
+  @Test
+  public void testSerDeNotRequiredKafkaProducerConfig() throws IOException
+  {
+    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("localhost:9092", "metricTest",
+                                                                   "alertTest", "clusterNameTest",
+                                                                   null
+    );
+    try {
+      KafkaEmitter emitter = new KafkaEmitter(kafkaEmitterConfig, mapper);
+    } catch (NullPointerException e) {
+      Assert.fail();
+    }
+  }
 }

--- a/extensions-contrib/kafka-emitter/src/test/java/io/druid/emitter/kafka/KafkaEmitterConfigTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/io/druid/emitter/kafka/KafkaEmitterConfigTest.java
@@ -62,7 +62,8 @@ public class KafkaEmitterConfigTest
     );
     try {
       KafkaEmitter emitter = new KafkaEmitter(kafkaEmitterConfig, mapper);
-    } catch (NullPointerException e) {
+    }
+    catch (NullPointerException e) {
       Assert.fail();
     }
   }


### PR DESCRIPTION
I found this exception when using kafka emitter according to doc [kafka-emitter](http://druid.io/docs/0.10.1-rc2/development/extensions-contrib/kafka-emitter.html).
It said "druid.emitter.kafka.producer.config" is not required, so I didn't set it. As a result I got an NPE exception when starting up my overlord. 