### PR TITLE
CliCoordinator: LoadQueueTaskMaster should use an escalated http client.

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/LoadQueueTaskMaster.java
+++ b/server/src/main/java/io/druid/server/coordinator/LoadQueueTaskMaster.java
@@ -20,11 +20,8 @@
 package io.druid.server.coordinator;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.inject.Inject;
-import io.druid.java.util.http.client.HttpClient;
 import io.druid.client.ImmutableDruidServer;
-import io.druid.guice.annotations.Global;
-import io.druid.guice.annotations.Json;
+import io.druid.java.util.http.client.HttpClient;
 import io.druid.server.initialization.ZkPathsConfig;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.utils.ZKPaths;
@@ -45,14 +42,13 @@ public class LoadQueueTaskMaster
   private final HttpClient httpClient;
   private final ZkPathsConfig zkPaths;
 
-  @Inject
   public LoadQueueTaskMaster(
       CuratorFramework curator,
-      @Json ObjectMapper jsonMapper,
+      ObjectMapper jsonMapper,
       ScheduledExecutorService peonExec,
       ExecutorService callbackExec,
       DruidCoordinatorConfig config,
-      @Global HttpClient httpClient,
+      HttpClient httpClient,
       ZkPathsConfig zkPaths
   )
   {

--- a/services/src/main/java/io/druid/cli/CliCoordinator.java
+++ b/services/src/main/java/io/druid/cli/CliCoordinator.java
@@ -28,7 +28,6 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.name.Names;
-import io.druid.java.util.http.client.HttpClient;
 import io.airlift.airline.Command;
 import io.druid.audit.AuditManager;
 import io.druid.client.CoordinatorServerView;
@@ -44,9 +43,10 @@ import io.druid.guice.LazySingleton;
 import io.druid.guice.LifecycleModule;
 import io.druid.guice.ManageLifecycle;
 import io.druid.guice.annotations.CoordinatorIndexingServiceHelper;
-import io.druid.guice.annotations.Global;
+import io.druid.guice.annotations.EscalatedGlobal;
 import io.druid.java.util.common.concurrent.ScheduledExecutorFactory;
 import io.druid.java.util.common.logger.Logger;
+import io.druid.java.util.http.client.HttpClient;
 import io.druid.metadata.MetadataRuleManager;
 import io.druid.metadata.MetadataRuleManagerConfig;
 import io.druid.metadata.MetadataRuleManagerProvider;
@@ -232,7 +232,7 @@ public class CliCoordinator extends ServerRunnable
               ObjectMapper jsonMapper,
               ScheduledExecutorFactory factory,
               DruidCoordinatorConfig config,
-              @Global HttpClient httpClient,
+              @EscalatedGlobal HttpClient httpClient,
               ZkPathsConfig zkPaths
           )
           {


### PR DESCRIPTION
Also remove Guice annotations from LoadQueueTaskMaster, since it is
provided by CliCoordinator, so Guice does not need to know how to
build one directly.

Fixes #5325