### PR TITLE
Upgrade Curator.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,9 +59,7 @@
 
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>
-
-        <!-- Curator cannot be updated to 2.12.0 yet, see https://github.com/druid-io/druid/pull/4103 -->
-        <apache.curator.version>2.11.0</apache.curator.version>
+        <apache.curator.version>4.0.0</apache.curator.version>
         <avatica.version>1.9.0</avatica.version>
         <calcite.version>1.12.0</calcite.version>
         <guava.version>16.0.1</guava.version>


### PR DESCRIPTION
Curator 4.0.0 contains a fix for CURATOR-394 (see also #4103)
and supports both ZooKeeper 3.4.x and 3.5.x.

Fixes #4056, fixes #3837.

We have run this on one of our internal clusters for about a week.