### PR TITLE
Allow index job to utilize hadoop cluster information from job config.

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerConfig.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerConfig.java
@@ -562,11 +562,7 @@ public class HadoopDruidIndexerConfig
 
   public void addJobProperties(Job job)
   {
-    Configuration conf = job.getConfiguration();
-
-    for (final Map.Entry<String, String> entry : schema.getTuningConfig().getJobProperties().entrySet()) {
-      conf.set(entry.getKey(), entry.getValue());
-    }
+    addJobProperties(job.getConfiguration());
   }
 
   public void addJobProperties(Configuration conf)

--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerConfig.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerConfig.java
@@ -569,6 +569,13 @@ public class HadoopDruidIndexerConfig
     }
   }
 
+  public void addJobProperties(Configuration conf)
+  {
+    for (final Map.Entry<String, String> entry : schema.getTuningConfig().getJobProperties().entrySet()) {
+      conf.set(entry.getKey(), entry.getValue());
+    }
+  }
+
   public void intoConfiguration(Job job)
   {
     Configuration conf = job.getConfiguration();

--- a/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
@@ -100,7 +100,7 @@ public class IndexGeneratorJob implements Jobby
 
   public static List<DataSegment> getPublishedSegments(HadoopDruidIndexerConfig config)
   {
-    final Configuration conf = JobHelper.injectJobProperties(JobHelper.injectSystemProperties(new Configuration()), config);
+    final Configuration conf = JobHelper.injectSystemAndJobProperties(new Configuration(), config);
     final ObjectMapper jsonMapper = HadoopDruidIndexerConfig.JSON_MAPPER;
 
     ImmutableList.Builder<DataSegment> publishedSegmentsBuilder = ImmutableList.builder();

--- a/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
@@ -101,6 +101,8 @@ public class IndexGeneratorJob implements Jobby
   public static List<DataSegment> getPublishedSegments(HadoopDruidIndexerConfig config)
   {
     final Configuration conf = JobHelper.injectSystemProperties(new Configuration());
+    config.addJobProperties(conf);
+
     final ObjectMapper jsonMapper = HadoopDruidIndexerConfig.JSON_MAPPER;
 
     ImmutableList.Builder<DataSegment> publishedSegmentsBuilder = ImmutableList.builder();
@@ -108,7 +110,6 @@ public class IndexGeneratorJob implements Jobby
     final Path descriptorInfoDir = config.makeDescriptorInfoDir();
 
     try {
-      config.addJobProperties(conf);
       FileSystem fs = descriptorInfoDir.getFileSystem(conf);
 
       for (FileStatus status : fs.listStatus(descriptorInfoDir)) {

--- a/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
@@ -100,7 +100,7 @@ public class IndexGeneratorJob implements Jobby
 
   public static List<DataSegment> getPublishedSegments(HadoopDruidIndexerConfig config)
   {
-    final Configuration conf = JobHelper.injectSystemAndJobProperties(new Configuration(), config);
+    final Configuration conf = JobHelper.injectSystemProperties(new Configuration());
     final ObjectMapper jsonMapper = HadoopDruidIndexerConfig.JSON_MAPPER;
 
     ImmutableList.Builder<DataSegment> publishedSegmentsBuilder = ImmutableList.builder();
@@ -108,6 +108,7 @@ public class IndexGeneratorJob implements Jobby
     final Path descriptorInfoDir = config.makeDescriptorInfoDir();
 
     try {
+      config.addJobProperties(conf);
       FileSystem fs = descriptorInfoDir.getFileSystem(conf);
 
       for (FileStatus status : fs.listStatus(descriptorInfoDir)) {

--- a/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
@@ -100,7 +100,7 @@ public class IndexGeneratorJob implements Jobby
 
   public static List<DataSegment> getPublishedSegments(HadoopDruidIndexerConfig config)
   {
-    final Configuration conf = JobHelper.injectSystemProperties(new Configuration());
+    final Configuration conf = JobHelper.injectJobProperties(JobHelper.injectSystemProperties(new Configuration()), config);
     final ObjectMapper jsonMapper = HadoopDruidIndexerConfig.JSON_MAPPER;
 
     ImmutableList.Builder<DataSegment> publishedSegmentsBuilder = ImmutableList.builder();

--- a/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
@@ -339,6 +339,15 @@ public class JobHelper
     return conf;
   }
 
+  public static Configuration injectJobProperties(Configuration conf, HadoopDruidIndexerConfig config)
+  {
+    HadoopIngestionSpec schema = config.getSchema() ;
+    for (final Map.Entry<String, String> entry : schema.getTuningConfig().getJobProperties().entrySet()) {
+      conf.set(entry.getKey(), entry.getValue());
+    }
+    return conf;
+  }
+
   public static void ensurePaths(HadoopDruidIndexerConfig config)
   {
     authenticate(config);
@@ -376,7 +385,7 @@ public class JobHelper
         Path workingPath = config.makeIntermediatePath();
         log.info("Deleting path[%s]", workingPath);
         try {
-          workingPath.getFileSystem(injectSystemProperties(new Configuration())).delete(workingPath, true);
+          workingPath.getFileSystem(injectJobProperties(injectSystemProperties(new Configuration()), config)).delete(workingPath, true);
         }
         catch (IOException e) {
           log.error(e, "Failed to cleanup path[%s]", workingPath);

--- a/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
@@ -339,13 +339,15 @@ public class JobHelper
     return conf;
   }
 
-  public static Configuration injectJobProperties(Configuration conf, HadoopDruidIndexerConfig config)
+  public static Configuration injectSystemAndJobProperties(Configuration conf, HadoopDruidIndexerConfig config)
   {
-    HadoopIngestionSpec schema = config.getSchema() ;
+    Configuration updatedConf = injectSystemProperties(conf);
+    HadoopIngestionSpec schema = config.getSchema();
+
     for (final Map.Entry<String, String> entry : schema.getTuningConfig().getJobProperties().entrySet()) {
-      conf.set(entry.getKey(), entry.getValue());
+      updatedConf.set(entry.getKey(), entry.getValue());
     }
-    return conf;
+    return updatedConf;
   }
 
   public static void ensurePaths(HadoopDruidIndexerConfig config)
@@ -385,7 +387,7 @@ public class JobHelper
         Path workingPath = config.makeIntermediatePath();
         log.info("Deleting path[%s]", workingPath);
         try {
-          workingPath.getFileSystem(injectJobProperties(injectSystemProperties(new Configuration()), config)).delete(workingPath, true);
+          workingPath.getFileSystem(injectSystemAndJobProperties(new Configuration(), config)).delete(workingPath, true);
         }
         catch (IOException e) {
           log.error(e, "Failed to cleanup path[%s]", workingPath);

--- a/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
@@ -339,17 +339,6 @@ public class JobHelper
     return conf;
   }
 
-  public static Configuration injectSystemAndJobProperties(Configuration conf, HadoopDruidIndexerConfig config)
-  {
-    Configuration updatedConf = injectSystemProperties(conf);
-    HadoopIngestionSpec schema = config.getSchema();
-
-    for (final Map.Entry<String, String> entry : schema.getTuningConfig().getJobProperties().entrySet()) {
-      updatedConf.set(entry.getKey(), entry.getValue());
-    }
-    return updatedConf;
-  }
-
   public static void ensurePaths(HadoopDruidIndexerConfig config)
   {
     authenticate(config);
@@ -387,7 +376,9 @@ public class JobHelper
         Path workingPath = config.makeIntermediatePath();
         log.info("Deleting path[%s]", workingPath);
         try {
-          workingPath.getFileSystem(injectSystemAndJobProperties(new Configuration(), config)).delete(workingPath, true);
+          Configuration conf = injectSystemProperties(new Configuration());
+          config.addJobProperties(conf);
+          workingPath.getFileSystem(conf).delete(workingPath, true);
         }
         catch (IOException e) {
           log.error(e, "Failed to cleanup path[%s]", workingPath);


### PR DESCRIPTION
Making changes to allow Hadoop Batch ingestion job to utilize multiple Hadoop clusters for ingesting data. Existing Hadoop based batch ingestion task allow submitter to supply Hadoop cluster related information via jobProperties ( http://druid.io/docs/latest/ingestion/batch-ingestion.html ), but fail on step to publish segments without the new code changes.

This feature is necessary in utilizing transient AWS-EMR clusters for different indexing jobs or have multiple clusters that require indexing different data sets into single DRUID cluster.