### PR TITLE
docs: fix broken link to ingestions and tasks on the Druid Concepts page

### DIFF
--- a/docs/content/design/index.md
+++ b/docs/content/design/index.md
@@ -150,3 +150,4 @@ Druid is designed to have no single point of failure. Different node types are a
 ### Comprehensive Architecture
 
 For a comprehensive look at Druid architecture, please read our [white paper](http://static.druid.io/docs/druid.pdf).
+

--- a/docs/content/design/index.md
+++ b/docs/content/design/index.md
@@ -84,11 +84,11 @@ Hence, Druid ingestion specs define this granularity as the `queryGranularity` o
 
 Druid supports two roll-up modes, i.e., _perfect roll-up_ and _best-effort roll-up_. In the perfect roll-up mode, Druid guarantees that input data are perfectly aggregated at ingestion time. Meanwhile, in the best-effort roll-up, input data might not be perfectly aggregated and thus there can be multiple segments holding the rows which should belong to the same segment with the perfect roll-up since they have the same dimension value and their timestamps fall into the same interval.
 
-The perfect roll-up mode encompasses an additional preprocessing step to determine intervals and shardSpecs before actual data ingestion if they are not specified in the ingestionSpec. This preprocessing step usually scans the entire input data which might increase the ingestion time. The [Hadoop indexing task](./ingestion/batch-ingestion.html) always runs with this perfect roll-up mode.
+The perfect roll-up mode encompasses an additional preprocessing step to determine intervals and shardSpecs before actual data ingestion if they are not specified in the ingestionSpec. This preprocessing step usually scans the entire input data which might increase the ingestion time. The [Hadoop indexing task](../ingestion/batch-ingestion.html) always runs with this perfect roll-up mode.
 
-On the contrary, the best-effort roll-up mode doesn't require any preprocessing step, but the size of ingested data might be larger than that of the perfect roll-up. All types of [streaming indexing (i.e., realtime index task, kafka indexing service, ...)](./ingestion/stream-ingestion.html) run with this mode.
+On the contrary, the best-effort roll-up mode doesn't require any preprocessing step, but the size of ingested data might be larger than that of the perfect roll-up. All types of [streaming indexing (i.e., realtime index task, kafka indexing service, ...)](../ingestion/stream-ingestion.html) run with this mode.
 
-Finally, the [native index task](./ingestion/tasks.html) supports both modes and you can choose either one which fits to your application.
+Finally, the [native index task](../ingestion/tasks.html) supports both modes and you can choose either one which fits to your application.
 
 ## Indexing the Data
 
@@ -150,4 +150,3 @@ Druid is designed to have no single point of failure. Different node types are a
 ### Comprehensive Architecture
 
 For a comprehensive look at Druid architecture, please read our [white paper](http://static.druid.io/docs/druid.pdf).
-


### PR DESCRIPTION
I fixed broken link to ingestions and tasks on the Druid Concepts page.

Please check this Pull Request.
Thank you.