### PR TITLE
Use deprecated-2017Q4 group for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
 
+# On 12-12-2017, Travis updated their trusty image, which caused integration tests to fail.
+# The group: config instructs Travis to use the previous trusty image.
+# Please see https://github.com/druid-io/druid/pull/5155 for more information.
 sudo: required
 dist: trusty
 group: deprecated-2017Q4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: java
 
+sudo: required
 dist: trusty
+group: deprecated-2017Q4
 
 jdk:
   - oraclejdk8


### PR DESCRIPTION
Travis updated their trusty image today: https://blog.travis-ci.com/2017-12-12-new-trusty-images-q4-launch

After this update, the integration test docker image build fails with the following error:

```
Status: Downloaded newer image for imply/druiditbase:latest
 ---> 6163e110c5e1
Step 2/19 : RUN /etc/init.d/mysql start       && echo "GRANT ALL ON druid.* TO 'druid'@'%' IDENTIFIED BY 'diurd'; CREATE database druid DEFAULT CHARACTER SET utf8;" | mysql -u root       && /etc/init.d/mysql stop
 ---> Running in e3364460e227
 * Starting MySQL database server mysqld
   ...fail!
The command '/bin/sh -c /etc/init.d/mysql start       && echo "GRANT ALL ON druid.* TO 'druid'@'%' IDENTIFIED BY 'diurd'; CREATE database druid DEFAULT CHARACTER SET utf8;" | mysql -u root       && /etc/init.d/mysql stop' returned a non-zero code: 1
Unable to find image 'druid/cluster:latest' locally
docker: Error response from daemon: pull access denied for druid/cluster, repository does not exist or may require 'docker login'.
See 'docker run --help'.
```

This PR causes Travis to use the previous image, as described in this link: https://blog.travis-ci.com/2017-12-12-new-trusty-images-q4-launch