### PR TITLE
Remove IndexedInts.fill()

### DIFF
--- a/processing/src/main/java/io/druid/segment/CompressedVSizeIndexedSupplier.java
+++ b/processing/src/main/java/io/druid/segment/CompressedVSizeIndexedSupplier.java
@@ -201,12 +201,6 @@ public class CompressedVSizeIndexedSupplier implements WritableSupplier<IndexedM
         }
 
         @Override
-        public void fill(int index, int[] toFill)
-        {
-          throw new UnsupportedOperationException("fill not supported");
-        }
-
-        @Override
         public void close() throws IOException
         {
           // no-op

--- a/processing/src/main/java/io/druid/segment/data/ArrayBasedIndexedInts.java
+++ b/processing/src/main/java/io/druid/segment/data/ArrayBasedIndexedInts.java
@@ -83,12 +83,6 @@ public final class ArrayBasedIndexedInts implements IndexedInts
   }
 
   @Override
-  public void fill(int index, int[] toFill)
-  {
-    throw new UnsupportedOperationException("fill not supported");
-  }
-
-  @Override
   public void close() throws IOException
   {
   }

--- a/processing/src/main/java/io/druid/segment/data/BitmapCompressedIndexedInts.java
+++ b/processing/src/main/java/io/druid/segment/data/BitmapCompressedIndexedInts.java
@@ -89,12 +89,6 @@ public class BitmapCompressedIndexedInts implements IndexedInts, Comparable<Immu
   }
 
   @Override
-  public void fill(int index, int[] toFill)
-  {
-    throw new UnsupportedOperationException("fill not supported");
-  }
-
-  @Override
   public void close() throws IOException
   {
   }

--- a/processing/src/main/java/io/druid/segment/data/CompressedIntsIndexedSupplier.java
+++ b/processing/src/main/java/io/druid/segment/data/CompressedIntsIndexedSupplier.java
@@ -25,7 +25,6 @@ import com.google.common.primitives.Ints;
 import io.druid.collections.ResourceHolder;
 import io.druid.collections.StupidResourceHolder;
 import io.druid.java.util.common.IAE;
-import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.guava.CloseQuietly;
 import io.druid.java.util.common.io.smoosh.SmooshedFileMapper;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
@@ -316,37 +315,6 @@ public class CompressedIntsIndexedSupplier implements WritableSupplier<IndexedIn
     public IntIterator iterator()
     {
       return new IndexedIntsIterator(this);
-    }
-
-    @Override
-    public void fill(int index, int[] toFill)
-    {
-      if (totalSize - index < toFill.length) {
-        throw new IndexOutOfBoundsException(
-            StringUtils.format(
-                "Cannot fill array of size[%,d] at index[%,d].  Max size[%,d]", toFill.length, index, totalSize
-            )
-        );
-      }
-
-      int bufferNum = index / sizePer;
-      int bufferIndex = index % sizePer;
-
-      int leftToFill = toFill.length;
-      while (leftToFill > 0) {
-        if (bufferNum != currIndex) {
-          loadBuffer(bufferNum);
-        }
-
-        buffer.mark();
-        buffer.position(buffer.position() + bufferIndex);
-        final int numToGet = Math.min(buffer.remaining(), leftToFill);
-        buffer.get(toFill, toFill.length - leftToFill, numToGet);
-        buffer.reset();
-        leftToFill -= numToGet;
-        ++bufferNum;
-        bufferIndex = 0;
-      }
     }
 
     protected void loadBuffer(int bufferNum)

--- a/processing/src/main/java/io/druid/segment/data/CompressedVSizeIntsIndexedSupplier.java
+++ b/processing/src/main/java/io/druid/segment/data/CompressedVSizeIntsIndexedSupplier.java
@@ -380,12 +380,6 @@ public class CompressedVSizeIntsIndexedSupplier implements WritableSupplier<Inde
       return new IndexedIntsIterator(this);
     }
 
-    @Override
-    public void fill(int index, int[] toFill)
-    {
-      throw new UnsupportedOperationException("fill not supported");
-    }
-
     protected void loadBuffer(int bufferNum)
     {
       CloseQuietly.close(holder);

--- a/processing/src/main/java/io/druid/segment/data/EmptyIndexedInts.java
+++ b/processing/src/main/java/io/druid/segment/data/EmptyIndexedInts.java
@@ -54,12 +54,6 @@ public class EmptyIndexedInts implements IndexedInts
   }
 
   @Override
-  public void fill(int index, int[] toFill)
-  {
-    throw new UnsupportedOperationException("fill not supported");
-  }
-
-  @Override
   public void close() throws IOException
   {
   }

--- a/processing/src/main/java/io/druid/segment/data/IndexedInts.java
+++ b/processing/src/main/java/io/druid/segment/data/IndexedInts.java
@@ -34,5 +34,4 @@ public interface IndexedInts extends IntIterable, Closeable, HotLoopCallee
   int size();
   @CalledFromHotLoop
   int get(int index);
-  void fill(int index, int[] toFill);
 }

--- a/processing/src/main/java/io/druid/segment/data/RangeIndexedInts.java
+++ b/processing/src/main/java/io/druid/segment/data/RangeIndexedInts.java
@@ -73,12 +73,6 @@ public class RangeIndexedInts implements IndexedInts
   }
 
   @Override
-  public void fill(int index, int[] toFill)
-  {
-    throw new UnsupportedOperationException("fill");
-  }
-
-  @Override
   public IntIterator iterator()
   {
     return IntIterators.fromTo(0, size);

--- a/processing/src/main/java/io/druid/segment/data/SingleIndexedInt.java
+++ b/processing/src/main/java/io/druid/segment/data/SingleIndexedInt.java
@@ -56,12 +56,6 @@ public final class SingleIndexedInt implements IndexedInts
   }
 
   @Override
-  public void fill(int index, int[] toFill)
-  {
-    throw new UnsupportedOperationException("fill not supported");
-  }
-
-  @Override
   public void close() throws IOException
   {
   }

--- a/processing/src/main/java/io/druid/segment/data/VSizeIndexedInts.java
+++ b/processing/src/main/java/io/druid/segment/data/VSizeIndexedInts.java
@@ -211,12 +211,6 @@ public class VSizeIndexedInts implements IndexedInts, Comparable<VSizeIndexedInt
   }
 
   @Override
-  public void fill(int index, int[] toFill)
-  {
-    throw new UnsupportedOperationException("fill not supported");
-  }
-
-  @Override
   public void close() throws IOException
   {
   }

--- a/processing/src/main/java/io/druid/segment/data/ZeroIndexedInts.java
+++ b/processing/src/main/java/io/druid/segment/data/ZeroIndexedInts.java
@@ -57,12 +57,6 @@ public class ZeroIndexedInts implements IndexedInts
   }
 
   @Override
-  public void fill(int index, int[] toFill)
-  {
-    throw new UnsupportedOperationException("fill");
-  }
-
-  @Override
   public IntIterator iterator()
   {
     return IntIterators.singleton(0);

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexAdapter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexAdapter.java
@@ -292,12 +292,6 @@ public class IncrementalIndexAdapter implements IndexableAdapter
     }
 
     @Override
-    public void fill(int index, int[] toFill)
-    {
-      throw new UnsupportedOperationException("fill not supported");
-    }
-
-    @Override
     public void close() throws IOException
     {
     }

--- a/processing/src/test/java/io/druid/query/aggregation/cardinality/CardinalityAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/cardinality/CardinalityAggregatorTest.java
@@ -149,12 +149,6 @@ public class CardinalityAggregatorTest
         }
 
         @Override
-        public void fill(int index, int[] toFill)
-        {
-          throw new UnsupportedOperationException("fill not supported");
-        }
-
-        @Override
         public void close() throws IOException
         {
         }

--- a/processing/src/test/java/io/druid/segment/data/CompressedIntsIndexedSupplierTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedIntsIndexedSupplierTest.java
@@ -163,48 +163,12 @@ public class CompressedIntsIndexedSupplierTest extends CompressionStrategyTest
   }
 
   @Test
-  public void testBulkFill() throws Exception
-  {
-    setupSimple(5);
-
-    tryFill(0, 15);
-    tryFill(3, 6);
-    tryFill(7, 7);
-    tryFill(7, 9);
-  }
-
-  @Test(expected = IndexOutOfBoundsException.class)
-  public void testBulkFillTooMuch() throws Exception
-  {
-    setupSimple(5);
-    tryFill(7, 10);
-  }
-
-  @Test
   public void testSanityWithSerde() throws Exception
   {
     setupSimpleWithSerde(5);
 
     Assert.assertEquals(4, supplier.getBaseIntBuffers().size());
     assertIndexMatchesVals();
-  }
-
-  @Test
-  public void testBulkFillWithSerde() throws Exception
-  {
-    setupSimpleWithSerde(5);
-
-    tryFill(0, 15);
-    tryFill(3, 6);
-    tryFill(7, 7);
-    tryFill(7, 9);
-  }
-
-  @Test(expected = IndexOutOfBoundsException.class)
-  public void testBulkFillTooMuchWithSerde() throws Exception
-  {
-    setupSimpleWithSerde(5);
-    tryFill(7, 10);
   }
 
   // This test attempts to cause a race condition with the DirectByteBuffers, it's non-deterministic in causing it,
@@ -308,16 +272,6 @@ public class CompressedIntsIndexedSupplierTest extends CompressionStrategyTest
 
     if (failureHappened.get()) {
       Assert.fail("Failure happened.  Reason: " + reason.get());
-    }
-  }
-
-  private void tryFill(final int startIndex, final int size)
-  {
-    int[] filled = new int[size];
-    indexed.fill(startIndex, filled);
-
-    for (int i = startIndex; i < filled.length; i++) {
-      Assert.assertEquals(vals[i + startIndex], filled[i]);
     }
   }
 


### PR DESCRIPTION
This method is unused.

No compatibility implications, because `IndexedInts` is not a part of public API.