### PR TITLE
Support replaceExisting parameter for segments pushers

### DIFF
--- a/extensions-contrib/azure-extensions/src/main/java/io/druid/storage/azure/AzureDataSegmentPusher.java
+++ b/extensions-contrib/azure-extensions/src/main/java/io/druid/storage/azure/AzureDataSegmentPusher.java
@@ -109,12 +109,13 @@ public class AzureDataSegmentPusher implements DataSegmentPusher
       final long size,
       final File compressedSegmentData,
       final File descriptorFile,
-      final Map<String, String> azurePaths
+      final Map<String, String> azurePaths,
+      final boolean replaceExisting
   )
       throws StorageException, IOException, URISyntaxException
   {
-    azureStorage.uploadBlob(compressedSegmentData, config.getContainer(), azurePaths.get("index"));
-    azureStorage.uploadBlob(descriptorFile, config.getContainer(), azurePaths.get("descriptor"));
+    azureStorage.uploadBlob(compressedSegmentData, config.getContainer(), azurePaths.get("index"), replaceExisting);
+    azureStorage.uploadBlob(descriptorFile, config.getContainer(), azurePaths.get("descriptor"), replaceExisting);
 
     final DataSegment outSegment = segment
         .withSize(size)
@@ -131,9 +132,9 @@ public class AzureDataSegmentPusher implements DataSegmentPusher
   }
 
   @Override
-  public DataSegment push(final File indexFilesDir, final DataSegment segment) throws IOException
+  public DataSegment push(final File indexFilesDir, final DataSegment segment, final boolean replaceExisting)
+      throws IOException
   {
-
     log.info("Uploading [%s] to Azure.", indexFilesDir);
 
     final int version = SegmentUtils.getVersionFromDir(indexFilesDir);
@@ -153,7 +154,7 @@ public class AzureDataSegmentPusher implements DataSegmentPusher
             @Override
             public DataSegment call() throws Exception
             {
-              return uploadDataSegment(segment, version, size, outFile, descFile, azurePaths);
+              return uploadDataSegment(segment, version, size, outFile, descFile, azurePaths, replaceExisting);
             }
           },
           config.getMaxTries()

--- a/extensions-contrib/azure-extensions/src/main/java/io/druid/storage/azure/AzureStorage.java
+++ b/extensions-contrib/azure-extensions/src/main/java/io/druid/storage/azure/AzureStorage.java
@@ -25,7 +25,6 @@ import com.microsoft.azure.storage.blob.CloudBlobClient;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
 import com.microsoft.azure.storage.blob.ListBlobItem;
-
 import io.druid.java.util.common.logger.Logger;
 
 import java.io.File;
@@ -81,14 +80,24 @@ public class AzureStorage
 
   }
 
-  public void uploadBlob(final File file, final String containerName, final String blobPath)
+  public void uploadBlob(
+      final File file,
+      final String containerName,
+      final String blobPath,
+      final boolean replaceExisting
+  )
       throws IOException, StorageException, URISyntaxException
 
   {
     CloudBlobContainer container = getCloudBlobContainer(containerName);
     try (FileInputStream stream = new FileInputStream(file)) {
       CloudBlockBlob blob = container.getBlockBlobReference(blobPath);
-      blob.upload(stream, file.length());
+
+      if (!replaceExisting && blob.exists()) {
+        log.info("Skipping push because blob [%s] exists && replaceExisting == false", blobPath);
+      } else {
+        blob.upload(stream, file.length());
+      }
     }
   }
 

--- a/extensions-contrib/azure-extensions/src/main/java/io/druid/storage/azure/AzureTaskLogs.java
+++ b/extensions-contrib/azure-extensions/src/main/java/io/druid/storage/azure/AzureTaskLogs.java
@@ -59,7 +59,7 @@ public class AzureTaskLogs implements TaskLogs
     try {
       AzureUtils.retryAzureOperation(
           (Callable<Void>) () -> {
-            azureStorage.uploadBlob(logFile, config.getContainer(), taskKey);
+            azureStorage.uploadBlob(logFile, config.getContainer(), taskKey, true);
             return null;
           },
           config.getMaxTries()

--- a/extensions-contrib/azure-extensions/src/test/java/io/druid/storage/azure/AzureDataSegmentPusherTest.java
+++ b/extensions-contrib/azure-extensions/src/test/java/io/druid/storage/azure/AzureDataSegmentPusherTest.java
@@ -104,7 +104,7 @@ public class AzureDataSegmentPusherTest extends EasyMockSupport
         size
     );
 
-    DataSegment segment = pusher.push(tempFolder.getRoot(), segmentToPush);
+    DataSegment segment = pusher.push(tempFolder.getRoot(), segmentToPush, true);
 
     Assert.assertEquals(segmentToPush.getSize(), segment.getSize());
   }
@@ -133,9 +133,9 @@ public class AzureDataSegmentPusherTest extends EasyMockSupport
     final File descriptorFile = new File("descriptor.json");
     final Map<String, String> azurePaths = pusher.getAzurePaths(dataSegment);
 
-    azureStorage.uploadBlob(compressedSegmentData, containerName, azurePaths.get("index"));
+    azureStorage.uploadBlob(compressedSegmentData, containerName, azurePaths.get("index"), true);
     expectLastCall();
-    azureStorage.uploadBlob(descriptorFile, containerName, azurePaths.get("descriptor"));
+    azureStorage.uploadBlob(descriptorFile, containerName, azurePaths.get("descriptor"), true);
     expectLastCall();
 
     replayAll();
@@ -146,7 +146,8 @@ public class AzureDataSegmentPusherTest extends EasyMockSupport
         0, // empty file
         compressedSegmentData,
         descriptorFile,
-        azurePaths
+        azurePaths,
+        true
     );
 
     assertEquals(compressedSegmentData.length(), pushedDataSegment.getSize());

--- a/extensions-contrib/azure-extensions/src/test/java/io/druid/storage/azure/AzureTaskLogsTest.java
+++ b/extensions-contrib/azure-extensions/src/test/java/io/druid/storage/azure/AzureTaskLogsTest.java
@@ -65,7 +65,7 @@ public class AzureTaskLogsTest extends EasyMockSupport
     try {
       final File logFile = new File(tmpDir, "log");
 
-      azureStorage.uploadBlob(logFile, container, prefix + "/" + taskid + "/log");
+      azureStorage.uploadBlob(logFile, container, prefix + "/" + taskid + "/log", true);
       expectLastCall();
 
       replayAll();

--- a/extensions-contrib/cloudfiles-extensions/src/main/java/io/druid/storage/cloudfiles/CloudFilesDataSegmentPusher.java
+++ b/extensions-contrib/cloudfiles-extensions/src/main/java/io/druid/storage/cloudfiles/CloudFilesDataSegmentPusher.java
@@ -74,7 +74,8 @@ public class CloudFilesDataSegmentPusher implements DataSegmentPusher
   }
 
   @Override
-  public DataSegment push(final File indexFilesDir, final DataSegment inSegment) throws IOException
+  public DataSegment push(final File indexFilesDir, final DataSegment inSegment, final boolean replaceExisting)
+      throws IOException
   {
     final String segmentPath = CloudFilesUtils.buildCloudFilesPath(this.config.getBasePath(), getStorageDir(inSegment));
 
@@ -98,18 +99,23 @@ public class CloudFilesDataSegmentPusher implements DataSegmentPusher
                   segmentPath, outFile, objectApi.getRegion(),
                   objectApi.getContainer()
               );
-              log.info("Pushing %s.", segmentData.getPath());
-              objectApi.put(segmentData);
 
-              // Avoid using Guava in DataSegmentPushers because they might be used with very diverse Guava versions in
-              // runtime, and because Guava deletes methods over time, that causes incompatibilities.
-              Files.write(descFile.toPath(), jsonMapper.writeValueAsBytes(inSegment));
-              CloudFilesObject descriptorData = new CloudFilesObject(
-                  segmentPath, descFile,
-                  objectApi.getRegion(), objectApi.getContainer()
-              );
-              log.info("Pushing %s.", descriptorData.getPath());
-              objectApi.put(descriptorData);
+              if (!replaceExisting && objectApi.exists(segmentData.getPath())) {
+                log.info("Skipping push because object [%s] exists && replaceExisting == false", segmentData.getPath());
+              } else {
+                log.info("Pushing %s.", segmentData.getPath());
+                objectApi.put(segmentData);
+
+                // Avoid using Guava in DataSegmentPushers because they might be used with very diverse Guava versions in
+                // runtime, and because Guava deletes methods over time, that causes incompatibilities.
+                Files.write(descFile.toPath(), jsonMapper.writeValueAsBytes(inSegment));
+                CloudFilesObject descriptorData = new CloudFilesObject(
+                    segmentPath, descFile,
+                    objectApi.getRegion(), objectApi.getContainer()
+                );
+                log.info("Pushing %s.", descriptorData.getPath());
+                objectApi.put(descriptorData);
+              }
 
               final DataSegment outSegment = inSegment
                   .withSize(indexSize)

--- a/extensions-contrib/cloudfiles-extensions/src/main/java/io/druid/storage/cloudfiles/CloudFilesObjectApiProxy.java
+++ b/extensions-contrib/cloudfiles-extensions/src/main/java/io/druid/storage/cloudfiles/CloudFilesObjectApiProxy.java
@@ -58,4 +58,9 @@ public class CloudFilesObjectApiProxy
     Payload payload = swiftObject.getPayload();
     return new CloudFilesObject(payload, this.region, this.container, path);
   }
+
+  public boolean exists(String path)
+  {
+    return objectApi.getWithoutBody(path) != null;
+  }
 }

--- a/extensions-contrib/cloudfiles-extensions/src/test/java/io/druid/storage/cloudfiles/CloudFilesDataSegmentPusherTest.java
+++ b/extensions-contrib/cloudfiles-extensions/src/test/java/io/druid/storage/cloudfiles/CloudFilesDataSegmentPusherTest.java
@@ -84,7 +84,7 @@ public class CloudFilesDataSegmentPusherTest
         size
     );
 
-    DataSegment segment = pusher.push(tempFolder.getRoot(), segmentToPush);
+    DataSegment segment = pusher.push(tempFolder.getRoot(), segmentToPush, true);
 
     Assert.assertEquals(segmentToPush.getSize(), segment.getSize());
 

--- a/extensions-contrib/google-extensions/src/main/java/io/druid/storage/google/GoogleDataSegmentPusher.java
+++ b/extensions-contrib/google-extensions/src/main/java/io/druid/storage/google/GoogleDataSegmentPusher.java
@@ -93,7 +93,8 @@ public class GoogleDataSegmentPusher implements DataSegmentPusher
     return descriptorFile;
   }
 
-  public void insert(final File file, final String contentType, final String path) throws IOException
+  public void insert(final File file, final String contentType, final String path, final boolean replaceExisting)
+      throws IOException
   {
     LOG.info("Inserting [%s] to [%s]", file, path);
 
@@ -102,11 +103,16 @@ public class GoogleDataSegmentPusher implements DataSegmentPusher
     InputStreamContent mediaContent = new InputStreamContent(contentType, fileSteam);
     mediaContent.setLength(file.length());
 
-    storage.insert(config.getBucket(), path, mediaContent);
+    if (!replaceExisting && storage.exists(config.getBucket(), path)) {
+      LOG.info("Skipping push because path [%s] exists && replaceExisting == false", path);
+    } else {
+      storage.insert(config.getBucket(), path, mediaContent);
+    }
   }
 
   @Override
-  public DataSegment push(final File indexFilesDir, final DataSegment segment) throws IOException
+  public DataSegment push(final File indexFilesDir, final DataSegment segment, final boolean replaceExisting)
+      throws IOException
   {
     LOG.info("Uploading [%s] to Google.", indexFilesDir);
 
@@ -128,8 +134,8 @@ public class GoogleDataSegmentPusher implements DataSegmentPusher
 
       descriptorFile = createDescriptorFile(jsonMapper, outSegment);
 
-      insert(indexFile, "application/zip", indexPath);
-      insert(descriptorFile, "application/json", descriptorPath);
+      insert(indexFile, "application/zip", indexPath, replaceExisting);
+      insert(descriptorFile, "application/json", descriptorPath, replaceExisting);
 
       return outSegment;
     }

--- a/extensions-contrib/google-extensions/src/test/java/io/druid/storage/google/GoogleDataSegmentPusherTest.java
+++ b/extensions-contrib/google-extensions/src/test/java/io/druid/storage/google/GoogleDataSegmentPusherTest.java
@@ -103,20 +103,30 @@ public class GoogleDataSegmentPusherTest extends EasyMockSupport
         storage,
         googleAccountConfig,
          jsonMapper
-    ).addMockedMethod("insert", File.class, String.class, String.class).createMock();
+    ).addMockedMethod("insert", File.class, String.class, String.class, boolean.class).createMock();
 
     final String storageDir = pusher.getStorageDir(segmentToPush);
     final String indexPath = prefix + "/" + storageDir + "/" + "index.zip";
     final String descriptorPath = prefix + "/" + storageDir + "/" + "descriptor.json";
 
-    pusher.insert(EasyMock.anyObject(File.class), EasyMock.eq("application/zip"), EasyMock.eq(indexPath));
+    pusher.insert(
+        EasyMock.anyObject(File.class),
+        EasyMock.eq("application/zip"),
+        EasyMock.eq(indexPath),
+        EasyMock.eq(true)
+    );
     expectLastCall();
-    pusher.insert(EasyMock.anyObject(File.class), EasyMock.eq("application/json"), EasyMock.eq(descriptorPath));
+    pusher.insert(
+        EasyMock.anyObject(File.class),
+        EasyMock.eq("application/json"),
+        EasyMock.eq(descriptorPath),
+        EasyMock.eq(true)
+    );
     expectLastCall();
 
     replayAll();
 
-    DataSegment segment = pusher.push(tempFolder.getRoot(), segmentToPush);
+    DataSegment segment = pusher.push(tempFolder.getRoot(), segmentToPush, true);
 
     Assert.assertEquals(segmentToPush.getSize(), segment.getSize());
     Assert.assertEquals(segmentToPush, segment);

--- a/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsDataSegmentPusher.java
+++ b/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsDataSegmentPusher.java
@@ -89,7 +89,7 @@ public class HdfsDataSegmentPusher implements DataSegmentPusher
   }
 
   @Override
-  public DataSegment push(File inDir, DataSegment segment) throws IOException
+  public DataSegment push(File inDir, DataSegment segment, boolean replaceExisting) throws IOException
   {
     final String storageDir = this.getStorageDir(segment);
 
@@ -145,8 +145,8 @@ public class HdfsDataSegmentPusher implements DataSegmentPusher
 
       // Create parent if it does not exist, recreation is not an error
       fs.mkdirs(outIndexFile.getParent());
-      copyFilesWithChecks(fs, tmpDescriptorFile, outDescriptorFile);
-      copyFilesWithChecks(fs, tmpIndexFile, outIndexFile);
+      copyFilesWithChecks(fs, tmpDescriptorFile, outDescriptorFile, replaceExisting);
+      copyFilesWithChecks(fs, tmpIndexFile, outIndexFile, replaceExisting);
     }
     finally {
       try {
@@ -162,9 +162,10 @@ public class HdfsDataSegmentPusher implements DataSegmentPusher
     return dataSegment;
   }
 
-  private void copyFilesWithChecks(final FileSystem fs, final Path from, final Path to) throws IOException
+  private void copyFilesWithChecks(final FileSystem fs, final Path from, final Path to, final boolean replaceExisting)
+      throws IOException
   {
-    if (!HadoopFsWrapper.rename(fs, from, to)) {
+    if (!HadoopFsWrapper.rename(fs, from, to, replaceExisting)) {
       if (fs.exists(to)) {
         log.info(
             "Unable to rename temp Index file[%s] to final segment path [%s]. "

--- a/extensions-core/hdfs-storage/src/main/java/org/apache/hadoop/fs/HadoopFsWrapper.java
+++ b/extensions-core/hdfs-storage/src/main/java/org/apache/hadoop/fs/HadoopFsWrapper.java
@@ -36,23 +36,25 @@ public class HadoopFsWrapper
   private HadoopFsWrapper() {}
 
   /**
-   * Same as FileSystem.rename(from, to, Options.Rename.NONE) . That is,
-   * it returns "false" when "to" directory already exists. It is different from FileSystem.rename(from, to)
-   * which moves "from" directory inside "to" directory if it already exists.
+   * Same as FileSystem.rename(from, to, Options.Rename). It is different from FileSystem.rename(from, to) which moves
+   * "from" directory inside "to" directory if it already exists.
    *
    * @param from
    * @param to
-   * @return
-   * @throws IOException
+   * @param replaceExisting if existing files should be overwritten
+   *
+   * @return true if operation succeeded, false if replaceExisting == false and destination already exists
+   *
+   * @throws IOException if trying to overwrite a non-empty directory
    */
-  public static boolean rename(FileSystem fs, Path from, Path to) throws IOException
+  public static boolean rename(FileSystem fs, Path from, Path to, boolean replaceExisting) throws IOException
   {
     try {
-      fs.rename(from, to, Options.Rename.NONE);
+      fs.rename(from, to, replaceExisting ? Options.Rename.OVERWRITE : Options.Rename.NONE);
       return true;
     }
-    catch (IOException ex) {
-      log.warn(ex, "Failed to rename [%s] to [%s].", from, to);
+    catch (FileAlreadyExistsException ex) {
+      log.info(ex, "Destination exists while renaming [%s] to [%s]", from, to);
       return false;
     }
   }

--- a/extensions-core/hdfs-storage/src/test/java/io/druid/storage/hdfs/HdfsDataSegmentPusherTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/io/druid/storage/hdfs/HdfsDataSegmentPusherTest.java
@@ -161,7 +161,7 @@ public class HdfsDataSegmentPusherTest
         size
     );
 
-    DataSegment segment = pusher.push(segmentDir, segmentToPush);
+    DataSegment segment = pusher.push(segmentDir, segmentToPush, true);
 
 
     String indexUri = StringUtils.format(
@@ -201,7 +201,7 @@ public class HdfsDataSegmentPusherTest
     File outDir = new File(StringUtils.format("%s/%s", config.getStorageDirectory(), segmentPath));
     outDir.setReadOnly();
     try {
-      pusher.push(segmentDir, segmentToPush);
+      pusher.push(segmentDir, segmentToPush, true);
     }
     catch (IOException e) {
       Assert.fail("should not throw exception");
@@ -246,7 +246,7 @@ public class HdfsDataSegmentPusherTest
     }
 
     for (int i = 0; i < numberOfSegments; i++) {
-      final DataSegment pushedSegment = pusher.push(segmentDir, segments[i]);
+      final DataSegment pushedSegment = pusher.push(segmentDir, segments[i], true);
 
       String indexUri = StringUtils.format(
           "%s/%s/%d_index.zip",
@@ -308,7 +308,7 @@ public class HdfsDataSegmentPusherTest
       File outDir = new File(StringUtils.format("%s/%s", config.getStorageDirectory(), segmentPath));
       outDir.setReadOnly();
       try {
-        pusher.push(segmentDir, segments[i]);
+        pusher.push(segmentDir, segments[i], true);
       }
       catch (IOException e) {
         Assert.fail("should not throw exception");

--- a/extensions-core/s3-extensions/src/main/java/io/druid/storage/s3/S3DataSegmentPusher.java
+++ b/extensions-core/s3-extensions/src/main/java/io/druid/storage/s3/S3DataSegmentPusher.java
@@ -30,7 +30,6 @@ import io.druid.java.util.common.StringUtils;
 import io.druid.segment.SegmentUtils;
 import io.druid.segment.loading.DataSegmentPusher;
 import io.druid.timeline.DataSegment;
-import org.jets3t.service.S3ServiceException;
 import org.jets3t.service.ServiceException;
 import org.jets3t.service.acl.gs.GSAccessControlList;
 import org.jets3t.service.impl.rest.httpclient.RestS3Service;
@@ -171,7 +170,7 @@ public class S3DataSegmentPusher implements DataSegmentPusher
   }
 
   private void putObject(String bucketName, String path, S3Object object, boolean replaceExisting)
-      throws S3ServiceException
+      throws ServiceException
   {
     object.setBucketName(bucketName);
     object.setKey(path);
@@ -181,21 +180,10 @@ public class S3DataSegmentPusher implements DataSegmentPusher
 
     log.info("Pushing %s.", object);
 
-    if (!replaceExisting && doesObjectExist(bucketName, object.getKey())) {
+    if (!replaceExisting && S3Utils.isObjectInBucket(s3Client, bucketName, object.getKey())) {
       log.info("Skipping push because key [%s] exists && replaceExisting == false", object.getKey());
     } else {
       s3Client.putObject(bucketName, object);
-    }
-  }
-
-  private boolean doesObjectExist(String bucketName, String objectKey)
-  {
-    try {
-      s3Client.getObjectDetails(bucketName, objectKey);
-      return true;
-    }
-    catch (ServiceException e) {
-      return false;
     }
   }
 }

--- a/extensions-core/s3-extensions/src/test/java/io/druid/storage/s3/S3DataSegmentPusherTest.java
+++ b/extensions-core/s3-extensions/src/test/java/io/druid/storage/s3/S3DataSegmentPusherTest.java
@@ -113,7 +113,7 @@ public class S3DataSegmentPusherTest
         size
     );
 
-    DataSegment segment = pusher.push(tempFolder.getRoot(), segmentToPush);
+    DataSegment segment = pusher.push(tempFolder.getRoot(), segmentToPush, true);
 
     Assert.assertEquals(segmentToPush.getSize(), segment.getSize());
     Assert.assertEquals(1, (int) segment.getBinaryVersion());

--- a/indexing-service/src/main/java/io/druid/indexing/common/index/YeOldePlumberSchool.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/index/YeOldePlumberSchool.java
@@ -199,7 +199,7 @@ public class YeOldePlumberSchool implements PlumberSchool
                                                      .withDimensions(ImmutableList.copyOf(mappedSegment.getAvailableDimensions()))
                                                      .withBinaryVersion(SegmentUtils.getVersionFromDir(fileToUpload));
 
-          dataSegmentPusher.push(fileToUpload, segmentToUpload);
+          dataSegmentPusher.push(fileToUpload, segmentToUpload, false);
 
           log.info(
               "Uploaded segment[%s]",

--- a/indexing-service/src/main/java/io/druid/indexing/common/index/YeOldePlumberSchool.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/index/YeOldePlumberSchool.java
@@ -199,7 +199,10 @@ public class YeOldePlumberSchool implements PlumberSchool
                                                      .withDimensions(ImmutableList.copyOf(mappedSegment.getAvailableDimensions()))
                                                      .withBinaryVersion(SegmentUtils.getVersionFromDir(fileToUpload));
 
-          dataSegmentPusher.push(fileToUpload, segmentToUpload, false);
+          // This plumber is only used in batch ingestion situations where you do not have replica tasks pushing
+          // segments with the same identifier but potentially different contents. In case of conflict, favor the most
+          // recently pushed segment (replaceExisting == true).
+          dataSegmentPusher.push(fileToUpload, segmentToUpload, true);
 
           log.info(
               "Uploaded segment[%s]",

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/ConvertSegmentTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/ConvertSegmentTask.java
@@ -440,7 +440,7 @@ public class ConvertSegmentTask extends AbstractFixedIntervalTask
         // Appending to the version makes a new version that inherits most comparability parameters of the original
         // version, but is "newer" than said original version.
         DataSegment updatedSegment = segment.withVersion(StringUtils.format("%s_v%s", segment.getVersion(), outVersion));
-        updatedSegment = toolbox.getSegmentPusher().push(outLocation, updatedSegment);
+        updatedSegment = toolbox.getSegmentPusher().push(outLocation, updatedSegment, true);
 
         actionClient.submit(new SegmentInsertAction(Sets.newHashSet(updatedSegment)));
       } else {

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/ConvertSegmentTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/ConvertSegmentTask.java
@@ -440,6 +440,10 @@ public class ConvertSegmentTask extends AbstractFixedIntervalTask
         // Appending to the version makes a new version that inherits most comparability parameters of the original
         // version, but is "newer" than said original version.
         DataSegment updatedSegment = segment.withVersion(StringUtils.format("%s_v%s", segment.getVersion(), outVersion));
+
+        // The convert segment task does not support replicas where different tasks could generate segments with the
+        // same identifier but potentially different contents. In case of conflict, favor the most recently pushed
+        // segment (replaceExisting == true).
         updatedSegment = toolbox.getSegmentPusher().push(outLocation, updatedSegment, true);
 
         actionClient.submit(new SegmentInsertAction(Sets.newHashSet(updatedSegment)));

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/MergeTaskBase.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/MergeTaskBase.java
@@ -185,6 +185,10 @@ public abstract class MergeTaskBase extends AbstractFixedIntervalTask
       long uploadStart = System.currentTimeMillis();
 
       // Upload file
+
+      // The merge task does not support replicas where different tasks could generate segments with the
+      // same identifier but potentially different contents. In case of conflict, favor the most recently pushed
+      // segment (replaceExisting == true).
       final DataSegment uploadedSegment = toolbox.getSegmentPusher().push(fileToUpload, mergedSegment, true);
 
       emitter.emit(builder.build("merger/uploadTime", System.currentTimeMillis() - uploadStart));

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/MergeTaskBase.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/MergeTaskBase.java
@@ -185,7 +185,7 @@ public abstract class MergeTaskBase extends AbstractFixedIntervalTask
       long uploadStart = System.currentTimeMillis();
 
       // Upload file
-      final DataSegment uploadedSegment = toolbox.getSegmentPusher().push(fileToUpload, mergedSegment);
+      final DataSegment uploadedSegment = toolbox.getSegmentPusher().push(fileToUpload, mergedSegment, true);
 
       emitter.emit(builder.build("merger/uploadTime", System.currentTimeMillis() - uploadStart));
       emitter.emit(builder.build("merger/mergeSize", uploadedSegment.getSize()));

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/IndexTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/IndexTaskTest.java
@@ -1006,7 +1006,7 @@ public class IndexTaskTest
       }
 
       @Override
-      public DataSegment push(File file, DataSegment segment) throws IOException
+      public DataSegment push(File file, DataSegment segment, boolean replaceExisting) throws IOException
       {
         segments.add(segment);
         return segment;

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/SameIntervalMergeTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/SameIntervalMergeTaskTest.java
@@ -201,7 +201,7 @@ public class SameIntervalMergeTaskTest
               }
 
               @Override
-              public DataSegment push(File file, DataSegment segment) throws IOException
+              public DataSegment push(File file, DataSegment segment, boolean replaceExisting) throws IOException
               {
                 // the merged segment is pushed to storage
                 segments.add(segment);

--- a/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
@@ -249,7 +249,7 @@ public class IngestSegmentFirehoseFactoryTest
           }
 
           @Override
-          public DataSegment push(File file, DataSegment segment) throws IOException
+          public DataSegment push(File file, DataSegment segment, boolean replaceExisting) throws IOException
           {
             return segment;
           }

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLifecycleTest.java
@@ -484,7 +484,7 @@ public class TaskLifecycleTest
       }
 
       @Override
-      public DataSegment push(File file, DataSegment segment) throws IOException
+      public DataSegment push(File file, DataSegment segment, boolean replaceExisting) throws IOException
       {
         pushedSegments++;
         return segment;
@@ -1033,7 +1033,7 @@ public class TaskLifecycleTest
       }
 
       @Override
-      public DataSegment push(File file, DataSegment dataSegment) throws IOException
+      public DataSegment push(File file, DataSegment dataSegment, boolean replaceExisting) throws IOException
       {
         throw new RuntimeException("FAILURE");
       }

--- a/indexing-service/src/test/java/io/druid/indexing/test/TestDataSegmentPusher.java
+++ b/indexing-service/src/test/java/io/druid/indexing/test/TestDataSegmentPusher.java
@@ -48,7 +48,7 @@ public class TestDataSegmentPusher implements DataSegmentPusher
   }
 
   @Override
-  public DataSegment push(File file, DataSegment segment) throws IOException
+  public DataSegment push(File file, DataSegment segment, boolean replaceExisting) throws IOException
   {
     pushedSegments.add(segment);
     return segment;

--- a/java-util/src/main/java/io/druid/java/util/common/CompressionUtils.java
+++ b/java-util/src/main/java/io/druid/java/util/common/CompressionUtils.java
@@ -48,9 +48,38 @@ public class CompressionUtils
 {
   private static final Logger log = new Logger(CompressionUtils.class);
   private static final int DEFAULT_RETRY_COUNT = 3;
+  private static final String GZ_SUFFIX = ".gz";
+  private static final String ZIP_SUFFIX = ".zip";
 
-  public static final String GZ_SUFFIX = ".gz";
-  public static final String ZIP_SUFFIX = ".zip";
+  /**
+   * Zip the contents of directory into the file indicated by outputZipFile. Sub directories are skipped
+   *
+   * @param directory     The directory whose contents should be added to the zip in the output stream.
+   * @param outputZipFile The output file to write the zipped data to
+   * @param fsync         True if the output file should be fsynced to disk
+   *
+   * @return The number of bytes (uncompressed) read from the input directory.
+   *
+   * @throws IOException
+   */
+  public static long zip(File directory, File outputZipFile, boolean fsync) throws IOException
+  {
+    if (!isZip(outputZipFile.getName())) {
+      log.warn("No .zip suffix[%s], putting files from [%s] into it anyway.", outputZipFile, directory);
+    }
+
+    try (final FileOutputStream out = new FileOutputStream(outputZipFile)) {
+      long bytes = zip(directory, out);
+
+      // For explanation of why fsyncing here is a good practice:
+      // https://github.com/druid-io/druid/pull/5187#pullrequestreview-85188984
+      if (fsync) {
+        out.getChannel().force(true);
+      }
+
+      return bytes;
+    }
+  }
 
   /**
    * Zip the contents of directory into the file indicated by outputZipFile. Sub directories are skipped
@@ -64,20 +93,14 @@ public class CompressionUtils
    */
   public static long zip(File directory, File outputZipFile) throws IOException
   {
-    if (!isZip(outputZipFile.getName())) {
-      log.warn("No .zip suffix[%s], putting files from [%s] into it anyway.", outputZipFile, directory);
-    }
-
-    try (final FileOutputStream out = new FileOutputStream(outputZipFile)) {
-      return zip(directory, out);
-    }
+    return zip(directory, outputZipFile, false);
   }
 
   /**
    * Zips the contents of the input directory to the output stream. Sub directories are skipped
    *
    * @param directory The directory whose contents should be added to the zip in the output stream.
-   * @param out       The output stream to write the zip data to. It is closed in the process
+   * @param out       The output stream to write the zip data to. Caller is responsible for closing this stream.
    *
    * @return The number of bytes (uncompressed) read from the input directory.
    *
@@ -88,28 +111,23 @@ public class CompressionUtils
     if (!directory.isDirectory()) {
       throw new IOE("directory[%s] is not a directory", directory);
     }
-    final File[] files = directory.listFiles();
+
+    final ZipOutputStream zipOut = new ZipOutputStream(out);
 
     long totalSize = 0;
-    try (final ZipOutputStream zipOut = new ZipOutputStream(out)) {
-      for (File file : files) {
-        log.info("Adding file[%s] with size[%,d].  Total size so far[%,d]", file, file.length(), totalSize);
-        if (file.length() >= Integer.MAX_VALUE) {
-          zipOut.finish();
-          throw new IOE("file[%s] too large [%,d]", file, file.length());
-        }
-        zipOut.putNextEntry(new ZipEntry(file.getName()));
-        totalSize += Files.asByteSource(file).copyTo(zipOut);
+    for (File file : directory.listFiles()) {
+      log.info("Adding file[%s] with size[%,d].  Total size so far[%,d]", file, file.length(), totalSize);
+      if (file.length() >= Integer.MAX_VALUE) {
+        zipOut.finish();
+        throw new IOE("file[%s] too large [%,d]", file, file.length());
       }
-      zipOut.closeEntry();
-      // Workaround for http://hg.openjdk.java.net/jdk8/jdk8/jdk/rev/759aa847dcaf
-      zipOut.flush();
-
-      // fsync needs to happen before the FileOutputStream is closed by the try-with-resources
-      if (out instanceof FileOutputStream) {
-        ((FileOutputStream) out).getChannel().force(true);
-      }
+      zipOut.putNextEntry(new ZipEntry(file.getName()));
+      totalSize += Files.asByteSource(file).copyTo(zipOut);
     }
+    zipOut.closeEntry();
+    // Workaround for http://hg.openjdk.java.net/jdk8/jdk8/jdk/rev/759aa847dcaf
+    zipOut.flush();
+    zipOut.finish();
 
     return totalSize;
   }

--- a/java-util/src/main/java/io/druid/java/util/common/CompressionUtils.java
+++ b/java-util/src/main/java/io/druid/java/util/common/CompressionUtils.java
@@ -102,8 +102,13 @@ public class CompressionUtils
         totalSize += Files.asByteSource(file).copyTo(zipOut);
       }
       zipOut.closeEntry();
-      // Workarround for http://hg.openjdk.java.net/jdk8/jdk8/jdk/rev/759aa847dcaf
+      // Workaround for http://hg.openjdk.java.net/jdk8/jdk8/jdk/rev/759aa847dcaf
       zipOut.flush();
+
+      // fsync needs to happen before the FileOutputStream is closed by the try-with-resources
+      if (out instanceof FileOutputStream) {
+        ((FileOutputStream) out).getChannel().force(true);
+      }
     }
 
     return totalSize;

--- a/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -635,7 +635,8 @@ public class AppenderatorImpl implements Appenderator
       final DataSegment segment = RetryUtils.retry(
           () -> dataSegmentPusher.push(
               mergedFile,
-              sink.getSegment().withDimensions(IndexMerger.getMergedDimensionsFromQueryableIndexes(indexes))
+              sink.getSegment().withDimensions(IndexMerger.getMergedDimensionsFromQueryableIndexes(indexes)),
+              true
           ),
           exception -> exception instanceof Exception,
           5

--- a/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -556,6 +556,10 @@ public class AppenderatorImpl implements Appenderator
    * Merge segment, push to deep storage. Should only be used on segments that have been fully persisted. Must only
    * be run in the single-threaded pushExecutor.
    *
+   * Note that this calls DataSegmentPusher.push() with replaceExisting == true which is appropriate for the indexing
+   * tasks it is currently being used for (local indexing and Kafka indexing). If this is going to be used by an
+   * indexing task type that requires replaceExisting == false, this setting will need to be pushed to the caller.
+   *
    * @param identifier sink identifier
    * @param sink       sink to push
    *

--- a/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -444,6 +444,13 @@ public class RealtimePlumber implements Plumber
 
               log.info("Pushing [%s] to deep storage", sink.getSegment().getIdentifier());
 
+              // The realtime plumber can generate segments with the same identifier (i.e. replica tasks) but does not
+              // have any strict requirement that the contents of these segments be identical. It is possible that two
+              // tasks generate a segment with the same identifier containing different data, and in this situation we
+              // want to favor the data from the task which pushed first. This is because it is possible that one
+              // historical could load the segment after the first task pushed and another historical load the same
+              // segment after the second task pushed. If the second task's segment overwrote the first one, the second
+              // historical node would be serving different data from the first. Hence set replaceExisting == false.
               DataSegment segment = dataSegmentPusher.push(
                   mergedFile,
                   sink.getSegment().withDimensions(IndexMerger.getMergedDimensionsFromQueryableIndexes(indexes)),

--- a/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -446,7 +446,8 @@ public class RealtimePlumber implements Plumber
 
               DataSegment segment = dataSegmentPusher.push(
                   mergedFile,
-                  sink.getSegment().withDimensions(IndexMerger.getMergedDimensionsFromQueryableIndexes(indexes))
+                  sink.getSegment().withDimensions(IndexMerger.getMergedDimensionsFromQueryableIndexes(indexes)),
+                  false
               );
               log.info("Inserting [%s] to the metadata store", sink.getSegment().getIdentifier());
               segmentPublisher.publishSegment(segment);

--- a/server/src/test/java/io/druid/segment/loading/LocalDataSegmentPusherTest.java
+++ b/server/src/test/java/io/druid/segment/loading/LocalDataSegmentPusherTest.java
@@ -23,11 +23,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Files;
 import com.google.common.primitives.Ints;
+import io.druid.java.util.common.CompressionUtils;
 import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.StringUtils;
 import io.druid.segment.TestHelper;
 import io.druid.timeline.DataSegment;
 import io.druid.timeline.partition.NoneShardSpec;
+import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -54,7 +56,18 @@ public class LocalDataSegmentPusherTest
       Intervals.utc(0, 1),
       "v1",
       null,
+      ImmutableList.of("dim1"),
       null,
+      NoneShardSpec.instance(),
+      null,
+      -1
+  );
+  DataSegment dataSegment2 = new DataSegment(
+      "ds",
+      Intervals.utc(0, 1),
+      "v1",
+      null,
+      ImmutableList.of("dim2"),
       null,
       NoneShardSpec.instance(),
       null,
@@ -106,14 +119,45 @@ public class LocalDataSegmentPusherTest
   }
 
   @Test
-  public void testFirstPushWinsForConcurrentPushes() throws IOException
+  public void testFirstPushWinsForConcurrentPushesWhenReplaceExistingFalse() throws IOException
+  {
+    File replicatedDataSegmentFiles = temporaryFolder.newFolder();
+    Files.asByteSink(new File(replicatedDataSegmentFiles, "version.bin")).write(Ints.toByteArray(0x8));
+    DataSegment returnSegment1 = localDataSegmentPusher.push(dataSegmentFiles, dataSegment, false);
+    DataSegment returnSegment2 = localDataSegmentPusher.push(replicatedDataSegmentFiles, dataSegment2, false);
+
+    Assert.assertEquals(dataSegment.getDimensions(), returnSegment1.getDimensions());
+    Assert.assertEquals(dataSegment.getDimensions(), returnSegment2.getDimensions());
+
+    File unzipDir = new File(config.storageDirectory, "unzip");
+    FileUtils.forceMkdir(unzipDir);
+    CompressionUtils.unzip(
+        new File(config.storageDirectory, "/ds/1970-01-01T00:00:00.000Z_1970-01-01T00:00:00.001Z/v1/0/index.zip"),
+        unzipDir
+    );
+
+    Assert.assertEquals(0x9, Ints.fromByteArray(Files.toByteArray(new File(unzipDir, "version.bin"))));
+  }
+
+  @Test
+  public void testLastPushWinsForConcurrentPushesWhenReplaceExistingTrue() throws IOException
   {
     File replicatedDataSegmentFiles = temporaryFolder.newFolder();
     Files.asByteSink(new File(replicatedDataSegmentFiles, "version.bin")).write(Ints.toByteArray(0x8));
     DataSegment returnSegment1 = localDataSegmentPusher.push(dataSegmentFiles, dataSegment, true);
-    DataSegment returnSegment2 = localDataSegmentPusher.push(replicatedDataSegmentFiles, dataSegment, true);
+    DataSegment returnSegment2 = localDataSegmentPusher.push(replicatedDataSegmentFiles, dataSegment2, true);
 
-    Assert.assertEquals(returnSegment1, returnSegment2);
+    Assert.assertEquals(dataSegment.getDimensions(), returnSegment1.getDimensions());
+    Assert.assertEquals(dataSegment2.getDimensions(), returnSegment2.getDimensions());
+
+    File unzipDir = new File(config.storageDirectory, "unzip");
+    FileUtils.forceMkdir(unzipDir);
+    CompressionUtils.unzip(
+        new File(config.storageDirectory, "/ds/1970-01-01T00:00:00.000Z_1970-01-01T00:00:00.001Z/v1/0/index.zip"),
+        unzipDir
+    );
+
+    Assert.assertEquals(0x8, Ints.fromByteArray(Files.toByteArray(new File(unzipDir, "version.bin"))));
   }
 
   @Test

--- a/server/src/test/java/io/druid/segment/loading/LocalDataSegmentPusherTest.java
+++ b/server/src/test/java/io/druid/segment/loading/LocalDataSegmentPusherTest.java
@@ -79,8 +79,8 @@ public class LocalDataSegmentPusherTest
       */
     final DataSegment dataSegment2 = dataSegment.withVersion("v2");
 
-    DataSegment returnSegment1 = localDataSegmentPusher.push(dataSegmentFiles, dataSegment);
-    DataSegment returnSegment2 = localDataSegmentPusher.push(dataSegmentFiles, dataSegment2);
+    DataSegment returnSegment1 = localDataSegmentPusher.push(dataSegmentFiles, dataSegment, true);
+    DataSegment returnSegment2 = localDataSegmentPusher.push(dataSegmentFiles, dataSegment2, true);
 
     Assert.assertNotNull(returnSegment1);
     Assert.assertEquals(dataSegment, returnSegment1);
@@ -110,8 +110,8 @@ public class LocalDataSegmentPusherTest
   {
     File replicatedDataSegmentFiles = temporaryFolder.newFolder();
     Files.asByteSink(new File(replicatedDataSegmentFiles, "version.bin")).write(Ints.toByteArray(0x8));
-    DataSegment returnSegment1 = localDataSegmentPusher.push(dataSegmentFiles, dataSegment);
-    DataSegment returnSegment2 = localDataSegmentPusher.push(replicatedDataSegmentFiles, dataSegment);
+    DataSegment returnSegment1 = localDataSegmentPusher.push(dataSegmentFiles, dataSegment, true);
+    DataSegment returnSegment2 = localDataSegmentPusher.push(replicatedDataSegmentFiles, dataSegment, true);
 
     Assert.assertEquals(returnSegment1, returnSegment2);
   }
@@ -124,7 +124,7 @@ public class LocalDataSegmentPusherTest
     config.storageDirectory = new File(config.storageDirectory, "xxx");
     Assert.assertTrue(config.storageDirectory.mkdir());
     config.storageDirectory.setWritable(false);
-    localDataSegmentPusher.push(dataSegmentFiles, dataSegment);
+    localDataSegmentPusher.push(dataSegmentFiles, dataSegment, true);
   }
 
   @Test

--- a/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorTester.java
+++ b/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorTester.java
@@ -193,7 +193,7 @@ public class AppenderatorTester implements AutoCloseable
       }
 
       @Override
-      public DataSegment push(File file, DataSegment segment) throws IOException
+      public DataSegment push(File file, DataSegment segment, boolean replaceExisting) throws IOException
       {
         if (enablePushFailure && mustFail) {
           mustFail = false;

--- a/services/src/main/java/io/druid/cli/CliRealtimeExample.java
+++ b/services/src/main/java/io/druid/cli/CliRealtimeExample.java
@@ -155,7 +155,7 @@ public class CliRealtimeExample extends ServerRunnable
     }
 
     @Override
-    public DataSegment push(File file, DataSegment segment) throws IOException
+    public DataSegment push(File file, DataSegment segment, boolean replaceExisting) throws IOException
     {
       return segment;
     }


### PR DESCRIPTION
AppenderatorImpl (used by Kafka indexing, local indexing) uses replaceExisting=true, RealtimePlumber uses replaceExisting=false. See #5161 for details on the issue.

Fixes #5161.

This PR breaks compatibility with implementations of `DataSegmentPusher`. The signature for: 
```
DataSegment push(File file, DataSegment segment) throws IOException
```

has changed to:

```
DataSegment push(File file, DataSegment segment, boolean replaceExisting) throws IOException;
```