### PR TITLE
Fix NPE when locations are empty

### DIFF
--- a/docs/content/configuration/historical.md
+++ b/docs/content/configuration/historical.md
@@ -31,7 +31,7 @@ The historical node uses several of the global configs in [Configuration](../con
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.segmentCache.locations`|Segments assigned to a Historical node are first stored on the local file system (in a disk cache) and then served by the Historical node. These locations define where that local cache resides. | none (no caching) |
+|`druid.segmentCache.locations`|Segments assigned to a Historical node are first stored on the local file system (in a disk cache) and then served by the Historical node. These locations define where that local cache resides. This value cannot be NULL or EMPTY. Here is an example druid.segmentCache.locations=[{"path": "/mnt/druidSegments", "maxSize": 10000}].| none |
 |`druid.segmentCache.deleteOnRemove`|Delete segment files from cache once a node is no longer serving a segment.|true|
 |`druid.segmentCache.dropSegmentDelayMillis`|How long a node delays before completely dropping segment.|30000 (30 seconds)|
 |`druid.segmentCache.infoDir`|Historical nodes keep track of the segments they are serving so that when the process is restarted they can reload the same segments without waiting for the Coordinator to reassign. This path defines where this metadata is kept. Directory will be created if needed.|${first_location}/info_dir|

--- a/docs/content/configuration/historical.md
+++ b/docs/content/configuration/historical.md
@@ -31,7 +31,7 @@ The historical node uses several of the global configs in [Configuration](../con
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.segmentCache.locations`|Segments assigned to a Historical node are first stored on the local file system (in a disk cache) and then served by the Historical node. These locations define where that local cache resides. This value cannot be NULL or EMPTY. Here is an example druid.segmentCache.locations=[{"path": "/mnt/druidSegments", "maxSize": 10000}].| none |
+|`druid.segmentCache.locations`|Segments assigned to a Historical node are first stored on the local file system (in a disk cache) and then served by the Historical node. These locations define where that local cache resides. This value cannot be NULL or EMPTY. Here is an example `druid.segmentCache.locations=[{"path": "/mnt/druidSegments", "maxSize": 10000}]`.| none |
 |`druid.segmentCache.deleteOnRemove`|Delete segment files from cache once a node is no longer serving a segment.|true|
 |`druid.segmentCache.dropSegmentDelayMillis`|How long a node delays before completely dropping segment.|30000 (30 seconds)|
 |`druid.segmentCache.infoDir`|Historical nodes keep track of the segments they are serving so that when the process is restarted they can reload the same segments without waiting for the Coordinator to reassign. This path defines where this metadata is kept. Directory will be created if needed.|${first_location}/info_dir|

--- a/server/src/main/java/io/druid/segment/loading/SegmentLoaderConfig.java
+++ b/server/src/main/java/io/druid/segment/loading/SegmentLoaderConfig.java
@@ -85,7 +85,10 @@ public class SegmentLoaderConfig
   public File getInfoDir()
   {
     if (infoDir == null) {
-      infoDir = new File(locations.get(0).getPath(), "info_dir");
+      StorageLocationConfig storageLocation = locations.get(0);
+      if (storageLocation != null) {
+        infoDir = new File(storageLocation.getPath(), "info_dir");
+      }
     }
 
     return infoDir;

--- a/server/src/main/java/io/druid/segment/loading/SegmentLoaderConfig.java
+++ b/server/src/main/java/io/druid/segment/loading/SegmentLoaderConfig.java
@@ -21,6 +21,7 @@ package io.druid.segment.loading;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Lists;
+import io.druid.java.util.common.ISE;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import java.io.File;
@@ -85,10 +86,11 @@ public class SegmentLoaderConfig
   public File getInfoDir()
   {
     if (infoDir == null) {
-      StorageLocationConfig storageLocation = locations.get(0);
-      if (storageLocation != null) {
-        infoDir = new File(storageLocation.getPath(), "info_dir");
+
+      if (locations == null || locations.size() == 0) {
+        throw new ISE("You have no segment cache locations defined. Please configure druid.segmentCache.locations to use one or more locations.");
       }
+      infoDir = new File(locations.get(0).getPath(), "info_dir");
     }
 
     return infoDir;


### PR DESCRIPTION
Fix NPE when locations are empty. 
Fix docs making the config variable description more verbose.