### PR TITLE
Revert Parquet-avro to 1.8.1

### DIFF
--- a/extensions-contrib/parquet-extensions/pom.xml
+++ b/extensions-contrib/parquet-extensions/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-avro</artifactId>
-            <version>1.8.2</version>
+            <version>1.8.1</version>
         </dependency>
         <dependency>
             <groupId>io.druid</groupId>


### PR DESCRIPTION
Hi @gianm @leventov 

I've updated Parquet-avro to 1.8.2 quite a while ago:
https://github.com/druid-io/druid/commit/13143f9376aefb8f55595a1de938418b1634ddbf

But, parquet-avro 1.8.2 updates the Avro dependancy to Avro 1.8.x. This is incompatible with the currenct version of druid-avro. Therefore we should revert parquet-avro to 1.8.1 and update druid-avro with the parquet extension together. We've deployed it on our acceptance cluster and we run into Avro classpath problems because we have 1.7 from druid-avro and 1.8 from druid-parquet.

I've started on moving to Avro 1.8.0 in another PR:
https://github.com/druid-io/druid/pull/5015

It would be awesome to revert to 1.8.1 for the 0.11.0 release, and move to Avro 1.8.x in both druid-parquet and druid-avro in a later release, since 0.11.0 is about to released.

Cheers, Fokko