### PR TITLE
DruidLeaderClient: Throw IOException on retryable errors.

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/common/actions/RemoteTaskActionClient.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/actions/RemoteTaskActionClient.java
@@ -77,17 +77,10 @@ public class RemoteTaskActionClient implements TaskActionClient
 
         log.info("Submitting action for task[%s] to overlord: [%s].", task.getId(), taskAction);
 
-        try {
-          fullResponseHolder = druidLeaderClient.go(
-              druidLeaderClient.makeRequest(HttpMethod.POST, "/druid/indexer/v1/action")
-                               .setContent(MediaType.APPLICATION_JSON, dataToSend)
-          );
-        }
-        catch (Exception e) {
-          Throwables.propagateIfInstanceOf(e.getCause(), IOException.class);
-          Throwables.propagateIfInstanceOf(e.getCause(), ChannelException.class);
-          throw Throwables.propagate(e);
-        }
+        fullResponseHolder = druidLeaderClient.go(
+            druidLeaderClient.makeRequest(HttpMethod.POST, "/druid/indexer/v1/action")
+                             .setContent(MediaType.APPLICATION_JSON, dataToSend)
+        );
 
         if (fullResponseHolder.getStatus().getCode() / 100 == 2) {
           final Map<String, Object> responseDict = jsonMapper.readValue(
@@ -119,6 +112,9 @@ public class RemoteTaskActionClient implements TaskActionClient
             throw Throwables.propagate(e2);
           }
         }
+      }
+      catch (InterruptedException e) {
+        throw new RuntimeException(e);
       }
     }
   }

--- a/server/src/test/java/io/druid/discovery/DruidLeaderClientTest.java
+++ b/server/src/test/java/io/druid/discovery/DruidLeaderClientTest.java
@@ -52,7 +52,9 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -60,12 +62,16 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.io.IOException;
 import java.net.URI;
 
 /**
  */
 public class DruidLeaderClientTest extends BaseJettyTest
 {
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
   private DiscoveryDruidNode discoveryDruidNode;
   private HttpClient httpClient;
 
@@ -124,6 +130,31 @@ public class DruidLeaderClientTest extends BaseJettyTest
     Request request = druidLeaderClient.makeRequest(HttpMethod.POST, "/simple/direct");
     request.setContent("hello".getBytes("UTF-8"));
     Assert.assertEquals("hello", druidLeaderClient.go(request).getContent());
+  }
+
+  @Test
+  public void testNoLeaderFound() throws Exception
+  {
+    DruidNodeDiscovery druidNodeDiscovery = EasyMock.createMock(DruidNodeDiscovery.class);
+    EasyMock.expect(druidNodeDiscovery.getAllNodes()).andReturn(ImmutableList.of());
+
+    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForNodeType("nodetype")).andReturn(druidNodeDiscovery);
+
+    EasyMock.replay(druidNodeDiscovery, druidNodeDiscoveryProvider);
+
+    DruidLeaderClient druidLeaderClient = new DruidLeaderClient(
+        httpClient,
+        druidNodeDiscoveryProvider,
+        "nodetype",
+        "/simple/leader",
+        EasyMock.createNiceMock(ServerDiscoverySelector.class)
+    );
+    druidLeaderClient.start();
+
+    expectedException.expect(IOException.class);
+    expectedException.expectMessage("No known leader");
+    druidLeaderClient.makeRequest(HttpMethod.POST, "/simple/direct");
   }
 
   @Test

--- a/server/src/test/java/io/druid/discovery/DruidLeaderClientTest.java
+++ b/server/src/test/java/io/druid/discovery/DruidLeaderClientTest.java
@@ -153,7 +153,7 @@ public class DruidLeaderClientTest extends BaseJettyTest
     druidLeaderClient.start();
 
     expectedException.expect(IOException.class);
-    expectedException.expectMessage("No known leader");
+    expectedException.expectMessage("No known server");
     druidLeaderClient.makeRequest(HttpMethod.POST, "/simple/direct");
   }
 


### PR DESCRIPTION
Fixes #4911.