### PR TITLE
prevent NPE from suppressing actual exception

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIndexTask.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIndexTask.java
@@ -883,7 +883,10 @@ public class KafkaIndexTask extends AbstractTask implements ChatHandler
       if (chatHandlerProvider.isPresent()) {
         chatHandlerProvider.get().unregister(getId());
       }
-      publishExecService.shutdownNow();
+
+      if (publishExecService != null) {
+        publishExecService.shutdownNow();
+      }
 
       toolbox.getDruidNodeAnnouncer().unannounce(discoveryDruidNode);
       toolbox.getDataSegmentServerAnnouncer().unannounce();


### PR DESCRIPTION
If an exception happens before `publishExecService` is created then in finally block that exception can be suppressed with NPE from  `publishExecService.shutdownNow()` statement.