### PR TITLE
Move checks for bitmap size == 0 to isEmpty

### DIFF
--- a/processing/src/main/java/io/druid/query/search/UseIndexesStrategy.java
+++ b/processing/src/main/java/io/druid/query/search/UseIndexesStrategy.java
@@ -269,7 +269,7 @@ public class UseIndexesStrategy extends SearchStrategy
           if (timeFilteredBitmap != null) {
             bitmap = bitmapFactory.intersection(Arrays.asList(timeFilteredBitmap, bitmap));
           }
-          if (bitmap.size() > 0) {
+          if (!bitmap.isEmpty()) {
             retVal.addTo(new SearchHit(dimension.getOutputName(), dimVal), bitmap.size());
             if (retVal.size() >= limit) {
               return retVal;

--- a/processing/src/main/java/io/druid/segment/data/BitmapCompressedIndexedInts.java
+++ b/processing/src/main/java/io/druid/segment/data/BitmapCompressedIndexedInts.java
@@ -39,13 +39,13 @@ public class BitmapCompressedIndexedInts implements IndexedInts, Comparable<Immu
         ImmutableBitmap set, ImmutableBitmap set1
     )
     {
-      if (set.size() == 0 && set1.size() == 0) {
+      if (set.isEmpty() && set1.isEmpty()) {
         return 0;
       }
-      if (set.size() == 0) {
+      if (set.isEmpty()) {
         return -1;
       }
-      if (set1.size() == 0) {
+      if (set1.isEmpty()) {
         return 1;
       }
       return set.compareTo(set1);

--- a/processing/src/main/java/io/druid/segment/data/ConciseBitmapSerdeFactory.java
+++ b/processing/src/main/java/io/druid/segment/data/ConciseBitmapSerdeFactory.java
@@ -48,20 +48,20 @@ public class ConciseBitmapSerdeFactory implements BitmapSerdeFactory
     return bitmapFactory;
   }
 
-  private static Ordering<WrappedImmutableConciseBitmap> conciseComparator = new Ordering<WrappedImmutableConciseBitmap>()
+  private static final Ordering<WrappedImmutableConciseBitmap> CONCISE_COMPARATOR = new Ordering<WrappedImmutableConciseBitmap>()
   {
     @Override
     public int compare(
         WrappedImmutableConciseBitmap conciseSet, WrappedImmutableConciseBitmap conciseSet1
     )
     {
-      if (conciseSet.size() == 0 && conciseSet1.size() == 0) {
+      if (conciseSet.isEmpty() && conciseSet1.isEmpty()) {
         return 0;
       }
-      if (conciseSet.size() == 0) {
+      if (conciseSet.isEmpty()) {
         return -1;
       }
-      if (conciseSet1.size() == 0) {
+      if (conciseSet1.isEmpty()) {
         return 1;
       }
       return conciseSet.compareTo(conciseSet1);
@@ -87,7 +87,7 @@ public class ConciseBitmapSerdeFactory implements BitmapSerdeFactory
     @Override
     public byte[] toBytes(ImmutableBitmap val)
     {
-      if (val == null || val.size() == 0) {
+      if (val == null || val.isEmpty()) {
         return new byte[]{};
       }
       return val.toBytes();
@@ -96,7 +96,7 @@ public class ConciseBitmapSerdeFactory implements BitmapSerdeFactory
     @Override
     public int compare(ImmutableBitmap o1, ImmutableBitmap o2)
     {
-      return conciseComparator.compare((WrappedImmutableConciseBitmap) o1, (WrappedImmutableConciseBitmap) o2);
+      return CONCISE_COMPARATOR.compare((WrappedImmutableConciseBitmap) o1, (WrappedImmutableConciseBitmap) o2);
     }
   }
 

--- a/processing/src/main/java/io/druid/segment/data/RoaringBitmapSerdeFactory.java
+++ b/processing/src/main/java/io/druid/segment/data/RoaringBitmapSerdeFactory.java
@@ -69,20 +69,20 @@ public class RoaringBitmapSerdeFactory implements BitmapSerdeFactory
     return bitmapFactory;
   }
 
-  private static Ordering<WrappedImmutableRoaringBitmap> roaringComparator = new Ordering<WrappedImmutableRoaringBitmap>()
+  private static final Ordering<WrappedImmutableRoaringBitmap> RORING_COMPARATOR = new Ordering<WrappedImmutableRoaringBitmap>()
   {
     @Override
     public int compare(
         WrappedImmutableRoaringBitmap set1, WrappedImmutableRoaringBitmap set2
     )
     {
-      if (set1.size() == 0 && set2.size() == 0) {
+      if (set1.isEmpty() && set2.isEmpty()) {
         return 0;
       }
-      if (set1.size() == 0) {
+      if (set1.isEmpty()) {
         return -1;
       }
-      if (set2.size() == 0) {
+      if (set2.isEmpty()) {
         return 1;
       }
 
@@ -118,7 +118,7 @@ public class RoaringBitmapSerdeFactory implements BitmapSerdeFactory
     @Override
     public int compare(ImmutableBitmap o1, ImmutableBitmap o2)
     {
-      return roaringComparator.compare((WrappedImmutableRoaringBitmap) o1, (WrappedImmutableRoaringBitmap) o2);
+      return RORING_COMPARATOR.compare((WrappedImmutableRoaringBitmap) o1, (WrappedImmutableRoaringBitmap) o2);
     }
   }
 


### PR DESCRIPTION
Some of the `size()` implementations go through the whole bitmap when all that is really wanted is an `isEmpty` check. This moves `bitmap.size() == 0` style checks to call `isEmpty()` instead