### PR TITLE
More informative QueryInterruptedException toString()

### DIFF
--- a/processing/src/main/java/io/druid/query/QueryInterruptedException.java
+++ b/processing/src/main/java/io/druid/query/QueryInterruptedException.java
@@ -21,6 +21,7 @@ package io.druid.query;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.druid.java.util.common.StringUtils;
 
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeoutException;
@@ -107,6 +108,18 @@ public class QueryInterruptedException extends RuntimeException
   public String getHost()
   {
     return host;
+  }
+
+  @Override
+  public String toString()
+  {
+    return StringUtils.nonStrictFormat(
+        "QueryInterruptedException{msg=%s, code=%s, class=%s, host=%s}",
+        getMessage(),
+        errorCode,
+        errorClass,
+        host
+    );
   }
 
   private static String getErrorCodeFromThrowable(Throwable e)

--- a/processing/src/main/java/io/druid/query/QueryInterruptedException.java
+++ b/processing/src/main/java/io/druid/query/QueryInterruptedException.java
@@ -113,7 +113,7 @@ public class QueryInterruptedException extends RuntimeException
   @Override
   public String toString()
   {
-    return StringUtils.nonStrictFormat(
+    return StringUtils.format(
         "QueryInterruptedException{msg=%s, code=%s, class=%s, host=%s}",
         getMessage(),
         errorCode,


### PR DESCRIPTION
This makes the QueryInterruptedException's toString() more informative, fields such as `host` are very useful for troubleshooting.

Previously the toString() would only contain the exception message.