### PR TITLE
Use daemon thread pool for AsyncHttpClient in emitters

### DIFF
--- a/server/src/main/java/io/druid/server/emitter/HttpEmitterModule.java
+++ b/server/src/main/java/io/druid/server/emitter/HttpEmitterModule.java
@@ -35,6 +35,7 @@ import io.druid.guice.ManageLifecycle;
 import io.druid.java.util.common.lifecycle.Lifecycle;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.JdkSslContext;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClientConfig;
@@ -82,6 +83,7 @@ public class HttpEmitterModule implements Module
     if (sslContext != null) {
       builder.setSslContext(new JdkSslContext(sslContext, true, ClientAuth.NONE));
     }
+    builder.setThreadFactory(new DefaultThreadFactory("emitter-http-client", true));
     final AsyncHttpClient client = new DefaultAsyncHttpClient(builder.build());
     lifecycle.addCloseableInstance(client);
 

--- a/server/src/main/java/io/druid/server/emitter/HttpEmitterModule.java
+++ b/server/src/main/java/io/druid/server/emitter/HttpEmitterModule.java
@@ -32,10 +32,10 @@ import com.metamx.emitter.core.HttpPostEmitter;
 import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.LazySingleton;
 import io.druid.guice.ManageLifecycle;
+import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.lifecycle.Lifecycle;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.JdkSslContext;
-import io.netty.util.concurrent.DefaultThreadFactory;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClientConfig;
@@ -83,7 +83,7 @@ public class HttpEmitterModule implements Module
     if (sslContext != null) {
       builder.setSslContext(new JdkSslContext(sslContext, true, ClientAuth.NONE));
     }
-    builder.setThreadFactory(new DefaultThreadFactory("emitter-http-client", true));
+    builder.setThreadFactory(Execs.makeThreadFactory("HttpPostEmitter-AsyncHttpClient-%d"));
     final AsyncHttpClient client = new DefaultAsyncHttpClient(builder.build());
     lifecycle.addCloseableInstance(client);
 

--- a/server/src/main/java/io/druid/server/emitter/ParametrizedUriEmitterModule.java
+++ b/server/src/main/java/io/druid/server/emitter/ParametrizedUriEmitterModule.java
@@ -33,6 +33,7 @@ import io.druid.guice.ManageLifecycle;
 import io.druid.java.util.common.lifecycle.Lifecycle;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.JdkSslContext;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClientConfig;
@@ -63,6 +64,7 @@ public class ParametrizedUriEmitterModule implements Module
     if (sslContext != null) {
       builder.setSslContext(new JdkSslContext(sslContext, true, ClientAuth.NONE));
     }
+    builder.setThreadFactory(new DefaultThreadFactory("parametrized-emitter-http-client", true));
     final AsyncHttpClient client = new DefaultAsyncHttpClient(builder.build());
     lifecycle.addCloseableInstance(client);
 

--- a/server/src/main/java/io/druid/server/emitter/ParametrizedUriEmitterModule.java
+++ b/server/src/main/java/io/druid/server/emitter/ParametrizedUriEmitterModule.java
@@ -30,13 +30,7 @@ import com.metamx.emitter.core.ParametrizedUriEmitter;
 import com.metamx.emitter.core.ParametrizedUriEmitterConfig;
 import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.ManageLifecycle;
-import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.lifecycle.Lifecycle;
-import io.netty.handler.ssl.ClientAuth;
-import io.netty.handler.ssl.JdkSslContext;
-import org.asynchttpclient.AsyncHttpClient;
-import org.asynchttpclient.DefaultAsyncHttpClient;
-import org.asynchttpclient.DefaultAsyncHttpClientConfig;
 
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
@@ -60,14 +54,12 @@ public class ParametrizedUriEmitterModule implements Module
       ObjectMapper jsonMapper
   )
   {
-    final DefaultAsyncHttpClientConfig.Builder builder = new DefaultAsyncHttpClientConfig.Builder();
-    if (sslContext != null) {
-      builder.setSslContext(new JdkSslContext(sslContext, true, ClientAuth.NONE));
-    }
-    builder.setThreadFactory(Execs.makeThreadFactory("ParametrizedUriEmitter-AsyncHttpClient-%d"));
-    final AsyncHttpClient client = new DefaultAsyncHttpClient(builder.build());
-    lifecycle.addCloseableInstance(client);
-
-    return new ParametrizedUriEmitter(config.get(), client, jsonMapper);
+    return new ParametrizedUriEmitter(
+        config.get(),
+        lifecycle.addCloseableInstance(
+            HttpEmitterModule.createAsyncHttpClient("ParmetrizedUriEmitter-AsyncHttpClient-%d", sslContext)
+        ),
+        jsonMapper
+    );
   }
 }

--- a/server/src/main/java/io/druid/server/emitter/ParametrizedUriEmitterModule.java
+++ b/server/src/main/java/io/druid/server/emitter/ParametrizedUriEmitterModule.java
@@ -30,10 +30,10 @@ import com.metamx.emitter.core.ParametrizedUriEmitter;
 import com.metamx.emitter.core.ParametrizedUriEmitterConfig;
 import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.ManageLifecycle;
+import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.lifecycle.Lifecycle;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.JdkSslContext;
-import io.netty.util.concurrent.DefaultThreadFactory;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClientConfig;
@@ -64,7 +64,7 @@ public class ParametrizedUriEmitterModule implements Module
     if (sslContext != null) {
       builder.setSslContext(new JdkSslContext(sslContext, true, ClientAuth.NONE));
     }
-    builder.setThreadFactory(new DefaultThreadFactory("parametrized-emitter-http-client", true));
+    builder.setThreadFactory(Execs.makeThreadFactory("ParametrizedUriEmitter-AsyncHttpClient-%d"));
     final AsyncHttpClient client = new DefaultAsyncHttpClient(builder.build());
     lifecycle.addCloseableInstance(client);
 


### PR DESCRIPTION
This PR is to configure `AsyncHttpClient`s to use daemon thread pool: https://github.com/druid-io/druid/pull/4973#issuecomment-342871574