### PR TITLE
small optimization in timeseries if 'skipEmptyBuckets' is true and cursor completed

### DIFF
--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryEngine.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryEngine.java
@@ -62,16 +62,16 @@ public class TimeseriesQueryEngine
           @Override
           public Result<TimeseriesResultValue> apply(Cursor cursor)
           {
+            if (skipEmptyBuckets && cursor.isDone()) {
+              return null;
+            }
+
             Aggregator[] aggregators = new Aggregator[aggregatorSpecs.size()];
             String[] aggregatorNames = new String[aggregatorSpecs.size()];
 
             for (int i = 0; i < aggregatorSpecs.size(); i++) {
               aggregators[i] = aggregatorSpecs.get(i).factorize(cursor.getColumnSelectorFactory());
               aggregatorNames[i] = aggregatorSpecs.get(i).getName();
-            }
-
-            if (skipEmptyBuckets && cursor.isDone()) {
-              return null;
             }
 
             try {


### PR DESCRIPTION
Re-arrange some code in `TimeseriesQueryEngine` in order to not do work/allocate space then immediately throw away when `skipEmptyBuckets` is set and `Cursor.isDone()`. Gains will likely be very small because the empty case is not a major driver in overall query time, but every little bit counts.