### PR TITLE
clean up intermediate_pushes directory for LocalDataSegmentPusher

### DIFF
--- a/server/src/main/java/io/druid/segment/loading/LocalDataSegmentPusher.java
+++ b/server/src/main/java/io/druid/segment/loading/LocalDataSegmentPusher.java
@@ -73,9 +73,8 @@ public class LocalDataSegmentPusher implements DataSegmentPusher
   @Override
   public DataSegment push(File dataSegmentFile, DataSegment segment, boolean replaceExisting) throws IOException
   {
-    final String storageDir = this.getStorageDir(segment);
     final File baseStorageDir = config.getStorageDirectory();
-    final File outDir = new File(baseStorageDir, storageDir);
+    final File outDir = new File(baseStorageDir, this.getStorageDir(segment));
 
     log.info("Copying segment[%s] to local filesystem at location[%s]", segment.getIdentifier(), outDir.toString());
 
@@ -93,7 +92,7 @@ public class LocalDataSegmentPusher implements DataSegmentPusher
       );
     }
 
-    final File tmpOutDir = new File(baseStorageDir, intermediateDirFor(storageDir));
+    final File tmpOutDir = new File(baseStorageDir, makeIntermediateDir());
     log.info("Creating intermediate directory[%s] for segment[%s]", tmpOutDir.toString(), segment.getIdentifier());
     FileUtils.forceMkdir(tmpOutDir);
 
@@ -150,9 +149,9 @@ public class LocalDataSegmentPusher implements DataSegmentPusher
     return ImmutableMap.<String, Object>of("type", "local", "path", finalIndexZipFilePath.getPath());
   }
 
-  private String intermediateDirFor(String storageDir)
+  private String makeIntermediateDir()
   {
-    return "intermediate_pushes/" + storageDir + "." + UUID.randomUUID().toString();
+    return "intermediate_pushes/" + UUID.randomUUID().toString();
   }
 
   private long compressSegment(File dataSegmentFile, File dest) throws IOException


### PR DESCRIPTION
`intermediateDirFor()` used to create intermediate directories like:

/druid/localStorage/intermediate_pushes/myDatasource/2016-05-14T00:00:00.000Z_2016-05-15T00:00:00.000Z/2018-01-30T07:22:02.796Z/0.73253533-1fd0-4787-9240-d01f3faad752

with only the innermost directory being cleaned up (0.73253533-1fd0-4787-9240-d01f3faad752), leaving lots of empty directories on the filesystem.

Switched to a flat /druid/localStorage/intermediate_pushes/{UUID} which is removed on completion.
