### PR TITLE
fix lookups endpoint collisions

### DIFF
--- a/docs/content/querying/lookups.md
+++ b/docs/content/querying/lookups.md
@@ -48,12 +48,12 @@ The tiers for lookups are completely independent of historical tiers.
 These configs are accessed using JSON through the following URI template
 
 ```
-http://<COORDINATOR_IP>:<PORT>/druid/coordinator/v1/lookups/{tier}/{id}
+http://<COORDINATOR_IP>:<PORT>/druid/coordinator/v1/lookups/config/{tier}/{id}
 ```
 
 All URIs below are assumed to have `http://<COORDINATOR_IP>:<PORT>` prepended.
 
-If you have NEVER configured lookups before, you MUST post an empty json object `{}` to `/druid/coordinator/v1/lookups` to initialize the configuration.
+If you have NEVER configured lookups before, you MUST post an empty json object `{}` to `/druid/coordinator/v1/lookups/config` to initialize the configuration.
 
 These endpoints will return one of the following results:
 
@@ -70,7 +70,7 @@ The coordinator periodically checks if any of the nodes need to load/drop lookup
 # API for configuring lookups
 
 ## Bulk update
-Lookups can be updated in bulk by posting a JSON object to `/druid/coordinator/v1/lookups`. The format of the json object is as follows:
+Lookups can be updated in bulk by posting a JSON object to `/druid/coordinator/v1/lookups/config`. The format of the json object is as follows:
 
 ```json
 {
@@ -188,9 +188,9 @@ For example, a config might look something like:
 All entries in the map will UPDATE existing entries. No entries will be deleted.
 
 ## Update Lookup
-A `POST` to a particular lookup extractor factory via `/druid/coordinator/v1/lookups/{tier}/{id}` will update that specific extractor factory.
+A `POST` to a particular lookup extractor factory via `/druid/coordinator/v1/lookups/config/{tier}/{id}` will update that specific extractor factory.
 
-For example, a post to `/druid/coordinator/v1/lookups/realtime_customer1/site_id_customer1` might contain the following:
+For example, a post to `/druid/coordinator/v1/lookups/config/realtime_customer1/site_id_customer1` might contain the following:
 
 ```json
 {
@@ -209,7 +209,7 @@ This will replace the `site_id_customer1` lookup in the `realtime_customer1` wit
 ## Get Lookup
 A `GET` to a particular lookup extractor factory is accomplished via `/druid/coordinator/v1/lookups/{tier}/{id}`
 
-Using the prior example, a `GET` to `/druid/coordinator/v1/lookups/realtime_customer2/site_id_customer2` should return
+Using the prior example, a `GET` to `/druid/coordinator/v1/lookups/config/realtime_customer2/site_id_customer2` should return
 
 ```json
 {
@@ -224,14 +224,14 @@ Using the prior example, a `GET` to `/druid/coordinator/v1/lookups/realtime_cust
 ```
 
 ## Delete Lookup
-A `DELETE` to `/druid/coordinator/v1/lookups/{tier}/{id}` will remove that lookup from the cluster.
+A `DELETE` to `/druid/coordinator/v1/lookups/config/{tier}/{id}` will remove that lookup from the cluster.
 
 ## List tier names
-A `GET` to `/druid/coordinator/v1/lookups` will return a list of known tier names in the dynamic configuration.
+A `GET` to `/druid/coordinator/v1/lookups/config` will return a list of known tier names in the dynamic configuration.
 To discover a list of tiers currently active in the cluster **instead of** ones known in the dynamic configuration, the parameter `discover=true` can be added as per `/druid/coordinator/v1/lookups?discover=true`.
 
 ## List lookup names
-A `GET` to `/druid/coordinator/v1/lookups/{tier}` will return a list of known lookup names for that tier.
+A `GET` to `/druid/coordinator/v1/lookups/config/{tier}` will return a list of known lookup names for that tier.
 
 # Additional API related to status of configured lookups
 These end points can be used to get the propagation status of configured lookups to lookup nodes such as historicals.

--- a/server/src/main/java/io/druid/query/lookup/LookupReferencesManager.java
+++ b/server/src/main/java/io/druid/query/lookup/LookupReferencesManager.java
@@ -518,7 +518,7 @@ public class LookupReferencesManager
         druidLeaderClient.makeRequest(
             HttpMethod.GET,
             StringUtils.format(
-                "/druid/coordinator/v1/lookups/%s?detailed=true",
+                "/druid/coordinator/v1/lookups/config/%s?detailed=true",
                 tier
             )
         ));

--- a/server/src/main/java/io/druid/server/http/LookupCoordinatorResource.java
+++ b/server/src/main/java/io/druid/server/http/LookupCoordinatorResource.java
@@ -90,6 +90,7 @@ public class LookupCoordinatorResource
   }
 
   @GET
+  @Path("/config")
   @Produces({MediaType.APPLICATION_JSON, SmileMediaTypes.APPLICATION_JACKSON_SMILE})
   public Response getTiers(
       @DefaultValue("false") @QueryParam("discover") boolean discover
@@ -113,6 +114,7 @@ public class LookupCoordinatorResource
   }
 
   @POST
+  @Path("/config")
   @Produces({MediaType.APPLICATION_JSON, SmileMediaTypes.APPLICATION_JACKSON_SMILE})
   @Consumes({MediaType.APPLICATION_JSON, SmileMediaTypes.APPLICATION_JACKSON_SMILE})
   public Response updateAllLookups(
@@ -148,7 +150,7 @@ public class LookupCoordinatorResource
 
   @DELETE
   @Produces({MediaType.APPLICATION_JSON, SmileMediaTypes.APPLICATION_JACKSON_SMILE})
-  @Path("/{tier}/{lookup}")
+  @Path("/config/{tier}/{lookup}")
   public Response deleteLookup(
       @PathParam("tier") String tier,
       @PathParam("lookup") String lookup,
@@ -184,7 +186,7 @@ public class LookupCoordinatorResource
 
   @POST
   @Produces({MediaType.APPLICATION_JSON, SmileMediaTypes.APPLICATION_JACKSON_SMILE})
-  @Path("/{tier}/{lookup}")
+  @Path("/config/{tier}/{lookup}")
   public Response createOrUpdateLookup(
       @PathParam("tier") String tier,
       @PathParam("lookup") String lookup,
@@ -234,7 +236,7 @@ public class LookupCoordinatorResource
 
   @GET
   @Produces({MediaType.APPLICATION_JSON, SmileMediaTypes.APPLICATION_JACKSON_SMILE})
-  @Path("/{tier}/{lookup}")
+  @Path("/config/{tier}/{lookup}")
   public Response getSpecificLookup(
       @PathParam("tier") String tier,
       @PathParam("lookup") String lookup
@@ -267,7 +269,7 @@ public class LookupCoordinatorResource
 
   @GET
   @Produces({MediaType.APPLICATION_JSON, SmileMediaTypes.APPLICATION_JACKSON_SMILE})
-  @Path("/{tier}")
+  @Path("/config/{tier}")
   public Response getSpecificTier(
       @PathParam("tier") String tier,
       @DefaultValue("false") @QueryParam("detailed") boolean detailed

--- a/server/src/test/java/io/druid/query/lookup/LookupReferencesManagerTest.java
+++ b/server/src/test/java/io/druid/query/lookup/LookupReferencesManagerTest.java
@@ -110,7 +110,7 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.OK,
@@ -171,7 +171,7 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.OK,
@@ -209,7 +209,7 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.OK,
@@ -240,7 +240,7 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.OK,
@@ -268,7 +268,7 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.OK,
@@ -298,7 +298,7 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.OK,
@@ -332,7 +332,7 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.OK,
@@ -360,7 +360,7 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.OK,
@@ -411,7 +411,7 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.OK,
@@ -453,7 +453,7 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.OK,
@@ -529,7 +529,7 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.OK,
@@ -555,7 +555,7 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.NOT_FOUND,
@@ -578,7 +578,7 @@ public class LookupReferencesManagerTest
     reset(druidLeaderClient);
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
     expect(druidLeaderClient.go(request)).andThrow(new IllegalStateException());
     replay(druidLeaderClient);

--- a/server/src/test/java/io/druid/query/lookup/LookupReferencesManagerTest.java
+++ b/server/src/test/java/io/druid/query/lookup/LookupReferencesManagerTest.java
@@ -37,7 +37,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import javax.ws.rs.HEAD;
 import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
@@ -57,13 +56,7 @@ public class LookupReferencesManagerTest
 
   private LookupListeningAnnouncerConfig config;
 
-  private static final String propertyBase = "some.property";
-
   private static final String LOOKUP_TIER = "lookupTier";
-
-  private static final int LOOKUP_THREADS = 1;
-
-  private static final boolean LOOKUP_DISABLE = false;
 
   LookupExtractorFactory lookupExtractorFactory;
 


### PR DESCRIPTION
basically endpoints like '/{tier}/{name}' collide with '/status/{tier}' etc. this patch fixes all such collisions by consolidating all endpoints into 3 prefixes..

/config - for all endpoints dealing with lookups config
/status - dealing with load status of lookups
/nodeStatus - dealing with lookup statuses on individual nodes

this is backward incompatible as some of those endpoints are used by the users to change lookups configuration via coordinator.

Reported by user: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/druid-user/K_bjOWaLliM/eLX7uvqxBgAJ


