### PR TITLE
add LookupExtractorFactory.destroy() method

### DIFF
--- a/processing/src/main/java/io/druid/query/lookup/LookupExtractorFactory.java
+++ b/processing/src/main/java/io/druid/query/lookup/LookupExtractorFactory.java
@@ -44,12 +44,27 @@ public interface LookupExtractorFactory extends Supplier<LookupExtractor>
 
   /**
    * <p>
-   *   This method will be called to stop the LookupExtractor upon deletion.
+   *   This method will be called to stop the LookupExtractor upon Druid process stop. This would be used, for
+   *   example, to stop any thread pools it might have.
    *   Calling this method multiple times should always return true if successfully closed.
    * </p>
    * @return Returns false if not successfully closed the {@link LookupExtractor} otherwise returns true
    */
   boolean close();
+
+  /**
+   * <p>
+   *   This method will be called to drop the LookupExtractor upon explicit user request to coordinator to drop
+   *   this lookup. In this method user can do additional cleanup (e.g. deleting disk persisted cache) not done simply
+   *   when Druid process was being stopped to be restarted.
+   *   Calling this method multiple times should always return true if successfully destroyed.
+   * </p>
+   * @return Returns false if not successfully destroyed the {@link LookupExtractor} otherwise returns true
+   */
+  default boolean destroy()
+  {
+    return close();
+  }
 
   /**
    * This method is deprecated and is not removed only to allow 0.10.0 to 0.10.1 transition. It is not used

--- a/server/src/main/java/io/druid/query/lookup/LookupReferencesManager.java
+++ b/server/src/main/java/io/druid/query/lookup/LookupReferencesManager.java
@@ -626,8 +626,8 @@ public class LookupReferencesManager
       LOG.debug("Loaded lookup [%s] with spec [%s].", lookupName, lookupExtractorFactoryContainer);
 
       if (old != null) {
-        if (!old.getLookupExtractorFactory().close()) {
-          throw new ISE("close method returned false for lookup [%s]:[%s]", lookupName, old);
+        if (!old.getLookupExtractorFactory().destroy()) {
+          throw new ISE("destroy method returned false for lookup [%s]:[%s]", lookupName, old);
         }
       }
     }
@@ -659,9 +659,9 @@ public class LookupReferencesManager
       if (lookupExtractorFactoryContainer != null) {
         LOG.debug("Removed lookup [%s] with spec [%s].", lookupName, lookupExtractorFactoryContainer);
 
-        if (!lookupExtractorFactoryContainer.getLookupExtractorFactory().close()) {
+        if (!lookupExtractorFactoryContainer.getLookupExtractorFactory().destroy()) {
           throw new ISE(
-              "close method returned false for lookup [%s]:[%s]",
+              "destroy method returned false for lookup [%s]:[%s]",
               lookupName,
               lookupExtractorFactoryContainer
           );

--- a/server/src/test/java/io/druid/query/lookup/LookupReferencesManagerTest.java
+++ b/server/src/test/java/io/druid/query/lookup/LookupReferencesManagerTest.java
@@ -156,7 +156,7 @@ public class LookupReferencesManagerTest
   {
     LookupExtractorFactory lookupExtractorFactory = EasyMock.createMock(LookupExtractorFactory.class);
     EasyMock.expect(lookupExtractorFactory.start()).andReturn(true).once();
-    EasyMock.expect(lookupExtractorFactory.close()).andReturn(true).once();
+    EasyMock.expect(lookupExtractorFactory.destroy()).andReturn(true).once();
     EasyMock.replay(lookupExtractorFactory);
 
     Map<String, Object> lookupMap = new HashMap<>();
@@ -221,15 +221,15 @@ public class LookupReferencesManagerTest
   }
 
   @Test
-  public void testCloseIsCalledAfterRemove() throws Exception
+  public void testDestroyIsCalledAfterRemove() throws Exception
   {
     LookupExtractorFactory lookupExtractorFactory = EasyMock.createStrictMock(LookupExtractorFactory.class);
     EasyMock.expect(lookupExtractorFactory.start()).andReturn(true).once();
-    EasyMock.expect(lookupExtractorFactory.close()).andReturn(true).once();
+    EasyMock.expect(lookupExtractorFactory.destroy()).andReturn(true).once();
     EasyMock.replay(lookupExtractorFactory);
 
     Map<String, Object> lookupMap = new HashMap<>();
-    lookupMap.put("testMockForCloseIsCalledAfterRemove", container);
+    lookupMap.put("testMockForDestroyIsCalledAfterRemove", container);
     String strResult = mapper.writeValueAsString(lookupMap);
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
@@ -280,7 +280,7 @@ public class LookupReferencesManagerTest
   {
     LookupExtractorFactory lookupExtractorFactory1 = EasyMock.createNiceMock(LookupExtractorFactory.class);
     EasyMock.expect(lookupExtractorFactory1.start()).andReturn(true).once();
-    EasyMock.expect(lookupExtractorFactory1.close()).andReturn(true).once();
+    EasyMock.expect(lookupExtractorFactory1.destroy()).andReturn(true).once();
 
     LookupExtractorFactory lookupExtractorFactory2 = EasyMock.createNiceMock(LookupExtractorFactory.class);
     EasyMock.expect(lookupExtractorFactory2.start()).andReturn(true).once();
@@ -461,7 +461,7 @@ public class LookupReferencesManagerTest
 
     LookupExtractorFactory lookupExtractorFactory = EasyMock.createMock(LookupExtractorFactory.class);
     EasyMock.expect(lookupExtractorFactory.start()).andReturn(true).once();
-    EasyMock.expect(lookupExtractorFactory.close()).andReturn(true).once();
+    EasyMock.expect(lookupExtractorFactory.destroy()).andReturn(true).once();
     EasyMock.replay(lookupExtractorFactory);
     Assert.assertNull(lookupReferencesManager.get("test"));
 


### PR DESCRIPTION
many custom lookup extensions when started keep thread-pools and also persist caches on disk for fast restart of historicals.
when historical process is stopped , thread-pools etc should be properly closed but persisted cache should be left untouched on disk.
when historical is asked to drop the lookup, thread-pools etc should be properly closed and also persisted cache should be removed from the disk.
it requires additional method on LookupExtractorFactory to tell the extension writer when they are simply supposed to let go off transient resources in process memory vs when lookup is being dropped and everything (including persistent information) relevant should be deleted.

this PR is completely backward compatible.