### PR TITLE
Add identity to query metrics, logs.

### DIFF
--- a/processing/src/main/java/io/druid/query/DefaultQueryMetrics.java
+++ b/processing/src/main/java/io/druid/query/DefaultQueryMetrics.java
@@ -184,6 +184,12 @@ public class DefaultQueryMetrics<QueryType extends Query<?>> implements QueryMet
   }
 
   @Override
+  public void identity(String identity)
+  {
+    setDimension("identity", identity);
+  }
+
+  @Override
   public BitmapResultFactory<?> makeBitmapResultFactory(BitmapFactory factory)
   {
     return new DefaultBitmapResultFactory(factory);

--- a/processing/src/main/java/io/druid/query/DefaultQueryMetrics.java
+++ b/processing/src/main/java/io/druid/query/DefaultQueryMetrics.java
@@ -186,7 +186,7 @@ public class DefaultQueryMetrics<QueryType extends Query<?>> implements QueryMet
   @Override
   public void identity(String identity)
   {
-    setDimension("identity", identity);
+    // Emit nothing by default.
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/QueryMetrics.java
+++ b/processing/src/main/java/io/druid/query/QueryMetrics.java
@@ -208,6 +208,11 @@ public interface QueryMetrics<QueryType extends Query<?>>
   void postFilters(List<Filter> postFilters);
 
   /**
+   * Sets identity of the requester for a query. See {@code AuthenticationResult}.
+   */
+  void identity(String identity);
+
+  /**
    * Creates a {@link BitmapResultFactory} which may record some information along bitmap construction from {@link
    * #preFilters(List)}. The returned BitmapResultFactory may add some dimensions to this QueryMetrics from it's {@link
    * BitmapResultFactory#toImmutableBitmap(Object)} method. See {@link BitmapResultFactory} Javadoc for more

--- a/server/src/main/java/io/druid/server/QueryResource.java
+++ b/server/src/main/java/io/druid/server/QueryResource.java
@@ -125,7 +125,7 @@ public class QueryResource implements QueryCountStatsProvider
   @DELETE
   @Path("{id}")
   @Produces(MediaType.APPLICATION_JSON)
-  public Response getServer(@PathParam("id") String queryId, @Context final HttpServletRequest req)
+  public Response cancelQuery(@PathParam("id") String queryId, @Context final HttpServletRequest req)
   {
     if (log.isDebugEnabled()) {
       log.debug("Received cancel request for query [%s]", queryId);

--- a/server/src/main/java/io/druid/server/RequestLogLine.java
+++ b/server/src/main/java/io/druid/server/RequestLogLine.java
@@ -27,6 +27,7 @@ import io.druid.query.Query;
 import org.joda.time.DateTime;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 public class RequestLogLine
 {
@@ -79,5 +80,38 @@ public class RequestLogLine
   public QueryStats getQueryStats()
   {
     return queryStats;
+  }
+
+  @Override
+  public boolean equals(final Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final RequestLogLine that = (RequestLogLine) o;
+    return Objects.equals(timestamp, that.timestamp) &&
+           Objects.equals(remoteAddr, that.remoteAddr) &&
+           Objects.equals(query, that.query) &&
+           Objects.equals(queryStats, that.queryStats);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(timestamp, remoteAddr, query, queryStats);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "RequestLogLine{" +
+           "timestamp=" + timestamp +
+           ", remoteAddr='" + remoteAddr + '\'' +
+           ", query=" + query +
+           ", queryStats=" + queryStats +
+           '}';
   }
 }

--- a/server/src/main/java/io/druid/server/security/AuthorizationUtils.java
+++ b/server/src/main/java/io/druid/server/security/AuthorizationUtils.java
@@ -44,9 +44,10 @@ public class AuthorizationUtils
    *
    * If this attribute is already set when this function is called, an exception is thrown.
    *
-   * @param request HTTP request to be authorized
-   * @param resourceAction A resource identifier and the action to be taken the resource.
+   * @param request          HTTP request to be authorized
+   * @param resourceAction   A resource identifier and the action to be taken the resource.
    * @param authorizerMapper The singleton AuthorizerMapper instance
+   *
    * @return ACCESS_OK or the failed Access object returned by the Authorizer that checked the request.
    */
   public static Access authorizeResourceAction(
@@ -63,6 +64,28 @@ public class AuthorizationUtils
   }
 
   /**
+   * Returns the authentication information for a request.
+   *
+   * @param request http request
+   *
+   * @return authentication result
+   *
+   * @throws IllegalStateException if the request was not authenticated
+   */
+  public static AuthenticationResult authenticationResultFromRequest(final HttpServletRequest request)
+  {
+    final AuthenticationResult authenticationResult = (AuthenticationResult) request.getAttribute(
+        AuthConfig.DRUID_AUTHENTICATION_RESULT
+    );
+
+    if (authenticationResult == null) {
+      throw new ISE("Null authentication result");
+    }
+
+    return authenticationResult;
+  }
+
+  /**
    * Check a list of resource-actions to be performed by the identity represented by authenticationResult.
    *
    * If one of the resource-actions fails the authorization check, this method returns the failed
@@ -71,7 +94,8 @@ public class AuthorizationUtils
    * Otherwise, return ACCESS_OK if all resource-actions were successfully authorized.
    *
    * @param authenticationResult Authentication result representing identity of requester
-   * @param resourceActions An Iterable of resource-actions to authorize
+   * @param resourceActions      An Iterable of resource-actions to authorize
+   *
    * @return ACCESS_OK or the Access object from the first failed check
    */
   public static Access authorizeAllResourceActions(
@@ -119,8 +143,9 @@ public class AuthorizationUtils
    *
    * If this attribute is already set when this function is called, an exception is thrown.
    *
-   * @param request HTTP request to be authorized
+   * @param request         HTTP request to be authorized
    * @param resourceActions An Iterable of resource-actions to authorize
+   *
    * @return ACCESS_OK or the Access object from the first failed check
    */
   public static Access authorizeAllResourceActions(
@@ -133,15 +158,8 @@ public class AuthorizationUtils
       throw new ISE("Request already had authorization check.");
     }
 
-    final AuthenticationResult authenticationResult = (AuthenticationResult) request.getAttribute(
-        AuthConfig.DRUID_AUTHENTICATION_RESULT
-    );
-    if (authenticationResult == null) {
-      throw new ISE("Null authentication result");
-    }
-
     Access access = authorizeAllResourceActions(
-        authenticationResult,
+        authenticationResultFromRequest(request),
         resourceActions,
         authorizerMapper
     );
@@ -168,12 +186,12 @@ public class AuthorizationUtils
    *
    * If this attribute is already set when this function is called, an exception is thrown.
    *
-   * @param request HTTP request to be authorized
-   * @param resources resources to be processed into resource-actions
+   * @param request                 HTTP request to be authorized
+   * @param resources               resources to be processed into resource-actions
    * @param resourceActionGenerator Function that creates an iterable of resource-actions from a resource
-   * @param authorizerMapper authorizer mapper
-   * @return Iterable containing resources that were authorized
+   * @param authorizerMapper        authorizer mapper
    *
+   * @return Iterable containing resources that were authorized
    */
   public static <ResType> Iterable<ResType> filterAuthorizedResources(
       final HttpServletRequest request,
@@ -186,12 +204,7 @@ public class AuthorizationUtils
       throw new ISE("Request already had authorization check.");
     }
 
-    final AuthenticationResult authenticationResult = (AuthenticationResult) request.getAttribute(
-        AuthConfig.DRUID_AUTHENTICATION_RESULT
-    );
-    if (authenticationResult == null) {
-      throw new ISE("Null authentication result");
-    }
+    final AuthenticationResult authenticationResult = authenticationResultFromRequest(request);
 
     final Authorizer authorizer = authorizerMapper.getAuthorizer(authenticationResult.getAuthorizerName());
     if (authorizer == null) {
@@ -229,7 +242,6 @@ public class AuthorizationUtils
 
     return filteredResources;
   }
-
 
 
   /**

--- a/server/src/test/java/io/druid/server/log/TestRequestLogger.java
+++ b/server/src/test/java/io/druid/server/log/TestRequestLogger.java
@@ -17,52 +17,43 @@
  * under the License.
  */
 
-package io.druid.server;
+package io.druid.server.log;
 
-import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.ImmutableList;
+import io.druid.server.RequestLogLine;
 
-import java.util.Map;
-import java.util.Objects;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
-/**
- */
-public class QueryStats
+public class TestRequestLogger implements RequestLogger
 {
-  private final Map<String, Object> stats;
+  private final List<RequestLogLine> logs;
 
-  public QueryStats(Map<String, Object> stats)
+  public TestRequestLogger()
   {
-    this.stats = stats;
-  }
-
-  @JsonValue
-  public Map<String, Object> getStats()
-  {
-    return stats;
+    this.logs = new ArrayList<>();
   }
 
   @Override
-  public boolean equals(final Object o)
+  public void log(final RequestLogLine requestLogLine) throws IOException
   {
-    if (this == o) {
-      return true;
+    synchronized (logs) {
+      logs.add(requestLogLine);
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+  }
+
+  public List<RequestLogLine> getLogs()
+  {
+    synchronized (logs) {
+      return ImmutableList.copyOf(logs);
     }
-    final QueryStats that = (QueryStats) o;
-    return Objects.equals(stats, that.stats);
   }
 
-  @Override
-  public int hashCode()
+  public void clear()
   {
-    return Objects.hash(stats);
-  }
-
-  @Override
-  public String toString()
-  {
-    return String.valueOf(stats);
+    synchronized (logs) {
+      logs.clear();
+    }
   }
 }


### PR DESCRIPTION
Adds "identity" to metrics and logs generated by QueryLifecycle.

Also fix a bug where unauthorized requests would not emit any logs or metrics,
and instead would log a "Tried to emit logs and metrics twice" warning.

Also rename QueryResource's "getServer" to "cancelQuery", because that's what
it does.

@leventov FYI in this patch I added `identity` as a dimension that is always part of
query metrics. I did it for three reasons.

1. In 0.11 Druid now always has a concept of an authenticated user for each query. By default the authenticated user is a system superuser, but the concept is still there.
2. Reporting user identity is a nearly universal feature of similar software (other databases).
3. If a site isn't using any authorization beyond the default, then this dimension will not hurt aggregation of metrics at all, since it will always have the same value.