### PR TITLE
integration-tests cluster setup: consider docker ip be 127.0.0.1 by default

### DIFF
--- a/integration-tests/run_cluster.sh
+++ b/integration-tests/run_cluster.sh
@@ -13,7 +13,7 @@ SUPERVISORDIR=/usr/lib/druid/conf
 RESOURCEDIR=$DIR/src/test/resources
 
 # so docker IP addr will be known during docker build
-echo $DOCKER_IP > $DOCKERDIR/docker_ip
+echo ${DOCKER_IP:=127.0.0.1} > $DOCKERDIR/docker_ip
 
 # Make directories if they dont exist
 mkdir -p $SHARED_DIR/logs


### PR DESCRIPTION
takes a step away when doing things locally which is easily missed.