### PR TITLE
Try to improve CI reliability.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,15 @@ matrix:
       # processing module test
     - sudo: false
       install: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn install -q -ff -DskipTests -B
+      before_script:
+        - unset _JAVA_OPTIONS
       script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -Pparallel-test -Dmaven.fork.count=2 -pl processing
 
       # non-processing modules test
     - sudo: false
       install: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn install -q -ff -DskipTests -B
+      before_script:
+        - unset _JAVA_OPTIONS
       script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -Pparallel-test -Dmaven.fork.count=2 -pl '!processing'
 
       # run integration tests

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/JSONPathParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/JSONPathParser.java
@@ -195,8 +195,7 @@ public class JSONPathParser implements Parser<String, Object>
 
     if (val.isArray()) {
       List<Object> newList = new ArrayList<>();
-      for (Iterator<JsonNode> it = val.iterator(); it.hasNext(); ) {
-        JsonNode entry = it.next();
+      for (JsonNode entry : val) {
         newList.add(valueConversionFunction(entry));
       }
       return newList;


### PR DESCRIPTION
Unset _JAVA_OPTIONS just in case it is causing us to use more memory than expected. I saw 2x "Picked up _JAVA_OPTIONS: -Xmx2048m" in some CI logs with the parallel test runner, and we don't have enough memory to run 2x of those.

Also adjust a TC inspection error that came in from #4171.