### PR TITLE
Document HTTP based segment management and Deprecate classes to remove in future

### DIFF
--- a/docs/content/configuration/broker.md
+++ b/docs/content/configuration/broker.md
@@ -109,6 +109,11 @@ You can optionally only configure caching to be enabled on the broker by setting
 
 See [cache configuration](caching.html) for how to configure cache settings.
 
+### Segment Discovery
+|Property|Possible Values|Description|Default|
+|--------|---------------|-----------|-------|
+|`druid.announcer.type`|batch or http|Segment discovery method to use. "http" enables discovering segments using HTTP instead of zookeeper.|batch|
+
 ### Others
 
 |Property|Possible Values|Description|Default|

--- a/docs/content/configuration/coordinator.md
+++ b/docs/content/configuration/coordinator.md
@@ -38,6 +38,17 @@ The coordinator node uses several of the global configs in [Configuration](../co
 |`druid.coordinator.asOverlord.enabled`|Boolean value for whether this coordinator node should act like an overlord as well. This configuration allows users to simplify a druid cluster by not having to deploy any standalone overlord nodes. If set to true, then overlord console is available at `http://coordinator-host:port/console.html` and be sure to set `druid.coordinator.asOverlord.overlordService` also. See next.|false|
 |`druid.coordinator.asOverlord.overlordService`| Required, if `druid.coordinator.asOverlord.enabled` is `true`. This must be same value as `druid.service` on standalone Overlord nodes and `druid.selectors.indexing.serviceName` on Middle Managers.|NULL|
 
+### Segment Management
+|Property|Possible Values|Description|Default|
+|--------|---------------|-----------|-------|
+|`druid.announcer.type`|batch or http|Segment discovery method to use. "http" enables discovering segments using HTTP instead of zookeeper.|batch|
+|`druid.coordinator.loadqueuepeon.type`|curator or http|Whether to use "http" or "curator" implementation to assign segment loads/drops to historical|curator|
+
+#### Additional config when "http" loadqueuepeon is used
+|Property|Description|Default|
+|--------|-----------|-------|
+|`druid.coordinator.loadqueuepeon.http.batchSize`|Number of segment load/drop requests to batch in one HTTP request. Note that it must be smaller than `druid.segmentCache.numLoadingThreads` config on historical node.|1|
+
 ### Metadata Retrieval
 
 |Property|Description|Default|

--- a/server/src/main/java/io/druid/client/BatchServerInventoryView.java
+++ b/server/src/main/java/io/druid/client/BatchServerInventoryView.java
@@ -43,7 +43,9 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 
 /**
+ * This class is deprecated. Use {@link HttpServerInventoryView} instead.
  */
+@Deprecated
 @ManageLifecycle
 public class BatchServerInventoryView extends AbstractCuratorServerInventoryView<Set<DataSegment>>
     implements FilteredServerInventoryView

--- a/server/src/main/java/io/druid/client/SingleServerInventoryView.java
+++ b/server/src/main/java/io/druid/client/SingleServerInventoryView.java
@@ -38,7 +38,9 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 
 /**
+ * This class is deprecated. Use {@link HttpServerInventoryView} instead.
  */
+@Deprecated
 @ManageLifecycle
 public class SingleServerInventoryView extends AbstractCuratorServerInventoryView<DataSegment> implements FilteredServerInventoryView
 {

--- a/server/src/main/java/io/druid/curator/discovery/CuratorServiceAnnouncer.java
+++ b/server/src/main/java/io/druid/curator/discovery/CuratorServiceAnnouncer.java
@@ -30,8 +30,11 @@ import org.apache.curator.x.discovery.ServiceInstance;
 import java.util.Map;
 
 /**
+ * This class is deprecated, Add service to {@link io.druid.discovery.DruidNodeAnnouncer} node announcement instead.
+ *
  * Uses the Curator Service Discovery recipe to announce services.
  */
+@Deprecated
 public class CuratorServiceAnnouncer implements ServiceAnnouncer
 {
   private static final EmittingLogger log = new EmittingLogger(CuratorServiceAnnouncer.class);

--- a/server/src/main/java/io/druid/curator/discovery/CuratorServiceUtils.java
+++ b/server/src/main/java/io/druid/curator/discovery/CuratorServiceUtils.java
@@ -19,6 +19,10 @@
 
 package io.druid.curator.discovery;
 
+/**
+ * This class is only used by Deprecated classes.
+ */
+@Deprecated
 public class CuratorServiceUtils
 {
   /**

--- a/server/src/main/java/io/druid/curator/discovery/NoopServiceAnnouncer.java
+++ b/server/src/main/java/io/druid/curator/discovery/NoopServiceAnnouncer.java
@@ -24,6 +24,7 @@ import io.druid.server.DruidNode;
 /**
  * Does nothing.
  */
+@Deprecated
 public class NoopServiceAnnouncer implements ServiceAnnouncer
 {
   @Override

--- a/server/src/main/java/io/druid/curator/discovery/ServerDiscoveryFactory.java
+++ b/server/src/main/java/io/druid/curator/discovery/ServerDiscoveryFactory.java
@@ -28,7 +28,9 @@ import java.io.IOException;
 import java.util.Collection;
 
 /**
+ * Use {@link io.druid.discovery.DruidNodeDiscovery} for discovery.
  */
+@Deprecated
 public class ServerDiscoveryFactory
 {
   private final ServiceDiscovery<Void> serviceDiscovery;

--- a/server/src/main/java/io/druid/curator/discovery/ServerDiscoverySelector.java
+++ b/server/src/main/java/io/druid/curator/discovery/ServerDiscoverySelector.java
@@ -36,7 +36,9 @@ import java.util.Collection;
 import java.util.Collections;
 
 /**
+ * Use {@link io.druid.discovery.DruidNodeDiscovery} for discovery.
  */
+@Deprecated
 public class ServerDiscoverySelector implements DiscoverySelector<Server>
 {
   private static final Logger log = new Logger(ServerDiscoverySelector.class);

--- a/server/src/main/java/io/druid/curator/discovery/ServiceAnnouncer.java
+++ b/server/src/main/java/io/druid/curator/discovery/ServiceAnnouncer.java
@@ -22,9 +22,12 @@ package io.druid.curator.discovery;
 import io.druid.server.DruidNode;
 
 /**
+ * This class is deprecated, Add service to {@link io.druid.discovery.DruidNodeAnnouncer} node announcement instead.
+ *
  * Announces our ability to serve a particular function. Multiple users may announce the same service, in which
  * case they are treated as interchangeable instances of that service.
  */
+@Deprecated
 public interface ServiceAnnouncer
 {
   void announce(DruidNode node);

--- a/server/src/main/java/io/druid/curator/inventory/CuratorInventoryManager.java
+++ b/server/src/main/java/io/druid/curator/inventory/CuratorInventoryManager.java
@@ -43,6 +43,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
+ * This class is deprecated. Use {@link io.druid.client.HttpServerInventoryView} for segment discovery.
+ *
  * An InventoryManager watches updates to inventory on Zookeeper (or some other discovery-like service publishing
  * system).  It is built up on two object types: containers and inventory objects.
  * <p/>
@@ -52,6 +54,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * A Strategy is provided to the constructor of an Inventory manager, this strategy provides all of the
  * object-specific logic to serialize, deserialize, compose and alter the container and inventory objects.
  */
+@Deprecated
 public class CuratorInventoryManager<ContainerClass, InventoryClass>
 {
   private static final Logger log = new Logger(CuratorInventoryManager.class);

--- a/server/src/main/java/io/druid/query/lookup/LookupModule.java
+++ b/server/src/main/java/io/druid/query/lookup/LookupModule.java
@@ -214,6 +214,7 @@ class LookupListeningResource extends ListenerResource
   }
 }
 
+@Deprecated
 class LookupResourceListenerAnnouncer extends ListenerResourceAnnouncer
 {
   @Inject

--- a/server/src/main/java/io/druid/server/coordination/CuratorDataSegmentServerAnnouncer.java
+++ b/server/src/main/java/io/druid/server/coordination/CuratorDataSegmentServerAnnouncer.java
@@ -29,7 +29,9 @@ import io.druid.server.initialization.ZkPathsConfig;
 import org.apache.curator.utils.ZKPaths;
 
 /**
+ * {@link DataSegmentServerAnnouncer} is deprecated.
  */
+@Deprecated
 public class CuratorDataSegmentServerAnnouncer implements DataSegmentServerAnnouncer
 {
   private static final Logger log = new Logger(CuratorDataSegmentServerAnnouncer.class);

--- a/server/src/main/java/io/druid/server/coordination/DataSegmentServerAnnouncer.java
+++ b/server/src/main/java/io/druid/server/coordination/DataSegmentServerAnnouncer.java
@@ -20,7 +20,9 @@
 package io.druid.server.coordination;
 
 /**
+ * Use announcement made by {@link io.druid.discovery.DruidNodeAnnouncer}
  */
+@Deprecated
 public interface DataSegmentServerAnnouncer
 {
   void announce();

--- a/server/src/main/java/io/druid/server/coordination/ZkCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordination/ZkCoordinator.java
@@ -37,7 +37,9 @@ import org.apache.curator.utils.ZKPaths;
 import java.io.IOException;
 
 /**
+ * Use {@link io.druid.server.coordinator.HttpLoadQueuePeon} for segment load/drops.
  */
+@Deprecated
 public class ZkCoordinator
 {
   private static final EmittingLogger log = new EmittingLogger(ZkCoordinator.class);

--- a/server/src/main/java/io/druid/server/coordinator/CuratorLoadQueuePeon.java
+++ b/server/src/main/java/io/druid/server/coordinator/CuratorLoadQueuePeon.java
@@ -51,7 +51,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
+ * Use {@link HttpLoadQueuePeon} instead.
  */
+@Deprecated
 public class CuratorLoadQueuePeon extends LoadQueuePeon
 {
   private static final EmittingLogger log = new EmittingLogger(CuratorLoadQueuePeon.class);

--- a/server/src/main/java/io/druid/server/listener/announcer/ListenerResourceAnnouncer.java
+++ b/server/src/main/java/io/druid/server/listener/announcer/ListenerResourceAnnouncer.java
@@ -31,8 +31,9 @@ import org.apache.curator.utils.ZKPaths;
 import java.nio.ByteBuffer;
 
 /**
- * Announces that there is a particular ListenerResource at the listener_key.
+ * Starting 0.11.0 Coordinator uses announcements made by {@link io.druid.discovery.DruidNodeAnnouncer} .
  */
+@Deprecated
 public abstract class ListenerResourceAnnouncer
 {
   private static final byte[] ANNOUNCE_BYTES = ByteBuffer


### PR DESCRIPTION
This PR documents the HTTP based segment management (both discovery and load/drop management). We have been running HTTP them on our metrics cluster for more than a month now. I would encourage users to try these out in next release and make them default afterwards.

Also, many classes are deprecated whose replacements have been introduced. These should be removed after https://github.com/druid-io/druid/issues/4996 is done.