### PR TITLE
Add IndexedInts.debugToString() and AbstractIndex.toString(); Add Sequence.toList() and limit()

### DIFF
--- a/benchmarks/src/main/java/io/druid/benchmark/ExpressionAggregationBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/ExpressionAggregationBenchmark.java
@@ -27,7 +27,6 @@ import io.druid.benchmark.datagen.SegmentGenerator;
 import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.js.JavaScriptConfig;
 import io.druid.query.aggregation.BufferAggregator;
 import io.druid.query.aggregation.DoubleSumAggregatorFactory;
@@ -58,7 +57,6 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -172,25 +170,21 @@ public class ExpressionAggregationBenchmark
         null
     );
 
-    final List<Double> results = Sequences.toList(
-        Sequences.map(
-            cursors,
-            cursor -> {
-              final BufferAggregator bufferAggregator = aggregatorFactory.apply(cursor.getColumnSelectorFactory());
-              bufferAggregator.init(aggregationBuffer, 0);
+    final List<Double> results = cursors
+        .map(cursor -> {
+          final BufferAggregator bufferAggregator = aggregatorFactory.apply(cursor.getColumnSelectorFactory());
+          bufferAggregator.init(aggregationBuffer, 0);
 
-              while (!cursor.isDone()) {
-                bufferAggregator.aggregate(aggregationBuffer, 0);
-                cursor.advance();
-              }
+          while (!cursor.isDone()) {
+            bufferAggregator.aggregate(aggregationBuffer, 0);
+            cursor.advance();
+          }
 
-              final Double dbl = (Double) bufferAggregator.get(aggregationBuffer, 0);
-              bufferAggregator.close();
-              return dbl;
-            }
-        ),
-        new ArrayList<>()
-    );
+          final Double dbl = (Double) bufferAggregator.get(aggregationBuffer, 0);
+          bufferAggregator.close();
+          return dbl;
+        })
+        .toList();
 
     return Iterables.getOnlyElement(results);
   }

--- a/benchmarks/src/main/java/io/druid/benchmark/ExpressionSelectorBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/ExpressionSelectorBenchmark.java
@@ -26,7 +26,6 @@ import io.druid.benchmark.datagen.SegmentGenerator;
 import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.dimension.DefaultDimensionSpec;
 import io.druid.query.dimension.ExtractionDimensionSpec;
 import io.druid.query.expression.TestExprMacroTable;
@@ -58,7 +57,6 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
-import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -145,20 +143,16 @@ public class ExpressionSelectorBenchmark
         null
     );
 
-    final List<?> results = Sequences.toList(
-        Sequences.map(
-            cursors,
-            cursor -> {
-              final ColumnValueSelector selector = cursor.getColumnSelectorFactory().makeColumnValueSelector("v");
-              while (!cursor.isDone()) {
-                blackhole.consume(selector.getLong());
-                cursor.advance();
-              }
-              return null;
-            }
-        ),
-        new ArrayList<>()
-    );
+    final List<?> results = cursors
+        .map(cursor -> {
+          final ColumnValueSelector selector = cursor.getColumnSelectorFactory().makeColumnValueSelector("v");
+          while (!cursor.isDone()) {
+            blackhole.consume(selector.getLong());
+            cursor.advance();
+          }
+          return null;
+        })
+        .toList();
 
     blackhole.consume(results);
   }
@@ -175,26 +169,21 @@ public class ExpressionSelectorBenchmark
         null
     );
 
-    final List<?> results = Sequences.toList(
-        Sequences.map(
-            cursors,
-            cursor -> {
-              final DimensionSelector selector = cursor
-                  .getColumnSelectorFactory()
-                  .makeDimensionSelector(
-                      new ExtractionDimensionSpec(
-                          Column.TIME_COLUMN_NAME,
-                          "v",
-                          new TimeFormatExtractionFn(null, null, null, Granularities.HOUR, true)
-                      )
-                  );
-
-              consumeDimension(cursor, selector, blackhole);
-              return null;
-            }
-        ),
-        new ArrayList<>()
-    );
+    final List<?> results = cursors
+        .map(cursor -> {
+          final DimensionSelector selector = cursor
+              .getColumnSelectorFactory()
+              .makeDimensionSelector(
+                  new ExtractionDimensionSpec(
+                      Column.TIME_COLUMN_NAME,
+                      "v",
+                      new TimeFormatExtractionFn(null, null, null, Granularities.HOUR, true)
+                  )
+              );
+          consumeDimension(cursor, selector, blackhole);
+          return null;
+        })
+        .toList();
 
     blackhole.consume(results);
   }
@@ -211,20 +200,16 @@ public class ExpressionSelectorBenchmark
         null
     );
 
-    final List<Long> results = Sequences.toList(
-        Sequences.map(
-            cursors,
-            cursor -> {
-              long count = 0L;
-              while (!cursor.isDone()) {
-                count++;
-                cursor.advance();
-              }
-              return count;
-            }
-        ),
-        new ArrayList<>()
-    );
+    final List<Long> results = cursors
+        .map(cursor -> {
+          long count = 0L;
+          while (!cursor.isDone()) {
+            count++;
+            cursor.advance();
+          }
+          return count;
+        })
+        .toList();
 
     long count = 0L;
     for (Long result : results) {
@@ -255,17 +240,13 @@ public class ExpressionSelectorBenchmark
         null
     );
 
-    final List<?> results = Sequences.toList(
-        Sequences.map(
-            cursors,
-            cursor -> {
-              final ColumnValueSelector selector = cursor.getColumnSelectorFactory().makeColumnValueSelector("v");
-              consumeLong(cursor, selector, blackhole);
-              return null;
-            }
-        ),
-        new ArrayList<>()
-    );
+    final List<?> results = cursors
+        .map(cursor -> {
+          final ColumnValueSelector selector = cursor.getColumnSelectorFactory().makeColumnValueSelector("v");
+          consumeLong(cursor, selector, blackhole);
+          return null;
+        })
+        .toList();
 
     blackhole.consume(results);
   }
@@ -291,20 +272,16 @@ public class ExpressionSelectorBenchmark
         null
     );
 
-    final List<?> results = Sequences.toList(
-        Sequences.map(
-            cursors,
-            cursor -> {
-              final DimensionSelector selector = cursor.getColumnSelectorFactory().makeDimensionSelector(
-                  new DefaultDimensionSpec("v", "v", ValueType.STRING)
-              );
+    final List<?> results = cursors
+        .map(cursor -> {
+          final DimensionSelector selector = cursor
+              .getColumnSelectorFactory()
+              .makeDimensionSelector(new DefaultDimensionSpec("v", "v", ValueType.STRING));
 
-              consumeDimension(cursor, selector, blackhole);
-              return null;
-            }
-        ),
-        new ArrayList<>()
-    );
+          consumeDimension(cursor, selector, blackhole);
+          return null;
+        })
+        .toList();
 
     blackhole.consume(results);
   }
@@ -321,20 +298,16 @@ public class ExpressionSelectorBenchmark
         null
     );
 
-    final List<?> results = Sequences.toList(
-        Sequences.map(
-            cursors,
-            cursor -> {
-              final DimensionSelector selector = cursor
-                  .getColumnSelectorFactory()
-                  .makeDimensionSelector(new ExtractionDimensionSpec("x", "v", StrlenExtractionFn.instance()));
+    final List<?> results = cursors
+        .map(cursor -> {
+          final DimensionSelector selector = cursor
+              .getColumnSelectorFactory()
+              .makeDimensionSelector(new ExtractionDimensionSpec("x", "v", StrlenExtractionFn.instance()));
 
-              consumeDimension(cursor, selector, blackhole);
-              return null;
-            }
-        ),
-        new ArrayList<>()
-    );
+          consumeDimension(cursor, selector, blackhole);
+          return null;
+        })
+        .toList();
 
     blackhole.consume(results);
   }

--- a/benchmarks/src/main/java/io/druid/benchmark/FilterPartitionBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/FilterPartitionBenchmark.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import io.druid.benchmark.datagen.BenchmarkDataGenerator;
 import io.druid.benchmark.datagen.BenchmarkSchemaInfo;
@@ -245,7 +244,7 @@ public class FilterPartitionBenchmark
     Sequence<Cursor> cursors = makeCursors(sa, null);
 
     Sequence<List<String>> stringListSeq = readCursors(cursors, blackhole);
-    List<String> strings = Sequences.toList(Sequences.limit(stringListSeq, 1), Lists.<List<String>>newArrayList()).get(0);
+    List<String> strings = stringListSeq.limit(1).toList().get(0);
     for (String st : strings) {
       blackhole.consume(st);
     }
@@ -260,7 +259,7 @@ public class FilterPartitionBenchmark
     Sequence<Cursor> cursors = makeCursors(sa, null);
 
     Sequence<List<Long>> longListSeq = readCursorsLong(cursors, blackhole);
-    List<Long> strings = Sequences.toList(Sequences.limit(longListSeq, 1), Lists.<List<Long>>newArrayList()).get(0);
+    List<Long> strings = longListSeq.limit(1).toList().get(0);
     for (Long st : strings) {
       blackhole.consume(st);
     }
@@ -275,7 +274,7 @@ public class FilterPartitionBenchmark
     Sequence<Cursor> cursors = makeCursors(sa, timeFilterNone);
 
     Sequence<List<Long>> longListSeq = readCursorsLong(cursors, blackhole);
-    List<Long> strings = Sequences.toList(Sequences.limit(longListSeq, 1), Lists.<List<Long>>newArrayList()).get(0);
+    List<Long> strings = longListSeq.limit(1).toList().get(0);
     for (Long st : strings) {
       blackhole.consume(st);
     }
@@ -290,7 +289,7 @@ public class FilterPartitionBenchmark
     Sequence<Cursor> cursors = makeCursors(sa, timeFilterHalf);
 
     Sequence<List<Long>> longListSeq = readCursorsLong(cursors, blackhole);
-    List<Long> strings = Sequences.toList(Sequences.limit(longListSeq, 1), Lists.<List<Long>>newArrayList()).get(0);
+    List<Long> strings = longListSeq.limit(1).toList().get(0);
     for (Long st : strings) {
       blackhole.consume(st);
     }
@@ -305,7 +304,7 @@ public class FilterPartitionBenchmark
     Sequence<Cursor> cursors = makeCursors(sa, timeFilterAll);
 
     Sequence<List<Long>> longListSeq = readCursorsLong(cursors, blackhole);
-    List<Long> strings = Sequences.toList(Sequences.limit(longListSeq, 1), Lists.<List<Long>>newArrayList()).get(0);
+    List<Long> strings = longListSeq.limit(1).toList().get(0);
     for (Long st : strings) {
       blackhole.consume(st);
     }
@@ -322,7 +321,7 @@ public class FilterPartitionBenchmark
     Sequence<Cursor> cursors = makeCursors(sa, filter);
 
     Sequence<List<String>> stringListSeq = readCursors(cursors, blackhole);
-    List<String> strings = Sequences.toList(Sequences.limit(stringListSeq, 1), Lists.<List<String>>newArrayList()).get(0);
+    List<String> strings = stringListSeq.limit(1).toList().get(0);
     for (String st : strings) {
       blackhole.consume(st);
     }
@@ -339,7 +338,7 @@ public class FilterPartitionBenchmark
     Sequence<Cursor> cursors = makeCursors(sa, filter);
 
     Sequence<List<String>> stringListSeq = readCursors(cursors, blackhole);
-    List<String> strings = Sequences.toList(Sequences.limit(stringListSeq, 1), Lists.<List<String>>newArrayList()).get(0);
+    List<String> strings = stringListSeq.limit(1).toList().get(0);
     for (String st : strings) {
       blackhole.consume(st);
     }
@@ -356,7 +355,7 @@ public class FilterPartitionBenchmark
     Sequence<Cursor> cursors = makeCursors(sa, filter);
 
     Sequence<List<String>> stringListSeq = readCursors(cursors, blackhole);
-    List<String> strings = Sequences.toList(Sequences.limit(stringListSeq, 1), Lists.<List<String>>newArrayList()).get(0);
+    List<String> strings = stringListSeq.limit(1).toList().get(0);
     for (String st : strings) {
       blackhole.consume(st);
     }
@@ -373,7 +372,7 @@ public class FilterPartitionBenchmark
     Sequence<Cursor> cursors = makeCursors(sa, filter);
 
     Sequence<List<String>> stringListSeq = readCursors(cursors, blackhole);
-    List<String> strings = Sequences.toList(Sequences.limit(stringListSeq, 1), Lists.<List<String>>newArrayList()).get(0);
+    List<String> strings = stringListSeq.limit(1).toList().get(0);
     for (String st : strings) {
       blackhole.consume(st);
     }
@@ -392,7 +391,7 @@ public class FilterPartitionBenchmark
     Sequence<Cursor> cursors = makeCursors(sa, orFilter);
 
     Sequence<List<String>> stringListSeq = readCursors(cursors, blackhole);
-    List<String> strings = Sequences.toList(Sequences.limit(stringListSeq, 1), Lists.<List<String>>newArrayList()).get(0);
+    List<String> strings = stringListSeq.limit(1).toList().get(0);
     for (String st : strings) {
       blackhole.consume(st);
     }
@@ -411,7 +410,7 @@ public class FilterPartitionBenchmark
     Sequence<Cursor> cursors = makeCursors(sa, Filters.convertToCNF(orFilter));
 
     Sequence<List<String>> stringListSeq = readCursors(cursors, blackhole);
-    List<String> strings = Sequences.toList(Sequences.limit(stringListSeq, 1), Lists.<List<String>>newArrayList()).get(0);
+    List<String> strings = stringListSeq.limit(1).toList().get(0);
     for (String st : strings) {
       blackhole.consume(st);
     }
@@ -453,7 +452,7 @@ public class FilterPartitionBenchmark
     Sequence<Cursor> cursors = makeCursors(sa, dimFilter3.toFilter());
 
     Sequence<List<String>> stringListSeq = readCursors(cursors, blackhole);
-    List<String> strings = Sequences.toList(Sequences.limit(stringListSeq, 1), Lists.<List<String>>newArrayList()).get(0);
+    List<String> strings = stringListSeq.limit(1).toList().get(0);
     for (String st : strings) {
       blackhole.consume(st);
     }
@@ -495,7 +494,7 @@ public class FilterPartitionBenchmark
     Sequence<Cursor> cursors = makeCursors(sa, Filters.convertToCNF(dimFilter3.toFilter()));
 
     Sequence<List<String>> stringListSeq = readCursors(cursors, blackhole);
-    List<String> strings = Sequences.toList(Sequences.limit(stringListSeq, 1), Lists.<List<String>>newArrayList()).get(0);
+    List<String> strings = stringListSeq.limit(1).toList().get(0);
     for (String st : strings) {
       blackhole.consume(st);
     }

--- a/benchmarks/src/main/java/io/druid/benchmark/FilteredAggregatorBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/FilteredAggregatorBenchmark.java
@@ -20,7 +20,6 @@
 package io.druid.benchmark;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import io.druid.benchmark.datagen.BenchmarkDataGenerator;
@@ -32,10 +31,8 @@ import io.druid.hll.HyperLogLogHash;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.js.JavaScriptConfig;
-import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import io.druid.query.Druids;
 import io.druid.query.FinalizeResultsQueryRunner;
 import io.druid.query.Query;
@@ -73,6 +70,7 @@ import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
+import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.commons.io.FileUtils;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -247,7 +245,7 @@ public class FilteredAggregatorBenchmark
     );
 
     Sequence<T> queryResult = theRunner.run(QueryPlus.wrap(query), Maps.newHashMap());
-    return Sequences.toList(queryResult, Lists.<T>newArrayList());
+    return queryResult.toList();
   }
 
   @Benchmark

--- a/benchmarks/src/main/java/io/druid/benchmark/GroupByTypeInterfaceBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/GroupByTypeInterfaceBenchmark.java
@@ -35,18 +35,16 @@ import io.druid.collections.BlockingPool;
 import io.druid.collections.DefaultBlockingPool;
 import io.druid.collections.NonBlockingPool;
 import io.druid.collections.StupidPool;
-import io.druid.java.util.common.concurrent.Execs;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.Row;
 import io.druid.hll.HyperLogLogHash;
 import io.druid.jackson.DefaultObjectMapper;
+import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.granularity.Granularity;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.offheap.OffheapBufferGenerator;
-import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import io.druid.query.DruidProcessingConfig;
 import io.druid.query.FinalizeResultsQueryRunner;
 import io.druid.query.Query;
@@ -77,6 +75,7 @@ import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
+import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.commons.io.FileUtils;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -104,8 +103,9 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
-// Benchmark for determining the interface overhead of GroupBy with multiple type implementations
-
+/**
+ * Benchmark for determining the interface overhead of GroupBy with multiple type implementations
+ */
 @State(Scope.Benchmark)
 @Fork(value = 1)
 @Warmup(iterations = 15)
@@ -477,7 +477,7 @@ public class GroupByTypeInterfaceBenchmark
     );
 
     Sequence<T> queryResult = theRunner.run(QueryPlus.wrap(query), Maps.newHashMap());
-    return Sequences.toList(queryResult, Lists.<T>newArrayList());
+    return queryResult.toList();
   }
 
   @Benchmark

--- a/benchmarks/src/main/java/io/druid/benchmark/TopNTypeInterfaceBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/TopNTypeInterfaceBenchmark.java
@@ -20,7 +20,6 @@
 package io.druid.benchmark;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import io.druid.benchmark.datagen.BenchmarkDataGenerator;
@@ -28,16 +27,14 @@ import io.druid.benchmark.datagen.BenchmarkSchemaInfo;
 import io.druid.benchmark.datagen.BenchmarkSchemas;
 import io.druid.benchmark.query.QueryBenchmarkUtil;
 import io.druid.collections.StupidPool;
-import io.druid.java.util.common.concurrent.Execs;
 import io.druid.data.input.InputRow;
 import io.druid.hll.HyperLogLogHash;
 import io.druid.jackson.DefaultObjectMapper;
+import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.offheap.OffheapBufferGenerator;
-import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import io.druid.query.FinalizeResultsQueryRunner;
 import io.druid.query.Query;
 import io.druid.query.QueryPlus;
@@ -72,6 +69,7 @@ import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
+import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -332,7 +330,7 @@ public class TopNTypeInterfaceBenchmark
     );
 
     Sequence<T> queryResult = theRunner.run(QueryPlus.wrap(query), Maps.newHashMap());
-    return Sequences.toList(queryResult, Lists.<T>newArrayList());
+    return queryResult.toList();
   }
 
   @Benchmark

--- a/benchmarks/src/main/java/io/druid/benchmark/indexing/IncrementalIndexReadBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/indexing/IncrementalIndexReadBenchmark.java
@@ -19,7 +19,6 @@
 
 package io.druid.benchmark.indexing;
 
-import com.google.common.collect.Lists;
 import io.druid.benchmark.datagen.BenchmarkDataGenerator;
 import io.druid.benchmark.datagen.BenchmarkSchemaInfo;
 import io.druid.benchmark.datagen.BenchmarkSchemas;
@@ -27,7 +26,6 @@ import io.druid.data.input.InputRow;
 import io.druid.hll.HyperLogLogHash;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.js.JavaScriptConfig;
 import io.druid.query.aggregation.hyperloglog.HyperUniquesSerde;
@@ -141,7 +139,7 @@ public class IncrementalIndexReadBenchmark
   {
     IncrementalIndexStorageAdapter sa = new IncrementalIndexStorageAdapter(incIndex);
     Sequence<Cursor> cursors = makeCursors(sa, null);
-    Cursor cursor = Sequences.toList(Sequences.limit(cursors, 1), Lists.<Cursor>newArrayList()).get(0);
+    Cursor cursor = cursors.limit(1).toList().get(0);
 
     List<DimensionSelector> selectors = new ArrayList<>();
     selectors.add(makeDimensionSelector(cursor, "dimSequential"));
@@ -176,7 +174,7 @@ public class IncrementalIndexReadBenchmark
 
     IncrementalIndexStorageAdapter sa = new IncrementalIndexStorageAdapter(incIndex);
     Sequence<Cursor> cursors = makeCursors(sa, filter);
-    Cursor cursor = Sequences.toList(Sequences.limit(cursors, 1), Lists.<Cursor>newArrayList()).get(0);
+    Cursor cursor = cursors.limit(1).toList().get(0);
 
     List<DimensionSelector> selectors = new ArrayList<>();
     selectors.add(makeDimensionSelector(cursor, "dimSequential"));

--- a/benchmarks/src/main/java/io/druid/benchmark/query/GroupByBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/GroupByBenchmark.java
@@ -36,18 +36,16 @@ import io.druid.collections.BlockingPool;
 import io.druid.collections.DefaultBlockingPool;
 import io.druid.collections.NonBlockingPool;
 import io.druid.collections.StupidPool;
-import io.druid.java.util.common.concurrent.Execs;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.Row;
 import io.druid.hll.HyperLogLogHash;
 import io.druid.jackson.DefaultObjectMapper;
+import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.granularity.Granularity;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.offheap.OffheapBufferGenerator;
-import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import io.druid.query.DruidProcessingConfig;
 import io.druid.query.FinalizeResultsQueryRunner;
 import io.druid.query.Query;
@@ -84,6 +82,7 @@ import io.druid.segment.column.ValueType;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.serde.ComplexMetrics;
+import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.commons.io.FileUtils;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -577,7 +576,7 @@ public class GroupByBenchmark
     );
 
     Sequence<T> queryResult = theRunner.run(QueryPlus.wrap(query), Maps.<String, Object>newHashMap());
-    return Sequences.toList(queryResult, Lists.<T>newArrayList());
+    return queryResult.toList();
   }
 
   @Benchmark
@@ -630,7 +629,7 @@ public class GroupByBenchmark
     );
 
     Sequence<Row> queryResult = theRunner.run(QueryPlus.wrap(query), Maps.newHashMap());
-    List<Row> results = Sequences.toList(queryResult, Lists.<Row>newArrayList());
+    List<Row> results = queryResult.toList();
 
     for (Row result : results) {
       blackhole.consume(result);
@@ -654,7 +653,7 @@ public class GroupByBenchmark
         ImmutableMap.<String, Object>of("bufferGrouperMaxSize", 4000)
     );
     Sequence<Row> queryResult = theRunner.run(QueryPlus.wrap(spillingQuery), Maps.newHashMap());
-    List<Row> results = Sequences.toList(queryResult, Lists.<Row>newArrayList());
+    List<Row> results = queryResult.toList();
 
     for (Row result : results) {
       blackhole.consume(result);
@@ -681,7 +680,7 @@ public class GroupByBenchmark
     );
 
     Sequence<Row> queryResult = theRunner.run(QueryPlus.wrap(query), Maps.<String, Object>newHashMap());
-    List<Row> results = Sequences.toList(queryResult, Lists.<Row>newArrayList());
+    List<Row> results = queryResult.toList();
 
     for (Row result : results) {
       blackhole.consume(result);

--- a/benchmarks/src/main/java/io/druid/benchmark/query/SearchBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/SearchBenchmark.java
@@ -29,16 +29,14 @@ import com.google.common.io.Files;
 import io.druid.benchmark.datagen.BenchmarkDataGenerator;
 import io.druid.benchmark.datagen.BenchmarkSchemaInfo;
 import io.druid.benchmark.datagen.BenchmarkSchemas;
-import io.druid.java.util.common.concurrent.Execs;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.Row;
 import io.druid.hll.HyperLogLogHash;
 import io.druid.jackson.DefaultObjectMapper;
+import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.logger.Logger;
-import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import io.druid.query.Druids;
 import io.druid.query.Druids.SearchQueryBuilder;
 import io.druid.query.FinalizeResultsQueryRunner;
@@ -60,13 +58,13 @@ import io.druid.query.filter.BoundDimFilter;
 import io.druid.query.filter.DimFilter;
 import io.druid.query.filter.InDimFilter;
 import io.druid.query.filter.SelectorDimFilter;
+import io.druid.query.search.SearchHit;
+import io.druid.query.search.SearchQuery;
+import io.druid.query.search.SearchQueryConfig;
 import io.druid.query.search.SearchQueryQueryToolChest;
 import io.druid.query.search.SearchQueryRunnerFactory;
 import io.druid.query.search.SearchResultValue;
 import io.druid.query.search.SearchStrategySelector;
-import io.druid.query.search.SearchHit;
-import io.druid.query.search.SearchQuery;
-import io.druid.query.search.SearchQueryConfig;
 import io.druid.query.spec.MultipleIntervalSegmentSpec;
 import io.druid.query.spec.QuerySegmentSpec;
 import io.druid.segment.IncrementalIndexSegment;
@@ -78,6 +76,7 @@ import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
+import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.commons.io.FileUtils;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -405,7 +404,7 @@ public class SearchBenchmark
     );
 
     Sequence<T> queryResult = theRunner.run(QueryPlus.wrap(query), Maps.<String, Object>newHashMap());
-    return Sequences.toList(queryResult, Lists.<T>newArrayList());
+    return queryResult.toList();
   }
 
   @Benchmark
@@ -473,10 +472,7 @@ public class SearchBenchmark
         QueryPlus.wrap(query),
         Maps.<String, Object>newHashMap()
     );
-    List<Result<SearchResultValue>> results = Sequences.toList(
-        queryResult,
-        Lists.<Result<SearchResultValue>>newArrayList()
-    );
+    List<Result<SearchResultValue>> results = queryResult.toList();
 
     for (Result<SearchResultValue> result : results) {
       List<SearchHit> hits = result.getValue().getValue();

--- a/benchmarks/src/main/java/io/druid/benchmark/query/SelectBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/SelectBenchmark.java
@@ -28,16 +28,14 @@ import com.google.common.io.Files;
 import io.druid.benchmark.datagen.BenchmarkDataGenerator;
 import io.druid.benchmark.datagen.BenchmarkSchemaInfo;
 import io.druid.benchmark.datagen.BenchmarkSchemas;
-import io.druid.java.util.common.concurrent.Execs;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.Row;
 import io.druid.hll.HyperLogLogHash;
 import io.druid.jackson.DefaultObjectMapper;
+import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.logger.Logger;
-import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import io.druid.query.Druids;
 import io.druid.query.FinalizeResultsQueryRunner;
 import io.druid.query.Query;
@@ -68,6 +66,7 @@ import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
+import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.commons.io.FileUtils;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -270,7 +269,7 @@ public class SelectBenchmark
     );
 
     Sequence<T> queryResult = theRunner.run(QueryPlus.wrap(query), Maps.<String, Object>newHashMap());
-    return Sequences.toList(queryResult, Lists.<T>newArrayList());
+    return queryResult.toList();
   }
 
   // don't run this benchmark with a query that doesn't use QueryGranularities.ALL,
@@ -379,7 +378,7 @@ public class SelectBenchmark
     boolean done = false;
     while (!done) {
       Sequence<Result<SelectResultValue>> queryResult = theRunner.run(QueryPlus.wrap(queryCopy), Maps.newHashMap());
-      List<Result<SelectResultValue>> results = Sequences.toList(queryResult, Lists.<Result<SelectResultValue>>newArrayList());
+      List<Result<SelectResultValue>> results = queryResult.toList();
       
       SelectResultValue result = results.get(0).getValue();
 

--- a/benchmarks/src/main/java/io/druid/benchmark/query/SqlBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/SqlBenchmark.java
@@ -19,7 +19,6 @@
 
 package io.druid.benchmark.query;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import io.druid.benchmark.datagen.BenchmarkSchemaInfo;
@@ -29,7 +28,6 @@ import io.druid.data.input.Row;
 import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.query.QueryPlus;
 import io.druid.query.QueryRunnerFactoryConglomerate;
@@ -39,9 +37,9 @@ import io.druid.query.dimension.DefaultDimensionSpec;
 import io.druid.query.dimension.DimensionSpec;
 import io.druid.query.groupby.GroupByQuery;
 import io.druid.segment.QueryableIndex;
-import io.druid.server.security.NoopEscalator;
 import io.druid.server.security.AuthConfig;
 import io.druid.server.security.AuthTestUtils;
+import io.druid.server.security.NoopEscalator;
 import io.druid.sql.calcite.planner.DruidPlanner;
 import io.druid.sql.calcite.planner.PlannerConfig;
 import io.druid.sql.calcite.planner.PlannerFactory;
@@ -67,8 +65,8 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -171,7 +169,7 @@ public class SqlBenchmark
   public void queryNative(Blackhole blackhole) throws Exception
   {
     final Sequence<Row> resultSequence = QueryPlus.wrap(groupByQuery).run(walker, Maps.newHashMap());
-    final ArrayList<Row> resultList = Sequences.toList(resultSequence, Lists.<Row>newArrayList());
+    final List<Row> resultList = resultSequence.toList();
 
     for (Row row : resultList) {
       blackhole.consume(row);
@@ -185,7 +183,7 @@ public class SqlBenchmark
   {
     try (final DruidPlanner planner = plannerFactory.createPlanner(null)) {
       final PlannerResult plannerResult = planner.plan(sqlQuery);
-      final ArrayList<Object[]> results = Sequences.toList(plannerResult.run(), Lists.<Object[]>newArrayList());
+      final List<Object[]> results = plannerResult.run().toList();
       blackhole.consume(results);
     }
   }

--- a/benchmarks/src/main/java/io/druid/benchmark/query/TimeseriesBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/TimeseriesBenchmark.java
@@ -26,16 +26,14 @@ import com.google.common.io.Files;
 import io.druid.benchmark.datagen.BenchmarkDataGenerator;
 import io.druid.benchmark.datagen.BenchmarkSchemaInfo;
 import io.druid.benchmark.datagen.BenchmarkSchemas;
-import io.druid.java.util.common.concurrent.Execs;
 import io.druid.data.input.InputRow;
 import io.druid.hll.HyperLogLogHash;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.Intervals;
+import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.logger.Logger;
-import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import io.druid.query.Druids;
 import io.druid.query.FinalizeResultsQueryRunner;
 import io.druid.query.Query;
@@ -73,6 +71,7 @@ import io.druid.segment.column.Column;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
+import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.commons.io.FileUtils;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -329,7 +328,7 @@ public class TimeseriesBenchmark
     );
 
     Sequence<T> queryResult = theRunner.run(QueryPlus.wrap(query), Maps.<String, Object>newHashMap());
-    return Sequences.toList(queryResult, Lists.<T>newArrayList());
+    return queryResult.toList();
   }
 
   @Benchmark
@@ -414,7 +413,7 @@ public class TimeseriesBenchmark
         QueryPlus.wrap(query),
         Maps.<String, Object>newHashMap()
     );
-    List<Result<TimeseriesResultValue>> results = Sequences.toList(queryResult, Lists.<Result<TimeseriesResultValue>>newArrayList());
+    List<Result<TimeseriesResultValue>> results = queryResult.toList();
 
     for (Result<TimeseriesResultValue> result : results) {
       blackhole.consume(result);

--- a/benchmarks/src/main/java/io/druid/benchmark/query/TopNBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/TopNBenchmark.java
@@ -27,16 +27,14 @@ import io.druid.benchmark.datagen.BenchmarkDataGenerator;
 import io.druid.benchmark.datagen.BenchmarkSchemaInfo;
 import io.druid.benchmark.datagen.BenchmarkSchemas;
 import io.druid.collections.StupidPool;
-import io.druid.java.util.common.concurrent.Execs;
 import io.druid.data.input.InputRow;
 import io.druid.hll.HyperLogLogHash;
 import io.druid.jackson.DefaultObjectMapper;
+import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.offheap.OffheapBufferGenerator;
-import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import io.druid.query.FinalizeResultsQueryRunner;
 import io.druid.query.Query;
 import io.druid.query.QueryPlus;
@@ -70,6 +68,7 @@ import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.serde.ComplexMetrics;
+import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.commons.io.FileUtils;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -310,7 +309,7 @@ public class TopNBenchmark
     );
 
     Sequence<T> queryResult = theRunner.run(QueryPlus.wrap(query), Maps.<String, Object>newHashMap());
-    return Sequences.toList(queryResult, Lists.<T>newArrayList());
+    return queryResult.toList();
   }
 
   @Benchmark
@@ -375,7 +374,7 @@ public class TopNBenchmark
         QueryPlus.wrap(query),
         Maps.<String, Object>newHashMap()
     );
-    List<Result<TopNResultValue>> results = Sequences.toList(queryResult, Lists.<Result<TopNResultValue>>newArrayList());
+    List<Result<TopNResultValue>> results = queryResult.toList();
 
     for (Result<TopNResultValue> result : results) {
       blackhole.consume(result);

--- a/common/src/test/java/io/druid/common/guava/CombiningSequenceTest.java
+++ b/common/src/test/java/io/druid/common/guava/CombiningSequenceTest.java
@@ -29,7 +29,6 @@ import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.guava.Yielder;
 import io.druid.java.util.common.guava.YieldingAccumulator;
-import io.druid.java.util.common.guava.nary.BinaryFn;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -228,33 +227,23 @@ public class CombiningSequenceTest
       }
     };
 
-    Sequence<Pair<Integer, Integer>> seq = Sequences.limit(
-        CombiningSequence.create(
-            Sequences.withBaggage(Sequences.simple(pairs), closeable),
-            Ordering.natural().onResultOf(Pair.<Integer, Integer>lhsFn()),
-            new BinaryFn<Pair<Integer, Integer>, Pair<Integer, Integer>, Pair<Integer, Integer>>()
-            {
-              @Override
-              public Pair<Integer, Integer> apply(
-                  Pair<Integer, Integer> lhs, Pair<Integer, Integer> rhs
-              )
-              {
-                if (lhs == null) {
-                  return rhs;
-                }
+    Sequence<Pair<Integer, Integer>> seq = CombiningSequence.create(
+        Sequences.simple(pairs).withBaggage(closeable),
+        Ordering.natural().onResultOf(Pair.lhsFn()),
+        (lhs, rhs) -> {
+          if (lhs == null) {
+            return rhs;
+          }
 
-                if (rhs == null) {
-                  return lhs;
-                }
+          if (rhs == null) {
+            return lhs;
+          }
 
-                return Pair.of(lhs.lhs, lhs.rhs + rhs.rhs);
-              }
-            }
-        ),
-        limit
-    );
+          return Pair.of(lhs.lhs, lhs.rhs + rhs.rhs);
+        }
+    ).limit(limit);
 
-    List<Pair<Integer, Integer>> merged = Sequences.toList(seq, Lists.<Pair<Integer, Integer>>newArrayList());
+    List<Pair<Integer, Integer>> merged = seq.toList();
 
     Assert.assertEquals(expected, merged);
 

--- a/common/src/test/java/io/druid/common/guava/ComplexSequenceTest.java
+++ b/common/src/test/java/io/druid/common/guava/ComplexSequenceTest.java
@@ -48,7 +48,7 @@ public class ComplexSequenceTest
 
   private void check(String expected, Sequence<Integer> complex)
   {
-    List<Integer> combined = Sequences.toList(complex, new ArrayList<Integer>());
+    List<Integer> combined = complex.toList();
     Assert.assertEquals(expected, combined.toString());
 
     Yielder<Integer> yielder = complex.toYielder(

--- a/extensions-contrib/distinctcount/src/test/java/io/druid/query/aggregation/distinctcount/DistinctCountTimeseriesQueryTest.java
+++ b/extensions-contrib/distinctcount/src/test/java/io/druid/query/aggregation/distinctcount/DistinctCountTimeseriesQueryTest.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Lists;
 import io.druid.data.input.MapBasedInputRow;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.granularity.Granularities;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.Druids;
 import io.druid.query.QueryRunnerTestHelper;
 import io.druid.query.Result;
@@ -98,13 +97,8 @@ public class DistinctCountTimeseriesQueryTest
                                   )
                                   .build();
 
-    final Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        engine.process(
-            query,
-            new IncrementalIndexStorageAdapter(index)
-        ),
-        Lists.<Result<TimeseriesResultValue>>newLinkedList()
-    );
+    final Iterable<Result<TimeseriesResultValue>> results =
+        engine.process(query, new IncrementalIndexStorageAdapter(index)).toList();
 
     List<Result<TimeseriesResultValue>> expectedResults = Collections.singletonList(
         new Result<>(

--- a/extensions-contrib/distinctcount/src/test/java/io/druid/query/aggregation/distinctcount/DistinctCountTopNQueryTest.java
+++ b/extensions-contrib/distinctcount/src/test/java/io/druid/query/aggregation/distinctcount/DistinctCountTopNQueryTest.java
@@ -26,7 +26,6 @@ import io.druid.collections.StupidPool;
 import io.druid.data.input.MapBasedInputRow;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.granularity.Granularities;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.QueryRunnerTestHelper;
 import io.druid.query.Result;
 import io.druid.query.aggregation.CountAggregatorFactory;
@@ -117,10 +116,8 @@ public class DistinctCountTopNQueryTest
                           )
                           .build();
 
-    final Iterable<Result<TopNResultValue>> results = Sequences.toList(
-        engine.query(query, new IncrementalIndexStorageAdapter(index), null),
-        Lists.<Result<TopNResultValue>>newLinkedList()
-    );
+    final Iterable<Result<TopNResultValue>> results =
+        engine.query(query, new IncrementalIndexStorageAdapter(index), null).toList();
 
     List<Result<TopNResultValue>> expectedResults = Collections.singletonList(
         new Result<>(

--- a/extensions-contrib/time-min-max/src/test/java/io/druid/query/aggregation/TimestampAggregationSelectTest.java
+++ b/extensions-contrib/time-min-max/src/test/java/io/druid/query/aggregation/TimestampAggregationSelectTest.java
@@ -23,12 +23,10 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.Result;
 import io.druid.query.select.SelectResultValue;
 import io.druid.segment.ColumnSelectorFactory;
@@ -152,7 +150,7 @@ public class TimestampAggregationSelectTest
         Resources.toString(Resources.getResource("select.json"), Charsets.UTF_8)
     );
 
-    Result<SelectResultValue> result = (Result<SelectResultValue>) Iterables.getOnlyElement(Sequences.toList(seq, Lists.newArrayList()));
+    Result<SelectResultValue> result = (Result<SelectResultValue>) Iterables.getOnlyElement(seq.toList());
     Assert.assertEquals(36, result.getValue().getEvents().size());
     Assert.assertEquals(expected, result.getValue().getEvents().get(0).getEvent().get(aggField));
   }

--- a/extensions-contrib/time-min-max/src/test/java/io/druid/query/aggregation/TimestampGroupByAggregationTest.java
+++ b/extensions-contrib/time-min-max/src/test/java/io/druid/query/aggregation/TimestampGroupByAggregationTest.java
@@ -26,7 +26,6 @@ import io.druid.data.input.Row;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.groupby.GroupByQueryConfig;
 import io.druid.query.groupby.GroupByQueryRunnerTest;
 import io.druid.segment.ColumnSelectorFactory;
@@ -178,7 +177,7 @@ public class TimestampGroupByAggregationTest
         groupBy
     );
 
-    List<Row> results = Sequences.toList(seq, Lists.<Row>newArrayList());
+    List<Row> results = seq.toList();
     Assert.assertEquals(36, results.size());
     Assert.assertEquals(expected, ((MapBasedRow) results.get(0)).getEvent().get(groupByField));
   }

--- a/extensions-contrib/virtual-columns/src/test/java/io/druid/segment/MapVirtualColumnTest.java
+++ b/extensions-contrib/virtual-columns/src/test/java/io/druid/segment/MapVirtualColumnTest.java
@@ -22,7 +22,6 @@ package io.druid.segment;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.CharSource;
 import io.druid.data.input.impl.DelimitedParseSpec;
@@ -31,7 +30,6 @@ import io.druid.data.input.impl.StringInputRowParser;
 import io.druid.data.input.impl.TimestampSpec;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.DateTimes;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.Druids;
 import io.druid.query.QueryPlus;
 import io.druid.query.QueryRunner;
@@ -57,12 +55,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import static io.druid.query.QueryRunnerTestHelper.allGran;
-import static io.druid.query.QueryRunnerTestHelper.dataSource;
-import static io.druid.query.QueryRunnerTestHelper.fullOnInterval;
-import static io.druid.query.QueryRunnerTestHelper.makeQueryRunner;
-import static io.druid.query.QueryRunnerTestHelper.transformToConstructionFeeder;
 
 /**
  */
@@ -114,10 +106,20 @@ public class MapVirtualColumnTest
     IncrementalIndex index1 = TestIndex.loadIncrementalIndex(index, input, parser);
     QueryableIndex index2 = TestIndex.persistRealtimeAndLoadMMapped(index1);
 
-    return transformToConstructionFeeder(
+    return QueryRunnerTestHelper.transformToConstructionFeeder(
         Arrays.asList(
-            makeQueryRunner(factory, "index1", new IncrementalIndexSegment(index1, "index1"), "incremental"),
-            makeQueryRunner(factory, "index2", new QueryableIndexSegment("index2", index2), "queryable")
+            QueryRunnerTestHelper.makeQueryRunner(
+                factory,
+                "index1",
+                new IncrementalIndexSegment(index1, "index1"),
+                "incremental"
+            ),
+            QueryRunnerTestHelper.makeQueryRunner(
+                factory,
+                "index2",
+                new QueryableIndexSegment("index2", index2),
+                "queryable"
+            )
         )
     );
   }
@@ -132,9 +134,9 @@ public class MapVirtualColumnTest
   private Druids.SelectQueryBuilder testBuilder()
   {
     return Druids.newSelectQueryBuilder()
-                 .dataSource(dataSource)
-                 .granularity(allGran)
-                 .intervals(fullOnInterval)
+                 .dataSource(QueryRunnerTestHelper.dataSource)
+                 .granularity(QueryRunnerTestHelper.allGran)
+                 .intervals(QueryRunnerTestHelper.fullOnInterval)
                  .pagingSpec(new PagingSpec(null, 3));
   }
 
@@ -185,10 +187,7 @@ public class MapVirtualColumnTest
 
   private void checkSelectQuery(SelectQuery searchQuery, List<Map> expected) throws Exception
   {
-    List<Result<SelectResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(searchQuery), ImmutableMap.of()),
-        Lists.<Result<SelectResultValue>>newArrayList()
-    );
+    List<Result<SelectResultValue>> results = runner.run(QueryPlus.wrap(searchQuery), ImmutableMap.of()).toList();
     Assert.assertEquals(1, results.size());
 
     List<EventHolder> events = results.get(0).getValue().getEvents();

--- a/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/quantiles/DoublesSketchAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/quantiles/DoublesSketchAggregatorTest.java
@@ -26,7 +26,6 @@ import io.druid.initialization.DruidModule;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.aggregation.AggregationTestHelper;
 import io.druid.query.groupby.GroupByQueryConfig;
 import io.druid.query.groupby.GroupByQueryRunnerTest;
@@ -38,7 +37,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -130,7 +128,7 @@ public class DoublesSketchAggregatorTest
             "  ],",
             "  \"intervals\": [\"2016-01-01T00:00:00.000Z/2016-01-31T00:00:00.000Z\"]",
             "}"));
-    List<Row> results = Sequences.toList(seq, new ArrayList<Row>());
+    List<Row> results = seq.toList();
     Assert.assertEquals(1, results.size());
     Row row = results.get(0);
 
@@ -201,7 +199,7 @@ public class DoublesSketchAggregatorTest
             "  ],",
             "  \"intervals\": [\"2016-01-01T00:00:00.000Z/2016-01-31T00:00:00.000Z\"]",
             "}"));
-    List<Row> results = Sequences.toList(seq, new ArrayList<Row>());
+    List<Row> results = seq.toList();
     Assert.assertEquals(1, results.size());
     Row row = results.get(0);
 
@@ -268,7 +266,7 @@ public class DoublesSketchAggregatorTest
             "  ],",
             "  \"intervals\": [\"2016-01-01T00:00:00.000Z/2016-01-31T00:00:00.000Z\"]",
             "}"));
-    List<Row> results = Sequences.toList(seq, new ArrayList<Row>());
+    List<Row> results = seq.toList();
     Assert.assertEquals(1, results.size());
     Row row = results.get(0);
 
@@ -341,7 +339,7 @@ public class DoublesSketchAggregatorTest
             "  ],",
             "  \"intervals\": [\"2016-01-01T00:00:00.000Z/2016-01-31T00:00:00.000Z\"]",
             "}"));
-    List<Row> results = Sequences.toList(seq, new ArrayList<Row>());
+    List<Row> results = seq.toList();
     Assert.assertEquals(1, results.size());
     Row row = results.get(0);
 
@@ -413,7 +411,7 @@ public class DoublesSketchAggregatorTest
             "  ],",
             "  \"intervals\": [\"2016-01-01T00:00:00.000Z/2016-01-31T00:00:00.000Z\"]",
             "}"));
-    List<Row> results = Sequences.toList(seq, new ArrayList<Row>());
+    List<Row> results = seq.toList();
     Assert.assertEquals(1, results.size());
   }
 }

--- a/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/theta/SketchAggregationTest.java
+++ b/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/theta/SketchAggregationTest.java
@@ -34,7 +34,6 @@ import io.druid.data.input.Row;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.aggregation.AggregationTestHelper;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.PostAggregator;
@@ -102,7 +101,7 @@ public class SketchAggregationTest
         readFileFromClasspathAsString("sketch_test_data_group_by_query.json")
     );
 
-    List<Row> results = Sequences.toList(seq, Lists.<Row>newArrayList());
+    List<Row> results = seq.toList();
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
         new MapBasedRow(
@@ -143,7 +142,7 @@ public class SketchAggregationTest
         readFileFromClasspathAsString("simple_test_data_group_by_query.json")
     );
 
-    List<Row> results = Sequences.toList(seq, Lists.<Row>newArrayList());
+    List<Row> results = seq.toList();
     Assert.assertEquals(5, results.size());
     Assert.assertEquals(
         ImmutableList.of(
@@ -341,7 +340,7 @@ public class SketchAggregationTest
         readFileFromClasspathAsString("retention_test_data_group_by_query.json")
     );
 
-    List<Row> results = Sequences.toList(seq, Lists.<Row>newArrayList());
+    List<Row> results = seq.toList();
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
         ImmutableList.of(

--- a/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/theta/SketchAggregationWithSimpleDataTest.java
+++ b/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/theta/SketchAggregationWithSimpleDataTest.java
@@ -29,7 +29,6 @@ import io.druid.data.input.Row;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.Result;
 import io.druid.query.aggregation.AggregationTestHelper;
 import io.druid.query.groupby.GroupByQueryConfig;
@@ -130,7 +129,7 @@ public class SketchAggregationWithSimpleDataTest
         readFileFromClasspathAsString("simple_test_data_group_by_query.json")
     );
 
-    List<Row> results = Sequences.toList(seq, Lists.<Row>newArrayList());
+    List<Row> results = seq.toList();
     Assert.assertEquals(5, results.size());
     Assert.assertEquals(
         ImmutableList.of(
@@ -217,9 +216,7 @@ public class SketchAggregationWithSimpleDataTest
         readFileFromClasspathAsString("timeseries_query.json")
     );
 
-    Result<TimeseriesResultValue> result = (Result<TimeseriesResultValue>) Iterables.getOnlyElement(
-        Sequences.toList(seq, Lists.newArrayList())
-    );
+    Result<TimeseriesResultValue> result = (Result<TimeseriesResultValue>) Iterables.getOnlyElement(seq.toList());
 
     Assert.assertEquals(DateTimes.of("2014-10-20T00:00:00.000Z"), result.getTimestamp());
 
@@ -245,9 +242,7 @@ public class SketchAggregationWithSimpleDataTest
         readFileFromClasspathAsString("topn_query.json")
     );
 
-    Result<TopNResultValue> result = (Result<TopNResultValue>) Iterables.getOnlyElement(
-        Sequences.toList(seq, Lists.newArrayList())
-    );
+    Result<TopNResultValue> result = (Result<TopNResultValue>) Iterables.getOnlyElement(seq.toList());
 
     Assert.assertEquals(DateTimes.of("2014-10-20T00:00:00.000Z"), result.getTimestamp());
 
@@ -276,7 +271,7 @@ public class SketchAggregationWithSimpleDataTest
         readFileFromClasspathAsString("select_query.json")
     );
 
-    Result<SelectResultValue> result = (Result<SelectResultValue>) Iterables.getOnlyElement(Sequences.toList(seq, Lists.newArrayList()));
+    Result<SelectResultValue> result = (Result<SelectResultValue>) Iterables.getOnlyElement(seq.toList());
     Assert.assertEquals(DateTimes.of("2014-10-20T00:00:00.000Z"), result.getTimestamp());
     Assert.assertEquals(100, result.getValue().getEvents().size());
     Assert.assertEquals("AgMDAAAazJMCAAAAAACAPzz9j7pWTMdROWGf15uY1nI=", result.getValue().getEvents().get(0).getEvent().get("pty_country"));

--- a/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/theta/oldapi/OldApiSketchAggregationTest.java
+++ b/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/theta/oldapi/OldApiSketchAggregationTest.java
@@ -28,7 +28,6 @@ import io.druid.data.input.MapBasedRow;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.aggregation.AggregationTestHelper;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.PostAggregator;
@@ -96,7 +95,7 @@ public class OldApiSketchAggregationTest
         readFileFromClasspathAsString("oldapi/old_simple_test_data_group_by_query.json")
     );
 
-    List results = Sequences.toList(seq, Lists.newArrayList());
+    List results = seq.toList();
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
         new MapBasedRow(
@@ -128,7 +127,7 @@ public class OldApiSketchAggregationTest
         readFileFromClasspathAsString("oldapi/old_sketch_test_data_group_by_query.json")
     );
 
-    List results = Sequences.toList(seq, Lists.newArrayList());
+    List results = seq.toList();
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
         new MapBasedRow(

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregationTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregationTest.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Lists;
 import io.druid.data.input.MapBasedRow;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.aggregation.AggregationTestHelper;
 import io.druid.query.groupby.GroupByQueryConfig;
 import io.druid.query.groupby.GroupByQueryRunnerTest;
@@ -140,6 +139,6 @@ public class ApproximateHistogramAggregationTest
         query
     );
 
-    return (MapBasedRow) Sequences.toList(seq, Lists.newArrayList()).get(0);
+    return (MapBasedRow) seq.toList().get(0);
   }
 }

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/sql/QuantileSqlAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/sql/QuantileSqlAggregatorTest.java
@@ -24,8 +24,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import io.druid.java.util.common.granularity.Granularities;
-import io.druid.java.util.common.guava.Sequences;
-import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import io.druid.query.Druids;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.query.aggregation.DoubleSumAggregatorFactory;
@@ -43,9 +41,10 @@ import io.druid.segment.QueryableIndex;
 import io.druid.segment.column.ValueType;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.virtual.ExpressionVirtualColumn;
-import io.druid.server.security.NoopEscalator;
+import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import io.druid.server.security.AuthConfig;
 import io.druid.server.security.AuthTestUtils;
+import io.druid.server.security.NoopEscalator;
 import io.druid.sql.calcite.filtration.Filtration;
 import io.druid.sql.calcite.planner.Calcites;
 import io.druid.sql.calcite.planner.DruidOperatorTable;
@@ -66,7 +65,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class QuantileSqlAggregatorTest
@@ -169,7 +167,7 @@ public class QuantileSqlAggregatorTest
       final PlannerResult plannerResult = planner.plan(sql);
 
       // Verify results
-      final List<Object[]> results = Sequences.toList(plannerResult.run(), new ArrayList<Object[]>());
+      final List<Object[]> results = plannerResult.run().toList();
       final List<Object[]> expectedResults = ImmutableList.of(
           new Object[]{
               1.0,
@@ -251,7 +249,7 @@ public class QuantileSqlAggregatorTest
       final PlannerResult plannerResult = planner.plan(sql);
 
       // Verify results
-      final List<Object[]> results = Sequences.toList(plannerResult.run(), new ArrayList<Object[]>());
+      final List<Object[]> results = plannerResult.run().toList();
       final List<Object[]> expectedResults = ImmutableList.of(
           new Object[]{1.0, 3.0, 5.880000114440918, 5.940000057220459, 6.0, 4.994999885559082, 6.0}
       );

--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -80,7 +80,6 @@ import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.granularity.Granularities;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.java.util.common.parsers.JSONPathFieldSpec;
 import io.druid.java.util.common.parsers.JSONPathSpec;
@@ -93,7 +92,6 @@ import io.druid.query.DefaultQueryRunnerFactoryConglomerate;
 import io.druid.query.Druids;
 import io.druid.query.IntervalChunkingQueryRunnerDecorator;
 import io.druid.query.Query;
-import io.druid.query.QueryPlus;
 import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerFactory;
 import io.druid.query.QueryRunnerFactoryConglomerate;
@@ -115,8 +113,6 @@ import io.druid.segment.QueryableIndex;
 import io.druid.segment.TestHelper;
 import io.druid.segment.column.DictionaryEncodedColumn;
 import io.druid.segment.indexing.DataSchema;
-import io.druid.segment.transform.ExpressionTransform;
-import io.druid.segment.transform.TransformSpec;
 import io.druid.segment.indexing.granularity.UniformGranularitySpec;
 import io.druid.segment.loading.DataSegmentPusher;
 import io.druid.segment.loading.LocalDataSegmentPusher;
@@ -127,6 +123,8 @@ import io.druid.segment.loading.StorageLocationConfig;
 import io.druid.segment.realtime.appenderator.AppenderatorImpl;
 import io.druid.segment.realtime.plumber.SegmentHandoffNotifier;
 import io.druid.segment.realtime.plumber.SegmentHandoffNotifierFactory;
+import io.druid.segment.transform.ExpressionTransform;
+import io.druid.segment.transform.TransformSpec;
 import io.druid.server.DruidNode;
 import io.druid.server.coordination.DataSegmentServerAnnouncer;
 import io.druid.server.coordination.ServerType;
@@ -153,7 +151,6 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -163,6 +160,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
+import static io.druid.query.QueryPlus.wrap;
 
 @RunWith(Parameterized.class)
 public class KafkaIndexTaskTest
@@ -1936,10 +1935,8 @@ public class KafkaIndexTaskTest
                                   .intervals("0000/3000")
                                   .build();
 
-    ArrayList<Result<TimeseriesResultValue>> results = Sequences.toList(
-        task.getQueryRunner(query).run(QueryPlus.wrap(query), ImmutableMap.<String, Object>of()),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    List<Result<TimeseriesResultValue>> results =
+        task.getQueryRunner(query).run(wrap(query), ImmutableMap.of()).toList();
 
     return results.isEmpty() ? 0 : results.get(0).getValue().getLongMetric("rows");
   }

--- a/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceTimeseriesQueryTest.java
+++ b/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceTimeseriesQueryTest.java
@@ -19,9 +19,7 @@
 
 package io.druid.query.aggregation.variance;
 
-import com.google.common.collect.Lists;
 import io.druid.java.util.common.DateTimes;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.Druids;
 import io.druid.query.QueryPlus;
 import io.druid.query.QueryRunner;
@@ -103,10 +101,7 @@ public class VarianceTimeseriesQueryTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), new HashMap<String, Object>()),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), new HashMap<>()).toList();
     assertExpectedResults(expectedResults, results);
   }
 

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/CompactionTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/CompactionTaskTest.java
@@ -582,7 +582,6 @@ public class CompactionTaskTest
             entry.getValue(),
             new SimpleQueryableIndex(
                 segment.getInterval(),
-                new ListIndexed<>(columnNames, String.class),
                 new ListIndexed<>(segment.getDimensions(), String.class),
                 null,
                 columnMap,

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/RealtimeIndexTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/RealtimeIndexTaskTest.java
@@ -73,7 +73,6 @@ import io.druid.java.util.common.Pair;
 import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.granularity.Granularities;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.jackson.JacksonUtils;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.java.util.common.parsers.ParseException;
@@ -103,10 +102,8 @@ import io.druid.query.timeseries.TimeseriesQueryRunnerFactory;
 import io.druid.query.timeseries.TimeseriesResultValue;
 import io.druid.segment.TestHelper;
 import io.druid.segment.indexing.DataSchema;
-import io.druid.segment.transform.ExpressionTransform;
 import io.druid.segment.indexing.RealtimeIOConfig;
 import io.druid.segment.indexing.RealtimeTuningConfig;
-import io.druid.segment.transform.TransformSpec;
 import io.druid.segment.indexing.granularity.UniformGranularitySpec;
 import io.druid.segment.loading.SegmentLoaderConfig;
 import io.druid.segment.loading.SegmentLoaderLocalCacheManager;
@@ -115,6 +112,8 @@ import io.druid.segment.realtime.FireDepartment;
 import io.druid.segment.realtime.plumber.SegmentHandoffNotifier;
 import io.druid.segment.realtime.plumber.SegmentHandoffNotifierFactory;
 import io.druid.segment.realtime.plumber.ServerTimeRejectionPolicyFactory;
+import io.druid.segment.transform.ExpressionTransform;
+import io.druid.segment.transform.TransformSpec;
 import io.druid.server.DruidNode;
 import io.druid.server.coordination.DataSegmentServerAnnouncer;
 import io.druid.server.coordination.ServerType;
@@ -136,7 +135,6 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -1110,10 +1108,8 @@ public class RealtimeIndexTaskTest
                                   .intervals("2000/3000")
                                   .build();
 
-    ArrayList<Result<TimeseriesResultValue>> results = Sequences.toList(
-        task.getQueryRunner(query).run(QueryPlus.wrap(query), ImmutableMap.<String, Object>of()),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    List<Result<TimeseriesResultValue>> results =
+        task.getQueryRunner(query).run(QueryPlus.wrap(query), ImmutableMap.of()).toList();
     return results.isEmpty() ? 0 : results.get(0).getValue().getLongMetric(metric);
   }
 }

--- a/java-util/src/main/java/io/druid/java/util/common/guava/Sequence.java
+++ b/java-util/src/main/java/io/druid/java/util/common/guava/Sequence.java
@@ -22,6 +22,8 @@ package io.druid.java.util.common.guava;
 import com.google.common.collect.Ordering;
 
 import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 
@@ -67,6 +69,16 @@ public interface Sequence<T>
   default <U> Sequence<U> map(Function<? super T, ? extends U> mapper)
   {
     return new MappedSequence<>(this, mapper);
+  }
+
+  default List<T> toList()
+  {
+    return accumulate(new ArrayList<>(), Accumulators.list());
+  }
+
+  default Sequence<T> limit(int limit)
+  {
+    return new LimitedSequence<>(this, limit);
   }
 
   default <R> Sequence<R> flatMap(

--- a/java-util/src/main/java/io/druid/java/util/common/guava/Sequences.java
+++ b/java-util/src/main/java/io/druid/java/util/common/guava/Sequences.java
@@ -22,7 +22,6 @@ package io.druid.java.util.common.guava;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
-import com.google.common.collect.Lists;
 
 import java.io.Closeable;
 import java.util.Arrays;
@@ -140,14 +139,9 @@ public class Sequences
   // This will materialize the entire sequence in memory. Use at your own risk.
   public static <T> Sequence<T> sort(final Sequence<T> sequence, final Comparator<T> comparator)
   {
-    List<T> seqList = Sequences.toList(sequence, Lists.<T>newArrayList());
+    List<T> seqList = sequence.toList();
     Collections.sort(seqList, comparator);
     return simple(seqList);
-  }
-
-  public static <T, ListType extends List<T>> ListType toList(Sequence<T> seq, ListType list)
-  {
-    return seq.accumulate(list, Accumulators.<ListType, T>list());
   }
 
   private static class EmptySequence implements Sequence<Object>

--- a/java-util/src/test/java/io/druid/java/util/common/guava/LimitedSequenceTest.java
+++ b/java-util/src/test/java/io/druid/java/util/common/guava/LimitedSequenceTest.java
@@ -19,7 +19,6 @@
 
 package io.druid.java.util.common.guava;
 
-import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.junit.Assert;
@@ -39,7 +38,7 @@ public class LimitedSequenceTest
     final List<Integer> nums = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
     final int threshold = 5;
     SequenceTestHelper.testAll(
-        Sequences.limit(Sequences.simple(nums), threshold),
+        Sequences.simple(nums).limit(threshold),
         Lists.newArrayList(Iterables.limit(nums, threshold))
     );
   }
@@ -51,7 +50,7 @@ public class LimitedSequenceTest
     final int threshold = 2;
 
     SequenceTestHelper.testAll(
-        Sequences.limit(Sequences.simple(nums), threshold),
+        Sequences.simple(nums).limit(threshold),
         Lists.newArrayList(Iterables.limit(nums, threshold))
     );
   }
@@ -63,7 +62,7 @@ public class LimitedSequenceTest
     final int threshold = 1;
 
     SequenceTestHelper.testAll(
-        Sequences.limit(Sequences.simple(nums), threshold),
+        Sequences.simple(nums).limit(threshold),
         Lists.newArrayList(Iterables.limit(nums, threshold))
     );
   }
@@ -73,23 +72,15 @@ public class LimitedSequenceTest
   {
     final List<Integer> nums = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
     final AtomicLong accumulated = new AtomicLong(0);
-    final Sequence<Integer> seq = Sequences.limit(
-        Sequences.simple(
-            Iterables.transform(
-                nums,
-                new Function<Integer, Integer>()
-                {
-                  @Override
-                  public Integer apply(Integer input)
-                  {
-                    accumulated.addAndGet(input);
-                    return input;
-                  }
-                }
-            )
-        ),
-        5
-    );
+    final Sequence<Integer> seq = Sequences.simple(
+        Iterables.transform(
+            nums,
+            input -> {
+              accumulated.addAndGet(input);
+              return input;
+            }
+        )
+    ).limit(5);
 
     Assert.assertEquals(10, seq.accumulate(0, new IntAdditionAccumulator()).intValue());
     Assert.assertEquals(10, accumulated.get());

--- a/processing/src/main/java/io/druid/query/BySegmentQueryRunner.java
+++ b/processing/src/main/java/io/druid/query/BySegmentQueryRunner.java
@@ -19,7 +19,6 @@
 
 package io.druid.query;
 
-import com.google.common.collect.Lists;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.guava.Sequences;
 import org.joda.time.DateTime;
@@ -53,7 +52,7 @@ public class BySegmentQueryRunner<T> implements QueryRunner<T>
   {
     if (QueryContexts.isBySegment(queryPlus.getQuery())) {
       final Sequence<T> baseSequence = base.run(queryPlus, responseContext);
-      final List<T> results = Sequences.toList(baseSequence, Lists.<T>newArrayList());
+      final List<T> results = baseSequence.toList();
       return Sequences.simple(
           Collections.singletonList(
               (T) new Result<BySegmentResultValueClass<T>>(

--- a/processing/src/main/java/io/druid/query/ChainedExecutionQueryRunner.java
+++ b/processing/src/main/java/io/druid/query/ChainedExecutionQueryRunner.java
@@ -32,7 +32,6 @@ import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.guava.BaseSequence;
 import io.druid.java.util.common.guava.MergeIterable;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.logger.Logger;
 
 import java.util.Arrays;
@@ -127,7 +126,7 @@ public class ChainedExecutionQueryRunner<T> implements QueryRunner<T>
                                         throw new ISE("Got a null result! Segments are missing!");
                                       }
 
-                                      List<T> retVal = Sequences.toList(result, Lists.<T>newArrayList());
+                                      List<T> retVal = result.toList();
                                       if (retVal == null) {
                                         throw new ISE("Got a null list of results! WTF?!");
                                       }

--- a/processing/src/main/java/io/druid/query/datasourcemetadata/DataSourceQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/datasourcemetadata/DataSourceQueryQueryToolChest.java
@@ -100,12 +100,7 @@ public class DataSourceQueryQueryToolChest
       {
         DataSourceMetadataQuery query = (DataSourceMetadataQuery) input.getQuery();
         return Sequences.simple(
-            query.mergeResults(
-                Sequences.toList(
-                    baseRunner.run(input, context),
-                    Lists.<Result<DataSourceMetadataResultValue>>newArrayList()
-                )
-            )
+            query.mergeResults(baseRunner.run(input, context).toList())
         );
       }
     };

--- a/processing/src/main/java/io/druid/query/groupby/orderby/DefaultLimitSpec.java
+++ b/processing/src/main/java/io/druid/query/groupby/orderby/DefaultLimitSpec.java
@@ -281,11 +281,9 @@ public class DefaultLimitSpec implements LimitSpec
     }
 
     @Override
-    public Sequence<Row> apply(
-        Sequence<Row> input
-    )
+    public Sequence<Row> apply(Sequence<Row> input)
     {
-      return Sequences.limit(input, limit);
+      return input.limit(limit);
     }
   }
 

--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
@@ -50,7 +50,6 @@ import io.druid.segment.Metadata;
 import io.druid.segment.Segment;
 import org.joda.time.Interval;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -213,12 +212,7 @@ public class SegmentMetadataQueryRunnerFactory implements QueryRunnerFactory<Seg
                           @Override
                           public Sequence<SegmentAnalysis> call() throws Exception
                           {
-                            return Sequences.simple(
-                                Sequences.toList(
-                                    input.run(threadSafeQueryPlus, responseContext),
-                                    new ArrayList<>()
-                                )
-                            );
+                            return Sequences.simple(input.run(threadSafeQueryPlus, responseContext).toList());
                           }
                         }
                     );

--- a/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQueryQueryToolChest.java
@@ -117,9 +117,7 @@ public class TimeBoundaryQueryQueryToolChest
       {
         TimeBoundaryQuery query = (TimeBoundaryQuery) input.getQuery();
         return Sequences.simple(
-            query.mergeResults(
-                Sequences.toList(baseRunner.run(input, context), Lists.<Result<TimeBoundaryResultValue>>newArrayList())
-            )
+            query.mergeResults(baseRunner.run(input, context).toList())
         );
       }
     };

--- a/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQueryRunnerFactory.java
+++ b/processing/src/main/java/io/druid/query/timeboundary/TimeBoundaryQueryRunnerFactory.java
@@ -20,14 +20,12 @@
 package io.druid.query.timeboundary;
 
 import com.google.common.base.Function;
-import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.BaseSequence;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.ChainedExecutionQueryRunner;
 import io.druid.query.Query;
 import io.druid.query.QueryPlus;
@@ -122,10 +120,7 @@ public class TimeBoundaryQueryRunnerFactory
           Granularities.ALL,
           this.skipToFirstMatching
       );
-      final List<Result<DateTime>> resultList = Sequences.toList(
-          Sequences.limit(resultSequence, 1),
-          Lists.<Result<DateTime>>newArrayList()
-      );
+      final List<Result<DateTime>> resultList = resultSequence.limit(1).toList();
       if (resultList.size() > 0) {
         return resultList.get(0).getValue();
       }

--- a/processing/src/main/java/io/druid/segment/AbstractIndex.java
+++ b/processing/src/main/java/io/druid/segment/AbstractIndex.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment;
+
+import io.druid.java.util.common.Intervals;
+import io.druid.java.util.common.granularity.Granularities;
+import io.druid.segment.column.Column;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public abstract class AbstractIndex
+{
+  public abstract List<String> getColumnNames();
+
+  public abstract StorageAdapter toStorageAdapter();
+
+  @Override
+  public String toString()
+  {
+    StringBuilder sb = new StringBuilder();
+    StorageAdapter storageAdapter = toStorageAdapter();
+    List<Cursor> cursors = storageAdapter.makeCursors(
+        null,
+        Intervals.ETERNITY,
+        VirtualColumns.EMPTY,
+        Granularities.ALL,
+        false,
+        null
+    ).toList();
+    List<String> columnNames = new ArrayList<>();
+    columnNames.add(Column.TIME_COLUMN_NAME);
+    columnNames.addAll(getColumnNames());
+    for (Cursor cursor : cursors) {
+      ColumnSelectorFactory columnSelectorFactory = cursor.getColumnSelectorFactory();
+      List<ColumnValueSelector> selectors =
+          columnNames.stream().map(columnSelectorFactory::makeColumnValueSelector).collect(Collectors.toList());
+      while (!cursor.isDone()) {
+        sb.append('[');
+        for (int i = 0; i < selectors.size(); i++) {
+          sb.append(columnNames.get(i)).append('=');
+          ColumnValueSelector selector = selectors.get(i);
+          Object columnValue = selector.getObject();
+          if (columnValue instanceof Object[]) {
+            sb.append(Arrays.toString((Object[]) columnValue));
+          } else {
+            sb.append(columnValue);
+          }
+          sb.append(", ");
+        }
+        sb.setLength(sb.length() - 2);
+        sb.append("]\n");
+        cursor.advance();
+      }
+      sb.append("\n");
+    }
+    return sb.toString();
+  }
+}

--- a/processing/src/main/java/io/druid/segment/ColumnSelector.java
+++ b/processing/src/main/java/io/druid/segment/ColumnSelector.java
@@ -20,15 +20,16 @@
 package io.druid.segment;
 
 import io.druid.segment.column.Column;
-import io.druid.segment.data.Indexed;
 
 import javax.annotation.Nullable;
+import java.util.List;
 
 /**
  */
 public interface ColumnSelector
 {
-  Indexed<String> getColumnNames();
+  List<String> getColumnNames();
+
   @Nullable
   Column getColumn(String columnName);
 }

--- a/processing/src/main/java/io/druid/segment/CursorFactory.java
+++ b/processing/src/main/java/io/druid/segment/CursorFactory.java
@@ -32,7 +32,7 @@ import javax.annotation.Nullable;
 public interface CursorFactory
 {
   Sequence<Cursor> makeCursors(
-      Filter filter,
+      @Nullable Filter filter,
       Interval interval,
       VirtualColumns virtualColumns,
       Granularity gran,

--- a/processing/src/main/java/io/druid/segment/IndexIO.java
+++ b/processing/src/main/java/io/druid/segment/IndexIO.java
@@ -44,14 +44,12 @@ import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.io.smoosh.Smoosh;
 import io.druid.java.util.common.io.smoosh.SmooshedFileMapper;
 import io.druid.java.util.common.logger.Logger;
-import io.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import io.druid.segment.column.Column;
 import io.druid.segment.column.ColumnBuilder;
 import io.druid.segment.column.ColumnCapabilities;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.column.ColumnDescriptor;
 import io.druid.segment.column.ValueType;
-import io.druid.segment.data.ArrayIndexed;
 import io.druid.segment.data.BitmapSerde;
 import io.druid.segment.data.BitmapSerdeFactory;
 import io.druid.segment.data.ByteBufferSerializer;
@@ -69,6 +67,7 @@ import io.druid.segment.serde.DictionaryEncodedColumnSupplier;
 import io.druid.segment.serde.FloatGenericColumnSupplier;
 import io.druid.segment.serde.LongGenericColumnSupplier;
 import io.druid.segment.serde.SpatialIndexColumnPartSupplier;
+import io.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
@@ -510,16 +509,15 @@ public class IndexIO
         colSet.add(metric);
       }
 
-      String[] cols = colSet.toArray(new String[colSet.size()]);
       columns.put(
-          Column.TIME_COLUMN_NAME, new ColumnBuilder()
+          Column.TIME_COLUMN_NAME,
+          new ColumnBuilder()
               .setType(ValueType.LONG)
               .setGenericColumn(new LongGenericColumnSupplier(index.timestamps))
               .build()
       );
       return new SimpleQueryableIndex(
           index.getDataInterval(),
-          new ArrayIndexed<>(cols, String.class),
           index.getAvailableDimensions(),
           new ConciseBitmapFactory(),
           columns,
@@ -608,7 +606,12 @@ public class IndexIO
       columns.put(Column.TIME_COLUMN_NAME, deserializeColumn(mapper, smooshedFiles.mapFile("__time"), smooshedFiles));
 
       final QueryableIndex index = new SimpleQueryableIndex(
-          dataInterval, cols, dims, segmentBitmapSerdeFactory.getBitmapFactory(), columns, smooshedFiles, metadata
+          dataInterval,
+          dims,
+          segmentBitmapSerdeFactory.getBitmapFactory(),
+          columns,
+          smooshedFiles,
+          metadata
       );
 
       log.debug("Mapped v9 index[%s] in %,d millis", inDir, System.currentTimeMillis() - startTime);

--- a/processing/src/main/java/io/druid/segment/QueryableIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/QueryableIndexStorageAdapter.java
@@ -186,7 +186,7 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
 
   @Override
   public Sequence<Cursor> makeCursors(
-      Filter filter,
+      @Nullable Filter filter,
       Interval interval,
       VirtualColumns virtualColumns,
       Granularity gran,

--- a/processing/src/main/java/io/druid/segment/SimpleQueryableIndex.java
+++ b/processing/src/main/java/io/druid/segment/SimpleQueryableIndex.java
@@ -20,6 +20,7 @@
 package io.druid.segment;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import io.druid.collections.bitmap.BitmapFactory;
 import io.druid.java.util.common.io.smoosh.SmooshedFileMapper;
@@ -30,14 +31,15 @@ import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 /**
  */
-public class SimpleQueryableIndex implements QueryableIndex
+public class SimpleQueryableIndex extends AbstractIndex implements QueryableIndex
 {
   private final Interval dataInterval;
-  private final Indexed<String> columnNames;
+  private final List<String> columnNames;
   private final Indexed<String> availableDimensions;
   private final BitmapFactory bitmapFactory;
   private final Map<String, Column> columns;
@@ -46,9 +48,7 @@ public class SimpleQueryableIndex implements QueryableIndex
   private final Map<String, DimensionHandler> dimensionHandlers;
 
   public SimpleQueryableIndex(
-      Interval dataInterval,
-      Indexed<String> columnNames,
-      Indexed<String> dimNames,
+      Interval dataInterval, Indexed<String> dimNames,
       BitmapFactory bitmapFactory,
       Map<String, Column> columns,
       SmooshedFileMapper fileMapper,
@@ -57,7 +57,13 @@ public class SimpleQueryableIndex implements QueryableIndex
   {
     Preconditions.checkNotNull(columns.get(Column.TIME_COLUMN_NAME));
     this.dataInterval = dataInterval;
-    this.columnNames = columnNames;
+    ImmutableList.Builder<String> columnNamesBuilder = ImmutableList.builder();
+    for (String column : columns.keySet()) {
+      if (!Column.TIME_COLUMN_NAME.equals(column)) {
+        columnNamesBuilder.add(column);
+      }
+    }
+    this.columnNames = columnNamesBuilder.build();
     this.availableDimensions = dimNames;
     this.bitmapFactory = bitmapFactory;
     this.columns = columns;
@@ -80,9 +86,15 @@ public class SimpleQueryableIndex implements QueryableIndex
   }
 
   @Override
-  public Indexed<String> getColumnNames()
+  public List<String> getColumnNames()
   {
     return columnNames;
+  }
+
+  @Override
+  public StorageAdapter toStorageAdapter()
+  {
+    return new QueryableIndexStorageAdapter(this);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/data/IndexedInts.java
+++ b/processing/src/main/java/io/druid/segment/data/IndexedInts.java
@@ -47,4 +47,16 @@ public interface IndexedInts extends Closeable, HotLoopCallee
       action.accept(get(i));
     }
   }
+
+  @SuppressWarnings("unused") // Set up your IDE to render IndexedInts impls using this method during debug.
+  default String debugToString()
+  {
+    StringBuilder sb = new StringBuilder("[");
+    forEach(v -> sb.append(v).append(',').append(' '));
+    if (sb.length() > 1) {
+      sb.setLength(sb.length() - 2);
+    }
+    sb.append(']');
+    return sb.toString();
+  }
 }

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -47,6 +47,7 @@ import io.druid.query.aggregation.PostAggregator;
 import io.druid.query.dimension.DimensionSpec;
 import io.druid.query.groupby.RowBasedColumnSelectorFactory;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+import io.druid.segment.AbstractIndex;
 import io.druid.segment.ColumnSelectorFactory;
 import io.druid.segment.ColumnValueSelector;
 import io.druid.segment.DimensionHandler;
@@ -59,6 +60,7 @@ import io.druid.segment.LongColumnSelector;
 import io.druid.segment.Metadata;
 import io.druid.segment.NilColumnValueSelector;
 import io.druid.segment.ObjectColumnSelector;
+import io.druid.segment.StorageAdapter;
 import io.druid.segment.VirtualColumns;
 import io.druid.segment.column.Column;
 import io.druid.segment.column.ColumnCapabilities;
@@ -94,7 +96,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  */
-public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>, Closeable
+public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex implements Iterable<Row>, Closeable
 {
   private volatile DateTime maxIngestedEventTime;
 
@@ -760,6 +762,20 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
   public List<String> getMetricNames()
   {
     return ImmutableList.copyOf(metricDescs.keySet());
+  }
+
+  @Override
+  public List<String> getColumnNames()
+  {
+    List<String> columnNames = new ArrayList<>(getDimensionNames());
+    columnNames.addAll(getMetricNames());
+    return columnNames;
+  }
+
+  @Override
+  public StorageAdapter toStorageAdapter()
+  {
+    return new IncrementalIndexStorageAdapter(this);
   }
 
   public ColumnCapabilities getCapabilities(String column)

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
@@ -169,7 +169,7 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
 
   @Override
   public Sequence<Cursor> makeCursors(
-      final Filter filter,
+      @Nullable final Filter filter,
       final Interval interval,
       final VirtualColumns virtualColumns,
       final Granularity gran,

--- a/processing/src/test/java/io/druid/query/AsyncQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/AsyncQueryRunnerTest.java
@@ -82,7 +82,7 @@ public class AsyncQueryRunnerTest
 
     Sequence lazy = asyncRunner.run(QueryPlus.wrap(query), Collections.EMPTY_MAP);
     latch.countDown();
-    Assert.assertEquals(Lists.newArrayList(1), Sequences.toList(lazy, Lists.newArrayList()));
+    Assert.assertEquals(Lists.newArrayList(1), lazy.toList());
   }
   
   @Test(timeout = TEST_TIMEOUT)
@@ -115,7 +115,7 @@ public class AsyncQueryRunnerTest
     );
 
     try {
-      Sequences.toList(lazy, Lists.newArrayList());
+      lazy.toList();
     }
     catch (RuntimeException ex) {
       Assert.assertTrue(ex.getCause() instanceof TimeoutException);

--- a/processing/src/test/java/io/druid/query/ChainedExecutionQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/ChainedExecutionQueryRunnerTest.java
@@ -132,7 +132,7 @@ public class ChainedExecutionQueryRunnerTest
           @Override
           public void run()
           {
-            Sequences.toList(seq, Lists.newArrayList());
+            seq.toList();
           }
         }
     );
@@ -258,7 +258,7 @@ public class ChainedExecutionQueryRunnerTest
           @Override
           public void run()
           {
-            Sequences.toList(seq, Lists.newArrayList());
+            seq.toList();
           }
         }
     );

--- a/processing/src/test/java/io/druid/query/DoubleStorageTest.java
+++ b/processing/src/test/java/io/druid/query/DoubleStorageTest.java
@@ -31,8 +31,6 @@ import io.druid.data.input.impl.SpatialDimensionSchema;
 import io.druid.data.input.impl.TimestampSpec;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.Intervals;
-import io.druid.java.util.common.guava.Sequences;
-import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import io.druid.query.aggregation.DoubleSumAggregatorFactory;
 import io.druid.query.metadata.SegmentMetadataQueryConfig;
 import io.druid.query.metadata.SegmentMetadataQueryQueryToolChest;
@@ -41,12 +39,12 @@ import io.druid.query.metadata.metadata.ColumnAnalysis;
 import io.druid.query.metadata.metadata.ListColumnIncluderator;
 import io.druid.query.metadata.metadata.SegmentAnalysis;
 import io.druid.query.metadata.metadata.SegmentMetadataQuery;
-
 import io.druid.query.scan.ScanQuery;
 import io.druid.query.scan.ScanQueryConfig;
 import io.druid.query.scan.ScanQueryEngine;
 import io.druid.query.scan.ScanQueryQueryToolChest;
 import io.druid.query.scan.ScanQueryRunnerFactory;
+import io.druid.query.scan.ScanQueryRunnerTest;
 import io.druid.query.scan.ScanResultValue;
 import io.druid.query.spec.LegacySegmentSpec;
 import io.druid.segment.IndexIO;
@@ -55,10 +53,12 @@ import io.druid.segment.IndexSpec;
 import io.druid.segment.QueryableIndex;
 import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.TestHelper;
+import io.druid.segment.column.Column;
 import io.druid.segment.column.ValueType;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.IndexSizeExceededException;
+import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.joda.time.Interval;
 import org.junit.After;
 import org.junit.Assert;
@@ -77,9 +77,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-
-import static io.druid.segment.column.Column.DOUBLE_STORAGE_TYPE_PROPERTY;
-import static io.druid.query.scan.ScanQueryRunnerTest.verify;
 
 @RunWith(Parameterized.class)
 public class DoubleStorageTest
@@ -274,10 +271,7 @@ public class DoubleStorageTest
                                                       )
                                                       .merge(true)
                                                       .build();
-    List<SegmentAnalysis> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(segmentMetadataQuery), Maps.newHashMap()),
-        Lists.<SegmentAnalysis>newArrayList()
-    );
+    List<SegmentAnalysis> results = runner.run(QueryPlus.wrap(segmentMetadataQuery), Maps.newHashMap()).toList();
 
     Assert.assertEquals(Arrays.asList(expectedSegmentAnalysis), results);
 
@@ -299,10 +293,7 @@ public class DoubleStorageTest
         .build();
 
     HashMap<String, Object> context = new HashMap<String, Object>();
-    Iterable<ScanResultValue> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<ScanResultValue>newArrayList()
-    );
+    Iterable<ScanResultValue> results = runner.run(QueryPlus.wrap(query), context).toList();
 
     ScanResultValue expectedScanResult = new ScanResultValue(
         SEGMENT_ID,
@@ -310,13 +301,13 @@ public class DoubleStorageTest
         getStreamOfEvents().collect(Collectors.toList())
     );
     List<ScanResultValue> expectedResults = Lists.newArrayList(expectedScanResult);
-    verify(expectedResults, results);
+    ScanQueryRunnerTest.verify(expectedResults, results);
   }
 
   private static QueryableIndex buildIndex(String storeDoubleAsFloat) throws IOException
   {
-    String oldValue = System.getProperty(DOUBLE_STORAGE_TYPE_PROPERTY);
-    System.setProperty(DOUBLE_STORAGE_TYPE_PROPERTY, storeDoubleAsFloat);
+    String oldValue = System.getProperty(Column.DOUBLE_STORAGE_TYPE_PROPERTY);
+    System.setProperty(Column.DOUBLE_STORAGE_TYPE_PROPERTY, storeDoubleAsFloat);
     final IncrementalIndexSchema schema = new IncrementalIndexSchema.Builder()
         .withMinTimestamp(DateTimes.of("2011-01-13T00:00:00.000Z").getMillis())
         .withDimensionsSpec(ROW_PARSER)
@@ -341,9 +332,9 @@ public class DoubleStorageTest
     });
 
     if (oldValue == null) {
-      System.clearProperty(DOUBLE_STORAGE_TYPE_PROPERTY);
+      System.clearProperty(Column.DOUBLE_STORAGE_TYPE_PROPERTY);
     } else {
-      System.setProperty(DOUBLE_STORAGE_TYPE_PROPERTY, oldValue);
+      System.setProperty(Column.DOUBLE_STORAGE_TYPE_PROPERTY, oldValue);
     }
     File someTmpFile = File.createTempFile("billy", "yay");
     someTmpFile.delete();

--- a/processing/src/test/java/io/druid/query/MultiValuedDimensionTest.java
+++ b/processing/src/test/java/io/druid/query/MultiValuedDimensionTest.java
@@ -34,10 +34,6 @@ import io.druid.data.input.impl.TimestampSpec;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
-import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
-import io.druid.segment.writeout.SegmentWriteOutMediumFactory;
-import io.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
 import io.druid.query.aggregation.AggregationTestHelper;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.query.dimension.DefaultDimensionSpec;
@@ -63,6 +59,9 @@ import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.Segment;
 import io.druid.segment.TestHelper;
 import io.druid.segment.incremental.IncrementalIndex;
+import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
+import io.druid.segment.writeout.SegmentWriteOutMediumFactory;
+import io.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -72,7 +71,6 @@ import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -183,7 +181,7 @@ public class MultiValuedDimensionTest
         GroupByQueryRunnerTestHelper.createExpectedRow("1970-01-01T00:00:00.000Z", "tags", "t7", "count", 2L)
     );
 
-    TestHelper.assertExpectedObjects(expectedResults, Sequences.toList(result, new ArrayList<Row>()), "");
+    TestHelper.assertExpectedObjects(expectedResults, result.toList(), "");
   }
 
   @Test
@@ -215,7 +213,7 @@ public class MultiValuedDimensionTest
         GroupByQueryRunnerTestHelper.createExpectedRow("1970-01-01T00:00:00.000Z", "tags", "t5", "count", 2L)
     );
 
-    TestHelper.assertExpectedObjects(expectedResults, Sequences.toList(result, new ArrayList<Row>()), "");
+    TestHelper.assertExpectedObjects(expectedResults, result.toList(), "");
   }
 
   @Test
@@ -250,7 +248,7 @@ public class MultiValuedDimensionTest
         GroupByQueryRunnerTestHelper.createExpectedRow("1970-01-01T00:00:00.000Z", "tags", "t3", "count", 4L)
     );
 
-    TestHelper.assertExpectedObjects(expectedResults, Sequences.toList(result, new ArrayList<Row>()), "");
+    TestHelper.assertExpectedObjects(expectedResults, result.toList(), "");
   }
 
   @Test
@@ -298,11 +296,7 @@ public class MultiValuedDimensionTest
             )
         )
     );
-    TestHelper.assertExpectedObjects(
-        expectedResults,
-        Sequences.toList(result, new ArrayList<Result<TopNResultValue>>()),
-        ""
-    );
+    TestHelper.assertExpectedObjects(expectedResults, result.toList(), "");
   }
 
   @After

--- a/processing/src/test/java/io/druid/query/RetryQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/RetryQueryRunnerTest.java
@@ -119,10 +119,7 @@ public class RetryQueryRunnerTest
         jsonMapper
     );
 
-    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> actualResults = runner.run(QueryPlus.wrap(query), context).toList();
 
     Assert.assertTrue(
         "Should have one entry in the list of missing segments",
@@ -171,10 +168,7 @@ public class RetryQueryRunnerTest
         jsonMapper
     );
 
-    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> actualResults = runner.run(QueryPlus.wrap(query), context).toList();
 
     Assert.assertTrue("Should return a list with one element", ((List) actualResults).size() == 1);
     Assert.assertTrue(
@@ -222,10 +216,7 @@ public class RetryQueryRunnerTest
         jsonMapper
     );
 
-    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> actualResults = runner.run(QueryPlus.wrap(query), context).toList();
 
     Assert.assertTrue("Should return a list with one element", ((List) actualResults).size() == 1);
     Assert.assertTrue(
@@ -258,10 +249,7 @@ public class RetryQueryRunnerTest
         jsonMapper
     );
 
-    Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    runner.run(QueryPlus.wrap(query), context).toList();
 
     Assert.assertTrue(
         "Should have one entry in the list of missing segments",
@@ -344,10 +332,7 @@ public class RetryQueryRunnerTest
         jsonMapper
     );
 
-    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> actualResults = runner.run(QueryPlus.wrap(query), context).toList();
 
     Assert.assertTrue("Should return a list with 3 elements", ((List) actualResults).size() == 3);
     Assert.assertTrue(

--- a/processing/src/test/java/io/druid/query/SchemaEvolutionTest.java
+++ b/processing/src/test/java/io/druid/query/SchemaEvolutionTest.java
@@ -22,7 +22,6 @@ package io.druid.query;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Closeables;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -35,7 +34,6 @@ import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.guava.FunctionalIterable;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.query.aggregation.DoubleSumAggregatorFactory;
@@ -124,7 +122,7 @@ public class SchemaEvolutionTest
         ),
         (QueryToolChest<T, Query<T>>) factory.getToolchest()
     ).run(QueryPlus.wrap(query), Maps.<String, Object>newHashMap());
-    return Sequences.toList(results, Lists.<T>newArrayList());
+    return results.toList();
   }
 
   @Rule

--- a/processing/src/test/java/io/druid/query/TimewarpOperatorTest.java
+++ b/processing/src/test/java/io/druid/query/TimewarpOperatorTest.java
@@ -123,10 +123,7 @@ public class TimewarpOperatorTest
                 new TimeseriesResultValue(ImmutableMap.<String, Object>of("metric", 5))
             )
         ),
-        Sequences.toList(
-            queryRunner.run(QueryPlus.wrap(query), CONTEXT),
-            Lists.<Result<TimeseriesResultValue>>newArrayList()
-        )
+        queryRunner.run(QueryPlus.wrap(query), CONTEXT).toList()
     );
 
 
@@ -175,10 +172,7 @@ public class TimewarpOperatorTest
                 new TimeBoundaryResultValue(ImmutableMap.<String, Object>of("maxTime", DateTimes.of("2014-08-02")))
             )
         ),
-        Sequences.toList(
-            timeBoundaryRunner.run(QueryPlus.wrap(timeBoundaryQuery), CONTEXT),
-            Lists.<Result<TimeBoundaryResultValue>>newArrayList()
-        )
+        timeBoundaryRunner.run(QueryPlus.wrap(timeBoundaryQuery), CONTEXT).toList()
     );
 
   }
@@ -231,10 +225,7 @@ public class TimewarpOperatorTest
                 new TimeseriesResultValue(ImmutableMap.<String, Object>of("metric", 3))
             )
         ),
-        Sequences.toList(
-            queryRunner.run(QueryPlus.wrap(query), Maps.<String, Object>newHashMap()),
-            Lists.<Result<TimeseriesResultValue>>newArrayList()
-        )
+        queryRunner.run(QueryPlus.wrap(query), Maps.<String, Object>newHashMap()).toList()
     );
   }
 }

--- a/processing/src/test/java/io/druid/query/UnionQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/UnionQueryRunnerTest.java
@@ -20,7 +20,6 @@
 package io.druid.query;
 
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.guava.Sequences;
@@ -71,7 +70,7 @@ public class UnionQueryRunnerTest
                     .build();
     Map<String, Object> responseContext = Maps.newHashMap();
     Sequence<?> result = runner.run(QueryPlus.wrap(q), responseContext);
-    List res = Sequences.toList(result, Lists.newArrayList());
+    List res = result.toList();
     Assert.assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6), res);
 
     // verify response context

--- a/processing/src/test/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregationTest.java
@@ -24,7 +24,6 @@ import io.druid.data.input.MapBasedRow;
 import io.druid.jackson.AggregatorsModule;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.aggregation.AggregationTestHelper;
 import io.druid.query.groupby.GroupByQueryConfig;
 import io.druid.query.groupby.GroupByQueryRunnerTest;
@@ -119,7 +118,7 @@ public class HyperUniquesAggregationTest
         query
     );
 
-    MapBasedRow row = (MapBasedRow) Sequences.toList(seq, Lists.newArrayList()).get(0);
+    MapBasedRow row = (MapBasedRow) seq.toList().get(0);
     Assert.assertEquals(3.0, row.getMetric("index_hll").floatValue(), 0.1);
     Assert.assertEquals(3.0, row.getMetric("index_unique_count").floatValue(), 0.1);
   }
@@ -181,7 +180,7 @@ public class HyperUniquesAggregationTest
             query
     );
 
-    MapBasedRow row = (MapBasedRow) Sequences.toList(seq, Lists.newArrayList()).get(0);
+    MapBasedRow row = (MapBasedRow) seq.toList().get(0);
     Assert.assertEquals(4.0, row.getMetric("index_hll").floatValue(), 0.1);
     Assert.assertEquals(4.0, row.getMetric("index_unique_count").floatValue(), 0.1);
   }

--- a/processing/src/test/java/io/druid/query/aggregation/post/FinalizingFieldAccessPostAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/post/FinalizingFieldAccessPostAggregatorTest.java
@@ -27,7 +27,6 @@ import io.druid.data.input.MapBasedRow;
 import io.druid.jackson.AggregatorsModule;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.aggregation.AggregationTestHelper;
 import io.druid.query.aggregation.Aggregator;
 import io.druid.query.aggregation.AggregatorFactory;
@@ -234,7 +233,7 @@ public class FinalizingFieldAccessPostAggregatorTest
         query
     );
 
-    MapBasedRow row = (MapBasedRow) Sequences.toList(seq, Lists.newArrayList()).get(0);
+    MapBasedRow row = (MapBasedRow) seq.toList().get(0);
     Assert.assertEquals(3.0, row.getMetric("hll_market").floatValue(), 0.1);
     Assert.assertEquals(9.0, row.getMetric("hll_quality").floatValue(), 0.1);
     Assert.assertEquals(12.0, row.getMetric("uniq_add").floatValue(), 0.1);

--- a/processing/src/test/java/io/druid/query/datasourcemetadata/DataSourceMetadataQueryTest.java
+++ b/processing/src/test/java/io/druid/query/datasourcemetadata/DataSourceMetadataQueryTest.java
@@ -27,7 +27,6 @@ import io.druid.data.input.MapBasedInputRow;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.Intervals;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.jackson.JacksonUtils;
 import io.druid.query.DefaultGenericQueryMetricsFactory;
 import io.druid.query.Druids;
@@ -139,10 +138,8 @@ public class DataSourceMetadataQueryTest
                                                             .build();
     Map<String, Object> context = new ConcurrentHashMap<>();
     context.put(Result.MISSING_SEGMENTS_KEY, Lists.newArrayList());
-    Iterable<Result<DataSourceMetadataResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(dataSourceMetadataQuery), context),
-        Lists.<Result<DataSourceMetadataResultValue>>newArrayList()
-    );
+    Iterable<Result<DataSourceMetadataResultValue>> results =
+        runner.run(QueryPlus.wrap(dataSourceMetadataQuery), context).toList();
     DataSourceMetadataResultValue val = results.iterator().next().getValue();
     DateTime maxIngestedEventTime = val.getMaxIngestedEventTime();
 

--- a/processing/src/test/java/io/druid/query/groupby/GroupByLimitPushDownInsufficientBufferTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByLimitPushDownInsufficientBufferTest.java
@@ -483,7 +483,7 @@ public class GroupByLimitPushDownInsufficientBufferTest
         .build();
 
     Sequence<Row> queryResult = theRunner3.run(QueryPlus.wrap(query), Maps.newHashMap());
-    List<Row> results = Sequences.toList(queryResult, Lists.<Row>newArrayList());
+    List<Row> results = queryResult.toList();
 
     Row expectedRow0 = GroupByQueryRunnerTestHelper.createExpectedRow(
         "1970-01-01T00:00:00.000Z",
@@ -581,7 +581,7 @@ public class GroupByLimitPushDownInsufficientBufferTest
         .build();
 
     Sequence<Row> queryResult = theRunner3.run(QueryPlus.wrap(query), Maps.newHashMap());
-    List<Row> results = Sequences.toList(queryResult, Lists.<Row>newArrayList());
+    List<Row> results = queryResult.toList();
 
     Row expectedRow0 = GroupByQueryRunnerTestHelper.createExpectedRow(
         "1970-01-01T00:00:00.000Z",

--- a/processing/src/test/java/io/druid/query/groupby/GroupByLimitPushDownMultiNodeMergeTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByLimitPushDownMultiNodeMergeTest.java
@@ -461,7 +461,7 @@ public class GroupByLimitPushDownMultiNodeMergeTest
         .build();
 
     Sequence<Row> queryResult = finalRunner.run(QueryPlus.wrap(query), Maps.newHashMap());
-    List<Row> results = Sequences.toList(queryResult, Lists.<Row>newArrayList());
+    List<Row> results = queryResult.toList();
 
     Row expectedRow0 = GroupByQueryRunnerTestHelper.createExpectedRow(
         "2017-07-14T02:40:00.000Z",

--- a/processing/src/test/java/io/druid/query/groupby/GroupByMultiSegmentTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByMultiSegmentTest.java
@@ -32,7 +32,6 @@ import io.druid.collections.BlockingPool;
 import io.druid.collections.DefaultBlockingPool;
 import io.druid.collections.NonBlockingPool;
 import io.druid.collections.StupidPool;
-import io.druid.java.util.common.concurrent.Execs;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.MapBasedInputRow;
 import io.druid.data.input.Row;
@@ -41,12 +40,11 @@ import io.druid.data.input.impl.LongDimensionSchema;
 import io.druid.data.input.impl.StringDimensionSchema;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.Intervals;
+import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.math.expr.ExprMacroTable;
-import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import io.druid.query.BySegmentQueryRunner;
 import io.druid.query.DruidProcessingConfig;
 import io.druid.query.FinalizeResultsQueryRunner;
@@ -77,6 +75,7 @@ import io.druid.segment.Segment;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
+import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Assert;
@@ -342,7 +341,7 @@ public class GroupByMultiSegmentTest
         .build();
 
     Sequence<Row> queryResult = theRunner.run(QueryPlus.wrap(query), Maps.newHashMap());
-    List<Row> results = Sequences.toList(queryResult, Lists.<Row>newArrayList());
+    List<Row> results = queryResult.toList();
 
     Row expectedRow = GroupByQueryRunnerTestHelper.createExpectedRow(
         "1970-01-01T00:00:00.000Z",

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerFactoryTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerFactoryTest.java
@@ -48,7 +48,6 @@ import io.druid.segment.incremental.IncrementalIndex;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -117,7 +116,7 @@ public class GroupByQueryRunnerFactoryTest
         GroupByQueryRunnerTestHelper.createExpectedRow("1970-01-01T00:00:00.000Z", "tags", "t2", "count", 4L)
     );
 
-    TestHelper.assertExpectedObjects(expectedResults, Sequences.toList(result, new ArrayList<Row>()), "");
+    TestHelper.assertExpectedObjects(expectedResults, result.toList(), "");
   }
 
   private Segment createSegment() throws Exception

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -151,8 +151,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static org.junit.Assert.assertEquals;
-
 @RunWith(Parameterized.class)
 public class GroupByQueryRunnerTest
 {
@@ -2169,7 +2167,7 @@ public class GroupByQueryRunnerTest
 
     List<Row> expectedResults = ImmutableList.of();
     Iterable<Row> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);
-    assertEquals(expectedResults, results);
+    Assert.assertEquals(expectedResults, results);
   }
 
   @Test
@@ -3581,7 +3579,7 @@ public class GroupByQueryRunnerTest
 
     final Object next1 = resultsIter.next();
     Object expectedNext1 = expectedResultsIter.next();
-    assertEquals("order-limit", expectedNext1, next1);
+    Assert.assertEquals("order-limit", expectedNext1, next1);
 
     final Object next2 = resultsIter.next();
     Object expectedNext2 = expectedResultsIter.next();
@@ -7433,7 +7431,7 @@ public class GroupByQueryRunnerTest
         .setGranularity(QueryRunnerTestHelper.dayGran)
         .build();
 
-    assertEquals(
+    Assert.assertEquals(
         Functions.<Sequence<Row>>identity(),
         query.getLimitSpec().build(
             query.getDimensions(),
@@ -7697,7 +7695,7 @@ public class GroupByQueryRunnerTest
         .setGranularity(QueryRunnerTestHelper.dayGran)
         .build();
 
-    assertEquals(
+    Assert.assertEquals(
         Functions.<Sequence<Row>>identity(),
         query.getLimitSpec().build(
             query.getDimensions(),
@@ -8877,10 +8875,7 @@ public class GroupByQueryRunnerTest
         GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "alias", "travel", "rows", 2L, "idx", 243L)
     );
 
-    Iterable<Row> results = Sequences.toList(
-        mergedRunner.run(QueryPlus.wrap(allGranQuery), context),
-        new ArrayList<Row>()
-    );
+    Iterable<Row> results = mergedRunner.run(QueryPlus.wrap(allGranQuery), context).toList();
     TestHelper.assertExpectedObjects(allGranExpectedResults, results, "merged");
   }
 
@@ -8970,10 +8965,7 @@ public class GroupByQueryRunnerTest
         GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "alias", "premium", "market", "spot", "rows", 2L, "idx", 257L)
     );
 
-    Iterable<Row> results = Sequences.toList(
-        mergedRunner.run(QueryPlus.wrap(allGranQuery), context),
-        Lists.<Row>newArrayList()
-    );
+    Iterable<Row> results = mergedRunner.run(QueryPlus.wrap(allGranQuery), context).toList();
     TestHelper.assertExpectedObjects(allGranExpectedResults, results, "merged");
   }
 
@@ -9067,10 +9059,7 @@ public class GroupByQueryRunnerTest
         GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "alias", "premium", "market", "spot", "rows", 2L, "idx", 257L)
     );
 
-    Iterable<Row> results = Sequences.toList(
-        mergedRunner.run(QueryPlus.wrap(allGranQuery), context),
-        Lists.<Row>newArrayList()
-    );
+    Iterable<Row> results = mergedRunner.run(QueryPlus.wrap(allGranQuery), context).toList();
     TestHelper.assertExpectedObjects(allGranExpectedResults, results, "merged");
   }
 

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTestHelper.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTestHelper.java
@@ -26,7 +26,6 @@ import io.druid.data.input.MapBasedRow;
 import io.druid.data.input.Row;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.FinalizeResultsQueryRunner;
 import io.druid.query.Query;
 import io.druid.query.QueryPlus;
@@ -54,8 +53,8 @@ public class GroupByQueryRunnerTestHelper
         toolChest
     );
 
-    Sequence<T> queryResult = theRunner.run(QueryPlus.wrap(query), Maps.<String, Object>newHashMap());
-    return Sequences.toList(queryResult, Lists.<T>newArrayList());
+    Sequence<T> queryResult = theRunner.run(QueryPlus.wrap(query), Maps.newHashMap());
+    return queryResult.toList();
   }
 
   public static Row createExpectedRow(final String timestamp, Object... vals)

--- a/processing/src/test/java/io/druid/query/groupby/GroupByTimeseriesQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByTimeseriesQueryRunnerTest.java
@@ -50,7 +50,6 @@ import org.junit.runners.Parameterized;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Map;
 
 /**
@@ -147,10 +146,8 @@ public class GroupByTimeseriesQueryRunnerTest extends TimeseriesQueryRunnerTest
                                   .granularity(Granularities.ALL)
                                   .intervals(QueryRunnerTestHelper.fullOnInterval)
                                   .aggregators(
-                                      Arrays.asList(
-                                          new DoubleMaxAggregatorFactory("maxIndex", "index"),
-                                          new DoubleMinAggregatorFactory("minIndex", "index")
-                                      )
+                                      new DoubleMaxAggregatorFactory("maxIndex", "index"),
+                                      new DoubleMinAggregatorFactory("minIndex", "index")
                                   )
                                   .descending(descending)
                                   .build();
@@ -158,10 +155,7 @@ public class GroupByTimeseriesQueryRunnerTest extends TimeseriesQueryRunnerTest
     DateTime expectedEarliest = DateTimes.of("1970-01-01");
     DateTime expectedLast = DateTimes.of("2011-04-15");
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     Result<TimeseriesResultValue> result = results.iterator().next();
 
     Assert.assertEquals(expectedEarliest, result.getTimestamp());

--- a/processing/src/test/java/io/druid/query/groupby/orderby/DefaultLimitSpecTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/orderby/DefaultLimitSpecTest.java
@@ -43,7 +43,6 @@ import io.druid.segment.TestHelper;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -165,7 +164,7 @@ public class DefaultLimitSpecTest
 
     Assert.assertEquals(
         ImmutableList.of(testRowsList.get(0), testRowsList.get(1)),
-        Sequences.toList(limitFn.apply(testRowsSequence), new ArrayList<Row>())
+        limitFn.apply(testRowsSequence).toList()
     );
   }
 
@@ -187,7 +186,7 @@ public class DefaultLimitSpecTest
     // in the future.
     Assert.assertEquals(
         ImmutableList.of(testRowsList.get(2), testRowsList.get(1)),
-        Sequences.toList(limitFn.apply(testRowsSequence), new ArrayList<Row>())
+        limitFn.apply(testRowsSequence).toList()
     );
   }
 
@@ -214,7 +213,7 @@ public class DefaultLimitSpecTest
     );
     Assert.assertEquals(
         ImmutableList.of(testRowsList.get(0), testRowsList.get(1)),
-        Sequences.toList(limitFn.apply(testRowsSequence), new ArrayList<Row>())
+        limitFn.apply(testRowsSequence).toList()
     );
 
     // if there is an aggregator with same name then that is used to build ordering
@@ -231,7 +230,7 @@ public class DefaultLimitSpecTest
     );
     Assert.assertEquals(
         ImmutableList.of(testRowsList.get(2), testRowsList.get(0)),
-        Sequences.toList(limitFn.apply(testRowsSequence), new ArrayList<Row>())
+        limitFn.apply(testRowsSequence).toList()
     );
 
     // if there is a post-aggregator with same name then that is used to build ordering
@@ -254,7 +253,7 @@ public class DefaultLimitSpecTest
     );
     Assert.assertEquals(
         (List) ImmutableList.of(testRowsList.get(2), testRowsList.get(0)),
-        (List) Sequences.toList(limitFn.apply(testRowsSequence), new ArrayList<Row>())
+        (List) limitFn.apply(testRowsSequence).toList()
     );
 
     // makes same result
@@ -265,7 +264,7 @@ public class DefaultLimitSpecTest
     );
     Assert.assertEquals(
         (List) ImmutableList.of(testRowsList.get(2), testRowsList.get(0)),
-        (List) Sequences.toList(limitFn.apply(testRowsSequence), new ArrayList<Row>())
+        (List) limitFn.apply(testRowsSequence).toList()
     );
   }
 

--- a/processing/src/test/java/io/druid/query/groupby/orderby/TopNSequenceTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/orderby/TopNSequenceTest.java
@@ -96,6 +96,6 @@ public class TopNSequenceTest
 
     Sequence<String> result = new TopNSequence<String>(Sequences.simple(inputs), ordering, limit);
 
-    Assert.assertEquals(expected, Sequences.toList(result, Lists.<String>newArrayList()));
+    Assert.assertEquals(expected, result.toList());
   }
 }

--- a/processing/src/test/java/io/druid/query/metadata/SegmentAnalyzerTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentAnalyzerTest.java
@@ -19,9 +19,7 @@
 
 package io.druid.query.metadata;
 
-import com.google.common.collect.Lists;
 import io.druid.data.input.impl.DimensionSchema;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.LegacyDataSource;
 import io.druid.query.QueryPlus;
 import io.druid.query.QueryRunner;
@@ -195,6 +193,6 @@ public class SegmentAnalyzerTest
         new LegacyDataSource("test"), new LegacySegmentSpec("2011/2012"), null, null, null, analyses, false, false
     );
     HashMap<String, Object> context = new HashMap<String, Object>();
-    return Sequences.toList(runner.run(QueryPlus.wrap(query), context), Lists.<SegmentAnalysis>newArrayList());
+    return runner.run(QueryPlus.wrap(query), context).toList();
   }
 }

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
@@ -26,11 +26,10 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.MoreExecutors;
-import io.druid.java.util.common.Intervals;
 import io.druid.data.input.impl.TimestampSpec;
 import io.druid.jackson.DefaultObjectMapper;
+import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.granularity.Granularities;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.BySegmentResultValue;
 import io.druid.query.BySegmentResultValueClass;
 import io.druid.query.Druids;
@@ -257,10 +256,7 @@ public class SegmentMetadataQueryTest
   @SuppressWarnings("unchecked")
   public void testSegmentMetadataQuery()
   {
-    List<SegmentAnalysis> results = Sequences.toList(
-        runner1.run(QueryPlus.wrap(testQuery), Maps.newHashMap()),
-        Lists.<SegmentAnalysis>newArrayList()
-    );
+    List<SegmentAnalysis> results = runner1.run(QueryPlus.wrap(testQuery), Maps.newHashMap()).toList();
 
     Assert.assertEquals(Arrays.asList(expectedSegmentAnalysis1), results);
   }

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataUnionQueryTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataUnionQueryTest.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.druid.java.util.common.Intervals;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.Druids;
 import io.druid.query.QueryPlus;
 import io.druid.query.QueryRunner;
@@ -129,10 +128,7 @@ public class SegmentMetadataUnionQueryTest
             SegmentMetadataQuery.AnalysisType.MINMAX
         )
         .build();
-    List result = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), Maps.newHashMap()),
-        Lists.<SegmentAnalysis>newArrayList()
-    );
+    List result = runner.run(QueryPlus.wrap(query), Maps.newHashMap()).toList();
     TestHelper.assertExpectedObjects(ImmutableList.of(expected), result, "failed SegmentMetadata union query");
   }
 

--- a/processing/src/test/java/io/druid/query/scan/MultiSegmentScanQueryTest.java
+++ b/processing/src/test/java/io/druid/query/scan/MultiSegmentScanQueryTest.java
@@ -193,13 +193,12 @@ public class MultiSegmentScanQueryTest
   public void testMergeRunnersWithLimit()
   {
     ScanQuery query = newBuilder().build();
-    List<ScanResultValue> results = Sequences.toList(
-        factory.mergeRunners(MoreExecutors.sameThreadExecutor(), ImmutableList.of(
-            factory.createRunner(segment0),
-            factory.createRunner(segment1)
-        )).run(QueryPlus.wrap(query), new HashMap<String, Object>()),
-        Lists.<ScanResultValue>newArrayList()
-    );
+    List<ScanResultValue> results = factory
+        .mergeRunners(
+            MoreExecutors.sameThreadExecutor(),
+            ImmutableList.of(factory.createRunner(segment0), factory.createRunner(segment1)))
+        .run(QueryPlus.wrap(query), new HashMap<>())
+        .toList();
     int totalCount = 0;
     for (ScanResultValue result : results) {
       System.out.println(((List) result.getEvents()).size());
@@ -233,10 +232,7 @@ public class MultiSegmentScanQueryTest
         }
     );
     ScanQuery query = newBuilder().build();
-    List<ScanResultValue> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), new HashMap<String, Object>()),
-        Lists.<ScanResultValue>newArrayList()
-    );
+    List<ScanResultValue> results = runner.run(QueryPlus.wrap(query), new HashMap<>()).toList();
     int totalCount = 0;
     for (ScanResultValue result : results) {
       totalCount += ((List) result.getEvents()).size();

--- a/processing/src/test/java/io/druid/query/scan/ScanQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/scan/ScanQueryRunnerTest.java
@@ -32,7 +32,6 @@ import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.StringUtils;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.DefaultGenericQueryMetricsFactory;
 import io.druid.query.QueryPlus;
 import io.druid.query.QueryRunner;
@@ -179,10 +178,7 @@ public class ScanQueryRunnerTest
         .build();
 
     HashMap<String, Object> context = new HashMap<String, Object>();
-    Iterable<ScanResultValue> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<ScanResultValue>newArrayList()
-    );
+    Iterable<ScanResultValue> results = runner.run(QueryPlus.wrap(query), context).toList();
 
     List<ScanResultValue> expectedResults = toExpected(
         toFullEvents(V_0112_0114),
@@ -224,10 +220,7 @@ public class ScanQueryRunnerTest
         .build();
 
     HashMap<String, Object> context = new HashMap<String, Object>();
-    Iterable<ScanResultValue> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<ScanResultValue>newArrayList()
-    );
+    Iterable<ScanResultValue> results = runner.run(QueryPlus.wrap(query), context).toList();
 
     List<ScanResultValue> expectedResults = toExpected(
         toFullEvents(V_0112_0114),
@@ -247,10 +240,7 @@ public class ScanQueryRunnerTest
         .build();
 
     HashMap<String, Object> context = new HashMap<String, Object>();
-    Iterable<ScanResultValue> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<ScanResultValue>newArrayList()
-    );
+    Iterable<ScanResultValue> results = runner.run(QueryPlus.wrap(query), context).toList();
 
     final List<List<Map<String, Object>>> expectedEvents = toEvents(
         new String[]{
@@ -297,10 +287,7 @@ public class ScanQueryRunnerTest
         .build();
 
     HashMap<String, Object> context = new HashMap<String, Object>();
-    Iterable<ScanResultValue> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<ScanResultValue>newArrayList()
-    );
+    Iterable<ScanResultValue> results = runner.run(QueryPlus.wrap(query), context).toList();
 
     List<ScanResultValue> expectedResults = toExpected(
         toEvents(
@@ -335,10 +322,7 @@ public class ScanQueryRunnerTest
         .build();
 
     HashMap<String, Object> context = new HashMap<String, Object>();
-    Iterable<ScanResultValue> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<ScanResultValue>newArrayList()
-    );
+    Iterable<ScanResultValue> results = runner.run(QueryPlus.wrap(query), context).toList();
 
     List<ScanResultValue> expectedResults = toExpected(
         toEvents(
@@ -376,10 +360,7 @@ public class ScanQueryRunnerTest
           .build();
 
       HashMap<String, Object> context = new HashMap<String, Object>();
-      Iterable<ScanResultValue> results = Sequences.toList(
-          runner.run(QueryPlus.wrap(query), context),
-          Lists.<ScanResultValue>newArrayList()
-      );
+      Iterable<ScanResultValue> results = runner.run(QueryPlus.wrap(query), context).toList();
 
       final List<List<Map<String, Object>>> events = toEvents(
           new String[]{
@@ -438,15 +419,11 @@ public class ScanQueryRunnerTest
         .columns(QueryRunnerTestHelper.qualityDimension, QueryRunnerTestHelper.indexMetric)
         .build();
 
-    Iterable<ScanResultValue> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), Maps.newHashMap()),
-        Lists.<ScanResultValue>newArrayList()
-    );
-    Iterable<ScanResultValue> resultsOptimize = Sequences.toList(
-        toolChest
-            .postMergeQueryDecoration(toolChest.mergeResults(toolChest.preMergeQueryDecoration(runner)))
-            .run(QueryPlus.wrap(query), Maps.<String, Object>newHashMap()), Lists.<ScanResultValue>newArrayList()
-    );
+    Iterable<ScanResultValue> results = runner.run(QueryPlus.wrap(query), Maps.newHashMap()).toList();
+    Iterable<ScanResultValue> resultsOptimize = toolChest
+        .postMergeQueryDecoration(toolChest.mergeResults(toolChest.preMergeQueryDecoration(runner)))
+        .run(QueryPlus.wrap(query), Maps.<String, Object>newHashMap())
+        .toList();
 
     final List<List<Map<String, Object>>> events = toEvents(
         new String[]{
@@ -501,10 +478,7 @@ public class ScanQueryRunnerTest
         )
         .build();
 
-    Iterable<ScanResultValue> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), Maps.newHashMap()),
-        Lists.<ScanResultValue>newArrayList()
-    );
+    Iterable<ScanResultValue> results = runner.run(QueryPlus.wrap(query), Maps.newHashMap()).toList();
 
     List<ScanResultValue> expectedResults = Collections.emptyList();
 
@@ -519,10 +493,7 @@ public class ScanQueryRunnerTest
         .columns("foo", "foo2")
         .build();
 
-    Iterable<ScanResultValue> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), Maps.newHashMap()),
-        Lists.<ScanResultValue>newArrayList()
-    );
+    Iterable<ScanResultValue> results = runner.run(QueryPlus.wrap(query), Maps.newHashMap()).toList();
 
     final List<List<Map<String, Object>>> events = toEvents(
         legacy ? new String[]{getTimestampName() + ":TIME"} : new String[0],

--- a/processing/src/test/java/io/druid/query/search/SearchQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/search/SearchQueryRunnerTest.java
@@ -780,10 +780,7 @@ public class SearchQueryRunnerTest
 
   private void checkSearchQuery(Query searchQuery, QueryRunner runner, List<SearchHit> expectedResults)
   {
-    Iterable<Result<SearchResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(searchQuery), ImmutableMap.of()),
-        Lists.<Result<SearchResultValue>>newArrayList()
-    );
+    Iterable<Result<SearchResultValue>> results = runner.run(QueryPlus.wrap(searchQuery), ImmutableMap.of()).toList();
     List<SearchHit> copy = Lists.newLinkedList(expectedResults);
     for (Result<SearchResultValue> result : results) {
       Assert.assertEquals(DateTimes.of("2011-01-12T00:00:00.000Z"), result.getTimestamp());

--- a/processing/src/test/java/io/druid/query/search/SearchQueryRunnerWithCaseTest.java
+++ b/processing/src/test/java/io/druid/query/search/SearchQueryRunnerWithCaseTest.java
@@ -26,7 +26,6 @@ import com.google.common.collect.Sets;
 import com.google.common.io.CharSource;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.StringUtils;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.Druids;
 import io.druid.query.QueryPlus;
 import io.druid.query.QueryRunner;
@@ -237,10 +236,8 @@ public class SearchQueryRunnerWithCaseTest
   private void checkSearchQuery(SearchQuery searchQuery, Map<String, Set<String>> expectedResults)
   {
     HashMap<String, List> context = new HashMap<>();
-    Iterable<Result<SearchResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.<Result<SearchResultValue>>wrap(searchQuery), context),
-        Lists.<Result<SearchResultValue>>newArrayList()
-    );
+    Iterable<Result<SearchResultValue>> results =
+        runner.run(QueryPlus.<Result<SearchResultValue>>wrap(searchQuery), context).toList();
 
     for (Result<SearchResultValue> result : results) {
       Assert.assertEquals(DateTimes.of("2011-01-12T00:00:00.000Z"), result.getTimestamp());

--- a/processing/src/test/java/io/druid/query/select/MultiSegmentSelectQueryTest.java
+++ b/processing/src/test/java/io/druid/query/select/MultiSegmentSelectQueryTest.java
@@ -29,7 +29,6 @@ import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.granularity.Granularities;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.Druids;
 import io.druid.query.QueryPlus;
 import io.druid.query.QueryRunner;
@@ -249,10 +248,7 @@ public class MultiSegmentSelectQueryTest
   private void runAllGranularityTest(SelectQuery query, int[][] expectedOffsets)
   {
     for (int[] expected : expectedOffsets) {
-      List<Result<SelectResultValue>> results = Sequences.toList(
-          runner.run(QueryPlus.wrap(query), ImmutableMap.of()),
-          Lists.<Result<SelectResultValue>>newArrayList()
-      );
+      List<Result<SelectResultValue>> results = runner.run(QueryPlus.wrap(query), ImmutableMap.of()).toList();
       Assert.assertEquals(1, results.size());
 
       SelectResultValue value = results.get(0).getValue();
@@ -296,10 +292,7 @@ public class MultiSegmentSelectQueryTest
   private void runDayGranularityTest(SelectQuery query, int[][] expectedOffsets)
   {
     for (int[] expected : expectedOffsets) {
-      List<Result<SelectResultValue>> results = Sequences.toList(
-          runner.run(QueryPlus.wrap(query), ImmutableMap.of()),
-          Lists.<Result<SelectResultValue>>newArrayList()
-      );
+      List<Result<SelectResultValue>> results = runner.run(QueryPlus.wrap(query), ImmutableMap.of()).toList();
       Assert.assertEquals(2, results.size());
 
       SelectResultValue value0 = results.get(0).getValue();
@@ -341,18 +334,12 @@ public class MultiSegmentSelectQueryTest
     SelectQuery query = selectQueryBuilder.build();
     QueryRunner unionQueryRunner = new UnionQueryRunner(runner);
 
-    List<Result<SelectResultValue>> results = Sequences.toList(
-        unionQueryRunner.run(QueryPlus.wrap(query), ImmutableMap.of()),
-        Lists.<Result<SelectResultValue>>newArrayList()
-    );
+    List<Result<SelectResultValue>> results = unionQueryRunner.run(QueryPlus.wrap(query), ImmutableMap.of()).toList();
 
     Map<String, Integer> pagingIdentifiers = results.get(0).getValue().getPagingIdentifiers();
     query = query.withPagingSpec(toNextCursor(PagingSpec.merge(Arrays.asList(pagingIdentifiers)), query, 3));
 
-    Sequences.toList(
-        unionQueryRunner.run(QueryPlus.wrap(query), ImmutableMap.of()),
-        Lists.<Result<SelectResultValue>>newArrayList()
-    );
+    unionQueryRunner.run(QueryPlus.wrap(query), ImmutableMap.of()).toList();
   }
 
   private PagingSpec toNextCursor(Map<String, Integer> merged, SelectQuery query, int threshold)

--- a/processing/src/test/java/io/druid/query/select/SelectQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/select/SelectQueryRunnerTest.java
@@ -32,7 +32,6 @@ import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.Intervals;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.js.JavaScriptConfig;
 import io.druid.query.Druids;
 import io.druid.query.QueryPlus;
@@ -169,10 +168,7 @@ public class SelectQueryRunnerTest
         .build();
 
     HashMap<String, Object> context = new HashMap<String, Object>();
-    Iterable<Result<SelectResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<Result<SelectResultValue>>newArrayList()
-    );
+    Iterable<Result<SelectResultValue>> results = runner.run(QueryPlus.wrap(query), context).toList();
 
     PagingOffset offset = query.getPagingOffset(QueryRunnerTestHelper.segmentId);
     List<Result<SelectResultValue>> expectedResults = toExpected(
@@ -213,10 +209,7 @@ public class SelectQueryRunnerTest
 
     SelectQuery query = newTestQuery().intervals(I_0112_0114).build();
     for (int offset : expected) {
-      List<Result<SelectResultValue>> results = Sequences.toList(
-          runner.run(QueryPlus.wrap(query), ImmutableMap.of()),
-          Lists.<Result<SelectResultValue>>newArrayList()
-      );
+      List<Result<SelectResultValue>> results = runner.run(QueryPlus.wrap(query), ImmutableMap.of()).toList();
 
       Assert.assertEquals(1, results.size());
 
@@ -230,10 +223,7 @@ public class SelectQueryRunnerTest
 
     query = newTestQuery().intervals(I_0112_0114).build();
     for (int offset : expected) {
-      List<Result<SelectResultValue>> results = Sequences.toList(
-          runner.run(QueryPlus.wrap(query), ImmutableMap.of()),
-          Lists.<Result<SelectResultValue>>newArrayList()
-      );
+      List<Result<SelectResultValue>> results = runner.run(QueryPlus.wrap(query), ImmutableMap.of()).toList();
 
       Assert.assertEquals(1, results.size());
 
@@ -275,10 +265,7 @@ public class SelectQueryRunnerTest
         .build();
 
     HashMap<String, Object> context = new HashMap<String, Object>();
-    Iterable<Result<SelectResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<Result<SelectResultValue>>newArrayList()
-    );
+    Iterable<Result<SelectResultValue>> results = runner.run(QueryPlus.wrap(query), context).toList();
 
     List<Result<SelectResultValue>> expectedResultsAsc = Arrays.asList(
         new Result<SelectResultValue>(
@@ -385,10 +372,7 @@ public class SelectQueryRunnerTest
         .build();
 
     HashMap<String, Object> context = new HashMap<String, Object>();
-    Iterable<Result<SelectResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<Result<SelectResultValue>>newArrayList()
-    );
+    Iterable<Result<SelectResultValue>> results = runner.run(QueryPlus.wrap(query), context).toList();
 
     PagingOffset offset = query.getPagingOffset(QueryRunnerTestHelper.segmentId);
     List<Result<SelectResultValue>> expectedResults = toExpected(
@@ -424,10 +408,7 @@ public class SelectQueryRunnerTest
         .pagingSpec(new PagingSpec(toPagingIdentifier(3, descending), 3))
         .build();
 
-    Iterable<Result<SelectResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), Maps.newHashMap()),
-        Lists.<Result<SelectResultValue>>newArrayList()
-    );
+    Iterable<Result<SelectResultValue>> results = runner.run(QueryPlus.wrap(query), Maps.newHashMap()).toList();
 
     PagingOffset offset = query.getPagingOffset(QueryRunnerTestHelper.segmentId);
     List<Result<SelectResultValue>> expectedResults = toExpected(
@@ -462,10 +443,7 @@ public class SelectQueryRunnerTest
           .build();
 
       HashMap<String, Object> context = new HashMap<String, Object>();
-      Iterable<Result<SelectResultValue>> results = Sequences.toList(
-          runner.run(QueryPlus.wrap(query), context),
-          Lists.<Result<SelectResultValue>>newArrayList()
-      );
+      Iterable<Result<SelectResultValue>> results = runner.run(QueryPlus.wrap(query), context).toList();
 
       final List<List<Map<String, Object>>> events = toEvents(
           new String[]{
@@ -536,10 +514,7 @@ public class SelectQueryRunnerTest
         .build();
 
     HashMap<String, Object> context = new HashMap<String, Object>();
-    Iterable<Result<SelectResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<Result<SelectResultValue>>newArrayList()
-    );
+    Iterable<Result<SelectResultValue>> results = runner.run(QueryPlus.wrap(query), context).toList();
 
     final List<List<Map<String, Object>>> events = toEvents(
         new String[]{
@@ -584,15 +559,11 @@ public class SelectQueryRunnerTest
         .metrics(Lists.<String>newArrayList(QueryRunnerTestHelper.indexMetric))
         .build();
 
-    Iterable<Result<SelectResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), Maps.newHashMap()),
-        Lists.<Result<SelectResultValue>>newArrayList()
-    );
-    Iterable<Result<SelectResultValue>> resultsOptimize = Sequences.toList(
-        toolChest
-            .postMergeQueryDecoration(toolChest.mergeResults(toolChest.preMergeQueryDecoration(runner)))
-            .run(QueryPlus.wrap(query), Maps.newHashMap()), Lists.<Result<SelectResultValue>>newArrayList()
-    );
+    Iterable<Result<SelectResultValue>> results = runner.run(QueryPlus.wrap(query), Maps.newHashMap()).toList();
+    Iterable<Result<SelectResultValue>> resultsOptimize = toolChest
+        .postMergeQueryDecoration(toolChest.mergeResults(toolChest.preMergeQueryDecoration(runner)))
+        .run(QueryPlus.wrap(query), Maps.newHashMap())
+        .toList();
 
     final List<List<Map<String, Object>>> events = toEvents(
         new String[]{
@@ -642,10 +613,7 @@ public class SelectQueryRunnerTest
         )
         .build();
 
-    Iterable<Result<SelectResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), Maps.newHashMap()),
-        Lists.<Result<SelectResultValue>>newArrayList()
-    );
+    Iterable<Result<SelectResultValue>> results = runner.run(QueryPlus.wrap(query), Maps.newHashMap()).toList();
 
     List<Result<SelectResultValue>> expectedResults = Arrays.asList(
         new Result<SelectResultValue>(
@@ -690,10 +658,7 @@ public class SelectQueryRunnerTest
         .metrics(Lists.<String>newArrayList("foo2"))
         .build();
 
-    Iterable<Result<SelectResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), Maps.newHashMap()),
-        Lists.<Result<SelectResultValue>>newArrayList()
-    );
+    Iterable<Result<SelectResultValue>> results = runner.run(QueryPlus.wrap(query), Maps.newHashMap()).toList();
 
     final List<List<Map<String, Object>>> events = toEvents(
         new String[]{
@@ -730,10 +695,7 @@ public class SelectQueryRunnerTest
         .build();
 
     HashMap<String, Object> context = new HashMap<String, Object>();
-    Iterable<Result<SelectResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<Result<SelectResultValue>>newArrayList()
-    );
+    Iterable<Result<SelectResultValue>> results = runner.run(QueryPlus.wrap(query), context).toList();
 
     List<Result<SelectResultValue>> expectedResultsAsc = Arrays.asList(
         new Result<SelectResultValue>(
@@ -848,10 +810,7 @@ public class SelectQueryRunnerTest
         .build();
 
     HashMap<String, Object> context = new HashMap<String, Object>();
-    Iterable<Result<SelectResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<Result<SelectResultValue>>newArrayList()
-    );
+    Iterable<Result<SelectResultValue>> results = runner.run(QueryPlus.wrap(query), context).toList();
 
     List<Result<SelectResultValue>> expectedResultsAsc = Arrays.asList(
         new Result<SelectResultValue>(

--- a/processing/src/test/java/io/druid/query/spec/SpecificSegmentQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/spec/SpecificSegmentQueryRunnerTest.java
@@ -108,7 +108,7 @@ public class SpecificSegmentQueryRunnerTest
                                   )
                                   .build();
     Sequence results = queryRunner.run(QueryPlus.wrap(query), responseContext);
-    Sequences.toList(results, Lists.newArrayList());
+    results.toList();
     validate(mapper, descriptor, responseContext);
 
     // from toYielder
@@ -185,10 +185,7 @@ public class SpecificSegmentQueryRunnerTest
                                   )
                                   .build();
     Sequence results = queryRunner.run(QueryPlus.wrap(query), responseContext);
-    List<Result<TimeseriesResultValue>> res = Sequences.toList(
-        results,
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    List<Result<TimeseriesResultValue>> res = results.toList();
 
     Assert.assertEquals(1, res.size());
 

--- a/processing/src/test/java/io/druid/query/timeboundary/TimeBoundaryQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/timeboundary/TimeBoundaryQueryRunnerTest.java
@@ -26,7 +26,6 @@ import com.google.common.io.CharSource;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.granularity.Granularities;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.Druids;
 import io.druid.query.QueryPlus;
 import io.druid.query.QueryRunner;
@@ -177,10 +176,8 @@ public class TimeBoundaryQueryRunnerTest
                                                 .build();
     Assert.assertTrue(timeBoundaryQuery.hasFilters());
     HashMap<String, Object> context = new HashMap<String, Object>();
-    Iterable<Result<TimeBoundaryResultValue>> results = Sequences.toList(
-        customRunner.run(QueryPlus.wrap(timeBoundaryQuery), context),
-        Lists.<Result<TimeBoundaryResultValue>>newArrayList()
-    );
+    List<Result<TimeBoundaryResultValue>> results =
+        customRunner.run(QueryPlus.wrap(timeBoundaryQuery), context).toList();
 
     Assert.assertTrue(Iterables.size(results) > 0);
 
@@ -203,10 +200,8 @@ public class TimeBoundaryQueryRunnerTest
                                                 .build();
     Assert.assertTrue(timeBoundaryQuery.hasFilters());
     HashMap<String, Object> context = new HashMap<String, Object>();
-    Iterable<Result<TimeBoundaryResultValue>> results = Sequences.toList(
-        customRunner.run(QueryPlus.wrap(timeBoundaryQuery), context),
-        Lists.<Result<TimeBoundaryResultValue>>newArrayList()
-    );
+    List<Result<TimeBoundaryResultValue>> results =
+        customRunner.run(QueryPlus.wrap(timeBoundaryQuery), context).toList();
 
     Assert.assertTrue(Iterables.size(results) == 0);
   }
@@ -220,10 +215,7 @@ public class TimeBoundaryQueryRunnerTest
                                                 .build();
     Assert.assertFalse(timeBoundaryQuery.hasFilters());
     HashMap<String, Object> context = new HashMap<String, Object>();
-    Iterable<Result<TimeBoundaryResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(timeBoundaryQuery), context),
-        Lists.<Result<TimeBoundaryResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeBoundaryResultValue>> results = runner.run(QueryPlus.wrap(timeBoundaryQuery), context).toList();
     TimeBoundaryResultValue val = results.iterator().next().getValue();
     DateTime minTime = val.getMinTime();
     DateTime maxTime = val.getMaxTime();
@@ -242,10 +234,7 @@ public class TimeBoundaryQueryRunnerTest
                                                 .build();
     Map<String, Object> context = new ConcurrentHashMap<>();
     context.put(Result.MISSING_SEGMENTS_KEY, Lists.newArrayList());
-    Iterable<Result<TimeBoundaryResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(timeBoundaryQuery), context),
-        Lists.<Result<TimeBoundaryResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeBoundaryResultValue>> results = runner.run(QueryPlus.wrap(timeBoundaryQuery), context).toList();
     TimeBoundaryResultValue val = results.iterator().next().getValue();
     DateTime minTime = val.getMinTime();
     DateTime maxTime = val.getMaxTime();
@@ -264,10 +253,7 @@ public class TimeBoundaryQueryRunnerTest
                                                 .build();
     Map<String, Object> context = new ConcurrentHashMap<>();
     context.put(Result.MISSING_SEGMENTS_KEY, Lists.newArrayList());
-    Iterable<Result<TimeBoundaryResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(timeBoundaryQuery), context),
-        Lists.<Result<TimeBoundaryResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeBoundaryResultValue>> results = runner.run(QueryPlus.wrap(timeBoundaryQuery), context).toList();
     TimeBoundaryResultValue val = results.iterator().next().getValue();
     DateTime minTime = val.getMinTime();
     DateTime maxTime = val.getMaxTime();

--- a/processing/src/test/java/io/druid/query/timeseries/TimeSeriesUnionQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/timeseries/TimeSeriesUnionQueryRunnerTest.java
@@ -21,7 +21,6 @@ package io.druid.query.timeseries;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.guava.Sequences;
@@ -120,10 +119,7 @@ public class TimeSeriesUnionQueryRunnerTest
         )
     );
     HashMap<String, Object> context = new HashMap<>();
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), context).toList();
 
     assertExpectedResults(expectedResults, results);
   }
@@ -226,10 +222,8 @@ public class TimeSeriesUnionQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        mergingrunner.run(QueryPlus.wrap(query), Maps.<String, Object>newHashMap()),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results =
+        mergingrunner.run(QueryPlus.wrap(query), new HashMap<>()).toList();
 
     assertExpectedResults(expectedResults, results);
 

--- a/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerBonusTest.java
+++ b/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerBonusTest.java
@@ -21,12 +21,10 @@ package io.druid.query.timeseries;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import io.druid.data.input.MapBasedInputRow;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.granularity.Granularities;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.Druids;
 import io.druid.query.FinalizeResultsQueryRunner;
 import io.druid.query.Query;
@@ -35,7 +33,6 @@ import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerFactory;
 import io.druid.query.QueryRunnerTestHelper;
 import io.druid.query.Result;
-import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.segment.IncrementalIndexSegment;
 import io.druid.segment.Segment;
@@ -130,18 +127,11 @@ public class TimeseriesQueryRunnerBonusTest
                                   .dataSource("xxx")
                                   .granularity(Granularities.ALL)
                                   .intervals(ImmutableList.of(Intervals.of("2012-01-01T00:00:00Z/P1D")))
-                                  .aggregators(
-                                      ImmutableList.<AggregatorFactory>of(
-                                          new CountAggregatorFactory("rows")
-                                      )
-                                  )
+                                  .aggregators(new CountAggregatorFactory("rows"))
                                   .descending(descending)
                                   .build();
     HashMap<String, Object> context = new HashMap<String, Object>();
-    return Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    return runner.run(QueryPlus.wrap(query), context).toList();
   }
 
   private static <T> QueryRunner<T> makeQueryRunner(

--- a/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerTest.java
@@ -30,7 +30,6 @@ import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.granularity.Granularity;
 import io.druid.java.util.common.granularity.PeriodGranularity;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.Druids;
 import io.druid.query.FinalizeResultsQueryRunner;
 import io.druid.query.QueryPlus;
@@ -159,10 +158,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> actualResults = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     TestHelper.assertExpectedResults(expectedResults, actualResults);
   }
 
@@ -183,10 +179,7 @@ public class TimeseriesQueryRunnerTest
                                   .descending(descending)
                                   .build();
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
 
     final String[] expectedIndex = descending ?
                                    QueryRunnerTestHelper.expectedFullOnIndexValuesDesc :
@@ -249,10 +242,7 @@ public class TimeseriesQueryRunnerTest
                                   .descending(descending)
                                   .build();
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
 
     final DateTime expectedLast = descending ?
                                   QueryRunnerTestHelper.earliest :
@@ -291,10 +281,7 @@ public class TimeseriesQueryRunnerTest
     DateTime expectedEarliest = DateTimes.of("2011-01-12");
     DateTime expectedLast = DateTimes.of("2011-04-15");
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     Result<TimeseriesResultValue> result = results.iterator().next();
 
     Assert.assertEquals(expectedEarliest, result.getTimestamp());
@@ -336,10 +323,7 @@ public class TimeseriesQueryRunnerTest
                                   QueryRunnerTestHelper.earliest :
                                   QueryRunnerTestHelper.last;
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
 
     for (Result<TimeseriesResultValue> result : results) {
       DateTime current = result.getTimestamp();
@@ -401,10 +385,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
 
     assertExpectedResults(expectedResults, results);
   }
@@ -449,10 +430,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
 
     assertExpectedResults(expectedResults, results);
   }
@@ -497,10 +475,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
 
     assertExpectedResults(expectedResults, results);
   }
@@ -538,10 +513,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results1 = Sequences.toList(
-        runner.run(QueryPlus.wrap(query1), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results1 = runner.run(QueryPlus.wrap(query1), CONTEXT).toList();
     assertExpectedResults(expectedResults1, results1);
 
     TimeseriesQuery query2 = Druids.newTimeseriesQueryBuilder()
@@ -573,10 +545,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results2 = Sequences.toList(
-        runner.run(QueryPlus.wrap(query2), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results2 = runner.run(QueryPlus.wrap(query2), CONTEXT).toList();
     assertExpectedResults(expectedResults2, results2);
   }
 
@@ -625,10 +594,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results1 = Sequences.toList(
-        runner.run(QueryPlus.wrap(query1), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results1 = runner.run(QueryPlus.wrap(query1), CONTEXT).toList();
     assertExpectedResults(expectedResults1, results1);
   }
 
@@ -693,10 +659,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results1 = Sequences.toList(
-        runner.run(QueryPlus.wrap(query1), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results1 = runner.run(QueryPlus.wrap(query1), CONTEXT).toList();
     assertExpectedResults(expectedResults1, results1);
   }
 
@@ -735,10 +698,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results1 = Sequences.toList(
-        runner.run(QueryPlus.wrap(query1), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results1 = runner.run(QueryPlus.wrap(query1), CONTEXT).toList();
     assertExpectedResults(expectedResults1, results1);
   }
 
@@ -775,10 +735,7 @@ public class TimeseriesQueryRunnerTest
             )
         )
     );
-    Iterable<Result<TimeseriesResultValue>> results1 = Sequences.toList(
-        runner.run(QueryPlus.wrap(query1), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results1 = runner.run(QueryPlus.wrap(query1), CONTEXT).toList();
     assertExpectedResults(expectedResults1, results1);
 
     TimeseriesQuery query2 = Druids.newTimeseriesQueryBuilder()
@@ -811,10 +768,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results2 = Sequences.toList(
-        runner.run(QueryPlus.wrap(query2), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results2 = runner.run(QueryPlus.wrap(query2), CONTEXT).toList();
     assertExpectedResults(expectedResults2, results2);
   }
 
@@ -843,10 +797,7 @@ public class TimeseriesQueryRunnerTest
 
     List<Result<TimeseriesResultValue>> expectedResults = Collections.emptyList();
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     assertExpectedResults(expectedResults, results);
   }
 
@@ -892,10 +843,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     assertExpectedResults(expectedResults, results);
   }
 
@@ -941,10 +889,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     assertExpectedResults(expectedResults, results);
   }
 
@@ -990,10 +935,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     assertExpectedResults(expectedResults, results);
   }
 
@@ -1039,10 +981,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     assertExpectedResults(expectedResults, results);
   }
 
@@ -1088,10 +1027,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     assertExpectedResults(expectedResults, results);
   }
 
@@ -1137,10 +1073,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     assertExpectedResults(expectedResults, results);
   }
 
@@ -1186,10 +1119,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     assertExpectedResults(expectedResults, results);
   }
 
@@ -1235,10 +1165,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     assertExpectedResults(expectedResults, results);
   }
 
@@ -1290,10 +1217,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     assertExpectedResults(expectedResults, results);
   }
 
@@ -1351,10 +1275,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     assertExpectedResults(expectedResults, results);
   }
 
@@ -1400,10 +1321,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     assertExpectedResults(expectedResults, results);
   }
 
@@ -1445,10 +1363,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     assertExpectedResults(expectedResults, results);
   }
 
@@ -1468,10 +1383,7 @@ public class TimeseriesQueryRunnerTest
 
     List<Result<TimeseriesResultValue>> expectedResults = Collections.emptyList();
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), new HashMap<String, Object>()),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), new HashMap<String, Object>()).toList();
     assertExpectedResults(expectedResults, results);
   }
 
@@ -1513,10 +1425,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), new HashMap<String, Object>()),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), new HashMap<String, Object>()).toList();
     assertExpectedResults(expectedResults, results);
   }
 
@@ -1558,10 +1467,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), new HashMap<String, Object>()),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), new HashMap<String, Object>()).toList();
     assertExpectedResults(expectedResults, results);
   }
 
@@ -1603,10 +1509,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     assertExpectedResults(expectedResults, results);
   }
 
@@ -1652,10 +1555,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     assertExpectedResults(expectedResults, results);
   }
 
@@ -1689,10 +1589,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> actualResults = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     assertExpectedResults(expectedResults, actualResults);
   }
 
@@ -1727,10 +1624,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> actualResults = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     assertExpectedResults(expectedResults, actualResults);
   }
 
@@ -1831,10 +1725,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> actualResults = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     if (descending) {
       TestHelper.assertExpectedResults(expectedDescendingResults, actualResults);
     } else {
@@ -1865,14 +1756,8 @@ public class TimeseriesQueryRunnerTest
         .postAggregators(QueryRunnerTestHelper.addRowsIndexConstant)
         .descending(descending)
         .build();
-    Iterable<Result<TimeseriesResultValue>> expectedResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query1), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
-    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> expectedResults = runner.run(QueryPlus.wrap(query1), CONTEXT).toList();
+    Iterable<Result<TimeseriesResultValue>> actualResults = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     TestHelper.assertExpectedResults(expectedResults, actualResults);
   }
 
@@ -1900,14 +1785,8 @@ public class TimeseriesQueryRunnerTest
         .postAggregators(QueryRunnerTestHelper.addRowsIndexConstant)
         .descending(descending)
         .build();
-    Iterable<Result<TimeseriesResultValue>> expectedResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query1), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
-    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> expectedResults = runner.run(QueryPlus.wrap(query1), CONTEXT).toList();
+    Iterable<Result<TimeseriesResultValue>> actualResults = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     TestHelper.assertExpectedResults(expectedResults, actualResults);
   }
 
@@ -1944,14 +1823,8 @@ public class TimeseriesQueryRunnerTest
         .postAggregators(QueryRunnerTestHelper.addRowsIndexConstant)
         .descending(descending)
         .build();
-    Iterable<Result<TimeseriesResultValue>> expectedResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query2), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
-    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> expectedResults = runner.run(QueryPlus.wrap(query2), CONTEXT).toList();
+    Iterable<Result<TimeseriesResultValue>> actualResults = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     TestHelper.assertExpectedResults(expectedResults, actualResults);
   }
 
@@ -1988,14 +1861,8 @@ public class TimeseriesQueryRunnerTest
         .postAggregators(QueryRunnerTestHelper.addRowsIndexConstant)
         .descending(descending)
         .build();
-    Iterable<Result<TimeseriesResultValue>> expectedResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query2), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
-    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> expectedResults = runner.run(QueryPlus.wrap(query2), CONTEXT).toList();
+    Iterable<Result<TimeseriesResultValue>> actualResults = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     TestHelper.assertExpectedResults(expectedResults, actualResults);
   }
 
@@ -2024,10 +1891,7 @@ public class TimeseriesQueryRunnerTest
         .descending(descending)
         .build();
 
-    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> actualResults = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     List<Result<TimeseriesResultValue>> expectedResults = Collections.singletonList(
         new Result<>(
             DateTimes.of("2011-04-01"),
@@ -2071,10 +1935,7 @@ public class TimeseriesQueryRunnerTest
         .descending(descending)
         .build();
 
-    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> actualResults = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
 
     List<Result<TimeseriesResultValue>> expectedResults = Collections.singletonList(
         new Result<>(
@@ -2119,10 +1980,7 @@ public class TimeseriesQueryRunnerTest
         .descending(descending)
         .build();
 
-    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> actualResults = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
 
     List<Result<TimeseriesResultValue>> expectedResults = Collections.singletonList(
         new Result<>(
@@ -2169,10 +2027,7 @@ public class TimeseriesQueryRunnerTest
         .descending(descending)
         .build();
 
-    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> actualResults = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     List<Result<TimeseriesResultValue>> expectedResults = Collections.singletonList(
         new Result<>(
             DateTimes.of("2011-04-01"),
@@ -2216,10 +2071,7 @@ public class TimeseriesQueryRunnerTest
         .descending(descending)
         .build();
 
-    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> actualResults = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     List<Result<TimeseriesResultValue>> expectedResults = Collections.singletonList(
         new Result<>(
             DateTimes.of("2011-04-01"),
@@ -2271,10 +2123,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> actualResults = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
 
     assertExpectedResults(expectedResults, actualResults);
   }
@@ -2355,10 +2204,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     TestHelper.assertExpectedResults(expectedResults, results);
   }
 
@@ -2410,10 +2256,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    Iterable<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), CONTEXT).toList();
     TestHelper.assertExpectedResults(expectedResults, results);
 
     QueryToolChest<Result<TimeseriesResultValue>, TimeseriesQuery> toolChest = new TimeseriesQueryQueryToolChest(
@@ -2421,10 +2264,9 @@ public class TimeseriesQueryRunnerTest
     );
     QueryRunner<Result<TimeseriesResultValue>> optimizedRunner = toolChest.postMergeQueryDecoration(
         toolChest.mergeResults(toolChest.preMergeQueryDecoration(runner)));
-    Iterable<Result<TimeseriesResultValue>> results2 = Sequences.toList(
-        new FinalizeResultsQueryRunner(optimizedRunner, toolChest).run(QueryPlus.wrap(query), CONTEXT),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> results2 = new FinalizeResultsQueryRunner(optimizedRunner, toolChest)
+        .run(QueryPlus.wrap(query), CONTEXT)
+        .toList();
     TestHelper.assertExpectedResults(expectedResults, results2);
 
   }

--- a/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerTest.java
@@ -19,7 +19,6 @@
 
 package io.druid.query.topn;
 
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -37,7 +36,6 @@ import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.Pair;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.js.JavaScriptConfig;
 import io.druid.math.expr.ExprMacroTable;
 import io.druid.query.BySegmentResultValue;
@@ -99,7 +97,6 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -1310,58 +1307,36 @@ public class TopNQueryRunnerTest
         query,
         specialContext
     );
-    List<Result<BySegmentTopNResultValue>> resultList = Sequences.toList(
-        Sequences.map(
-            results,
-            new Function<Result<TopNResultValue>, Result<BySegmentTopNResultValue>>()
-            {
-              @Nullable
-              @Override
-              public Result<BySegmentTopNResultValue> apply(
-                  Result<TopNResultValue> input
-              )
-              {
-                // Stupid type erasure
-                Object val = input.getValue();
-                if (val instanceof BySegmentResultValue) {
-                  BySegmentResultValue bySegVal = (BySegmentResultValue) val;
-                  List<?> results = bySegVal.getResults();
-                  return new Result<BySegmentTopNResultValue>(
-                      input.getTimestamp(),
-                      new BySegmentTopNResultValue(
-                          Lists.transform(
-                              results,
-                              new Function<Object, Result<TopNResultValue>>()
-                              {
-                                @Nullable
-                                @Override
-                                public Result<TopNResultValue> apply(@Nullable Object input)
-                                {
-                                  if (Preconditions.checkNotNull(input) instanceof Result) {
-                                    Result result = (Result) input;
-                                    Object resVal = result.getValue();
-                                    if (resVal instanceof TopNResultValue) {
-                                      return new Result<TopNResultValue>(
-                                          result.getTimestamp(),
-                                          (TopNResultValue) resVal
-                                      );
-                                    }
-                                  }
-                                  throw new IAE("Bad input: [%s]", input);
-                                }
-                              }
-                          ),
-                          bySegVal.getSegmentId(),
-                          bySegVal.getInterval()
-                      )
-                  );
-                }
-                throw new ISE("Bad type");
-              }
-            }
-        ),
-        Lists.<Result<BySegmentTopNResultValue>>newArrayList()
-    );
+    List<Result<BySegmentTopNResultValue>> resultList = results
+        .map((Result<TopNResultValue> input) -> {
+          // Stupid type erasure
+          Object val = input.getValue();
+          if (val instanceof BySegmentResultValue) {
+            BySegmentResultValue bySegVal = (BySegmentResultValue) val;
+            return new Result<>(
+                input.getTimestamp(),
+                new BySegmentTopNResultValue(
+                    Lists.transform(
+                        bySegVal.getResults(),
+                        res -> {
+                          if (Preconditions.checkNotNull(res) instanceof Result) {
+                            Result theResult = (Result) res;
+                            Object resVal = theResult.getValue();
+                            if (resVal instanceof TopNResultValue) {
+                              return new Result<>(theResult.getTimestamp(), (TopNResultValue) resVal);
+                            }
+                          }
+                          throw new IAE("Bad input: [%s]", res);
+                        }
+                    ),
+                    bySegVal.getSegmentId(),
+                    bySegVal.getInterval()
+                )
+            );
+          }
+          throw new ISE("Bad type");
+        })
+        .toList();
     Result<BySegmentTopNResultValue> result = resultList.get(0);
     TestHelper.assertExpectedResults(expectedResults, result.getValue().getResults());
   }
@@ -1795,21 +1770,20 @@ public class TopNQueryRunnerTest
         .build();
 
     assertExpectedResults(
-        Sequences.toList(
-            runWithMerge(
-                new TopNQueryBuilder()
-                    .dataSource(QueryRunnerTestHelper.dataSource)
-                    .granularity(QueryRunnerTestHelper.allGran)
-                    .filters(QueryRunnerTestHelper.qualityDimension, "mezzanine")
-                    .dimension(QueryRunnerTestHelper.marketDimension)
-                    .metric(QueryRunnerTestHelper.indexMetric)
-                    .threshold(4)
-                    .intervals(QueryRunnerTestHelper.firstToThird)
-                    .aggregators(commonAggregators)
-                    .postAggregators(Arrays.<PostAggregator>asList(QueryRunnerTestHelper.addRowsIndexConstant))
-                    .build()
-            ), Lists.<Result<TopNResultValue>>newArrayList()
-        ), query
+        runWithMerge(
+            new TopNQueryBuilder()
+                .dataSource(QueryRunnerTestHelper.dataSource)
+                .granularity(QueryRunnerTestHelper.allGran)
+                .filters(QueryRunnerTestHelper.qualityDimension, "mezzanine")
+                .dimension(QueryRunnerTestHelper.marketDimension)
+                .metric(QueryRunnerTestHelper.indexMetric)
+                .threshold(4)
+                .intervals(QueryRunnerTestHelper.firstToThird)
+                .aggregators(commonAggregators)
+                .postAggregators(Arrays.<PostAggregator>asList(QueryRunnerTestHelper.addRowsIndexConstant))
+                .build()
+        ).toList(),
+        query
     );
   }
 
@@ -1829,21 +1803,25 @@ public class TopNQueryRunnerTest
         .build();
 
     assertExpectedResults(
-        Sequences.toList(
-            runWithMerge(
-                new TopNQueryBuilder()
-                    .dataSource(QueryRunnerTestHelper.dataSource)
-                    .granularity(QueryRunnerTestHelper.allGran)
-                    .filters(QueryRunnerTestHelper.qualityDimension, "mezzanine", "automotive", "business")
-                    .dimension(QueryRunnerTestHelper.qualityDimension)
-                    .metric(QueryRunnerTestHelper.indexMetric)
-                    .threshold(4)
-                    .intervals(QueryRunnerTestHelper.firstToThird)
-                    .aggregators(commonAggregators)
-                    .postAggregators(Arrays.<PostAggregator>asList(QueryRunnerTestHelper.addRowsIndexConstant))
-                    .build()
-            ), Lists.<Result<TopNResultValue>>newArrayList()
-        ), query
+        runWithMerge(
+            new TopNQueryBuilder()
+                .dataSource(QueryRunnerTestHelper.dataSource)
+                .granularity(QueryRunnerTestHelper.allGran)
+                .filters(
+                    QueryRunnerTestHelper.qualityDimension,
+                    "mezzanine",
+                    "automotive",
+                    "business"
+                )
+                .dimension(QueryRunnerTestHelper.qualityDimension)
+                .metric(QueryRunnerTestHelper.indexMetric)
+                .threshold(4)
+                .intervals(QueryRunnerTestHelper.firstToThird)
+                .aggregators(commonAggregators)
+                .postAggregators(Arrays.asList(QueryRunnerTestHelper.addRowsIndexConstant))
+                .build()
+        ).toList(),
+        query
     );
   }
 
@@ -2369,10 +2347,7 @@ public class TopNQueryRunnerTest
             )
         )
     );
-    List<Result<TopNResultValue>> list = Sequences.toList(
-        runWithMerge(query),
-        new ArrayList<Result<TopNResultValue>>()
-    );
+    List<Result<TopNResultValue>> list = runWithMerge(query).toList();
     Assert.assertEquals(list.size(), 1);
     Assert.assertEquals("Didn't merge results", list.get(0).getValue().getValue().size(), 1);
     TestHelper.assertExpectedResults(expectedResults, list, "Failed to match");
@@ -3793,7 +3768,7 @@ public class TopNQueryRunnerTest
         )
     );
     Sequence<Result<TopNResultValue>> results = runWithMerge(query);
-    for (Result<TopNResultValue> result : Sequences.toList(results, new ArrayList<Result<TopNResultValue>>())) {
+    for (Result<TopNResultValue> result : results.toList()) {
       Assert.assertEquals(result.getValue(), result.getValue()); // TODO: fix this test
     }
   }
@@ -5635,6 +5610,6 @@ public class TopNQueryRunnerTest
         .build();
 
     // Don't check results, just the fact that the query could complete
-    Assert.assertNotNull(Sequences.toList(runWithMerge(query), new ArrayList<>()));
+    Assert.assertNotNull(runWithMerge(query).toList());
   }
 }

--- a/processing/src/test/java/io/druid/segment/EmptyIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/EmptyIndexTest.java
@@ -94,7 +94,7 @@ public class EmptyIndexTest
       QueryableIndex emptyQueryableIndex = TestHelper.getTestIndexIO(segmentWriteOutMediumFactory).loadIndex(tmpDir);
 
       Assert.assertEquals("getDimensionNames", 0, Iterables.size(emptyQueryableIndex.getAvailableDimensions()));
-      Assert.assertEquals("getMetricNames", 0, Iterables.size(emptyQueryableIndex.getColumnNames()));
+      Assert.assertEquals("getMetricNames", 0, emptyQueryableIndex.getColumnNames().size());
       Assert.assertEquals("getDataInterval", Intervals.of("2012-08-01/P3D"), emptyQueryableIndex.getDataInterval());
       Assert.assertEquals(
           "getReadOnlyTimestamps",

--- a/processing/src/test/java/io/druid/segment/SchemalessTestFullTest.java
+++ b/processing/src/test/java/io/druid/segment/SchemalessTestFullTest.java
@@ -29,10 +29,6 @@ import io.druid.java.util.common.Pair;
 import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.granularity.Granularity;
-import io.druid.java.util.common.guava.Sequences;
-import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
-import io.druid.segment.writeout.SegmentWriteOutMediumFactory;
-import io.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
 import io.druid.query.Druids;
 import io.druid.query.QueryPlus;
 import io.druid.query.QueryRunner;
@@ -49,9 +45,9 @@ import io.druid.query.aggregation.hyperloglog.HyperUniquesAggregatorFactory;
 import io.druid.query.aggregation.post.ArithmeticPostAggregator;
 import io.druid.query.aggregation.post.ConstantPostAggregator;
 import io.druid.query.aggregation.post.FieldAccessPostAggregator;
-import io.druid.query.search.SearchResultValue;
 import io.druid.query.search.SearchHit;
 import io.druid.query.search.SearchQuery;
+import io.druid.query.search.SearchResultValue;
 import io.druid.query.spec.MultipleIntervalSegmentSpec;
 import io.druid.query.spec.QuerySegmentSpec;
 import io.druid.query.timeboundary.TimeBoundaryQuery;
@@ -61,6 +57,9 @@ import io.druid.query.timeseries.TimeseriesResultValue;
 import io.druid.query.topn.TopNQuery;
 import io.druid.query.topn.TopNQueryBuilder;
 import io.druid.query.topn.TopNResultValue;
+import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
+import io.druid.segment.writeout.SegmentWriteOutMediumFactory;
+import io.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -1476,10 +1475,7 @@ public class SchemalessTestFullTest
 
     failMsg += " timeseries ";
     HashMap<String, Object> context = new HashMap<>();
-    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> actualResults = runner.run(QueryPlus.wrap(query), context).toList();
     TestHelper.assertExpectedResults(expectedResults, actualResults, failMsg);
   }
 
@@ -1510,10 +1506,7 @@ public class SchemalessTestFullTest
 
     failMsg += " filtered timeseries ";
     HashMap<String, Object> context = new HashMap<>();
-    Iterable<Result<TimeseriesResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<Result<TimeseriesResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeseriesResultValue>> actualResults = runner.run(QueryPlus.wrap(query), context).toList();
     TestHelper.assertExpectedResults(expectedResults, actualResults, failMsg);
   }
 
@@ -1544,10 +1537,7 @@ public class SchemalessTestFullTest
 
     failMsg += " topN ";
     HashMap<String, Object> context = new HashMap<>();
-    Iterable<Result<TopNResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<Result<TopNResultValue>>newArrayList()
-    );
+    Iterable<Result<TopNResultValue>> actualResults = runner.run(QueryPlus.wrap(query), context).toList();
 
     TestHelper.assertExpectedResults(expectedResults, actualResults, failMsg);
   }
@@ -1580,10 +1570,7 @@ public class SchemalessTestFullTest
 
     failMsg += " filtered topN ";
     HashMap<String, Object> context = new HashMap<>();
-    Iterable<Result<TopNResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<Result<TopNResultValue>>newArrayList()
-    );
+    Iterable<Result<TopNResultValue>> actualResults = runner.run(QueryPlus.wrap(query), context).toList();
     TestHelper.assertExpectedResults(expectedResults, actualResults, failMsg);
   }
 
@@ -1598,10 +1585,7 @@ public class SchemalessTestFullTest
 
     failMsg += " search ";
     HashMap<String, Object> context = new HashMap<>();
-    Iterable<Result<SearchResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<Result<SearchResultValue>>newArrayList()
-    );
+    Iterable<Result<SearchResultValue>> actualResults = runner.run(QueryPlus.wrap(query), context).toList();
     TestHelper.assertExpectedResults(expectedResults, actualResults, failMsg);
   }
 
@@ -1617,10 +1601,7 @@ public class SchemalessTestFullTest
 
     failMsg += " filtered search ";
     HashMap<String, Object> context = new HashMap<>();
-    Iterable<Result<SearchResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<Result<SearchResultValue>>newArrayList()
-    );
+    Iterable<Result<SearchResultValue>> actualResults = runner.run(QueryPlus.wrap(query), context).toList();
     TestHelper.assertExpectedResults(expectedResults, actualResults, failMsg);
   }
 
@@ -1636,10 +1617,7 @@ public class SchemalessTestFullTest
 
     failMsg += " timeBoundary ";
     HashMap<String, Object> context = new HashMap<>();
-    Iterable<Result<TimeBoundaryResultValue>> actualResults = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        Lists.<Result<TimeBoundaryResultValue>>newArrayList()
-    );
+    Iterable<Result<TimeBoundaryResultValue>> actualResults = runner.run(QueryPlus.wrap(query), context).toList();
     TestHelper.assertExpectedResults(expectedResults, actualResults, failMsg);
   }
 }

--- a/processing/src/test/java/io/druid/segment/TestHelper.java
+++ b/processing/src/test/java/io/druid/segment/TestHelper.java
@@ -27,14 +27,13 @@ import io.druid.data.input.Row;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.math.expr.ExprMacroTable;
-import io.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import io.druid.query.Result;
 import io.druid.query.expression.TestExprMacroTable;
 import io.druid.query.timeseries.TimeseriesResultValue;
 import io.druid.query.topn.TopNResultValue;
 import io.druid.segment.column.ColumnConfig;
+import io.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import io.druid.timeline.DataSegment;
 import org.junit.Assert;
 
@@ -101,7 +100,7 @@ public class TestHelper
 
   public static <T> void assertExpectedResults(Iterable<Result<T>> expectedResults, Sequence<Result<T>> results)
   {
-    assertResults(expectedResults, Sequences.toList(results, Lists.<Result<T>>newArrayList()), "");
+    assertResults(expectedResults, results.toList(), "");
   }
 
   public static <T> void assertExpectedResults(Iterable<Result<T>> expectedResults, Iterable<Result<T>> results)
@@ -125,7 +124,7 @@ public class TestHelper
 
   public static <T> void assertExpectedObjects(Iterable<T> expectedResults, Sequence<T> results, String failMsg)
   {
-    assertObjects(expectedResults, Sequences.toList(results, Lists.<T>newArrayList()), failMsg);
+    assertObjects(expectedResults, results.toList(), failMsg);
   }
 
   private static <T> void assertResults(

--- a/processing/src/test/java/io/druid/segment/data/IncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/data/IncrementalIndexTest.java
@@ -39,7 +39,6 @@ import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Accumulator;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.Druids;
 import io.druid.query.FinalizeResultsQueryRunner;
 import io.druid.query.QueryPlus;
@@ -81,7 +80,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -480,10 +478,7 @@ public class IncrementalIndexTest
     );
 
 
-    List<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), new HashMap<String, Object>()),
-        new LinkedList<Result<TimeseriesResultValue>>()
-    );
+    List<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), new HashMap<String, Object>()).toList();
     Result<TimeseriesResultValue> result = Iterables.getOnlyElement(results);
     boolean isRollup = index.isRollup();
     Assert.assertEquals(rows * (isRollup ? 1 : 2), result.getValue().getLongMetric("rows").intValue());
@@ -697,10 +692,7 @@ public class IncrementalIndexTest
                                   .aggregators(queryAggregatorFactories)
                                   .build();
     Map<String, Object> context = new HashMap<String, Object>();
-    List<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        new LinkedList<Result<TimeseriesResultValue>>()
-    );
+    List<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), context).toList();
     boolean isRollup = index.isRollup();
     for (Result<TimeseriesResultValue> result : results) {
       Assert.assertEquals(

--- a/processing/src/test/java/io/druid/segment/filter/BaseFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/BaseFilterTest.java
@@ -75,7 +75,6 @@ import org.junit.runners.Parameterized;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -337,7 +336,7 @@ public abstract class BaseFilterTest
           }
         }
     );
-    return Sequences.toList(seq, new ArrayList<List<String>>()).get(0);
+    return seq.toList().get(0);
   }
 
   private long selectCountUsingFilteredAggregator(final DimFilter filter)
@@ -363,7 +362,7 @@ public abstract class BaseFilterTest
           }
         }
     );
-    return Sequences.toList(aggSeq, new ArrayList<Aggregator>()).get(0).getLong();
+    return aggSeq.toList().get(0).getLong();
   }
 
   private List<String> selectColumnValuesMatchingFilterUsingPostFiltering(
@@ -432,7 +431,7 @@ public abstract class BaseFilterTest
           }
         }
     );
-    return Sequences.toList(seq, new ArrayList<List<String>>()).get(0);
+    return seq.toList().get(0);
   }
 
   private List<String> selectColumnValuesMatchingFilterUsingRowBasedColumnSelectorFactory(

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
@@ -19,7 +19,6 @@
 
 package io.druid.segment.incremental;
 
-import com.google.common.base.Function;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
@@ -33,10 +32,8 @@ import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.js.JavaScriptConfig;
 import io.druid.query.Result;
-import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.query.aggregation.JavaScriptAggregatorFactory;
 import io.druid.query.aggregation.LongSumAggregatorFactory;
@@ -61,12 +58,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -143,7 +140,7 @@ public class IncrementalIndexStorageAdapterTest
         new IncrementalIndexStorageAdapter(index)
     );
 
-    final ArrayList<Row> results = Sequences.toList(rows, Lists.<Row>newArrayList());
+    final List<Row> results = rows.toList();
 
     Assert.assertEquals(2, results.size());
 
@@ -202,7 +199,7 @@ public class IncrementalIndexStorageAdapterTest
         new IncrementalIndexStorageAdapter(index)
     );
 
-    final ArrayList<Row> results = Sequences.toList(rows, Lists.<Row>newArrayList());
+    final List<Row> results = rows.toList();
 
     Assert.assertEquals(2, results.size());
 
@@ -275,7 +272,7 @@ public class IncrementalIndexStorageAdapterTest
           null
       );
 
-      Cursor cursor = Sequences.toList(Sequences.limit(cursorSequence, 1), Lists.<Cursor>newArrayList()).get(0);
+      Cursor cursor = cursorSequence.limit(1).toList().get(0);
       DimensionSelector dimSelector;
 
       dimSelector = cursor
@@ -328,28 +325,21 @@ public class IncrementalIndexStorageAdapterTest
         )
     );
 
-    final Iterable<Result<TopNResultValue>> results = Sequences.toList(
-        engine.query(
-            new TopNQueryBuilder().dataSource("test")
-                                  .granularity(Granularities.ALL)
-                                  .intervals(Lists.newArrayList(new Interval(DateTimes.EPOCH, DateTimes.nowUtc())))
-                                  .dimension("sally")
-                                  .metric("cnt")
-                                  .threshold(10)
-                                  .aggregators(
-                                      Lists.<AggregatorFactory>newArrayList(
-                                          new LongSumAggregatorFactory(
-                                              "cnt",
-                                              "cnt"
-                                          )
-                                      )
-                                  )
-                                  .build(),
+    final Iterable<Result<TopNResultValue>> results = engine
+        .query(
+            new TopNQueryBuilder()
+                .dataSource("test")
+                .granularity(Granularities.ALL)
+                .intervals(Lists.newArrayList(new Interval(DateTimes.EPOCH, DateTimes.nowUtc())))
+                .dimension("sally")
+                .metric("cnt")
+                .threshold(10)
+                .aggregators(Collections.singletonList(new LongSumAggregatorFactory("cnt", "cnt")))
+                .build(),
             new IncrementalIndexStorageAdapter(index),
             null
-        ),
-        Lists.<Result<TopNResultValue>>newLinkedList()
-    );
+        )
+        .toList();
 
     Assert.assertEquals(1, Iterables.size(results));
     Assert.assertEquals(1, results.iterator().next().getValue().getValue().size());
@@ -389,7 +379,7 @@ public class IncrementalIndexStorageAdapterTest
         new IncrementalIndexStorageAdapter(index)
     );
 
-    final ArrayList<Row> results = Sequences.toList(rows, Lists.<Row>newArrayList());
+    final List<Row> results = rows.toList();
 
     Assert.assertEquals(1, results.size());
 
@@ -425,53 +415,37 @@ public class IncrementalIndexStorageAdapterTest
     );
     final AtomicInteger assertCursorsNotEmpty = new AtomicInteger(0);
 
-    Sequences.toList(
-        Sequences.map(
-            cursors,
-            new Function<Cursor, Object>()
-            {
-              @Nullable
-              @Override
-              public Object apply(Cursor cursor)
-              {
-                DimensionSelector dimSelector = cursor
-                    .getColumnSelectorFactory()
-                    .makeDimensionSelector(new DefaultDimensionSpec("billy", "billy"));
-                int cardinality = dimSelector.getValueCardinality();
+    cursors
+        .map(cursor -> {
+          DimensionSelector dimSelector = cursor
+              .getColumnSelectorFactory()
+              .makeDimensionSelector(new DefaultDimensionSpec("billy", "billy"));
+          int cardinality = dimSelector.getValueCardinality();
 
-                //index gets more rows at this point, while other thread is iterating over the cursor
-                try {
-                  for (int i = 0; i < 1; i++) {
-                    index.add(
-                        new MapBasedInputRow(
-                            timestamp,
-                            Lists.newArrayList("billy"),
-                            ImmutableMap.<String, Object>of("billy", "v2" + i)
-                        )
-                    );
-                  }
-                }
-                catch (Exception ex) {
-                  throw new RuntimeException(ex);
-                }
-
-                int rowNumInCursor = 0;
-                // and then, cursoring continues in the other thread
-                while (!cursor.isDone()) {
-                  IndexedInts row = dimSelector.getRow();
-                  row.forEach(i -> Assert.assertTrue(i < cardinality));
-                  cursor.advance();
-                  rowNumInCursor++;
-                }
-                Assert.assertEquals(2, rowNumInCursor);
-                assertCursorsNotEmpty.incrementAndGet();
-
-                return null;
-              }
+          //index gets more rows at this point, while other thread is iterating over the cursor
+          try {
+            for (int i = 0; i < 1; i++) {
+              index.add(new MapBasedInputRow(timestamp, Lists.newArrayList("billy"), ImmutableMap.of("billy", "v2" + i)));
             }
-        ),
-        new ArrayList<>()
-    );
+          }
+          catch (Exception ex) {
+            throw new RuntimeException(ex);
+          }
+
+          int rowNumInCursor = 0;
+          // and then, cursoring continues in the other thread
+          while (!cursor.isDone()) {
+            IndexedInts row = dimSelector.getRow();
+            row.forEach(i -> Assert.assertTrue(i < cardinality));
+            cursor.advance();
+            rowNumInCursor++;
+          }
+          Assert.assertEquals(2, rowNumInCursor);
+          assertCursorsNotEmpty.incrementAndGet();
+
+          return null;
+        })
+        .toList();
     Assert.assertEquals(1, assertCursorsNotEmpty.get());
   }
 
@@ -503,118 +477,78 @@ public class IncrementalIndexStorageAdapterTest
     );
     final AtomicInteger assertCursorsNotEmpty = new AtomicInteger(0);
 
-    Sequences.toList(
-        Sequences.map(
-            cursors,
-            new Function<Cursor, Object>()
-            {
-              @Nullable
-              @Override
-              public Object apply(Cursor cursor)
-              {
-                DimensionSelector dimSelector1A = cursor
-                    .getColumnSelectorFactory()
-                    .makeDimensionSelector(new DefaultDimensionSpec("billy", "billy"));
-                int cardinalityA = dimSelector1A.getValueCardinality();
+    cursors
+        .map(cursor -> {
+          DimensionSelector dimSelector1A = cursor
+              .getColumnSelectorFactory()
+              .makeDimensionSelector(new DefaultDimensionSpec("billy", "billy"));
+          int cardinalityA = dimSelector1A.getValueCardinality();
 
-                //index gets more rows at this point, while other thread is iterating over the cursor
-                try {
-                  index.add(
-                      new MapBasedInputRow(
-                          timestamp,
-                          Lists.newArrayList("billy"),
-                          ImmutableMap.<String, Object>of("billy", "v1")
-                      )
-                  );
-                }
-                catch (Exception ex) {
-                  throw new RuntimeException(ex);
-                }
+          //index gets more rows at this point, while other thread is iterating over the cursor
+          try {
+            index.add(new MapBasedInputRow(timestamp, Lists.newArrayList("billy"), ImmutableMap.of("billy", "v1")));
+          }
+          catch (Exception ex) {
+            throw new RuntimeException(ex);
+          }
 
-                DimensionSelector dimSelector1B = cursor
-                    .getColumnSelectorFactory()
-                    .makeDimensionSelector(new DefaultDimensionSpec("billy", "billy"));
-                //index gets more rows at this point, while other thread is iterating over the cursor
-                try {
-                  index.add(
-                      new MapBasedInputRow(
-                          timestamp,
-                          Lists.newArrayList("billy"),
-                          ImmutableMap.<String, Object>of("billy", "v2")
-                      )
-                  );
-                  index.add(
-                      new MapBasedInputRow(
-                          timestamp,
-                          Lists.newArrayList("billy2"),
-                          ImmutableMap.<String, Object>of("billy2", "v3")
-                      )
-                  );
-                }
-                catch (Exception ex) {
-                  throw new RuntimeException(ex);
-                }
+          DimensionSelector dimSelector1B = cursor
+              .getColumnSelectorFactory()
+              .makeDimensionSelector(new DefaultDimensionSpec("billy", "billy"));
+          //index gets more rows at this point, while other thread is iterating over the cursor
+          try {
+            index.add(new MapBasedInputRow(timestamp, Lists.newArrayList("billy"), ImmutableMap.of("billy", "v2")));
+            index.add(new MapBasedInputRow(timestamp, Lists.newArrayList("billy2"), ImmutableMap.of("billy2", "v3")));
+          }
+          catch (Exception ex) {
+            throw new RuntimeException(ex);
+          }
 
-                DimensionSelector dimSelector1C = cursor
-                    .getColumnSelectorFactory()
-                    .makeDimensionSelector(new DefaultDimensionSpec("billy", "billy"));
+          DimensionSelector dimSelector1C = cursor
+              .getColumnSelectorFactory()
+              .makeDimensionSelector(new DefaultDimensionSpec("billy", "billy"));
 
-                DimensionSelector dimSelector2D = cursor
-                    .getColumnSelectorFactory()
-                    .makeDimensionSelector(new DefaultDimensionSpec("billy2", "billy2"));
-                //index gets more rows at this point, while other thread is iterating over the cursor
-                try {
-                  index.add(
-                      new MapBasedInputRow(
-                          timestamp,
-                          Lists.newArrayList("billy"),
-                          ImmutableMap.<String, Object>of("billy", "v3")
-                      )
-                  );
-                  index.add(
-                      new MapBasedInputRow(
-                          timestamp,
-                          Lists.newArrayList("billy3"),
-                          ImmutableMap.<String, Object>of("billy3", "")
-                      )
-                  );
-                }
-                catch (Exception ex) {
-                  throw new RuntimeException(ex);
-                }
+          DimensionSelector dimSelector2D = cursor
+              .getColumnSelectorFactory()
+              .makeDimensionSelector(new DefaultDimensionSpec("billy2", "billy2"));
+          //index gets more rows at this point, while other thread is iterating over the cursor
+          try {
+            index.add(new MapBasedInputRow(timestamp, Lists.newArrayList("billy"), ImmutableMap.of("billy", "v3")));
+            index.add(new MapBasedInputRow(timestamp, Lists.newArrayList("billy3"), ImmutableMap.of("billy3", "")));
+          }
+          catch (Exception ex) {
+            throw new RuntimeException(ex);
+          }
 
-                DimensionSelector dimSelector3E = cursor
-                    .getColumnSelectorFactory()
-                    .makeDimensionSelector(new DefaultDimensionSpec("billy3", "billy3"));
+          DimensionSelector dimSelector3E = cursor
+              .getColumnSelectorFactory()
+              .makeDimensionSelector(new DefaultDimensionSpec("billy3", "billy3"));
 
-                int rowNumInCursor = 0;
-                // and then, cursoring continues in the other thread
-                while (!cursor.isDone()) {
-                  IndexedInts rowA = dimSelector1A.getRow();
-                  rowA.forEach(i -> Assert.assertTrue(i < cardinalityA));
-                  IndexedInts rowB = dimSelector1B.getRow();
-                  rowB.forEach(i -> Assert.assertTrue(i < cardinalityA));
-                  IndexedInts rowC = dimSelector1C.getRow();
-                  rowC.forEach(i -> Assert.assertTrue(i < cardinalityA));
-                  IndexedInts rowD = dimSelector2D.getRow();
-                  // no null id, so should get empty dims array
-                  Assert.assertEquals(0, rowD.size());
-                  IndexedInts rowE = dimSelector3E.getRow();
-                  Assert.assertEquals(1, rowE.size());
-                  // the null id
-                  Assert.assertEquals(0, rowE.get(0));
-                  cursor.advance();
-                  rowNumInCursor++;
-                }
-                Assert.assertEquals(2, rowNumInCursor);
-                assertCursorsNotEmpty.incrementAndGet();
+          int rowNumInCursor = 0;
+          // and then, cursoring continues in the other thread
+          while (!cursor.isDone()) {
+            IndexedInts rowA = dimSelector1A.getRow();
+            rowA.forEach(i -> Assert.assertTrue(i < cardinalityA));
+            IndexedInts rowB = dimSelector1B.getRow();
+            rowB.forEach(i -> Assert.assertTrue(i < cardinalityA));
+            IndexedInts rowC = dimSelector1C.getRow();
+            rowC.forEach(i -> Assert.assertTrue(i < cardinalityA));
+            IndexedInts rowD = dimSelector2D.getRow();
+            // no null id, so should get empty dims array
+            Assert.assertEquals(0, rowD.size());
+            IndexedInts rowE = dimSelector3E.getRow();
+            Assert.assertEquals(1, rowE.size());
+            // the null id
+            Assert.assertEquals(0, rowE.get(0));
+            cursor.advance();
+            rowNumInCursor++;
+          }
+          Assert.assertEquals(2, rowNumInCursor);
+          assertCursorsNotEmpty.incrementAndGet();
 
-                return null;
-              }
-            }
-        ),
-        new ArrayList<>()
-    );
+          return null;
+        })
+        .toList();
     Assert.assertEquals(1, assertCursorsNotEmpty.get());
   }
 }

--- a/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
+++ b/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
@@ -37,7 +37,6 @@ import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.granularity.Granularity;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.parsers.ParseException;
 import io.druid.query.Druids;
 import io.druid.query.FinalizeResultsQueryRunner;
@@ -394,10 +393,7 @@ public class OnheapIncrementalIndexBenchmark extends AbstractBenchmark
                                                 .aggregators(queryAggregatorFactories)
                                                 .build();
                   Map<String, Object> context = new HashMap<String, Object>();
-                  LinkedList<Result<TimeseriesResultValue>> results = Sequences.toList(
-                      runner.run(QueryPlus.wrap(query), context),
-                      new LinkedList<Result<TimeseriesResultValue>>()
-                  );
+                  List<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), context).toList();
                   for (Result<TimeseriesResultValue> result : results) {
                     if (someoneRan.get()) {
                       Assert.assertTrue(result.getValue().getDoubleMetric("doubleSumResult0") > 0);
@@ -430,10 +426,7 @@ public class OnheapIncrementalIndexBenchmark extends AbstractBenchmark
                                   .aggregators(queryAggregatorFactories)
                                   .build();
     Map<String, Object> context = new HashMap<String, Object>();
-    List<Result<TimeseriesResultValue>> results = Sequences.toList(
-        runner.run(QueryPlus.wrap(query), context),
-        new LinkedList<Result<TimeseriesResultValue>>()
-    );
+    List<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query), context).toList();
     final int expectedVal = elementsPerThread * taskCount;
     for (Result<TimeseriesResultValue> result : results) {
       Assert.assertEquals(elementsPerThread, result.getValue().getLongMetric("rows").intValue());

--- a/server/src/test/java/io/druid/client/CachingClusteredClientTest.java
+++ b/server/src/test/java/io/druid/client/CachingClusteredClientTest.java
@@ -1754,7 +1754,7 @@ public class CachingClusteredClientTest
     descriptors.add(new SegmentDescriptor(interval3, "v", 6));
     MultipleSpecificSegmentSpec expected = new MultipleSpecificSegmentSpec(descriptors);
 
-    Sequences.toList(runner.run(QueryPlus.wrap(query), context), Lists.newArrayList());
+    runner.run(QueryPlus.wrap(query), context).toList();
 
     Assert.assertEquals(expected, ((TimeseriesQuery) capture.getValue().getQuery()).getQuerySegmentSpec());
   }

--- a/server/src/test/java/io/druid/client/CachingQueryRunnerTest.java
+++ b/server/src/test/java/io/druid/client/CachingQueryRunnerTest.java
@@ -65,7 +65,6 @@ import org.junit.runners.Parameterized;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -306,7 +305,7 @@ public class CachingQueryRunnerTest
     Assert.assertFalse("sequence must not be closed", closable.isClosed());
     Assert.assertNull("cache must be empty", cache.get(cacheKey));
 
-    ArrayList results = Sequences.toList(res, new ArrayList());
+    List results = res.toList();
     Assert.assertTrue(closable.isClosed());
     Assert.assertEquals(expectedRes.toString(), results.toString());
 
@@ -387,7 +386,7 @@ public class CachingQueryRunnerTest
 
     );
     HashMap<String, Object> context = new HashMap<String, Object>();
-    List<Result> results = Sequences.toList(runner.run(QueryPlus.wrap(query), context), new ArrayList());
+    List<Result> results = runner.run(QueryPlus.wrap(query), context).toList();
     Assert.assertEquals(expectedResults.toString(), results.toString());
   }
 

--- a/server/src/test/java/io/druid/client/DirectDruidClientTest.java
+++ b/server/src/test/java/io/druid/client/DirectDruidClientTest.java
@@ -38,7 +38,6 @@ import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.Druids;
 import io.druid.query.QueryInterruptedException;
 import io.druid.query.QueryPlus;
@@ -191,7 +190,7 @@ public class DirectDruidClientTest
             StringUtils.toUtf8("[{\"timestamp\":\"2014-01-01T01:02:03Z\", \"result\": 42.0}]")
         )
     );
-    List<Result> results = Sequences.toList(s1, Lists.<Result>newArrayList());
+    List<Result> results = s1.toList();
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(DateTimes.of("2014-01-01T01:02:03Z"), results.get(0).getTimestamp());
     Assert.assertEquals(3, client1.getNumOpenConnections());
@@ -277,7 +276,7 @@ public class DirectDruidClientTest
 
     QueryInterruptedException exception = null;
     try {
-      Sequences.toList(results, Lists.newArrayList());
+      results.toList();
     }
     catch (QueryInterruptedException e) {
       exception = e;
@@ -349,7 +348,7 @@ public class DirectDruidClientTest
 
     QueryInterruptedException actualException = null;
     try {
-      Sequences.toList(results, Lists.newArrayList());
+      results.toList();
     }
     catch (QueryInterruptedException e) {
       actualException = e;

--- a/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorTest.java
@@ -367,8 +367,8 @@ public class AppenderatorTest
                                            .granularity(Granularities.DAY)
                                            .build();
 
-      final List<Result<TimeseriesResultValue>> results1 = Lists.newArrayList();
-      QueryPlus.wrap(query1).run(appenderator, ImmutableMap.of()).toList();
+      final List<Result<TimeseriesResultValue>> results1 =
+          QueryPlus.wrap(query1).run(appenderator, ImmutableMap.of()).toList();
       Assert.assertEquals(
           "query1",
           ImmutableList.of(
@@ -393,8 +393,8 @@ public class AppenderatorTest
                                            .granularity(Granularities.DAY)
                                            .build();
 
-      final List<Result<TimeseriesResultValue>> results2 = Lists.newArrayList();
-      QueryPlus.wrap(query2).run(appenderator, ImmutableMap.of()).toList();
+      final List<Result<TimeseriesResultValue>> results2 =
+          QueryPlus.wrap(query2).run(appenderator, ImmutableMap.of()).toList();
       Assert.assertEquals(
           "query2",
           ImmutableList.of(
@@ -423,8 +423,8 @@ public class AppenderatorTest
                                            .granularity(Granularities.DAY)
                                            .build();
 
-      final List<Result<TimeseriesResultValue>> results3 = Lists.newArrayList();
-      QueryPlus.wrap(query3).run(appenderator, ImmutableMap.of()).toList();
+      final List<Result<TimeseriesResultValue>> results3 =
+          QueryPlus.wrap(query3).run(appenderator, ImmutableMap.of()).toList();
       Assert.assertEquals(
           ImmutableList.of(
               new Result<>(
@@ -457,8 +457,8 @@ public class AppenderatorTest
                                            .granularity(Granularities.DAY)
                                            .build();
 
-      final List<Result<TimeseriesResultValue>> results4 = Lists.newArrayList();
-      QueryPlus.wrap(query4).run(appenderator, ImmutableMap.of()).toList();
+      final List<Result<TimeseriesResultValue>> results4 =
+          QueryPlus.wrap(query4).run(appenderator, ImmutableMap.of()).toList();
       Assert.assertEquals(
           ImmutableList.of(
               new Result<>(
@@ -513,8 +513,8 @@ public class AppenderatorTest
                                            )
                                            .build();
 
-      final List<Result<TimeseriesResultValue>> results1 = Lists.newArrayList();
-      QueryPlus.wrap(query1).run(appenderator, ImmutableMap.of()).toList();
+      final List<Result<TimeseriesResultValue>> results1 =
+          QueryPlus.wrap(query1).run(appenderator, ImmutableMap.of()).toList();
       Assert.assertEquals(
           "query1",
           ImmutableList.of(
@@ -549,8 +549,8 @@ public class AppenderatorTest
                                            )
                                            .build();
 
-      final List<Result<TimeseriesResultValue>> results2 = Lists.newArrayList();
-      QueryPlus.wrap(query2).run(appenderator, ImmutableMap.of()).toList();
+      final List<Result<TimeseriesResultValue>> results2 =
+          QueryPlus.wrap(query2).run(appenderator, ImmutableMap.of()).toList();
       Assert.assertEquals(
           "query2",
           ImmutableList.of(
@@ -590,8 +590,8 @@ public class AppenderatorTest
                                            )
                                            .build();
 
-      final List<Result<TimeseriesResultValue>> results3 = Lists.newArrayList();
-      QueryPlus.wrap(query3).run(appenderator, ImmutableMap.of()).toList();
+      final List<Result<TimeseriesResultValue>> results3 =
+          QueryPlus.wrap(query3).run(appenderator, ImmutableMap.of()).toList();
       Assert.assertEquals(
           "query2",
           ImmutableList.of(

--- a/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorTest.java
@@ -31,7 +31,6 @@ import io.druid.data.input.MapBasedInputRow;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.granularity.Granularities;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.Druids;
 import io.druid.query.QueryPlus;
 import io.druid.query.Result;
@@ -369,7 +368,7 @@ public class AppenderatorTest
                                            .build();
 
       final List<Result<TimeseriesResultValue>> results1 = Lists.newArrayList();
-      Sequences.toList(QueryPlus.wrap(query1).run(appenderator, ImmutableMap.of()), results1);
+      QueryPlus.wrap(query1).run(appenderator, ImmutableMap.of()).toList();
       Assert.assertEquals(
           "query1",
           ImmutableList.of(
@@ -395,7 +394,7 @@ public class AppenderatorTest
                                            .build();
 
       final List<Result<TimeseriesResultValue>> results2 = Lists.newArrayList();
-      Sequences.toList(QueryPlus.wrap(query2).run(appenderator, ImmutableMap.of()), results2);
+      QueryPlus.wrap(query2).run(appenderator, ImmutableMap.of()).toList();
       Assert.assertEquals(
           "query2",
           ImmutableList.of(
@@ -425,7 +424,7 @@ public class AppenderatorTest
                                            .build();
 
       final List<Result<TimeseriesResultValue>> results3 = Lists.newArrayList();
-      Sequences.toList(QueryPlus.wrap(query3).run(appenderator, ImmutableMap.of()), results3);
+      QueryPlus.wrap(query3).run(appenderator, ImmutableMap.of()).toList();
       Assert.assertEquals(
           ImmutableList.of(
               new Result<>(
@@ -459,7 +458,7 @@ public class AppenderatorTest
                                            .build();
 
       final List<Result<TimeseriesResultValue>> results4 = Lists.newArrayList();
-      Sequences.toList(QueryPlus.wrap(query4).run(appenderator, ImmutableMap.of()), results4);
+      QueryPlus.wrap(query4).run(appenderator, ImmutableMap.of()).toList();
       Assert.assertEquals(
           ImmutableList.of(
               new Result<>(
@@ -515,7 +514,7 @@ public class AppenderatorTest
                                            .build();
 
       final List<Result<TimeseriesResultValue>> results1 = Lists.newArrayList();
-      Sequences.toList(QueryPlus.wrap(query1).run(appenderator, ImmutableMap.of()), results1);
+      QueryPlus.wrap(query1).run(appenderator, ImmutableMap.of()).toList();
       Assert.assertEquals(
           "query1",
           ImmutableList.of(
@@ -551,7 +550,7 @@ public class AppenderatorTest
                                            .build();
 
       final List<Result<TimeseriesResultValue>> results2 = Lists.newArrayList();
-      Sequences.toList(QueryPlus.wrap(query2).run(appenderator, ImmutableMap.of()), results2);
+      QueryPlus.wrap(query2).run(appenderator, ImmutableMap.of()).toList();
       Assert.assertEquals(
           "query2",
           ImmutableList.of(
@@ -592,7 +591,7 @@ public class AppenderatorTest
                                            .build();
 
       final List<Result<TimeseriesResultValue>> results3 = Lists.newArrayList();
-      Sequences.toList(QueryPlus.wrap(query3).run(appenderator, ImmutableMap.of()), results3);
+      QueryPlus.wrap(query3).run(appenderator, ImmutableMap.of()).toList();
       Assert.assertEquals(
           "query2",
           ImmutableList.of(

--- a/server/src/test/java/io/druid/server/coordination/ServerManagerTest.java
+++ b/server/src/test/java/io/druid/server/coordination/ServerManagerTest.java
@@ -446,7 +446,7 @@ public class ServerManagerTest
           {
             Map<String, Object> context = new HashMap<String, Object>();
             Sequence<Result<SearchResultValue>> seq = runner.run(QueryPlus.wrap(query), context);
-            Sequences.toList(seq, Lists.<Result<SearchResultValue>>newArrayList());
+            seq.toList();
             Iterator<SegmentForTesting> adaptersIter = factory.getAdapters().iterator();
 
             while (expectedIter.hasNext() && adaptersIter.hasNext()) {

--- a/sql/src/main/java/io/druid/sql/avatica/DruidStatement.java
+++ b/sql/src/main/java/io/druid/sql/avatica/DruidStatement.java
@@ -26,7 +26,6 @@ import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.guava.Sequence;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.guava.Yielder;
 import io.druid.java.util.common.guava.Yielders;
 import io.druid.server.security.AuthenticationResult;
@@ -202,7 +201,7 @@ public class DruidStatement implements Closeable
         // We can't apply limits greater than Integer.MAX_VALUE, ignore them.
         final Sequence<Object[]> retSequence =
             maxRowCount >= 0 && maxRowCount <= Integer.MAX_VALUE
-            ? Sequences.limit(baseSequence, (int) maxRowCount)
+            ? baseSequence.limit((int) maxRowCount)
             : baseSequence;
 
         yielder = Yielders.each(retSequence);

--- a/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
@@ -22,7 +22,6 @@ package io.druid.sql.calcite;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.druid.hll.HLLCV1;
 import io.druid.java.util.common.DateTimes;
@@ -30,7 +29,6 @@ import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.granularity.PeriodGranularity;
-import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.math.expr.ExprMacroTable;
 import io.druid.query.Druids;
@@ -6377,7 +6375,7 @@ public class CalciteQueryTest
 
     try (DruidPlanner planner = plannerFactory.createPlanner(queryContext)) {
       final PlannerResult plan = planner.plan(sql, null, authenticationResult);
-      return Sequences.toList(plan.run(), Lists.newArrayList());
+      return plan.run().toList();
     }
   }
 


### PR DESCRIPTION
 - Added `IndexedInts.debugToString()`. Configure your IDE to render `IndexedInts` impls using this method during debug.
 - Added `toString()` to `QueryableIndex` and `IncrementalIndex` via `AbstractIndex`

Unrelated:

 - Added `Sequence.toList()` and `limit()`, simplify code.