### PR TITLE
Make enabled final in JavaScriptConfig 

### DIFF
--- a/api/src/main/java/io/druid/js/JavaScriptConfig.java
+++ b/api/src/main/java/io/druid/js/JavaScriptConfig.java
@@ -35,16 +35,14 @@ public class JavaScriptConfig
   private static final JavaScriptConfig ENABLED_INSTANCE = new JavaScriptConfig(true);
 
   @JsonProperty
-  private boolean enabled = false;
+  private final boolean enabled;
 
   @JsonCreator
   public JavaScriptConfig(
       @JsonProperty("enabled") Boolean enabled
   )
   {
-    if (enabled != null) {
-      this.enabled = enabled.booleanValue();
-    }
+    this.enabled = enabled != null && enabled.booleanValue();
   }
 
   public boolean isEnabled()

--- a/api/src/main/java/io/druid/js/JavaScriptConfig.java
+++ b/api/src/main/java/io/druid/js/JavaScriptConfig.java
@@ -39,10 +39,10 @@ public class JavaScriptConfig
 
   @JsonCreator
   public JavaScriptConfig(
-      @JsonProperty("enabled") Boolean enabled
+      @JsonProperty("enabled") boolean enabled
   )
   {
-    this.enabled = enabled != null && enabled.booleanValue();
+    this.enabled = enabled;
   }
 
   public boolean isEnabled()


### PR DESCRIPTION
Make 'enabled' final in JavaScriptConfig class as it is used in equals and hashCode. Since final members can be assigned value only once, replacing if statement with a single line assignment. 