### PR TITLE
Pass config from context into JobConf for DatasourceInputFormat splits

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceInputFormat.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceInputFormat.java
@@ -29,7 +29,6 @@ import io.druid.indexer.HadoopDruidIndexerConfig;
 import io.druid.indexer.JobHelper;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.logger.Logger;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -65,7 +64,7 @@ public class DatasourceInputFormat extends InputFormat<NullWritable, InputRow>
   @Override
   public List<InputSplit> getSplits(JobContext context) throws IOException, InterruptedException
   {
-    Configuration conf = context.getConfiguration();
+    JobConf conf = new JobConf(context.getConfiguration());
 
     String segmentsStr = Preconditions.checkNotNull(
         conf.get(CONF_INPUT_SEGMENTS),
@@ -92,7 +91,7 @@ public class DatasourceInputFormat extends InputFormat<NullWritable, InputRow>
       for (WindowedDataSegment segment : segments) {
         totalSize += segment.getSegment().getSize();
       }
-      int mapTask = ((JobConf) conf).getNumMapTasks();
+      int mapTask = conf.getNumMapTasks();
       if (mapTask > 0) {
         maxSize = totalSize / mapTask;
       }
@@ -119,11 +118,10 @@ public class DatasourceInputFormat extends InputFormat<NullWritable, InputRow>
     List<WindowedDataSegment> list = new ArrayList<>();
     long size = 0;
 
-    JobConf dummyConf = new JobConf();
     org.apache.hadoop.mapred.InputFormat fio = supplier.get();
     for (WindowedDataSegment segment : segments) {
       if (size + segment.getSegment().getSize() > maxSize && size > 0) {
-        splits.add(toDataSourceSplit(list, fio, dummyConf));
+        splits.add(toDataSourceSplit(list, fio, conf));
         list = Lists.newArrayList();
         size = 0;
       }
@@ -133,7 +131,7 @@ public class DatasourceInputFormat extends InputFormat<NullWritable, InputRow>
     }
 
     if (list.size() > 0) {
-      splits.add(toDataSourceSplit(list, fio, dummyConf));
+      splits.add(toDataSourceSplit(list, fio, conf));
     }
 
     logger.info("Number of splits [%d]", splits.size());
@@ -217,14 +215,14 @@ public class DatasourceInputFormat extends InputFormat<NullWritable, InputRow>
                   try {
                     return Arrays.stream(split.getLocations());
                   }
-                  catch (final IOException e) {
+                  catch (final Exception e) {
                     logger.error(e, "Exception getting locations");
                     return Stream.empty();
                   }
                 }
             );
           }
-          catch (final IOException e) {
+          catch (final Exception e) {
             logger.error(e, "Exception getting splits");
             return Stream.empty();
           }


### PR DESCRIPTION
Fixes #5135. 

I'm not clear why in #2223 there was reluctance in using the actual job configuration and a dummy JobConf was used instead. This caused configs set in `jobProperties` such as `fs.s3n.awsAccessKeyId` and `fs.s3n.awsSecretAccessKey` to not be used, resulting in exceptions such as:

```
Caused by: java.lang.IllegalArgumentException: AWS Access Key ID and Secret Access Key must be specified as the username or password (respectively) of a s3n URL, or by setting the fs.s3n.awsAccessKeyId or fs.s3n.awsSecretAccessKey properties (respectively).
	at org.apache.hadoop.fs.s3.S3Credentials.initialize(S3Credentials.java:70) ~[?:?]
	at org.apache.hadoop.fs.s3native.Jets3tNativeFileSystemStore.initialize(Jets3tNativeFileSystemStore.java:80) ~[?:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_152]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_152]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_152]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_152]
	at org.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:191) ~[?:?]
	at org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:102) ~[?:?]
	at org.apache.hadoop.fs.s3native.$Proxy223.initialize(Unknown Source) ~[?:?]
	at org.apache.hadoop.fs.s3native.NativeS3FileSystem.initialize(NativeS3FileSystem.java:334) ~[?:?]
	at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:2669) ~[?:?]
	at org.apache.hadoop.fs.FileSystem.access$200(FileSystem.java:94) ~[?:?]
	at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:2703) ~[?:?]
	at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:2685) ~[?:?]
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:373) ~[?:?]
	at org.apache.hadoop.fs.Path.getFileSystem(Path.java:295) ~[?:?]
	at io.druid.indexer.hadoop.DatasourceInputFormat$3$1.listStatus(DatasourceInputFormat.java:175) ~[?:?]
	at org.apache.hadoop.mapred.FileInputFormat.getSplits(FileInputFormat.java:315) ~[?:?]
	at io.druid.indexer.hadoop.DatasourceInputFormat.lambda$getLocations$1(DatasourceInputFormat.java:215) ~[?:?]
	at java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:267) ~[?:1.8.0_152]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1382) ~[?:1.8.0_152]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481) ~[?:1.8.0_152]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471) ~[?:1.8.0_152]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_152]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_152]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499) ~[?:1.8.0_152]
	at io.druid.indexer.hadoop.DatasourceInputFormat.getFrequentLocations(DatasourceInputFormat.java:238) ~[?:?]
	at io.druid.indexer.hadoop.DatasourceInputFormat.toDataSourceSplit(DatasourceInputFormat.java:196) ~[?:?]
	at io.druid.indexer.hadoop.DatasourceInputFormat.getSplits(DatasourceInputFormat.java:126) ~[?:?]
	at org.apache.hadoop.mapreduce.lib.input.DelegatingInputFormat.getSplits(DelegatingInputFormat.java:115) ~[?:?]
	at org.apache.hadoop.mapreduce.JobSubmitter.writeNewSplits(JobSubmitter.java:301) ~[?:?]
	at org.apache.hadoop.mapreduce.JobSubmitter.writeSplits(JobSubmitter.java:318) ~[?:?]
	at org.apache.hadoop.mapreduce.JobSubmitter.submitJobInternal(JobSubmitter.java:196) ~[?:?]
	at org.apache.hadoop.mapreduce.Job$10.run(Job.java:1290) ~[?:?]
	at org.apache.hadoop.mapreduce.Job$10.run(Job.java:1287) ~[?:?]
	at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_152]
	at javax.security.auth.Subject.doAs(Subject.java:422) ~[?:1.8.0_152]
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1698) ~[?:?]
	at org.apache.hadoop.mapreduce.Job.submit(Job.java:1287) ~[?:?]
	at io.druid.indexer.IndexGeneratorJob.run(IndexGeneratorJob.java:208) ~[druid-indexing-hadoop-0.13.0-SNAPSHOT.jar:0.13.0-SNAPSHOT]
	at io.druid.indexer.JobHelper.runJobs(JobHelper.java:362) ~[druid-indexing-hadoop-0.13.0-SNAPSHOT.jar:0.13.0-SNAPSHOT]
	at io.druid.indexer.HadoopDruidIndexerJob.run(HadoopDruidIndexerJob.java:95) ~[druid-indexing-hadoop-0.13.0-SNAPSHOT.jar:0.13.0-SNAPSHOT]
	at io.druid.indexing.common.task.HadoopIndexTask$HadoopIndexGeneratorInnerProcessing.runTask(HadoopIndexTask.java:293) ~[druid-indexing-service-0.13.0-SNAPSHOT.jar:0.13.0-SNAPSHOT]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_152]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_152]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_152]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_152]
	at io.druid.indexing.common.task.HadoopTask.invokeForeignLoader(HadoopTask.java:219) ~[druid-indexing-service-0.13.0-SNAPSHOT.jar:0.13.0-SNAPSHOT]
	... 7 more
```

@navis and @himanshug please let me know if there's something I'm missing here and some reason why this may not be a good idea.

Also changed the catch for `IOException` to general `Exception` since this operation is optional and should be best effort.