### PR TITLE
Fix IntelliJ Inspection build

### DIFF
--- a/extensions-contrib/time-min-max/src/test/java/io/druid/query/aggregation/TimestampAggregationSelectTest.java
+++ b/extensions-contrib/time-min-max/src/test/java/io/druid/query/aggregation/TimestampAggregationSelectTest.java
@@ -101,7 +101,7 @@ public class TimestampAggregationSelectTest
         temporaryFolder
     );
 
-    selector = new TestObjectColumnSelector(values);
+    selector = new TestObjectColumnSelector<>(values);
     selectorFactory = EasyMock.createMock(ColumnSelectorFactory.class);
     EasyMock.expect(selectorFactory.makeObjectColumnSelector("test")).andReturn(selector);
     EasyMock.replay(selectorFactory);
@@ -144,7 +144,7 @@ public class TimestampAggregationSelectTest
         "  }\n" +
         "]";
     ZipFile zip = new ZipFile(new File(this.getClass().getClassLoader().getResource("druid.sample.tsv.zip").toURI()));
-    Sequence seq = helper.createIndexAndRunQueryOnSegment(
+    Sequence<?> seq = helper.createIndexAndRunQueryOnSegment(
         zip.getInputStream(zip.getEntry("druid.sample.tsv")),
         recordParser,
         aggregator,

--- a/extensions-contrib/time-min-max/src/test/java/io/druid/query/aggregation/TimestampGroupByAggregationTest.java
+++ b/extensions-contrib/time-min-max/src/test/java/io/druid/query/aggregation/TimestampGroupByAggregationTest.java
@@ -111,7 +111,7 @@ public class TimestampGroupByAggregationTest
         temporaryFolder
     );
 
-    selector = new TestObjectColumnSelector(values);
+    selector = new TestObjectColumnSelector<>(values);
     selectorFactory = EasyMock.createMock(ColumnSelectorFactory.class);
     EasyMock.expect(selectorFactory.makeObjectColumnSelector("test")).andReturn(selector);
     EasyMock.replay(selectorFactory);

--- a/extensions-contrib/time-min-max/src/test/java/io/druid/query/aggregation/TimestampMinMaxAggregatorTest.java
+++ b/extensions-contrib/time-min-max/src/test/java/io/druid/query/aggregation/TimestampMinMaxAggregatorTest.java
@@ -123,7 +123,7 @@ public class TimestampMinMaxAggregatorTest
     String json = "{\"type\":\"" + aggType + "\",\"name\":\"" + aggType + "\",\"fieldName\":\"test\"}";
 
     aggregatorFactory = mapper.readValue(json, aggClass);
-    selector = new TestObjectColumnSelector(values);
+    selector = new TestObjectColumnSelector<>(values);
     selectorFactory = EasyMock.createMock(ColumnSelectorFactory.class);
     EasyMock.expect(selectorFactory.makeObjectColumnSelector("test")).andReturn(selector);
     EasyMock.replay(selectorFactory);

--- a/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceAggregatorTest.java
+++ b/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceAggregatorTest.java
@@ -66,7 +66,8 @@ public class VarianceAggregatorTest
   {
     selector = new TestFloatColumnSelector(values);
     colSelectorFactory = EasyMock.createMock(ColumnSelectorFactory.class);
-    EasyMock.expect(colSelectorFactory.makeObjectColumnSelector("nilly")).andReturn(new TestObjectColumnSelector(0.0f));
+    EasyMock.expect(colSelectorFactory.makeObjectColumnSelector("nilly"))
+            .andReturn(new TestObjectColumnSelector<>(new Object[] {0.0f}));
     EasyMock.expect(colSelectorFactory.makeFloatColumnSelector("nilly")).andReturn(selector);
     EasyMock.replay(colSelectorFactory);
   }

--- a/processing/src/main/java/io/druid/query/scan/ScanQuery.java
+++ b/processing/src/main/java/io/druid/query/scan/ScanQuery.java
@@ -223,7 +223,7 @@ public class ScanQuery extends BaseQuery<ScanResultValue>
    *                                  .build();
    * </code></pre>
    *
-   * @see io.druid.query.scan.ScanQuery
+   * @see ScanQuery
    */
   public static class ScanQueryBuilder
   {

--- a/processing/src/main/java/io/druid/segment/Capabilities.java
+++ b/processing/src/main/java/io/druid/segment/Capabilities.java
@@ -54,9 +54,9 @@ public class Capabilities
       return this;
     }
 
-    public io.druid.segment.Capabilities build()
+    public Capabilities build()
     {
-      return new io.druid.segment.Capabilities(
+      return new Capabilities(
           dimensionValuesSorted
       );
     }

--- a/processing/src/test/java/io/druid/query/aggregation/JavaScriptAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/JavaScriptAggregatorTest.java
@@ -240,7 +240,9 @@ public class JavaScriptAggregatorTest
   @Test
   public void testAggregateStrings()
   {
-    final TestObjectColumnSelector ocs = new TestObjectColumnSelector("what", null, new String[]{"hey", "there"});
+    final TestObjectColumnSelector ocs = new TestObjectColumnSelector<>(
+        new Object[]{"what", null, new String[]{"hey", "there"}}
+    );
     final JavaScriptAggregator agg = new JavaScriptAggregator(
         Collections.<ObjectColumnSelector>singletonList(ocs),
         JavaScriptAggregatorFactory.compileScript(

--- a/processing/src/test/java/io/druid/query/aggregation/TestObjectColumnSelector.java
+++ b/processing/src/test/java/io/druid/query/aggregation/TestObjectColumnSelector.java
@@ -23,13 +23,13 @@ import io.druid.segment.ObjectColumnSelector;
 
 /**
  */
-public class TestObjectColumnSelector implements ObjectColumnSelector
+public class TestObjectColumnSelector<T> implements ObjectColumnSelector
 {
   private final Object[] objects;
 
   private int index = 0;
 
-  public TestObjectColumnSelector(Object... objects)
+  public TestObjectColumnSelector(T[] objects)
   {
     this.objects = objects;
   }

--- a/processing/src/test/java/io/druid/query/aggregation/first/DoubleFirstAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/first/DoubleFirstAggregationTest.java
@@ -60,7 +60,7 @@ public class DoubleFirstAggregationTest
     combiningAggFactory = (DoubleFirstAggregatorFactory) doubleFirstAggFactory.getCombiningFactory();
     timeSelector = new TestLongColumnSelector(times);
     valueSelector = new TestDoubleColumnSelectorImpl(doubleValues);
-    objectSelector = new TestObjectColumnSelector(pairs);
+    objectSelector = new TestObjectColumnSelector<>(pairs);
     colSelectorFactory = EasyMock.createMock(ColumnSelectorFactory.class);
     EasyMock.expect(colSelectorFactory.makeLongColumnSelector(Column.TIME_COLUMN_NAME)).andReturn(timeSelector);
     EasyMock.expect(colSelectorFactory.makeDoubleColumnSelector("nilly")).andReturn(valueSelector);

--- a/processing/src/test/java/io/druid/query/aggregation/first/FloatFirstAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/first/FloatFirstAggregationTest.java
@@ -60,7 +60,7 @@ public class FloatFirstAggregationTest
     combiningAggFactory = (FloatFirstAggregatorFactory) floatFirstAggregatorFactory.getCombiningFactory();
     timeSelector = new TestLongColumnSelector(times);
     valueSelector = new TestFloatColumnSelector(floats);
-    objectSelector = new TestObjectColumnSelector(pairs);
+    objectSelector = new TestObjectColumnSelector<>(pairs);
     colSelectorFactory = EasyMock.createMock(ColumnSelectorFactory.class);
     EasyMock.expect(colSelectorFactory.makeLongColumnSelector(Column.TIME_COLUMN_NAME)).andReturn(timeSelector);
     EasyMock.expect(colSelectorFactory.makeFloatColumnSelector("nilly")).andReturn(valueSelector);

--- a/processing/src/test/java/io/druid/query/aggregation/first/LongFirstAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/first/LongFirstAggregationTest.java
@@ -59,7 +59,7 @@ public class LongFirstAggregationTest
     combiningAggFactory = (LongFirstAggregatorFactory) longFirstAggFactory.getCombiningFactory();
     timeSelector = new TestLongColumnSelector(times);
     valueSelector = new TestLongColumnSelector(longValues);
-    objectSelector = new TestObjectColumnSelector(pairs);
+    objectSelector = new TestObjectColumnSelector<>(pairs);
     colSelectorFactory = EasyMock.createMock(ColumnSelectorFactory.class);
     EasyMock.expect(colSelectorFactory.makeLongColumnSelector(Column.TIME_COLUMN_NAME)).andReturn(timeSelector);
     EasyMock.expect(colSelectorFactory.makeLongColumnSelector("nilly")).andReturn(valueSelector);

--- a/processing/src/test/java/io/druid/query/aggregation/last/DoubleLastAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/last/DoubleLastAggregationTest.java
@@ -60,7 +60,7 @@ public class DoubleLastAggregationTest
     combiningAggFactory = (DoubleLastAggregatorFactory) doubleLastAggFactory.getCombiningFactory();
     timeSelector = new TestLongColumnSelector(times);
     valueSelector = new TestDoubleColumnSelectorImpl(doubles);
-    objectSelector = new TestObjectColumnSelector(pairs);
+    objectSelector = new TestObjectColumnSelector<>(pairs);
     colSelectorFactory = EasyMock.createMock(ColumnSelectorFactory.class);
     EasyMock.expect(colSelectorFactory.makeLongColumnSelector(Column.TIME_COLUMN_NAME)).andReturn(timeSelector);
     EasyMock.expect(colSelectorFactory.makeDoubleColumnSelector("nilly")).andReturn(valueSelector);

--- a/processing/src/test/java/io/druid/query/aggregation/last/FloatLastAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/last/FloatLastAggregationTest.java
@@ -60,7 +60,7 @@ public class FloatLastAggregationTest
     combiningAggFactory = (FloatLastAggregatorFactory) floatLastAggregatorFactory.getCombiningFactory();
     timeSelector = new TestLongColumnSelector(times);
     valueSelector = new TestFloatColumnSelector(floats);
-    objectSelector = new TestObjectColumnSelector(pairs);
+    objectSelector = new TestObjectColumnSelector<>(pairs);
     colSelectorFactory = EasyMock.createMock(ColumnSelectorFactory.class);
     EasyMock.expect(colSelectorFactory.makeLongColumnSelector(Column.TIME_COLUMN_NAME)).andReturn(timeSelector);
     EasyMock.expect(colSelectorFactory.makeFloatColumnSelector("nilly")).andReturn(valueSelector);

--- a/processing/src/test/java/io/druid/query/aggregation/last/LongLastAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/last/LongLastAggregationTest.java
@@ -59,7 +59,7 @@ public class LongLastAggregationTest
     combiningAggFactory = (LongLastAggregatorFactory) longLastAggFactory.getCombiningFactory();
     timeSelector = new TestLongColumnSelector(times);
     valueSelector = new TestLongColumnSelector(longValues);
-    objectSelector = new TestObjectColumnSelector(pairs);
+    objectSelector = new TestObjectColumnSelector<>(pairs);
     colSelectorFactory = EasyMock.createMock(ColumnSelectorFactory.class);
     EasyMock.expect(colSelectorFactory.makeLongColumnSelector(Column.TIME_COLUMN_NAME)).andReturn(timeSelector);
     EasyMock.expect(colSelectorFactory.makeLongColumnSelector("nilly")).andReturn(valueSelector);


### PR DESCRIPTION
Try to make IntelliJ inspections happy.

Likely the problem is caused not by changes in the druid code base, but because IntelliJ was updated on CI servers and now it is able to find new violations of some inspections.