### PR TITLE
SQL: Improve translation of time floor expressions.

### DIFF
--- a/common/src/main/java/io/druid/math/expr/Parser.java
+++ b/common/src/main/java/io/druid/math/expr/Parser.java
@@ -35,6 +35,7 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 
+import javax.annotation.Nullable;
 import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.Map;
@@ -145,6 +146,16 @@ public class Parser
         }
     );
     return Lists.newArrayList(found);
+  }
+
+  @Nullable
+  public static String getIdentifierIfIdentifier(Expr expr)
+  {
+    if (expr instanceof IdentifierExpr) {
+      return expr.toString();
+    } else {
+      return null;
+    }
   }
 
   public static Expr.ObjectBinding withMap(final Map<String, ?> bindings)

--- a/processing/src/main/java/io/druid/query/expression/ExprUtils.java
+++ b/processing/src/main/java/io/druid/query/expression/ExprUtils.java
@@ -28,6 +28,8 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.Period;
 import org.joda.time.chrono.ISOChronology;
 
+import javax.annotation.Nullable;
+
 public class ExprUtils
 {
   private static final Expr.ObjectBinding NIL_BINDINGS = name -> null;
@@ -49,8 +51,8 @@ public class ExprUtils
 
   public static PeriodGranularity toPeriodGranularity(
       final Expr periodArg,
-      final Expr originArg,
-      final Expr timeZoneArg,
+      @Nullable final Expr originArg,
+      @Nullable final Expr timeZoneArg,
       final Expr.ObjectBinding bindings
   )
   {

--- a/sql/src/main/java/io/druid/sql/calcite/expression/builtin/CastOperatorConversion.java
+++ b/sql/src/main/java/io/druid/sql/calcite/expression/builtin/CastOperatorConversion.java
@@ -126,7 +126,8 @@ public class CastOperatorConversion implements SqlOperatorConversion
         // Floor to day when casting to DATE.
         return TimeFloorOperatorConversion.applyTimestampFloor(
             typeCastExpression,
-            new PeriodGranularity(Period.days(1), null, plannerContext.getTimeZone())
+            new PeriodGranularity(Period.days(1), null, plannerContext.getTimeZone()),
+            plannerContext.getExprMacroTable()
         );
       } else {
         return typeCastExpression;
@@ -153,7 +154,8 @@ public class CastOperatorConversion implements SqlOperatorConversion
     if (toType == SqlTypeName.DATE) {
       return TimeFloorOperatorConversion.applyTimestampFloor(
           timestampExpression,
-          new PeriodGranularity(Period.days(1), null, plannerContext.getTimeZone())
+          new PeriodGranularity(Period.days(1), null, plannerContext.getTimeZone()),
+          plannerContext.getExprMacroTable()
       );
     } else if (toType == SqlTypeName.TIMESTAMP) {
       return timestampExpression;

--- a/sql/src/main/java/io/druid/sql/calcite/expression/builtin/FloorOperatorConversion.java
+++ b/sql/src/main/java/io/druid/sql/calcite/expression/builtin/FloorOperatorConversion.java
@@ -73,7 +73,11 @@ public class FloorOperatorConversion implements SqlOperatorConversion
         return null;
       }
 
-      return TimeFloorOperatorConversion.applyTimestampFloor(druidExpression, granularity);
+      return TimeFloorOperatorConversion.applyTimestampFloor(
+          druidExpression,
+          granularity,
+          plannerContext.getExprMacroTable()
+      );
     } else {
       // WTF? FLOOR with 3 arguments?
       return null;

--- a/sql/src/main/java/io/druid/sql/calcite/expression/builtin/TimeFloorOperatorConversion.java
+++ b/sql/src/main/java/io/druid/sql/calcite/expression/builtin/TimeFloorOperatorConversion.java
@@ -22,9 +22,10 @@ package io.druid.sql.calcite.expression.builtin;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import io.druid.java.util.common.granularity.PeriodGranularity;
+import io.druid.math.expr.ExprMacroTable;
+import io.druid.query.expression.TimestampFloorExprMacro;
 import io.druid.sql.calcite.expression.DruidExpression;
 import io.druid.sql.calcite.expression.Expressions;
-import io.druid.sql.calcite.expression.ExtractionFns;
 import io.druid.sql.calcite.expression.OperatorConversions;
 import io.druid.sql.calcite.expression.SqlOperatorConversion;
 import io.druid.sql.calcite.planner.Calcites;
@@ -44,6 +45,7 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.Period;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class TimeFloorOperatorConversion implements SqlOperatorConversion
@@ -58,26 +60,50 @@ public class TimeFloorOperatorConversion implements SqlOperatorConversion
 
   public static DruidExpression applyTimestampFloor(
       final DruidExpression input,
-      final PeriodGranularity granularity
+      final PeriodGranularity granularity,
+      final ExprMacroTable macroTable
   )
   {
     Preconditions.checkNotNull(input, "input");
     Preconditions.checkNotNull(granularity, "granularity");
 
-    return input.map(
-        simpleExtraction -> simpleExtraction.cascade(ExtractionFns.fromQueryGranularity(granularity)),
-        expression -> DruidExpression.functionCall(
-            "timestamp_floor",
-            ImmutableList.of(
-                expression,
-                DruidExpression.stringLiteral(granularity.getPeriod().toString()),
-                DruidExpression.numberLiteral(
-                    granularity.getOrigin() == null ? null : granularity.getOrigin().getMillis()
-                ),
-                DruidExpression.stringLiteral(granularity.getTimeZone().toString())
-            ).stream().map(DruidExpression::fromExpression).collect(Collectors.toList())
-        )
+    // Collapse floor chains if possible. Useful for constructs like CAST(FLOOR(__time TO QUARTER) AS DATE).
+    if (granularity.getPeriod().equals(Period.days(1))) {
+      final TimestampFloorExprMacro.TimestampFloorExpr floorExpr = Expressions.asTimestampFloorExpr(
+          input,
+          macroTable
+      );
+
+      if (floorExpr != null) {
+        final PeriodGranularity inputGranularity = floorExpr.getGranularity();
+        if (Objects.equals(inputGranularity.getTimeZone(), granularity.getTimeZone())
+            && Objects.equals(inputGranularity.getOrigin(), granularity.getOrigin())
+            && periodIsDayMultiple(inputGranularity.getPeriod())) {
+          return input;
+        }
+      }
+    }
+
+    return DruidExpression.fromFunctionCall(
+        "timestamp_floor",
+        ImmutableList.of(
+            input.getExpression(),
+            DruidExpression.stringLiteral(granularity.getPeriod().toString()),
+            DruidExpression.numberLiteral(
+                granularity.getOrigin() == null ? null : granularity.getOrigin().getMillis()
+            ),
+            DruidExpression.stringLiteral(granularity.getTimeZone().toString())
+        ).stream().map(DruidExpression::fromExpression).collect(Collectors.toList())
     );
+  }
+
+  private static boolean periodIsDayMultiple(final Period period)
+  {
+    return period.getMillis() == 0
+           && period.getSeconds() == 0
+           && period.getMinutes() == 0
+           && period.getHours() == 0
+           && (period.getDays() > 0 || period.getWeeks() > 0 || period.getMonths() > 0 || period.getYears() > 0);
   }
 
   @Override
@@ -117,7 +143,7 @@ public class TimeFloorOperatorConversion implements SqlOperatorConversion
           ? DateTimeZone.forID(RexLiteral.stringValue(operands.get(3)))
           : plannerContext.getTimeZone();
       final PeriodGranularity granularity = new PeriodGranularity(period, origin, timeZone);
-      return applyTimestampFloor(druidExpressions.get(0), granularity);
+      return applyTimestampFloor(druidExpressions.get(0), granularity, plannerContext.getExprMacroTable());
     } else {
       // Granularity is dynamic
       return DruidExpression.fromFunctionCall("timestamp_floor", druidExpressions);

--- a/sql/src/test/java/io/druid/sql/calcite/expression/ExpressionsTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/expression/ExpressionsTest.java
@@ -22,12 +22,9 @@ package io.druid.sql.calcite.expression;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.druid.java.util.common.DateTimes;
-import io.druid.java.util.common.granularity.Granularities;
-import io.druid.java.util.common.granularity.PeriodGranularity;
 import io.druid.math.expr.ExprEval;
 import io.druid.math.expr.Parser;
 import io.druid.query.extraction.RegexDimExtractionFn;
-import io.druid.query.extraction.TimeFormatExtractionFn;
 import io.druid.segment.column.ValueType;
 import io.druid.server.security.AuthTestUtils;
 import io.druid.sql.calcite.expression.builtin.DateTruncOperatorConversion;
@@ -403,19 +400,7 @@ public class ExpressionsTest
             rexBuilder.makeNullLiteral(typeFactory.createSqlType(SqlTypeName.TIMESTAMP)),
             rexBuilder.makeLiteral("America/Los_Angeles")
         ),
-        DruidExpression.of(
-            SimpleExtraction.of(
-                "t",
-                new TimeFormatExtractionFn(
-                    null,
-                    null,
-                    null,
-                    new PeriodGranularity(Period.days(1), null, LOS_ANGELES),
-                    true
-                )
-            ),
-            "timestamp_floor(\"t\",'P1D','','America/Los_Angeles')"
-        ),
+        DruidExpression.fromExpression("timestamp_floor(\"t\",'P1D','','America/Los_Angeles')"),
         DateTimes.of("2000-02-02T08:00:00").getMillis()
     );
   }
@@ -431,13 +416,7 @@ public class ExpressionsTest
             inputRef("t"),
             rexBuilder.makeFlag(TimeUnitRange.YEAR)
         ),
-        DruidExpression.of(
-            SimpleExtraction.of(
-                "t",
-                new TimeFormatExtractionFn(null, null, null, Granularities.YEAR, true)
-            ),
-            "timestamp_floor(\"t\",'P1Y','','UTC')"
-        ),
+        DruidExpression.fromExpression("timestamp_floor(\"t\",'P1Y','','UTC')"),
         DateTimes.of("2000").getMillis()
     );
   }
@@ -735,10 +714,7 @@ public class ExpressionsTest
             typeFactory.createSqlType(SqlTypeName.DATE),
             inputRef("t")
         ),
-        DruidExpression.of(
-            SimpleExtraction.of("t", new TimeFormatExtractionFn(null, null, null, Granularities.DAY, true)),
-            "timestamp_floor(\"t\",'P1D','','UTC')"
-        ),
+        DruidExpression.fromExpression("timestamp_floor(\"t\",'P1D','','UTC')"),
         DateTimes.of("2000-02-03").getMillis()
     );
 
@@ -779,10 +755,7 @@ public class ExpressionsTest
                 inputRef("t")
             )
         ),
-        DruidExpression.of(
-            SimpleExtraction.of("t", new TimeFormatExtractionFn(null, null, null, Granularities.DAY, true)),
-            "timestamp_floor(\"t\",'P1D','','UTC')"
-        ),
+        DruidExpression.fromExpression("timestamp_floor(\"t\",'P1D','','UTC')"),
         DateTimes.of("2000-02-03").getMillis()
     );
   }


### PR DESCRIPTION
The main change is to TimeFloorOperatorConversion.applyTimestampFloor.

- Prefer timestamp_floor expressions to timeFormat extractionFns, to
  avoid turning things into strings when it isn't necessary.
- Collapse CAST(FLOOR(X TO Y) AS DATE) to FLOOR(X TO Y) if appropriate.