### PR TITLE
Fix numLookupLoadingThreads default value

### DIFF
--- a/processing/src/main/java/io/druid/query/lookup/LookupConfig.java
+++ b/processing/src/main/java/io/druid/query/lookup/LookupConfig.java
@@ -37,7 +37,7 @@ public class LookupConfig
 
   @Min(1)
   @JsonProperty("numLookupLoadingThreads")
-  private int numLookupLoadingThreads = Runtime.getRuntime().availableProcessors() / 2;
+  private int numLookupLoadingThreads = Math.max(1, Runtime.getRuntime().availableProcessors() / 2);
 
   @Min(1)
   @JsonProperty("coordinatorFetchRetries")


### PR DESCRIPTION
If `Runtime.getRuntime().availableProcessors()` is less than 2, injecting LookupConfig fails with the following:

```
Exception in thread "main" com.google.inject.CreationException: Unable to create injector, see the following errors:

1) Error in custom provider, java.lang.RuntimeException: com.fasterxml.jackson.databind.JsonMappingException: Unable to provision, see the following errors:

1) druid.lookup.numLookupLoadingThreads - must be greater than or equal to 1
  at io.druid.guice.JsonConfigProvider.bind(JsonConfigProvider.java:133) (via modules: com.google.inject.util.Modules$OverrideModule -> com.google.inject.util.Modules$OverrideModule -> io.druid.query.lookup.LookupModule)
```

This PR makes sure the value will be at least 1, if left unspecified.