### PR TITLE
Update Apache Avro to 1.8.2

### DIFF
--- a/extensions-core/avro-extensions/pom.xml
+++ b/extensions-core/avro-extensions/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <schemarepo.version>0.1.3</schemarepo.version>
     <confluent.version>3.0.1</confluent.version>
-    <avro.version>1.8.0</avro.version>
+    <avro.version>1.8.2</avro.version>
     <pig.version>0.15.0</pig.version>
   </properties>
 
@@ -49,11 +49,11 @@
   </repositories>
 
   <dependencies>
-      <dependency>
-          <groupId>org.apache.avro</groupId>
-          <artifactId>avro</artifactId>
-          <version>${avro.version}</version>
-      </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>${avro.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro-mapred</artifactId>

--- a/extensions-core/druid-kerberos/pom.xml
+++ b/extensions-core/druid-kerberos/pom.xml
@@ -121,6 +121,10 @@
           <artifactId>zookeeper</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
         </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -642,6 +642,12 @@
                 <artifactId>hadoop-client</artifactId>
                 <version>${hadoop.compile.version}</version>
                 <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.avro</groupId>
+                        <artifactId>avro</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.mapdb</groupId>


### PR DESCRIPTION
Hi all,

I still experience some error while importing datetime columns:
```
2017-11-10T20:41:37,813 ERROR [main] org.apache.hadoop.mapred.YarnChild - Error running child : java.lang.NoSuchMethodError: org.apache.avro.Schema.setLogicalType(Lorg/apache/avro/LogicalType;)V
	at org.apache.avro.LogicalType.addToSchema(LogicalType.java:72)
	at org.apache.parquet.avro.AvroSchemaConverter.convertField(AvroSchemaConverter.java:309)
	at org.apache.parquet.avro.AvroSchemaConverter.convertFields(AvroSchemaConverter.java:241)
	at org.apache.parquet.avro.AvroSchemaConverter.convert(AvroSchemaConverter.java:231)
	at org.apache.parquet.avro.DruidParquetReadSupport.prepareForRead(DruidParquetReadSupport.java:98)
	at org.apache.parquet.hadoop.InternalParquetRecordReader.initialize(InternalParquetRecordReader.java:175)
	at org.apache.parquet.hadoop.ParquetRecordReader.initializeInternalReader(ParquetRecordReader.java:190)
	at org.apache.parquet.hadoop.ParquetRecordReader.initialize(ParquetRecordReader.java:147)
	at org.apache.hadoop.mapreduce.lib.input.DelegatingRecordReader.initialize(DelegatingRecordReader.java:84)
	at org.apache.hadoop.mapred.MapTask$NewTrackingRecordReader.initialize(MapTask.java:548)
	at org.apache.hadoop.mapred.MapTask.runNewMapper(MapTask.java:786)
	at org.apache.hadoop.mapred.MapTask.run(MapTask.java:341)
	at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:164)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:422)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1698)
	at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:158)
```

I need to exclude some of the avro pulled in with other dependancies. I'm also working to get all the Avro dependancies on the same level:
https://github.com/apache/parquet-mr/commit/ba7b8ba69984bd2c91c41eeab9a2f030661e5a49
But this is something for the future, but it would be nice to have Druid compatible with Avro 1.8.2

Old Dependancy tree:
https://gist.github.com/Fokko/e2f6d805c4f9a0b70f8ff34f12c952f0
New one:
https://gist.github.com/Fokko/7bcce0b547bc79caa7bd95ad54c63a4c

I did a test and I'm able to parse datetime fields in Parquet.

Cheers, Fokko