### PR TITLE
git ignore dependency-reduced-pom.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ target
 *.log
 *.DS_Store
 _site
+dependency-reduced-pom.xml


### PR DESCRIPTION
Every time I compile the code, it will produce `extensions-core/protobuf-extensions/dependency-reduced-pom.xml`. And if I use `git add .` command, this file will also be included. So why not let git ignore this file