### PR TITLE
Log exceptions thrown before persist() for indexing tasks

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIndexTask.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIndexTask.java
@@ -796,6 +796,10 @@ public class KafkaIndexTask extends AbstractTask implements ChatHandler
           }
         }
       }
+      catch (Exception e) {
+        log.error(e, "Encountered exception in run() before persisting.");
+        throw e;
+      }
       finally {
         log.info("Persisting all pending data");
         driver.persist(committerSupplier.get()); // persist pending data

--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIndexTask.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIndexTask.java
@@ -1159,6 +1159,10 @@ public class KafkaIndexTask extends AbstractTask implements ChatHandler
           }
         }
       }
+      catch (Exception e) {
+        log.error(e, "Encountered exception in runLegacy() before persisting.");
+        throw e;
+      }
       finally {
         driver.persist(committerSupplier.get()); // persist pending data
       }

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
@@ -735,6 +735,10 @@ public class IndexTask extends AbstractTask
           }
         }
       }
+      catch (Exception e) {
+        log.error(e, "Encountered exception in generateAndPublishSegments() before persisting.");
+        throw e;
+      }
       finally {
         driver.persist(committerSupplier.get());
       }


### PR DESCRIPTION
I've seen the issues like the following sometimes: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/druid-user/GN59raqMeb4/9kLXGRZcAgAJ

```
2018-02-07T12:36:34,705 INFO [task-runner-0-priority-0] io.druid.segment.realtime.appenderator.AppenderatorDriver - New segment[retail_2010-12-01T00:00:00.00
0Z_2010-12-02T00:00:00.000Z_2018-02-07T12:36:29.193Z] for sequenceName[index_retail_2018-02-07T12:36:29.191Z].
2018-02-07T12:36:34,760 INFO [task-runner-0-priority-0] io.druid.segment.realtime.appenderator.AppenderatorDriver - Persisting data.
2018-02-07T12:36:34,766 INFO [task-runner-0-priority-0] io.druid.segment.realtime.appenderator.AppenderatorImpl - Shutting down...
2018-02-07T12:36:34,770 INFO [appenderator_persist_0] io.druid.segment.realtime.appenderator.AppenderatorImpl - Removing sink for segment[retail_2010-12-01T00:00:00.000Z_2010-12-02T00:00:00.000Z_2018-02-07T12:36:29.193Z].
2018-02-07T12:36:34,776 ERROR [task-runner-0-priority-0] io.druid.indexing.overlord.ThreadPoolTaskRunner - Exception while running task[IndexTask{id=index_retail_2018-02-07T12:36:29.191Z, type=index, dataSource=retail}]
java.lang.IllegalArgumentException: fromIndex(0) > toIndex(-1)
        at java.util.ArrayList.subListRangeCheck(ArrayList.java:1014) ~[?:1.8.0_152]
        at java.util.ArrayList.subList(ArrayList.java:1004) ~[?:1.8.0_152]
        at io.druid.segment.realtime.appenderator.AppenderatorImpl.persist(AppenderatorImpl.java:381) ~[druid-server-0.11.0.jar:0.11.0]
        at io.druid.segment.realtime.appenderator.AppenderatorImpl.persistAll(AppenderatorImpl.java:462) ~[druid-server-0.11.0.jar:0.11.0]
        at io.druid.segment.realtime.appenderator.AppenderatorDriver.persist(AppenderatorDriver.java:258) ~[druid-server-0.11.0.jar:0.11.0]
        at io.druid.indexing.common.task.IndexTask.generateAndPublishSegments(IndexTask.java:695) ~[druid-indexing-service-0.11.0.jar:0.11.0]
        at io.druid.indexing.common.task.IndexTask.run(IndexTask.java:233) ~[druid-indexing-service-0.11.0.jar:0.11.0]
        at io.druid.indexing.overlord.ThreadPoolTaskRunner$ThreadPoolTaskRunnerCallable.call(ThreadPoolTaskRunner.java:436) [druid-indexing-service-0.11.0.jar:0.11.0]
        at io.druid.indexing.overlord.ThreadPoolTaskRunner$ThreadPoolTaskRunnerCallable.call(ThreadPoolTaskRunner.java:408) [druid-indexing-service-0.11.0.jar:0.11.0]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_152]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_152]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_152]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_152]
2018-02-07T12:36:34,783 INFO [task-runner-0-priority-0] io.druid.indexing.overlord.TaskRunnerUtils - Task [index_retail_2018-02-07T12:36:29.191Z] status changed to [FAILED].
2018-02-07T12:36:34,787 INFO [task-runner-0-priority-0] io.druid.indexing.worker.executor.ExecutorLifecycle - Task completed with status: {
  "id" : "index_retail_2018-02-07T12:36:29.191Z",
  "status" : "FAILED",
  "duration" : 354
}
```

This exception `java.lang.IllegalArgumentException: fromIndex(0) > toIndex(-1)` thrown during the appenderator driver persist call can occur when there are no rows to be persisted. In some cases this can sometimes occur when an exception in the preceding try{} block breaks the task before it can ingest anything. However, if an exception occurs in persist(), the original exception is lost.

This PR catches, logs, and rethrows any exceptions that occur before the persist() call in the finally{} block for the local indexing task and the kafka index task.
