### PR TITLE
remove unnecessary log that pontetially take up lots of heap when reindexing

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerConfig.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerConfig.java
@@ -573,13 +573,6 @@ public class HadoopDruidIndexerConfig
 
   public void verify()
   {
-    try {
-      log.info("Running with config:%n%s", JSON_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(this));
-    }
-    catch (IOException e) {
-      throw Throwables.propagate(e);
-    }
-
     Preconditions.checkNotNull(schema.getDataSchema().getDataSource(), "dataSource");
     Preconditions.checkNotNull(schema.getDataSchema().getParser().getParseSpec(), "parseSpec");
     Preconditions.checkNotNull(schema.getDataSchema().getParser().getParseSpec().getTimestampSpec(), "timestampSpec");

--- a/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceInputFormat.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceInputFormat.java
@@ -81,7 +81,10 @@ public class DatasourceInputFormat extends InputFormat<NullWritable, InputRow>
       throw new ISE("No segments found to read");
     }
 
-    logger.info("segments to read [%s]", segmentsStr);
+    // Note: log is splitted into two lines so that a new String is not generated to print it.
+    // segmentsStr could be quite large when re-indexing multiple months of data.
+    logger.info("Segment to read are...");
+    logger.info(segmentsStr);
 
     long maxSize = conf.getLong(CONF_MAX_SPLIT_SIZE, 0);
     if (maxSize < 0) {


### PR DESCRIPTION
when users run large hadoop re-indexing job, size of list of segment specs is quite large and constructing strings to print them causes ununecessary memory churn. also, printing them many times causes excess amount of logs.

`HadoopDruidIndexerConfig.verify(..)` was printing the whole config which included segment spec in many different places as a side effect and isn't desired, so removed. It becomes more troublesome due to hadoop calling `IndexGeneratorJob.IndexGeneratorCombiner.setup(..) ->  HadoopDruidIndexerConfig.fromConfiguration(..) -> HadoopDruidIndexerConfig.verify(..)`multiple times leading to it getting printed many many times and filling up hadoop logs.

config is still available in the peon log as each peon process prints task to be run in the logs anyway and same is available in hadoop job config too which is visible from hadoop job history.