### PR TITLE
Generate UUID if query id is empty

### DIFF
--- a/server/src/main/java/io/druid/server/QueryLifecycle.java
+++ b/server/src/main/java/io/druid/server/QueryLifecycle.java
@@ -167,7 +167,7 @@ public class QueryLifecycle
     transition(State.NEW, State.INITIALIZED);
 
     String queryId = baseQuery.getId();
-    if (queryId == null) {
+    if (Strings.isNullOrEmpty(queryId)) {
       queryId = UUID.randomUUID().toString();
     }
 


### PR DESCRIPTION
We see logs like `2017-09-09T03:24:52,110 INFO [qtp269145726-337[groupBy_[test]_]] com.metamx.http.client.pool.ChannelResourceFactory - Generating: http://xxxx:8091` 
 
Generate UUID if query id is empty or null