### PR TITLE
free() dictionary merging buffers in IndexMerger

### DIFF
--- a/processing/src/main/java/io/druid/segment/StringDimensionMergerV9.java
+++ b/processing/src/main/java/io/druid/segment/StringDimensionMergerV9.java
@@ -295,6 +295,9 @@ public class StringDimensionMergerV9 implements DimensionMergerV9<int[]>
     try (
         Closeable toCloseEncodedValueWriter = encodedValueWriter;
         Closeable toCloseBitmapWriter = bitmapWriter;
+        // We need to free the ByteBuffers allocated by the dictionary merge iterator here,
+        // these buffers are used by dictIdSeeker in mergeBitmaps() below. The iterator is created and only used
+        // in writeMergedValueMetadata(), but the buffers are still used until after mergeBitmaps().
         Closeable toCloseDictionaryMergeIterator = dictionaryMergeIterator;
         Closeable dimValsMappedUnmapper = new Closeable()
     {

--- a/processing/src/test/java/io/druid/segment/DictionaryMergeIteratorTest.java
+++ b/processing/src/test/java/io/druid/segment/DictionaryMergeIteratorTest.java
@@ -31,7 +31,7 @@ public class DictionaryMergeIteratorTest
 {
 
   @Test
-  public void basicTest()
+  public void basicTest() throws Exception
   {
     // a b c d e f
     String[] s1 = {"a", "c", "d", "e"};   // 0 2 3 4


### PR DESCRIPTION
Direct buffers allocated for merging String column dictionaries are not explicitly deallocated (see this comment for context: https://github.com/druid-io/druid/pull/4631#discussion_r132332250)

This PR deallocates those buffers using ByteBufferUtils.free() after bitmap indices are written.
