### PR TITLE
Update Avro to 1.8.0

### DIFF
--- a/extensions-contrib/parquet-extensions/pom.xml
+++ b/extensions-contrib/parquet-extensions/pom.xml
@@ -28,6 +28,11 @@
             <version>1.8.2</version>
         </dependency>
         <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <version>1.1.4</version>
+        </dependency>
+        <dependency>
             <groupId>io.druid</groupId>
             <artifactId>druid-indexing-hadoop</artifactId>
             <version>${project.parent.version}</version>

--- a/extensions-core/avro-extensions/pom.xml
+++ b/extensions-core/avro-extensions/pom.xml
@@ -37,7 +37,8 @@
   <properties>
     <schemarepo.version>0.1.3</schemarepo.version>
     <confluent.version>3.0.1</confluent.version>
-    <avro.version>1.7.7</avro.version>
+    <avro.version>1.8.0</avro.version>
+    <pig.version>0.15.0</pig.version>
   </properties>
 
   <repositories>
@@ -48,6 +49,11 @@
   </repositories>
 
   <dependencies>
+      <dependency>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro</artifactId>
+          <version>${avro.version}</version>
+      </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro-mapred</artifactId>
@@ -105,7 +111,7 @@
     <dependency>
       <groupId>org.apache.pig</groupId>
       <artifactId>pig</artifactId>
-      <version>0.15.0</version>
+      <version>${pig.version}</version>
       <classifier>h2</classifier>
       <scope>test</scope>
       <exclusions>
@@ -122,7 +128,7 @@
     <dependency>
       <groupId>org.apache.pig</groupId>
       <artifactId>piggybank</artifactId>
-      <version>0.15.0</version>
+      <version>${pig.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/extensions-core/avro-extensions/src/test/java/io/druid/data/input/AvroStreamInputRowParserTest.java
+++ b/extensions-core/avro-extensions/src/test/java/io/druid/data/input/AvroStreamInputRowParserTest.java
@@ -38,10 +38,10 @@ import io.druid.data.input.impl.TimestampSpec;
 import io.druid.data.input.schemarepo.Avro1124RESTRepositoryClientWrapper;
 import io.druid.data.input.schemarepo.Avro1124SubjectAndIdConverter;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumWriter;
 import org.joda.time.DateTime;
 import org.joda.time.chrono.ISOChronology;
 import org.junit.Before;
@@ -210,7 +210,7 @@ public class AvroStreamInputRowParserTest
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     out.write(byteBuffer.array());
     // encode data
-    DatumWriter<GenericRecord> writer = new GenericDatumWriter<GenericRecord>(someAvroDatum.getSchema());
+    DatumWriter<GenericRecord> writer = new SpecificDatumWriter<>(someAvroDatum.getSchema());
     // write avro datum to bytes
     writer.write(someAvroDatum, EncoderFactory.get().directBinaryEncoder(out, null));
 
@@ -251,7 +251,7 @@ public class AvroStreamInputRowParserTest
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     out.write(byteBuffer.array());
     // encode data
-    DatumWriter<GenericRecord> writer = new GenericDatumWriter<GenericRecord>(someAvroDatum.getSchema());
+    DatumWriter<GenericRecord> writer = new SpecificDatumWriter<>(someAvroDatum.getSchema());
     // write avro datum to bytes
     writer.write(someAvroDatum, EncoderFactory.get().directBinaryEncoder(out, null));
 
@@ -321,29 +321,27 @@ public class AvroStreamInputRowParserTest
     assertEquals(SOME_INT_VALUE, inputRow.getMetric("someInt"));
   }
 
-  public static GenericRecord buildSomeAvroDatum() throws IOException
+  public static SomeAvroDatum buildSomeAvroDatum() throws IOException
   {
-    SomeAvroDatum datum = SomeAvroDatum.newBuilder()
-                                       .setTimestamp(DATE_TIME.getMillis())
-                                       .setEventType(EVENT_TYPE_VALUE)
-                                       .setId(ID_VALUE)
-                                       .setSomeOtherId(SOME_OTHER_ID_VALUE)
-                                       .setIsValid(true)
-                                       .setSomeFloat(SOME_FLOAT_VALUE)
-                                       .setSomeInt(SOME_INT_VALUE)
-                                       .setSomeLong(SOME_LONG_VALUE)
-                                       .setSomeIntArray(SOME_INT_ARRAY_VALUE)
-                                       .setSomeStringArray(SOME_STRING_ARRAY_VALUE)
-                                       .setSomeIntValueMap(SOME_INT_VALUE_MAP_VALUE)
-                                       .setSomeStringValueMap(SOME_STRING_VALUE_MAP_VALUE)
-                                       .setSomeUnion(SOME_UNION_VALUE)
-                                       .setSomeFixed(SOME_FIXED_VALUE)
-                                       .setSomeBytes(SOME_BYTES_VALUE)
-                                       .setSomeNull(null)
-                                       .setSomeEnum(MyEnum.ENUM1)
-                                       .setSomeRecord(SOME_RECORD_VALUE)
-                                       .build();
-
-    return datum;
+    return SomeAvroDatum.newBuilder()
+                                   .setTimestamp(DATE_TIME.getMillis())
+                                   .setEventType(EVENT_TYPE_VALUE)
+                                   .setId(ID_VALUE)
+                                   .setSomeOtherId(SOME_OTHER_ID_VALUE)
+                                   .setIsValid(true)
+                                   .setSomeFloat(SOME_FLOAT_VALUE)
+                                   .setSomeInt(SOME_INT_VALUE)
+                                   .setSomeLong(SOME_LONG_VALUE)
+                                   .setSomeIntArray(SOME_INT_ARRAY_VALUE)
+                                   .setSomeStringArray(SOME_STRING_ARRAY_VALUE)
+                                   .setSomeIntValueMap(SOME_INT_VALUE_MAP_VALUE)
+                                   .setSomeStringValueMap(SOME_STRING_VALUE_MAP_VALUE)
+                                   .setSomeUnion(SOME_UNION_VALUE)
+                                   .setSomeFixed(SOME_FIXED_VALUE)
+                                   .setSomeBytes(SOME_BYTES_VALUE)
+                                   .setSomeNull(null)
+                                   .setSomeEnum(MyEnum.ENUM1)
+                                   .setSomeRecord(SOME_RECORD_VALUE)
+                                   .build();
   }
 }

--- a/extensions-core/avro-extensions/src/test/java/io/druid/data/input/avro/InlineSchemaAvroBytesDecoderTest.java
+++ b/extensions-core/avro-extensions/src/test/java/io/druid/data/input/avro/InlineSchemaAvroBytesDecoderTest.java
@@ -25,10 +25,10 @@ import io.druid.data.input.AvroStreamInputRowParserTest;
 import io.druid.data.input.SomeAvroDatum;
 import io.druid.jackson.DefaultObjectMapper;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumWriter;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -81,7 +81,7 @@ public class InlineSchemaAvroBytesDecoderTest
 
     ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-    DatumWriter<GenericRecord> writer = new GenericDatumWriter<GenericRecord>(schema);
+    DatumWriter<GenericRecord> writer = new SpecificDatumWriter<>(schema);
     writer.write(someAvroDatum, EncoderFactory.get().directBinaryEncoder(out, null));
 
     GenericRecord actual = new InlineSchemaAvroBytesDecoder(schema).parse(ByteBuffer.wrap(out.toByteArray()));

--- a/extensions-core/avro-extensions/src/test/java/io/druid/data/input/avro/InlineSchemasAvroBytesDecoderTest.java
+++ b/extensions-core/avro-extensions/src/test/java/io/druid/data/input/avro/InlineSchemasAvroBytesDecoderTest.java
@@ -26,10 +26,10 @@ import io.druid.data.input.AvroStreamInputRowParserTest;
 import io.druid.data.input.SomeAvroDatum;
 import io.druid.jackson.DefaultObjectMapper;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumWriter;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -95,7 +95,7 @@ public class InlineSchemasAvroBytesDecoderTest
 
     out.write(new byte[]{1});
     out.write(ByteBuffer.allocate(4).putInt(10).array());
-    DatumWriter<GenericRecord> writer = new GenericDatumWriter<GenericRecord>(schema);
+    DatumWriter<GenericRecord> writer = new SpecificDatumWriter<>(schema);
     writer.write(someAvroDatum, EncoderFactory.get().directBinaryEncoder(out, null));
 
     GenericRecord actual = new InlineSchemasAvroBytesDecoder(

--- a/extensions-core/avro-extensions/src/test/java/io/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoderTest.java
+++ b/extensions-core/avro-extensions/src/test/java/io/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoderTest.java
@@ -24,10 +24,10 @@ import io.druid.data.input.AvroStreamInputRowParserTest;
 import io.druid.data.input.SomeAvroDatum;
 import io.druid.java.util.common.parsers.ParseException;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumWriter;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -99,7 +99,7 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
   byte[] getAvroDatum(Schema schema, GenericRecord someAvroDatum) throws IOException
   {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
-    DatumWriter<GenericRecord> writer = new GenericDatumWriter<GenericRecord>(schema);
+    DatumWriter<GenericRecord> writer = new SpecificDatumWriter<>(schema);
     writer.write(someAvroDatum, EncoderFactory.get().directBinaryEncoder(out, null));
     return out.toByteArray();
   }


### PR DESCRIPTION
Hi guys,

Since we've updated in our Parquet contrib extension from Parquet 1.8.1 to 1.8.2, the dependancy on Avro updated from 1.7.6 to 1.8.0:
https://mvnrepository.com/artifact/org.apache.parquet/parquet-avro/1.8.1
https://mvnrepository.com/artifact/org.apache.parquet/parquet-avro/1.8.2

Avro changelog: https://github.com/apache/avro/blob/master/CHANGES.txt#L274

Therefore I would like to update the Avro extension from 1.7.7 to 1.8.0 to get to the same version. We've deployed 0.10.1 on our acceptance servers and we ran into these classpath issues.

I had to rewrite the Generic writers to the specific ones because due to a bug in the Generic writer:
https://issues.apache.org/jira/browse/AVRO-1810
This should not impact Druid itself, since it only affects testcode.

Cheers, Fokko

