### PR TITLE
Implemented a new endpoint to get running tasks by datasource

### DIFF
--- a/api/src/main/java/io/druid/indexer/TaskStatusPlus.java
+++ b/api/src/main/java/io/druid/indexer/TaskStatusPlus.java
@@ -36,6 +36,7 @@ public class TaskStatusPlus
   private final TaskState state;
   private final Long duration;
   private final TaskLocation location;
+  private final String dataSource;
 
   @JsonCreator
   public TaskStatusPlus(
@@ -45,7 +46,8 @@ public class TaskStatusPlus
       @JsonProperty("queueInsertionTime") DateTime queueInsertionTime,
       @JsonProperty("statusCode") @Nullable TaskState state,
       @JsonProperty("duration") @Nullable Long duration,
-      @JsonProperty("location") TaskLocation location
+      @JsonProperty("location") TaskLocation location,
+      @JsonProperty("dataSource") String dataSource
   )
   {
     if (state != null && state.isComplete()) {
@@ -58,6 +60,7 @@ public class TaskStatusPlus
     this.state = state;
     this.duration = duration;
     this.location = Preconditions.checkNotNull(location, "location");
+    this.dataSource = dataSource;
   }
 
   @JsonProperty
@@ -143,4 +146,11 @@ public class TaskStatusPlus
   {
     return Objects.hash(id, type, createdTime, queueInsertionTime, state, duration, location);
   }
+  
+  @JsonProperty
+  public String getDataSource()
+  {
+    return dataSource;
+  }
+  
 }

--- a/api/src/test/java/io/druid/indexer/TaskStatusPlusTest.java
+++ b/api/src/test/java/io/druid/indexer/TaskStatusPlusTest.java
@@ -52,7 +52,8 @@ public class TaskStatusPlusTest
         DateTimes.nowUtc(),
         TaskState.RUNNING,
         1000L,
-        TaskLocation.create("testHost", 1010, -1)
+        TaskLocation.create("testHost", 1010, -1),
+        "ds_test"
     );
     final String json = mapper.writeValueAsString(status);
     Assert.assertEquals(status, mapper.readValue(json, TaskStatusPlus.class));

--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -2060,12 +2060,14 @@ public class KafkaSupervisorTest extends EasyMockSupport
   {
     private final String taskType;
     private final TaskLocation location;
+    private final String dataSource;
 
     public TestTaskRunnerWorkItem(Task task, ListenableFuture<TaskStatus> result, TaskLocation location)
     {
       super(task.getId(), result);
       this.taskType = task.getType();
       this.location = location;
+      this.dataSource = task.getDataSource();
     }
 
     @Override
@@ -2079,6 +2081,13 @@ public class KafkaSupervisorTest extends EasyMockSupport
     {
       return taskType;
     }
+
+    @Override
+    public String getDataSource() 
+    {
+      return dataSource;
+    }
+ 
   }
 
   private static class TestableKafkaSupervisor extends KafkaSupervisor

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/ForkingTaskRunner.java
@@ -772,6 +772,12 @@ public class ForkingTaskRunner implements TaskRunner, TaskLogStreamer
     {
       return task.getType();
     }
+
+    @Override
+    public String getDataSource()
+    {
+      return task.getDataSource();
+    }
   }
 
   private static class ProcessHolder

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunner.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunner.java
@@ -628,7 +628,8 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
         task.getId(),
         task.getType(),
         null,
-        null
+        null,
+        task.getDataSource()
     );
     pendingTaskPayloads.put(task.getId(), task);
     pendingTasks.put(task.getId(), taskRunnerWorkItem);
@@ -966,7 +967,8 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
                             taskId,
                             announcement.getTaskType(),
                             zkWorker.getWorker(),
-                            TaskLocation.unknown()
+                            TaskLocation.unknown(),
+                            runningTasks.get(taskId).getDataSource()
                         );
                         final RemoteTaskRunnerWorkItem existingItem = runningTasks.putIfAbsent(
                             taskId,

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunnerWorkItem.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/RemoteTaskRunnerWorkItem.java
@@ -31,6 +31,7 @@ public class RemoteTaskRunnerWorkItem extends TaskRunnerWorkItem
 {
   private final SettableFuture<TaskStatus> result;
   private String taskType;
+  private final String dataSource;
   private Worker worker;
   private TaskLocation location;
 
@@ -38,10 +39,11 @@ public class RemoteTaskRunnerWorkItem extends TaskRunnerWorkItem
       String taskId,
       String taskType,
       Worker worker,
-      TaskLocation location
+      TaskLocation location,
+      String dataSource
   )
   {
-    this(taskId, taskType, SettableFuture.<TaskStatus>create(), worker, location);
+    this(taskId, taskType, SettableFuture.<TaskStatus>create(), worker, location, dataSource);
   }
 
   private RemoteTaskRunnerWorkItem(
@@ -49,7 +51,8 @@ public class RemoteTaskRunnerWorkItem extends TaskRunnerWorkItem
       String taskType,
       SettableFuture<TaskStatus> result,
       Worker worker,
-      TaskLocation location
+      TaskLocation location,
+      String dataSource
   )
   {
     super(taskId, result);
@@ -57,6 +60,7 @@ public class RemoteTaskRunnerWorkItem extends TaskRunnerWorkItem
     this.taskType = taskType;
     this.worker = worker;
     this.location = location == null ? TaskLocation.unknown() : location;
+    this.dataSource = dataSource;
   }
 
   private RemoteTaskRunnerWorkItem(
@@ -66,7 +70,8 @@ public class RemoteTaskRunnerWorkItem extends TaskRunnerWorkItem
       DateTime createdTime,
       DateTime queueInsertionTime,
       Worker worker,
-      TaskLocation location
+      TaskLocation location,
+      String dataSource
   )
   {
     super(taskId, result, createdTime, queueInsertionTime);
@@ -74,6 +79,7 @@ public class RemoteTaskRunnerWorkItem extends TaskRunnerWorkItem
     this.taskType = taskType;
     this.worker = worker;
     this.location = location == null ? TaskLocation.unknown() : location;
+    this.dataSource = dataSource;
   }
 
   public void setLocation(TaskLocation location)
@@ -97,6 +103,12 @@ public class RemoteTaskRunnerWorkItem extends TaskRunnerWorkItem
   {
     return taskType;
   }
+  
+  @Override
+  public String getDataSource()
+  {
+    return dataSource;
+  }
 
   public void setWorker(Worker worker)
   {
@@ -115,7 +127,7 @@ public class RemoteTaskRunnerWorkItem extends TaskRunnerWorkItem
 
   public RemoteTaskRunnerWorkItem withQueueInsertionTime(DateTime time)
   {
-    return new RemoteTaskRunnerWorkItem(getTaskId(), taskType, result, getCreatedTime(), time, worker, location);
+    return new RemoteTaskRunnerWorkItem(getTaskId(), taskType, result, getCreatedTime(), time, worker, location, dataSource);
   }
 
   public RemoteTaskRunnerWorkItem withWorker(Worker theWorker, TaskLocation location)
@@ -127,7 +139,8 @@ public class RemoteTaskRunnerWorkItem extends TaskRunnerWorkItem
         getCreatedTime(),
         getQueueInsertionTime(),
         theWorker,
-        location
+        location,
+        dataSource
     );
   }
 }

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/TaskRunnerWorkItem.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/TaskRunnerWorkItem.java
@@ -93,6 +93,7 @@ public abstract class TaskRunnerWorkItem
    */
   @Nullable
   public abstract String getTaskType();
+  public abstract String getDataSource();
 
   @Override
   public String toString()

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/TaskStorageQueryAdapter.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/TaskStorageQueryAdapter.java
@@ -97,4 +97,10 @@ public class TaskStorageQueryAdapter
     }
     return segments;
   }
+  
+  public Pair<DateTime, String> getCreatedDateAndDataSource(String taskId)
+  {
+    return storage.getCreatedDateTimeAndDataSource(taskId);
+  }
+  
 }

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/ThreadPoolTaskRunner.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/ThreadPoolTaskRunner.java
@@ -417,6 +417,12 @@ public class ThreadPoolTaskRunner implements TaskRunner, QuerySegmentWalker
     {
       return task.getType();
     }
+    
+    @Override
+    public String getDataSource()
+    {
+      return task.getDataSource();
+    }
   }
 
   private class ThreadPoolTaskRunnerCallable implements Callable<TaskStatus>

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/hrtr/HttpRemoteTaskRunner.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/hrtr/HttpRemoteTaskRunner.java
@@ -1343,7 +1343,7 @@ public class HttpRemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
         State state
     )
     {
-      super(taskId, taskType, worker, location);
+      super(taskId, task == null ? null : task.getType(), worker, location, task == null ? null : task.getDataSource());
       this.state = Preconditions.checkNotNull(state);
       Preconditions.checkArgument(task == null || taskType == null || taskType.equals(task.getType()));
 

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/RemoteTaskRunnerTest.java
@@ -43,7 +43,6 @@ import io.druid.indexing.worker.Worker;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.StringUtils;
 import org.apache.curator.framework.CuratorFramework;
-import org.apache.zookeeper.CreateMode;
 import org.easymock.EasyMock;
 import org.joda.time.Period;
 import org.junit.After;
@@ -321,22 +320,41 @@ public class RemoteTaskRunnerTest
   @Test
   public void testBootstrap() throws Exception
   {
-    cf.create()
-      .creatingParentsIfNeeded()
-      .withMode(CreateMode.EPHEMERAL)
-      .forPath(joiner.join(statusPath, "first"), jsonMapper.writeValueAsBytes(TaskStatus.running("first")));
-    cf.create()
-      .creatingParentsIfNeeded()
-      .withMode(CreateMode.EPHEMERAL)
-      .forPath(joiner.join(statusPath, "second"), jsonMapper.writeValueAsBytes(TaskStatus.running("second")));
+    Period timeoutPeriod = Period.millis(1000);
+    makeWorker();
 
-    doSetup();
+    RemoteTaskRunnerConfig rtrConfig = new TestRemoteTaskRunnerConfig(timeoutPeriod);
+    rtrConfig.setMaxPercentageBlacklistWorkers(100);
 
-    final Set<String> existingTasks = Sets.newHashSet();
-    for (ImmutableWorkerInfo workerInfo : remoteTaskRunner.getWorkers()) {
-      existingTasks.addAll(workerInfo.getRunningTasks());
-    }
-    Assert.assertEquals("existingTasks", ImmutableSet.of("first", "second"), existingTasks);
+    makeRemoteTaskRunner(rtrConfig);
+
+    TestRealtimeTask task1 = new TestRealtimeTask(
+        "first",
+        new TaskResource("first", 1),
+        "foo",
+        TaskStatus.running("first"),
+        jsonMapper);
+    remoteTaskRunner.run(task1);
+    Assert.assertTrue(taskAnnounced(task1.getId()));
+    mockWorkerRunningTask(task1);
+
+    TestRealtimeTask task = new TestRealtimeTask(
+        "second",
+        new TaskResource("task", 2),
+        "foo",
+        TaskStatus.running("task"),
+        jsonMapper);
+    remoteTaskRunner.run(task);
+    
+    TestRealtimeTask task2 = new TestRealtimeTask(
+        "second",
+        new TaskResource("second", 2),
+        "foo",
+        TaskStatus.running("second"),
+        jsonMapper);
+    remoteTaskRunner.run(task2);
+    Assert.assertTrue(taskAnnounced(task2.getId()));
+    mockWorkerRunningTask(task2);
 
     final Set<String> runningTasks = Sets.newHashSet(
         Iterables.transform(
@@ -357,18 +375,19 @@ public class RemoteTaskRunnerTest
   @Test
   public void testRunWithTaskComplete() throws Exception
   {
-    cf.create()
-      .creatingParentsIfNeeded()
-      .withMode(CreateMode.EPHEMERAL)
-      .forPath(joiner.join(statusPath, task.getId()), jsonMapper.writeValueAsBytes(TaskStatus.success(task.getId())));
-
     doSetup();
+    TestRealtimeTask task1 = new TestRealtimeTask(
+        "testTask",
+        new TaskResource("testTask", 2),
+        "foo",
+        TaskStatus.success("testTask"),
+        jsonMapper);
+    remoteTaskRunner.run(task1);
+    Assert.assertTrue(taskAnnounced(task1.getId()));
+    mockWorkerRunningTask(task1);
+    mockWorkerCompleteSuccessfulTask(task1);
 
-    ListenableFuture<TaskStatus> future = remoteTaskRunner.run(task);
-
-    TaskStatus status = future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
-
-    Assert.assertEquals(TaskState.SUCCESS, status.getStatusCode());
+    Assert.assertEquals(TaskState.SUCCESS, remoteTaskRunner.run(task1).get().getStatusCode());
   }
 
   @Test
@@ -621,11 +640,11 @@ public class RemoteTaskRunnerTest
   @Test
   public void testSortByInsertionTime() throws Exception
   {
-    RemoteTaskRunnerWorkItem item1 = new RemoteTaskRunnerWorkItem("b", "t", null, null)
+    RemoteTaskRunnerWorkItem item1 = new RemoteTaskRunnerWorkItem("b", "t", null, null, "ds_test")
         .withQueueInsertionTime(DateTimes.of("2015-01-01T00:00:03Z"));
-    RemoteTaskRunnerWorkItem item2 = new RemoteTaskRunnerWorkItem("a", "t", null, null)
+    RemoteTaskRunnerWorkItem item2 = new RemoteTaskRunnerWorkItem("a", "t", null, null, "ds_test")
         .withQueueInsertionTime(DateTimes.of("2015-01-01T00:00:02Z"));
-    RemoteTaskRunnerWorkItem item3 = new RemoteTaskRunnerWorkItem("c", "t", null, null)
+    RemoteTaskRunnerWorkItem item3 = new RemoteTaskRunnerWorkItem("c", "t", null, null, "ds_test")
         .withQueueInsertionTime(DateTimes.of("2015-01-01T00:00:01Z"));
     ArrayList<RemoteTaskRunnerWorkItem> workItems = Lists.newArrayList(item1, item2, item3);
     RemoteTaskRunner.sortByInsertionTime(workItems);

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/PendingTaskBasedProvisioningStrategyTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/PendingTaskBasedProvisioningStrategyTest.java
@@ -339,7 +339,8 @@ public class PendingTaskBasedProvisioningStrategyTest
                 testTask.getId(),
                 testTask.getType(),
                 null,
-                TaskLocation.unknown()
+                TaskLocation.unknown(),
+                testTask.getDataSource()
             ).withQueueInsertionTime(DateTimes.nowUtc())
         )
     ).times(2);

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/SimpleProvisioningStrategyTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/SimpleProvisioningStrategyTest.java
@@ -125,7 +125,7 @@ public class SimpleProvisioningStrategyTest
     RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
     EasyMock.expect(runner.getPendingTasks()).andReturn(
         Collections.singletonList(
-            new RemoteTaskRunnerWorkItem(testTask.getId(), testTask.getType(), null, null)
+            new RemoteTaskRunnerWorkItem(testTask.getId(), testTask.getType(), null, null, testTask.getDataSource())
                 .withQueueInsertionTime(DateTimes.nowUtc())
         )
     );
@@ -163,7 +163,7 @@ public class SimpleProvisioningStrategyTest
     RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
     EasyMock.expect(runner.getPendingTasks()).andReturn(
         Collections.singletonList(
-            new RemoteTaskRunnerWorkItem(testTask.getId(), testTask.getType(), null, null)
+            new RemoteTaskRunnerWorkItem(testTask.getId(), testTask.getType(), null, null, testTask.getDataSource())
                 .withQueueInsertionTime(DateTimes.nowUtc())
         )
     ).times(2);
@@ -222,7 +222,7 @@ public class SimpleProvisioningStrategyTest
     RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
     EasyMock.expect(runner.getPendingTasks()).andReturn(
         Collections.singletonList(
-            new RemoteTaskRunnerWorkItem(testTask.getId(), testTask.getType(), null, null)
+            new RemoteTaskRunnerWorkItem(testTask.getId(), testTask.getType(), null, null, testTask.getDataSource())
                 .withQueueInsertionTime(DateTimes.nowUtc())
         )
     ).times(2);
@@ -275,7 +275,7 @@ public class SimpleProvisioningStrategyTest
     RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
     EasyMock.expect(runner.getPendingTasks()).andReturn(
         Collections.singletonList(
-            new RemoteTaskRunnerWorkItem(testTask.getId(), testTask.getType(), null, null)
+            new RemoteTaskRunnerWorkItem(testTask.getId(), testTask.getType(), null, null, testTask.getDataSource())
                 .withQueueInsertionTime(DateTimes.nowUtc())
         )
     ).times(2);
@@ -316,7 +316,7 @@ public class SimpleProvisioningStrategyTest
     RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
     EasyMock.expect(runner.getPendingTasks()).andReturn(
         Collections.singletonList(
-            new RemoteTaskRunnerWorkItem(testTask.getId(), testTask.getType(), null, null)
+            new RemoteTaskRunnerWorkItem(testTask.getId(), testTask.getType(), null, null, testTask.getDataSource())
                 .withQueueInsertionTime(DateTimes.nowUtc())
         )
     ).times(2);
@@ -364,7 +364,7 @@ public class SimpleProvisioningStrategyTest
     RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
     EasyMock.expect(runner.getPendingTasks()).andReturn(
         Collections.singletonList(
-            new RemoteTaskRunnerWorkItem(testTask.getId(), testTask.getType(), null, null)
+            new RemoteTaskRunnerWorkItem(testTask.getId(), testTask.getType(), null, null, testTask.getDataSource())
                 .withQueueInsertionTime(DateTimes.nowUtc())
         )
     ).times(2);
@@ -468,7 +468,7 @@ public class SimpleProvisioningStrategyTest
     RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
     EasyMock.expect(runner.getPendingTasks()).andReturn(
         Collections.singletonList(
-            new RemoteTaskRunnerWorkItem(testTask.getId(), testTask.getType(), null, null)
+            new RemoteTaskRunnerWorkItem(testTask.getId(), testTask.getType(), null, null, testTask.getDataSource())
                 .withQueueInsertionTime(DateTimes.nowUtc())
         )
     ).times(2);

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/http/OverlordTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/http/OverlordTest.java
@@ -394,6 +394,12 @@ public class OverlordTest
         {
           return task.getType();
         }
+
+        @Override
+        public String getDataSource()
+        {
+          return task.getDataSource();
+        }
       };
       taskRunnerWorkItems.put(taskId, taskRunnerWorkItem);
       return future;


### PR DESCRIPTION
* added datasource information as part of existing endpoint /druid/indexer/v1/runningTasks.
* Added junit test cases and fixed existing test cases
* Fixed review comments 

Use case for us - We have multiple jobs running for different datasources, so we want to filter running tasks only for particular datasource in the console. 