### PR TITLE
Change WorkerSelectStrategy's defaultImpl from FillCapacityWorkerSelectStrategy to EqualDistributionWorkerSelectStrategy

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/overlord/setup/WorkerSelectStrategy.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/setup/WorkerSelectStrategy.java
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
 /**
  * The {@link io.druid.indexing.overlord.RemoteTaskRunner} uses this class to select a worker to assign tasks to.
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = FillCapacityWorkerSelectStrategy.class)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = EqualDistributionWorkerSelectStrategy.class)
 @JsonSubTypes(value = {
     @JsonSubTypes.Type(name = "fillCapacity", value = FillCapacityWorkerSelectStrategy.class),
     @JsonSubTypes.Type(name = "fillCapacityWithAffinity", value = FillCapacityWithAffinityWorkerSelectStrategy.class),


### PR DESCRIPTION
Recently, I found the default WorkerSelectStrategy had been changed from FillCapacityWorkerSelectStrategy to EqualDistributionWorkerSelectStrategy. However, interface WorkerSelectStrategy's `defaultImpl` still is FillCapacityWorkerSelectStrategy. So I modified it for consistency.