### PR TITLE
Add relogin logic to renew the Kerberos TGT once it expire

### DIFF
--- a/extensions-core/druid-kerberos/src/main/java/io/druid/security/kerberos/DruidKerberosUtil.java
+++ b/extensions-core/druid-kerberos/src/main/java/io/druid/security/kerberos/DruidKerberosUtil.java
@@ -99,10 +99,21 @@ public class DruidKerberosUtil
       conf.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION, "kerberos");
       UserGroupInformation.setConfiguration(conf);
       try {
+        //login for the first time.
         if (UserGroupInformation.getCurrentUser().hasKerberosCredentials() == false
             || !UserGroupInformation.getCurrentUser().getUserName().equals(internalClientPrincipal)) {
           log.info("trying to authenticate user [%s] with keytab [%s]", internalClientPrincipal, internalClientKeytab);
           UserGroupInformation.loginUserFromKeytab(internalClientPrincipal, internalClientKeytab);
+        }
+        //try to relogin in case the TGT expired
+        if (UserGroupInformation.isLoginKeytabBased()) {
+          log.info("Re-Login from key tab [%s] with principal [%s]", internalClientKeytab, internalClientPrincipal);
+          UserGroupInformation.getLoginUser().checkTGTAndReloginFromKeytab();
+          return;
+        } else if (UserGroupInformation.isLoginTicketBased()) {
+          log.info("Re-Login from Ticket cache");
+          UserGroupInformation.getLoginUser().reloginFromTicketCache();
+          return;
         }
       }
       catch (IOException e) {

--- a/extensions-core/druid-kerberos/src/main/java/io/druid/security/kerberos/DruidKerberosUtil.java
+++ b/extensions-core/druid-kerberos/src/main/java/io/druid/security/kerberos/DruidKerberosUtil.java
@@ -104,6 +104,7 @@ public class DruidKerberosUtil
             || !UserGroupInformation.getCurrentUser().getUserName().equals(internalClientPrincipal)) {
           log.info("trying to authenticate user [%s] with keytab [%s]", internalClientPrincipal, internalClientKeytab);
           UserGroupInformation.loginUserFromKeytab(internalClientPrincipal, internalClientKeytab);
+          return;
         }
         //try to relogin in case the TGT expired
         if (UserGroupInformation.isLoginKeytabBased()) {


### PR DESCRIPTION
Kerberos Credentials expire after some period of time and need to re-login in order to renew the tickets. 
