### PR TITLE
Fix spacing in KafkaEmitterConfig

### DIFF
--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
@@ -55,7 +55,7 @@ public class KafkaEmitterConfig
     this.metricTopic = Preconditions.checkNotNull(metricTopic, "metric.topic can not be null");
     this.alertTopic = Preconditions.checkNotNull(alertTopic, "alert.topic can not be null");
     this.clusterName = clusterName;
-    this.kafkaProducerConfig = kafkaProducerConfig == null? ImmutableMap.<String,String>of() : kafkaProducerConfig;
+    this.kafkaProducerConfig = kafkaProducerConfig == null ? ImmutableMap.of() : kafkaProducerConfig;
   }
 
   @JsonProperty


### PR DESCRIPTION
Fixes build. The reason is unclean merge of #4608 and #4651.