### PR TITLE
TimestampAggregator: Avoid cross-classloader access of package-private field.

### DIFF
--- a/extensions-contrib/time-min-max/src/main/java/io/druid/query/aggregation/TimestampAggregator.java
+++ b/extensions-contrib/time-min-max/src/main/java/io/druid/query/aggregation/TimestampAggregator.java
@@ -27,7 +27,7 @@ import java.util.Comparator;
 
 public class TimestampAggregator implements Aggregator
 {
-  static final Comparator COMPARATOR = (a, b) -> Longs.compare(((Number) a).longValue(), ((Number) b).longValue());
+  static final Comparator COMPARATOR = Comparator.comparingLong(n -> ((Number) n).longValue());
 
   static Object combineValues(Comparator<Long> comparator, Object lhs, Object rhs)
   {

--- a/extensions-contrib/time-min-max/src/main/java/io/druid/query/aggregation/TimestampAggregator.java
+++ b/extensions-contrib/time-min-max/src/main/java/io/druid/query/aggregation/TimestampAggregator.java
@@ -19,6 +19,7 @@
 
 package io.druid.query.aggregation;
 
+import com.google.common.primitives.Longs;
 import io.druid.data.input.impl.TimestampSpec;
 import io.druid.segment.ObjectColumnSelector;
 
@@ -26,7 +27,7 @@ import java.util.Comparator;
 
 public class TimestampAggregator implements Aggregator
 {
-  static final Comparator COMPARATOR = LongMaxAggregator.COMPARATOR;
+  static final Comparator COMPARATOR = (a, b) -> Longs.compare(((Number) a).longValue(), ((Number) b).longValue());
 
   static Object combineValues(Comparator<Long> comparator, Object lhs, Object rhs)
   {

--- a/extensions-contrib/time-min-max/src/main/java/io/druid/query/aggregation/TimestampAggregator.java
+++ b/extensions-contrib/time-min-max/src/main/java/io/druid/query/aggregation/TimestampAggregator.java
@@ -19,7 +19,6 @@
 
 package io.druid.query.aggregation;
 
-import com.google.common.primitives.Longs;
 import io.druid.data.input.impl.TimestampSpec;
 import io.druid.segment.ObjectColumnSelector;
 


### PR DESCRIPTION
Fixes IllegalAccessError reported in the lists.