### PR TITLE
Using ImmutableDruidDataSource as a key for map and set instead of DruidDataSource

### DIFF
--- a/indexing-hadoop/src/test/java/io/druid/indexer/updater/HadoopConverterJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/updater/HadoopConverterJobTest.java
@@ -27,7 +27,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.io.ByteSource;
 import com.google.common.io.Files;
-import io.druid.client.DruidDataSource;
+import io.druid.client.ImmutableDruidDataSource;
 import io.druid.data.input.impl.DelimitedParseSpec;
 import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.data.input.impl.StringInputRowParser;
@@ -263,7 +263,7 @@ public class HadoopConverterJobTest
       Thread.sleep(10);
     }
     manager.poll();
-    final DruidDataSource druidDataSource = manager.getInventoryValue(DATASOURCE);
+    final ImmutableDruidDataSource druidDataSource = manager.getInventoryValue(DATASOURCE);
     manager.stop();
     return Lists.newArrayList(druidDataSource.getSegments());
   }

--- a/indexing-service/src/test/java/io/druid/indexing/test/TestServerView.java
+++ b/indexing-service/src/test/java/io/druid/indexing/test/TestServerView.java
@@ -27,6 +27,7 @@ import io.druid.java.util.common.Pair;
 import io.druid.server.coordination.DruidServerMetadata;
 import io.druid.timeline.DataSegment;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -126,7 +127,7 @@ public class TestServerView implements FilteredServerInventoryView, ServerView.S
   }
 
   @Override
-  public Iterable<DruidServer> getInventory()
+  public Collection<DruidServer> getInventory()
   {
     return null;
   }

--- a/server/src/main/java/io/druid/client/AbstractCuratorServerInventoryView.java
+++ b/server/src/main/java/io/druid/client/AbstractCuratorServerInventoryView.java
@@ -36,6 +36,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.utils.ZKPaths;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -204,7 +205,7 @@ public abstract class AbstractCuratorServerInventoryView<InventoryType> implemen
   }
 
   @Override
-  public Iterable<DruidServer> getInventory()
+  public Collection<DruidServer> getInventory()
   {
     return inventoryManager.getInventory();
   }
@@ -282,7 +283,7 @@ public abstract class AbstractCuratorServerInventoryView<InventoryType> implemen
       return;
     }
 
-    container.addDataSegment(inventory.getIdentifier(), inventory);
+    container.addDataSegment(inventory);
 
     runSegmentCallbacks(
         new Function<SegmentCallback, CallbackAction>()

--- a/server/src/main/java/io/druid/client/CoordinatorServerView.java
+++ b/server/src/main/java/io/druid/client/CoordinatorServerView.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.inject.Inject;
-
 import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.query.DataSource;
@@ -32,6 +31,7 @@ import io.druid.timeline.DataSegment;
 import io.druid.timeline.VersionedIntervalTimeline;
 import io.druid.timeline.partition.PartitionChunk;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
@@ -203,7 +203,7 @@ public class CoordinatorServerView implements InventoryView
   }
 
   @Override
-  public Iterable<DruidServer> getInventory()
+  public Collection<DruidServer> getInventory()
   {
     return baseView.getInventory();
   }

--- a/server/src/main/java/io/druid/client/DruidDataSource.java
+++ b/server/src/main/java/io/druid/client/DruidDataSource.java
@@ -70,12 +70,6 @@ public class DruidDataSource
     return this;
   }
 
-  public DruidDataSource addSegments(Map<String, DataSegment> partitionMap)
-  {
-    idToSegmentMap.putAll(partitionMap);
-    return this;
-  }
-
   public DruidDataSource removePartition(String segmentId)
   {
     idToSegmentMap.remove(segmentId);

--- a/server/src/main/java/io/druid/client/DruidDataSource.java
+++ b/server/src/main/java/io/druid/client/DruidDataSource.java
@@ -20,10 +20,12 @@
 package io.druid.client;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import io.druid.timeline.DataSegment;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -40,7 +42,7 @@ public class DruidDataSource
       Map<String, String> properties
   )
   {
-    this.name = name;
+    this.name = Preconditions.checkNotNull(name);
     this.properties = properties;
     this.idToSegmentMap = new ConcurrentHashMap<>();
   }
@@ -59,7 +61,7 @@ public class DruidDataSource
 
   public Collection<DataSegment> getSegments()
   {
-    return idToSegmentMap.values();
+    return Collections.unmodifiableCollection(idToSegmentMap.values());
   }
 
   public DruidDataSource addSegment(DataSegment dataSegment)
@@ -104,7 +106,7 @@ public class DruidDataSource
   {
     return "DruidDataSource{" +
            "properties=" + properties +
-           ", partitions=" + getSegments().toString() +
+           ", partitions=" + idToSegmentMap.values() +
            '}';
   }
 

--- a/server/src/main/java/io/druid/client/DruidServer.java
+++ b/server/src/main/java/io/druid/client/DruidServer.java
@@ -24,13 +24,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-
 import io.druid.java.util.common.logger.Logger;
 import io.druid.server.DruidNode;
 import io.druid.server.coordination.DruidServerMetadata;
 import io.druid.server.coordination.ServerType;
 import io.druid.timeline.DataSegment;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -167,9 +167,10 @@ public class DruidServer implements Comparable
     return segments.get(segmentName);
   }
 
-  public DruidServer addDataSegment(String segmentId, DataSegment segment)
+  public DruidServer addDataSegment(DataSegment segment)
   {
     synchronized (lock) {
+      final String segmentId = segment.getIdentifier();
       DataSegment shouldNotExist = segments.get(segmentId);
 
       if (shouldNotExist != null) {
@@ -188,7 +189,7 @@ public class DruidServer implements Comparable
         dataSources.put(dataSourceName, dataSource);
       }
 
-      dataSource.addSegment(segmentId, segment);
+      dataSource.addSegment(segment);
 
       segments.put(segmentId, segment);
       currSize += segment.getSize();
@@ -199,9 +200,7 @@ public class DruidServer implements Comparable
   public DruidServer addDataSegments(DruidServer server)
   {
     synchronized (lock) {
-      for (Map.Entry<String, DataSegment> entry : server.segments.entrySet()) {
-        addDataSegment(entry.getKey(), entry.getValue());
-      }
+      server.segments.values().forEach(this::addDataSegment);
     }
     return this;
   }
@@ -246,7 +245,7 @@ public class DruidServer implements Comparable
     return dataSources.get(dataSource);
   }
 
-  public Iterable<DruidDataSource> getDataSources()
+  public Collection<DruidDataSource> getDataSources()
   {
     return dataSources.values();
   }

--- a/server/src/main/java/io/druid/client/DruidServer.java
+++ b/server/src/main/java/io/druid/client/DruidServer.java
@@ -271,7 +271,7 @@ public class DruidServer implements Comparable
 
     DruidServer that = (DruidServer) o;
 
-    if (getName() != null ? !getName().equals(that.getName()) : that.getName() != null) {
+    if (!metadata.equals(that.metadata)) {
       return false;
     }
 
@@ -281,7 +281,7 @@ public class DruidServer implements Comparable
   @Override
   public int hashCode()
   {
-    return getName() != null ? getName().hashCode() : 0;
+    return metadata.hashCode();
   }
 
   @Override

--- a/server/src/main/java/io/druid/client/HttpServerInventoryView.java
+++ b/server/src/main/java/io/druid/client/HttpServerInventoryView.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.jaxrs.smile.SmileMediaTypes;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.FutureCallback;
@@ -67,6 +66,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
@@ -78,6 +78,7 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 /**
  * This class uses CuratorInventoryManager to listen for queryable server membership which serve segments(e.g. Historicals).
@@ -294,18 +295,11 @@ public class HttpServerInventoryView implements ServerInventoryView, FilteredSer
   }
 
   @Override
-  public Iterable<DruidServer> getInventory()
+  public Collection<DruidServer> getInventory()
   {
-    return Iterables.transform(
-        servers.values(), new Function<DruidServerHolder, DruidServer>()
-        {
-          @Override
-          public DruidServer apply(DruidServerHolder input)
-          {
-            return input.druidServer;
-          }
-        }
-    );
+    return servers.values().stream()
+                  .map(serverHolder -> serverHolder.druidServer)
+                  .collect(Collectors.toList());
   }
 
   private void runSegmentCallbacks(
@@ -657,7 +651,7 @@ public class HttpServerInventoryView implements ServerInventoryView, FilteredSer
     {
       if (finalPredicate.apply(Pair.of(druidServer.getMetadata(), segment))) {
         if (druidServer.getSegment(segment.getIdentifier()) == null) {
-          druidServer.addDataSegment(segment.getIdentifier(), segment);
+          druidServer.addDataSegment(segment);
           runSegmentCallbacks(
               new Function<SegmentCallback, CallbackAction>()
               {

--- a/server/src/main/java/io/druid/client/HttpServerInventoryView.java
+++ b/server/src/main/java/io/druid/client/HttpServerInventoryView.java
@@ -297,7 +297,8 @@ public class HttpServerInventoryView implements ServerInventoryView, FilteredSer
   @Override
   public Collection<DruidServer> getInventory()
   {
-    return servers.values().stream()
+    return servers.values()
+                  .stream()
                   .map(serverHolder -> serverHolder.druidServer)
                   .collect(Collectors.toList());
   }

--- a/server/src/main/java/io/druid/client/ImmutableDruidDataSource.java
+++ b/server/src/main/java/io/druid/client/ImmutableDruidDataSource.java
@@ -19,6 +19,7 @@
 
 package io.druid.client;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import io.druid.timeline.DataSegment;
 
@@ -40,7 +41,7 @@ public class ImmutableDruidDataSource
       ImmutableMap<String, DataSegment> idToSegments
   )
   {
-    this.name = name;
+    this.name = Preconditions.checkNotNull(name);
     this.properties = properties;
     this.idToSegments = idToSegments;
   }
@@ -73,7 +74,6 @@ public class ImmutableDruidDataSource
   @Override
   public String toString()
   {
-    // idToSegments is intentionally ignored because it is usually large
     return "ImmutableDruidDataSource{"
            + "name='" + name
            + "', segments='" + idToSegments.values()

--- a/server/src/main/java/io/druid/client/ImmutableDruidDataSource.java
+++ b/server/src/main/java/io/druid/client/ImmutableDruidDataSource.java
@@ -20,12 +20,11 @@
 package io.druid.client;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.druid.timeline.DataSegment;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  */
@@ -34,19 +33,16 @@ public class ImmutableDruidDataSource
   private final String name;
   private final ImmutableMap<String, String> properties;
   private final ImmutableMap<String, DataSegment> idToSegments;
-  private final ImmutableSet<DataSegment> segmentsHolder;
 
   public ImmutableDruidDataSource(
       String name,
       ImmutableMap<String, String> properties,
-      ImmutableMap<String, DataSegment> idToSegments,
-      ImmutableSet<DataSegment> segmentsHolder
+      ImmutableMap<String, DataSegment> idToSegments
   )
   {
     this.name = name;
     this.properties = properties;
     this.idToSegments = idToSegments;
-    this.segmentsHolder = segmentsHolder;
   }
 
   public String getName()
@@ -61,12 +57,12 @@ public class ImmutableDruidDataSource
 
   public boolean isEmpty()
   {
-    return segmentsHolder.isEmpty();
+    return idToSegments.isEmpty();
   }
 
-  public Set<DataSegment> getSegments()
+  public Collection<DataSegment> getSegments()
   {
-    return segmentsHolder;
+    return idToSegments.values();
   }
 
   public DataSegment getSegment(String segmentIdentifier)
@@ -80,7 +76,7 @@ public class ImmutableDruidDataSource
     // idToSegments is intentionally ignored because it is usually large
     return "ImmutableDruidDataSource{"
            + "name='" + name
-           + "', segments='" + segmentsHolder
+           + "', segments='" + idToSegments.values()
            + "', properties='" + properties
            + "'}";
   }
@@ -105,16 +101,12 @@ public class ImmutableDruidDataSource
       return false;
     }
 
-    if (!this.idToSegments.equals(that.idToSegments)) {
-      return false;
-    }
-
-    return this.segmentsHolder.equals(that.segmentsHolder);
+    return this.idToSegments.equals(that.idToSegments);
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(name, properties, idToSegments, segmentsHolder);
+    return Objects.hash(name, properties, idToSegments);
   }
 }

--- a/server/src/main/java/io/druid/client/ImmutableDruidDataSource.java
+++ b/server/src/main/java/io/druid/client/ImmutableDruidDataSource.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableSet;
 import io.druid.timeline.DataSegment;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -32,19 +33,19 @@ public class ImmutableDruidDataSource
 {
   private final String name;
   private final ImmutableMap<String, String> properties;
-  private final ImmutableMap<String, DataSegment> partitionNames;
+  private final ImmutableMap<String, DataSegment> idToSegments;
   private final ImmutableSet<DataSegment> segmentsHolder;
 
   public ImmutableDruidDataSource(
       String name,
       ImmutableMap<String, String> properties,
-      ImmutableMap<String, DataSegment> partitionNames,
+      ImmutableMap<String, DataSegment> idToSegments,
       ImmutableSet<DataSegment> segmentsHolder
   )
   {
     this.name = name;
     this.properties = properties;
-    this.partitionNames = partitionNames;
+    this.idToSegments = idToSegments;
     this.segmentsHolder = segmentsHolder;
   }
 
@@ -58,11 +59,6 @@ public class ImmutableDruidDataSource
     return properties;
   }
 
-  public Map<String, DataSegment> getPartitionNames()
-  {
-    return partitionNames;
-  }
-
   public boolean isEmpty()
   {
     return segmentsHolder.isEmpty();
@@ -73,14 +69,52 @@ public class ImmutableDruidDataSource
     return segmentsHolder;
   }
 
+  public DataSegment getSegment(String segmentIdentifier)
+  {
+    return idToSegments.get(segmentIdentifier);
+  }
+
   @Override
   public String toString()
   {
-    // partitionNames is intentionally ignored because it is usually large
+    // idToSegments is intentionally ignored because it is usually large
     return "ImmutableDruidDataSource{"
            + "name='" + name
            + "', segments='" + segmentsHolder
            + "', properties='" + properties
            + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || !getClass().equals(o.getClass())) {
+      return false;
+    }
+
+    final ImmutableDruidDataSource that = (ImmutableDruidDataSource) o;
+    if (!this.name.equals(that.name)) {
+      return false;
+    }
+
+    if (!this.properties.equals(that.properties)) {
+      return false;
+    }
+
+    if (!this.idToSegments.equals(that.idToSegments)) {
+      return false;
+    }
+
+    return this.segmentsHolder.equals(that.segmentsHolder);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(name, properties, idToSegments, segmentsHolder);
   }
 }

--- a/server/src/main/java/io/druid/client/ImmutableDruidDataSource.java
+++ b/server/src/main/java/io/druid/client/ImmutableDruidDataSource.java
@@ -74,9 +74,10 @@ public class ImmutableDruidDataSource
   @Override
   public String toString()
   {
+    // The detail of idToSegments is intentionally ignored because it is usually large
     return "ImmutableDruidDataSource{"
            + "name='" + name
-           + "', segments='" + idToSegments.values()
+           + "', # of segments='" + idToSegments.size()
            + "', properties='" + properties
            + "'}";
   }

--- a/server/src/main/java/io/druid/client/ImmutableDruidServer.java
+++ b/server/src/main/java/io/druid/client/ImmutableDruidServer.java
@@ -19,6 +19,7 @@
 
 package io.druid.client;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.metamx.common.StringUtils;
 import io.druid.server.coordination.DruidServerMetadata;
@@ -43,7 +44,7 @@ public class ImmutableDruidServer
       ImmutableMap<String, DataSegment> segments
   )
   {
-    this.metadata = metadata;
+    this.metadata = Preconditions.checkNotNull(metadata);
     this.currSize = currSize;
     this.segments = segments;
     this.dataSources = dataSources;
@@ -139,9 +140,9 @@ public class ImmutableDruidServer
       return false;
     }
 
-    DruidServer that = (DruidServer) o;
+    ImmutableDruidServer that = (ImmutableDruidServer) o;
 
-    if (getName() != null ? !getName().equals(that.getName()) : that.getName() != null) {
+    if (metadata.equals(that.metadata)) {
       return false;
     }
 
@@ -151,6 +152,6 @@ public class ImmutableDruidServer
   @Override
   public int hashCode()
   {
-    return getName() != null ? getName().hashCode() : 0;
+    return metadata.hashCode();
   }
 }

--- a/server/src/main/java/io/druid/client/ImmutableDruidServer.java
+++ b/server/src/main/java/io/druid/client/ImmutableDruidServer.java
@@ -128,4 +128,29 @@ public class ImmutableDruidServer
            + "', sources='" + dataSources
            + "'}";
   }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    DruidServer that = (DruidServer) o;
+
+    if (getName() != null ? !getName().equals(that.getName()) : that.getName() != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return getName() != null ? getName().hashCode() : 0;
+  }
 }

--- a/server/src/main/java/io/druid/client/InventoryView.java
+++ b/server/src/main/java/io/druid/client/InventoryView.java
@@ -21,12 +21,14 @@ package io.druid.client;
 
 import io.druid.timeline.DataSegment;
 
+import java.util.Collection;
+
 /**
  */
 public interface InventoryView
 {
   DruidServer getInventoryValue(String string);
-  Iterable<DruidServer> getInventory();
+  Collection<DruidServer> getInventory();
   boolean isStarted();
   boolean isSegmentLoadedByServer(String serverKey, DataSegment segment);
 }

--- a/server/src/main/java/io/druid/curator/inventory/CuratorInventoryManager.java
+++ b/server/src/main/java/io/druid/curator/inventory/CuratorInventoryManager.java
@@ -19,8 +19,6 @@
 
 package io.druid.curator.inventory;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import io.druid.curator.cache.PathChildrenCacheFactory;
 import io.druid.java.util.common.StringUtils;
@@ -36,11 +34,13 @@ import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
 import org.apache.curator.utils.ZKPaths;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 /**
  * This class is deprecated. Use {@link io.druid.client.HttpServerInventoryView} for segment discovery.
@@ -163,19 +163,11 @@ public class CuratorInventoryManager<ContainerClass, InventoryClass>
     return containerHolder == null ? null : containerHolder.getContainer();
   }
 
-  public Iterable<ContainerClass> getInventory()
+  public Collection<ContainerClass> getInventory()
   {
-    return Iterables.transform(
-        containers.values(),
-        new Function<ContainerHolder, ContainerClass>()
-        {
-          @Override
-          public ContainerClass apply(ContainerHolder input)
-          {
-            return input.getContainer();
-          }
-        }
-    );
+    return containers.values().stream()
+                     .map(ContainerHolder::getContainer)
+                     .collect(Collectors.toList());
   }
 
   private byte[] getZkDataForNode(String path)

--- a/server/src/main/java/io/druid/curator/inventory/CuratorInventoryManager.java
+++ b/server/src/main/java/io/druid/curator/inventory/CuratorInventoryManager.java
@@ -165,7 +165,8 @@ public class CuratorInventoryManager<ContainerClass, InventoryClass>
 
   public Collection<ContainerClass> getInventory()
   {
-    return containers.values().stream()
+    return containers.values()
+                     .stream()
                      .map(ContainerHolder::getContainer)
                      .collect(Collectors.toList());
   }

--- a/server/src/main/java/io/druid/metadata/MetadataSegmentManager.java
+++ b/server/src/main/java/io/druid/metadata/MetadataSegmentManager.java
@@ -20,10 +20,12 @@
 package io.druid.metadata;
 
 import io.druid.client.DruidDataSource;
+import io.druid.client.ImmutableDruidDataSource;
 import org.joda.time.Interval;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  */
@@ -46,7 +48,17 @@ public interface MetadataSegmentManager
 
   DruidDataSource getInventoryValue(String key);
 
+  default ImmutableDruidDataSource getImmutableInventoryValue(String key)
+  {
+    return getInventoryValue(key).toImmutableDruidDataSource();
+  }
+
   Collection<DruidDataSource> getInventory();
+
+  default Collection<ImmutableDruidDataSource> getImmutableInventory()
+  {
+    return getInventory().stream().map(DruidDataSource::toImmutableDruidDataSource).collect(Collectors.toList());
+  }
 
   Collection<String> getAllDatasourceNames();
 

--- a/server/src/main/java/io/druid/metadata/MetadataSegmentManager.java
+++ b/server/src/main/java/io/druid/metadata/MetadataSegmentManager.java
@@ -19,13 +19,12 @@
 
 package io.druid.metadata;
 
-import io.druid.client.DruidDataSource;
 import io.druid.client.ImmutableDruidDataSource;
 import org.joda.time.Interval;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  */
@@ -46,19 +45,10 @@ public interface MetadataSegmentManager
 
   boolean isStarted();
 
-  DruidDataSource getInventoryValue(String key);
+  @Nullable
+  ImmutableDruidDataSource getInventoryValue(String key);
 
-  default ImmutableDruidDataSource getImmutableInventoryValue(String key)
-  {
-    return getInventoryValue(key).toImmutableDruidDataSource();
-  }
-
-  Collection<DruidDataSource> getInventory();
-
-  default Collection<ImmutableDruidDataSource> getImmutableInventory()
-  {
-    return getInventory().stream().map(DruidDataSource::toImmutableDruidDataSource).collect(Collectors.toList());
-  }
+  Collection<ImmutableDruidDataSource> getInventory();
 
   Collection<String> getAllDatasourceNames();
 

--- a/server/src/main/java/io/druid/metadata/SQLMetadataSegmentManager.java
+++ b/server/src/main/java/io/druid/metadata/SQLMetadataSegmentManager.java
@@ -35,6 +35,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
 import com.metamx.emitter.EmittingLogger;
 import io.druid.client.DruidDataSource;
+import io.druid.client.ImmutableDruidDataSource;
 import io.druid.concurrent.LifecycleLock;
 import io.druid.guice.ManageLifecycle;
 import io.druid.java.util.common.DateTimes;
@@ -63,6 +64,7 @@ import org.skife.jdbi.v2.tweak.HandleCallback;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 import org.skife.jdbi.v2.util.ByteArrayMapper;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -74,6 +76,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 /**
  */
@@ -369,15 +372,21 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
   }
 
   @Override
-  public DruidDataSource getInventoryValue(String key)
+  @Nullable
+  public ImmutableDruidDataSource getInventoryValue(String key)
   {
-    return dataSourcesRef.get().get(key);
+    final DruidDataSource dataSource = dataSourcesRef.get().get(key);
+    return dataSource == null ? null : dataSource.toImmutableDruidDataSource();
   }
 
   @Override
-  public Collection<DruidDataSource> getInventory()
+  public Collection<ImmutableDruidDataSource> getInventory()
   {
-    return dataSourcesRef.get().values();
+    return dataSourcesRef.get()
+                         .values()
+                         .stream()
+                         .map(DruidDataSource::toImmutableDruidDataSource)
+                         .collect(Collectors.toList());
   }
 
   @Override

--- a/server/src/main/java/io/druid/metadata/SQLMetadataSegmentManager.java
+++ b/server/src/main/java/io/druid/metadata/SQLMetadataSegmentManager.java
@@ -495,7 +495,7 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
         }
 
         if (!dataSource.getSegments().contains(segment)) {
-          dataSource.addSegment(segment.getIdentifier(), segment);
+          dataSource.addSegment(segment);
         }
       }
 

--- a/server/src/main/java/io/druid/server/coordination/DruidServerMetadata.java
+++ b/server/src/main/java/io/druid/server/coordination/DruidServerMetadata.java
@@ -21,6 +21,9 @@ package io.druid.server.coordination;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+
+import java.util.Objects;
 
 /**
  */
@@ -45,7 +48,7 @@ public class DruidServerMetadata
       @JsonProperty("priority") int priority
   )
   {
-    this.name = name;
+    this.name = Preconditions.checkNotNull(name);
     this.hostAndPort = hostAndPort;
     this.hostAndTlsPort = hostAndTlsPort;
     this.maxSize = maxSize;
@@ -118,38 +121,31 @@ public class DruidServerMetadata
 
     DruidServerMetadata that = (DruidServerMetadata) o;
 
+    if (!name.equals(that.name)) {
+      return false;
+    }
+    if (!Objects.equals(hostAndPort, that.hostAndPort)) {
+      return false;
+    }
+    if (!Objects.equals(hostAndTlsPort, that.hostAndTlsPort)) {
+      return false;
+    }
     if (maxSize != that.maxSize) {
       return false;
     }
-    if (priority != that.priority) {
+    if (!Objects.equals(tier, that.tier)) {
       return false;
     }
-    if (name != null ? !name.equals(that.name) : that.name != null) {
+    if (type != that.type) {
       return false;
     }
-    if (hostAndPort != null ? !hostAndPort.equals(that.hostAndPort) : that.hostAndPort != null) {
-      return false;
-    }
-    if (hostAndTlsPort != null ? !hostAndTlsPort.equals(that.hostAndTlsPort) : that.hostAndTlsPort != null) {
-      return false;
-    }
-    if (tier != null ? !tier.equals(that.tier) : that.tier != null) {
-      return false;
-    }
-    return type == that.type;
+    return priority == that.priority;
   }
 
   @Override
   public int hashCode()
   {
-    int result = name != null ? name.hashCode() : 0;
-    result = 31 * result + (hostAndPort != null ? hostAndPort.hashCode() : 0);
-    result = 31 * result + (hostAndTlsPort != null ? hostAndTlsPort.hashCode() : 0);
-    result = 31 * result + (int) (maxSize ^ (maxSize >>> 32));
-    result = 31 * result + (tier != null ? tier.hashCode() : 0);
-    result = 31 * result + (type != null ? type.hashCode() : 0);
-    result = 31 * result + priority;
-    return result;
+    return Objects.hash(name, hostAndPort, hostAndTlsPort, maxSize, tier, type, priority);
   }
 
   @Override

--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
@@ -23,7 +23,6 @@ import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
@@ -41,7 +40,6 @@ import io.druid.client.ServerInventoryView;
 import io.druid.client.coordinator.Coordinator;
 import io.druid.client.indexing.IndexingServiceClient;
 import io.druid.common.config.JacksonConfigManager;
-import io.druid.java.util.common.concurrent.Execs;
 import io.druid.curator.discovery.ServiceAnnouncer;
 import io.druid.discovery.DruidLeaderSelector;
 import io.druid.guice.ManageLifecycle;
@@ -49,7 +47,9 @@ import io.druid.guice.annotations.CoordinatorIndexingServiceHelper;
 import io.druid.guice.annotations.Self;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.IAE;
+import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.Pair;
+import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.concurrent.ScheduledExecutorFactory;
 import io.druid.java.util.common.concurrent.ScheduledExecutors;
 import io.druid.java.util.common.guava.Comparators;
@@ -88,6 +88,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
 
 /**
  */
@@ -290,7 +291,7 @@ public class DruidCoordinator
   public Map<String, Double> getLoadStatus()
   {
     Map<String, Double> loadStatus = Maps.newHashMap();
-    for (DruidDataSource dataSource : metadataSegmentManager.getInventory()) {
+    for (ImmutableDruidDataSource dataSource : metadataSegmentManager.getImmutableInventory()) {
       final Set<DataSegment> segments = Sets.newHashSet(dataSource.getSegments());
       final int availableSegmentSize = segments.size();
 
@@ -326,16 +327,6 @@ public class DruidCoordinator
     metadataSegmentManager.removeSegment(segment.getDataSource(), segment.getIdentifier());
   }
 
-  public void removeDatasource(String ds)
-  {
-    metadataSegmentManager.removeDatasource(ds);
-  }
-
-  public void enableDatasource(String ds)
-  {
-    metadataSegmentManager.enableDatasource(ds);
-  }
-
   public String getCurrentLeader()
   {
     return coordLeaderSelector.getCurrentLeader();
@@ -353,6 +344,7 @@ public class DruidCoordinator
       if (callback != null) {
         callback.execute();
       }
+      throw new ISE("Cannot move null DataSegment");
     }
     String segmentName = segment.getIdentifier();
     try {
@@ -360,7 +352,7 @@ public class DruidCoordinator
         throw new IAE("Cannot move [%s] to and from the same server [%s]", segmentName, fromServer.getName());
       }
 
-      DruidDataSource dataSource = metadataSegmentManager.getInventoryValue(segment.getDataSource());
+      ImmutableDruidDataSource dataSource = metadataSegmentManager.getImmutableInventoryValue(segment.getDataSource());
       if (dataSource == null) {
         throw new IAE("Unable to find dataSource for segment [%s] in metadata", segmentName);
       }
@@ -460,21 +452,11 @@ public class DruidCoordinator
     return availableSegments;
   }
 
-  public Iterable<DataSegment> getAvailableDataSegments()
+  private List<DataSegment> getAvailableDataSegments()
   {
-    return Iterables.concat(
-        Iterables.transform(
-            metadataSegmentManager.getInventory(),
-            new Function<DruidDataSource, Iterable<DataSegment>>()
-            {
-              @Override
-              public Iterable<DataSegment> apply(DruidDataSource input)
-              {
-                return input.getSegments();
-              }
-            }
-        )
-    );
+    return metadataSegmentManager.getImmutableInventory().stream()
+        .flatMap(source -> source.getSegments().stream())
+        .collect(Collectors.toList());
   }
 
   @LifecycleStart
@@ -660,7 +642,7 @@ public class DruidCoordinator
         DruidCoordinatorRuntimeParams params =
                 DruidCoordinatorRuntimeParams.newBuilder()
                         .withStartTime(startTime)
-                        .withDatasources(metadataSegmentManager.getInventory())
+                        .withDatasources(metadataSegmentManager.getImmutableInventory())
                         .withDynamicConfigs(getDynamicConfigs())
                         .withEmitter(emitter)
                         .withBalancerStrategy(balancerStrategy)

--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
@@ -454,7 +454,8 @@ public class DruidCoordinator
 
   private List<DataSegment> getAvailableDataSegments()
   {
-    return metadataSegmentManager.getInventory().stream()
+    return metadataSegmentManager.getInventory()
+                                 .stream()
                                  .flatMap(source -> source.getSegments().stream())
                                  .collect(Collectors.toList());
   }

--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
@@ -291,7 +291,7 @@ public class DruidCoordinator
   public Map<String, Double> getLoadStatus()
   {
     Map<String, Double> loadStatus = Maps.newHashMap();
-    for (ImmutableDruidDataSource dataSource : metadataSegmentManager.getImmutableInventory()) {
+    for (ImmutableDruidDataSource dataSource : metadataSegmentManager.getInventory()) {
       final Set<DataSegment> segments = Sets.newHashSet(dataSource.getSegments());
       final int availableSegmentSize = segments.size();
 
@@ -352,7 +352,7 @@ public class DruidCoordinator
         throw new IAE("Cannot move [%s] to and from the same server [%s]", segmentName, fromServer.getName());
       }
 
-      ImmutableDruidDataSource dataSource = metadataSegmentManager.getImmutableInventoryValue(segment.getDataSource());
+      ImmutableDruidDataSource dataSource = metadataSegmentManager.getInventoryValue(segment.getDataSource());
       if (dataSource == null) {
         throw new IAE("Unable to find dataSource for segment [%s] in metadata", segmentName);
       }
@@ -454,9 +454,9 @@ public class DruidCoordinator
 
   private List<DataSegment> getAvailableDataSegments()
   {
-    return metadataSegmentManager.getImmutableInventory().stream()
-        .flatMap(source -> source.getSegments().stream())
-        .collect(Collectors.toList());
+    return metadataSegmentManager.getInventory().stream()
+                                 .flatMap(source -> source.getSegments().stream())
+                                 .collect(Collectors.toList());
   }
 
   @LifecycleStart
@@ -642,7 +642,7 @@ public class DruidCoordinator
         DruidCoordinatorRuntimeParams params =
                 DruidCoordinatorRuntimeParams.newBuilder()
                         .withStartTime(startTime)
-                        .withDatasources(metadataSegmentManager.getImmutableInventory())
+                        .withDatasources(metadataSegmentManager.getInventory())
                         .withDynamicConfigs(getDynamicConfigs())
                         .withEmitter(emitter)
                         .withBalancerStrategy(balancerStrategy)

--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinatorRuntimeParams.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinatorRuntimeParams.java
@@ -22,7 +22,7 @@ package io.druid.server.coordinator;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.metamx.emitter.service.ServiceEmitter;
-import io.druid.client.DruidDataSource;
+import io.druid.client.ImmutableDruidDataSource;
 import io.druid.java.util.common.DateTimes;
 import io.druid.metadata.MetadataRuleManager;
 import io.druid.timeline.DataSegment;
@@ -30,8 +30,10 @@ import org.joda.time.DateTime;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  */
@@ -41,7 +43,7 @@ public class DruidCoordinatorRuntimeParams
   private final DruidCluster druidCluster;
   private final MetadataRuleManager databaseRuleManager;
   private final SegmentReplicantLookup segmentReplicantLookup;
-  private final Set<DruidDataSource> dataSources;
+  private final Set<ImmutableDruidDataSource> dataSources;
   private final Set<DataSegment> availableSegments;
   private final Map<String, LoadQueuePeon> loadManagementPeons;
   private final ReplicationThrottler replicationManager;
@@ -56,7 +58,7 @@ public class DruidCoordinatorRuntimeParams
       DruidCluster druidCluster,
       MetadataRuleManager databaseRuleManager,
       SegmentReplicantLookup segmentReplicantLookup,
-      Set<DruidDataSource> dataSources,
+      Set<ImmutableDruidDataSource> dataSources,
       Set<DataSegment> availableSegments,
       Map<String, LoadQueuePeon> loadManagementPeons,
       ReplicationThrottler replicationManager,
@@ -102,7 +104,7 @@ public class DruidCoordinatorRuntimeParams
     return segmentReplicantLookup;
   }
 
-  public Set<DruidDataSource> getDataSources()
+  public Set<ImmutableDruidDataSource> getDataSources()
   {
     return dataSources;
   }
@@ -201,7 +203,7 @@ public class DruidCoordinatorRuntimeParams
     private DruidCluster druidCluster;
     private MetadataRuleManager databaseRuleManager;
     private SegmentReplicantLookup segmentReplicantLookup;
-    private final Set<DruidDataSource> dataSources;
+    private final Set<ImmutableDruidDataSource> dataSources;
     private final Set<DataSegment> availableSegments;
     private final Map<String, LoadQueuePeon> loadManagementPeons;
     private ReplicationThrottler replicationManager;
@@ -217,8 +219,8 @@ public class DruidCoordinatorRuntimeParams
       this.druidCluster = null;
       this.databaseRuleManager = null;
       this.segmentReplicantLookup = null;
-      this.dataSources = Sets.newHashSet();
-      this.availableSegments = Sets.newTreeSet(DruidCoordinator.SEGMENT_COMPARATOR);
+      this.dataSources = new HashSet<>();
+      this.availableSegments = new TreeSet<>(DruidCoordinator.SEGMENT_COMPARATOR);
       this.loadManagementPeons = Maps.newHashMap();
       this.replicationManager = null;
       this.emitter = null;
@@ -232,7 +234,7 @@ public class DruidCoordinatorRuntimeParams
         DruidCluster cluster,
         MetadataRuleManager databaseRuleManager,
         SegmentReplicantLookup segmentReplicantLookup,
-        Set<DruidDataSource> dataSources,
+        Set<ImmutableDruidDataSource> dataSources,
         Set<DataSegment> availableSegments,
         Map<String, LoadQueuePeon> loadManagementPeons,
         ReplicationThrottler replicationManager,
@@ -301,7 +303,7 @@ public class DruidCoordinatorRuntimeParams
       return this;
     }
 
-    public Builder withDatasources(Collection<DruidDataSource> dataSourcesCollection)
+    public Builder withDatasources(Collection<ImmutableDruidDataSource> dataSourcesCollection)
     {
       dataSources.addAll(Collections.unmodifiableCollection(dataSourcesCollection));
       return this;

--- a/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorLogger.java
+++ b/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorLogger.java
@@ -259,7 +259,7 @@ public class DruidCoordinatorLogger implements DruidCoordinatorHelper
     final Stream<DataSegment> allSegments = params
         .getDataSources()
         .stream()
-        .flatMap((ImmutableDruidDataSource dataSource) -> dataSource.getSegments().stream());
+        .flatMap(dataSource -> dataSource.getSegments().stream());
 
     allSegments
         .collect(Collectors.groupingBy(DataSegment::getDataSource))

--- a/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorLogger.java
+++ b/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorLogger.java
@@ -21,7 +21,7 @@ package io.druid.server.coordinator.helper;
 
 import com.metamx.emitter.service.ServiceEmitter;
 import com.metamx.emitter.service.ServiceMetricEvent;
-import io.druid.client.DruidDataSource;
+import io.druid.client.ImmutableDruidDataSource;
 import io.druid.client.ImmutableDruidServer;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.query.DruidMetrics;
@@ -259,7 +259,7 @@ public class DruidCoordinatorLogger implements DruidCoordinatorHelper
     final Stream<DataSegment> allSegments = params
         .getDataSources()
         .stream()
-        .flatMap((final DruidDataSource dataSource) -> dataSource.getSegments().stream());
+        .flatMap((ImmutableDruidDataSource dataSource) -> dataSource.getSegments().stream());
 
     allSegments
         .collect(Collectors.groupingBy(DataSegment::getDataSource))

--- a/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorLogger.java
+++ b/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorLogger.java
@@ -21,7 +21,6 @@ package io.druid.server.coordinator.helper;
 
 import com.metamx.emitter.service.ServiceEmitter;
 import com.metamx.emitter.service.ServiceMetricEvent;
-import io.druid.client.ImmutableDruidDataSource;
 import io.druid.client.ImmutableDruidServer;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.query.DruidMetrics;

--- a/server/src/main/java/io/druid/server/http/DatasourcesResource.java
+++ b/server/src/main/java/io/druid/server/http/DatasourcesResource.java
@@ -493,6 +493,7 @@ public class DatasourcesResource
     return Response.ok(retVal).build();
   }
 
+  @Nullable
   private ImmutableDruidDataSource getDataSource(final String dataSourceName)
   {
     List<ImmutableDruidDataSource> dataSources = serverInventoryView
@@ -515,10 +516,11 @@ public class DatasourcesResource
       }
     }
 
-    return new DruidDataSource(
+    return new ImmutableDruidDataSource(
         dataSourceName,
-        ImmutableMap.of()
-    ).addSegments(segmentMap).toImmutableDruidDataSource();
+        ImmutableMap.of(),
+        ImmutableMap.copyOf(segmentMap)
+    );
   }
 
   private Pair<DataSegment, Set<String>> getSegment(String segmentId)

--- a/server/src/main/java/io/druid/server/http/DatasourcesResource.java
+++ b/server/src/main/java/io/druid/server/http/DatasourcesResource.java
@@ -29,6 +29,7 @@ import com.sun.jersey.spi.container.ResourceFilters;
 import io.druid.client.CoordinatorServerView;
 import io.druid.client.DruidDataSource;
 import io.druid.client.DruidServer;
+import io.druid.client.ImmutableDruidDataSource;
 import io.druid.client.ImmutableSegmentLoadInfo;
 import io.druid.client.SegmentLoadInfo;
 import io.druid.client.indexing.IndexingServiceClient;
@@ -68,7 +69,9 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  */
@@ -108,33 +111,27 @@ public class DatasourcesResource
   )
   {
     Response.ResponseBuilder builder = Response.ok();
-    final Set<DruidDataSource> datasources = InventoryViewUtils.getSecuredDataSources(
+    final Set<ImmutableDruidDataSource> datasources = InventoryViewUtils.getSecuredDataSources(
         req,
         serverInventoryView,
         authorizerMapper
     );
 
+    final Object entity;
+
     if (full != null) {
-      return builder.entity(datasources).build();
+      entity = datasources;
     } else if (simple != null) {
-      return builder.entity(
-          Lists.newArrayList(
-              Iterables.transform(
-                  datasources,
-                  (DruidDataSource dataSource) -> makeSimpleDatasource(dataSource)
-              )
-          )
-      ).build();
+      entity = datasources.stream()
+                          .map(this::makeSimpleDatasource)
+                          .collect(Collectors.toList());
+    } else {
+      entity = datasources.stream()
+                          .map(ImmutableDruidDataSource::getName)
+                          .collect(Collectors.toList());
     }
 
-    return builder.entity(
-        Lists.newArrayList(
-            Iterables.transform(
-                datasources,
-                (DruidDataSource dataSource) -> dataSource.getName()
-            )
-        )
-    ).build();
+    return builder.entity(entity).build();
   }
 
   @GET
@@ -146,7 +143,7 @@ public class DatasourcesResource
       @QueryParam("full") final String full
   )
   {
-    DruidDataSource dataSource = getDataSource(dataSourceName);
+    ImmutableDruidDataSource dataSource = getDataSource(dataSourceName);
 
     if (dataSource == null) {
       return Response.noContent().build();
@@ -270,7 +267,7 @@ public class DatasourcesResource
       @QueryParam("full") String full
   )
   {
-    final DruidDataSource dataSource = getDataSource(dataSourceName);
+    final ImmutableDruidDataSource dataSource = getDataSource(dataSourceName);
 
     if (dataSource == null) {
       return Response.noContent().build();
@@ -335,7 +332,7 @@ public class DatasourcesResource
       @QueryParam("full") String full
   )
   {
-    final DruidDataSource dataSource = getDataSource(dataSourceName);
+    final ImmutableDruidDataSource dataSource = getDataSource(dataSourceName);
     final Interval theInterval = Intervals.of(interval.replace("_", "/"));
 
     if (dataSource == null) {
@@ -404,7 +401,7 @@ public class DatasourcesResource
       @QueryParam("full") String full
   )
   {
-    DruidDataSource dataSource = getDataSource(dataSourceName);
+    ImmutableDruidDataSource dataSource = getDataSource(dataSourceName);
     if (dataSource == null) {
       return Response.noContent().build();
     }
@@ -431,7 +428,7 @@ public class DatasourcesResource
       @PathParam("segmentId") String segmentId
   )
   {
-    DruidDataSource dataSource = getDataSource(dataSourceName);
+    ImmutableDruidDataSource dataSource = getDataSource(dataSourceName);
     if (dataSource == null) {
       return Response.noContent().build();
     }
@@ -496,40 +493,32 @@ public class DatasourcesResource
     return Response.ok(retVal).build();
   }
 
-  private DruidDataSource getDataSource(final String dataSourceName)
+  private ImmutableDruidDataSource getDataSource(final String dataSourceName)
   {
-    Iterable<DruidDataSource> dataSources =
-        Iterables.concat(
-            Iterables.transform(
-                serverInventoryView.getInventory(),
-                (DruidServer input) -> input.getDataSource(dataSourceName)
-            )
-        );
+    List<ImmutableDruidDataSource> dataSources = serverInventoryView
+        .getInventory()
+        .stream()
+        .map(server -> server.getDataSource(dataSourceName))
+        .filter(Objects::nonNull)
+        .map(DruidDataSource::toImmutableDruidDataSource)
+        .collect(Collectors.toList());
 
-    List<DruidDataSource> validDataSources = Lists.newArrayList();
-    for (DruidDataSource dataSource : dataSources) {
-      if (dataSource != null) {
-        validDataSources.add(dataSource);
-      }
-    }
-    if (validDataSources.isEmpty()) {
+    if (dataSources.isEmpty()) {
       return null;
     }
 
     Map<String, DataSegment> segmentMap = Maps.newHashMap();
-    for (DruidDataSource dataSource : validDataSources) {
-      if (dataSource != null) {
-        Iterable<DataSegment> segments = dataSource.getSegments();
-        for (DataSegment segment : segments) {
-          segmentMap.put(segment.getIdentifier(), segment);
-        }
+    for (ImmutableDruidDataSource dataSource : dataSources) {
+      Iterable<DataSegment> segments = dataSource.getSegments();
+      for (DataSegment segment : segments) {
+        segmentMap.put(segment.getIdentifier(), segment);
       }
     }
 
     return new DruidDataSource(
         dataSourceName,
         ImmutableMap.of()
-    ).addSegments(segmentMap);
+    ).addSegments(segmentMap).toImmutableDruidDataSource();
   }
 
   private Pair<DataSegment, Set<String>> getSegment(String segmentId)
@@ -551,7 +540,7 @@ public class DatasourcesResource
     return new Pair<>(theSegment, servers);
   }
 
-  private Map<String, Object> makeSimpleDatasource(DruidDataSource input)
+  private Map<String, Object> makeSimpleDatasource(ImmutableDruidDataSource input)
   {
     return new ImmutableMap.Builder<String, Object>()
         .put("name", input.getName())

--- a/server/src/main/java/io/druid/server/http/IntervalsResource.java
+++ b/server/src/main/java/io/druid/server/http/IntervalsResource.java
@@ -21,7 +21,7 @@ package io.druid.server.http;
 
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
-import io.druid.client.DruidDataSource;
+import io.druid.client.ImmutableDruidDataSource;
 import io.druid.client.InventoryView;
 import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.MapUtils;
@@ -70,14 +70,14 @@ public class IntervalsResource
   public Response getIntervals(@Context final HttpServletRequest req)
   {
     final Comparator<Interval> comparator = Comparators.inverse(Comparators.intervalsByStartThenEnd());
-    final Set<DruidDataSource> datasources = InventoryViewUtils.getSecuredDataSources(
+    final Set<ImmutableDruidDataSource> datasources = InventoryViewUtils.getSecuredDataSources(
         req,
         serverInventoryView,
         authorizerMapper
     );
 
     final Map<Interval, Map<String, Map<String, Object>>> retVal = Maps.newTreeMap(comparator);
-    for (DruidDataSource dataSource : datasources) {
+    for (ImmutableDruidDataSource dataSource : datasources) {
       for (DataSegment dataSegment : dataSource.getSegments()) {
         Map<String, Map<String, Object>> interval = retVal.get(dataSegment.getInterval());
         if (interval == null) {
@@ -102,7 +102,7 @@ public class IntervalsResource
   )
   {
     final Interval theInterval = Intervals.of(interval.replace("_", "/"));
-    final Set<DruidDataSource> datasources = InventoryViewUtils.getSecuredDataSources(
+    final Set<ImmutableDruidDataSource> datasources = InventoryViewUtils.getSecuredDataSources(
         req,
         serverInventoryView,
         authorizerMapper
@@ -112,7 +112,7 @@ public class IntervalsResource
 
     if (full != null) {
       final Map<Interval, Map<String, Map<String, Object>>> retVal = Maps.newTreeMap(comparator);
-      for (DruidDataSource dataSource : datasources) {
+      for (ImmutableDruidDataSource dataSource : datasources) {
         for (DataSegment dataSegment : dataSource.getSegments()) {
           if (theInterval.contains(dataSegment.getInterval())) {
             Map<String, Map<String, Object>> dataSourceInterval = retVal.get(dataSegment.getInterval());
@@ -130,7 +130,7 @@ public class IntervalsResource
 
     if (simple != null) {
       final Map<Interval, Map<String, Object>> retVal = Maps.newHashMap();
-      for (DruidDataSource dataSource : datasources) {
+      for (ImmutableDruidDataSource dataSource : datasources) {
         for (DataSegment dataSegment : dataSource.getSegments()) {
           if (theInterval.contains(dataSegment.getInterval())) {
             Map<String, Object> properties = retVal.get(dataSegment.getInterval());
@@ -152,7 +152,7 @@ public class IntervalsResource
     }
 
     final Map<String, Object> retVal = Maps.newHashMap();
-    for (DruidDataSource dataSource : datasources) {
+    for (ImmutableDruidDataSource dataSource : datasources) {
       for (DataSegment dataSegment : dataSource.getSegments()) {
         if (theInterval.contains(dataSegment.getInterval())) {
           retVal.put("size", MapUtils.getLong(retVal, "size", 0L) + dataSegment.getSize());
@@ -166,7 +166,7 @@ public class IntervalsResource
 
   private void setProperties(
       final Map<Interval, Map<String, Map<String, Object>>> retVal,
-      DruidDataSource dataSource, DataSegment dataSegment
+      ImmutableDruidDataSource dataSource, DataSegment dataSegment
   )
   {
     Map<String, Object> properties = retVal.get(dataSegment.getInterval()).get(dataSource.getName());

--- a/server/src/main/java/io/druid/server/http/InventoryViewUtils.java
+++ b/server/src/main/java/io/druid/server/http/InventoryViewUtils.java
@@ -29,9 +29,8 @@ import io.druid.server.security.AuthorizationUtils;
 import io.druid.server.security.AuthorizerMapper;
 
 import javax.servlet.http.HttpServletRequest;
-import java.util.Comparator;
 import java.util.Set;
-import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 public interface InventoryViewUtils
 {
@@ -42,11 +41,7 @@ public interface InventoryViewUtils
                               .stream()
                               .flatMap(server -> server.getDataSources().stream())
                               .map(DruidDataSource::toImmutableDruidDataSource)
-                              .collect(
-                                  () -> new TreeSet<>(Comparator.comparing(ImmutableDruidDataSource::getName)),
-                                  TreeSet::add,
-                                  TreeSet::addAll
-                              );
+                              .collect(Collectors.toSet());
   }
 
   static Set<ImmutableDruidDataSource> getSecuredDataSources(

--- a/server/src/main/java/io/druid/server/http/InventoryViewUtils.java
+++ b/server/src/main/java/io/druid/server/http/InventoryViewUtils.java
@@ -38,7 +38,8 @@ public interface InventoryViewUtils
 
   static Set<ImmutableDruidDataSource> getDataSources(InventoryView serverInventoryView)
   {
-    return serverInventoryView.getInventory().stream()
+    return serverInventoryView.getInventory()
+                              .stream()
                               .flatMap(server -> server.getDataSources().stream())
                               .map(DruidDataSource::toImmutableDruidDataSource)
                               .collect(

--- a/server/src/test/java/io/druid/metadata/MetadataSegmentManagerTest.java
+++ b/server/src/test/java/io/druid/metadata/MetadataSegmentManagerTest.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
 import com.metamx.emitter.EmittingLogger;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.Intervals;
@@ -39,6 +39,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.HashSet;
 
 
 public class MetadataSegmentManagerTest
@@ -123,8 +124,8 @@ public class MetadataSegmentManagerTest
         manager.getAllDatasourceNames()
     );
     Assert.assertEquals(
-        ImmutableSet.of(segment1, segment2),
-        manager.getInventoryValue("wikipedia").getSegments()
+        Sets.newHashSet(segment1, segment2),
+        new HashSet<>(manager.getInventoryValue("wikipedia").getSegments())
     );
   }
 

--- a/server/src/test/java/io/druid/metadata/MetadataSegmentManagerTest.java
+++ b/server/src/test/java/io/druid/metadata/MetadataSegmentManagerTest.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
 import com.metamx.emitter.EmittingLogger;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.Intervals;
@@ -39,7 +39,6 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.HashSet;
 
 
 public class MetadataSegmentManagerTest
@@ -124,8 +123,8 @@ public class MetadataSegmentManagerTest
         manager.getAllDatasourceNames()
     );
     Assert.assertEquals(
-        Sets.newHashSet(segment1, segment2),
-        new HashSet<>(manager.getInventoryValue("wikipedia").getSegments())
+        ImmutableSet.of(segment1, segment2),
+        ImmutableSet.copyOf(manager.getInventoryValue("wikipedia").getSegments())
     );
   }
 

--- a/server/src/test/java/io/druid/server/ClientInfoResourceTest.java
+++ b/server/src/test/java/io/druid/server/ClientInfoResourceTest.java
@@ -380,7 +380,7 @@ public class ClientInfoResourceTest
                                      .metrics(metrics)
                                      .size(1)
                                      .build();
-    server.addDataSegment(segment.getIdentifier(), segment);
+    server.addDataSegment(segment);
     ServerSelector ss = new ServerSelector(segment, new HighestPriorityTierSelectorStrategy(new RandomServerSelectorStrategy()));
     timeline.add(Intervals.of(interval), version, new SingleElementPartitionChunk<ServerSelector>(ss));
   }
@@ -404,7 +404,7 @@ public class ClientInfoResourceTest
                                      .shardSpec(shardSpec)
                                      .size(1)
                                      .build();
-    server.addDataSegment(segment.getIdentifier(), segment);
+    server.addDataSegment(segment);
     ServerSelector ss = new ServerSelector(segment, new HighestPriorityTierSelectorStrategy(new RandomServerSelectorStrategy()));
     timeline.add(Intervals.of(interval), version, shardSpec.createChunk(ss));
   }

--- a/server/src/test/java/io/druid/server/coordinator/DruidClusterTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidClusterTest.java
@@ -75,15 +75,13 @@ public class DruidClusterTest
       new ImmutableDruidDataSource(
           "src1",
           ImmutableMap.of(),
-          ImmutableMap.of(),
-          ImmutableSet.of()
+          ImmutableMap.of()
       ),
       "src2",
       new ImmutableDruidDataSource(
           "src2",
           ImmutableMap.of(),
-          ImmutableMap.of(),
-          ImmutableSet.of()
+          ImmutableMap.of()
       )
   );
 

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorRuleRunnerTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorRuleRunnerTest.java
@@ -363,7 +363,7 @@ public class DruidCoordinatorRuleRunnerTest
         0
     );
     for (DataSegment availableSegment : availableSegments) {
-      normServer.addDataSegment(availableSegment.getIdentifier(), availableSegment);
+      normServer.addDataSegment(availableSegment);
     }
 
     DruidCluster druidCluster = new DruidCluster(
@@ -583,7 +583,7 @@ public class DruidCoordinatorRuleRunnerTest
         0
     );
     for (DataSegment segment : availableSegments) {
-      server.addDataSegment(segment.getIdentifier(), segment);
+      server.addDataSegment(segment);
     }
 
     DruidCluster druidCluster = new DruidCluster(
@@ -653,7 +653,7 @@ public class DruidCoordinatorRuleRunnerTest
         "normal",
         0
     );
-    server1.addDataSegment(availableSegments.get(0).getIdentifier(), availableSegments.get(0));
+    server1.addDataSegment(availableSegments.get(0));
 
     DruidServer server2 = new DruidServer(
         "serverNorm2",
@@ -665,7 +665,7 @@ public class DruidCoordinatorRuleRunnerTest
         0
     );
     for (DataSegment segment : availableSegments) {
-      server2.addDataSegment(segment.getIdentifier(), segment);
+      server2.addDataSegment(segment);
     }
 
     DruidCluster druidCluster = new DruidCluster(
@@ -742,7 +742,7 @@ public class DruidCoordinatorRuleRunnerTest
         "hot",
         0
     );
-    server1.addDataSegment(availableSegments.get(0).getIdentifier(), availableSegments.get(0));
+    server1.addDataSegment(availableSegments.get(0));
     DruidServer server2 = new DruidServer(
         "serverNorm2",
         "hostNorm2",
@@ -753,7 +753,7 @@ public class DruidCoordinatorRuleRunnerTest
         0
     );
     for (DataSegment segment : availableSegments) {
-      server2.addDataSegment(segment.getIdentifier(), segment);
+      server2.addDataSegment(segment);
     }
 
     DruidCluster druidCluster = new DruidCluster(
@@ -841,7 +841,7 @@ public class DruidCoordinatorRuleRunnerTest
         0
     );
     for (DataSegment segment : availableSegments) {
-      server2.addDataSegment(segment.getIdentifier(), segment);
+      server2.addDataSegment(segment);
     }
     DruidCluster druidCluster = new DruidCluster(
         null,
@@ -913,7 +913,7 @@ public class DruidCoordinatorRuleRunnerTest
         "normal",
         0
     );
-    server1.addDataSegment(availableSegments.get(0).getIdentifier(), availableSegments.get(0));
+    server1.addDataSegment(availableSegments.get(0));
     DruidServer server2 = new DruidServer(
         "serverNorm2",
         "hostNorm2",
@@ -923,7 +923,7 @@ public class DruidCoordinatorRuleRunnerTest
         "normal",
         0
     );
-    server2.addDataSegment(availableSegments.get(1).getIdentifier(), availableSegments.get(1));
+    server2.addDataSegment(availableSegments.get(1));
     DruidServer server3 = new DruidServer(
         "serverNorm3",
         "hostNorm3",
@@ -933,8 +933,8 @@ public class DruidCoordinatorRuleRunnerTest
         "normal",
         0
     );
-    server3.addDataSegment(availableSegments.get(1).getIdentifier(), availableSegments.get(1));
-    server3.addDataSegment(availableSegments.get(2).getIdentifier(), availableSegments.get(2));
+    server3.addDataSegment(availableSegments.get(1));
+    server3.addDataSegment(availableSegments.get(2));
 
     mockPeon.dropSegment(EasyMock.<DataSegment>anyObject(), EasyMock.<LoadPeonCallback>anyObject());
     EasyMock.expectLastCall().atLeastOnce();
@@ -1248,7 +1248,7 @@ public class DruidCoordinatorRuleRunnerTest
         0
     );
     for (DataSegment availableSegment : longerAvailableSegments) {
-      server1.addDataSegment(availableSegment.getIdentifier(), availableSegment);
+      server1.addDataSegment(availableSegment);
     }
     DruidServer server2 = new DruidServer(
         "serverNorm2",
@@ -1260,7 +1260,7 @@ public class DruidCoordinatorRuleRunnerTest
         0
     );
     for (DataSegment availableSegment : longerAvailableSegments) {
-      server2.addDataSegment(availableSegment.getIdentifier(), availableSegment);
+      server2.addDataSegment(availableSegment);
     }
 
     DruidCluster druidCluster = new DruidCluster(

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
@@ -240,7 +240,7 @@ public class DruidCoordinatorTest extends CuratorTestBase
     ImmutableDruidDataSource druidDataSource = EasyMock.createNiceMock(ImmutableDruidDataSource.class);
     EasyMock.expect(druidDataSource.getSegment(EasyMock.anyString())).andReturn(segment);
     EasyMock.replay(druidDataSource);
-    EasyMock.expect(databaseSegmentManager.getImmutableInventoryValue(EasyMock.anyString())).andReturn(druidDataSource);
+    EasyMock.expect(databaseSegmentManager.getInventoryValue(EasyMock.anyString())).andReturn(druidDataSource);
     EasyMock.replay(databaseSegmentManager);
     scheduledExecutorFactory = EasyMock.createNiceMock(ScheduledExecutorFactory.class);
     EasyMock.replay(scheduledExecutorFactory);
@@ -326,7 +326,7 @@ public class DruidCoordinatorTest extends CuratorTestBase
     druidDataSources[0].addSegment(dataSegment);
 
     EasyMock.expect(databaseSegmentManager.isStarted()).andReturn(true).anyTimes();
-    EasyMock.expect(databaseSegmentManager.getImmutableInventory()).andReturn(
+    EasyMock.expect(databaseSegmentManager.getInventory()).andReturn(
         ImmutableList.of(druidDataSources[0].toImmutableDruidDataSource())
     ).atLeastOnce();
     EasyMock.replay(databaseSegmentManager);
@@ -435,7 +435,7 @@ public class DruidCoordinatorTest extends CuratorTestBase
       dataSource.addSegment(segment);
     }
 
-    EasyMock.expect(databaseSegmentManager.getImmutableInventory()).andReturn(
+    EasyMock.expect(databaseSegmentManager.getInventory()).andReturn(
         ImmutableList.of(dataSource.toImmutableDruidDataSource())
     ).atLeastOnce();
     EasyMock.replay(databaseSegmentManager);

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
@@ -30,12 +30,12 @@ import io.druid.client.ImmutableDruidDataSource;
 import io.druid.client.ImmutableDruidServer;
 import io.druid.client.SingleServerInventoryView;
 import io.druid.common.config.JacksonConfigManager;
-import io.druid.java.util.common.concurrent.Execs;
 import io.druid.curator.CuratorTestBase;
 import io.druid.curator.discovery.NoopServiceAnnouncer;
 import io.druid.discovery.DruidLeaderSelector;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.Intervals;
+import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.concurrent.ScheduledExecutorFactory;
 import io.druid.metadata.MetadataRuleManager;
 import io.druid.metadata.MetadataSegmentManager;
@@ -237,10 +237,10 @@ public class DruidCoordinatorTest extends CuratorTestBase
     EasyMock.expect(loadQueuePeon.getSegmentsToDrop()).andReturn(new HashSet<>()).once();
     EasyMock.replay(loadQueuePeon);
 
-    DruidDataSource druidDataSource = EasyMock.createNiceMock(DruidDataSource.class);
+    ImmutableDruidDataSource druidDataSource = EasyMock.createNiceMock(ImmutableDruidDataSource.class);
     EasyMock.expect(druidDataSource.getSegment(EasyMock.anyString())).andReturn(segment);
     EasyMock.replay(druidDataSource);
-    EasyMock.expect(databaseSegmentManager.getInventoryValue(EasyMock.anyString())).andReturn(druidDataSource);
+    EasyMock.expect(databaseSegmentManager.getImmutableInventoryValue(EasyMock.anyString())).andReturn(druidDataSource);
     EasyMock.replay(databaseSegmentManager);
     scheduledExecutorFactory = EasyMock.createNiceMock(ScheduledExecutorFactory.class);
     EasyMock.replay(scheduledExecutorFactory);
@@ -275,7 +275,8 @@ public class DruidCoordinatorTest extends CuratorTestBase
     coordinator.moveSegment(
         druidServer.toImmutableDruidServer(),
         druidServer2.toImmutableDruidServer(),
-        segment, null
+        segment,
+        null
     );
 
     LoadPeonCallback loadCallback = loadCallbackCapture.getValue();
@@ -322,11 +323,11 @@ public class DruidCoordinatorTest extends CuratorTestBase
         0x9,
         0
     );
-    druidDataSources[0].addSegment("0", dataSegment);
+    druidDataSources[0].addSegment(dataSegment);
 
     EasyMock.expect(databaseSegmentManager.isStarted()).andReturn(true).anyTimes();
-    EasyMock.expect(databaseSegmentManager.getInventory()).andReturn(
-        ImmutableList.of(druidDataSources[0])
+    EasyMock.expect(databaseSegmentManager.getImmutableInventory()).andReturn(
+        ImmutableList.of(druidDataSources[0].toImmutableDruidDataSource())
     ).atLeastOnce();
     EasyMock.replay(databaseSegmentManager);
     ImmutableDruidDataSource immutableDruidDataSource = EasyMock.createNiceMock(ImmutableDruidDataSource.class);
@@ -364,7 +365,7 @@ public class DruidCoordinatorTest extends CuratorTestBase
               if (assignSegmentLatch.getCount() > 0) {
                 //Coordinator should try to assign segment to druidServer historical
                 //Simulate historical loading segment
-                druidServer.addDataSegment(dataSegment.getIdentifier(), dataSegment);
+                druidServer.addDataSegment(dataSegment);
                 assignSegmentLatch.countDown();
               } else {
                 Assert.fail("The same segment is assigned to the same server multiple times");
@@ -431,11 +432,11 @@ public class DruidCoordinatorTest extends CuratorTestBase
         getSegment("test", Intervals.of("2016-01-09T10:00:00Z/2016-01-09T12:00:00Z"))
     };
     for (DataSegment segment : segments) {
-      dataSource.addSegment(segment.getIdentifier(), segment);
+      dataSource.addSegment(segment);
     }
 
-    EasyMock.expect(databaseSegmentManager.getInventory()).andReturn(
-        ImmutableList.of(dataSource)
+    EasyMock.expect(databaseSegmentManager.getImmutableInventory()).andReturn(
+        ImmutableList.of(dataSource.toImmutableDruidDataSource())
     ).atLeastOnce();
     EasyMock.replay(databaseSegmentManager);
     Set<DataSegment> availableSegments = coordinator.getOrderedAvailableDataSegments();

--- a/server/src/test/java/io/druid/server/coordinator/ServerHolderTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/ServerHolderTest.java
@@ -21,7 +21,6 @@ package io.druid.server.coordinator;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.druid.client.ImmutableDruidDataSource;
 import io.druid.client.ImmutableDruidServer;
 import io.druid.java.util.common.Intervals;
@@ -67,15 +66,13 @@ public class ServerHolderTest
       new ImmutableDruidDataSource(
           "src1",
           ImmutableMap.of(),
-          ImmutableMap.of(),
-          ImmutableSet.of()
+          ImmutableMap.of()
       ),
       "src2",
       new ImmutableDruidDataSource(
           "src2",
           ImmutableMap.of(),
-          ImmutableMap.of(),
-          ImmutableSet.of()
+          ImmutableMap.of()
       )
   );
 

--- a/server/src/test/java/io/druid/server/coordinator/cost/CachingCostBalancerStrategyTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/cost/CachingCostBalancerStrategyTest.java
@@ -138,7 +138,7 @@ public class CachingCostBalancerStrategyTest
   {
     DruidServer druidServer = new DruidServer(name, host, null, maxSize, ServerType.HISTORICAL, "normal", 0);
     createDataSegments(numberOfSegments, random, referenceTime)
-        .forEach(segment -> druidServer.addDataSegment(segment.getIdentifier(), segment));
+        .forEach(druidServer::addDataSegment);
     return new ServerHolder(
         druidServer.toImmutableDruidServer(),
         new LoadQueuePeonTester()

--- a/server/src/test/java/io/druid/server/coordinator/rules/BroadcastDistributionRuleTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/rules/BroadcastDistributionRuleTest.java
@@ -114,7 +114,7 @@ public class BroadcastDistributionRuleTest
             ServerType.HISTORICAL,
             "hot",
             0
-        ).addDataSegment(smallSegment.getIdentifier(), smallSegment)
+        ).addDataSegment(smallSegment)
          .toImmutableDruidServer(),
         new LoadQueuePeonTester()
     );
@@ -129,7 +129,7 @@ public class BroadcastDistributionRuleTest
                 ServerType.HISTORICAL,
                 "hot",
                 0
-            ).addDataSegment(largeSegments.get(0).getIdentifier(), largeSegments.get(0))
+            ).addDataSegment(largeSegments.get(0))
              .toImmutableDruidServer(),
             new LoadQueuePeonTester()
         )
@@ -144,7 +144,7 @@ public class BroadcastDistributionRuleTest
                 ServerType.HISTORICAL,
                 DruidServer.DEFAULT_TIER,
                 0
-            ).addDataSegment(largeSegments.get(1).getIdentifier(), largeSegments.get(1))
+            ).addDataSegment(largeSegments.get(1))
              .toImmutableDruidServer(),
             new LoadQueuePeonTester()
         )
@@ -159,7 +159,7 @@ public class BroadcastDistributionRuleTest
                 ServerType.HISTORICAL,
                 DruidServer.DEFAULT_TIER,
                 0
-            ).addDataSegment(largeSegments.get(2).getIdentifier(), largeSegments.get(2))
+            ).addDataSegment(largeSegments.get(2))
              .toImmutableDruidServer(),
             new LoadQueuePeonTester()
         )
@@ -175,7 +175,7 @@ public class BroadcastDistributionRuleTest
                 ServerType.HISTORICAL,
                 "hot",
                 0
-            ).addDataSegment(largeSegments2.get(0).getIdentifier(), largeSegments2.get(0))
+            ).addDataSegment(largeSegments2.get(0))
              .toImmutableDruidServer(),
             new LoadQueuePeonTester()
         )
@@ -190,7 +190,7 @@ public class BroadcastDistributionRuleTest
                 ServerType.HISTORICAL,
                 DruidServer.DEFAULT_TIER,
                 0
-            ).addDataSegment(largeSegments2.get(1).getIdentifier(), largeSegments2.get(1))
+            ).addDataSegment(largeSegments2.get(1))
              .toImmutableDruidServer(),
             new LoadQueuePeonTester()
         )

--- a/server/src/test/java/io/druid/server/coordinator/rules/LoadRuleTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/rules/LoadRuleTest.java
@@ -303,7 +303,7 @@ public class LoadRuleTest
         "hot",
         0
     );
-    server1.addDataSegment(segment.getIdentifier(), segment);
+    server1.addDataSegment(segment);
     DruidServer server2 = new DruidServer(
         "serverNorm",
         "hostNorm",
@@ -313,7 +313,7 @@ public class LoadRuleTest
         DruidServer.DEFAULT_TIER,
         0
     );
-    server2.addDataSegment(segment.getIdentifier(), segment);
+    server2.addDataSegment(segment);
     DruidServer server3 = new DruidServer(
         "serverNormNotServing",
         "hostNorm",
@@ -457,8 +457,8 @@ public class LoadRuleTest
         "hot",
         0
     );
-    server1.addDataSegment(segment.getIdentifier(), segment);
-    server2.addDataSegment(segment.getIdentifier(), segment);
+    server1.addDataSegment(segment);
+    server2.addDataSegment(segment);
 
     DruidCluster druidCluster = new DruidCluster(
         null,

--- a/server/src/test/java/io/druid/server/http/DatasourcesResourceTest.java
+++ b/server/src/test/java/io/druid/server/http/DatasourcesResourceTest.java
@@ -68,7 +68,7 @@ public class DatasourcesResourceTest
   {
     request = EasyMock.createStrictMock(HttpServletRequest.class);
     inventoryView = EasyMock.createStrictMock(CoordinatorServerView.class);
-    server = EasyMock.createStrictMock(DruidServer.class);
+    server = EasyMock.niceMock(DruidServer.class);
     dataSegmentList = new ArrayList<>();
     dataSegmentList.add(
         new DataSegment(
@@ -274,7 +274,6 @@ public class DatasourcesResourceTest
     EasyMock.expect(server.getDataSource("datasource2")).andReturn(
         listDataSources.get(1)
     ).atLeastOnce();
-    EasyMock.expect(server.getTier()).andReturn(null).atLeastOnce();
     EasyMock.expect(inventoryView.getInventory()).andReturn(
         ImmutableList.of(server)
     ).atLeastOnce();

--- a/server/src/test/java/io/druid/server/http/DatasourcesResourceTest.java
+++ b/server/src/test/java/io/druid/server/http/DatasourcesResourceTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableSet;
 import io.druid.client.CoordinatorServerView;
 import io.druid.client.DruidDataSource;
 import io.druid.client.DruidServer;
+import io.druid.client.ImmutableDruidDataSource;
 import io.druid.client.indexing.IndexingServiceClient;
 import io.druid.java.util.common.Intervals;
 import io.druid.server.coordination.ServerType;
@@ -46,11 +47,13 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 public class DatasourcesResourceTest
 {
@@ -108,10 +111,10 @@ public class DatasourcesResourceTest
     );
     listDataSources = new ArrayList<>();
     listDataSources.add(
-        new DruidDataSource("datasource1", new HashMap()).addSegment("part1", dataSegmentList.get(0))
+        new DruidDataSource("datasource1", new HashMap<>()).addSegment(dataSegmentList.get(0))
     );
     listDataSources.add(
-        new DruidDataSource("datasource2", new HashMap()).addSegment("part1", dataSegmentList.get(1))
+        new DruidDataSource("datasource2", new HashMap<>()).addSegment(dataSegmentList.get(1))
     );
   }
 
@@ -155,12 +158,13 @@ public class DatasourcesResourceTest
         AuthTestUtils.TEST_AUTHORIZER_MAPPER
     );
     Response response = datasourcesResource.getQueryableDataSources("full", null, request);
-    Set<DruidDataSource> result = (Set<DruidDataSource>) response.getEntity();
-    DruidDataSource[] resultantDruidDataSources = new DruidDataSource[result.size()];
-    result.toArray(resultantDruidDataSources);
+    Set<ImmutableDruidDataSource> result = (Set<ImmutableDruidDataSource>) response.getEntity();
     Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(2, resultantDruidDataSources.length);
-    Assert.assertArrayEquals(listDataSources.toArray(), resultantDruidDataSources);
+    Assert.assertEquals(2, result.size());
+    Assert.assertEquals(
+        listDataSources.stream().map(DruidDataSource::toImmutableDruidDataSource).collect(Collectors.toSet()),
+        new HashSet<>(result)
+    );
 
     response = datasourcesResource.getQueryableDataSources(null, null, request);
     List<String> result1 = (List<String>) response.getEntity();
@@ -236,13 +240,16 @@ public class DatasourcesResourceTest
         authMapper
     );
     Response response = datasourcesResource.getQueryableDataSources("full", null, request);
-    Set<DruidDataSource> result = (Set<DruidDataSource>) response.getEntity();
-    DruidDataSource[] resultantDruidDataSources = new DruidDataSource[result.size()];
-    result.toArray(resultantDruidDataSources);
+    Set<ImmutableDruidDataSource> result = (Set<ImmutableDruidDataSource>) response.getEntity();
 
     Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(1, resultantDruidDataSources.length);
-    Assert.assertArrayEquals(listDataSources.subList(0, 1).toArray(), resultantDruidDataSources);
+    Assert.assertEquals(1, result.size());
+    Assert.assertEquals(
+        listDataSources.subList(0, 1).stream()
+                       .map(DruidDataSource::toImmutableDruidDataSource)
+                       .collect(Collectors.toSet()),
+        new HashSet<>(result)
+    );
 
     response = datasourcesResource.getQueryableDataSources(null, null, request);
     List<String> result1 = (List<String>) response.getEntity();
@@ -314,9 +321,9 @@ public class DatasourcesResourceTest
     EasyMock.replay(inventoryView, server);
     DatasourcesResource datasourcesResource = new DatasourcesResource(inventoryView, null, null, new AuthConfig(), null);
     Response response = datasourcesResource.getTheDataSource("datasource1", "full");
-    DruidDataSource result = (DruidDataSource) response.getEntity();
+    ImmutableDruidDataSource result = (ImmutableDruidDataSource) response.getEntity();
     Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(dataSource1, result);
+    Assert.assertEquals(dataSource1.toImmutableDruidDataSource(), result);
     EasyMock.verify(inventoryView, server);
   }
 
@@ -337,9 +344,8 @@ public class DatasourcesResourceTest
   @Test
   public void testSimpleGetTheDataSource() throws Exception
   {
-    DruidDataSource dataSource1 = new DruidDataSource("datasource1", new HashMap());
+    DruidDataSource dataSource1 = new DruidDataSource("datasource1", new HashMap<>());
     dataSource1.addSegment(
-        "partition",
         new DataSegment("datasegment1", Intervals.of("2010-01-01/P1D"), null, null, null, null, null, 0x9, 10)
     );
     EasyMock.expect(server.getDataSource("datasource1")).andReturn(
@@ -410,9 +416,9 @@ public class DatasourcesResourceTest
   public void testGetSegmentDataSourceIntervals()
   {
     server = new DruidServer("who", "host", null, 1234, ServerType.HISTORICAL, "tier1", 0);
-    server.addDataSegment(dataSegmentList.get(0).getIdentifier(), dataSegmentList.get(0));
-    server.addDataSegment(dataSegmentList.get(1).getIdentifier(), dataSegmentList.get(1));
-    server.addDataSegment(dataSegmentList.get(2).getIdentifier(), dataSegmentList.get(2));
+    server.addDataSegment(dataSegmentList.get(0));
+    server.addDataSegment(dataSegmentList.get(1));
+    server.addDataSegment(dataSegmentList.get(2));
     EasyMock.expect(inventoryView.getInventory()).andReturn(
         ImmutableList.of(server)
     ).atLeastOnce();
@@ -460,9 +466,9 @@ public class DatasourcesResourceTest
   public void testGetSegmentDataSourceSpecificInterval()
   {
     server = new DruidServer("who", "host", null, 1234, ServerType.HISTORICAL, "tier1", 0);
-    server.addDataSegment(dataSegmentList.get(0).getIdentifier(), dataSegmentList.get(0));
-    server.addDataSegment(dataSegmentList.get(1).getIdentifier(), dataSegmentList.get(1));
-    server.addDataSegment(dataSegmentList.get(2).getIdentifier(), dataSegmentList.get(2));
+    server.addDataSegment(dataSegmentList.get(0));
+    server.addDataSegment(dataSegmentList.get(1));
+    server.addDataSegment(dataSegmentList.get(2));
     EasyMock.expect(inventoryView.getInventory()).andReturn(
         ImmutableList.of(server)
     ).atLeastOnce();

--- a/server/src/test/java/io/druid/server/http/IntervalsResourceTest.java
+++ b/server/src/test/java/io/druid/server/http/IntervalsResourceTest.java
@@ -97,9 +97,9 @@ public class IntervalsResourceTest
         )
     );
     server = new DruidServer("who", "host", null, 1234, ServerType.HISTORICAL, "tier1", 0);
-    server.addDataSegment(dataSegmentList.get(0).getIdentifier(), dataSegmentList.get(0));
-    server.addDataSegment(dataSegmentList.get(1).getIdentifier(), dataSegmentList.get(1));
-    server.addDataSegment(dataSegmentList.get(2).getIdentifier(), dataSegmentList.get(2));
+    server.addDataSegment(dataSegmentList.get(0));
+    server.addDataSegment(dataSegmentList.get(1));
+    server.addDataSegment(dataSegmentList.get(2));
   }
 
   @Test

--- a/server/src/test/java/io/druid/server/http/ServersResourceTest.java
+++ b/server/src/test/java/io/druid/server/http/ServersResourceTest.java
@@ -51,7 +51,7 @@ public class ServersResourceTest
                                      .version("v0")
                                      .size(1L)
                                      .build();
-    dummyServer.addDataSegment(segment.getIdentifier(), segment);
+    dummyServer.addDataSegment(segment);
 
     CoordinatorServerView inventoryView = EasyMock.createMock(CoordinatorServerView.class);
     EasyMock.expect(inventoryView.getInventory()).andReturn(ImmutableList.of(dummyServer)).anyTimes();

--- a/services/src/main/java/io/druid/cli/CliRealtimeExample.java
+++ b/services/src/main/java/io/druid/cli/CliRealtimeExample.java
@@ -44,6 +44,7 @@ import io.druid.timeline.DataSegment;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -119,7 +120,7 @@ public class CliRealtimeExample extends ServerRunnable
     }
 
     @Override
-    public Iterable<DruidServer> getInventory()
+    public Collection<DruidServer> getInventory()
     {
       return ImmutableList.of();
     }


### PR DESCRIPTION
DruidDataSource is mutable and thus should not be used as a key of map or set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/druid-io/druid/5054)
<!-- Reviewable:end -->
