### PR TITLE
Fix JdbcCacheGenerator, null values shouldn't be allowed

### DIFF
--- a/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/JdbcCacheGenerator.java
+++ b/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/JdbcCacheGenerator.java
@@ -131,19 +131,21 @@ public final class JdbcCacheGenerator implements CacheGenerator<JdbcExtractionNa
   {
     if (Strings.isNullOrEmpty(filter)) {
       return StringUtils.format(
-          "SELECT %s, %s FROM %s",
+          "SELECT %s, %s FROM %s WHERE %s IS NOT NULL",
           keyColumn,
           valueColumn,
-          table
+          table,
+          valueColumn
       );
     }
 
     return StringUtils.format(
-        "SELECT %s, %s FROM %s WHERE %s",
+        "SELECT %s, %s FROM %s WHERE %s AND %s IS NOT NULL",
         keyColumn,
         valueColumn,
         table,
-        filter
+        filter,
+        valueColumn
     );
   }
 


### PR DESCRIPTION
The stacktrace : 
```
java.lang.NullPointerException
        at java.util.concurrent.ConcurrentHashMap.putVal(ConcurrentHashMap.java:1011) ~[?:1.8.0_101]
        at java.util.concurrent.ConcurrentHashMap.put(ConcurrentHashMap.java:1006) ~[?:1.8.0_101]
        at io.druid.server.lookup.namespace.JDBCExtractionNamespaceCacheFactory.populateCache(JDBCExtractionNamespaceCacheFactory.java:122) ~[druid-lookups-cached-global-0.10.0.jar:?]
        at io.druid.server.lookup.namespace.JDBCExtractionNamespaceCacheFactory.populateCache(JDBCExtractionNamespaceCacheFactory.java:50) ~[druid-lookups-cached-global-0.10.0.jar:?]
        at io.druid.server.lookup.namespace.cache.CacheScheduler$EntryImpl.tryUpdateCache(CacheScheduler.java:222) [druid-lookups-cached-global-0.10.0.jar:?]
        at io.druid.server.lookup.namespace.cache.CacheScheduler$EntryImpl.updateCache(CacheScheduler.java:201) [druid-lookups-cached-global-0.10.0.jar:?]
        at io.druid.server.lookup.namespace.cache.CacheScheduler$EntryImpl.access$600(CacheScheduler.java:137) [druid-lookups-cached-global-0.10.0.jar:?]
        at io.druid.server.lookup.namespace.cache.CacheScheduler$EntryImpl$2.run(CacheScheduler.java:183) [druid-lookups-cached-global-0.10.0.jar:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_101]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [?:1.8.0_101]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [?:1.8.0_101]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [?:1.8.0_101]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_101]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_101]
        at java.lang.Thread.run(Thread.java:745) [?:1.8.0_101]
```

The code has moved from JDBCExtractionNamespaceCacheFactory in 0.10.x to JdbcCacheGenerator but hasn't changed afaik.