### PR TITLE
Fix max connections in DruidAvaticaHandlerTest

### DIFF
--- a/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
+++ b/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
@@ -96,7 +96,7 @@ public class DruidAvaticaHandlerTest
     @Override
     public int getMaxConnections()
     {
-      return 2;
+      return 3;
     }
 
     @Override

--- a/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
+++ b/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
@@ -96,6 +96,7 @@ public class DruidAvaticaHandlerTest
     @Override
     public int getMaxConnections()
     {
+      // This must match the number of Connection objects created in setUp()
       return 3;
     }
 
@@ -687,7 +688,7 @@ public class DruidAvaticaHandlerTest
 
     final Connection connection3 = DriverManager.getConnection(url);
     connection3.createStatement().close();
-    
+
     final Connection connection4 = DriverManager.getConnection(url);
     Assert.assertTrue(true);
   }

--- a/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
+++ b/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
@@ -667,9 +667,13 @@ public class DruidAvaticaHandlerTest
     final Connection connection2 = DriverManager.getConnection(url);
     final Statement statement2 = connection2.createStatement();
 
-    expectedException.expect(AvaticaClientRuntimeException.class);
-    expectedException.expectMessage("Too many connections, limit is[2]");
     final Connection connection3 = DriverManager.getConnection(url);
+    final Statement statement3 = connection3.createStatement();
+
+    expectedException.expect(AvaticaClientRuntimeException.class);
+    expectedException.expectMessage("Too many connections, limit is[3]");
+
+    final Connection connection4 = DriverManager.getConnection(url);
   }
 
   @Test
@@ -682,6 +686,9 @@ public class DruidAvaticaHandlerTest
     connection2.createStatement().close();
 
     final Connection connection3 = DriverManager.getConnection(url);
+    connection3.createStatement().close();
+    
+    final Connection connection4 = DriverManager.getConnection(url);
     Assert.assertTrue(true);
   }
 


### PR DESCRIPTION
Fixes #5183 

DruidAvaticaHandlerTest uses 3 Connections (client, superuserClient, and clientLosAngeles) but the connection limit was set at 2.

This was causing testConcurrentQueries to fail sometimes when `client` (the connection object used by the test) was cleared from the connection map, and the multiple concurrent threads attempted to re-open the connection