### PR TITLE
Fix AnnouncerTest.testSanity()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,20 @@ matrix:
         - unset _JAVA_OPTIONS
       script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -Pparallel-test -Dmaven.fork.count=2 -pl processing
 
-      # non-processing modules test
+      # server module test
     - sudo: false
       install: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn install -q -ff -DskipTests -B
       before_script:
         - unset _JAVA_OPTIONS
-      script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -Pparallel-test -Dmaven.fork.count=2 -pl '!processing'
+      # Server module test is run without the parallel-test option because it's memory sensitive and often fails with that option.
+      script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -pl server
+
+      # other modules test
+    - sudo: false
+      install: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn install -q -ff -DskipTests -B
+      before_script:
+        - unset _JAVA_OPTIONS
+      script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -Pparallel-test -Dmaven.fork.count=2 -pl '!processing,!server'
 
       # run integration tests
     - sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,16 @@ matrix:
   include:
       # strict compilation
     - sudo: false
+      env:
+        - NAME="strict compilation"
       install: true
       # Strict compilation requires more than 2 GB
       script: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn clean -Pstrict -pl '!benchmarks' compile test-compile -B
 
       # processing module test
     - sudo: false
+      env:
+        - NAME="processing module test"
       install: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn install -q -ff -DskipTests -B
       before_script:
         - unset _JAVA_OPTIONS
@@ -26,6 +30,8 @@ matrix:
 
       # server module test
     - sudo: false
+      env:
+        - NAME="server module test"
       install: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn install -q -ff -DskipTests -B
       before_script:
         - unset _JAVA_OPTIONS
@@ -34,6 +40,8 @@ matrix:
 
       # other modules test
     - sudo: false
+      env:
+        - NAME="other modules test"
       install: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn install -q -ff -DskipTests -B
       before_script:
         - unset _JAVA_OPTIONS
@@ -44,6 +52,7 @@ matrix:
       services:
         - docker
       env:
+        - NAME="integration test"
         - DOCKER_IP=172.17.0.1
       install:
         # Only errors will be shown with the -q option. This is to avoid generating too many logs which make travis build failed.

--- a/server/src/main/java/io/druid/curator/announcement/Announcer.java
+++ b/server/src/main/java/io/druid/curator/announcement/Announcer.java
@@ -236,6 +236,8 @@ public class Announcer
                 @Override
                 public void childEvent(CuratorFramework client, PathChildrenCacheEvent event) throws Exception
                 {
+                  // NOTE: ZooKeeper does not guarantee that we will get every event, and thus PathChildrenCache doesn't
+                  // as well. If one of the below events are missed, Announcer might not work properly.
                   log.debug("Path[%s] got event[%s]", parentPath, event);
                   switch (event.getType()) {
                     case CHILD_REMOVED:

--- a/server/src/test/java/io/druid/curator/announcement/AnnouncerTest.java
+++ b/server/src/test/java/io/druid/curator/announcement/AnnouncerTest.java
@@ -103,7 +103,7 @@ public class AnnouncerTest extends CuratorTestBase
       Assert.assertArrayEquals("/test1 still has data", billy, curator.getData().decompressed().forPath(testPath1));
       Assert.assertArrayEquals("/somewhere/test2 has data", billy, curator.getData().decompressed().forPath(testPath2));
 
-      final CountDownLatch deleteLatch = new CountDownLatch(1);
+      final CountDownLatch recreateLatch = new CountDownLatch(1);
       curator.getCuratorListenable().addListener(
           new CuratorListener()
           {
@@ -111,7 +111,7 @@ public class AnnouncerTest extends CuratorTestBase
             public void eventReceived(CuratorFramework client, CuratorEvent event) throws Exception
             {
               if (event.getType() == CuratorEventType.CREATE && event.getPath().equals(testPath1)) {
-                deleteLatch.countDown();
+                recreateLatch.countDown();
               }
             }
           }
@@ -123,7 +123,7 @@ public class AnnouncerTest extends CuratorTestBase
       final CuratorTransactionResult result = results.iterator().next();
       Assert.assertEquals(Code.OK.intValue(), result.getError()); // assert delete
 
-      Assert.assertTrue("Wait for /test1 to be created", timing.forWaiting().awaitLatch(deleteLatch));
+      Assert.assertTrue("Wait for /test1 to be created", timing.forWaiting().awaitLatch(recreateLatch));
 
       Assert.assertNotNull("/test1 does exists", curator.checkExists().forPath(testPath1));
 


### PR DESCRIPTION
Fix #2253.

AnnouncerTest essentially

1. Makes a PathChildrenCache for ```/``` and writes something on a ```/test1``` in background. The PathChildrenCache has an event listener for the ```CHILD_REMOVED``` event.
2. Deletes ```/test1``` transactionally.
3. Expects PathChildrenCache recreates the removed path on ```CHILD_REMOVED``` event.

However, if the delete in the second step is performed before the write in the first step is finished, PathChildrenCache never receives ```CHILD_REMOVED``` event. 

I fixed this issue by waiting for the ```/test1``` path to be created before calling the delete operation. However, I'm still concerned with that this issue may exist in real applications.

Since ZooKeeper and Curator offers eventual consistency, it doesn't guarantee that all events are received. So I think the best solution is to use another coordination system guaranteeing all events are seen. HTTP-based coordination system @himanshug is working on can be a good solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/druid-io/druid/5077)
<!-- Reviewable:end -->
