### PR TITLE
Added JSON Parse Spec support to Avro Input Row Parser

### DIFF
--- a/extensions-contrib/parquet-extensions/src/main/java/io/druid/data/input/parquet/ParquetHadoopInputRowParser.java
+++ b/extensions-contrib/parquet-extensions/src/main/java/io/druid/data/input/parquet/ParquetHadoopInputRowParser.java
@@ -24,7 +24,7 @@ import com.google.common.collect.Lists;
 import io.druid.data.input.AvroStreamInputRowParser;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.MapBasedInputRow;
-import io.druid.data.input.avro.GenericRecordAsMap;
+import io.druid.data.input.avro.record.GenericRecordAsMap;
 import io.druid.data.input.impl.DimensionSchema;
 import io.druid.data.input.impl.InputRowParser;
 import io.druid.data.input.impl.ParseSpec;

--- a/extensions-core/avro-extensions/src/main/java/io/druid/data/input/AvroHadoopInputRowParser.java
+++ b/extensions-core/avro-extensions/src/main/java/io/druid/data/input/AvroHadoopInputRowParser.java
@@ -18,19 +18,20 @@
  */
 package io.druid.data.input;
 
+
+import org.apache.avro.generic.GenericRecord;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.druid.data.input.avro.record.GenericRecordRowConverter;
 import io.druid.data.input.impl.InputRowParser;
 import io.druid.data.input.impl.ParseSpec;
-import org.apache.avro.generic.GenericRecord;
 
-import java.util.List;
 
 public class AvroHadoopInputRowParser implements InputRowParser<GenericRecord>
 {
   private final ParseSpec parseSpec;
-  private final List<String> dimensions;
   private final boolean fromPigAvroStorage;
+  private final GenericRecordRowConverter recordConverter;
 
   @JsonCreator
   public AvroHadoopInputRowParser(
@@ -39,14 +40,18 @@ public class AvroHadoopInputRowParser implements InputRowParser<GenericRecord>
   )
   {
     this.parseSpec = parseSpec;
-    this.dimensions = parseSpec.getDimensionsSpec().getDimensionNames();
     this.fromPigAvroStorage = fromPigAvroStorage == null ? false : fromPigAvroStorage;
+    this.recordConverter = GenericRecordRowConverter.fromParseSpec(
+        parseSpec,
+        fromPigAvroStorage,
+        false
+    );
   }
 
   @Override
   public InputRow parse(GenericRecord record)
   {
-    return AvroStreamInputRowParser.parseGenericRecord(record, parseSpec, dimensions, fromPigAvroStorage, false);
+    return this.recordConverter.convert(record);
   }
 
   @JsonProperty

--- a/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/record/GenericRecordAsMap.java
+++ b/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/record/GenericRecordAsMap.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package io.druid.data.input.avro;
+package io.druid.data.input.avro.record;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;

--- a/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/record/GenericRecordJSONRowConverter.java
+++ b/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/record/GenericRecordJSONRowConverter.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.druid.data.input.avro.record;
+
+import io.druid.data.input.MapBasedInputRow;
+import io.druid.data.input.impl.ParseSpec;
+import io.druid.data.input.impl.TimestampSpec;
+import io.druid.java.util.common.parsers.Parser;
+import org.apache.avro.generic.GenericRecord;
+import org.joda.time.DateTime;
+
+import java.util.Map;
+
+public class GenericRecordJSONRowConverter extends GenericRecordRowConverter
+{
+  private final Parser<String, Object> parser;
+
+  GenericRecordJSONRowConverter(ParseSpec parseSpec, boolean fromPigAvroStorage, boolean binaryAsString)
+  {
+    super(parseSpec, fromPigAvroStorage, binaryAsString);
+
+    parser = parseSpec.makeParser();
+  }
+
+  @Override
+  public MapBasedInputRow convert(GenericRecord record)
+  {
+    System.out.println(record.toString());
+    Map<String, Object> map = parser.parse(record.toString());
+    TimestampSpec timestampSpec = parseSpec.getTimestampSpec();
+    DateTime dateTime = timestampSpec.extractTimestamp(map);
+    return new MapBasedInputRow(dateTime, dimensions, map);
+  }
+
+}

--- a/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/record/GenericRecordJSONRowConverter.java
+++ b/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/record/GenericRecordJSONRowConverter.java
@@ -41,7 +41,6 @@ public class GenericRecordJSONRowConverter extends GenericRecordRowConverter
   @Override
   public MapBasedInputRow convert(GenericRecord record)
   {
-    System.out.println(record.toString());
     Map<String, Object> map = parser.parse(record.toString());
     TimestampSpec timestampSpec = parseSpec.getTimestampSpec();
     DateTime dateTime = timestampSpec.extractTimestamp(map);

--- a/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/record/GenericRecordRowConverter.java
+++ b/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/record/GenericRecordRowConverter.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.druid.data.input.avro.record;
+
+import io.druid.data.input.MapBasedInputRow;
+import io.druid.data.input.impl.JSONParseSpec;
+import io.druid.data.input.impl.ParseSpec;
+import io.druid.data.input.impl.TimestampSpec;
+import org.apache.avro.generic.GenericRecord;
+import org.joda.time.DateTime;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ *
+ */
+public class GenericRecordRowConverter
+{
+  protected ParseSpec parseSpec;
+  protected List<String> dimensions;
+  protected boolean fromPigAvroStorage;
+  protected boolean binaryAsString;
+
+  protected GenericRecordRowConverter(
+      ParseSpec parseSpec,
+      boolean fromPigAvroStorage,
+      boolean binaryAsString
+  )
+  {
+    this.parseSpec = parseSpec;
+    this.dimensions = parseSpec.getDimensionsSpec().getDimensionNames();
+    this.fromPigAvroStorage = fromPigAvroStorage;
+    this.binaryAsString = binaryAsString;
+  }
+
+  public static GenericRecordRowConverter fromParseSpec(
+      ParseSpec parseSpec,
+      boolean fromPigAvroStorage,
+      boolean binaryAsString
+  )
+  {
+    return parseSpec instanceof JSONParseSpec ?
+           new GenericRecordJSONRowConverter(parseSpec, fromPigAvroStorage, binaryAsString) :
+           new GenericRecordRowConverter(parseSpec, fromPigAvroStorage, binaryAsString);
+  }
+
+  public MapBasedInputRow convert(GenericRecord record)
+  {
+    GenericRecordAsMap genericRecordAsMap = new GenericRecordAsMap(record, fromPigAvroStorage, binaryAsString);
+    TimestampSpec timestampSpec = parseSpec.getTimestampSpec();
+    DateTime dateTime = timestampSpec.extractTimestamp(genericRecordAsMap);
+    return new MapBasedInputRow(dateTime, dimensions, genericRecordAsMap);
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    GenericRecordRowConverter that = (GenericRecordRowConverter) o;
+
+    return parseSpec.equals(that.parseSpec) &&
+           dimensions.equals(that.dimensions);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(parseSpec, dimensions, fromPigAvroStorage);
+  }
+}


### PR DESCRIPTION
Added support for JSON parse spec to the Avro parser. 

Currently the Avro parser does not support nested fields and can only consume top level fields in an Avro record. This feature allows nested field support using a JSON Parse Spec. If an ingestion spec using an Avro Stream or Avro Hadoop parser contains a JSON parse spec then the extension will allow extraction of nested properties using the JSON parse spec / Flatten spec. 

The implementation is basic and is probably lacking in some areas but I've created it to allow us to get off the ground without a lot of effort for a prototype. I've not documented this feature as did not think it was worth it until seeing if it would be pulled in. If it's of use to the community then I can document it via another commit. Alternatively if there is a better way of doing this without a lot of effort or I am fundamentally doing something wrong then let me know.

Basically it works such that If the ingestion spec supplied is a JSON parse spec then at runtime a new Converter is used which essentially calls GenericRecord.toString to turn the GenericAvroRecord into JSON and passes this to the standard JSON parser to do it's dimension mapping. If any other type of parse spec is supplied then the existing implementation is used.

Some of the important bits of code.

- GenericRecordRowConverter 
```java
  public MapBasedInputRow convert(GenericRecord record)
  {
    GenericRecordAsMap genericRecordAsMap = new GenericRecordAsMap(record, fromPigAvroStorage, false);
    TimestampSpec timestampSpec = parseSpec.getTimestampSpec();
    DateTime dateTime = timestampSpec.extractTimestamp(genericRecordAsMap);
    return new MapBasedInputRow(dateTime, dimensions, genericRecordAsMap);
  }
```

- GenericRecordJSONConveter

```java
  @Override
  public MapBasedInputRow convert(GenericRecord record)
  {
    Map<String, Object> map = parser.parse(record.toString()); //note the tostring
    TimestampSpec timestampSpec = parseSpec.getTimestampSpec();
    DateTime dateTime = timestampSpec.extractTimestamp(map);
    return new MapBasedInputRow(dateTime, dimensions, map);
  }
```

- Factory method to instantiate correct converter based on spec type. 
```java
  public static GenericRecordRowConverter fromParseSpec(
      ParseSpec parseSpec,
      boolean fromPigAvroStorage,
      boolean binaryAsString
  )
  {
    return parseSpec instanceof JSONParseSpec ?
           new GenericRecordJSONRowConverter(parseSpec, fromPigAvroStorage) :
           new GenericRecordRowConverter(parseSpec, fromPigAvroStorage, binaryAsString);
  }
```
- Example Spec.
```java
 "parser": {
            "type": "avro_stream",
            "parseSpec": {
              "format": "json",
              "timestampSpec": {
                "format": "posix",
                "column": "timestamp"
              },
              "flattenSpec": {
                "useFieldDiscovery": true,
                "fields": [{
                  "type": "root",
                  "name": "timestamp"
                }, {
                  "type": "path",
                  "name": "markers_forecasting_projected_impression",
                  "expr": "$.markers.forecasting.projected_impression"
                }, {
                  "type": "path",
                  "name": "targeting_geo_country",
                  "expr": "$.targets.geo.country"
...
```