### PR TITLE
Add "round" option to cardinality and hyperUnique aggregators.

### DIFF
--- a/docs/content/querying/aggregations.md
+++ b/docs/content/querying/aggregations.md
@@ -227,11 +227,16 @@ instead of the cardinality aggregator if you do not care about the individual va
   "type": "cardinality",
   "name": "<output_name>",
   "fields": [ <dimension1>, <dimension2>, ... ],
-  "byRow": <false | true> # (optional, defaults to false)
+  "byRow": <false | true> # (optional, defaults to false),
+  "round": <false | true> # (optional, defaults to false)
 }
 ```
 
 Each individual element of the "fields" list can be a String or [DimensionSpec](../querying/dimensionspecs.html). A String dimension in the fields list is equivalent to a DefaultDimensionSpec (no transformations).
+
+The HyperLogLog algorithm generates decimal estimates with some error. "round" can be set to true to round off estimated
+values to whole numbers. Note that even with rounding, the cardinality is still an estimate. The "round" field only
+affects query-time behavior, and is ignored at ingestion-time.
 
 #### Cardinality by value
 
@@ -315,12 +320,17 @@ Uses [HyperLogLog](http://algo.inria.fr/flajolet/Publications/FlFuGaMe07.pdf) to
   "type" : "hyperUnique",
   "name" : <output_name>,
   "fieldName" : <metric_name>,
-  "isInputHyperUnique" : false
+  "isInputHyperUnique" : false,
+  "round" : false
 }
 ```
 
-isInputHyperUnique can be set to true to index pre-computed HLL (Base64 encoded output from druid-hll is expected).
-The isInputHyperUnique field only affects ingestion-time behavior, and is ignored at query time.
+"isInputHyperUnique" can be set to true to index pre-computed HLL (Base64 encoded output from druid-hll is expected).
+The "isInputHyperUnique" field only affects ingestion-time behavior, and is ignored at query-time.
+
+The HyperLogLog algorithm generates decimal estimates with some error. "round" can be set to true to round off estimated
+values to whole numbers. Note that even with rounding, the cardinality is still an estimate. The "round" field only
+affects query-time behavior, and is ignored at ingestion-time.
 
 For more approximate aggregators, please see [theta sketches](../development/extensions-core/datasketches-aggregators.html).
 

--- a/docs/content/querying/post-aggregations.md
+++ b/docs/content/querying/post-aggregations.md
@@ -107,7 +107,11 @@ JavaScript-based functionality is disabled by default. Please refer to the Druid
 The hyperUniqueCardinality post aggregator is used to wrap a hyperUnique object such that it can be used in post aggregations.
 
 ```json
-{ "type"  : "hyperUniqueCardinality", "name": <output name>, "fieldName"  : <the name field value of the hyperUnique aggregator>}
+{
+  "type"  : "hyperUniqueCardinality",
+  "name": <output name>,
+  "fieldName"  : <the name field value of the hyperUnique aggregator>
+}
 ```
 
 It can be used in a sample calculation as so:
@@ -127,6 +131,10 @@ It can be used in a sample calculation as so:
     ]
   }]
 ```
+
+This post-aggregator will inherit the rounding behavior of the aggregator it references. Note that this inheritance
+is only effective if you directly reference an aggregator. Going through another post-aggregator, for example, will
+cause the user-specified rounding behavior to get lost and default to "no rounding".
 
 ## Example Usage
 

--- a/hll/src/main/java/io/druid/hll/HyperLogLogCollector.java
+++ b/hll/src/main/java/io/druid/hll/HyperLogLogCollector.java
@@ -502,6 +502,11 @@ public abstract class HyperLogLogCollector implements Comparable<HyperLogLogColl
     return theBytes;
   }
 
+  public long estimateCardinalityRound()
+  {
+    return Math.round(estimateCardinality());
+  }
+
   public double estimateCardinality()
   {
     if (estimatedCardinality == null) {

--- a/indexing-hadoop/src/main/java/io/druid/indexer/DetermineHashedPartitionsJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/DetermineHashedPartitionsJob.java
@@ -344,7 +344,7 @@ public class DetermineHashedPartitionsJob implements Jobby
             }
         ).writeValue(
             out,
-            new Double(aggregate.estimateCardinality()).longValue()
+            aggregate.estimateCardinalityRound()
         );
       }
       finally {

--- a/indexing-hadoop/src/test/java/io/druid/indexer/BatchDeltaIngestionTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/BatchDeltaIngestionTest.java
@@ -425,7 +425,7 @@ public class BatchDeltaIngestionTest
       Assert.assertEquals(expected.get("visited_sum"), actual.getLongMetric("visited_sum"));
       Assert.assertEquals(
           (Double) expected.get("unique_hosts"),
-          (Double) HyperUniquesAggregatorFactory.estimateCardinality(actual.getRaw("unique_hosts")),
+          (Double) HyperUniquesAggregatorFactory.estimateCardinality(actual.getRaw("unique_hosts"), false),
           0.001
       );
     }

--- a/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorCombinerTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorCombinerTest.java
@@ -187,7 +187,14 @@ public class IndexGeneratorCombinerTest
     Assert.assertEquals(ImmutableList.of(), capturedRow.getDimension("host"));
     Assert.assertEquals(Arrays.asList("bar", "foo"), capturedRow.getDimension("keywords"));
     Assert.assertEquals(15, capturedRow.getLongMetric("visited_sum"));
-    Assert.assertEquals(2.0, (Double) HyperUniquesAggregatorFactory.estimateCardinality(capturedRow.getRaw("unique_hosts")), 0.001);
+    Assert.assertEquals(
+        2.0,
+        (Double) HyperUniquesAggregatorFactory.estimateCardinality(
+            capturedRow.getRaw("unique_hosts"),
+            false
+        ),
+        0.001
+    );
   }
 
   @Test
@@ -250,13 +257,21 @@ public class IndexGeneratorCombinerTest
     Assert.assertEquals(Collections.singletonList("host1"), capturedRow1.getDimension("host"));
     Assert.assertEquals(Arrays.asList("bar", "foo"), capturedRow1.getDimension("keywords"));
     Assert.assertEquals(10, capturedRow1.getLongMetric("visited_sum"));
-    Assert.assertEquals(1.0, (Double) HyperUniquesAggregatorFactory.estimateCardinality(capturedRow1.getRaw("unique_hosts")), 0.001);
+    Assert.assertEquals(
+        1.0,
+        (Double) HyperUniquesAggregatorFactory.estimateCardinality(capturedRow1.getRaw("unique_hosts"), false),
+        0.001
+    );
 
     InputRow capturedRow2 = InputRowSerde.fromBytes(captureVal2.getValue().getBytes(), aggregators);
     Assert.assertEquals(Arrays.asList("host", "keywords"), capturedRow2.getDimensions());
     Assert.assertEquals(Collections.singletonList("host2"), capturedRow2.getDimension("host"));
     Assert.assertEquals(Arrays.asList("bar", "foo"), capturedRow2.getDimension("keywords"));
     Assert.assertEquals(5, capturedRow2.getLongMetric("visited_sum"));
-    Assert.assertEquals(1.0, (Double) HyperUniquesAggregatorFactory.estimateCardinality(capturedRow2.getRaw("unique_hosts")), 0.001);
+    Assert.assertEquals(
+        1.0,
+        (Double) HyperUniquesAggregatorFactory.estimateCardinality(capturedRow2.getRaw("unique_hosts"), false),
+        0.001
+    );
   }
 }

--- a/indexing-hadoop/src/test/java/io/druid/indexer/hadoop/DatasourceRecordReaderTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/hadoop/DatasourceRecordReaderTest.java
@@ -130,7 +130,7 @@ public class DatasourceRecordReaderTest
       Assert.assertEquals(expected.get("visited_sum"), actual.getLongMetric("visited_sum"));
       Assert.assertEquals(
           (Double) expected.get("unique_hosts"),
-          (Double) HyperUniquesAggregatorFactory.estimateCardinality(actual.getRaw("unique_hosts")),
+          (Double) HyperUniquesAggregatorFactory.estimateCardinality(actual.getRaw("unique_hosts"), false),
           0.001
       );
     }

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
@@ -377,7 +377,7 @@ public class IndexTask extends AbstractTask
 
       final int numShards;
       if (determineNumPartitions) {
-        final long numRows = new Double(collector.estimateCardinality()).longValue();
+        final long numRows = collector.estimateCardinalityRound();
         numShards = (int) Math.ceil((double) numRows / tuningConfig.getTargetPartitionSize());
         log.info("Estimated [%,d] rows of data for interval [%s], creating [%,d] shards", numRows, interval, numShards);
       } else {

--- a/processing/src/main/java/io/druid/query/aggregation/cardinality/CardinalityAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/cardinality/CardinalityAggregatorFactory.java
@@ -211,14 +211,16 @@ public class CardinalityAggregatorFactory extends AggregatorFactory
   {
     return fields.stream()
                  .map(
-                     input -> new CardinalityAggregatorFactory(
-                         input.getOutputName(),
-                         null,
-                         Collections.singletonList(input),
-                         byRow,
-                         round
-                     )
-                 ).collect(Collectors.toList());
+                     field ->
+                         new CardinalityAggregatorFactory(
+                             field.getOutputName(),
+                             null,
+                             Collections.singletonList(field),
+                             byRow,
+                             round
+                         )
+                 )
+                 .collect(Collectors.toList());
   }
 
   @Override

--- a/processing/src/test/java/io/druid/query/QueryRunnerTestHelper.java
+++ b/processing/src/test/java/io/druid/query/QueryRunnerTestHelper.java
@@ -158,6 +158,12 @@ public class QueryRunnerTestHelper
       "uniques",
       "quality_uniques"
   );
+  public static final HyperUniquesAggregatorFactory qualityUniquesRounded = new HyperUniquesAggregatorFactory(
+      "uniques",
+      "quality_uniques",
+      false,
+      true
+  );
   public static final CardinalityAggregatorFactory qualityCardinality = new CardinalityAggregatorFactory(
       "cardinality",
       Arrays.<DimensionSpec>asList(new DefaultDimensionSpec("quality", "quality")),

--- a/processing/src/test/java/io/druid/query/aggregation/cardinality/CardinalityAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/cardinality/CardinalityAggregatorTest.java
@@ -286,6 +286,7 @@ public class CardinalityAggregatorTest
   List<ColumnSelectorPlus<CardinalityAggregatorColumnSelectorStrategy>> dimInfoList;
   List<DimensionSelector> selectorList;
   CardinalityAggregatorFactory rowAggregatorFactory;
+  CardinalityAggregatorFactory rowAggregatorFactoryRounded;
   CardinalityAggregatorFactory valueAggregatorFactory;
   final TestDimensionSelector dim1;
   final TestDimensionSelector dim2;
@@ -332,6 +333,17 @@ public class CardinalityAggregatorTest
             dimSpec1,
             dimSpec2
         ),
+        true
+    );
+
+    rowAggregatorFactoryRounded = new CardinalityAggregatorFactory(
+        "billy",
+        null,
+        Lists.<DimensionSpec>newArrayList(
+            dimSpec1,
+            dimSpec2
+        ),
+        true,
         true
     );
 
@@ -403,6 +415,7 @@ public class CardinalityAggregatorTest
       aggregate(selectorList, agg);
     }
     Assert.assertEquals(9.0, (Double) rowAggregatorFactory.finalizeComputation(agg.get()), 0.05);
+    Assert.assertEquals(9L, rowAggregatorFactoryRounded.finalizeComputation(agg.get()));
   }
 
   @Test
@@ -418,6 +431,7 @@ public class CardinalityAggregatorTest
       aggregate(selectorList, agg);
     }
     Assert.assertEquals(7.0, (Double) valueAggregatorFactory.finalizeComputation(agg.get()), 0.05);
+    Assert.assertEquals(7L, rowAggregatorFactoryRounded.finalizeComputation(agg.get()));
   }
 
   @Test
@@ -439,6 +453,7 @@ public class CardinalityAggregatorTest
       bufferAggregate(selectorList, agg, buf, pos);
     }
     Assert.assertEquals(9.0, (Double) rowAggregatorFactory.finalizeComputation(agg.get(buf, pos)), 0.05);
+    Assert.assertEquals(9L, rowAggregatorFactoryRounded.finalizeComputation(agg.get(buf, pos)));
   }
 
   @Test
@@ -460,6 +475,7 @@ public class CardinalityAggregatorTest
       bufferAggregate(selectorList, agg, buf, pos);
     }
     Assert.assertEquals(7.0, (Double) valueAggregatorFactory.finalizeComputation(agg.get(buf, pos)), 0.05);
+    Assert.assertEquals(7L, rowAggregatorFactoryRounded.finalizeComputation(agg.get(buf, pos)));
   }
 
   @Test
@@ -606,11 +622,13 @@ public class CardinalityAggregatorTest
   {
     CardinalityAggregatorFactory factory = new CardinalityAggregatorFactory(
         "billy",
+        null,
         ImmutableList.<DimensionSpec>of(
             new DefaultDimensionSpec("b", "b"),
             new DefaultDimensionSpec("a", "a"),
             new DefaultDimensionSpec("c", "c")
         ),
+        true,
         true
     );
     ObjectMapper objectMapper = new DefaultObjectMapper();
@@ -619,7 +637,13 @@ public class CardinalityAggregatorTest
         objectMapper.readValue(objectMapper.writeValueAsString(factory), AggregatorFactory.class)
     );
 
-    String fieldNamesOnly = "{\"type\":\"cardinality\",\"name\":\"billy\",\"fields\":[\"b\",\"a\",\"c\"],\"byRow\":true}";
+    String fieldNamesOnly = "{"
+                            + "\"type\":\"cardinality\","
+                            + "\"name\":\"billy\","
+                            + "\"fields\":[\"b\",\"a\",\"c\"],"
+                            + "\"byRow\":true,"
+                            + "\"round\":true"
+                            + "}";
     Assert.assertEquals(
         factory,
         objectMapper.readValue(fieldNamesOnly, AggregatorFactory.class)

--- a/processing/src/test/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactoryTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactoryTest.java
@@ -19,11 +19,14 @@
 
 package io.druid.query.aggregation.hyperloglog;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import io.druid.hll.HLLCV0;
 import io.druid.hll.HyperLogLogCollector;
 import io.druid.java.util.common.StringUtils;
+import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.segment.TestHelper;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -83,8 +86,8 @@ public class HyperUniquesAggregatorFactoryTest
       }
 
       Assert.assertEquals(
-              Double.compare(collector1.estimateCardinality(), collector2.estimateCardinality()),
-              comparator.compare(collector1, collector2)
+          Double.compare(collector1.estimateCardinality(), collector2.estimateCardinality()),
+          comparator.compare(collector1, collector2)
       );
     }
 
@@ -102,8 +105,8 @@ public class HyperUniquesAggregatorFactoryTest
       }
 
       Assert.assertEquals(
-              Double.compare(collector1.estimateCardinality(), collector2.estimateCardinality()),
-              comparator.compare(collector1, collector2)
+          Double.compare(collector1.estimateCardinality(), collector2.estimateCardinality()),
+          comparator.compare(collector1, collector2)
       );
     }
 
@@ -121,8 +124,8 @@ public class HyperUniquesAggregatorFactoryTest
       }
 
       Assert.assertEquals(
-              Double.compare(collector1.estimateCardinality(), collector2.estimateCardinality()),
-              comparator.compare(collector1, collector2)
+          Double.compare(collector1.estimateCardinality(), collector2.estimateCardinality()),
+          comparator.compare(collector1, collector2)
       );
     }
   }
@@ -150,20 +153,42 @@ public class HyperUniquesAggregatorFactoryTest
       }
 
       // when
-      final int orderedByCardinality = Double.compare(leftCollector.estimateCardinality(),
-              rightCollector.estimateCardinality());
+      final int orderedByCardinality = Double.compare(
+          leftCollector.estimateCardinality(),
+          rightCollector.estimateCardinality()
+      );
       final int orderedByComparator = comparator.compare(leftCollector, rightCollector);
 
       // then, assert hyperloglog comparator behaves consistently with estimated cardinalities
       Assert.assertEquals(
-              StringUtils.format("orderedByComparator=%d, orderedByCardinality=%d,\n" +
-                                 "Left={cardinality=%f, hll=%s},\n" +
-                                 "Right={cardinality=%f, hll=%s},\n", orderedByComparator, orderedByCardinality,
-                                 leftCollector.estimateCardinality(), leftCollector,
-                                 rightCollector.estimateCardinality(), rightCollector),
-              orderedByCardinality,
-              orderedByComparator
+          StringUtils.format("orderedByComparator=%d, orderedByCardinality=%d,\n" +
+                             "Left={cardinality=%f, hll=%s},\n" +
+                             "Right={cardinality=%f, hll=%s},\n", orderedByComparator, orderedByCardinality,
+                             leftCollector.estimateCardinality(), leftCollector,
+                             rightCollector.estimateCardinality(), rightCollector
+          ),
+          orderedByCardinality,
+          orderedByComparator
       );
     }
+  }
+
+  @Test
+  public void testSerde() throws Exception
+  {
+    final HyperUniquesAggregatorFactory factory = new HyperUniquesAggregatorFactory(
+        "foo",
+        "bar",
+        true,
+        true
+    );
+
+    final ObjectMapper jsonMapper = TestHelper.getJsonMapper();
+    final AggregatorFactory factory2 = jsonMapper.readValue(
+        jsonMapper.writeValueAsString(factory),
+        AggregatorFactory.class
+    );
+
+    Assert.assertEquals(factory, factory2);
   }
 }

--- a/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerTest.java
@@ -713,6 +713,56 @@ public class TopNQueryRunnerTest
   }
 
   @Test
+  public void testTopNOverHyperUniqueExpressionRounded()
+  {
+    TopNQuery query = new TopNQueryBuilder()
+        .dataSource(QueryRunnerTestHelper.dataSource)
+        .granularity(QueryRunnerTestHelper.allGran)
+        .dimension(QueryRunnerTestHelper.marketDimension)
+        .metric(QueryRunnerTestHelper.hyperUniqueFinalizingPostAggMetric)
+        .threshold(3)
+        .intervals(QueryRunnerTestHelper.fullOnInterval)
+        .aggregators(
+            Arrays.<AggregatorFactory>asList(QueryRunnerTestHelper.qualityUniquesRounded)
+        )
+        .postAggregators(
+            Collections.singletonList(new ExpressionPostAggregator(
+                QueryRunnerTestHelper.hyperUniqueFinalizingPostAggMetric,
+                "uniques + 1",
+                null,
+                TestExprMacroTable.INSTANCE
+            ))
+        )
+        .build();
+
+    List<Result<TopNResultValue>> expectedResults = Arrays.asList(
+        new Result<>(
+            DateTimes.of("2011-01-12T00:00:00.000Z"),
+            new TopNResultValue(
+                Arrays.<Map<String, Object>>asList(
+                    ImmutableMap.<String, Object>builder()
+                        .put("market", "spot")
+                        .put(QueryRunnerTestHelper.uniqueMetric, 9L)
+                        .put(QueryRunnerTestHelper.hyperUniqueFinalizingPostAggMetric, 10L)
+                        .build(),
+                    ImmutableMap.<String, Object>builder()
+                        .put("market", "total_market")
+                        .put(QueryRunnerTestHelper.uniqueMetric, 2L)
+                        .put(QueryRunnerTestHelper.hyperUniqueFinalizingPostAggMetric, 3L)
+                        .build(),
+                    ImmutableMap.<String, Object>builder()
+                        .put("market", "upfront")
+                        .put(QueryRunnerTestHelper.uniqueMetric, 2L)
+                        .put(QueryRunnerTestHelper.hyperUniqueFinalizingPostAggMetric, 3L)
+                        .build()
+                )
+            )
+        )
+    );
+    assertExpectedResults(expectedResults, query);
+  }
+
+  @Test
   public void testTopNOverFirstLastAggregator()
   {
     TopNQuery query = new TopNQueryBuilder()

--- a/sql/src/main/java/io/druid/sql/calcite/aggregation/ApproxCountDistinctSqlAggregator.java
+++ b/sql/src/main/java/io/druid/sql/calcite/aggregation/ApproxCountDistinctSqlAggregator.java
@@ -91,7 +91,7 @@ public class ApproxCountDistinctSqlAggregator implements SqlAggregator
     final AggregatorFactory aggregatorFactory;
 
     if (input.isDirectColumnAccess() && rowSignature.getColumnType(input.getDirectColumn()) == ValueType.COMPLEX) {
-      aggregatorFactory = new HyperUniquesAggregatorFactory(name, input.getDirectColumn());
+      aggregatorFactory = new HyperUniquesAggregatorFactory(name, input.getDirectColumn(), false, true);
     } else {
       final SqlTypeName sqlTypeName = rexNode.getType().getSqlTypeName();
       final ValueType inputType = Calcites.getValueTypeForSqlTypeName(sqlTypeName);
@@ -113,7 +113,7 @@ public class ApproxCountDistinctSqlAggregator implements SqlAggregator
         virtualColumns.add(virtualColumn);
       }
 
-      aggregatorFactory = new CardinalityAggregatorFactory(name, ImmutableList.of(dimensionSpec), false);
+      aggregatorFactory = new CardinalityAggregatorFactory(name, null, ImmutableList.of(dimensionSpec), false, true);
     }
 
     return Aggregation.create(virtualColumns, aggregatorFactory).filter(filter);

--- a/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
@@ -3557,8 +3557,10 @@ public class CalciteQueryTest
                             new CountAggregatorFactory("a0"),
                             new CardinalityAggregatorFactory(
                                 "a1",
+                                null,
                                 DIMS(new DefaultDimensionSpec("d0", null)),
-                                false
+                                false,
+                                true
                             )
                         ))
                         .setPostAggregatorSpecs(
@@ -3706,7 +3708,7 @@ public class CalciteQueryTest
                   .build()
         ),
         ImmutableList.of(
-            new Object[]{6L, 3L, 3.0f, 1L, 4L, 5.0f}
+            new Object[]{6L, 3L, 3.0f, 2L, 5L, 5.0f}
         )
     );
   }

--- a/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
@@ -2979,9 +2979,10 @@ public class CalciteQueryTest
                               "a1",
                               null,
                               DIMS(new DefaultDimensionSpec("dim2", null)),
-                              false
+                              false,
+                              true
                           ),
-                          new HyperUniquesAggregatorFactory("a2", "unique_dim1")
+                          new HyperUniquesAggregatorFactory("a2", "unique_dim1", false, true)
                       )
                   )
                   .context(TIMESERIES_CONTEXT_DEFAULT)
@@ -3050,7 +3051,8 @@ public class CalciteQueryTest
                               "a0",
                               null,
                               DIMS(new DefaultDimensionSpec("dim2", null)),
-                              false
+                              false,
+                              true
                           )
                       )
                   )
@@ -3136,19 +3138,22 @@ public class CalciteQueryTest
                               "a1",
                               null,
                               DIMS(new DefaultDimensionSpec("dim2", "dim2")),
-                              false
+                              false,
+                              true
                           ),
                           new FilteredAggregatorFactory(
                               new CardinalityAggregatorFactory(
                                   "a2",
                                   null,
                                   DIMS(new DefaultDimensionSpec("dim2", "dim2")),
-                                  false
+                                  false,
+                                  true
                               ),
                               NOT(SELECTOR("dim2", "", null))
                           ),
                           new CardinalityAggregatorFactory(
                               "a3",
+                              null,
                               DIMS(
                                   new ExtractionDimensionSpec(
                                       "dim2",
@@ -3157,14 +3162,17 @@ public class CalciteQueryTest
                                       new SubstringDimExtractionFn(0, 1)
                                   )
                               ),
-                              false
+                              false,
+                              true
                           ),
                           new CardinalityAggregatorFactory(
                               "a4",
+                              null,
                               DIMS(new DefaultDimensionSpec("a4:v", "a4:v", ValueType.STRING)),
-                              false
+                              false,
+                              true
                           ),
-                          new HyperUniquesAggregatorFactory("a5", "unique_dim1")
+                          new HyperUniquesAggregatorFactory("a5", "unique_dim1", false, true)
                       )
                   )
                   .context(TIMESERIES_CONTEXT_DEFAULT)
@@ -3562,7 +3570,7 @@ public class CalciteQueryTest
                         .build()
         ),
         ImmutableList.of(
-            new Object[]{5L, 5L, -0.12226936f}
+            new Object[]{5L, 5L, 0.0f}
         )
     );
   }
@@ -3683,7 +3691,8 @@ public class CalciteQueryTest
                               "a1",
                               null,
                               DIMS(new DefaultDimensionSpec("dim2", null)),
-                              false
+                              false,
+                              true
                           )
                       )
                   )
@@ -3697,7 +3706,7 @@ public class CalciteQueryTest
                   .build()
         ),
         ImmutableList.of(
-            new Object[]{6L, 3L, 3.0021994f, 1L, 4L, 4.9985347f}
+            new Object[]{6L, 3L, 3.0f, 1L, 4L, 5.0f}
         )
     );
   }
@@ -3717,6 +3726,7 @@ public class CalciteQueryTest
                       AGGS(
                           new CardinalityAggregatorFactory(
                               "a0",
+                              null,
                               DIMS(
                                   new ExtractionDimensionSpec(
                                       "dim1",
@@ -3724,7 +3734,8 @@ public class CalciteQueryTest
                                       new SubstringDimExtractionFn(0, 1)
                                   )
                               ),
-                              false
+                              false,
+                              true
                           )
                       )
                   )
@@ -4408,8 +4419,10 @@ public class CalciteQueryTest
                   .aggregators(AGGS(
                       new CardinalityAggregatorFactory(
                           "a0",
+                          null,
                           ImmutableList.<DimensionSpec>of(new ExtractionDimensionSpec("dim1", null, extractionFn)),
-                          false
+                          false,
+                          true
                       )
                   ))
                   .context(TIMESERIES_CONTEXT_DEFAULT)


### PR DESCRIPTION
Also turn it on by default in SQL, to make math on distinct counts
work more as expected.