### PR TITLE
Better logging for SegmentAllocateAction

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/common/actions/SegmentAllocateAction.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/actions/SegmentAllocateAction.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import io.druid.indexing.common.TaskLock;
 import io.druid.indexing.common.task.Task;
 import io.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
@@ -40,6 +39,7 @@ import org.joda.time.Interval;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Allocates a pending segment for a given timestamp. The preferredSegmentGranularity is used if there are no prior
@@ -148,47 +148,22 @@ public class SegmentAllocateAction implements TaskAction<SegmentIdentifier>
       // 1) if something overlaps our timestamp, use that
       // 2) otherwise try preferredSegmentGranularity & going progressively smaller
 
-      final List<Interval> tryIntervals = Lists.newArrayList();
-
       final Interval rowInterval = queryGranularity.bucket(timestamp);
 
       final Set<DataSegment> usedSegmentsForRow = ImmutableSet.copyOf(
           msc.getUsedSegmentsForInterval(dataSource, rowInterval)
       );
 
-      if (usedSegmentsForRow.isEmpty()) {
-        // No existing segments for this row, but there might still be nearby ones that conflict with our preferred
-        // segment granularity. Try that first, and then progressively smaller ones if it fails.
-        for (Granularity gran : Granularity.granularitiesFinerThan(preferredSegmentGranularity)) {
-          tryIntervals.add(gran.bucket(timestamp));
-        }
-        for (Interval tryInterval : tryIntervals) {
-          if (tryInterval.contains(rowInterval)) {
-            final SegmentIdentifier identifier = tryAllocate(toolbox, task, tryInterval, rowInterval, false);
-            if (identifier != null) {
-              return identifier;
-            }
-          }
-        }
-      } else {
-        // Existing segment(s) exist for this row; use the interval of the first one.
-        final DataSegment firstSegment = usedSegmentsForRow.iterator().next();
-        if (!firstSegment.getInterval().contains(rowInterval)) {
-          log.error("The interval of existing segment[%s] doesn't contain rowInterval[%s]", firstSegment, rowInterval);
-        } else {
-          // If segment allocation failed here, it is highly likely an unrecoverable error. We log here for easier
-          // debugging.
-          final SegmentIdentifier identifier = tryAllocate(
-              toolbox,
-              task,
-              firstSegment.getInterval(),
-              rowInterval,
-              true
-          );
-          if (identifier != null) {
-            return identifier;
-          }
-        }
+      final SegmentIdentifier identifier = usedSegmentsForRow.isEmpty() ?
+                                           tryAllocateFirstSegment(toolbox, task, rowInterval) :
+                                           tryAllocateSubsequentSegment(
+                                               toolbox,
+                                               task,
+                                               rowInterval,
+                                               usedSegmentsForRow.iterator().next()
+                                           );
+      if (identifier != null) {
+        return identifier;
       }
 
       // Could not allocate a pending segment. There's a chance that this is because someone else inserted a segment
@@ -222,6 +197,47 @@ public class SegmentAllocateAction implements TaskAction<SegmentIdentifier>
       } else {
         return null;
       }
+    }
+  }
+
+  private SegmentIdentifier tryAllocateFirstSegment(
+      TaskActionToolbox toolbox,
+      Task task,
+      Interval rowInterval
+  ) throws IOException
+  {
+    // No existing segments for this row, but there might still be nearby ones that conflict with our preferred
+    // segment granularity. Try that first, and then progressively smaller ones if it fails.
+    final List<Interval> tryIntervals = Granularity.granularitiesFinerThan(preferredSegmentGranularity)
+                                                   .stream()
+                                                   .map(granularity -> granularity.bucket(timestamp))
+                                                   .collect(Collectors.toList());
+    for (Interval tryInterval : tryIntervals) {
+      if (tryInterval.contains(rowInterval)) {
+        final SegmentIdentifier identifier = tryAllocate(toolbox, task, tryInterval, rowInterval, false);
+        if (identifier != null) {
+          return identifier;
+        }
+      }
+    }
+    return null;
+  }
+
+  private SegmentIdentifier tryAllocateSubsequentSegment(
+      TaskActionToolbox toolbox,
+      Task task,
+      Interval rowInterval,
+      DataSegment usedSegment
+  ) throws IOException
+  {
+    // Existing segment(s) exist for this row; use the interval of the first one.
+    if (!usedSegment.getInterval().contains(rowInterval)) {
+      log.error("The interval of existing segment[%s] doesn't contain rowInterval[%s]", usedSegment, rowInterval);
+      return null;
+    } else {
+      // If segment allocation failed here, it is highly likely an unrecoverable error. We log here for easier
+      // debugging.
+      return tryAllocate(toolbox, task, usedSegment.getInterval(), rowInterval, true);
     }
   }
 


### PR DESCRIPTION
SegmentAllocateAction logs in DEBUG level when it fails to allocate a segment. This is because SegmentAllocateAction can write too many logs as it tries with different intervals for allocating a segment. However, DEBUG log level is rarely used in production, so it makes difficult to understand why the allocation failed. 

This patch simply changes the log level to ERROR only when the segment allocation is not exploratory, that is, SegmentAllocateAction knows the exact interval it should try.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/druid-io/druid/4884)
<!-- Reviewable:end -->
