### PR TITLE
Fix improper rounding of ORC decimals.

### DIFF
--- a/extensions-contrib/orc-extensions/src/main/java/io/druid/data/input/orc/OrcHadoopInputRowParser.java
+++ b/extensions-contrib/orc-extensions/src/main/java/io/druid/data/input/orc/OrcHadoopInputRowParser.java
@@ -32,10 +32,10 @@ import io.druid.data.input.impl.ParseSpec;
 import io.druid.data.input.impl.TimestampSpec;
 import io.druid.java.util.common.StringUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.ql.io.orc.OrcSerde;
 import org.apache.hadoop.hive.ql.io.orc.OrcStruct;
 import org.apache.hadoop.hive.serde2.SerDeException;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
@@ -51,14 +51,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 public class OrcHadoopInputRowParser implements InputRowParser<OrcStruct>
 {
   private final ParseSpec parseSpec;
-  private String typeString;
+  private final String typeString;
   private final List<String> dimensions;
-  private StructObjectInspector oip;
-  private final OrcSerde serde;
+  private final StructObjectInspector oip;
 
   @JsonCreator
   public OrcHadoopInputRowParser(
@@ -67,10 +67,9 @@ public class OrcHadoopInputRowParser implements InputRowParser<OrcStruct>
   )
   {
     this.parseSpec = parseSpec;
-    this.typeString = typeString;
+    this.typeString = typeString == null ? typeStringFromParseSpec(parseSpec) : typeString;
     this.dimensions = parseSpec.getDimensionsSpec().getDimensionNames();
-    this.serde = new OrcSerde();
-    initialize();
+    this.oip = makeObjectInspector(this.typeString);
   }
 
   @SuppressWarnings("ArgumentParameterSwap")
@@ -87,7 +86,8 @@ public class OrcHadoopInputRowParser implements InputRowParser<OrcStruct>
           map.put(
               field.getFieldName(),
               coercePrimitiveObject(
-                  primitiveObjectInspector.getPrimitiveJavaObject(oip.getStructFieldData(input, field))
+                  primitiveObjectInspector,
+                  oip.getStructFieldData(input, field)
               )
           );
           break;
@@ -109,46 +109,20 @@ public class OrcHadoopInputRowParser implements InputRowParser<OrcStruct>
     return new MapBasedInputRow(dateTime, dimensions, map);
   }
 
-  private void initialize()
-  {
-    if (typeString == null) {
-      typeString = typeStringFromParseSpec(parseSpec);
-    }
-    TypeInfo typeInfo = TypeInfoUtils.getTypeInfoFromTypeString(typeString);
-    Preconditions.checkArgument(
-        typeInfo instanceof StructTypeInfo,
-        StringUtils.format("typeString should be struct type but not [%s]", typeString)
-    );
-    Properties table = getTablePropertiesFromStructTypeInfo((StructTypeInfo) typeInfo);
-    serde.initialize(new Configuration(), table);
-    try {
-      oip = (StructObjectInspector) serde.getObjectInspector();
-    }
-    catch (SerDeException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
   private List getListObject(ListObjectInspector listObjectInspector, Object listObject)
   {
     if (listObjectInspector.getListLength(listObject) < 0) {
       return null;
     }
-    List objectList = listObjectInspector.getList(listObject);
-    List list = null;
+    List<?> objectList = listObjectInspector.getList(listObject);
+    List<?> list = null;
     ObjectInspector child = listObjectInspector.getListElementObjectInspector();
     switch (child.getCategory()) {
       case PRIMITIVE:
         final PrimitiveObjectInspector primitiveObjectInspector = (PrimitiveObjectInspector) child;
-        list = Lists.transform(objectList, new Function()
-        {
-          @Nullable
-          @Override
-          public Object apply(@Nullable Object input)
-          {
-            return coercePrimitiveObject(primitiveObjectInspector.getPrimitiveJavaObject(input));
-          }
-        });
+        list = objectList.stream()
+                         .map(input -> coercePrimitiveObject(primitiveObjectInspector, input))
+                         .collect(Collectors.toList());
         break;
       default:
         break;
@@ -220,12 +194,32 @@ public class OrcHadoopInputRowParser implements InputRowParser<OrcStruct>
     return builder.toString();
   }
 
-  private static Object coercePrimitiveObject(final Object object)
+  private static Object coercePrimitiveObject(final PrimitiveObjectInspector inspector, final Object object)
   {
-    if (object instanceof HiveDecimal) {
-      return ((HiveDecimal) object).doubleValue();
+    if (object instanceof HiveDecimalWritable) {
+      // inspector on HiveDecimal rounds off to integer for some reason.
+      return ((HiveDecimalWritable) object).getHiveDecimal().doubleValue();
     } else {
-      return object;
+      return inspector.getPrimitiveJavaObject(object);
+    }
+  }
+
+  private static StructObjectInspector makeObjectInspector(final String typeString)
+  {
+    final OrcSerde serde = new OrcSerde();
+
+    TypeInfo typeInfo = TypeInfoUtils.getTypeInfoFromTypeString(typeString);
+    Preconditions.checkArgument(
+        typeInfo instanceof StructTypeInfo,
+        StringUtils.format("typeString should be struct type but not [%s]", typeString)
+    );
+    Properties table = getTablePropertiesFromStructTypeInfo((StructTypeInfo) typeInfo);
+    serde.initialize(new Configuration(), table);
+    try {
+      return (StructObjectInspector) serde.getObjectInspector();
+    }
+    catch (SerDeException e) {
+      throw new RuntimeException(e);
     }
   }
 

--- a/extensions-contrib/orc-extensions/src/test/java/io/druid/data/input/orc/OrcHadoopInputRowParserTest.java
+++ b/extensions-contrib/orc-extensions/src/test/java/io/druid/data/input/orc/OrcHadoopInputRowParserTest.java
@@ -37,6 +37,7 @@ import io.druid.guice.GuiceInjectors;
 import io.druid.initialization.Initialization;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.DateTimes;
+import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.ql.io.orc.OrcStruct;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.SettableStructObjectInspector;
@@ -49,6 +50,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 
 public class OrcHadoopInputRowParserTest
 {
@@ -161,18 +163,22 @@ public class OrcHadoopInputRowParserTest
     oi.setStructFieldData(struct, oi.getStructFieldRef("timestamp"), new Text("2000-01-01"));
     oi.setStructFieldData(struct, oi.getStructFieldRef("col1"), new Text("foo"));
     oi.setStructFieldData(struct, oi.getStructFieldRef("col2"), ImmutableList.of(new Text("foo"), new Text("bar")));
-    oi.setStructFieldData(struct, oi.getStructFieldRef("col3"), new FloatWritable(1));
+    oi.setStructFieldData(struct, oi.getStructFieldRef("col3"), new FloatWritable(1.5f));
     oi.setStructFieldData(struct, oi.getStructFieldRef("col4"), new LongWritable(2));
-    oi.setStructFieldData(struct, oi.getStructFieldRef("col5"), new HiveDecimalWritable(3));
+    oi.setStructFieldData(
+        struct,
+        oi.getStructFieldRef("col5"),
+        new HiveDecimalWritable(HiveDecimal.create(BigDecimal.valueOf(3.5d)))
+    );
     oi.setStructFieldData(struct, oi.getStructFieldRef("col6"), null);
 
     final InputRow row = parser.parse(struct);
     Assert.assertEquals("timestamp", DateTimes.of("2000-01-01"), row.getTimestamp());
     Assert.assertEquals("col1", "foo", row.getRaw("col1"));
     Assert.assertEquals("col2", ImmutableList.of("foo", "bar"), row.getRaw("col2"));
-    Assert.assertEquals("col3", 1.0f, row.getRaw("col3"));
+    Assert.assertEquals("col3", 1.5f, row.getRaw("col3"));
     Assert.assertEquals("col4", 2L, row.getRaw("col4"));
-    Assert.assertEquals("col5", 3.0d, row.getRaw("col5"));
+    Assert.assertEquals("col5", 3.5d, row.getRaw("col5"));
     Assert.assertNull("col6", row.getRaw("col6"));
   }
 }


### PR DESCRIPTION
For some reason, using the primitive object inspector on a HiveDecimal yields a rounded number. This patch adjusts the ORC parser so instead we treat it as a double at the highest fidelity possible, and adjusts the test to use a non-integer value.

The patch also slightly reorganizes the OrcHadoopInputRowParser code so some more fields can be final.