### PR TITLE
move row up/down for null metric ordering

### DIFF
--- a/processing/src/main/java/io/druid/query/groupby/orderby/DefaultLimitSpec.java
+++ b/processing/src/main/java/io/druid/query/groupby/orderby/DefaultLimitSpec.java
@@ -255,6 +255,13 @@ public class DefaultLimitSpec implements LimitSpec
       @Override
       public int compare(Row left, Row right)
       {
+        if (left.getRaw(column) == null & right.getRaw(column) == null) {
+          return 0;
+        } else if (left.getRaw(column) == null) {
+          return 1;
+        } else if (right.getRaw(column) == null) {
+          return -1;
+        }
         return comparator.compare(left.getRaw(column), right.getRaw(column));
       }
     };

--- a/processing/src/main/java/io/druid/query/groupby/orderby/DefaultLimitSpec.java
+++ b/processing/src/main/java/io/druid/query/groupby/orderby/DefaultLimitSpec.java
@@ -249,22 +249,7 @@ public class DefaultLimitSpec implements LimitSpec
 
   private Ordering<Row> metricOrdering(final String column, final Comparator comparator)
   {
-    return new Ordering<Row>()
-    {
-      @SuppressWarnings("unchecked")
-      @Override
-      public int compare(Row left, Row right)
-      {
-        if (left.getRaw(column) == null & right.getRaw(column) == null) {
-          return 0;
-        } else if (left.getRaw(column) == null) {
-          return 1;
-        } else if (right.getRaw(column) == null) {
-          return -1;
-        }
-        return comparator.compare(left.getRaw(column), right.getRaw(column));
-      }
-    };
+    return Ordering.from(Comparator.comparing((Row row) -> row.getRaw(column), Comparator.nullsFirst(comparator)));
   }
 
   private Ordering<Row> dimensionOrdering(final String dimension, final StringComparator comparator)

--- a/processing/src/main/java/io/druid/query/groupby/orderby/DefaultLimitSpec.java
+++ b/processing/src/main/java/io/druid/query/groupby/orderby/DefaultLimitSpec.java
@@ -249,25 +249,12 @@ public class DefaultLimitSpec implements LimitSpec
 
   private Ordering<Row> metricOrdering(final String column, final Comparator comparator)
   {
-    return Ordering.from(Comparator.comparing((Row row) -> row.getRaw(column), Comparator.nullsFirst(comparator)));
+    return Ordering.from(Comparator.comparing((Row row) -> row.getRaw(column), Comparator.nullsLast(comparator)));
   }
 
   private Ordering<Row> dimensionOrdering(final String dimension, final StringComparator comparator)
   {
-    return Ordering.from(comparator)
-                   .nullsFirst()
-                   .onResultOf(
-                       new Function<Row, String>()
-                       {
-                         @Override
-                         public String apply(Row input)
-                         {
-                           // Multi-value dimensions have all been flattened at this point;
-                           final List<String> dimList = input.getDimension(dimension);
-                           return dimList.isEmpty() ? null : dimList.get(0);
-                         }
-                       }
-                   );
+    return Ordering.from(Comparator.comparing((Row row) -> row.getDimension(dimension).isEmpty() ? null : row.getDimension(dimension).get(0), Comparator.nullsFirst(comparator)));
   }
 
   @Override


### PR DESCRIPTION
when metrics sorted with null value - druid breaks
with this PR - we can check for nulls on left and right and move the row up/down accordingly