### PR TITLE
Add druid kafka extension based on Kafka 1.0.

### DIFF
--- a/docs/content/development/extensions-contrib/kafka-firehose.md
+++ b/docs/content/development/extensions-contrib/kafka-firehose.md
@@ -1,0 +1,37 @@
+---
+layout: doc_page
+---
+
+# Kafka Firehose
+
+Make sure to [include](../../operations/including-extensions.html) `druid-kafka` as an extension.
+
+This firehose acts as a Kafka 1.0.x consumer and ingests data from Kafka.
+
+**Note:** Add **kafka-clients-1.0.0.jar** to lib directory of druid to use this firehose.
+
+Sample spec:
+
+```json
+"firehose": {
+  "type": "kafka-1.0",
+  "consumerProps": {
+    "bootstrap.servers": "localhost:9092",
+    "group.id": "druid-example",
+    "fetch.max.bytes" : "1048586",
+    "auto.offset.reset": "latest",
+    "enable.auto.commit": "false"
+  },
+  "feed": "wikipedia",
+  "rowDelimiter": "\n",
+  "messageEncoding": "UTF-8"
+}
+```
+
+|Property|Description|Required|Default|
+|--------|-----------|--------|-------|
+|type|This should be "kafka-1.0"|yes||
+|consumerProps|The full list of consumer configs can be [here](https://kafka.apache.org/10/documentation/#newconsumerconfigs).|yes||
+|feed|Kafka maintains feeds of messages in categories called topics. This is the topic name.|yes||
+|rowDelimiter|Kafka maintains feeds of messages in categories called topics. This is the topic name.|no|`null`, which means one meassge is one row|
+|messageEncoding|The Kafka message encoding. Only available when `rowDelimiter` is set.|no|"UTF-8"|

--- a/docs/content/development/extensions.md
+++ b/docs/content/development/extensions.md
@@ -71,6 +71,7 @@ All of these community extensions can be downloaded using *pull-deps* with the c
 |statsd-emitter|StatsD metrics emitter|[link](../development/extensions-contrib/statsd.html)|
 |kafka-emitter|Kafka metrics emitter|[link](../development/extensions-contrib/kafka-emitter.html)|
 |druid-thrift-extensions|Support thrift ingestion |[link](../development/extensions-contrib/thrift.html)|
+|druid-kafka|Kafka ingest firehose (high level consumer) for realtime nodes based on Kafka 1.0.|[link](../development/extensions-contrib/kafka-firehose.html)|
 
 ## Promoting Community Extension to Core Extension
 

--- a/extensions-contrib/druid-kafka/pom.xml
+++ b/extensions-contrib/druid-kafka/pom.xml
@@ -16,8 +16,7 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.druid.extensions</groupId>
@@ -53,6 +52,11 @@
                     <artifactId>lz4-java</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
         </dependency>
 
         <!-- Tests -->

--- a/extensions-contrib/druid-kafka/pom.xml
+++ b/extensions-contrib/druid-kafka/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Druid - a distributed column store.
+  ~ Copyright 2012 - 2015 Metamarkets Group Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.druid.extensions</groupId>
+    <artifactId>druid-kafka</artifactId>
+    <name>druid-kafka</name>
+    <description>druid-kafka 1.0</description>
+
+    <parent>
+        <groupId>io.druid</groupId>
+        <artifactId>druid</artifactId>
+        <version>0.13.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.druid</groupId>
+            <artifactId>druid-api</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>1.0.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.lz4</groupId>
+                    <artifactId>lz4-java</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Tests -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/extensions-contrib/druid-kafka/src/main/java/io/druid/firehose/kafka/KafkaFirehoseDruidModule.java
+++ b/extensions-contrib/druid-kafka/src/main/java/io/druid/firehose/kafka/KafkaFirehoseDruidModule.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.firehose.kafka;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import io.druid.initialization.DruidModule;
+
+import java.util.List;
+
+/**
+ */
+public class KafkaFirehoseDruidModule implements DruidModule
+{
+  @Override
+  public List<? extends Module> getJacksonModules()
+  {
+    return ImmutableList.of(
+        new SimpleModule("KafkaFirehoseModule")
+            .registerSubtypes(
+                new NamedType(KafkaFirehoseFactory.class, "kafka-1.0")
+            )
+    );
+  }
+
+  @Override
+  public void configure(Binder binder)
+  {
+
+  }
+}

--- a/extensions-contrib/druid-kafka/src/main/java/io/druid/firehose/kafka/KafkaFirehoseFactory.java
+++ b/extensions-contrib/druid-kafka/src/main/java/io/druid/firehose/kafka/KafkaFirehoseFactory.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.firehose.kafka;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+import io.druid.data.input.ByteBufferInputRowParser;
+import io.druid.data.input.Firehose;
+import io.druid.data.input.FirehoseFactory;
+import io.druid.data.input.InputRow;
+import io.druid.data.input.impl.StringInputRowParser;
+import io.druid.java.util.common.logger.Logger;
+import org.apache.commons.lang.StringUtils;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.errors.InterruptException;
+import org.apache.kafka.common.serialization.ByteBufferDeserializer;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Kafka Firehose base on Kafka 1.0
+ */
+public class KafkaFirehoseFactory implements FirehoseFactory<ByteBufferInputRowParser>
+{
+  private static final Logger log = new Logger(KafkaFirehoseFactory.class);
+  private static final String DEFAULT_MESSAGE_ENCODING = "UTF-8";
+  private final Charset charset;
+
+  @JsonProperty
+  private final Properties consumerProps;
+
+  @JsonProperty
+  private final String feed;
+
+  @JsonProperty
+  @Nullable
+  private final String rowDelimiter;
+
+  @JsonProperty
+  private final String messageEncoding;
+
+  @JsonCreator
+  public KafkaFirehoseFactory(
+      @JsonProperty("consumerProps") Properties consumerProps,
+      @JsonProperty("feed") String feed,
+      @JsonProperty("rowDelimiter") @Nullable String rowDelimiter,
+      @JsonProperty("messageEncoding") @Nullable String messageEncoding
+  )
+  {
+    this.consumerProps = consumerProps;
+    this.feed = feed;
+    this.rowDelimiter = rowDelimiter;
+    this.messageEncoding = messageEncoding == null ? DEFAULT_MESSAGE_ENCODING : messageEncoding;
+    this.charset = Charset.forName(this.messageEncoding);
+  }
+
+  @Override
+  public Firehose connect(final ByteBufferInputRowParser firehoseParser, File temporaryDirectory) throws IOException
+  {
+    Set<String> newDimExclus = Sets.union(
+        firehoseParser.getParseSpec().getDimensionsSpec().getDimensionExclusions(),
+        Sets.newHashSet("feed")
+    );
+    final ByteBufferInputRowParser theParser = firehoseParser.withParseSpec(
+        firehoseParser.getParseSpec()
+                      .withDimensionsSpec(
+                          firehoseParser.getParseSpec()
+                                        .getDimensionsSpec()
+                                        .withDimensionExclusions(
+                                            newDimExclus
+                                        )
+                      )
+    );
+    if (rowDelimiter != null) {
+      Preconditions.checkArgument(
+          theParser.getClass().equals(StringInputRowParser.class),
+          "rowDelimiter is available only for string input"
+      );
+    }
+
+    final KafkaConsumer<ByteBuffer, ByteBuffer> consumer = new KafkaConsumer<>(
+        consumerProps,
+        new ByteBufferDeserializer(),
+        new ByteBufferDeserializer()
+    );
+    consumer.subscribe(ImmutableList.of(feed));
+
+    return new Firehose()
+    {
+      private Iterator<ByteBuffer> iter = null;
+      private List<ByteBuffer> bufferList = new ArrayList<>();
+      private AtomicBoolean isCommited = new AtomicBoolean(false);
+      private CharBuffer chars = null;
+
+      /**
+       * Transform {@code byteBuffer} to String using the charset.<p>
+       * Codes are copied from {@link StringInputRowParser} {@code buildStringKeyMap} funtion.
+       *
+       * @param byteBuffer  the {@link ByteBuffer} to be transformed
+       * @return transformed string. return null if failed with {@link CoderResult}
+       */
+      @Nullable
+      private String getString(ByteBuffer byteBuffer)
+      {
+        int payloadSize = byteBuffer.remaining();
+
+        if (chars == null || chars.remaining() < payloadSize) {
+          chars = CharBuffer.allocate(payloadSize);
+        }
+
+        final CoderResult coderResult = charset.newDecoder()
+                                               .onMalformedInput(CodingErrorAction.REPLACE)
+                                               .onUnmappableCharacter(CodingErrorAction.REPLACE)
+                                               .decode(byteBuffer, chars, true);
+        if (coderResult.isUnderflow()) {
+          chars.flip();
+          try {
+            return chars.toString();
+          }
+          finally {
+            chars.clear();
+          }
+        } else {
+          // Failed with CoderResult
+          return null;
+        }
+      }
+
+      @Override
+      public boolean hasMore()
+      {
+        if (isCommited.get()) {
+          // do commit here
+          consumer.commitSync();
+          log.info("offsets committed.");
+          isCommited.set(false);
+        }
+        try {
+          if (iter == null || !iter.hasNext()) {
+            bufferList.clear();
+
+            // Always wait for results
+            ConsumerRecords<ByteBuffer, ByteBuffer> records = consumer.poll(Long.MAX_VALUE);
+            for (ConsumerRecord<ByteBuffer, ByteBuffer> record : records) {
+              // For each ConsumerRecord, its value is the message we want
+              if (rowDelimiter == null) {
+                bufferList.add(record.value());
+              } else {
+                String recordString = getString(record.value());
+                if (recordString != null) {
+                  String[] split = StringUtils.split(recordString, rowDelimiter);
+                  for (String eachRecordString : split) {
+                    bufferList.add(ByteBuffer.wrap(eachRecordString.getBytes(charset)));
+                  }
+                }
+              }
+            }
+            iter = bufferList.iterator();
+          }
+        }
+        catch (InterruptException e) {
+          /*
+             If the process is killed, InterruptException will be thrown. It is good to return false.
+             But it may not to commit sucessfully. Need a better solution.
+            */
+          log.error(e, "Polling message interrupted.");
+          consumer.commitSync();
+          return false;
+        }
+        return iter.hasNext();
+      }
+
+      @Override
+      public InputRow nextRow()
+      {
+        return theParser.parse(iter.next());
+      }
+
+      @Override
+      public Runnable commit()
+      {
+        return new Runnable()
+        {
+          @Override
+          public void run()
+          {
+            /*
+               KafkaConsumer is not thead safe, so we have to let the thread which polled messages do commit.
+             */
+            log.info("committing offsets");
+            isCommited.set(true);
+          }
+        };
+      }
+
+      @Override
+      public void close() throws IOException
+      {
+        consumer.close();
+      }
+    };
+  }
+}

--- a/extensions-contrib/druid-kafka/src/main/resources/META-INF/services/io.druid.initialization.DruidModule
+++ b/extensions-contrib/druid-kafka/src/main/resources/META-INF/services/io.druid.initialization.DruidModule
@@ -1,0 +1,1 @@
+io.druid.firehose.kafka.KafkaFirehoseDruidModule

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,7 @@
         <module>extensions-contrib/sqlserver-metadata-storage</module>
         <module>extensions-contrib/kafka-emitter</module>
         <module>extensions-contrib/redis-cache</module>
+        <module>extensions-contrib/druid-kafka</module>
         <!-- distribution packaging -->
         <module>distribution</module>
     </modules>


### PR DESCRIPTION
As mentioned in #5371 .

There are still some questions:

1. Does it need some reconnect logic if the Kafka consumer throw exceptions while polling records?
2. There is a function to trasform `ByteBuffer` to `String` in Firehose, should it be moved to `io.druid.java.util.common.ByteBufferUtils`?