### PR TITLE
Use trusty for travis jobs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 
-dist: precise
+dist: trusty
 
 jdk:
   - oraclejdk8
@@ -29,7 +29,6 @@ matrix:
 
       # run integration tests
     - sudo: required
-      dist: trusty
       services:
         - docker
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,13 @@ matrix:
 
       # processing module test
     - sudo: false
-      install: mvn install -ff -DskipTests -B
-      script: mvn test -B -Pparallel-test -Dmaven.fork.count=2 -pl processing
+      install: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn install -ff -DskipTests -B
+      script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -Pparallel-test -Dmaven.fork.count=2 -pl processing
 
       # non-processing modules test
     - sudo: false
-      install: mvn install -ff -DskipTests -B
-      script: mvn test -B -Pparallel-test -Dmaven.fork.count=2 -pl '!processing'
+      install: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn install -ff -DskipTests -B
+      script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -Pparallel-test -Dmaven.fork.count=2 -pl '!processing'
 
       # run integration tests
     - sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,12 @@ matrix:
 
       # processing module test
     - sudo: false
-      install: mvn install -q -ff -DskipTests -B
+      install: mvn install -ff -DskipTests -B
       script: mvn test -B -Pparallel-test -Dmaven.fork.count=2 -pl processing
 
       # non-processing modules test
     - sudo: false
-      install: mvn install -q -ff -DskipTests -B
+      install: mvn install -ff -DskipTests -B
       script: mvn test -B -Pparallel-test -Dmaven.fork.count=2 -pl '!processing'
 
       # run integration tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,12 @@ matrix:
       # processing module test
     - sudo: false
       install: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn install -q -ff -DskipTests -B
-      script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -Pparallel-test -Dmaven.fork.count=2 -pl processing
+      script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -e -Pparallel-test -Dmaven.fork.count=2 -pl processing
 
       # non-processing modules test
     - sudo: false
       install: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn install -q -ff -DskipTests -B
-      script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -Pparallel-test -Dmaven.fork.count=2 -pl '!processing'
+      script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -e -Pparallel-test -Dmaven.fork.count=2 -pl '!processing'
 
       # run integration tests
     - sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,12 @@ matrix:
 
       # processing module test
     - sudo: false
-      install: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn install -ff -DskipTests -B
+      install: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn install -q -ff -DskipTests -B
       script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -Pparallel-test -Dmaven.fork.count=2 -pl processing
 
       # non-processing modules test
     - sudo: false
-      install: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn install -ff -DskipTests -B
+      install: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn install -q -ff -DskipTests -B
       script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -Pparallel-test -Dmaven.fork.count=2 -pl '!processing'
 
       # run integration tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,12 @@ matrix:
       # processing module test
     - sudo: false
       install: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn install -q -ff -DskipTests -B
-      script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -e -Pparallel-test -Dmaven.fork.count=2 -pl processing
+      script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -Pparallel-test -Dmaven.fork.count=2 -pl processing
 
       # non-processing modules test
     - sudo: false
       install: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn install -q -ff -DskipTests -B
-      script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -e -Pparallel-test -Dmaven.fork.count=2 -pl '!processing'
+      script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -Pparallel-test -Dmaven.fork.count=2 -pl '!processing'
 
       # run integration tests
     - sudo: required

--- a/pom.xml
+++ b/pom.xml
@@ -1157,7 +1157,7 @@
                             <forceJavacCompilerUse>true</forceJavacCompilerUse>
                             <fork>true</fork>
                             <meminitial>1024m</meminitial>
-                            <maxmem>1500m</maxmem>
+                            <maxmem>3000m</maxmem>
                             <source>${maven.compiler.target}</source>
                             <target>${maven.compiler.target}</target>
                             <showWarnings>false</showWarnings>

--- a/pom.xml
+++ b/pom.xml
@@ -1238,7 +1238,7 @@
                             <trimStackTrace>false</trimStackTrace>
                             <!-- locale settings must be set on the command line before startup -->
                             <!-- set heap size to work around https://github.com/travis-ci/travis-ci/issues/3396 -->
-                            <argLine>-Xmx1024m -Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8
+                            <argLine>-Xmx768m -Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8
                                 -Duser.timezone=UTC -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
                             </argLine>
                             <!-- our tests are very verbose, let's keep the volume down -->

--- a/pom.xml
+++ b/pom.xml
@@ -1157,7 +1157,7 @@
                             <forceJavacCompilerUse>true</forceJavacCompilerUse>
                             <fork>true</fork>
                             <meminitial>1024m</meminitial>
-                            <maxmem>3000m</maxmem>
+                            <maxmem>1500m</maxmem>
                             <source>${maven.compiler.target}</source>
                             <target>${maven.compiler.target}</target>
                             <showWarnings>false</showWarnings>


### PR DESCRIPTION
The distro was set to "precise" in #4572 due to memory issues on trusty,
but we've been seeing performance issues on "precise" recently so let's
see how trusty is working these days.