### PR TITLE
misc http segment discovery fixes

### DIFF
--- a/server/src/main/java/io/druid/client/HttpServerInventoryView.java
+++ b/server/src/main/java/io/druid/client/HttpServerInventoryView.java
@@ -388,11 +388,7 @@ public class HttpServerInventoryView implements ServerInventoryView, FilteredSer
   public boolean isSegmentLoadedByServer(String serverKey, DataSegment segment)
   {
     DruidServerHolder holder = servers.get(serverKey);
-    if (holder != null) {
-      return holder.druidServer.getSegment(segment.getIdentifier()) != null;
-    } else {
-      return false;
-    }
+    return holder != null && holder.druidServer.getSegment(segment.getIdentifier()) != null;
   }
 
   private class DruidServerHolder

--- a/server/src/main/java/io/druid/client/HttpServerInventoryViewConfig.java
+++ b/server/src/main/java/io/druid/client/HttpServerInventoryViewConfig.java
@@ -24,12 +24,21 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import org.joda.time.Period;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  */
 public class HttpServerInventoryViewConfig
 {
+  // HTTP request timeout
   @JsonProperty
   private final long serverTimeout;
+
+  // Requests to server may fail when it is shutsdown abruptly and there is a lag in coordinator
+  // discovering its disappearance. So, failure would be logged only after the acceptable
+  // unstableTimeout has passed.
+  @JsonProperty
+  private final long serverUnstabilityTimeout;
 
   @JsonProperty
   private final int numThreads;
@@ -37,12 +46,17 @@ public class HttpServerInventoryViewConfig
   @JsonCreator
   public HttpServerInventoryViewConfig(
       @JsonProperty("serverTimeout") Period serverTimeout,
+      @JsonProperty("serverUnstabilityTimeout") Period serverUnstabilityTimeout,
       @JsonProperty("numThreads") Integer numThreads
   )
   {
     this.serverTimeout = serverTimeout != null
                          ? serverTimeout.toStandardDuration().getMillis()
-                         : 4*60*1000; //4 mins
+                         : TimeUnit.MINUTES.toMillis(4);
+
+    this.serverUnstabilityTimeout = serverUnstabilityTimeout != null
+                         ? serverUnstabilityTimeout.toStandardDuration().getMillis()
+                         : TimeUnit.MINUTES.toMillis(1);
 
     this.numThreads = numThreads != null ? numThreads.intValue() : 5;
 
@@ -53,6 +67,11 @@ public class HttpServerInventoryViewConfig
   public long getServerTimeout()
   {
     return serverTimeout;
+  }
+
+  public long getServerUnstabilityTimeout()
+  {
+    return serverUnstabilityTimeout;
   }
 
   public int getNumThreads()

--- a/server/src/test/java/io/druid/client/HttpServerInventoryViewConfigTest.java
+++ b/server/src/test/java/io/druid/client/HttpServerInventoryViewConfigTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.client;
+
+import io.druid.segment.TestHelper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ */
+public class HttpServerInventoryViewConfigTest
+{
+  @Test
+  public void testDeserializationWithDefaults() throws Exception
+  {
+    String json = "{}";
+
+    HttpServerInventoryViewConfig config = TestHelper.getJsonMapper().readValue(json, HttpServerInventoryViewConfig.class);
+
+    Assert.assertEquals(TimeUnit.MINUTES.toMillis(4), config.getServerTimeout());
+    Assert.assertEquals(TimeUnit.MINUTES.toMillis(1), config.getServerUnstabilityTimeout());
+    Assert.assertEquals(5, config.getNumThreads());
+  }
+
+  @Test
+  public void testDeserializationWithNonDefaults() throws Exception
+  {
+    String json = "{\n"
+                  + "  \"serverTimeout\": \"PT2M\",\n"
+                  + "  \"serverUnstabilityTimeout\": \"PT3M\",\n"
+                  + "  \"numThreads\": 7\n"
+                  + "}";
+
+    HttpServerInventoryViewConfig config = TestHelper.getJsonMapper().readValue(json, HttpServerInventoryViewConfig.class);
+
+    Assert.assertEquals(TimeUnit.MINUTES.toMillis(2), config.getServerTimeout());
+    Assert.assertEquals(TimeUnit.MINUTES.toMillis(3), config.getServerUnstabilityTimeout());
+    Assert.assertEquals(7, config.getNumThreads());
+  }
+}


### PR DESCRIPTION
Fixes following
1) getInventory() impl inadvertantly leaked `servers` hashmap, it is updated to be ConcurrentHashMap for safety.
2) suppress error logging when queryable server is not reachable for a configurable duration (default 1 minute) , it happens regularly during MM upgrades. changes are made to print info messages without exceptions in that duration.