### PR TITLE
Fix docs for MOD.

### DIFF
--- a/docs/content/querying/sql.md
+++ b/docs/content/querying/sql.md
@@ -116,7 +116,7 @@ Numeric functions will return 64 bit integers or 64 bit floats, depending on the
 |`x - y`|Subtraction.|
 |`x * y`|Multiplication.|
 |`x / y`|Division.|
-|`x % y`|Mod.|
+|`MOD(x, y)`|Modulo (remainder of x divided by y).|
 
 ### String functions
 


### PR DESCRIPTION
`x % y` is not supported but `MOD(x, y)` is.