### PR TITLE
Replace HistoricalFloatColumnSelector with more generic HistoricalColumnSelector

### DIFF
--- a/processing/src/main/java/io/druid/query/topn/Historical1SimpleDoubleAggPooledTopNScannerPrototype.java
+++ b/processing/src/main/java/io/druid/query/topn/Historical1SimpleDoubleAggPooledTopNScannerPrototype.java
@@ -24,21 +24,21 @@ import io.druid.segment.data.IndexedInts;
 import io.druid.segment.data.Offset;
 import io.druid.segment.historical.HistoricalCursor;
 import io.druid.segment.historical.HistoricalDimensionSelector;
-import io.druid.segment.historical.HistoricalFloatColumnSelector;
+import io.druid.segment.historical.HistoricalColumnSelector;
 
 import java.nio.ByteBuffer;
 
 public class Historical1SimpleDoubleAggPooledTopNScannerPrototype
     implements Historical1AggPooledTopNScanner<
         HistoricalDimensionSelector,
-        HistoricalFloatColumnSelector,
+        HistoricalColumnSelector,
         SimpleDoubleBufferAggregator
     >
 {
   @Override
   public long scanAndAggregate(
       HistoricalDimensionSelector dimensionSelector,
-      HistoricalFloatColumnSelector metricSelector,
+      HistoricalColumnSelector metricSelector,
       SimpleDoubleBufferAggregator aggregator,
       int aggregatorSize,
       HistoricalCursor cursor,
@@ -52,7 +52,7 @@ public class Historical1SimpleDoubleAggPooledTopNScannerPrototype
     int positionToAllocate = 0;
     while (offset.withinBounds() && !Thread.currentThread().isInterrupted()) {
       int rowNum = offset.getOffset();
-      double metric = metricSelector.get(rowNum);
+      double metric = metricSelector.getDouble(rowNum);
       final IndexedInts dimValues = dimensionSelector.getRow(rowNum);
       final int dimSize = dimValues.size();
       for (int i = 0; i < dimSize; i++) {

--- a/processing/src/main/java/io/druid/query/topn/HistoricalSingleValueDimSelector1SimpleDoubleAggPooledTopNScannerPrototype.java
+++ b/processing/src/main/java/io/druid/query/topn/HistoricalSingleValueDimSelector1SimpleDoubleAggPooledTopNScannerPrototype.java
@@ -22,7 +22,7 @@ package io.druid.query.topn;
 import io.druid.query.aggregation.SimpleDoubleBufferAggregator;
 import io.druid.segment.data.Offset;
 import io.druid.segment.historical.HistoricalCursor;
-import io.druid.segment.historical.HistoricalFloatColumnSelector;
+import io.druid.segment.historical.HistoricalColumnSelector;
 import io.druid.segment.historical.SingleValueHistoricalDimensionSelector;
 
 import java.nio.ByteBuffer;
@@ -30,14 +30,14 @@ import java.nio.ByteBuffer;
 public class HistoricalSingleValueDimSelector1SimpleDoubleAggPooledTopNScannerPrototype
     implements Historical1AggPooledTopNScanner<
         SingleValueHistoricalDimensionSelector,
-        HistoricalFloatColumnSelector,
+        HistoricalColumnSelector,
         SimpleDoubleBufferAggregator
     >
 {
   @Override
   public long scanAndAggregate(
       SingleValueHistoricalDimensionSelector dimensionSelector,
-      HistoricalFloatColumnSelector metricSelector,
+      HistoricalColumnSelector metricSelector,
       SimpleDoubleBufferAggregator aggregator,
       int aggregatorSize,
       HistoricalCursor cursor,
@@ -54,10 +54,10 @@ public class HistoricalSingleValueDimSelector1SimpleDoubleAggPooledTopNScannerPr
       int dimIndex = dimensionSelector.getRowValue(rowNum);
       int position = positions[dimIndex];
       if (position >= 0) {
-        aggregator.aggregate(resultsBuffer, position, metricSelector.get(rowNum));
+        aggregator.aggregate(resultsBuffer, position, metricSelector.getDouble(rowNum));
       } else if (position == TopNAlgorithm.INIT_POSITION_VALUE) {
         positions[dimIndex] = positionToAllocate;
-        aggregator.putFirst(resultsBuffer, positionToAllocate, metricSelector.get(rowNum));
+        aggregator.putFirst(resultsBuffer, positionToAllocate, metricSelector.getDouble(rowNum));
         positionToAllocate += aggregatorSize;
       }
       processedRows++;

--- a/processing/src/main/java/io/druid/query/topn/PooledTopNAlgorithm.java
+++ b/processing/src/main/java/io/druid/query/topn/PooledTopNAlgorithm.java
@@ -41,7 +41,7 @@ import io.druid.segment.data.IndexedInts;
 import io.druid.segment.data.Offset;
 import io.druid.segment.historical.HistoricalCursor;
 import io.druid.segment.historical.HistoricalDimensionSelector;
-import io.druid.segment.historical.HistoricalFloatColumnSelector;
+import io.druid.segment.historical.HistoricalColumnSelector;
 import io.druid.segment.historical.SingleValueHistoricalDimensionSelector;
 
 import java.nio.ByteBuffer;
@@ -131,7 +131,7 @@ public class PooledTopNAlgorithm
           final Cursor cursor = params.getCursor();
           if (cursor instanceof HistoricalCursor && aggregator instanceof SimpleDoubleBufferAggregator) {
             if (params.getDimSelector() instanceof SingleValueHistoricalDimensionSelector &&
-                ((SimpleDoubleBufferAggregator) aggregator).getSelector() instanceof HistoricalFloatColumnSelector) {
+                ((SimpleDoubleBufferAggregator) aggregator).getSelector() instanceof HistoricalColumnSelector) {
               return scanAndAggregateHistorical1SimpleDoubleAgg(
                   params,
                   positions,
@@ -152,7 +152,7 @@ public class PooledTopNAlgorithm
           final Cursor cursor = params.getCursor();
           if (cursor instanceof HistoricalCursor && aggregator instanceof SimpleDoubleBufferAggregator) {
             if (params.getDimSelector() instanceof HistoricalDimensionSelector &&
-                ((SimpleDoubleBufferAggregator) aggregator).getSelector() instanceof HistoricalFloatColumnSelector) {
+                ((SimpleDoubleBufferAggregator) aggregator).getSelector() instanceof HistoricalColumnSelector) {
               return scanAndAggregateHistorical1SimpleDoubleAgg(
                   params,
                   positions,

--- a/processing/src/main/java/io/druid/segment/ZeroFloatColumnSelector.java
+++ b/processing/src/main/java/io/druid/segment/ZeroFloatColumnSelector.java
@@ -20,9 +20,9 @@
 package io.druid.segment;
 
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
-import io.druid.segment.historical.HistoricalFloatColumnSelector;
+import io.druid.segment.historical.HistoricalColumnSelector;
 
-public final class ZeroFloatColumnSelector implements HistoricalFloatColumnSelector
+public final class ZeroFloatColumnSelector implements FloatColumnSelector, HistoricalColumnSelector
 {
   private static final ZeroFloatColumnSelector INSTANCE = new ZeroFloatColumnSelector();
 
@@ -43,9 +43,9 @@ public final class ZeroFloatColumnSelector implements HistoricalFloatColumnSelec
   }
 
   @Override
-  public float get(int offset)
+  public double getDouble(int offset)
   {
-    return getFloat();
+    return 0.0;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/column/GenericColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/GenericColumn.java
@@ -22,9 +22,9 @@ package io.druid.segment.column;
 import io.druid.query.monomorphicprocessing.CalledFromHotLoop;
 import io.druid.query.monomorphicprocessing.HotLoopCallee;
 import io.druid.segment.DoubleColumnSelector;
+import io.druid.segment.FloatColumnSelector;
 import io.druid.segment.LongColumnSelector;
 import io.druid.segment.data.ReadableOffset;
-import io.druid.segment.historical.HistoricalFloatColumnSelector;
 
 import java.io.Closeable;
 
@@ -41,7 +41,7 @@ public interface GenericColumn extends HotLoopCallee, Closeable
 
   @CalledFromHotLoop
   float getFloatSingleValueRow(int rowNum);
-  HistoricalFloatColumnSelector makeFloatSingleValueRowSelector(ReadableOffset offset);
+  FloatColumnSelector makeFloatSingleValueRowSelector(ReadableOffset offset);
 
   @CalledFromHotLoop
   long getLongSingleValueRow(int rowNum);

--- a/processing/src/main/java/io/druid/segment/column/IndexedDoublesGenericColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/IndexedDoublesGenericColumn.java
@@ -21,10 +21,10 @@ package io.druid.segment.column;
 
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.DoubleColumnSelector;
+import io.druid.segment.FloatColumnSelector;
 import io.druid.segment.LongColumnSelector;
 import io.druid.segment.data.IndexedDoubles;
 import io.druid.segment.data.ReadableOffset;
-import io.druid.segment.historical.HistoricalFloatColumnSelector;
 
 
 public class IndexedDoublesGenericColumn implements GenericColumn
@@ -67,7 +67,7 @@ public class IndexedDoublesGenericColumn implements GenericColumn
   }
 
   @Override
-  public HistoricalFloatColumnSelector makeFloatSingleValueRowSelector(ReadableOffset offset)
+  public FloatColumnSelector makeFloatSingleValueRowSelector(ReadableOffset offset)
   {
     return column.makeFloatColumnSelector(offset);
   }

--- a/processing/src/main/java/io/druid/segment/column/IndexedFloatsGenericColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/IndexedFloatsGenericColumn.java
@@ -21,10 +21,10 @@ package io.druid.segment.column;
 
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.DoubleColumnSelector;
+import io.druid.segment.FloatColumnSelector;
 import io.druid.segment.LongColumnSelector;
 import io.druid.segment.data.IndexedFloats;
 import io.druid.segment.data.ReadableOffset;
-import io.druid.segment.historical.HistoricalFloatColumnSelector;
 
 /**
 */
@@ -68,7 +68,7 @@ public class IndexedFloatsGenericColumn implements GenericColumn
   }
 
   @Override
-  public HistoricalFloatColumnSelector makeFloatSingleValueRowSelector(ReadableOffset offset)
+  public FloatColumnSelector makeFloatSingleValueRowSelector(ReadableOffset offset)
   {
     return column.makeFloatColumnSelector(offset);
   }

--- a/processing/src/main/java/io/druid/segment/column/IndexedLongsGenericColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/IndexedLongsGenericColumn.java
@@ -21,10 +21,10 @@ package io.druid.segment.column;
 
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.DoubleColumnSelector;
+import io.druid.segment.FloatColumnSelector;
 import io.druid.segment.LongColumnSelector;
 import io.druid.segment.data.IndexedLongs;
 import io.druid.segment.data.ReadableOffset;
-import io.druid.segment.historical.HistoricalFloatColumnSelector;
 
 /**
 */
@@ -68,7 +68,7 @@ public class IndexedLongsGenericColumn implements GenericColumn
   }
 
   @Override
-  public HistoricalFloatColumnSelector makeFloatSingleValueRowSelector(ReadableOffset offset)
+  public FloatColumnSelector makeFloatSingleValueRowSelector(ReadableOffset offset)
   {
     return column.makeFloatColumnSelector(offset);
   }

--- a/processing/src/main/java/io/druid/segment/data/IndexedDoubles.java
+++ b/processing/src/main/java/io/druid/segment/data/IndexedDoubles.java
@@ -21,8 +21,9 @@ package io.druid.segment.data;
 
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.DoubleColumnSelector;
+import io.druid.segment.FloatColumnSelector;
 import io.druid.segment.LongColumnSelector;
-import io.druid.segment.historical.HistoricalFloatColumnSelector;
+import io.druid.segment.historical.HistoricalColumnSelector;
 
 import java.io.Closeable;
 
@@ -37,7 +38,7 @@ public interface IndexedDoubles extends Closeable
 
   default DoubleColumnSelector makeDoubleColumnSelector(ReadableOffset offset)
   {
-    return new DoubleColumnSelector()
+    class HistoricalDoubleColumnSelector implements DoubleColumnSelector, HistoricalColumnSelector
     {
       @Override
       public double getDouble()
@@ -46,24 +47,25 @@ public interface IndexedDoubles extends Closeable
       }
 
       @Override
+      public double getDouble(int offset)
+      {
+        return IndexedDoubles.this.get(offset);
+      }
+
+      @Override
       public void inspectRuntimeShape(RuntimeShapeInspector inspector)
       {
         inspector.visit("indexed", IndexedDoubles.this);
         inspector.visit("offset", offset);
       }
-    };
+    }
+    return new HistoricalDoubleColumnSelector();
   }
 
-  default HistoricalFloatColumnSelector makeFloatColumnSelector(ReadableOffset offset)
+  default FloatColumnSelector makeFloatColumnSelector(ReadableOffset offset)
   {
-    return new HistoricalFloatColumnSelector()
+    class HistoricalFloatColumnSelector implements FloatColumnSelector, HistoricalColumnSelector
     {
-      @Override
-      public float get(int offset)
-      {
-        return (float) IndexedDoubles.this.get(offset);
-      }
-
       @Override
       public float getFloat()
       {
@@ -71,17 +73,24 @@ public interface IndexedDoubles extends Closeable
       }
 
       @Override
+      public double getDouble(int offset)
+      {
+        return IndexedDoubles.this.get(offset);
+      }
+
+      @Override
       public void inspectRuntimeShape(RuntimeShapeInspector inspector)
       {
         inspector.visit("indexed", IndexedDoubles.this);
         inspector.visit("offset", offset);
       }
-    };
+    }
+    return new HistoricalFloatColumnSelector();
   }
 
   default LongColumnSelector makeLongColumnSelector(ReadableOffset offset)
   {
-    return new LongColumnSelector()
+    class HistoricalLongColumnSelector implements LongColumnSelector, HistoricalColumnSelector
     {
       @Override
       public long getLong()
@@ -90,12 +99,19 @@ public interface IndexedDoubles extends Closeable
       }
 
       @Override
+      public double getDouble(int offset)
+      {
+        return IndexedDoubles.this.get(offset);
+      }
+
+      @Override
       public void inspectRuntimeShape(RuntimeShapeInspector inspector)
       {
         inspector.visit("indexed", IndexedDoubles.this);
         inspector.visit("offset", offset);
       }
-    };
+    }
+    return new HistoricalLongColumnSelector();
   }
 }
 

--- a/processing/src/main/java/io/druid/segment/data/IndexedFloats.java
+++ b/processing/src/main/java/io/druid/segment/data/IndexedFloats.java
@@ -21,8 +21,9 @@ package io.druid.segment.data;
 
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.DoubleColumnSelector;
+import io.druid.segment.FloatColumnSelector;
 import io.druid.segment.LongColumnSelector;
-import io.druid.segment.historical.HistoricalFloatColumnSelector;
+import io.druid.segment.historical.HistoricalColumnSelector;
 
 import java.io.Closeable;
 
@@ -38,9 +39,9 @@ public interface IndexedFloats extends Closeable
   @Override
   void close();
 
-  default HistoricalFloatColumnSelector makeFloatColumnSelector(ReadableOffset offset)
+  default FloatColumnSelector makeFloatColumnSelector(ReadableOffset offset)
   {
-    return new HistoricalFloatColumnSelector()
+    class HistoricalFloatColumnSelector implements FloatColumnSelector, HistoricalColumnSelector
     {
       @Override
       public float getFloat()
@@ -49,7 +50,7 @@ public interface IndexedFloats extends Closeable
       }
 
       @Override
-      public float get(int offset)
+      public double getDouble(int offset)
       {
         return IndexedFloats.this.get(offset);
       }
@@ -60,12 +61,13 @@ public interface IndexedFloats extends Closeable
         inspector.visit("indexed", IndexedFloats.this);
         inspector.visit("offset", offset);
       }
-    };
+    }
+    return new HistoricalFloatColumnSelector();
   }
 
   default DoubleColumnSelector makeDoubleColumnSelector(ReadableOffset offset)
   {
-    return new DoubleColumnSelector()
+    class HistoricalDoubleColumnSelector implements DoubleColumnSelector, HistoricalColumnSelector
     {
       @Override
       public double getDouble()
@@ -74,17 +76,24 @@ public interface IndexedFloats extends Closeable
       }
 
       @Override
+      public double getDouble(int offset)
+      {
+        return IndexedFloats.this.get(offset);
+      }
+
+      @Override
       public void inspectRuntimeShape(RuntimeShapeInspector inspector)
       {
         inspector.visit("indexed", IndexedFloats.this);
         inspector.visit("offset", offset);
       }
-    };
+    }
+    return new HistoricalDoubleColumnSelector();
   }
 
   default LongColumnSelector makeLongColumnSelector(ReadableOffset offset)
   {
-    return new LongColumnSelector()
+    class HistoricalLongColumnSelector implements LongColumnSelector, HistoricalColumnSelector
     {
       @Override
       public long getLong()
@@ -93,11 +102,18 @@ public interface IndexedFloats extends Closeable
       }
 
       @Override
+      public double getDouble(int offset)
+      {
+        return IndexedFloats.this.get(offset);
+      }
+
+      @Override
       public void inspectRuntimeShape(RuntimeShapeInspector inspector)
       {
         inspector.visit("indexed", IndexedFloats.this);
         inspector.visit("offset", offset);
       }
-    };
+    }
+    return new HistoricalLongColumnSelector();
   }
 }

--- a/processing/src/main/java/io/druid/segment/data/IndexedLongs.java
+++ b/processing/src/main/java/io/druid/segment/data/IndexedLongs.java
@@ -21,8 +21,9 @@ package io.druid.segment.data;
 
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.DoubleColumnSelector;
+import io.druid.segment.FloatColumnSelector;
 import io.druid.segment.LongColumnSelector;
-import io.druid.segment.historical.HistoricalFloatColumnSelector;
+import io.druid.segment.historical.HistoricalColumnSelector;
 
 import java.io.Closeable;
 
@@ -40,7 +41,7 @@ public interface IndexedLongs extends Closeable
 
   default LongColumnSelector makeLongColumnSelector(ReadableOffset offset)
   {
-    return new LongColumnSelector()
+    class HistoricalLongColumnSelector implements LongColumnSelector, HistoricalColumnSelector
     {
       @Override
       public long getLong()
@@ -49,17 +50,24 @@ public interface IndexedLongs extends Closeable
       }
 
       @Override
+      public double getDouble(int offset)
+      {
+        return IndexedLongs.this.get(offset);
+      }
+
+      @Override
       public void inspectRuntimeShape(RuntimeShapeInspector inspector)
       {
         inspector.visit("indexed", IndexedLongs.this);
         inspector.visit("offset", offset);
       }
-    };
+    }
+    return new HistoricalLongColumnSelector();
   }
 
-  default HistoricalFloatColumnSelector makeFloatColumnSelector(ReadableOffset offset)
+  default FloatColumnSelector makeFloatColumnSelector(ReadableOffset offset)
   {
-    return new HistoricalFloatColumnSelector()
+    class HistoricalFloatColumnSelector implements FloatColumnSelector, HistoricalColumnSelector
     {
       @Override
       public float getFloat()
@@ -68,9 +76,9 @@ public interface IndexedLongs extends Closeable
       }
 
       @Override
-      public float get(int offset)
+      public double getDouble(int offset)
       {
-        return (float) IndexedLongs.this.get(offset);
+        return IndexedLongs.this.get(offset);
       }
 
       @Override
@@ -79,12 +87,13 @@ public interface IndexedLongs extends Closeable
         inspector.visit("indexed", IndexedLongs.this);
         inspector.visit("offset", offset);
       }
-    };
+    }
+    return new HistoricalFloatColumnSelector();
   }
 
   default DoubleColumnSelector makeDoubleColumnSelector(ReadableOffset offset)
   {
-    return new DoubleColumnSelector()
+    class HistoricalDoubleColumnSelector implements DoubleColumnSelector, HistoricalColumnSelector
     {
       @Override
       public double getDouble()
@@ -93,11 +102,18 @@ public interface IndexedLongs extends Closeable
       }
 
       @Override
+      public double getDouble(int offset)
+      {
+        return IndexedLongs.this.get(offset);
+      }
+
+      @Override
       public void inspectRuntimeShape(RuntimeShapeInspector inspector)
       {
         inspector.visit("indexed", IndexedLongs.this);
         inspector.visit("offset", offset);
       }
-    };
+    }
+    return new HistoricalDoubleColumnSelector();
   }
 }

--- a/processing/src/main/java/io/druid/segment/historical/HistoricalColumnSelector.java
+++ b/processing/src/main/java/io/druid/segment/historical/HistoricalColumnSelector.java
@@ -20,10 +20,10 @@
 package io.druid.segment.historical;
 
 import io.druid.query.monomorphicprocessing.CalledFromHotLoop;
-import io.druid.segment.FloatColumnSelector;
+import io.druid.segment.ColumnValueSelector;
 
-public interface HistoricalFloatColumnSelector extends FloatColumnSelector
+public interface HistoricalColumnSelector extends ColumnValueSelector
 {
   @CalledFromHotLoop
-  float get(int offset);
+  double getDouble(int offset);
 }


### PR DESCRIPTION
Fixes a bug introduced in #4491, this: https://github.com/druid-io/druid/blob/aa7e4ae5e46a13a9db8d0ee29885249fd0afd02e/processing/src/main/java/io/druid/query/topn/PooledTopNAlgorithm.java#L134 and this: https://github.com/druid-io/druid/blob/aa7e4ae5e46a13a9db8d0ee29885249fd0afd02e/processing/src/main/java/io/druid/query/topn/PooledTopNAlgorithm.java#L155 conditions could never be true.