### PR TITLE
Make optional Peon "stdin" check 

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/worker/executor/ExecutorLifecycleConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/worker/executor/ExecutorLifecycleConfig.java
@@ -20,7 +20,6 @@
 package io.druid.indexing.worker.executor;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import io.druid.java.util.common.ISE;
 
 import javax.validation.constraints.NotNull;
@@ -43,6 +42,22 @@ public class ExecutorLifecycleConfig
   @JsonProperty
   @Pattern(regexp = "\\{stdin\\}")
   private String parentStreamName = "stdin";
+  @JsonProperty
+  private boolean parentStreamDefined = true;
+
+  /**
+   * Should parent stream be monitored.
+   */
+  public boolean isParentStreamDefined()
+  {
+    return parentStreamDefined;
+  }
+
+  public ExecutorLifecycleConfig setParentStreamDefined(boolean parentStreamDefined)
+  {
+    this.parentStreamDefined = parentStreamDefined;
+    return this;
+  }
 
   public File getTaskFile()
   {


### PR DESCRIPTION
Right now _Peon_ checks whether stdin is open, if it's not then _Peon_ shutdowns _JVM_. That way _Peon_ controls it doesn't lose the parent process. However it could be convenient to use _Peon_ within the same _JVM_ without open _stdin_. For example, a _Druid extension_ can send _Peon_ to a cluster managed by _Yarn/Mesos_ within a wrapper which uses _Peon_ functionality. This PR makes it possible to disable that check by using _Guice_ module overrides.