### PR TITLE
Datasources resource throws NPE when segments are requested

### DIFF
--- a/server/src/main/java/io/druid/server/http/DatasourcesResource.java
+++ b/server/src/main/java/io/druid/server/http/DatasourcesResource.java
@@ -19,7 +19,6 @@
 
 package io.druid.server.http;
 
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -120,14 +119,7 @@ public class DatasourcesResource
           Lists.newArrayList(
               Iterables.transform(
                   datasources,
-                  new Function<DruidDataSource, Map<String, Object>>()
-                  {
-                    @Override
-                    public Map<String, Object> apply(DruidDataSource dataSource)
-                    {
-                      return makeSimpleDatasource(dataSource);
-                    }
-                  }
+                  (DruidDataSource dataSource) -> makeSimpleDatasource(dataSource)
               )
           )
       ).build();
@@ -137,14 +129,7 @@ public class DatasourcesResource
         Lists.newArrayList(
             Iterables.transform(
                 datasources,
-                new Function<DruidDataSource, String>()
-                {
-                  @Override
-                  public String apply(DruidDataSource dataSource)
-                  {
-                    return dataSource.getName();
-                  }
-                }
+                (DruidDataSource dataSource) -> dataSource.getName()
             )
         )
     ).build();
@@ -300,7 +285,10 @@ public class DatasourcesResource
         }
 
         Pair<DataSegment, Set<String>> val = getSegment(dataSegment.getIdentifier());
-        segments.put(dataSegment.getIdentifier(), ImmutableMap.of("metadata", val.lhs, "servers", val.rhs));
+
+        if (val != null) {
+          segments.put(dataSegment.getIdentifier(), ImmutableMap.of("metadata", val.lhs, "servers", val.rhs));
+        }
       }
 
       return Response.ok(retVal).build();
@@ -363,7 +351,10 @@ public class DatasourcesResource
           }
 
           Pair<DataSegment, Set<String>> val = getSegment(dataSegment.getIdentifier());
-          segments.put(dataSegment.getIdentifier(), ImmutableMap.of("metadata", val.lhs, "servers", val.rhs));
+
+          if (val != null) {
+            segments.put(dataSegment.getIdentifier(), ImmutableMap.of("metadata", val.lhs, "servers", val.rhs));
+          }
         }
       }
 
@@ -423,14 +414,7 @@ public class DatasourcesResource
     return builder.entity(
         Iterables.transform(
             dataSource.getSegments(),
-            new Function<DataSegment, Object>()
-            {
-              @Override
-              public Object apply(DataSegment segment)
-              {
-                return segment.getIdentifier();
-              }
-            }
+            (DataSegment segment) -> segment.getIdentifier()
         )
     ).build();
   }
@@ -515,14 +499,7 @@ public class DatasourcesResource
         Iterables.concat(
             Iterables.transform(
                 serverInventoryView.getInventory(),
-                new Function<DruidServer, DruidDataSource>()
-                {
-                  @Override
-                  public DruidDataSource apply(DruidServer input)
-                  {
-                    return input.getDataSource(dataSourceName);
-                  }
-                }
+                (DruidServer input) -> input.getDataSource(dataSourceName)
             )
         );
 
@@ -548,7 +525,7 @@ public class DatasourcesResource
 
     return new DruidDataSource(
         dataSourceName,
-        ImmutableMap.<String, String>of()
+        ImmutableMap.of()
     ).addSegments(segmentMap);
   }
 
@@ -668,28 +645,12 @@ public class DatasourcesResource
     Iterable<TimelineObjectHolder<String, SegmentLoadInfo>> lookup = timeline.lookupWithIncompletePartitions(theInterval);
     FunctionalIterable<ImmutableSegmentLoadInfo> retval = FunctionalIterable
         .create(lookup).transformCat(
-            new Function<TimelineObjectHolder<String, SegmentLoadInfo>, Iterable<ImmutableSegmentLoadInfo>>()
-            {
-              @Override
-              public Iterable<ImmutableSegmentLoadInfo> apply(
-                  TimelineObjectHolder<String, SegmentLoadInfo> input
-              )
-              {
-                return Iterables.transform(
+            (TimelineObjectHolder<String, SegmentLoadInfo> input) ->
+                Iterables.transform(
                     input.getObject(),
-                    new Function<PartitionChunk<SegmentLoadInfo>, ImmutableSegmentLoadInfo>()
-                    {
-                      @Override
-                      public ImmutableSegmentLoadInfo apply(
-                          PartitionChunk<SegmentLoadInfo> chunk
-                      )
-                      {
-                        return chunk.getObject().toImmutableSegmentLoadInfo();
-                      }
-                    }
-                );
-              }
-            }
+                    (PartitionChunk<SegmentLoadInfo> chunk) ->
+                        chunk.getObject().toImmutableSegmentLoadInfo()
+                )
         );
     return Response.ok(retval).build();
   }


### PR DESCRIPTION
Datasources resource throws NPE when segments are requested. This happens when new segments are being loaded and old ones have not fully disappeared from the Coordinator Server View

```
2017-09-06T21:48:00,725 WARN [qtp571696027-191] org.eclipse.jetty.servlet.ServletHandler - /druid/coordinator/v1/datasources/test/intervals/2017-09-05T00:00:00.000Z_2017-09-06T00:00:00.000Z
java.lang.NullPointerException
        at io.druid.server.http.DatasourcesResource.getSegmentDataSourceSpecificInterval(DatasourcesResource.java:364) ~[druid-server-0.10.1.jar:0.10.1]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_112]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_112]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_112]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_112]
        at com.sun.jersey.spi.container.JavaMethodInvokerFactory$1.invoke(JavaMethodInvokerFactory.java:60) ~[jersey-server-1.19.3.jar:1.19.3]
        at com.sun.jersey.server.impl.model.method.dispatch.AbstractResourceMethodDispatchProvider$ResponseOutInvoker._dispatch(AbstractResourceMethodDispatchProvider.java:205) ~[jersey-server-1.19.3.jar:1.19.3]
```