### PR TITLE
[Backport] Fix DefaultLimitSpec to respect sortByDimsFirst

### DIFF
--- a/processing/src/main/java/io/druid/query/groupby/GroupByQuery.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQuery.java
@@ -136,8 +136,13 @@ public class GroupByQuery extends BaseQuery<Row>
 
   private Function<Sequence<Row>, Sequence<Row>> makePostProcessingFn()
   {
-    Function<Sequence<Row>, Sequence<Row>> postProcessingFn =
-        limitSpec.build(dimensions, aggregatorSpecs, postAggregatorSpecs);
+    Function<Sequence<Row>, Sequence<Row>> postProcessingFn = limitSpec.build(
+        dimensions,
+        aggregatorSpecs,
+        postAggregatorSpecs,
+        getGranularity(),
+        getContextSortByDimsFirst()
+    );
 
     if (havingSpec != null) {
       postProcessingFn = Functions.compose(

--- a/processing/src/main/java/io/druid/query/groupby/orderby/LimitSpec.java
+++ b/processing/src/main/java/io/druid/query/groupby/orderby/LimitSpec.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.base.Function;
 import io.druid.data.input.Row;
 import io.druid.java.util.common.Cacheable;
+import io.druid.java.util.common.granularity.Granularity;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.PostAggregator;
@@ -48,16 +49,20 @@ public interface LimitSpec extends Cacheable
   /**
    * Returns a function that applies a limit to an input sequence that is assumed to be sorted on dimensions.
    *
-   * @param dimensions query dimensions
-   * @param aggs       query aggregators
-   * @param postAggs   query postAggregators
+   * @param dimensions      query dimensions
+   * @param aggs            query aggregators
+   * @param postAggs        query postAggregators
+   * @param granularity     query granularity
+   * @param sortByDimsFirst 'sortByDimsFirst' value in queryContext
    *
    * @return limit function
    */
   Function<Sequence<Row>, Sequence<Row>> build(
       List<DimensionSpec> dimensions,
       List<AggregatorFactory> aggs,
-      List<PostAggregator> postAggs
+      List<PostAggregator> postAggs,
+      Granularity granularity,
+      boolean sortByDimsFirst
   );
 
   LimitSpec merge(LimitSpec other);

--- a/processing/src/main/java/io/druid/query/groupby/orderby/NoopLimitSpec.java
+++ b/processing/src/main/java/io/druid/query/groupby/orderby/NoopLimitSpec.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import io.druid.data.input.Row;
+import io.druid.java.util.common.granularity.Granularity;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.PostAggregator;
@@ -52,7 +53,9 @@ public final class NoopLimitSpec implements LimitSpec
   public Function<Sequence<Row>, Sequence<Row>> build(
       List<DimensionSpec> dimensions,
       List<AggregatorFactory> aggs,
-      List<PostAggregator> postAggs
+      List<PostAggregator> postAggs,
+      Granularity granularity,
+      boolean sortByDimsFirst
   )
   {
     return Functions.identity();

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -3533,6 +3533,68 @@ public class GroupByQueryRunnerTest
     TestHelper.assertExpectedObjects(expectedResults, results, "");
   }
 
+  @Test
+  public void testGroupByWithLookupAndLimitAndSortByDimsFirst()
+  {
+    Map<String, String> map = new HashMap<>();
+    map.put("automotive", "9");
+    map.put("business", "8");
+    map.put("entertainment", "7");
+    map.put("health", "6");
+    map.put("mezzanine", "5");
+    map.put("news", "4");
+    map.put("premium", "3");
+    map.put("technology", "2");
+    map.put("travel", "1");
+
+    GroupByQuery query = GroupByQuery
+        .builder()
+        .setDataSource(QueryRunnerTestHelper.dataSource)
+        .setQuerySegmentSpec(QueryRunnerTestHelper.firstToThird)
+        .setDimensions(
+            Lists.<DimensionSpec>newArrayList(
+                new ExtractionDimensionSpec(
+                    "quality",
+                    "alias",
+                    new LookupExtractionFn(new MapLookupExtractor(map, false), false, null, false, false)
+                )
+            )
+        )
+        .setAggregatorSpecs(
+            Arrays.asList(
+                QueryRunnerTestHelper.rowsCount,
+                new LongSumAggregatorFactory("idx", "index")
+            )
+        )
+        .setLimitSpec(new DefaultLimitSpec(Lists.<OrderByColumnSpec>newArrayList(
+            new OrderByColumnSpec("alias", null, StringComparators.ALPHANUMERIC)), 11))
+        .setGranularity(QueryRunnerTestHelper.dayGran)
+        .setContext(ImmutableMap.of("sortByDimsFirst", true))
+        .build();
+
+    List<Row> expectedResults = Arrays.asList(
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-01", "alias", "1", "rows", 1L, "idx", 119L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "alias", "1", "rows", 1L, "idx", 126L),
+
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-01", "alias", "2", "rows", 1L, "idx", 78L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "alias", "2", "rows", 1L, "idx", 97L),
+
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-01", "alias", "3", "rows", 3L, "idx", 2900L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "alias", "3", "rows", 3L, "idx", 2505L),
+
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-01", "alias", "4", "rows", 1L, "idx", 121L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "alias", "4", "rows", 1L, "idx", 114L),
+
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-01", "alias", "5", "rows", 3L, "idx", 2870L),
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-02", "alias", "5", "rows", 3L, "idx", 2447L),
+
+        GroupByQueryRunnerTestHelper.createExpectedRow("2011-04-01", "alias", "6", "rows", 1L, "idx", 120L)
+    );
+
+    Iterable<Row> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);
+    TestHelper.assertExpectedObjects(expectedResults, results, "");
+  }
+
   @Ignore
   @Test
   // This is a test to verify per limit groupings, but Druid currently does not support this functionality. At a point
@@ -7438,7 +7500,9 @@ public class GroupByQueryRunnerTest
         query.getLimitSpec().build(
             query.getDimensions(),
             query.getAggregatorSpecs(),
-            query.getPostAggregatorSpecs()
+            query.getPostAggregatorSpecs(),
+            query.getGranularity(),
+            query.getContextSortByDimsFirst()
         )
     );
 
@@ -7499,7 +7563,9 @@ public class GroupByQueryRunnerTest
         query.getLimitSpec().build(
             query.getDimensions(),
             query.getAggregatorSpecs(),
-            query.getPostAggregatorSpecs()
+            query.getPostAggregatorSpecs(),
+            query.getGranularity(),
+            query.getContextSortByDimsFirst()
         )
     );
 
@@ -7702,7 +7768,9 @@ public class GroupByQueryRunnerTest
         query.getLimitSpec().build(
             query.getDimensions(),
             query.getAggregatorSpecs(),
-            query.getPostAggregatorSpecs()
+            query.getPostAggregatorSpecs(),
+            query.getGranularity(),
+            query.getContextSortByDimsFirst()
         )
     );
 
@@ -7764,7 +7832,9 @@ public class GroupByQueryRunnerTest
         query.getLimitSpec().build(
             query.getDimensions(),
             query.getAggregatorSpecs(),
-            query.getPostAggregatorSpecs()
+            query.getPostAggregatorSpecs(),
+            query.getGranularity(),
+            query.getContextSortByDimsFirst()
         )
     );
 
@@ -7825,7 +7895,9 @@ public class GroupByQueryRunnerTest
         query.getLimitSpec().build(
             query.getDimensions(),
             query.getAggregatorSpecs(),
-            query.getPostAggregatorSpecs()
+            query.getPostAggregatorSpecs(),
+            query.getGranularity(),
+            query.getContextSortByDimsFirst()
         )
     );
 

--- a/processing/src/test/java/io/druid/query/groupby/orderby/DefaultLimitSpecTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/orderby/DefaultLimitSpecTest.java
@@ -191,7 +191,7 @@ public class DefaultLimitSpecTest
 
     Assert.assertEquals(
         ImmutableList.of(testRowsList.get(0), testRowsList.get(1)),
-        limitFn.apply(testRowsSequence).toList()
+        Sequences.toList(limitFn.apply(testRowsSequence), new ArrayList<>())
     );
   }
 
@@ -213,7 +213,7 @@ public class DefaultLimitSpecTest
 
     Assert.assertEquals(
         ImmutableList.of(testRowsList.get(2), testRowsList.get(0)),
-        limitFn.apply(testRowsSequence).toList()
+        Sequences.toList(limitFn.apply(testRowsSequence), new ArrayList<>())
     );
   }
 

--- a/processing/src/test/java/io/druid/query/groupby/orderby/DefaultLimitSpecTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/orderby/DefaultLimitSpecTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Maps;
 import io.druid.data.input.MapBasedRow;
 import io.druid.data.input.Row;
 import io.druid.java.util.common.DateTimes;
+import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.aggregation.AggregatorFactory;
@@ -40,6 +41,7 @@ import io.druid.query.dimension.DimensionSpec;
 import io.druid.query.expression.TestExprMacroTable;
 import io.druid.query.ordering.StringComparators;
 import io.druid.segment.TestHelper;
+import io.druid.segment.column.ValueType;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -160,12 +162,58 @@ public class DefaultLimitSpecTest
     Function<Sequence<Row>, Sequence<Row>> limitFn = limitSpec.build(
         ImmutableList.<DimensionSpec>of(),
         ImmutableList.<AggregatorFactory>of(),
-        ImmutableList.<PostAggregator>of()
+        ImmutableList.<PostAggregator>of(),
+        Granularities.NONE,
+        false
     );
 
     Assert.assertEquals(
         ImmutableList.of(testRowsList.get(0), testRowsList.get(1)),
         Sequences.toList(limitFn.apply(testRowsSequence), new ArrayList<Row>())
+    );
+  }
+
+  @Test
+  public void testWithAllGranularity()
+  {
+    DefaultLimitSpec limitSpec = new DefaultLimitSpec(
+        ImmutableList.of(new OrderByColumnSpec("k1", OrderByColumnSpec.Direction.ASCENDING, StringComparators.NUMERIC)),
+        2
+    );
+
+    Function<Sequence<Row>, Sequence<Row>> limitFn = limitSpec.build(
+        ImmutableList.of(new DefaultDimensionSpec("k1", "k1", ValueType.DOUBLE)),
+        ImmutableList.of(),
+        ImmutableList.of(),
+        Granularities.ALL,
+        true
+    );
+
+    Assert.assertEquals(
+        ImmutableList.of(testRowsList.get(0), testRowsList.get(1)),
+        limitFn.apply(testRowsSequence).toList()
+    );
+  }
+
+  @Test
+  public void testWithSortByDimsFirst()
+  {
+    DefaultLimitSpec limitSpec = new DefaultLimitSpec(
+        ImmutableList.of(new OrderByColumnSpec("k1", OrderByColumnSpec.Direction.ASCENDING, StringComparators.NUMERIC)),
+        2
+    );
+
+    Function<Sequence<Row>, Sequence<Row>> limitFn = limitSpec.build(
+        ImmutableList.of(new DefaultDimensionSpec("k1", "k1", ValueType.DOUBLE)),
+        ImmutableList.of(),
+        ImmutableList.of(),
+        Granularities.NONE,
+        true
+    );
+
+    Assert.assertEquals(
+        ImmutableList.of(testRowsList.get(2), testRowsList.get(0)),
+        limitFn.apply(testRowsSequence).toList()
     );
   }
 
@@ -180,7 +228,9 @@ public class DefaultLimitSpecTest
     Function<Sequence<Row>, Sequence<Row>> limitFn = limitSpec.build(
         ImmutableList.<DimensionSpec>of(new DefaultDimensionSpec("k1", "k1")),
         ImmutableList.<AggregatorFactory>of(),
-        ImmutableList.<PostAggregator>of()
+        ImmutableList.<PostAggregator>of(),
+        Granularities.NONE,
+        false
     );
 
     // Note: This test encodes the fact that limitSpec sorts numbers like strings; we might want to change this
@@ -210,7 +260,9 @@ public class DefaultLimitSpecTest
         ),
         ImmutableList.<PostAggregator>of(
             new ConstantPostAggregator("k3", 1L)
-        )
+        ),
+        Granularities.NONE,
+        false
     );
     Assert.assertEquals(
         ImmutableList.of(testRowsList.get(0), testRowsList.get(1)),
@@ -227,7 +279,9 @@ public class DefaultLimitSpecTest
         ),
         ImmutableList.<PostAggregator>of(
             new ConstantPostAggregator("k3", 1L)
-        )
+        ),
+        Granularities.NONE,
+        false
     );
     Assert.assertEquals(
         ImmutableList.of(testRowsList.get(2), testRowsList.get(0)),
@@ -250,7 +304,9 @@ public class DefaultLimitSpecTest
                     new ConstantPostAggregator("x", 1),
                     new ConstantPostAggregator("y", 1))
             )
-        )
+        ),
+        Granularities.NONE,
+        false
     );
     Assert.assertEquals(
         (List) ImmutableList.of(testRowsList.get(2), testRowsList.get(0)),
@@ -261,7 +317,9 @@ public class DefaultLimitSpecTest
     limitFn = limitSpec.build(
         ImmutableList.<DimensionSpec>of(new DefaultDimensionSpec("k1", "k1")),
         ImmutableList.<AggregatorFactory>of(new LongSumAggregatorFactory("k2", "k2")),
-        ImmutableList.<PostAggregator>of(new ExpressionPostAggregator("k1", "1 + 1", null, TestExprMacroTable.INSTANCE))
+        ImmutableList.<PostAggregator>of(new ExpressionPostAggregator("k1", "1 + 1", null, TestExprMacroTable.INSTANCE)),
+        Granularities.NONE,
+        false
     );
     Assert.assertEquals(
         (List) ImmutableList.of(testRowsList.get(2), testRowsList.get(0)),


### PR DESCRIPTION
Backport #5385 to 0.12.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/druid-io/druid/5398)
<!-- Reviewable:end -->
