### PR TITLE
Reduce code duplication between test ExprMacroTables.

### DIFF
--- a/common/src/main/java/io/druid/math/expr/ExprMacroTable.java
+++ b/common/src/main/java/io/druid/math/expr/ExprMacroTable.java
@@ -19,6 +19,7 @@
 
 package io.druid.math.expr;
 
+import com.google.common.collect.ImmutableList;
 import io.druid.java.util.common.StringUtils;
 
 import javax.annotation.Nullable;
@@ -46,6 +47,11 @@ public class ExprMacroTable
   public static ExprMacroTable nil()
   {
     return NIL;
+  }
+
+  public List<ExprMacro> getMacros()
+  {
+    return ImmutableList.copyOf(macroMap.values());
   }
 
   /**

--- a/indexing-service/src/test/java/io/druid/indexing/common/TestUtils.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/TestUtils.java
@@ -29,7 +29,7 @@ import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.math.expr.ExprMacroTable;
-import io.druid.query.expression.TestExpressionMacroTable;
+import io.druid.query.expression.LookupEnabledTestExprMacroTable;
 import io.druid.segment.IndexIO;
 import io.druid.segment.IndexMergerV9;
 import io.druid.segment.column.ColumnConfig;
@@ -74,7 +74,7 @@ public class TestUtils
 
     jsonMapper.setInjectableValues(
         new InjectableValues.Std()
-            .addValue(ExprMacroTable.class.getName(), TestExpressionMacroTable.INSTANCE)
+            .addValue(ExprMacroTable.class.getName(), LookupEnabledTestExprMacroTable.INSTANCE)
             .addValue(IndexIO.class, indexIO)
             .addValue(ObjectMapper.class, jsonMapper)
             .addValue(ChatHandlerProvider.class, new NoopChatHandlerProvider())

--- a/server/src/test/java/io/druid/query/expression/ExprMacroTest.java
+++ b/server/src/test/java/io/druid/query/expression/ExprMacroTest.java
@@ -174,7 +174,7 @@ public class ExprMacroTest
 
   private void assertExpr(final String expression, final Object expectedResult)
   {
-    final Expr expr = Parser.parse(expression, TestExpressionMacroTable.INSTANCE);
+    final Expr expr = Parser.parse(expression, LookupEnabledTestExprMacroTable.INSTANCE);
     Assert.assertEquals(expression, expectedResult, expr.eval(BINDINGS).value());
   }
 }

--- a/server/src/test/java/io/druid/query/expression/LookupEnabledTestExprMacroTable.java
+++ b/server/src/test/java/io/druid/query/expression/LookupEnabledTestExprMacroTable.java
@@ -19,8 +19,9 @@
 
 package io.druid.query.expression;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import io.druid.math.expr.ExprMacroTable;
 import io.druid.query.extraction.MapLookupExtractor;
 import io.druid.query.lookup.LookupExtractor;
@@ -31,27 +32,26 @@ import io.druid.query.lookup.LookupReferencesManager;
 import org.easymock.EasyMock;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
 
-public class TestExpressionMacroTable extends ExprMacroTable
+/**
+ * Separate from {@link TestExprMacroTable} since that one is in druid-processing, which doesn't have
+ * {@link LookupReferencesManager}.
+ */
+public class LookupEnabledTestExprMacroTable extends ExprMacroTable
 {
-  public static final ExprMacroTable INSTANCE = new TestExpressionMacroTable();
+  public static final ExprMacroTable INSTANCE = new LookupEnabledTestExprMacroTable();
 
-  private TestExpressionMacroTable()
+  private LookupEnabledTestExprMacroTable()
   {
     super(
-        ImmutableList.of(
-            new LikeExprMacro(),
-            new LookupExprMacro(createTestLookupReferencesManager(ImmutableMap.of("foo", "xfoo"))),
-            new RegexpExtractExprMacro(),
-            new TimestampCeilExprMacro(),
-            new TimestampExtractExprMacro(),
-            new TimestampFloorExprMacro(),
-            new TimestampFormatExprMacro(),
-            new TimestampParseExprMacro(),
-            new TimestampShiftExprMacro(),
-            new TrimExprMacro.BothTrimExprMacro(),
-            new TrimExprMacro.LeftTrimExprMacro(),
-            new TrimExprMacro.RightTrimExprMacro()
+        Lists.newArrayList(
+            Iterables.concat(
+                TestExprMacroTable.INSTANCE.getMacros(),
+                Collections.singletonList(
+                    new LookupExprMacro(createTestLookupReferencesManager(ImmutableMap.of("foo", "xfoo")))
+                )
+            )
         )
     );
   }

--- a/sql/src/test/java/io/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/io/druid/sql/calcite/util/CalciteTests.java
@@ -58,7 +58,7 @@ import io.druid.query.aggregation.DoubleSumAggregatorFactory;
 import io.druid.query.aggregation.FloatSumAggregatorFactory;
 import io.druid.query.aggregation.hyperloglog.HyperUniquesAggregatorFactory;
 import io.druid.query.expression.LookupExprMacro;
-import io.druid.query.expression.TestExpressionMacroTable;
+import io.druid.query.expression.LookupEnabledTestExprMacroTable;
 import io.druid.query.groupby.GroupByQuery;
 import io.druid.query.groupby.GroupByQueryConfig;
 import io.druid.query.groupby.GroupByQueryRunnerTest;
@@ -140,7 +140,7 @@ public class CalciteTests
 
           binder.bind(LookupReferencesManager.class)
                 .toInstance(
-                    TestExpressionMacroTable.createTestLookupReferencesManager(
+                    LookupEnabledTestExprMacroTable.createTestLookupReferencesManager(
                         ImmutableMap.of(
                             "a", "xa",
                             "abc", "xabc"


### PR DESCRIPTION
Removes duplicated code between TestExprMacroTable and LookupEnabledTestExprMacroTable.