### PR TITLE
Use a separate snapshot file per lookup tier.

### DIFF
--- a/processing/src/main/java/io/druid/query/lookup/LookupSnapshotTaker.java
+++ b/processing/src/main/java/io/druid/query/lookup/LookupSnapshotTaker.java
@@ -19,14 +19,15 @@
 
 package io.druid.query.lookup;
 
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import io.druid.guice.annotations.Json;
 import io.druid.java.util.common.FileUtils;
 import io.druid.java.util.common.ISE;
+import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.logger.Logger;
 
 import java.io.File;
@@ -34,16 +35,13 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
-
 public class LookupSnapshotTaker
 {
   private static final Logger LOGGER = new Logger(LookupSnapshotTaker.class);
-  protected static final String PERSIST_FILE_NAME = "lookupSnapshot.json";
+  private static final String PERSIST_FILE_SUFFIX = "lookupSnapshot.json";
 
   private final ObjectMapper objectMapper;
   private final File persistDirectory;
-  private final File persistFile;
-
 
   public LookupSnapshotTaker(
       final @Json ObjectMapper jsonMapper,
@@ -62,11 +60,12 @@ public class LookupSnapshotTaker
     if (!this.persistDirectory.isDirectory()) {
       throw new ISE("Can only persist to directories, [%s] wasn't a directory", persistDirectory);
     }
-    this.persistFile = new File(persistDirectory, PERSIST_FILE_NAME);
   }
 
-  public synchronized List<LookupBean> pullExistingSnapshot()
+  public synchronized List<LookupBean> pullExistingSnapshot(final String tier)
   {
+    final File persistFile = getPersistFile(tier);
+
     List<LookupBean> lookupBeanList;
     try {
       if (!persistFile.isFile()) {
@@ -84,8 +83,10 @@ public class LookupSnapshotTaker
     }
   }
 
-  public synchronized void takeSnapshot(List<LookupBean> lookups)
+  public synchronized void takeSnapshot(String tier, List<LookupBean> lookups)
   {
+    final File persistFile = getPersistFile(tier);
+
     try {
       FileUtils.writeAtomically(persistFile, out -> objectMapper.writeValue(out, lookups));
     }
@@ -94,8 +95,9 @@ public class LookupSnapshotTaker
     }
   }
 
-  public File getPersistFile()
+  @VisibleForTesting
+  File getPersistFile(final String tier)
   {
-    return persistFile;
+    return new File(persistDirectory, StringUtils.format("%s.%s", tier, PERSIST_FILE_SUFFIX));
   }
 }

--- a/server/src/main/java/io/druid/query/lookup/LookupReferencesManager.java
+++ b/server/src/main/java/io/druid/query/lookup/LookupReferencesManager.java
@@ -28,8 +28,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
-import io.druid.java.util.emitter.EmittingLogger;
-import io.druid.java.util.http.client.response.FullResponseHolder;
 import io.druid.client.coordinator.Coordinator;
 import io.druid.concurrent.LifecycleLock;
 import io.druid.discovery.DruidLeaderClient;
@@ -43,6 +41,8 @@ import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.lifecycle.LifecycleStart;
 import io.druid.java.util.common.lifecycle.LifecycleStop;
+import io.druid.java.util.emitter.EmittingLogger;
+import io.druid.java.util.http.client.response.FullResponseHolder;
 import org.apache.commons.lang.mutable.MutableBoolean;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
@@ -339,7 +339,7 @@ public class LookupReferencesManager
   private void takeSnapshot(Map<String, LookupExtractorFactoryContainer> lookupMap)
   {
     if (lookupSnapshotTaker != null) {
-      lookupSnapshotTaker.takeSnapshot(getLookupBeanList(lookupMap));
+      lookupSnapshotTaker.takeSnapshot(lookupListeningAnnouncerConfig.getLookupTier(), getLookupBeanList(lookupMap));
     }
   }
 
@@ -362,8 +362,7 @@ public class LookupReferencesManager
   {
     List<LookupBean> lookupBeanList;
     if (lookupConfig.getEnableLookupSyncOnStartup()) {
-      String tier = lookupListeningAnnouncerConfig.getLookupTier();
-      lookupBeanList = getLookupListFromCoordinator(tier);
+      lookupBeanList = getLookupListFromCoordinator(lookupListeningAnnouncerConfig.getLookupTier());
       if (lookupBeanList == null) {
         LOG.info("Coordinator is unavailable. Loading saved snapshot instead");
         lookupBeanList = getLookupListFromSnapshot();
@@ -455,7 +454,7 @@ public class LookupReferencesManager
   private List<LookupBean> getLookupListFromSnapshot()
   {
     if (lookupSnapshotTaker != null) {
-      return lookupSnapshotTaker.pullExistingSnapshot();
+      return lookupSnapshotTaker.pullExistingSnapshot(lookupListeningAnnouncerConfig.getLookupTier());
     }
     return null;
   }

--- a/server/src/test/java/io/druid/query/lookup/LookupReferencesManagerTest.java
+++ b/server/src/test/java/io/druid/query/lookup/LookupReferencesManagerTest.java
@@ -102,7 +102,7 @@ public class LookupReferencesManagerTest
     lookupMap.put("testMockForStartStop", container);
     String strResult = mapper.writeValueAsString(lookupMap);
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
-    expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
+    expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
     expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
@@ -163,7 +163,7 @@ public class LookupReferencesManagerTest
     lookupMap.put("testMockForAddGetRemove", container);
     String strResult = mapper.writeValueAsString(lookupMap);
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
-    expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
+    expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
     expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
@@ -201,7 +201,7 @@ public class LookupReferencesManagerTest
     lookupMap.put("testMockForCloseIsCalledAfterStopping", container);
     String strResult = mapper.writeValueAsString(lookupMap);
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
-    expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
+    expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
     expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
@@ -232,7 +232,7 @@ public class LookupReferencesManagerTest
     lookupMap.put("testMockForDestroyIsCalledAfterRemove", container);
     String strResult = mapper.writeValueAsString(lookupMap);
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
-    expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
+    expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
     expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
@@ -260,7 +260,7 @@ public class LookupReferencesManagerTest
     lookupMap.put("testMockForGetNotThere", container);
     String strResult = mapper.writeValueAsString(lookupMap);
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
-    expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
+    expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
     expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
@@ -290,7 +290,7 @@ public class LookupReferencesManagerTest
     lookupMap.put("testMockForUpdateWithHigherVersion", container);
     String strResult = mapper.writeValueAsString(lookupMap);
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
-    expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
+    expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
     expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
@@ -324,7 +324,7 @@ public class LookupReferencesManagerTest
     lookupMap.put("testMockForUpdateWithLowerVersion", container);
     String strResult = mapper.writeValueAsString(lookupMap);
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
-    expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
+    expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
     expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
@@ -352,7 +352,7 @@ public class LookupReferencesManagerTest
     lookupMap.put("testMockForRemoveNonExisting", container);
     String strResult = mapper.writeValueAsString(lookupMap);
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
-    expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
+    expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
     expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
@@ -403,7 +403,7 @@ public class LookupReferencesManagerTest
     Map<String, Object> lookupMap = new HashMap<>();
     String strResult = mapper.writeValueAsString(lookupMap);
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
-    expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
+    expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
     expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
@@ -445,7 +445,7 @@ public class LookupReferencesManagerTest
     lookupMap.put("testMockForRealModeWithMainThread", container);
     String strResult = mapper.writeValueAsString(lookupMap);
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
-    expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
+    expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
     expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
@@ -521,7 +521,7 @@ public class LookupReferencesManagerTest
     lookupMap.put("testLookup3", container3);
     String strResult = mapper.writeValueAsString(lookupMap);
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
-    expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
+    expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
     expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request);
@@ -547,7 +547,7 @@ public class LookupReferencesManagerTest
     lookupMap.put("testMockForLoadLookupOnCoordinatorFailure", container);
     String strResult = mapper.writeValueAsString(lookupMap);
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
-    expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
+    expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
     expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request)
@@ -565,13 +565,13 @@ public class LookupReferencesManagerTest
     lookupReferencesManager.handlePendingNotices();
     lookupReferencesManager.stop();
     lookupReferencesManager = new LookupReferencesManager(
-        new LookupConfig(lookupReferencesManager.lookupSnapshotTaker.getPersistFile().getParent()),
+        new LookupConfig(lookupReferencesManager.lookupSnapshotTaker.getPersistFile(LOOKUP_TIER).getParent()),
         mapper, druidLeaderClient, config,
         true
     );
     reset(config);
     reset(druidLeaderClient);
-    expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
+    expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
     expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
         .andReturn(request)
@@ -593,7 +593,7 @@ public class LookupReferencesManagerTest
     lookupMap.put("testMockForDisableLookupSync", container);
     String strResult = mapper.writeValueAsString(lookupMap);
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
-    expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
+    expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
     expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/lookupTier?detailed=true"))
         .andReturn(request);


### PR DESCRIPTION
Prevents conflicts if two processes on the same machine use the
same lookup snapshot directory but are in different tiers.

Fixes issue raised in https://github.com/druid-io/druid/pull/5344#issuecomment-363563722.