### PR TITLE
Debug logging in HttpPostEmitter and Batch

### DIFF
--- a/java-util/src/main/java/io/druid/java/util/emitter/core/HttpPostEmitter.java
+++ b/java-util/src/main/java/io/druid/java/util/emitter/core/HttpPostEmitter.java
@@ -37,6 +37,7 @@ import org.asynchttpclient.ListenableFuture;
 import org.asynchttpclient.RequestBuilder;
 import org.asynchttpclient.Response;
 
+import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.Flushable;
 import java.io.IOException;
@@ -223,6 +224,7 @@ public class HttpPostEmitter implements Flushable, Closeable, Emitter
   }
 
   @VisibleForTesting
+  @Nullable
   Batch emitAndReturnBatch(Event event)
   {
     awaitStarted();
@@ -251,6 +253,8 @@ public class HttpPostEmitter implements Flushable, Closeable, Emitter
       }
       if (batch.tryAddEvent(eventBytes)) {
         return batch;
+      } else {
+        log.debug("Failed to emit an event in batch [%s]", batch);
       }
       // Spin loop, until the thread calling onSealExclusive() updates the concurrentBatch. This update becomes visible
       // eventually, because concurrentBatch.get() is a volatile read.


### PR DESCRIPTION
This addition should help to debug #5338, but it could also remain in the source code, because normally debug logging is not enabled.

@pjain1 @niketh @himanshug 

1) Setup logging so that debug logging is enabled only in `io.druid.java.util.emitter.core` package, or just in `HttpPostEmitter` and `Batch` classes.

2) Setup logging so that the thread name is printed.

