### PR TITLE
Remove Escalator jetty http client escalation method

### DIFF
--- a/extensions-core/druid-basic-security/src/main/java/io/druid/security/basic/authentication/BasicHTTPEscalator.java
+++ b/extensions-core/druid-basic-security/src/main/java/io/druid/security/basic/authentication/BasicHTTPEscalator.java
@@ -22,21 +22,11 @@ package io.druid.security.basic.authentication;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.google.common.base.Throwables;
 import io.druid.java.util.http.client.CredentialedHttpClient;
 import io.druid.java.util.http.client.HttpClient;
 import io.druid.java.util.http.client.auth.BasicCredentials;
-import io.druid.java.util.common.StringUtils;
-import io.druid.security.basic.BasicAuthUtils;
 import io.druid.server.security.AuthenticationResult;
 import io.druid.server.security.Escalator;
-import org.eclipse.jetty.client.api.Authentication;
-import org.eclipse.jetty.client.api.ContentResponse;
-import org.eclipse.jetty.client.api.Request;
-import org.eclipse.jetty.util.Attributes;
-import org.jboss.netty.handler.codec.http.HttpHeaders;
-
-import java.net.URI;
 
 @JsonTypeName("basic")
 public class BasicHTTPEscalator implements Escalator
@@ -64,48 +54,6 @@ public class BasicHTTPEscalator implements Escalator
         new BasicCredentials(internalClientUsername, internalClientPassword),
         baseClient
     );
-  }
-
-  @Override
-  public org.eclipse.jetty.client.HttpClient createEscalatedJettyClient(org.eclipse.jetty.client.HttpClient baseClient)
-  {
-    baseClient.getAuthenticationStore().addAuthentication(new Authentication()
-    {
-      @Override
-      public boolean matches(String type, URI uri, String realm)
-      {
-        return true;
-      }
-
-      @Override
-      public Result authenticate(
-          final Request request, ContentResponse response, Authentication.HeaderInfo headerInfo, Attributes context
-      )
-      {
-        return new Result()
-        {
-          @Override
-          public URI getURI()
-          {
-            return request.getURI();
-          }
-
-          @Override
-          public void apply(Request request)
-          {
-            try {
-              final String unencodedCreds = StringUtils.format("%s:%s", internalClientUsername, internalClientPassword);
-              final String base64Creds = BasicAuthUtils.getEncodedCredentials(unencodedCreds);
-              request.getHeaders().add(HttpHeaders.Names.AUTHORIZATION, "Basic " + base64Creds);
-            }
-            catch (Throwable e) {
-              Throwables.propagate(e);
-            }
-          }
-        };
-      }
-    });
-    return baseClient;
   }
 
   @Override

--- a/extensions-core/druid-kerberos/src/main/java/io/druid/security/kerberos/KerberosEscalator.java
+++ b/extensions-core/druid-kerberos/src/main/java/io/druid/security/kerberos/KerberosEscalator.java
@@ -22,20 +22,10 @@ package io.druid.security.kerberos;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.google.common.base.Throwables;
 import io.druid.java.util.http.client.HttpClient;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.server.security.AuthenticationResult;
 import io.druid.server.security.Escalator;
-import org.apache.hadoop.security.UserGroupInformation;
-import org.eclipse.jetty.client.api.Authentication;
-import org.eclipse.jetty.client.api.ContentResponse;
-import org.eclipse.jetty.client.api.Request;
-import org.eclipse.jetty.util.Attributes;
-import org.jboss.netty.handler.codec.http.HttpHeaders;
-
-import java.net.URI;
-import java.security.PrivilegedExceptionAction;
 
 @JsonTypeName("kerberos")
 public class KerberosEscalator implements Escalator
@@ -62,68 +52,6 @@ public class KerberosEscalator implements Escalator
   public HttpClient createEscalatedClient(HttpClient baseClient)
   {
     return new KerberosHttpClient(baseClient, internalClientPrincipal, internalClientKeytab);
-  }
-
-  @Override
-  public org.eclipse.jetty.client.HttpClient createEscalatedJettyClient(org.eclipse.jetty.client.HttpClient baseClient)
-  {
-    baseClient.getAuthenticationStore().addAuthentication(new Authentication()
-    {
-      @Override
-      public boolean matches(String type, URI uri, String realm)
-      {
-        return true;
-      }
-
-      @Override
-      public Result authenticate(
-          final Request request, ContentResponse response, Authentication.HeaderInfo headerInfo, Attributes context
-      )
-      {
-        return new Result()
-        {
-          @Override
-          public URI getURI()
-          {
-            return request.getURI();
-          }
-
-          @Override
-          public void apply(Request request)
-          {
-            try {
-              // No need to set cookies as they are handled by Jetty Http Client itself.
-              URI uri = request.getURI();
-              if (DruidKerberosUtil.needToSendCredentials(baseClient.getCookieStore(), uri)) {
-                log.debug(
-                    "No Auth Cookie found for URI[%s]. Existing Cookies[%s] Authenticating... ",
-                    uri,
-                    baseClient.getCookieStore().getCookies()
-                );
-                final String host = request.getHost();
-                DruidKerberosUtil.authenticateIfRequired(internalClientPrincipal, internalClientKeytab);
-                UserGroupInformation currentUser = UserGroupInformation.getCurrentUser();
-                String challenge = currentUser.doAs(new PrivilegedExceptionAction<String>()
-                {
-                  @Override
-                  public String run() throws Exception
-                  {
-                    return DruidKerberosUtil.kerberosChallenge(host);
-                  }
-                });
-                request.getHeaders().add(HttpHeaders.Names.AUTHORIZATION, "Negotiate " + challenge);
-              } else {
-                log.debug("Found Auth Cookie found for URI[%s].", uri);
-              }
-            }
-            catch (Throwable e) {
-              Throwables.propagate(e);
-            }
-          }
-        };
-      }
-    });
-    return baseClient;
   }
 
   @Override

--- a/server/src/main/java/io/druid/server/initialization/AuthorizerMapperModule.java
+++ b/server/src/main/java/io/druid/server/initialization/AuthorizerMapperModule.java
@@ -95,11 +95,20 @@ public class AuthorizerMapperModule implements DruidModule
 
       // Default is allow all
       if (authorizers == null) {
+        AllowAllAuthorizer allowAllAuthorizer = new AllowAllAuthorizer();
+        authorizerMap.put(AuthConfig.ALLOW_ALL_NAME, allowAllAuthorizer);
+
         return new AuthorizerMapper(null) {
           @Override
           public Authorizer getAuthorizer(String name)
           {
-            return new AllowAllAuthorizer();
+            return allowAllAuthorizer;
+          }
+
+          @Override
+          public Map<String, Authorizer> getAuthorizerMap()
+          {
+            return authorizerMap;
           }
         };
       }

--- a/server/src/main/java/io/druid/server/security/Escalator.java
+++ b/server/src/main/java/io/druid/server/security/Escalator.java
@@ -47,18 +47,6 @@ public interface Escalator
   HttpClient createEscalatedClient(HttpClient baseClient);
 
   /**
-   * Return a client that sends requests with the format/information necessary to authenticate successfully
-   * against this Authenticator's authentication scheme using the identity of the internal system user.
-   * <p>
-   * This HTTP client is used by the Druid Router node.
-   *
-   * @param baseClient Base Jetty HttpClient
-   *
-   * @return Jetty HttpClient that sends requests with the credentials of the internal system user
-   */
-  org.eclipse.jetty.client.HttpClient createEscalatedJettyClient(org.eclipse.jetty.client.HttpClient baseClient);
-
-  /**
    * @return an AuthenticationResult representing the identity of the internal system user.
    */
   AuthenticationResult createEscalatedAuthenticationResult();

--- a/server/src/main/java/io/druid/server/security/NoopEscalator.java
+++ b/server/src/main/java/io/druid/server/security/NoopEscalator.java
@@ -30,12 +30,6 @@ public class NoopEscalator implements Escalator
   }
 
   @Override
-  public org.eclipse.jetty.client.HttpClient createEscalatedJettyClient(org.eclipse.jetty.client.HttpClient baseClient)
-  {
-    return baseClient;
-  }
-
-  @Override
   public AuthenticationResult createEscalatedAuthenticationResult()
   {
     return AllowAllAuthenticator.ALLOW_ALL_RESULT;

--- a/server/src/test/java/io/druid/server/AsyncQueryForwardingServletTest.java
+++ b/server/src/test/java/io/druid/server/AsyncQueryForwardingServletTest.java
@@ -54,7 +54,6 @@ import io.druid.server.router.RendezvousHashAvaticaConnectionBalancer;
 import io.druid.server.security.AllowAllAuthorizer;
 import io.druid.server.security.Authorizer;
 import io.druid.server.security.AuthorizerMapper;
-import io.druid.server.security.NoopEscalator;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
@@ -252,8 +251,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
                   // noop
                 }
               },
-              new DefaultGenericQueryMetricsFactory(jsonMapper),
-              new NoopEscalator()
+              new DefaultGenericQueryMetricsFactory(jsonMapper)
           )
           {
             @Override


### PR DESCRIPTION
The jetty HttpClient used in the Router should not have any "internal system user" escalation applied to it, as the proxy requests sent by the router should be sent with the same credentials in the original requests that the Router receives.

This did not occur in practice with the existing druid-basic-security extension because its implementation added an AuthenticationStore to the jetty HttpClient, which is only used when the client receives an authentication challenge (see https://www.eclipse.org/jetty/documentation/9.4.x/http-client-authentication.html). The challenge does not occur when using HTTP basic auth with the Router because ProxyServlet copies the original request's headers into the proxy request and the original request must have had valid HTTP basic auth credentials to be accepted by the Router, bypassing the need for the authentication challenge. 

However, any Escalator implementations that function by unconditionally adding credential headers to outgoing requests could incorrectly attach the privileged internal system user's credentials.

The escalated client was also being used for query cancellations sent by the Router, which is incorrect behavior as these cancellation requests should use the credentials of the requester, not the privileged internal system user. 

This PR removes the unnecessary/incorrect `createEscalatedJettyClient` method from the Escalator interface, fixes the `broadcastClient` such that it copies the headers of the original request, and also fixes a crash in AuthorizerMapperModule when the authorizers list is null.