### PR TITLE
Parallel sort for ConcurrentGrouper

### DIFF
--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/ConcurrentGrouper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/ConcurrentGrouper.java
@@ -23,17 +23,24 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
 import io.druid.java.util.common.ISE;
+import io.druid.query.AbstractPrioritizedCallable;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.groupby.orderby.DefaultLimitSpec;
 import io.druid.segment.ColumnSelectorFactory;
 
+import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 /**
  * Grouper based around a set of underlying {@link SpillingGrouper} instances. Thread-safe.
@@ -51,7 +58,6 @@ public class ConcurrentGrouper<KeyType> implements Grouper<KeyType>
   private final AtomicInteger threadNumber = new AtomicInteger();
   private volatile boolean spilling = false;
   private volatile boolean closed = false;
-  private final Comparator<Grouper.Entry<KeyType>> keyObjComparator;
 
   private final Supplier<ByteBuffer> bufferSupplier;
   private final ColumnSelectorFactory columnSelectorFactory;
@@ -65,6 +71,10 @@ public class ConcurrentGrouper<KeyType> implements Grouper<KeyType>
   private final KeySerdeFactory<KeyType> keySerdeFactory;
   private final DefaultLimitSpec limitSpec;
   private final boolean sortHasNonGroupingFields;
+  private final Comparator<Grouper.Entry<KeyType>> keyObjComparator;
+  @Nullable
+  private final ListeningExecutorService grouperSorter;
+  private final int priority;
 
   private volatile boolean initialized = false;
 
@@ -80,7 +90,9 @@ public class ConcurrentGrouper<KeyType> implements Grouper<KeyType>
       final ObjectMapper spillMapper,
       final int concurrencyHint,
       final DefaultLimitSpec limitSpec,
-      final boolean sortHasNonGroupingFields
+      final boolean sortHasNonGroupingFields,
+      @Nullable final ListeningExecutorService grouperSorter,
+      final int priority
   )
   {
     Preconditions.checkArgument(concurrencyHint > 0, "concurrencyHint > 0");
@@ -108,6 +120,8 @@ public class ConcurrentGrouper<KeyType> implements Grouper<KeyType>
     this.limitSpec = limitSpec;
     this.sortHasNonGroupingFields = sortHasNonGroupingFields;
     this.keyObjComparator = keySerdeFactory.objectComparator(sortHasNonGroupingFields);
+    this.grouperSorter = grouperSorter;
+    this.priority = priority;
   }
 
   @Override
@@ -216,15 +230,53 @@ public class ConcurrentGrouper<KeyType> implements Grouper<KeyType>
       throw new ISE("Grouper is closed");
     }
 
-    final List<Iterator<Entry<KeyType>>> iterators = new ArrayList<>(groupers.size());
+    return Groupers.mergeIterators(
+        sorted && isParallelSortAvailable() ? parallelSortAndGetGroupersIterator() : getGroupersIterator(sorted),
+        sorted ? keyObjComparator : null
+    );
+  }
 
-    for (Grouper<KeyType> grouper : groupers) {
-      synchronized (grouper) {
-        iterators.add(grouper.iterator(sorted));
-      }
+  private boolean isParallelSortAvailable()
+  {
+    return grouperSorter != null && concurrencyHint > 1;
+  }
+
+  private List<Iterator<Entry<KeyType>>> parallelSortAndGetGroupersIterator()
+  {
+    // The number of groupers is same with the number of processing threads in grouperSorter
+    final List<ListenableFuture<Iterator<Entry<KeyType>>>> futures = groupers
+        .stream()
+        .map(grouper ->
+                 grouperSorter.submit(
+                     new AbstractPrioritizedCallable<Iterator<Entry<KeyType>>>(priority)
+                     {
+                       @Override
+                       public Iterator<Entry<KeyType>> call() throws Exception
+                       {
+                         synchronized (grouper) {
+                           return grouper.iterator(true);
+                         }
+                       }
+                     }
+                 )
+        ).collect(Collectors.toList());
+
+    try {
+      return Futures.allAsList(futures).get();
     }
+    catch (InterruptedException | ExecutionException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
-    return Groupers.mergeIterators(iterators, sorted ? keyObjComparator : null);
+  private List<Iterator<Entry<KeyType>>> getGroupersIterator(boolean sorted)
+  {
+    return groupers.stream()
+                   .map(grouper -> {
+                     synchronized (grouper) {
+                       return grouper.iterator(sorted);
+                     }
+                   }).collect(Collectors.toList());
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByMergingQueryRunnerV2.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByMergingQueryRunnerV2.java
@@ -194,7 +194,9 @@ public class GroupByMergingQueryRunnerV2 implements QueryRunner<Row>
                   concurrencyHint,
                   temporaryStorage,
                   spillMapper,
-                  combiningAggregatorFactories
+                  combiningAggregatorFactories,
+                  exec,
+                  priority
               );
               final Grouper<RowBasedKey> grouper = pair.lhs;
               final Accumulator<AggregateResult, Row> accumulator = pair.rhs;

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByMergingQueryRunnerV2.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByMergingQueryRunnerV2.java
@@ -196,7 +196,9 @@ public class GroupByMergingQueryRunnerV2 implements QueryRunner<Row>
                   spillMapper,
                   combiningAggregatorFactories,
                   exec,
-                  priority
+                  priority,
+                  hasTimeout,
+                  timeoutAt
               );
               final Grouper<RowBasedKey> grouper = pair.lhs;
               final Accumulator<AggregateResult, Row> accumulator = pair.rhs;

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByRowProcessor.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByRowProcessor.java
@@ -155,12 +155,9 @@ public class GroupByRowProcessor
                       return mergeBufferHolder.get();
                     }
                   },
-                  -1,
                   temporaryStorage,
                   spillMapper,
-                  aggregatorFactories,
-                  null,
-                  -1 // priority doesn't matter if grouperMerger is null
+                  aggregatorFactories
               );
               final Grouper<RowBasedKey> grouper = pair.lhs;
               final Accumulator<AggregateResult, Row> accumulator = pair.rhs;

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByRowProcessor.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByRowProcessor.java
@@ -158,7 +158,9 @@ public class GroupByRowProcessor
                   -1,
                   temporaryStorage,
                   spillMapper,
-                  aggregatorFactories
+                  aggregatorFactories,
+                  null,
+                  -1 // priority doesn't matter if grouperMerger is null
               );
               final Grouper<RowBasedKey> grouper = pair.lhs;
               final Accumulator<AggregateResult, Row> accumulator = pair.rhs;

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/Grouper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/Grouper.java
@@ -102,7 +102,8 @@ public interface Grouper<KeyType> extends Closeable
    * <p>
    * Once this method is called, writes are no longer safe. After you are done with the iterator returned by this
    * method, you should either call {@link #close()} (if you are done with the Grouper), {@link #reset()} (if you
-   * want to reuse it), or {@link #iterator(boolean)} again if you want another iterator.
+   * want to reuse it), or {@link #iterator(boolean)} again if you want another iterator. This method is not thread-safe
+   * and must not be called by multiple threads concurrently.
    * <p>
    * If "sorted" is true then the iterator will return sorted results. It will use KeyType's natural ordering on
    * deserialized objects, and will use the {@link KeySerde#comparator()} on serialized objects. Woe be unto you

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -33,6 +33,7 @@ import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Floats;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
+import com.google.common.util.concurrent.ListeningExecutorService;
 import io.druid.data.input.MapBasedRow;
 import io.druid.data.input.Row;
 import io.druid.java.util.common.IAE;
@@ -65,6 +66,7 @@ import io.druid.segment.column.ValueType;
 import io.druid.segment.data.IndexedInts;
 import org.joda.time.DateTime;
 
+import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -92,7 +94,9 @@ public class RowBasedGrouperHelper
       final int concurrencyHint,
       final LimitedTemporaryStorage temporaryStorage,
       final ObjectMapper spillMapper,
-      final AggregatorFactory[] aggregatorFactories
+      final AggregatorFactory[] aggregatorFactories,
+      @Nullable final ListeningExecutorService grouperSorter,
+      final int priority
   )
   {
     // concurrencyHint >= 1 for concurrent groupers, -1 for single-threaded
@@ -160,7 +164,9 @@ public class RowBasedGrouperHelper
           spillMapper,
           concurrencyHint,
           limitSpec,
-          sortHasNonGroupingFields
+          sortHasNonGroupingFields,
+          grouperSorter,
+          priority
       );
     }
 

--- a/processing/src/test/java/io/druid/query/groupby/epinephelinae/ConcurrentGrouperTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/epinephelinae/ConcurrentGrouperTest.java
@@ -21,6 +21,8 @@ package io.druid.query.groupby.epinephelinae;
 
 import com.google.common.base.Supplier;
 import com.google.common.primitives.Longs;
+import com.google.common.util.concurrent.MoreExecutors;
+import io.druid.concurrent.Execs;
 import io.druid.java.util.common.IAE;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
@@ -202,7 +204,9 @@ public class ConcurrentGrouperTest
         null,
         8,
         null,
-        false
+        false,
+        MoreExecutors.listeningDecorator(Execs.multiThreaded(4, "concurrent-grouper-test-%d")),
+        0
     );
 
     Future<?>[] futures = new Future[8];

--- a/processing/src/test/java/io/druid/query/groupby/epinephelinae/ConcurrentGrouperTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/epinephelinae/ConcurrentGrouperTest.java
@@ -189,7 +189,7 @@ public class ConcurrentGrouperTest
     }
   };
 
-  @Test
+  @Test(timeout = 5000L)
   public void testAggregate() throws InterruptedException, ExecutionException
   {
     final ConcurrentGrouper<Long> grouper = new ConcurrentGrouper<>(
@@ -206,6 +206,8 @@ public class ConcurrentGrouperTest
         null,
         false,
         MoreExecutors.listeningDecorator(Execs.multiThreaded(4, "concurrent-grouper-test-%d")),
+        0,
+        false,
         0
     );
 


### PR DESCRIPTION
```ConcurrentGrouper.iterator()``` is one of the bottlenecks for groupBy v2 because it sorts the underlying groupers sequentially to make a merged iterator when ```sorted``` is true. With this patch, historicals can sort the groupers in parallel. The performance gain is about 10% without serde and spilling. Here is the benchmark result.

```
master

Benchmark                                              (defaultStrategy)  (initialBuckets)  (numProcessingThreads)  (numSegments)  (queryGranularity)  (rowsPerSegment)  (schemaAndQuery)  Mode  Cnt       Score       Error  Units
GroupByBenchmark.queryMultiQueryableIndex                             v2                -1                       8             16                 all            100000           basic.A  avgt   30  218997.450 ±  2063.168  us/op
GroupByBenchmark.queryMultiQueryableIndexWithSerde                    v2                -1                       8             16                 all            100000           basic.A  avgt   30  339409.220 ± 22152.255  us/op
GroupByBenchmark.queryMultiQueryableIndexWithSpilling                 v2                -1                       8             16                 all            100000           basic.A  avgt   30  782910.486 ±  4979.416  us/op


patch

Benchmark                                              (defaultStrategy)  (initialBuckets)  (numProcessingThreads)  (numSegments)  (queryGranularity)  (rowsPerSegment)  (schemaAndQuery)  Mode  Cnt       Score      Error  Units
GroupByBenchmark.queryMultiQueryableIndex                             v2                -1                       8             16                 all            100000           basic.A  avgt   30  197634.705 ± 1401.627  us/op
GroupByBenchmark.queryMultiQueryableIndexWithSerde                    v2                -1                       8             16                 all            100000           basic.A  avgt   30  321135.049 ± 2654.269  us/op
GroupByBenchmark.queryMultiQueryableIndexWithSpilling                 v2                -1                       8             16                 all            100000           basic.A  avgt   30  779848.190 ± 5956.896  us/op
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/druid-io/druid/4660)
<!-- Reviewable:end -->
