### PR TITLE
Use ubuntu image with pre-installed java 8 for IT docker

### DIFF
--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -1,12 +1,11 @@
-FROM ubuntu:14.04
+FROM openjdk:8u141-jdk
 
 # Java 8
 RUN apt-get update \
       && apt-get install -y software-properties-common \
       && add-apt-repository -y ppa:openjdk-r/ppa \
       && apt-get purge --auto-remove -y software-properties-common \
-      && apt-get update \
-      && apt-get install -y openjdk-8-jdk
+      && apt-get update
 
 # wget
 RUN apt-get install -y wget

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -8,9 +8,6 @@ RUN apt-get update \
       && apt-get update \
       && apt-get install -y openjdk-8-jdk
 
-# wget
-RUN apt-get install -y wget
-
 # MySQL (Metadata store)
 RUN apt-get install -y mysql-server
 

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -1,15 +1,4 @@
-FROM ubuntu:14.04
-
-# Java 8
-RUN apt-get update \
-      && apt-get install -y software-properties-common \
-      && apt-add-repository -y ppa:webupd8team/java \
-      && apt-get purge --auto-remove -y software-properties-common \
-      && apt-get update \
-      && echo oracle-java-8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections \
-      && apt-get install -y oracle-java8-installer \
-      && apt-get install -y oracle-java8-set-default \
-      && rm -rf /var/cache/oracle-jdk8-installer
+FROM jonweiimply/ubuntu-j8
 
 # MySQL (Metadata store)
 RUN apt-get install -y mysql-server

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -8,6 +8,9 @@ RUN apt-get update \
       && apt-get update \
       && apt-get install -y openjdk-8-jdk
 
+# wget
+RUN apt-get install -y wget
+
 # MySQL (Metadata store)
 RUN apt-get install -y mysql-server
 

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -3,13 +3,10 @@ FROM ubuntu:14.04
 # Java 8
 RUN apt-get update \
       && apt-get install -y software-properties-common \
-      && apt-add-repository -y ppa:webupd8team/java \
+      && add-apt-repository -y ppa:openjdk-r/ppa \
       && apt-get purge --auto-remove -y software-properties-common \
       && apt-get update \
-      && echo oracle-java-8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections \
-      && apt-get install -y oracle-java8-installer \
-      && apt-get install -y oracle-java8-set-default \
-      && rm -rf /var/cache/oracle-jdk8-installer
+      && apt-get install -y openjdk-8-jdk
 
 # MySQL (Metadata store)
 RUN apt-get install -y mysql-server

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -1,3 +1,7 @@
+# This is intended to be a temporary unblocker for Travis CI
+# We should revert this when ppa:webupd8team/java repo maintainers fix the issue shown here: https://github.com/druid-io/druid/pull/4970
+# Or if we stick to using a non-base Ubuntu image, the custom image should reside in an org repo and not an individual repo
+# https://hub.docker.com/r/jonweiimply/ubuntu-j8/
 FROM jonweiimply/ubuntu-j8
 
 # MySQL (Metadata store)

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -1,11 +1,12 @@
-FROM openjdk:8u141-jdk
+FROM ubuntu:14.04
 
 # Java 8
 RUN apt-get update \
       && apt-get install -y software-properties-common \
       && add-apt-repository -y ppa:openjdk-r/ppa \
       && apt-get purge --auto-remove -y software-properties-common \
-      && apt-get update
+      && apt-get update \
+      && apt-get install -y openjdk-8-jdk
 
 # wget
 RUN apt-get install -y wget

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -3,10 +3,13 @@ FROM ubuntu:14.04
 # Java 8
 RUN apt-get update \
       && apt-get install -y software-properties-common \
-      && add-apt-repository -y ppa:openjdk-r/ppa \
+      && apt-add-repository -y ppa:webupd8team/java \
       && apt-get purge --auto-remove -y software-properties-common \
       && apt-get update \
-      && apt-get install -y openjdk-8-jdk
+      && echo oracle-java-8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections \
+      && apt-get install -y oracle-java8-installer \
+      && apt-get install -y oracle-java8-set-default \
+      && rm -rf /var/cache/oracle-jdk8-installer
 
 # MySQL (Metadata store)
 RUN apt-get install -y mysql-server


### PR DESCRIPTION
The integration tests in Travis CI are failing because the docker image can't be built:

```
Location: http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-linux-x64.tar.gz?AuthParam=1508271753_28541b80944dd708d047e6e43e9143b5 [following]
--2017-10-17 20:20:33--  http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-linux-x64.tar.gz?AuthParam=1508271753_28541b80944dd708d047e6e43e9143b5
Connecting to download.oracle.com (download.oracle.com)|165.254.94.208|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2017-10-17 20:20:33 ERROR 404: Not Found.
download failed
Oracle JDK 8 is NOT installed.
dpkg: error processing package oracle-java8-installer (--configure):
 subprocess installed post-installation script returned error exit status 1
Errors were encountered while processing:
 oracle-java8-installer
```

The patch changes the integration test docker container to build from an ubuntu 14.04 image with these commands already completed:

```
-# Java 8		
 -RUN apt-get update \		
 -      && apt-get install -y software-properties-common \		
 -      && apt-add-repository -y ppa:webupd8team/java \		
 -      && apt-get purge --auto-remove -y software-properties-common \		
 -      && apt-get update \		
 -      && echo oracle-java-8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections \		
 -      && apt-get install -y oracle-java8-installer \		
 -      && apt-get install -y oracle-java8-set-default \		
 -      && rm -rf /var/cache/oracle-jdk8-installer
```

This is intended to be a temporary change, please refer to the comment in the PR change.

https://hub.docker.com/r/jonweiimply/ubuntu-j8/