### PR TITLE
Cache: Add maxEntrySize config.

### DIFF
--- a/docs/content/configuration/broker.md
+++ b/docs/content/configuration/broker.md
@@ -107,6 +107,7 @@ You can optionally only configure caching to be enabled on the broker by setting
 |`druid.broker.cache.populateCache`|true, false|Populate the cache on the broker.|false|
 |`druid.broker.cache.unCacheable`|All druid query types|All query types to not cache.|`["groupBy", "select"]`|
 |`druid.broker.cache.cacheBulkMergeLimit`|positive integer or 0|Queries with more segments than this number will not attempt to fetch from cache at the broker level, leaving potential caching fetches (and cache result merging) to the historicals|`Integer.MAX_VALUE`|
+|`druid.broker.cache.maxEntrySize`|positive integer or -1|Maximum size of an individual cache entry (processed results for one segment), in bytes, or -1 for unlimited.|`-1`|
 
 See [cache configuration](caching.html) for how to configure cache settings.
 

--- a/docs/content/configuration/historical.md
+++ b/docs/content/configuration/historical.md
@@ -93,6 +93,7 @@ You can optionally only configure caching to be enabled on the historical by set
 |`druid.historical.cache.useCache`|true, false|Enable the cache on the historical.|false|
 |`druid.historical.cache.populateCache`|true, false|Populate the cache on the historical.|false|
 |`druid.historical.cache.unCacheable`|All druid query types|All query types to not cache.|["groupBy", "select"]|
+|`druid.historical.cache.maxEntrySize`|positive integer or -1|Maximum size of an individual cache entry (processed results for one segment), in bytes, or -1 for unlimited.|`-1`|
 
 
 See [cache configuration](caching.html) for how to configure cache settings.

--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -328,12 +328,17 @@ You can enable caching of results at the broker, historical, or realtime level u
 
 |Property|Possible Values|Description|Default|
 |--------|---------------|-----------|-------|
-|`druid.cache.type`|`local`, `memcached`|The type of cache to use for queries.|`local`|
+|`druid.cache.type`|`memcached`, `caffeine`, `local`|The type of cache to use for queries.|`caffeine`|
 |<code>druid.(broker&#124;historical&#124;realtime).cache.unCacheable</code>|All druid query types|All query types to not cache.|["groupBy", "select"]|
 |<code>druid.(broker&#124;historical&#124;realtime).cache.useCache</code>|true, false|Whether to use cache for getting query results.|false|
 |<code>druid.(broker&#124;historical&#124;realtime).cache.populateCache</code>|true, false|Whether to populate cache.|false|
+|<code>druid.(broker&#124;historical&#124;realtime).cache.maxEntrySize</code>|positive integer or -1|Maximum size of an individual cache entry (processed results for one segment), in bytes, or -1 for unlimited.|`-1`|
 
 #### Local Cache
+
+<div class="note caution">
+DEPRECATED: Use caffeine instead
+</div>
 
 |Property|Description|Default|
 |--------|-----------|-------|
@@ -341,7 +346,7 @@ You can enable caching of results at the broker, historical, or realtime level u
 |`druid.cache.initialSize`|Initial size of the hashtable backing the cache.|500000|
 |`druid.cache.logEvictionCount`|If non-zero, log cache eviction every `logEvictionCount` items.|0|
 
-#### Memcache
+#### Memcached
 
 |Property|Description|Default|
 |--------|-----------|-------|
@@ -350,6 +355,22 @@ You can enable caching of results at the broker, historical, or realtime level u
 |`druid.cache.hosts`|Comma separated list of Memcached hosts `<host:port>`.|none|
 |`druid.cache.maxObjectSize`|Maximum object size in bytes for a Memcached object.|52428800 (50 MB)|
 |`druid.cache.memcachedPrefix`|Key prefix for all keys in Memcached.|druid|
+
+#### Caffeine Cache
+
+A highly performant local cache implementation for Druid based on [Caffeine](https://github.com/ben-manes/caffeine). Requires a JRE8u60 or higher if using `COMMON_FJP`.
+
+Below are the configuration options known to this module:
+
+|`runtime.properties`|Description|Default|
+|--------------------|-----------|-------|
+|`druid.cache.type`| Set this to `caffeine`|`local`|
+|`druid.cache.sizeInBytes`|The maximum size of the cache in bytes on heap.|None (unlimited)|
+|`druid.cache.expireAfter`|The time (in ms) after an access for which a cache entry may be expired|None (no time limit)|
+|`druid.cache.cacheExecutorFactory`|The executor factory to use for Caffeine maintenance. One of `COMMON_FJP`, `SINGLE_THREAD`, or `SAME_THREAD`|ForkJoinPool common pool (`COMMON_FJP`)|
+|`druid.cache.evictOnClose`|If a close of a namespace (ex: removing a segment from a node) should cause an eager eviction of associated cache values|`false`|
+
+See the [Caching documentation](caching.html) for more detail.
 
 ### Indexing Service Discovery
 

--- a/docs/content/configuration/realtime.md
+++ b/docs/content/configuration/realtime.md
@@ -73,5 +73,6 @@ You can optionally configure caching to be enabled on the realtime node by setti
 |`druid.realtime.cache.useCache`|true, false|Enable the cache on the realtime.|false|
 |`druid.realtime.cache.populateCache`|true, false|Populate the cache on the realtime.|false|
 |`druid.realtime.cache.unCacheable`|All druid query types|All query types to not cache.|`["groupBy", "select"]`|
+|`druid.realtime.cache.maxEntrySize`|positive integer or -1|Maximum size of an individual cache entry (processed results for one segment), in bytes, or -1 for unlimited.|`-1`|
 
 See [cache configuration](caching.html) for how to configure cache settings.

--- a/server/src/main/java/io/druid/client/CacheUtil.java
+++ b/server/src/main/java/io/druid/client/CacheUtil.java
@@ -19,9 +19,6 @@
 
 package io.druid.client;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Throwables;
 import io.druid.client.cache.Cache;
 import io.druid.client.cache.CacheConfig;
 import io.druid.java.util.common.StringUtils;
@@ -31,8 +28,6 @@ import io.druid.query.QueryContexts;
 import io.druid.query.SegmentDescriptor;
 import org.joda.time.Interval;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 
 public class CacheUtil
@@ -55,23 +50,6 @@ public class CacheUtil
         .putInt(descriptor.getPartitionNumber())
         .put(queryCacheKey).array()
     );
-  }
-
-  public static void populate(Cache cache, ObjectMapper mapper, Cache.NamedKey key, Iterable<Object> results)
-  {
-    try {
-      ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-      try (JsonGenerator gen = mapper.getFactory().createGenerator(bytes)) {
-        for (Object result : results) {
-          gen.writeObject(result);
-        }
-      }
-
-      cache.put(key, bytes.toByteArray());
-    }
-    catch (IOException e) {
-      throw Throwables.propagate(e);
-    }
   }
 
   public static <T> boolean useCacheOnBrokers(

--- a/server/src/main/java/io/druid/client/CachingClusteredClient.java
+++ b/server/src/main/java/io/druid/client/CachingClusteredClient.java
@@ -34,23 +34,18 @@ import com.google.common.collect.RangeSet;
 import com.google.common.collect.Sets;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.ListeningExecutorService;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
 import com.metamx.emitter.EmittingLogger;
 import io.druid.client.cache.Cache;
+import io.druid.client.cache.CachePopulator;
 import io.druid.client.cache.CacheConfig;
 import io.druid.client.selector.QueryableDruidServer;
 import io.druid.client.selector.ServerSelector;
-import io.druid.java.util.common.concurrent.Execs;
-import io.druid.guice.annotations.BackgroundCaching;
 import io.druid.guice.annotations.Smile;
 import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.Pair;
 import io.druid.java.util.common.StringUtils;
+import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.guava.BaseSequence;
 import io.druid.java.util.common.guava.LazySequence;
 import io.druid.java.util.common.guava.Sequence;
@@ -89,8 +84,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ExecutorService;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
@@ -103,8 +96,8 @@ public class CachingClusteredClient implements QuerySegmentWalker
   private final TimelineServerView serverView;
   private final Cache cache;
   private final ObjectMapper objectMapper;
+  private final CachePopulator cachePopulator;
   private final CacheConfig cacheConfig;
-  private final ListeningExecutorService backgroundExecutorService;
 
   @Inject
   public CachingClusteredClient(
@@ -112,7 +105,7 @@ public class CachingClusteredClient implements QuerySegmentWalker
       TimelineServerView serverView,
       Cache cache,
       @Smile ObjectMapper objectMapper,
-      @BackgroundCaching ExecutorService backgroundExecutorService,
+      CachePopulator cachePopulator,
       CacheConfig cacheConfig
   )
   {
@@ -120,13 +113,13 @@ public class CachingClusteredClient implements QuerySegmentWalker
     this.serverView = serverView;
     this.cache = cache;
     this.objectMapper = objectMapper;
+    this.cachePopulator = cachePopulator;
     this.cacheConfig = cacheConfig;
-    this.backgroundExecutorService = MoreExecutors.listeningDecorator(backgroundExecutorService);
 
-    if (cacheConfig.isQueryCacheable(Query.GROUP_BY)) {
+    if (cacheConfig.isQueryCacheable(Query.GROUP_BY) && (cacheConfig.isUseCache() || cacheConfig.isPopulateCache())) {
       log.warn(
-          "Even though groupBy caching is enabled, v2 groupBys will not be cached. "
-          + "Consider disabling cache on your broker and enabling it on your data nodes to enable v2 groupBy caching."
+          "Even though groupBy caching is enabled in your configuration, v2 groupBys will not be cached on the broker. "
+          + "Consider enabling caching on your data nodes if it is not already enabled."
       );
     }
 
@@ -219,7 +212,7 @@ public class CachingClusteredClient implements QuerySegmentWalker
     private final boolean isBySegment;
     private final int uncoveredIntervalsLimit;
     private final Query<T> downstreamQuery;
-    private final Map<String, CachePopulator> cachePopulatorMap = Maps.newHashMap();
+    private final Map<String, Cache.NamedKey> cachePopulatorKeyMap = Maps.newHashMap();
 
     SpecificQueryRunnable(final QueryPlus<T> queryPlus, final Map<String, Object> responseContext)
     {
@@ -417,7 +410,7 @@ public class CachingClusteredClient implements QuerySegmentWalker
         } else if (populateCache) {
           // otherwise, if populating cache, add segment to list of segments to cache
           final String segmentIdentifier = segment.getServer().getSegment().getIdentifier();
-          addCachePopulator(segmentCacheKey, segmentIdentifier, segmentQueryInterval);
+          addCachePopulatorKey(segmentCacheKey, segmentIdentifier, segmentQueryInterval);
         }
       });
       return alreadyCachedResults;
@@ -450,22 +443,22 @@ public class CachingClusteredClient implements QuerySegmentWalker
       }
     }
 
-    private void addCachePopulator(
+    private void addCachePopulatorKey(
         Cache.NamedKey segmentCacheKey,
         String segmentIdentifier,
         Interval segmentQueryInterval
     )
     {
-      cachePopulatorMap.put(
+      cachePopulatorKeyMap.put(
           StringUtils.format("%s_%s", segmentIdentifier, segmentQueryInterval),
-          new CachePopulator(cache, objectMapper, segmentCacheKey)
+          segmentCacheKey
       );
     }
 
     @Nullable
-    private CachePopulator getCachePopulator(String segmentId, Interval segmentInterval)
+    private Cache.NamedKey getCachePopulatorKey(String segmentId, Interval segmentInterval)
     {
-      return cachePopulatorMap.get(StringUtils.format("%s_%s", segmentId, segmentInterval));
+      return cachePopulatorKeyMap.get(StringUtils.format("%s_%s", segmentId, segmentInterval));
     }
 
     private SortedMap<DruidServer, List<SegmentDescriptor>> groupSegmentsByServer(Set<ServerToSegment> segments)
@@ -597,28 +590,18 @@ public class CachingClusteredClient implements QuerySegmentWalker
               .withQuerySegmentSpec(segmentsOfServerSpec),
           responseContext
       );
-      final Function<T, Object> cacheFn = strategy.prepareForCache();
       return resultsBySegments
           .map(result -> {
             final BySegmentResultValueClass<T> resultsOfSegment = result.getValue();
-            final CachePopulator cachePopulator =
-                getCachePopulator(resultsOfSegment.getSegmentId(), resultsOfSegment.getInterval());
-            Sequence<T> res = Sequences
-                .simple(resultsOfSegment.getResults())
-                .map(r -> {
-                  if (cachePopulator != null) {
-                    // only compute cache data if populating cache
-                    cachePopulator.cacheFutures.add(backgroundExecutorService.submit(() -> cacheFn.apply(r)));
-                  }
-                  return r;
-                })
-                .map(
-                    toolChest.makePreComputeManipulatorFn(downstreamQuery, MetricManipulatorFns.deserializing())::apply
-                );
-            if (cachePopulator != null) {
-              res = res.withEffect(cachePopulator::populate, MoreExecutors.sameThreadExecutor());
+            final Cache.NamedKey cachePopulatorKey =
+                getCachePopulatorKey(resultsOfSegment.getSegmentId(), resultsOfSegment.getInterval());
+            Sequence<T> res = Sequences.simple(resultsOfSegment.getResults());
+            if (cachePopulatorKey != null) {
+              res = cachePopulator.wrap(res, strategy, cache, cachePopulatorKey);
             }
-            return res;
+            return res.map(
+                toolChest.makePreComputeManipulatorFn(downstreamQuery, MetricManipulatorFns.deserializing())::apply
+            );
           })
           .flatMerge(seq -> seq, query.getResultOrdering());
     }
@@ -639,45 +622,6 @@ public class CachingClusteredClient implements QuerySegmentWalker
     SegmentDescriptor getSegmentDescriptor()
     {
       return rhs;
-    }
-  }
-
-  private class CachePopulator
-  {
-    private final Cache cache;
-    private final ObjectMapper mapper;
-    private final Cache.NamedKey key;
-    private final ConcurrentLinkedQueue<ListenableFuture<Object>> cacheFutures = new ConcurrentLinkedQueue<>();
-
-    CachePopulator(Cache cache, ObjectMapper mapper, Cache.NamedKey key)
-    {
-      this.cache = cache;
-      this.mapper = mapper;
-      this.key = key;
-    }
-
-    public void populate()
-    {
-      Futures.addCallback(
-          Futures.allAsList(cacheFutures),
-          new FutureCallback<List<Object>>()
-          {
-            @Override
-            public void onSuccess(List<Object> cacheData)
-            {
-              CacheUtil.populate(cache, mapper, key, cacheData);
-              // Help out GC by making sure all references are gone
-              cacheFutures.clear();
-            }
-
-            @Override
-            public void onFailure(Throwable throwable)
-            {
-              log.error(throwable, "Background caching failed");
-            }
-          },
-          backgroundExecutorService
-      );
     }
   }
 }

--- a/server/src/main/java/io/druid/client/CachingQueryRunner.java
+++ b/server/src/main/java/io/druid/client/CachingQueryRunner.java
@@ -24,18 +24,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.ListeningExecutorService;
-import com.google.common.util.concurrent.MoreExecutors;
-import com.google.common.util.concurrent.SettableFuture;
 import io.druid.client.cache.Cache;
+import io.druid.client.cache.CachePopulator;
 import io.druid.client.cache.CacheConfig;
 import io.druid.java.util.common.guava.BaseSequence;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.guava.Sequences;
-import io.druid.java.util.common.logger.Logger;
 import io.druid.query.CacheStrategy;
 import io.druid.query.Query;
 import io.druid.query.QueryPlus;
@@ -44,23 +38,19 @@ import io.druid.query.QueryToolChest;
 import io.druid.query.SegmentDescriptor;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
 
 public class CachingQueryRunner<T> implements QueryRunner<T>
 {
-  private static final Logger log = new Logger(CachingQueryRunner.class);
   private final String segmentIdentifier;
   private final SegmentDescriptor segmentDescriptor;
   private final QueryRunner<T> base;
   private final QueryToolChest toolChest;
   private final Cache cache;
   private final ObjectMapper mapper;
+  private final CachePopulator cachePopulator;
   private final CacheConfig cacheConfig;
-  private final ListeningExecutorService backgroundExecutorService;
 
   public CachingQueryRunner(
       String segmentIdentifier,
@@ -69,7 +59,7 @@ public class CachingQueryRunner<T> implements QueryRunner<T>
       Cache cache,
       QueryToolChest toolchest,
       QueryRunner<T> base,
-      ExecutorService backgroundExecutorService,
+      CachePopulator cachePopulator,
       CacheConfig cacheConfig
   )
   {
@@ -79,7 +69,7 @@ public class CachingQueryRunner<T> implements QueryRunner<T>
     this.toolChest = toolchest;
     this.cache = cache;
     this.mapper = mapper;
-    this.backgroundExecutorService = MoreExecutors.listeningDecorator(backgroundExecutorService);
+    this.cachePopulator = cachePopulator;
     this.cacheConfig = cacheConfig;
   }
 
@@ -141,56 +131,8 @@ public class CachingQueryRunner<T> implements QueryRunner<T>
       }
     }
 
-    final Collection<ListenableFuture<?>> cacheFutures = Collections.synchronizedList(Lists.<ListenableFuture<?>>newLinkedList());
     if (populateCache) {
-      final Function cacheFn = strategy.prepareForCache();
-
-      return Sequences.withEffect(
-          Sequences.map(
-              base.run(queryPlus, responseContext),
-              new Function<T, T>()
-              {
-                @Override
-                public T apply(final T input)
-                {
-                  final SettableFuture<Object> future = SettableFuture.create();
-                  cacheFutures.add(future);
-                  backgroundExecutorService.submit(
-                      new Runnable()
-                      {
-                        @Override
-                        public void run()
-                        {
-                          try {
-                            future.set(cacheFn.apply(input));
-                          }
-                          catch (Exception e) {
-                            // if there is exception, should setException to quit the caching processing
-                            future.setException(e);
-                          }
-                        }
-                      }
-                  );
-                  return input;
-                }
-              }
-          ),
-          new Runnable()
-          {
-            @Override
-            public void run()
-            {
-              try {
-                CacheUtil.populate(cache, mapper, key, Futures.allAsList(cacheFutures).get());
-              }
-              catch (Exception e) {
-                log.error(e, "Error while getting future for cache task");
-                throw Throwables.propagate(e);
-              }
-            }
-          },
-          backgroundExecutorService
-      );
+      return cachePopulator.wrap(base.run(queryPlus, responseContext), strategy, cache, key);
     } else {
       return base.run(queryPlus, responseContext);
     }

--- a/server/src/main/java/io/druid/client/cache/BackgroundCachePopulator.java
+++ b/server/src/main/java/io/druid/client/cache/BackgroundCachePopulator.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.client.cache;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import io.druid.java.util.common.guava.Sequence;
+import io.druid.java.util.common.guava.Sequences;
+import io.druid.java.util.common.logger.Logger;
+import io.druid.query.CacheStrategy;
+import io.druid.query.Query;
+
+import java.io.ByteArrayOutputStream;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+public class BackgroundCachePopulator implements CachePopulator
+{
+  private static final Logger log = new Logger(BackgroundCachePopulator.class);
+
+  private final ListeningExecutorService exec;
+  private final ObjectMapper objectMapper;
+  private final long maxEntrySize;
+
+  public BackgroundCachePopulator(
+      final ExecutorService exec,
+      final ObjectMapper objectMapper,
+      final long maxEntrySize
+  )
+  {
+    this.exec = MoreExecutors.listeningDecorator(exec);
+    this.objectMapper = Preconditions.checkNotNull(objectMapper, "objectMapper");
+    this.maxEntrySize = maxEntrySize;
+  }
+
+  @Override
+  public <T, CacheType, QueryType extends Query<T>> Sequence<T> wrap(
+      final Sequence<T> sequence,
+      final CacheStrategy<T, CacheType, QueryType> cacheStrategy,
+      final Cache cache,
+      final Cache.NamedKey cacheKey
+  )
+  {
+    final Function<T, CacheType> cacheFn = cacheStrategy.prepareForCache();
+    final List<ListenableFuture<CacheType>> cacheFutures = new LinkedList<>();
+
+    final Sequence<T> wrappedSequence = Sequences.map(
+        sequence,
+        input -> {
+          cacheFutures.add(exec.submit(() -> cacheFn.apply(input)));
+          return input;
+        }
+    );
+
+    return Sequences.withEffect(
+        wrappedSequence,
+        () -> {
+          Futures.addCallback(
+              Futures.allAsList(cacheFutures),
+              new FutureCallback<List<CacheType>>()
+              {
+                @Override
+                public void onSuccess(List<CacheType> results)
+                {
+                  populateCache(cache, cacheKey, results);
+                  // Help out GC by making sure all references are gone
+                  cacheFutures.clear();
+                }
+
+                @Override
+                public void onFailure(Throwable t)
+                {
+                  log.error(t, "Background caching failed");
+                }
+              },
+              exec
+          );
+        },
+        MoreExecutors.sameThreadExecutor()
+    );
+  }
+
+  private <CacheType> void populateCache(
+      final Cache cache,
+      final Cache.NamedKey cacheKey,
+      final List<CacheType> results
+  )
+  {
+    try {
+      final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+
+      try (JsonGenerator gen = objectMapper.getFactory().createGenerator(bytes)) {
+        for (CacheType result : results) {
+          gen.writeObject(result);
+
+          if (maxEntrySize > 0 && bytes.size() > maxEntrySize) {
+            return;
+          }
+        }
+      }
+
+      if (maxEntrySize > 0 && bytes.size() > maxEntrySize) {
+        return;
+      }
+
+      cache.put(cacheKey, bytes.toByteArray());
+    }
+    catch (Exception e) {
+      log.warn(e, "Could not populate cache");
+    }
+  }
+}

--- a/server/src/main/java/io/druid/client/cache/CacheConfig.java
+++ b/server/src/main/java/io/druid/client/cache/CacheConfig.java
@@ -20,10 +20,10 @@
 package io.druid.client.cache;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import io.druid.query.Query;
 
 import javax.validation.constraints.Min;
-import java.util.Arrays;
 import java.util.List;
 
 public class CacheConfig
@@ -46,7 +46,10 @@ public class CacheConfig
   private int cacheBulkMergeLimit = Integer.MAX_VALUE;
 
   @JsonProperty
-  private List<String> unCacheable = Arrays.asList(Query.GROUP_BY, Query.SELECT);
+  private int maxEntrySize = -1;
+
+  @JsonProperty
+  private List<String> unCacheable = ImmutableList.of(Query.GROUP_BY, Query.SELECT);
 
   public boolean isPopulateCache()
   {
@@ -66,6 +69,11 @@ public class CacheConfig
   public int getCacheBulkMergeLimit()
   {
     return cacheBulkMergeLimit;
+  }
+
+  public int getMaxEntrySize()
+  {
+    return maxEntrySize;
   }
 
   public boolean isQueryCacheable(Query query)

--- a/server/src/main/java/io/druid/client/cache/CachePopulator.java
+++ b/server/src/main/java/io/druid/client/cache/CachePopulator.java
@@ -17,21 +17,18 @@
  * under the License.
  */
 
-package io.druid.guice.annotations;
+package io.druid.client.cache;
 
-import com.google.inject.BindingAnnotation;
+import io.druid.java.util.common.guava.Sequence;
+import io.druid.query.CacheStrategy;
+import io.druid.query.Query;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
-/**
- *
- */
-@BindingAnnotation
-@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
-@Retention(RetentionPolicy.RUNTIME)
-public @interface BackgroundCaching
+public interface CachePopulator
 {
+  <T, CacheType, QueryType extends Query<T>> Sequence<T> wrap(
+      Sequence<T> sequence,
+      CacheStrategy<T, CacheType, QueryType> cacheStrategy,
+      Cache cache,
+      Cache.NamedKey cacheKey
+  );
 }

--- a/server/src/main/java/io/druid/client/cache/ForegroundCachePopulator.java
+++ b/server/src/main/java/io/druid/client/cache/ForegroundCachePopulator.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.client.cache;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import io.druid.java.util.common.guava.Sequence;
+import io.druid.java.util.common.guava.SequenceWrapper;
+import io.druid.java.util.common.guava.Sequences;
+import io.druid.java.util.common.logger.Logger;
+import io.druid.query.CacheStrategy;
+import io.druid.query.Query;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ForegroundCachePopulator implements CachePopulator
+{
+  private static final Logger log = new Logger(ForegroundCachePopulator.class);
+
+  private final Object lock = new Object();
+  private final ObjectMapper objectMapper;
+  private final long maxEntrySize;
+
+  public ForegroundCachePopulator(final ObjectMapper objectMapper, final long maxEntrySize)
+  {
+    this.objectMapper = Preconditions.checkNotNull(objectMapper, "objectMapper");
+    this.maxEntrySize = maxEntrySize;
+  }
+
+  @Override
+  public <T, CacheType, QueryType extends Query<T>> Sequence<T> wrap(
+      final Sequence<T> sequence,
+      final CacheStrategy<T, CacheType, QueryType> cacheStrategy,
+      final Cache cache,
+      final Cache.NamedKey cacheKey
+  )
+  {
+    final Function<T, CacheType> cacheFn = cacheStrategy.prepareForCache();
+    final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    final AtomicBoolean tooBig = new AtomicBoolean(false);
+    final JsonGenerator jsonGenerator;
+
+    try {
+      jsonGenerator = objectMapper.getFactory().createGenerator(bytes);
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    return Sequences.wrap(
+        Sequences.map(
+            sequence,
+            input -> {
+              if (!tooBig.get()) {
+                synchronized (lock) {
+                  try {
+                    jsonGenerator.writeObject(cacheFn.apply(input));
+
+                    // Not flushing jsonGenerator before checking this, but should be ok since Jackson buffers are
+                    // typically just a few KB, and we don't want to waste cycles flushing.
+                    if (maxEntrySize > 0 && bytes.size() > maxEntrySize) {
+                      tooBig.set(true);
+                    }
+                  }
+                  catch (IOException e) {
+                    throw new RuntimeException(e);
+                  }
+                }
+              }
+
+              return input;
+            }
+        ),
+        new SequenceWrapper()
+        {
+          @Override
+          public void after(final boolean isDone, final Throwable thrown) throws Exception
+          {
+            synchronized (lock) {
+              jsonGenerator.close();
+
+              if (isDone && !tooBig.get()) {
+                // Check maxEntrySize one more time, after closing/flushing jsonGenerator.
+                if (maxEntrySize > 0 && bytes.size() > maxEntrySize) {
+                  return;
+                }
+
+                try {
+                  cache.put(cacheKey, bytes.toByteArray());
+                }
+                catch (Exception e) {
+                  log.warn(e, "Unable to write to cache");
+                }
+              }
+            }
+          }
+        }
+    );
+  }
+}

--- a/server/src/main/java/io/druid/guice/RouterProcessingModule.java
+++ b/server/src/main/java/io/druid/guice/RouterProcessingModule.java
@@ -22,16 +22,14 @@ package io.druid.guice;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
-import io.druid.client.cache.CacheConfig;
 import io.druid.collections.BlockingPool;
 import io.druid.collections.DummyBlockingPool;
 import io.druid.collections.DummyNonBlockingPool;
 import io.druid.collections.NonBlockingPool;
-import io.druid.java.util.common.concurrent.Execs;
-import io.druid.guice.annotations.BackgroundCaching;
 import io.druid.guice.annotations.Global;
 import io.druid.guice.annotations.Merging;
 import io.druid.guice.annotations.Processing;
+import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.concurrent.ExecutorServiceConfig;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.query.DruidProcessingConfig;
@@ -56,20 +54,6 @@ public class RouterProcessingModule implements Module
   {
     binder.bind(ExecutorServiceConfig.class).to(DruidProcessingConfig.class);
     MetricsModule.register(binder, ExecutorServiceMonitor.class);
-  }
-
-  @Provides
-  @BackgroundCaching
-  @LazySingleton
-  public ExecutorService getBackgroundExecutorService(CacheConfig cacheConfig)
-  {
-    if (cacheConfig.getNumBackgroundThreads() > 0) {
-      log.error(
-          "numBackgroundThreads[%d] configured, that is ignored on Router",
-          cacheConfig.getNumBackgroundThreads()
-      );
-    }
-    return Execs.dummy();
   }
 
   @Provides

--- a/server/src/main/java/io/druid/segment/realtime/appenderator/SinkQuerySegmentWalker.java
+++ b/server/src/main/java/io/druid/segment/realtime/appenderator/SinkQuerySegmentWalker.java
@@ -29,6 +29,7 @@ import com.metamx.emitter.service.ServiceEmitter;
 import io.druid.client.CachingQueryRunner;
 import io.druid.client.cache.Cache;
 import io.druid.client.cache.CacheConfig;
+import io.druid.client.cache.ForegroundCachePopulator;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.Pair;
 import io.druid.java.util.common.guava.CloseQuietly;
@@ -235,7 +236,11 @@ public class SinkQuerySegmentWalker implements QuerySegmentWalker
                                                             cache,
                                                             toolChest,
                                                             baseRunner,
-                                                            MoreExecutors.sameThreadExecutor(),
+                                                            // Always populate in foreground regardless of config
+                                                            new ForegroundCachePopulator(
+                                                                objectMapper,
+                                                                cacheConfig.getMaxEntrySize()
+                                                            ),
                                                             cacheConfig
                                                         );
                                                       } else {

--- a/server/src/main/java/io/druid/server/coordination/ServerManager.java
+++ b/server/src/main/java/io/druid/server/coordination/ServerManager.java
@@ -27,8 +27,8 @@ import com.metamx.emitter.EmittingLogger;
 import com.metamx.emitter.service.ServiceEmitter;
 import io.druid.client.CachingQueryRunner;
 import io.druid.client.cache.Cache;
+import io.druid.client.cache.CachePopulator;
 import io.druid.client.cache.CacheConfig;
-import io.druid.guice.annotations.BackgroundCaching;
 import io.druid.guice.annotations.Processing;
 import io.druid.guice.annotations.Smile;
 import io.druid.java.util.common.ISE;
@@ -76,7 +76,7 @@ public class ServerManager implements QuerySegmentWalker
   private final QueryRunnerFactoryConglomerate conglomerate;
   private final ServiceEmitter emitter;
   private final ExecutorService exec;
-  private final ExecutorService cachingExec;
+  private final CachePopulator cachePopulator;
   private final Cache cache;
   private final ObjectMapper objectMapper;
   private final CacheConfig cacheConfig;
@@ -88,7 +88,7 @@ public class ServerManager implements QuerySegmentWalker
       QueryRunnerFactoryConglomerate conglomerate,
       ServiceEmitter emitter,
       @Processing ExecutorService exec,
-      @BackgroundCaching ExecutorService cachingExec,
+      CachePopulator cachePopulator,
       @Smile ObjectMapper objectMapper,
       Cache cache,
       CacheConfig cacheConfig,
@@ -100,7 +100,7 @@ public class ServerManager implements QuerySegmentWalker
     this.emitter = emitter;
 
     this.exec = exec;
-    this.cachingExec = cachingExec;
+    this.cachePopulator = cachePopulator;
     this.cache = cache;
     this.objectMapper = objectMapper;
 
@@ -303,7 +303,7 @@ public class ServerManager implements QuerySegmentWalker
                                 QueryMetrics::reportSegmentTime,
                                 queryMetrics -> queryMetrics.segment(segmentId)
                             ),
-                            cachingExec,
+                            cachePopulator,
                             cacheConfig
                         )
                     ),

--- a/server/src/test/java/io/druid/client/CachingClusteredClientTest.java
+++ b/server/src/test/java/io/druid/client/CachingClusteredClientTest.java
@@ -44,8 +44,11 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
+import io.druid.client.cache.BackgroundCachePopulator;
 import io.druid.client.cache.Cache;
+import io.druid.client.cache.CachePopulator;
 import io.druid.client.cache.CacheConfig;
+import io.druid.client.cache.ForegroundCachePopulator;
 import io.druid.client.cache.MapCache;
 import io.druid.client.selector.HighestPriorityTierSelectorStrategy;
 import io.druid.client.selector.QueryableDruidServer;
@@ -103,11 +106,11 @@ import io.druid.query.groupby.GroupByQueryConfig;
 import io.druid.query.groupby.GroupByQueryRunnerTest;
 import io.druid.query.groupby.strategy.GroupByStrategySelector;
 import io.druid.query.ordering.StringComparators;
-import io.druid.query.search.SearchQueryQueryToolChest;
-import io.druid.query.search.SearchResultValue;
 import io.druid.query.search.SearchHit;
 import io.druid.query.search.SearchQuery;
 import io.druid.query.search.SearchQueryConfig;
+import io.druid.query.search.SearchQueryQueryToolChest;
+import io.druid.query.search.SearchResultValue;
 import io.druid.query.select.EventHolder;
 import io.druid.query.select.PagingSpec;
 import io.druid.query.select.SelectQuery;
@@ -332,7 +335,7 @@ public class CachingClusteredClientTest
     timeline = new VersionedIntervalTimeline<>(Ordering.<String>natural());
     serverView = EasyMock.createNiceMock(TimelineServerView.class);
     cache = MapCache.create(100000);
-    client = makeClient(MoreExecutors.sameThreadExecutor());
+    client = makeClient(new ForegroundCachePopulator(jsonMapper, -1));
 
     servers = new DruidServer[]{
         new DruidServer("test1", "test1", null, 10, ServerType.HISTORICAL, "bye", 0),
@@ -424,7 +427,7 @@ public class CachingClusteredClientTest
       }
     };
 
-    client = makeClient(randomizingExecutorService);
+    client = makeClient(new BackgroundCachePopulator(randomizingExecutorService, jsonMapper, -1));
 
     // callback to be run every time a query run is complete, to ensure all background
     // caching tasks are executed, and cache is populated before we move onto the next query
@@ -581,7 +584,7 @@ public class CachingClusteredClientTest
             .andReturn(ImmutableMap.<Cache.NamedKey, byte[]>of())
             .once();
     EasyMock.replay(cache);
-    client = makeClient(MoreExecutors.sameThreadExecutor(), cache, limit);
+    client = makeClient(new ForegroundCachePopulator(jsonMapper, -1), cache, limit);
     final DruidServer lastServer = servers[random.nextInt(servers.length)];
     final DataSegment dataSegment = EasyMock.createNiceMock(DataSegment.class);
     EasyMock.expect(dataSegment.getIdentifier()).andReturn(DATA_SOURCE).anyTimes();
@@ -606,7 +609,7 @@ public class CachingClusteredClientTest
             .andReturn(ImmutableMap.<Cache.NamedKey, byte[]>of())
             .once();
     EasyMock.replay(cache);
-    client = makeClient(MoreExecutors.sameThreadExecutor(), cache, 0);
+    client = makeClient(new ForegroundCachePopulator(jsonMapper, -1), cache, 0);
     getDefaultQueryRunner().run(QueryPlus.wrap(query), context);
     EasyMock.verify(cache);
     EasyMock.verify(dataSegment);
@@ -2663,13 +2666,13 @@ public class CachingClusteredClientTest
     EasyMock.reset(mocks);
   }
 
-  protected CachingClusteredClient makeClient(final ListeningExecutorService backgroundExecutorService)
+  protected CachingClusteredClient makeClient(final CachePopulator cachePopulator)
   {
-    return makeClient(backgroundExecutorService, cache, 10);
+    return makeClient(cachePopulator, cache, 10);
   }
 
   protected CachingClusteredClient makeClient(
-      final ListeningExecutorService backgroundExecutorService,
+      final CachePopulator cachePopulator,
       final Cache cache,
       final int mergeLimit
   )
@@ -2709,7 +2712,7 @@ public class CachingClusteredClientTest
         },
         cache,
         jsonMapper,
-        backgroundExecutorService,
+        cachePopulator,
         new CacheConfig()
         {
           @Override

--- a/server/src/test/java/io/druid/client/CachingQueryRunnerTest.java
+++ b/server/src/test/java/io/druid/client/CachingQueryRunnerTest.java
@@ -19,21 +19,26 @@
 
 package io.druid.client;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.metamx.emitter.service.ServiceEmitter;
+import io.druid.client.cache.BackgroundCachePopulator;
 import io.druid.client.cache.Cache;
+import io.druid.client.cache.CachePopulator;
 import io.druid.client.cache.CacheConfig;
 import io.druid.client.cache.CacheStats;
+import io.druid.client.cache.ForegroundCachePopulator;
 import io.druid.client.cache.MapCache;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.Intervals;
+import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.guava.SequenceWrapper;
@@ -63,6 +68,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -72,8 +78,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -100,14 +104,21 @@ public class CachingQueryRunnerTest
       DateTimes.of("2011-01-09"), "a", 50, 4985, "b", 50, 4984, "c", 50, 4983
   };
 
-  private ExecutorService backgroundExecutorService;
+  private ObjectMapper objectMapper;
+  private CachePopulator cachePopulator;
 
   public CachingQueryRunnerTest(int numBackgroundThreads)
   {
+    objectMapper = new DefaultObjectMapper();
+
     if (numBackgroundThreads > 0) {
-      backgroundExecutorService = Executors.newFixedThreadPool(numBackgroundThreads);
+      cachePopulator = new BackgroundCachePopulator(
+          Execs.multiThreaded(numBackgroundThreads, "CachingQueryRunnerTest-%d"),
+          objectMapper,
+          -1
+      );
     } else {
-      backgroundExecutorService = MoreExecutors.sameThreadExecutor();
+      cachePopulator = new ForegroundCachePopulator(objectMapper, -1);
     }
   }
 
@@ -276,7 +287,7 @@ public class CachingQueryRunnerTest
             return resultSeq;
           }
         },
-        backgroundExecutorService,
+        cachePopulator,
         new CacheConfig()
         {
           @Override
@@ -347,12 +358,7 @@ public class CachingQueryRunnerTest
     );
 
     Cache cache = MapCache.create(1024 * 1024);
-    CacheUtil.populate(
-        cache,
-        objectMapper,
-        cacheKey,
-        Iterables.transform(expectedResults, cacheStrategy.prepareForCache())
-    );
+    cache.put(cacheKey, toByteArray(Iterables.transform(expectedResults, cacheStrategy.prepareForCache())));
 
     CachingQueryRunner runner = new CachingQueryRunner(
         segmentIdentifier,
@@ -369,7 +375,7 @@ public class CachingQueryRunnerTest
             return Sequences.empty();
           }
         },
-        backgroundExecutorService,
+        cachePopulator,
         new CacheConfig()
         {
           @Override
@@ -434,6 +440,19 @@ public class CachingQueryRunnerTest
       retVal.add(new Result<>(timestamp, new TopNResultValue(values)));
     }
     return retVal;
+  }
+
+  private <T> byte[] toByteArray(final Iterable<T> results) throws IOException
+  {
+    final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+
+    try (JsonGenerator gen = objectMapper.getFactory().createGenerator(bytes)) {
+      for (T result : results) {
+        gen.writeObject(result);
+      }
+    }
+
+    return bytes.toByteArray();
   }
 
   private static class AssertingClosable implements Closeable

--- a/server/src/test/java/io/druid/server/coordination/ServerManagerTest.java
+++ b/server/src/test/java/io/druid/server/coordination/ServerManagerTest.java
@@ -26,9 +26,9 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.metamx.emitter.EmittingLogger;
 import io.druid.client.cache.CacheConfig;
+import io.druid.client.cache.ForegroundCachePopulator;
 import io.druid.client.cache.LocalCacheProvider;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.IAE;
@@ -55,8 +55,8 @@ import io.druid.query.QueryRunnerFactoryConglomerate;
 import io.druid.query.QueryToolChest;
 import io.druid.query.Result;
 import io.druid.query.aggregation.MetricManipulationFn;
-import io.druid.query.search.SearchResultValue;
 import io.druid.query.search.SearchQuery;
+import io.druid.query.search.SearchResultValue;
 import io.druid.segment.AbstractSegment;
 import io.druid.segment.IndexIO;
 import io.druid.segment.QueryableIndex;
@@ -152,7 +152,7 @@ public class ServerManagerTest
         },
         new NoopServiceEmitter(),
         serverManagerExec,
-        MoreExecutors.sameThreadExecutor(),
+        new ForegroundCachePopulator(new DefaultObjectMapper(), -1),
         new DefaultObjectMapper(),
         new LocalCacheProvider().get(),
         new CacheConfig(),


### PR DESCRIPTION
WIP: Still need to add tests. But comments are welcome.

The idea is this makes it more feasible to cache query types that
can potentially generate large result sets, like groupBy and select,
without fear of writing too much to the cache per query.

Includes a refactor of cache population code in CachingQueryRunner and
CachingClusteredClient, such that they now use the same CachePopulator
interface with two implementations: one for foreground and one for
background.

The main reason for splitting the foreground / background impls is
that the foreground impl can have a more effective implementation of
maxEntrySize. It can stop retaining subvalues for the cache early.