### PR TITLE
Fix PreResponseAuthorizationCheckFilter HTTP error masking

### DIFF
--- a/server/src/main/java/io/druid/server/security/PreResponseAuthorizationCheckFilter.java
+++ b/server/src/main/java/io/druid/server/security/PreResponseAuthorizationCheckFilter.java
@@ -150,6 +150,8 @@ public class PreResponseAuthorizationCheckFilter implements Filter
     log.makeAlert(errorMsg)
        .addData("uri", servletRequest.getRequestURI())
        .addData("method", servletRequest.getMethod())
+       .addData("remoteAddr", servletRequest.getRemoteAddr())
+       .addData("remoteHost", servletRequest.getRemoteHost())
        .emit();
 
     if (servletResponse.isCommitted()) {

--- a/server/src/main/java/io/druid/server/security/PreResponseAuthorizationCheckFilter.java
+++ b/server/src/main/java/io/druid/server/security/PreResponseAuthorizationCheckFilter.java
@@ -84,7 +84,7 @@ public class PreResponseAuthorizationCheckFilter implements Filter
     filterChain.doFilter(servletRequest, servletResponse);
 
     Boolean authInfoChecked = (Boolean) servletRequest.getAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED);
-    if (authInfoChecked == null && !errorOverridesMissingAuth(response.getStatus())) {
+    if (authInfoChecked == null && statusIsSuccess(response.getStatus())) {
       // Note: rather than throwing an exception here, it would be nice to blank out the original response
       // since the request didn't have any authorization checks performed. However, this breaks proxying
       // (e.g. OverlordServletProxy), so this is not implemented for now.
@@ -164,9 +164,9 @@ public class PreResponseAuthorizationCheckFilter implements Filter
     }
   }
 
-  private static boolean errorOverridesMissingAuth(int status)
+  private static boolean statusIsSuccess(int status)
   {
-    return status == Response.SC_INTERNAL_SERVER_ERROR;
+    return 200 <= status && status < 300;
   }
 
   public static void sendJsonError(HttpServletResponse resp, int error, String errorJson, OutputStream outputStream)

--- a/server/src/test/java/io/druid/server/http/security/PreResponseAuthorizationCheckFilterTest.java
+++ b/server/src/test/java/io/druid/server/http/security/PreResponseAuthorizationCheckFilterTest.java
@@ -115,6 +115,8 @@ public class PreResponseAuthorizationCheckFilterTest
     EasyMock.expect(resp.getStatus()).andReturn(200).once();
     EasyMock.expect(req.getRequestURI()).andReturn("uri").once();
     EasyMock.expect(req.getMethod()).andReturn("GET").once();
+    EasyMock.expect(req.getRemoteAddr()).andReturn("1.2.3.4").once();
+    EasyMock.expect(req.getRemoteHost()).andReturn("ahostname").once();
     EasyMock.expect(resp.isCommitted()).andReturn(true).once();
     resp.setStatus(403);
     EasyMock.expectLastCall().once();

--- a/server/src/test/java/io/druid/server/http/security/PreResponseAuthorizationCheckFilterTest.java
+++ b/server/src/test/java/io/druid/server/http/security/PreResponseAuthorizationCheckFilterTest.java
@@ -131,4 +131,28 @@ public class PreResponseAuthorizationCheckFilterTest
     filter.doFilter(req, resp, filterChain);
     EasyMock.verify(req, resp, filterChain, outputStream);
   }
+
+  @Test
+  public void testMissingAuthorizationCheckWithError() throws Exception
+  {
+    EmittingLogger.registerEmitter(EasyMock.createNiceMock(ServiceEmitter.class));
+    AuthenticationResult authenticationResult = new AuthenticationResult("so-very-valid", "so-very-valid", null);
+
+    HttpServletRequest req = EasyMock.createStrictMock(HttpServletRequest.class);
+    HttpServletResponse resp = EasyMock.createStrictMock(HttpServletResponse.class);
+    FilterChain filterChain = EasyMock.createNiceMock(FilterChain.class);
+    ServletOutputStream outputStream = EasyMock.createNiceMock(ServletOutputStream.class);
+
+    EasyMock.expect(req.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT)).andReturn(authenticationResult).once();
+    EasyMock.expect(req.getAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED)).andReturn(null).once();
+    EasyMock.expect(resp.getStatus()).andReturn(404).once();
+    EasyMock.replay(req, resp, filterChain, outputStream);
+
+    PreResponseAuthorizationCheckFilter filter = new PreResponseAuthorizationCheckFilter(
+        authenticators,
+        new DefaultObjectMapper()
+    );
+    filter.doFilter(req, resp, filterChain);
+    EasyMock.verify(req, resp, filterChain, outputStream);
+  }
 }


### PR DESCRIPTION
Fixes #4898 

Adjusts PreResponseAuthorizationFilter so that it does not mask non-2xx HTTP response status codes when the corresponding request doesn't have an authorization check attribute.