### PR TITLE
DruidLeaderSelector interface for leader election and Curator based impl.

### DIFF
--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -71,7 +71,6 @@ The indexing service also uses its own set of paths. These configs can be includ
 |`druid.zk.paths.indexer.announcementsPath`|Middle managers announce themselves here.|`${druid.zk.paths.indexer.base}/announcements`|
 |`druid.zk.paths.indexer.tasksPath`|Used to assign tasks to middle managers.|`${druid.zk.paths.indexer.base}/tasks`|
 |`druid.zk.paths.indexer.statusPath`|Parent path for announcement of task statuses.|`${druid.zk.paths.indexer.base}/status`|
-|`druid.zk.paths.indexer.leaderLatchPath`|Used for Overlord leader election.|`${druid.zk.paths.indexer.base}/leaderLatchPath`|
 
 If `druid.zk.paths.base` and `druid.zk.paths.indexer.base` are both set, and none of the other `druid.zk.paths.*` or `druid.zk.paths.indexer.*` values are set, then the other properties will be evaluated relative to their respective `base`.
 For example, if `druid.zk.paths.base` is set to `/druid1` and `druid.zk.paths.indexer.base` is set to `/druid2` then `druid.zk.paths.announcementsPath` will default to `/druid1/announcements` while `druid.zk.paths.indexer.announcementsPath` will default to `/druid2/announcements`.

--- a/indexing-service/src/main/java/io/druid/server/initialization/IndexerZkConfig.java
+++ b/indexing-service/src/main/java/io/druid/server/initialization/IndexerZkConfig.java
@@ -35,8 +35,7 @@ public class IndexerZkConfig
       @JsonProperty("base") String base,
       @JsonProperty("announcementsPath") String announcementsPath,
       @JsonProperty("tasksPath") String tasksPath,
-      @JsonProperty("statusPath") String statusPath,
-      @JsonProperty("leaderLatchPath") String leaderLatchPath
+      @JsonProperty("statusPath") String statusPath
   )
   {
     this.zkPathsConfig = zkPathsConfig;
@@ -44,7 +43,6 @@ public class IndexerZkConfig
     this.announcementsPath = announcementsPath;
     this.tasksPath = tasksPath;
     this.statusPath = statusPath;
-    this.leaderLatchPath = leaderLatchPath;
   }
 
   @JacksonInject
@@ -61,9 +59,6 @@ public class IndexerZkConfig
 
   @JsonProperty
   private final String statusPath;
-
-  @JsonProperty
-  private final String leaderLatchPath;
 
   private String defaultIndexerPath(final String subPath)
   {
@@ -88,11 +83,6 @@ public class IndexerZkConfig
   public String getStatusPath()
   {
     return statusPath == null ? defaultIndexerPath("status") : statusPath;
-  }
-
-  public String getLeaderLatchPath()
-  {
-    return leaderLatchPath == null ? defaultIndexerPath("leaderLatchPath") : leaderLatchPath;
   }
 
   public ZkPathsConfig getZkPathsConfig()
@@ -120,9 +110,6 @@ public class IndexerZkConfig
     if (base != null ? !base.equals(that.base) : that.base != null) {
       return false;
     }
-    if (leaderLatchPath != null ? !leaderLatchPath.equals(that.leaderLatchPath) : that.leaderLatchPath != null) {
-      return false;
-    }
     if (statusPath != null ? !statusPath.equals(that.statusPath) : that.statusPath != null) {
       return false;
     }
@@ -144,7 +131,6 @@ public class IndexerZkConfig
     result = 31 * result + (announcementsPath != null ? announcementsPath.hashCode() : 0);
     result = 31 * result + (tasksPath != null ? tasksPath.hashCode() : 0);
     result = 31 * result + (statusPath != null ? statusPath.hashCode() : 0);
-    result = 31 * result + (leaderLatchPath != null ? leaderLatchPath.hashCode() : 0);
     return result;
   }
 }

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTestUtils.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTestUtils.java
@@ -125,7 +125,7 @@ public class RemoteTaskRunnerTestUtils
               {
                 return basePath;
               }
-            }, null, null, null, null, null
+            }, null, null, null, null
         ),
         cf,
         new PathChildrenCacheFactory.Builder(),

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/http/OverlordTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/http/OverlordTest.java
@@ -155,11 +155,10 @@ public class OverlordTest
     taskCompletionCountDownLatches[0] = new CountDownLatch(1);
     taskCompletionCountDownLatches[1] = new CountDownLatch(1);
     announcementLatch = new CountDownLatch(1);
-    IndexerZkConfig indexerZkConfig = new IndexerZkConfig(new ZkPathsConfig(), null, null, null, null, null);
+    IndexerZkConfig indexerZkConfig = new IndexerZkConfig(new ZkPathsConfig(), null, null, null, null);
     setupServerAndCurator();
     curator.start();
     curator.blockUntilConnected();
-    curator.create().creatingParentsIfNeeded().forPath(indexerZkConfig.getLeaderLatchPath());
     druidNode = new DruidNode("hey", "what", 1234, null, new ServerConfig());
     ServiceEmitter serviceEmitter = new NoopServiceEmitter();
     taskMaster = new TaskMaster(

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/http/OverlordTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/http/OverlordTest.java
@@ -454,17 +454,13 @@ public class OverlordTest
     public void registerListener(Listener listener)
     {
       this.listener = listener;
-    }
 
-    @Override
-    public void start()
-    {
       leader = "what:1234";
       listener.becomeLeader();
     }
 
     @Override
-    public void stop()
+    public void unregisterListener()
     {
       leader = null;
       listener.stopBeingLeader();

--- a/indexing-service/src/test/java/io/druid/indexing/worker/WorkerTaskMonitorTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/worker/WorkerTaskMonitorTest.java
@@ -126,7 +126,7 @@ public class WorkerTaskMonitorTest
               {
                 return basePath;
               }
-            }, null, null, null, null, null
+            }, null, null, null, null
         ),
         new TestRemoteTaskRunnerConfig(new Period("PT1S")),
         cf,

--- a/indexing-service/src/test/java/io/druid/indexing/worker/http/WorkerResourceTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/worker/http/WorkerResourceTest.java
@@ -87,7 +87,7 @@ public class WorkerResourceTest
           {
             return basePath;
           }
-        }, null, null, null, null, null),
+        }, null, null, null, null),
         new RemoteTaskRunnerConfig(),
         cf,
         worker

--- a/indexing-service/src/test/java/io/druid/server/initialization/IndexerZkConfigTest.java
+++ b/indexing-service/src/test/java/io/druid/server/initialization/IndexerZkConfigTest.java
@@ -156,7 +156,7 @@ public class IndexerZkConfigTest
     );
     indexerZkConfig.inject(propertyValues, configurator);
 
-    Assert.assertEquals("/druid/indexer/leaderLatchPath", indexerZkConfig.get().get().getLeaderLatchPath());
+    Assert.assertEquals("/druid/indexer/tasks", indexerZkConfig.get().get().getTasksPath());
   }
 
   @Test
@@ -245,7 +245,7 @@ public class IndexerZkConfigTest
 
     ZkPathsConfig zkPathsConfig1 = zkPathsConfig.get().get();
 
-    IndexerZkConfig indexerZkConfig = new IndexerZkConfig(zkPathsConfig1, null, null, null, null, null);
+    IndexerZkConfig indexerZkConfig = new IndexerZkConfig(zkPathsConfig1, null, null, null, null);
 
     Assert.assertEquals("/druid/metrics/indexer", indexerZkConfig.getBase());
     Assert.assertEquals("/druid/metrics/indexer/announcements", indexerZkConfig.getAnnouncementsPath());
@@ -262,8 +262,7 @@ public class IndexerZkConfigTest
         "/druid/prod",
         "/druid/prod/a",
         "/druid/prod/t",
-        "/druid/prod/s",
-        "/druid/prod/l"
+        "/druid/prod/s"
     );
 
     Map<String, String> value = mapper.readValue(
@@ -276,8 +275,7 @@ public class IndexerZkConfigTest
         value.get("base"),
         value.get("announcementsPath"),
         value.get("tasksPath"),
-        value.get("statusPath"),
-        value.get("leaderLatchPath")
+        value.get("statusPath")
     );
 
     Assert.assertEquals(indexerZkConfig, newConfig);

--- a/integration-tests/src/main/java/io/druid/testing/guice/DruidTestModule.java
+++ b/integration-tests/src/main/java/io/druid/testing/guice/DruidTestModule.java
@@ -35,6 +35,9 @@ import io.druid.curator.CuratorConfig;
 import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.ManageLifecycle;
 import io.druid.guice.annotations.Client;
+import io.druid.guice.annotations.Self;
+import io.druid.server.DruidNode;
+import io.druid.server.initialization.ServerConfig;
 import io.druid.testing.IntegrationTestingConfig;
 import io.druid.testing.IntegrationTestingConfigProvider;
 import io.druid.testing.IntegrationTestingCuratorConfig;
@@ -52,6 +55,11 @@ public class DruidTestModule implements Module
     JsonConfigProvider.bind(binder, "druid.test.config", IntegrationTestingConfigProvider.class);
 
     binder.bind(CuratorConfig.class).to(IntegrationTestingCuratorConfig.class);
+
+    // Bind DruidNode instance to make Guice happy. This instance is currently unused.
+    binder.bind(DruidNode.class).annotatedWith(Self.class).toInstance(
+        new DruidNode("integration-tests", "localhost", 9191, null, null, new ServerConfig())
+    );
   }
 
   @Provides

--- a/server/src/main/java/io/druid/curator/discovery/CuratorDruidLeaderSelector.java
+++ b/server/src/main/java/io/druid/curator/discovery/CuratorDruidLeaderSelector.java
@@ -169,20 +169,13 @@ public class CuratorDruidLeaderSelector implements DruidLeaderSelector
   @Override
   public void registerListener(DruidLeaderSelector.Listener listener)
   {
-    Preconditions.checkArgument(this.listener == null, "listener is already registered.");
-    this.listener = listener;
-  }
+    Preconditions.checkArgument(listener != null, "listener is null.");
 
-  @Override
-  public void start()
-  {
     if (!lifecycleLock.canStart()) {
       throw new ISE("can't start.");
     }
     try {
-      if (listener == null) {
-        throw new ISE("listener is not registered yet");
-      }
+      this.listener = listener;
 
       createNewLeaderLatch();
       leaderLatch.get().start();
@@ -198,7 +191,7 @@ public class CuratorDruidLeaderSelector implements DruidLeaderSelector
   }
 
   @Override
-  public void stop()
+  public void unregisterListener()
   {
     if (!lifecycleLock.canStop()) {
       throw new ISE("can't stop.");

--- a/server/src/main/java/io/druid/curator/discovery/CuratorDruidLeaderSelector.java
+++ b/server/src/main/java/io/druid/curator/discovery/CuratorDruidLeaderSelector.java
@@ -26,6 +26,7 @@ import io.druid.concurrent.LifecycleLock;
 import io.druid.discovery.DruidLeaderSelector;
 import io.druid.guice.annotations.Self;
 import io.druid.java.util.common.ISE;
+import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.guava.CloseQuietly;
 import io.druid.server.DruidNode;
 import org.apache.curator.framework.CuratorFramework;
@@ -122,7 +123,7 @@ public class CuratorDruidLeaderSelector implements DruidLeaderSelector
             }
           }
         },
-        Execs.singleThreaded(String.format("LeaderSelector[%s]", latchPath))
+        Execs.singleThreaded(StringUtils.format("LeaderSelector[%s]", latchPath))
     );
 
     return leaderLatch.getAndSet(newLeaderLatch);

--- a/server/src/main/java/io/druid/curator/discovery/CuratorDruidLeaderSelector.java
+++ b/server/src/main/java/io/druid/curator/discovery/CuratorDruidLeaderSelector.java
@@ -19,6 +19,7 @@
 
 package io.druid.curator.discovery;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.metamx.emitter.EmittingLogger;
 import io.druid.concurrent.Execs;
@@ -34,6 +35,7 @@ import org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.apache.curator.framework.recipes.leader.LeaderLatchListener;
 import org.apache.curator.framework.recipes.leader.Participant;
 
+import javax.annotation.Nullable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -129,6 +131,7 @@ public class CuratorDruidLeaderSelector implements DruidLeaderSelector
     return leaderLatch.getAndSet(newLeaderLatch);
   }
 
+  @Nullable
   @Override
   public String getCurrentLeader()
   {
@@ -166,6 +169,7 @@ public class CuratorDruidLeaderSelector implements DruidLeaderSelector
   @Override
   public void registerListener(DruidLeaderSelector.Listener listener)
   {
+    Preconditions.checkArgument(this.listener == null, "listener is already registered.");
     this.listener = listener;
   }
 

--- a/server/src/main/java/io/druid/curator/discovery/CuratorDruidLeaderSelector.java
+++ b/server/src/main/java/io/druid/curator/discovery/CuratorDruidLeaderSelector.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.curator.discovery;
+
+import com.google.common.base.Throwables;
+import com.metamx.emitter.EmittingLogger;
+import io.druid.concurrent.Execs;
+import io.druid.concurrent.LifecycleLock;
+import io.druid.discovery.DruidLeaderSelector;
+import io.druid.guice.annotations.Self;
+import io.druid.java.util.common.ISE;
+import io.druid.java.util.common.guava.CloseQuietly;
+import io.druid.server.DruidNode;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.leader.LeaderLatch;
+import org.apache.curator.framework.recipes.leader.LeaderLatchListener;
+import org.apache.curator.framework.recipes.leader.Participant;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ */
+public class CuratorDruidLeaderSelector implements DruidLeaderSelector
+{
+  private static final EmittingLogger log = new EmittingLogger(CuratorDruidLeaderSelector.class);
+
+  private final LifecycleLock lifecycleLock = new LifecycleLock();
+
+  private final DruidNode self;
+  private final CuratorFramework curator;
+  private final String latchPath;
+
+  private DruidLeaderSelector.Listener listener = null;
+  private final AtomicReference<LeaderLatch> leaderLatch = new AtomicReference<>();
+
+  private volatile boolean leader = false;
+  private volatile int term = 0;
+
+  public CuratorDruidLeaderSelector(CuratorFramework curator, @Self DruidNode self, String latchPath)
+  {
+    this.curator = curator;
+    this.self = self;
+    this.latchPath = latchPath;
+  }
+
+  private LeaderLatch createNewLeaderLatch()
+  {
+    final LeaderLatch newLeaderLatch = new LeaderLatch(
+        curator, latchPath, self.getHostAndPortToUse()
+    );
+
+    newLeaderLatch.addListener(
+        new LeaderLatchListener()
+        {
+          @Override
+          public void isLeader()
+          {
+            try {
+              if (leader) {
+                log.warn("I'm being asked to become leader. But I am already the leader. Ignored event.");
+                return;
+              }
+
+              leader = true;
+              term++;
+              listener.becomeLeader();
+            }
+            catch (Exception ex) {
+              log.makeAlert(ex, "listener becomeLeader() failed. Unable to become leader").emit();
+
+              // give others a chance to become leader.
+              final LeaderLatch oldLatch = createNewLeaderLatch();
+              CloseQuietly.close(oldLatch);
+              leader = false;
+              try {
+                //Small delay before starting the latch so that others waiting are chosen to become leader.
+                Thread.sleep(1000);
+
+                leaderLatch.get().start();
+              }
+              catch (Exception e) {
+                // If an exception gets thrown out here, then the node will zombie out 'cause it won't be looking for
+                // the latch anymore.  I don't believe it's actually possible for an Exception to throw out here, but
+                // Curator likes to have "throws Exception" on methods so it might happen...
+                log.makeAlert(e, "I am a zombie").emit();
+              }
+            }
+          }
+
+          @Override
+          public void notLeader()
+          {
+            try {
+              if (!leader) {
+                log.warn("I'm being asked to stop being leader. But I am not the leader. Ignored event.");
+                return;
+              }
+
+              leader = false;
+              listener.stopBeingLeader();
+            }
+            catch (Exception ex) {
+              log.makeAlert(ex, "listener.stopBeingLeader() failed. Unable to stopBeingLeader").emit();
+            }
+          }
+        },
+        Execs.singleThreaded(String.format("LeaderSelector[%s]", latchPath))
+    );
+
+    return leaderLatch.getAndSet(newLeaderLatch);
+  }
+
+  @Override
+  public String getCurrentLeader()
+  {
+    if (!lifecycleLock.awaitStarted(1, TimeUnit.MILLISECONDS)) {
+      throw new ISE("not started");
+    }
+
+    try {
+      final LeaderLatch latch = leaderLatch.get();
+
+      Participant participant = latch.getLeader();
+      if (participant.isLeader()) {
+        return participant.getId();
+      }
+
+      return null;
+    }
+    catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public boolean isLeader()
+  {
+    return leader;
+  }
+
+  @Override
+  public int localTerm()
+  {
+    return term;
+  }
+
+  @Override
+  public void registerListener(DruidLeaderSelector.Listener listener)
+  {
+    this.listener = listener;
+  }
+
+  @Override
+  public void start()
+  {
+    if (!lifecycleLock.canStart()) {
+      throw new ISE("can't start.");
+    }
+    try {
+      if (listener == null) {
+        throw new ISE("listener is not registered yet");
+      }
+
+      createNewLeaderLatch();
+      leaderLatch.get().start();
+
+      lifecycleLock.started();
+    }
+    catch (Exception ex) {
+      throw Throwables.propagate(ex);
+    }
+    finally {
+      lifecycleLock.exitStart();
+    }
+  }
+
+  @Override
+  public void stop()
+  {
+    if (!lifecycleLock.canStop()) {
+      throw new ISE("can't stop.");
+    }
+    CloseQuietly.close(leaderLatch.get());
+  }
+}

--- a/server/src/main/java/io/druid/curator/discovery/CuratorDruidLeaderSelector.java
+++ b/server/src/main/java/io/druid/curator/discovery/CuratorDruidLeaderSelector.java
@@ -37,6 +37,7 @@ import org.apache.curator.framework.recipes.leader.Participant;
 
 import javax.annotation.Nullable;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -98,8 +99,7 @@ public class CuratorDruidLeaderSelector implements DruidLeaderSelector
               leader = false;
               try {
                 //Small delay before starting the latch so that others waiting are chosen to become leader.
-                Thread.sleep(1000);
-
+                Thread.sleep(ThreadLocalRandom.current().nextInt(1000, 5000));
                 leaderLatch.get().start();
               }
               catch (Exception e) {

--- a/server/src/main/java/io/druid/curator/discovery/DiscoveryModule.java
+++ b/server/src/main/java/io/druid/curator/discovery/DiscoveryModule.java
@@ -23,13 +23,18 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.inject.Binder;
+import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
+import com.google.inject.Provider;
 import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
+import io.druid.client.coordinator.Coordinator;
+import io.druid.client.indexing.IndexingService;
+import io.druid.discovery.DruidLeaderSelector;
 import io.druid.discovery.DruidNodeAnnouncer;
 import io.druid.discovery.DruidNodeDiscoveryProvider;
 import io.druid.guice.DruidBinders;
@@ -38,11 +43,14 @@ import io.druid.guice.KeyHolder;
 import io.druid.guice.LazySingleton;
 import io.druid.guice.LifecycleModule;
 import io.druid.guice.PolyBind;
+import io.druid.guice.annotations.Self;
 import io.druid.java.util.common.lifecycle.Lifecycle;
 import io.druid.server.DruidNode;
 import io.druid.server.initialization.CuratorDiscoveryConfig;
+import io.druid.server.initialization.ZkPathsConfig;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.utils.CloseableExecutorService;
+import org.apache.curator.utils.ZKPaths;
 import org.apache.curator.x.discovery.DownInstancePolicy;
 import org.apache.curator.x.discovery.InstanceFilter;
 import org.apache.curator.x.discovery.ProviderStrategy;
@@ -64,6 +72,7 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
+import java.util.function.Function;
 
 /**
  * The DiscoveryModule allows for the registration of Keys of DruidNode objects, which it intends to be
@@ -161,6 +170,14 @@ public class DiscoveryModule implements Module
         binder, INTERNAL_DISCOVERY_PROP, Key.get(DruidNodeDiscoveryProvider.class), CURATOR_KEY
     );
 
+    PolyBind.createChoiceWithDefault(
+        binder, INTERNAL_DISCOVERY_PROP, Key.get(DruidLeaderSelector.class, () -> Coordinator.class), CURATOR_KEY
+    );
+
+    PolyBind.createChoiceWithDefault(
+        binder, INTERNAL_DISCOVERY_PROP, Key.get(DruidLeaderSelector.class, () -> IndexingService.class), CURATOR_KEY
+    );
+
     PolyBind.optionBinder(binder, Key.get(DruidNodeDiscoveryProvider.class))
             .addBinding(CURATOR_KEY)
             .to(CuratorDruidNodeDiscoveryProvider.class)
@@ -169,6 +186,20 @@ public class DiscoveryModule implements Module
     PolyBind.optionBinder(binder, Key.get(DruidNodeAnnouncer.class))
             .addBinding(CURATOR_KEY)
             .to(CuratorDruidNodeAnnouncer.class)
+            .in(LazySingleton.class);
+
+    PolyBind.optionBinder(binder, Key.get(DruidLeaderSelector.class, Coordinator.class))
+            .addBinding(CURATOR_KEY)
+            .toProvider(new DruidLeaderSelectorProvider(
+                (zkPathsConfig) -> ZKPaths.makePath(zkPathsConfig.getCoordinatorPath(), "druid:coordinator"))
+            )
+            .in(LazySingleton.class);
+
+    PolyBind.optionBinder(binder, Key.get(DruidLeaderSelector.class, IndexingService.class))
+            .addBinding(CURATOR_KEY)
+            .toProvider(new DruidLeaderSelectorProvider(
+                (zkPathsConfig) -> ZKPaths.makePath(zkPathsConfig.getOverlordPath(), "druid:overlord"))
+            )
             .in(LazySingleton.class);
   }
 
@@ -474,6 +505,36 @@ public class DiscoveryModule implements Module
     public void close() throws IOException
     {
       // nothing
+    }
+  }
+
+  private static class DruidLeaderSelectorProvider implements Provider<DruidLeaderSelector>
+  {
+    @Inject
+    private CuratorFramework curatorFramework;
+
+    @Inject
+    @Self
+    private DruidNode druidNode;
+
+    @Inject
+    private ZkPathsConfig zkPathsConfig;
+
+    private final Function<ZkPathsConfig, String> latchPathFn;
+
+    DruidLeaderSelectorProvider(Function<ZkPathsConfig, String> latchPathFn)
+    {
+      this.latchPathFn = latchPathFn;
+    }
+
+    @Override
+    public DruidLeaderSelector get()
+    {
+      return new CuratorDruidLeaderSelector(
+          curatorFramework,
+          druidNode,
+          latchPathFn.apply(zkPathsConfig)
+      );
     }
   }
 }

--- a/server/src/main/java/io/druid/curator/discovery/DiscoveryModule.java
+++ b/server/src/main/java/io/druid/curator/discovery/DiscoveryModule.java
@@ -191,14 +191,14 @@ public class DiscoveryModule implements Module
     PolyBind.optionBinder(binder, Key.get(DruidLeaderSelector.class, Coordinator.class))
             .addBinding(CURATOR_KEY)
             .toProvider(new DruidLeaderSelectorProvider(
-                (zkPathsConfig) -> ZKPaths.makePath(zkPathsConfig.getCoordinatorPath(), "druid:coordinator"))
+                (zkPathsConfig) -> ZKPaths.makePath(zkPathsConfig.getCoordinatorPath(), "_COORDINATOR"))
             )
             .in(LazySingleton.class);
 
     PolyBind.optionBinder(binder, Key.get(DruidLeaderSelector.class, IndexingService.class))
             .addBinding(CURATOR_KEY)
             .toProvider(new DruidLeaderSelectorProvider(
-                (zkPathsConfig) -> ZKPaths.makePath(zkPathsConfig.getOverlordPath(), "druid:overlord"))
+                (zkPathsConfig) -> ZKPaths.makePath(zkPathsConfig.getOverlordPath(), "_OVERLORD"))
             )
             .in(LazySingleton.class);
   }

--- a/server/src/main/java/io/druid/discovery/DruidLeaderSelector.java
+++ b/server/src/main/java/io/druid/discovery/DruidLeaderSelector.java
@@ -38,6 +38,8 @@ public interface DruidLeaderSelector
 
   /**
    * Get ID of current Leader. Returns NULL if it can't find the leader.
+   * Note that it is possible for leadership to change right after this call returns, so caller would get wrong
+   * leader.
    */
   @Nullable
   String getCurrentLeader();
@@ -45,6 +47,8 @@ public interface DruidLeaderSelector
   /**
    * Returns true if this node is elected leader from underlying system's point of view. For example if curator
    * is used to implement this then true would be returned when curator believes this node to be the leader.
+   * Note that it is possible for leadership to change right after this call returns, so caller would get wrong
+   * status.
    */
   boolean isLeader();
 

--- a/server/src/main/java/io/druid/discovery/DruidLeaderSelector.java
+++ b/server/src/main/java/io/druid/discovery/DruidLeaderSelector.java
@@ -29,16 +29,15 @@ import javax.annotation.Nullable;
  * Usage is as follow.
  * On lifecycle start:
  *  druidLeaderSelector.registerListener(myListener);
- *  druidLeaderSelector.start();
  *
  * On lifecycle stop:
- *  druidLeaderSelector.stop();
+ *  druidLeaderSelector.unregisterListener();
  */
 public interface DruidLeaderSelector
 {
 
   /**
-   * Get ID of current Leader.
+   * Get ID of current Leader. Returns NULL if it can't find the leader.
    */
   @Nullable
   String getCurrentLeader();
@@ -58,19 +57,14 @@ public interface DruidLeaderSelector
   int localTerm();
 
   /**
-   * Register the listener for watching leadership notifications.
+   * Register the listener for watching leadership notifications. It should only be called once.
    */
   void registerListener(Listener listener);
 
   /**
-   * Must be called right after registerLeader(Listener).
+   * Unregisters the listener.
    */
-  void start();
-
-  /**
-   * Must be called when the Druid process is stopping.
-   */
-  void stop();
+  void unregisterListener();
 
   interface Listener
   {

--- a/server/src/main/java/io/druid/discovery/DruidLeaderSelector.java
+++ b/server/src/main/java/io/druid/discovery/DruidLeaderSelector.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.discovery;
+
+/**
+ */
+public interface DruidLeaderSelector
+{
+  String getCurrentLeader();
+  boolean isLeader();
+  int localTerm();
+
+  void registerListener(Listener listener);
+
+  void start();
+  void stop();
+
+  interface Listener
+  {
+    void becomeLeader();
+    void stopBeingLeader();
+  }
+}

--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
@@ -494,7 +494,6 @@ public class DruidCoordinator
             }
           }
       );
-      coordLeaderSelector.start();
     }
   }
 
@@ -506,7 +505,7 @@ public class DruidCoordinator
         return;
       }
 
-      coordLeaderSelector.stop();
+      coordLeaderSelector.unregisterListener();
 
       started = false;
 

--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
@@ -93,8 +93,6 @@ import java.util.concurrent.ScheduledExecutorService;
 @ManageLifecycle
 public class DruidCoordinator
 {
-  public static final String COORDINATOR_OWNER_NODE = "_COORDINATOR";
-
   public static Comparator<DataSegment> SEGMENT_COMPARATOR = Ordering.from(Comparators.intervalsByEndThenStart())
                                                                      .onResultOf(
                                                                          new Function<DataSegment, Interval>()

--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
@@ -38,10 +38,12 @@ import io.druid.client.DruidServer;
 import io.druid.client.ImmutableDruidDataSource;
 import io.druid.client.ImmutableDruidServer;
 import io.druid.client.ServerInventoryView;
+import io.druid.client.coordinator.Coordinator;
 import io.druid.client.indexing.IndexingServiceClient;
 import io.druid.common.config.JacksonConfigManager;
 import io.druid.concurrent.Execs;
 import io.druid.curator.discovery.ServiceAnnouncer;
+import io.druid.discovery.DruidLeaderSelector;
 import io.druid.guice.ManageLifecycle;
 import io.druid.guice.annotations.CoordinatorIndexingServiceHelper;
 import io.druid.guice.annotations.Self;
@@ -50,7 +52,6 @@ import io.druid.java.util.common.IAE;
 import io.druid.java.util.common.Pair;
 import io.druid.java.util.common.concurrent.ScheduledExecutorFactory;
 import io.druid.java.util.common.concurrent.ScheduledExecutors;
-import io.druid.java.util.common.guava.CloseQuietly;
 import io.druid.java.util.common.guava.Comparators;
 import io.druid.java.util.common.guava.FunctionalIterable;
 import io.druid.java.util.common.lifecycle.LifecycleStart;
@@ -73,15 +74,11 @@ import io.druid.timeline.DataSegment;
 import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.recipes.leader.LeaderLatch;
-import org.apache.curator.framework.recipes.leader.LeaderLatchListener;
-import org.apache.curator.framework.recipes.leader.Participant;
 import org.apache.curator.utils.ZKPaths;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -90,7 +87,6 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  */
@@ -126,16 +122,14 @@ public class DruidCoordinator
   private final ScheduledExecutorService exec;
   private final LoadQueueTaskMaster taskMaster;
   private final Map<String, LoadQueuePeon> loadManagementPeons;
-  private final AtomicReference<LeaderLatch> leaderLatch;
   private final ServiceAnnouncer serviceAnnouncer;
   private final DruidNode self;
   private final Set<DruidCoordinatorHelper> indexingServiceHelpers;
   private volatile boolean started = false;
-  private volatile int leaderCounter = 0;
-  private volatile boolean leader = false;
   private volatile SegmentReplicantLookup segmentReplicantLookup = null;
   private final BalancerStrategyFactory factory;
   private final LookupCoordinatorManager lookupCoordinatorManager;
+  private final DruidLeaderSelector coordLeaderSelector;
 
   @Inject
   public DruidCoordinator(
@@ -154,7 +148,8 @@ public class DruidCoordinator
       @Self DruidNode self,
       @CoordinatorIndexingServiceHelper Set<DruidCoordinatorHelper> indexingServiceHelpers,
       BalancerStrategyFactory factory,
-      LookupCoordinatorManager lookupCoordinatorManager
+      LookupCoordinatorManager lookupCoordinatorManager,
+      @Coordinator DruidLeaderSelector coordLeaderSelector
   )
   {
     this(
@@ -174,7 +169,8 @@ public class DruidCoordinator
         Maps.<String, LoadQueuePeon>newConcurrentMap(),
         indexingServiceHelpers,
         factory,
-        lookupCoordinatorManager
+        lookupCoordinatorManager,
+        coordLeaderSelector
     );
   }
 
@@ -195,7 +191,8 @@ public class DruidCoordinator
       ConcurrentMap<String, LoadQueuePeon> loadQueuePeonMap,
       Set<DruidCoordinatorHelper> indexingServiceHelpers,
       BalancerStrategyFactory factory,
-      LookupCoordinatorManager lookupCoordinatorManager
+      LookupCoordinatorManager lookupCoordinatorManager,
+      DruidLeaderSelector coordLeaderSelector
   )
   {
     this.config = config;
@@ -215,15 +212,15 @@ public class DruidCoordinator
 
     this.exec = scheduledExecutorFactory.create(1, "Coordinator-Exec--%d");
 
-    this.leaderLatch = new AtomicReference<>(null);
     this.loadManagementPeons = loadQueuePeonMap;
     this.factory = factory;
     this.lookupCoordinatorManager = lookupCoordinatorManager;
+    this.coordLeaderSelector = coordLeaderSelector;
   }
 
   public boolean isLeader()
   {
-    return leader;
+    return coordLeaderSelector.isLeader();
   }
 
   public Map<String, LoadQueuePeon> getLoadManagementPeons()
@@ -264,7 +261,6 @@ public class DruidCoordinator
 
     return retVal;
   }
-
 
   public Object2LongMap<String> getSegmentAvailability()
   {
@@ -345,23 +341,7 @@ public class DruidCoordinator
 
   public String getCurrentLeader()
   {
-    try {
-      final LeaderLatch latch = leaderLatch.get();
-
-      if (latch == null) {
-        return null;
-      }
-
-      Participant participant = latch.getLeader();
-      if (participant.isLeader()) {
-        return participant.getId();
-      }
-
-      return null;
-    }
-    catch (Exception e) {
-      throw Throwables.propagate(e);
-    }
+    return coordLeaderSelector.getCurrentLeader();
   }
 
   public void moveSegment(
@@ -498,41 +478,24 @@ public class DruidCoordinator
       }
       started = true;
 
-      createNewLeaderLatch();
-      try {
-        leaderLatch.get().start();
-      }
-      catch (Exception e) {
-        throw Throwables.propagate(e);
-      }
+      coordLeaderSelector.registerListener(
+          new DruidLeaderSelector.Listener()
+          {
+            @Override
+            public void becomeLeader()
+            {
+              DruidCoordinator.this.becomeLeader();
+            }
+
+            @Override
+            public void stopBeingLeader()
+            {
+              DruidCoordinator.this.stopBeingLeader();
+            }
+          }
+      );
+      coordLeaderSelector.start();
     }
-  }
-
-  private LeaderLatch createNewLeaderLatch()
-  {
-    final LeaderLatch newLeaderLatch = new LeaderLatch(
-        curator, ZKPaths.makePath(zkPaths.getCoordinatorPath(), COORDINATOR_OWNER_NODE), self.getHostAndPortToUse()
-    );
-
-    newLeaderLatch.addListener(
-        new LeaderLatchListener()
-        {
-          @Override
-          public void isLeader()
-          {
-            DruidCoordinator.this.becomeLeader();
-          }
-
-          @Override
-          public void notLeader()
-          {
-            DruidCoordinator.this.stopBeingLeader();
-          }
-        },
-        Execs.singleThreaded("CoordinatorLeader-%s")
-    );
-
-    return leaderLatch.getAndSet(newLeaderLatch);
   }
 
   @LifecycleStop
@@ -543,14 +506,7 @@ public class DruidCoordinator
         return;
       }
 
-      stopBeingLeader();
-
-      try {
-        leaderLatch.get().close();
-      }
-      catch (IOException e) {
-        log.warn(e, "Unable to close leaderLatch, ignoring");
-      }
+      coordLeaderSelector.stop();
 
       started = false;
 
@@ -567,103 +523,76 @@ public class DruidCoordinator
 
       log.info("I am the leader of the coordinators, all must bow!");
       log.info("Starting coordination in [%s]", config.getCoordinatorStartDelay());
-      try {
-        leaderCounter++;
-        leader = true;
-        metadataSegmentManager.start();
-        metadataRuleManager.start();
-        serviceAnnouncer.announce(self);
-        final int startingLeaderCounter = leaderCounter;
 
-        final List<Pair<? extends CoordinatorRunnable, Duration>> coordinatorRunnables = Lists.newArrayList();
+      metadataSegmentManager.start();
+      metadataRuleManager.start();
+      serviceAnnouncer.announce(self);
+      final int startingLeaderCounter = coordLeaderSelector.localTerm();
+
+      final List<Pair<? extends CoordinatorRunnable, Duration>> coordinatorRunnables = Lists.newArrayList();
+      coordinatorRunnables.add(
+          Pair.of(
+              new CoordinatorHistoricalManagerRunnable(startingLeaderCounter),
+              config.getCoordinatorPeriod()
+          )
+      );
+      if (indexingServiceClient != null) {
         coordinatorRunnables.add(
             Pair.of(
-                new CoordinatorHistoricalManagerRunnable(startingLeaderCounter),
-                config.getCoordinatorPeriod()
+                new CoordinatorIndexingServiceRunnable(
+                    makeIndexingServiceHelpers(),
+                    startingLeaderCounter
+                ),
+                config.getCoordinatorIndexingPeriod()
             )
         );
-        if (indexingServiceClient != null) {
-          coordinatorRunnables.add(
-              Pair.of(
-                  new CoordinatorIndexingServiceRunnable(
-                      makeIndexingServiceHelpers(),
-                      startingLeaderCounter
-                  ),
-                  config.getCoordinatorIndexingPeriod()
-              )
-          );
-        }
+      }
 
-        for (final Pair<? extends CoordinatorRunnable, Duration> coordinatorRunnable : coordinatorRunnables) {
-          ScheduledExecutors.scheduleWithFixedDelay(
-              exec,
-              config.getCoordinatorStartDelay(),
-              coordinatorRunnable.rhs,
-              new Callable<ScheduledExecutors.Signal>()
+      for (final Pair<? extends CoordinatorRunnable, Duration> coordinatorRunnable : coordinatorRunnables) {
+        ScheduledExecutors.scheduleWithFixedDelay(
+            exec,
+            config.getCoordinatorStartDelay(),
+            coordinatorRunnable.rhs,
+            new Callable<ScheduledExecutors.Signal>()
+            {
+              private final CoordinatorRunnable theRunnable = coordinatorRunnable.lhs;
+
+              @Override
+              public ScheduledExecutors.Signal call()
               {
-                private final CoordinatorRunnable theRunnable = coordinatorRunnable.lhs;
-
-                @Override
-                public ScheduledExecutors.Signal call()
-                {
-                  if (leader && startingLeaderCounter == leaderCounter) {
-                    theRunnable.run();
-                  }
-                  if (leader && startingLeaderCounter == leaderCounter) { // (We might no longer be leader)
-                    return ScheduledExecutors.Signal.REPEAT;
-                  } else {
-                    return ScheduledExecutors.Signal.STOP;
-                  }
+                if (coordLeaderSelector.isLeader() && startingLeaderCounter == coordLeaderSelector.localTerm()) {
+                  theRunnable.run();
+                }
+                if (coordLeaderSelector.isLeader() && startingLeaderCounter == coordLeaderSelector.localTerm()) { // (We might no longer be leader)
+                  return ScheduledExecutors.Signal.REPEAT;
+                } else {
+                  return ScheduledExecutors.Signal.STOP;
                 }
               }
-          );
-        }
+            }
+        );
+      }
 
-        lookupCoordinatorManager.start();
-      }
-      catch (Exception e) {
-        log.makeAlert(e, "Unable to become leader")
-           .emit();
-        final LeaderLatch oldLatch = createNewLeaderLatch();
-        CloseQuietly.close(oldLatch);
-        try {
-          leaderLatch.get().start();
-        }
-        catch (Exception e1) {
-          // If an exception gets thrown out here, then the coordinator will zombie out 'cause it won't be looking for
-          // the latch anymore.  I don't believe it's actually possible for an Exception to throw out here, but
-          // Curator likes to have "throws Exception" on methods so it might happen...
-          log.makeAlert(e1, "I am a zombie")
-             .emit();
-        }
-      }
+      lookupCoordinatorManager.start();
     }
   }
 
   private void stopBeingLeader()
   {
     synchronized (lock) {
-      try {
-        leaderCounter++;
 
-        log.info("I am no longer the leader...");
+      log.info("I am no longer the leader...");
 
-        for (String server : loadManagementPeons.keySet()) {
-          LoadQueuePeon peon = loadManagementPeons.remove(server);
-          peon.stop();
-        }
-        loadManagementPeons.clear();
-
-        serviceAnnouncer.unannounce(self);
-        metadataRuleManager.stop();
-        metadataSegmentManager.stop();
-        lookupCoordinatorManager.stop();
-
-        leader = false;
+      for (String server : loadManagementPeons.keySet()) {
+        LoadQueuePeon peon = loadManagementPeons.remove(server);
+        peon.stop();
       }
-      catch (Exception e) {
-        log.makeAlert(e, "Unable to stopBeingLeader").emit();
-      }
+      loadManagementPeons.clear();
+
+      serviceAnnouncer.unannounce(self);
+      metadataRuleManager.stop();
+      metadataSegmentManager.stop();
+      lookupCoordinatorManager.stop();
     }
   }
 
@@ -695,9 +624,8 @@ public class DruidCoordinator
       ListeningExecutorService balancerExec = null;
       try {
         synchronized (lock) {
-          final LeaderLatch latch = leaderLatch.get();
-          if (latch == null || !latch.hasLeadership()) {
-            log.info("LEGGO MY EGGO. [%s] is leader.", latch == null ? null : latch.getLeader().getId());
+          if (!coordLeaderSelector.isLeader()) {
+            log.info("LEGGO MY EGGO. [%s] is leader.", coordLeaderSelector.getCurrentLeader());
             stopBeingLeader();
             return;
           }
@@ -732,7 +660,7 @@ public class DruidCoordinator
                         .build();
         for (DruidCoordinatorHelper helper : helpers) {
           // Don't read state and run state in the same helper otherwise racy conditions may exist
-          if (leader && startingLeaderCounter == leaderCounter) {
+          if (coordLeaderSelector.isLeader() && startingLeaderCounter == coordLeaderSelector.localTerm()) {
             params = helper.run(params);
           }
         }

--- a/server/src/main/java/io/druid/server/initialization/ZkPathsConfig.java
+++ b/server/src/main/java/io/druid/server/initialization/ZkPathsConfig.java
@@ -80,6 +80,11 @@ public class ZkPathsConfig
     return (null == coordinatorPath) ? defaultPath("coordinator") : coordinatorPath;
   }
 
+  public String getOverlordPath()
+  {
+    return defaultPath("overlord");
+  }
+
   public String getLoadQueuePath()
   {
     return (null == loadQueuePath) ? defaultPath("loadQueue") : loadQueuePath;

--- a/server/src/test/java/io/druid/curator/discovery/CuratorDruidLeaderSelectorTest.java
+++ b/server/src/test/java/io/druid/curator/discovery/CuratorDruidLeaderSelectorTest.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.curator.discovery;
+
+import com.metamx.emitter.EmittingLogger;
+import com.metamx.emitter.service.ServiceEmitter;
+import io.druid.curator.CuratorTestBase;
+import io.druid.discovery.DruidLeaderSelector;
+import io.druid.java.util.common.logger.Logger;
+import io.druid.server.DruidNode;
+import io.druid.server.initialization.ServerConfig;
+import org.easymock.EasyMock;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ */
+public class CuratorDruidLeaderSelectorTest extends CuratorTestBase
+{
+  private static final Logger logger = new Logger(CuratorDruidLeaderSelectorTest.class);
+
+  @Before
+  public void setUp() throws Exception
+  {
+    EmittingLogger.registerEmitter(EasyMock.createNiceMock(ServiceEmitter.class));
+    setupServerAndCurator();
+  }
+
+  @Test(timeout = 5000)
+  public void testSimple() throws Exception
+  {
+    curator.start();
+    curator.blockUntilConnected();
+
+    AtomicReference<String> currLeader = new AtomicReference<>();
+
+    String latchPath = "/testlatchPath";
+
+    CuratorDruidLeaderSelector leaderSelector1 = new CuratorDruidLeaderSelector(
+        curator,
+        new DruidNode("s1", "h1", 8080, null, new ServerConfig()),
+        latchPath
+    );
+    leaderSelector1.registerListener(
+        new DruidLeaderSelector.Listener()
+        {
+          @Override
+          public void becomeLeader()
+          {
+            logger.info("listener1.becomeLeader().");
+            currLeader.set("h1:8080");
+            throw new RuntimeException("I am Rogue.");
+          }
+
+          @Override
+          public void stopBeingLeader()
+          {
+            logger.info("listener1.stopBeingLeader().");
+            throw new RuntimeException("I said I am Rogue.");
+          }
+        }
+    );
+
+    CuratorDruidLeaderSelector leaderSelector2 = new CuratorDruidLeaderSelector(
+        curator,
+        new DruidNode("s2", "h2", 8080, null, new ServerConfig()),
+        latchPath
+    );
+    leaderSelector2.registerListener(
+        new DruidLeaderSelector.Listener()
+        {
+          @Override
+          public void becomeLeader()
+          {
+            logger.info("listener2.becomeLeader().");
+            currLeader.set("h2:8080");
+          }
+
+          @Override
+          public void stopBeingLeader()
+          {
+            logger.info("listener2.stopBeingLeader().");
+            throw new RuntimeException("I am broken.");
+          }
+        }
+    );
+
+    CuratorDruidLeaderSelector leaderSelector3 = new CuratorDruidLeaderSelector(
+        curator,
+        new DruidNode("s3", "h3", 8080, null, new ServerConfig()),
+        latchPath
+    );
+    leaderSelector3.registerListener(
+        new DruidLeaderSelector.Listener()
+        {
+          @Override
+          public void becomeLeader()
+          {
+            logger.info("listener3.becomeLeader().");
+            currLeader.set("h3:8080");
+          }
+
+          @Override
+          public void stopBeingLeader()
+          {
+            logger.info("listener3.stopBeingLeader().");
+          }
+        }
+    );
+
+    leaderSelector1.start();
+    while (!"h1:8080".equals(currLeader.get())) {
+      logger.info("current leader = [%s]", currLeader.get());
+      Thread.sleep(100);
+    }
+
+    Assert.assertTrue(leaderSelector1.localTerm() >= 1);
+
+    leaderSelector2.start();
+    while (!"h2:8080".equals(currLeader.get())) {
+      logger.info("current leader = [%s]", currLeader.get());
+      Thread.sleep(100);
+    }
+
+    Assert.assertTrue(leaderSelector2.isLeader());
+    Assert.assertEquals("h2:8080", leaderSelector1.getCurrentLeader());
+    Assert.assertEquals(1, leaderSelector2.localTerm());
+
+    leaderSelector3.start();
+    leaderSelector2.stop();
+    while (!"h3:8080".equals(currLeader.get())) {
+      logger.info("current leader = [%s]", currLeader.get());
+      Thread.sleep(100);
+    }
+
+    Assert.assertTrue(leaderSelector3.isLeader());
+    Assert.assertEquals("h3:8080", leaderSelector1.getCurrentLeader());
+    Assert.assertEquals(1, leaderSelector3.localTerm());
+  }
+
+  @After
+  public void tearDown()
+  {
+    tearDownServerAndCurator();
+  }
+}

--- a/server/src/test/java/io/druid/curator/discovery/CuratorDruidLeaderSelectorTest.java
+++ b/server/src/test/java/io/druid/curator/discovery/CuratorDruidLeaderSelectorTest.java
@@ -82,6 +82,13 @@ public class CuratorDruidLeaderSelectorTest extends CuratorTestBase
         }
     );
 
+    while (!"h1:8080".equals(currLeader.get())) {
+      logger.info("current leader = [%s]", currLeader.get());
+      Thread.sleep(100);
+    }
+
+    Assert.assertTrue(leaderSelector1.localTerm() >= 1);
+
     CuratorDruidLeaderSelector leaderSelector2 = new CuratorDruidLeaderSelector(
         curator,
         new DruidNode("s2", "h2", 8080, null, new ServerConfig()),
@@ -106,6 +113,15 @@ public class CuratorDruidLeaderSelectorTest extends CuratorTestBase
         }
     );
 
+    while (!"h2:8080".equals(currLeader.get())) {
+      logger.info("current leader = [%s]", currLeader.get());
+      Thread.sleep(100);
+    }
+
+    Assert.assertTrue(leaderSelector2.isLeader());
+    Assert.assertEquals("h2:8080", leaderSelector1.getCurrentLeader());
+    Assert.assertEquals(1, leaderSelector2.localTerm());
+
     CuratorDruidLeaderSelector leaderSelector3 = new CuratorDruidLeaderSelector(
         curator,
         new DruidNode("s3", "h3", 8080, null, new ServerConfig()),
@@ -129,26 +145,7 @@ public class CuratorDruidLeaderSelectorTest extends CuratorTestBase
         }
     );
 
-    leaderSelector1.start();
-    while (!"h1:8080".equals(currLeader.get())) {
-      logger.info("current leader = [%s]", currLeader.get());
-      Thread.sleep(100);
-    }
-
-    Assert.assertTrue(leaderSelector1.localTerm() >= 1);
-
-    leaderSelector2.start();
-    while (!"h2:8080".equals(currLeader.get())) {
-      logger.info("current leader = [%s]", currLeader.get());
-      Thread.sleep(100);
-    }
-
-    Assert.assertTrue(leaderSelector2.isLeader());
-    Assert.assertEquals("h2:8080", leaderSelector1.getCurrentLeader());
-    Assert.assertEquals(1, leaderSelector2.localTerm());
-
-    leaderSelector3.start();
-    leaderSelector2.stop();
+    leaderSelector2.unregisterListener();
     while (!"h3:8080".equals(currLeader.get())) {
       logger.info("current leader = [%s]", currLeader.get());
       Thread.sleep(100);

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
@@ -450,17 +450,12 @@ public class DruidCoordinatorTest extends CuratorTestBase
     public void registerListener(Listener listener)
     {
       this.listener = listener;
-    }
-
-    @Override
-    public void start()
-    {
       leader = "what:1234";
       listener.becomeLeader();
     }
 
     @Override
-    public void stop()
+    public void unregisterListener()
     {
       leader = null;
       listener.stopBeingLeader();

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
@@ -35,6 +35,7 @@ import io.druid.common.config.JacksonConfigManager;
 import io.druid.concurrent.Execs;
 import io.druid.curator.CuratorTestBase;
 import io.druid.curator.discovery.NoopServiceAnnouncer;
+import io.druid.discovery.DruidLeaderSelector;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.concurrent.ScheduledExecutorFactory;
@@ -193,7 +194,8 @@ public class DruidCoordinatorTest extends CuratorTestBase
         loadManagementPeons,
         null,
         new CostBalancerStrategyFactory(),
-        EasyMock.createNiceMock(LookupCoordinatorManager.class)
+        EasyMock.createNiceMock(LookupCoordinatorManager.class),
+        new TestDruidLeaderSelector()
     );
   }
 
@@ -419,5 +421,49 @@ public class DruidCoordinatorTest extends CuratorTestBase
         Lists.<String>newArrayList(), Lists.<String>newArrayList(), null, 0, 0L
     );
     return segment;
+  }
+
+  private static class TestDruidLeaderSelector implements DruidLeaderSelector
+  {
+    private volatile Listener listener;
+    private volatile String leader;
+
+    @Override
+    public String getCurrentLeader()
+    {
+      return leader;
+    }
+
+    @Override
+    public boolean isLeader()
+    {
+      return leader != null;
+    }
+
+    @Override
+    public int localTerm()
+    {
+      return 0;
+    }
+
+    @Override
+    public void registerListener(Listener listener)
+    {
+      this.listener = listener;
+    }
+
+    @Override
+    public void start()
+    {
+      leader = "what:1234";
+      listener.becomeLeader();
+    }
+
+    @Override
+    public void stop()
+    {
+      leader = null;
+      listener.stopBeingLeader();
+    }
   }
 }


### PR DESCRIPTION
Follow up to #4634 

Introduces `DruidLeaderSelector` interface and curator based implementation used at coordinator (in DruidCoordinator) and overlord (in TaskMaster).

**note for 0.11.0 release upgrade:**
Because overlord leader election algorithm changes with this patch, so it is required to shutdown all overlords and upgrade them and start. There should be no time when two different overlords are not running 0.11.0 during the upgrade.
Note that at least one overlord should be brought up as quickly as possible after shutting them all down so that peons, tranquility etc continue to work after some retries.
`druid.zk.paths.indexer.leaderLatchPath` is ignored now.