### PR TITLE
Fix #5212 - typo in auth.md.

### DIFF
--- a/docs/content/configuration/auth.md
+++ b/docs/content/configuration/auth.md
@@ -36,7 +36,7 @@ This built-in Authenticator authenticates all requests, and always directs them 
 ## Escalator
 The `druid.escalator.type` property determines what authentication scheme should be used for internal Druid cluster communications (such as when a broker node communicates with historical nodes for query processing).
 
-The Escalator chosen for this property must use an authentication scheme that is supported by an Authenticator in `druid.auth.authenticationChain. Authenticator extension implementors must also provide a corresponding Escalator implementation if they intend to use a particular authentication scheme for internal Druid communications.
+The Escalator chosen for this property must use an authentication scheme that is supported by an Authenticator in `druid.auth.authenticationChain`. Authenticator extension implementors must also provide a corresponding Escalator implementation if they intend to use a particular authentication scheme for internal Druid communications.
 
 ### Noop Escalator
 


### PR DESCRIPTION
> The Escalator chosen for this property must use an authentication scheme that is supported by an Authenticator in `druid.auth.authenticationChain. Authenticator extension implementors must also provide a corresponding Escalator implementation if they intend to use a particular authentication scheme for internal Druid communications.

Add a backquote after druid.auth.authenticationChain.

Location:
- docs/content/configuration/auth.md#L39