### PR TITLE
SQL: Fix CASE-filtered aggregations with GROUP BY.

### DIFF
--- a/sql/src/main/java/io/druid/sql/calcite/rule/CaseFilteredAggregatorRule.java
+++ b/sql/src/main/java/io/druid/sql/calcite/rule/CaseFilteredAggregatorRule.java
@@ -87,8 +87,12 @@ public class CaseFilteredAggregatorRule extends RelOptRule
     final RexBuilder rexBuilder = aggregate.getCluster().getRexBuilder();
     final List<AggregateCall> newCalls = new ArrayList<>(aggregate.getAggCallList().size());
     final List<RexNode> newProjects = new ArrayList<>(project.getChildExps());
-    final List<RexNode> newCasts = new ArrayList<>(aggregate.getAggCallList().size());
+    final List<RexNode> newCasts = new ArrayList<>(aggregate.getGroupCount() + aggregate.getAggCallList().size());
     final RelDataTypeFactory typeFactory = aggregate.getCluster().getTypeFactory();
+
+    for (int fieldNumber : aggregate.getGroupSet()) {
+      newCasts.add(rexBuilder.makeInputRef(project.getChildExps().get(fieldNumber).getType(), fieldNumber));
+    }
 
     for (AggregateCall aggregateCall : aggregate.getAggCallList()) {
       AggregateCall newCall = null;
@@ -197,7 +201,6 @@ public class CaseFilteredAggregatorRule extends RelOptRule
 
       final RelBuilder.GroupKey groupKey = relBuilder.groupKey(
           aggregate.getGroupSet(),
-          aggregate.indicator,
           aggregate.getGroupSets()
       );
 


### PR DESCRIPTION
CaseFilteredAggregatorRule did not generate the correct projection when the dimensions list was nonempty.

It's a regression from #4360 (new in 0.11.0) so I will backport it too.