### PR TITLE
Lookups: Inherit "injective" from registered lookups, improve docs.

### DIFF
--- a/docs/content/development/extensions-core/lookups-cached-global.md
+++ b/docs/content/development/extensions-core/lookups-cached-global.md
@@ -71,7 +71,7 @@ The parameters are as follows
 |--------|-----------|--------|-------|
 |`extractionNamespace`|Specifies how to populate the local cache. See below|Yes|-|
 |`firstCacheTimeout`|How long to wait (in ms) for the first run of the cache to populate. 0 indicates to not wait|No|`0` (do not wait)|
-|`injective`|If the underlying map is injective (keys and values are unique) then optimizations can occur internally by setting this to `true`|No|`false`|
+|`injective`|If the underlying map is [injective](../../querying/lookups.html#query-execution) (keys and values are unique) then optimizations can occur internally by setting this to `true`|No|`false`|
 
 If `firstCacheTimeout` is set to a non-zero value, it should be less than `druid.manager.lookups.hostUpdateTimeout`. If `firstCacheTimeout` is NOT set, then management is essentially asynchronous and does not know if a lookup succeeded or failed in starting. In such a case logs from the lookup nodes should be monitored for repeated failures.
 

--- a/processing/src/main/java/io/druid/query/lookup/LookupExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/lookup/LookupExtractionFn.java
@@ -37,18 +37,14 @@ public class LookupExtractionFn extends FunctionalExtraction
 {
   private final LookupExtractor lookup;
   private final boolean optimize;
-  // Thes are retained for auto generated hashCode and Equals
-  private final boolean retainMissingValue;
-  private final String replaceMissingValueWith;
-  private final boolean injective;
 
   @JsonCreator
   public LookupExtractionFn(
       @JsonProperty("lookup") final LookupExtractor lookup,
       @JsonProperty("retainMissingValue") final boolean retainMissingValue,
       @Nullable @JsonProperty("replaceMissingValueWith") final String replaceMissingValueWith,
-      @JsonProperty("injective") final boolean injective,
-      @JsonProperty("optimize") Boolean optimize
+      @JsonProperty("injective") final Boolean injective,
+      @JsonProperty("optimize") final Boolean optimize
   )
   {
     super(
@@ -63,13 +59,10 @@ public class LookupExtractionFn extends FunctionalExtraction
         },
         retainMissingValue,
         replaceMissingValueWith,
-        injective
+        injective != null ? injective : lookup.isOneToOne()
     );
     this.lookup = lookup;
     this.optimize = optimize == null ? true : optimize;
-    this.retainMissingValue = retainMissingValue;
-    this.injective = injective;
-    this.replaceMissingValueWith = replaceMissingValueWith;
   }
 
 
@@ -175,9 +168,9 @@ public class LookupExtractionFn extends FunctionalExtraction
     return "LookupExtractionFn{" +
            "lookup=" + lookup +
            ", optimize=" + optimize +
-           ", retainMissingValue=" + retainMissingValue +
-           ", replaceMissingValueWith='" + replaceMissingValueWith + '\'' +
-           ", injective=" + injective +
+           ", retainMissingValue=" + isRetainMissingValue() +
+           ", replaceMissingValueWith='" + getReplaceMissingValueWith() + '\'' +
+           ", injective=" + isInjective() +
            '}';
   }
 }

--- a/server/src/test/java/io/druid/query/lookup/RegisteredLookupExtractionFnTest.java
+++ b/server/src/test/java/io/druid/query/lookup/RegisteredLookupExtractionFnTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.jackson.JacksonUtils;
+import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.extraction.MapLookupExtractor;
 import org.easymock.EasyMock;
 import org.junit.Assert;
@@ -57,16 +58,39 @@ public class RegisteredLookupExtractionFnTest
         LOOKUP_NAME,
         true,
         null,
-        true,
+        false,
         false
     );
     EasyMock.verify(manager);
+
+    Assert.assertEquals(false, fn.isInjective());
+    Assert.assertEquals(ExtractionFn.ExtractionType.MANY_TO_ONE, fn.getExtractionType());
+
     for (String orig : Arrays.asList("", "foo", "bat")) {
       Assert.assertEquals(LOOKUP_EXTRACTOR.apply(orig), fn.apply(orig));
     }
     Assert.assertEquals("not in the map", fn.apply("not in the map"));
   }
 
+  @Test
+  public void testInheritInjective()
+  {
+    final LookupReferencesManager manager = EasyMock.createStrictMock(LookupReferencesManager.class);
+    managerReturnsMap(manager);
+    EasyMock.replay(manager);
+    final RegisteredLookupExtractionFn fn = new RegisteredLookupExtractionFn(
+        manager,
+        LOOKUP_NAME,
+        true,
+        null,
+        null,
+        false
+    );
+    EasyMock.verify(manager);
+
+    Assert.assertNull(fn.isInjective());
+    Assert.assertEquals(ExtractionFn.ExtractionType.ONE_TO_ONE, fn.getExtractionType());
+  }
 
   @Test
   public void testMissingDelegation()


### PR DESCRIPTION
Code changes:
- In the lookup-based extractionFns, inherit injective property from
  the lookup itself if not specified. The fact that this was not done
  already is a bug: it means the extractionFn ignores a valid
  "injective" parameter from the lookup configuration.

Doc changes:
- Add a "Query execution" section to the lookups doc explaining how
  injective lookups and their optimizations work.
- Remove scary warnings against using registeredLookup extractionFns.
  They are necessary and important since they work with filters and
  function cascades -- two things that the dimension specs do not do.
  They deserve to be first class citizens.
- Move the "registeredLookup" fn above the "lookup" fn. It's probably
  more commonly used, so the docs read better this way.