### PR TITLE
Fix bugs in RTR related to blacklisting, change default worker strategy

### DIFF
--- a/docs/content/configuration/indexing-service.md
+++ b/docs/content/configuration/indexing-service.md
@@ -193,7 +193,7 @@ Issuing a GET request at the same URL will return the current worker config spec
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`selectStrategy`|How to assign tasks to middle managers. Choices are `fillCapacity`, `fillCapacityWithAffinity`, `equalDistribution`, `equalDistributionWithAffinity` and `javascript`.|fillCapacity|
+|`selectStrategy`|How to assign tasks to middle managers. Choices are `fillCapacity`, `fillCapacityWithAffinity`, `equalDistribution`, `equalDistributionWithAffinity` and `javascript`.|equalDistribution|
 |`autoScaler`|Only used if autoscaling is enabled. See below.|null|
 
 To view the audit history of worker config issue a GET request to the URL -

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/ImmutableWorkerInfo.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/ImmutableWorkerInfo.java
@@ -26,6 +26,7 @@ import io.druid.indexing.common.task.Task;
 import io.druid.indexing.worker.Worker;
 import org.joda.time.DateTime;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Set;
 
@@ -39,6 +40,7 @@ public class ImmutableWorkerInfo
   private final ImmutableSet<String> availabilityGroups;
   private final ImmutableSet<String> runningTasks;
   private final DateTime lastCompletedTaskTime;
+  private final DateTime blacklistedUntil;
 
   @JsonCreator
   public ImmutableWorkerInfo(
@@ -46,7 +48,8 @@ public class ImmutableWorkerInfo
       @JsonProperty("currCapacityUsed") int currCapacityUsed,
       @JsonProperty("availabilityGroups") Set<String> availabilityGroups,
       @JsonProperty("runningTasks") Collection<String> runningTasks,
-      @JsonProperty("lastCompletedTaskTime") DateTime lastCompletedTaskTime
+      @JsonProperty("lastCompletedTaskTime") DateTime lastCompletedTaskTime,
+      @Nullable @JsonProperty("blacklistedUntil") DateTime blacklistedUntil
   )
   {
     this.worker = worker;
@@ -54,6 +57,18 @@ public class ImmutableWorkerInfo
     this.availabilityGroups = ImmutableSet.copyOf(availabilityGroups);
     this.runningTasks = ImmutableSet.copyOf(runningTasks);
     this.lastCompletedTaskTime = lastCompletedTaskTime;
+    this.blacklistedUntil = blacklistedUntil;
+  }
+
+  public ImmutableWorkerInfo(
+      Worker worker,
+      int currCapacityUsed,
+      Set<String> availabilityGroups,
+      Collection<String> runningTasks,
+      DateTime lastCompletedTaskTime
+  )
+  {
+    this(worker, currCapacityUsed, availabilityGroups, runningTasks, lastCompletedTaskTime, null);
   }
 
   @JsonProperty("worker")
@@ -91,6 +106,12 @@ public class ImmutableWorkerInfo
     return lastCompletedTaskTime;
   }
 
+  @JsonProperty
+  public DateTime getBlacklistedUntil()
+  {
+    return blacklistedUntil;
+  }
+
   public boolean isValidVersion(String minVersion)
   {
     return worker.getVersion().compareTo(minVersion) >= 0;
@@ -126,8 +147,12 @@ public class ImmutableWorkerInfo
     if (!runningTasks.equals(that.runningTasks)) {
       return false;
     }
-    return lastCompletedTaskTime.equals(that.lastCompletedTaskTime);
-
+    if (!lastCompletedTaskTime.equals(that.lastCompletedTaskTime)) {
+      return false;
+    }
+    return !(blacklistedUntil != null
+             ? !blacklistedUntil.equals(that.blacklistedUntil)
+             : that.blacklistedUntil != null);
   }
 
   @Override
@@ -138,6 +163,7 @@ public class ImmutableWorkerInfo
     result = 31 * result + availabilityGroups.hashCode();
     result = 31 * result + runningTasks.hashCode();
     result = 31 * result + lastCompletedTaskTime.hashCode();
+    result = 31 * result + (blacklistedUntil != null ? blacklistedUntil.hashCode() : 0);
     return result;
   }
 
@@ -150,6 +176,7 @@ public class ImmutableWorkerInfo
            ", availabilityGroups=" + availabilityGroups +
            ", runningTasks=" + runningTasks +
            ", lastCompletedTaskTime=" + lastCompletedTaskTime +
+           ", blacklistedUntil=" + blacklistedUntil +
            '}';
   }
 }

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/ZkWorker.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/ZkWorker.java
@@ -52,7 +52,7 @@ public class ZkWorker implements Closeable
 
   private AtomicReference<Worker> worker;
   private AtomicReference<DateTime> lastCompletedTaskTime = new AtomicReference<DateTime>(new DateTime());
-  private AtomicInteger countinouslyFailedTasksCount = new AtomicInteger(0);
+  private AtomicInteger continuouslyFailedTasksCount = new AtomicInteger(0);
 
   public ZkWorker(Worker worker, PathChildrenCache statusCache, final ObjectMapper jsonMapper)
   {
@@ -161,7 +161,13 @@ public class ZkWorker implements Closeable
   public ImmutableWorkerInfo toImmutable()
   {
 
-    return new ImmutableWorkerInfo(worker.get(), getCurrCapacityUsed(), getAvailabilityGroups(), getRunningTaskIds(), lastCompletedTaskTime.get());
+    return new ImmutableWorkerInfo(
+        worker.get(),
+        getCurrCapacityUsed(),
+        getAvailabilityGroups(),
+        getRunningTaskIds(),
+        lastCompletedTaskTime.get()
+    );
   }
 
   @Override
@@ -170,19 +176,19 @@ public class ZkWorker implements Closeable
     statusCache.close();
   }
 
-  public int getCountinouslyFailedTasksCount()
+  public int getContinuouslyFailedTasksCount()
   {
-    return countinouslyFailedTasksCount.get();
+    return continuouslyFailedTasksCount.get();
   }
 
-  public void resetCountinouslyFailedTasksCount()
+  public void resetContinuouslyFailedTasksCount()
   {
-    this.countinouslyFailedTasksCount.set(0);
+    this.continuouslyFailedTasksCount.set(0);
   }
 
-  public void incrementCountinouslyFailedTasksCount()
+  public void incrementContinuouslyFailedTasksCount()
   {
-    this.countinouslyFailedTasksCount.incrementAndGet();
+    this.continuouslyFailedTasksCount.incrementAndGet();
   }
 
   @Override

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/ZkWorker.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/ZkWorker.java
@@ -51,7 +51,9 @@ public class ZkWorker implements Closeable
   private final Function<ChildData, TaskAnnouncement> cacheConverter;
 
   private AtomicReference<Worker> worker;
-  private AtomicReference<DateTime> lastCompletedTaskTime = new AtomicReference<DateTime>(new DateTime());
+  private AtomicReference<DateTime> lastCompletedTaskTime = new AtomicReference<>(new DateTime());
+  private AtomicReference<DateTime> blacklistedUntil = new AtomicReference<>();
+
   private AtomicInteger continuouslyFailedTasksCount = new AtomicInteger(0);
 
   public ZkWorker(Worker worker, PathChildrenCache statusCache, final ObjectMapper jsonMapper)
@@ -134,6 +136,12 @@ public class ZkWorker implements Closeable
     return lastCompletedTaskTime.get();
   }
 
+  @JsonProperty
+  public DateTime getBlacklistedUntil()
+  {
+    return blacklistedUntil.get();
+  }
+
   public boolean isRunningTask(String taskId)
   {
     return getRunningTasks().containsKey(taskId);
@@ -158,6 +166,11 @@ public class ZkWorker implements Closeable
     lastCompletedTaskTime.set(completedTaskTime);
   }
 
+  public void setBlacklistedUntil(DateTime blacklistedUntil)
+  {
+    this.blacklistedUntil.set(blacklistedUntil);
+  }
+
   public ImmutableWorkerInfo toImmutable()
   {
 
@@ -166,7 +179,8 @@ public class ZkWorker implements Closeable
         getCurrCapacityUsed(),
         getAvailabilityGroups(),
         getRunningTaskIds(),
-        lastCompletedTaskTime.get()
+        lastCompletedTaskTime.get(),
+        blacklistedUntil.get()
     );
   }
 
@@ -197,6 +211,7 @@ public class ZkWorker implements Closeable
     return "ZkWorker{" +
            "worker=" + worker +
            ", lastCompletedTaskTime=" + lastCompletedTaskTime +
+           ", blacklistedUntil=" + blacklistedUntil +
            '}';
   }
 }

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/config/RemoteTaskRunnerConfig.java
@@ -65,7 +65,7 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
   @JsonProperty
   @Max(100)
   @Min(0)
-  private double maxPercentageBlacklistWorkers = 20;
+  private int maxPercentageBlacklistWorkers = 20;
 
   public Period getTaskAssignmentTimeout()
   {
@@ -123,7 +123,7 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
     this.workerBlackListCleanupPeriod = workerBlackListCleanupPeriod;
   }
 
-  public double getMaxPercentageBlacklistWorkers()
+  public int getMaxPercentageBlacklistWorkers()
   {
     return maxPercentageBlacklistWorkers;
   }
@@ -188,7 +188,7 @@ public class RemoteTaskRunnerConfig extends WorkerTaskRunnerConfig
     result = 31 * result + maxRetriesBeforeBlacklist;
     result = 31 * result + workerBlackListBackoffTime.hashCode();
     result = 31 * result + workerBlackListCleanupPeriod.hashCode();
-    result = 31 * result + (int)maxPercentageBlacklistWorkers;
+    result = 31 * result + maxPercentageBlacklistWorkers;
     return result;
   }
 

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/setup/WorkerBehaviorConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/setup/WorkerBehaviorConfig.java
@@ -29,7 +29,7 @@ import io.druid.indexing.overlord.autoscaling.NoopAutoScaler;
 public class WorkerBehaviorConfig
 {
   public static final String CONFIG_KEY = "worker.config";
-  public static WorkerSelectStrategy DEFAULT_STRATEGY = new FillCapacityWorkerSelectStrategy();
+  public static WorkerSelectStrategy DEFAULT_STRATEGY = new EqualDistributionWorkerSelectStrategy();
   public static AutoScaler DEFAULT_AUTOSCALER = new NoopAutoScaler();
 
   public static WorkerBehaviorConfig defaultConfig()

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/ImmutableWorkerInfoTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/ImmutableWorkerInfoTest.java
@@ -167,6 +167,26 @@ public class ImmutableWorkerInfoTest
         new DateTime("2015-01-01T01:01:02Z")
     ), false);
 
+    // same worker different blacklistedUntil
+    assertEqualsAndHashCode(new ImmutableWorkerInfo(
+        new Worker(
+            "http", "testWorker1", "192.0.0.1", 10, "v1"
+        ),
+        3,
+        ImmutableSet.of("grp1", "grp2"),
+        ImmutableSet.of("task1", "task2"),
+        new DateTime("2015-01-01T01:01:01Z"),
+        new DateTime("2017-07-30")
+    ), new ImmutableWorkerInfo(
+        new Worker(
+            "http", "testWorker2", "192.0.0.1", 10, "v1"
+        ),
+        2,
+        ImmutableSet.of("grp1", "grp2"),
+        ImmutableSet.of("task1", "task2"),
+        new DateTime("2015-01-01T01:01:02Z"),
+        new DateTime("2017-07-31")
+    ), false);
   }
 
   private void assertEqualsAndHashCode(ImmutableWorkerInfo o1, ImmutableWorkerInfo o2, boolean shouldMatch)

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerRunPendingTasksConcurrencyTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerRunPendingTasksConcurrencyTest.java
@@ -59,8 +59,8 @@ public class RemoteTaskRunnerRunPendingTasksConcurrencyTest
   @Test(timeout = 60_000)
   public void testConcurrency() throws Exception
   {
-    rtrTestUtils.makeWorker("worker0");
-    rtrTestUtils.makeWorker("worker1");
+    rtrTestUtils.makeWorker("worker0", 3);
+    rtrTestUtils.makeWorker("worker1", 3);
 
     remoteTaskRunner = rtrTestUtils.makeRemoteTaskRunner(
         new TestRemoteTaskRunnerConfig(new Period("PT3600S"))

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTest.java
@@ -439,7 +439,7 @@ public class RemoteTaskRunnerTest
 
   private void makeWorker() throws Exception
   {
-    worker = rtrTestUtils.makeWorker(workerHost);
+    worker = rtrTestUtils.makeWorker(workerHost, 3);
   }
 
   private void disableWorker() throws Exception
@@ -609,7 +609,7 @@ public class RemoteTaskRunnerTest
         .withQueueInsertionTime(new DateTime("2015-01-01T00:00:01Z"));
     ArrayList<RemoteTaskRunnerWorkItem> workItems = Lists.newArrayList(item1, item2, item3);
     RemoteTaskRunner.sortByInsertionTime(workItems);
-    Assert.assertEquals(item3,workItems.get(0));
+    Assert.assertEquals(item3, workItems.get(0));
     Assert.assertEquals(item2, workItems.get(1));
     Assert.assertEquals(item1, workItems.get(2));
   }
@@ -619,7 +619,11 @@ public class RemoteTaskRunnerTest
   {
     Period timeoutPeriod = Period.millis(1000);
     makeWorker();
-    makeRemoteTaskRunner(new TestRemoteTaskRunnerConfig(timeoutPeriod));
+
+    RemoteTaskRunnerConfig rtrConfig = new TestRemoteTaskRunnerConfig(timeoutPeriod);
+    rtrConfig.setMaxPercentageBlacklistWorkers(100);
+
+    makeRemoteTaskRunner(rtrConfig);
 
     TestRealtimeTask task1 = new TestRealtimeTask(
             "realtime1",
@@ -635,7 +639,7 @@ public class RemoteTaskRunnerTest
     Assert.assertTrue(taskFuture1.get(TIMEOUT_SECONDS, TimeUnit.SECONDS).isFailure());
     Assert.assertEquals(0, remoteTaskRunner.getBlackListedWorkers().size());
     Assert.assertEquals(1,
-            remoteTaskRunner.findWorkerRunningTask(task1.getId()).getCountinouslyFailedTasksCount());
+            remoteTaskRunner.findWorkerRunningTask(task1.getId()).getContinuouslyFailedTasksCount());
 
     TestRealtimeTask task2 = new TestRealtimeTask(
             "realtime2",
@@ -651,7 +655,7 @@ public class RemoteTaskRunnerTest
     Assert.assertTrue(taskFuture2.get(TIMEOUT_SECONDS, TimeUnit.SECONDS).isFailure());
     Assert.assertEquals(1, remoteTaskRunner.getBlackListedWorkers().size());
     Assert.assertEquals(2,
-            remoteTaskRunner.findWorkerRunningTask(task2.getId()).getCountinouslyFailedTasksCount());
+            remoteTaskRunner.findWorkerRunningTask(task2.getId()).getContinuouslyFailedTasksCount());
 
     remoteTaskRunner.cleanBlackListedNode(remoteTaskRunner.findWorkerRunningTask(task2.getId()),
             System.currentTimeMillis() + 2*timeoutPeriod.toStandardDuration().getMillis());
@@ -659,7 +663,7 @@ public class RemoteTaskRunnerTest
     // After backOffTime the nodes are whitelisted
     Assert.assertEquals(0, remoteTaskRunner.getBlackListedWorkers().size());
     Assert.assertEquals(2,
-            remoteTaskRunner.findWorkerRunningTask(task2.getId()).getCountinouslyFailedTasksCount());
+            remoteTaskRunner.findWorkerRunningTask(task2.getId()).getContinuouslyFailedTasksCount());
 
     TestRealtimeTask task3 = new TestRealtimeTask(
             "realtime3",
@@ -675,6 +679,82 @@ public class RemoteTaskRunnerTest
     Assert.assertTrue(taskFuture3.get(TIMEOUT_SECONDS, TimeUnit.SECONDS).isSuccess());
     Assert.assertEquals(0, remoteTaskRunner.getBlackListedWorkers().size());
     Assert.assertEquals(0,
-            remoteTaskRunner.findWorkerRunningTask(task3.getId()).getCountinouslyFailedTasksCount());
+            remoteTaskRunner.findWorkerRunningTask(task3.getId()).getContinuouslyFailedTasksCount());
+  }
+
+  /**
+   * With 2 workers and maxPercentageBlacklistWorkers(25), neither worker should ever be blacklisted even after
+   * exceeding maxRetriesBeforeBlacklist.
+   */
+  @Test
+  public void testBlacklistZKWorkers25Percent() throws Exception
+  {
+    Period timeoutPeriod = Period.millis(1000);
+
+    rtrTestUtils.makeWorker("worker", 10);
+    rtrTestUtils.makeWorker("worker2", 10);
+
+    RemoteTaskRunnerConfig rtrConfig = new TestRemoteTaskRunnerConfig(timeoutPeriod);
+    rtrConfig.setMaxPercentageBlacklistWorkers(25);
+
+    makeRemoteTaskRunner(rtrConfig);
+
+    for (int i = 1; i < 13; i++) {
+      String taskId = String.format("rt-%d", i);
+      TestRealtimeTask task = new TestRealtimeTask(
+          taskId, new TaskResource(taskId, 1), "foo", TaskStatus.success(taskId), jsonMapper
+      );
+
+      Future<TaskStatus> taskFuture = remoteTaskRunner.run(task);
+
+      rtrTestUtils.taskAnnounced(i % 2 == 0 ? "worker2" : "worker", task.getId());
+      rtrTestUtils.mockWorkerRunningTask(i % 2 == 0 ? "worker2" : "worker", task);
+      rtrTestUtils.mockWorkerCompleteFailedTask(i % 2 == 0 ? "worker2" : "worker", task);
+
+      Assert.assertTrue(taskFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS).isFailure());
+      Assert.assertEquals(0, remoteTaskRunner.getBlackListedWorkers().size());
+      Assert.assertEquals(
+          ((i + 1) / 2),
+          remoteTaskRunner.findWorkerRunningTask(task.getId()).getContinuouslyFailedTasksCount()
+      );
+    }
+  }
+
+  /**
+   * With 2 workers and maxPercentageBlacklistWorkers(50), one worker should get blacklisted after the second failure
+   * and the second worker should never be blacklisted even after exceeding maxRetriesBeforeBlacklist.
+   */
+  @Test
+  public void testBlacklistZKWorkers50Percent() throws Exception
+  {
+    Period timeoutPeriod = Period.millis(1000);
+
+    rtrTestUtils.makeWorker("worker", 10);
+    rtrTestUtils.makeWorker("worker2", 10);
+
+    RemoteTaskRunnerConfig rtrConfig = new TestRemoteTaskRunnerConfig(timeoutPeriod);
+    rtrConfig.setMaxPercentageBlacklistWorkers(50);
+
+    makeRemoteTaskRunner(rtrConfig);
+
+    for (int i = 1; i < 13; i++) {
+      String taskId = String.format("rt-%d", i);
+      TestRealtimeTask task = new TestRealtimeTask(
+          taskId, new TaskResource(taskId, 1), "foo", TaskStatus.success(taskId), jsonMapper
+      );
+
+      Future<TaskStatus> taskFuture = remoteTaskRunner.run(task);
+
+      rtrTestUtils.taskAnnounced(i % 2 == 0 || i > 4 ? "worker2" : "worker", task.getId());
+      rtrTestUtils.mockWorkerRunningTask(i % 2 == 0 || i > 4 ? "worker2" : "worker", task);
+      rtrTestUtils.mockWorkerCompleteFailedTask(i % 2 == 0 || i > 4 ? "worker2" : "worker", task);
+
+      Assert.assertTrue(taskFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS).isFailure());
+      Assert.assertEquals(i > 2 ? 1 : 0, remoteTaskRunner.getBlackListedWorkers().size());
+      Assert.assertEquals(
+          i > 4 ? i - 2 : ((i + 1) / 2),
+          remoteTaskRunner.findWorkerRunningTask(task.getId()).getContinuouslyFailedTasksCount()
+      );
+    }
   }
 }

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTestUtils.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTestUtils.java
@@ -138,13 +138,13 @@ public class RemoteTaskRunnerTestUtils
     return remoteTaskRunner;
   }
 
-  Worker makeWorker(final String workerId) throws Exception
+  Worker makeWorker(final String workerId, final int capacity) throws Exception
   {
     Worker worker = new Worker(
         "http",
         workerId,
         workerId,
-        3,
+        capacity,
         "0"
     );
 

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTestUtils.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTestUtils.java
@@ -219,7 +219,7 @@ public class RemoteTaskRunnerTestUtils
     );
   }
 
-  public class TestableRemoteTaskRunner extends RemoteTaskRunner
+  public static class TestableRemoteTaskRunner extends RemoteTaskRunner
   {
     private long currentTimeMillis = System.currentTimeMillis();
 


### PR DESCRIPTION
- Fixes bug where a single worker can get blacklisted with enough failures
- Fixes bug where pending tasks don't get assigned when worker is removed from blacklist
- Fixes concurrent modification exception while iterating through blacklisted nodes
- Fixes NPE if task hasn't been assigned to a worker
- Adds additional logging
- Changes default worker selection strategy to equalDistribution