### PR TITLE
Automatically insert authenticator/authorizer names into config properties

### DIFF
--- a/docs/content/configuration/auth.md
+++ b/docs/content/configuration/auth.md
@@ -100,3 +100,15 @@ Authenticators must implement three methods related to the internal system user:
 `createEscalatedJettyClient` is similar to `createEscalatedClient`, except that it operates on a Jetty HttpClient.
 
 `createEscalatedAuthenticationResult` returns an AuthenticationResult containing the identity of the "internal system user".
+
+## Reserved Name Configuration Property
+
+For extension implementers, please note that the following configuration properties are reserved for the names of Authenticators and Authorizers:
+
+```
+druid.auth.authenticator.<authenticator-name>.name=<authenticator-name>
+druid.auth.authorizer.<authorizer-name>.name=<authorizer-name>
+
+```
+
+These properties provide the authenticator and authorizer names to the implementations as @JsonProperty parameters, potentially useful when multiple authenticators or authorizers of the same type are configured.

--- a/server/src/main/java/io/druid/server/initialization/AuthenticatorMapperModule.java
+++ b/server/src/main/java/io/druid/server/initialization/AuthenticatorMapperModule.java
@@ -108,7 +108,14 @@ public class AuthenticatorMapperModule implements DruidModule
             Authenticator.class
         );
 
-        authenticatorProvider.inject(props, configurator);
+        String nameProperty = StringUtils.format("druid.auth.authenticator.%s.name", authenticatorName);
+        Properties adjustedProps = new Properties(props);
+        if (adjustedProps.containsKey(nameProperty)) {
+          throw new IAE("Name property [%s] is reserved.", nameProperty);
+        } else {
+          adjustedProps.put(nameProperty, authenticatorName);
+        }
+        authenticatorProvider.inject(adjustedProps, configurator);
 
         Supplier<Authenticator> authenticatorSupplier = authenticatorProvider.get();
         if (authenticatorSupplier == null) {

--- a/server/src/main/java/io/druid/server/initialization/AuthorizerMapperModule.java
+++ b/server/src/main/java/io/druid/server/initialization/AuthorizerMapperModule.java
@@ -111,7 +111,15 @@ public class AuthorizerMapperModule implements DruidModule
             Authorizer.class
         );
 
-        authorizerProvider.inject(props, configurator);
+        String nameProperty = StringUtils.format("druid.auth.authorizer.%s.name", authorizerName);
+        Properties adjustedProps = new Properties(props);
+        if (adjustedProps.containsKey(nameProperty)) {
+          throw new IAE("Name property [%s] is reserved.", nameProperty);
+        } else {
+          adjustedProps.put(nameProperty, authorizerName);
+        }
+
+        authorizerProvider.inject(adjustedProps, configurator);
 
         Supplier<Authorizer> authorizerSupplier = authorizerProvider.get();
         if (authorizerSupplier == null) {


### PR DESCRIPTION
This PR automatically inserts the following properties into the Properties object provided to Authenticator and Authorizer implementations:

```
druid.auth.authenticator.<authenticator-name>.name=<authenticator-name>
druid.auth.authorizer.<authorizer-name>.name=<authorizer-name>
```

Providing the name which is not easily accessible without this PR can be useful when there are multiple authenticator/authorizer instances of the same type.