### PR TITLE
[Backport] Add HistoricalCursor.getReadableOffset() to access unwrapped offset in selectors

### DIFF
--- a/processing/src/main/java/io/druid/segment/FilteredOffset.java
+++ b/processing/src/main/java/io/druid/segment/FilteredOffset.java
@@ -162,7 +162,7 @@ public final class FilteredOffset extends Offset
           @Override
           public boolean matches()
           {
-            int currentOffset = holder.getOffset().getOffset();
+            int currentOffset = holder.getReadableOffset().getOffset();
             while (iterOffset > currentOffset && iter.hasNext()) {
               iterOffset = iter.next();
             }
@@ -174,6 +174,7 @@ public final class FilteredOffset extends Offset
           public void inspectRuntimeShape(RuntimeShapeInspector inspector)
           {
             inspector.visit("holder", holder);
+            inspector.visit("offset", holder.getReadableOffset());
             inspector.visit("iter", iter);
           }
         };
@@ -185,7 +186,7 @@ public final class FilteredOffset extends Offset
           @Override
           public boolean matches()
           {
-            int currentOffset = holder.getOffset().getOffset();
+            int currentOffset = holder.getReadableOffset().getOffset();
             while (iterOffset < currentOffset && iter.hasNext()) {
               iterOffset = iter.next();
             }
@@ -197,6 +198,7 @@ public final class FilteredOffset extends Offset
           public void inspectRuntimeShape(RuntimeShapeInspector inspector)
           {
             inspector.visit("holder", holder);
+            inspector.visit("offset", holder.getReadableOffset());
             inspector.visit("iter", iter);
           }
         };

--- a/processing/src/main/java/io/druid/segment/column/SimpleDictionaryEncodedColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/SimpleDictionaryEncodedColumn.java
@@ -158,7 +158,7 @@ public class SimpleDictionaryEncodedColumn
         @Override
         public IndexedInts getRow()
         {
-          return multiValueColumn.get(offsetHolder.getOffset().getOffset());
+          return multiValueColumn.get(offsetHolder.getReadableOffset().getOffset());
         }
 
         @Override
@@ -184,7 +184,7 @@ public class SimpleDictionaryEncodedColumn
         {
           inspector.visit("multiValueColumn", multiValueColumn);
           inspector.visit("offsetHolder", offsetHolder);
-          inspector.visit("offset", offsetHolder.getOffset());
+          inspector.visit("offset", offsetHolder.getReadableOffset());
           inspector.visit("extractionFn", extractionFn);
         }
       }
@@ -202,7 +202,7 @@ public class SimpleDictionaryEncodedColumn
         @Override
         public int getRowValue()
         {
-          return column.get(offsetHolder.getOffset().getOffset());
+          return column.get(offsetHolder.getReadableOffset().getOffset());
         }
 
         @Override
@@ -274,7 +274,7 @@ public class SimpleDictionaryEncodedColumn
         {
           inspector.visit("column", column);
           inspector.visit("offsetHolder", offsetHolder);
-          inspector.visit("offset", offsetHolder.getOffset());
+          inspector.visit("offset", offsetHolder.getReadableOffset());
           inspector.visit("extractionFn", extractionFn);
         }
       }

--- a/processing/src/main/java/io/druid/segment/historical/OffsetHolder.java
+++ b/processing/src/main/java/io/druid/segment/historical/OffsetHolder.java
@@ -20,8 +20,16 @@
 package io.druid.segment.historical;
 
 import io.druid.segment.data.Offset;
+import io.druid.segment.data.ReadableOffset;
 
 public interface OffsetHolder
 {
   Offset getOffset();
+
+  /**
+   * Should return the same, or a "view" of the same offset as {@link #getOffset()}. The difference is that smaller
+   * interface allows to return unwrapped underlying offset sometimes, e. g. {@link
+   * io.druid.segment.FilteredOffset#baseOffset}, instead of the wrapper {@link io.druid.segment.FilteredOffset}.
+   */
+  ReadableOffset getReadableOffset();
 }


### PR DESCRIPTION
Backport of #4633 to 0.10.1.