### PR TITLE
Fix two improper casts in HavingSpecMetricComparator.

### DIFF
--- a/processing/src/main/java/io/druid/query/groupby/having/HavingSpecMetricComparator.java
+++ b/processing/src/main/java/io/druid/query/groupby/having/HavingSpecMetricComparator.java
@@ -48,11 +48,15 @@ class HavingSpecMetricComparator
       }
 
       if (metricValueObj instanceof Long || metricValueObj instanceof Integer) {
+        // Cast ints metrics to longs. It makes the code simpler and won't change the result.
         long n = ((Number) metricValueObj).longValue();
 
         if (value instanceof Long || value instanceof Integer) {
           return Longs.compare(n, value.longValue());
         } else if (value instanceof Double || value instanceof Float) {
+          // Use BigDecimal for comparison, a convenient way to handle edge cases without worrying about them
+          // ourselves. Cast the value to double since that's what BigDecimal wants. Should be fine since doubles can
+          // represent all float values.
           return BigDecimal.valueOf(n).compareTo(BigDecimal.valueOf(value.doubleValue()));
         } else {
           throw new ISE("Number was[%s]?!?", value.getClass().getName());

--- a/processing/src/test/java/io/druid/query/groupby/having/HavingSpecTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/having/HavingSpecTest.java
@@ -170,7 +170,7 @@ public class HavingSpecTest
     assertFalse(spec.eval(getTestRow(100d)));
     assertTrue(spec.eval(getTestRow(100.56d)));
     assertFalse(spec.eval(getTestRow(90.53d)));
-    assertTrue(spec.eval(getTestRow(100.56f)));
+    assertFalse(spec.eval(getTestRow(100.56f))); // False since 100.56d != (double) 100.56f
     assertFalse(spec.eval(getTestRow(90.53f)));
     assertFalse(spec.eval(getTestRow(Long.MAX_VALUE)));
 

--- a/processing/src/test/java/io/druid/query/groupby/having/HavingSpecTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/having/HavingSpecTest.java
@@ -101,9 +101,8 @@ public class HavingSpecTest
         "value", 1.3
     );
     ObjectMapper mapper = new DefaultObjectMapper();
-    @SuppressWarnings("unused") // expected exception
+    // noinspection unused
     HavingSpec spec = mapper.convertValue(greaterMap, HavingSpec.class);
-
   }
 
   @Test
@@ -156,7 +155,62 @@ public class HavingSpecTest
     assertFalse(spec.eval(getTestRow(100.05f)));
 
     spec = new EqualToHavingSpec("metric", 100.56f);
+    assertFalse(spec.eval(getTestRow(100L)));
+    assertFalse(spec.eval(getTestRow(100.0)));
+    assertFalse(spec.eval(getTestRow(100d)));
+    assertFalse(spec.eval(getTestRow(100.56d))); // False since 100.56d != (double) 100.56f
+    assertFalse(spec.eval(getTestRow(90.53d)));
     assertTrue(spec.eval(getTestRow(100.56f)));
+    assertFalse(spec.eval(getTestRow(90.53f)));
+    assertFalse(spec.eval(getTestRow(Long.MAX_VALUE)));
+
+    spec = new EqualToHavingSpec("metric", 100.56d);
+    assertFalse(spec.eval(getTestRow(100L)));
+    assertFalse(spec.eval(getTestRow(100.0)));
+    assertFalse(spec.eval(getTestRow(100d)));
+    assertTrue(spec.eval(getTestRow(100.56d))); // True since 100.56f == (float) 100.56d
+    assertFalse(spec.eval(getTestRow(90.53d)));
+    assertTrue(spec.eval(getTestRow(100.56f)));
+    assertFalse(spec.eval(getTestRow(90.53f)));
+    assertFalse(spec.eval(getTestRow(Long.MAX_VALUE)));
+
+    spec = new EqualToHavingSpec("metric", 100.0f);
+    assertTrue(spec.eval(getTestRow(100L)));
+    assertTrue(spec.eval(getTestRow(100.0)));
+    assertTrue(spec.eval(getTestRow(100d)));
+    assertFalse(spec.eval(getTestRow(100.56d)));
+    assertFalse(spec.eval(getTestRow(90.53d)));
+    assertFalse(spec.eval(getTestRow(100.56f)));
+    assertFalse(spec.eval(getTestRow(90.53f)));
+    assertFalse(spec.eval(getTestRow(Long.MAX_VALUE)));
+
+    spec = new EqualToHavingSpec("metric", 100.0d);
+    assertTrue(spec.eval(getTestRow(100L)));
+    assertTrue(spec.eval(getTestRow(100.0)));
+    assertTrue(spec.eval(getTestRow(100d)));
+    assertFalse(spec.eval(getTestRow(100.56d)));
+    assertFalse(spec.eval(getTestRow(90.53d)));
+    assertFalse(spec.eval(getTestRow(100.56f)));
+    assertFalse(spec.eval(getTestRow(90.53f)));
+    assertFalse(spec.eval(getTestRow(Long.MAX_VALUE)));
+
+    spec = new EqualToHavingSpec("metric", 100);
+    assertTrue(spec.eval(getTestRow(100L)));
+    assertTrue(spec.eval(getTestRow(100.0)));
+    assertTrue(spec.eval(getTestRow(100d)));
+    assertFalse(spec.eval(getTestRow(100.56d)));
+    assertFalse(spec.eval(getTestRow(90.53d)));
+    assertFalse(spec.eval(getTestRow(100.56f)));
+    assertFalse(spec.eval(getTestRow(90.53f)));
+    assertFalse(spec.eval(getTestRow(Long.MAX_VALUE)));
+
+    spec = new EqualToHavingSpec("metric", 100L);
+    assertTrue(spec.eval(getTestRow(100L)));
+    assertTrue(spec.eval(getTestRow(100.0)));
+    assertTrue(spec.eval(getTestRow(100d)));
+    assertFalse(spec.eval(getTestRow(100.56d)));
+    assertFalse(spec.eval(getTestRow(90.53d)));
+    assertFalse(spec.eval(getTestRow(100.56f)));
     assertFalse(spec.eval(getTestRow(90.53f)));
     assertFalse(spec.eval(getTestRow(Long.MAX_VALUE)));
   }

--- a/processing/src/test/java/io/druid/query/groupby/having/HavingSpecTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/having/HavingSpecTest.java
@@ -168,7 +168,7 @@ public class HavingSpecTest
     assertFalse(spec.eval(getTestRow(100L)));
     assertFalse(spec.eval(getTestRow(100.0)));
     assertFalse(spec.eval(getTestRow(100d)));
-    assertTrue(spec.eval(getTestRow(100.56d))); // True since 100.56f == (float) 100.56d
+    assertTrue(spec.eval(getTestRow(100.56d)));
     assertFalse(spec.eval(getTestRow(90.53d)));
     assertTrue(spec.eval(getTestRow(100.56f)));
     assertFalse(spec.eval(getTestRow(90.53f)));


### PR DESCRIPTION
Fixes two things:

1. An improper double-to-long cast when comparing double metrics to any
   kind of value, which was a regression from #4883.
2. An improper double-to-long cast when comparing a long/int metric to a
   double/float value: the value was cast to long/int, drawing strange
   conclusions like int 100 matching a havingSpec of equalTo(100.5).

Marked 0.12.0 since one of these was introduced in #4883, new in 0.12.0.