### PR TITLE
SQL compatible Null Handling Part - Expressions and Storage Changes

### DIFF
--- a/common/src/main/antlr4/io/druid/math/expr/antlr/Expr.g4
+++ b/common/src/main/antlr4/io/druid/math/expr/antlr/Expr.g4
@@ -1,6 +1,7 @@
 grammar Expr;
 
-expr : ('-'|'!') expr                                 # unaryOpExpr
+expr : 'null'                                         # null
+     | ('-'|'!') expr                                 # unaryOpExpr
      |<assoc=right> expr '^' expr                     # powOpExpr
      | expr ('*'|'/'|'%') expr                        # mulDivModuloExpr
      | expr ('+'|'-') expr                            # addSubExpr

--- a/common/src/main/java/io/druid/common/config/NullHandling.java
+++ b/common/src/main/java/io/druid/common/config/NullHandling.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.common.config;
+
+import com.google.common.base.Strings;
+import com.google.inject.Inject;
+
+import javax.annotation.Nullable;
+
+/**
+ * Helper class for NullHandling. This class is used to switch between SQL compatible Null Handling behavior
+ * introduced as part of {@link https://github.com/druid-io/druid/issues/4349} and the old druid behavior
+ * where null values are replaced with default values e.g Null Strings are replaced with empty values.
+ */
+public class NullHandling
+{
+  private static String NULL_HANDLING_CONFIG_STRING = "druid.generic.useDefaultValueForNull";
+
+  /**
+   * use these values to ensure that {@link NullHandling#defaultDoubleValue()},
+   * {@link NullHandling#defaultFloatValue()} , {@link NullHandling#defaultFloatValue()}
+   * return the same boxed object when returning a constant zero
+   */
+  public static final Double ZERO_DOUBLE = 0.0d;
+  public static final Float ZERO_FLOAT = 0.0f;
+  public static final Long ZERO_LONG = 0L;
+
+  /**
+   * INSTANCE is injected using static injection to avoid adding JacksonInject annotations all over the code.
+   * See {@link io.druid.guice.NullHandlingModule} for details.
+   * It does not take effect in all unit tests since we don't use Guice Injection.
+   * For tests default system property is supposed to be used only in tests
+   */
+  @Inject
+  private static NullValueHandlingConfig INSTANCE = new NullValueHandlingConfig(
+      Boolean.valueOf(System.getProperty(NULL_HANDLING_CONFIG_STRING, "true"))
+  );
+
+  public static boolean useDefaultValuesForNull()
+  {
+    return INSTANCE.isUseDefaultValuesForNull();
+  }
+
+  @Nullable
+  public static String nullToEmptyIfNeeded(@Nullable String value)
+  {
+    //CHECKSTYLE.OFF: Regexp
+    return useDefaultValuesForNull() ? Strings.nullToEmpty(value) : value;
+    //CHECKSTYLE.ON: Regexp
+  }
+
+  @Nullable
+  public static String emptyToNullIfNeeded(@Nullable String value)
+  {
+    //CHECKSTYLE.OFF: Regexp
+    return useDefaultValuesForNull() ? Strings.emptyToNull(value) : value;
+    //CHECKSTYLE.ON: Regexp
+  }
+
+  @Nullable
+  public static String defaultStringValue()
+  {
+    return useDefaultValuesForNull() ? "" : null;
+  }
+
+  @Nullable
+  public static Long defaultLongValue()
+  {
+    return useDefaultValuesForNull() ? ZERO_LONG : null;
+  }
+
+  @Nullable
+  public static Float defaultFloatValue()
+  {
+    return useDefaultValuesForNull() ? ZERO_FLOAT : null;
+  }
+
+  @Nullable
+  public static Double defaultDoubleValue()
+  {
+    return useDefaultValuesForNull() ? ZERO_DOUBLE : null;
+  }
+
+  public static boolean isNullOrEquivalent(@Nullable String value)
+  {
+    return INSTANCE.isUseDefaultValuesForNull() ? Strings.isNullOrEmpty(value) : value == null;
+  }
+
+}

--- a/common/src/main/java/io/druid/common/config/NullHandling.java
+++ b/common/src/main/java/io/druid/common/config/NullHandling.java
@@ -53,16 +53,21 @@ public class NullHandling
       Boolean.valueOf(System.getProperty(NULL_HANDLING_CONFIG_STRING, "true"))
   );
 
-  public static boolean useDefaultValuesForNull()
+  public static boolean replaceWithDefault()
   {
     return INSTANCE.isUseDefaultValuesForNull();
+  }
+
+  public static boolean sqlCompatible()
+  {
+    return !replaceWithDefault();
   }
 
   @Nullable
   public static String nullToEmptyIfNeeded(@Nullable String value)
   {
     //CHECKSTYLE.OFF: Regexp
-    return useDefaultValuesForNull() ? Strings.nullToEmpty(value) : value;
+    return replaceWithDefault() ? Strings.nullToEmpty(value) : value;
     //CHECKSTYLE.ON: Regexp
   }
 
@@ -70,32 +75,32 @@ public class NullHandling
   public static String emptyToNullIfNeeded(@Nullable String value)
   {
     //CHECKSTYLE.OFF: Regexp
-    return useDefaultValuesForNull() ? Strings.emptyToNull(value) : value;
+    return replaceWithDefault() ? Strings.emptyToNull(value) : value;
     //CHECKSTYLE.ON: Regexp
   }
 
   @Nullable
   public static String defaultStringValue()
   {
-    return useDefaultValuesForNull() ? "" : null;
+    return replaceWithDefault() ? "" : null;
   }
 
   @Nullable
   public static Long defaultLongValue()
   {
-    return useDefaultValuesForNull() ? ZERO_LONG : null;
+    return replaceWithDefault() ? ZERO_LONG : null;
   }
 
   @Nullable
   public static Float defaultFloatValue()
   {
-    return useDefaultValuesForNull() ? ZERO_FLOAT : null;
+    return replaceWithDefault() ? ZERO_FLOAT : null;
   }
 
   @Nullable
   public static Double defaultDoubleValue()
   {
-    return useDefaultValuesForNull() ? ZERO_DOUBLE : null;
+    return replaceWithDefault() ? ZERO_DOUBLE : null;
   }
 
   public static boolean isNullOrEquivalent(@Nullable String value)

--- a/common/src/main/java/io/druid/common/config/NullHandling.java
+++ b/common/src/main/java/io/druid/common/config/NullHandling.java
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
  */
 public class NullHandling
 {
-  private static String NULL_HANDLING_CONFIG_STRING = "druid.generic.useDefaultValueForNull";
+  public static String NULL_HANDLING_CONFIG_STRING = "druid.generic.useDefaultValueForNull";
 
   /**
    * use these values to ensure that {@link NullHandling#defaultDoubleValue()},

--- a/common/src/main/java/io/druid/common/config/NullHandling.java
+++ b/common/src/main/java/io/druid/common/config/NullHandling.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
 
 /**
  * Helper class for NullHandling. This class is used to switch between SQL compatible Null Handling behavior
- * introduced as part of {@link https://github.com/druid-io/druid/issues/4349} and the old druid behavior
+ * introduced as part of https://github.com/druid-io/druid/issues/4349 and the old druid behavior
  * where null values are replaced with default values e.g Null Strings are replaced with empty values.
  */
 public class NullHandling
@@ -44,7 +44,7 @@ public class NullHandling
 
   /**
    * INSTANCE is injected using static injection to avoid adding JacksonInject annotations all over the code.
-   * See {@link io.druid.guice.NullHandlingModule} for details.
+   * See io.druid.guice.NullHandlingModule for details.
    * It does not take effect in all unit tests since we don't use Guice Injection.
    * For tests default system property is supposed to be used only in tests
    */

--- a/common/src/main/java/io/druid/common/config/NullHandling.java
+++ b/common/src/main/java/io/druid/common/config/NullHandling.java
@@ -105,7 +105,7 @@ public class NullHandling
 
   public static boolean isNullOrEquivalent(@Nullable String value)
   {
-    return INSTANCE.isUseDefaultValuesForNull() ? Strings.isNullOrEmpty(value) : value == null;
+    return replaceWithDefault() ? Strings.isNullOrEmpty(value) : value == null;
   }
 
 }

--- a/common/src/main/java/io/druid/common/config/NullValueHandlingConfig.java
+++ b/common/src/main/java/io/druid/common/config/NullValueHandlingConfig.java
@@ -17,33 +17,27 @@
  * under the License.
  */
 
-package io.druid.segment.serde;
+package io.druid.common.config;
 
-import com.google.common.base.Supplier;
-import io.druid.collections.bitmap.ImmutableBitmap;
-import io.druid.segment.column.GenericColumn;
-import io.druid.segment.column.FloatsColumn;
-import io.druid.segment.data.CompressedColumnarFloatsSupplier;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-/**
-*/
-public class FloatGenericColumnSupplier implements Supplier<GenericColumn>
+public class NullValueHandlingConfig
 {
-  private final CompressedColumnarFloatsSupplier column;
-  private final ImmutableBitmap nullValueBitmap;
 
-  public FloatGenericColumnSupplier(
-      CompressedColumnarFloatsSupplier column,
-      ImmutableBitmap nullValueBitmap
-  )
+  @JsonProperty("useDefaultValueForNull")
+  private final boolean useDefaultValuesForNull;
+
+  @JsonCreator
+  public NullValueHandlingConfig(@JsonProperty("useDefaultValueForNull") Boolean useDefaultValuesForNull)
   {
-    this.column = column;
-    this.nullValueBitmap = nullValueBitmap;
+    this.useDefaultValuesForNull = useDefaultValuesForNull == null
+                                   ? true
+                                   : useDefaultValuesForNull;
   }
 
-  @Override
-  public GenericColumn get()
+  public boolean isUseDefaultValuesForNull()
   {
-    return new FloatsColumn(column.get(), nullValueBitmap);
+    return useDefaultValuesForNull;
   }
 }

--- a/common/src/main/java/io/druid/common/utils/SerializerUtils.java
+++ b/common/src/main/java/io/druid/common/utils/SerializerUtils.java
@@ -142,7 +142,7 @@ public class SerializerUtils
     out.write(Ints.toByteArray(intValue));
   }
 
-  private void writeInt(WritableByteChannel out, int intValue) throws IOException
+  public static void writeInt(WritableByteChannel out, int intValue) throws IOException
   {
     final ByteBuffer buffer = ByteBuffer.allocate(Integer.BYTES);
     buffer.putInt(intValue);

--- a/common/src/main/java/io/druid/math/expr/Expr.java
+++ b/common/src/main/java/io/druid/math/expr/Expr.java
@@ -20,9 +20,9 @@
 package io.druid.math.expr;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.google.common.math.LongMath;
 import com.google.common.primitives.Ints;
+import io.druid.common.config.NullHandling;
 import io.druid.java.util.common.IAE;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.guava.Comparators;
@@ -124,7 +124,7 @@ class StringExpr extends ConstantExpr
 
   public StringExpr(String value)
   {
-    this.value = Strings.emptyToNull(value);
+    this.value = NullHandling.emptyToNullIfNeeded(value);
   }
 
   @Nullable
@@ -362,6 +362,13 @@ abstract class BinaryEvalOpExprBase extends BinaryOpExprBase
   {
     ExprEval leftVal = left.eval(bindings);
     ExprEval rightVal = right.eval(bindings);
+
+    // Result of any Binary expressions is null if any of the argument is null.
+    // e.g "select null * 2 as c;" or "select null + 1 as c;" will return null as per Standard SQL spec.
+    if (!NullHandling.useDefaultValuesForNull() && (leftVal.isNull() || rightVal.isNull())) {
+      return ExprEval.of(null);
+    }
+
     if (leftVal.type() == ExprType.STRING && rightVal.type() == ExprType.STRING) {
       return evalString(leftVal.asString(), rightVal.asString());
     } else if (leftVal.type() == ExprType.LONG && rightVal.type() == ExprType.LONG) {
@@ -491,7 +498,8 @@ class BinPlusExpr extends BinaryEvalOpExprBase
   @Override
   protected ExprEval evalString(@Nullable String left, @Nullable String right)
   {
-    return ExprEval.of(Strings.nullToEmpty(left) + Strings.nullToEmpty(right));
+    return ExprEval.of(NullHandling.nullToEmptyIfNeeded(left)
+                       + NullHandling.nullToEmptyIfNeeded(right));
   }
 
   @Override

--- a/common/src/main/java/io/druid/math/expr/Expr.java
+++ b/common/src/main/java/io/druid/math/expr/Expr.java
@@ -365,7 +365,7 @@ abstract class BinaryEvalOpExprBase extends BinaryOpExprBase
 
     // Result of any Binary expressions is null if any of the argument is null.
     // e.g "select null * 2 as c;" or "select null + 1 as c;" will return null as per Standard SQL spec.
-    if (!NullHandling.useDefaultValuesForNull() && (leftVal.isNull() || rightVal.isNull())) {
+    if (NullHandling.sqlCompatible() && (leftVal.isNull() || rightVal.isNull())) {
       return ExprEval.of(null);
     }
 

--- a/common/src/main/java/io/druid/math/expr/ExprEval.java
+++ b/common/src/main/java/io/druid/math/expr/ExprEval.java
@@ -20,11 +20,13 @@
 package io.druid.math.expr;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Ints;
+import io.druid.common.config.NullHandling;
 import io.druid.common.guava.GuavaUtils;
 import io.druid.java.util.common.IAE;
+
+import javax.annotation.Nullable;
 
 /**
  */
@@ -50,7 +52,7 @@ public abstract class ExprEval<T>
     return new DoubleExprEval(doubleValue);
   }
 
-  public static ExprEval of(String stringValue)
+  public static ExprEval of(@Nullable String stringValue)
   {
     return new StringExprEval(stringValue);
   }
@@ -108,6 +110,7 @@ public abstract class ExprEval<T>
 
   public abstract double asDouble();
 
+  @Nullable
   public String asString()
   {
     return value == null ? null : String.valueOf(value);
@@ -228,9 +231,9 @@ public abstract class ExprEval<T>
 
   private static class StringExprEval extends ExprEval<String>
   {
-    private StringExprEval(String value)
+    private StringExprEval(@Nullable String value)
     {
-      super(Strings.emptyToNull(value));
+      super(NullHandling.emptyToNullIfNeeded(value));
     }
 
     @Override

--- a/common/src/main/java/io/druid/math/expr/ExprEval.java
+++ b/common/src/main/java/io/druid/math/expr/ExprEval.java
@@ -133,18 +133,21 @@ public abstract class ExprEval<T>
     @Override
     public final int asInt()
     {
+      assert NullHandling.replaceWithDefault() || !isNull();
       return value.intValue();
     }
 
     @Override
     public final long asLong()
     {
+      assert NullHandling.replaceWithDefault() || !isNull();
       return value.longValue();
     }
 
     @Override
     public final double asDouble()
     {
+      assert NullHandling.replaceWithDefault() || !isNull();
       return value.doubleValue();
     }
   }
@@ -246,6 +249,7 @@ public abstract class ExprEval<T>
     public final int asInt()
     {
       if (value == null) {
+        assert NullHandling.replaceWithDefault();
         return 0;
       }
 
@@ -258,6 +262,7 @@ public abstract class ExprEval<T>
     {
       // GuavaUtils.tryParseLong handles nulls, no need for special null handling here.
       final Long theLong = GuavaUtils.tryParseLong(value);
+      assert NullHandling.replaceWithDefault() || theLong != null;
       return theLong == null ? 0L : theLong;
     }
 
@@ -265,6 +270,7 @@ public abstract class ExprEval<T>
     public final double asDouble()
     {
       if (value == null) {
+        assert NullHandling.replaceWithDefault();
         return 0.0;
       }
 

--- a/common/src/main/java/io/druid/math/expr/ExprEval.java
+++ b/common/src/main/java/io/druid/math/expr/ExprEval.java
@@ -133,21 +133,18 @@ public abstract class ExprEval<T>
     @Override
     public final int asInt()
     {
-      assert NullHandling.replaceWithDefault() || !isNull();
       return value.intValue();
     }
 
     @Override
     public final long asLong()
     {
-      assert NullHandling.replaceWithDefault() || !isNull();
       return value.longValue();
     }
 
     @Override
     public final double asDouble()
     {
-      assert NullHandling.replaceWithDefault() || !isNull();
       return value.doubleValue();
     }
   }
@@ -254,6 +251,7 @@ public abstract class ExprEval<T>
       }
 
       final Integer theInt = Ints.tryParse(value);
+      assert NullHandling.replaceWithDefault() || theInt != null;
       return theInt == null ? 0 : theInt;
     }
 
@@ -275,6 +273,7 @@ public abstract class ExprEval<T>
       }
 
       final Double theDouble = Doubles.tryParse(value);
+      assert NullHandling.replaceWithDefault() || theDouble != null;
       return theDouble == null ? 0.0 : theDouble;
     }
 

--- a/common/src/main/java/io/druid/math/expr/ExprListenerImpl.java
+++ b/common/src/main/java/io/druid/math/expr/ExprListenerImpl.java
@@ -335,4 +335,10 @@ public class ExprListenerImpl extends ExprBaseListener
 
     nodes.put(ctx, args);
   }
+
+  @Override
+  public void exitNull(ExprParser.NullContext ctx)
+  {
+    nodes.put(ctx, new StringExpr(null));
+  }
 }

--- a/common/src/main/java/io/druid/math/expr/Function.java
+++ b/common/src/main/java/io/druid/math/expr/Function.java
@@ -19,7 +19,7 @@
 
 package io.druid.math.expr;
 
-import com.google.common.base.Strings;
+import io.druid.common.config.NullHandling;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.IAE;
 import io.druid.java.util.common.StringUtils;
@@ -74,6 +74,9 @@ interface Function
     @Override
     protected final ExprEval eval(ExprEval param)
     {
+      if (!NullHandling.useDefaultValuesForNull() && param.isNull()) {
+        return ExprEval.of(null);
+      }
       if (param.type() == ExprType.LONG) {
         return eval(param.asLong());
       } else if (param.type() == ExprType.DOUBLE) {
@@ -896,10 +899,20 @@ interface Function
         return ExprEval.of(null);
       } else {
         // Pass first argument in to the constructor to provide StringBuilder a little extra sizing hint.
-        final StringBuilder builder = new StringBuilder(Strings.nullToEmpty(args.get(0).eval(bindings).asString()));
+        String first = NullHandling.nullToEmptyIfNeeded(args.get(0).eval(bindings).asString());
+        if (first == null) {
+          // Result of concatenation is null if any of the Values is null.
+          // e.g. 'select CONCAT(null, "abc") as c;' will return null as per Standard SQL spec.
+          return ExprEval.of(null);
+        }
+        final StringBuilder builder = new StringBuilder(first);
         for (int i = 1; i < args.size(); i++) {
-          final String s = args.get(i).eval(bindings).asString();
-          if (s != null) {
+          final String s = NullHandling.nullToEmptyIfNeeded(args.get(i).eval(bindings).asString());
+          if (s == null) {
+            // Result of concatenation is null if any of the Values is null.
+            // e.g. 'select CONCAT(null, "abc") as c;' will return null as per Standard SQL spec.
+            return ExprEval.of(null);
+          } else {
             builder.append(s);
           }
         }
@@ -943,9 +956,12 @@ interface Function
         throw new IAE("Function[%s] needs 2 arguments", name());
       }
 
-      final String haystack = Strings.nullToEmpty(args.get(0).eval(bindings).asString());
-      final String needle = Strings.nullToEmpty(args.get(1).eval(bindings).asString());
+      final String haystack = NullHandling.nullToEmptyIfNeeded(args.get(0).eval(bindings).asString());
+      final String needle = NullHandling.nullToEmptyIfNeeded(args.get(1).eval(bindings).asString());
 
+      if (haystack == null || needle == null) {
+        return ExprEval.of(null);
+      }
       return ExprEval.of(haystack.indexOf(needle));
     }
   }
@@ -982,7 +998,9 @@ interface Function
           return ExprEval.of(arg.substring(index));
         }
       } else {
-        return ExprEval.of(null);
+        // If starting index of substring is greater then the length of string, the result will be a zero length string.
+        // e.g. 'select substring("abc", 4,5) as c;' will return an empty string
+        return ExprEval.of(NullHandling.defaultStringValue());
       }
     }
   }
@@ -1005,8 +1023,11 @@ interface Function
       final String arg = args.get(0).eval(bindings).asString();
       final String pattern = args.get(1).eval(bindings).asString();
       final String replacement = args.get(2).eval(bindings).asString();
+      if (arg == null) {
+        return ExprEval.of(NullHandling.defaultStringValue());
+      }
       return ExprEval.of(
-          Strings.nullToEmpty(arg).replace(Strings.nullToEmpty(pattern), Strings.nullToEmpty(replacement))
+          arg.replace(NullHandling.nullToEmptyIfNeeded(pattern), NullHandling.nullToEmptyIfNeeded(replacement))
       );
     }
   }
@@ -1027,7 +1048,10 @@ interface Function
       }
 
       final String arg = args.get(0).eval(bindings).asString();
-      return ExprEval.of(StringUtils.toLowerCase(Strings.nullToEmpty(arg)));
+      if (arg == null) {
+        return ExprEval.of(NullHandling.defaultStringValue());
+      }
+      return ExprEval.of(StringUtils.toLowerCase(arg));
     }
   }
 
@@ -1047,7 +1071,50 @@ interface Function
       }
 
       final String arg = args.get(0).eval(bindings).asString();
-      return ExprEval.of(StringUtils.toUpperCase(Strings.nullToEmpty(arg)));
+      if (arg == null) {
+        return ExprEval.of(NullHandling.defaultStringValue());
+      }
+      return ExprEval.of(StringUtils.toUpperCase(arg));
+    }
+  }
+
+  class IsNullFunc implements Function
+  {
+    @Override
+    public String name()
+    {
+      return "isnull";
+    }
+
+    @Override
+    public ExprEval apply(List<Expr> args, Expr.ObjectBinding bindings)
+    {
+      if (args.size() != 1) {
+        throw new IAE("Function[%s] needs 1 argument", name());
+      }
+
+      final ExprEval expr = args.get(0).eval(bindings);
+      return ExprEval.of(expr.isNull(), ExprType.LONG);
+    }
+  }
+
+  class IsNotNullFunc implements Function
+  {
+    @Override
+    public String name()
+    {
+      return "notnull";
+    }
+
+    @Override
+    public ExprEval apply(List<Expr> args, Expr.ObjectBinding bindings)
+    {
+      if (args.size() != 1) {
+        throw new IAE("Function[%s] needs 1 argument", name());
+      }
+
+      final ExprEval expr = args.get(0).eval(bindings);
+      return ExprEval.of(!expr.isNull(), ExprType.LONG);
     }
   }
 }

--- a/common/src/main/java/io/druid/math/expr/Function.java
+++ b/common/src/main/java/io/druid/math/expr/Function.java
@@ -74,7 +74,7 @@ interface Function
     @Override
     protected final ExprEval eval(ExprEval param)
     {
-      if (!NullHandling.useDefaultValuesForNull() && param.isNull()) {
+      if (NullHandling.sqlCompatible() && param.isNull()) {
         return ExprEval.of(null);
       }
       if (param.type() == ExprType.LONG) {

--- a/common/src/test/java/io/druid/math/expr/EvalTest.java
+++ b/common/src/test/java/io/druid/math/expr/EvalTest.java
@@ -140,7 +140,7 @@ public class EvalTest
     Assert.assertEquals(1271055781L, evalLong("unix_timestamp('2010-04-12T07:03:01')", bindings));
     Assert.assertEquals(1271023381L, evalLong("unix_timestamp('2010-04-12T07:03:01+09:00')", bindings));
     Assert.assertEquals(1271023381L, evalLong("unix_timestamp('2010-04-12T07:03:01.419+09:00')", bindings));
-    if (NullHandling.useDefaultValuesForNull()) {
+    if (NullHandling.replaceWithDefault()) {
       Assert.assertEquals("NULL", eval("nvl(if(x == 9223372036854775807, '', 'x'), 'NULL')", bindings).asString());
     } else {
       Assert.assertEquals("", eval("nvl(if(x == 9223372036854775807, '', 'x'), 'NULL')", bindings).asString());

--- a/common/src/test/java/io/druid/math/expr/EvalTest.java
+++ b/common/src/test/java/io/druid/math/expr/EvalTest.java
@@ -20,6 +20,7 @@
 package io.druid.math.expr;
 
 import com.google.common.collect.ImmutableMap;
+import io.druid.common.config.NullHandling;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -139,8 +140,11 @@ public class EvalTest
     Assert.assertEquals(1271055781L, evalLong("unix_timestamp('2010-04-12T07:03:01')", bindings));
     Assert.assertEquals(1271023381L, evalLong("unix_timestamp('2010-04-12T07:03:01+09:00')", bindings));
     Assert.assertEquals(1271023381L, evalLong("unix_timestamp('2010-04-12T07:03:01.419+09:00')", bindings));
-
-    Assert.assertEquals("NULL", eval("nvl(if(x == 9223372036854775807, '', 'x'), 'NULL')", bindings).asString());
+    if (NullHandling.useDefaultValuesForNull()) {
+      Assert.assertEquals("NULL", eval("nvl(if(x == 9223372036854775807, '', 'x'), 'NULL')", bindings).asString());
+    } else {
+      Assert.assertEquals("", eval("nvl(if(x == 9223372036854775807, '', 'x'), 'NULL')", bindings).asString());
+    }
     Assert.assertEquals("x", eval("nvl(if(x == 9223372036854775806, '', 'x'), 'NULL')", bindings).asString());
   }
 

--- a/common/src/test/java/io/druid/math/expr/FunctionTest.java
+++ b/common/src/test/java/io/druid/math/expr/FunctionTest.java
@@ -56,7 +56,7 @@ public class FunctionTest
   public void testConcat()
   {
     assertExpr("concat(x,' ',y)", "foo 2");
-    if (NullHandling.useDefaultValuesForNull()) {
+    if (NullHandling.replaceWithDefault()) {
       assertExpr("concat(x,' ',nonexistent,' ',y)", "foo  2");
     } else {
       assertExpr("concat(x,' ',nonexistent,' ',y)", null);

--- a/common/src/test/java/io/druid/math/expr/FunctionTest.java
+++ b/common/src/test/java/io/druid/math/expr/FunctionTest.java
@@ -20,6 +20,7 @@
 package io.druid.math.expr;
 
 import com.google.common.collect.ImmutableMap;
+import io.druid.common.config.NullHandling;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -55,7 +56,12 @@ public class FunctionTest
   public void testConcat()
   {
     assertExpr("concat(x,' ',y)", "foo 2");
-    assertExpr("concat(x,' ',nonexistent,' ',y)", "foo  2");
+    if (NullHandling.useDefaultValuesForNull()) {
+      assertExpr("concat(x,' ',nonexistent,' ',y)", "foo  2");
+    } else {
+      assertExpr("concat(x,' ',nonexistent,' ',y)", null);
+    }
+
     assertExpr("concat(z)", "3.1");
     assertExpr("concat()", null);
   }
@@ -109,5 +115,19 @@ public class FunctionTest
   {
     final Expr expr = Parser.parse(expression, ExprMacroTable.nil());
     Assert.assertEquals(expression, expectedResult, expr.eval(bindings).value());
+  }
+
+  @Test
+  public void testIsNull()
+  {
+    assertExpr("isnull(null)", 1L);
+    assertExpr("isnull('abc')", 0L);
+  }
+
+  @Test
+  public void testIsNotNull()
+  {
+    assertExpr("notnull(null)", 0L);
+    assertExpr("notnull('abc')", 1L);
   }
 }

--- a/extensions-contrib/virtual-columns/src/main/java/io/druid/segment/MapVirtualColumn.java
+++ b/extensions-contrib/virtual-columns/src/main/java/io/druid/segment/MapVirtualColumn.java
@@ -193,6 +193,12 @@ public class MapVirtualColumn implements VirtualColumn
     }
 
     @Override
+    public boolean isNull()
+    {
+      return false;
+    }
+
+    @Override
     public void inspectRuntimeShape(RuntimeShapeInspector inspector)
     {
       inspector.visit("keySelector", keySelector);

--- a/extensions-contrib/virtual-columns/src/main/java/io/druid/segment/MapVirtualColumn.java
+++ b/extensions-contrib/virtual-columns/src/main/java/io/druid/segment/MapVirtualColumn.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
+import io.druid.common.config.NullHandling;
 import io.druid.java.util.common.StringUtils;
 import io.druid.query.dimension.DefaultDimensionSpec;
 import io.druid.query.dimension.DimensionSpec;
@@ -177,18 +178,21 @@ public class MapVirtualColumn implements VirtualColumn
     @Override
     public double getDouble()
     {
+      assert NullHandling.replaceWithDefault();
       return 0.0;
     }
 
     @Override
     public float getFloat()
     {
+      assert NullHandling.replaceWithDefault();
       return 0.0f;
     }
 
     @Override
     public long getLong()
     {
+      assert NullHandling.replaceWithDefault();
       return 0L;
     }
 

--- a/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceAggregatorCollectorTest.java
+++ b/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceAggregatorCollectorTest.java
@@ -151,6 +151,13 @@ public class VarianceAggregatorCollectorTest
     {
       return v;
     }
+
+    @Override
+    public boolean isNull()
+    {
+      return false;
+    }
+
   }
 
   private static class ObjectHandOver extends TestObjectColumnSelector

--- a/java-util/src/main/java/io/druid/java/util/common/StringUtils.java
+++ b/java-util/src/main/java/io/druid/java/util/common/StringUtils.java
@@ -22,6 +22,7 @@ package io.druid.java.util.common;
 import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 
+import javax.annotation.Nullable;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
@@ -77,11 +78,37 @@ public class StringUtils
     }
   }
 
+  @Nullable
+  public static String fromUtf8Nullable(@Nullable final byte[] bytes)
+  {
+    if (bytes == null) {
+      return null;
+    }
+    return fromUtf8(bytes);
+  }
+
   public static String fromUtf8(final ByteBuffer buffer, final int numBytes)
   {
     final byte[] bytes = new byte[numBytes];
     buffer.get(bytes);
-    return StringUtils.fromUtf8(bytes);
+    return fromUtf8(bytes);
+  }
+
+  /**
+   * Reads numBytes bytes from buffer and converts that to a utf-8 string
+   * @param buffer buffer to read bytes from
+   * @param numBytes number of bytes to read
+   * @return returns null if numBytes is -1 otherwise utf-8 string represetation of bytes read
+   */
+  @Nullable
+  public static String fromUtf8Nullable(final ByteBuffer buffer, final int numBytes)
+  {
+    if (numBytes < 0) {
+      return null;
+    }
+    final byte[] bytes = new byte[numBytes];
+    buffer.get(bytes);
+    return fromUtf8Nullable(bytes);
   }
 
   public static String fromUtf8(final ByteBuffer buffer)
@@ -98,6 +125,15 @@ public class StringUtils
       // Should never happen
       throw Throwables.propagate(e);
     }
+  }
+
+  @Nullable
+  public static byte[] toUtf8Nullable(@Nullable final String string)
+  {
+    if (string == null) {
+      return null;
+    }
+    return toUtf8(string);
   }
 
   /**

--- a/processing/src/main/java/io/druid/query/aggregation/AggregateCombiner.java
+++ b/processing/src/main/java/io/druid/query/aggregation/AggregateCombiner.java
@@ -71,6 +71,12 @@ public interface AggregateCombiner<T> extends ColumnValueSelector<T>
   void fold(ColumnValueSelector selector);
 
   @Override
+  default boolean isNull()
+  {
+    return false;
+  }
+
+  @Override
   default void inspectRuntimeShape(RuntimeShapeInspector inspector)
   {
     // Usually AggregateCombiner has nothing to inspect

--- a/processing/src/main/java/io/druid/query/aggregation/Aggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/Aggregator.java
@@ -53,6 +53,19 @@ public interface Aggregator extends Closeable
     return (double) getFloat();
   }
 
+  /**
+   * returns true if aggregator's output type is primitive long/double/float and aggregated value is null,
+   * but when aggregated output type is Object, this method always returns false,
+   * and users are advised to check nullability for the object returned by {@link #get()}
+   * method.
+   * The default implementation always return false to enable smooth backward compatibility,
+   * re-implement if your aggregator is nullable.
+   */
+  default boolean isNull()
+  {
+    return false;
+  }
+
   @Override
   void close();
 }

--- a/processing/src/main/java/io/druid/query/aggregation/AggregatorUtil.java
+++ b/processing/src/main/java/io/druid/query/aggregation/AggregatorUtil.java
@@ -164,6 +164,13 @@ public class AggregatorUtil
         {
           inspector.visit("baseSelector", baseSelector);
         }
+
+        @Override
+        public boolean isNull()
+        {
+          final ExprEval exprEval = baseSelector.getObject();
+          return exprEval.isNull();
+        }
       }
       return new ExpressionFloatColumnSelector();
     }
@@ -198,6 +205,13 @@ public class AggregatorUtil
         {
           inspector.visit("baseSelector", baseSelector);
         }
+
+        @Override
+        public boolean isNull()
+        {
+          final ExprEval exprEval = baseSelector.getObject();
+          return exprEval.isNull();
+        }
       }
       return new ExpressionLongColumnSelector();
     }
@@ -231,6 +245,13 @@ public class AggregatorUtil
         public void inspectRuntimeShape(RuntimeShapeInspector inspector)
         {
           inspector.visit("baseSelector", baseSelector);
+        }
+
+        @Override
+        public boolean isNull()
+        {
+          final ExprEval exprEval = baseSelector.getObject();
+          return exprEval.isNull();
         }
       }
       return new ExpressionDoubleColumnSelector();

--- a/processing/src/main/java/io/druid/query/aggregation/BufferAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/BufferAggregator.java
@@ -181,7 +181,7 @@ public interface BufferAggregator extends HotLoopCallee
   /**
    * returns true if aggregator's output type is primitive long/double/float and aggregated value is null,
    * but when aggregated output type is Object, this method always returns false,
-   * and users are advised to check nullability for the object returned by {@link #get()}
+   * and users are advised to check nullability for the object returned by {@link #get(ByteBuffer, int)} ()}
    * method.
    * The default implementation always return false to enable smooth backward compatibility,
    * re-implement if your aggregator is nullable.
@@ -191,7 +191,6 @@ public interface BufferAggregator extends HotLoopCallee
    *
    * @return true if the aggregated value is primitive long/double/float and aggregated value is null otherwise false.
    */
-  @CalledFromHotLoop
   default boolean isNull(ByteBuffer buf, int position)
   {
     return false;

--- a/processing/src/main/java/io/druid/query/aggregation/BufferAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/BufferAggregator.java
@@ -181,7 +181,7 @@ public interface BufferAggregator extends HotLoopCallee
   /**
    * returns true if aggregator's output type is primitive long/double/float and aggregated value is null,
    * but when aggregated output type is Object, this method always returns false,
-   * and users are advised to check nullability for the object returned by {@link #get(ByteBuffer, int)} ()}
+   * and users are advised to check nullability for the object returned by {@link BufferAggregator#get(ByteBuffer, int)}
    * method.
    * The default implementation always return false to enable smooth backward compatibility,
    * re-implement if your aggregator is nullable.

--- a/processing/src/main/java/io/druid/query/aggregation/BufferAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/BufferAggregator.java
@@ -189,10 +189,9 @@ public interface BufferAggregator extends HotLoopCallee
    * @param buf      byte buffer storing the byte array representation of the aggregate
    * @param position offset within the byte buffer at which the aggregate value is stored
    *
-   * @return true if the aggrgeated value is null otherwise false.
-   * The default implementation always return false to enable smooth backward compatibility,
-   * re-implement if your aggregator is nullable.
+   * @return true if the aggregated value is primitive long/double/float and aggregated value is null otherwise false.
    */
+  @CalledFromHotLoop
   default boolean isNull(ByteBuffer buf, int position)
   {
     return false;

--- a/processing/src/main/java/io/druid/query/aggregation/BufferAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/BufferAggregator.java
@@ -190,7 +190,8 @@ public interface BufferAggregator extends HotLoopCallee
    * @param position offset within the byte buffer at which the aggregate value is stored
    *
    * @return true if the aggrgeated value is null otherwise false.
-   * For backwards compatibility, isNull() may return false even if {@link BufferAggregator#get(ByteBuffer, int)} returns null. Users of this method should account for this case.
+   * The default implementation always return false to enable smooth backward compatibility,
+   * re-implement if your aggregator is nullable.
    */
   default boolean isNull(ByteBuffer buf, int position)
   {

--- a/processing/src/main/java/io/druid/query/aggregation/BufferAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/BufferAggregator.java
@@ -178,4 +178,23 @@ public interface BufferAggregator extends HotLoopCallee
   {
   }
 
+  /**
+   * returns true if aggregator's output type is primitive long/double/float and aggregated value is null,
+   * but when aggregated output type is Object, this method always returns false,
+   * and users are advised to check nullability for the object returned by {@link #get()}
+   * method.
+   * The default implementation always return false to enable smooth backward compatibility,
+   * re-implement if your aggregator is nullable.
+   *
+   * @param buf      byte buffer storing the byte array representation of the aggregate
+   * @param position offset within the byte buffer at which the aggregate value is stored
+   *
+   * @return true if the aggrgeated value is null otherwise false.
+   * For backwards compatibility, isNull() may return false even if {@link BufferAggregator#get(ByteBuffer, int)} returns null. Users of this method should account for this case.
+   */
+  default boolean isNull(ByteBuffer buf, int position)
+  {
+    return false;
+  }
+
 }

--- a/processing/src/main/java/io/druid/query/aggregation/ObjectAggregateCombiner.java
+++ b/processing/src/main/java/io/druid/query/aggregation/ObjectAggregateCombiner.java
@@ -24,11 +24,7 @@ import io.druid.segment.ObjectColumnSelector;
 /**
  * Specialization of {@link AggregateCombiner} for object aggregations.
  */
-public abstract class ObjectAggregateCombiner<T> implements AggregateCombiner<T>, ObjectColumnSelector<T>
+public abstract class ObjectAggregateCombiner<T> extends ObjectColumnSelector<T> implements AggregateCombiner<T>
 {
-  @Override
-  public final boolean isNull()
-  {
-    return false;
-  }
+ // No methods
 }

--- a/processing/src/main/java/io/druid/query/aggregation/ObjectAggregateCombiner.java
+++ b/processing/src/main/java/io/druid/query/aggregation/ObjectAggregateCombiner.java
@@ -27,7 +27,7 @@ import io.druid.segment.ObjectColumnSelector;
 public abstract class ObjectAggregateCombiner<T> implements AggregateCombiner<T>, ObjectColumnSelector<T>
 {
   @Override
-  public boolean isNull()
+  public final boolean isNull()
   {
     return false;
   }

--- a/processing/src/main/java/io/druid/query/aggregation/ObjectAggregateCombiner.java
+++ b/processing/src/main/java/io/druid/query/aggregation/ObjectAggregateCombiner.java
@@ -26,4 +26,9 @@ import io.druid.segment.ObjectColumnSelector;
  */
 public abstract class ObjectAggregateCombiner<T> implements AggregateCombiner<T>, ObjectColumnSelector<T>
 {
+  @Override
+  public boolean isNull()
+  {
+    return false;
+  }
 }

--- a/processing/src/main/java/io/druid/query/groupby/RowBasedColumnSelectorFactory.java
+++ b/processing/src/main/java/io/druid/query/groupby/RowBasedColumnSelectorFactory.java
@@ -20,9 +20,9 @@
 package io.druid.query.groupby;
 
 import com.google.common.base.Predicate;
-import com.google.common.base.Strings;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMap;
+import io.druid.common.config.NullHandling;
 import io.druid.data.input.Row;
 import io.druid.query.dimension.DimensionSpec;
 import io.druid.query.extraction.ExtractionFn;
@@ -30,6 +30,7 @@ import io.druid.query.filter.ValueMatcher;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.ColumnSelectorFactory;
 import io.druid.segment.ColumnValueSelector;
+import io.druid.segment.DimensionHandlerUtils;
 import io.druid.segment.DimensionSelector;
 import io.druid.segment.IdLookup;
 import io.druid.segment.LongColumnSelector;
@@ -228,7 +229,7 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
                 }
 
                 for (String dimensionValue : dimensionValues) {
-                  if (Objects.equals(Strings.emptyToNull(dimensionValue), value)) {
+                  if (Objects.equals(NullHandling.emptyToNullIfNeeded(dimensionValue), value)) {
                     return true;
                   }
                 }
@@ -253,7 +254,7 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
                 }
 
                 for (String dimensionValue : dimensionValues) {
-                  if (Objects.equals(extractionFn.apply(Strings.emptyToNull(dimensionValue)), value)) {
+                  if (Objects.equals(extractionFn.apply(NullHandling.emptyToNullIfNeeded(dimensionValue)), value)) {
                     return true;
                   }
                 }
@@ -286,7 +287,7 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
                 }
 
                 for (String dimensionValue : dimensionValues) {
-                  if (predicate.apply(Strings.emptyToNull(dimensionValue))) {
+                  if (predicate.apply(NullHandling.emptyToNullIfNeeded(dimensionValue))) {
                     return true;
                   }
                 }
@@ -312,7 +313,7 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
                 }
 
                 for (String dimensionValue : dimensionValues) {
-                  if (predicate.apply(extractionFn.apply(Strings.emptyToNull(dimensionValue)))) {
+                  if (predicate.apply(extractionFn.apply(NullHandling.emptyToNullIfNeeded(dimensionValue)))) {
                     return true;
                   }
                 }
@@ -338,7 +339,7 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
         @Override
         public String lookupName(int id)
         {
-          final String value = Strings.emptyToNull(row.get().getDimension(dimension).get(id));
+          final String value = NullHandling.emptyToNullIfNeeded(row.get().getDimension(dimension).get(id));
           return extractionFn == null ? value : extractionFn.apply(value);
         }
 
@@ -398,6 +399,13 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
         }
 
         @Override
+        public boolean isNull()
+        {
+          // Time column never has null values
+          return false;
+        }
+
+        @Override
         public void inspectRuntimeShape(RuntimeShapeInspector inspector)
         {
           inspector.visit("row", row);
@@ -410,19 +418,25 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
         @Override
         public double getDouble()
         {
-          return row.get().getMetric(columnName).doubleValue();
+          return DimensionHandlerUtils.nullToZeroDouble(row.get().getMetric(columnName)).doubleValue();
+        }
+
+        @Override
+        public boolean isNull()
+        {
+          return row.get().getRaw(columnName) == null;
         }
 
         @Override
         public float getFloat()
         {
-          return row.get().getMetric(columnName).floatValue();
+          return DimensionHandlerUtils.nullToZeroDouble(row.get().getMetric(columnName)).floatValue();
         }
 
         @Override
         public long getLong()
         {
-          return row.get().getMetric(columnName).longValue();
+          return DimensionHandlerUtils.nullToZeroDouble(row.get().getMetric(columnName)).longValue();
         }
 
         @Nullable

--- a/processing/src/main/java/io/druid/query/groupby/RowBasedColumnSelectorFactory.java
+++ b/processing/src/main/java/io/druid/query/groupby/RowBasedColumnSelectorFactory.java
@@ -426,7 +426,7 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
         {
           Number metric = row.get().getMetric(columnName);
           if (NullHandling.sqlCompatible() && metric == null) {
-            throw new IllegalStateException("Cannot return double for Null Value");
+            throw new IllegalStateException("Cannot return null value as double");
           }
           return DimensionHandlerUtils.nullToZero(metric).doubleValue();
         }
@@ -436,7 +436,7 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
         {
           Number metric = row.get().getMetric(columnName);
           if (NullHandling.sqlCompatible() && metric == null) {
-            throw new IllegalStateException("Cannot return float for Null Value");
+            throw new IllegalStateException("Cannot return null value as float");
           }
           return DimensionHandlerUtils.nullToZero(metric).floatValue();
         }
@@ -446,7 +446,7 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
         {
           Number metric = row.get().getMetric(columnName);
           if (NullHandling.sqlCompatible() && metric == null) {
-            throw new IllegalStateException("Cannot return long for Null Value");
+            throw new IllegalStateException("Cannot return null value as long");
           }
           return DimensionHandlerUtils.nullToZero(metric).longValue();
         }

--- a/processing/src/main/java/io/druid/query/groupby/RowBasedColumnSelectorFactory.java
+++ b/processing/src/main/java/io/druid/query/groupby/RowBasedColumnSelectorFactory.java
@@ -416,27 +416,39 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
       return new ColumnValueSelector()
       {
         @Override
-        public double getDouble()
-        {
-          return DimensionHandlerUtils.nullToZeroDouble(row.get().getMetric(columnName)).doubleValue();
-        }
-
-        @Override
         public boolean isNull()
         {
           return row.get().getRaw(columnName) == null;
         }
 
         @Override
+        public double getDouble()
+        {
+          Number metric = row.get().getMetric(columnName);
+          if (NullHandling.sqlCompatible() && metric == null) {
+            throw new IllegalStateException("Cannot return double for Null Value");
+          }
+          return DimensionHandlerUtils.nullToZero(metric).doubleValue();
+        }
+
+        @Override
         public float getFloat()
         {
-          return DimensionHandlerUtils.nullToZeroDouble(row.get().getMetric(columnName)).floatValue();
+          Number metric = row.get().getMetric(columnName);
+          if (NullHandling.sqlCompatible() && metric == null) {
+            throw new IllegalStateException("Cannot return float for Null Value");
+          }
+          return DimensionHandlerUtils.nullToZero(metric).floatValue();
         }
 
         @Override
         public long getLong()
         {
-          return DimensionHandlerUtils.nullToZeroDouble(row.get().getMetric(columnName)).longValue();
+          Number metric = row.get().getMetric(columnName);
+          if (NullHandling.sqlCompatible() && metric == null) {
+            throw new IllegalStateException("Cannot return long for Null Value");
+          }
+          return DimensionHandlerUtils.nullToZero(metric).longValue();
         }
 
         @Nullable

--- a/processing/src/main/java/io/druid/query/groupby/RowBasedColumnSelectorFactory.java
+++ b/processing/src/main/java/io/druid/query/groupby/RowBasedColumnSelectorFactory.java
@@ -425,9 +425,7 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
         public double getDouble()
         {
           Number metric = row.get().getMetric(columnName);
-          if (NullHandling.sqlCompatible() && metric == null) {
-            throw new IllegalStateException("Cannot return null value as double");
-          }
+          assert NullHandling.replaceWithDefault() || metric != null;
           return DimensionHandlerUtils.nullToZero(metric).doubleValue();
         }
 
@@ -435,9 +433,7 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
         public float getFloat()
         {
           Number metric = row.get().getMetric(columnName);
-          if (NullHandling.sqlCompatible() && metric == null) {
-            throw new IllegalStateException("Cannot return null value as float");
-          }
+          assert NullHandling.replaceWithDefault() || metric != null;
           return DimensionHandlerUtils.nullToZero(metric).floatValue();
         }
 
@@ -445,9 +441,7 @@ public class RowBasedColumnSelectorFactory implements ColumnSelectorFactory
         public long getLong()
         {
           Number metric = row.get().getMetric(columnName);
-          if (NullHandling.sqlCompatible() && metric == null) {
-            throw new IllegalStateException("Cannot return null value as long");
-          }
+          assert NullHandling.replaceWithDefault() || metric != null;
           return DimensionHandlerUtils.nullToZero(metric).longValue();
         }
 

--- a/processing/src/main/java/io/druid/segment/BaseDoubleColumnValueSelector.java
+++ b/processing/src/main/java/io/druid/segment/BaseDoubleColumnValueSelector.java
@@ -31,7 +31,7 @@ import io.druid.query.monomorphicprocessing.HotLoopCallee;
  * All implementations of this interface MUST also implement {@link ColumnValueSelector}.
  */
 @PublicApi
-public interface BaseDoubleColumnValueSelector extends HotLoopCallee
+public interface BaseDoubleColumnValueSelector extends HotLoopCallee, BaseNullableColumnValueSelector
 {
   @CalledFromHotLoop
   double getDouble();

--- a/processing/src/main/java/io/druid/segment/BaseFloatColumnValueSelector.java
+++ b/processing/src/main/java/io/druid/segment/BaseFloatColumnValueSelector.java
@@ -31,7 +31,7 @@ import io.druid.query.monomorphicprocessing.HotLoopCallee;
  * All implementations of this interface MUST also implement {@link ColumnValueSelector}.
  */
 @PublicApi
-public interface BaseFloatColumnValueSelector extends HotLoopCallee
+public interface BaseFloatColumnValueSelector extends HotLoopCallee, BaseNullableColumnValueSelector
 {
   @CalledFromHotLoop
   float getFloat();

--- a/processing/src/main/java/io/druid/segment/BaseLongColumnValueSelector.java
+++ b/processing/src/main/java/io/druid/segment/BaseLongColumnValueSelector.java
@@ -31,7 +31,7 @@ import io.druid.query.monomorphicprocessing.HotLoopCallee;
  * All implementations of this interface MUST also implement {@link ColumnValueSelector}.
  */
 @PublicApi
-public interface BaseLongColumnValueSelector extends HotLoopCallee
+public interface BaseLongColumnValueSelector extends HotLoopCallee, BaseNullableColumnValueSelector
 {
   @CalledFromHotLoop
   long getLong();

--- a/processing/src/main/java/io/druid/segment/BaseNullableColumnValueSelector.java
+++ b/processing/src/main/java/io/druid/segment/BaseNullableColumnValueSelector.java
@@ -20,6 +20,7 @@
 package io.druid.segment;
 
 import io.druid.guice.annotations.PublicApi;
+import io.druid.query.monomorphicprocessing.CalledFromHotLoop;
 
 /**
  * Null value checking polymorphic "part" of the {@link ColumnValueSelector} interface for primitive values.
@@ -34,5 +35,6 @@ public interface BaseNullableColumnValueSelector
    * returns true if selected primitive value is null for {@link BaseFloatColumnValueSelector},
    * {@link BaseLongColumnValueSelector} and {@link BaseDoubleColumnValueSelector} otherwise false.
    */
+  @CalledFromHotLoop
   boolean isNull();
 }

--- a/processing/src/main/java/io/druid/segment/BaseNullableColumnValueSelector.java
+++ b/processing/src/main/java/io/druid/segment/BaseNullableColumnValueSelector.java
@@ -17,33 +17,12 @@
  * under the License.
  */
 
-package io.druid.segment.serde;
+package io.druid.segment;
 
-import com.google.common.base.Supplier;
-import io.druid.collections.bitmap.ImmutableBitmap;
-import io.druid.segment.column.GenericColumn;
-import io.druid.segment.column.FloatsColumn;
-import io.druid.segment.data.CompressedColumnarFloatsSupplier;
+import io.druid.guice.annotations.PublicApi;
 
-/**
-*/
-public class FloatGenericColumnSupplier implements Supplier<GenericColumn>
+@PublicApi
+public interface BaseNullableColumnValueSelector
 {
-  private final CompressedColumnarFloatsSupplier column;
-  private final ImmutableBitmap nullValueBitmap;
-
-  public FloatGenericColumnSupplier(
-      CompressedColumnarFloatsSupplier column,
-      ImmutableBitmap nullValueBitmap
-  )
-  {
-    this.column = column;
-    this.nullValueBitmap = nullValueBitmap;
-  }
-
-  @Override
-  public GenericColumn get()
-  {
-    return new FloatsColumn(column.get(), nullValueBitmap);
-  }
+  boolean isNull();
 }

--- a/processing/src/main/java/io/druid/segment/BaseNullableColumnValueSelector.java
+++ b/processing/src/main/java/io/druid/segment/BaseNullableColumnValueSelector.java
@@ -21,8 +21,18 @@ package io.druid.segment;
 
 import io.druid.guice.annotations.PublicApi;
 
+/**
+ * Null value checking polymorphic "part" of the {@link ColumnValueSelector} interface for primitive values.
+ * Users of {@link BaseLongColumnValueSelector#getLong()}, {@link BaseDoubleColumnValueSelector#getDouble()}
+ * and {@link BaseFloatColumnValueSelector#getFloat()} are required to check the nullability of the primitive
+ * types returned.
+ */
 @PublicApi
 public interface BaseNullableColumnValueSelector
 {
+  /**
+   * returns true if selected primitive value is null for {@link BaseFloatColumnValueSelector},
+   * {@link BaseLongColumnValueSelector} and {@link BaseDoubleColumnValueSelector} otherwise false.
+   */
   boolean isNull();
 }

--- a/processing/src/main/java/io/druid/segment/ColumnSelectorBitmapIndexSelector.java
+++ b/processing/src/main/java/io/druid/segment/ColumnSelectorBitmapIndexSelector.java
@@ -174,12 +174,15 @@ public class ColumnSelectorBitmapIndexSelector implements BitmapIndexSelector
           return bitmapFactory;
         }
 
+        /**
+         * Return -2 for non-null values to match what the {@link BitmapIndex} implementation in
+         * {@link io.druid.segment.serde.BitmapIndexColumnPartSupplier}
+         * would return for {@link BitmapIndex#getIndex(String)} when there is only a single index, for the null value.
+         * i.e., return an 'insertion point' of 1 for non-null values (see {@link BitmapIndex} interface)
+         */
         @Override
         public int getIndex(String value)
         {
-          // Return -2 for non-null values to match what the BitmapIndex implementation in BitmapIndexColumnPartSupplier
-          // would return for getIndex() when there is only a single index, for the null value.
-          // i.e., return an 'insertion point' of 1 for non-null values (see BitmapIndex interface)
           return NullHandling.isNullOrEquivalent(value) ? 0 : -2;
         }
 

--- a/processing/src/main/java/io/druid/segment/ColumnSelectorBitmapIndexSelector.java
+++ b/processing/src/main/java/io/druid/segment/ColumnSelectorBitmapIndexSelector.java
@@ -19,10 +19,10 @@
 
 package io.druid.segment;
 
-import com.google.common.base.Strings;
 import io.druid.collections.bitmap.BitmapFactory;
 import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.collections.spatial.ImmutableRTree;
+import io.druid.common.config.NullHandling;
 import io.druid.query.filter.BitmapIndexSelector;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.column.BitmapIndex;
@@ -180,7 +180,7 @@ public class ColumnSelectorBitmapIndexSelector implements BitmapIndexSelector
           // Return -2 for non-null values to match what the BitmapIndex implementation in BitmapIndexColumnPartSupplier
           // would return for getIndex() when there is only a single index, for the null value.
           // i.e., return an 'insertion point' of 1 for non-null values (see BitmapIndex interface)
-          return Strings.isNullOrEmpty(value) ? 0 : -2;
+          return NullHandling.isNullOrEquivalent(value) ? 0 : -2;
         }
 
         @Override
@@ -210,7 +210,7 @@ public class ColumnSelectorBitmapIndexSelector implements BitmapIndexSelector
 
     final Column column = index.getColumn(dimension);
     if (column == null || !columnSupportsFiltering(column)) {
-      if (Strings.isNullOrEmpty(value)) {
+      if (NullHandling.isNullOrEquivalent(value)) {
         return bitmapFactory.complement(bitmapFactory.makeEmptyImmutableBitmap(), getNumRows());
       } else {
         return bitmapFactory.makeEmptyImmutableBitmap();
@@ -222,7 +222,7 @@ public class ColumnSelectorBitmapIndexSelector implements BitmapIndexSelector
     }
 
     final BitmapIndex bitmapIndex = column.getBitmapIndex();
-    return bitmapIndex.getBitmap(bitmapIndex.getIndex(value));
+    return bitmapIndex.getBitmap(bitmapIndex.getIndex(NullHandling.emptyToNullIfNeeded(value)));
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/ConstantColumnValueSelector.java
+++ b/processing/src/main/java/io/druid/segment/ConstantColumnValueSelector.java
@@ -90,6 +90,6 @@ public class ConstantColumnValueSelector<T> implements ColumnValueSelector<T>
   @Override
   public boolean isNull()
   {
-    return objectValue == null;
+    return false;
   }
 }

--- a/processing/src/main/java/io/druid/segment/ConstantColumnValueSelector.java
+++ b/processing/src/main/java/io/druid/segment/ConstantColumnValueSelector.java
@@ -22,15 +22,12 @@ package io.druid.segment;
 import com.google.common.base.Preconditions;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 
-import javax.annotation.Nullable;
-
 public class ConstantColumnValueSelector<T> implements ColumnValueSelector<T>
 {
   private long longValue;
   private float floatValue;
   private double doubleValue;
 
-  @Nullable
   private T objectValue;
 
   private Class<T> objectClass;
@@ -39,7 +36,7 @@ public class ConstantColumnValueSelector<T> implements ColumnValueSelector<T>
       final long longValue,
       final float floatValue,
       final double doubleValue,
-      @Nullable final T objectValue,
+      final T objectValue,
       final Class<T> objectClass
   )
   {
@@ -68,7 +65,6 @@ public class ConstantColumnValueSelector<T> implements ColumnValueSelector<T>
     return longValue;
   }
 
-  @Nullable
   @Override
   public T getObject()
   {

--- a/processing/src/main/java/io/druid/segment/ConstantColumnValueSelector.java
+++ b/processing/src/main/java/io/druid/segment/ConstantColumnValueSelector.java
@@ -86,4 +86,10 @@ public class ConstantColumnValueSelector<T> implements ColumnValueSelector<T>
   {
     // Nothing here: objectValue is nullable but getObject is not @CalledFromHotLoop
   }
+
+  @Override
+  public boolean isNull()
+  {
+    return objectValue == null;
+  }
 }

--- a/processing/src/main/java/io/druid/segment/ConstantColumnValueSelector.java
+++ b/processing/src/main/java/io/druid/segment/ConstantColumnValueSelector.java
@@ -90,6 +90,7 @@ public class ConstantColumnValueSelector<T> implements ColumnValueSelector<T>
   @Override
   public boolean isNull()
   {
+    // return false always as the primitive values for this selector can never be null.
     return false;
   }
 }

--- a/processing/src/main/java/io/druid/segment/ConstantDimensionSelector.java
+++ b/processing/src/main/java/io/druid/segment/ConstantDimensionSelector.java
@@ -20,7 +20,7 @@
 package io.druid.segment;
 
 import com.google.common.base.Predicate;
-import com.google.common.base.Strings;
+import io.druid.common.config.NullHandling;
 import io.druid.query.filter.ValueMatcher;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.data.IndexedInts;
@@ -37,7 +37,7 @@ public class ConstantDimensionSelector implements SingleValueHistoricalDimension
 
   public ConstantDimensionSelector(final String value)
   {
-    if (Strings.isNullOrEmpty(value)) {
+    if (NullHandling.isNullOrEquivalent(value)) {
       // There's an optimized implementation for nulls that callers should use instead.
       throw new IllegalArgumentException("Use NullDimensionSelector or DimensionSelectorUtils.constantSelector");
     }

--- a/processing/src/main/java/io/druid/segment/DimensionHandlerUtils.java
+++ b/processing/src/main/java/io/druid/segment/DimensionHandlerUtils.java
@@ -239,15 +239,6 @@ public final class DimensionHandlerUtils
   }
 
   @Nullable
-  public static String convertObjectToString(@Nullable Object valObj)
-  {
-    if (valObj == null) {
-      return null;
-    }
-    return valObj.toString();
-  }
-
-  @Nullable
   public static Long convertObjectToLong(@Nullable Object valObj)
   {
     return convertObjectToLong(valObj, false);

--- a/processing/src/main/java/io/druid/segment/DimensionHandlerUtils.java
+++ b/processing/src/main/java/io/druid/segment/DimensionHandlerUtils.java
@@ -22,7 +22,6 @@ package io.druid.segment;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Floats;
-import io.druid.common.config.NullHandling;
 import io.druid.common.guava.GuavaUtils;
 import io.druid.data.input.impl.DimensionSchema.MultiValueHandling;
 import io.druid.java.util.common.IAE;
@@ -358,18 +357,23 @@ public final class DimensionHandlerUtils
     }
   }
 
-  public static Number nullToZeroDouble(@Nullable Number number)
+  public static Double nullToZero(@Nullable Double number)
   {
-    return number == null ? NullHandling.ZERO_DOUBLE : number;
+    return number == null ? ZERO_DOUBLE : number;
   }
 
-  public static Number nullToZeroLong(@Nullable Number number)
+  public static Long nullToZero(@Nullable Long number)
   {
-    return number == null ? NullHandling.ZERO_LONG : number;
+    return number == null ? ZERO_LONG : number;
   }
 
-  public static Number nullToZeroFloat(@Nullable Number number)
+  public static Float nullToZero(@Nullable Float number)
   {
-    return number == null ? NullHandling.ZERO_FLOAT : number;
+    return number == null ? ZERO_FLOAT : number;
+  }
+
+  public static Number nullToZero(@Nullable Number number)
+  {
+    return number == null ? ZERO_DOUBLE : number;
   }
 }

--- a/processing/src/main/java/io/druid/segment/DimensionHandlerUtils.java
+++ b/processing/src/main/java/io/druid/segment/DimensionHandlerUtils.java
@@ -22,6 +22,7 @@ package io.druid.segment;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Floats;
+import io.druid.common.config.NullHandling;
 import io.druid.common.guava.GuavaUtils;
 import io.druid.data.input.impl.DimensionSchema.MultiValueHandling;
 import io.druid.java.util.common.IAE;
@@ -238,6 +239,15 @@ public final class DimensionHandlerUtils
   }
 
   @Nullable
+  public static String convertObjectToString(@Nullable Object valObj)
+  {
+    if (valObj == null) {
+      return null;
+    }
+    return valObj.toString();
+  }
+
+  @Nullable
   public static Long convertObjectToLong(@Nullable Object valObj)
   {
     return convertObjectToLong(valObj, false);
@@ -247,7 +257,7 @@ public final class DimensionHandlerUtils
   public static Long convertObjectToLong(@Nullable Object valObj, boolean reportParseExceptions)
   {
     if (valObj == null) {
-      return ZERO_LONG;
+      return null;
     }
 
     if (valObj instanceof Long) {
@@ -275,7 +285,7 @@ public final class DimensionHandlerUtils
   public static Float convertObjectToFloat(@Nullable Object valObj, boolean reportParseExceptions)
   {
     if (valObj == null) {
-      return ZERO_FLOAT;
+      return null;
     }
 
     if (valObj instanceof Float) {
@@ -303,7 +313,7 @@ public final class DimensionHandlerUtils
   public static Double convertObjectToDouble(@Nullable Object valObj, boolean reportParseExceptions)
   {
     if (valObj == null) {
-      return ZERO_DOUBLE;
+      return null;
     }
 
     if (valObj instanceof Double) {
@@ -357,18 +367,18 @@ public final class DimensionHandlerUtils
     }
   }
 
-  public static Double nullToZero(@Nullable Double number)
+  public static Number nullToZeroDouble(@Nullable Number number)
   {
-    return number == null ? ZERO_DOUBLE : number;
+    return number == null ? NullHandling.ZERO_DOUBLE : number;
   }
 
-  public static Long nullToZero(@Nullable Long number)
+  public static Number nullToZeroLong(@Nullable Number number)
   {
-    return number == null ? ZERO_LONG : number;
+    return number == null ? NullHandling.ZERO_LONG : number;
   }
 
-  public static Float nullToZero(@Nullable Float number)
+  public static Number nullToZeroFloat(@Nullable Number number)
   {
-    return number == null ? ZERO_FLOAT : number;
+    return number == null ? NullHandling.ZERO_FLOAT : number;
   }
 }

--- a/processing/src/main/java/io/druid/segment/DimensionSelector.java
+++ b/processing/src/main/java/io/druid/segment/DimensionSelector.java
@@ -149,18 +149,14 @@ public interface DimensionSelector extends ColumnValueSelector, HotLoopCallee
     return 0L;
   }
 
-  /**
-   * @deprecated always throws {@link UnsupportedOperationException}
-   */
   @Deprecated
   @Override
   default boolean isNull()
   {
-    throw new UnsupportedOperationException("DimensionSelector cannot be operated as numeric ColumnValueSelector" + this.getClass());
+    return false;
   }
 
   /**
-   * @deprecated always throws {@link UnsupportedOperationException}
    * Converts the current result of {@link #getRow()} into null, if the row is empty, a String, if the row has size 1,
    * or a String[] array, if the row has size > 1, using {@link #lookupName(int)}.
    *

--- a/processing/src/main/java/io/druid/segment/DimensionSelector.java
+++ b/processing/src/main/java/io/druid/segment/DimensionSelector.java
@@ -149,6 +149,7 @@ public interface DimensionSelector extends ColumnValueSelector, HotLoopCallee
     return 0L;
   }
 
+  @Deprecated
   @Override
   default boolean isNull()
   {
@@ -162,7 +163,6 @@ public interface DimensionSelector extends ColumnValueSelector, HotLoopCallee
    * This method is not the default implementation of {@link #getObject()} to minimize the chance that implementations
    * "forget" to override it with more optimized version.
    */
-  @Deprecated
   @Nullable
   default Object defaultGetObject()
   {

--- a/processing/src/main/java/io/druid/segment/DimensionSelector.java
+++ b/processing/src/main/java/io/druid/segment/DimensionSelector.java
@@ -149,7 +149,6 @@ public interface DimensionSelector extends ColumnValueSelector, HotLoopCallee
     return 0L;
   }
 
-  @Deprecated
   @Override
   default boolean isNull()
   {

--- a/processing/src/main/java/io/druid/segment/DimensionSelector.java
+++ b/processing/src/main/java/io/druid/segment/DimensionSelector.java
@@ -150,12 +150,24 @@ public interface DimensionSelector extends ColumnValueSelector, HotLoopCallee
   }
 
   /**
+   * @deprecated always throws {@link UnsupportedOperationException}
+   */
+  @Deprecated
+  @Override
+  default boolean isNull()
+  {
+    throw new UnsupportedOperationException("DimensionSelector cannot be operated as numeric ColumnValueSelector" + this.getClass());
+  }
+
+  /**
+   * @deprecated always throws {@link UnsupportedOperationException}
    * Converts the current result of {@link #getRow()} into null, if the row is empty, a String, if the row has size 1,
    * or a String[] array, if the row has size > 1, using {@link #lookupName(int)}.
    *
    * This method is not the default implementation of {@link #getObject()} to minimize the chance that implementations
    * "forget" to override it with more optimized version.
    */
+  @Deprecated
   @Nullable
   default Object defaultGetObject()
   {

--- a/processing/src/main/java/io/druid/segment/DimensionSelectorUtils.java
+++ b/processing/src/main/java/io/druid/segment/DimensionSelectorUtils.java
@@ -21,7 +21,7 @@ package io.druid.segment;
 
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
-import com.google.common.base.Strings;
+import io.druid.common.config.NullHandling;
 import io.druid.java.util.common.IAE;
 import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.filter.ValueMatcher;
@@ -252,7 +252,7 @@ public final class DimensionSelectorUtils
 
   public static DimensionSelector constantSelector(@Nullable final String value)
   {
-    if (Strings.isNullOrEmpty(value)) {
+    if (NullHandling.isNullOrEquivalent(value)) {
       return NullDimensionSelector.instance();
     } else {
       return new ConstantDimensionSelector(value);

--- a/processing/src/main/java/io/druid/segment/DoubleColumnSelector.java
+++ b/processing/src/main/java/io/druid/segment/DoubleColumnSelector.java
@@ -61,6 +61,9 @@ public interface DoubleColumnSelector extends ColumnValueSelector<Double>
   @Override
   default Double getObject()
   {
+    if (isNull()) {
+      return null;
+    }
     return getDouble();
   }
 

--- a/processing/src/main/java/io/druid/segment/DoubleColumnSelector.java
+++ b/processing/src/main/java/io/druid/segment/DoubleColumnSelector.java
@@ -19,6 +19,8 @@
 
 package io.druid.segment;
 
+import javax.annotation.Nullable;
+
 /**
  * This interface is convenient for implementation of "double-sourcing" {@link ColumnValueSelector}s, it provides
  * default implementations for all {@link ColumnValueSelector}'s methods except {@link #getDouble()}.
@@ -59,6 +61,7 @@ public interface DoubleColumnSelector extends ColumnValueSelector<Double>
    */
   @Deprecated
   @Override
+  @Nullable
   default Double getObject()
   {
     if (isNull()) {

--- a/processing/src/main/java/io/druid/segment/DoubleColumnSerializerV2.java
+++ b/processing/src/main/java/io/druid/segment/DoubleColumnSerializerV2.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment;
+
+import com.google.common.primitives.Ints;
+import io.druid.collections.bitmap.ImmutableBitmap;
+import io.druid.collections.bitmap.MutableBitmap;
+import io.druid.java.util.common.StringUtils;
+import io.druid.java.util.common.io.smoosh.FileSmoosher;
+import io.druid.segment.data.BitmapSerdeFactory;
+import io.druid.segment.data.ByteBufferWriter;
+import io.druid.segment.data.ColumnarDoublesSerializer;
+import io.druid.segment.data.CompressionFactory;
+import io.druid.segment.data.CompressionStrategy;
+import io.druid.segment.writeout.SegmentWriteOutMedium;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.WritableByteChannel;
+
+public class DoubleColumnSerializerV2 implements GenericColumnSerializer
+{
+  public static DoubleColumnSerializerV2 create(
+      SegmentWriteOutMedium segmentWriteOutMedium,
+      String filenameBase,
+      CompressionStrategy compression,
+      BitmapSerdeFactory bitmapSerdeFactory
+  )
+  {
+    return new DoubleColumnSerializerV2(
+        segmentWriteOutMedium,
+        filenameBase,
+        IndexIO.BYTE_ORDER,
+        compression,
+        bitmapSerdeFactory
+    );
+  }
+
+  private final SegmentWriteOutMedium segmentWriteOutMedium;
+  private final String filenameBase;
+  private final ByteOrder byteOrder;
+  private final CompressionStrategy compression;
+  private final BitmapSerdeFactory bitmapSerdeFactory;
+
+  private ColumnarDoublesSerializer writer;
+  private ByteBufferWriter<ImmutableBitmap> nullValueBitmapWriter;
+  private MutableBitmap nullRowsBitmap;
+  private int rowCount = 0;
+
+  private DoubleColumnSerializerV2(
+      SegmentWriteOutMedium segmentWriteOutMedium,
+      String filenameBase,
+      ByteOrder byteOrder,
+      CompressionStrategy compression,
+      BitmapSerdeFactory bitmapSerdeFactory
+  )
+  {
+    this.segmentWriteOutMedium = segmentWriteOutMedium;
+    this.filenameBase = filenameBase;
+    this.byteOrder = byteOrder;
+    this.compression = compression;
+    this.bitmapSerdeFactory = bitmapSerdeFactory;
+  }
+
+  @Override
+  public void open() throws IOException
+  {
+    writer = CompressionFactory.getDoubleSerializer(
+        segmentWriteOutMedium,
+        StringUtils.format("%s.double_column", filenameBase),
+        byteOrder,
+        compression
+    );
+    writer.open();
+    nullValueBitmapWriter = new ByteBufferWriter<>(
+        segmentWriteOutMedium,
+        bitmapSerdeFactory.getObjectStrategy()
+    );
+    nullValueBitmapWriter.open();
+    nullRowsBitmap = bitmapSerdeFactory.getBitmapFactory().makeEmptyMutableBitmap();
+  }
+
+  @Override
+  public void serialize(@Nullable Object obj) throws IOException
+  {
+    if (obj == null) {
+      nullRowsBitmap.add(rowCount);
+      writer.add(0D);
+    } else {
+      writer.add(((Number) obj).doubleValue());
+    }
+    rowCount++;
+  }
+
+  @Override
+  public long getSerializedSize() throws IOException
+  {
+    nullValueBitmapWriter.write(bitmapSerdeFactory.getBitmapFactory().makeImmutableBitmap(nullRowsBitmap));
+    long bitmapSize = nullRowsBitmap.isEmpty()
+                      ? 0L
+                      : nullValueBitmapWriter.getSerializedSize();
+    return Integer.BYTES + writer.getSerializedSize() + bitmapSize;
+  }
+
+  @Override
+  public void writeTo(WritableByteChannel channel, FileSmoosher smoosher) throws IOException
+  {
+    channel.write(ByteBuffer.wrap(Ints.toByteArray((int) writer.getSerializedSize())));
+    writer.writeTo(channel, smoosher);
+    if (!nullRowsBitmap.isEmpty()) {
+      nullValueBitmapWriter.writeTo(channel, smoosher);
+    }
+  }
+
+}

--- a/processing/src/main/java/io/druid/segment/DoubleColumnSerializerV2.java
+++ b/processing/src/main/java/io/druid/segment/DoubleColumnSerializerV2.java
@@ -19,9 +19,9 @@
 
 package io.druid.segment;
 
-import com.google.common.primitives.Ints;
 import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.collections.bitmap.MutableBitmap;
+import io.druid.common.utils.SerializerUtils;
 import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.io.smoosh.FileSmoosher;
 import io.druid.segment.data.BitmapSerdeFactory;
@@ -33,10 +33,15 @@ import io.druid.segment.writeout.SegmentWriteOutMedium;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.WritableByteChannel;
 
+/**
+ * Column Serializer for double column.
+ * The column is serialized in two parts, first a bitmap indicating the nullability of row values
+ * and second the actual row values.
+ * This class is Unsafe for concurrent use from multiple threads.
+ */
 public class DoubleColumnSerializerV2 implements GenericColumnSerializer
 {
   public static DoubleColumnSerializerV2 create(
@@ -124,7 +129,7 @@ public class DoubleColumnSerializerV2 implements GenericColumnSerializer
   @Override
   public void writeTo(WritableByteChannel channel, FileSmoosher smoosher) throws IOException
   {
-    channel.write(ByteBuffer.wrap(Ints.toByteArray((int) writer.getSerializedSize())));
+    SerializerUtils.writeInt(channel, (int) writer.getSerializedSize());
     writer.writeTo(channel, smoosher);
     if (!nullRowsBitmap.isEmpty()) {
       nullValueBitmapWriter.writeTo(channel, smoosher);

--- a/processing/src/main/java/io/druid/segment/DoubleColumnSerializerV2.java
+++ b/processing/src/main/java/io/druid/segment/DoubleColumnSerializerV2.java
@@ -19,6 +19,7 @@
 
 package io.druid.segment;
 
+import com.google.common.primitives.Ints;
 import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.collections.bitmap.MutableBitmap;
 import io.druid.common.utils.SerializerUtils;
@@ -129,7 +130,7 @@ public class DoubleColumnSerializerV2 implements GenericColumnSerializer
   @Override
   public void writeTo(WritableByteChannel channel, FileSmoosher smoosher) throws IOException
   {
-    SerializerUtils.writeInt(channel, (int) writer.getSerializedSize());
+    SerializerUtils.writeInt(channel, Ints.checkedCast(writer.getSerializedSize()));
     writer.writeTo(channel, smoosher);
     if (!nullRowsBitmap.isEmpty()) {
       nullValueBitmapWriter.writeTo(channel, smoosher);

--- a/processing/src/main/java/io/druid/segment/DoubleDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/DoubleDimensionIndexer.java
@@ -102,9 +102,6 @@ public class DoubleDimensionIndexer implements DimensionIndexer<Double, Double, 
       @Override
       public boolean isNull()
       {
-        if (NullHandling.replaceWithDefault()) {
-          return false;
-        }
         final Object[] dims = currEntry.get().getDims();
         return dimIndex >= dims.length || dims[dimIndex] == null;
       }

--- a/processing/src/main/java/io/druid/segment/DoubleDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/DoubleDimensionIndexer.java
@@ -116,7 +116,7 @@ public class DoubleDimensionIndexer implements DimensionIndexer<Double, Double, 
 
         if (dimIndex >= dims.length || dims[dimIndex] == null) {
           if (NullHandling.sqlCompatible()) {
-            throw new IllegalStateException("Cannot return double for Null Value");
+            throw new IllegalStateException("Cannot return null value as double");
           }
           return 0.0;
         }

--- a/processing/src/main/java/io/druid/segment/DoubleDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/DoubleDimensionIndexer.java
@@ -112,9 +112,7 @@ public class DoubleDimensionIndexer implements DimensionIndexer<Double, Double, 
         final Object[] dims = currEntry.get().getDims();
 
         if (dimIndex >= dims.length || dims[dimIndex] == null) {
-          if (NullHandling.sqlCompatible()) {
-            throw new IllegalStateException("Cannot return null value as double");
-          }
+          assert NullHandling.replaceWithDefault();
           return 0.0;
         }
         return (Double) dims[dimIndex];

--- a/processing/src/main/java/io/druid/segment/DoubleDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/DoubleDimensionIndexer.java
@@ -21,6 +21,8 @@ package io.druid.segment;
 
 import io.druid.collections.bitmap.BitmapFactory;
 import io.druid.collections.bitmap.MutableBitmap;
+import io.druid.common.config.NullHandling;
+import io.druid.java.util.common.guava.Comparators;
 import io.druid.query.dimension.DimensionSpec;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.data.Indexed;
@@ -28,10 +30,13 @@ import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.TimeAndDimsHolder;
 
 import javax.annotation.Nullable;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 public class DoubleDimensionIndexer implements DimensionIndexer<Double, Double, Double>
 {
+  public static final Comparator DOUBLE_COMPARATOR = Comparators.<Double>naturalNullsFirst();
 
   @Override
   public Double processRowValsToUnsortedEncodedKeyComponent(Object dimValues, boolean reportParseExceptions)
@@ -93,12 +98,23 @@ public class DoubleDimensionIndexer implements DimensionIndexer<Double, Double, 
     final int dimIndex = desc.getIndex();
     class IndexerDoubleColumnSelector implements DoubleColumnSelector
     {
+
+      @Override
+      public boolean isNull()
+      {
+        if (NullHandling.useDefaultValuesForNull()) {
+          return false;
+        }
+        final Object[] dims = currEntry.get().getDims();
+        return dimIndex >= dims.length || dims[dimIndex] == null;
+      }
+
       @Override
       public double getDouble()
       {
         final Object[] dims = currEntry.get().getDims();
 
-        if (dimIndex >= dims.length) {
+        if (dimIndex >= dims.length || dims[dimIndex] == null) {
           return 0.0;
         }
         return (Double) dims[dimIndex];
@@ -130,19 +146,19 @@ public class DoubleDimensionIndexer implements DimensionIndexer<Double, Double, 
   @Override
   public int compareUnsortedEncodedKeyComponents(@Nullable Double lhs, @Nullable Double rhs)
   {
-    return Double.compare(DimensionHandlerUtils.nullToZero(lhs), DimensionHandlerUtils.nullToZero(rhs));
+    return DOUBLE_COMPARATOR.compare(lhs, rhs);
   }
 
   @Override
   public boolean checkUnsortedEncodedKeyComponentsEqual(@Nullable Double lhs, @Nullable Double rhs)
   {
-    return DimensionHandlerUtils.nullToZero(lhs).equals(DimensionHandlerUtils.nullToZero(rhs));
+    return Objects.equals(lhs, rhs);
   }
 
   @Override
   public int getUnsortedEncodedKeyComponentHashCode(@Nullable Double key)
   {
-    return DimensionHandlerUtils.nullToZero(key).hashCode();
+    return DimensionHandlerUtils.nullToZeroDouble(key).hashCode();
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/DoubleDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/DoubleDimensionIndexer.java
@@ -36,7 +36,7 @@ import java.util.Objects;
 
 public class DoubleDimensionIndexer implements DimensionIndexer<Double, Double, Double>
 {
-  public static final Comparator DOUBLE_COMPARATOR = Comparators.<Double>naturalNullsFirst();
+  public static final Comparator<Double> DOUBLE_COMPARATOR = Comparators.<Double>naturalNullsFirst();
 
   @Override
   public Double processRowValsToUnsortedEncodedKeyComponent(Object dimValues, boolean reportParseExceptions)
@@ -115,6 +115,9 @@ public class DoubleDimensionIndexer implements DimensionIndexer<Double, Double, 
         final Object[] dims = currEntry.get().getDims();
 
         if (dimIndex >= dims.length || dims[dimIndex] == null) {
+          if (NullHandling.sqlCompatible()) {
+            throw new IllegalStateException("Cannot return double for Null Value");
+          }
           return 0.0;
         }
         return (Double) dims[dimIndex];

--- a/processing/src/main/java/io/druid/segment/DoubleDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/DoubleDimensionIndexer.java
@@ -102,7 +102,7 @@ public class DoubleDimensionIndexer implements DimensionIndexer<Double, Double, 
       @Override
       public boolean isNull()
       {
-        if (NullHandling.useDefaultValuesForNull()) {
+        if (NullHandling.replaceWithDefault()) {
           return false;
         }
         final Object[] dims = currEntry.get().getDims();
@@ -158,7 +158,7 @@ public class DoubleDimensionIndexer implements DimensionIndexer<Double, Double, 
   @Override
   public int getUnsortedEncodedKeyComponentHashCode(@Nullable Double key)
   {
-    return DimensionHandlerUtils.nullToZeroDouble(key).hashCode();
+    return DimensionHandlerUtils.nullToZero(key).hashCode();
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/DoubleDimensionMergerV9.java
+++ b/processing/src/main/java/io/druid/segment/DoubleDimensionMergerV9.java
@@ -21,7 +21,6 @@ package io.druid.segment;
 
 import io.druid.segment.column.ColumnDescriptor;
 import io.druid.segment.column.ValueType;
-import io.druid.segment.data.CompressionStrategy;
 import io.druid.segment.serde.ColumnPartSerde;
 import io.druid.segment.writeout.SegmentWriteOutMedium;
 
@@ -54,12 +53,9 @@ public class DoubleDimensionMergerV9 implements DimensionMergerV9<Double>
 
   private void setupEncodedValueWriter(SegmentWriteOutMedium segmentWriteOutMedium) throws IOException
   {
-    final CompressionStrategy metCompression = indexSpec.getMetricCompression();
-    // If using default values for null use DoubleColumnSerializer to allow rollback to previous versions.
     this.serializer = IndexMergerV9.createDoubleColumnSerializer(
         segmentWriteOutMedium,
         dimensionName,
-        metCompression,
         indexSpec
     );
 

--- a/processing/src/main/java/io/druid/segment/FloatColumnSelector.java
+++ b/processing/src/main/java/io/druid/segment/FloatColumnSelector.java
@@ -19,6 +19,8 @@
 
 package io.druid.segment;
 
+import javax.annotation.Nullable;
+
 /**
  * This interface is convenient for implementation of "float-sourcing" {@link ColumnValueSelector}s, it provides default
  * implementations for all {@link ColumnValueSelector}'s methods except {@link #getFloat()}.
@@ -59,8 +61,12 @@ public interface FloatColumnSelector extends ColumnValueSelector<Float>
    */
   @Deprecated
   @Override
+  @Nullable
   default Float getObject()
   {
+    if (isNull()) {
+      return null;
+    }
     return getFloat();
   }
 

--- a/processing/src/main/java/io/druid/segment/FloatColumnSerializerV2.java
+++ b/processing/src/main/java/io/druid/segment/FloatColumnSerializerV2.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment;
+
+import com.google.common.primitives.Ints;
+import io.druid.collections.bitmap.ImmutableBitmap;
+import io.druid.collections.bitmap.MutableBitmap;
+import io.druid.java.util.common.StringUtils;
+import io.druid.java.util.common.io.smoosh.FileSmoosher;
+import io.druid.segment.data.BitmapSerdeFactory;
+import io.druid.segment.data.ByteBufferWriter;
+import io.druid.segment.data.ColumnarFloatsSerializer;
+import io.druid.segment.data.CompressionFactory;
+import io.druid.segment.data.CompressionStrategy;
+import io.druid.segment.writeout.SegmentWriteOutMedium;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.WritableByteChannel;
+
+public class FloatColumnSerializerV2 implements GenericColumnSerializer
+{
+  public static FloatColumnSerializerV2 create(
+      SegmentWriteOutMedium segmentWriteOutMedium,
+      String filenameBase,
+      CompressionStrategy compression,
+      BitmapSerdeFactory bitmapSerdeFactory
+  )
+  {
+    return new FloatColumnSerializerV2(segmentWriteOutMedium, filenameBase, IndexIO.BYTE_ORDER, compression, bitmapSerdeFactory);
+  }
+
+  private final SegmentWriteOutMedium segmentWriteOutMedium;
+  private final String filenameBase;
+  private final ByteOrder byteOrder;
+  private final CompressionStrategy compression;
+  private final BitmapSerdeFactory bitmapSerdeFactory;
+
+  private ColumnarFloatsSerializer writer;
+  private ByteBufferWriter<ImmutableBitmap> nullValueBitmapWriter;
+  private MutableBitmap nullRowsBitmap;
+  private int rowCount = 0;
+
+  private FloatColumnSerializerV2(
+      SegmentWriteOutMedium segmentWriteOutMedium,
+      String filenameBase,
+      ByteOrder byteOrder,
+      CompressionStrategy compression,
+      BitmapSerdeFactory bitmapSerdeFactory
+  )
+  {
+    this.segmentWriteOutMedium = segmentWriteOutMedium;
+    this.filenameBase = filenameBase;
+    this.byteOrder = byteOrder;
+    this.compression = compression;
+    this.bitmapSerdeFactory = bitmapSerdeFactory;
+  }
+
+  @Override
+  public void open() throws IOException
+  {
+    writer = CompressionFactory.getFloatSerializer(
+        segmentWriteOutMedium,
+        StringUtils.format("%s.float_column", filenameBase),
+        byteOrder,
+        compression
+    );
+    writer.open();
+    nullValueBitmapWriter = new ByteBufferWriter<>(
+        segmentWriteOutMedium,
+        bitmapSerdeFactory.getObjectStrategy()
+    );
+    nullValueBitmapWriter.open();
+    nullRowsBitmap = bitmapSerdeFactory.getBitmapFactory().makeEmptyMutableBitmap();
+  }
+
+  @Override
+  public void serialize(@Nullable Object obj) throws IOException
+  {
+    if (obj == null) {
+      nullRowsBitmap.add(rowCount);
+      writer.add(0L);
+    } else {
+      writer.add(((Number) obj).floatValue());
+    }
+    rowCount++;
+  }
+
+  @Override
+
+  public long getSerializedSize() throws IOException
+  {
+    nullValueBitmapWriter.write(bitmapSerdeFactory.getBitmapFactory().makeImmutableBitmap(nullRowsBitmap));
+    long bitmapSize = nullRowsBitmap.isEmpty()
+                      ? 0L
+                      : nullValueBitmapWriter.getSerializedSize();
+    return Integer.BYTES + writer.getSerializedSize() + bitmapSize;
+  }
+
+  @Override
+  public void writeTo(WritableByteChannel channel, FileSmoosher smoosher) throws IOException
+  {
+    channel.write(ByteBuffer.wrap(Ints.toByteArray((int) writer.getSerializedSize())));
+    writer.writeTo(channel, smoosher);
+    if (!nullRowsBitmap.isEmpty()) {
+      nullValueBitmapWriter.writeTo(channel, smoosher);
+    }
+  }
+}

--- a/processing/src/main/java/io/druid/segment/FloatColumnSerializerV2.java
+++ b/processing/src/main/java/io/druid/segment/FloatColumnSerializerV2.java
@@ -19,6 +19,7 @@
 
 package io.druid.segment;
 
+import com.google.common.primitives.Ints;
 import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.collections.bitmap.MutableBitmap;
 import io.druid.common.utils.SerializerUtils;
@@ -130,7 +131,7 @@ public class FloatColumnSerializerV2 implements GenericColumnSerializer
   @Override
   public void writeTo(WritableByteChannel channel, FileSmoosher smoosher) throws IOException
   {
-    SerializerUtils.writeInt(channel, (int) writer.getSerializedSize());
+    SerializerUtils.writeInt(channel, Ints.checkedCast(writer.getSerializedSize()));
     writer.writeTo(channel, smoosher);
     if (!nullRowsBitmap.isEmpty()) {
       nullValueBitmapWriter.writeTo(channel, smoosher);

--- a/processing/src/main/java/io/druid/segment/FloatDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/FloatDimensionIndexer.java
@@ -117,7 +117,7 @@ public class FloatDimensionIndexer implements DimensionIndexer<Float, Float, Flo
 
         if (dimIndex >= dims.length || dims[dimIndex] == null) {
           if (NullHandling.sqlCompatible()) {
-            throw new IllegalStateException("Cannot return float for Null Value");
+            throw new IllegalStateException("Cannot return null value as float");
           }
           return 0.0f;
         }

--- a/processing/src/main/java/io/druid/segment/FloatDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/FloatDimensionIndexer.java
@@ -103,9 +103,6 @@ public class FloatDimensionIndexer implements DimensionIndexer<Float, Float, Flo
       @Override
       public boolean isNull()
       {
-        if (NullHandling.replaceWithDefault()) {
-          return false;
-        }
         final Object[] dims = currEntry.get().getDims();
         return dimIndex >= dims.length || dims[dimIndex] == null;
       }

--- a/processing/src/main/java/io/druid/segment/FloatDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/FloatDimensionIndexer.java
@@ -113,9 +113,7 @@ public class FloatDimensionIndexer implements DimensionIndexer<Float, Float, Flo
         final Object[] dims = currEntry.get().getDims();
 
         if (dimIndex >= dims.length || dims[dimIndex] == null) {
-          if (NullHandling.sqlCompatible()) {
-            throw new IllegalStateException("Cannot return null value as float");
-          }
+          assert NullHandling.replaceWithDefault();
           return 0.0f;
         }
 

--- a/processing/src/main/java/io/druid/segment/FloatDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/FloatDimensionIndexer.java
@@ -157,7 +157,7 @@ public class FloatDimensionIndexer implements DimensionIndexer<Float, Float, Flo
   @Override
   public int getUnsortedEncodedKeyComponentHashCode(@Nullable Float key)
   {
-    return DimensionHandlerUtils.nullToZeroFloat(key).hashCode();
+    return DimensionHandlerUtils.nullToZero(key).hashCode();
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/FloatDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/FloatDimensionIndexer.java
@@ -21,6 +21,7 @@ package io.druid.segment;
 
 import io.druid.collections.bitmap.BitmapFactory;
 import io.druid.collections.bitmap.MutableBitmap;
+import io.druid.java.util.common.guava.Comparators;
 import io.druid.query.dimension.DimensionSpec;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.data.Indexed;
@@ -28,10 +29,14 @@ import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.TimeAndDimsHolder;
 
 import javax.annotation.Nullable;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 public class FloatDimensionIndexer implements DimensionIndexer<Float, Float, Float>
 {
+
+  public static final Comparator FLOAT_COMPARATOR = Comparators.<Float>naturalNullsFirst();
 
   @Override
   public Float processRowValsToUnsortedEncodedKeyComponent(Object dimValues, boolean reportParseExceptions)
@@ -99,11 +104,18 @@ public class FloatDimensionIndexer implements DimensionIndexer<Float, Float, Flo
       {
         final Object[] dims = currEntry.get().getDims();
 
-        if (dimIndex >= dims.length) {
+        if (dimIndex >= dims.length || dims[dimIndex] == null) {
           return 0.0f;
         }
 
         return (Float) dims[dimIndex];
+      }
+
+      @Override
+      public boolean isNull()
+      {
+        final Object[] dims = currEntry.get().getDims();
+        return dimIndex >= dims.length || dims[dimIndex] == null;
       }
 
       @SuppressWarnings("deprecation")
@@ -133,19 +145,19 @@ public class FloatDimensionIndexer implements DimensionIndexer<Float, Float, Flo
   @Override
   public int compareUnsortedEncodedKeyComponents(@Nullable Float lhs, @Nullable Float rhs)
   {
-    return DimensionHandlerUtils.nullToZero(lhs).compareTo(DimensionHandlerUtils.nullToZero(rhs));
+    return FLOAT_COMPARATOR.compare(lhs, rhs);
   }
 
   @Override
   public boolean checkUnsortedEncodedKeyComponentsEqual(@Nullable Float lhs, @Nullable Float rhs)
   {
-    return DimensionHandlerUtils.nullToZero(lhs).equals(DimensionHandlerUtils.nullToZero(rhs));
+    return Objects.equals(lhs, rhs);
   }
 
   @Override
   public int getUnsortedEncodedKeyComponentHashCode(@Nullable Float key)
   {
-    return DimensionHandlerUtils.nullToZero(key).hashCode();
+    return DimensionHandlerUtils.nullToZeroFloat(key).hashCode();
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/FloatDimensionMergerV9.java
+++ b/processing/src/main/java/io/druid/segment/FloatDimensionMergerV9.java
@@ -21,7 +21,6 @@ package io.druid.segment;
 
 import io.druid.segment.column.ColumnDescriptor;
 import io.druid.segment.column.ValueType;
-import io.druid.segment.data.CompressionStrategy;
 import io.druid.segment.serde.ColumnPartSerde;
 import io.druid.segment.writeout.SegmentWriteOutMedium;
 
@@ -54,12 +53,9 @@ public class FloatDimensionMergerV9 implements DimensionMergerV9<Float>
 
   private void setupEncodedValueWriter(SegmentWriteOutMedium segmentWriteOutMedium) throws IOException
   {
-    final CompressionStrategy metCompression = indexSpec.getMetricCompression();
-    // If using default values for null use FloatColumnSerializer to allow rollback to previous versions.
     this.serializer = IndexMergerV9.createFloatColumnSerializer(
         segmentWriteOutMedium,
         dimensionName,
-        metCompression,
         indexSpec
     );
     serializer.open();

--- a/processing/src/main/java/io/druid/segment/FloatDimensionMergerV9.java
+++ b/processing/src/main/java/io/druid/segment/FloatDimensionMergerV9.java
@@ -55,6 +55,7 @@ public class FloatDimensionMergerV9 implements DimensionMergerV9<Float>
   private void setupEncodedValueWriter(SegmentWriteOutMedium segmentWriteOutMedium) throws IOException
   {
     final CompressionStrategy metCompression = indexSpec.getMetricCompression();
+    // If using default values for null use FloatColumnSerializer to allow rollback to previous versions.
     this.serializer = IndexMergerV9.createFloatColumnSerializer(
         segmentWriteOutMedium,
         dimensionName,

--- a/processing/src/main/java/io/druid/segment/IndexMerger.java
+++ b/processing/src/main/java/io/druid/segment/IndexMerger.java
@@ -21,13 +21,14 @@ package io.druid.segment;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Ordering;
 import com.google.common.collect.PeekingIterator;
 import com.google.common.collect.Sets;
 import com.google.inject.ImplementedBy;
+import io.druid.common.config.NullHandling;
 import io.druid.common.utils.SerializerUtils;
 import io.druid.java.util.common.ByteBufferUtils;
 import io.druid.java.util.common.ISE;
@@ -52,10 +53,10 @@ import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -431,16 +432,10 @@ public interface IndexMerger
 
     DictionaryMergeIterator(Indexed<String>[] dimValueLookups, boolean useDirect)
     {
+      final Ordering<String> stringOrdering = Comparators.naturalNullsFirst();
       pQueue = new PriorityQueue<>(
           dimValueLookups.length,
-          new Comparator<Pair<Integer, PeekingIterator<String>>>()
-          {
-            @Override
-            public int compare(Pair<Integer, PeekingIterator<String>> lhs, Pair<Integer, PeekingIterator<String>> rhs)
-            {
-              return lhs.rhs.peek().compareTo(rhs.rhs.peek());
-            }
-          }
+          (lhs, rhs) -> stringOrdering.compare(lhs.rhs.peek(), rhs.rhs.peek())
       );
       conversions = new IntBuffer[dimValueLookups.length];
       for (int i = 0; i < conversions.length; i++) {
@@ -461,14 +456,7 @@ public interface IndexMerger
         final PeekingIterator<String> iter = Iterators.peekingIterator(
             Iterators.transform(
                 indexed.iterator(),
-                new Function<String, String>()
-                {
-                  @Override
-                  public String apply(@Nullable String input)
-                  {
-                    return Strings.nullToEmpty(input);
-                  }
-                }
+                input -> NullHandling.nullToEmptyIfNeeded(input)
             )
         );
         if (iter.hasNext()) {
@@ -492,7 +480,7 @@ public interface IndexMerger
       }
       final String value = writeTranslate(smallest, counter);
 
-      while (!pQueue.isEmpty() && value.equals(pQueue.peek().rhs.peek())) {
+      while (!pQueue.isEmpty() && Objects.equals(value, pQueue.peek().rhs.peek())) {
         writeTranslate(pQueue.remove(), counter);
       }
       counter++;

--- a/processing/src/main/java/io/druid/segment/IndexMerger.java
+++ b/processing/src/main/java/io/druid/segment/IndexMerger.java
@@ -456,7 +456,7 @@ public interface IndexMerger
         final PeekingIterator<String> iter = Iterators.peekingIterator(
             Iterators.transform(
                 indexed.iterator(),
-                input -> NullHandling.nullToEmptyIfNeeded(input)
+                NullHandling::nullToEmptyIfNeeded
             )
         );
         if (iter.hasNext()) {

--- a/processing/src/main/java/io/druid/segment/IndexMergerV9.java
+++ b/processing/src/main/java/io/druid/segment/IndexMergerV9.java
@@ -388,7 +388,7 @@ public class IndexMergerV9 implements IndexMerger
   static ColumnPartSerde createLongColumnPartSerde(GenericColumnSerializer serializer, IndexSpec indexSpec)
   {
     // If using default values for null use LongGenericColumnPartSerde to allow rollback to previous versions.
-    if (NullHandling.useDefaultValuesForNull()) {
+    if (NullHandling.replaceWithDefault()) {
       return LongGenericColumnPartSerde.serializerBuilder()
                                        .withByteOrder(IndexIO.BYTE_ORDER)
                                        .withDelegate(serializer)
@@ -405,7 +405,7 @@ public class IndexMergerV9 implements IndexMerger
   static ColumnPartSerde createDoubleColumnPartSerde(GenericColumnSerializer serializer, IndexSpec indexSpec)
   {
     // If using default values for null use DoubleGenericColumnPartSerde to allow rollback to previous versions.
-    if (NullHandling.useDefaultValuesForNull()) {
+    if (NullHandling.replaceWithDefault()) {
       return DoubleGenericColumnPartSerde.serializerBuilder()
                                          .withByteOrder(IndexIO.BYTE_ORDER)
                                          .withDelegate(serializer)
@@ -422,7 +422,7 @@ public class IndexMergerV9 implements IndexMerger
   static ColumnPartSerde createFloatColumnPartSerde(GenericColumnSerializer serializer, IndexSpec indexSpec)
   {
     // If using default values for null use FloatGenericColumnPartSerde to allow rollback to previous versions.
-    if (NullHandling.useDefaultValuesForNull()) {
+    if (NullHandling.replaceWithDefault()) {
       return FloatGenericColumnPartSerde.serializerBuilder()
                                         .withByteOrder(IndexIO.BYTE_ORDER)
                                         .withDelegate(serializer)
@@ -607,7 +607,7 @@ public class IndexMergerV9 implements IndexMerger
   )
   {
     // If using default values for null use LongColumnSerializer to allow rollback to previous versions.
-    if (NullHandling.useDefaultValuesForNull()) {
+    if (NullHandling.replaceWithDefault()) {
       return LongColumnSerializer.create(
           segmentWriteOutMedium,
           columnName,
@@ -633,7 +633,7 @@ public class IndexMergerV9 implements IndexMerger
   )
   {
     // If using default values for null use DoubleColumnSerializer to allow rollback to previous versions.
-    if (NullHandling.useDefaultValuesForNull()) {
+    if (NullHandling.replaceWithDefault()) {
       return DoubleColumnSerializer.create(
           segmentWriteOutMedium,
           columnName,
@@ -657,7 +657,7 @@ public class IndexMergerV9 implements IndexMerger
   )
   {
     // If using default values for null use FloatColumnSerializer to allow rollback to previous versions.
-    if (NullHandling.useDefaultValuesForNull()) {
+    if (NullHandling.replaceWithDefault()) {
       return FloatColumnSerializer.create(
           segmentWriteOutMedium,
           columnName,

--- a/processing/src/main/java/io/druid/segment/IndexMergerV9.java
+++ b/processing/src/main/java/io/druid/segment/IndexMergerV9.java
@@ -52,8 +52,6 @@ import io.druid.segment.column.ColumnCapabilities;
 import io.druid.segment.column.ColumnCapabilitiesImpl;
 import io.druid.segment.column.ColumnDescriptor;
 import io.druid.segment.column.ValueType;
-import io.druid.segment.data.CompressionFactory;
-import io.druid.segment.data.CompressionStrategy;
 import io.druid.segment.data.GenericIndexed;
 import io.druid.segment.data.Indexed;
 import io.druid.segment.incremental.IncrementalIndex;
@@ -547,8 +545,6 @@ public class IndexMergerV9 implements IndexMerger
     GenericColumnSerializer timeWriter = createLongColumnSerializer(
         segmentWriteOutMedium,
         "little_end_time",
-        CompressionStrategy.DEFAULT_COMPRESSION_STRATEGY,
-        indexSpec.getLongEncoding(),
         indexSpec
     );
     // we will close this writer after we added all the timestamps
@@ -565,20 +561,19 @@ public class IndexMergerV9 implements IndexMerger
   ) throws IOException
   {
     ArrayList<GenericColumnSerializer> metWriters = Lists.newArrayListWithCapacity(mergedMetrics.size());
-    final CompressionStrategy metCompression = indexSpec.getMetricCompression();
-    final CompressionFactory.LongEncodingStrategy longEncoding = indexSpec.getLongEncoding();
+
     for (String metric : mergedMetrics) {
       ValueType type = metricsValueTypes.get(metric);
       GenericColumnSerializer writer;
       switch (type) {
         case LONG:
-          writer = createLongColumnSerializer(segmentWriteOutMedium, metric, metCompression, longEncoding, indexSpec);
+          writer = createLongColumnSerializer(segmentWriteOutMedium, metric, indexSpec);
           break;
         case FLOAT:
-          writer = createFloatColumnSerializer(segmentWriteOutMedium, metric, metCompression, indexSpec);
+          writer = createFloatColumnSerializer(segmentWriteOutMedium, metric, indexSpec);
           break;
         case DOUBLE:
-          writer = createDoubleColumnSerializer(segmentWriteOutMedium, metric, metCompression, indexSpec);
+          writer = createDoubleColumnSerializer(segmentWriteOutMedium, metric, indexSpec);
           break;
         case COMPLEX:
           final String typeName = metricTypeNames.get(metric);
@@ -601,8 +596,6 @@ public class IndexMergerV9 implements IndexMerger
   static GenericColumnSerializer createLongColumnSerializer(
       SegmentWriteOutMedium segmentWriteOutMedium,
       String columnName,
-      CompressionStrategy metCompression,
-      CompressionFactory.LongEncodingStrategy longEncoding,
       IndexSpec indexSpec
   )
   {
@@ -611,15 +604,15 @@ public class IndexMergerV9 implements IndexMerger
       return LongColumnSerializer.create(
           segmentWriteOutMedium,
           columnName,
-          metCompression,
-          longEncoding
+          indexSpec.getMetricCompression(),
+          indexSpec.getLongEncoding()
       );
     } else {
       return LongColumnSerializerV2.create(
           segmentWriteOutMedium,
           columnName,
-          metCompression,
-          longEncoding,
+          indexSpec.getMetricCompression(),
+          indexSpec.getLongEncoding(),
           indexSpec.getBitmapSerdeFactory()
       );
     }
@@ -628,7 +621,6 @@ public class IndexMergerV9 implements IndexMerger
   static GenericColumnSerializer createDoubleColumnSerializer(
       SegmentWriteOutMedium segmentWriteOutMedium,
       String columnName,
-      CompressionStrategy metCompression,
       IndexSpec indexSpec
   )
   {
@@ -637,13 +629,13 @@ public class IndexMergerV9 implements IndexMerger
       return DoubleColumnSerializer.create(
           segmentWriteOutMedium,
           columnName,
-          metCompression
+          indexSpec.getMetricCompression()
       );
     } else {
       return DoubleColumnSerializerV2.create(
           segmentWriteOutMedium,
           columnName,
-          metCompression,
+          indexSpec.getMetricCompression(),
           indexSpec.getBitmapSerdeFactory()
       );
     }
@@ -652,7 +644,6 @@ public class IndexMergerV9 implements IndexMerger
   static GenericColumnSerializer createFloatColumnSerializer(
       SegmentWriteOutMedium segmentWriteOutMedium,
       String columnName,
-      CompressionStrategy metCompression,
       IndexSpec indexSpec
   )
   {
@@ -661,13 +652,13 @@ public class IndexMergerV9 implements IndexMerger
       return FloatColumnSerializer.create(
           segmentWriteOutMedium,
           columnName,
-          metCompression
+          indexSpec.getMetricCompression()
       );
     } else {
       return FloatColumnSerializerV2.create(
           segmentWriteOutMedium,
           columnName,
-          metCompression,
+          indexSpec.getMetricCompression(),
           indexSpec.getBitmapSerdeFactory()
       );
     }

--- a/processing/src/main/java/io/druid/segment/IndexMergerV9.java
+++ b/processing/src/main/java/io/druid/segment/IndexMergerV9.java
@@ -33,6 +33,7 @@ import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import com.google.inject.Inject;
 import io.druid.collections.CombiningIterable;
+import io.druid.common.config.NullHandling;
 import io.druid.io.ZeroCopyByteArrayOutputStream;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.IAE;
@@ -58,12 +59,16 @@ import io.druid.segment.data.Indexed;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexAdapter;
 import io.druid.segment.loading.MMappedQueryableSegmentizerFactory;
+import io.druid.segment.serde.ColumnPartSerde;
 import io.druid.segment.serde.ComplexColumnPartSerde;
 import io.druid.segment.serde.ComplexMetricSerde;
 import io.druid.segment.serde.ComplexMetrics;
 import io.druid.segment.serde.DoubleGenericColumnPartSerde;
+import io.druid.segment.serde.DoubleGenericColumnPartSerdeV2;
 import io.druid.segment.serde.FloatGenericColumnPartSerde;
+import io.druid.segment.serde.FloatGenericColumnPartSerdeV2;
 import io.druid.segment.serde.LongGenericColumnPartSerde;
+import io.druid.segment.serde.LongGenericColumnPartSerdeV2;
 import io.druid.segment.writeout.SegmentWriteOutMedium;
 import io.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
@@ -196,7 +201,7 @@ public class IndexMergerV9 implements IndexMerger
           handlers,
           mergers
       );
-      final LongColumnSerializer timeWriter = setupTimeWriter(segmentWriteOutMedium, indexSpec);
+      final GenericColumnSerializer timeWriter = setupTimeWriter(segmentWriteOutMedium, indexSpec);
       final ArrayList<GenericColumnSerializer> metWriters = setupMetricsWriters(
           segmentWriteOutMedium,
           mergedMetrics,
@@ -211,8 +216,16 @@ public class IndexMergerV9 implements IndexMerger
       /************ Create Inverted Indexes and Finalize Build Columns *************/
       final String section = "build inverted index and columns";
       progress.startSection(section);
-      makeTimeColumn(v9Smoosher, progress, timeWriter);
-      makeMetricsColumns(v9Smoosher, progress, mergedMetrics, metricsValueTypes, metricTypeNames, metWriters);
+      makeTimeColumn(v9Smoosher, progress, timeWriter, indexSpec);
+      makeMetricsColumns(
+          v9Smoosher,
+          progress,
+          mergedMetrics,
+          metricsValueTypes,
+          metricTypeNames,
+          metWriters,
+          indexSpec
+      );
 
       for (int i = 0; i < mergedDimensions.size(); i++) {
         DimensionMergerV9 merger = (DimensionMergerV9) mergers.get(i);
@@ -323,7 +336,8 @@ public class IndexMergerV9 implements IndexMerger
       final List<String> mergedMetrics,
       final Map<String, ValueType> metricsValueTypes,
       final Map<String, String> metricTypeNames,
-      final List<GenericColumnSerializer> metWriters
+      final List<GenericColumnSerializer> metWriters,
+      final IndexSpec indexSpec
   ) throws IOException
   {
     final String section = "make metric columns";
@@ -340,33 +354,15 @@ public class IndexMergerV9 implements IndexMerger
       switch (type) {
         case LONG:
           builder.setValueType(ValueType.LONG);
-          builder.addSerde(
-              LongGenericColumnPartSerde
-                  .serializerBuilder()
-                  .withByteOrder(IndexIO.BYTE_ORDER)
-                  .withDelegate((LongColumnSerializer) writer)
-                  .build()
-          );
+          builder.addSerde(createLongColumnPartSerde(writer, indexSpec));
           break;
         case FLOAT:
           builder.setValueType(ValueType.FLOAT);
-          builder.addSerde(
-              FloatGenericColumnPartSerde
-                  .serializerBuilder()
-                  .withByteOrder(IndexIO.BYTE_ORDER)
-                  .withDelegate((FloatColumnSerializer) writer)
-                  .build()
-          );
+          builder.addSerde(createFloatColumnPartSerde(writer, indexSpec));
           break;
         case DOUBLE:
           builder.setValueType(ValueType.DOUBLE);
-          builder.addSerde(
-              DoubleGenericColumnPartSerde
-                  .serializerBuilder()
-                  .withByteOrder(IndexIO.BYTE_ORDER)
-                  .withDelegate((DoubleColumnSerializer) writer)
-                  .build()
-          );
+          builder.addSerde(createDoubleColumnPartSerde(writer, indexSpec));
           break;
         case COMPLEX:
           final String typeName = metricTypeNames.get(metric);
@@ -389,10 +385,62 @@ public class IndexMergerV9 implements IndexMerger
     progress.stopSection(section);
   }
 
+  static ColumnPartSerde createLongColumnPartSerde(GenericColumnSerializer serializer, IndexSpec indexSpec)
+  {
+    // If using default values for null use LongGenericColumnPartSerde to allow rollback to previous versions.
+    if (NullHandling.useDefaultValuesForNull()) {
+      return LongGenericColumnPartSerde.serializerBuilder()
+                                       .withByteOrder(IndexIO.BYTE_ORDER)
+                                       .withDelegate(serializer)
+                                       .build();
+    } else {
+      return LongGenericColumnPartSerdeV2.serializerBuilder()
+                                         .withByteOrder(IndexIO.BYTE_ORDER)
+                                         .withBitmapSerdeFactory(indexSpec.getBitmapSerdeFactory())
+                                         .withDelegate(serializer)
+                                         .build();
+    }
+  }
+
+  static ColumnPartSerde createDoubleColumnPartSerde(GenericColumnSerializer serializer, IndexSpec indexSpec)
+  {
+    // If using default values for null use DoubleGenericColumnPartSerde to allow rollback to previous versions.
+    if (NullHandling.useDefaultValuesForNull()) {
+      return DoubleGenericColumnPartSerde.serializerBuilder()
+                                         .withByteOrder(IndexIO.BYTE_ORDER)
+                                         .withDelegate(serializer)
+                                         .build();
+    } else {
+      return DoubleGenericColumnPartSerdeV2.serializerBuilder()
+                                           .withByteOrder(IndexIO.BYTE_ORDER)
+                                           .withBitmapSerdeFactory(indexSpec.getBitmapSerdeFactory())
+                                           .withDelegate(serializer)
+                                           .build();
+    }
+  }
+
+  static ColumnPartSerde createFloatColumnPartSerde(GenericColumnSerializer serializer, IndexSpec indexSpec)
+  {
+    // If using default values for null use FloatGenericColumnPartSerde to allow rollback to previous versions.
+    if (NullHandling.useDefaultValuesForNull()) {
+      return FloatGenericColumnPartSerde.serializerBuilder()
+                                        .withByteOrder(IndexIO.BYTE_ORDER)
+                                        .withDelegate(serializer)
+                                        .build();
+    } else {
+      return FloatGenericColumnPartSerdeV2.serializerBuilder()
+                                          .withByteOrder(IndexIO.BYTE_ORDER)
+                                          .withBitmapSerdeFactory(indexSpec.getBitmapSerdeFactory())
+                                          .withDelegate(serializer)
+                                          .build();
+    }
+  }
+
   private void makeTimeColumn(
       final FileSmoosher v9Smoosher,
       final ProgressIndicator progress,
-      final LongColumnSerializer timeWriter
+      final GenericColumnSerializer timeWriter,
+      final IndexSpec indexSpec
   ) throws IOException
   {
     final String section = "make time column";
@@ -402,12 +450,7 @@ public class IndexMergerV9 implements IndexMerger
     final ColumnDescriptor serdeficator = ColumnDescriptor
         .builder()
         .setValueType(ValueType.LONG)
-        .addSerde(
-            LongGenericColumnPartSerde.serializerBuilder()
-                                      .withByteOrder(IndexIO.BYTE_ORDER)
-                                      .withDelegate(timeWriter)
-                                      .build()
-        )
+        .addSerde(createLongColumnPartSerde(timeWriter, indexSpec))
         .build();
     makeColumn(v9Smoosher, Column.TIME_COLUMN_NAME, serdeficator);
     log.info("Completed time column in %,d millis.", System.currentTimeMillis() - startTime);
@@ -435,7 +478,7 @@ public class IndexMergerV9 implements IndexMerger
       final List<IndexableAdapter> adapters,
       final ProgressIndicator progress,
       final Iterable<Rowboat> theRows,
-      final LongColumnSerializer timeWriter,
+      final GenericColumnSerializer timeWriter,
       final ArrayList<GenericColumnSerializer> metWriters,
       final List<IntBuffer> rowNumConversions,
       final List<DimensionMerger> mergers
@@ -498,13 +541,15 @@ public class IndexMergerV9 implements IndexMerger
     progress.stopSection(section);
   }
 
-  private LongColumnSerializer setupTimeWriter(SegmentWriteOutMedium segmentWriteOutMedium, IndexSpec indexSpec) throws IOException
+  private GenericColumnSerializer setupTimeWriter(SegmentWriteOutMedium segmentWriteOutMedium, IndexSpec indexSpec)
+      throws IOException
   {
-    LongColumnSerializer timeWriter = LongColumnSerializer.create(
+    GenericColumnSerializer timeWriter = createLongColumnSerializer(
         segmentWriteOutMedium,
         "little_end_time",
         CompressionStrategy.DEFAULT_COMPRESSION_STRATEGY,
-        indexSpec.getLongEncoding()
+        indexSpec.getLongEncoding(),
+        indexSpec
     );
     // we will close this writer after we added all the timestamps
     timeWriter.open();
@@ -527,13 +572,13 @@ public class IndexMergerV9 implements IndexMerger
       GenericColumnSerializer writer;
       switch (type) {
         case LONG:
-          writer = LongColumnSerializer.create(segmentWriteOutMedium, metric, metCompression, longEncoding);
+          writer = createLongColumnSerializer(segmentWriteOutMedium, metric, metCompression, longEncoding, indexSpec);
           break;
         case FLOAT:
-          writer = FloatColumnSerializer.create(segmentWriteOutMedium, metric, metCompression);
+          writer = createFloatColumnSerializer(segmentWriteOutMedium, metric, metCompression, indexSpec);
           break;
         case DOUBLE:
-          writer = DoubleColumnSerializer.create(segmentWriteOutMedium, metric, metCompression);
+          writer = createDoubleColumnSerializer(segmentWriteOutMedium, metric, metCompression, indexSpec);
           break;
         case COMPLEX:
           final String typeName = metricTypeNames.get(metric);
@@ -551,6 +596,81 @@ public class IndexMergerV9 implements IndexMerger
       metWriters.add(writer);
     }
     return metWriters;
+  }
+
+  static GenericColumnSerializer createLongColumnSerializer(
+      SegmentWriteOutMedium segmentWriteOutMedium,
+      String columnName,
+      CompressionStrategy metCompression,
+      CompressionFactory.LongEncodingStrategy longEncoding,
+      IndexSpec indexSpec
+  )
+  {
+    // If using default values for null use LongColumnSerializer to allow rollback to previous versions.
+    if (NullHandling.useDefaultValuesForNull()) {
+      return LongColumnSerializer.create(
+          segmentWriteOutMedium,
+          columnName,
+          metCompression,
+          longEncoding
+      );
+    } else {
+      return LongColumnSerializerV2.create(
+          segmentWriteOutMedium,
+          columnName,
+          metCompression,
+          longEncoding,
+          indexSpec.getBitmapSerdeFactory()
+      );
+    }
+  }
+
+  static GenericColumnSerializer createDoubleColumnSerializer(
+      SegmentWriteOutMedium segmentWriteOutMedium,
+      String columnName,
+      CompressionStrategy metCompression,
+      IndexSpec indexSpec
+  )
+  {
+    // If using default values for null use DoubleColumnSerializer to allow rollback to previous versions.
+    if (NullHandling.useDefaultValuesForNull()) {
+      return DoubleColumnSerializer.create(
+          segmentWriteOutMedium,
+          columnName,
+          metCompression
+      );
+    } else {
+      return DoubleColumnSerializerV2.create(
+          segmentWriteOutMedium,
+          columnName,
+          metCompression,
+          indexSpec.getBitmapSerdeFactory()
+      );
+    }
+  }
+
+  static GenericColumnSerializer createFloatColumnSerializer(
+      SegmentWriteOutMedium segmentWriteOutMedium,
+      String columnName,
+      CompressionStrategy metCompression,
+      IndexSpec indexSpec
+  )
+  {
+    // If using default values for null use FloatColumnSerializer to allow rollback to previous versions.
+    if (NullHandling.useDefaultValuesForNull()) {
+      return FloatColumnSerializer.create(
+          segmentWriteOutMedium,
+          columnName,
+          metCompression
+      );
+    } else {
+      return FloatColumnSerializerV2.create(
+          segmentWriteOutMedium,
+          columnName,
+          metCompression,
+          indexSpec.getBitmapSerdeFactory()
+      );
+    }
   }
 
   private void writeDimValueAndSetupDimConversion(

--- a/processing/src/main/java/io/druid/segment/LongColumnSelector.java
+++ b/processing/src/main/java/io/druid/segment/LongColumnSelector.java
@@ -19,6 +19,8 @@
 
 package io.druid.segment;
 
+import javax.annotation.Nullable;
+
 /**
  * This interface is convenient for implementation of "long-sourcing" {@link ColumnValueSelector}s, it provides default
  * implementations for all {@link ColumnValueSelector}'s methods except {@link #getLong()}.
@@ -59,8 +61,12 @@ public interface LongColumnSelector extends ColumnValueSelector<Long>
    */
   @Deprecated
   @Override
+  @Nullable
   default Long getObject()
   {
+    if (isNull()) {
+      return null;
+    }
     return getLong();
   }
 

--- a/processing/src/main/java/io/druid/segment/LongColumnSerializerV2.java
+++ b/processing/src/main/java/io/druid/segment/LongColumnSerializerV2.java
@@ -19,9 +19,9 @@
 
 package io.druid.segment;
 
-import com.google.common.primitives.Ints;
 import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.collections.bitmap.MutableBitmap;
+import io.druid.common.utils.SerializerUtils;
 import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.io.smoosh.FileSmoosher;
 import io.druid.segment.data.BitmapSerdeFactory;
@@ -33,12 +33,14 @@ import io.druid.segment.writeout.SegmentWriteOutMedium;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.WritableByteChannel;
 
 /**
- * Unsafe for concurrent use from multiple threads.
+ * Column Serializer for long column.
+ * The column is serialized in two parts, first a bitmap indicating the nullability of row values
+ * and second the actual row values.
+ * This class is Unsafe for concurrent use from multiple threads.
  */
 public class LongColumnSerializerV2 implements GenericColumnSerializer
 {
@@ -133,7 +135,7 @@ public class LongColumnSerializerV2 implements GenericColumnSerializer
   @Override
   public void writeTo(WritableByteChannel channel, FileSmoosher smoosher) throws IOException
   {
-    channel.write(ByteBuffer.wrap(Ints.toByteArray((int) writer.getSerializedSize())));
+    SerializerUtils.writeInt(channel, (int) writer.getSerializedSize());
     writer.writeTo(channel, smoosher);
     if (!nullRowsBitmap.isEmpty()) {
       nullValueBitmapWriter.writeTo(channel, smoosher);

--- a/processing/src/main/java/io/druid/segment/LongColumnSerializerV2.java
+++ b/processing/src/main/java/io/druid/segment/LongColumnSerializerV2.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment;
+
+import com.google.common.primitives.Ints;
+import io.druid.collections.bitmap.ImmutableBitmap;
+import io.druid.collections.bitmap.MutableBitmap;
+import io.druid.java.util.common.StringUtils;
+import io.druid.java.util.common.io.smoosh.FileSmoosher;
+import io.druid.segment.data.BitmapSerdeFactory;
+import io.druid.segment.data.ByteBufferWriter;
+import io.druid.segment.data.ColumnarLongsSerializer;
+import io.druid.segment.data.CompressionFactory;
+import io.druid.segment.data.CompressionStrategy;
+import io.druid.segment.writeout.SegmentWriteOutMedium;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.WritableByteChannel;
+
+/**
+ * Unsafe for concurrent use from multiple threads.
+ */
+public class LongColumnSerializerV2 implements GenericColumnSerializer
+{
+  public static LongColumnSerializerV2 create(
+      SegmentWriteOutMedium segmentWriteOutMedium,
+      String filenameBase,
+      CompressionStrategy compression,
+      CompressionFactory.LongEncodingStrategy encoding,
+      BitmapSerdeFactory bitmapSerdeFactory
+  )
+  {
+    return new LongColumnSerializerV2(
+        segmentWriteOutMedium,
+        filenameBase,
+        IndexIO.BYTE_ORDER,
+        compression,
+        encoding,
+        bitmapSerdeFactory
+    );
+  }
+
+  private final SegmentWriteOutMedium segmentWriteOutMedium;
+  private final String filenameBase;
+  private final ByteOrder byteOrder;
+  private final CompressionStrategy compression;
+  private final CompressionFactory.LongEncodingStrategy encoding;
+  private final BitmapSerdeFactory bitmapSerdeFactory;
+
+  private ColumnarLongsSerializer writer;
+  private ByteBufferWriter<ImmutableBitmap> nullValueBitmapWriter;
+  private MutableBitmap nullRowsBitmap;
+  private int rowCount = 0;
+
+  private LongColumnSerializerV2(
+      SegmentWriteOutMedium segmentWriteOutMedium,
+      String filenameBase,
+      ByteOrder byteOrder,
+      CompressionStrategy compression,
+      CompressionFactory.LongEncodingStrategy encoding,
+      BitmapSerdeFactory bitmapSerdeFactory
+  )
+  {
+    this.segmentWriteOutMedium = segmentWriteOutMedium;
+    this.filenameBase = filenameBase;
+    this.byteOrder = byteOrder;
+    this.compression = compression;
+    this.encoding = encoding;
+    this.bitmapSerdeFactory = bitmapSerdeFactory;
+  }
+
+  @Override
+  public void open() throws IOException
+  {
+    writer = CompressionFactory.getLongSerializer(
+        segmentWriteOutMedium,
+        StringUtils.format("%s.long_column", filenameBase),
+        byteOrder,
+        encoding,
+        compression
+    );
+    writer.open();
+    nullValueBitmapWriter = new ByteBufferWriter<>(
+        segmentWriteOutMedium,
+        bitmapSerdeFactory.getObjectStrategy()
+    );
+    nullValueBitmapWriter.open();
+    nullRowsBitmap = bitmapSerdeFactory.getBitmapFactory().makeEmptyMutableBitmap();
+  }
+
+  @Override
+  public void serialize(@Nullable Object obj) throws IOException
+  {
+    if (obj == null) {
+      nullRowsBitmap.add(rowCount);
+      writer.add(0L);
+    } else {
+      writer.add(((Number) obj).longValue());
+    }
+    rowCount++;
+  }
+
+  @Override
+  public long getSerializedSize() throws IOException
+  {
+    nullValueBitmapWriter.write(bitmapSerdeFactory.getBitmapFactory().makeImmutableBitmap(nullRowsBitmap));
+    long bitmapSize = nullRowsBitmap.isEmpty()
+                      ? 0L
+                      : nullValueBitmapWriter.getSerializedSize();
+    return Integer.BYTES + writer.getSerializedSize() + bitmapSize;
+  }
+
+  @Override
+  public void writeTo(WritableByteChannel channel, FileSmoosher smoosher) throws IOException
+  {
+    channel.write(ByteBuffer.wrap(Ints.toByteArray((int) writer.getSerializedSize())));
+    writer.writeTo(channel, smoosher);
+    if (!nullRowsBitmap.isEmpty()) {
+      nullValueBitmapWriter.writeTo(channel, smoosher);
+    }
+  }
+}

--- a/processing/src/main/java/io/druid/segment/LongColumnSerializerV2.java
+++ b/processing/src/main/java/io/druid/segment/LongColumnSerializerV2.java
@@ -19,6 +19,7 @@
 
 package io.druid.segment;
 
+import com.google.common.primitives.Ints;
 import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.collections.bitmap.MutableBitmap;
 import io.druid.common.utils.SerializerUtils;
@@ -135,7 +136,7 @@ public class LongColumnSerializerV2 implements GenericColumnSerializer
   @Override
   public void writeTo(WritableByteChannel channel, FileSmoosher smoosher) throws IOException
   {
-    SerializerUtils.writeInt(channel, (int) writer.getSerializedSize());
+    SerializerUtils.writeInt(channel, Ints.checkedCast(writer.getSerializedSize()));
     writer.writeTo(channel, smoosher);
     if (!nullRowsBitmap.isEmpty()) {
       nullValueBitmapWriter.writeTo(channel, smoosher);

--- a/processing/src/main/java/io/druid/segment/LongDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/LongDimensionIndexer.java
@@ -117,7 +117,7 @@ public class LongDimensionIndexer implements DimensionIndexer<Long, Long, Long>
 
         if (dimIndex >= dims.length || dims[dimIndex] == null) {
           if (NullHandling.sqlCompatible()) {
-            throw new IllegalStateException("Cannot return long for Null Value");
+            throw new IllegalStateException("Cannot return null value as long");
           }
           return 0;
         }

--- a/processing/src/main/java/io/druid/segment/LongDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/LongDimensionIndexer.java
@@ -103,9 +103,6 @@ public class LongDimensionIndexer implements DimensionIndexer<Long, Long, Long>
       @Override
       public boolean isNull()
       {
-        if (NullHandling.replaceWithDefault()) {
-          return false;
-        }
         final Object[] dims = currEntry.get().getDims();
         return dimIndex >= dims.length || dims[dimIndex] == null;
       }

--- a/processing/src/main/java/io/druid/segment/LongDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/LongDimensionIndexer.java
@@ -156,7 +156,7 @@ public class LongDimensionIndexer implements DimensionIndexer<Long, Long, Long>
   @Override
   public int getUnsortedEncodedKeyComponentHashCode(@Nullable Long key)
   {
-    return DimensionHandlerUtils.nullToZeroLong(key).hashCode();
+    return DimensionHandlerUtils.nullToZero(key).hashCode();
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/LongDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/LongDimensionIndexer.java
@@ -113,9 +113,7 @@ public class LongDimensionIndexer implements DimensionIndexer<Long, Long, Long>
         final Object[] dims = currEntry.get().getDims();
 
         if (dimIndex >= dims.length || dims[dimIndex] == null) {
-          if (NullHandling.sqlCompatible()) {
-            throw new IllegalStateException("Cannot return null value as long");
-          }
+          assert NullHandling.replaceWithDefault();
           return 0;
         }
 

--- a/processing/src/main/java/io/druid/segment/LongDimensionMergerV9.java
+++ b/processing/src/main/java/io/druid/segment/LongDimensionMergerV9.java
@@ -22,8 +22,6 @@ package io.druid.segment;
 import com.google.common.base.Throwables;
 import io.druid.segment.column.ColumnDescriptor;
 import io.druid.segment.column.ValueType;
-import io.druid.segment.data.CompressionFactory;
-import io.druid.segment.data.CompressionStrategy;
 import io.druid.segment.serde.ColumnPartSerde;
 import io.druid.segment.writeout.SegmentWriteOutMedium;
 
@@ -56,14 +54,9 @@ public class LongDimensionMergerV9 implements DimensionMergerV9<Long>
 
   protected void setupEncodedValueWriter(SegmentWriteOutMedium segmentWriteOutMedium) throws IOException
   {
-    final CompressionStrategy metCompression = indexSpec.getMetricCompression();
-    final CompressionFactory.LongEncodingStrategy longEncoding = indexSpec.getLongEncoding();
-    // If using default values for null use LongColumnSerializer to allow rollback to previous versions.
     this.serializer = IndexMergerV9.createLongColumnSerializer(
         segmentWriteOutMedium,
         dimensionName,
-        metCompression,
-        longEncoding,
         indexSpec
     );
     serializer.open();

--- a/processing/src/main/java/io/druid/segment/LongDimensionMergerV9.java
+++ b/processing/src/main/java/io/druid/segment/LongDimensionMergerV9.java
@@ -24,7 +24,7 @@ import io.druid.segment.column.ColumnDescriptor;
 import io.druid.segment.column.ValueType;
 import io.druid.segment.data.CompressionFactory;
 import io.druid.segment.data.CompressionStrategy;
-import io.druid.segment.serde.LongGenericColumnPartSerde;
+import io.druid.segment.serde.ColumnPartSerde;
 import io.druid.segment.writeout.SegmentWriteOutMedium;
 
 import java.io.IOException;
@@ -35,7 +35,7 @@ public class LongDimensionMergerV9 implements DimensionMergerV9<Long>
 {
   protected String dimensionName;
   protected final IndexSpec indexSpec;
-  protected LongColumnSerializer serializer;
+  protected GenericColumnSerializer serializer;
 
   LongDimensionMergerV9(
       String dimensionName,
@@ -58,7 +58,14 @@ public class LongDimensionMergerV9 implements DimensionMergerV9<Long>
   {
     final CompressionStrategy metCompression = indexSpec.getMetricCompression();
     final CompressionFactory.LongEncodingStrategy longEncoding = indexSpec.getLongEncoding();
-    this.serializer = LongColumnSerializer.create(segmentWriteOutMedium, dimensionName, metCompression, longEncoding);
+
+    this.serializer = IndexMergerV9.createLongColumnSerializer(
+        segmentWriteOutMedium,
+        dimensionName,
+        metCompression,
+        longEncoding,
+        indexSpec
+    );
     serializer.open();
   }
 
@@ -89,7 +96,6 @@ public class LongDimensionMergerV9 implements DimensionMergerV9<Long>
   @Override
   public boolean canSkip()
   {
-    // a long column can never be all null
     return false;
   }
 
@@ -98,12 +104,8 @@ public class LongDimensionMergerV9 implements DimensionMergerV9<Long>
   {
     final ColumnDescriptor.Builder builder = ColumnDescriptor.builder();
     builder.setValueType(ValueType.LONG);
-    builder.addSerde(
-        LongGenericColumnPartSerde.serializerBuilder()
-                                  .withByteOrder(IndexIO.BYTE_ORDER)
-                                  .withDelegate(serializer)
-                                  .build()
-    );
+    ColumnPartSerde serde = IndexMergerV9.createLongColumnPartSerde(serializer, indexSpec);
+    builder.addSerde(serde);
     return builder.build();
   }
 }

--- a/processing/src/main/java/io/druid/segment/LongDimensionMergerV9.java
+++ b/processing/src/main/java/io/druid/segment/LongDimensionMergerV9.java
@@ -58,7 +58,7 @@ public class LongDimensionMergerV9 implements DimensionMergerV9<Long>
   {
     final CompressionStrategy metCompression = indexSpec.getMetricCompression();
     final CompressionFactory.LongEncodingStrategy longEncoding = indexSpec.getLongEncoding();
-
+    // If using default values for null use LongColumnSerializer to allow rollback to previous versions.
     this.serializer = IndexMergerV9.createLongColumnSerializer(
         segmentWriteOutMedium,
         dimensionName,

--- a/processing/src/main/java/io/druid/segment/NilColumnValueSelector.java
+++ b/processing/src/main/java/io/druid/segment/NilColumnValueSelector.java
@@ -86,6 +86,12 @@ public final class NilColumnValueSelector implements ColumnValueSelector
   }
 
   @Override
+  public boolean isNull()
+  {
+    return true;
+  }
+
+  @Override
   public void inspectRuntimeShape(RuntimeShapeInspector inspector)
   {
     // nothing to inspect

--- a/processing/src/main/java/io/druid/segment/NilColumnValueSelector.java
+++ b/processing/src/main/java/io/druid/segment/NilColumnValueSelector.java
@@ -43,7 +43,9 @@ public class NilColumnValueSelector implements ColumnValueSelector
   private NilColumnValueSelector() {}
 
   /**
-   * Always returns 0.0.
+   * always returns 0, if {@link io.druid.common.config.NullHandling#NULL_HANDLING_CONFIG_STRING} is set to true,
+   * or always throws an exception, if {@link io.druid.common.config.NullHandling#NULL_HANDLING_CONFIG_STRING} is
+   * set to false.
    */
   @Override
   public double getDouble()
@@ -52,7 +54,9 @@ public class NilColumnValueSelector implements ColumnValueSelector
   }
 
   /**
-   * Always returns 0.0f.
+   * always returns 0.0f, if {@link io.druid.common.config.NullHandling#NULL_HANDLING_CONFIG_STRING} is set to true,
+   * or always throws an exception, if {@link io.druid.common.config.NullHandling#NULL_HANDLING_CONFIG_STRING} is
+   * set to false.
    */
   @Override
   public float getFloat()
@@ -61,7 +65,9 @@ public class NilColumnValueSelector implements ColumnValueSelector
   }
 
   /**
-   * Always returns 0L.
+   * always returns 0L, if {@link io.druid.common.config.NullHandling#NULL_HANDLING_CONFIG_STRING} is set to true,
+   * or always throws an exception, if {@link io.druid.common.config.NullHandling#NULL_HANDLING_CONFIG_STRING} is
+   * set to false.
    */
   @Override
   public long getLong()
@@ -102,27 +108,18 @@ public class NilColumnValueSelector implements ColumnValueSelector
 
   private static class SqlCompatibleNilColumnValueSelector extends NilColumnValueSelector
   {
-    /**
-     * Always throws IllegalStateException.
-     */
     @Override
     public double getDouble()
     {
       throw new IllegalStateException("Cannot return null value as double");
     }
 
-    /**
-     * Always throws IllegalStateException.
-     */
     @Override
     public float getFloat()
     {
       throw new IllegalStateException("Cannot return null value as float");
     }
-
-    /**
-     * Always throws IllegalStateException.
-     */
+    
     @Override
     public long getLong()
     {

--- a/processing/src/main/java/io/druid/segment/NilColumnValueSelector.java
+++ b/processing/src/main/java/io/druid/segment/NilColumnValueSelector.java
@@ -91,7 +91,7 @@ public class NilColumnValueSelector implements ColumnValueSelector
   @Override
   public boolean isNull()
   {
-    return false;
+    return true;
   }
 
   @Override
@@ -102,11 +102,6 @@ public class NilColumnValueSelector implements ColumnValueSelector
 
   private static class SqlCompatibleNilColumnValueSelector extends NilColumnValueSelector
   {
-    @Override
-    public boolean isNull()
-    {
-      return true;
-    }
 
     @Override
     public double getDouble()

--- a/processing/src/main/java/io/druid/segment/NilColumnValueSelector.java
+++ b/processing/src/main/java/io/druid/segment/NilColumnValueSelector.java
@@ -102,19 +102,27 @@ public class NilColumnValueSelector implements ColumnValueSelector
 
   private static class SqlCompatibleNilColumnValueSelector extends NilColumnValueSelector
   {
-
+    /**
+     * Always throws IllegalStateException.
+     */
     @Override
     public double getDouble()
     {
       throw new IllegalStateException("Cannot return null value as double");
     }
 
+    /**
+     * Always throws IllegalStateException.
+     */
     @Override
     public float getFloat()
     {
       throw new IllegalStateException("Cannot return null value as float");
     }
 
+    /**
+     * Always throws IllegalStateException.
+     */
     @Override
     public long getLong()
     {

--- a/processing/src/main/java/io/druid/segment/NilColumnValueSelector.java
+++ b/processing/src/main/java/io/druid/segment/NilColumnValueSelector.java
@@ -43,8 +43,8 @@ public class NilColumnValueSelector implements ColumnValueSelector
   private NilColumnValueSelector() {}
 
   /**
-   * always returns 0, if {@link io.druid.common.config.NullHandling#NULL_HANDLING_CONFIG_STRING} is set to true,
-   * or always throws an exception, if {@link io.druid.common.config.NullHandling#NULL_HANDLING_CONFIG_STRING} is
+   * always returns 0, if {@link NullHandling#NULL_HANDLING_CONFIG_STRING} is set to true,
+   * or always throws an exception, if {@link NullHandling#NULL_HANDLING_CONFIG_STRING} is
    * set to false.
    */
   @Override
@@ -54,8 +54,8 @@ public class NilColumnValueSelector implements ColumnValueSelector
   }
 
   /**
-   * always returns 0.0f, if {@link io.druid.common.config.NullHandling#NULL_HANDLING_CONFIG_STRING} is set to true,
-   * or always throws an exception, if {@link io.druid.common.config.NullHandling#NULL_HANDLING_CONFIG_STRING} is
+   * always returns 0.0f, if {@link NullHandling#NULL_HANDLING_CONFIG_STRING} is set to true,
+   * or always throws an exception, if {@link NullHandling#NULL_HANDLING_CONFIG_STRING} is
    * set to false.
    */
   @Override
@@ -65,8 +65,8 @@ public class NilColumnValueSelector implements ColumnValueSelector
   }
 
   /**
-   * always returns 0L, if {@link io.druid.common.config.NullHandling#NULL_HANDLING_CONFIG_STRING} is set to true,
-   * or always throws an exception, if {@link io.druid.common.config.NullHandling#NULL_HANDLING_CONFIG_STRING} is
+   * always returns 0L, if {@link NullHandling#NULL_HANDLING_CONFIG_STRING} is set to true,
+   * or always throws an exception, if {@link NullHandling#NULL_HANDLING_CONFIG_STRING} is
    * set to false.
    */
   @Override

--- a/processing/src/main/java/io/druid/segment/NullDimensionSelector.java
+++ b/processing/src/main/java/io/druid/segment/NullDimensionSelector.java
@@ -20,7 +20,7 @@
 package io.druid.segment;
 
 import com.google.common.base.Predicate;
-import com.google.common.base.Strings;
+import io.druid.common.config.NullHandling;
 import io.druid.query.filter.ValueMatcher;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.data.IndexedInts;
@@ -103,7 +103,7 @@ public class NullDimensionSelector implements SingleValueHistoricalDimensionSele
   @Override
   public int lookupId(String name)
   {
-    return Strings.isNullOrEmpty(name) ? 0 : -1;
+    return NullHandling.isNullOrEquivalent(name) ? 0 : -1;
   }
 
   @Nullable

--- a/processing/src/main/java/io/druid/segment/ObjectColumnSelector.java
+++ b/processing/src/main/java/io/druid/segment/ObjectColumnSelector.java
@@ -76,4 +76,17 @@ public interface ObjectColumnSelector<T> extends ColumnValueSelector<T>
     }
     return ((Number) value).longValue();
   }
+
+  /**
+   * @deprecated This method is marked as deprecated in ObjectColumnSelector to minimize the probability of accidential
+   * calling. "Polymorphism" of ObjectColumnSelector should be used only when operating on {@link ColumnValueSelector}
+   * objects.
+   */
+  @Deprecated
+  @Override
+  default boolean isNull()
+  {
+    T value = getObject();
+    return value == null;
+  }
 }

--- a/processing/src/main/java/io/druid/segment/ObjectColumnSelector.java
+++ b/processing/src/main/java/io/druid/segment/ObjectColumnSelector.java
@@ -27,7 +27,7 @@ package io.druid.segment;
  * This interface should appear ONLY in "implements" clause or anonymous class creation, but NOT in "user" code, where
  * {@link BaseObjectColumnValueSelector} must be used instead.
  */
-public interface ObjectColumnSelector<T> extends ColumnValueSelector<T>
+public abstract class ObjectColumnSelector<T> implements ColumnValueSelector<T>
 {
   /**
    * @deprecated This method is marked as deprecated in ObjectColumnSelector to minimize the probability of accidential
@@ -36,7 +36,7 @@ public interface ObjectColumnSelector<T> extends ColumnValueSelector<T>
    */
   @Deprecated
   @Override
-  default float getFloat()
+  public float getFloat()
   {
     T value = getObject();
     if (value == null) {
@@ -52,7 +52,7 @@ public interface ObjectColumnSelector<T> extends ColumnValueSelector<T>
    */
   @Deprecated
   @Override
-  default double getDouble()
+  public double getDouble()
   {
     T value = getObject();
     if (value == null) {
@@ -68,7 +68,7 @@ public interface ObjectColumnSelector<T> extends ColumnValueSelector<T>
    */
   @Deprecated
   @Override
-  default long getLong()
+  public long getLong()
   {
     T value = getObject();
     if (value == null) {
@@ -78,15 +78,13 @@ public interface ObjectColumnSelector<T> extends ColumnValueSelector<T>
   }
 
   /**
-   * @deprecated This method is marked as deprecated in ObjectColumnSelector to minimize the probability of accidential
-   * calling. "Polymorphism" of ObjectColumnSelector should be used only when operating on {@link ColumnValueSelector}
-   * objects.
+   * @deprecated This method is marked as deprecated in ObjectColumnSelector since it always returns false.
+   * There is no need to call this method.
    */
   @Deprecated
   @Override
-  default boolean isNull()
+  public final boolean isNull()
   {
-    T value = getObject();
-    return value == null;
+    return false;
   }
 }

--- a/processing/src/main/java/io/druid/segment/QueryableIndexIndexableAdapter.java
+++ b/processing/src/main/java/io/druid/segment/QueryableIndexIndexableAdapter.java
@@ -39,8 +39,8 @@ import io.druid.segment.column.DoublesColumn;
 import io.druid.segment.column.FloatsColumn;
 import io.druid.segment.column.LongsColumn;
 import io.druid.segment.column.ValueType;
-import io.druid.segment.data.ImmutableBitmapValues;
 import io.druid.segment.data.BitmapValues;
+import io.druid.segment.data.ImmutableBitmapValues;
 import io.druid.segment.data.Indexed;
 import io.druid.segment.data.IndexedIterable;
 import io.druid.segment.data.ListIndexed;
@@ -270,11 +270,14 @@ public class QueryableIndexIndexableAdapter implements IndexableAdapter
             Object[] metricArray = new Object[numMetrics];
             for (int i = 0; i < metricArray.length; ++i) {
               if (metrics[i] instanceof FloatsColumn) {
-                metricArray[i] = ((GenericColumn) metrics[i]).getFloatSingleValueRow(currRow);
+                GenericColumn genericColumn = (GenericColumn) metrics[i];
+                metricArray[i] = genericColumn.isNull(currRow) ? null : genericColumn.getFloatSingleValueRow(currRow);
               } else if (metrics[i] instanceof DoublesColumn) {
-                metricArray[i] = ((GenericColumn) metrics[i]).getDoubleSingleValueRow(currRow);
+                GenericColumn genericColumn = (GenericColumn) metrics[i];
+                metricArray[i] = genericColumn.isNull(currRow) ? null : genericColumn.getDoubleSingleValueRow(currRow);
               } else if (metrics[i] instanceof LongsColumn) {
-                metricArray[i] = ((GenericColumn) metrics[i]).getLongSingleValueRow(currRow);
+                GenericColumn genericColumn = (GenericColumn) metrics[i];
+                metricArray[i] = genericColumn.isNull(currRow) ? null : genericColumn.getLongSingleValueRow(currRow);
               } else if (metrics[i] instanceof ComplexColumn) {
                 metricArray[i] = ((ComplexColumn) metrics[i]).getRowValue(currRow);
               }

--- a/processing/src/main/java/io/druid/segment/StringDimensionHandler.java
+++ b/processing/src/main/java/io/druid/segment/StringDimensionHandler.java
@@ -77,6 +77,20 @@ public class StringDimensionHandler implements DimensionHandler<Integer, int[], 
     return retVal;
   }
 
+  private boolean isNUllRow(int[] row, Indexed<String> encodings)
+  {
+    if (row == null) {
+      return true;
+    }
+    for (int i : row) {
+      if (encodings.get(i) != null) {
+        // Non-Null value
+        return false;
+      }
+    }
+    return true;
+  }
+
   @Override
   public void validateSortedEncodedKeyComponents(
       int[] lhs,
@@ -86,7 +100,7 @@ public class StringDimensionHandler implements DimensionHandler<Integer, int[], 
   ) throws SegmentValidationException
   {
     if (lhs == null || rhs == null) {
-      if (lhs != null || rhs != null) {
+      if (!isNUllRow(lhs, lhsEncodings) || !isNUllRow(rhs, rhsEncodings)) {
         throw new SegmentValidationException(
             "Expected nulls, found %s and %s",
             Arrays.toString(lhs),

--- a/processing/src/main/java/io/druid/segment/StringDimensionHandler.java
+++ b/processing/src/main/java/io/druid/segment/StringDimensionHandler.java
@@ -28,6 +28,7 @@ import io.druid.segment.column.DictionaryEncodedColumn;
 import io.druid.segment.data.Indexed;
 import io.druid.segment.data.IndexedInts;
 
+import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.lang.reflect.Array;
 import java.util.Arrays;
@@ -77,13 +78,13 @@ public class StringDimensionHandler implements DimensionHandler<Integer, int[], 
     return retVal;
   }
 
-  private boolean isNullRow(int[] row, Indexed<String> encodings)
+  private boolean isNullRow(@Nullable int[] row, Indexed<String> encodings)
   {
     if (row == null) {
       return true;
     }
-    for (int i : row) {
-      if (encodings.get(i) != null) {
+    for (int value : row) {
+      if (encodings.get(value) != null) {
         // Non-Null value
         return false;
       }

--- a/processing/src/main/java/io/druid/segment/StringDimensionHandler.java
+++ b/processing/src/main/java/io/druid/segment/StringDimensionHandler.java
@@ -77,7 +77,7 @@ public class StringDimensionHandler implements DimensionHandler<Integer, int[], 
     return retVal;
   }
 
-  private boolean isNUllRow(int[] row, Indexed<String> encodings)
+  private boolean isNullRow(int[] row, Indexed<String> encodings)
   {
     if (row == null) {
       return true;
@@ -100,7 +100,7 @@ public class StringDimensionHandler implements DimensionHandler<Integer, int[], 
   ) throws SegmentValidationException
   {
     if (lhs == null || rhs == null) {
-      if (!isNUllRow(lhs, lhsEncodings) || !isNUllRow(rhs, rhsEncodings)) {
+      if (!isNullRow(lhs, lhsEncodings) || !isNullRow(rhs, rhsEncodings)) {
         throw new SegmentValidationException(
             "Expected nulls, found %s and %s",
             Arrays.toString(lhs),

--- a/processing/src/main/java/io/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/StringDimensionIndexer.java
@@ -105,16 +105,6 @@ public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], 
       }
     }
 
-    public boolean contains(String value)
-    {
-      synchronized (lock) {
-        if (value == null) {
-          return idForNull != ABSENT_VALUE_ID;
-        }
-        return valueToId.containsKey(value);
-      }
-    }
-
     public int size()
     {
       synchronized (lock) {

--- a/processing/src/main/java/io/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/io/druid/segment/StringDimensionIndexer.java
@@ -66,7 +66,6 @@ public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], 
   }
 
   private static final int ABSENT_VALUE_ID = -1;
-  private static final int[] EMPTY_INT_ARRAY = IntArrays.EMPTY_ARRAY;
 
   private static class DimensionDictionary
   {
@@ -222,7 +221,7 @@ public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], 
       List<Object> dimValuesList = (List) dimValues;
       if (dimValuesList.isEmpty()) {
         dimLookup.add(null);
-        encodedDimensionValues = EMPTY_INT_ARRAY;
+        encodedDimensionValues = IntArrays.EMPTY_ARRAY;
       } else if (dimValuesList.size() == 1) {
         encodedDimensionValues = new int[]{dimLookup.add(emptytoNullIfNeeded(dimValuesList.get(0)))};
       } else {

--- a/processing/src/main/java/io/druid/segment/StringDimensionMergerV9.java
+++ b/processing/src/main/java/io/druid/segment/StringDimensionMergerV9.java
@@ -20,7 +20,6 @@
 package io.druid.segment;
 
 import com.google.common.base.Splitter;
-import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import io.druid.collections.bitmap.BitmapFactory;
 import io.druid.collections.bitmap.ImmutableBitmap;
@@ -28,6 +27,7 @@ import io.druid.collections.bitmap.MutableBitmap;
 import io.druid.collections.spatial.ImmutableRTree;
 import io.druid.collections.spatial.RTree;
 import io.druid.collections.spatial.split.LinearGutmanSplitStrategy;
+import io.druid.common.config.NullHandling;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.logger.Logger;
@@ -63,8 +63,11 @@ public class StringDimensionMergerV9 implements DimensionMergerV9<int[]>
 {
   private static final Logger log = new Logger(StringDimensionMergerV9.class);
 
-  private static final Indexed<String> EMPTY_STR_DIM_VAL = new ArrayIndexed<>(new String[]{""}, String.class);
-  private static final int[] EMPTY_STR_DIM_ARRAY = new int[]{0};
+  protected static final Indexed<String> NULL_STR_DIM_VAL = new ArrayIndexed<>(
+      new String[]{(String) null},
+      String.class
+  );
+  protected static final int[] NULL_STR_DIM_ARRAY = new int[]{0};
   private static final Splitter SPLITTER = Splitter.on(",");
 
   private ColumnarIntsSerializer encodedValueWriter;
@@ -145,7 +148,7 @@ public class StringDimensionMergerV9 implements DimensionMergerV9<int[]>
      */
     if (convertMissingValues && !hasNull) {
       hasNull = true;
-      dimValueLookups[adapters.size()] = dimValueLookup = EMPTY_STR_DIM_VAL;
+      dimValueLookups[adapters.size()] = dimValueLookup = NULL_STR_DIM_VAL;
       numMergeIndex++;
     }
 
@@ -184,7 +187,7 @@ public class StringDimensionMergerV9 implements DimensionMergerV9<int[]>
   {
     for (String value : dictionaryValues) {
       dictionaryWriter.write(value);
-      value = Strings.emptyToNull(value);
+      value = NullHandling.emptyToNullIfNeeded(value);
       if (dictionarySize == 0) {
         firstDictionaryValue = value;
       }
@@ -231,7 +234,7 @@ public class StringDimensionMergerV9 implements DimensionMergerV9<int[]>
     // For strings, convert missing values to null/empty if conversion flag is set
     // But if bitmap/dictionary is not used, always convert missing to 0
     if (dimVals == null) {
-      return convertMissingValues ? EMPTY_STR_DIM_ARRAY : null;
+      return convertMissingValues ? NULL_STR_DIM_ARRAY : null;
     }
 
     int[] newDimVals = new int[dimVals.length];

--- a/processing/src/main/java/io/druid/segment/column/DoublesColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/DoublesColumn.java
@@ -19,6 +19,7 @@
 
 package io.druid.segment.column;
 
+import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.ColumnValueSelector;
 import io.druid.segment.data.ColumnarDoubles;
@@ -28,10 +29,12 @@ import io.druid.segment.data.ReadableOffset;
 public class DoublesColumn implements GenericColumn
 {
   private final ColumnarDoubles column;
+  private final ImmutableBitmap nullValueBitmap;
 
-  public DoublesColumn(ColumnarDoubles columnarDoubles)
+  public DoublesColumn(ColumnarDoubles columnarDoubles, ImmutableBitmap nullValueBitmap)
   {
     column = columnarDoubles;
+    this.nullValueBitmap = nullValueBitmap;
   }
 
   @Override
@@ -43,7 +46,7 @@ public class DoublesColumn implements GenericColumn
   @Override
   public ColumnValueSelector makeColumnValueSelector(ReadableOffset offset)
   {
-    return column.makeColumnValueSelector(offset);
+    return column.makeColumnValueSelector(offset, nullValueBitmap);
   }
 
   @Override
@@ -62,6 +65,12 @@ public class DoublesColumn implements GenericColumn
   public double getDoubleSingleValueRow(int rowNum)
   {
     return column.get(rowNum);
+  }
+
+  @Override
+  public boolean isNull(int rowNum)
+  {
+    return nullValueBitmap.get(rowNum);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/column/DoublesColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/DoublesColumn.java
@@ -21,6 +21,7 @@ package io.druid.segment.column;
 
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.ColumnValueSelector;
+import io.druid.segment.IndexIO;
 import io.druid.segment.data.ColumnarDoubles;
 import io.druid.segment.data.ReadableOffset;
 
@@ -43,7 +44,8 @@ public class DoublesColumn implements GenericColumn
   @Override
   public ColumnValueSelector makeColumnValueSelector(ReadableOffset offset)
   {
-    return column.makeColumnValueSelector(offset);
+    return column.makeColumnValueSelector(offset, IndexIO.LEGACY_FACTORY.getBitmapFactory()
+                                                                        .makeEmptyImmutableBitmap());
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/column/DoublesColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/DoublesColumn.java
@@ -19,6 +19,7 @@
 
 package io.druid.segment.column;
 
+import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.ColumnValueSelector;
 import io.druid.segment.IndexIO;
@@ -28,9 +29,21 @@ import io.druid.segment.data.ReadableOffset;
 
 public class DoublesColumn implements GenericColumn
 {
+  /**
+   * Factory method to create DoublesColumn.
+   */
+  public static DoublesColumn create(ColumnarDoubles column, ImmutableBitmap nullValueBitmap)
+  {
+    if (nullValueBitmap.isEmpty()) {
+      return new DoublesColumn(column);
+    } else {
+      return new DoublesColumnWithNulls(column, nullValueBitmap);
+    }
+  }
+
   final ColumnarDoubles column;
 
-  public DoublesColumn(ColumnarDoubles columnarDoubles)
+  DoublesColumn(ColumnarDoubles columnarDoubles)
   {
     column = columnarDoubles;
   }

--- a/processing/src/main/java/io/druid/segment/column/DoublesColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/DoublesColumn.java
@@ -30,11 +30,13 @@ public class DoublesColumn implements GenericColumn
 {
   private final ColumnarDoubles column;
   private final ImmutableBitmap nullValueBitmap;
+  private final boolean hasNulls;
 
   public DoublesColumn(ColumnarDoubles columnarDoubles, ImmutableBitmap nullValueBitmap)
   {
     column = columnarDoubles;
     this.nullValueBitmap = nullValueBitmap;
+    this.hasNulls = !nullValueBitmap.isEmpty();
   }
 
   @Override
@@ -70,7 +72,7 @@ public class DoublesColumn implements GenericColumn
   @Override
   public boolean isNull(int rowNum)
   {
-    return nullValueBitmap.get(rowNum);
+    return hasNulls && nullValueBitmap.get(rowNum);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/column/DoublesColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/DoublesColumn.java
@@ -19,7 +19,6 @@
 
 package io.druid.segment.column;
 
-import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.ColumnValueSelector;
 import io.druid.segment.data.ColumnarDoubles;
@@ -28,15 +27,11 @@ import io.druid.segment.data.ReadableOffset;
 
 public class DoublesColumn implements GenericColumn
 {
-  private final ColumnarDoubles column;
-  private final ImmutableBitmap nullValueBitmap;
-  private final boolean hasNulls;
+  final ColumnarDoubles column;
 
-  public DoublesColumn(ColumnarDoubles columnarDoubles, ImmutableBitmap nullValueBitmap)
+  public DoublesColumn(ColumnarDoubles columnarDoubles)
   {
     column = columnarDoubles;
-    this.nullValueBitmap = nullValueBitmap;
-    this.hasNulls = !nullValueBitmap.isEmpty();
   }
 
   @Override
@@ -48,7 +43,7 @@ public class DoublesColumn implements GenericColumn
   @Override
   public ColumnValueSelector makeColumnValueSelector(ReadableOffset offset)
   {
-    return column.makeColumnValueSelector(offset, nullValueBitmap);
+    return column.makeColumnValueSelector(offset);
   }
 
   @Override
@@ -72,7 +67,7 @@ public class DoublesColumn implements GenericColumn
   @Override
   public boolean isNull(int rowNum)
   {
-    return hasNulls && nullValueBitmap.get(rowNum);
+    return false;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/column/DoublesColumnWithNulls.java
+++ b/processing/src/main/java/io/druid/segment/column/DoublesColumnWithNulls.java
@@ -17,35 +17,36 @@
  * under the License.
  */
 
-package io.druid.segment.serde;
+package io.druid.segment.column;
 
-import com.google.common.base.Supplier;
 import io.druid.collections.bitmap.ImmutableBitmap;
-import io.druid.segment.column.GenericColumn;
-import io.druid.segment.column.LongsColumn;
-import io.druid.segment.column.LongsColumnWithNulls;
-import io.druid.segment.data.CompressedColumnarLongsSupplier;
+import io.druid.segment.ColumnValueSelector;
+import io.druid.segment.data.ColumnarDoubles;
+import io.druid.segment.data.ReadableOffset;
 
 /**
-*/
-public class LongGenericColumnSupplier implements Supplier<GenericColumn>
+ * DoublesColumn with null values.
+ */
+public class DoublesColumnWithNulls extends DoublesColumn
 {
-  private final CompressedColumnarLongsSupplier column;
   private final ImmutableBitmap nullValueBitmap;
 
-  public LongGenericColumnSupplier(CompressedColumnarLongsSupplier column, ImmutableBitmap nullValueBitmap)
+  public DoublesColumnWithNulls(ColumnarDoubles columnarDoubles, ImmutableBitmap nullValueBitmap)
   {
-    this.column = column;
+    super(columnarDoubles);
     this.nullValueBitmap = nullValueBitmap;
   }
 
   @Override
-  public GenericColumn get()
+  public ColumnValueSelector makeColumnValueSelector(ReadableOffset offset)
   {
-    if (nullValueBitmap.isEmpty()) {
-      return new LongsColumn(column.get());
-    } else {
-      return new LongsColumnWithNulls(column.get(), nullValueBitmap);
-    }
+    return column.makeColumnValueSelector(offset, nullValueBitmap);
   }
+
+  @Override
+  public boolean isNull(int rowNum)
+  {
+    return nullValueBitmap.get(rowNum);
+  }
+
 }

--- a/processing/src/main/java/io/druid/segment/column/DoublesColumnWithNulls.java
+++ b/processing/src/main/java/io/druid/segment/column/DoublesColumnWithNulls.java
@@ -28,11 +28,11 @@ import io.druid.segment.data.ReadableOffset;
 /**
  * DoublesColumn with null values.
  */
-public class DoublesColumnWithNulls extends DoublesColumn
+class DoublesColumnWithNulls extends DoublesColumn
 {
   private final ImmutableBitmap nullValueBitmap;
 
-  public DoublesColumnWithNulls(ColumnarDoubles columnarDoubles, ImmutableBitmap nullValueBitmap)
+  DoublesColumnWithNulls(ColumnarDoubles columnarDoubles, ImmutableBitmap nullValueBitmap)
   {
     super(columnarDoubles);
     this.nullValueBitmap = nullValueBitmap;
@@ -55,5 +55,26 @@ public class DoublesColumnWithNulls extends DoublesColumn
   {
     super.inspectRuntimeShape(inspector);
     inspector.visit("nullValueBitmap", nullValueBitmap);
+  }
+
+  @Override
+  public float getFloatSingleValueRow(int rowNum)
+  {
+    assert !isNull(rowNum);
+    return super.getFloatSingleValueRow(rowNum);
+  }
+
+  @Override
+  public long getLongSingleValueRow(int rowNum)
+  {
+    assert !isNull(rowNum);
+    return super.getLongSingleValueRow(rowNum);
+  }
+
+  @Override
+  public double getDoubleSingleValueRow(int rowNum)
+  {
+    assert !isNull(rowNum);
+    return super.getLongSingleValueRow(rowNum);
   }
 }

--- a/processing/src/main/java/io/druid/segment/column/DoublesColumnWithNulls.java
+++ b/processing/src/main/java/io/druid/segment/column/DoublesColumnWithNulls.java
@@ -20,6 +20,7 @@
 package io.druid.segment.column;
 
 import io.druid.collections.bitmap.ImmutableBitmap;
+import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.ColumnValueSelector;
 import io.druid.segment.data.ColumnarDoubles;
 import io.druid.segment.data.ReadableOffset;
@@ -49,4 +50,10 @@ public class DoublesColumnWithNulls extends DoublesColumn
     return nullValueBitmap.get(rowNum);
   }
 
+  @Override
+  public void inspectRuntimeShape(RuntimeShapeInspector inspector)
+  {
+    super.inspectRuntimeShape(inspector);
+    inspector.visit("nullValueBitmap", nullValueBitmap);
+  }
 }

--- a/processing/src/main/java/io/druid/segment/column/FloatsColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/FloatsColumn.java
@@ -19,6 +19,7 @@
 
 package io.druid.segment.column;
 
+import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.ColumnValueSelector;
 import io.druid.segment.data.ColumnarFloats;
@@ -29,10 +30,15 @@ import io.druid.segment.data.ReadableOffset;
 public class FloatsColumn implements GenericColumn
 {
   private final ColumnarFloats column;
+  private final ImmutableBitmap nullValueBitmap;
 
-  public FloatsColumn(final ColumnarFloats column)
+  public FloatsColumn(
+      final ColumnarFloats column,
+      ImmutableBitmap nullValueBitmap
+  )
   {
     this.column = column;
+    this.nullValueBitmap = nullValueBitmap;
   }
 
   @Override
@@ -44,7 +50,7 @@ public class FloatsColumn implements GenericColumn
   @Override
   public ColumnValueSelector makeColumnValueSelector(ReadableOffset offset)
   {
-    return column.makeColumnValueSelector(offset);
+    return column.makeColumnValueSelector(offset, nullValueBitmap);
   }
 
   @Override
@@ -63,6 +69,12 @@ public class FloatsColumn implements GenericColumn
   public double getDoubleSingleValueRow(int rowNum)
   {
     return (double) column.get(rowNum);
+  }
+
+  @Override
+  public boolean isNull(int rowNum)
+  {
+    return nullValueBitmap.get(rowNum);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/column/FloatsColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/FloatsColumn.java
@@ -19,7 +19,6 @@
 
 package io.druid.segment.column;
 
-import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.ColumnValueSelector;
 import io.druid.segment.data.ColumnarFloats;
@@ -29,18 +28,11 @@ import io.druid.segment.data.ReadableOffset;
 */
 public class FloatsColumn implements GenericColumn
 {
-  private final ColumnarFloats column;
-  private final ImmutableBitmap nullValueBitmap;
-  private final boolean hasNulls;
+  final ColumnarFloats column;
 
-  public FloatsColumn(
-      final ColumnarFloats column,
-      ImmutableBitmap nullValueBitmap
-  )
+  public FloatsColumn(final ColumnarFloats column)
   {
     this.column = column;
-    this.nullValueBitmap = nullValueBitmap;
-    this.hasNulls = !nullValueBitmap.isEmpty();
   }
 
   @Override
@@ -52,7 +44,7 @@ public class FloatsColumn implements GenericColumn
   @Override
   public ColumnValueSelector makeColumnValueSelector(ReadableOffset offset)
   {
-    return column.makeColumnValueSelector(offset, nullValueBitmap);
+    return column.makeColumnValueSelector(offset);
   }
 
   @Override
@@ -76,7 +68,7 @@ public class FloatsColumn implements GenericColumn
   @Override
   public boolean isNull(int rowNum)
   {
-    return hasNulls && nullValueBitmap.get(rowNum);
+    return false;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/column/FloatsColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/FloatsColumn.java
@@ -44,7 +44,7 @@ public class FloatsColumn implements GenericColumn
 
   final ColumnarFloats column;
 
-  protected FloatsColumn(final ColumnarFloats column)
+  FloatsColumn(final ColumnarFloats column)
   {
     this.column = column;
   }

--- a/processing/src/main/java/io/druid/segment/column/FloatsColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/FloatsColumn.java
@@ -21,11 +21,12 @@ package io.druid.segment.column;
 
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.ColumnValueSelector;
+import io.druid.segment.IndexIO;
 import io.druid.segment.data.ColumnarFloats;
 import io.druid.segment.data.ReadableOffset;
 
 /**
-*/
+ */
 public class FloatsColumn implements GenericColumn
 {
   final ColumnarFloats column;
@@ -44,7 +45,8 @@ public class FloatsColumn implements GenericColumn
   @Override
   public ColumnValueSelector makeColumnValueSelector(ReadableOffset offset)
   {
-    return column.makeColumnValueSelector(offset);
+    return column.makeColumnValueSelector(offset, IndexIO.LEGACY_FACTORY.getBitmapFactory()
+                                                                        .makeEmptyImmutableBitmap());
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/column/FloatsColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/FloatsColumn.java
@@ -31,6 +31,7 @@ public class FloatsColumn implements GenericColumn
 {
   private final ColumnarFloats column;
   private final ImmutableBitmap nullValueBitmap;
+  private final boolean hasNulls;
 
   public FloatsColumn(
       final ColumnarFloats column,
@@ -39,6 +40,7 @@ public class FloatsColumn implements GenericColumn
   {
     this.column = column;
     this.nullValueBitmap = nullValueBitmap;
+    this.hasNulls = !nullValueBitmap.isEmpty();
   }
 
   @Override
@@ -74,7 +76,7 @@ public class FloatsColumn implements GenericColumn
   @Override
   public boolean isNull(int rowNum)
   {
-    return nullValueBitmap.get(rowNum);
+    return hasNulls && nullValueBitmap.get(rowNum);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/column/FloatsColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/FloatsColumn.java
@@ -19,6 +19,7 @@
 
 package io.druid.segment.column;
 
+import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.ColumnValueSelector;
 import io.druid.segment.IndexIO;
@@ -29,9 +30,21 @@ import io.druid.segment.data.ReadableOffset;
  */
 public class FloatsColumn implements GenericColumn
 {
+  /**
+   * Factory method to create FloatsColumn.
+   */
+  public static FloatsColumn create(ColumnarFloats column, ImmutableBitmap nullValueBitmap)
+  {
+    if (nullValueBitmap.isEmpty()) {
+      return new FloatsColumn(column);
+    } else {
+      return new FloatsColumnWithNulls(column, nullValueBitmap);
+    }
+  }
+
   final ColumnarFloats column;
 
-  public FloatsColumn(final ColumnarFloats column)
+  protected FloatsColumn(final ColumnarFloats column)
   {
     this.column = column;
   }

--- a/processing/src/main/java/io/druid/segment/column/FloatsColumnWithNulls.java
+++ b/processing/src/main/java/io/druid/segment/column/FloatsColumnWithNulls.java
@@ -20,6 +20,7 @@
 package io.druid.segment.column;
 
 import io.druid.collections.bitmap.ImmutableBitmap;
+import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.ColumnValueSelector;
 import io.druid.segment.data.ColumnarFloats;
 import io.druid.segment.data.ReadableOffset;
@@ -44,9 +45,10 @@ public class FloatsColumnWithNulls extends FloatsColumn
   }
 
   @Override
-  public boolean isNull(int rowNum)
+  public void inspectRuntimeShape(RuntimeShapeInspector inspector)
   {
-    return nullValueBitmap.get(rowNum);
+    super.inspectRuntimeShape(inspector);
+    inspector.visit("nullValueBitmap", nullValueBitmap);
   }
 
 }

--- a/processing/src/main/java/io/druid/segment/column/FloatsColumnWithNulls.java
+++ b/processing/src/main/java/io/druid/segment/column/FloatsColumnWithNulls.java
@@ -17,35 +17,36 @@
  * under the License.
  */
 
-package io.druid.segment.serde;
+package io.druid.segment.column;
 
-import com.google.common.base.Supplier;
 import io.druid.collections.bitmap.ImmutableBitmap;
-import io.druid.segment.column.GenericColumn;
-import io.druid.segment.column.LongsColumn;
-import io.druid.segment.column.LongsColumnWithNulls;
-import io.druid.segment.data.CompressedColumnarLongsSupplier;
+import io.druid.segment.ColumnValueSelector;
+import io.druid.segment.data.ColumnarFloats;
+import io.druid.segment.data.ReadableOffset;
 
 /**
-*/
-public class LongGenericColumnSupplier implements Supplier<GenericColumn>
+ * FloatsColumn with null values.
+ */
+public class FloatsColumnWithNulls extends FloatsColumn
 {
-  private final CompressedColumnarLongsSupplier column;
   private final ImmutableBitmap nullValueBitmap;
 
-  public LongGenericColumnSupplier(CompressedColumnarLongsSupplier column, ImmutableBitmap nullValueBitmap)
+  public FloatsColumnWithNulls(ColumnarFloats columnarFloats, ImmutableBitmap nullValueBitmap)
   {
-    this.column = column;
+    super(columnarFloats);
     this.nullValueBitmap = nullValueBitmap;
   }
 
   @Override
-  public GenericColumn get()
+  public ColumnValueSelector makeColumnValueSelector(ReadableOffset offset)
   {
-    if (nullValueBitmap.isEmpty()) {
-      return new LongsColumn(column.get());
-    } else {
-      return new LongsColumnWithNulls(column.get(), nullValueBitmap);
-    }
+    return column.makeColumnValueSelector(offset, nullValueBitmap);
   }
+
+  @Override
+  public boolean isNull(int rowNum)
+  {
+    return nullValueBitmap.get(rowNum);
+  }
+
 }

--- a/processing/src/main/java/io/druid/segment/column/FloatsColumnWithNulls.java
+++ b/processing/src/main/java/io/druid/segment/column/FloatsColumnWithNulls.java
@@ -28,11 +28,11 @@ import io.druid.segment.data.ReadableOffset;
 /**
  * FloatsColumn with null values.
  */
-public class FloatsColumnWithNulls extends FloatsColumn
+class FloatsColumnWithNulls extends FloatsColumn
 {
   private final ImmutableBitmap nullValueBitmap;
 
-  public FloatsColumnWithNulls(ColumnarFloats columnarFloats, ImmutableBitmap nullValueBitmap)
+  FloatsColumnWithNulls(ColumnarFloats columnarFloats, ImmutableBitmap nullValueBitmap)
   {
     super(columnarFloats);
     this.nullValueBitmap = nullValueBitmap;
@@ -51,4 +51,24 @@ public class FloatsColumnWithNulls extends FloatsColumn
     inspector.visit("nullValueBitmap", nullValueBitmap);
   }
 
+  @Override
+  public float getFloatSingleValueRow(int rowNum)
+  {
+    assert !isNull(rowNum);
+    return super.getFloatSingleValueRow(rowNum);
+  }
+
+  @Override
+  public long getLongSingleValueRow(int rowNum)
+  {
+    assert !isNull(rowNum);
+    return super.getLongSingleValueRow(rowNum);
+  }
+
+  @Override
+  public double getDoubleSingleValueRow(int rowNum)
+  {
+    assert !isNull(rowNum);
+    return super.getLongSingleValueRow(rowNum);
+  }
 }

--- a/processing/src/main/java/io/druid/segment/column/GenericColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/GenericColumn.java
@@ -37,6 +37,9 @@ public interface GenericColumn extends BaseColumn, HotLoopCallee
   @CalledFromHotLoop
   double getDoubleSingleValueRow(int rowNum);
 
+  @CalledFromHotLoop
+  boolean isNull(int rowNum);
+
   @Override
   void close();
 }

--- a/processing/src/main/java/io/druid/segment/column/LongsColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/LongsColumn.java
@@ -19,6 +19,7 @@
 
 package io.druid.segment.column;
 
+import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.ColumnValueSelector;
 import io.druid.segment.data.ColumnarLongs;
@@ -29,10 +30,15 @@ import io.druid.segment.data.ReadableOffset;
 public class LongsColumn implements GenericColumn
 {
   private final ColumnarLongs column;
+  private final ImmutableBitmap nullValueBitmap;
 
-  public LongsColumn(final ColumnarLongs column)
+  public LongsColumn(
+      final ColumnarLongs column,
+      ImmutableBitmap nullValueBitmap
+  )
   {
     this.column = column;
+    this.nullValueBitmap = nullValueBitmap;
   }
 
   @Override
@@ -44,7 +50,7 @@ public class LongsColumn implements GenericColumn
   @Override
   public ColumnValueSelector makeColumnValueSelector(ReadableOffset offset)
   {
-    return column.makeColumnValueSelector(offset);
+    return column.makeColumnValueSelector(offset, nullValueBitmap);
   }
 
   @Override
@@ -63,6 +69,12 @@ public class LongsColumn implements GenericColumn
   public double getDoubleSingleValueRow(int rowNum)
   {
     return (double) column.get(rowNum);
+  }
+
+  @Override
+  public boolean isNull(int rowNum)
+  {
+    return nullValueBitmap.get(rowNum);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/column/LongsColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/LongsColumn.java
@@ -44,7 +44,7 @@ public class LongsColumn implements GenericColumn
 
   final ColumnarLongs column;
 
-  protected LongsColumn(final ColumnarLongs column)
+  LongsColumn(final ColumnarLongs column)
   {
     this.column = column;
   }

--- a/processing/src/main/java/io/druid/segment/column/LongsColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/LongsColumn.java
@@ -21,11 +21,12 @@ package io.druid.segment.column;
 
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.ColumnValueSelector;
+import io.druid.segment.IndexIO;
 import io.druid.segment.data.ColumnarLongs;
 import io.druid.segment.data.ReadableOffset;
 
 /**
-*/
+ */
 public class LongsColumn implements GenericColumn
 {
   final ColumnarLongs column;
@@ -44,7 +45,8 @@ public class LongsColumn implements GenericColumn
   @Override
   public ColumnValueSelector makeColumnValueSelector(ReadableOffset offset)
   {
-    return column.makeColumnValueSelector(offset);
+    return column.makeColumnValueSelector(offset, IndexIO.LEGACY_FACTORY.getBitmapFactory()
+                                                                        .makeEmptyImmutableBitmap());
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/column/LongsColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/LongsColumn.java
@@ -19,7 +19,6 @@
 
 package io.druid.segment.column;
 
-import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.ColumnValueSelector;
 import io.druid.segment.data.ColumnarLongs;
@@ -29,18 +28,11 @@ import io.druid.segment.data.ReadableOffset;
 */
 public class LongsColumn implements GenericColumn
 {
-  private final ColumnarLongs column;
-  private final ImmutableBitmap nullValueBitmap;
-  private final boolean hasNulls;
+  final ColumnarLongs column;
 
-  public LongsColumn(
-      final ColumnarLongs column,
-      ImmutableBitmap nullValueBitmap
-  )
+  public LongsColumn(final ColumnarLongs column)
   {
     this.column = column;
-    this.nullValueBitmap = nullValueBitmap;
-    this.hasNulls = !nullValueBitmap.isEmpty();
   }
 
   @Override
@@ -52,7 +44,7 @@ public class LongsColumn implements GenericColumn
   @Override
   public ColumnValueSelector makeColumnValueSelector(ReadableOffset offset)
   {
-    return column.makeColumnValueSelector(offset, nullValueBitmap);
+    return column.makeColumnValueSelector(offset);
   }
 
   @Override
@@ -76,7 +68,7 @@ public class LongsColumn implements GenericColumn
   @Override
   public boolean isNull(int rowNum)
   {
-    return hasNulls && nullValueBitmap.get(rowNum);
+    return false;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/column/LongsColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/LongsColumn.java
@@ -19,6 +19,7 @@
 
 package io.druid.segment.column;
 
+import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.ColumnValueSelector;
 import io.druid.segment.IndexIO;
@@ -29,9 +30,21 @@ import io.druid.segment.data.ReadableOffset;
  */
 public class LongsColumn implements GenericColumn
 {
+  /**
+   * Factory method to create LongsColumn.
+   */
+  public static LongsColumn create(ColumnarLongs column, ImmutableBitmap nullValueBitmap)
+  {
+    if (nullValueBitmap.isEmpty()) {
+      return new LongsColumn(column);
+    } else {
+      return new LongsColumnWithNulls(column, nullValueBitmap);
+    }
+  }
+
   final ColumnarLongs column;
 
-  public LongsColumn(final ColumnarLongs column)
+  protected LongsColumn(final ColumnarLongs column)
   {
     this.column = column;
   }

--- a/processing/src/main/java/io/druid/segment/column/LongsColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/LongsColumn.java
@@ -31,6 +31,7 @@ public class LongsColumn implements GenericColumn
 {
   private final ColumnarLongs column;
   private final ImmutableBitmap nullValueBitmap;
+  private final boolean hasNulls;
 
   public LongsColumn(
       final ColumnarLongs column,
@@ -39,6 +40,7 @@ public class LongsColumn implements GenericColumn
   {
     this.column = column;
     this.nullValueBitmap = nullValueBitmap;
+    this.hasNulls = !nullValueBitmap.isEmpty();
   }
 
   @Override
@@ -74,7 +76,7 @@ public class LongsColumn implements GenericColumn
   @Override
   public boolean isNull(int rowNum)
   {
-    return nullValueBitmap.get(rowNum);
+    return hasNulls && nullValueBitmap.get(rowNum);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/column/LongsColumnWithNulls.java
+++ b/processing/src/main/java/io/druid/segment/column/LongsColumnWithNulls.java
@@ -17,35 +17,36 @@
  * under the License.
  */
 
-package io.druid.segment.serde;
+package io.druid.segment.column;
 
-import com.google.common.base.Supplier;
 import io.druid.collections.bitmap.ImmutableBitmap;
-import io.druid.segment.column.GenericColumn;
-import io.druid.segment.column.LongsColumn;
-import io.druid.segment.column.LongsColumnWithNulls;
-import io.druid.segment.data.CompressedColumnarLongsSupplier;
+import io.druid.segment.ColumnValueSelector;
+import io.druid.segment.data.ColumnarLongs;
+import io.druid.segment.data.ReadableOffset;
 
 /**
-*/
-public class LongGenericColumnSupplier implements Supplier<GenericColumn>
+ * LongsColumn with null values.
+ */
+public class LongsColumnWithNulls extends LongsColumn
 {
-  private final CompressedColumnarLongsSupplier column;
   private final ImmutableBitmap nullValueBitmap;
 
-  public LongGenericColumnSupplier(CompressedColumnarLongsSupplier column, ImmutableBitmap nullValueBitmap)
+  public LongsColumnWithNulls(ColumnarLongs columnarLongs, ImmutableBitmap nullValueBitmap)
   {
-    this.column = column;
+    super(columnarLongs);
     this.nullValueBitmap = nullValueBitmap;
   }
 
   @Override
-  public GenericColumn get()
+  public ColumnValueSelector makeColumnValueSelector(ReadableOffset offset)
   {
-    if (nullValueBitmap.isEmpty()) {
-      return new LongsColumn(column.get());
-    } else {
-      return new LongsColumnWithNulls(column.get(), nullValueBitmap);
-    }
+    return column.makeColumnValueSelector(offset, nullValueBitmap);
   }
+
+  @Override
+  public boolean isNull(int rowNum)
+  {
+    return nullValueBitmap.get(rowNum);
+  }
+
 }

--- a/processing/src/main/java/io/druid/segment/column/LongsColumnWithNulls.java
+++ b/processing/src/main/java/io/druid/segment/column/LongsColumnWithNulls.java
@@ -20,6 +20,7 @@
 package io.druid.segment.column;
 
 import io.druid.collections.bitmap.ImmutableBitmap;
+import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.ColumnValueSelector;
 import io.druid.segment.data.ColumnarLongs;
 import io.druid.segment.data.ReadableOffset;
@@ -44,9 +45,9 @@ public class LongsColumnWithNulls extends LongsColumn
   }
 
   @Override
-  public boolean isNull(int rowNum)
+  public void inspectRuntimeShape(RuntimeShapeInspector inspector)
   {
-    return nullValueBitmap.get(rowNum);
+    super.inspectRuntimeShape(inspector);
+    inspector.visit("nullValueBitmap", nullValueBitmap);
   }
-
 }

--- a/processing/src/main/java/io/druid/segment/column/LongsColumnWithNulls.java
+++ b/processing/src/main/java/io/druid/segment/column/LongsColumnWithNulls.java
@@ -28,11 +28,11 @@ import io.druid.segment.data.ReadableOffset;
 /**
  * LongsColumn with null values.
  */
-public class LongsColumnWithNulls extends LongsColumn
+class LongsColumnWithNulls extends LongsColumn
 {
   private final ImmutableBitmap nullValueBitmap;
 
-  public LongsColumnWithNulls(ColumnarLongs columnarLongs, ImmutableBitmap nullValueBitmap)
+  LongsColumnWithNulls(ColumnarLongs columnarLongs, ImmutableBitmap nullValueBitmap)
   {
     super(columnarLongs);
     this.nullValueBitmap = nullValueBitmap;
@@ -49,5 +49,26 @@ public class LongsColumnWithNulls extends LongsColumn
   {
     super.inspectRuntimeShape(inspector);
     inspector.visit("nullValueBitmap", nullValueBitmap);
+  }
+
+  @Override
+  public float getFloatSingleValueRow(int rowNum)
+  {
+    assert !isNull(rowNum);
+    return super.getFloatSingleValueRow(rowNum);
+  }
+
+  @Override
+  public long getLongSingleValueRow(int rowNum)
+  {
+    assert !isNull(rowNum);
+    return super.getLongSingleValueRow(rowNum);
+  }
+
+  @Override
+  public double getDoubleSingleValueRow(int rowNum)
+  {
+    assert !isNull(rowNum);
+    return super.getLongSingleValueRow(rowNum);
   }
 }

--- a/processing/src/main/java/io/druid/segment/column/SimpleDictionaryEncodedColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/SimpleDictionaryEncodedColumn.java
@@ -21,7 +21,6 @@ package io.druid.segment.column;
 
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
-import com.google.common.base.Strings;
 import io.druid.java.util.common.guava.CloseQuietly;
 import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.filter.ValueMatcher;
@@ -86,10 +85,10 @@ public class SimpleDictionaryEncodedColumn implements DictionaryEncodedColumn<St
   }
 
   @Override
+  @Nullable
   public String lookupName(int id)
   {
-    //Empty to Null will ensure that null and empty are equivalent for extraction function
-    return Strings.emptyToNull(cachedLookups.get(id));
+    return cachedLookups.get(id);
   }
 
   @Override
@@ -175,6 +174,13 @@ public class SimpleDictionaryEncodedColumn implements DictionaryEncodedColumn<St
         public ValueMatcher makeValueMatcher(Predicate<String> predicate)
         {
           return DimensionSelectorUtils.makeValueMatcherGeneric(this, predicate);
+        }
+
+        @Override
+        public boolean isNull()
+        {
+          IndexedInts row = getRow();
+          return row == null || row.size() == 0;
         }
 
         @Nullable
@@ -280,6 +286,12 @@ public class SimpleDictionaryEncodedColumn implements DictionaryEncodedColumn<St
               inspector.visit("column", SimpleDictionaryEncodedColumn.this);
             }
           };
+        }
+
+        @Override
+        public boolean isNull()
+        {
+          return getObject() == null;
         }
 
         @Override

--- a/processing/src/main/java/io/druid/segment/column/SimpleDictionaryEncodedColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/SimpleDictionaryEncodedColumn.java
@@ -282,12 +282,6 @@ public class SimpleDictionaryEncodedColumn implements DictionaryEncodedColumn<St
         }
 
         @Override
-        public boolean isNull()
-        {
-          return getObject() == null;
-        }
-
-        @Override
         public Object getObject()
         {
           return lookupName(getRowValue());

--- a/processing/src/main/java/io/druid/segment/column/SimpleDictionaryEncodedColumn.java
+++ b/processing/src/main/java/io/druid/segment/column/SimpleDictionaryEncodedColumn.java
@@ -176,13 +176,6 @@ public class SimpleDictionaryEncodedColumn implements DictionaryEncodedColumn<St
           return DimensionSelectorUtils.makeValueMatcherGeneric(this, predicate);
         }
 
-        @Override
-        public boolean isNull()
-        {
-          IndexedInts row = getRow();
-          return row == null || row.size() == 0;
-        }
-
         @Nullable
         @Override
         public Object getObject()

--- a/processing/src/main/java/io/druid/segment/data/ColumnarDoubles.java
+++ b/processing/src/main/java/io/druid/segment/data/ColumnarDoubles.java
@@ -19,6 +19,7 @@
 
 package io.druid.segment.data;
 
+import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.ColumnValueSelector;
 import io.druid.segment.DoubleColumnSelector;
@@ -38,7 +39,7 @@ public interface ColumnarDoubles extends Closeable
   @Override
   void close();
 
-  default ColumnValueSelector<Double> makeColumnValueSelector(ReadableOffset offset)
+  default ColumnValueSelector<Double> makeColumnValueSelector(ReadableOffset offset, ImmutableBitmap nullValueBitmap)
   {
     class HistoricalDoubleColumnSelector implements DoubleColumnSelector, HistoricalColumnSelector<Double>
     {
@@ -52,6 +53,12 @@ public interface ColumnarDoubles extends Closeable
       public double getDouble(int offset)
       {
         return ColumnarDoubles.this.get(offset);
+      }
+
+      @Override
+      public boolean isNull()
+      {
+        return nullValueBitmap.get(offset.getOffset());
       }
 
       @Override

--- a/processing/src/main/java/io/druid/segment/data/ColumnarDoubles.java
+++ b/processing/src/main/java/io/druid/segment/data/ColumnarDoubles.java
@@ -41,6 +41,7 @@ public interface ColumnarDoubles extends Closeable
 
   default ColumnValueSelector<Double> makeColumnValueSelector(ReadableOffset offset, ImmutableBitmap nullValueBitmap)
   {
+    final boolean hasNulls = !nullValueBitmap.isEmpty();
     class HistoricalDoubleColumnSelector implements DoubleColumnSelector, HistoricalColumnSelector<Double>
     {
       @Override
@@ -58,7 +59,7 @@ public interface ColumnarDoubles extends Closeable
       @Override
       public boolean isNull()
       {
-        return nullValueBitmap.get(offset.getOffset());
+        return hasNulls && nullValueBitmap.get(offset.getOffset());
       }
 
       @Override

--- a/processing/src/main/java/io/druid/segment/data/ColumnarDoubles.java
+++ b/processing/src/main/java/io/druid/segment/data/ColumnarDoubles.java
@@ -20,6 +20,7 @@
 package io.druid.segment.data;
 
 import io.druid.collections.bitmap.ImmutableBitmap;
+import io.druid.common.config.NullHandling;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.ColumnValueSelector;
 import io.druid.segment.DoubleColumnSelector;
@@ -46,6 +47,12 @@ public interface ColumnarDoubles extends Closeable
       class HistoricalDoubleColumnSelector implements DoubleColumnSelector, HistoricalColumnSelector<Double>
       {
         @Override
+        public boolean isNull()
+        {
+          return false;
+        }
+
+        @Override
         public double getDouble()
         {
           return ColumnarDoubles.this.get(offset.getOffset());
@@ -55,12 +62,6 @@ public interface ColumnarDoubles extends Closeable
         public double getDouble(int offset)
         {
           return ColumnarDoubles.this.get(offset);
-        }
-
-        @Override
-        public boolean isNull()
-        {
-          return false;
         }
 
         @Override
@@ -75,21 +76,23 @@ public interface ColumnarDoubles extends Closeable
       class HistoricalDoubleColumnSelectorWithNulls implements DoubleColumnSelector, HistoricalColumnSelector<Double>
       {
         @Override
+        public boolean isNull()
+        {
+          return nullValueBitmap.get(offset.getOffset());
+        }
+
+        @Override
         public double getDouble()
         {
+          assert NullHandling.replaceWithDefault() || !isNull();
           return ColumnarDoubles.this.get(offset.getOffset());
         }
 
         @Override
         public double getDouble(int offset)
         {
+          assert NullHandling.replaceWithDefault() || !nullValueBitmap.get(offset);
           return ColumnarDoubles.this.get(offset);
-        }
-
-        @Override
-        public boolean isNull()
-        {
-          return nullValueBitmap.get(offset.getOffset());
         }
 
         @Override

--- a/processing/src/main/java/io/druid/segment/data/ColumnarFloats.java
+++ b/processing/src/main/java/io/druid/segment/data/ColumnarFloats.java
@@ -19,6 +19,7 @@
 
 package io.druid.segment.data;
 
+import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.ColumnValueSelector;
 import io.druid.segment.FloatColumnSelector;
@@ -39,7 +40,7 @@ public interface ColumnarFloats extends Closeable
   @Override
   void close();
 
-  default ColumnValueSelector<Float> makeColumnValueSelector(ReadableOffset offset)
+  default ColumnValueSelector<Float> makeColumnValueSelector(ReadableOffset offset, ImmutableBitmap nullValueBitmap)
   {
     class HistoricalFloatColumnSelector implements FloatColumnSelector, HistoricalColumnSelector<Float>
     {
@@ -47,6 +48,12 @@ public interface ColumnarFloats extends Closeable
       public float getFloat()
       {
         return ColumnarFloats.this.get(offset.getOffset());
+      }
+
+      @Override
+      public boolean isNull()
+      {
+        return nullValueBitmap.get(offset.getOffset());
       }
 
       @Override

--- a/processing/src/main/java/io/druid/segment/data/ColumnarFloats.java
+++ b/processing/src/main/java/io/druid/segment/data/ColumnarFloats.java
@@ -20,6 +20,7 @@
 package io.druid.segment.data;
 
 import io.druid.collections.bitmap.ImmutableBitmap;
+import io.druid.common.config.NullHandling;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.ColumnValueSelector;
 import io.druid.segment.FloatColumnSelector;
@@ -48,15 +49,15 @@ public interface ColumnarFloats extends Closeable
       class HistoricalFloatColumnSelector implements FloatColumnSelector, HistoricalColumnSelector<Float>
       {
         @Override
-        public float getFloat()
-        {
-          return ColumnarFloats.this.get(offset.getOffset());
-        }
-
-        @Override
         public boolean isNull()
         {
           return false;
+        }
+
+        @Override
+        public float getFloat()
+        {
+          return ColumnarFloats.this.get(offset.getOffset());
         }
 
         @Override
@@ -77,20 +78,22 @@ public interface ColumnarFloats extends Closeable
       class HistoricalFloatColumnSelectorwithNulls implements FloatColumnSelector, HistoricalColumnSelector<Float>
       {
         @Override
-        public float getFloat()
-        {
-          return ColumnarFloats.this.get(offset.getOffset());
-        }
-
-        @Override
         public boolean isNull()
         {
           return nullValueBitmap.get(offset.getOffset());
         }
 
         @Override
+        public float getFloat()
+        {
+          assert NullHandling.replaceWithDefault() || !isNull();
+          return ColumnarFloats.this.get(offset.getOffset());
+        }
+
+        @Override
         public double getDouble(int offset)
         {
+          assert NullHandling.replaceWithDefault() || !nullValueBitmap.get(offset);
           return ColumnarFloats.this.get(offset);
         }
 

--- a/processing/src/main/java/io/druid/segment/data/ColumnarFloats.java
+++ b/processing/src/main/java/io/druid/segment/data/ColumnarFloats.java
@@ -40,6 +40,38 @@ public interface ColumnarFloats extends Closeable
   @Override
   void close();
 
+  default ColumnValueSelector<Float> makeColumnValueSelector(ReadableOffset offset)
+  {
+    class HistoricalFloatColumnSelector implements FloatColumnSelector, HistoricalColumnSelector<Float>
+    {
+      @Override
+      public float getFloat()
+      {
+        return ColumnarFloats.this.get(offset.getOffset());
+      }
+
+      @Override
+      public boolean isNull()
+      {
+        return false;
+      }
+
+      @Override
+      public double getDouble(int offset)
+      {
+        return ColumnarFloats.this.get(offset);
+      }
+
+      @Override
+      public void inspectRuntimeShape(RuntimeShapeInspector inspector)
+      {
+        inspector.visit("columnar", ColumnarFloats.this);
+        inspector.visit("offset", offset);
+      }
+    }
+    return new HistoricalFloatColumnSelector();
+  }
+
   default ColumnValueSelector<Float> makeColumnValueSelector(ReadableOffset offset, ImmutableBitmap nullValueBitmap)
   {
     final boolean hasNulls = !nullValueBitmap.isEmpty();

--- a/processing/src/main/java/io/druid/segment/data/ColumnarFloats.java
+++ b/processing/src/main/java/io/druid/segment/data/ColumnarFloats.java
@@ -42,6 +42,7 @@ public interface ColumnarFloats extends Closeable
 
   default ColumnValueSelector<Float> makeColumnValueSelector(ReadableOffset offset, ImmutableBitmap nullValueBitmap)
   {
+    final boolean hasNulls = !nullValueBitmap.isEmpty();
     class HistoricalFloatColumnSelector implements FloatColumnSelector, HistoricalColumnSelector<Float>
     {
       @Override
@@ -53,7 +54,7 @@ public interface ColumnarFloats extends Closeable
       @Override
       public boolean isNull()
       {
-        return nullValueBitmap.get(offset.getOffset());
+        return hasNulls && nullValueBitmap.get(offset.getOffset());
       }
 
       @Override

--- a/processing/src/main/java/io/druid/segment/data/ColumnarLongs.java
+++ b/processing/src/main/java/io/druid/segment/data/ColumnarLongs.java
@@ -19,6 +19,7 @@
 
 package io.druid.segment.data;
 
+import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.ColumnValueSelector;
 import io.druid.segment.LongColumnSelector;
@@ -39,7 +40,7 @@ public interface ColumnarLongs extends Closeable
   @Override
   void close();
 
-  default ColumnValueSelector<Long> makeColumnValueSelector(ReadableOffset offset)
+  default ColumnValueSelector<Long> makeColumnValueSelector(ReadableOffset offset, ImmutableBitmap nullValueBitmap)
   {
     class HistoricalLongColumnSelector implements LongColumnSelector, HistoricalColumnSelector<Long>
     {
@@ -53,6 +54,12 @@ public interface ColumnarLongs extends Closeable
       public double getDouble(int offset)
       {
         return ColumnarLongs.this.get(offset);
+      }
+
+      @Override
+      public boolean isNull()
+      {
+        return nullValueBitmap.get(offset.getOffset());
       }
 
       @Override

--- a/processing/src/main/java/io/druid/segment/data/ColumnarLongs.java
+++ b/processing/src/main/java/io/druid/segment/data/ColumnarLongs.java
@@ -72,4 +72,36 @@ public interface ColumnarLongs extends Closeable
     }
     return new HistoricalLongColumnSelector();
   }
+
+  default ColumnValueSelector<Long> makeColumnValueSelector(ReadableOffset offset)
+  {
+    class HistoricalLongColumnSelector implements LongColumnSelector, HistoricalColumnSelector<Long>
+    {
+      @Override
+      public long getLong()
+      {
+        return ColumnarLongs.this.get(offset.getOffset());
+      }
+
+      @Override
+      public double getDouble(int offset)
+      {
+        return ColumnarLongs.this.get(offset);
+      }
+
+      @Override
+      public boolean isNull()
+      {
+        return false;
+      }
+
+      @Override
+      public void inspectRuntimeShape(RuntimeShapeInspector inspector)
+      {
+        inspector.visit("columnar", ColumnarLongs.this);
+        inspector.visit("offset", offset);
+      }
+    }
+    return new HistoricalLongColumnSelector();
+  }
 }

--- a/processing/src/main/java/io/druid/segment/data/ColumnarLongs.java
+++ b/processing/src/main/java/io/druid/segment/data/ColumnarLongs.java
@@ -42,6 +42,7 @@ public interface ColumnarLongs extends Closeable
 
   default ColumnValueSelector<Long> makeColumnValueSelector(ReadableOffset offset, ImmutableBitmap nullValueBitmap)
   {
+    final boolean hasNulls = !nullValueBitmap.isEmpty();
     class HistoricalLongColumnSelector implements LongColumnSelector, HistoricalColumnSelector<Long>
     {
       @Override
@@ -59,7 +60,7 @@ public interface ColumnarLongs extends Closeable
       @Override
       public boolean isNull()
       {
-        return nullValueBitmap.get(offset.getOffset());
+        return hasNulls && nullValueBitmap.get(offset.getOffset());
       }
 
       @Override

--- a/processing/src/main/java/io/druid/segment/data/ColumnarLongs.java
+++ b/processing/src/main/java/io/druid/segment/data/ColumnarLongs.java
@@ -20,6 +20,7 @@
 package io.druid.segment.data;
 
 import io.druid.collections.bitmap.ImmutableBitmap;
+import io.druid.common.config.NullHandling;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.ColumnValueSelector;
 import io.druid.segment.LongColumnSelector;
@@ -48,6 +49,12 @@ public interface ColumnarLongs extends Closeable
       class HistoricalLongColumnSelector implements LongColumnSelector, HistoricalColumnSelector<Long>
       {
         @Override
+        public boolean isNull()
+        {
+          return false;
+        }
+
+        @Override
         public long getLong()
         {
           return ColumnarLongs.this.get(offset.getOffset());
@@ -57,12 +64,6 @@ public interface ColumnarLongs extends Closeable
         public double getDouble(int offset)
         {
           return ColumnarLongs.this.get(offset);
-        }
-
-        @Override
-        public boolean isNull()
-        {
-          return false;
         }
 
         @Override
@@ -77,21 +78,23 @@ public interface ColumnarLongs extends Closeable
       class HistoricalLongColumnSelectorWithNulls implements LongColumnSelector, HistoricalColumnSelector<Long>
       {
         @Override
+        public boolean isNull()
+        {
+          return nullValueBitmap.get(offset.getOffset());
+        }
+
+        @Override
         public long getLong()
         {
+          assert NullHandling.replaceWithDefault() || !isNull();
           return ColumnarLongs.this.get(offset.getOffset());
         }
 
         @Override
         public double getDouble(int offset)
         {
+          assert NullHandling.replaceWithDefault() || !nullValueBitmap.get(offset);
           return ColumnarLongs.this.get(offset);
-        }
-
-        @Override
-        public boolean isNull()
-        {
-          return nullValueBitmap.get(offset.getOffset());
         }
 
         @Override

--- a/processing/src/main/java/io/druid/segment/data/GenericIndexed.java
+++ b/processing/src/main/java/io/druid/segment/data/GenericIndexed.java
@@ -105,10 +105,11 @@ public class GenericIndexed<T> implements Indexed<T>, Serializer
     @Nullable
     public String fromByteBuffer(final ByteBuffer buffer, final int numBytes)
     {
-      // numBytes will be -1 when the value is null and SQL compatible behavior for null handling is used.
-      // numBytes will be 0 when the value is empty string,
-      // For non-sql compliant, legacy null handling, nulls are stored as empty string
-      // and numBytes will be 0 for null values also.
+      // When SQL Compatibility is ON
+      //   1. numBytes will be -1 for null value, return value will be null
+      //   2. numBytes will be 0 for empty string, return value will be empty string
+      // For Legacy null handling when nulls and empty string are considered same -
+      //     numBytes will be 0 for both empty string and null and return value will be null for both.
       if (numBytes < 0) {
         return null;
       }

--- a/processing/src/main/java/io/druid/segment/data/GenericIndexed.java
+++ b/processing/src/main/java/io/druid/segment/data/GenericIndexed.java
@@ -412,7 +412,7 @@ public class GenericIndexed<T> implements Indexed<T>, Serializer
     T bufferedIndexedGet(ByteBuffer copyValueBuffer, int startOffset, int endOffset)
     {
       int size = endOffset - startOffset;
-      if (size == 0 && copyValueBuffer.get(startOffset - Ints.BYTES) == NULL_VALUE_SIZE_MARKER) {
+      if (size == 0 && copyValueBuffer.get(startOffset - Integer.BYTES) == NULL_VALUE_SIZE_MARKER) {
         return null;
       }
       lastReadSize = size;
@@ -562,7 +562,7 @@ public class GenericIndexed<T> implements Indexed<T>, Serializer
         final int endOffset;
 
         if (index == 0) {
-          startOffset = Ints.BYTES;
+          startOffset = Integer.BYTES;
           endOffset = headerBuffer.getInt(0);
         } else {
           int headerPosition = (index - 1) * Integer.BYTES;

--- a/processing/src/main/java/io/druid/segment/data/GenericIndexedWriter.java
+++ b/processing/src/main/java/io/druid/segment/data/GenericIndexedWriter.java
@@ -214,9 +214,8 @@ public class GenericIndexedWriter<T> implements Serializer
     }
 
     ++numWritten;
-    // for compatibility with the format (see GenericIndexed javadoc for description of the format), but this field is
-    // unused.
-    valuesOut.writeInt(0);
+
+    valuesOut.writeInt(objectToWrite == null ? -1 : 0);
     if (objectToWrite != null) {
       strategy.writeTo(objectToWrite, valuesOut);
     }

--- a/processing/src/main/java/io/druid/segment/data/GenericIndexedWriter.java
+++ b/processing/src/main/java/io/druid/segment/data/GenericIndexedWriter.java
@@ -214,8 +214,9 @@ public class GenericIndexedWriter<T> implements Serializer
     }
 
     ++numWritten;
-
-    valuesOut.writeInt(objectToWrite == null ? -1 : 0);
+    // for compatibility with the format (see GenericIndexed javadoc for description of the format),
+    // this field is used to store nullness marker, but in a better format this info can take 1 bit.
+    valuesOut.writeInt(objectToWrite == null ? GenericIndexed.NULL_VALUE_SIZE_MARKER : 0);
     if (objectToWrite != null) {
       strategy.writeTo(objectToWrite, valuesOut);
     }

--- a/processing/src/main/java/io/druid/segment/data/ObjectStrategy.java
+++ b/processing/src/main/java/io/druid/segment/data/ObjectStrategy.java
@@ -22,6 +22,7 @@ package io.druid.segment.data;
 import io.druid.guice.annotations.ExtensionPoint;
 import io.druid.segment.writeout.WriteOutBytes;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Comparator;
@@ -44,8 +45,11 @@ public interface ObjectStrategy<T> extends Comparator<T>
    * @param numBytes number of bytes used to store the value, starting at buffer.position()
    * @return an object created from the given byte buffer representation
    */
+  @Nullable
   T fromByteBuffer(ByteBuffer buffer, int numBytes);
-  byte[] toBytes(T val);
+
+  @Nullable
+  byte[] toBytes(@Nullable T val);
 
   /**
    * Reads 4-bytes numBytes from the given buffer, and then delegates to {@link #fromByteBuffer(ByteBuffer, int)}.
@@ -62,6 +66,9 @@ public interface ObjectStrategy<T> extends Comparator<T>
 
   default void writeTo(T val, WriteOutBytes out) throws IOException
   {
-    out.write(toBytes(val));
+    byte[] bytes = toBytes(val);
+    if (bytes != null) {
+      out.write(toBytes(val));
+    }
   }
 }

--- a/processing/src/main/java/io/druid/segment/data/RoaringBitmapSerdeFactory.java
+++ b/processing/src/main/java/io/druid/segment/data/RoaringBitmapSerdeFactory.java
@@ -79,6 +79,9 @@ public class RoaringBitmapSerdeFactory implements BitmapSerdeFactory
     @Override
     public ImmutableBitmap fromByteBuffer(ByteBuffer buffer, int numBytes)
     {
+      if (numBytes == 0) {
+        return null;
+      }
       buffer.limit(buffer.position() + numBytes);
       return new WrappedImmutableRoaringBitmap(new ImmutableRoaringBitmap(buffer));
     }

--- a/processing/src/main/java/io/druid/segment/data/RoaringBitmapSerdeFactory.java
+++ b/processing/src/main/java/io/druid/segment/data/RoaringBitmapSerdeFactory.java
@@ -27,6 +27,7 @@ import io.druid.collections.bitmap.RoaringBitmapFactory;
 import io.druid.collections.bitmap.WrappedImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 
+import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 
 /**
@@ -77,6 +78,7 @@ public class RoaringBitmapSerdeFactory implements BitmapSerdeFactory
     }
 
     @Override
+    @Nullable
     public ImmutableBitmap fromByteBuffer(ByteBuffer buffer, int numBytes)
     {
       if (numBytes == 0) {

--- a/processing/src/main/java/io/druid/segment/data/RoaringBitmapSerdeFactory.java
+++ b/processing/src/main/java/io/druid/segment/data/RoaringBitmapSerdeFactory.java
@@ -81,9 +81,6 @@ public class RoaringBitmapSerdeFactory implements BitmapSerdeFactory
     @Nullable
     public ImmutableBitmap fromByteBuffer(ByteBuffer buffer, int numBytes)
     {
-      if (numBytes == 0) {
-        return null;
-      }
       buffer.limit(buffer.position() + numBytes);
       return new WrappedImmutableRoaringBitmap(new ImmutableRoaringBitmap(buffer));
     }

--- a/processing/src/main/java/io/druid/segment/filter/Filters.java
+++ b/processing/src/main/java/io/druid/segment/filter/Filters.java
@@ -25,6 +25,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import io.druid.collections.bitmap.ImmutableBitmap;
+import io.druid.common.config.NullHandling;
 import io.druid.java.util.common.guava.FunctionalIterable;
 import io.druid.query.BitmapResultFactory;
 import io.druid.query.ColumnSelectorPlus;
@@ -132,7 +133,7 @@ public class Filters
             columnSelectorFactory
         );
 
-    return selector.getColumnSelectorStrategy().makeValueMatcher(selector.getSelector(), value);
+    return selector.getColumnSelectorStrategy().makeValueMatcher(selector.getSelector(), NullHandling.emptyToNullIfNeeded(value));
   }
 
   /**

--- a/processing/src/main/java/io/druid/segment/filter/Filters.java
+++ b/processing/src/main/java/io/druid/segment/filter/Filters.java
@@ -133,7 +133,8 @@ public class Filters
             columnSelectorFactory
         );
 
-    return selector.getColumnSelectorStrategy().makeValueMatcher(selector.getSelector(), NullHandling.emptyToNullIfNeeded(value));
+    return selector.getColumnSelectorStrategy()
+                   .makeValueMatcher(selector.getSelector(), NullHandling.emptyToNullIfNeeded(value));
   }
 
   /**

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -1417,7 +1417,7 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
     }
   }
 
-  private class ObjectMetricColumnSelector implements ObjectColumnSelector
+  private class ObjectMetricColumnSelector extends ObjectColumnSelector
   {
     private final TimeAndDimsHolder currEntry;
     private final int metricIndex;

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -160,19 +160,19 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
             @Override
             public long getLong()
             {
-              return DimensionHandlerUtils.nullToZeroLong(in.get().getMetric(column)).longValue();
+              return DimensionHandlerUtils.nullToZero(in.get().getMetric(column)).longValue();
             }
 
             @Override
             public float getFloat()
             {
-              return DimensionHandlerUtils.nullToZeroFloat(in.get().getMetric(column)).floatValue();
+              return DimensionHandlerUtils.nullToZero(in.get().getMetric(column)).floatValue();
             }
 
             @Override
             public double getDouble()
             {
-              return DimensionHandlerUtils.nullToZeroDouble(in.get().getMetric(column)).doubleValue();
+              return DimensionHandlerUtils.nullToZero(in.get().getMetric(column)).doubleValue();
             }
 
             @Override

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -152,21 +152,27 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
           return new ColumnValueSelector()
           {
             @Override
+            public boolean isNull()
+            {
+              return in.get().getMetric(column) == null;
+            }
+
+            @Override
             public long getLong()
             {
-              return in.get().getMetric(column).longValue();
+              return DimensionHandlerUtils.nullToZeroLong(in.get().getMetric(column)).longValue();
             }
 
             @Override
             public float getFloat()
             {
-              return in.get().getMetric(column).floatValue();
+              return DimensionHandlerUtils.nullToZeroFloat(in.get().getMetric(column)).floatValue();
             }
 
             @Override
             public double getDouble()
             {
-              return in.get().getMetric(column).doubleValue();
+              return DimensionHandlerUtils.nullToZeroDouble(in.get().getMetric(column)).doubleValue();
             }
 
             @Override
@@ -460,6 +466,9 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
   protected abstract Object getMetricObjectValue(int rowOffset, int aggOffset);
 
   protected abstract double getMetricDoubleValue(int rowOffset, int aggOffset);
+
+  protected abstract boolean isNull(int rowOffset, int aggOffset);
+
 
   @Override
   public void close()
@@ -1400,6 +1409,12 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
     {
       inspector.visit("index", IncrementalIndex.this);
     }
+
+    @Override
+    public boolean isNull()
+    {
+      return IncrementalIndex.this.isNull(currEntry.getValue(), metricIndex);
+    }
   }
 
   private class ObjectMetricColumnSelector implements ObjectColumnSelector
@@ -1461,6 +1476,12 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
     {
       inspector.visit("index", IncrementalIndex.this);
     }
+
+    @Override
+    public boolean isNull()
+    {
+      return IncrementalIndex.this.isNull(currEntry.getValue(), metricIndex);
+    }
   }
 
   private class DoubleMetricColumnSelector implements DoubleColumnSelector
@@ -1478,6 +1499,12 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
     public double getDouble()
     {
       return getMetricDoubleValue(currEntry.getValue(), metricIndex);
+    }
+
+    @Override
+    public boolean isNull()
+    {
+      return IncrementalIndex.this.isNull(currEntry.getValue(), metricIndex);
     }
 
     @Override

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Maps;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import io.druid.collections.NonBlockingPool;
+import io.druid.common.config.NullHandling;
 import io.druid.common.guava.GuavaUtils;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.MapBasedRow;
@@ -160,19 +161,25 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
             @Override
             public long getLong()
             {
-              return DimensionHandlerUtils.nullToZero(in.get().getMetric(column)).longValue();
+              Number metric = in.get().getMetric(column);
+              assert NullHandling.replaceWithDefault() || metric != null;
+              return DimensionHandlerUtils.nullToZero(metric).longValue();
             }
 
             @Override
             public float getFloat()
             {
-              return DimensionHandlerUtils.nullToZero(in.get().getMetric(column)).floatValue();
+              Number metric = in.get().getMetric(column);
+              assert NullHandling.replaceWithDefault() || metric != null;
+              return DimensionHandlerUtils.nullToZero(metric).floatValue();
             }
 
             @Override
             public double getDouble()
             {
-              return DimensionHandlerUtils.nullToZero(in.get().getMetric(column)).doubleValue();
+              Number metric = in.get().getMetric(column);
+              assert NullHandling.replaceWithDefault() || metric != null;
+              return DimensionHandlerUtils.nullToZero(metric).doubleValue();
             }
 
             @Override
@@ -1401,6 +1408,7 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
     @Override
     public long getLong()
     {
+      assert NullHandling.replaceWithDefault() || !isNull();
       return getMetricLongValue(currEntry.getValue(), metricIndex);
     }
 
@@ -1468,6 +1476,7 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
     @Override
     public float getFloat()
     {
+      assert NullHandling.replaceWithDefault() || !isNull();
       return getMetricFloatValue(currEntry.getValue(), metricIndex);
     }
 
@@ -1498,6 +1507,7 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
     @Override
     public double getDouble()
     {
+      assert NullHandling.replaceWithDefault() || !isNull();
       return getMetricDoubleValue(currEntry.getValue(), metricIndex);
     }
 

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexColumnSelectorFactory.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexColumnSelectorFactory.java
@@ -121,6 +121,12 @@ class IncrementalIndexColumnSelectorFactory implements ColumnSelectorFactory
         {
           // nothing to inspect
         }
+
+        @Override
+        public boolean isNull()
+        {
+          return false;
+        }
       }
       return new TimeLongColumnSelector();
     }

--- a/processing/src/main/java/io/druid/segment/incremental/OffheapIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OffheapIncrementalIndex.java
@@ -313,6 +313,15 @@ public class OffheapIncrementalIndex extends IncrementalIndex<BufferAggregator>
     return agg.getDouble(bb, indexAndOffset[1] + aggOffsetInBuffer[aggOffset]);
   }
 
+  @Override
+  public boolean isNull(int rowOffset, int aggOffset)
+  {
+    BufferAggregator agg = getAggs()[aggOffset];
+    int[] indexAndOffset = indexAndOffsets.get(rowOffset);
+    ByteBuffer bb = aggBuffers.get(indexAndOffset[0]).get();
+    return agg.isNull(bb, indexAndOffset[1] + aggOffsetInBuffer[aggOffset]);
+  }
+
   /**
    * NOTE: This is NOT thread-safe with add... so make sure all the adding is DONE before closing
    */

--- a/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -286,6 +286,12 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
     return concurrentGet(rowOffset)[aggOffset].getDouble();
   }
 
+  @Override
+  public boolean isNull(int rowOffset, int aggOffset)
+  {
+    return concurrentGet(rowOffset)[aggOffset].isNull();
+  }
+
   /**
    * Clear out maps to allow GC
    * NOTE: This is NOT thread-safe with add... so make sure all the adding is DONE before closing

--- a/processing/src/main/java/io/druid/segment/serde/BitmapIndexColumnPartSupplier.java
+++ b/processing/src/main/java/io/druid/segment/serde/BitmapIndexColumnPartSupplier.java
@@ -22,6 +22,7 @@ package io.druid.segment.serde;
 import com.google.common.base.Supplier;
 import io.druid.collections.bitmap.BitmapFactory;
 import io.druid.collections.bitmap.ImmutableBitmap;
+import io.druid.common.config.NullHandling;
 import io.druid.segment.column.BitmapIndex;
 import io.druid.segment.data.GenericIndexed;
 
@@ -77,7 +78,7 @@ public class BitmapIndexColumnPartSupplier implements Supplier<BitmapIndex>
       public int getIndex(String value)
       {
         // GenericIndexed.indexOf satisfies contract needed by BitmapIndex.indexOf
-        return dictionary.indexOf(value);
+        return dictionary.indexOf(NullHandling.emptyToNullIfNeeded(value));
       }
 
       @Override

--- a/processing/src/main/java/io/druid/segment/serde/ColumnPartSerde.java
+++ b/processing/src/main/java/io/druid/segment/serde/ColumnPartSerde.java
@@ -34,7 +34,10 @@ import java.nio.ByteBuffer;
     @JsonSubTypes.Type(name = "float", value = FloatGenericColumnPartSerde.class),
     @JsonSubTypes.Type(name = "long", value = LongGenericColumnPartSerde.class),
     @JsonSubTypes.Type(name = "double", value = DoubleGenericColumnPartSerde.class),
-    @JsonSubTypes.Type(name = "stringDictionary", value = DictionaryEncodedColumnPartSerde.class)
+    @JsonSubTypes.Type(name = "stringDictionary", value = DictionaryEncodedColumnPartSerde.class),
+    @JsonSubTypes.Type(name = "floatV2", value = FloatGenericColumnPartSerdeV2.class),
+    @JsonSubTypes.Type(name = "longV2", value = LongGenericColumnPartSerdeV2.class),
+    @JsonSubTypes.Type(name = "doubleV2", value = DoubleGenericColumnPartSerdeV2.class),
 })
 public interface ColumnPartSerde
 {

--- a/processing/src/main/java/io/druid/segment/serde/DoubleGenericColumnPartSerde.java
+++ b/processing/src/main/java/io/druid/segment/serde/DoubleGenericColumnPartSerde.java
@@ -22,7 +22,7 @@ package io.druid.segment.serde;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Supplier;
-import io.druid.segment.DoubleColumnSerializer;
+import io.druid.segment.IndexIO;
 import io.druid.segment.column.ColumnBuilder;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.column.ValueType;
@@ -65,7 +65,7 @@ public class DoubleGenericColumnPartSerde implements ColumnPartSerde
   public static class SerializerBuilder
   {
     private ByteOrder byteOrder = null;
-    private DoubleColumnSerializer delegate = null;
+    private Serializer delegate = null;
 
     public SerializerBuilder withByteOrder(final ByteOrder byteOrder)
     {
@@ -73,7 +73,7 @@ public class DoubleGenericColumnPartSerde implements ColumnPartSerde
       return this;
     }
 
-    public SerializerBuilder withDelegate(final DoubleColumnSerializer delegate)
+    public SerializerBuilder withDelegate(final Serializer delegate)
     {
       this.delegate = delegate;
       return this;
@@ -105,7 +105,8 @@ public class DoubleGenericColumnPartSerde implements ColumnPartSerde
         );
         builder.setType(ValueType.DOUBLE)
                .setHasMultipleValues(false)
-               .setGenericColumn(new DoubleGenericColumnSupplier(column));
+               .setGenericColumn(new DoubleGenericColumnSupplier(column, IndexIO.LEGACY_FACTORY.getBitmapFactory()
+                                                                                             .makeEmptyImmutableBitmap()));
 
       }
     };

--- a/processing/src/main/java/io/druid/segment/serde/DoubleGenericColumnPartSerdeV2.java
+++ b/processing/src/main/java/io/druid/segment/serde/DoubleGenericColumnPartSerdeV2.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.serde;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Supplier;
+import io.druid.collections.bitmap.ImmutableBitmap;
+import io.druid.java.util.common.io.smoosh.FileSmoosher;
+import io.druid.segment.column.ValueType;
+import io.druid.segment.data.BitmapSerde;
+import io.druid.segment.data.BitmapSerdeFactory;
+import io.druid.segment.data.ColumnarDoubles;
+import io.druid.segment.data.CompressedColumnarDoublesSuppliers;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.ByteOrder;
+import java.nio.channels.WritableByteChannel;
+
+public class DoubleGenericColumnPartSerdeV2 implements ColumnPartSerde
+{
+  private final ByteOrder byteOrder;
+  private Serializer serialize;
+  private final BitmapSerdeFactory bitmapSerdeFactory;
+
+  @JsonCreator
+  public static DoubleGenericColumnPartSerdeV2 getDoubleGenericColumnPartSerde(
+      @JsonProperty("byteOrder") ByteOrder byteOrder,
+      @Nullable @JsonProperty("bitmapSerdeFactory") BitmapSerdeFactory bitmapSerdeFactory
+  )
+  {
+    return new DoubleGenericColumnPartSerdeV2(byteOrder,
+                                              bitmapSerdeFactory != null
+                                              ? bitmapSerdeFactory
+                                              : new BitmapSerde.LegacyBitmapSerdeFactory(), null
+    );
+  }
+
+  @JsonProperty
+  public ByteOrder getByteOrder()
+  {
+    return byteOrder;
+  }
+
+  @JsonProperty
+  public BitmapSerdeFactory getBitmapSerdeFactory()
+  {
+    return bitmapSerdeFactory;
+  }
+
+  public DoubleGenericColumnPartSerdeV2(
+      ByteOrder byteOrder,
+      BitmapSerdeFactory bitmapSerdeFactory,
+      Serializer serialize
+  )
+  {
+    this.byteOrder = byteOrder;
+    this.bitmapSerdeFactory = bitmapSerdeFactory;
+    this.serialize = serialize;
+  }
+
+  @Override
+  public Serializer getSerializer()
+  {
+    return serialize;
+  }
+
+  @Override
+  public Deserializer getDeserializer()
+  {
+    return (buffer, builder, columnConfig) -> {
+      int offset = buffer.getInt();
+      int initialPos = buffer.position();
+      final Supplier<ColumnarDoubles> column = CompressedColumnarDoublesSuppliers.fromByteBuffer(
+          buffer,
+          byteOrder
+      );
+
+      buffer.position(initialPos + offset);
+      final ImmutableBitmap bitmap;
+      if (buffer.hasRemaining()) {
+        bitmap = bitmapSerdeFactory.getObjectStrategy().fromByteBufferWithSize(buffer);
+      } else {
+        bitmap = bitmapSerdeFactory.getBitmapFactory().makeEmptyImmutableBitmap();
+      }
+      builder.setType(ValueType.DOUBLE)
+             .setHasMultipleValues(false)
+             .setGenericColumn(new DoubleGenericColumnSupplier(column, bitmap));
+    };
+  }
+
+  public static SerializerBuilder serializerBuilder()
+  {
+    return new SerializerBuilder();
+  }
+
+  public static class SerializerBuilder
+  {
+    private ByteOrder byteOrder = null;
+    private Serializer delegate = null;
+    private BitmapSerdeFactory bitmapSerdeFactory = null;
+
+    public SerializerBuilder withByteOrder(final ByteOrder byteOrder)
+    {
+      this.byteOrder = byteOrder;
+      return this;
+    }
+
+    public SerializerBuilder withDelegate(final Serializer delegate)
+    {
+      this.delegate = delegate;
+      return this;
+    }
+
+    public SerializerBuilder withBitmapSerdeFactory(BitmapSerdeFactory bitmapSerdeFactory)
+    {
+      this.bitmapSerdeFactory = bitmapSerdeFactory;
+      return this;
+    }
+
+    public DoubleGenericColumnPartSerdeV2 build()
+    {
+      return new DoubleGenericColumnPartSerdeV2(
+          byteOrder,
+          bitmapSerdeFactory,
+          new Serializer()
+          {
+            @Override
+            public long getSerializedSize() throws IOException
+            {
+              return delegate.getSerializedSize();
+            }
+
+            @Override
+            public void writeTo(WritableByteChannel channel, FileSmoosher fileSmoosher) throws IOException
+            {
+              delegate.writeTo(channel, fileSmoosher);
+            }
+          }
+      );
+    }
+  }
+}

--- a/processing/src/main/java/io/druid/segment/serde/DoubleGenericColumnPartSerdeV2.java
+++ b/processing/src/main/java/io/druid/segment/serde/DoubleGenericColumnPartSerdeV2.java
@@ -48,9 +48,8 @@ public class DoubleGenericColumnPartSerdeV2 implements ColumnPartSerde
   {
     return new DoubleGenericColumnPartSerdeV2(
         byteOrder,
-        bitmapSerdeFactory != null
-        ? bitmapSerdeFactory
-        : new BitmapSerde.LegacyBitmapSerdeFactory(), null
+        bitmapSerdeFactory != null ? bitmapSerdeFactory : new BitmapSerde.LegacyBitmapSerdeFactory(),
+        null
     );
   }
 

--- a/processing/src/main/java/io/druid/segment/serde/DoubleGenericColumnSupplier.java
+++ b/processing/src/main/java/io/druid/segment/serde/DoubleGenericColumnSupplier.java
@@ -20,6 +20,7 @@
 package io.druid.segment.serde;
 
 import com.google.common.base.Supplier;
+import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.segment.column.GenericColumn;
 import io.druid.segment.column.DoublesColumn;
 import io.druid.segment.data.ColumnarDoubles;
@@ -28,15 +29,20 @@ import io.druid.segment.data.ColumnarDoubles;
 public class DoubleGenericColumnSupplier implements Supplier<GenericColumn>
 {
   private final Supplier<ColumnarDoubles> column;
+  private final ImmutableBitmap nullValueBitmap;
 
-  public DoubleGenericColumnSupplier(Supplier<ColumnarDoubles> column)
+  public DoubleGenericColumnSupplier(
+      Supplier<ColumnarDoubles> column,
+      ImmutableBitmap nullValueBitmap
+  )
   {
     this.column = column;
+    this.nullValueBitmap = nullValueBitmap;
   }
 
   @Override
   public GenericColumn get()
   {
-    return new DoublesColumn(column.get());
+    return new DoublesColumn(column.get(), nullValueBitmap);
   }
 }

--- a/processing/src/main/java/io/druid/segment/serde/DoubleGenericColumnSupplier.java
+++ b/processing/src/main/java/io/druid/segment/serde/DoubleGenericColumnSupplier.java
@@ -22,7 +22,6 @@ package io.druid.segment.serde;
 import com.google.common.base.Supplier;
 import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.segment.column.DoublesColumn;
-import io.druid.segment.column.DoublesColumnWithNulls;
 import io.druid.segment.column.GenericColumn;
 import io.druid.segment.data.ColumnarDoubles;
 
@@ -44,10 +43,6 @@ public class DoubleGenericColumnSupplier implements Supplier<GenericColumn>
   @Override
   public GenericColumn get()
   {
-    if (nullValueBitmap.isEmpty()) {
-      return new DoublesColumn(column.get());
-    } else {
-      return new DoublesColumnWithNulls(column.get(), nullValueBitmap);
-    }
+    return DoublesColumn.create(column.get(), nullValueBitmap);
   }
 }

--- a/processing/src/main/java/io/druid/segment/serde/DoubleGenericColumnSupplier.java
+++ b/processing/src/main/java/io/druid/segment/serde/DoubleGenericColumnSupplier.java
@@ -21,8 +21,9 @@ package io.druid.segment.serde;
 
 import com.google.common.base.Supplier;
 import io.druid.collections.bitmap.ImmutableBitmap;
-import io.druid.segment.column.GenericColumn;
 import io.druid.segment.column.DoublesColumn;
+import io.druid.segment.column.DoublesColumnWithNulls;
+import io.druid.segment.column.GenericColumn;
 import io.druid.segment.data.ColumnarDoubles;
 
 
@@ -43,6 +44,10 @@ public class DoubleGenericColumnSupplier implements Supplier<GenericColumn>
   @Override
   public GenericColumn get()
   {
-    return new DoublesColumn(column.get(), nullValueBitmap);
+    if (nullValueBitmap.isEmpty()) {
+      return new DoublesColumn(column.get());
+    } else {
+      return new DoublesColumnWithNulls(column.get(), nullValueBitmap);
+    }
   }
 }

--- a/processing/src/main/java/io/druid/segment/serde/FloatGenericColumnPartSerde.java
+++ b/processing/src/main/java/io/druid/segment/serde/FloatGenericColumnPartSerde.java
@@ -21,7 +21,7 @@ package io.druid.segment.serde;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.druid.segment.FloatColumnSerializer;
+import io.druid.segment.IndexIO;
 import io.druid.segment.column.ColumnBuilder;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.column.ValueType;
@@ -65,7 +65,7 @@ public class FloatGenericColumnPartSerde implements ColumnPartSerde
   public static class SerializerBuilder
   {
     private ByteOrder byteOrder = null;
-    private FloatColumnSerializer delegate = null;
+    private Serializer delegate = null;
 
     public SerializerBuilder withByteOrder(final ByteOrder byteOrder)
     {
@@ -73,7 +73,7 @@ public class FloatGenericColumnPartSerde implements ColumnPartSerde
       return this;
     }
 
-    public SerializerBuilder withDelegate(final FloatColumnSerializer delegate)
+    public SerializerBuilder withDelegate(final Serializer delegate)
     {
       this.delegate = delegate;
       return this;
@@ -105,7 +105,11 @@ public class FloatGenericColumnPartSerde implements ColumnPartSerde
         );
         builder.setType(ValueType.FLOAT)
                .setHasMultipleValues(false)
-               .setGenericColumn(new FloatGenericColumnSupplier(column));
+               .setGenericColumn(new FloatGenericColumnSupplier(
+                   column,
+                   IndexIO.LEGACY_FACTORY.getBitmapFactory()
+                                         .makeEmptyImmutableBitmap()
+               ));
       }
     };
   }

--- a/processing/src/main/java/io/druid/segment/serde/FloatGenericColumnPartSerdeV2.java
+++ b/processing/src/main/java/io/druid/segment/serde/FloatGenericColumnPartSerdeV2.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.serde;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.druid.collections.bitmap.ImmutableBitmap;
+import io.druid.java.util.common.io.smoosh.FileSmoosher;
+import io.druid.segment.column.ValueType;
+import io.druid.segment.data.BitmapSerde;
+import io.druid.segment.data.BitmapSerdeFactory;
+import io.druid.segment.data.CompressedColumnarFloatsSupplier;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.ByteOrder;
+import java.nio.channels.WritableByteChannel;
+
+/**
+ */
+public class FloatGenericColumnPartSerdeV2 implements ColumnPartSerde
+{
+  @JsonCreator
+  public static FloatGenericColumnPartSerdeV2 createDeserializer(
+      @JsonProperty("byteOrder") ByteOrder byteOrder,
+      @Nullable @JsonProperty("bitmapSerdeFactory") BitmapSerdeFactory bitmapSerdeFactory
+  )
+  {
+    return new FloatGenericColumnPartSerdeV2(
+        byteOrder,
+        bitmapSerdeFactory != null ? bitmapSerdeFactory : new BitmapSerde.LegacyBitmapSerdeFactory(),
+        null
+    );
+  }
+
+  private final ByteOrder byteOrder;
+  private final BitmapSerdeFactory bitmapSerdeFactory;
+  private Serializer serializer;
+
+  private FloatGenericColumnPartSerdeV2(
+      ByteOrder byteOrder,
+      BitmapSerdeFactory bitmapSerdeFactory,
+      Serializer serializer
+  )
+  {
+    this.byteOrder = byteOrder;
+    this.bitmapSerdeFactory = bitmapSerdeFactory;
+    this.serializer = serializer;
+  }
+
+  @JsonProperty
+  public ByteOrder getByteOrder()
+  {
+    return byteOrder;
+  }
+
+  @JsonProperty
+  public BitmapSerdeFactory getBitmapSerdeFactory()
+  {
+    return bitmapSerdeFactory;
+  }
+
+  public static SerializerBuilder serializerBuilder()
+  {
+    return new SerializerBuilder();
+  }
+
+  public static class SerializerBuilder
+  {
+    private ByteOrder byteOrder = null;
+    private Serializer delegate = null;
+    private BitmapSerdeFactory bitmapSerdeFactory = null;
+
+    public SerializerBuilder withByteOrder(final ByteOrder byteOrder)
+    {
+      this.byteOrder = byteOrder;
+      return this;
+    }
+
+    public SerializerBuilder withDelegate(final Serializer delegate)
+    {
+      this.delegate = delegate;
+      return this;
+    }
+
+    public SerializerBuilder withBitmapSerdeFactory(BitmapSerdeFactory bitmapSerdeFactory)
+    {
+      this.bitmapSerdeFactory = bitmapSerdeFactory;
+      return this;
+    }
+
+    public FloatGenericColumnPartSerdeV2 build()
+    {
+      return new FloatGenericColumnPartSerdeV2(
+          byteOrder, bitmapSerdeFactory,
+          new Serializer()
+          {
+            @Override
+            public long getSerializedSize() throws IOException
+            {
+              return delegate.getSerializedSize();
+            }
+
+            @Override
+            public void writeTo(WritableByteChannel channel, FileSmoosher fileSmoosher) throws IOException
+            {
+              delegate.writeTo(channel, fileSmoosher);
+            }
+          }
+      );
+    }
+
+  }
+
+  @Override
+  public Serializer getSerializer()
+  {
+    return serializer;
+  }
+
+  @Override
+  public Deserializer getDeserializer()
+  {
+    return (buffer, builder, columnConfig) -> {
+      int offset = buffer.getInt();
+      int initialPos = buffer.position();
+      final CompressedColumnarFloatsSupplier column = CompressedColumnarFloatsSupplier.fromByteBuffer(
+          buffer,
+          byteOrder
+      );
+      buffer.position(initialPos + offset);
+      final ImmutableBitmap bitmap;
+      if (buffer.hasRemaining()) {
+        bitmap = bitmapSerdeFactory.getObjectStrategy().fromByteBufferWithSize(buffer);
+      } else {
+        bitmap = bitmapSerdeFactory.getBitmapFactory().makeEmptyImmutableBitmap();
+      }
+      builder.setType(ValueType.FLOAT)
+             .setHasMultipleValues(false)
+             .setGenericColumn(new FloatGenericColumnSupplier(column, bitmap));
+
+    };
+  }
+}

--- a/processing/src/main/java/io/druid/segment/serde/FloatGenericColumnPartSerdeV2.java
+++ b/processing/src/main/java/io/druid/segment/serde/FloatGenericColumnPartSerdeV2.java
@@ -51,8 +51,8 @@ public class FloatGenericColumnPartSerdeV2 implements ColumnPartSerde
   }
 
   private final ByteOrder byteOrder;
-  private final BitmapSerdeFactory bitmapSerdeFactory;
   private Serializer serializer;
+  private final BitmapSerdeFactory bitmapSerdeFactory;
 
   private FloatGenericColumnPartSerdeV2(
       ByteOrder byteOrder,
@@ -126,7 +126,6 @@ public class FloatGenericColumnPartSerdeV2 implements ColumnPartSerde
           }
       );
     }
-
   }
 
   @Override
@@ -155,7 +154,6 @@ public class FloatGenericColumnPartSerdeV2 implements ColumnPartSerde
       builder.setType(ValueType.FLOAT)
              .setHasMultipleValues(false)
              .setGenericColumn(new FloatGenericColumnSupplier(column, bitmap));
-
     };
   }
 }

--- a/processing/src/main/java/io/druid/segment/serde/FloatGenericColumnSupplier.java
+++ b/processing/src/main/java/io/druid/segment/serde/FloatGenericColumnSupplier.java
@@ -21,8 +21,9 @@ package io.druid.segment.serde;
 
 import com.google.common.base.Supplier;
 import io.druid.collections.bitmap.ImmutableBitmap;
-import io.druid.segment.column.GenericColumn;
 import io.druid.segment.column.FloatsColumn;
+import io.druid.segment.column.FloatsColumnWithNulls;
+import io.druid.segment.column.GenericColumn;
 import io.druid.segment.data.CompressedColumnarFloatsSupplier;
 
 /**
@@ -44,6 +45,10 @@ public class FloatGenericColumnSupplier implements Supplier<GenericColumn>
   @Override
   public GenericColumn get()
   {
-    return new FloatsColumn(column.get(), nullValueBitmap);
+    if (nullValueBitmap.isEmpty()) {
+      return new FloatsColumn(column.get());
+    } else {
+      return new FloatsColumnWithNulls(column.get(), nullValueBitmap);
+    }
   }
 }

--- a/processing/src/main/java/io/druid/segment/serde/FloatGenericColumnSupplier.java
+++ b/processing/src/main/java/io/druid/segment/serde/FloatGenericColumnSupplier.java
@@ -22,7 +22,6 @@ package io.druid.segment.serde;
 import com.google.common.base.Supplier;
 import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.segment.column.FloatsColumn;
-import io.druid.segment.column.FloatsColumnWithNulls;
 import io.druid.segment.column.GenericColumn;
 import io.druid.segment.data.CompressedColumnarFloatsSupplier;
 
@@ -45,10 +44,6 @@ public class FloatGenericColumnSupplier implements Supplier<GenericColumn>
   @Override
   public GenericColumn get()
   {
-    if (nullValueBitmap.isEmpty()) {
-      return new FloatsColumn(column.get());
-    } else {
-      return new FloatsColumnWithNulls(column.get(), nullValueBitmap);
-    }
+    return FloatsColumn.create(column.get(), nullValueBitmap);
   }
 }

--- a/processing/src/main/java/io/druid/segment/serde/LongGenericColumnPartSerde.java
+++ b/processing/src/main/java/io/druid/segment/serde/LongGenericColumnPartSerde.java
@@ -21,7 +21,7 @@ package io.druid.segment.serde;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.druid.segment.LongColumnSerializer;
+import io.druid.segment.IndexIO;
 import io.druid.segment.column.ColumnBuilder;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.column.ValueType;
@@ -65,7 +65,7 @@ public class LongGenericColumnPartSerde implements ColumnPartSerde
   public static class SerializerBuilder
   {
     private ByteOrder byteOrder = null;
-    private LongColumnSerializer delegate = null;
+    private Serializer delegate = null;
 
     public SerializerBuilder withByteOrder(final ByteOrder byteOrder)
     {
@@ -73,7 +73,7 @@ public class LongGenericColumnPartSerde implements ColumnPartSerde
       return this;
     }
 
-    public SerializerBuilder withDelegate(final LongColumnSerializer delegate)
+    public SerializerBuilder withDelegate(final Serializer delegate)
     {
       this.delegate = delegate;
       return this;
@@ -105,7 +105,11 @@ public class LongGenericColumnPartSerde implements ColumnPartSerde
         );
         builder.setType(ValueType.LONG)
                .setHasMultipleValues(false)
-               .setGenericColumn(new LongGenericColumnSupplier(column));
+               .setGenericColumn(new LongGenericColumnSupplier(
+                   column,
+                   IndexIO.LEGACY_FACTORY.getBitmapFactory()
+                                         .makeEmptyImmutableBitmap()
+               ));
       }
     };
   }

--- a/processing/src/main/java/io/druid/segment/serde/LongGenericColumnPartSerdeV2.java
+++ b/processing/src/main/java/io/druid/segment/serde/LongGenericColumnPartSerdeV2.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.serde;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.druid.collections.bitmap.ImmutableBitmap;
+import io.druid.java.util.common.io.smoosh.FileSmoosher;
+import io.druid.segment.column.ValueType;
+import io.druid.segment.data.BitmapSerde;
+import io.druid.segment.data.BitmapSerdeFactory;
+import io.druid.segment.data.CompressedColumnarLongsSupplier;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.ByteOrder;
+import java.nio.channels.WritableByteChannel;
+
+/**
+ */
+public class LongGenericColumnPartSerdeV2 implements ColumnPartSerde
+{
+  @JsonCreator
+  public static LongGenericColumnPartSerdeV2 createDeserializer(
+      @JsonProperty("byteOrder") ByteOrder byteOrder,
+      @Nullable @JsonProperty("bitmapSerdeFactory") BitmapSerdeFactory bitmapSerdeFactory
+  )
+  {
+    return new LongGenericColumnPartSerdeV2(
+        byteOrder,
+        bitmapSerdeFactory != null ? bitmapSerdeFactory : new BitmapSerde.LegacyBitmapSerdeFactory(),
+        null
+    );
+  }
+
+  private final ByteOrder byteOrder;
+  private final BitmapSerdeFactory bitmapSerdeFactory;
+  private Serializer serializer;
+
+  private LongGenericColumnPartSerdeV2(
+      ByteOrder byteOrder,
+      BitmapSerdeFactory bitmapSerdeFactory, Serializer serializer
+  )
+  {
+    this.byteOrder = byteOrder;
+    this.bitmapSerdeFactory = bitmapSerdeFactory;
+    this.serializer = serializer;
+  }
+
+  @JsonProperty
+  public ByteOrder getByteOrder()
+  {
+    return byteOrder;
+  }
+
+  @JsonProperty
+  public BitmapSerdeFactory getBitmapSerdeFactory()
+  {
+    return bitmapSerdeFactory;
+  }
+
+  public static SerializerBuilder serializerBuilder()
+  {
+    return new SerializerBuilder();
+  }
+
+  public static class SerializerBuilder
+  {
+    private ByteOrder byteOrder = null;
+    private Serializer delegate = null;
+    private BitmapSerdeFactory bitmapSerdeFactory = null;
+
+    public SerializerBuilder withByteOrder(final ByteOrder byteOrder)
+    {
+      this.byteOrder = byteOrder;
+      return this;
+    }
+
+    public SerializerBuilder withDelegate(final Serializer delegate)
+    {
+      this.delegate = delegate;
+      return this;
+    }
+
+    public SerializerBuilder withBitmapSerdeFactory(BitmapSerdeFactory bitmapSerdeFactory)
+    {
+      this.bitmapSerdeFactory = bitmapSerdeFactory;
+      return this;
+    }
+
+    public LongGenericColumnPartSerdeV2 build()
+    {
+      return new LongGenericColumnPartSerdeV2(
+          byteOrder, bitmapSerdeFactory,
+          new Serializer()
+          {
+            @Override
+            public long getSerializedSize() throws IOException
+            {
+              return delegate.getSerializedSize();
+            }
+
+            @Override
+            public void writeTo(WritableByteChannel channel, FileSmoosher smoosher) throws IOException
+            {
+              delegate.writeTo(channel, smoosher);
+            }
+          }
+      );
+    }
+  }
+
+  @Override
+  public Serializer getSerializer()
+  {
+    return serializer;
+  }
+
+  @Override
+  public Deserializer getDeserializer()
+  {
+    return (buffer, builder, columnConfig) -> {
+      int offset = buffer.getInt();
+      int initialPos = buffer.position();
+      final CompressedColumnarLongsSupplier column = CompressedColumnarLongsSupplier.fromByteBuffer(
+          buffer,
+          byteOrder
+      );
+      buffer.position(initialPos + offset);
+      final ImmutableBitmap bitmap;
+      if (buffer.hasRemaining()) {
+        bitmap = bitmapSerdeFactory.getObjectStrategy().fromByteBufferWithSize(buffer);
+      } else {
+        bitmap = bitmapSerdeFactory.getBitmapFactory().makeEmptyImmutableBitmap();
+      }
+      builder.setType(ValueType.LONG)
+             .setHasMultipleValues(false)
+             .setGenericColumn(new LongGenericColumnSupplier(column, bitmap));
+
+    };
+  }
+}

--- a/processing/src/main/java/io/druid/segment/serde/LongGenericColumnPartSerdeV2.java
+++ b/processing/src/main/java/io/druid/segment/serde/LongGenericColumnPartSerdeV2.java
@@ -51,8 +51,8 @@ public class LongGenericColumnPartSerdeV2 implements ColumnPartSerde
   }
 
   private final ByteOrder byteOrder;
-  private final BitmapSerdeFactory bitmapSerdeFactory;
   private Serializer serializer;
+  private final BitmapSerdeFactory bitmapSerdeFactory;
 
   private LongGenericColumnPartSerdeV2(
       ByteOrder byteOrder,
@@ -153,7 +153,6 @@ public class LongGenericColumnPartSerdeV2 implements ColumnPartSerde
       builder.setType(ValueType.LONG)
              .setHasMultipleValues(false)
              .setGenericColumn(new LongGenericColumnSupplier(column, bitmap));
-
     };
   }
 }

--- a/processing/src/main/java/io/druid/segment/serde/LongGenericColumnSupplier.java
+++ b/processing/src/main/java/io/druid/segment/serde/LongGenericColumnSupplier.java
@@ -20,6 +20,7 @@
 package io.druid.segment.serde;
 
 import com.google.common.base.Supplier;
+import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.segment.column.GenericColumn;
 import io.druid.segment.column.LongsColumn;
 import io.druid.segment.data.CompressedColumnarLongsSupplier;
@@ -29,15 +30,17 @@ import io.druid.segment.data.CompressedColumnarLongsSupplier;
 public class LongGenericColumnSupplier implements Supplier<GenericColumn>
 {
   private final CompressedColumnarLongsSupplier column;
+  private final ImmutableBitmap nullValueBitmap;
 
-  public LongGenericColumnSupplier(CompressedColumnarLongsSupplier column)
+  public LongGenericColumnSupplier(CompressedColumnarLongsSupplier column, ImmutableBitmap nullValueBitmap)
   {
     this.column = column;
+    this.nullValueBitmap = nullValueBitmap;
   }
 
   @Override
   public GenericColumn get()
   {
-    return new LongsColumn(column.get());
+    return new LongsColumn(column.get(), nullValueBitmap);
   }
 }

--- a/processing/src/main/java/io/druid/segment/serde/LongGenericColumnSupplier.java
+++ b/processing/src/main/java/io/druid/segment/serde/LongGenericColumnSupplier.java
@@ -23,7 +23,6 @@ import com.google.common.base.Supplier;
 import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.segment.column.GenericColumn;
 import io.druid.segment.column.LongsColumn;
-import io.druid.segment.column.LongsColumnWithNulls;
 import io.druid.segment.data.CompressedColumnarLongsSupplier;
 
 /**
@@ -42,10 +41,6 @@ public class LongGenericColumnSupplier implements Supplier<GenericColumn>
   @Override
   public GenericColumn get()
   {
-    if (nullValueBitmap.isEmpty()) {
-      return new LongsColumn(column.get());
-    } else {
-      return new LongsColumnWithNulls(column.get(), nullValueBitmap);
-    }
+    return LongsColumn.create(column.get(), nullValueBitmap);
   }
 }

--- a/processing/src/main/java/io/druid/segment/virtual/ExpressionColumnValueSelector.java
+++ b/processing/src/main/java/io/druid/segment/virtual/ExpressionColumnValueSelector.java
@@ -75,4 +75,10 @@ public class ExpressionColumnValueSelector implements ColumnValueSelector<ExprEv
     inspector.visit("expression", expression);
     inspector.visit("bindings", bindings);
   }
+
+  @Override
+  public boolean isNull()
+  {
+    return getObject() == null;
+  }
 }

--- a/processing/src/main/java/io/druid/segment/virtual/ExpressionColumnValueSelector.java
+++ b/processing/src/main/java/io/druid/segment/virtual/ExpressionColumnValueSelector.java
@@ -79,6 +79,6 @@ public class ExpressionColumnValueSelector implements ColumnValueSelector<ExprEv
   @Override
   public boolean isNull()
   {
-    return getObject() == null;
+    return getObject().isNull();
   }
 }

--- a/processing/src/main/java/io/druid/segment/virtual/ExpressionColumnValueSelector.java
+++ b/processing/src/main/java/io/druid/segment/virtual/ExpressionColumnValueSelector.java
@@ -41,18 +41,21 @@ public class ExpressionColumnValueSelector implements ColumnValueSelector<ExprEv
   @Override
   public double getDouble()
   {
+    // No Assert for null handling as ExprEval already have it.
     return getObject().asDouble();
   }
 
   @Override
   public float getFloat()
   {
+    // No Assert for null handling as ExprEval already have it.
     return (float) getObject().asDouble();
   }
 
   @Override
   public long getLong()
   {
+    // No Assert for null handling as ExprEval already have it.
     return getObject().asLong();
   }
 

--- a/processing/src/main/java/io/druid/segment/virtual/ExpressionSelectors.java
+++ b/processing/src/main/java/io/druid/segment/virtual/ExpressionSelectors.java
@@ -21,10 +21,10 @@ package io.druid.segment.virtual;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
+import io.druid.common.config.NullHandling;
 import io.druid.math.expr.Expr;
 import io.druid.math.expr.ExprEval;
 import io.druid.math.expr.Parser;
@@ -75,6 +75,12 @@ public class ExpressionSelectors
       public double getDouble()
       {
         return baseSelector.getDouble();
+      }
+
+      @Override
+      public boolean isNull()
+      {
+        return baseSelector.getObject().isNull();
       }
 
       @Override
@@ -198,7 +204,7 @@ public class ExpressionSelectors
         @Override
         protected String getValue()
         {
-          return Strings.emptyToNull(baseSelector.getObject().asString());
+          return NullHandling.emptyToNullIfNeeded(baseSelector.getObject().asString());
         }
 
         @Override
@@ -214,7 +220,7 @@ public class ExpressionSelectors
         @Override
         protected String getValue()
         {
-          return extractionFn.apply(Strings.emptyToNull(baseSelector.getObject().asString()));
+          return extractionFn.apply(NullHandling.emptyToNullIfNeeded(baseSelector.getObject().asString()));
         }
 
         @Override

--- a/processing/src/main/java/io/druid/segment/virtual/ExpressionSelectors.java
+++ b/processing/src/main/java/io/druid/segment/virtual/ExpressionSelectors.java
@@ -75,25 +75,28 @@ public class ExpressionSelectors
       @Override
       public double getDouble()
       {
+        // No Assert for null handling as baseSelector already have it.
         return baseSelector.getDouble();
-      }
-
-      @Override
-      public boolean isNull()
-      {
-        return baseSelector.getObject().isNull();
       }
 
       @Override
       public float getFloat()
       {
+        // No Assert for null handling as baseSelector already have it.
         return baseSelector.getFloat();
       }
 
       @Override
       public long getLong()
       {
+        // No Assert for null handling as baseSelector already have it.
         return baseSelector.getLong();
+      }
+
+      @Override
+      public boolean isNull()
+      {
+        return baseSelector.isNull();
       }
 
       @Nullable

--- a/processing/src/main/java/io/druid/segment/virtual/SingleLongInputCachingExpressionColumnValueSelector.java
+++ b/processing/src/main/java/io/druid/segment/virtual/SingleLongInputCachingExpressionColumnValueSelector.java
@@ -143,4 +143,10 @@ public class SingleLongInputCachingExpressionColumnValueSelector implements Colu
     bindings.set(value);
     return expression.eval(bindings);
   }
+
+  @Override
+  public boolean isNull()
+  {
+    return getObject().isNull();
+  }
 }

--- a/processing/src/main/java/io/druid/segment/virtual/SingleLongInputCachingExpressionColumnValueSelector.java
+++ b/processing/src/main/java/io/druid/segment/virtual/SingleLongInputCachingExpressionColumnValueSelector.java
@@ -80,6 +80,7 @@ public class SingleLongInputCachingExpressionColumnValueSelector implements Colu
   @Override
   public double getDouble()
   {
+    // No Assert for null handling as delegate selector already have it.
     final long currentInput = selector.getLong();
 
     if (lastInput == currentInput && validity == Validity.DOUBLE) {
@@ -96,12 +97,14 @@ public class SingleLongInputCachingExpressionColumnValueSelector implements Colu
   @Override
   public float getFloat()
   {
+    // No Assert for null handling as delegate selector already have it.
     return (float) getDouble();
   }
 
   @Override
   public long getLong()
   {
+    // No Assert for null handling as delegate selector already have it.
     final long currentInput = selector.getLong();
 
     if (lastInput == currentInput && validity == Validity.LONG) {

--- a/processing/src/main/java/io/druid/segment/virtual/SingleStringInputCachingExpressionColumnValueSelector.java
+++ b/processing/src/main/java/io/druid/segment/virtual/SingleStringInputCachingExpressionColumnValueSelector.java
@@ -133,6 +133,12 @@ public class SingleStringInputCachingExpressionColumnValueSelector implements Co
     return expression.eval(bindings);
   }
 
+  @Override
+  public boolean isNull()
+  {
+    return eval().isNull();
+  }
+
   public static class LruEvalCache
   {
     private final Expr expression;

--- a/processing/src/main/java/io/druid/segment/virtual/SingleStringInputCachingExpressionColumnValueSelector.java
+++ b/processing/src/main/java/io/druid/segment/virtual/SingleStringInputCachingExpressionColumnValueSelector.java
@@ -84,18 +84,21 @@ public class SingleStringInputCachingExpressionColumnValueSelector implements Co
   @Override
   public double getDouble()
   {
+    // No Assert for null handling as ExprEval already have it.
     return eval().asDouble();
   }
 
   @Override
   public float getFloat()
   {
+    // No Assert for null handling as ExprEval already have it.
     return (float) eval().asDouble();
   }
 
   @Override
   public long getLong()
   {
+    // No Assert for null handling as ExprEval already have it.
     return eval().asLong();
   }
 

--- a/processing/src/test/java/io/druid/query/aggregation/MetricManipulatorFnsTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/MetricManipulatorFnsTest.java
@@ -50,6 +50,12 @@ public class MetricManipulatorFnsTest
           {
             return longVal;
           }
+
+          @Override
+          public boolean isNull()
+          {
+            return false;
+          }
         }
     );
     LongMinAggregatorFactory longMinAggregatorFactory = new LongMinAggregatorFactory(NAME, FIELD);
@@ -88,6 +94,12 @@ public class MetricManipulatorFnsTest
           public long getLong()
           {
             return longVal;
+          }
+
+          @Override
+          public boolean isNull()
+          {
+            return false;
           }
         }
     );

--- a/processing/src/test/java/io/druid/query/aggregation/TestDoubleColumnSelectorImpl.java
+++ b/processing/src/test/java/io/druid/query/aggregation/TestDoubleColumnSelectorImpl.java
@@ -39,6 +39,12 @@ public class TestDoubleColumnSelectorImpl extends TestDoubleColumnSelector
     return doubles[index];
   }
 
+  @Override
+  public boolean isNull()
+  {
+    return false;
+  }
+
   public void increment()
   {
     ++index;

--- a/processing/src/test/java/io/druid/query/aggregation/TestFloatColumnSelector.java
+++ b/processing/src/test/java/io/druid/query/aggregation/TestFloatColumnSelector.java
@@ -38,6 +38,12 @@ public class TestFloatColumnSelector extends io.druid.segment.TestFloatColumnSel
     return floats[index];
   }
 
+  @Override
+  public boolean isNull()
+  {
+    return false;
+  }
+
   public void increment()
   {
     ++index;

--- a/processing/src/test/java/io/druid/query/aggregation/TestLongColumnSelector.java
+++ b/processing/src/test/java/io/druid/query/aggregation/TestLongColumnSelector.java
@@ -38,6 +38,12 @@ public class TestLongColumnSelector extends io.druid.segment.TestLongColumnSelec
     return longs[index];
   }
 
+  @Override
+  public boolean isNull()
+  {
+    return false;
+  }
+
   public void increment()
   {
     ++index;

--- a/processing/src/test/java/io/druid/query/groupby/epinephelinae/TestColumnSelectorFactory.java
+++ b/processing/src/test/java/io/druid/query/groupby/epinephelinae/TestColumnSelectorFactory.java
@@ -85,6 +85,14 @@ public class TestColumnSelectorFactory implements ColumnSelectorFactory
       {
         // don't inspect in tests
       }
+
+      @Override
+      public boolean isNull()
+      {
+        return row.get().getMetric(columnName) == null;
+      }
+
+
     };
   }
 

--- a/processing/src/test/java/io/druid/segment/IndexMergerNullHandlingTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerNullHandlingTest.java
@@ -91,7 +91,7 @@ public class IndexMergerNullHandlingTest
     nullFlavors.add(mNull);
     nullFlavors.add(mListOfNull);
 
-    if (NullHandling.useDefaultValuesForNull()) {
+    if (NullHandling.replaceWithDefault()) {
       nullFlavors.add(mEmptyString);
       nullFlavors.add(mListOfEmptyString);
     } else {

--- a/processing/src/test/java/io/druid/segment/IndexMergerNullHandlingTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerNullHandlingTest.java
@@ -19,12 +19,12 @@
 
 package io.druid.segment;
 
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.Sets;
 import io.druid.collections.bitmap.ImmutableBitmap;
+import io.druid.common.config.NullHandling;
 import io.druid.data.input.MapBasedInputRow;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.guava.Comparators;
@@ -89,9 +89,15 @@ public class IndexMergerNullHandlingTest
     nullFlavors.add(mMissing);
     nullFlavors.add(mEmptyList);
     nullFlavors.add(mNull);
-    nullFlavors.add(mEmptyString);
     nullFlavors.add(mListOfNull);
-    nullFlavors.add(mListOfEmptyString);
+
+    if (NullHandling.useDefaultValuesForNull()) {
+      nullFlavors.add(mEmptyString);
+      nullFlavors.add(mListOfEmptyString);
+    } else {
+      nonNullFlavors.add(mEmptyString);
+      nonNullFlavors.add(mListOfEmptyString);
+    }
 
     Set<Map<String, Object>> allValues = new HashSet<>();
     allValues.addAll(nonNullFlavors);
@@ -174,7 +180,7 @@ public class IndexMergerNullHandlingTest
             final List<Integer> expectedNullRows = new ArrayList<>();
             for (int i = 0; i < index.getNumRows(); i++) {
               final List<String> row = getRow(dictionaryColumn, i);
-              if (row.isEmpty() || row.stream().anyMatch(Strings::isNullOrEmpty)) {
+              if (row.isEmpty() || row.stream().anyMatch(NullHandling::isNullOrEquivalent)) {
                 expectedNullRows.add(i);
               }
             }
@@ -209,19 +215,16 @@ public class IndexMergerNullHandlingTest
     final List<String> retVal = new ArrayList<>();
 
     if (value == null) {
-      if (!hasMultipleValues) {
-        // nulls become nulls in single valued columns, but are empty lists in multi valued columns
-        retVal.add(null);
-      }
+      retVal.add(null);
     } else if (value instanceof String) {
-      retVal.add(Strings.emptyToNull(((String) value)));
+      retVal.add(NullHandling.emptyToNullIfNeeded(((String) value)));
     } else if (value instanceof List) {
       final List<String> list = (List<String>) value;
       if (list.isEmpty() && !hasMultipleValues) {
         // empty lists become nulls in single valued columns
-        retVal.add(null);
+        retVal.add(NullHandling.emptyToNullIfNeeded(null));
       } else {
-        retVal.addAll(list.stream().map(Strings::emptyToNull).collect(Collectors.toList()));
+        retVal.addAll(list.stream().map(NullHandling::emptyToNullIfNeeded).collect(Collectors.toList()));
       }
     } else {
       throw new ISE("didn't expect class[%s]", value.getClass());

--- a/processing/src/test/java/io/druid/segment/TestObjectColumnSelector.java
+++ b/processing/src/test/java/io/druid/segment/TestObjectColumnSelector.java
@@ -21,7 +21,7 @@ package io.druid.segment;
 
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 
-public abstract class TestObjectColumnSelector<T> implements ObjectColumnSelector<T>
+public abstract class TestObjectColumnSelector<T> extends ObjectColumnSelector<T>
 {
   @Override
   public void inspectRuntimeShape(RuntimeShapeInspector inspector)

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
@@ -538,7 +538,7 @@ public class IncrementalIndexStorageAdapterTest
             // no null id, so should get empty dims array
             Assert.assertEquals(0, rowD.size());
             IndexedInts rowE = dimSelector3E.getRow();
-            if (NullHandling.useDefaultValuesForNull()) {
+            if (NullHandling.replaceWithDefault()) {
               Assert.assertEquals(1, rowE.size());
               // the null id
               Assert.assertEquals(0, rowE.get(0));

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import io.druid.collections.StupidPool;
+import io.druid.common.config.NullHandling;
 import io.druid.data.input.MapBasedInputRow;
 import io.druid.data.input.MapBasedRow;
 import io.druid.data.input.Row;
@@ -537,9 +538,13 @@ public class IncrementalIndexStorageAdapterTest
             // no null id, so should get empty dims array
             Assert.assertEquals(0, rowD.size());
             IndexedInts rowE = dimSelector3E.getRow();
-            Assert.assertEquals(1, rowE.size());
-            // the null id
-            Assert.assertEquals(0, rowE.get(0));
+            if (NullHandling.useDefaultValuesForNull()) {
+              Assert.assertEquals(1, rowE.size());
+              // the null id
+              Assert.assertEquals(0, rowE.get(0));
+            } else {
+              Assert.assertEquals(0, rowE.size());
+            }
             cursor.advance();
             rowNumInCursor++;
           }

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexTest.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.druid.collections.StupidPool;
-import io.druid.common.config.NullHandling;
 import io.druid.data.input.MapBasedInputRow;
 import io.druid.data.input.impl.DimensionSchema;
 import io.druid.data.input.impl.DimensionsSpec;

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.druid.collections.StupidPool;
+import io.druid.common.config.NullHandling;
 import io.druid.data.input.MapBasedInputRow;
 import io.druid.data.input.impl.DimensionSchema;
 import io.druid.data.input.impl.DimensionsSpec;

--- a/processing/src/test/java/io/druid/segment/virtual/ExpressionVirtualColumnTest.java
+++ b/processing/src/test/java/io/druid/segment/virtual/ExpressionVirtualColumnTest.java
@@ -114,7 +114,7 @@ public class ExpressionVirtualColumnTest
     Assert.assertEquals(null, selector.getObject());
 
     CURRENT_ROW.set(ROW1);
-    if (NullHandling.useDefaultValuesForNull()) {
+    if (NullHandling.replaceWithDefault()) {
       Assert.assertEquals(4.0d, selector.getObject());
     } else {
       // y is null for row1
@@ -137,7 +137,7 @@ public class ExpressionVirtualColumnTest
     Assert.assertEquals(0L, selector.getLong());
 
     CURRENT_ROW.set(ROW1);
-    if (NullHandling.useDefaultValuesForNull()) {
+    if (NullHandling.replaceWithDefault()) {
       Assert.assertEquals(4L, selector.getLong());
     } else {
       // y is null for row1
@@ -160,7 +160,7 @@ public class ExpressionVirtualColumnTest
     Assert.assertEquals(0L, selector.getLong());
 
     CURRENT_ROW.set(ROW1);
-    if (NullHandling.useDefaultValuesForNull()) {
+    if (NullHandling.replaceWithDefault()) {
       Assert.assertEquals(4L, selector.getLong());
     } else {
       // y is null for row1
@@ -183,7 +183,7 @@ public class ExpressionVirtualColumnTest
     Assert.assertEquals(0.0f, selector.getFloat(), 0.0f);
 
     CURRENT_ROW.set(ROW1);
-    if (NullHandling.useDefaultValuesForNull()) {
+    if (NullHandling.replaceWithDefault()) {
       Assert.assertEquals(4.0f, selector.getFloat(), 0.0f);
     } else {
       // y is null for row1
@@ -216,7 +216,7 @@ public class ExpressionVirtualColumnTest
     Assert.assertEquals(null, selector.lookupName(selector.getRow().get(0)));
 
     CURRENT_ROW.set(ROW1);
-    if (NullHandling.useDefaultValuesForNull()) {
+    if (NullHandling.replaceWithDefault()) {
       Assert.assertEquals(false, nullMatcher.matches());
       Assert.assertEquals(false, fiveMatcher.matches());
       Assert.assertEquals(true, nonNullMatcher.matches());
@@ -259,7 +259,7 @@ public class ExpressionVirtualColumnTest
     CURRENT_ROW.set(ROW1);
     Assert.assertEquals(1, selector.getRow().size());
     Assert.assertEquals(
-        NullHandling.useDefaultValuesForNull() ? "4" : null,
+        NullHandling.replaceWithDefault() ? "4" : null,
         selector.lookupName(selector.getRow().get(0))
     );
 
@@ -291,7 +291,7 @@ public class ExpressionVirtualColumnTest
     Assert.assertEquals(null, selector.lookupName(selector.getRow().get(0)));
 
     CURRENT_ROW.set(ROW1);
-    if (NullHandling.useDefaultValuesForNull()) {
+    if (NullHandling.replaceWithDefault()) {
       Assert.assertEquals(false, nullMatcher.matches());
       Assert.assertEquals(false, fiveMatcher.matches());
       Assert.assertEquals(true, nonNullMatcher.matches());

--- a/processing/src/test/java/io/druid/segment/virtual/ExpressionVirtualColumnTest.java
+++ b/processing/src/test/java/io/druid/segment/virtual/ExpressionVirtualColumnTest.java
@@ -22,6 +22,7 @@ package io.druid.segment.virtual;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.druid.common.config.NullHandling;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.MapBasedInputRow;
 import io.druid.data.input.Row;
@@ -113,7 +114,12 @@ public class ExpressionVirtualColumnTest
     Assert.assertEquals(null, selector.getObject());
 
     CURRENT_ROW.set(ROW1);
-    Assert.assertEquals(4.0d, selector.getObject());
+    if (NullHandling.useDefaultValuesForNull()) {
+      Assert.assertEquals(4.0d, selector.getObject());
+    } else {
+      // y is null for row1
+      Assert.assertEquals(null, selector.getObject());
+    }
 
     CURRENT_ROW.set(ROW2);
     Assert.assertEquals(5.1d, selector.getObject());
@@ -131,7 +137,12 @@ public class ExpressionVirtualColumnTest
     Assert.assertEquals(0L, selector.getLong());
 
     CURRENT_ROW.set(ROW1);
-    Assert.assertEquals(4L, selector.getLong());
+    if (NullHandling.useDefaultValuesForNull()) {
+      Assert.assertEquals(4L, selector.getLong());
+    } else {
+      // y is null for row1
+      Assert.assertTrue(selector.isNull());
+    }
 
     CURRENT_ROW.set(ROW2);
     Assert.assertEquals(5L, selector.getLong());
@@ -149,7 +160,12 @@ public class ExpressionVirtualColumnTest
     Assert.assertEquals(0L, selector.getLong());
 
     CURRENT_ROW.set(ROW1);
-    Assert.assertEquals(4L, selector.getLong());
+    if (NullHandling.useDefaultValuesForNull()) {
+      Assert.assertEquals(4L, selector.getLong());
+    } else {
+      // y is null for row1
+      Assert.assertTrue(selector.isNull());
+    }
 
     CURRENT_ROW.set(ROW2);
     Assert.assertEquals(0L, selector.getLong());
@@ -167,7 +183,12 @@ public class ExpressionVirtualColumnTest
     Assert.assertEquals(0.0f, selector.getFloat(), 0.0f);
 
     CURRENT_ROW.set(ROW1);
-    Assert.assertEquals(4.0f, selector.getFloat(), 0.0f);
+    if (NullHandling.useDefaultValuesForNull()) {
+      Assert.assertEquals(4.0f, selector.getFloat(), 0.0f);
+    } else {
+      // y is null for row1
+      Assert.assertTrue(selector.isNull());
+    }
 
     CURRENT_ROW.set(ROW2);
     Assert.assertEquals(5.1f, selector.getFloat(), 0.0f);
@@ -195,10 +216,18 @@ public class ExpressionVirtualColumnTest
     Assert.assertEquals(null, selector.lookupName(selector.getRow().get(0)));
 
     CURRENT_ROW.set(ROW1);
-    Assert.assertEquals(false, nullMatcher.matches());
-    Assert.assertEquals(false, fiveMatcher.matches());
-    Assert.assertEquals(true, nonNullMatcher.matches());
-    Assert.assertEquals("4.0", selector.lookupName(selector.getRow().get(0)));
+    if (NullHandling.useDefaultValuesForNull()) {
+      Assert.assertEquals(false, nullMatcher.matches());
+      Assert.assertEquals(false, fiveMatcher.matches());
+      Assert.assertEquals(true, nonNullMatcher.matches());
+      Assert.assertEquals("4.0", selector.lookupName(selector.getRow().get(0)));
+    } else {
+      // y is null in row1
+      Assert.assertEquals(true, nullMatcher.matches());
+      Assert.assertEquals(false, fiveMatcher.matches());
+      Assert.assertEquals(false, nonNullMatcher.matches());
+      Assert.assertEquals(null, selector.lookupName(selector.getRow().get(0)));
+    }
 
     CURRENT_ROW.set(ROW2);
     Assert.assertEquals(false, nullMatcher.matches());
@@ -229,7 +258,10 @@ public class ExpressionVirtualColumnTest
 
     CURRENT_ROW.set(ROW1);
     Assert.assertEquals(1, selector.getRow().size());
-    Assert.assertEquals("4", selector.lookupName(selector.getRow().get(0)));
+    Assert.assertEquals(
+        NullHandling.useDefaultValuesForNull() ? "4" : null,
+        selector.lookupName(selector.getRow().get(0))
+    );
 
     CURRENT_ROW.set(ROW2);
     Assert.assertEquals(1, selector.getRow().size());
@@ -259,10 +291,18 @@ public class ExpressionVirtualColumnTest
     Assert.assertEquals(null, selector.lookupName(selector.getRow().get(0)));
 
     CURRENT_ROW.set(ROW1);
-    Assert.assertEquals(false, nullMatcher.matches());
-    Assert.assertEquals(false, fiveMatcher.matches());
-    Assert.assertEquals(true, nonNullMatcher.matches());
-    Assert.assertEquals("4", selector.lookupName(selector.getRow().get(0)));
+    if (NullHandling.useDefaultValuesForNull()) {
+      Assert.assertEquals(false, nullMatcher.matches());
+      Assert.assertEquals(false, fiveMatcher.matches());
+      Assert.assertEquals(true, nonNullMatcher.matches());
+      Assert.assertEquals("4", selector.lookupName(selector.getRow().get(0)));
+    } else {
+      // y is null in row1
+      Assert.assertEquals(true, nullMatcher.matches());
+      Assert.assertEquals(false, fiveMatcher.matches());
+      Assert.assertEquals(false, nonNullMatcher.matches());
+      Assert.assertEquals(null, selector.lookupName(selector.getRow().get(0)));
+    }
 
     CURRENT_ROW.set(ROW2);
     Assert.assertEquals(false, nullMatcher.matches());

--- a/processing/src/test/java/io/druid/segment/virtual/VirtualColumnsTest.java
+++ b/processing/src/test/java/io/druid/segment/virtual/VirtualColumnsTest.java
@@ -379,6 +379,12 @@ public class VirtualColumnsTest
         {
           return String.class;
         }
+
+        @Override
+        public boolean isNull()
+        {
+          return selector.isNull();
+        }
       };
 
       return dimensionSpec.decorate(dimensionSelector);
@@ -396,6 +402,12 @@ public class VirtualColumnsTest
         public long getLong()
         {
           return theLong;
+        }
+
+        @Override
+        public boolean isNull()
+        {
+          return false;
         }
       };
     }

--- a/services/src/main/java/io/druid/cli/DumpSegment.java
+++ b/services/src/main/java/io/druid/cli/DumpSegment.java
@@ -22,7 +22,6 @@ package io.druid.cli;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
-import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -41,6 +40,7 @@ import io.druid.collections.bitmap.BitmapFactory;
 import io.druid.collections.bitmap.ConciseBitmapFactory;
 import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.collections.bitmap.RoaringBitmapFactory;
+import io.druid.common.config.NullHandling;
 import io.druid.guice.DruidProcessingModule;
 import io.druid.guice.QueryRunnerFactoryModule;
 import io.druid.guice.QueryableModule;
@@ -364,18 +364,20 @@ public class DumpSegment extends GuiceRunnable
                   jg.writeFieldName(columnName);
                   jg.writeStartObject();
                   for (int i = 0; i < bitmapIndex.getCardinality(); i++) {
-                    jg.writeFieldName(Strings.nullToEmpty(bitmapIndex.getValue(i)));
-                    final ImmutableBitmap bitmap = bitmapIndex.getBitmap(i);
-                    if (decompressBitmaps) {
-                      jg.writeStartArray();
-                      final IntIterator iterator = bitmap.iterator();
-                      while (iterator.hasNext()) {
-                        final int rowNum = iterator.next();
-                        jg.writeNumber(rowNum);
+                    String val = NullHandling.nullToEmptyIfNeeded(bitmapIndex.getValue(i));
+                    if (val != null) {
+                      final ImmutableBitmap bitmap = bitmapIndex.getBitmap(i);
+                      if (decompressBitmaps) {
+                        jg.writeStartArray();
+                        final IntIterator iterator = bitmap.iterator();
+                        while (iterator.hasNext()) {
+                          final int rowNum = iterator.next();
+                          jg.writeNumber(rowNum);
+                        }
+                        jg.writeEndArray();
+                      } else {
+                        jg.writeBinary(bitmapSerdeFactory.getObjectStrategy().toBytes(bitmap));
                       }
-                      jg.writeEndArray();
-                    } else {
-                      jg.writeBinary(bitmapSerdeFactory.getObjectStrategy().toBytes(bitmap));
                     }
                   }
                   jg.writeEndObject();
@@ -551,6 +553,12 @@ public class DumpSegment extends GuiceRunnable
     public void inspectRuntimeShape(RuntimeShapeInspector inspector)
     {
       inspector.visit("delegate", delegate);
+    }
+
+    @Override
+    public boolean isNull()
+    {
+      return delegate.isNull();
     }
   }
 }


### PR DESCRIPTION
Part 1 of Null Handling Changes -  https://github.com/druid-io/druid/pull/4754 which contains changes in Expressions and Storage Layer.

This PR contains changes to improve handling of null values in druid by treating nulls as missing values which don’t actually exist. This will make it more compatible to SQL standard and help with integration with other existing BI systems which support ODBC/JDBC. (Detailed description in proposal - https://github.com/druid-io/druid/issues/4349)

Changes include - 

## New Configuration 

* New configuration - **_"druid.generic.useDefaultValueForNull"_** in class NullValueHandlingConfig default to true for preserving old behavior.
* NullHandling - this a helper class with static methods for handling optional nullToEmpty / emptyToNull conversions for switching between old/new behavior. Without this static helper, we would need to inject NullValueHandlingConfig almost everywhere throughout the querying and indexing layer. 

## Storage Layer - 

* GenericIndexed - Added ability to distinguish between null/empty bytes. the value buffer for GenericIndexed contains element size followed by  the bytes, for null values size is written as -1 and for empty bytes size is 0. 
* String Columns - the dictionary is stores as a genericIndexed, which now can contain null value. An inverted index is created with the id assigned to null value. Null and empty strings will get different id's in dictionary encoding.
* Numeric Columns - The column is serialized as primitive objects of long/float/double type, a nullRowsBitmap is also stored which is used to distinguish rows having 0 and null values.  
* Complex columns - Complex columns use genericIndexed internally for storage, so supported nulls in genericIndexed make this work. the ObjectStrategy can choose to return null objects when deserializing data. 

## Indexing Layer - 

* Row - instead of returning primitive types return Float/Long/Double objects so that indexer can distinguish between null and 0 values.
* StringIndexer,DoubleIndexer,LongIndexer,FloatIndexer changed to distinguish between null and empty values. 
* ColumnValueSelector - added new method isNull() to check whether a value is null or not while aggregating. this is mainly done in order to avoid boxing/unboxing from primitive values while doing segment scans. 

## Expressions Null Handling
* For general calculations like sum, full expression is be considered as null if any of the components is null. 
* StringLiteral now supports null and and expressions containing non-quoted null is parsed as StringLiteral with null 
* Specifying a default value for null is supported by the use of NVL or IF clause to assign default values at query time.

## Backwards Compatibility 
* **_"druid.generic.useDefaultValueForNull"_** is added as a new config. The default value is set to true for backwards compatibility. 
*  code places in query/ingestion where we converted emptyToNull or nullToEmpty now use NullHandlingHelper which only does the conversion if backwards compatibility is enabled. 
* Storage layer changes are backwards compatible for GenericIndexed/String columns. 
* For Numeric columns new V2 serde implementations are introduced which also supports serde of nullRowsBitmaps. Previous implementations are kept unchanged to read any existing segments. 
* Note:- New serde are only used when Null Handling is enabled to enable rollback to a previous version when needed. 
