### PR TITLE
FilteredHttpServerInventoryViewProvider to start with always false predicate for each segment discovered

### DIFF
--- a/server/src/main/java/io/druid/client/FilteredHttpServerInventoryViewProvider.java
+++ b/server/src/main/java/io/druid/client/FilteredHttpServerInventoryViewProvider.java
@@ -60,7 +60,7 @@ public class FilteredHttpServerInventoryViewProvider implements FilteredServerIn
     return new HttpServerInventoryView(
         smileMapper, httpClient,
         druidNodeDiscoveryProvider,
-        Predicates.<Pair<DruidServerMetadata, DataSegment>>alwaysTrue(),
+        Predicates.<Pair<DruidServerMetadata, DataSegment>>alwaysFalse(),
         config
     );
   }

--- a/server/src/main/java/io/druid/client/HttpServerInventoryView.java
+++ b/server/src/main/java/io/druid/client/HttpServerInventoryView.java
@@ -97,10 +97,12 @@ public class HttpServerInventoryView implements ServerInventoryView, FilteredSer
   private final ConcurrentMap<SegmentCallback, Predicate<Pair<DruidServerMetadata, DataSegment>>> segmentPredicates =
       new ConcurrentHashMap<>();
 
-  // Users of this instance can register filters for what segments should be stored and reported to registered
-  // listeners. For example, A Broker node can be configured to keep state for segments of specific DataSource
-  // by using this feature. In that way, Different Broker nodes can be used for dealing with Queries of Different
-  // DataSources and not maintaining any segment information of other DataSources in memory.
+  /**
+   * Users of this instance can register filters for what segments should be stored and reported to registered
+   * listeners. For example, A Broker node can be configured to keep state for segments of specific DataSource
+   * by using this feature. In that way, Different Broker nodes can be used for dealing with Queries of Different
+   * DataSources and not maintaining any segment information of other DataSources in memory.
+   */
   private final Predicate<Pair<DruidServerMetadata, DataSegment>> defaultFilter;
   private volatile Predicate<Pair<DruidServerMetadata, DataSegment>> finalPredicate;
 

--- a/server/src/main/java/io/druid/client/HttpServerInventoryView.java
+++ b/server/src/main/java/io/druid/client/HttpServerInventoryView.java
@@ -262,6 +262,10 @@ public class HttpServerInventoryView implements ServerInventoryView, FilteredSer
       Executor exec, SegmentCallback callback, Predicate<Pair<DruidServerMetadata, DataSegment>> filter
   )
   {
+    if (lifecycleLock.isStarted()) {
+      throw new ISE("Lifecycle has already started.");
+    }
+
     SegmentCallback filteringSegmentCallback = new SingleServerInventoryView.FilteringSegmentCallback(callback, filter);
     segmentCallbacks.put(filteringSegmentCallback, exec);
     segmentPredicates.put(filteringSegmentCallback, filter);
@@ -275,12 +279,20 @@ public class HttpServerInventoryView implements ServerInventoryView, FilteredSer
   @Override
   public void registerServerRemovedCallback(Executor exec, ServerRemovedCallback callback)
   {
+    if (lifecycleLock.isStarted()) {
+      throw new ISE("Lifecycle has already started.");
+    }
+
     serverCallbacks.put(callback, exec);
   }
 
   @Override
   public void registerSegmentCallback(Executor exec, SegmentCallback callback)
   {
+    if (lifecycleLock.isStarted()) {
+      throw new ISE("Lifecycle has already started.");
+    }
+
     segmentCallbacks.put(callback, exec);
   }
 

--- a/server/src/main/java/io/druid/client/HttpServerInventoryView.java
+++ b/server/src/main/java/io/druid/client/HttpServerInventoryView.java
@@ -96,6 +96,11 @@ public class HttpServerInventoryView implements ServerInventoryView, FilteredSer
 
   private final ConcurrentMap<SegmentCallback, Predicate<Pair<DruidServerMetadata, DataSegment>>> segmentPredicates =
       new ConcurrentHashMap<>();
+
+  // Users of this instance can register filters for what segments should be stored and reported to registered
+  // listeners. For example, A Broker node can be configured to keep state for segments of specific DataSource
+  // by using this feature. In that way, Different Broker nodes can be used for dealing with Queries of Different
+  // DataSources and not maintaining any segment information of other DataSources in memory.
   private final Predicate<Pair<DruidServerMetadata, DataSegment>> defaultFilter;
   private volatile Predicate<Pair<DruidServerMetadata, DataSegment>> finalPredicate;
 

--- a/server/src/test/java/io/druid/client/HttpServerInventoryViewTest.java
+++ b/server/src/test/java/io/druid/client/HttpServerInventoryViewTest.java
@@ -20,7 +20,6 @@
 package io.druid.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
@@ -98,6 +97,11 @@ public class HttpServerInventoryViewTest
         null, null, null, null, 0, 0
     );
 
+    final DataSegment segment5 = new DataSegment(
+        "non-loading-datasource", Intervals.of("2014/2015"), "v1",
+        null, null, null, null, 0, 0
+    );
+
     TestHttpClient httpClient = new TestHttpClient(
         ImmutableList.of(
             Futures.immediateFuture(
@@ -151,7 +155,8 @@ public class HttpServerInventoryViewTest
                             SegmentChangeRequestHistory.Counter.ZERO,
                             ImmutableList.of(
                                 new SegmentChangeRequestLoad(segment3),
-                                new SegmentChangeRequestLoad(segment4)
+                                new SegmentChangeRequestLoad(segment4),
+                                new SegmentChangeRequestLoad(segment5)
                             )
                         )
                     )
@@ -172,7 +177,7 @@ public class HttpServerInventoryViewTest
         jsonMapper,
         httpClient,
         druidNodeDiscoveryProvider,
-        Predicates.alwaysTrue(),
+        (pair) -> !pair.rhs.getDataSource().equals("non-loading-datasource"),
         new HttpServerInventoryViewConfig(null, null, null)
     );
 


### PR DESCRIPTION
Fixes #5121 

and minor unrelated change to ensure all predicates are registered before lifecycle starts. it happens that way already but just adding the verification for same.