### PR TITLE
add localhost as advertised hostname

### DIFF
--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -245,7 +245,7 @@ public class KafkaIndexTaskTest
         zkServer.getConnectString(),
         null,
         1,
-        ImmutableMap.of("num.partitions", "2", "advertised.host.name", "localhost")
+        ImmutableMap.of("num.partitions", "2")
     );
     kafkaServer.start();
 

--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -245,7 +245,7 @@ public class KafkaIndexTaskTest
         zkServer.getConnectString(),
         null,
         1,
-        ImmutableMap.of("num.partitions", "2")
+        ImmutableMap.of("num.partitions", "2", "advertised.host.name", "localhost")
     );
     kafkaServer.start();
 

--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/test/TestBroker.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/test/TestBroker.java
@@ -77,6 +77,7 @@ public class TestBroker implements Closeable
     props.setProperty("log.dirs", directory.toString());
     props.setProperty("broker.id", String.valueOf(id));
     props.setProperty("port", String.valueOf(new Random().nextInt(9999) + 10000));
+    props.setProperty("advertised.host.name", "localhost");
     props.putAll(brokerProps);
 
     final KafkaConfig config = new KafkaConfig(props);


### PR DESCRIPTION
Many times KafkaIndexingTaskTests times out while testing locally, setting `advertised.host.name` to `localhost` to prevent that