### PR TITLE
fixed missing gz extension from wikiticker json example

### DIFF
--- a/examples/quickstart/wikiticker-index.json
+++ b/examples/quickstart/wikiticker-index.json
@@ -5,7 +5,7 @@
       "type" : "hadoop",
       "inputSpec" : {
         "type" : "static",
-        "paths" : "quickstart/wikiticker-2015-09-12-sampled.json"
+        "paths" : "quickstart/wikiticker-2015-09-12-sampled.json.gz"
       }
     },
     "dataSchema" : {


### PR DESCRIPTION
fixed missing gz extension from wikiticker json quickstart example
Without this fix running the quickstart will fails with the exception

2017-12-24T19:02:25,097 ERROR [task-runner-0-priority-0] io.druid.indexing.overlord.ThreadPoolTaskRunner - Exception while running task[HadoopIndexTask{id=index_hadoop_wikiticker_2017-12-24T19:02:12.487Z, type=index_hadoop, dataSource=wikiticker}]
...
...
Caused by: java.lang.RuntimeException: org.apache.hadoop.mapreduce.lib.input.InvalidInputException: Input path does not exist: .../quickstart/wikiticker-2015-09-12-sampled.json
...