### PR TITLE
Fix coordinator->overlord proxy auth failure

### DIFF
--- a/integration-tests/src/main/java/io/druid/testing/clients/CoordinatorResourceTestClient.java
+++ b/integration-tests/src/main/java/io/druid/testing/clients/CoordinatorResourceTestClient.java
@@ -29,6 +29,7 @@ import com.metamx.http.client.Request;
 import com.metamx.http.client.response.StatusResponseHandler;
 import com.metamx.http.client.response.StatusResponseHolder;
 import io.druid.java.util.common.ISE;
+import io.druid.java.util.common.RE;
 import io.druid.java.util.common.StringUtils;
 import io.druid.testing.IntegrationTestingConfig;
 import io.druid.testing.guice.TestClient;
@@ -168,7 +169,7 @@ public class CoordinatorResourceTestClient
       return response.getStatus();
     }
     catch (Exception e) {
-      throw Throwables.propagate(e);
+      throw new RE(e, "Unable to get scaling status from [%s]", coordinator);
     }
   }
 

--- a/integration-tests/src/main/java/io/druid/testing/clients/CoordinatorResourceTestClient.java
+++ b/integration-tests/src/main/java/io/druid/testing/clients/CoordinatorResourceTestClient.java
@@ -155,6 +155,23 @@ public class CoordinatorResourceTestClient
     }
   }
 
+  public HttpResponseStatus getProxiedOverlordScalingResponseStatus()
+  {
+    try {
+      StatusResponseHolder response = makeRequest(
+          HttpMethod.GET,
+          StringUtils.format(
+              "%s/druid/indexer/v1/scaling",
+              coordinator
+          )
+      );
+      return response.getStatus();
+    }
+    catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
   private StatusResponseHolder makeRequest(HttpMethod method, String url)
   {
     try {

--- a/integration-tests/src/test/java/io/druid/tests/security/ITCoordinatorOverlordProxyAuthTest.java
+++ b/integration-tests/src/test/java/io/druid/tests/security/ITCoordinatorOverlordProxyAuthTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.tests.security;
+
+import com.google.inject.Inject;
+import io.druid.testing.clients.CoordinatorResourceTestClient;
+import io.druid.testing.guice.DruidTestModuleFactory;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.testng.Assert;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+@Guice(moduleFactory = DruidTestModuleFactory.class)
+public class ITCoordinatorOverlordProxyAuthTest
+{
+  @Inject
+  CoordinatorResourceTestClient coordinatorClient;
+  
+  @Test
+  public void testProxyAuth() throws Exception
+  {
+    HttpResponseStatus responseStatus = coordinatorClient.getProxiedOverlordScalingResponseStatus();
+    Assert.assertEquals(HttpResponseStatus.OK, responseStatus);
+  }
+}


### PR DESCRIPTION
Fixes #5038 

This sets "authorization checked=true"  on the original client request for coordinator->overlord proxied requests.