### PR TITLE
Downgrade Netty version 4.1 -> 4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,9 @@
         <!-- Watch out for Hadoop compatibility when updating to >= 2.5; see https://github.com/druid-io/druid/pull/1669 -->
         <jackson.version>2.4.6</jackson.version>
         <log4j.version>2.5</log4j.version>
-        <netty.version>4.1.11.Final</netty.version>
+        <!-- Update to Netty 4.1 is not possible yet, see https://github.com/druid-io/druid/issues/4390 and comments
+             in https://github.com/druid-io/druid/pull/4973 -->
+        <netty.version>4.0.52.Final</netty.version>
         <slf4j.version>1.7.12</slf4j.version>
         <!-- If compiling with different hadoop version also modify default hadoop coordinates in TaskConfig.java -->
         <hadoop.compile.version>2.7.3</hadoop.compile.version>


### PR DESCRIPTION
Because of #4390 and the problems with client: https://github.com/druid-io/druid/pull/4973#issuecomment-342958133, I agree now that it's better to downgrade, as was suggested here: https://github.com/druid-io/druid/issues/4390#issuecomment-307913911