### PR TITLE
Add profile for building for use with Spark 2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1150,6 +1150,12 @@
 
     <profiles>
         <profile>
+            <id>spark2</id>
+            <properties>
+                <jackson.version>2.6.5</jackson.version>
+            </properties>
+        </profile>
+        <profile>
             <id>strict</id>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -1153,6 +1153,7 @@
             <id>spark2</id>
             <properties>
                 <jackson.version>2.6.5</jackson.version>
+                <aws.sdk.version>1.11.143</aws.sdk.version>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
In order to have compatibility with Spark 2.x, Druid needs an updated Jackson version.

We've been running it this way for a [while](https://github.com/metamx/druid/commit/7d9ef4ead251bc583346b111643f41d17c21331e)