### PR TITLE
Fix removeDataSource() and removeSegment() of SQLMetadataSegmentManager

### DIFF
--- a/common/src/main/java/io/druid/concurrent/LifecycleLock.java
+++ b/common/src/main/java/io/druid/concurrent/LifecycleLock.java
@@ -115,6 +115,11 @@ public final class LifecycleLock
       }
     }
 
+    boolean isStarted()
+    {
+      return getState() == START_EXITED_SUCCESSFUL;
+    }
+
     boolean awaitStarted()
     {
       try {
@@ -124,7 +129,7 @@ public final class LifecycleLock
       catch (InterruptedException e) {
         throw new RuntimeException(e);
       }
-      return getState() == START_EXITED_SUCCESSFUL;
+      return isStarted();
     }
 
     boolean awaitStarted(long timeNanos)
@@ -138,7 +143,7 @@ public final class LifecycleLock
       catch (InterruptedException e) {
         throw new RuntimeException(e);
       }
-      return getState() == START_EXITED_SUCCESSFUL;
+      return isStarted();
     }
 
     @Override
@@ -208,6 +213,15 @@ public final class LifecycleLock
   public void exitStart()
   {
     sync.exitStart();
+  }
+
+  /**
+   * Returns {@code true} if {@link #started()} was called before that. Returns {@code false} if {@link #started()} is
+   * not called before {@link #exitStart()}, or if {@link #canStop()} is already called on this LifecycleLock.
+   */
+  public boolean isStarted()
+  {
+    return sync.isStarted();
   }
 
   /**

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunner.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunner.java
@@ -379,6 +379,9 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
     catch (Exception e) {
       throw Throwables.propagate(e);
     }
+    finally {
+      lifecycleLock.exitStop();
+    }
   }
 
   @Override

--- a/server/src/main/java/io/druid/metadata/SQLMetadataSegmentManager.java
+++ b/server/src/main/java/io/druid/metadata/SQLMetadataSegmentManager.java
@@ -35,12 +35,13 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
 import com.metamx.emitter.EmittingLogger;
 import io.druid.client.DruidDataSource;
-import io.druid.java.util.common.concurrent.Execs;
+import io.druid.concurrent.LifecycleLock;
 import io.druid.guice.ManageLifecycle;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.MapUtils;
 import io.druid.java.util.common.StringUtils;
+import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.lifecycle.LifecycleStart;
 import io.druid.java.util.common.lifecycle.LifecycleStop;
 import io.druid.timeline.DataSegment;
@@ -82,19 +83,16 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
   private static final Interner<DataSegment> DATA_SEGMENT_INTERNER = Interners.newWeakInterner();
   private static final EmittingLogger log = new EmittingLogger(SQLMetadataSegmentManager.class);
 
-
-  private final Object lock = new Object();
+  private final LifecycleLock lifecycleLock = new LifecycleLock();
 
   private final ObjectMapper jsonMapper;
   private final Supplier<MetadataSegmentManagerConfig> config;
   private final Supplier<MetadataStorageTablesConfig> dbTables;
-  private final AtomicReference<ConcurrentHashMap<String, DruidDataSource>> dataSources;
+  private final AtomicReference<ConcurrentHashMap<String, DruidDataSource>> dataSourcesRef;
   private final SQLMetadataConnector connector;
 
   private volatile ListeningScheduledExecutorService exec = null;
   private volatile ListenableFuture<?> future = null;
-
-  private volatile boolean started = false;
 
   @Inject
   public SQLMetadataSegmentManager(
@@ -107,7 +105,7 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
     this.jsonMapper = jsonMapper;
     this.config = config;
     this.dbTables = dbTables;
-    this.dataSources = new AtomicReference<>(
+    this.dataSourcesRef = new AtomicReference<>(
         new ConcurrentHashMap<String, DruidDataSource>()
     );
     this.connector = connector;
@@ -117,11 +115,11 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
   @LifecycleStart
   public void start()
   {
-    synchronized (lock) {
-      if (started) {
-        return;
-      }
+    if (!lifecycleLock.canStart()) {
+      return;
+    }
 
+    try {
       exec = MoreExecutors.listeningDecorator(Execs.scheduledSingleThreaded("DatabaseSegmentManager-Exec--%d"));
 
       final Duration delay = config.get().getPollDuration().toStandardDuration();
@@ -144,7 +142,10 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
           delay.getMillis(),
           TimeUnit.MILLISECONDS
       );
-      started = true;
+      lifecycleLock.started();
+    }
+    finally {
+      lifecycleLock.exitStart();
     }
   }
 
@@ -152,17 +153,23 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
   @LifecycleStop
   public void stop()
   {
-    synchronized (lock) {
-      if (!started) {
-        return;
-      }
+    if (!lifecycleLock.canStop()) {
+      return;
+    }
+    try {
+      final ConcurrentHashMap<String, DruidDataSource> emptyMap = new ConcurrentHashMap<>();
+      ConcurrentHashMap<String, DruidDataSource> current;
+      do {
+        current = dataSourcesRef.get();
+      } while (!dataSourcesRef.compareAndSet(current, emptyMap));
 
-      started = false;
-      dataSources.set(new ConcurrentHashMap<String, DruidDataSource>());
       future.cancel(false);
       future = null;
       exec.shutdownNow();
       exec = null;
+    }
+    finally {
+      lifecycleLock.exitStop();
     }
   }
 
@@ -302,31 +309,17 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
   public boolean removeDatasource(final String ds)
   {
     try {
-      ConcurrentHashMap<String, DruidDataSource> dataSourceMap = dataSources.get();
-
-      if (!dataSourceMap.containsKey(ds)) {
-        log.warn("Cannot delete datasource %s, does not exist", ds);
-        return false;
-      }
-
-      connector.getDBI().withHandle(
-          new HandleCallback<Void>()
-          {
-            @Override
-            public Void withHandle(Handle handle) throws Exception
-            {
-              handle.createStatement(
-                  StringUtils.format("UPDATE %s SET used=false WHERE dataSource = :dataSource", getSegmentsTable())
-              )
-                    .bind("dataSource", ds)
-                    .execute();
-
-              return null;
-            }
-          }
+      final int removed = connector.getDBI().withHandle(
+          handle -> handle.createStatement(
+              StringUtils.format("UPDATE %s SET used=false WHERE dataSource = :dataSource", getSegmentsTable())
+          ).bind("dataSource", ds).execute()
       );
 
-      dataSourceMap.remove(ds);
+      dataSourcesRef.get().remove(ds);
+
+      if (removed == 0) {
+        return false;
+      }
     }
     catch (Exception e) {
       log.error(e, "Error removing datasource %s", ds);
@@ -340,34 +333,25 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
   public boolean removeSegment(String ds, final String segmentID)
   {
     try {
-      connector.getDBI().withHandle(
-          new HandleCallback<Void>()
-          {
-            @Override
-            public Void withHandle(Handle handle) throws Exception
-            {
-              handle.createStatement(
-                  StringUtils.format("UPDATE %s SET used=false WHERE id = :segmentID", getSegmentsTable())
-              ).bind("segmentID", segmentID)
-                    .execute();
-
-              return null;
-            }
-          }
+      final int removed = connector.getDBI().withHandle(
+          handle -> handle.createStatement(
+              StringUtils.format("UPDATE %s SET used=false WHERE id = :segmentID", getSegmentsTable())
+          ).bind("segmentID", segmentID).execute()
       );
 
-      ConcurrentHashMap<String, DruidDataSource> dataSourceMap = dataSources.get();
-
-      if (!dataSourceMap.containsKey(ds)) {
-        log.warn("Cannot find datasource %s", ds);
-        return false;
-      }
+      ConcurrentHashMap<String, DruidDataSource> dataSourceMap = dataSourcesRef.get();
 
       DruidDataSource dataSource = dataSourceMap.get(ds);
-      dataSource.removePartition(segmentID);
+      if (dataSource != null) {
+        dataSource.removePartition(segmentID);
 
-      if (dataSource.isEmpty()) {
-        dataSourceMap.remove(ds);
+        if (dataSource.isEmpty()) {
+          dataSourceMap.remove(ds);
+        }
+      }
+
+      if (removed == 0) {
+        return false;
       }
     }
     catch (Exception e) {
@@ -381,69 +365,59 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
   @Override
   public boolean isStarted()
   {
-    return started;
+    return lifecycleLock.isStarted();
   }
 
   @Override
   public DruidDataSource getInventoryValue(String key)
   {
-    return dataSources.get().get(key);
+    return dataSourcesRef.get().get(key);
   }
 
   @Override
   public Collection<DruidDataSource> getInventory()
   {
-    return dataSources.get().values();
+    return dataSourcesRef.get().values();
   }
 
   @Override
   public Collection<String> getAllDatasourceNames()
   {
-    synchronized (lock) {
-      return connector.getDBI().withHandle(
-          new HandleCallback<List<String>>()
-          {
-            @Override
-            public List<String> withHandle(Handle handle) throws Exception
-            {
-              return handle.createQuery(
-                  StringUtils.format("SELECT DISTINCT(datasource) FROM %s", getSegmentsTable())
-              )
-                           .fold(
-                               Lists.<String>newArrayList(),
-                               new Folder3<ArrayList<String>, Map<String, Object>>()
-                               {
-                                 @Override
-                                 public ArrayList<String> fold(
-                                     ArrayList<String> druidDataSources,
-                                     Map<String, Object> stringObjectMap,
-                                     FoldController foldController,
-                                     StatementContext statementContext
-                                 ) throws SQLException
-                                 {
-                                   druidDataSources.add(
-                                       MapUtils.getString(stringObjectMap, "datasource")
-                                   );
-                                   return druidDataSources;
-                                 }
-                               }
-                           );
-
-            }
-          }
-      );
-    }
+    return connector.getDBI().withHandle(
+        handle -> handle.createQuery(
+            StringUtils.format("SELECT DISTINCT(datasource) FROM %s", getSegmentsTable())
+        )
+                        .fold(
+                            new ArrayList<>(),
+                            new Folder3<List<String>, Map<String, Object>>()
+                            {
+                              @Override
+                              public List<String> fold(
+                                  List<String> druidDataSources,
+                                  Map<String, Object> stringObjectMap,
+                                  FoldController foldController,
+                                  StatementContext statementContext
+                              ) throws SQLException
+                              {
+                                druidDataSources.add(
+                                    MapUtils.getString(stringObjectMap, "datasource")
+                                );
+                                return druidDataSources;
+                              }
+                            }
+                        )
+    );
   }
 
   @Override
   public void poll()
   {
     try {
-      if (!started) {
+      if (!lifecycleLock.isStarted()) {
         return;
       }
 
-      ConcurrentHashMap<String, DruidDataSource> newDataSources = new ConcurrentHashMap<String, DruidDataSource>();
+      ConcurrentHashMap<String, DruidDataSource> newDataSources = new ConcurrentHashMap<>();
 
       log.debug("Starting polling of segment table");
 
@@ -525,11 +499,10 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
         }
       }
 
-      synchronized (lock) {
-        if (started) {
-          dataSources.set(newDataSources);
-        }
-      }
+      ConcurrentHashMap<String, DruidDataSource> current;
+      do {
+        current = dataSourcesRef.get();
+      } while (!dataSourcesRef.compareAndSet(current, newDataSources));
     }
     catch (Exception e) {
       log.makeAlert(e, "Problem polling DB.").emit();


### PR DESCRIPTION
removeDataSource() currently checks a snapshot of dataSources and returns false if the target dataSource doesn't exist in the snapshot. However, SQLMetadataSegmentManager updates the snapshot by polling periodically, and thus it's possible that the target dataSource isn't in the snapshot but in the metadata store. removeSegment() has a similar issue. 
This patch fixes this issue. An unnecessary lock is also removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/druid-io/druid/5001)
<!-- Reviewable:end -->
