### PR TITLE
Remove Aggregator.reset()

### DIFF
--- a/extensions-contrib/distinctcount/src/main/java/io/druid/query/aggregation/distinctcount/DistinctCountAggregator.java
+++ b/extensions-contrib/distinctcount/src/main/java/io/druid/query/aggregation/distinctcount/DistinctCountAggregator.java
@@ -50,12 +50,6 @@ public class DistinctCountAggregator implements Aggregator
   }
 
   @Override
-  public void reset()
-  {
-    mutableBitmap.clear();
-  }
-
-  @Override
   public Object get()
   {
     return mutableBitmap.size();

--- a/extensions-contrib/distinctcount/src/main/java/io/druid/query/aggregation/distinctcount/EmptyDistinctCountAggregator.java
+++ b/extensions-contrib/distinctcount/src/main/java/io/druid/query/aggregation/distinctcount/EmptyDistinctCountAggregator.java
@@ -34,11 +34,6 @@ public class EmptyDistinctCountAggregator implements Aggregator
   }
 
   @Override
-  public void reset()
-  {
-  }
-
-  @Override
   public Object get()
   {
     return 0L;

--- a/extensions-contrib/time-min-max/src/main/java/io/druid/query/aggregation/TimestampAggregator.java
+++ b/extensions-contrib/time-min-max/src/main/java/io/druid/query/aggregation/TimestampAggregator.java
@@ -59,7 +59,7 @@ public class TimestampAggregator implements Aggregator
     this.comparator = comparator;
     this.initValue = initValue;
 
-    reset();
+    most = this.initValue;
   }
 
   @Override
@@ -70,12 +70,6 @@ public class TimestampAggregator implements Aggregator
     if (value != null) {
       most = comparator.compare(most, value) > 0 ? most : value;
     }
-  }
-
-  @Override
-  public void reset()
-  {
-    most = initValue;
   }
 
   @Override

--- a/extensions-contrib/time-min-max/src/test/java/io/druid/query/aggregation/TimestampMinMaxAggregatorTest.java
+++ b/extensions-contrib/time-min-max/src/test/java/io/druid/query/aggregation/TimestampMinMaxAggregatorTest.java
@@ -134,15 +134,13 @@ public class TimestampMinMaxAggregatorTest
   {
     TimestampAggregator aggregator = (TimestampAggregator) aggregatorFactory.factorize(selectorFactory);
 
-    for (Timestamp value: values) {
+    Assert.assertEquals(initValue, aggregator.get());
+
+    for (Timestamp value : values) {
       aggregate(selector, aggregator);
     }
 
     Assert.assertEquals(expected, new Timestamp(aggregator.getLong()));
-
-    aggregator.reset();
-
-    Assert.assertEquals(initValue, aggregator.get());
   }
 
   @Test

--- a/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/quantiles/DoublesSketchBuildAggregator.java
+++ b/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/quantiles/DoublesSketchBuildAggregator.java
@@ -64,12 +64,6 @@ public class DoublesSketchBuildAggregator implements Aggregator
   }
 
   @Override
-  public synchronized void reset()
-  {
-    sketch = UpdateDoublesSketch.builder().setK(size).build();
-  }
-
-  @Override
   public synchronized void close()
   {
     sketch = null;

--- a/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/quantiles/DoublesSketchMergeAggregator.java
+++ b/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/quantiles/DoublesSketchMergeAggregator.java
@@ -66,12 +66,6 @@ public class DoublesSketchMergeAggregator implements Aggregator
   }
 
   @Override
-  public synchronized void reset()
-  {
-    union.reset();
-  }
-
-  @Override
   public synchronized void close()
   {
     union = null;

--- a/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/quantiles/DoublesSketchNoOpAggregator.java
+++ b/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/quantiles/DoublesSketchNoOpAggregator.java
@@ -36,11 +36,6 @@ public class DoublesSketchNoOpAggregator implements Aggregator
   }
 
   @Override
-  public void reset()
-  {
-  }
-
-  @Override
   public void close()
   {
   }

--- a/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchAggregator.java
+++ b/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchAggregator.java
@@ -59,14 +59,6 @@ public class SketchAggregator implements Aggregator
   }
 
   @Override
-  public void reset()
-  {
-    if (union != null) {
-      union.reset();
-    }
-  }
-
-  @Override
   public Object get()
   {
     if (union == null) {

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregator.java
@@ -69,12 +69,6 @@ public class ApproximateHistogramAggregator implements Aggregator
   }
 
   @Override
-  public void reset()
-  {
-    this.histogram = new ApproximateHistogram(resolution, lowerLimit, upperLimit);
-  }
-
-  @Override
   public Object get()
   {
     return histogram;

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregator.java
@@ -67,12 +67,6 @@ public class ApproximateHistogramFoldingAggregator implements Aggregator
   }
 
   @Override
-  public void reset()
-  {
-    this.histogram = new ApproximateHistogram(resolution, lowerLimit, upperLimit);
-  }
-
-  @Override
   public Object get()
   {
     return histogram;

--- a/extensions-core/stats/src/main/java/io/druid/query/aggregation/variance/VarianceAggregator.java
+++ b/extensions-core/stats/src/main/java/io/druid/query/aggregation/variance/VarianceAggregator.java
@@ -35,12 +35,6 @@ public abstract class VarianceAggregator implements Aggregator
   }
 
   @Override
-  public void reset()
-  {
-    holder.reset();
-  }
-
-  @Override
   public Object get()
   {
     return holder;

--- a/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceAggregatorTest.java
+++ b/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceAggregatorTest.java
@@ -83,9 +83,6 @@ public class VarianceAggregatorTest
     assertValues((VarianceAggregatorCollector) agg.get(), 3, 7.3d, 2.9866d);
     aggregate(selector, agg);
     assertValues((VarianceAggregatorCollector) agg.get(), 4, 8.6d, 3.95d);
-
-    agg.reset();
-    assertValues((VarianceAggregatorCollector) agg.get(), 0, 0d, 0d);
   }
 
   private void assertValues(VarianceAggregatorCollector holder, long count, double sum, double nvariance)

--- a/processing/src/main/java/io/druid/query/aggregation/Aggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/Aggregator.java
@@ -37,10 +37,7 @@ import java.io.Closeable;
 public interface Aggregator extends Closeable
 {
   void aggregate();
-  /** @deprecated unused, to be removed in Druid 0.12 (or hopefully the whole Aggregator class is removed) */
-  @Deprecated
-  @SuppressWarnings("unused")
-  void reset();
+
   @Nullable
   Object get();
   float getFloat();

--- a/processing/src/main/java/io/druid/query/aggregation/CountAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/CountAggregator.java
@@ -45,12 +45,6 @@ public class CountAggregator implements Aggregator
   }
 
   @Override
-  public void reset()
-  {
-    count = 0;
-  }
-
-  @Override
   public Object get()
   {
     return count;

--- a/processing/src/main/java/io/druid/query/aggregation/DoubleMaxAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/DoubleMaxAggregator.java
@@ -37,20 +37,13 @@ public class DoubleMaxAggregator implements Aggregator
   public DoubleMaxAggregator(BaseDoubleColumnValueSelector selector)
   {
     this.selector = selector;
-
-    reset();
+    this.max = Double.NEGATIVE_INFINITY;
   }
 
   @Override
   public void aggregate()
   {
     max = Math.max(max, selector.getDouble());
-  }
-
-  @Override
-  public void reset()
-  {
-    max = Double.NEGATIVE_INFINITY;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/DoubleMinAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/DoubleMinAggregator.java
@@ -37,20 +37,13 @@ public class DoubleMinAggregator implements Aggregator
   public DoubleMinAggregator(BaseDoubleColumnValueSelector selector)
   {
     this.selector = selector;
-
-    reset();
+    this.min = Double.POSITIVE_INFINITY;
   }
 
   @Override
   public void aggregate()
   {
     min = Math.min(min, selector.getDouble());
-  }
-
-  @Override
-  public void reset()
-  {
-    min = Double.POSITIVE_INFINITY;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/DoubleSumAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/DoubleSumAggregator.java
@@ -61,12 +61,6 @@ public class DoubleSumAggregator implements Aggregator
   }
 
   @Override
-  public void reset()
-  {
-    sum = 0;
-  }
-
-  @Override
   public Object get()
   {
     return sum;

--- a/processing/src/main/java/io/druid/query/aggregation/FilteredAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/FilteredAggregator.java
@@ -41,12 +41,6 @@ public class FilteredAggregator implements Aggregator
   }
 
   @Override
-  public void reset()
-  {
-    delegate.reset();
-  }
-
-  @Override
   public Object get()
   {
     return delegate.get();

--- a/processing/src/main/java/io/druid/query/aggregation/FloatMaxAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/FloatMaxAggregator.java
@@ -37,20 +37,13 @@ public class FloatMaxAggregator implements Aggregator
   public FloatMaxAggregator(BaseFloatColumnValueSelector selector)
   {
     this.selector = selector;
-
-    reset();
+    this.max = Float.NEGATIVE_INFINITY;
   }
 
   @Override
   public void aggregate()
   {
     max = Math.max(max, selector.getFloat());
-  }
-
-  @Override
-  public void reset()
-  {
-    max = Float.NEGATIVE_INFINITY;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/FloatMinAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/FloatMinAggregator.java
@@ -37,20 +37,13 @@ public class FloatMinAggregator implements Aggregator
   public FloatMinAggregator(BaseFloatColumnValueSelector selector)
   {
     this.selector = selector;
-
-    reset();
+    this.min = Float.POSITIVE_INFINITY;
   }
 
   @Override
   public void aggregate()
   {
     min = Math.min(min, selector.getFloat());
-  }
-
-  @Override
-  public void reset()
-  {
-    min = Float.POSITIVE_INFINITY;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/FloatSumAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/FloatSumAggregator.java
@@ -60,12 +60,6 @@ public class FloatSumAggregator implements Aggregator
   }
 
   @Override
-  public void reset()
-  {
-    sum = 0;
-  }
-
-  @Override
   public Object get()
   {
     return sum;

--- a/processing/src/main/java/io/druid/query/aggregation/HistogramAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/HistogramAggregator.java
@@ -57,12 +57,6 @@ public class HistogramAggregator implements Aggregator
   }
 
   @Override
-  public void reset()
-  {
-    this.histogram = new Histogram(histogram.breaks);
-  }
-
-  @Override
   public Object get()
   {
     return this.histogram;

--- a/processing/src/main/java/io/druid/query/aggregation/JavaScriptAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/JavaScriptAggregator.java
@@ -56,12 +56,6 @@ public class JavaScriptAggregator implements Aggregator
   }
 
   @Override
-  public void reset()
-  {
-    current = script.reset();
-  }
-
-  @Override
   public Object get()
   {
     return current;

--- a/processing/src/main/java/io/druid/query/aggregation/LongMaxAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/LongMaxAggregator.java
@@ -41,20 +41,13 @@ public class LongMaxAggregator implements Aggregator
   public LongMaxAggregator(BaseLongColumnValueSelector selector)
   {
     this.selector = selector;
-
-    reset();
+    this.max = Long.MIN_VALUE;
   }
 
   @Override
   public void aggregate()
   {
     max = Math.max(max, selector.getLong());
-  }
-
-  @Override
-  public void reset()
-  {
-    max = Long.MIN_VALUE;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/LongMinAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/LongMinAggregator.java
@@ -41,20 +41,13 @@ public class LongMinAggregator implements Aggregator
   public LongMinAggregator(BaseLongColumnValueSelector selector)
   {
     this.selector = selector;
-
-    reset();
+    this.min = Long.MAX_VALUE;
   }
 
   @Override
   public void aggregate()
   {
     min = Math.min(min, selector.getLong());
-  }
-
-  @Override
-  public void reset()
-  {
-    min = Long.MAX_VALUE;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/LongSumAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/LongSumAggregator.java
@@ -60,12 +60,6 @@ public class LongSumAggregator implements Aggregator
   }
 
   @Override
-  public void reset()
-  {
-    sum = 0;
-  }
-
-  @Override
   public Object get()
   {
     return sum;

--- a/processing/src/main/java/io/druid/query/aggregation/NoopAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/NoopAggregator.java
@@ -38,11 +38,6 @@ public final class NoopAggregator implements Aggregator
   }
 
   @Override
-  public void reset()
-  {
-  }
-
-  @Override
   public Object get()
   {
     return null;

--- a/processing/src/main/java/io/druid/query/aggregation/cardinality/CardinalityAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/cardinality/CardinalityAggregator.java
@@ -101,12 +101,6 @@ public class CardinalityAggregator implements Aggregator
   }
 
   @Override
-  public void reset()
-  {
-    collector = HyperLogLogCollector.makeLatestCollector();
-  }
-
-  @Override
   public Object get()
   {
     // Workaround for non-thread-safe use of HyperLogLogCollector.

--- a/processing/src/main/java/io/druid/query/aggregation/first/DoubleFirstAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/first/DoubleFirstAggregator.java
@@ -38,7 +38,8 @@ public class DoubleFirstAggregator implements Aggregator
     this.valueSelector = valueSelector;
     this.timeSelector = timeSelector;
 
-    reset();
+    firstTime = Long.MAX_VALUE;
+    firstValue = 0;
   }
 
   @Override
@@ -49,13 +50,6 @@ public class DoubleFirstAggregator implements Aggregator
       firstTime = time;
       firstValue = valueSelector.getDouble();
     }
-  }
-
-  @Override
-  public void reset()
-  {
-    firstTime = Long.MAX_VALUE;
-    firstValue = 0;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/first/FloatFirstAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/first/FloatFirstAggregator.java
@@ -41,7 +41,8 @@ public class FloatFirstAggregator implements Aggregator
     this.valueSelector = valueSelector;
     this.timeSelector = timeSelector;
 
-    reset();
+    firstTime = Long.MAX_VALUE;
+    firstValue = 0;
   }
 
   @Override
@@ -52,13 +53,6 @@ public class FloatFirstAggregator implements Aggregator
       firstTime = time;
       firstValue = valueSelector.getFloat();
     }
-  }
-
-  @Override
-  public void reset()
-  {
-    firstTime = Long.MAX_VALUE;
-    firstValue = 0;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/first/LongFirstAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/first/LongFirstAggregator.java
@@ -37,7 +37,8 @@ public class LongFirstAggregator implements Aggregator
     this.valueSelector = valueSelector;
     this.timeSelector = timeSelector;
 
-    reset();
+    firstTime = Long.MAX_VALUE;
+    firstValue = 0;
   }
 
   @Override
@@ -48,13 +49,6 @@ public class LongFirstAggregator implements Aggregator
       firstTime = time;
       firstValue = valueSelector.getLong();
     }
-  }
-
-  @Override
-  public void reset()
-  {
-    firstTime = Long.MAX_VALUE;
-    firstValue = 0;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregator.java
@@ -51,12 +51,6 @@ public class HyperUniquesAggregator implements Aggregator
     collector.fold((HyperLogLogCollector) object);
   }
 
-  @Override
-  public void reset()
-  {
-    collector = null;
-  }
-
   @Nullable
   @Override
   public Object get()

--- a/processing/src/main/java/io/druid/query/aggregation/last/DoubleLastAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/last/DoubleLastAggregator.java
@@ -38,7 +38,8 @@ public class DoubleLastAggregator implements Aggregator
     this.valueSelector = valueSelector;
     this.timeSelector = timeSelector;
 
-    reset();
+    lastTime = Long.MIN_VALUE;
+    lastValue = 0;
   }
 
   @Override
@@ -49,13 +50,6 @@ public class DoubleLastAggregator implements Aggregator
       lastTime = time;
       lastValue = valueSelector.getDouble();
     }
-  }
-
-  @Override
-  public void reset()
-  {
-    lastTime = Long.MIN_VALUE;
-    lastValue = 0;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/last/FloatLastAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/last/FloatLastAggregator.java
@@ -38,7 +38,8 @@ public class FloatLastAggregator implements Aggregator
     this.valueSelector = valueSelector;
     this.timeSelector = timeSelector;
 
-    reset();
+    lastTime = Long.MIN_VALUE;
+    lastValue = 0;
   }
 
   @Override
@@ -49,13 +50,6 @@ public class FloatLastAggregator implements Aggregator
       lastTime = time;
       lastValue = valueSelector.getFloat();
     }
-  }
-
-  @Override
-  public void reset()
-  {
-    lastTime = Long.MIN_VALUE;
-    lastValue = 0;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/last/LongLastAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/last/LongLastAggregator.java
@@ -36,7 +36,8 @@ public class LongLastAggregator implements Aggregator
     this.valueSelector = valueSelector;
     this.timeSelector = timeSelector;
 
-    reset();
+    lastTime = Long.MIN_VALUE;
+    lastValue = 0;
   }
 
   @Override
@@ -47,13 +48,6 @@ public class LongLastAggregator implements Aggregator
       lastTime = time;
       lastValue = valueSelector.getLong();
     }
-  }
-
-  @Override
-  public void reset()
-  {
-    lastTime = Long.MIN_VALUE;
-    lastValue = 0;
   }
 
   @Override

--- a/processing/src/test/java/io/druid/query/aggregation/DoubleMaxAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/DoubleMaxAggregationTest.java
@@ -67,9 +67,6 @@ public class DoubleMaxAggregationTest
     Assert.assertEquals(values[2], ((Double) agg.get()).doubleValue(), 0.0001);
     Assert.assertEquals((long) values[2], agg.getLong());
     Assert.assertEquals(values[2], agg.getFloat(), 0.0001);
-
-    agg.reset();
-    Assert.assertEquals(Double.NEGATIVE_INFINITY, (Double) agg.get(), 0.0001);
   }
 
   @Test

--- a/processing/src/test/java/io/druid/query/aggregation/DoubleMinAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/DoubleMinAggregationTest.java
@@ -67,9 +67,6 @@ public class DoubleMinAggregationTest
     Assert.assertEquals(values[2], ((Double) agg.get()).doubleValue(), 0.0001);
     Assert.assertEquals((long) values[2], agg.getLong());
     Assert.assertEquals(values[2], agg.getFloat(), 0.0001);
-
-    agg.reset();
-    Assert.assertEquals(Double.POSITIVE_INFINITY, (Double) agg.get(), 0.0001);
   }
 
   @Test

--- a/processing/src/test/java/io/druid/query/aggregation/JavaScriptAggregatorTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/JavaScriptAggregatorTest.java
@@ -125,8 +125,6 @@ public class JavaScriptAggregatorTest
         )
     );
 
-    agg.reset();
-
     double val = 10.;
     Assert.assertEquals(val, agg.get());
     Assert.assertEquals(val, agg.get());
@@ -199,7 +197,6 @@ public class JavaScriptAggregatorTest
 
     final double val = 0;
 
-    agg.reset();
     Assert.assertEquals(val, agg.get());
     Assert.assertEquals(val, agg.get());
     Assert.assertEquals(val, agg.get());
@@ -229,8 +226,6 @@ public class JavaScriptAggregatorTest
             scriptDoubleSum.get("fnCombine")
         )
     );
-
-    agg.reset();
 
     double val = 0.;
     Assert.assertEquals(val, agg.get());

--- a/processing/src/test/java/io/druid/query/aggregation/LongMaxAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/LongMaxAggregationTest.java
@@ -67,9 +67,6 @@ public class LongMaxAggregationTest
     Assert.assertEquals(values[2], ((Long) agg.get()).longValue());
     Assert.assertEquals(values[2], agg.getLong());
     Assert.assertEquals((float) values[2], agg.getFloat(), 0.0001);
-
-    agg.reset();
-    Assert.assertEquals(Long.MIN_VALUE, agg.getLong());
   }
 
   @Test

--- a/processing/src/test/java/io/druid/query/aggregation/LongMinAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/LongMinAggregationTest.java
@@ -67,9 +67,6 @@ public class LongMinAggregationTest
     Assert.assertEquals(values[2], ((Long) agg.get()).longValue());
     Assert.assertEquals(values[2], agg.getLong());
     Assert.assertEquals((float) values[2], agg.getFloat(), 0.0001);
-
-    agg.reset();
-    Assert.assertEquals(Long.MAX_VALUE, agg.getLong());
   }
 
   @Test

--- a/processing/src/test/java/io/druid/query/aggregation/first/DoubleFirstAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/first/DoubleFirstAggregationTest.java
@@ -84,9 +84,6 @@ public class DoubleFirstAggregationTest
     Assert.assertEquals(doubleValues[1], result.rhs, 0.0001);
     Assert.assertEquals((long) doubleValues[1], agg.getLong());
     Assert.assertEquals(doubleValues[1], agg.getDouble(), 0.0001);
-
-    agg.reset();
-    Assert.assertEquals(0, ((Pair<Long, Double>) agg.get()).rhs, 0.0001);
   }
 
   @Test
@@ -136,9 +133,6 @@ public class DoubleFirstAggregationTest
     Assert.assertEquals(expected.rhs, result.rhs, 0.0001);
     Assert.assertEquals(expected.rhs.longValue(), agg.getLong());
     Assert.assertEquals(expected.rhs, agg.getDouble(), 0.0001);
-
-    agg.reset();
-    Assert.assertEquals(0, ((Pair<Long, Double>) agg.get()).rhs, 0.0001);
   }
 
   @Test

--- a/processing/src/test/java/io/druid/query/aggregation/first/FloatFirstAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/first/FloatFirstAggregationTest.java
@@ -84,9 +84,6 @@ public class FloatFirstAggregationTest
     Assert.assertEquals(floats[1], result.rhs, 0.0001);
     Assert.assertEquals((long) floats[1], agg.getLong());
     Assert.assertEquals(floats[1], agg.getFloat(), 0.0001);
-
-    agg.reset();
-    Assert.assertEquals(0, ((Pair<Long, Float>) agg.get()).rhs, 0.0001);
   }
 
   @Test
@@ -136,9 +133,6 @@ public class FloatFirstAggregationTest
     Assert.assertEquals(expected.rhs, result.rhs, 0.0001);
     Assert.assertEquals(expected.rhs.longValue(), agg.getLong());
     Assert.assertEquals(expected.rhs, agg.getFloat(), 0.0001);
-
-    agg.reset();
-    Assert.assertEquals(0, ((Pair<Long, Float>) agg.get()).rhs, 0.0001);
   }
 
   @Test

--- a/processing/src/test/java/io/druid/query/aggregation/first/LongFirstAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/first/LongFirstAggregationTest.java
@@ -83,9 +83,6 @@ public class LongFirstAggregationTest
     Assert.assertEquals(longValues[3], result.rhs.longValue());
     Assert.assertEquals(longValues[3], agg.getLong());
     Assert.assertEquals(longValues[3], agg.getFloat(), 0.0001);
-
-    agg.reset();
-    Assert.assertEquals(0, ((Pair<Long, Long>) agg.get()).rhs, 0.0001);
   }
 
   @Test
@@ -135,9 +132,6 @@ public class LongFirstAggregationTest
     Assert.assertEquals(expected.rhs, result.rhs);
     Assert.assertEquals(expected.rhs.longValue(), agg.getLong());
     Assert.assertEquals(expected.rhs, agg.getFloat(), 0.0001);
-
-    agg.reset();
-    Assert.assertEquals(0, ((Pair<Long, Long>) agg.get()).rhs, 0.0001);
   }
 
   @Test

--- a/processing/src/test/java/io/druid/query/aggregation/last/DoubleLastAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/last/DoubleLastAggregationTest.java
@@ -84,9 +84,6 @@ public class DoubleLastAggregationTest
     Assert.assertEquals(doubles[0], result.rhs, 0.0001);
     Assert.assertEquals((long) doubles[0], agg.getLong());
     Assert.assertEquals(doubles[0], agg.getDouble(), 0.0001);
-
-    agg.reset();
-    Assert.assertEquals(0, ((Pair<Long, Double>) agg.get()).rhs, 0.0001);
   }
 
   @Test
@@ -136,9 +133,6 @@ public class DoubleLastAggregationTest
     Assert.assertEquals(expected.rhs, result.rhs, 0.0001);
     Assert.assertEquals(expected.rhs.longValue(), agg.getLong());
     Assert.assertEquals(expected.rhs, agg.getDouble(), 0.0001);
-
-    agg.reset();
-    Assert.assertEquals(0, ((Pair<Long, Double>) agg.get()).rhs, 0.0001);
   }
 
   @Test

--- a/processing/src/test/java/io/druid/query/aggregation/last/FloatLastAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/last/FloatLastAggregationTest.java
@@ -84,9 +84,6 @@ public class FloatLastAggregationTest
     Assert.assertEquals(floats[0], result.rhs, 0.0001);
     Assert.assertEquals((long) floats[0], agg.getLong());
     Assert.assertEquals(floats[0], agg.getFloat(), 0.0001);
-
-    agg.reset();
-    Assert.assertEquals(0, ((Pair<Long, Float>) agg.get()).rhs, 0.0001);
   }
 
   @Test
@@ -136,9 +133,6 @@ public class FloatLastAggregationTest
     Assert.assertEquals(expected.rhs, result.rhs, 0.0001);
     Assert.assertEquals(expected.rhs.longValue(), agg.getLong());
     Assert.assertEquals(expected.rhs, agg.getFloat(), 0.0001);
-
-    agg.reset();
-    Assert.assertEquals(0, ((Pair<Long, Float>) agg.get()).rhs, 0.0001);
   }
 
   @Test

--- a/processing/src/test/java/io/druid/query/aggregation/last/LongLastAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/last/LongLastAggregationTest.java
@@ -83,9 +83,6 @@ public class LongLastAggregationTest
     Assert.assertEquals(longValues[2], result.rhs.longValue());
     Assert.assertEquals(longValues[2], agg.getLong());
     Assert.assertEquals(longValues[2], agg.getFloat(), 1);
-
-    agg.reset();
-    Assert.assertEquals(0, ((Pair<Long, Long>) agg.get()).rhs.longValue());
   }
 
   @Test
@@ -135,9 +132,6 @@ public class LongLastAggregationTest
     Assert.assertEquals(expected.rhs, result.rhs);
     Assert.assertEquals(expected.rhs.longValue(), agg.getLong());
     Assert.assertEquals(expected.rhs, agg.getFloat(), 1);
-
-    agg.reset();
-    Assert.assertEquals(0, ((Pair<Long, Long>) agg.get()).rhs.longValue());
   }
 
   @Test


### PR DESCRIPTION
This method was scheduled for removal in Druid 0.12.