### PR TITLE
make AsyncHttpCLient instance timer thread daemon

### DIFF
--- a/server/src/main/java/io/druid/server/emitter/ParametrizedUriEmitterModule.java
+++ b/server/src/main/java/io/druid/server/emitter/ParametrizedUriEmitterModule.java
@@ -57,7 +57,11 @@ public class ParametrizedUriEmitterModule implements Module
     return new ParametrizedUriEmitter(
         config.get(),
         lifecycle.addCloseableInstance(
-            HttpEmitterModule.createAsyncHttpClient("ParmetrizedUriEmitter-AsyncHttpClient-%d", sslContext)
+            HttpEmitterModule.createAsyncHttpClient(
+                "ParmetrizedUriEmitter-AsyncHttpClient-%d",
+                "ParmetrizedUriEmitter-AsyncHttpClient-Timer-%d",
+                sslContext
+            )
         ),
         jsonMapper
     );


### PR DESCRIPTION
Unfortunately https://github.com/druid-io/druid/pull/5057 did not solve the problem mentioned in https://github.com/druid-io/druid/pull/4973#issuecomment-342871574 .

I did some more investigation and found that non-daemon thread actually comes from https://github.com/AsyncHttpClient/async-http-client/blob/async-http-client-project-2.0.37/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClient.java#L93 .

this patch overrides that timer to be exactly same except for using daemon threads. I tested it on my dev environment and problem appears to be solved.

For example, when I run druid code without this patch with Http emitter enabled, then I can see (in thread dump) non-daemon thread with name similar to "pool-39-thread-1"  and with this patch those don't exist and I see daemon threads with name like "HttpPostEmitter-AsyncHttpClient-Timer-0"  instead .

I'll test it more on some environments, but I think this fixed the issue.