### PR TITLE
Append instead of create log file so that it is possible to logrotate.

### DIFF
--- a/examples/bin/node.sh
+++ b/examples/bin/node.sh
@@ -40,7 +40,7 @@ case $command in
     fi
     if [ ! -d "$PID_DIR" ]; then mkdir -p $PID_DIR; fi
     if [ ! -d "$LOG_DIR" ]; then mkdir -p $LOG_DIR; fi
-    nohup java `cat $CONF_DIR/$nodeType/jvm.config | xargs` -cp $CONF_DIR/_common:$CONF_DIR/$nodeType:$LIB_DIR/*:$HADOOP_CONF_DIR io.druid.cli.Main server $nodeType > $LOG_DIR/$nodeType.log &
+    nohup java `cat $CONF_DIR/$nodeType/jvm.config | xargs` -cp $CONF_DIR/_common:$CONF_DIR/$nodeType:$LIB_DIR/*:$HADOOP_CONF_DIR io.druid.cli.Main server $nodeType >> $LOG_DIR/$nodeType.log &
     nodeType_PID=$!
     echo $nodeType_PID > $pid
     echo "Started $nodeType node ($nodeType_PID)"


### PR DESCRIPTION
In long running environment log files can grow without bound because of persistent error and can destabilize the system by filling up disk space. It is usefully to manage log files growth by automatic rotation, compression, removal, and moving them. It is not possible to rotate log file if ">" is used, changing the startup script to use ">>"  which allow to log file file management.