### PR TITLE
increase test timeout to 15sec as leader election jitter is random sleep between 1 to 5 secs

### DIFF
--- a/server/src/test/java/io/druid/curator/discovery/CuratorDruidLeaderSelectorTest.java
+++ b/server/src/test/java/io/druid/curator/discovery/CuratorDruidLeaderSelectorTest.java
@@ -48,7 +48,7 @@ public class CuratorDruidLeaderSelectorTest extends CuratorTestBase
     setupServerAndCurator();
   }
 
-  @Test(timeout = 5000)
+  @Test(timeout = 15000)
   public void testSimple() throws Exception
   {
     curator.start();


### PR DESCRIPTION
discussed in https://github.com/druid-io/druid/pull/4699#discussion_r137170784