### PR TITLE
Fix state check bug in Kafka Index Task

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisor.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisor.java
@@ -670,7 +670,7 @@ public class KafkaSupervisor implements Supervisor
         // as when the task starts they are sent existing checkpoints
         Preconditions.checkState(
             checkpoints.size() <= 1,
-            "Got checkpoint request with null as previous check point, however found more than one checkpoints in metadata store"
+            "Got checkpoint request with null as previous check point, however found more than one checkpoints"
         );
         if (checkpoints.size() == 1) {
           log.info("Already checkpointed with dataSourceMetadata [%s]", checkpoints.get(0));

--- a/server/src/main/java/io/druid/indexing/overlord/supervisor/Supervisor.java
+++ b/server/src/main/java/io/druid/indexing/overlord/supervisor/Supervisor.java
@@ -40,14 +40,14 @@ public interface Supervisor
   void reset(DataSourceMetadata dataSourceMetadata);
 
   /**
-   * The definition of checkpoint is not very strict as currently it does not affect data or control path
+   * The definition of checkpoint is not very strict as currently it does not affect data or control path.
    * On this call Supervisor can potentially checkpoint data processed so far to some durable storage
    * for example - Kafka Supervisor uses this to merge and handoff segments containing at least the data
-   * represented by dataSourceMetadata
+   * represented by {@param currentCheckpoint} DataSourceMetadata
    *
-   * @param sequenceName       unique Identifier to figure out for which sequence to do check pointing
-   * @param previousCheckPoint DataSourceMetadata check pointed in previous call
-   * @param currentCheckPoint  current DataSourceMetadata to be check pointed
+   * @param sequenceName       unique Identifier to figure out for which sequence to do checkpointing
+   * @param previousCheckPoint DataSourceMetadata checkpointed in previous call
+   * @param currentCheckPoint  current DataSourceMetadata to be checkpointed
    */
   void checkpoint(
       @Nullable String sequenceName,


### PR DESCRIPTION
Fix state check when a replacement task is started in place of a failed task. Without this fix, service can get into state where tasks are continuously failing and Supervisor is continuously starting new replacement tasks.

The problem is that if any task has done some handoffs then the start offsets of the latest sequence will not match with the start offsets of the task group, thus in the replacement task the condition check will fail.