### PR TITLE
Fix Router race condition and use default broker service name for invalid priority

### DIFF
--- a/.idea/inspectionProfiles/Druid.xml
+++ b/.idea/inspectionProfiles/Druid.xml
@@ -106,9 +106,6 @@
     <inspection_tool class="SuspiciousNameCombination" enabled="true" level="ERROR" enabled_by_default="true">
       <group names="x,width,left,right" />
       <group names="y,height,top,bottom" />
-      <ignored>
-        <option name="METHOD_MATCHER_CONFIG" value="java.io.PrintStream,println,java.io.PrintWriter,println,java.lang.System,identityHashCode,java.sql.PreparedStatement,set.*,java.sql.ResultSet,update.*,java.sql.SQLOutput,write.*,java.lang.Integer,compare.*,java.lang.Long,compare.*,java.lang.Short,compare,java.lang.Byte,compare,java.lang.Character,compare,java.lang.Boolean,compare,java.lang.Math,.*,java.lang.StrictMath,.*" />
-      </ignored>
     </inspection_tool>
     <inspection_tool class="SuspiciousSystemArraycopy" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="SuspiciousToArrayCall" enabled="true" level="ERROR" enabled_by_default="true" />
@@ -119,10 +116,8 @@
     <inspection_tool class="UnnecessaryFullyQualifiedName" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="NonGeneratedFiles" level="ERROR" enabled="true">
         <option name="m_ignoreJavadoc" value="true" />
-        <option name="ignoreInModuleStatements" value="true" />
       </scope>
       <option name="m_ignoreJavadoc" value="true" />
-      <option name="ignoreInModuleStatements" value="true" />
     </inspection_tool>
     <inspection_tool class="UnnecessaryInterfaceModifier" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="UseOfPropertiesAsHashtable" enabled="true" level="WARNING" enabled_by_default="true" />

--- a/.idea/inspectionProfiles/Druid.xml
+++ b/.idea/inspectionProfiles/Druid.xml
@@ -106,6 +106,9 @@
     <inspection_tool class="SuspiciousNameCombination" enabled="true" level="ERROR" enabled_by_default="true">
       <group names="x,width,left,right" />
       <group names="y,height,top,bottom" />
+      <ignored>
+        <option name="METHOD_MATCHER_CONFIG" value="java.io.PrintStream,println,java.io.PrintWriter,println,java.lang.System,identityHashCode,java.sql.PreparedStatement,set.*,java.sql.ResultSet,update.*,java.sql.SQLOutput,write.*,java.lang.Integer,compare.*,java.lang.Long,compare.*,java.lang.Short,compare,java.lang.Byte,compare,java.lang.Character,compare,java.lang.Boolean,compare,java.lang.Math,.*,java.lang.StrictMath,.*" />
+      </ignored>
     </inspection_tool>
     <inspection_tool class="SuspiciousSystemArraycopy" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="SuspiciousToArrayCall" enabled="true" level="ERROR" enabled_by_default="true" />
@@ -116,8 +119,10 @@
     <inspection_tool class="UnnecessaryFullyQualifiedName" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="NonGeneratedFiles" level="ERROR" enabled="true">
         <option name="m_ignoreJavadoc" value="true" />
+        <option name="ignoreInModuleStatements" value="true" />
       </scope>
       <option name="m_ignoreJavadoc" value="true" />
+      <option name="ignoreInModuleStatements" value="true" />
     </inspection_tool>
     <inspection_tool class="UnnecessaryInterfaceModifier" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="UseOfPropertiesAsHashtable" enabled="true" level="WARNING" enabled_by_default="true" />

--- a/server/src/main/java/io/druid/server/router/PriorityTieredBrokerSelectorStrategy.java
+++ b/server/src/main/java/io/druid/server/router/PriorityTieredBrokerSelectorStrategy.java
@@ -50,18 +50,10 @@ public class PriorityTieredBrokerSelectorStrategy implements TieredBrokerSelecto
 
     if (priority < minPriority) {
       return Optional.of(
-          Iterables.getLast(
-              tierConfig.getTierToBrokerMap().values(),
-              tierConfig.getDefaultBrokerServiceName()
-          )
+          tierConfig.getDefaultBrokerServiceName()
       );
     } else if (priority >= maxPriority) {
-      return Optional.of(
-          Iterables.getFirst(
-              tierConfig.getTierToBrokerMap().values(),
-              tierConfig.getDefaultBrokerServiceName()
-          )
-      );
+      return Optional.of(tierConfig.getDefaultBrokerServiceName());
     }
 
     return Optional.absent();

--- a/server/src/main/java/io/druid/server/router/PriorityTieredBrokerSelectorStrategy.java
+++ b/server/src/main/java/io/druid/server/router/PriorityTieredBrokerSelectorStrategy.java
@@ -22,7 +22,6 @@ package io.druid.server.router;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
-import com.google.common.collect.Iterables;
 import io.druid.query.Query;
 import io.druid.query.QueryContexts;
 

--- a/server/src/main/java/io/druid/server/router/PriorityTieredBrokerSelectorStrategy.java
+++ b/server/src/main/java/io/druid/server/router/PriorityTieredBrokerSelectorStrategy.java
@@ -47,12 +47,10 @@ public class PriorityTieredBrokerSelectorStrategy implements TieredBrokerSelecto
   {
     final int priority = QueryContexts.getPriority(query);
 
-    if (priority < minPriority) {
+    if (priority < minPriority || priority > maxPriority) {
       return Optional.of(
           tierConfig.getDefaultBrokerServiceName()
       );
-    } else if (priority >= maxPriority) {
-      return Optional.of(tierConfig.getDefaultBrokerServiceName());
     }
 
     return Optional.absent();

--- a/server/src/main/java/io/druid/server/router/TieredBrokerHostSelector.java
+++ b/server/src/main/java/io/druid/server/router/TieredBrokerHostSelector.java
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  */
@@ -277,7 +278,7 @@ public class TieredBrokerHostSelector<T>
 
   private static class NodesHolder
   {
-    private int roundRobinIndex = 0;
+    private AtomicInteger roundRobinIndex = new AtomicInteger(0);
 
     private Map<String, Server> nodesMap = new HashMap<>();
     private ImmutableList<Server> nodes = ImmutableList.of();
@@ -308,15 +309,15 @@ public class TieredBrokerHostSelector<T>
     {
       ImmutableList<Server> currNodes = nodes;
 
+      int index = roundRobinIndex.getAndIncrement();
+
       if (currNodes.size() == 0) {
         return null;
       }
 
-      if (roundRobinIndex >= currNodes.size()) {
-        roundRobinIndex %= currNodes.size();
-      }
+      index %= currNodes.size();
 
-      return currNodes.get(roundRobinIndex++);
+      return currNodes.get(index);
     }
   }
 }

--- a/server/src/main/java/io/druid/server/router/TieredBrokerHostSelector.java
+++ b/server/src/main/java/io/druid/server/router/TieredBrokerHostSelector.java
@@ -278,7 +278,7 @@ public class TieredBrokerHostSelector<T>
 
   private static class NodesHolder
   {
-    private AtomicInteger roundRobinIndex = new AtomicInteger(0);
+    private AtomicInteger roundRobinIndex = new AtomicInteger(-1);
 
     private Map<String, Server> nodesMap = new HashMap<>();
     private ImmutableList<Server> nodes = ImmutableList.of();
@@ -314,21 +314,20 @@ public class TieredBrokerHostSelector<T>
       }
 
       int index = roundRobinIndex.get();
+      int nextIndex = index + 1;
 
       while (true) {
-        int nextIndex = index + 1;
-        if (nextIndex < 0) {
-          nextIndex %= currNodes.size();
+        if (nextIndex < 0 || nextIndex >= currNodes.size()) {
+          nextIndex = 0;
         }
         if (roundRobinIndex.compareAndSet(index, nextIndex)) {
           break;
         }
         index = roundRobinIndex.get();
+        nextIndex = index + 1;
       }
 
-      index %= currNodes.size();
-
-      return currNodes.get(index);
+      return currNodes.get(nextIndex);
     }
   }
 }

--- a/server/src/main/java/io/druid/server/router/TieredBrokerHostSelector.java
+++ b/server/src/main/java/io/druid/server/router/TieredBrokerHostSelector.java
@@ -317,10 +317,12 @@ public class TieredBrokerHostSelector<T>
 
       while (true) {
         int nextIndex = index + 1;
-        if (nextIndex >= currNodes.size()) nextIndex = 0;
+        if (nextIndex < 0) nextIndex %= currNodes.size();
         if (roundRobinIndex.compareAndSet(index, nextIndex)) break;
         index = roundRobinIndex.get();
       }
+
+      index %= currNodes.size();
 
       return currNodes.get(index);
     }

--- a/server/src/main/java/io/druid/server/router/TieredBrokerHostSelector.java
+++ b/server/src/main/java/io/druid/server/router/TieredBrokerHostSelector.java
@@ -309,13 +309,18 @@ public class TieredBrokerHostSelector<T>
     {
       ImmutableList<Server> currNodes = nodes;
 
-      int index = roundRobinIndex.getAndIncrement();
-
       if (currNodes.size() == 0) {
         return null;
       }
 
-      index %= currNodes.size();
+      int index = roundRobinIndex.get();
+
+      while (true) {
+        int nextIndex = index + 1;
+        if (nextIndex >= currNodes.size()) nextIndex = 0;
+        if (roundRobinIndex.compareAndSet(index, nextIndex)) break;
+        index = roundRobinIndex.get();
+      }
 
       return currNodes.get(index);
     }

--- a/server/src/main/java/io/druid/server/router/TieredBrokerHostSelector.java
+++ b/server/src/main/java/io/druid/server/router/TieredBrokerHostSelector.java
@@ -313,21 +313,21 @@ public class TieredBrokerHostSelector<T>
         return null;
       }
 
-      int index = roundRobinIndex.get();
-      int nextIndex = index + 1;
+      return currNodes.get(getIndex(currNodes));
+    }
 
+    int getIndex(ImmutableList<Server> currNodes)
+    {
       while (true) {
-        if (nextIndex < 0 || nextIndex >= currNodes.size()) {
+        int index = roundRobinIndex.get();
+        int nextIndex = index + 1;
+        if (nextIndex >= currNodes.size()) {
           nextIndex = 0;
         }
         if (roundRobinIndex.compareAndSet(index, nextIndex)) {
-          break;
+          return nextIndex;
         }
-        index = roundRobinIndex.get();
-        nextIndex = index + 1;
       }
-
-      return currNodes.get(nextIndex);
     }
   }
 }

--- a/server/src/main/java/io/druid/server/router/TieredBrokerHostSelector.java
+++ b/server/src/main/java/io/druid/server/router/TieredBrokerHostSelector.java
@@ -317,8 +317,12 @@ public class TieredBrokerHostSelector<T>
 
       while (true) {
         int nextIndex = index + 1;
-        if (nextIndex < 0) nextIndex %= currNodes.size();
-        if (roundRobinIndex.compareAndSet(index, nextIndex)) break;
+        if (nextIndex < 0) {
+          nextIndex %= currNodes.size();
+        }
+        if (roundRobinIndex.compareAndSet(index, nextIndex)) {
+          break;
+        }
         index = roundRobinIndex.get();
       }
 

--- a/server/src/test/java/io/druid/server/router/TieredBrokerHostSelectorTest.java
+++ b/server/src/test/java/io/druid/server/router/TieredBrokerHostSelectorTest.java
@@ -265,7 +265,7 @@ public class TieredBrokerHostSelectorTest
               .build()
     ).lhs;
 
-    Assert.assertEquals("coldBroker", brokerName);
+    Assert.assertEquals("hotBroker", brokerName);
   }
 
   @Test


### PR DESCRIPTION
This PR suggests two changes:

1) I believe there's a race condition in `TieredBrokerHostSelector`, specifically in `NodeHolder.pick()` where multiple threads can access `roundRobinIndex`. For example, two threads can simultaneously access `roundRobinIndex` when `roundRobinIndex  == currNodes.size() - 1`, but then one of the threads will get index out of bounds error when calling `currNodes.get(roundRobinIndex++)` because the other thread had increased the value of `roundRobinIndex` by 1 already. I have encountered this situation in production, for example:
```
 WARN [qtp658824366-145] o.e.j.s.ServletHandler - /druid/v2/ - []
java.lang.IndexOutOfBoundsException: index (x) must be less than size (x)
    at com.google.common.base.Preconditions.checkElementIndex(Preconditions.java:313) ~[guava-16.0.1.jar:?]
    at com.google.common.base.Preconditions.checkElementIndex(Preconditions.java:295) ~[guava-16.0.1.jar:?]
    at com.google.common.collect.RegularImmutableList.get(RegularImmutableList.java:65) ~[guava-16.0.1.jar:?]
    at io.druid.server.router.TieredBrokerHostSelector$NodesHolder.pick(TieredBrokerHostSelector.java:319) ~[druid-server-0.11.0-mmx19.jar:0.11.0-mmx19]
    at io.druid.server.router.TieredBrokerHostSelector.getDefaultLookup(TieredBrokerHostSelector.java:260) ~[druid-server-0.11.0-mmx19.jar:0.11.0-mmx19]
    at io.druid.server.router.QueryHostFinder.findDefaultServer(QueryHostFinder.java:60) ~[druid-server-0.11.0-mmx19.jar:0.11.0-mmx19]
    at io.druid.server.router.QueryHostFinder.getDefaultServer(QueryHostFinder.java:90) ~[druid-server-0.11.0-mmx19.jar:0.11.0-mmx19]
    at io.druid.server.AsyncQueryForwardingServlet.service(AsyncQueryForwardingServlet.java:180) ~[druid-server-0.11.0-mmx19.jar:0.11.0-mmx19]
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:790) ~[javax.servlet-api-3.1.0.jar:3.1.0]
```

2) I think it might make more sense to use `DefaultBrokerServiceName` instead of the last value of `tierToBrokerMap` when the priority is out of range, as I understand that the default value is the one that's used whenever there's no specific broker service name for the given query. What is the reason behind using the last entry of `tierToBrokerMap` when the priority is out of range? 