### PR TITLE
remove ServerConfig from DruidNode as all information needs to be present in DruidNode serialized form

### DIFF
--- a/docs/content/configuration/broker.md
+++ b/docs/content/configuration/broker.md
@@ -16,7 +16,7 @@ The broker node uses several of the global configs in [Configuration](../configu
 |--------|-----------|-------|
 |`druid.host`|The host for the current node. This is used to advertise the current processes location as reachable from another node and should generally be specified such that `http://${druid.host}/` could actually talk to this process|InetAddress.getLocalHost().getCanonicalHostName()|
 |`druid.plaintextPort`|This is the port to actually listen on; unless port mapping is used, this will be the same port as is on `druid.host`|8082|
-|`druid.tlsPort`|TLS port for HTTPS connector, if [druid.server.http.tls](../operations/tls-support.html) is set then this config will be used. If `druid.host` contains port then that port will be ignored. This should be a non-negative Integer.|8282|
+|`druid.tlsPort`|TLS port for HTTPS connector, if [druid.enableTlsPort](../operations/tls-support.html) is set then this config will be used. If `druid.host` contains port then that port will be ignored. This should be a non-negative Integer.|8282|
 |`druid.service`|The name of the service. This is used as a dimension when emitting metrics and alerts to differentiate between the various services|druid/broker|
 
 ### Query Configs

--- a/docs/content/configuration/coordinator.md
+++ b/docs/content/configuration/coordinator.md
@@ -16,7 +16,7 @@ The coordinator node uses several of the global configs in [Configuration](../co
 |--------|-----------|-------|
 |`druid.host`|The host for the current node. This is used to advertise the current processes location as reachable from another node and should generally be specified such that `http://${druid.host}/` could actually talk to this process|InetAddress.getLocalHost().getCanonicalHostName()|
 |`druid.plaintextPort`|This is the port to actually listen on; unless port mapping is used, this will be the same port as is on `druid.host`|8081|
-|`druid.tlsPort`|TLS port for HTTPS connector, if [druid.server.http.tls](../operations/tls-support.html) is set then this config will be used. If `druid.host` contains port then that port will be ignored. This should be a non-negative Integer.|8281|
+|`druid.tlsPort`|TLS port for HTTPS connector, if [druid.enableTlsPort](../operations/tls-support.html) is set then this config will be used. If `druid.host` contains port then that port will be ignored. This should be a non-negative Integer.|8281|
 |`druid.service`|The name of the service. This is used as a dimension when emitting metrics and alerts to differentiate between the various services|druid/coordinator|
 
 ### Coordinator Operation

--- a/docs/content/configuration/historical.md
+++ b/docs/content/configuration/historical.md
@@ -16,7 +16,7 @@ The historical node uses several of the global configs in [Configuration](../con
 |--------|-----------|-------|
 |`druid.host`|The host for the current node. This is used to advertise the current processes location as reachable from another node and should generally be specified such that `http://${druid.host}/` could actually talk to this process|InetAddress.getLocalHost().getCanonicalHostName()|
 |`druid.plaintextPort`|This is the port to actually listen on; unless port mapping is used, this will be the same port as is on `druid.host`|8083|
-|`druid.tlsPort`|TLS port for HTTPS connector, if [druid.server.http.tls](../operations/tls-support.html) is set then this config will be used. If `druid.host` contains port then that port will be ignored. This should be a non-negative Integer.|8283|
+|`druid.tlsPort`|TLS port for HTTPS connector, if [druid.enableTlsPort](../operations/tls-support.html) is set then this config will be used. If `druid.host` contains port then that port will be ignored. This should be a non-negative Integer.|8283|
 |`druid.service`|The name of the service. This is used as a dimension when emitting metrics and alerts to differentiate between the various services|druid/historical|
 
 ### General Configuration

--- a/docs/content/configuration/indexing-service.md
+++ b/docs/content/configuration/indexing-service.md
@@ -15,7 +15,7 @@ The indexing service uses several of the global configs in [Configuration](../co
 |--------|-----------|-------|
 |`druid.host`|The host for the current node. This is used to advertise the current processes location as reachable from another node and should generally be specified such that `http://${druid.host}/` could actually talk to this process|InetAddress.getLocalHost().getCanonicalHostName()|
 |`druid.plaintextPort`|This is the port to actually listen on; unless port mapping is used, this will be the same port as is on `druid.host`|8090|
-|`druid.tlsPort`|TLS port for HTTPS connector, if [druid.server.http.tls](../operations/tls-support.html) is set then this config will be used. If `druid.host` contains port then that port will be ignored. This should be a non-negative Integer.|8290|
+|`druid.tlsPort`|TLS port for HTTPS connector, if [druid.enableTlsPort](../operations/tls-support.html) is set then this config will be used. If `druid.host` contains port then that port will be ignored. This should be a non-negative Integer.|8290|
 |`druid.service`|The name of the service. This is used as a dimension when emitting metrics and alerts to differentiate between the various services|druid/overlord|
 
 #### MiddleManager Node Configs
@@ -24,7 +24,7 @@ The indexing service uses several of the global configs in [Configuration](../co
 |--------|-----------|-------|
 |`druid.host`|The host for the current node. This is used to advertise the current processes location as reachable from another node and should generally be specified such that `http://${druid.host}/` could actually talk to this process|InetAddress.getLocalHost().getCanonicalHostName()|
 |`druid.plaintextPort`|This is the port to actually listen on; unless port mapping is used, this will be the same port as is on `druid.host`|8091|
-|`druid.tlsPort`|TLS port for HTTPS connector, if [druid.server.http.tls](../operations/tls-support.html) is set then this config will be used. If `druid.host` contains port then that port will be ignored. This should be a non-negative Integer.|8291|
+|`druid.tlsPort`|TLS port for HTTPS connector, if [druid.enableTlsPort](../operations/tls-support.html) is set then this config will be used. If `druid.host` contains port then that port will be ignored. This should be a non-negative Integer.|8291|
 |`druid.service`|The name of the service. This is used as a dimension when emitting metrics and alerts to differentiate between the various services|druid/middlemanager|
 
 #### Task Logging

--- a/docs/content/configuration/realtime.md
+++ b/docs/content/configuration/realtime.md
@@ -17,7 +17,7 @@ The realtime node uses several of the global configs in [Configuration](../confi
 |--------|-----------|-------|
 |`druid.host`|The host for the current node. This is used to advertise the current processes location as reachable from another node and should generally be specified such that `http://${druid.host}/` could actually talk to this process|InetAddress.getLocalHost().getCanonicalHostName()|
 |`druid.plaintextPort`|This is the port to actually listen on; unless port mapping is used, this will be the same port as is on `druid.host`|8084|
-|`druid.tlsPort`|TLS port for HTTPS connector, if [druid.server.http.tls](../operations/tls-support.html) is set then this config will be used. If `druid.host` contains port then that port will be ignored. This should be a non-negative Integer.|8284|
+|`druid.tlsPort`|TLS port for HTTPS connector, if [druid.enableTlsPort](../operations/tls-support.html) is set then this config will be used. If `druid.host` contains port then that port will be ignored. This should be a non-negative Integer.|8284|
 |`druid.service`|The name of the service. This is used as a dimension when emitting metrics and alerts to differentiate between the various services|druid/realtime|
 
 ### Realtime Operation

--- a/docs/content/operations/tls-support.md
+++ b/docs/content/operations/tls-support.md
@@ -9,8 +9,8 @@ TLS Support
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.server.http.plaintext`|Enable/Disable HTTP connector.|`true`|
-|`druid.server.http.tls`|Enable/Disable HTTPS connector.|`false`|
+|`druid.enablePlaintextPort`|Enable/Disable HTTP connector.|`true`|
+|`druid.enableTlsPort`|Enable/Disable HTTPS connector.|`false`|
 
 Although not recommended but both HTTP and HTTPS connectors can be enabled at a time and respective ports are configurable using `druid.plaintextPort`
 and `druid.tlsPort` properties on each node. Please see `Configuration` section of individual nodes to check the valid and default values for these ports.

--- a/extensions-core/lookups-cached-global/src/test/java/io/druid/query/lookup/NamespaceLookupExtractorFactoryTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/io/druid/query/lookup/NamespaceLookupExtractorFactoryTest.java
@@ -36,12 +36,11 @@ import io.druid.guice.annotations.Json;
 import io.druid.guice.annotations.Self;
 import io.druid.initialization.Initialization;
 import io.druid.jackson.DefaultObjectMapper;
-import io.druid.java.util.common.jackson.JacksonUtils;
 import io.druid.java.util.common.ISE;
+import io.druid.java.util.common.jackson.JacksonUtils;
 import io.druid.query.lookup.namespace.ExtractionNamespace;
 import io.druid.query.lookup.namespace.UriExtractionNamespace;
 import io.druid.server.DruidNode;
-import io.druid.server.initialization.ServerConfig;
 import io.druid.server.lookup.namespace.cache.CacheScheduler;
 import io.druid.server.lookup.namespace.cache.NamespaceExtractionCacheManager;
 import org.easymock.EasyMock;
@@ -525,7 +524,7 @@ public class NamespaceLookupExtractorFactoryTest
               public void configure(Binder binder)
               {
                 JsonConfigProvider.bindInstance(
-                    binder, Key.get(DruidNode.class, Self.class), new DruidNode("test-inject", null, null, null, new ServerConfig())
+                    binder, Key.get(DruidNode.class, Self.class), new DruidNode("test-inject", null, null, null, true, false)
                 );
               }
             }

--- a/extensions-core/lookups-cached-global/src/test/java/io/druid/server/lookup/namespace/cache/OffHeapNamespaceExtractionCacheManagerTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/io/druid/server/lookup/namespace/cache/OffHeapNamespaceExtractionCacheManagerTest.java
@@ -29,7 +29,6 @@ import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.annotations.Self;
 import io.druid.initialization.Initialization;
 import io.druid.server.DruidNode;
-import io.druid.server.initialization.ServerConfig;
 import io.druid.server.lookup.namespace.NamespaceExtractionModule;
 import org.junit.Assert;
 import org.junit.Test;
@@ -50,7 +49,7 @@ public class OffHeapNamespaceExtractionCacheManagerTest
               public void configure(Binder binder)
               {
                 JsonConfigProvider.bindInstance(
-                    binder, Key.get(DruidNode.class, Self.class), new DruidNode("test-inject", null, null, null, new ServerConfig())
+                    binder, Key.get(DruidNode.class, Self.class), new DruidNode("test-inject", null, null, null, true, false)
                 );
               }
             }

--- a/extensions-core/lookups-cached-global/src/test/java/io/druid/server/lookup/namespace/cache/OnHeapNamespaceExtractionCacheManagerTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/io/druid/server/lookup/namespace/cache/OnHeapNamespaceExtractionCacheManagerTest.java
@@ -29,7 +29,6 @@ import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.annotations.Self;
 import io.druid.initialization.Initialization;
 import io.druid.server.DruidNode;
-import io.druid.server.initialization.ServerConfig;
 import io.druid.server.lookup.namespace.NamespaceExtractionModule;
 import org.junit.Assert;
 import org.junit.Test;
@@ -50,7 +49,7 @@ public class OnHeapNamespaceExtractionCacheManagerTest
               public void configure(Binder binder)
               {
                 JsonConfigProvider.bindInstance(
-                    binder, Key.get(DruidNode.class, Self.class), new DruidNode("test-inject", null, null, null, new ServerConfig())
+                    binder, Key.get(DruidNode.class, Self.class), new DruidNode("test-inject", null, null, null, true, false)
                 );
               }
             }

--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerConfig.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerConfig.java
@@ -44,12 +44,12 @@ import io.druid.guice.annotations.Self;
 import io.druid.indexer.partitions.PartitionsSpec;
 import io.druid.indexer.path.PathSpec;
 import io.druid.initialization.Initialization;
-import io.druid.java.util.common.jackson.JacksonUtils;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.JodaUtils;
 import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.granularity.Granularity;
 import io.druid.java.util.common.guava.FunctionalIterable;
+import io.druid.java.util.common.jackson.JacksonUtils;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.segment.IndexIO;
 import io.druid.segment.IndexMergerV9;
@@ -57,7 +57,6 @@ import io.druid.segment.IndexSpec;
 import io.druid.segment.indexing.granularity.GranularitySpec;
 import io.druid.segment.loading.DataSegmentPusher;
 import io.druid.server.DruidNode;
-import io.druid.server.initialization.ServerConfig;
 import io.druid.timeline.DataSegment;
 import io.druid.timeline.partition.ShardSpec;
 import io.druid.timeline.partition.ShardSpecLookup;
@@ -111,7 +110,7 @@ public class HadoopDruidIndexerConfig
               public void configure(Binder binder)
               {
                 JsonConfigProvider.bindInstance(
-                    binder, Key.get(DruidNode.class, Self.class), new DruidNode("hadoop-indexer", null, null, null, new ServerConfig())
+                    binder, Key.get(DruidNode.class, Self.class), new DruidNode("hadoop-indexer", null, null, null, true, false)
                 );
                 JsonConfigProvider.bind(binder, "druid.hadoop.security.kerberos", HadoopKerberosConfig.class);
               }

--- a/indexing-hadoop/src/main/java/io/druid/indexer/updater/HadoopDruidConverterConfig.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/updater/HadoopDruidConverterConfig.java
@@ -39,7 +39,6 @@ import io.druid.segment.IndexMerger;
 import io.druid.segment.IndexSpec;
 import io.druid.segment.loading.DataSegmentPusher;
 import io.druid.server.DruidNode;
-import io.druid.server.initialization.ServerConfig;
 import io.druid.timeline.DataSegment;
 import org.joda.time.Interval;
 
@@ -66,7 +65,7 @@ public class HadoopDruidConverterConfig
             public void configure(Binder binder)
             {
               JsonConfigProvider.bindInstance(
-                  binder, Key.get(DruidNode.class, Self.class), new DruidNode("hadoop-converter", null, null, null, new ServerConfig())
+                  binder, Key.get(DruidNode.class, Self.class), new DruidNode("hadoop-converter", null, null, null, true, false)
               );
             }
           }

--- a/indexing-hadoop/src/test/java/io/druid/indexer/path/DatasourcePathSpecTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/path/DatasourcePathSpecTest.java
@@ -51,7 +51,6 @@ import io.druid.query.aggregation.LongSumAggregatorFactory;
 import io.druid.segment.indexing.DataSchema;
 import io.druid.segment.indexing.granularity.UniformGranularitySpec;
 import io.druid.server.DruidNode;
-import io.druid.server.initialization.ServerConfig;
 import io.druid.timeline.DataSegment;
 import io.druid.timeline.partition.NoneShardSpec;
 import org.apache.hadoop.conf.Configuration;
@@ -136,7 +135,7 @@ public class DatasourcePathSpecTest
               {
                 binder.bind(UsedSegmentLister.class).toInstance(segmentList);
                 JsonConfigProvider.bindInstance(
-                    binder, Key.get(DruidNode.class, Self.class), new DruidNode("dummy-node", null, null, null, new ServerConfig())
+                    binder, Key.get(DruidNode.class, Self.class), new DruidNode("dummy-node", null, null, null, true, false)
                 );
               }
             }

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/ForkingTaskRunnerFactory.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/ForkingTaskRunnerFactory.java
@@ -26,7 +26,6 @@ import io.druid.indexing.common.config.TaskConfig;
 import io.druid.indexing.overlord.config.ForkingTaskRunnerConfig;
 import io.druid.indexing.worker.config.WorkerConfig;
 import io.druid.server.DruidNode;
-import io.druid.server.initialization.ServerConfig;
 import io.druid.tasklogs.TaskLogPusher;
 
 import java.util.Properties;
@@ -42,7 +41,6 @@ public class ForkingTaskRunnerFactory implements TaskRunnerFactory<ForkingTaskRu
   private final ObjectMapper jsonMapper;
   private final TaskLogPusher persistentTaskLogs;
   private final DruidNode node;
-  private final ServerConfig serverConfig;
 
   @Inject
   public ForkingTaskRunnerFactory(
@@ -52,8 +50,7 @@ public class ForkingTaskRunnerFactory implements TaskRunnerFactory<ForkingTaskRu
       final Properties props,
       final ObjectMapper jsonMapper,
       final TaskLogPusher persistentTaskLogs,
-      @Self DruidNode node,
-      ServerConfig serverConfig
+      @Self DruidNode node
   )
   {
     this.config = config;
@@ -63,12 +60,11 @@ public class ForkingTaskRunnerFactory implements TaskRunnerFactory<ForkingTaskRu
     this.jsonMapper = jsonMapper;
     this.persistentTaskLogs = persistentTaskLogs;
     this.node = node;
-    this.serverConfig = serverConfig;
   }
 
   @Override
   public ForkingTaskRunner build()
   {
-    return new ForkingTaskRunner(config, taskConfig, workerConfig, props, persistentTaskLogs, jsonMapper, node, serverConfig);
+    return new ForkingTaskRunner(config, taskConfig, workerConfig, props, persistentTaskLogs, jsonMapper, node);
   }
 }

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLifecycleTest.java
@@ -112,7 +112,6 @@ import io.druid.server.DruidNode;
 import io.druid.server.coordination.DataSegmentAnnouncer;
 import io.druid.server.coordination.DataSegmentServerAnnouncer;
 import io.druid.server.coordination.ServerType;
-import io.druid.server.initialization.ServerConfig;
 import io.druid.server.metrics.NoopServiceEmitter;
 import io.druid.timeline.DataSegment;
 import io.druid.timeline.partition.NoneShardSpec;
@@ -620,7 +619,7 @@ public class TaskLifecycleTest
         tb,
         taskConfig,
         emitter,
-        new DruidNode("dummy", "dummy", 10000, null, new ServerConfig())
+        new DruidNode("dummy", "dummy", 10000, null, true, false)
     );
   }
 

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/http/OverlordTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/http/OverlordTest.java
@@ -56,7 +56,6 @@ import io.druid.java.util.common.guava.CloseQuietly;
 import io.druid.server.DruidNode;
 import io.druid.server.coordinator.CoordinatorOverlordServiceConfig;
 import io.druid.server.initialization.IndexerZkConfig;
-import io.druid.server.initialization.ServerConfig;
 import io.druid.server.initialization.ZkPathsConfig;
 import io.druid.server.metrics.NoopServiceEmitter;
 import io.druid.server.security.AuthConfig;
@@ -167,7 +166,7 @@ public class OverlordTest
     setupServerAndCurator();
     curator.start();
     curator.blockUntilConnected();
-    druidNode = new DruidNode("hey", "what", 1234, null, new ServerConfig());
+    druidNode = new DruidNode("hey", "what", 1234, null, true, false);
     ServiceEmitter serviceEmitter = new NoopServiceEmitter();
     taskMaster = new TaskMaster(
         new TaskQueueConfig(null, new Period(1), null, new Period(10)),

--- a/indexing-service/src/test/java/io/druid/indexing/worker/WorkerTaskMonitorTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/worker/WorkerTaskMonitorTest.java
@@ -47,7 +47,6 @@ import io.druid.segment.loading.StorageLocationConfig;
 import io.druid.segment.realtime.plumber.SegmentHandoffNotifierFactory;
 import io.druid.server.DruidNode;
 import io.druid.server.initialization.IndexerZkConfig;
-import io.druid.server.initialization.ServerConfig;
 import io.druid.server.initialization.ZkPathsConfig;
 import io.druid.server.metrics.NoopServiceEmitter;
 import org.apache.curator.framework.CuratorFramework;
@@ -71,7 +70,7 @@ public class WorkerTaskMonitorTest
   private static final String basePath = "/test/druid";
   private static final String tasksPath = StringUtils.format("%s/indexer/tasks/worker", basePath);
   private static final String statusPath = StringUtils.format("%s/indexer/status/worker", basePath);
-  private static final DruidNode DUMMY_NODE = new DruidNode("dummy", "dummy", 9000, null, new ServerConfig());
+  private static final DruidNode DUMMY_NODE = new DruidNode("dummy", "dummy", 9000, null, true, false);
 
   private TestingCluster testingCluster;
   private CuratorFramework cf;

--- a/integration-tests/src/main/java/io/druid/testing/guice/DruidTestModule.java
+++ b/integration-tests/src/main/java/io/druid/testing/guice/DruidTestModule.java
@@ -37,7 +37,6 @@ import io.druid.guice.ManageLifecycle;
 import io.druid.guice.annotations.EscalatedClient;
 import io.druid.guice.annotations.Self;
 import io.druid.server.DruidNode;
-import io.druid.server.initialization.ServerConfig;
 import io.druid.testing.IntegrationTestingConfig;
 import io.druid.testing.IntegrationTestingConfigProvider;
 import io.druid.testing.IntegrationTestingCuratorConfig;
@@ -58,7 +57,7 @@ public class DruidTestModule implements Module
 
     // Bind DruidNode instance to make Guice happy. This instance is currently unused.
     binder.bind(DruidNode.class).annotatedWith(Self.class).toInstance(
-        new DruidNode("integration-tests", "localhost", 9191, null, null, new ServerConfig())
+        new DruidNode("integration-tests", "localhost", 9191, null, null, true, false)
     );
   }
 

--- a/server/src/main/java/io/druid/segment/realtime/firehose/ServiceAnnouncingChatHandlerProvider.java
+++ b/server/src/main/java/io/druid/segment/realtime/firehose/ServiceAnnouncingChatHandlerProvider.java
@@ -123,6 +123,6 @@ public class ServiceAnnouncingChatHandlerProvider implements ChatHandlerProvider
 
   private DruidNode makeDruidNode(String key)
   {
-    return new DruidNode(key, node.getHost(), node.getPlaintextPort(), node.getTlsPort(), serverConfig);
+    return new DruidNode(key, node.getHost(), node.getPlaintextPort(), node.getTlsPort(), node.isEnablePlaintextPort(), node.isEnableTlsPort());
   }
 }

--- a/server/src/main/java/io/druid/server/http/ClusterResource.java
+++ b/server/src/main/java/io/druid/server/http/ClusterResource.java
@@ -19,6 +19,10 @@
 
 package io.druid.server.http;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.sun.jersey.spi.container.ResourceFilters;
@@ -26,12 +30,14 @@ import io.druid.discovery.DiscoveryDruidNode;
 import io.druid.discovery.DruidNodeDiscoveryProvider;
 import io.druid.guice.LazySingleton;
 import io.druid.java.util.common.StringUtils;
+import io.druid.server.DruidNode;
 import io.druid.server.http.security.StateResourceFilter;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Collection;
@@ -53,35 +59,31 @@ public class ClusterResource
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
-  public Response getClusterServers()
+  public Response getClusterServers(
+      @QueryParam("full") boolean full
+  )
   {
     ImmutableMap.Builder<String, Object> entityBuilder = new ImmutableMap.Builder<>();
 
     entityBuilder.put(DruidNodeDiscoveryProvider.NODE_TYPE_COORDINATOR,
-                      druidNodeDiscoveryProvider.getForNodeType(DruidNodeDiscoveryProvider.NODE_TYPE_COORDINATOR)
-                                                .getAllNodes()
+                      getNodes(DruidNodeDiscoveryProvider.NODE_TYPE_COORDINATOR, full)
     );
     entityBuilder.put(DruidNodeDiscoveryProvider.NODE_TYPE_OVERLORD,
-                      druidNodeDiscoveryProvider.getForNodeType(DruidNodeDiscoveryProvider.NODE_TYPE_OVERLORD)
-                                                .getAllNodes()
+                      getNodes(DruidNodeDiscoveryProvider.NODE_TYPE_OVERLORD, full)
     );
     entityBuilder.put(DruidNodeDiscoveryProvider.NODE_TYPE_BROKER,
-                      druidNodeDiscoveryProvider.getForNodeType(DruidNodeDiscoveryProvider.NODE_TYPE_BROKER)
-                                                .getAllNodes()
+                      getNodes(DruidNodeDiscoveryProvider.NODE_TYPE_BROKER, full)
     );
     entityBuilder.put(DruidNodeDiscoveryProvider.NODE_TYPE_HISTORICAL,
-                      druidNodeDiscoveryProvider.getForNodeType(DruidNodeDiscoveryProvider.NODE_TYPE_HISTORICAL)
-                                                .getAllNodes()
+                      getNodes(DruidNodeDiscoveryProvider.NODE_TYPE_HISTORICAL, full)
     );
 
-    Collection<DiscoveryDruidNode> mmNodes = druidNodeDiscoveryProvider.getForNodeType(DruidNodeDiscoveryProvider.NODE_TYPE_MM)
-                                                                       .getAllNodes();
+    Collection<Object> mmNodes = getNodes(DruidNodeDiscoveryProvider.NODE_TYPE_MM, full);
     if (!mmNodes.isEmpty()) {
       entityBuilder.put(DruidNodeDiscoveryProvider.NODE_TYPE_MM, mmNodes);
     }
 
-    Collection<DiscoveryDruidNode> routerNodes = druidNodeDiscoveryProvider.getForNodeType(DruidNodeDiscoveryProvider.NODE_TYPE_ROUTER)
-                                                                    .getAllNodes();
+    Collection<Object> routerNodes = getNodes(DruidNodeDiscoveryProvider.NODE_TYPE_ROUTER, full);
     if (!routerNodes.isEmpty()) {
       entityBuilder.put(DruidNodeDiscoveryProvider.NODE_TYPE_ROUTER, routerNodes);
     }
@@ -93,7 +95,8 @@ public class ClusterResource
   @Produces({MediaType.APPLICATION_JSON})
   @Path("/{nodeType}")
   public Response getClusterServers(
-      @PathParam("nodeType") String nodeType
+      @PathParam("nodeType") String nodeType,
+      @QueryParam("full") boolean full
   )
   {
     if (nodeType == null || !DruidNodeDiscoveryProvider.ALL_NODE_TYPES.contains(nodeType)) {
@@ -107,8 +110,74 @@ public class ClusterResource
                      .build();
     } else {
       return Response.status(Response.Status.OK).entity(
-          druidNodeDiscoveryProvider.getForNodeType(nodeType).getAllNodes()
+          getNodes(nodeType, full)
       ).build();
+    }
+  }
+
+  private Collection<Object> getNodes(String nodeType, boolean full)
+  {
+    Collection<DiscoveryDruidNode> discoveryDruidNodes = druidNodeDiscoveryProvider.getForNodeType(nodeType)
+                                                                                   .getAllNodes();
+    if (full) {
+      return (Collection) discoveryDruidNodes;
+    } else {
+      return Collections2.transform(
+          discoveryDruidNodes,
+          (discoveryDruidNode) -> Node.from(discoveryDruidNode.getDruidNode())
+      );
+    }
+  }
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private static class Node
+  {
+    private final String host;
+    private final String service;
+    private final Integer plaintextPort;
+    private final Integer tlsPort;
+
+    @JsonCreator
+    public Node(String host, String service, Integer plaintextPort, Integer tlsPort)
+    {
+      this.host = host;
+      this.service = service;
+      this.plaintextPort = plaintextPort;
+      this.tlsPort = tlsPort;
+    }
+
+    @JsonProperty
+    public String getHost()
+    {
+      return host;
+    }
+
+    @JsonProperty
+    public String getService()
+    {
+      return service;
+    }
+
+    @JsonProperty
+    public Integer getPlaintextPort()
+    {
+      return plaintextPort;
+    }
+
+    @JsonProperty
+    public Integer getTlsPort()
+    {
+      return tlsPort;
+    }
+
+    public static Node from(DruidNode druidNode)
+    {
+      return new Node(
+          druidNode.getHost(),
+          druidNode.getServiceName(),
+          druidNode.getPlaintextPort() > 0 ? druidNode.getPlaintextPort() : null,
+          druidNode.getTlsPort() > 0 ? druidNode.getTlsPort() : null
+      );
     }
   }
 }

--- a/server/src/main/java/io/druid/server/initialization/ServerConfig.java
+++ b/server/src/main/java/io/druid/server/initialization/ServerConfig.java
@@ -46,12 +46,6 @@ public class ServerConfig
   @Min(1)
   private long maxScatterGatherBytes = Long.MAX_VALUE;
 
-  @JsonProperty
-  private boolean plaintext = true;
-
-  @JsonProperty
-  private boolean tls = false;
-
   public int getNumThreads()
   {
     return numThreads;
@@ -72,16 +66,6 @@ public class ServerConfig
     return maxScatterGatherBytes;
   }
 
-  public boolean isPlaintext()
-  {
-    return plaintext;
-  }
-
-  public boolean isTls()
-  {
-    return tls;
-  }
-
   @Override
   public boolean equals(Object o)
   {
@@ -95,15 +79,13 @@ public class ServerConfig
     return numThreads == that.numThreads &&
            defaultQueryTimeout == that.defaultQueryTimeout &&
            maxScatterGatherBytes == that.maxScatterGatherBytes &&
-           plaintext == that.plaintext &&
-           tls == that.tls &&
            Objects.equals(maxIdleTime, that.maxIdleTime);
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(numThreads, maxIdleTime, defaultQueryTimeout, maxScatterGatherBytes, plaintext, tls);
+    return Objects.hash(numThreads, maxIdleTime, defaultQueryTimeout, maxScatterGatherBytes);
   }
 
   @Override
@@ -114,8 +96,6 @@ public class ServerConfig
            ", maxIdleTime=" + maxIdleTime +
            ", defaultQueryTimeout=" + defaultQueryTimeout +
            ", maxScatterGatherBytes=" + maxScatterGatherBytes +
-           ", plaintext=" + plaintext +
-           ", tls=" + tls +
            '}';
   }
 }

--- a/server/src/main/java/io/druid/server/initialization/jetty/JettyServerModule.java
+++ b/server/src/main/java/io/druid/server/initialization/jetty/JettyServerModule.java
@@ -196,13 +196,13 @@ public class JettyServerModule extends JerseyServletModule
 
     final List<ServerConnector> serverConnectors = new ArrayList<>();
 
-    if (config.isPlaintext()) {
+    if (node.isEnablePlaintextPort()) {
       log.info("Creating http connector with port [%d]", node.getPlaintextPort());
       final ServerConnector connector = new ServerConnector(server);
       connector.setPort(node.getPlaintextPort());
       serverConnectors.add(connector);
     }
-    if (config.isTls()) {
+    if (node.isEnableTlsPort()) {
       log.info("Creating https connector with port [%d]", node.getTlsPort());
       final SslContextFactory sslContextFactory;
       if (sslContextFactoryBinding == null) {

--- a/server/src/test/java/io/druid/client/HttpServerInventoryViewTest.java
+++ b/server/src/test/java/io/druid/client/HttpServerInventoryViewTest.java
@@ -43,7 +43,6 @@ import io.druid.server.coordination.SegmentChangeRequestHistory;
 import io.druid.server.coordination.SegmentChangeRequestLoad;
 import io.druid.server.coordination.SegmentChangeRequestsSnapshot;
 import io.druid.server.coordination.ServerType;
-import io.druid.server.initialization.ServerConfig;
 import io.druid.timeline.DataSegment;
 import org.easymock.EasyMock;
 import org.jboss.netty.buffer.ChannelBuffers;
@@ -162,7 +161,7 @@ public class HttpServerInventoryViewTest
     );
 
     DiscoveryDruidNode druidNode = new DiscoveryDruidNode(
-        new DruidNode("service", "host", 8080, null, new ServerConfig()),
+        new DruidNode("service", "host", 8080, null, true, false),
         DruidNodeDiscoveryProvider.NODE_TYPE_HISTORICAL,
         ImmutableMap.of(
             DataNodeService.DISCOVERY_SERVICE_KEY, new DataNodeService("tier", 1000, ServerType.HISTORICAL, 0)

--- a/server/src/test/java/io/druid/client/cache/CacheMonitorTest.java
+++ b/server/src/test/java/io/druid/client/cache/CacheMonitorTest.java
@@ -29,7 +29,6 @@ import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.annotations.Self;
 import io.druid.initialization.Initialization;
 import io.druid.server.DruidNode;
-import io.druid.server.initialization.ServerConfig;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -44,7 +43,7 @@ public class CacheMonitorTest
           public void configure(Binder binder)
           {
             JsonConfigProvider.bindInstance(
-                binder, Key.get(DruidNode.class, Self.class), new DruidNode("test-inject", null, null, null, new ServerConfig())
+                binder, Key.get(DruidNode.class, Self.class), new DruidNode("test-inject", null, null, null, true, false)
             );
           }
         }
@@ -63,7 +62,7 @@ public class CacheMonitorTest
           public void configure(Binder binder)
           {
             JsonConfigProvider.bindInstance(
-                binder, Key.get(DruidNode.class, Self.class), new DruidNode("test-inject", null, null, null, new ServerConfig())
+                binder, Key.get(DruidNode.class, Self.class), new DruidNode("test-inject", null, null, null, true, false)
             );
             binder.bind(Cache.class).toInstance(MapCache.create(0));
           }

--- a/server/src/test/java/io/druid/curator/discovery/CuratorDruidLeaderSelectorTest.java
+++ b/server/src/test/java/io/druid/curator/discovery/CuratorDruidLeaderSelectorTest.java
@@ -25,7 +25,6 @@ import io.druid.curator.CuratorTestBase;
 import io.druid.discovery.DruidLeaderSelector;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.server.DruidNode;
-import io.druid.server.initialization.ServerConfig;
 import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Assert;
@@ -60,7 +59,7 @@ public class CuratorDruidLeaderSelectorTest extends CuratorTestBase
 
     CuratorDruidLeaderSelector leaderSelector1 = new CuratorDruidLeaderSelector(
         curator,
-        new DruidNode("s1", "h1", 8080, null, new ServerConfig()),
+        new DruidNode("s1", "h1", 8080, null, true, false),
         latchPath
     );
     leaderSelector1.registerListener(
@@ -92,7 +91,7 @@ public class CuratorDruidLeaderSelectorTest extends CuratorTestBase
 
     CuratorDruidLeaderSelector leaderSelector2 = new CuratorDruidLeaderSelector(
         curator,
-        new DruidNode("s2", "h2", 8080, null, new ServerConfig()),
+        new DruidNode("s2", "h2", 8080, null, true, false),
         latchPath
     );
     leaderSelector2.registerListener(
@@ -132,7 +131,7 @@ public class CuratorDruidLeaderSelectorTest extends CuratorTestBase
 
     CuratorDruidLeaderSelector leaderSelector3 = new CuratorDruidLeaderSelector(
         curator,
-        new DruidNode("s3", "h3", 8080, null, new ServerConfig()),
+        new DruidNode("s3", "h3", 8080, null, true, false),
         latchPath
     );
     leaderSelector3.registerListener(

--- a/server/src/test/java/io/druid/curator/discovery/CuratorDruidNodeAnnouncerAndDiscoveryTest.java
+++ b/server/src/test/java/io/druid/curator/discovery/CuratorDruidNodeAnnouncerAndDiscoveryTest.java
@@ -80,25 +80,25 @@ public class CuratorDruidNodeAnnouncerAndDiscoveryTest extends CuratorTestBase
     );
 
     DiscoveryDruidNode node1 = new DiscoveryDruidNode(
-        new DruidNode("s1", "h1", 8080, null, new ServerConfig()),
+        new DruidNode("s1", "h1", 8080, null, true, false),
         DruidNodeDiscoveryProvider.NODE_TYPE_COORDINATOR,
         ImmutableMap.of()
     );
 
     DiscoveryDruidNode node2 = new DiscoveryDruidNode(
-        new DruidNode("s2", "h2", 8080, null, new ServerConfig()),
+        new DruidNode("s2", "h2", 8080, null, true, false),
         DruidNodeDiscoveryProvider.NODE_TYPE_COORDINATOR,
         ImmutableMap.of()
     );
 
     DiscoveryDruidNode node3 = new DiscoveryDruidNode(
-        new DruidNode("s3", "h3", 8080, null, new ServerConfig()),
+        new DruidNode("s3", "h3", 8080, null, true, false),
         DruidNodeDiscoveryProvider.NODE_TYPE_OVERLORD,
         ImmutableMap.of()
     );
 
     DiscoveryDruidNode node4 = new DiscoveryDruidNode(
-        new DruidNode("s4", "h4", 8080, null, new ServerConfig()),
+        new DruidNode("s4", "h4", 8080, null, true, false),
         DruidNodeDiscoveryProvider.NODE_TYPE_OVERLORD,
         ImmutableMap.of()
     );

--- a/server/src/test/java/io/druid/discovery/DruidLeaderClientTest.java
+++ b/server/src/test/java/io/druid/discovery/DruidLeaderClientTest.java
@@ -42,7 +42,6 @@ import io.druid.initialization.Initialization;
 import io.druid.java.util.common.StringUtils;
 import io.druid.server.DruidNode;
 import io.druid.server.initialization.BaseJettyTest;
-import io.druid.server.initialization.ServerConfig;
 import io.druid.server.initialization.jetty.JettyServerInitializer;
 import org.easymock.EasyMock;
 import org.eclipse.jetty.server.Handler;
@@ -73,7 +72,7 @@ public class DruidLeaderClientTest extends BaseJettyTest
   @Override
   protected Injector setupInjector()
   {
-    final DruidNode node = new DruidNode("test", "localhost", null, null, new ServerConfig());
+    final DruidNode node = new DruidNode("test", "localhost", null, null, true, false);
     discoveryDruidNode = new DiscoveryDruidNode(node, "test", ImmutableMap.of());
 
     Injector injector = Initialization.makeInjectorWithModules(
@@ -163,7 +162,7 @@ public class DruidLeaderClientTest extends BaseJettyTest
     DruidNodeDiscovery druidNodeDiscovery = EasyMock.createMock(DruidNodeDiscovery.class);
     EasyMock.expect(druidNodeDiscovery.getAllNodes()).andReturn(
         ImmutableList.of(new DiscoveryDruidNode(
-            new DruidNode("test", "dummyhost", 64231, null, new ServerConfig()),
+            new DruidNode("test", "dummyhost", 64231, null, true, false),
             "test",
             ImmutableMap.of()
         ))

--- a/server/src/test/java/io/druid/discovery/DruidNodeDiscoveryProviderTest.java
+++ b/server/src/test/java/io/druid/discovery/DruidNodeDiscoveryProviderTest.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.druid.server.DruidNode;
 import io.druid.server.coordination.ServerType;
-import io.druid.server.initialization.ServerConfig;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -87,7 +86,7 @@ public class DruidNodeDiscoveryProviderTest
     Assert.assertTrue(lookupNodeDiscovery.getAllNodes().isEmpty());
 
     DiscoveryDruidNode node1 = new DiscoveryDruidNode(
-        new DruidNode("s1", "h1", 8080, null, new ServerConfig()),
+        new DruidNode("s1", "h1", 8080, null, true, false),
         DruidNodeDiscoveryProvider.NODE_TYPE_HISTORICAL,
         ImmutableMap.of(
             DataNodeService.DISCOVERY_SERVICE_KEY, new DataNodeService("tier", 1000, ServerType.HISTORICAL, 0),
@@ -95,21 +94,21 @@ public class DruidNodeDiscoveryProviderTest
     );
 
     DiscoveryDruidNode node2 = new DiscoveryDruidNode(
-        new DruidNode("s2", "h2", 8080, null, new ServerConfig()),
+        new DruidNode("s2", "h2", 8080, null, true, false),
         DruidNodeDiscoveryProvider.NODE_TYPE_HISTORICAL,
         ImmutableMap.of(
             DataNodeService.DISCOVERY_SERVICE_KEY, new DataNodeService("tier", 1000, ServerType.HISTORICAL, 0))
     );
 
     DiscoveryDruidNode node3 = new DiscoveryDruidNode(
-        new DruidNode("s3", "h3", 8080, null, new ServerConfig()),
+        new DruidNode("s3", "h3", 8080, null, true, false),
         DruidNodeDiscoveryProvider.NODE_TYPE_HISTORICAL,
         ImmutableMap.of(
             LookupNodeService.DISCOVERY_SERVICE_KEY, new LookupNodeService("tier"))
     );
 
     DiscoveryDruidNode node4 = new DiscoveryDruidNode(
-        new DruidNode("s4", "h4", 8080, null, new ServerConfig()),
+        new DruidNode("s4", "h4", 8080, null, true, false),
         DruidNodeDiscoveryProvider.NODE_TYPE_PEON,
         ImmutableMap.of(
             DataNodeService.DISCOVERY_SERVICE_KEY, new DataNodeService("tier", 1000, ServerType.HISTORICAL, 0),
@@ -117,35 +116,35 @@ public class DruidNodeDiscoveryProviderTest
     );
 
     DiscoveryDruidNode node5 = new DiscoveryDruidNode(
-        new DruidNode("s5", "h5", 8080, null, new ServerConfig()),
+        new DruidNode("s5", "h5", 8080, null, true, false),
         DruidNodeDiscoveryProvider.NODE_TYPE_PEON,
         ImmutableMap.of(
             DataNodeService.DISCOVERY_SERVICE_KEY, new DataNodeService("tier", 1000, ServerType.HISTORICAL, 0))
     );
 
     DiscoveryDruidNode node6 = new DiscoveryDruidNode(
-        new DruidNode("s6", "h6", 8080, null, new ServerConfig()),
+        new DruidNode("s6", "h6", 8080, null, true, false),
         DruidNodeDiscoveryProvider.NODE_TYPE_PEON,
         ImmutableMap.of(
             LookupNodeService.DISCOVERY_SERVICE_KEY, new LookupNodeService("tier"))
     );
 
     DiscoveryDruidNode node7 = new DiscoveryDruidNode(
-        new DruidNode("s7", "h7", 8080, null, new ServerConfig()),
+        new DruidNode("s7", "h7", 8080, null, true, false),
         DruidNodeDiscoveryProvider.NODE_TYPE_BROKER,
         ImmutableMap.of(
             LookupNodeService.DISCOVERY_SERVICE_KEY, new LookupNodeService("tier"))
     );
 
     DiscoveryDruidNode node7Clone = new DiscoveryDruidNode(
-        new DruidNode("s7", "h7", 8080, null, new ServerConfig()),
+        new DruidNode("s7", "h7", 8080, null, true, false),
         DruidNodeDiscoveryProvider.NODE_TYPE_BROKER,
         ImmutableMap.of(
             LookupNodeService.DISCOVERY_SERVICE_KEY, new LookupNodeService("tier"))
     );
 
     DiscoveryDruidNode node8 = new DiscoveryDruidNode(
-        new DruidNode("s8", "h8", 8080, null, new ServerConfig()),
+        new DruidNode("s8", "h8", 8080, null, true, false),
         DruidNodeDiscoveryProvider.NODE_TYPE_COORDINATOR,
         ImmutableMap.of()
     );

--- a/server/src/test/java/io/druid/initialization/InitializationTest.java
+++ b/server/src/test/java/io/druid/initialization/InitializationTest.java
@@ -34,7 +34,6 @@ import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.annotations.Self;
 import io.druid.java.util.common.ISE;
 import io.druid.server.DruidNode;
-import io.druid.server.initialization.ServerConfig;
 import org.junit.Assert;
 import org.junit.FixMethodOrder;
 import org.junit.Rule;
@@ -142,7 +141,7 @@ public class InitializationTest
               public void configure(Binder binder)
               {
                 JsonConfigProvider.bindInstance(
-                    binder, Key.get(DruidNode.class, Self.class), new DruidNode("test-inject", null, null, null, new ServerConfig())
+                    binder, Key.get(DruidNode.class, Self.class), new DruidNode("test-inject", null, null, null, true, false)
                 );
               }
             }

--- a/server/src/test/java/io/druid/query/lookup/LookupListeningAnnouncerConfigTest.java
+++ b/server/src/test/java/io/druid/query/lookup/LookupListeningAnnouncerConfigTest.java
@@ -31,7 +31,6 @@ import io.druid.guice.JsonConfigurator;
 import io.druid.guice.annotations.Self;
 import io.druid.initialization.Initialization;
 import io.druid.server.DruidNode;
-import io.druid.server.initialization.ServerConfig;
 import io.druid.server.metrics.DataSourceTaskIdHolder;
 import org.junit.Assert;
 import org.junit.Before;
@@ -51,7 +50,7 @@ public class LookupListeningAnnouncerConfigTest
             public void configure(Binder binder)
             {
               JsonConfigProvider.bindInstance(
-                  binder, Key.get(DruidNode.class, Self.class), new DruidNode("test-inject", null, null, null, new ServerConfig())
+                  binder, Key.get(DruidNode.class, Self.class), new DruidNode("test-inject", null, null, null, true, false)
               );
               binder.bind(Key.get(
                   String.class,

--- a/server/src/test/java/io/druid/segment/realtime/firehose/ServiceAnnouncingChatHandlerProviderTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/firehose/ServiceAnnouncingChatHandlerProviderTest.java
@@ -91,6 +91,8 @@ public class ServiceAnnouncingChatHandlerProviderTest extends EasyMockSupport
 
     EasyMock.expect(node.getHost()).andReturn(TEST_HOST);
     EasyMock.expect(node.getPlaintextPort()).andReturn(TEST_PORT);
+    EasyMock.expect(node.isEnablePlaintextPort()).andReturn(true);
+    EasyMock.expect(node.isEnableTlsPort()).andReturn(false);
     EasyMock.expect(node.getTlsPort()).andReturn(-1);
     serviceAnnouncer.announce(EasyMock.capture(captured));
     replayAll();
@@ -117,7 +119,9 @@ public class ServiceAnnouncingChatHandlerProviderTest extends EasyMockSupport
     resetAll();
     EasyMock.expect(node.getHost()).andReturn(TEST_HOST);
     EasyMock.expect(node.getPlaintextPort()).andReturn(TEST_PORT);
+    EasyMock.expect(node.isEnablePlaintextPort()).andReturn(true);
     EasyMock.expect(node.getTlsPort()).andReturn(-1);
+    EasyMock.expect(node.isEnableTlsPort()).andReturn(false);
     serviceAnnouncer.unannounce(EasyMock.capture(captured));
     replayAll();
 

--- a/server/src/test/java/io/druid/server/AsyncQueryForwardingServletTest.java
+++ b/server/src/test/java/io/druid/server/AsyncQueryForwardingServletTest.java
@@ -45,7 +45,6 @@ import io.druid.query.MapQueryToolChestWarehouse;
 import io.druid.query.Query;
 import io.druid.query.QueryToolChest;
 import io.druid.server.initialization.BaseJettyTest;
-import io.druid.server.initialization.ServerConfig;
 import io.druid.server.initialization.jetty.JettyServerInitUtils;
 import io.druid.server.initialization.jetty.JettyServerInitializer;
 import io.druid.server.log.RequestLogger;
@@ -113,7 +112,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
                 JsonConfigProvider.bindInstance(
                     binder,
                     Key.get(DruidNode.class, Self.class),
-                    new DruidNode("test", "localhost", null, null, new ServerConfig())
+                    new DruidNode("test", "localhost", null, null, true, false)
                 );
                 binder.bind(JettyServerInitializer.class).to(ProxyJettyServerInit.class).in(LazySingleton.class);
                 binder.bind(AuthorizerMapper.class).toInstance(

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
@@ -44,7 +44,6 @@ import io.druid.server.coordination.DruidServerMetadata;
 import io.druid.server.coordination.ServerType;
 import io.druid.server.coordinator.rules.ForeverLoadRule;
 import io.druid.server.coordinator.rules.Rule;
-import io.druid.server.initialization.ServerConfig;
 import io.druid.server.initialization.ZkPathsConfig;
 import io.druid.server.lookup.cache.LookupCoordinatorManager;
 import io.druid.server.metrics.NoopServiceEmitter;
@@ -151,7 +150,7 @@ public class DruidCoordinatorTest extends CuratorTestBase
         druidCoordinatorConfig
     );
     loadQueuePeon.start();
-    druidNode = new DruidNode("hey", "what", 1234, null, new ServerConfig());
+    druidNode = new DruidNode("hey", "what", 1234, null, true, false);
     loadManagementPeons = new ConcurrentHashMap<>();
     scheduledExecutorFactory = new ScheduledExecutorFactory()
     {

--- a/server/src/test/java/io/druid/server/initialization/JettyQosTest.java
+++ b/server/src/test/java/io/druid/server/initialization/JettyQosTest.java
@@ -71,7 +71,7 @@ public class JettyQosTest extends BaseJettyTest
               public void configure(Binder binder)
               {
                 JsonConfigProvider.bindInstance(
-                    binder, Key.get(DruidNode.class, Self.class), new DruidNode("test", "localhost", null, null, new ServerConfig())
+                    binder, Key.get(DruidNode.class, Self.class), new DruidNode("test", "localhost", null, null, true, false)
                 );
                 binder.bind(JettyServerInitializer.class).to(JettyServerInit.class).in(LazySingleton.class);
                 Jerseys.addResource(binder, SlowResource.class);

--- a/server/src/test/java/io/druid/server/initialization/JettyTest.java
+++ b/server/src/test/java/io/druid/server/initialization/JettyTest.java
@@ -82,7 +82,7 @@ public class JettyTest extends BaseJettyTest
               public void configure(Binder binder)
               {
                 JsonConfigProvider.bindInstance(
-                    binder, Key.get(DruidNode.class, Self.class), new DruidNode("test", "localhost", null, null, new ServerConfig())
+                    binder, Key.get(DruidNode.class, Self.class), new DruidNode("test", "localhost", null, null, true, false)
                 );
                 binder.bind(JettyServerInitializer.class).to(JettyServerInit.class).in(LazySingleton.class);
 

--- a/server/src/test/java/io/druid/server/lookup/cache/LookupNodeDiscoveryTest.java
+++ b/server/src/test/java/io/druid/server/lookup/cache/LookupNodeDiscoveryTest.java
@@ -28,7 +28,6 @@ import io.druid.discovery.DruidNodeDiscoveryProvider;
 import io.druid.discovery.LookupNodeService;
 import io.druid.server.DruidNode;
 import io.druid.server.http.HostAndPortWithScheme;
-import io.druid.server.initialization.ServerConfig;
 import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;
@@ -53,21 +52,21 @@ public class LookupNodeDiscoveryTest
             .andReturn(druidNodeDiscovery);
 
     DiscoveryDruidNode node1 = new DiscoveryDruidNode(
-        new DruidNode("s1", "h1", 8080, null, new ServerConfig()),
+        new DruidNode("s1", "h1", 8080, null, true, false),
         DruidNodeDiscoveryProvider.NODE_TYPE_HISTORICAL,
         ImmutableMap.of(
             LookupNodeService.DISCOVERY_SERVICE_KEY, new LookupNodeService("tier1"))
     );
 
     DiscoveryDruidNode node2 = new DiscoveryDruidNode(
-        new DruidNode("s2", "h2", 8080, null, new ServerConfig()),
+        new DruidNode("s2", "h2", 8080, null, true, false),
         DruidNodeDiscoveryProvider.NODE_TYPE_PEON,
         ImmutableMap.of(
             LookupNodeService.DISCOVERY_SERVICE_KEY, new LookupNodeService("tier1"))
     );
 
     DiscoveryDruidNode node3 = new DiscoveryDruidNode(
-        new DruidNode("s3", "h3", 8080, null, new ServerConfig()),
+        new DruidNode("s3", "h3", 8080, null, true, false),
         DruidNodeDiscoveryProvider.NODE_TYPE_PEON,
         ImmutableMap.of(
             LookupNodeService.DISCOVERY_SERVICE_KEY, new LookupNodeService("tier2"))

--- a/server/src/test/java/io/druid/server/metrics/MetricsModuleTest.java
+++ b/server/src/test/java/io/druid/server/metrics/MetricsModuleTest.java
@@ -30,7 +30,6 @@ import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.annotations.Self;
 import io.druid.initialization.Initialization;
 import io.druid.server.DruidNode;
-import io.druid.server.initialization.ServerConfig;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -48,7 +47,7 @@ public class MetricsModuleTest
           public void configure(Binder binder)
           {
             JsonConfigProvider.bindInstance(
-                binder, Key.get(DruidNode.class, Self.class), new DruidNode("test-inject", null, null, null, new ServerConfig())
+                binder, Key.get(DruidNode.class, Self.class), new DruidNode("test-inject", null, null, null, true, false)
             );
           }
         })
@@ -73,7 +72,7 @@ public class MetricsModuleTest
           public void configure(Binder binder)
           {
             JsonConfigProvider.bindInstance(
-                binder, Key.get(DruidNode.class, Self.class), new DruidNode("test-inject", null, null, null, new ServerConfig())
+                binder, Key.get(DruidNode.class, Self.class), new DruidNode("test-inject", null, null, null, true, false)
             );
             binder.bind(Key.get(
                 String.class,

--- a/server/src/test/java/io/druid/server/router/TieredBrokerHostSelectorTest.java
+++ b/server/src/test/java/io/druid/server/router/TieredBrokerHostSelectorTest.java
@@ -43,7 +43,6 @@ import io.druid.query.timeseries.TimeseriesQuery;
 import io.druid.server.DruidNode;
 import io.druid.server.coordinator.rules.IntervalLoadRule;
 import io.druid.server.coordinator.rules.Rule;
-import io.druid.server.initialization.ServerConfig;
 import org.easymock.EasyMock;
 import org.joda.time.Interval;
 import org.junit.After;
@@ -75,19 +74,19 @@ public class TieredBrokerHostSelectorTest
     druidNodeDiscoveryProvider = EasyMock.createStrictMock(DruidNodeDiscoveryProvider.class);
 
     node1 = new DiscoveryDruidNode(
-        new DruidNode("hotBroker", "hotHost", 8080, null, new ServerConfig()),
+        new DruidNode("hotBroker", "hotHost", 8080, null, true, false),
         DruidNodeDiscoveryProvider.NODE_TYPE_BROKER,
         ImmutableMap.of()
     );
 
     node2 = new DiscoveryDruidNode(
-        new DruidNode("coldBroker", "coldHost1", 8080, null, new ServerConfig()),
+        new DruidNode("coldBroker", "coldHost1", 8080, null, true, false),
         DruidNodeDiscoveryProvider.NODE_TYPE_BROKER,
         ImmutableMap.of()
     );
 
     node3 = new DiscoveryDruidNode(
-        new DruidNode("coldBroker", "coldHost2", 8080, null, new ServerConfig()),
+        new DruidNode("coldBroker", "coldHost2", 8080, null, true, false),
         DruidNodeDiscoveryProvider.NODE_TYPE_BROKER,
         ImmutableMap.of()
     );

--- a/services/src/main/java/io/druid/cli/CreateTables.java
+++ b/services/src/main/java/io/druid/cli/CreateTables.java
@@ -36,7 +36,6 @@ import io.druid.metadata.MetadataStorageConnector;
 import io.druid.metadata.MetadataStorageConnectorConfig;
 import io.druid.metadata.MetadataStorageTablesConfig;
 import io.druid.server.DruidNode;
-import io.druid.server.initialization.ServerConfig;
 
 import java.util.List;
 
@@ -106,7 +105,7 @@ public class CreateTables extends GuiceRunnable
                 binder, Key.get(MetadataStorageTablesConfig.class), MetadataStorageTablesConfig.fromBase(base)
             );
             JsonConfigProvider.bindInstance(
-                binder, Key.get(DruidNode.class, Self.class), new DruidNode("tools", "localhost", -1, null, new ServerConfig())
+                binder, Key.get(DruidNode.class, Self.class), new DruidNode("tools", "localhost", -1, null, true, false)
             );
           }
         }

--- a/services/src/main/java/io/druid/cli/InsertSegment.java
+++ b/services/src/main/java/io/druid/cli/InsertSegment.java
@@ -40,7 +40,6 @@ import io.druid.java.util.common.logger.Logger;
 import io.druid.segment.loading.DataSegmentFinder;
 import io.druid.segment.loading.SegmentLoadingException;
 import io.druid.server.DruidNode;
-import io.druid.server.initialization.ServerConfig;
 import io.druid.timeline.DataSegment;
 
 import java.io.IOException;
@@ -87,7 +86,7 @@ public class InsertSegment extends GuiceRunnable
           public void configure(Binder binder)
           {
             JsonConfigProvider.bindInstance(
-                binder, Key.get(DruidNode.class, Self.class), new DruidNode("tools", "localhost", -1, null, new ServerConfig())
+                binder, Key.get(DruidNode.class, Self.class), new DruidNode("tools", "localhost", -1, null, true, false)
             );
           }
         }

--- a/services/src/main/java/io/druid/cli/ResetCluster.java
+++ b/services/src/main/java/io/druid/cli/ResetCluster.java
@@ -39,7 +39,6 @@ import io.druid.metadata.MetadataStorageConnector;
 import io.druid.metadata.MetadataStorageTablesConfig;
 import io.druid.segment.loading.DataSegmentKiller;
 import io.druid.server.DruidNode;
-import io.druid.server.initialization.ServerConfig;
 import io.druid.tasklogs.TaskLogKiller;
 
 import java.util.List;
@@ -92,7 +91,7 @@ public class ResetCluster extends GuiceRunnable
           public void configure(Binder binder)
           {
             JsonConfigProvider.bindInstance(
-                binder, Key.get(DruidNode.class, Self.class), new DruidNode("tools", "localhost", -1, null, new ServerConfig())
+                binder, Key.get(DruidNode.class, Self.class), new DruidNode("tools", "localhost", -1, null, true, false)
             );
             JsonConfigProvider.bind(binder, "druid.indexer.task", TaskConfig.class);
           }

--- a/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
+++ b/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
@@ -41,7 +41,6 @@ import io.druid.java.util.common.Pair;
 import io.druid.java.util.common.StringUtils;
 import io.druid.math.expr.ExprMacroTable;
 import io.druid.server.DruidNode;
-import io.druid.server.initialization.ServerConfig;
 import io.druid.server.security.AuthConfig;
 import io.druid.server.security.AuthTestUtils;
 import io.druid.sql.calcite.planner.Calcites;
@@ -163,7 +162,7 @@ public class DruidAvaticaHandlerTest
     );
     final DruidAvaticaHandler handler = new DruidAvaticaHandler(
         druidMeta,
-        new DruidNode("dummy", "dummy", 1, null, new ServerConfig()),
+        new DruidNode("dummy", "dummy", 1, null, true, false),
         new AvaticaMonitor()
     );
     final int port = new Random().nextInt(9999) + 10000;
@@ -622,7 +621,7 @@ public class DruidAvaticaHandlerTest
 
     final DruidAvaticaHandler handler = new DruidAvaticaHandler(
         smallFrameDruidMeta,
-        new DruidNode("dummy", "dummy", 1, null, new ServerConfig()),
+        new DruidNode("dummy", "dummy", 1, null, true, false),
         new AvaticaMonitor()
     );
     final int port = new Random().nextInt(9999) + 20000;


### PR DESCRIPTION
Fixes #4850 

This patch moves tls and plainText port enabling out of ServerConfig to DruidNode. Adds a bunch of 
 DruidNode serde tests to DruidNodeTest .
  Updates ClusterResource to not dump full DiscoveryDruidNode object in response but provide only essential information.
Remaining changes are just creators/dependents of ServerConfig and DruidNode classes due to the changes in those.

to enable tls and plainText connectors, users would configure `druid.enablePlaintextPort` and `druid.enableTlsPort` properties.