### PR TITLE
Standardize on using Integer.BYTES instead of Ints.BYTES from Guava

### DIFF
--- a/codestyle/checkstyle.xml
+++ b/codestyle/checkstyle.xml
@@ -163,5 +163,12 @@
       <property name="illegalPattern" value="true"/>
       <property name="message" value="Use io.druid.java.util.common.logger.Logger instead"/>
     </module>
+
+    <module name="Regexp">
+      <!-- Couldn't check this in forbidden-apis, because javac replaces compile-time constants without refs. -->
+      <property name="format" value="(Shorts|Chars|Ints|Longs|Floats|Doubles)\.BYTES"/>
+      <property name="illegalPattern" value="true"/>
+      <property name="message" value="Use java.lang.Primitive.BYTES instead."/>
+    </module>
   </module>
 </module>

--- a/common/src/main/java/io/druid/common/utils/SerializerUtils.java
+++ b/common/src/main/java/io/druid/common/utils/SerializerUtils.java
@@ -21,7 +21,6 @@ package io.druid.common.utils;
 
 import com.google.common.io.ByteStreams;
 import com.google.common.io.OutputSupplier;
-import com.google.common.primitives.Floats;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import io.druid.io.Channels;
@@ -53,7 +52,7 @@ public class SerializerUtils
       throw new IllegalArgumentException("Expected writable, big-endian, heap byteBuffer");
     }
     helperBuffer.putInt(0, value);
-    out.write(helperBuffer.array(), helperBuffer.arrayOffset(), Ints.BYTES);
+    out.write(helperBuffer.array(), helperBuffer.arrayOffset(), Integer.BYTES);
   }
 
   public <T extends OutputStream> void writeString(T out, String name) throws IOException
@@ -145,7 +144,7 @@ public class SerializerUtils
 
   private void writeInt(WritableByteChannel out, int intValue) throws IOException
   {
-    final ByteBuffer buffer = ByteBuffer.allocate(Ints.BYTES);
+    final ByteBuffer buffer = ByteBuffer.allocate(Integer.BYTES);
     buffer.putInt(intValue);
     buffer.flip();
     Channels.writeFully(out, buffer);
@@ -153,7 +152,7 @@ public class SerializerUtils
 
   private int readInt(InputStream in) throws IOException
   {
-    byte[] intBytes = new byte[Ints.BYTES];
+    byte[] intBytes = new byte[Integer.BYTES];
 
     ByteStreams.readFully(in, intBytes);
 
@@ -188,7 +187,7 @@ public class SerializerUtils
 
   public void writeLong(WritableByteChannel out, long longValue) throws IOException
   {
-    final ByteBuffer buffer = ByteBuffer.allocate(Longs.BYTES);
+    final ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
     buffer.putLong(longValue);
     buffer.flip();
     Channels.writeFully(out, buffer);
@@ -196,7 +195,7 @@ public class SerializerUtils
 
   long readLong(InputStream in) throws IOException
   {
-    byte[] longBytes = new byte[Longs.BYTES];
+    byte[] longBytes = new byte[Long.BYTES];
 
     ByteStreams.readFully(in, longBytes);
 
@@ -231,7 +230,7 @@ public class SerializerUtils
 
   void writeFloat(WritableByteChannel out, float floatValue) throws IOException
   {
-    final ByteBuffer buffer = ByteBuffer.allocate(Floats.BYTES);
+    final ByteBuffer buffer = ByteBuffer.allocate(Float.BYTES);
     buffer.putFloat(floatValue);
     buffer.flip();
     Channels.writeFully(out, buffer);
@@ -265,6 +264,6 @@ public class SerializerUtils
 
   public int getSerializedStringByteSize(String str)
   {
-    return Ints.BYTES + StringUtils.toUtf8(str).length;
+    return Integer.BYTES + StringUtils.toUtf8(str).length;
   }
 }

--- a/extendedset/src/main/java/io/druid/extendedset/intset/ImmutableConciseSet.java
+++ b/extendedset/src/main/java/io/druid/extendedset/intset/ImmutableConciseSet.java
@@ -19,7 +19,6 @@ package io.druid.extendedset.intset;
 
 import com.google.common.collect.Iterators;
 import com.google.common.collect.UnmodifiableIterator;
-import com.google.common.primitives.Ints;
 import io.druid.extendedset.utilities.IntList;
 import org.roaringbitmap.IntIterator;
 
@@ -811,7 +810,7 @@ public class ImmutableConciseSet
     if (words == null) {
       return new byte[]{};
     }
-    ByteBuffer buf = ByteBuffer.allocate(words.capacity() * Ints.BYTES);
+    ByteBuffer buf = ByteBuffer.allocate(words.capacity() * Integer.BYTES);
     buf.asIntBuffer().put(words.asReadOnlyBuffer());
     return buf.array();
   }

--- a/extensions-contrib/distinctcount/src/main/java/io/druid/query/aggregation/distinctcount/DistinctCountAggregatorFactory.java
+++ b/extensions-contrib/distinctcount/src/main/java/io/druid/query/aggregation/distinctcount/DistinctCountAggregatorFactory.java
@@ -199,7 +199,7 @@ public class DistinctCountAggregatorFactory extends AggregatorFactory
   @Override
   public int getMaxIntermediateSize()
   {
-    return Longs.BYTES;
+    return Long.BYTES;
   }
 
   @Override

--- a/extensions-contrib/time-min-max/src/main/java/io/druid/query/aggregation/TimestampAggregatorFactory.java
+++ b/extensions-contrib/time-min-max/src/main/java/io/druid/query/aggregation/TimestampAggregatorFactory.java
@@ -20,7 +20,6 @@
 package io.druid.query.aggregation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.primitives.Longs;
 import io.druid.data.input.impl.TimestampSpec;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.StringUtils;
@@ -207,7 +206,7 @@ public class TimestampAggregatorFactory extends AggregatorFactory
   @Override
   public int getMaxIntermediateSize()
   {
-    return Longs.BYTES;
+    return Long.BYTES;
   }
 
   @Override

--- a/extensions-contrib/time-min-max/src/test/java/io/druid/query/aggregation/TimestampMinMaxAggregatorTest.java
+++ b/extensions-contrib/time-min-max/src/test/java/io/druid/query/aggregation/TimestampMinMaxAggregatorTest.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.primitives.Longs;
 import com.google.inject.Binder;
 import com.google.inject.Injector;
 import com.google.inject.Module;
@@ -148,7 +147,7 @@ public class TimestampMinMaxAggregatorTest
   {
     TimestampBufferAggregator aggregator = (TimestampBufferAggregator) aggregatorFactory.factorizeBuffered(selectorFactory);
 
-    ByteBuffer buffer = ByteBuffer.wrap(new byte[Longs.BYTES]);
+    ByteBuffer buffer = ByteBuffer.wrap(new byte[Long.BYTES]);
     aggregator.init(buffer, 0);
 
     for (Timestamp value : values) {

--- a/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/io/druid/query/aggregation/datasketches/theta/SketchAggregatorFactory.java
@@ -21,7 +21,6 @@ package io.druid.query.aggregation.datasketches.theta;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import com.google.common.primitives.Ints;
 import com.yahoo.sketches.Family;
 import com.yahoo.sketches.Util;
 import com.yahoo.sketches.theta.SetOperation;
@@ -171,7 +170,7 @@ public abstract class SketchAggregatorFactory extends AggregatorFactory
   public byte[] getCacheKey()
   {
     byte[] fieldNameBytes = StringUtils.toUtf8(fieldName);
-    return ByteBuffer.allocate(1 + Ints.BYTES + fieldNameBytes.length)
+    return ByteBuffer.allocate(1 + Integer.BYTES + fieldNameBytes.length)
                      .put(cacheId)
                      .putInt(size)
                      .put(fieldNameBytes)

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogram.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogram.java
@@ -24,9 +24,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.primitives.Floats;
-import com.google.common.primitives.Ints;
-import com.google.common.primitives.Longs;
-import com.google.common.primitives.Shorts;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -1100,12 +1097,12 @@ public class ApproximateHistogram
 
   public int getDenseStorageSize()
   {
-    return Ints.BYTES * 2 + Floats.BYTES * size + Longs.BYTES * size + Floats.BYTES * 2;
+    return Integer.BYTES * 2 + Float.BYTES * size + Long.BYTES * size + Float.BYTES * 2;
   }
 
   public int getSparseStorageSize()
   {
-    return Ints.BYTES * 2 + Floats.BYTES * binCount + Longs.BYTES * binCount + Floats.BYTES * 2;
+    return Integer.BYTES * 2 + Float.BYTES * binCount + Long.BYTES * binCount + Float.BYTES * 2;
   }
 
   public int getCompactStorageSize()
@@ -1115,14 +1112,14 @@ public class ApproximateHistogram
 
     final long exactCount = getExactCount();
     if (exactCount == count) {
-      return Shorts.BYTES + 1 + Floats.BYTES * (int) exactCount;
+      return Short.BYTES + 1 + Float.BYTES * (int) exactCount;
     } else {
-      return Shorts.BYTES
+      return Short.BYTES
              + 1
-             + Floats.BYTES * (int) exactCount
+             + Float.BYTES * (int) exactCount
              + 1
-             + Floats.BYTES * (int) (count - exactCount)
-             + Floats.BYTES * 2;
+             + Float.BYTES * (int) (count - exactCount)
+             + Float.BYTES * 2;
     }
   }
 
@@ -1186,9 +1183,9 @@ public class ApproximateHistogram
     buf.putInt(binCount);
 
     buf.asFloatBuffer().put(positions);
-    buf.position(buf.position() + Floats.BYTES * positions.length);
+    buf.position(buf.position() + Float.BYTES * positions.length);
     buf.asLongBuffer().put(bins);
-    buf.position(buf.position() + Longs.BYTES * bins.length);
+    buf.position(buf.position() + Long.BYTES * bins.length);
 
     buf.putFloat(min);
     buf.putFloat(max);
@@ -1290,9 +1287,9 @@ public class ApproximateHistogram
     long[] bins = new long[size];
 
     buf.asFloatBuffer().get(positions);
-    buf.position(buf.position() + Floats.BYTES * positions.length);
+    buf.position(buf.position() + Float.BYTES * positions.length);
     buf.asLongBuffer().get(bins);
-    buf.position(buf.position() + Longs.BYTES * bins.length);
+    buf.position(buf.position() + Long.BYTES * bins.length);
 
     float min = buf.getFloat();
     float max = buf.getFloat();
@@ -1419,7 +1416,7 @@ public class ApproximateHistogram
       return fromBytesCompact(buf);
     } else {
       // ignore size, determine if sparse or dense based on sign of binCount
-      if (buf.getInt(buf.position() + Ints.BYTES) < 0) {
+      if (buf.getInt(buf.position() + Integer.BYTES) < 0) {
         return fromBytesSparse(buf);
       } else {
         return fromBytesDense(buf);

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
@@ -24,8 +24,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Preconditions;
-import com.google.common.primitives.Floats;
-import com.google.common.primitives.Ints;
 import io.druid.java.util.common.StringUtils;
 import io.druid.query.aggregation.AggregateCombiner;
 import io.druid.query.aggregation.Aggregator;
@@ -271,7 +269,7 @@ public class ApproximateHistogramAggregatorFactory extends AggregatorFactory
   public byte[] getCacheKey()
   {
     byte[] fieldNameBytes = StringUtils.toUtf8(fieldName);
-    return ByteBuffer.allocate(1 + fieldNameBytes.length + Ints.BYTES * 2 + Floats.BYTES * 2)
+    return ByteBuffer.allocate(1 + fieldNameBytes.length + Integer.BYTES * 2 + Float.BYTES * 2)
                      .put(AggregatorUtil.APPROX_HIST_CACHE_TYPE_ID)
                      .put(fieldNameBytes)
                      .putInt(resolution)

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregatorFactory.java
@@ -22,8 +22,6 @@ package io.druid.query.aggregation.histogram;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.google.common.primitives.Floats;
-import com.google.common.primitives.Ints;
 import io.druid.java.util.common.IAE;
 import io.druid.java.util.common.StringUtils;
 import io.druid.query.aggregation.Aggregator;
@@ -103,7 +101,7 @@ public class ApproximateHistogramFoldingAggregatorFactory extends ApproximateHis
   public byte[] getCacheKey()
   {
     byte[] fieldNameBytes = StringUtils.toUtf8(fieldName);
-    return ByteBuffer.allocate(1 + fieldNameBytes.length + Ints.BYTES * 2 + Floats.BYTES * 2)
+    return ByteBuffer.allocate(1 + fieldNameBytes.length + Integer.BYTES * 2 + Float.BYTES * 2)
                      .put(AggregatorUtil.APPROX_HIST_FOLDING_CACHE_TYPE_ID)
                      .put(fieldNameBytes)
                      .putInt(resolution)

--- a/extensions-core/kafka-extraction-namespace/src/main/java/io/druid/query/lookup/KafkaLookupExtractorFactory.java
+++ b/extensions-core/kafka-extraction-namespace/src/main/java/io/druid/query/lookup/KafkaLookupExtractorFactory.java
@@ -25,16 +25,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
-import com.google.common.primitives.Longs;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
-import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.IAE;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.StringUtils;
+import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.query.extraction.MapLookupExtractor;
 import io.druid.server.lookup.namespace.cache.CacheHandler;
@@ -367,7 +366,7 @@ public class KafkaLookupExtractorFactory implements LookupExtractorFactory
         // If the number of things added has not changed during the course of this extractor's life, we can cache it
         if (startCount == doubleEventCount.get()) {
           return ByteBuffer
-              .allocate(idutf8.length + 1 + Longs.BYTES)
+              .allocate(idutf8.length + 1 + Long.BYTES)
               .put(idutf8)
               .put((byte) 0xFF)
               .putLong(startCount)

--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIndexTask.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIndexTask.java
@@ -37,14 +37,12 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
-import io.druid.java.util.emitter.EmittingLogger;
 import io.druid.data.input.Committer;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.impl.InputRowParser;
@@ -71,6 +69,7 @@ import io.druid.java.util.common.collect.Utils;
 import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.parsers.ParseException;
+import io.druid.java.util.emitter.EmittingLogger;
 import io.druid.query.DruidMetrics;
 import io.druid.query.NoopQueryRunner;
 import io.druid.query.Query;
@@ -301,7 +300,7 @@ public class KafkaIndexTask extends AbstractTask implements ChatHandler
   private static String makeTaskId(String dataSource, int randomBits)
   {
     final StringBuilder suffix = new StringBuilder(8);
-    for (int i = 0; i < Ints.BYTES * 2; ++i) {
+    for (int i = 0; i < Integer.BYTES * 2; ++i) {
       suffix.append((char) ('a' + ((randomBits >>> (i * 4)) & 0x0F)));
     }
     return Joiner.on("_").join(TYPE, dataSource, suffix);

--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisor.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisor.java
@@ -36,18 +36,14 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
-import io.druid.java.util.emitter.EmittingLogger;
-import io.druid.java.util.emitter.service.ServiceEmitter;
-import io.druid.java.util.emitter.service.ServiceMetricEvent;
-import io.druid.indexing.common.TaskInfoProvider;
 import io.druid.indexer.TaskLocation;
+import io.druid.indexing.common.TaskInfoProvider;
 import io.druid.indexing.common.TaskStatus;
 import io.druid.indexing.common.task.Task;
 import io.druid.indexing.common.task.TaskResource;
@@ -74,6 +70,9 @@ import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.Pair;
 import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.concurrent.Execs;
+import io.druid.java.util.emitter.EmittingLogger;
+import io.druid.java.util.emitter.service.ServiceEmitter;
+import io.druid.java.util.emitter.service.ServiceMetricEvent;
 import io.druid.metadata.EntryExistsException;
 import io.druid.server.metrics.DruidMonitorSchedulerConfig;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -879,7 +878,7 @@ public class KafkaSupervisor implements Supervisor
   private static String getRandomId()
   {
     final StringBuilder suffix = new StringBuilder(8);
-    for (int i = 0; i < Ints.BYTES * 2; ++i) {
+    for (int i = 0; i < Integer.BYTES * 2; ++i) {
       suffix.append((char) ('a' + ((RANDOM.nextInt() >>> (i * 4)) & 0x0F)));
     }
     return suffix.toString();

--- a/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/cache/OnHeapNamespaceExtractionCacheManager.java
+++ b/extensions-core/lookups-cached-global/src/main/java/io/druid/server/lookup/namespace/cache/OnHeapNamespaceExtractionCacheManager.java
@@ -19,13 +19,12 @@
 
 package io.druid.server.lookup.namespace.cache;
 
-import com.google.common.primitives.Chars;
 import com.google.inject.Inject;
-import io.druid.java.util.emitter.service.ServiceEmitter;
-import io.druid.java.util.emitter.service.ServiceMetricEvent;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.lifecycle.Lifecycle;
 import io.druid.java.util.common.logger.Logger;
+import io.druid.java.util.emitter.service.ServiceEmitter;
+import io.druid.java.util.emitter.service.ServiceMetricEvent;
 import io.druid.server.lookup.namespace.NamespaceExtractionConfig;
 
 import java.lang.ref.WeakReference;
@@ -131,6 +130,6 @@ public class OnHeapNamespaceExtractionCacheManager extends NamespaceExtractionCa
       }
     }
     serviceEmitter.emit(ServiceMetricEvent.builder().build("namespace/cache/numEntries", numEntries));
-    serviceEmitter.emit(ServiceMetricEvent.builder().build("namespace/cache/heapSizeInBytes", size * Chars.BYTES));
+    serviceEmitter.emit(ServiceMetricEvent.builder().build("namespace/cache/heapSizeInBytes", size * Character.BYTES));
   }
 }

--- a/extensions-core/stats/src/main/java/io/druid/query/aggregation/variance/VarianceAggregatorCollector.java
+++ b/extensions-core/stats/src/main/java/io/druid/query/aggregation/variance/VarianceAggregatorCollector.java
@@ -102,7 +102,7 @@ public class VarianceAggregatorCollector
 
   static int getMaxIntermediateSize()
   {
-    return Longs.BYTES + Doubles.BYTES + Doubles.BYTES;
+    return Long.BYTES + Double.BYTES + Double.BYTES;
   }
 
   long count; // number of elements
@@ -182,7 +182,7 @@ public class VarianceAggregatorCollector
 
   public ByteBuffer toByteBuffer()
   {
-    return ByteBuffer.allocate(Longs.BYTES + Doubles.BYTES + Doubles.BYTES)
+    return ByteBuffer.allocate(Long.BYTES + Double.BYTES + Double.BYTES)
                      .putLong(count)
                      .putDouble(sum)
                      .putDouble(nvariance);

--- a/extensions-core/stats/src/main/java/io/druid/query/aggregation/variance/VarianceBufferAggregator.java
+++ b/extensions-core/stats/src/main/java/io/druid/query/aggregation/variance/VarianceBufferAggregator.java
@@ -20,8 +20,6 @@
 package io.druid.query.aggregation.variance;
 
 import com.google.common.base.Preconditions;
-import com.google.common.primitives.Doubles;
-import com.google.common.primitives.Longs;
 import io.druid.query.aggregation.BufferAggregator;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.BaseFloatColumnValueSelector;
@@ -35,8 +33,8 @@ import java.nio.ByteBuffer;
 public abstract class VarianceBufferAggregator implements BufferAggregator
 {
   private static final int COUNT_OFFSET = 0;
-  private static final int SUM_OFFSET = Longs.BYTES;
-  private static final int NVARIANCE_OFFSET = SUM_OFFSET + Doubles.BYTES;
+  private static final int SUM_OFFSET = Long.BYTES;
+  private static final int NVARIANCE_OFFSET = SUM_OFFSET + Double.BYTES;
 
   @Override
   public void init(final ByteBuffer buf, final int position)

--- a/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
@@ -28,7 +28,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
-import com.google.common.primitives.Longs;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
@@ -322,7 +321,7 @@ public class IndexGeneratorJob implements Jobby
           new SortableBytes(
               bucket.get().toGroupKey(),
               // sort rows by truncated timestamp and hashed dimensions to help reduce spilling on the reducer side
-              ByteBuffer.allocate(Longs.BYTES + hashedDimensions.length)
+              ByteBuffer.allocate(Long.BYTES + hashedDimensions.length)
                         .putLong(truncatedTimestamp)
                         .put(hashedDimensions)
                         .array()

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTask.java
@@ -26,7 +26,6 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.primitives.Ints;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.druid.data.input.Committer;
@@ -94,7 +93,7 @@ public class AppenderatorDriverRealtimeIndexTask extends AbstractTask
   private static String makeTaskId(RealtimeAppenderatorIngestionSpec spec)
   {
     final StringBuilder suffix = new StringBuilder(8);
-    for (int i = 0; i < Ints.BYTES * 2; ++i) {
+    for (int i = 0; i < Integer.BYTES * 2; ++i) {
       suffix.append((char) ('a' + ((random.nextInt() >>> (i * 4)) & 0x0F)));
     }
     return StringUtils.format(

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/RealtimeIndexTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/RealtimeIndexTask.java
@@ -27,7 +27,6 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.primitives.Ints;
 import io.druid.data.input.Committer;
 import io.druid.data.input.Firehose;
 import io.druid.data.input.FirehoseFactory;
@@ -102,7 +101,7 @@ public class RealtimeIndexTask extends AbstractTask
   static String makeTaskId(String dataSource, int partitionNumber, DateTime timestamp, int randomBits)
   {
     final StringBuilder suffix = new StringBuilder(8);
-    for (int i = 0; i < Ints.BYTES * 2; ++i) {
+    for (int i = 0; i < Integer.BYTES * 2; ++i) {
       suffix.append((char) ('a' + ((randomBits >>> (i * 4)) & 0x0F)));
     }
     return StringUtils.format(

--- a/java-util/src/main/java/io/druid/java/util/common/granularity/DurationGranularity.java
+++ b/java-util/src/main/java/io/druid/java/util/common/granularity/DurationGranularity.java
@@ -22,7 +22,6 @@ package io.druid.java.util.common.granularity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import com.google.common.primitives.Longs;
 import io.druid.java.util.common.DateTimes;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
@@ -109,7 +108,7 @@ public class DurationGranularity extends Granularity
   @Override
   public byte[] getCacheKey()
   {
-    return ByteBuffer.allocate(2 * Longs.BYTES).putLong(duration).putLong(origin).array();
+    return ByteBuffer.allocate(2 * Long.BYTES).putLong(duration).putLong(origin).array();
   }
 
   public long getDurationMillis()

--- a/processing/src/main/java/io/druid/collections/bitmap/WrappedConciseBitmap.java
+++ b/processing/src/main/java/io/druid/collections/bitmap/WrappedConciseBitmap.java
@@ -19,7 +19,6 @@
 
 package io.druid.collections.bitmap;
 
-import com.google.common.primitives.Ints;
 import io.druid.extendedset.intset.ConciseSet;
 import io.druid.extendedset.intset.ImmutableConciseSet;
 import org.roaringbitmap.IntIterator;
@@ -77,7 +76,7 @@ public class WrappedConciseBitmap implements MutableBitmap
   @Override
   public int getSizeInBytes()
   {
-    return bitmap.getWords().length * Ints.BYTES;
+    return bitmap.getWords().length * Integer.BYTES;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/collections/spatial/ImmutableNode.java
+++ b/processing/src/main/java/io/druid/collections/spatial/ImmutableNode.java
@@ -19,8 +19,6 @@
 
 package io.druid.collections.spatial;
 
-import com.google.common.primitives.Floats;
-import com.google.common.primitives.Ints;
 import io.druid.collections.bitmap.BitmapFactory;
 import io.druid.collections.bitmap.ImmutableBitmap;
 
@@ -32,8 +30,8 @@ import java.util.Iterator;
  * Header
  * 0 to 1 : the MSB is a boolean flag for isLeaf, the next 15 bits represent the number of children of a node
  * Body
- * 2 to 2 + numDims * Floats.BYTES : minCoordinates
- * 2 + numDims * Floats.BYTES to 2 + 2 * numDims * Floats.BYTES : maxCoordinates
+ * 2 to 2 + numDims * Float.BYTES : minCoordinates
+ * 2 + numDims * Float.BYTES to 2 + 2 * numDims * Float.BYTES : maxCoordinates
  * concise set
  * rest (children) : Every 4 bytes is storing an offset representing the position of a child.
  *
@@ -70,13 +68,13 @@ public class ImmutableNode
     short header = data.getShort(initialOffset + offsetFromInitial);
     this.isLeaf = (header & 0x8000) != 0;
     this.numChildren = (short) (header & 0x7FFF);
-    final int sizePosition = initialOffset + offsetFromInitial + HEADER_NUM_BYTES + 2 * numDims * Floats.BYTES;
+    final int sizePosition = initialOffset + offsetFromInitial + HEADER_NUM_BYTES + 2 * numDims * Float.BYTES;
     int bitmapSize = data.getInt(sizePosition);
     this.childrenOffset = initialOffset
                           + offsetFromInitial
                           + HEADER_NUM_BYTES
-                          + 2 * numDims * Floats.BYTES
-                          + Ints.BYTES
+                          + 2 * numDims * Float.BYTES
+                          + Integer.BYTES
                           + bitmapSize;
 
     this.data = data;
@@ -98,13 +96,13 @@ public class ImmutableNode
     this.offsetFromInitial = offsetFromInitial;
     this.numChildren = numChildren;
     this.isLeaf = leaf;
-    final int sizePosition = initialOffset + offsetFromInitial + HEADER_NUM_BYTES + 2 * numDims * Floats.BYTES;
+    final int sizePosition = initialOffset + offsetFromInitial + HEADER_NUM_BYTES + 2 * numDims * Float.BYTES;
     int bitmapSize = data.getInt(sizePosition);
     this.childrenOffset = initialOffset
                           + offsetFromInitial
                           + HEADER_NUM_BYTES
-                          + 2 * numDims * Floats.BYTES
-                          + Ints.BYTES
+                          + 2 * numDims * Float.BYTES
+                          + Integer.BYTES
                           + bitmapSize;
 
     this.data = data;
@@ -142,14 +140,14 @@ public class ImmutableNode
 
   public float[] getMaxCoordinates()
   {
-    return getCoords(initialOffset + offsetFromInitial + HEADER_NUM_BYTES + numDims * Floats.BYTES);
+    return getCoords(initialOffset + offsetFromInitial + HEADER_NUM_BYTES + numDims * Float.BYTES);
   }
 
   public ImmutableBitmap getImmutableBitmap()
   {
-    final int sizePosition = initialOffset + offsetFromInitial + HEADER_NUM_BYTES + 2 * numDims * Floats.BYTES;
+    final int sizePosition = initialOffset + offsetFromInitial + HEADER_NUM_BYTES + 2 * numDims * Float.BYTES;
     int numBytes = data.getInt(sizePosition);
-    data.position(sizePosition + Ints.BYTES);
+    data.position(sizePosition + Integer.BYTES);
     ByteBuffer tmpBuffer = data.slice();
     tmpBuffer.limit(numBytes);
     return bitmapFactory.mapImmutableBitmap(tmpBuffer.asReadOnlyBuffer());
@@ -180,7 +178,7 @@ public class ImmutableNode
               return new ImmutablePoint(
                   numDims,
                   initialOffset,
-                  data.getInt(childrenOffset + (count++) * Ints.BYTES),
+                  data.getInt(childrenOffset + (count++) * Integer.BYTES),
                   data,
                   bitmapFactory
               );
@@ -188,7 +186,7 @@ public class ImmutableNode
             return new ImmutableNode(
                 numDims,
                 initialOffset,
-                data.getInt(childrenOffset + (count++) * Ints.BYTES),
+                data.getInt(childrenOffset + (count++) * Integer.BYTES),
                 data,
                 bitmapFactory
             );

--- a/processing/src/main/java/io/druid/collections/spatial/ImmutableRTree.java
+++ b/processing/src/main/java/io/druid/collections/spatial/ImmutableRTree.java
@@ -21,7 +21,6 @@ package io.druid.collections.spatial;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.primitives.Ints;
 import io.druid.collections.bitmap.BitmapFactory;
 import io.druid.collections.bitmap.ImmutableBitmap;
 import io.druid.collections.spatial.search.Bound;
@@ -67,7 +66,7 @@ public final class ImmutableRTree
     Preconditions.checkArgument(data.get(initPosition) == VERSION, "Mismatching versions");
     this.numDims = data.getInt(1 + initPosition) & 0x7FFF;
     this.data = data;
-    this.root = new ImmutableNode(numDims, initPosition, 1 + Ints.BYTES, data, bitmapFactory);
+    this.root = new ImmutableNode(numDims, initPosition, 1 + Integer.BYTES, data, bitmapFactory);
   }
 
   public static ImmutableRTree newImmutableFromMutable(RTree rTree)
@@ -87,7 +86,7 @@ public final class ImmutableRTree
 
   private static int calcNumBytes(RTree tree)
   {
-    int total = 1 + Ints.BYTES; // VERSION and numDims
+    int total = 1 + Integer.BYTES; // VERSION and numDims
 
     total += calcNodeBytes(tree.getRoot());
 

--- a/processing/src/main/java/io/druid/collections/spatial/Node.java
+++ b/processing/src/main/java/io/druid/collections/spatial/Node.java
@@ -21,8 +21,6 @@ package io.druid.collections.spatial;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.google.common.primitives.Floats;
-import com.google.common.primitives.Ints;
 import io.druid.collections.bitmap.BitmapFactory;
 import io.druid.collections.bitmap.MutableBitmap;
 
@@ -181,10 +179,10 @@ public class Node
   public int getSizeInBytes()
   {
     return ImmutableNode.HEADER_NUM_BYTES
-           + 2 * getNumDims() * Floats.BYTES
-           + Ints.BYTES // size of the set
+           + 2 * getNumDims() * Float.BYTES
+           + Integer.BYTES // size of the set
            + bitmap.getSizeInBytes()
-           + getChildren().size() * Ints.BYTES;
+           + getChildren().size() * Integer.BYTES;
   }
 
   public int storeInByteBuffer(ByteBuffer buffer, int position)
@@ -202,11 +200,11 @@ public class Node
     buffer.put(bytes);
 
     int pos = buffer.position();
-    int childStartOffset = pos + getChildren().size() * Ints.BYTES;
+    int childStartOffset = pos + getChildren().size() * Integer.BYTES;
     for (Node child : getChildren()) {
       buffer.putInt(pos, childStartOffset);
       childStartOffset = child.storeInByteBuffer(buffer, childStartOffset);
-      pos += Ints.BYTES;
+      pos += Integer.BYTES;
     }
 
     return childStartOffset;

--- a/processing/src/main/java/io/druid/collections/spatial/search/PolygonBound.java
+++ b/processing/src/main/java/io/druid/collections/spatial/search/PolygonBound.java
@@ -24,8 +24,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
-import com.google.common.primitives.Floats;
-import com.google.common.primitives.Ints;
 import io.druid.collections.spatial.ImmutablePoint;
 
 import java.nio.ByteBuffer;
@@ -180,16 +178,16 @@ public class PolygonBound extends RectangularBound
   @Override
   public byte[] getCacheKey()
   {
-    ByteBuffer abscissaBuffer = ByteBuffer.allocate(abscissa.length * Floats.BYTES);
+    ByteBuffer abscissaBuffer = ByteBuffer.allocate(abscissa.length * Float.BYTES);
     abscissaBuffer.asFloatBuffer().put(abscissa);
     final byte[] abscissaCacheKey = abscissaBuffer.array();
 
-    ByteBuffer ordinateBuffer = ByteBuffer.allocate(ordinate.length * Floats.BYTES);
+    ByteBuffer ordinateBuffer = ByteBuffer.allocate(ordinate.length * Float.BYTES);
     ordinateBuffer.asFloatBuffer().put(ordinate);
     final byte[] ordinateCacheKey = ordinateBuffer.array();
 
     final ByteBuffer cacheKey = ByteBuffer
-        .allocate(1 + abscissaCacheKey.length + ordinateCacheKey.length + Ints.BYTES)
+        .allocate(1 + abscissaCacheKey.length + ordinateCacheKey.length + Integer.BYTES)
         .put(abscissaCacheKey)
         .put(ordinateCacheKey)
         .putInt(getLimit())

--- a/processing/src/main/java/io/druid/collections/spatial/search/RadiusBound.java
+++ b/processing/src/main/java/io/druid/collections/spatial/search/RadiusBound.java
@@ -23,8 +23,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
-import com.google.common.primitives.Floats;
-import com.google.common.primitives.Ints;
 import io.druid.collections.spatial.ImmutablePoint;
 
 import java.nio.ByteBuffer;
@@ -118,11 +116,11 @@ public class RadiusBound extends RectangularBound
   @Override
   public byte[] getCacheKey()
   {
-    final ByteBuffer minCoordsBuffer = ByteBuffer.allocate(coords.length * Floats.BYTES);
+    final ByteBuffer minCoordsBuffer = ByteBuffer.allocate(coords.length * Float.BYTES);
     minCoordsBuffer.asFloatBuffer().put(coords);
     final byte[] minCoordsCacheKey = minCoordsBuffer.array();
     final ByteBuffer cacheKey = ByteBuffer
-        .allocate(1 + minCoordsCacheKey.length + Ints.BYTES + Floats.BYTES)
+        .allocate(1 + minCoordsCacheKey.length + Integer.BYTES + Float.BYTES)
         .put(minCoordsCacheKey)
         .putFloat(radius)
         .putInt(getLimit())

--- a/processing/src/main/java/io/druid/collections/spatial/search/RectangularBound.java
+++ b/processing/src/main/java/io/druid/collections/spatial/search/RectangularBound.java
@@ -24,8 +24,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
-import com.google.common.primitives.Floats;
-import com.google.common.primitives.Ints;
 import io.druid.collections.spatial.ImmutableNode;
 import io.druid.collections.spatial.ImmutablePoint;
 
@@ -137,16 +135,16 @@ public class RectangularBound implements Bound
   @Override
   public byte[] getCacheKey()
   {
-    ByteBuffer minCoordsBuffer = ByteBuffer.allocate(minCoords.length * Floats.BYTES);
+    ByteBuffer minCoordsBuffer = ByteBuffer.allocate(minCoords.length * Float.BYTES);
     minCoordsBuffer.asFloatBuffer().put(minCoords);
     final byte[] minCoordsCacheKey = minCoordsBuffer.array();
 
-    ByteBuffer maxCoordsBuffer = ByteBuffer.allocate(maxCoords.length * Floats.BYTES);
+    ByteBuffer maxCoordsBuffer = ByteBuffer.allocate(maxCoords.length * Float.BYTES);
     maxCoordsBuffer.asFloatBuffer().put(maxCoords);
     final byte[] maxCoordsCacheKey = maxCoordsBuffer.array();
 
     final ByteBuffer cacheKey = ByteBuffer
-        .allocate(1 + minCoordsCacheKey.length + maxCoordsCacheKey.length + Ints.BYTES)
+        .allocate(1 + minCoordsCacheKey.length + maxCoordsCacheKey.length + Integer.BYTES)
         .put(minCoordsCacheKey)
         .put(maxCoordsCacheKey)
         .putInt(limit)

--- a/processing/src/main/java/io/druid/query/aggregation/CountAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/CountAggregatorFactory.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.primitives.Longs;
 import io.druid.segment.ColumnSelectorFactory;
 
 import java.util.Arrays;
@@ -128,7 +127,7 @@ public class CountAggregatorFactory extends AggregatorFactory
   @Override
   public int getMaxIntermediateSize()
   {
-    return Longs.BYTES;
+    return Long.BYTES;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/Histogram.java
+++ b/processing/src/main/java/io/druid/query/aggregation/Histogram.java
@@ -21,9 +21,6 @@ package io.druid.query.aggregation;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.base.Preconditions;
-import com.google.common.primitives.Floats;
-import com.google.common.primitives.Ints;
-import com.google.common.primitives.Longs;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -158,7 +155,7 @@ public class Histogram
   public byte[] toBytes()
   {
     ByteBuffer buf = ByteBuffer.allocate(
-        Ints.BYTES + Floats.BYTES * breaks.length + Longs.BYTES * bins.length + Floats.BYTES * 2
+        Integer.BYTES + Float.BYTES * breaks.length + Long.BYTES * bins.length + Float.BYTES * 2
     );
 
     buf.putInt(breaks.length);

--- a/processing/src/main/java/io/druid/query/aggregation/HistogramAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/HistogramAggregatorFactory.java
@@ -23,8 +23,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.google.common.primitives.Floats;
-import com.google.common.primitives.Longs;
 import io.druid.java.util.common.StringUtils;
 import io.druid.segment.ColumnSelectorFactory;
 import io.druid.segment.ColumnValueSelector;
@@ -191,7 +189,7 @@ public class HistogramAggregatorFactory extends AggregatorFactory
   {
     byte[] fieldNameBytes = StringUtils.toUtf8(fieldName);
     ByteBuffer buf = ByteBuffer
-        .allocate(1 + fieldNameBytes.length + Floats.BYTES * breaks.length)
+        .allocate(1 + fieldNameBytes.length + Float.BYTES * breaks.length)
         .put(AggregatorUtil.HIST_CACHE_TYPE_ID)
         .put(fieldNameBytes)
         .put((byte) 0xFF);
@@ -209,7 +207,7 @@ public class HistogramAggregatorFactory extends AggregatorFactory
   @Override
   public int getMaxIntermediateSize()
   {
-    return Longs.BYTES * (breaks.length + 1) + Floats.BYTES * 2;
+    return Long.BYTES * (breaks.length + 1) + Float.BYTES * 2;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/HistogramBufferAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/HistogramBufferAggregator.java
@@ -19,8 +19,6 @@
 
 package io.druid.query.aggregation;
 
-import com.google.common.primitives.Floats;
-import com.google.common.primitives.Longs;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.BaseFloatColumnValueSelector;
 
@@ -38,8 +36,8 @@ public class HistogramBufferAggregator implements BufferAggregator
   {
     this.selector = selector;
     this.breaks = breaks;
-    this.minOffset = Longs.BYTES * (breaks.length + 1);
-    this.maxOffset = this.minOffset + Floats.BYTES;
+    this.minOffset = Long.BYTES * (breaks.length + 1);
+    this.maxOffset = this.minOffset + Float.BYTES;
   }
 
   @Override
@@ -71,7 +69,7 @@ public class HistogramBufferAggregator implements BufferAggregator
     int index = Arrays.binarySearch(breaks, value);
     index = (index >= 0) ? index : -(index + 1);
 
-    final int offset = position + (index * Longs.BYTES);
+    final int offset = position + (index * Long.BYTES);
     final long count = buf.getLong(offset);
     buf.putLong(offset, count + 1);
   }

--- a/processing/src/main/java/io/druid/query/aggregation/JavaScriptAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/JavaScriptAggregatorFactory.java
@@ -27,7 +27,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.primitives.Doubles;
 import io.druid.java.util.common.StringUtils;
 import io.druid.js.JavaScriptConfig;
 import io.druid.segment.BaseObjectColumnValueSelector;
@@ -263,7 +262,7 @@ public class JavaScriptAggregatorFactory extends AggregatorFactory
   @Override
   public int getMaxIntermediateSize()
   {
-    return Doubles.BYTES;
+    return Double.BYTES;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/LongMaxAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/LongMaxAggregatorFactory.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import com.google.common.primitives.Longs;
 import io.druid.java.util.common.StringUtils;
 import io.druid.math.expr.ExprMacroTable;
 import io.druid.math.expr.Parser;
@@ -218,7 +217,7 @@ public class LongMaxAggregatorFactory extends AggregatorFactory
   @Override
   public int getMaxIntermediateSize()
   {
-    return Longs.BYTES;
+    return Long.BYTES;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/LongMinAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/LongMinAggregatorFactory.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import com.google.common.primitives.Longs;
 import io.druid.java.util.common.StringUtils;
 import io.druid.math.expr.ExprMacroTable;
 import io.druid.math.expr.Parser;
@@ -219,7 +218,7 @@ public class LongMinAggregatorFactory extends AggregatorFactory
   @Override
   public int getMaxIntermediateSize()
   {
-    return Longs.BYTES;
+    return Long.BYTES;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/LongSumAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/LongSumAggregatorFactory.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import com.google.common.primitives.Longs;
 import io.druid.java.util.common.StringUtils;
 import io.druid.math.expr.ExprMacroTable;
 import io.druid.math.expr.Parser;
@@ -196,7 +195,7 @@ public class LongSumAggregatorFactory extends AggregatorFactory
   @Override
   public int getMaxIntermediateSize()
   {
-    return Longs.BYTES;
+    return Long.BYTES;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/aggregation/first/DoubleFirstAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/first/DoubleFirstAggregatorFactory.java
@@ -24,8 +24,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Longs;
-import io.druid.java.util.common.StringUtils;
 import io.druid.collections.SerializablePair;
+import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.UOE;
 import io.druid.query.aggregation.AggregateCombiner;
 import io.druid.query.aggregation.Aggregator;
@@ -146,7 +146,7 @@ public class DoubleFirstAggregatorFactory extends AggregatorFactory
             long firstTime = buf.getLong(position);
             if (pair.lhs < firstTime) {
               buf.putLong(position, pair.lhs);
-              buf.putDouble(position + Longs.BYTES, pair.rhs);
+              buf.putDouble(position + Long.BYTES, pair.rhs);
             }
           }
 

--- a/processing/src/main/java/io/druid/query/aggregation/first/FloatFirstAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/first/FloatFirstAggregatorFactory.java
@@ -24,8 +24,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Longs;
-import io.druid.java.util.common.StringUtils;
 import io.druid.collections.SerializablePair;
+import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.UOE;
 import io.druid.query.aggregation.AggregateCombiner;
 import io.druid.query.aggregation.Aggregator;
@@ -144,7 +144,7 @@ public class FloatFirstAggregatorFactory extends AggregatorFactory
             long firstTime = buf.getLong(position);
             if (pair.lhs < firstTime) {
               buf.putLong(position, pair.lhs);
-              buf.putFloat(position + Longs.BYTES, pair.rhs);
+              buf.putFloat(position + Long.BYTES, pair.rhs);
             }
           }
 

--- a/processing/src/main/java/io/druid/query/aggregation/first/LongFirstBufferAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/first/LongFirstBufferAggregator.java
@@ -19,7 +19,6 @@
 
 package io.druid.query.aggregation.first;
 
-import com.google.common.primitives.Longs;
 import io.druid.collections.SerializablePair;
 import io.druid.query.aggregation.BufferAggregator;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
@@ -42,7 +41,7 @@ public class LongFirstBufferAggregator implements BufferAggregator
   public void init(ByteBuffer buf, int position)
   {
     buf.putLong(position, Long.MAX_VALUE);
-    buf.putLong(position + Longs.BYTES, 0);
+    buf.putLong(position + Long.BYTES, 0);
   }
 
   @Override
@@ -52,7 +51,7 @@ public class LongFirstBufferAggregator implements BufferAggregator
     long firstTime = buf.getLong(position);
     if (time < firstTime) {
       buf.putLong(position, time);
-      buf.putLong(position + Longs.BYTES, valueSelector.getLong());
+      buf.putLong(position + Long.BYTES, valueSelector.getLong());
     }
   }
 

--- a/processing/src/main/java/io/druid/query/aggregation/last/DoubleLastAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/last/DoubleLastAggregatorFactory.java
@@ -22,9 +22,8 @@ package io.druid.query.aggregation.last;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import com.google.common.primitives.Longs;
-import io.druid.java.util.common.StringUtils;
 import io.druid.collections.SerializablePair;
+import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.UOE;
 import io.druid.query.aggregation.AggregateCombiner;
 import io.druid.query.aggregation.Aggregator;
@@ -137,7 +136,7 @@ public class DoubleLastAggregatorFactory extends AggregatorFactory
             long lastTime = buf.getLong(position);
             if (pair.lhs >= lastTime) {
               buf.putLong(position, pair.lhs);
-              buf.putDouble(position + Longs.BYTES, pair.rhs);
+              buf.putDouble(position + Long.BYTES, pair.rhs);
             }
           }
 

--- a/processing/src/main/java/io/druid/query/aggregation/last/FloatLastAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/last/FloatLastAggregatorFactory.java
@@ -22,9 +22,8 @@ package io.druid.query.aggregation.last;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import com.google.common.primitives.Longs;
-import io.druid.java.util.common.StringUtils;
 import io.druid.collections.SerializablePair;
+import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.UOE;
 import io.druid.query.aggregation.AggregateCombiner;
 import io.druid.query.aggregation.Aggregator;
@@ -135,7 +134,7 @@ public class FloatLastAggregatorFactory extends AggregatorFactory
             long lastTime = buf.getLong(position);
             if (pair.lhs >= lastTime) {
               buf.putLong(position, pair.lhs);
-              buf.putFloat(position + Longs.BYTES, pair.rhs);
+              buf.putFloat(position + Long.BYTES, pair.rhs);
             }
           }
 

--- a/processing/src/main/java/io/druid/query/cache/CacheKeyBuilder.java
+++ b/processing/src/main/java/io/druid/query/cache/CacheKeyBuilder.java
@@ -22,13 +22,11 @@ package io.druid.query.cache;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.google.common.primitives.Doubles;
-import com.google.common.primitives.Floats;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.UnsignedBytes;
 import io.druid.guice.annotations.PublicApi;
-import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.Cacheable;
+import io.druid.java.util.common.StringUtils;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
@@ -88,7 +86,7 @@ public class CacheKeyBuilder
 
   private static byte[] floatArrayToByteArray(float[] input)
   {
-    final ByteBuffer buffer = ByteBuffer.allocate(Floats.BYTES * input.length);
+    final ByteBuffer buffer = ByteBuffer.allocate(Float.BYTES * input.length);
     buffer.asFloatBuffer().put(input);
     return buffer.array();
   }
@@ -160,7 +158,7 @@ public class CacheKeyBuilder
       }
 
       final Iterator<byte[]> iterator = byteArrayList.iterator();
-      final int bufSize = Ints.BYTES + separator.length * (byteArrayList.size() - 1) + totalByteLength;
+      final int bufSize = Integer.BYTES + separator.length * (byteArrayList.size() - 1) + totalByteLength;
       final ByteBuffer buffer = ByteBuffer.allocate(bufSize)
                                           .putInt(byteArrayList.size())
                                           .put(iterator.next());
@@ -245,13 +243,13 @@ public class CacheKeyBuilder
 
   public CacheKeyBuilder appendFloat(float input)
   {
-    appendItem(FLOAT_KEY, ByteBuffer.allocate(Floats.BYTES).putFloat(input).array());
+    appendItem(FLOAT_KEY, ByteBuffer.allocate(Float.BYTES).putFloat(input).array());
     return this;
   }
 
   public CacheKeyBuilder appendDouble(double input)
   {
-    appendItem(DOUBLE_KEY, ByteBuffer.allocate(Doubles.BYTES).putDouble(input).array());
+    appendItem(DOUBLE_KEY, ByteBuffer.allocate(Double.BYTES).putDouble(input).array());
     return this;
   }
 

--- a/processing/src/main/java/io/druid/query/extraction/BucketExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/BucketExtractionFn.java
@@ -21,7 +21,6 @@ package io.druid.query.extraction;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.primitives.Doubles;
 import io.druid.java.util.common.StringUtils;
 
 import javax.annotation.Nullable;
@@ -114,7 +113,7 @@ public class BucketExtractionFn implements ExtractionFn
   @Override
   public byte[] getCacheKey()
   {
-    return ByteBuffer.allocate(1 + 2 * Doubles.BYTES)
+    return ByteBuffer.allocate(1 + 2 * Double.BYTES)
                      .put(ExtractionCacheHelper.CACHE_TYPE_ID_BUCKET)
                      .putDouble(size)
                      .putDouble(offset)

--- a/processing/src/main/java/io/druid/query/filter/IntervalDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/IntervalDimFilter.java
@@ -85,7 +85,7 @@ public class IntervalDimFilter implements DimFilter
     byte[] dimensionBytes = StringUtils.toUtf8(dimension);
 
     byte[] extractionFnBytes = extractionFn == null ? new byte[0] : extractionFn.getCacheKey();
-    int intervalsBytesSize = intervalLongs.size() * Longs.BYTES * 2 + intervalLongs.size();
+    int intervalsBytesSize = intervalLongs.size() * Long.BYTES * 2 + intervalLongs.size();
 
     ByteBuffer filterCacheKey = ByteBuffer.allocate(3
                                                     + dimensionBytes.length

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryEngine.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryEngine.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.primitives.Ints;
 import com.google.inject.Inject;
 import io.druid.collections.NonBlockingPool;
 import io.druid.collections.ResourceHolder;
@@ -385,7 +384,7 @@ public class GroupByQueryEngine
         cursor.advance();
       }
       while (!cursor.isDone() && rowUpdater.getNumRows() < maxIntermediateRows) {
-        ByteBuffer key = ByteBuffer.allocate(dimensions.size() * Ints.BYTES);
+        ByteBuffer key = ByteBuffer.allocate(dimensions.size() * Integer.BYTES);
 
         unprocessedKeys = rowUpdater.updateValues(key, dimensions);
         if (unprocessedKeys != null) {

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/AbstractBufferHashGrouper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/AbstractBufferHashGrouper.java
@@ -20,7 +20,6 @@
 package io.druid.query.groupby.epinephelinae;
 
 import com.google.common.base.Supplier;
-import com.google.common.primitives.Ints;
 import io.druid.java.util.common.IAE;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.query.aggregation.AggregatorFactory;
@@ -30,7 +29,7 @@ import java.nio.ByteBuffer;
 
 public abstract class AbstractBufferHashGrouper<KeyType> implements Grouper<KeyType>
 {
-  protected static final int HASH_SIZE = Ints.BYTES;
+  protected static final int HASH_SIZE = Integer.BYTES;
   protected static final Logger log = new Logger(AbstractBufferHashGrouper.class);
 
   protected final Supplier<ByteBuffer> bufferSupplier;

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/BufferHashGrouper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/BufferHashGrouper.java
@@ -21,10 +21,9 @@ package io.druid.query.groupby.epinephelinae;
 
 import com.google.common.base.Supplier;
 import com.google.common.collect.Iterators;
-import com.google.common.primitives.Ints;
-import io.druid.java.util.common.parsers.CloseableIterator;
 import io.druid.java.util.common.CloseableIterators;
 import io.druid.java.util.common.IAE;
+import io.druid.java.util.common.parsers.CloseableIterator;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.segment.ColumnSelectorFactory;
 
@@ -102,7 +101,7 @@ public class BufferHashGrouper<KeyType> extends AbstractBufferHashGrouper<KeyTyp
       int hashTableSize = ByteBufferHashTable.calculateTableArenaSizeWithPerBucketAdditionalSize(
           buffer.capacity(),
           bucketSize,
-          Ints.BYTES
+          Integer.BYTES
       );
 
       hashTableBuffer = buffer.duplicate();
@@ -117,7 +116,7 @@ public class BufferHashGrouper<KeyType> extends AbstractBufferHashGrouper<KeyTyp
 
       this.offsetList = new ByteBufferIntList(
           offsetListBuffer,
-          offsetListBuffer.capacity() / Ints.BYTES
+          offsetListBuffer.capacity() / Integer.BYTES
       );
 
       this.hashTable = new ByteBufferHashTable(

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/ByteBufferHashTable.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/ByteBufferHashTable.java
@@ -19,7 +19,6 @@
 
 package io.druid.query.groupby.epinephelinae;
 
-import com.google.common.primitives.Ints;
 import io.druid.java.util.common.IAE;
 import io.druid.java.util.common.ISE;
 
@@ -47,7 +46,7 @@ public class ByteBufferHashTable
 
   protected final int maxSizeForTesting; // Integer.MAX_VALUE in production, only used for unit tests
 
-  protected static final int HASH_SIZE = Ints.BYTES;
+  protected static final int HASH_SIZE = Integer.BYTES;
 
   protected final float maxLoadFactor;
   protected final int initialBuckets;
@@ -109,7 +108,7 @@ public class ByteBufferHashTable
     if (maxBuckets < 1) {
       throw new IAE(
           "Not enough capacity for even one row! Need[%,d] but have[%,d].",
-          bucketSizeWithHash + Ints.BYTES,
+          bucketSizeWithHash + Integer.BYTES,
           buffer.capacity()
       );
     }

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/ByteBufferIntList.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/ByteBufferIntList.java
@@ -19,7 +19,6 @@
 
 package io.druid.query.groupby.epinephelinae;
 
-import com.google.common.primitives.Ints;
 import io.druid.java.util.common.IAE;
 import io.druid.java.util.common.StringUtils;
 
@@ -40,11 +39,11 @@ public class ByteBufferIntList
     this.maxElements = maxElements;
     this.numElements = 0;
 
-    if (buffer.capacity() < (maxElements * Ints.BYTES)) {
+    if (buffer.capacity() < (maxElements * Integer.BYTES)) {
       throw new IAE(
           "buffer for list is too small, was [%s] bytes, but need [%s] bytes.",
           buffer.capacity(),
-          maxElements * Ints.BYTES
+          maxElements * Integer.BYTES
       );
     }
   }
@@ -54,18 +53,18 @@ public class ByteBufferIntList
     if (numElements == maxElements) {
       throw new IndexOutOfBoundsException(StringUtils.format("List is full with %d elements.", maxElements));
     }
-    buffer.putInt(numElements * Ints.BYTES, val);
+    buffer.putInt(numElements * Integer.BYTES, val);
     numElements++;
   }
 
   public void set(int index, int val)
   {
-    buffer.putInt(index * Ints.BYTES, val);
+    buffer.putInt(index * Integer.BYTES, val);
   }
 
   public int get(int index)
   {
-    return buffer.getInt(index * Ints.BYTES);
+    return buffer.getInt(index * Integer.BYTES);
   }
 
   public void reset()

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/ByteBufferMinMaxOffsetHeap.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/ByteBufferMinMaxOffsetHeap.java
@@ -21,7 +21,6 @@ package io.druid.query.groupby.epinephelinae;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Ordering;
-import com.google.common.primitives.Ints;
 import io.druid.java.util.common.ISE;
 
 import java.nio.ByteBuffer;
@@ -68,7 +67,7 @@ public class ByteBufferMinMaxOffsetHeap
   public int addOffset(int offset)
   {
     int pos = heapSize;
-    buf.putInt(pos * Ints.BYTES, offset);
+    buf.putInt(pos * Integer.BYTES, offset);
     heapSize++;
 
     if (heapIndexUpdater != null) {
@@ -100,7 +99,7 @@ public class ByteBufferMinMaxOffsetHeap
     }
 
     int lastIndex = heapSize - 1;
-    int lastOffset = buf.getInt(lastIndex * Ints.BYTES);
+    int lastOffset = buf.getInt(lastIndex * Integer.BYTES);
     heapSize--;
     buf.putInt(0, lastOffset);
 
@@ -132,7 +131,7 @@ public class ByteBufferMinMaxOffsetHeap
     // index of max must be 1, just remove it and shrink the heap
     if (heapSize == 2) {
       heapSize--;
-      maxOffset = buf.getInt(Ints.BYTES);
+      maxOffset = buf.getInt(Integer.BYTES);
       if (heapIndexUpdater != null) {
         heapIndexUpdater.updateHeapIndexForOffset(maxOffset, -1);
       }
@@ -140,12 +139,12 @@ public class ByteBufferMinMaxOffsetHeap
     }
 
     int maxIndex = findMaxElementIndex();
-    maxOffset = buf.getInt(maxIndex * Ints.BYTES);
+    maxOffset = buf.getInt(maxIndex * Integer.BYTES);
 
     int lastIndex = heapSize - 1;
-    int lastOffset = buf.getInt(lastIndex * Ints.BYTES);
+    int lastOffset = buf.getInt(lastIndex * Integer.BYTES);
     heapSize--;
-    buf.putInt(maxIndex * Ints.BYTES, lastOffset);
+    buf.putInt(maxIndex * Integer.BYTES, lastOffset);
 
     if (heapIndexUpdater != null) {
       heapIndexUpdater.updateHeapIndexForOffset(maxOffset, -1);
@@ -163,7 +162,7 @@ public class ByteBufferMinMaxOffsetHeap
     if (heapSize < 1) {
       throw new ISE("Empty heap");
     }
-    int deletedOffset = buf.getInt(deletedIndex * Ints.BYTES);
+    int deletedOffset = buf.getInt(deletedIndex * Integer.BYTES);
     if (heapIndexUpdater != null) {
       heapIndexUpdater.updateHeapIndexForOffset(deletedOffset, -1);
     }
@@ -173,8 +172,8 @@ public class ByteBufferMinMaxOffsetHeap
     if (lastIndex == deletedIndex) {
       return deletedOffset;
     }
-    int lastOffset = buf.getInt(lastIndex * Ints.BYTES);
-    buf.putInt(deletedIndex * Ints.BYTES, lastOffset);
+    int lastOffset = buf.getInt(lastIndex * Integer.BYTES);
+    buf.putInt(deletedIndex * Integer.BYTES, lastOffset);
 
     if (heapIndexUpdater != null) {
       heapIndexUpdater.updateHeapIndexForOffset(lastOffset, deletedIndex);
@@ -190,18 +189,18 @@ public class ByteBufferMinMaxOffsetHeap
 
   public void setAt(int index, int newVal)
   {
-    buf.putInt(index * Ints.BYTES, newVal);
+    buf.putInt(index * Integer.BYTES, newVal);
   }
 
   public int getAt(int index)
   {
-    return buf.getInt(index * Ints.BYTES);
+    return buf.getInt(index * Integer.BYTES);
   }
 
   public int indexOf(int offset)
   {
     for (int i = 0; i < heapSize; i++) {
-      int curOffset = buf.getInt(i * Ints.BYTES);
+      int curOffset = buf.getInt(i * Integer.BYTES);
       if (curOffset == offset) {
         return i;
       }
@@ -227,11 +226,11 @@ public class ByteBufferMinMaxOffsetHeap
     if (isEvenLevel(pos)) {
       int parentIndex = getParentIndex(pos);
       if (parentIndex > -1) {
-        int parentOffset = buf.getInt(parentIndex * Ints.BYTES);
-        int offset = buf.getInt(pos * Ints.BYTES);
+        int parentOffset = buf.getInt(parentIndex * Integer.BYTES);
+        int offset = buf.getInt(pos * Integer.BYTES);
         if (minComparator.compare(offset, parentOffset) > 0) {
-          buf.putInt(parentIndex * Ints.BYTES, offset);
-          buf.putInt(pos * Ints.BYTES, parentOffset);
+          buf.putInt(parentIndex * Integer.BYTES, offset);
+          buf.putInt(pos * Integer.BYTES, parentOffset);
           if (heapIndexUpdater != null) {
             heapIndexUpdater.updateHeapIndexForOffset(offset, parentIndex);
             heapIndexUpdater.updateHeapIndexForOffset(parentOffset, pos);
@@ -246,11 +245,11 @@ public class ByteBufferMinMaxOffsetHeap
     } else {
       int parentIndex = getParentIndex(pos);
       if (parentIndex > -1) {
-        int parentOffset = buf.getInt(parentIndex * Ints.BYTES);
-        int offset = buf.getInt(pos * Ints.BYTES);
+        int parentOffset = buf.getInt(parentIndex * Integer.BYTES);
+        int offset = buf.getInt(pos * Integer.BYTES);
         if (minComparator.compare(offset, parentOffset) < 0) {
-          buf.putInt(parentIndex * Ints.BYTES, offset);
-          buf.putInt(pos * Ints.BYTES, parentOffset);
+          buf.putInt(parentIndex * Integer.BYTES, offset);
+          buf.putInt(pos * Integer.BYTES, parentOffset);
           if (heapIndexUpdater != null) {
             heapIndexUpdater.updateHeapIndexForOffset(offset, parentIndex);
             heapIndexUpdater.updateHeapIndexForOffset(parentOffset, pos);
@@ -269,12 +268,12 @@ public class ByteBufferMinMaxOffsetHeap
   {
     int grandparent = getGrandparentIndex(pos);
     while (grandparent > -1) {
-      int offset = buf.getInt(pos * Ints.BYTES);
-      int gpOffset = buf.getInt(grandparent * Ints.BYTES);
+      int offset = buf.getInt(pos * Integer.BYTES);
+      int gpOffset = buf.getInt(grandparent * Integer.BYTES);
 
       if (comparator.compare(offset, gpOffset) < 0) {
-        buf.putInt(pos * Ints.BYTES, gpOffset);
-        buf.putInt(grandparent * Ints.BYTES, offset);
+        buf.putInt(pos * Integer.BYTES, gpOffset);
+        buf.putInt(grandparent * Integer.BYTES, offset);
         if (heapIndexUpdater != null) {
           heapIndexUpdater.updateHeapIndexForOffset(gpOffset, pos);
           heapIndexUpdater.updateHeapIndexForOffset(offset, grandparent);
@@ -293,8 +292,8 @@ public class ByteBufferMinMaxOffsetHeap
     while (minChild > -1) {
       minGrandchild = findMinGrandChild(comparator, pos);
       if (minGrandchild > -1) {
-        int minChildOffset = buf.getInt(minChild * Ints.BYTES);
-        int minGcOffset = buf.getInt(minGrandchild * Ints.BYTES);
+        int minChildOffset = buf.getInt(minChild * Integer.BYTES);
+        int minGcOffset = buf.getInt(minGrandchild * Integer.BYTES);
         int cmp = comparator.compare(minChildOffset, minGcOffset);
         minIndex = (cmp > 0) ? minGrandchild : minChild;
       } else if (minChild > -1) {
@@ -303,23 +302,23 @@ public class ByteBufferMinMaxOffsetHeap
         break;
       }
       if (minIndex == minGrandchild) {
-        int offset = buf.getInt(pos * Ints.BYTES);
-        int minOffset = buf.getInt(minIndex * Ints.BYTES);
+        int offset = buf.getInt(pos * Integer.BYTES);
+        int minOffset = buf.getInt(minIndex * Integer.BYTES);
 
         if (comparator.compare(minOffset, offset) < 0) {
-          buf.putInt(pos * Ints.BYTES, minOffset);
-          buf.putInt(minIndex * Ints.BYTES, offset);
+          buf.putInt(pos * Integer.BYTES, minOffset);
+          buf.putInt(minIndex * Integer.BYTES, offset);
           if (heapIndexUpdater != null) {
             heapIndexUpdater.updateHeapIndexForOffset(minOffset, pos);
             heapIndexUpdater.updateHeapIndexForOffset(offset, minIndex);
           }
 
           int parent = getParentIndex(minIndex);
-          int parentOffset = buf.getInt(parent * Ints.BYTES);
+          int parentOffset = buf.getInt(parent * Integer.BYTES);
 
           if (comparator.compare(offset, parentOffset) > 0) {
-            buf.putInt(minIndex * Ints.BYTES, parentOffset);
-            buf.putInt(parent * Ints.BYTES, offset);
+            buf.putInt(minIndex * Integer.BYTES, parentOffset);
+            buf.putInt(parent * Integer.BYTES, offset);
             if (heapIndexUpdater != null) {
               heapIndexUpdater.updateHeapIndexForOffset(offset, parent);
               heapIndexUpdater.updateHeapIndexForOffset(parentOffset, minIndex);
@@ -329,11 +328,11 @@ public class ByteBufferMinMaxOffsetHeap
         }
         pos = minIndex;
       } else {
-        int offset = buf.getInt(pos * Ints.BYTES);
-        int minOffset = buf.getInt(minIndex * Ints.BYTES);
+        int offset = buf.getInt(pos * Integer.BYTES);
+        int minOffset = buf.getInt(minIndex * Integer.BYTES);
         if (comparator.compare(minOffset, offset) < 0) {
-          buf.putInt(pos * Ints.BYTES, minOffset);
-          buf.putInt(minIndex * Ints.BYTES, offset);
+          buf.putInt(pos * Integer.BYTES, minOffset);
+          buf.putInt(minIndex * Integer.BYTES, offset);
           if (heapIndexUpdater != null) {
             heapIndexUpdater.updateHeapIndexForOffset(offset, minIndex);
             heapIndexUpdater.updateHeapIndexForOffset(minOffset, pos);
@@ -363,7 +362,7 @@ public class ByteBufferMinMaxOffsetHeap
     int limit = Math.min(index, heapSize - len) + len;
     int minIndex = index;
     for (int i = index + 1; i < limit; i++) {
-      if (comparator.compare(buf.getInt(i * Ints.BYTES), buf.getInt(minIndex * Ints.BYTES)) < 0) {
+      if (comparator.compare(buf.getInt(i * Integer.BYTES), buf.getInt(minIndex * Integer.BYTES)) < 0) {
         minIndex = i;
       }
     }
@@ -429,8 +428,8 @@ public class ByteBufferMinMaxOffsetHeap
       default:
         // The max element must sit on the first level of the maxHeap. It is
         // actually the *lesser* of the two from the maxHeap's perspective.
-        int offset1 = buf.getInt(1 * Ints.BYTES);
-        int offset2 = buf.getInt(2 * Ints.BYTES);
+        int offset1 = buf.getInt(1 * Integer.BYTES);
+        int offset2 = buf.getInt(2 * Integer.BYTES);
         return maxComparator.compare(offset1, offset2) <= 0 ? 1 : 2;
     }
   }
@@ -449,11 +448,11 @@ public class ByteBufferMinMaxOffsetHeap
   private boolean verifyIndex(int i)
   {
     Comparator comparator = isEvenLevel(i) ? minComparator : maxComparator;
-    int offset = buf.getInt(i * Ints.BYTES);
+    int offset = buf.getInt(i * Integer.BYTES);
 
     int lcIdx = getLeftChildIndex(i);
     if (lcIdx < heapSize) {
-      int leftChildOffset = buf.getInt(lcIdx * Ints.BYTES);
+      int leftChildOffset = buf.getInt(lcIdx * Integer.BYTES);
       if (comparator.compare(offset, leftChildOffset) > 0) {
         throw new ISE("Left child val[%d] at idx[%d] is less than val[%d] at idx[%d]",
                       leftChildOffset, lcIdx, offset, i);
@@ -462,7 +461,7 @@ public class ByteBufferMinMaxOffsetHeap
 
     int rcIdx = getRightChildIndex(i);
     if (rcIdx < heapSize) {
-      int rightChildOffset = buf.getInt(rcIdx * Ints.BYTES);
+      int rightChildOffset = buf.getInt(rcIdx * Integer.BYTES);
       if (comparator.compare(offset, rightChildOffset) > 0) {
         throw new ISE("Right child val[%d] at idx[%d] is less than val[%d] at idx[%d]",
                       rightChildOffset, rcIdx, offset, i);
@@ -471,7 +470,7 @@ public class ByteBufferMinMaxOffsetHeap
 
     if (i > 0) {
       int parentIdx = getParentIndex(i);
-      int parentOffset = buf.getInt(parentIdx * Ints.BYTES);
+      int parentOffset = buf.getInt(parentIdx * Integer.BYTES);
       if (comparator.compare(offset, parentOffset) > 0) {
         throw new ISE("Parent val[%d] at idx[%d] is less than val[%d] at idx[%d]",
                       parentOffset, parentIdx, offset, i);
@@ -480,7 +479,7 @@ public class ByteBufferMinMaxOffsetHeap
 
     if (i > 2) {
       int gpIdx = getGrandparentIndex(i);
-      int gpOffset = buf.getInt(gpIdx * Ints.BYTES);
+      int gpOffset = buf.getInt(gpIdx * Integer.BYTES);
       if (comparator.compare(gpOffset, offset) > 0) {
         throw new ISE("Grandparent val[%d] at idx[%d] is less than val[%d] at idx[%d]",
                       gpOffset, gpIdx, offset, i);
@@ -499,7 +498,7 @@ public class ByteBufferMinMaxOffsetHeap
 
     String ret = "[";
     for (int i = 0; i < heapSize; i++) {
-      ret += buf.getInt(i * Ints.BYTES);
+      ret += buf.getInt(i * Integer.BYTES);
       if (i < heapSize - 1) {
         ret += ", ";
       }

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/LimitedBufferHashGrouper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/LimitedBufferHashGrouper.java
@@ -21,11 +21,10 @@ package io.druid.query.groupby.epinephelinae;
 
 import com.google.common.base.Supplier;
 import com.google.common.collect.Iterators;
-import com.google.common.primitives.Ints;
-import io.druid.java.util.common.parsers.CloseableIterator;
 import io.druid.java.util.common.CloseableIterators;
 import io.druid.java.util.common.IAE;
 import io.druid.java.util.common.ISE;
+import io.druid.java.util.common.parsers.CloseableIterator;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.segment.ColumnSelectorFactory;
 
@@ -98,7 +97,7 @@ public class LimitedBufferHashGrouper<KeyType> extends AbstractBufferHashGrouper
 
     // For each bucket, store an extra field indicating the bucket's current index within the heap when
     // pushing down limits
-    offset += Ints.BYTES;
+    offset += Integer.BYTES;
     this.bucketSize = offset;
   }
 
@@ -117,7 +116,7 @@ public class LimitedBufferHashGrouper<KeyType> extends AbstractBufferHashGrouper
     }
 
     //only store offsets up to `limit` + 1 instead of up to # of buckets, we only keep the top results
-    int heapByteSize = (limit + 1) * Ints.BYTES;
+    int heapByteSize = (limit + 1) * Integer.BYTES;
 
     int hashTableSize = ByteBufferHashTable.calculateTableArenaSizeWithFixedAdditionalSize(
         totalBuffer.capacity(),
@@ -143,7 +142,7 @@ public class LimitedBufferHashGrouper<KeyType> extends AbstractBufferHashGrouper
         keySize,
         bufferGrouperMaxSize
     );
-    this.heapIndexUpdater = new BufferGrouperOffsetHeapIndexUpdater(totalBuffer, bucketSize - Ints.BYTES);
+    this.heapIndexUpdater = new BufferGrouperOffsetHeapIndexUpdater(totalBuffer, bucketSize - Integer.BYTES);
     this.offsetHeap = new ByteBufferMinMaxOffsetHeap(offsetHeapBuffer, limit, makeHeapComparator(), heapIndexUpdater);
 
     reset();
@@ -392,7 +391,7 @@ public class LimitedBufferHashGrouper<KeyType> extends AbstractBufferHashGrouper
   {
     int numBucketsNeeded = (int) Math.ceil((limit + 1) / maxLoadFactor);
     int targetTableArenaSize = numBucketsNeeded * bucketSize * 2;
-    int heapSize = (limit + 1) * (Ints.BYTES);
+    int heapSize = (limit + 1) * (Integer.BYTES);
     int requiredSize = targetTableArenaSize + heapSize;
 
     if (bufferCapacity < requiredSize) {

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -27,9 +27,6 @@ import com.google.common.base.Strings;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.primitives.Chars;
-import com.google.common.primitives.Doubles;
-import com.google.common.primitives.Floats;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import com.google.common.util.concurrent.ListeningExecutorService;
@@ -89,7 +86,7 @@ import java.util.stream.IntStream;
 public class RowBasedGrouperHelper
 {
   // Entry in dictionary, node pointer in reverseDictionary, hash + k/v/next pointer in reverseDictionary nodes
-  private static final int ROUGH_OVERHEAD_PER_DICTIONARY_ENTRY = Longs.BYTES * 5 + Ints.BYTES;
+  private static final int ROUGH_OVERHEAD_PER_DICTIONARY_ENTRY = Long.BYTES * 5 + Integer.BYTES;
 
   private static final int SINGLE_THREAD_CONCURRENCY_HINT = -1;
   private static final int UNKNOWN_THREAD_PRIORITY = -1;
@@ -939,7 +936,7 @@ public class RowBasedGrouperHelper
 
   static long estimateStringKeySize(String key)
   {
-    return (long) key.length() * Chars.BYTES + ROUGH_OVERHEAD_PER_DICTIONARY_ENTRY;
+    return (long) key.length() * Character.BYTES + ROUGH_OVERHEAD_PER_DICTIONARY_ENTRY;
   }
 
   private static class RowBasedKeySerde implements Grouper.KeySerde<RowBasedGrouperHelper.RowBasedKey>
@@ -999,7 +996,7 @@ public class RowBasedGrouperHelper
       this.serdeHelpers = makeSerdeHelpers(limitSpec != null, enableRuntimeDictionaryGeneration);
       this.serdeHelperComparators = new BufferComparator[serdeHelpers.length];
       Arrays.setAll(serdeHelperComparators, i -> serdeHelpers[i].getBufferComparator());
-      this.keySize = (includeTimestamp ? Longs.BYTES : 0) + getTotalKeySize();
+      this.keySize = (includeTimestamp ? Long.BYTES : 0) + getTotalKeySize();
       this.keyBuffer = ByteBuffer.allocate(keySize);
 
       if (!enableRuntimeDictionaryGeneration) {
@@ -1083,7 +1080,7 @@ public class RowBasedGrouperHelper
       if (includeTimestamp) {
         key = new Comparable[dimCount + 1];
         key[0] = buffer.getLong(position);
-        dimsPosition = position + Longs.BYTES;
+        dimsPosition = position + Long.BYTES;
         dimStart = 1;
       } else {
         key = new Comparable[dimCount];
@@ -1202,7 +1199,7 @@ public class RowBasedGrouperHelper
             final RowBasedKeySerdeHelper serdeHelper;
             final StringComparator stringComparator = orderSpec.getDimensionComparator();
             final String typeName = aggregatorFactories[aggIndex].getTypeName();
-            final int aggOffset = aggregatorOffsets[aggIndex] - Ints.BYTES;
+            final int aggOffset = aggregatorOffsets[aggIndex] - Integer.BYTES;
 
             aggCount++;
 
@@ -1459,7 +1456,7 @@ public class RowBasedGrouperHelper
       @Override
       public int getKeyBufferValueSize()
       {
-        return Ints.BYTES;
+        return Integer.BYTES;
       }
 
       @Override
@@ -1578,7 +1575,7 @@ public class RowBasedGrouperHelper
       @Override
       public int getKeyBufferValueSize()
       {
-        return Longs.BYTES;
+        return Long.BYTES;
       }
 
       @Override
@@ -1629,7 +1626,7 @@ public class RowBasedGrouperHelper
       @Override
       public int getKeyBufferValueSize()
       {
-        return Floats.BYTES;
+        return Float.BYTES;
       }
 
       @Override
@@ -1681,7 +1678,7 @@ public class RowBasedGrouperHelper
       @Override
       public int getKeyBufferValueSize()
       {
-        return Doubles.BYTES;
+        return Double.BYTES;
       }
 
       @Override
@@ -1717,8 +1714,8 @@ public class RowBasedGrouperHelper
       final int cmp = comparator.compare(
           lhsBuffer,
           rhsBuffer,
-          lhsPosition + Longs.BYTES,
-          rhsPosition + Longs.BYTES
+          lhsPosition + Long.BYTES,
+          rhsPosition + Long.BYTES
       );
       if (cmp != 0) {
         return cmp;
@@ -1744,15 +1741,15 @@ public class RowBasedGrouperHelper
         cmp = serdeHelperComparators[i].compare(
             rhsBuffer,
             lhsBuffer,
-            rhsPosition + Longs.BYTES,
-            lhsPosition + Longs.BYTES
+            rhsPosition + Long.BYTES,
+            lhsPosition + Long.BYTES
         );
       } else {
         cmp = serdeHelperComparators[i].compare(
             lhsBuffer,
             rhsBuffer,
-            lhsPosition + Longs.BYTES,
-            rhsPosition + Longs.BYTES
+            lhsPosition + Long.BYTES,
+            rhsPosition + Long.BYTES
         );
       }
       if (cmp != 0) {

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/column/FloatGroupByColumnSelectorStrategy.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/column/FloatGroupByColumnSelectorStrategy.java
@@ -19,7 +19,6 @@
 
 package io.druid.query.groupby.epinephelinae.column;
 
-import com.google.common.primitives.Floats;
 import io.druid.segment.ColumnValueSelector;
 
 import java.nio.ByteBuffer;
@@ -31,7 +30,7 @@ public class FloatGroupByColumnSelectorStrategy implements GroupByColumnSelector
   @Override
   public int getGroupingKeySize()
   {
-    return Floats.BYTES;
+    return Float.BYTES;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/column/LongGroupByColumnSelectorStrategy.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/column/LongGroupByColumnSelectorStrategy.java
@@ -19,7 +19,6 @@
 
 package io.druid.query.groupby.epinephelinae.column;
 
-import com.google.common.primitives.Longs;
 import io.druid.segment.ColumnValueSelector;
 
 import java.nio.ByteBuffer;
@@ -31,7 +30,7 @@ public class LongGroupByColumnSelectorStrategy implements GroupByColumnSelectorS
   @Override
   public int getGroupingKeySize()
   {
-    return Longs.BYTES;
+    return Long.BYTES;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/column/StringGroupByColumnSelectorStrategy.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/column/StringGroupByColumnSelectorStrategy.java
@@ -20,7 +20,6 @@
 package io.druid.query.groupby.epinephelinae.column;
 
 import com.google.common.base.Preconditions;
-import com.google.common.primitives.Ints;
 import io.druid.segment.ColumnValueSelector;
 import io.druid.segment.DimensionSelector;
 import io.druid.segment.data.IndexedInts;
@@ -33,7 +32,7 @@ public class StringGroupByColumnSelectorStrategy implements GroupByColumnSelecto
   @Override
   public int getGroupingKeySize()
   {
-    return Ints.BYTES;
+    return Integer.BYTES;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/metadata/SegmentAnalyzer.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentAnalyzer.java
@@ -25,8 +25,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.google.common.primitives.Doubles;
-import com.google.common.primitives.Longs;
 import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Accumulator;
@@ -110,13 +108,13 @@ public class SegmentAnalyzer
       final ValueType type = capabilities.getType();
       switch (type) {
         case LONG:
-          analysis = analyzeNumericColumn(capabilities, length, Longs.BYTES);
+          analysis = analyzeNumericColumn(capabilities, length, Long.BYTES);
           break;
         case FLOAT:
           analysis = analyzeNumericColumn(capabilities, length, NUM_BYTES_IN_TEXT_FLOAT);
           break;
         case DOUBLE:
-          analysis = analyzeNumericColumn(capabilities, length, Doubles.BYTES);
+          analysis = analyzeNumericColumn(capabilities, length, Double.BYTES);
           break;
         case STRING:
           if (index != null) {

--- a/processing/src/main/java/io/druid/query/select/PagingSpec.java
+++ b/processing/src/main/java/io/druid/query/select/PagingSpec.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Maps;
-import com.google.common.primitives.Ints;
 import io.druid.java.util.common.StringUtils;
 
 import java.nio.ByteBuffer;
@@ -114,13 +113,13 @@ public class PagingSpec
     int pagingValuesSize = 0;
     for (Map.Entry<String, Integer> entry : pagingIdentifiers.entrySet()) {
       pagingKeys[index] = StringUtils.toUtf8(entry.getKey());
-      pagingValues[index] = ByteBuffer.allocate(Ints.BYTES).putInt(entry.getValue()).array();
+      pagingValues[index] = ByteBuffer.allocate(Integer.BYTES).putInt(entry.getValue()).array();
       pagingKeysSize += pagingKeys[index].length;
-      pagingValuesSize += Ints.BYTES;
+      pagingValuesSize += Integer.BYTES;
       index++;
     }
 
-    final byte[] thresholdBytes = ByteBuffer.allocate(Ints.BYTES).putInt(threshold).array();
+    final byte[] thresholdBytes = ByteBuffer.allocate(Integer.BYTES).putInt(threshold).array();
 
     final ByteBuffer queryCacheKey = ByteBuffer.allocate(pagingKeysSize + pagingValuesSize + thresholdBytes.length + 1);
 

--- a/processing/src/main/java/io/druid/segment/IndexMerger.java
+++ b/processing/src/main/java/io/druid/segment/IndexMerger.java
@@ -27,7 +27,6 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.PeekingIterator;
 import com.google.common.collect.Sets;
-import com.google.common.primitives.Ints;
 import com.google.inject.ImplementedBy;
 import io.druid.common.utils.SerializerUtils;
 import io.druid.java.util.common.ByteBufferUtils;
@@ -450,7 +449,7 @@ public interface IndexMerger
         }
         Indexed<String> indexed = dimValueLookups[i];
         if (useDirect) {
-          int allocationSize = indexed.size() * Ints.BYTES;
+          int allocationSize = indexed.size() * Integer.BYTES;
           log.info("Allocating dictionary merging direct buffer with size[%,d]", allocationSize);
           final ByteBuffer conversionDirectBuffer = ByteBuffer.allocateDirect(allocationSize);
           conversions[i] = conversionDirectBuffer.asIntBuffer();

--- a/processing/src/main/java/io/druid/segment/data/CompressedColumnarIntsSupplier.java
+++ b/processing/src/main/java/io/druid/segment/data/CompressedColumnarIntsSupplier.java
@@ -21,7 +21,6 @@ package io.druid.segment.data;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.primitives.Ints;
 import io.druid.collections.ResourceHolder;
 import io.druid.java.util.common.IAE;
 import io.druid.java.util.common.guava.CloseQuietly;
@@ -42,7 +41,7 @@ import java.util.Iterator;
 public class CompressedColumnarIntsSupplier implements WritableSupplier<ColumnarInts>
 {
   public static final byte VERSION = 0x2;
-  public static final int MAX_INTS_IN_BUFFER = CompressedPools.BUFFER_SIZE / Ints.BYTES;
+  public static final int MAX_INTS_IN_BUFFER = CompressedPools.BUFFER_SIZE / Integer.BYTES;
 
   private static MetaSerdeHelper<CompressedColumnarIntsSupplier> metaSerdeHelper = MetaSerdeHelper
       .firstWriteByte((CompressedColumnarIntsSupplier x) -> VERSION)
@@ -161,7 +160,7 @@ public class CompressedColumnarIntsSupplier implements WritableSupplier<Columnar
                   final IntBuffer myBuffer = buffer.asReadOnlyBuffer();
                   final ByteBuffer retVal = compression
                       .getCompressor()
-                      .allocateInBuffer(chunkFactor * Ints.BYTES, closer)
+                      .allocateInBuffer(chunkFactor * Integer.BYTES, closer)
                       .order(byteOrder);
                   final IntBuffer retValAsIntBuffer = retVal.asIntBuffer();
 
@@ -181,7 +180,7 @@ public class CompressedColumnarIntsSupplier implements WritableSupplier<Columnar
                     retValAsIntBuffer.clear();
                     retValAsIntBuffer.put(myBuffer);
                     myBuffer.limit(initialLimit);
-                    retVal.clear().limit(retValAsIntBuffer.position() * Ints.BYTES);
+                    retVal.clear().limit(retValAsIntBuffer.position() * Integer.BYTES);
                     return retVal;
                   }
 
@@ -194,7 +193,7 @@ public class CompressedColumnarIntsSupplier implements WritableSupplier<Columnar
               }
             },
             compression,
-            chunkFactor * Ints.BYTES,
+            chunkFactor * Integer.BYTES,
             byteOrder,
             closer
         ),
@@ -228,7 +227,7 @@ public class CompressedColumnarIntsSupplier implements WritableSupplier<Columnar
                 {
                   private final ByteBuffer retVal = compression
                       .getCompressor()
-                      .allocateInBuffer(chunkFactor * Ints.BYTES, closer)
+                      .allocateInBuffer(chunkFactor * Integer.BYTES, closer)
                       .order(byteOrder);
                   int position = 0;
 
@@ -259,7 +258,7 @@ public class CompressedColumnarIntsSupplier implements WritableSupplier<Columnar
               }
             },
             compression,
-            chunkFactor * Ints.BYTES,
+            chunkFactor * Integer.BYTES,
             byteOrder,
             closer
         ),

--- a/processing/src/main/java/io/druid/segment/data/CompressedVSizeColumnarIntsSerializer.java
+++ b/processing/src/main/java/io/druid/segment/data/CompressedVSizeColumnarIntsSerializer.java
@@ -19,7 +19,6 @@
 
 package io.druid.segment.data;
 
-import com.google.common.primitives.Ints;
 import io.druid.common.utils.ByteUtils;
 import io.druid.java.util.common.io.smoosh.FileSmoosher;
 import io.druid.segment.IndexIO;
@@ -111,7 +110,7 @@ public class CompressedVSizeColumnarIntsSerializer extends SingleValueColumnarIn
     this.isBigEndian = byteOrder.equals(ByteOrder.BIG_ENDIAN);
     this.compression = compression;
     this.flattener = flattener;
-    this.intBuffer = ByteBuffer.allocate(Ints.BYTES).order(byteOrder);
+    this.intBuffer = ByteBuffer.allocate(Integer.BYTES).order(byteOrder);
     CompressionStrategy.Compressor compressor = compression.getCompressor();
     this.endBuffer = compressor.allocateInBuffer(chunkBytes, segmentWriteOutMedium.getCloser()).order(byteOrder);
     this.numInserted = 0;
@@ -142,7 +141,7 @@ public class CompressedVSizeColumnarIntsSerializer extends SingleValueColumnarIn
     }
     intBuffer.putInt(0, val);
     if (isBigEndian) {
-      endBuffer.put(intBuffer.array(), Ints.BYTES - numBytes, numBytes);
+      endBuffer.put(intBuffer.array(), Integer.BYTES - numBytes, numBytes);
     } else {
       endBuffer.put(intBuffer.array(), 0, numBytes);
     }

--- a/processing/src/main/java/io/druid/segment/data/CompressedVSizeColumnarIntsSupplier.java
+++ b/processing/src/main/java/io/druid/segment/data/CompressedVSizeColumnarIntsSupplier.java
@@ -21,8 +21,6 @@ package io.druid.segment.data;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.primitives.Ints;
-import com.google.common.primitives.Shorts;
 import io.druid.collections.ResourceHolder;
 import io.druid.common.utils.ByteUtils;
 import io.druid.java.util.common.IAE;
@@ -96,11 +94,11 @@ public class CompressedVSizeColumnarIntsSupplier implements WritableSupplier<Col
     // beyond the end of the last value, since we use buffer.getInt() to read values.
     // for numBytes 1, 2 we remove the need for padding by reading bytes or shorts directly.
     switch (numBytes) {
-      case Shorts.BYTES:
+      case Short.BYTES:
       case 1:
         return 0;
       default:
-        return Ints.BYTES - numBytes;
+        return Integer.BYTES - numBytes;
     }
   }
 
@@ -113,9 +111,9 @@ public class CompressedVSizeColumnarIntsSupplier implements WritableSupplier<Col
   public ColumnarInts get()
   {
     // optimized versions for int, short, and byte columns
-    if (numBytes == Ints.BYTES) {
+    if (numBytes == Integer.BYTES) {
       return new CompressedFullSizeColumnarInts();
-    } else if (numBytes == Shorts.BYTES) {
+    } else if (numBytes == Short.BYTES) {
       return new CompressedShortSizeColumnarInts();
     } else if (numBytes == 1) {
       return new CompressedByteSizeColumnarInts();
@@ -206,7 +204,7 @@ public class CompressedVSizeColumnarIntsSupplier implements WritableSupplier<Col
                   private final ByteBuffer retVal =
                       compression.getCompressor().allocateInBuffer(chunkBytes, closer).order(byteOrder);
                   private final boolean isBigEndian = byteOrder.equals(ByteOrder.BIG_ENDIAN);
-                  private final ByteBuffer helperBuf = ByteBuffer.allocate(Ints.BYTES).order(byteOrder);
+                  private final ByteBuffer helperBuf = ByteBuffer.allocate(Integer.BYTES).order(byteOrder);
 
                   @Override
                   public boolean hasNext()
@@ -232,7 +230,7 @@ public class CompressedVSizeColumnarIntsSupplier implements WritableSupplier<Col
                   {
                     helperBuf.putInt(0, value);
                     if (isBigEndian) {
-                      retVal.put(helperBuf.array(), Ints.BYTES - numBytes, numBytes);
+                      retVal.put(helperBuf.array(), Integer.BYTES - numBytes, numBytes);
                     } else {
                       retVal.put(helperBuf.array(), 0, numBytes);
                     }

--- a/processing/src/main/java/io/druid/segment/data/DeltaLongEncodingWriter.java
+++ b/processing/src/main/java/io/druid/segment/data/DeltaLongEncodingWriter.java
@@ -19,8 +19,6 @@
 
 package io.druid.segment.data;
 
-import com.google.common.primitives.Ints;
-import com.google.common.primitives.Longs;
 import io.druid.segment.writeout.WriteOutBytes;
 
 import java.io.IOException;
@@ -70,7 +68,7 @@ public class DeltaLongEncodingWriter implements CompressionFactory.LongEncodingW
   @Override
   public int metaSize()
   {
-    return 1 + 1 + 1 + Longs.BYTES + Ints.BYTES;
+    return 1 + 1 + 1 + Long.BYTES + Integer.BYTES;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/data/GenericIndexed.java
+++ b/processing/src/main/java/io/druid/segment/data/GenericIndexed.java
@@ -31,10 +31,10 @@ import io.druid.java.util.common.guava.Comparators;
 import io.druid.java.util.common.io.Closer;
 import io.druid.java.util.common.io.smoosh.FileSmoosher;
 import io.druid.java.util.common.io.smoosh.SmooshedFileMapper;
-import io.druid.segment.writeout.HeapByteBufferWriteOutBytes;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.serde.MetaSerdeHelper;
 import io.druid.segment.serde.Serializer;
+import io.druid.segment.writeout.HeapByteBufferWriteOutBytes;
 import it.unimi.dsi.fastutil.bytes.ByteArrays;
 
 import java.io.Closeable;
@@ -215,7 +215,7 @@ public class GenericIndexed<T> implements Indexed<T>, Serializer
     size = theBuffer.getInt();
 
     int indexOffset = theBuffer.position();
-    int valuesOffset = theBuffer.position() + size * Ints.BYTES;
+    int valuesOffset = theBuffer.position() + size * Integer.BYTES;
 
     buffer.position(valuesOffset);
     // Ensure the value buffer's limit equals to capacity.
@@ -478,7 +478,7 @@ public class GenericIndexed<T> implements Indexed<T>, Serializer
   {
     Iterator<T> objects = objectsIterable.iterator();
     if (!objects.hasNext()) {
-      final ByteBuffer buffer = ByteBuffer.allocate(Ints.BYTES).putInt(0);
+      final ByteBuffer buffer = ByteBuffer.allocate(Integer.BYTES).putInt(0);
       buffer.flip();
       return new GenericIndexed<>(buffer, resultObjectStrategy, allowReverseLookup);
     }
@@ -517,7 +517,7 @@ public class GenericIndexed<T> implements Indexed<T>, Serializer
       throw new RuntimeException(e);
     }
 
-    ByteBuffer theBuffer = ByteBuffer.allocate(Ints.checkedCast(Ints.BYTES + headerOut.size() + valuesOut.size()));
+    ByteBuffer theBuffer = ByteBuffer.allocate(Ints.checkedCast(Integer.BYTES + headerOut.size() + valuesOut.size()));
     theBuffer.putInt(count);
     headerOut.writeTo(theBuffer);
     valuesOut.writeTo(theBuffer);
@@ -539,12 +539,12 @@ public class GenericIndexed<T> implements Indexed<T>, Serializer
     final int endOffset;
 
     if (index == 0) {
-      startOffset = Ints.BYTES;
+      startOffset = Integer.BYTES;
       endOffset = headerBuffer.getInt(0);
     } else {
-      int headerPosition = (index - 1) * Ints.BYTES;
-      startOffset = headerBuffer.getInt(headerPosition) + Ints.BYTES;
-      endOffset = headerBuffer.getInt(headerPosition + Ints.BYTES);
+      int headerPosition = (index - 1) * Integer.BYTES;
+      startOffset = headerBuffer.getInt(headerPosition) + Integer.BYTES;
+      endOffset = headerBuffer.getInt(headerPosition + Integer.BYTES);
     }
     return copyBufferAndGet(firstValueBuffer, startOffset, endOffset);
   }
@@ -566,9 +566,9 @@ public class GenericIndexed<T> implements Indexed<T>, Serializer
           startOffset = 4;
           endOffset = headerBuffer.getInt(0);
         } else {
-          int headerPosition = (index - 1) * Ints.BYTES;
-          startOffset = headerBuffer.getInt(headerPosition) + Ints.BYTES;
-          endOffset = headerBuffer.getInt(headerPosition + Ints.BYTES);
+          int headerPosition = (index - 1) * Integer.BYTES;
+          startOffset = headerBuffer.getInt(headerPosition) + Integer.BYTES;
+          endOffset = headerBuffer.getInt(headerPosition + Integer.BYTES);
         }
         return bufferedIndexedGet(copyBuffer, startOffset, endOffset);
       }
@@ -641,13 +641,13 @@ public class GenericIndexed<T> implements Indexed<T>, Serializer
 
     int relativePositionOfIndex = index & relativeIndexMask;
     if (relativePositionOfIndex == 0) {
-      int headerPosition = index * Ints.BYTES;
-      startOffset = Ints.BYTES;
+      int headerPosition = index * Integer.BYTES;
+      startOffset = Integer.BYTES;
       endOffset = headerBuffer.getInt(headerPosition);
     } else {
-      int headerPosition = (index - 1) * Ints.BYTES;
-      startOffset = headerBuffer.getInt(headerPosition) + Ints.BYTES;
-      endOffset = headerBuffer.getInt(headerPosition + Ints.BYTES);
+      int headerPosition = (index - 1) * Integer.BYTES;
+      startOffset = headerBuffer.getInt(headerPosition) + Integer.BYTES;
+      endOffset = headerBuffer.getInt(headerPosition + Integer.BYTES);
     }
     int fileNum = index >> logBaseTwoOfElementsPerValueFile;
     return copyBufferAndGet(valueBuffers[fileNum], startOffset, endOffset);
@@ -672,13 +672,13 @@ public class GenericIndexed<T> implements Indexed<T>, Serializer
 
         int relativePositionOfIndex = index & relativeIndexMask;
         if (relativePositionOfIndex == 0) {
-          int headerPosition = index * Ints.BYTES;
+          int headerPosition = index * Integer.BYTES;
           startOffset = 4;
           endOffset = headerBuffer.getInt(headerPosition);
         } else {
-          int headerPosition = (index - 1) * Ints.BYTES;
-          startOffset = headerBuffer.getInt(headerPosition) + Ints.BYTES;
-          endOffset = headerBuffer.getInt(headerPosition + Ints.BYTES);
+          int headerPosition = (index - 1) * Integer.BYTES;
+          startOffset = headerBuffer.getInt(headerPosition) + Integer.BYTES;
+          endOffset = headerBuffer.getInt(headerPosition + Integer.BYTES);
         }
         int fileNum = index >> logBaseTwoOfElementsPerValueFile;
         return bufferedIndexedGet(copyValueBuffers[fileNum], startOffset, endOffset);

--- a/processing/src/main/java/io/druid/segment/data/GenericIndexedWriter.java
+++ b/processing/src/main/java/io/druid/segment/data/GenericIndexedWriter.java
@@ -27,10 +27,10 @@ import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.io.Closer;
 import io.druid.java.util.common.io.smoosh.FileSmoosher;
 import io.druid.java.util.common.io.smoosh.SmooshedWriter;
-import io.druid.segment.writeout.WriteOutBytes;
-import io.druid.segment.writeout.SegmentWriteOutMedium;
 import io.druid.segment.serde.MetaSerdeHelper;
 import io.druid.segment.serde.Serializer;
+import io.druid.segment.writeout.SegmentWriteOutMedium;
+import io.druid.segment.writeout.WriteOutBytes;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongList;
 
@@ -425,7 +425,7 @@ public class GenericIndexedWriter<T> implements Serializer
   private void writeHeaderLong(FileSmoosher smoosher, int bagSizePower)
       throws IOException
   {
-    ByteBuffer helperBuffer = ByteBuffer.allocate(Ints.BYTES).order(ByteOrder.nativeOrder());
+    ByteBuffer helperBuffer = ByteBuffer.allocate(Integer.BYTES).order(ByteOrder.nativeOrder());
 
     int numberOfElementsPerValueFile = 1 << bagSizePower;
     long currentNumBytes = 0;

--- a/processing/src/main/java/io/druid/segment/data/LongsLongEncodingWriter.java
+++ b/processing/src/main/java/io/druid/segment/data/LongsLongEncodingWriter.java
@@ -19,7 +19,6 @@
 
 package io.druid.segment.data;
 
-import com.google.common.primitives.Longs;
 import io.druid.segment.writeout.WriteOutBytes;
 
 import java.io.IOException;
@@ -38,7 +37,7 @@ public class LongsLongEncodingWriter implements CompressionFactory.LongEncodingW
   public LongsLongEncodingWriter(ByteOrder order)
   {
     this.order = order;
-    orderBuffer = ByteBuffer.allocate(Longs.BYTES);
+    orderBuffer = ByteBuffer.allocate(Long.BYTES);
     orderBuffer.order(order);
   }
 
@@ -92,12 +91,12 @@ public class LongsLongEncodingWriter implements CompressionFactory.LongEncodingW
   @Override
   public int getBlockSize(int bytesPerBlock)
   {
-    return bytesPerBlock / Longs.BYTES;
+    return bytesPerBlock / Long.BYTES;
   }
 
   @Override
   public int getNumBytes(int values)
   {
-    return values * Longs.BYTES;
+    return values * Long.BYTES;
   }
 }

--- a/processing/src/main/java/io/druid/segment/data/TableLongEncodingWriter.java
+++ b/processing/src/main/java/io/druid/segment/data/TableLongEncodingWriter.java
@@ -19,8 +19,6 @@
 
 package io.druid.segment.data;
 
-import com.google.common.primitives.Ints;
-import com.google.common.primitives.Longs;
 import io.druid.java.util.common.IAE;
 import io.druid.segment.writeout.WriteOutBytes;
 import it.unimi.dsi.fastutil.longs.Long2IntMap;
@@ -88,7 +86,7 @@ public class TableLongEncodingWriter implements CompressionFactory.LongEncodingW
   @Override
   public int metaSize()
   {
-    return 1 + 1 + 1 + Ints.BYTES + (table.size() * Longs.BYTES);
+    return 1 + 1 + 1 + Integer.BYTES + (table.size() * Long.BYTES);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/data/VSizeColumnarInts.java
+++ b/processing/src/main/java/io/druid/segment/data/VSizeColumnarInts.java
@@ -67,7 +67,7 @@ public class VSizeColumnarInts implements ColumnarInts, Comparable<VSizeColumnar
 
   private static void writeToBuffer(ByteBuffer buffer, IntList list, int numBytes, int maxValue)
   {
-    ByteBuffer helperBuffer = ByteBuffer.allocate(Ints.BYTES);
+    ByteBuffer helperBuffer = ByteBuffer.allocate(Integer.BYTES);
     for (int i = 0; i < list.size(); i++) {
       int val = list.getInt(i);
       if (val < 0) {
@@ -78,7 +78,7 @@ public class VSizeColumnarInts implements ColumnarInts, Comparable<VSizeColumnar
       }
 
       helperBuffer.putInt(0, val);
-      buffer.put(helperBuffer.array(), Ints.BYTES - numBytes, numBytes);
+      buffer.put(helperBuffer.array(), Integer.BYTES - numBytes, numBytes);
     }
     buffer.position(0);
   }
@@ -130,13 +130,13 @@ public class VSizeColumnarInts implements ColumnarInts, Comparable<VSizeColumnar
 
   public int getNumBytesNoPadding()
   {
-    return buffer.remaining() - (Ints.BYTES - numBytes);
+    return buffer.remaining() - (Integer.BYTES - numBytes);
   }
 
   public void writeBytesNoPaddingTo(HeapByteBufferWriteOutBytes out)
   {
     ByteBuffer toWrite = buffer.slice();
-    toWrite.limit(toWrite.limit() - (Ints.BYTES - numBytes));
+    toWrite.limit(toWrite.limit() - (Integer.BYTES - numBytes));
     out.write(toWrite);
   }
 

--- a/processing/src/main/java/io/druid/segment/data/VSizeColumnarIntsSerializer.java
+++ b/processing/src/main/java/io/druid/segment/data/VSizeColumnarIntsSerializer.java
@@ -22,9 +22,9 @@ package io.druid.segment.data;
 import com.google.common.primitives.Ints;
 import io.druid.common.utils.ByteUtils;
 import io.druid.java.util.common.io.smoosh.FileSmoosher;
-import io.druid.segment.writeout.WriteOutBytes;
-import io.druid.segment.writeout.SegmentWriteOutMedium;
 import io.druid.segment.serde.MetaSerdeHelper;
+import io.druid.segment.writeout.SegmentWriteOutMedium;
+import io.druid.segment.writeout.WriteOutBytes;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -45,7 +45,7 @@ public class VSizeColumnarIntsSerializer extends SingleValueColumnarIntsSerializ
   private final SegmentWriteOutMedium segmentWriteOutMedium;
   private final int numBytes;
 
-  private final ByteBuffer helperBuffer = ByteBuffer.allocate(Ints.BYTES);
+  private final ByteBuffer helperBuffer = ByteBuffer.allocate(Integer.BYTES);
   private WriteOutBytes valuesOut = null;
   private boolean bufPaddingWritten = false;
 
@@ -68,7 +68,7 @@ public class VSizeColumnarIntsSerializer extends SingleValueColumnarIntsSerializ
       throw new IllegalStateException("written out already");
     }
     helperBuffer.putInt(0, val);
-    valuesOut.write(helperBuffer.array(), Ints.BYTES - numBytes, numBytes);
+    valuesOut.write(helperBuffer.array(), Integer.BYTES - numBytes, numBytes);
   }
 
   @Override
@@ -89,7 +89,7 @@ public class VSizeColumnarIntsSerializer extends SingleValueColumnarIntsSerializ
   private void writeBufPadding() throws IOException
   {
     if (!bufPaddingWritten) {
-      byte[] bufPadding = new byte[Ints.BYTES - numBytes];
+      byte[] bufPadding = new byte[Integer.BYTES - numBytes];
       valuesOut.write(bufPadding);
       bufPaddingWritten = true;
     }

--- a/processing/src/main/java/io/druid/segment/data/VSizeColumnarMultiInts.java
+++ b/processing/src/main/java/io/druid/segment/data/VSizeColumnarMultiInts.java
@@ -25,9 +25,9 @@ import io.druid.io.Channels;
 import io.druid.java.util.common.IAE;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.io.smoosh.FileSmoosher;
-import io.druid.segment.writeout.HeapByteBufferWriteOutBytes;
 import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import io.druid.segment.serde.MetaSerdeHelper;
+import io.druid.segment.writeout.HeapByteBufferWriteOutBytes;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -50,8 +50,8 @@ public class VSizeColumnarMultiInts implements ColumnarMultiInts, WritableSuppli
   {
     Iterator<VSizeColumnarInts> objects = objectsIterable.iterator();
     if (!objects.hasNext()) {
-      final ByteBuffer buffer = ByteBuffer.allocate(Ints.BYTES).putInt(0, 0);
-      return new VSizeColumnarMultiInts(buffer, Ints.BYTES);
+      final ByteBuffer buffer = ByteBuffer.allocate(Integer.BYTES).putInt(0, 0);
+      return new VSizeColumnarMultiInts(buffer, Integer.BYTES);
     }
 
     int numBytes = -1;
@@ -79,7 +79,7 @@ public class VSizeColumnarMultiInts implements ColumnarMultiInts, WritableSuppli
         headerBytes.writeInt(offset);
         object.writeBytesNoPaddingTo(valueBytes);
       }
-      valueBytes.write(new byte[Ints.BYTES - numBytes]);
+      valueBytes.write(new byte[Integer.BYTES - numBytes]);
     }
     catch (IOException e) {
       throw new RuntimeException(e);
@@ -139,7 +139,7 @@ public class VSizeColumnarMultiInts implements ColumnarMultiInts, WritableSuppli
     if (index == 0) {
       endOffset = myBuffer.getInt();
     } else {
-      myBuffer.position(myBuffer.position() + ((index - 1) * Ints.BYTES));
+      myBuffer.position(myBuffer.position() + ((index - 1) * Integer.BYTES));
       startOffset = myBuffer.getInt();
       endOffset = myBuffer.getInt();
     }

--- a/processing/src/main/java/io/druid/segment/serde/DictionaryEncodedColumnPartSerde.java
+++ b/processing/src/main/java/io/druid/segment/serde/DictionaryEncodedColumnPartSerde.java
@@ -39,10 +39,10 @@ import io.druid.segment.data.ColumnarIntsSerializer;
 import io.druid.segment.data.ColumnarMultiInts;
 import io.druid.segment.data.CompressedVSizeColumnarIntsSupplier;
 import io.druid.segment.data.CompressedVSizeColumnarMultiIntsSupplier;
-import io.druid.segment.data.V3CompressedVSizeColumnarMultiIntsSupplier;
 import io.druid.segment.data.GenericIndexed;
 import io.druid.segment.data.GenericIndexedWriter;
 import io.druid.segment.data.ImmutableRTreeObjectStrategy;
+import io.druid.segment.data.V3CompressedVSizeColumnarMultiIntsSupplier;
 import io.druid.segment.data.VSizeColumnarInts;
 import io.druid.segment.data.VSizeColumnarMultiInts;
 import io.druid.segment.data.WritableSupplier;
@@ -214,7 +214,7 @@ public class DictionaryEncodedColumnPartSerde implements ColumnPartSerde
             {
               long size = 1 + // version
                           (version.compareTo(VERSION.COMPRESSED) >= 0
-                           ? Ints.BYTES
+                           ? Integer.BYTES
                            : 0); // flag if version >= compressed
               if (dictionaryWriter != null) {
                 size += dictionaryWriter.getSerializedSize();

--- a/processing/src/main/java/io/druid/segment/writeout/ByteBufferWriteOutBytes.java
+++ b/processing/src/main/java/io/druid/segment/writeout/ByteBufferWriteOutBytes.java
@@ -98,14 +98,14 @@ public abstract class ByteBufferWriteOutBytes extends WriteOutBytes
   public void writeInt(int v)
   {
     checkOpen();
-    if (headBuffer.remaining() >= Ints.BYTES) {
+    if (headBuffer.remaining() >= Integer.BYTES) {
       headBuffer.putInt(v);
-      size += Ints.BYTES;
+      size += Integer.BYTES;
     } else {
-      ensureCapacity(Ints.BYTES);
-      if (headBuffer.remaining() >= Ints.BYTES) {
+      ensureCapacity(Integer.BYTES);
+      if (headBuffer.remaining() >= Integer.BYTES) {
         headBuffer.putInt(v);
-        size += Ints.BYTES;
+        size += Integer.BYTES;
       } else {
         write(v >> 24);
         write(v >> 16);

--- a/processing/src/test/java/io/druid/query/aggregation/DoubleMaxAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/DoubleMaxAggregationTest.java
@@ -19,7 +19,6 @@
 
 package io.druid.query.aggregation;
 
-import com.google.common.primitives.Doubles;
 import io.druid.segment.ColumnSelectorFactory;
 import io.druid.segment.TestHelper;
 import org.easymock.EasyMock;
@@ -74,7 +73,7 @@ public class DoubleMaxAggregationTest
   {
     DoubleMaxBufferAggregator agg = (DoubleMaxBufferAggregator) doubleMaxAggFactory.factorizeBuffered(colSelectorFactory);
 
-    ByteBuffer buffer = ByteBuffer.wrap(new byte[Doubles.BYTES]);
+    ByteBuffer buffer = ByteBuffer.wrap(new byte[Double.BYTES]);
     agg.init(buffer, 0);
 
     aggregate(selector, agg, buffer, 0);

--- a/processing/src/test/java/io/druid/query/aggregation/DoubleMinAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/DoubleMinAggregationTest.java
@@ -19,7 +19,6 @@
 
 package io.druid.query.aggregation;
 
-import com.google.common.primitives.Doubles;
 import io.druid.segment.ColumnSelectorFactory;
 import io.druid.segment.TestHelper;
 import org.easymock.EasyMock;
@@ -74,7 +73,7 @@ public class DoubleMinAggregationTest
   {
     DoubleMinBufferAggregator agg = (DoubleMinBufferAggregator) doubleMinAggFactory.factorizeBuffered(colSelectorFactory);
 
-    ByteBuffer buffer = ByteBuffer.wrap(new byte[Doubles.BYTES]);
+    ByteBuffer buffer = ByteBuffer.wrap(new byte[Double.BYTES]);
     agg.init(buffer, 0);
 
     aggregate(selector, agg, buffer, 0);

--- a/processing/src/test/java/io/druid/query/aggregation/LongMaxAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/LongMaxAggregationTest.java
@@ -19,7 +19,6 @@
 
 package io.druid.query.aggregation;
 
-import com.google.common.primitives.Longs;
 import io.druid.segment.ColumnSelectorFactory;
 import io.druid.segment.TestHelper;
 import org.easymock.EasyMock;
@@ -74,7 +73,7 @@ public class LongMaxAggregationTest
   {
     LongMaxBufferAggregator agg = (LongMaxBufferAggregator) longMaxAggFactory.factorizeBuffered(colSelectorFactory);
 
-    ByteBuffer buffer = ByteBuffer.wrap(new byte[Longs.BYTES]);
+    ByteBuffer buffer = ByteBuffer.wrap(new byte[Long.BYTES]);
     agg.init(buffer, 0);
 
     aggregate(selector, agg, buffer, 0);

--- a/processing/src/test/java/io/druid/query/aggregation/LongMinAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/LongMinAggregationTest.java
@@ -19,7 +19,6 @@
 
 package io.druid.query.aggregation;
 
-import com.google.common.primitives.Longs;
 import io.druid.segment.ColumnSelectorFactory;
 import io.druid.segment.TestHelper;
 import org.easymock.EasyMock;
@@ -74,7 +73,7 @@ public class LongMinAggregationTest
   {
     LongMinBufferAggregator agg = (LongMinBufferAggregator) longMinAggFactory.factorizeBuffered(colSelectorFactory);
 
-    ByteBuffer buffer = ByteBuffer.wrap(new byte[Longs.BYTES]);
+    ByteBuffer buffer = ByteBuffer.wrap(new byte[Long.BYTES]);
     agg.init(buffer, 0);
 
     aggregate(selector, agg, buffer, 0);

--- a/processing/src/test/java/io/druid/query/cache/CacheKeyBuilderTest.java
+++ b/processing/src/test/java/io/druid/query/cache/CacheKeyBuilderTest.java
@@ -21,11 +21,8 @@ package io.druid.query.cache;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.primitives.Doubles;
-import com.google.common.primitives.Floats;
-import com.google.common.primitives.Ints;
-import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.Cacheable;
+import io.druid.java.util.common.StringUtils;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
@@ -67,14 +64,14 @@ public class CacheKeyBuilderTest
     final int expectedSize = 1                                           // id
                              + 1                                         // bool
                              + 4                                         // 'test'
-                             + Ints.BYTES                                // 10
-                             + Floats.BYTES                              // 0.1f
-                             + Doubles.BYTES                             // 2.3
+                             + Integer.BYTES                             // 10
+                             + Float.BYTES                               // 0.1f
+                             + Double.BYTES                              // 2.3
                              + CacheKeyBuilder.STRING_SEPARATOR.length   // byte array
-                             + Floats.BYTES * 2                          // 10.0f, 11.0f
-                             + Ints.BYTES + 5 * 2 + 1                    // 'test1' 'test2'
+                             + Float.BYTES * 2                           // 10.0f, 11.0f
+                             + Integer.BYTES + 5 * 2 + 1                 // 'test1' 'test2'
                              + cacheable.getCacheKey().length            // cacheable
-                             + Ints.BYTES + 4                                // cacheable list
+                             + Integer.BYTES + 4                         // cacheable list
                              + 11;                                       // type keys
     assertEquals(expectedSize, actual.length);
 

--- a/processing/src/test/java/io/druid/query/groupby/epinephelinae/IntKeySerde.java
+++ b/processing/src/test/java/io/druid/query/groupby/epinephelinae/IntKeySerde.java
@@ -44,12 +44,12 @@ public class IntKeySerde implements Grouper.KeySerde<Integer>
     }
   };
 
-  private final ByteBuffer buf = ByteBuffer.allocate(Ints.BYTES);
+  private final ByteBuffer buf = ByteBuffer.allocate(Integer.BYTES);
 
   @Override
   public int keySize()
   {
-    return Ints.BYTES;
+    return Integer.BYTES;
   }
 
   @Override

--- a/processing/src/test/java/io/druid/segment/IndexMergerTestBase.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerTestBase.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import com.google.common.primitives.Ints;
 import io.druid.collections.bitmap.RoaringBitmapFactory;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.MapBasedInputRow;
@@ -41,7 +40,6 @@ import io.druid.java.util.common.IAE;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.io.smoosh.SmooshedFileMapper;
-import io.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.query.aggregation.LongSumAggregatorFactory;
@@ -58,6 +56,7 @@ import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexAdapter;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.IndexSizeExceededException;
+import io.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import org.joda.time.Interval;
 import org.junit.Assert;
@@ -2304,7 +2303,7 @@ public class IndexMergerTestBase
   @Test
   public void testDictIdSeeker() throws Exception
   {
-    IntBuffer dimConversions = ByteBuffer.allocateDirect(3 * Ints.BYTES).asIntBuffer();
+    IntBuffer dimConversions = ByteBuffer.allocateDirect(3 * Integer.BYTES).asIntBuffer();
     dimConversions.put(0);
     dimConversions.put(2);
     dimConversions.put(4);

--- a/processing/src/test/java/io/druid/segment/data/CompressedColumnarIntsSerializerTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedColumnarIntsSerializerTest.java
@@ -22,7 +22,6 @@ package io.druid.segment.data;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
-import com.google.common.primitives.Longs;
 import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.guava.CloseQuietly;
 import io.druid.java.util.common.io.smoosh.FileSmoosher;
@@ -30,8 +29,8 @@ import io.druid.java.util.common.io.smoosh.Smoosh;
 import io.druid.java.util.common.io.smoosh.SmooshedFileMapper;
 import io.druid.java.util.common.io.smoosh.SmooshedWriter;
 import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMedium;
-import io.druid.segment.writeout.WriteOutBytes;
 import io.druid.segment.writeout.SegmentWriteOutMedium;
+import io.druid.segment.writeout.WriteOutBytes;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -200,7 +199,7 @@ public class CompressedColumnarIntsSerializerTest
             segmentWriteOutMedium,
             "test",
             compressionStrategy,
-            Longs.BYTES * 10000
+            Long.BYTES * 10000
         )
     );
 

--- a/processing/src/test/java/io/druid/segment/data/CompressedColumnarIntsSupplierTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedColumnarIntsSupplierTest.java
@@ -19,7 +19,6 @@
 
 package io.druid.segment.data;
 
-import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.guava.CloseQuietly;
@@ -145,7 +144,7 @@ public class CompressedColumnarIntsSupplierTest extends CompressionStrategyTest
   @Test
   public void testLargeChunks() throws Exception
   {
-    final int maxChunkSize = CompressedPools.BUFFER_SIZE / Longs.BYTES;
+    final int maxChunkSize = CompressedPools.BUFFER_SIZE / Long.BYTES;
 
     setupLargeChunks(maxChunkSize, 10 * maxChunkSize);
     Assert.assertEquals(10, supplier.getBaseIntBuffers().size());
@@ -163,7 +162,7 @@ public class CompressedColumnarIntsSupplierTest extends CompressionStrategyTest
   @Test(expected = IllegalArgumentException.class)
   public void testChunkTooBig() throws Exception
   {
-    final int maxChunkSize = CompressedPools.BUFFER_SIZE / Ints.BYTES;
+    final int maxChunkSize = CompressedPools.BUFFER_SIZE / Integer.BYTES;
     setupLargeChunks(maxChunkSize + 1, 10 * (maxChunkSize + 1));
   }
 

--- a/processing/src/test/java/io/druid/segment/data/CompressedVSizeColumnarIntsSerializerTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedVSizeColumnarIntsSerializerTest.java
@@ -23,7 +23,6 @@ import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.common.primitives.Ints;
-import com.google.common.primitives.Longs;
 import io.druid.java.util.common.guava.CloseQuietly;
 import io.druid.java.util.common.io.smoosh.FileSmoosher;
 import io.druid.java.util.common.io.smoosh.Smoosh;
@@ -190,7 +189,7 @@ public class CompressedVSizeColumnarIntsSerializerTest
         segmentWriteOutMedium,
         "test",
         compressionStrategy,
-        Longs.BYTES * 10000
+        Long.BYTES * 10000
     );
     CompressedVSizeColumnarIntsSerializer writer = new CompressedVSizeColumnarIntsSerializer(
         segmentWriteOutMedium,

--- a/processing/src/test/java/io/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSerializerTest.java
+++ b/processing/src/test/java/io/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSerializerTest.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 import com.google.common.primitives.Ints;
-import com.google.common.primitives.Longs;
 import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.guava.CloseQuietly;
 import io.druid.java.util.common.io.smoosh.FileSmoosher;
@@ -240,7 +239,7 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
               segmentWriteOutMedium,
               "offset",
               compressionStrategy,
-              Longs.BYTES * 250000
+              Long.BYTES * 250000
           )
       );
 
@@ -248,7 +247,7 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
           segmentWriteOutMedium,
           "value",
           compressionStrategy,
-          Longs.BYTES * 250000
+          Long.BYTES * 250000
       );
       CompressedVSizeColumnarIntsSerializer valueWriter = new CompressedVSizeColumnarIntsSerializer(
           segmentWriteOutMedium,

--- a/processing/src/test/java/io/druid/segment/serde/LargeColumnSupportedComplexColumnSerializerTest.java
+++ b/processing/src/test/java/io/druid/segment/serde/LargeColumnSupportedComplexColumnSerializerTest.java
@@ -21,18 +21,17 @@ package io.druid.segment.serde;
 
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
-import com.google.common.primitives.Longs;
 import io.druid.hll.HyperLogLogCollector;
 import io.druid.java.util.common.io.smoosh.FileSmoosher;
 import io.druid.java.util.common.io.smoosh.Smoosh;
 import io.druid.java.util.common.io.smoosh.SmooshedFileMapper;
 import io.druid.java.util.common.io.smoosh.SmooshedWriter;
-import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMedium;
-import io.druid.segment.writeout.SegmentWriteOutMedium;
 import io.druid.segment.column.Column;
 import io.druid.segment.column.ColumnBuilder;
 import io.druid.segment.column.ComplexColumn;
 import io.druid.segment.column.ValueType;
+import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMedium;
+import io.druid.segment.writeout.SegmentWriteOutMedium;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -52,8 +51,8 @@ public class LargeColumnSupportedComplexColumnSerializerTest
     HyperUniquesSerdeForTest serde = new HyperUniquesSerdeForTest(Hashing.murmur3_128());
     int[] cases = {1000, 5000, 10000, 20000};
     int[] columnSizes = {
-        Integer.MAX_VALUE, Integer.MAX_VALUE / 2, Integer.MAX_VALUE / 4, 5000 * Longs.BYTES,
-        2500 * Longs.BYTES
+        Integer.MAX_VALUE, Integer.MAX_VALUE / 2, Integer.MAX_VALUE / 4, 5000 * Long.BYTES,
+        2500 * Long.BYTES
     };
 
     for (int columnSize : columnSizes) {

--- a/server/src/main/java/io/druid/client/cache/Cache.java
+++ b/server/src/main/java/io/druid/client/cache/Cache.java
@@ -20,9 +20,8 @@
 package io.druid.client.cache;
 
 import com.google.common.base.Preconditions;
-import com.google.common.primitives.Ints;
-import io.druid.java.util.emitter.service.ServiceEmitter;
 import io.druid.java.util.common.StringUtils;
+import io.druid.java.util.emitter.service.ServiceEmitter;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
@@ -73,7 +72,7 @@ public interface Cache
     public byte[] toByteArray()
     {
       final byte[] nsBytes = StringUtils.toUtf8(this.namespace);
-      return ByteBuffer.allocate(Ints.BYTES + nsBytes.length + this.key.length)
+      return ByteBuffer.allocate(Integer.BYTES + nsBytes.length + this.key.length)
           .putInt(nsBytes.length)
           .put(nsBytes)
           .put(this.key).array();

--- a/server/src/main/java/io/druid/client/cache/CaffeineCache.java
+++ b/server/src/main/java/io/druid/client/cache/CaffeineCache.java
@@ -25,12 +25,9 @@ import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-import com.google.common.primitives.Chars;
-import com.google.common.primitives.Ints;
+import io.druid.java.util.common.logger.Logger;
 import io.druid.java.util.emitter.service.ServiceEmitter;
 import io.druid.java.util.emitter.service.ServiceMetricEvent;
-
-import io.druid.java.util.common.logger.Logger;
 import net.jpountz.lz4.LZ4Compressor;
 import net.jpountz.lz4.LZ4Factory;
 import net.jpountz.lz4.LZ4FastDecompressor;
@@ -73,7 +70,7 @@ public class CaffeineCache implements io.druid.client.cache.Cache
           .maximumWeight(config.getSizeInBytes())
           .weigher((NamedKey key, byte[] value) -> value.length
                                                    + key.key.length
-                                                   + key.namespace.length() * Chars.BYTES
+                                                   + key.namespace.length() * Character.BYTES
                                                    + FIXED_COST);
     }
     builder.executor(executor);
@@ -176,7 +173,7 @@ public class CaffeineCache implements io.druid.client.cache.Cache
     }
     final int decompressedLen = ByteBuffer.wrap(bytes).getInt();
     final byte[] out = new byte[decompressedLen];
-    LZ4_DECOMPRESSOR.decompress(bytes, Ints.BYTES, out, 0, out.length);
+    LZ4_DECOMPRESSOR.decompress(bytes, Integer.BYTES, out, 0, out.length);
     return out;
   }
 
@@ -185,7 +182,7 @@ public class CaffeineCache implements io.druid.client.cache.Cache
     final int len = LZ4_COMPRESSOR.maxCompressedLength(value.length);
     final byte[] out = new byte[len];
     final int compressedSize = LZ4_COMPRESSOR.compress(value, 0, value.length, out, 0);
-    return ByteBuffer.allocate(compressedSize + Ints.BYTES)
+    return ByteBuffer.allocate(compressedSize + Integer.BYTES)
                      .putInt(value.length)
                      .put(out, 0, compressedSize)
                      .array();

--- a/server/src/main/java/io/druid/client/cache/LZ4Transcoder.java
+++ b/server/src/main/java/io/druid/client/cache/LZ4Transcoder.java
@@ -19,7 +19,6 @@
 
 package io.druid.client.cache;
 
-import com.google.common.primitives.Ints;
 import net.jpountz.lz4.LZ4Compressor;
 import net.jpountz.lz4.LZ4Factory;
 import net.jpountz.lz4.LZ4FastDecompressor;
@@ -56,7 +55,7 @@ public class LZ4Transcoder extends SerializingTranscoder
 
     getLogger().debug("Compressed %d bytes to %d", in.length, compressedLength);
 
-    return ByteBuffer.allocate(Ints.BYTES + compressedLength)
+    return ByteBuffer.allocate(Integer.BYTES + compressedLength)
                      .putInt(in.length)
                      .put(out, 0, compressedLength)
                      .array();
@@ -72,7 +71,7 @@ public class LZ4Transcoder extends SerializingTranscoder
       int size = ByteBuffer.wrap(in).getInt();
 
       out = new byte[size];
-      decompressor.decompress(in, Ints.BYTES, out, 0, out.length);
+      decompressor.decompress(in, Integer.BYTES, out, 0, out.length);
     }
     return out == null ? null : out;
   }

--- a/server/src/main/java/io/druid/client/cache/MemcachedCache.java
+++ b/server/src/main/java/io/druid/client/cache/MemcachedCache.java
@@ -31,13 +31,12 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
-import com.google.common.primitives.Ints;
-import io.druid.java.util.emitter.service.ServiceEmitter;
-import io.druid.java.util.emitter.service.ServiceMetricEvent;
-import io.druid.java.util.metrics.AbstractMonitor;
 import io.druid.collections.ResourceHolder;
 import io.druid.collections.StupidResourceHolder;
 import io.druid.java.util.common.logger.Logger;
+import io.druid.java.util.emitter.service.ServiceEmitter;
+import io.druid.java.util.emitter.service.ServiceMetricEvent;
+import io.druid.java.util.metrics.AbstractMonitor;
 import net.spy.memcached.AddrUtil;
 import net.spy.memcached.ConnectionFactory;
 import net.spy.memcached.ConnectionFactoryBuilder;
@@ -500,7 +499,7 @@ public class MemcachedCache implements Cache
   private static byte[] serializeValue(NamedKey key, byte[] value)
   {
     byte[] keyBytes = key.toByteArray();
-    return ByteBuffer.allocate(Ints.BYTES + keyBytes.length + value.length)
+    return ByteBuffer.allocate(Integer.BYTES + keyBytes.length + value.length)
                      .putInt(keyBytes.length)
                      .put(keyBytes)
                      .put(value)

--- a/server/src/main/java/io/druid/server/listener/announcer/ListenerResourceAnnouncer.java
+++ b/server/src/main/java/io/druid/server/listener/announcer/ListenerResourceAnnouncer.java
@@ -20,7 +20,6 @@
 package io.druid.server.listener.announcer;
 
 import com.google.common.base.Throwables;
-import com.google.common.primitives.Longs;
 import io.druid.curator.announcement.Announcer;
 import io.druid.java.util.common.lifecycle.LifecycleStart;
 import io.druid.java.util.common.lifecycle.LifecycleStop;
@@ -37,7 +36,7 @@ import java.nio.ByteBuffer;
 public abstract class ListenerResourceAnnouncer
 {
   private static final byte[] ANNOUNCE_BYTES = ByteBuffer
-      .allocate(Longs.BYTES)
+      .allocate(Long.BYTES)
       .putLong(System.currentTimeMillis())
       .array();
   private static final Logger LOG = new Logger(ListenerResourceAnnouncer.class);

--- a/server/src/test/java/io/druid/server/listener/announcer/ListenerResourceAnnouncerTest.java
+++ b/server/src/test/java/io/druid/server/listener/announcer/ListenerResourceAnnouncerTest.java
@@ -19,11 +19,10 @@
 
 package io.druid.server.listener.announcer;
 
-import com.google.common.primitives.Longs;
-import io.druid.java.util.common.concurrent.Execs;
 import io.druid.curator.CuratorTestBase;
 import io.druid.curator.announcement.Announcer;
 import io.druid.java.util.common.StringUtils;
+import io.druid.java.util.common.concurrent.Execs;
 import io.druid.segment.CloserRule;
 import io.druid.server.http.HostAndPortWithScheme;
 import io.druid.server.initialization.ZkPathsConfig;
@@ -93,7 +92,7 @@ public class ListenerResourceAnnouncerTest extends CuratorTestBase
     Assert.assertNotNull(curator.checkExists().forPath(announcePath));
     final String nodePath = ZKPaths.makePath(announcePath, StringUtils.format("%s:%s", node.getScheme(), node.getHostText()));
     Assert.assertNotNull(curator.checkExists().forPath(nodePath));
-    Assert.assertEquals(Longs.BYTES, curator.getData().decompressed().forPath(nodePath).length);
+    Assert.assertEquals(Long.BYTES, curator.getData().decompressed().forPath(nodePath).length);
     Assert.assertNull(curator.checkExists()
                              .forPath(listeningAnnouncerConfig.getAnnouncementPath(listenerKey + "FOO")));
     listenerResourceAnnouncer.stop();


### PR DESCRIPTION
And same for other primitives.

Why:
 - Standardize on one option to make codebase more homogeneous.
 - Prefer JDK to a library.
