### PR TITLE
SQL: Fix toTimeseriesQuery and toTopNQuery.

### DIFF
--- a/processing/src/main/java/io/druid/query/groupby/GroupByQuery.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQuery.java
@@ -348,7 +348,7 @@ public class GroupByQuery extends BaseQuery<Row>
         throw new IAE("When forcing limit push down, a limit spec must be provided.");
       }
 
-      if (((DefaultLimitSpec) limitSpec).getLimit() == Integer.MAX_VALUE) {
+      if (!((DefaultLimitSpec) limitSpec).isLimited()) {
         throw new IAE("When forcing limit push down, the provided limit spec must have a limit.");
       }
 
@@ -373,7 +373,7 @@ public class GroupByQuery extends BaseQuery<Row>
       DefaultLimitSpec defaultLimitSpec = (DefaultLimitSpec) limitSpec;
 
       // If only applying an orderby without a limit, don't try to push down
-      if (defaultLimitSpec.getLimit() == Integer.MAX_VALUE) {
+      if (!defaultLimitSpec.isLimited()) {
         return false;
       }
 

--- a/sql/src/main/java/io/druid/sql/calcite/filtration/Filtration.java
+++ b/sql/src/main/java/io/druid/sql/calcite/filtration/Filtration.java
@@ -21,8 +21,8 @@ package io.druid.sql.calcite.filtration;
 
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
-import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.ISE;
+import io.druid.java.util.common.Intervals;
 import io.druid.math.expr.ExprMacroTable;
 import io.druid.query.filter.DimFilter;
 import io.druid.query.filter.ExpressionDimFilter;

--- a/sql/src/main/java/io/druid/sql/calcite/planner/Calcites.java
+++ b/sql/src/main/java/io/druid/sql/calcite/planner/Calcites.java
@@ -133,6 +133,11 @@ public class Calcites
   public static StringComparator getStringComparatorForSqlTypeName(SqlTypeName sqlTypeName)
   {
     final ValueType valueType = getValueTypeForSqlTypeName(sqlTypeName);
+    return getStringComparatorForValueType(valueType);
+  }
+
+  public static StringComparator getStringComparatorForValueType(ValueType valueType)
+  {
     if (ValueType.isNumeric(valueType)) {
       return StringComparators.NUMERIC;
     } else if (ValueType.STRING == valueType) {

--- a/sql/src/main/java/io/druid/sql/calcite/rel/DruidQueryRel.java
+++ b/sql/src/main/java/io/druid/sql/calcite/rel/DruidQueryRel.java
@@ -220,7 +220,7 @@ public class DruidQueryRel extends DruidRel<DruidQueryRel>
       cost += COST_PER_COLUMN * queryBuilder.getGrouping().getPostAggregators().size();
     }
 
-    if (queryBuilder.getLimitSpec() != null && queryBuilder.getLimitSpec().getLimit() < Integer.MAX_VALUE) {
+    if (queryBuilder.getLimitSpec() != null && queryBuilder.getLimitSpec().isLimited()) {
       cost *= COST_LIMIT_MULTIPLIER;
     }
 

--- a/sql/src/main/java/io/druid/sql/calcite/rule/GroupByRules.java
+++ b/sql/src/main/java/io/druid/sql/calcite/rule/GroupByRules.java
@@ -648,7 +648,7 @@ public class GroupByRules
       }
     }
 
-    if (!orderBys.isEmpty() || limitSpec.getLimit() < Integer.MAX_VALUE) {
+    if (!orderBys.isEmpty() || limitSpec.isLimited()) {
       return druidRel.withQueryBuilder(
           druidRel.getQueryBuilder()
                   .withAdjustedGrouping(


### PR DESCRIPTION
The former would sometimes eat limits, and the latter would sometimes
use the wrong dimension comparator.