### PR TITLE
use java pointed by JAVA_HOME when it is set

### DIFF
--- a/examples/bin/node.sh
+++ b/examples/bin/node.sh
@@ -40,7 +40,13 @@ case $command in
     fi
     if [ ! -d "$PID_DIR" ]; then mkdir -p $PID_DIR; fi
     if [ ! -d "$LOG_DIR" ]; then mkdir -p $LOG_DIR; fi
-    nohup java `cat $CONF_DIR/$nodeType/jvm.config | xargs` -cp $CONF_DIR/_common:$CONF_DIR/$nodeType:$LIB_DIR/*:$HADOOP_CONF_DIR io.druid.cli.Main server $nodeType >> $LOG_DIR/$nodeType.log &
+
+    JAVA=java
+    if [ "$JAVA_HOME" != "" ]; then
+      JAVA=$JAVA_HOME/bin/java
+    fi
+
+    nohup $JAVA `cat $CONF_DIR/$nodeType/jvm.config | xargs` -cp $CONF_DIR/_common:$CONF_DIR/$nodeType:$LIB_DIR/*:$HADOOP_CONF_DIR io.druid.cli.Main server $nodeType >> $LOG_DIR/$nodeType.log 2>&1 &
     nodeType_PID=$!
     echo $nodeType_PID > $pid
     echo "Started $nodeType node ($nodeType_PID)"


### PR DESCRIPTION
If user has explicitly set JAVA_HOME env variable, use the java version pointed by JAVA_HOME instead of system default. 