### PR TITLE
Fix query/node/time metric calculation

### DIFF
--- a/server/src/main/java/io/druid/client/DirectDruidClient.java
+++ b/server/src/main/java/io/druid/client/DirectDruidClient.java
@@ -337,7 +337,7 @@ public class DirectDruidClient<T> implements QueryRunner<T>
         public ClientResponse<InputStream> done(ClientResponse<InputStream> clientResponse)
         {
           long stopTimeNs = System.nanoTime();
-          long nodeTimeNs = stopTimeNs - responseStartTimeNs;
+          long nodeTimeNs = stopTimeNs - requestStartTimeNs;
           final long nodeTimeMs = TimeUnit.NANOSECONDS.toMillis(nodeTimeNs);
           log.debug(
               "Completed queryId[%s] request to url[%s] with %,d bytes returned in %,d millis [%,f b/s].",


### PR DESCRIPTION
This PR reverts an accidental change to the logic of calculating the `query/node/time` metric. See this comment: https://github.com/druid-io/druid/commit/4b5ae31207359cf453ac220cc8309aded507b8d6#r25951667