### PR TITLE
RTR: Demote chatty log message.

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunner.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunner.java
@@ -747,7 +747,7 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
       WorkerSelectStrategy strategy;
       if (workerConfig == null || workerConfig.getSelectStrategy() == null) {
         strategy = WorkerBehaviorConfig.DEFAULT_STRATEGY;
-        log.info("No worker selection strategy set. Using default of [%s]", strategy.getClass().getSimpleName());
+        log.debug("No worker selection strategy set. Using default of [%s]", strategy.getClass().getSimpleName());
       } else {
         strategy = workerConfig.getSelectStrategy();
       }


### PR DESCRIPTION
"No worker selection strategy set." would get logged any time tryAssignTask runs
in the default configuration, which is often. It also doesn't provide much value.

It can especially get logged super-frequently if there are a lot of pending tasks,
since tryAssignTask runs for each one anytime something happens.