### PR TITLE
Filter unauthorized datasources in INFORMATION_SCHEMA queries

### DIFF
--- a/server/src/main/java/io/druid/server/security/AuthorizationUtils.java
+++ b/server/src/main/java/io/druid/server/security/AuthorizationUtils.java
@@ -206,6 +206,48 @@ public class AuthorizationUtils
 
     final AuthenticationResult authenticationResult = authenticationResultFromRequest(request);
 
+    final Iterable<ResType> filteredResources = filterAuthorizedResources(
+        authenticationResult,
+        resources,
+        resourceActionGenerator,
+        authorizerMapper
+    );
+
+    // We're filtering, so having access to none of the objects isn't an authorization failure (in terms of whether
+    // to send an error response or not.)
+    request.setAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED, true);
+
+    return filteredResources;
+  }
+
+  /**
+   * Filter a collection of resources by applying the resourceActionGenerator to each resource, return an iterable
+   * containing the filtered resources.
+   *
+   * The resourceActionGenerator returns an Iterable<ResourceAction> for each resource.
+   *
+   * If every resource-action in the iterable is authorized, the resource will be added to the filtered resources.
+   *
+   * If there is an authorization failure for one of the resource-actions, the resource will not be
+   * added to the returned filtered resources..
+   *
+   * If the resourceActionGenerator returns null for a resource, that resource will not be added to the filtered
+   * resources.
+   *
+   * @param authenticationResult    Authentication result representing identity of requester
+   * @param resources               resources to be processed into resource-actions
+   * @param resourceActionGenerator Function that creates an iterable of resource-actions from a resource
+   * @param authorizerMapper        authorizer mapper
+   *
+   * @return Iterable containing resources that were authorized
+   */
+  public static <ResType> Iterable<ResType> filterAuthorizedResources(
+      final AuthenticationResult authenticationResult,
+      final Iterable<ResType> resources,
+      final Function<? super ResType, Iterable<ResourceAction>> resourceActionGenerator,
+      final AuthorizerMapper authorizerMapper
+  )
+  {
     final Authorizer authorizer = authorizerMapper.getAuthorizer(authenticationResult.getAuthorizerName());
     if (authorizer == null) {
       throw new ISE("No authorizer found with name: [%s].", authenticationResult.getAuthorizerName());
@@ -235,10 +277,6 @@ public class AuthorizationUtils
           return true;
         }
     );
-
-    // We're filtering, so having access to none of the objects isn't an authorization failure (in terms of whether
-    // to send an error response or not.)
-    request.setAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED, true);
 
     return filteredResources;
   }

--- a/sql/src/main/java/io/druid/sql/calcite/planner/Calcites.java
+++ b/sql/src/main/java/io/druid/sql/calcite/planner/Calcites.java
@@ -28,6 +28,7 @@ import io.druid.java.util.common.StringUtils;
 import io.druid.query.ordering.StringComparator;
 import io.druid.query.ordering.StringComparators;
 import io.druid.segment.column.ValueType;
+import io.druid.server.security.AuthorizerMapper;
 import io.druid.sql.calcite.schema.DruidSchema;
 import io.druid.sql.calcite.schema.InformationSchema;
 import org.apache.calcite.jdbc.CalciteSchema;
@@ -93,11 +94,11 @@ public class Calcites
     return DEFAULT_CHARSET;
   }
 
-  public static SchemaPlus createRootSchema(final Schema druidSchema)
+  public static SchemaPlus createRootSchema(final Schema druidSchema, final AuthorizerMapper authorizerMapper)
   {
     final SchemaPlus rootSchema = CalciteSchema.createRootSchema(false, false).plus();
     rootSchema.add(DruidSchema.NAME, druidSchema);
-    rootSchema.add(InformationSchema.NAME, new InformationSchema(rootSchema));
+    rootSchema.add(InformationSchema.NAME, new InformationSchema(rootSchema, authorizerMapper));
     return rootSchema;
   }
 

--- a/sql/src/main/java/io/druid/sql/calcite/planner/PlannerContext.java
+++ b/sql/src/main/java/io/druid/sql/calcite/planner/PlannerContext.java
@@ -41,9 +41,12 @@ import java.util.Map;
  */
 public class PlannerContext
 {
+  // query context keys
   public static final String CTX_SQL_CURRENT_TIMESTAMP = "sqlCurrentTimestamp";
   public static final String CTX_SQL_TIME_ZONE = "sqlTimeZone";
-  public static final String CTX_AUTHENTICATION_RESULT = "authenticationResult";
+
+  // DataContext keys
+  public static final String DATA_CTX_AUTHENTICATION_RESULT = "authenticationResult";
 
   private final DruidOperatorTable operatorTable;
   private final ExprMacroTable macroTable;
@@ -171,7 +174,7 @@ public class PlannerContext
               localNow
           ).toDurationMillis(),
           DataContext.Variable.TIME_ZONE.camelName, localNow.getZone().toTimeZone().clone(),
-          CTX_AUTHENTICATION_RESULT, authenticationResult
+          DATA_CTX_AUTHENTICATION_RESULT, authenticationResult
       );
 
       @Override

--- a/sql/src/main/java/io/druid/sql/calcite/planner/PlannerContext.java
+++ b/sql/src/main/java/io/druid/sql/calcite/planner/PlannerContext.java
@@ -170,7 +170,8 @@ public class PlannerContext
               new DateTime("1970-01-01T00:00:00.000", localNow.getZone()),
               localNow
           ).toDurationMillis(),
-          DataContext.Variable.TIME_ZONE.camelName, localNow.getZone().toTimeZone()
+          DataContext.Variable.TIME_ZONE.camelName, localNow.getZone().toTimeZone().clone(),
+          CTX_AUTHENTICATION_RESULT, authenticationResult
       );
 
       @Override

--- a/sql/src/main/java/io/druid/sql/calcite/planner/PlannerFactory.java
+++ b/sql/src/main/java/io/druid/sql/calcite/planner/PlannerFactory.java
@@ -95,7 +95,7 @@ public class PlannerFactory
 
   public DruidPlanner createPlanner(final Map<String, Object> queryContext)
   {
-    final SchemaPlus rootSchema = Calcites.createRootSchema(druidSchema);
+    final SchemaPlus rootSchema = Calcites.createRootSchema(druidSchema, authorizerMapper);
     final PlannerContext plannerContext = PlannerContext.create(
         operatorTable,
         macroTable,

--- a/sql/src/main/java/io/druid/sql/calcite/schema/InformationSchema.java
+++ b/sql/src/main/java/io/druid/sql/calcite/schema/InformationSchema.java
@@ -199,7 +199,7 @@ public class InformationSchema extends AbstractSchema
                   final SchemaPlus subSchema = rootSchema.getSubSchema(schemaName);
 
                   final AuthenticationResult authenticationResult =
-                      (AuthenticationResult) root.get(PlannerContext.CTX_AUTHENTICATION_RESULT);
+                      (AuthenticationResult) root.get(PlannerContext.DATA_CTX_AUTHENTICATION_RESULT);
 
                   final Set<String> authorizedTableNames = getAuthorizedTableNamesFromSubSchema(
                       subSchema,
@@ -293,7 +293,7 @@ public class InformationSchema extends AbstractSchema
                   final JavaTypeFactoryImpl typeFactory = new JavaTypeFactoryImpl(TYPE_SYSTEM);
 
                   final AuthenticationResult authenticationResult =
-                      (AuthenticationResult) root.get(PlannerContext.CTX_AUTHENTICATION_RESULT);
+                      (AuthenticationResult) root.get(PlannerContext.DATA_CTX_AUTHENTICATION_RESULT);
 
                   final Set<String> authorizedTableNames = getAuthorizedTableNamesFromSubSchema(
                       subSchema,

--- a/sql/src/main/java/io/druid/sql/calcite/schema/InformationSchema.java
+++ b/sql/src/main/java/io/druid/sql/calcite/schema/InformationSchema.java
@@ -25,9 +25,16 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import io.druid.segment.column.ValueType;
+import io.druid.server.security.AuthenticationResult;
+import io.druid.server.security.AuthorizationUtils;
+import io.druid.server.security.AuthorizerMapper;
+import io.druid.server.security.ResourceAction;
+import io.druid.sql.calcite.planner.PlannerContext;
 import io.druid.sql.calcite.table.RowSignature;
 import org.apache.calcite.DataContext;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
@@ -50,6 +57,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 
 public class InformationSchema extends AbstractSchema
 {
@@ -97,12 +105,19 @@ public class InformationSchema extends AbstractSchema
       .add("JDBC_TYPE", ValueType.LONG)
       .build();
   private static final RelDataTypeSystem TYPE_SYSTEM = RelDataTypeSystem.DEFAULT;
+  private static final Function<String, Iterable<ResourceAction>> DRUID_TABLE_RA_GENERATOR = datasourceName -> {
+    return Lists.newArrayList(AuthorizationUtils.DATASOURCE_READ_RA_GENERATOR.apply(datasourceName));
+  };
 
   private final SchemaPlus rootSchema;
   private final Map<String, Table> tableMap;
+  private final AuthorizerMapper authorizerMapper;
 
   @Inject
-  public InformationSchema(final SchemaPlus rootSchema)
+  public InformationSchema(
+      final SchemaPlus rootSchema,
+      final AuthorizerMapper authorizerMapper
+  )
   {
     this.rootSchema = Preconditions.checkNotNull(rootSchema, "rootSchema");
     this.tableMap = ImmutableMap.<String, Table>of(
@@ -110,6 +125,7 @@ public class InformationSchema extends AbstractSchema
         TABLES_TABLE, new TablesTable(),
         COLUMNS_TABLE, new ColumnsTable()
     );
+    this.authorizerMapper = authorizerMapper;
   }
 
   @Override
@@ -181,9 +197,23 @@ public class InformationSchema extends AbstractSchema
                 public Iterable<Object[]> apply(final String schemaName)
                 {
                   final SchemaPlus subSchema = rootSchema.getSubSchema(schemaName);
+
+                  final AuthenticationResult authenticationResult =
+                      (AuthenticationResult) root.get(PlannerContext.CTX_AUTHENTICATION_RESULT);
+
+                  final Set<String> authorizedTableNames = getAuthorizedTableNamesFromSubSchema(
+                      subSchema,
+                      authenticationResult
+                  );
+
+                  final Set<String> authorizedFunctionNames = getAuthorizedFunctionNamesFromSubSchema(
+                      subSchema,
+                      authenticationResult
+                  );
+
                   return Iterables.filter(
                       Iterables.concat(
-                          FluentIterable.from(subSchema.getTableNames()).transform(
+                          FluentIterable.from(authorizedTableNames).transform(
                               new Function<String, Object[]>()
                               {
                                 @Override
@@ -198,7 +228,7 @@ public class InformationSchema extends AbstractSchema
                                 }
                               }
                           ),
-                          FluentIterable.from(subSchema.getFunctionNames()).transform(
+                          FluentIterable.from(authorizedFunctionNames).transform(
                               new Function<String, Object[]>()
                               {
                                 @Override
@@ -262,10 +292,23 @@ public class InformationSchema extends AbstractSchema
                   final SchemaPlus subSchema = rootSchema.getSubSchema(schemaName);
                   final JavaTypeFactoryImpl typeFactory = new JavaTypeFactoryImpl(TYPE_SYSTEM);
 
+                  final AuthenticationResult authenticationResult =
+                      (AuthenticationResult) root.get(PlannerContext.CTX_AUTHENTICATION_RESULT);
+
+                  final Set<String> authorizedTableNames = getAuthorizedTableNamesFromSubSchema(
+                      subSchema,
+                      authenticationResult
+                  );
+
+                  final Set<String> authorizedFunctionNames = getAuthorizedFunctionNamesFromSubSchema(
+                      subSchema,
+                      authenticationResult
+                  );
+
                   return Iterables.concat(
                       Iterables.filter(
                           Iterables.concat(
-                              FluentIterable.from(subSchema.getTableNames()).transform(
+                              FluentIterable.from(authorizedTableNames).transform(
                                   new Function<String, Iterable<Object[]>>()
                                   {
                                     @Override
@@ -280,7 +323,7 @@ public class InformationSchema extends AbstractSchema
                                     }
                                   }
                               ),
-                              FluentIterable.from(subSchema.getFunctionNames()).transform(
+                              FluentIterable.from(authorizedFunctionNames).transform(
                                   new Function<String, Iterable<Object[]>>()
                                   {
                                     @Override
@@ -401,5 +444,48 @@ public class InformationSchema extends AbstractSchema
     }
 
     return null;
+  }
+
+  private Set<String> getAuthorizedTableNamesFromSubSchema(
+      final SchemaPlus subSchema,
+      final AuthenticationResult authenticationResult
+  )
+  {
+    if (DruidSchema.NAME.equals(subSchema.getName())) {
+      // The "druid" schema's tables represent Druid datasources which require authorization
+      return ImmutableSet.copyOf(
+          AuthorizationUtils.filterAuthorizedResources(
+              authenticationResult,
+              subSchema.getTableNames(),
+              DRUID_TABLE_RA_GENERATOR,
+              authorizerMapper
+          )
+      );
+    } else {
+      // for non "druid" schema, we don't filter anything
+      return subSchema.getTableNames();
+    }
+  }
+
+  private Set<String> getAuthorizedFunctionNamesFromSubSchema(
+      final SchemaPlus subSchema,
+      final AuthenticationResult authenticationResult
+  )
+  {
+    if (DruidSchema.NAME.equals(subSchema.getName())) {
+      // The "druid" schema's functions represent views on Druid datasources, authorize them as if they were
+      // datasources for now
+      return ImmutableSet.copyOf(
+          AuthorizationUtils.filterAuthorizedResources(
+              authenticationResult,
+              subSchema.getFunctionNames(),
+              DRUID_TABLE_RA_GENERATOR,
+              authorizerMapper
+          )
+      );
+    } else {
+      // for non "druid" schema, we don't filter anything
+      return subSchema.getFunctionNames();
+    }
   }
 }

--- a/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
+++ b/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
@@ -43,6 +43,8 @@ import io.druid.math.expr.ExprMacroTable;
 import io.druid.server.DruidNode;
 import io.druid.server.security.AuthConfig;
 import io.druid.server.security.AuthTestUtils;
+import io.druid.server.security.AuthenticatorMapper;
+import io.druid.server.security.AuthorizerMapper;
 import io.druid.sql.calcite.planner.Calcites;
 import io.druid.sql.calcite.planner.DruidOperatorTable;
 import io.druid.sql.calcite.planner.PlannerConfig;
@@ -114,6 +116,7 @@ public class DruidAvaticaHandlerTest
   private SpecificSegmentsQuerySegmentWalker walker;
   private Server server;
   private Connection client;
+  private Connection superuserClient;
   private Connection clientLosAngeles;
   private DruidMeta druidMeta;
   private String url;
@@ -140,6 +143,8 @@ public class DruidAvaticaHandlerTest
                 binder.bindConstant().annotatedWith(Names.named("serviceName")).to("test");
                 binder.bindConstant().annotatedWith(Names.named("servicePort")).to(0);
                 binder.bindConstant().annotatedWith(Names.named("tlsServicePort")).to(-1);
+                binder.bind(AuthenticatorMapper.class).toInstance(CalciteTests.TEST_AUTHENTICATOR_MAPPER);
+                binder.bind(AuthorizerMapper.class).toInstance(CalciteTests.TEST_AUTHORIZER_MAPPER);
               }
             }
         )
@@ -152,8 +157,8 @@ public class DruidAvaticaHandlerTest
             macroTable,
             plannerConfig,
             new AuthConfig(),
-            AuthTestUtils.TEST_AUTHENTICATOR_MAPPER,
-            AuthTestUtils.TEST_AUTHORIZER_MAPPER,
+            CalciteTests.TEST_AUTHENTICATOR_MAPPER,
+            CalciteTests.TEST_AUTHORIZER_MAPPER,
             CalciteTests.getJsonMapper()
         ),
         AVATICA_CONFIG,
@@ -174,10 +179,12 @@ public class DruidAvaticaHandlerTest
         port,
         DruidAvaticaHandler.AVATICA_PATH
     );
-    client = DriverManager.getConnection(url, "admin", "druid");
+    client = DriverManager.getConnection(url, "regularUser", "druid");
+    superuserClient = DriverManager.getConnection(url, CalciteTests.TEST_SUPERUSER_NAME, "druid");
 
     final Properties propertiesLosAngeles = new Properties();
     propertiesLosAngeles.setProperty("sqlTimeZone", "America/Los_Angeles");
+    propertiesLosAngeles.setProperty("user", "regularUserLA");
     clientLosAngeles = DriverManager.getConnection(url, propertiesLosAngeles);
   }
 
@@ -345,6 +352,38 @@ public class DruidAvaticaHandlerTest
   }
 
   @Test
+  public void testDatabaseMetaDataTablesAsSuperuser() throws Exception
+  {
+    final DatabaseMetaData metaData = superuserClient.getMetaData();
+    Assert.assertEquals(
+        ImmutableList.of(
+            ROW(
+                Pair.of("TABLE_CAT", ""),
+                Pair.of("TABLE_NAME", CalciteTests.DATASOURCE1),
+                Pair.of("TABLE_SCHEM", "druid"),
+                Pair.of("TABLE_TYPE", "TABLE")
+            ),
+            ROW(
+                Pair.of("TABLE_CAT", ""),
+                Pair.of("TABLE_NAME", CalciteTests.DATASOURCE2),
+                Pair.of("TABLE_SCHEM", "druid"),
+                Pair.of("TABLE_TYPE", "TABLE")
+            ),
+            ROW(
+                Pair.of("TABLE_CAT", ""),
+                Pair.of("TABLE_NAME", CalciteTests.FORBIDDEN_DATASOURCE),
+                Pair.of("TABLE_SCHEM", "druid"),
+                Pair.of("TABLE_TYPE", "TABLE")
+            )
+        ),
+        getRows(
+            metaData.getTables(null, "druid", "%", null),
+            ImmutableSet.of("TABLE_CAT", "TABLE_NAME", "TABLE_SCHEM", "TABLE_TYPE")
+        )
+    );
+  }
+
+  @Test
   public void testDatabaseMetaDataColumns() throws Exception
   {
     final DatabaseMetaData metaData = client.getMetaData();
@@ -413,6 +452,90 @@ public class DruidAvaticaHandlerTest
         )
     );
   }
+
+  @Test
+  public void testDatabaseMetaDataColumnsOnForbiddenDatasource() throws Exception
+  {
+    final DatabaseMetaData metaData = client.getMetaData();
+    Assert.assertEquals(
+        ImmutableList.of(),
+        getRows(
+            metaData.getColumns(null, "dr_id", CalciteTests.FORBIDDEN_DATASOURCE, null),
+            ImmutableSet.of("IS_NULLABLE", "TABLE_NAME", "TABLE_SCHEM", "COLUMN_NAME", "DATA_TYPE", "TYPE_NAME")
+        )
+    );
+  }
+
+  @Test
+  public void testDatabaseMetaDataColumnsWithSuperuser() throws Exception
+  {
+    final DatabaseMetaData metaData = superuserClient.getMetaData();
+    Assert.assertEquals(
+        ImmutableList.of(
+            ROW(
+                Pair.of("TABLE_SCHEM", "druid"),
+                Pair.of("TABLE_NAME", CalciteTests.FORBIDDEN_DATASOURCE),
+                Pair.of("COLUMN_NAME", "__time"),
+                Pair.of("DATA_TYPE", Types.TIMESTAMP),
+                Pair.of("TYPE_NAME", "TIMESTAMP"),
+                Pair.of("IS_NULLABLE", "NO")
+            ),
+            ROW(
+                Pair.of("TABLE_SCHEM", "druid"),
+                Pair.of("TABLE_NAME", CalciteTests.FORBIDDEN_DATASOURCE),
+                Pair.of("COLUMN_NAME", "cnt"),
+                Pair.of("DATA_TYPE", Types.BIGINT),
+                Pair.of("TYPE_NAME", "BIGINT"),
+                Pair.of("IS_NULLABLE", "NO")
+            ),
+            ROW(
+                Pair.of("TABLE_SCHEM", "druid"),
+                Pair.of("TABLE_NAME", CalciteTests.FORBIDDEN_DATASOURCE),
+                Pair.of("COLUMN_NAME", "dim1"),
+                Pair.of("DATA_TYPE", Types.VARCHAR),
+                Pair.of("TYPE_NAME", "VARCHAR"),
+                Pair.of("IS_NULLABLE", "YES")
+            ),
+            ROW(
+                Pair.of("TABLE_SCHEM", "druid"),
+                Pair.of("TABLE_NAME", CalciteTests.FORBIDDEN_DATASOURCE),
+                Pair.of("COLUMN_NAME", "dim2"),
+                Pair.of("DATA_TYPE", Types.VARCHAR),
+                Pair.of("TYPE_NAME", "VARCHAR"),
+                Pair.of("IS_NULLABLE", "YES")
+            ),
+            ROW(
+                Pair.of("TABLE_SCHEM", "druid"),
+                Pair.of("TABLE_NAME", CalciteTests.FORBIDDEN_DATASOURCE),
+                Pair.of("COLUMN_NAME", "m1"),
+                Pair.of("DATA_TYPE", Types.FLOAT),
+                Pair.of("TYPE_NAME", "FLOAT"),
+                Pair.of("IS_NULLABLE", "NO")
+            ),
+            ROW(
+                Pair.of("TABLE_SCHEM", "druid"),
+                Pair.of("TABLE_NAME", CalciteTests.FORBIDDEN_DATASOURCE),
+                Pair.of("COLUMN_NAME", "m2"),
+                Pair.of("DATA_TYPE", Types.DOUBLE),
+                Pair.of("TYPE_NAME", "DOUBLE"),
+                Pair.of("IS_NULLABLE", "NO")
+            ),
+            ROW(
+                Pair.of("TABLE_SCHEM", "druid"),
+                Pair.of("TABLE_NAME", CalciteTests.FORBIDDEN_DATASOURCE),
+                Pair.of("COLUMN_NAME", "unique_dim1"),
+                Pair.of("DATA_TYPE", Types.OTHER),
+                Pair.of("TYPE_NAME", "OTHER"),
+                Pair.of("IS_NULLABLE", "NO")
+            )
+        ),
+        getRows(
+            metaData.getColumns(null, "dr_id", CalciteTests.FORBIDDEN_DATASOURCE, null),
+            ImmutableSet.of("IS_NULLABLE", "TABLE_NAME", "TABLE_SCHEM", "COLUMN_NAME", "DATA_TYPE", "TYPE_NAME")
+        )
+    );
+  }
+
 
   @Test(timeout = 90000)
   public void testConcurrentQueries() throws Exception
@@ -633,7 +756,7 @@ public class DruidAvaticaHandlerTest
         port,
         DruidAvaticaHandler.AVATICA_PATH
     );
-    Connection smallFrameClient = DriverManager.getConnection(smallFrameUrl);
+    Connection smallFrameClient = DriverManager.getConnection(smallFrameUrl, "regularUser", "druid");
 
     final ResultSet resultSet = smallFrameClient.createStatement().executeQuery(
         "SELECT dim1 FROM druid.foo"

--- a/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
@@ -246,7 +246,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT 1 + 1",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(),
         ImmutableList.of(
             new Object[]{2}
@@ -259,7 +258,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT 1 + 1, dim1 FROM foo LIMIT 1",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             newScanQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE1)
@@ -297,7 +295,6 @@ public class CalciteQueryTest
         + "RTRIM('xfoox', 'x'),\n"
         + "COUNT(*)\n"
         + "FROM foo",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -333,7 +330,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "EXPLAIN PLAN FOR SELECT 1 + 1",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(),
         ImmutableList.of(
             new Object[]{"BindableValues(tuples=[[{ 2 }]])\n"}
@@ -346,7 +342,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT DISTINCT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(),
         ImmutableList.of(
             new Object[]{"druid"},
@@ -362,7 +357,6 @@ public class CalciteQueryTest
         "SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE\n"
         + "FROM INFORMATION_SCHEMA.TABLES\n"
         + "WHERE TABLE_TYPE IN ('SYSTEM_TABLE', 'TABLE', 'VIEW')",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(),
         ImmutableList.of(
             new Object[]{"druid", "foo", "TABLE"},
@@ -376,6 +370,7 @@ public class CalciteQueryTest
     );
 
     testQuery(
+        PLANNER_CONFIG_DEFAULT,
         "SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE\n"
         + "FROM INFORMATION_SCHEMA.TABLES\n"
         + "WHERE TABLE_TYPE IN ('SYSTEM_TABLE', 'TABLE', 'VIEW')",
@@ -401,7 +396,6 @@ public class CalciteQueryTest
         "SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE\n"
         + "FROM INFORMATION_SCHEMA.COLUMNS\n"
         + "WHERE TABLE_SCHEMA = 'druid' AND TABLE_NAME = 'foo'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(),
         ImmutableList.of(
             new Object[]{"__time", "TIMESTAMP", "NO"},
@@ -422,12 +416,12 @@ public class CalciteQueryTest
         "SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE\n"
         + "FROM INFORMATION_SCHEMA.COLUMNS\n"
         + "WHERE TABLE_SCHEMA = 'druid' AND TABLE_NAME = 'forbiddenDatasource'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(),
         ImmutableList.of()
     );
 
     testQuery(
+        PLANNER_CONFIG_DEFAULT,
         "SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE\n"
         + "FROM INFORMATION_SCHEMA.COLUMNS\n"
         + "WHERE TABLE_SCHEMA = 'druid' AND TABLE_NAME = 'forbiddenDatasource'",
@@ -453,7 +447,6 @@ public class CalciteQueryTest
         "SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE\n"
         + "FROM INFORMATION_SCHEMA.COLUMNS\n"
         + "WHERE TABLE_SCHEMA = 'druid' AND TABLE_NAME = 'aview'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(),
         ImmutableList.of(
             new Object[]{"dim1_firstchar", "VARCHAR", "YES"}
@@ -474,7 +467,6 @@ public class CalciteQueryTest
         + "SELECT COLUMN_NAME, DATA_TYPE\n"
         + "FROM INFORMATION_SCHEMA.COLUMNS\n"
         + "WHERE TABLE_SCHEMA = 'druid' AND TABLE_NAME = 'foo'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(),
         ImmutableList.of(
             new Object[]{explanation}
@@ -487,7 +479,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT * FROM druid.foo",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.<Query>of(
             newScanQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE1)
@@ -517,6 +508,7 @@ public class CalciteQueryTest
     );
 
     testQuery(
+        PLANNER_CONFIG_DEFAULT,
         "SELECT * FROM druid.forbiddenDatasource",
         CalciteTests.SUPER_USER_AUTH_RESULT,
         ImmutableList.<Query>of(
@@ -539,7 +531,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT COUNT(*) FROM foo",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -560,7 +551,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "EXPLAIN PLAN FOR SELECT * FROM druid.foo",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(),
         ImmutableList.of(
             new Object[]{
@@ -575,7 +565,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT * FROM druid.foo LIMIT 2",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             newScanQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE1)
@@ -598,7 +587,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT SUBSTRING(dim2, 1, 1) FROM druid.foo LIMIT 2",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             newScanQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE1)
@@ -624,7 +612,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT * FROM druid.foo ORDER BY __time DESC LIMIT 2",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newSelectQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -649,7 +636,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT * FROM druid.foo ORDER BY __time",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newSelectQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -694,7 +680,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT dim2 x, dim2 y FROM druid.foo LIMIT 2",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             newScanQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE1)
@@ -717,7 +702,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT dim1 FROM druid.foo ORDER BY __time DESC LIMIT 2",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newSelectQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -840,7 +824,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT cnt, COUNT(*) FROM druid.foo GROUP BY cnt",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -862,7 +845,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT cnt, COUNT(*) FROM druid.foo GROUP BY 1",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -885,7 +867,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT cnt AS theCnt, COUNT(*) FROM druid.foo GROUP BY theCnt ORDER BY theCnt ASC",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -923,7 +904,6 @@ public class CalciteQueryTest
         + "COUNT(*)\n"
         + "FROM druid.foo\n"
         + "GROUP BY FLOOR(__time TO MONTH)",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -945,7 +925,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT cnt as theCnt, COUNT(*) FROM druid.foo GROUP BY 1 ORDER BY 1 ASC",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -979,7 +958,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT m1, COUNT(*) FROM druid.foo GROUP BY m1",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -1006,7 +984,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT m2, COUNT(*) FROM druid.foo GROUP BY m2",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -1033,7 +1010,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT COUNT(*) FROM druid.foo WHERE m1 = 1.0",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -1055,7 +1031,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT COUNT(*) FROM druid.foo WHERE m2 = 1.0",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -1077,7 +1052,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT dim1, SUM(m1) AS m1_sum FROM druid.foo GROUP BY dim1 HAVING SUM(m1) > 1",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -1158,7 +1132,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT dim1, m1, COUNT(*) FROM druid.foo WHERE m1 - 1 = dim1 GROUP BY dim1, m1",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -1192,7 +1165,6 @@ public class CalciteQueryTest
         + "FROM druid.foo\n"
         + "GROUP BY dim1\n"
         + "HAVING COUNT(*) FILTER(WHERE dim2 <> 'a')/COUNT(*) = 1",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -1231,7 +1203,6 @@ public class CalciteQueryTest
         + "  SUBSTRING(dim1, 2)\n"
         + "FROM druid.foo\n"
         + "GROUP BY dim1\n",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -1265,7 +1236,6 @@ public class CalciteQueryTest
         + "FROM druid.foo\n"
         + "GROUP BY dim1\n"
         + "ORDER BY CHARACTER_LENGTH(dim1) DESC, dim1",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -1315,7 +1285,6 @@ public class CalciteQueryTest
         + "FROM druid.foo\n"
         + "GROUP BY dim1\n"
         + "LIMIT 10",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             new TopNQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE1)
@@ -1352,7 +1321,6 @@ public class CalciteQueryTest
         + "GROUP BY dim1\n"
         + "ORDER BY CHARACTER_LENGTH(dim1) DESC\n"
         + "LIMIT 10",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             new TopNQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE1)
@@ -1397,7 +1365,6 @@ public class CalciteQueryTest
         + "    WHEN cnt THEN 'match-cnt'\n"
         + "    WHEN 0 THEN 'zero'"
         + "    END",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -1446,7 +1413,6 @@ public class CalciteQueryTest
           "SELECT COUNT(*)\n"
           + "FROM druid.foo\n"
           + "WHERE " + where,
-          CalciteTests.REGULAR_USER_AUTH_RESULT,
           ImmutableList.of(
               Druids.newTimeseriesQueryBuilder()
                     .dataSource(CalciteTests.DATASOURCE1)
@@ -1473,7 +1439,6 @@ public class CalciteQueryTest
 
     testQuery(
         "SELECT COALESCE(dim2, dim1), COUNT(*) FROM druid.foo GROUP BY COALESCE(dim2, dim1)\n",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -1508,7 +1473,6 @@ public class CalciteQueryTest
 
     testQuery(
         "SELECT COUNT(*) FROM druid.foo WHERE dim2 IS NULL\n",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -1580,6 +1544,9 @@ public class CalciteQueryTest
     }
   }
 
+  /**
+   * Provided for tests that wish to check multiple queries instead of relying on ExpectedException.
+   */
   private void assertQueryIsForbidden(final String sql, final AuthenticationResult authenticationResult)
   {
     assertQueryIsForbidden(PLANNER_CONFIG_DEFAULT, sql, authenticationResult);
@@ -1610,7 +1577,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT * FROM druid.foo WHERE dim1 > 'd' OR dim2 = 'a'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.<Query>of(
             newScanQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE1)
@@ -1639,7 +1605,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT COUNT(*), MAX(cnt) FROM druid.foo WHERE 1 = 0",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(),
         ImmutableList.of(
             new Object[]{0L, null}
@@ -1652,7 +1617,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT COUNT(*), MAX(cnt) FROM druid.foo WHERE 1 = 0 GROUP BY dim1",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(),
         ImmutableList.of()
     );
@@ -1666,7 +1630,6 @@ public class CalciteQueryTest
 
     testQuery(
         "SELECT COUNT(*), MAX(cnt) FROM druid.foo WHERE dim1 = 'foobar'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -1689,7 +1652,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT COUNT(*), MAX(cnt) FROM druid.foo WHERE dim1 = 'foobar' GROUP BY 'dummy'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -1712,7 +1674,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT COUNT(cnt) FROM druid.foo",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -1733,7 +1694,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT COUNT(dim2) FROM druid.foo",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -1759,7 +1719,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT COUNT(CASE WHEN dim2 = 'abc' THEN 'yes' WHEN dim2 = 'def' THEN 'yes' END) FROM druid.foo",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -1787,7 +1746,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT COUNT(*) FROM druid.foo",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -1809,7 +1767,6 @@ public class CalciteQueryTest
     testQuery(
         "WITH beep (dim1_firstchar) AS (SELECT SUBSTRING(dim1, 1, 1) FROM foo WHERE dim2 = 'a')\n"
         + "SELECT COUNT(*) FROM beep WHERE dim1_firstchar <> 'z'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -1834,7 +1791,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT COUNT(*) FROM druid.aview WHERE dim1_firstchar <> 'z'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -1873,7 +1829,6 @@ public class CalciteQueryTest
 
     testQuery(
         "EXPLAIN PLAN FOR SELECT COUNT(*) FROM aview WHERE dim1_firstchar <> 'z'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(),
         ImmutableList.of(
             new Object[]{explanation}
@@ -1886,7 +1841,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT COUNT(*) FROM druid.foo WHERE dim1 like 'a%' OR dim2 like '%xb%' escape 'x'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -1913,7 +1867,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT COUNT(*) FROM druid.foo WHERE cnt >= 3 OR cnt = 1",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -1940,7 +1893,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT COUNT(*) FROM druid.foo WHERE cnt > 1.1 and cnt < 100000001.0",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -1958,7 +1910,6 @@ public class CalciteQueryTest
 
     testQuery(
         "SELECT COUNT(*) FROM druid.foo WHERE cnt = 1.0",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -1978,7 +1929,6 @@ public class CalciteQueryTest
 
     testQuery(
         "SELECT COUNT(*) FROM druid.foo WHERE cnt = 100000001.0",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -1996,7 +1946,6 @@ public class CalciteQueryTest
 
     testQuery(
         "SELECT COUNT(*) FROM druid.foo WHERE cnt = 1.0 or cnt = 100000001.0",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -2020,7 +1969,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT COUNT(*) FROM druid.foo WHERE cnt = 1 OR cnt = 2",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -2044,7 +1992,6 @@ public class CalciteQueryTest
         "SELECT distinct dim1 FROM druid.foo WHERE "
         + "dim1 = 10 OR "
         + "(floor(CAST(dim1 AS float)) = 10.00 and CAST(dim1 AS float) > 9 and CAST(dim1 AS float) <= 10.5)",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -2074,7 +2021,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT COUNT(*), COUNT(cnt), COUNT(dim1), AVG(cnt), SUM(cnt), SUM(cnt) + MIN(cnt) + MAX(cnt) FROM druid.foo",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -2123,7 +2069,6 @@ public class CalciteQueryTest
 
     testQuery(
         "SELECT dim1, MIN(m1) + MAX(m1) AS x FROM druid.foo GROUP BY dim1 ORDER BY x LIMIT 3",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             new TopNQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE1)
@@ -2263,7 +2208,6 @@ public class CalciteQueryTest
         + "SUM(CASE WHEN dim1 <> '1' THEN cnt ELSE 0 END), "
         + "MAX(CASE WHEN dim1 <> '1' THEN cnt END) "
         + "FROM druid.foo",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.<Query>of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -2335,7 +2279,6 @@ public class CalciteQueryTest
         + "  SUM(CASE WHEN dim1 <> '1' THEN 1 ELSE 0 END) + SUM(cnt)\n"
         + "FROM druid.foo\n"
         + "GROUP BY cnt",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -2368,7 +2311,6 @@ public class CalciteQueryTest
         + "COUNT(*) filter(WHERE dim1 NOT IN ('1')),\n"
         + "COUNT(dim2) filter(WHERE dim1 NOT IN ('1'))\n"
         + "FROM druid.foo",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -2397,7 +2339,6 @@ public class CalciteQueryTest
         + "  SUM(CHARACTER_LENGTH(CAST(cnt * 10 AS VARCHAR))),\n"
         + "  MAX(CHARACTER_LENGTH(dim2) + LN(m1))\n"
         + "FROM druid.foo",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -2434,7 +2375,6 @@ public class CalciteQueryTest
         + "WHERE FLOOR(m1 / 2) * 2 > -1\n"
         + "GROUP BY FLOOR(m1 / 2) * 2\n"
         + "ORDER BY 1 DESC",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -2481,7 +2421,6 @@ public class CalciteQueryTest
         + "WHERE CAST(m1 AS BIGINT) / 2 * 2 > -1\n"
         + "GROUP BY CAST(m1 AS BIGINT) / 2 * 2\n"
         + "ORDER BY 1 DESC",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -2530,7 +2469,6 @@ public class CalciteQueryTest
         + "WHERE FLOOR(CAST(dim1 AS FLOAT) / 2) * 2 > -1\n"
         + "GROUP BY FLOOR(CAST(dim1 AS FLOAT) / 2) * 2\n"
         + "ORDER BY 1 DESC",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -2576,7 +2514,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT dim1, COUNT(*) FROM druid.foo WHERE dim1 IN ('abc', 'def', 'ghi') GROUP BY dim1",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -2616,7 +2553,6 @@ public class CalciteQueryTest
 
     testQuery(
         "SELECT dim1, COUNT(*) FROM druid.foo WHERE dim1 IN (" + elementsString + ") GROUP BY dim1",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -2644,7 +2580,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT COUNT(*) FROM druid.foo WHERE dim2 = 'a' and (dim1 > 'a' OR dim1 < 'b')",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -2666,7 +2601,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT COUNT(*) FROM druid.foo WHERE dim2 = 'a' and not (dim1 > 'a' OR dim1 < 'b')",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(),
         ImmutableList.of(new Object[]{0L})
     );
@@ -2677,7 +2611,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT COUNT(*) FROM druid.foo WHERE (dim1 >= 'a' and dim1 < 'b') OR dim1 = 'ab'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -2699,7 +2632,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT COUNT(*) FROM druid.foo WHERE (dim1 >= 'a' and dim1 < 'b') and dim1 = 'abc'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -2721,7 +2653,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT COUNT(*) FROM druid.foo WHERE CAST(dim1 AS bigint) = 2",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -2744,7 +2675,6 @@ public class CalciteQueryTest
     testQuery(
         "SELECT COUNT(*) FROM druid.foo "
         + "WHERE __time >= TIMESTAMP '2000-01-01 00:00:00' AND __time < TIMESTAMP '2001-01-01 00:00:00'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -2768,7 +2698,6 @@ public class CalciteQueryTest
     testQuery(
         "SELECT COUNT(*) FROM druid.foo "
         + "WHERE __time >= '2000-01-01 00:00:00' AND __time < '2001-01-01 00:00:00'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -2789,7 +2718,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT COUNT(*) FROM druid.foo WHERE __time = TIMESTAMP '2000-01-01 00:00:00'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -2811,7 +2739,6 @@ public class CalciteQueryTest
     testQuery(
         "SELECT COUNT(*) FROM druid.foo WHERE "
         + "__time = TIMESTAMP '2000-01-01 00:00:00' OR __time = TIMESTAMP '2000-01-01 00:00:00' + INTERVAL '1' DAY",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -2845,7 +2772,6 @@ public class CalciteQueryTest
         + "    and dim1 = 'abc'"
         + "  )"
         + ")",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -2887,7 +2813,6 @@ public class CalciteQueryTest
         + "    )"
         + "  )"
         + ")",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -2923,7 +2848,6 @@ public class CalciteQueryTest
         + "WHERE dim1 <> 'xxx' and not ("
         + "    (__time >= TIMESTAMP '2000-01-01 00:00:00' AND __time < TIMESTAMP '2001-01-01 00:00:00')"
         + "    OR (__time >= TIMESTAMP '2003-01-01 00:00:00' AND __time < TIMESTAMP '2004-01-01 00:00:00'))",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -2953,7 +2877,6 @@ public class CalciteQueryTest
         "SELECT COUNT(*) FROM druid.foo "
         + "WHERE dim2 <> 'a' "
         + "and __time BETWEEN TIMESTAMP '2000-01-01 00:00:00' AND TIMESTAMP '2000-12-31 23:59:59.999'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -2977,7 +2900,6 @@ public class CalciteQueryTest
         "SELECT COUNT(*) FROM druid.foo "
         + "WHERE dim2 <> 'a' "
         + "or __time BETWEEN TIMESTAMP '2000-01-01 00:00:00' AND TIMESTAMP '2000-12-31 23:59:59.999'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -3014,7 +2936,6 @@ public class CalciteQueryTest
         "SELECT COUNT(*) FROM druid.foo WHERE "
         + "cnt >= EXTRACT(EPOCH FROM TIMESTAMP '1970-01-01 00:00:00') * 1000 "
         + "AND cnt < EXTRACT(EPOCH FROM TIMESTAMP '1970-01-02 00:00:00') * 1000",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -3048,7 +2969,6 @@ public class CalciteQueryTest
         "SELECT COUNT(*) FROM druid.foo WHERE "
         + "cnt >= TIMESTAMP_TO_MILLIS(TIMESTAMP '1970-01-01 00:00:00') "
         + "AND cnt < TIMESTAMP_TO_MILLIS(TIMESTAMP '1970-01-02 00:00:00')",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -3082,7 +3002,6 @@ public class CalciteQueryTest
 
     testQuery(
         "SELECT SUM(CAST(dim1 AS INTEGER)) FROM druid.foo",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -3112,7 +3031,6 @@ public class CalciteQueryTest
 
     testQuery(
         "SELECT SUM(CAST(SUBSTRING(dim1, 1, 10) AS INTEGER)) FROM druid.foo",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -3149,7 +3067,6 @@ public class CalciteQueryTest
         + "  AND MILLIS_TO_TIMESTAMP(cnt) < TIMESTAMP '1970-01-02 00:00:00'\n"
         + "GROUP BY\n"
         + "  FLOOR(MILLIS_TO_TIMESTAMP(cnt) TO YEAR)",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             new GroupByQuery.Builder()
                 .setDataSource(CalciteTests.DATASOURCE1)
@@ -3189,7 +3106,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT distinct dim1 FROM druid.foo WHERE substring(substring(dim1, 2), 1, 1) = 'e' OR dim2 = 'a'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -3226,7 +3142,6 @@ public class CalciteQueryTest
     testQuery(
         "SELECT distinct dim1 FROM druid.foo "
         + "WHERE CHARACTER_LENGTH(dim1) = 3 OR CAST(CHARACTER_LENGTH(dim1) AS varchar) = 3",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -3256,7 +3171,6 @@ public class CalciteQueryTest
 
     testQuery(
         "SELECT DISTINCT dim2 FROM druid.foo LIMIT 10",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             new TopNQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE1)
@@ -3281,7 +3195,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT * FROM (SELECT DISTINCT dim2 FROM druid.foo ORDER BY dim2) LIMIT 10",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             new TopNQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE1)
@@ -3306,7 +3219,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT * FROM (SELECT DISTINCT dim2 FROM druid.foo ORDER BY dim2 LIMIT 5) LIMIT 10",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             new TopNQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE1)
@@ -3333,7 +3245,6 @@ public class CalciteQueryTest
 
     testQuery(
         "SELECT * FROM (SELECT DISTINCT dim2 FROM druid.foo ORDER BY dim2 LIMIT 2 OFFSET 5) OFFSET 2",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(),
         ImmutableList.of()
     );
@@ -3344,7 +3255,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT * FROM (SELECT DISTINCT dim2 FROM druid.foo ORDER BY dim2 DESC LIMIT 5) LIMIT 10",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             new TopNQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE1)
@@ -3369,7 +3279,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT SUM(cnt), COUNT(distinct dim2), COUNT(distinct unique_dim1) FROM druid.foo",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -3529,7 +3438,6 @@ public class CalciteQueryTest
         + "  APPROX_COUNT_DISTINCT(SUBSTRING(dim2, 1, 1) || 'x'),\n" // on expression
         + "  approx_count_distinct(unique_dim1)\n" // on native hyperUnique column
         + "FROM druid.foo",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -3610,7 +3518,6 @@ public class CalciteQueryTest
         + "    GROUP BY m2, dim1\n"
         + ")\n"
         + "GROUP BY FLOOR(__time to hour), dim1",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(
@@ -3665,7 +3572,6 @@ public class CalciteQueryTest
         + "  ) t1\n"
         + "  GROUP BY dim2\n"
         + ") t2",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(
@@ -3725,7 +3631,6 @@ public class CalciteQueryTest
         + "  ) t1\n"
         + "  GROUP BY dim2\n"
         + ") t2",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(),
         ImmutableList.of(
             new Object[]{explanation}
@@ -3790,7 +3695,6 @@ public class CalciteQueryTest
         + ") t2 ON (t1.dim2 = t2.dim2)\n"
         + "GROUP BY t1.dim1\n"
         + "ORDER BY 1\n",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             new TopNQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE1)
@@ -3853,7 +3757,6 @@ public class CalciteQueryTest
         + "  LIMIT 2\n"
         + ") t2 ON (t1.dim2 = t2.dim2)\n"
         + "GROUP BY SUBSTRING(t1.dim1, 1, 10)",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             new TopNQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE1)
@@ -3916,7 +3819,6 @@ public class CalciteQueryTest
         + ") t2 ON (t1.dim2 = t2.dim2)\n"
         + "GROUP BY t1.dim1\n"
         + "ORDER BY 1\n",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -3962,7 +3864,6 @@ public class CalciteQueryTest
         + "    SELECT SUBSTRING(dim1, 1, 1) FROM druid.foo WHERE dim1 <> ''\n"
         + "  )\n"
         + ")",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -4024,7 +3925,6 @@ public class CalciteQueryTest
         + "    SELECT SUBSTRING(dim1, 1, 1) FROM druid.foo WHERE dim1 <> ''\n"
         + "  )\n"
         + ")",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(),
         ImmutableList.of(new Object[]{explanation})
     );
@@ -4039,7 +3939,6 @@ public class CalciteQueryTest
         + "  COUNT(*)\n"
         + "FROM (SELECT dim2, SUM(cnt) AS cnt FROM druid.foo GROUP BY dim2)\n"
         + "WHERE dim2 <> ''",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(
@@ -4079,7 +3978,6 @@ public class CalciteQueryTest
         + "  COUNT(*)\n"
         + "FROM (SELECT dim2, SUM(cnt) AS cnt FROM druid.foo GROUP BY dim2 LIMIT 1)"
         + "WHERE cnt > 0",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(
@@ -4120,7 +4018,6 @@ public class CalciteQueryTest
         + "  COUNT(DISTINCT dim1) AS approx_count,\n"
         + "  (CAST(1 AS FLOAT) - COUNT(DISTINCT dim1) / COUNT(*)) * 100 AS error_pct\n"
         + "FROM (SELECT DISTINCT dim1 FROM druid.foo WHERE dim1 <> '')",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(
@@ -4170,7 +4067,6 @@ public class CalciteQueryTest
         + "  COUNT(*)\n"
         + "FROM (SELECT dim2, SUM(cnt) AS thecnt FROM druid.foo GROUP BY dim2)\n"
         + "GROUP BY CAST(thecnt AS VARCHAR)",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(
@@ -4211,7 +4107,6 @@ public class CalciteQueryTest
         + "  COUNT(*)\n"
         + "FROM (SELECT dim2, SUM(cnt) AS thecnt FROM druid.foo GROUP BY dim2)\n"
         + "GROUP BY CAST(thecnt AS VARCHAR) ORDER BY CAST(thecnt AS VARCHAR) LIMIT 2",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(
@@ -4264,7 +4159,6 @@ public class CalciteQueryTest
         + "  SUM(cnt) / COUNT(DISTINCT dim2) + 3,\n"
         + "  CAST(SUM(cnt) AS FLOAT) / CAST(COUNT(DISTINCT dim2) AS FLOAT) + 3\n"
         + "FROM druid.foo",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -4302,7 +4196,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT COUNT(DISTINCT SUBSTRING(dim1, 1, 1)) FROM druid.foo WHERE dim1 <> ''",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -4342,7 +4235,6 @@ public class CalciteQueryTest
 
     testQuery(
         "SELECT COUNT(DISTINCT TRIM(BOTH ' ' FROM dim1)) FROM druid.foo WHERE TRIM(dim1) <> ''",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -4380,7 +4272,6 @@ public class CalciteQueryTest
         "SELECT CAST((EXTRACT(MONTH FROM __time) - 1 ) / 3 + 1 AS INTEGER) AS quarter, COUNT(*)\n"
         + "FROM foo\n"
         + "GROUP BY CAST((EXTRACT(MONTH FROM __time) - 1 ) / 3 + 1 AS INTEGER)",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -4411,7 +4302,6 @@ public class CalciteQueryTest
         + "  REGEXP_EXTRACT(dim1, '^(.)', 1)\n"
         + "FROM foo\n"
         + "WHERE REGEXP_EXTRACT(dim1, '^(.)', 1) <> 'x'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -4456,7 +4346,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT dim2, dim1, SUM(cnt) FROM druid.foo GROUP BY dim2, dim1 ORDER BY dim1 LIMIT 4",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -4503,7 +4392,6 @@ public class CalciteQueryTest
         + "having SUM(cnt) = 1 "
         + "order by dim2 "
         + "limit 4",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -4549,7 +4437,6 @@ public class CalciteQueryTest
         + "WHERE\n"
         + "FLOOR(__time TO MONTH) = TIMESTAMP '2000-01-01 00:00:00'\n"
         + "OR FLOOR(__time TO MONTH) = TIMESTAMP '2000-02-01 00:00:00'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -4573,7 +4460,6 @@ public class CalciteQueryTest
         + "WHERE\n"
         + "  __time >= CURRENT_TIMESTAMP + INTERVAL '01:02' HOUR TO MINUTE\n"
         + "  AND __time < TIMESTAMP '2003-02-02 01:00:00' - INTERVAL '1 1' DAY TO HOUR - INTERVAL '1-1' YEAR TO MONTH",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -4633,7 +4519,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT * FROM bview",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -4682,7 +4567,6 @@ public class CalciteQueryTest
         "SELECT COUNT(*) FROM druid.foo\n"
         + "WHERE\n"
         + "FLOOR(__time TO MONTH) <> TIMESTAMP '2001-01-01 00:00:00'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -4708,7 +4592,6 @@ public class CalciteQueryTest
         "SELECT COUNT(*) FROM druid.foo\n"
         + "WHERE\n"
         + "FLOOR(__time TO MONTH) < TIMESTAMP '2000-02-01 00:00:00'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -4731,7 +4614,6 @@ public class CalciteQueryTest
         "SELECT COUNT(*) FROM druid.foo\n"
         + "WHERE\n"
         + "FLOOR(__time TO MONTH) < TIMESTAMP '2000-02-01 00:00:01'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -4755,7 +4637,6 @@ public class CalciteQueryTest
         "SELECT COUNT(*) FROM druid.foo\n"
         + "WHERE EXTRACT(YEAR FROM __time) = 2000\n"
         + "AND EXTRACT(MONTH FROM __time) = 1",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -4779,7 +4660,6 @@ public class CalciteQueryTest
         "SELECT COUNT(*) FROM druid.foo\n"
         + "WHERE EXTRACT(YEAR FROM __time) = 2000\n"
         + "AND EXTRACT(MONTH FROM __time) IN (2, 3, 5)",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -4801,7 +4681,6 @@ public class CalciteQueryTest
     testQuery(
         "SELECT COUNT(*) FROM druid.foo "
         + "WHERE floor(__time TO month) = TIMESTAMP '2000-01-01 00:00:01'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -4849,7 +4728,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT floor(CAST(dim1 AS float)) AS fl, COUNT(*) FROM druid.foo GROUP BY floor(CAST(dim1 AS float)) ORDER BY fl DESC",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -4904,7 +4782,6 @@ public class CalciteQueryTest
         + " FROM druid.foo"
         + " GROUP BY floor(__time TO year), dim2"
         + " ORDER BY floor(__time TO year), dim2, COUNT(*) DESC",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -4966,7 +4843,6 @@ public class CalciteQueryTest
   {
     testQuery(
         "SELECT CHARACTER_LENGTH(dim1), COUNT(*) FROM druid.foo GROUP BY CHARACTER_LENGTH(dim1)",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -5003,7 +4879,6 @@ public class CalciteQueryTest
         "SELECT LOOKUP(dim1, 'lookyloo'), COUNT(*) FROM foo\n"
         + "WHERE LOOKUP(dim1, 'lookyloo') <> 'xxx'\n"
         + "GROUP BY LOOKUP(dim1, 'lookyloo')",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -5055,7 +4930,6 @@ public class CalciteQueryTest
 
     testQuery(
         "SELECT COUNT(DISTINCT LOOKUP(dim1, 'lookyloo')) FROM foo",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -5089,7 +4963,6 @@ public class CalciteQueryTest
         + ") AS x\n"
         + "GROUP BY gran\n"
         + "ORDER BY gran",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -5119,7 +4992,6 @@ public class CalciteQueryTest
         + "WHERE\n"
         + "  __time >= TIMESTAMP '2000-01-01 00:00:00'\n"
         + "  AND __time < TIMESTAMP '2001-02-01 00:00:00'",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -5201,7 +5073,6 @@ public class CalciteQueryTest
         + ") AS x\n"
         + "GROUP BY gran\n"
         + "ORDER BY gran",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -5228,7 +5099,6 @@ public class CalciteQueryTest
         + ") AS x\n"
         + "GROUP BY gran\n"
         + "ORDER BY gran",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -5277,7 +5147,6 @@ public class CalciteQueryTest
         + ") AS x\n"
         + "GROUP BY gran\n"
         + "ORDER BY gran",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -5312,7 +5181,6 @@ public class CalciteQueryTest
         + ") AS x\n"
         + "GROUP BY gran\n"
         + "ORDER BY gran",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -5425,7 +5293,6 @@ public class CalciteQueryTest
         + ") AS x\n"
         + "GROUP BY dt\n"
         + "ORDER BY dt",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -5456,7 +5323,6 @@ public class CalciteQueryTest
         + ") AS x\n"
         + "GROUP BY gran\n"
         + "ORDER BY gran DESC",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -5484,7 +5350,6 @@ public class CalciteQueryTest
         + "FROM druid.foo\n"
         + "GROUP BY EXTRACT(YEAR FROM __time)\n"
         + "ORDER BY 1",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -5539,7 +5404,6 @@ public class CalciteQueryTest
         + "FROM druid.foo\n"
         + "GROUP BY TIME_FORMAT(__time, 'yyyy MM')\n"
         + "ORDER BY 1",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -5592,7 +5456,6 @@ public class CalciteQueryTest
         + "EXTRACT(YEAR FROM FLOOR(__time TO YEAR)) AS \"year\", SUM(cnt)\n"
         + "FROM druid.foo\n"
         + "GROUP BY EXTRACT(YEAR FROM FLOOR(__time TO YEAR))",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -5731,7 +5594,6 @@ public class CalciteQueryTest
         + ") AS x\n"
         + "GROUP BY gran\n"
         + "LIMIT 1",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             new TopNQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE1)
@@ -5769,7 +5631,6 @@ public class CalciteQueryTest
         + "GROUP BY gran\n"
         + "ORDER BY gran\n"
         + "LIMIT 1",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             new TopNQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE1)
@@ -5803,7 +5664,6 @@ public class CalciteQueryTest
         + "FROM (SELECT FLOOR(__time TO MONTH) AS gran, dim2, cnt FROM druid.foo) AS x\n"
         + "GROUP BY dim2, gran\n"
         + "ORDER BY dim2, gran",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -5955,7 +5815,6 @@ public class CalciteQueryTest
         + "     HAVING COUNT(*) = 1"
         + "   )"
         + " )",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -5998,7 +5857,6 @@ public class CalciteQueryTest
         + "   GROUP BY dim2\n"
         + "   ORDER BY dim2 DESC\n"
         + " )",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -6045,7 +5903,6 @@ public class CalciteQueryTest
         "SELECT dim2, COUNT(*) FROM druid.foo "
         + "WHERE substring(dim2, 1, 1) IN (SELECT substring(dim1, 1, 1) FROM druid.foo WHERE dim1 <> '')"
         + "group by dim2",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -6091,7 +5948,6 @@ public class CalciteQueryTest
         + "  dim1 LIKE U&'\u05D3\\05E8%'\n" // First char is actually in the string; second is a SQL U& escape
         + "  OR dim1 = 'друид'\n"
         + "GROUP BY dim1, dim2",
-        CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE2)
@@ -6118,7 +5974,6 @@ public class CalciteQueryTest
 
   private void testQuery(
       final String sql,
-      final AuthenticationResult authenticationResult,
       final List<Query> expectedQueries,
       final List<Object[]> expectedResults
   ) throws Exception
@@ -6127,7 +5982,7 @@ public class CalciteQueryTest
         PLANNER_CONFIG_DEFAULT,
         QUERY_CONTEXT_DEFAULT,
         sql,
-        authenticationResult,
+        CalciteTests.REGULAR_USER_AUTH_RESULT,
         expectedQueries,
         expectedResults
     );

--- a/sql/src/test/java/io/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/io/druid/sql/calcite/util/CalciteTests.java
@@ -26,6 +26,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.inject.Binder;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -93,8 +94,17 @@ import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.server.QueryLifecycleFactory;
 import io.druid.server.initialization.ServerConfig;
 import io.druid.server.log.NoopRequestLogger;
+import io.druid.server.security.Access;
+import io.druid.server.security.Action;
+import io.druid.server.security.AllowAllAuthenticator;
 import io.druid.server.security.AuthConfig;
-import io.druid.server.security.AuthTestUtils;
+import io.druid.server.security.AuthenticationResult;
+import io.druid.server.security.Authenticator;
+import io.druid.server.security.AuthenticatorMapper;
+import io.druid.server.security.Authorizer;
+import io.druid.server.security.AuthorizerMapper;
+import io.druid.server.security.Resource;
+import io.druid.server.security.ResourceType;
 import io.druid.sql.calcite.expression.SqlOperatorConversion;
 import io.druid.sql.calcite.expression.builtin.LookupOperatorConversion;
 import io.druid.sql.calcite.planner.DruidOperatorTable;
@@ -122,6 +132,66 @@ public class CalciteTests
 {
   public static final String DATASOURCE1 = "foo";
   public static final String DATASOURCE2 = "foo2";
+  public static final String FORBIDDEN_DATASOURCE = "forbiddenDatasource";
+
+  public static final String TEST_SUPERUSER_NAME = "testSuperuser";
+  public static final AuthorizerMapper TEST_AUTHORIZER_MAPPER = new AuthorizerMapper(null) {
+    @Override
+    public Authorizer getAuthorizer(String name)
+    {
+      return new Authorizer()
+      {
+        @Override
+        public Access authorize(
+            AuthenticationResult authenticationResult, Resource resource, Action action
+        )
+        {
+          if (authenticationResult.getIdentity().equals(TEST_SUPERUSER_NAME)) {
+            return Access.OK;
+          }
+
+          if (resource.getType() == ResourceType.DATASOURCE && resource.getName().equals(FORBIDDEN_DATASOURCE)) {
+            return new Access(false);
+          } else {
+            return Access.OK;
+          }
+        }
+      };
+    }
+  };
+  public static final AuthenticatorMapper TEST_AUTHENTICATOR_MAPPER;
+  static {
+    final Map<String, Authenticator> defaultMap = Maps.newHashMap();
+    defaultMap.put(
+        "allowAll",
+        new AllowAllAuthenticator() {
+          @Override
+          public AuthenticationResult authenticateJDBCContext(Map<String, Object> context)
+          {
+            return new AuthenticationResult((String) context.get("user"), "allowAll", null);
+          }
+
+          @Override
+          public AuthenticationResult createEscalatedAuthenticationResult()
+          {
+            return new AuthenticationResult(TEST_SUPERUSER_NAME, "allowAll", null);
+          }
+        }
+    );
+    TEST_AUTHENTICATOR_MAPPER = new AuthenticatorMapper(defaultMap, "allowAll");
+  }
+
+  public static final AuthenticationResult REGULAR_USER_AUTH_RESULT = new AuthenticationResult(
+      "allowAll",
+      "allowAll",
+      null
+  );
+
+  public static final AuthenticationResult SUPER_USER_AUTH_RESULT = new AuthenticationResult(
+      TEST_SUPERUSER_NAME,
+      "allowAll",
+      null
+  );
 
   private static final String TIMESTAMP_COLUMN = "t";
   private static final Supplier<SelectQueryConfig> SELECT_CONFIG_SUPPLIER = Suppliers.ofInstance(
@@ -303,6 +373,10 @@ public class CalciteTests
       createRow("2000-01-01", "друид", "ru", 1.0)
   );
 
+  public static final List<InputRow> FORBIDDEN_ROWS = ImmutableList.of(
+      createRow("2000-01-01", "forbidden", "abcd", 9999.0)
+  );
+
   private CalciteTests()
   {
     // No instantiation.
@@ -330,7 +404,7 @@ public class CalciteTests
         new NoopRequestLogger(),
         new ServerConfig(),
         new AuthConfig(),
-        AuthTestUtils.TEST_AUTHORIZER_MAPPER
+        TEST_AUTHORIZER_MAPPER
     );
   }
 
@@ -355,6 +429,13 @@ public class CalciteTests
                                               .rows(ROWS2)
                                               .buildMMappedIndex();
 
+    final QueryableIndex forbiddenIndex = IndexBuilder.create()
+                                                      .tmpDir(new File(tmpDir, "forbidden"))
+                                                      .indexMerger(TestHelper.getTestIndexMergerV9())
+                                                      .schema(INDEX_SCHEMA)
+                                                      .rows(FORBIDDEN_ROWS)
+                                                      .buildMMappedIndex();
+
     return new SpecificSegmentsQuerySegmentWalker(queryRunnerFactoryConglomerate()).add(
         DataSegment.builder()
                    .dataSource(DATASOURCE1)
@@ -371,6 +452,14 @@ public class CalciteTests
                    .shardSpec(new LinearShardSpec(0))
                    .build(),
         index2
+    ).add(
+        DataSegment.builder()
+                   .dataSource(FORBIDDEN_DATASOURCE)
+                   .interval(forbiddenIndex.getDataInterval())
+                   .version("1")
+                   .shardSpec(new LinearShardSpec(0))
+                   .build(),
+        forbiddenIndex
     );
   }
 
@@ -415,7 +504,7 @@ public class CalciteTests
         new TestServerInventoryView(walker.getSegments()),
         plannerConfig,
         viewManager,
-        AuthTestUtils.TEST_AUTHENTICATOR_MAPPER
+        TEST_AUTHENTICATOR_MAPPER
     );
 
     schema.start();


### PR DESCRIPTION
This PR filters out datasources that the user is not authorized to read from the output of SQL INFORMATION_SCHEMA queries.

Prior to this patch, access to INFORMATION_SCHEMA was all-or-nothing based on whether the user had access to a datasource type resource named "INFORMATION_SCHEMA".

