### PR TITLE
SQL: Avoid using timeseries with "having" clauses.

### DIFF
--- a/sql/src/main/java/io/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/io/druid/sql/calcite/rel/DruidQuery.java
@@ -642,7 +642,7 @@ public class DruidQuery
   @Nullable
   public TimeseriesQuery toTimeseriesQuery()
   {
-    if (grouping == null) {
+    if (grouping == null || grouping.getHavingFilter() != null) {
       return null;
     }
 

--- a/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
@@ -1048,6 +1048,27 @@ public class CalciteQueryTest
   }
 
   @Test
+  public void testHavingOnGrandTotal() throws Exception
+  {
+    testQuery(
+        "SELECT SUM(m1) AS m1_sum FROM foo HAVING m1_sum = 21",
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(CalciteTests.DATASOURCE1)
+                        .setInterval(QSS(Filtration.eternity()))
+                        .setGranularity(Granularities.ALL)
+                        .setAggregatorSpecs(AGGS(new DoubleSumAggregatorFactory("a0", "m1")))
+                        .setHavingSpec(new DimFilterHavingSpec(NUMERIC_SELECTOR("a0", "21", null)))
+                        .setContext(QUERY_CONTEXT_DEFAULT)
+                        .build()
+        ),
+        ImmutableList.of(
+            new Object[]{21d}
+        )
+    );
+  }
+
+  @Test
   public void testHavingOnDoubleSum() throws Exception
   {
     testQuery(


### PR DESCRIPTION
Timeseries cannot do "having" filters, so avoid using them in that case. We should
use a groupBy instead.