### PR TITLE
Fix CompactionTask doc

### DIFF
--- a/docs/content/configuration/coordinator.md
+++ b/docs/content/configuration/coordinator.md
@@ -148,18 +148,6 @@ An example of compaction config is:
 
 For the realtime dataSources, it's recommended to set `skipOffsetFromLatest` to some sufficiently large values to avoid frequent compact task failures.
 
-## Compact Task TuningConfig
-
-Compact task tuning config is a subset of the tuningConfig of IndexTask. See [TuningConfig](../ingestion/tasks.html#tuningconfig) for more details.
-
-|Property|Required|
-|--------|--------|
-|`maxRowsInMemory`|no|
-|`maxTotalRows`|no|
-|`indexSpec`|no|
-|`maxPendingPersists`|no|
-|`publishTimeout`|no|
-
 # Lookups Dynamic Config (EXPERIMENTAL)
 These configuration options control the behavior of the Lookup dynamic configuration described in the [lookups page](../querying/lookups.html)
 

--- a/docs/content/ingestion/tasks.md
+++ b/docs/content/ingestion/tasks.md
@@ -276,8 +276,10 @@ An example of compaction task is
 }
 ```
 
-This compaction task merges _all segments_ of the interval `2017-01-01/2018-01-01` into a _single segment_.
-To merge each day's worth of data into a separate segment, you can submit multiple `compact` tasks, one for each day. They will run in parallel.
+This compaction task reads _all segments_ of the interval `2017-01-01/2018-01-01` and results in new segments.
+Note that intervals of the input segments are merged into a single interval of `2017-01-01/2018-01-01` no matter what the segmentGranularity was.
+To controll the number of result segments, you can set `targetPartitionSize` or `numShards`. See [indexTuningConfig](#tuningconfig) for more details.
+To merge each day's worth of data into separate segments, you can submit multiple `compact` tasks, one for each day. They will run in parallel.
 
 A compaction task internally generates an `index` task spec for performing compaction work with some fixed parameters.
 For example, its `firehose` is always the [ingestSegmentSpec](./firehose.html), and `dimensionsSpec` and `metricsSpec`


### PR DESCRIPTION
A `compactionTask` should be able to generate multiple segments because it internally runs an `indexTask`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/druid-io/druid/5351)
<!-- Reviewable:end -->
