### PR TITLE
Log used flag

### DIFF
--- a/server/src/main/java/io/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/io/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -631,10 +631,10 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
             .bind("payload", jsonMapper.writeValueAsBytes(segment))
             .execute();
 
-      log.info("Published segment [%s] to DB", segment.getIdentifier());
+      log.info("Published segment [%s] to DB with used flag [%s]", segment.getIdentifier(), used);
     }
     catch (Exception e) {
-      log.error(e, "Exception inserting segment [%s] into DB", segment.getIdentifier());
+      log.error(e, "Exception inserting segment [%s] with used flag [%s] into DB", segment.getIdentifier(), used);
       throw e;
     }
 


### PR DESCRIPTION
The `used` flag is important piece of information that was not being logged. It took us days to debug an issue where the overlord is marking segments as unused and the `killtask` was deleting unused segments and metadata.