### PR TITLE
Fix APPROX_QUANTILE on outer groupBys.

### DIFF
--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/sql/QuantileSqlAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/sql/QuantileSqlAggregator.java
@@ -93,15 +93,27 @@ public class QuantileSqlAggregator implements SqlAggregator
         project,
         aggregateCall.getArgList().get(1)
     );
-    final float probability = ((Number) RexLiteral.value(probabilityArg)).floatValue();
 
+    if (!probabilityArg.isA(SqlKind.LITERAL)) {
+      // Probability must be a literal in order to plan.
+      return null;
+    }
+
+    final float probability = ((Number) RexLiteral.value(probabilityArg)).floatValue();
     final int resolution;
+
     if (aggregateCall.getArgList().size() >= 3) {
       final RexNode resolutionArg = Expressions.fromFieldAccess(
           rowSignature,
           project,
           aggregateCall.getArgList().get(2)
       );
+
+      if (!resolutionArg.isA(SqlKind.LITERAL)) {
+        // Resolution must be a literal in order to plan.
+        return null;
+      }
+
       resolution = ((Number) RexLiteral.value(resolutionArg)).intValue();
     } else {
       resolution = ApproximateHistogram.DEFAULT_HISTOGRAM_SIZE;


### PR DESCRIPTION
Calcite evaluates a possible plan where the literal probability is pushed down to the inner query, transforming it into not-a-literal. This caused an assertion error in `RexLiteral.value(probabilityArg)`. This patch returns null here, skipping that possible plan and moving on to the next one where the literal is _not_ pushed down (and the query works fine).