### PR TITLE
DruidCoordinatorBalancer: Fix log message.

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorBalancer.java
+++ b/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorBalancer.java
@@ -99,7 +99,7 @@ public class DruidCoordinatorBalancer implements DruidCoordinatorHelper
 
     if (!currentlyMovingSegments.get(tier).isEmpty()) {
       reduceLifetimes(tier);
-      log.info("[%s]: Still waiting on %,d segments to be moved", tier, currentlyMovingSegments.size());
+      log.info("[%s]: Still waiting on %,d segments to be moved", tier, currentlyMovingSegments.get(tier).size());
       return;
     }
 


### PR DESCRIPTION
The log message was logging the number of tiers rather than the number of segments in the proper tier.