### PR TITLE
Add /readiness to HistoricalResource

### DIFF
--- a/docs/content/design/historical.md
+++ b/docs/content/design/historical.md
@@ -50,4 +50,11 @@ Returns the Druid version, loaded extensions, memory used, total memory and othe
 
 * `/druid/historical/v1/loadstatus`
 
-Returns a flag indicating if all segments in the local cache have been loaded. This can be used to know when a historical node is ready to be queried after a restart.
+Returns JSON of the form `{"cacheInitialized":<value>}`, where value is either `true` or `false` indicating if all
+segments in the local cache have been loaded. This can be used to know when a historical node is ready
+to be queried after a restart.
+
+* `/druid/historical/v1/loadStatusCode`
+
+Similar to `/druid/historical/v1/loadstatus`, but instead or returning JSON with a flag, responses 200 OK with an
+empty JSON `{}` body, if segments in the local cache have been loaded, and 503 SERVICE UNAVAILABLE, if they haven't.

--- a/docs/content/design/historical.md
+++ b/docs/content/design/historical.md
@@ -54,7 +54,7 @@ Returns JSON of the form `{"cacheInitialized":<value>}`, where value is either `
 segments in the local cache have been loaded. This can be used to know when a historical node is ready
 to be queried after a restart.
 
-* `/druid/historical/v1/loadStatusCode`
+* `/druid/historical/v1/readiness`
 
-Similar to `/druid/historical/v1/loadstatus`, but instead or returning JSON with a flag, responses 200 OK with an
-empty JSON `{}` body, if segments in the local cache have been loaded, and 503 SERVICE UNAVAILABLE, if they haven't.
+Similar to `/druid/historical/v1/loadstatus`, but instead or returning JSON with a flag, responses 200 OK if segments
+in the local cache have been loaded, and 503 SERVICE UNAVAILABLE, if they haven't.

--- a/docs/content/design/historical.md
+++ b/docs/content/design/historical.md
@@ -56,5 +56,5 @@ to be queried after a restart.
 
 * `/druid/historical/v1/readiness`
 
-Similar to `/druid/historical/v1/loadstatus`, but instead or returning JSON with a flag, responses 200 OK if segments
+Similar to `/druid/historical/v1/loadstatus`, but instead of returning JSON with a flag, responses 200 OK if segments
 in the local cache have been loaded, and 503 SERVICE UNAVAILABLE, if they haven't.

--- a/server/src/main/java/io/druid/server/http/HistoricalResource.java
+++ b/server/src/main/java/io/druid/server/http/HistoricalResource.java
@@ -52,4 +52,16 @@ public class HistoricalResource
   {
     return Response.ok(ImmutableMap.of("cacheInitialized", coordinator.isStarted())).build();
   }
+
+  @GET
+  @Path("/loadStatusCode")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response getLoadStatusCode()
+  {
+    if (coordinator.isStarted()) {
+      return Response.ok(ImmutableMap.of()).build();
+    } else {
+      return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
+    }
+  }
 }

--- a/server/src/main/java/io/druid/server/http/HistoricalResource.java
+++ b/server/src/main/java/io/druid/server/http/HistoricalResource.java
@@ -54,12 +54,11 @@ public class HistoricalResource
   }
 
   @GET
-  @Path("/loadStatusCode")
-  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/readiness")
   public Response getLoadStatusCode()
   {
     if (coordinator.isStarted()) {
-      return Response.ok(ImmutableMap.of()).build();
+      return Response.ok().build();
     } else {
       return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
     }

--- a/server/src/main/java/io/druid/server/http/HistoricalResource.java
+++ b/server/src/main/java/io/druid/server/http/HistoricalResource.java
@@ -55,7 +55,7 @@ public class HistoricalResource
 
   @GET
   @Path("/readiness")
-  public Response getLoadStatusCode()
+  public Response getReadiness()
   {
     if (coordinator.isStarted()) {
       return Response.ok().build();


### PR DESCRIPTION
Add an endpoint that returns local cache load status as HTTP response code: 200 or 503.