### PR TITLE
SQL: Lower default JDBC frame size.

### DIFF
--- a/docs/content/querying/sql.md
+++ b/docs/content/querying/sql.md
@@ -488,7 +488,7 @@ The Druid SQL server is configured through the following properties on the broke
 |`druid.sql.enable`|Whether to enable SQL at all, including background metadata fetching. If false, this overrides all other SQL-related properties and disables SQL metadata, serving, and planning completely.|false|
 |`druid.sql.avatica.enable`|Whether to enable JDBC querying at `/druid/v2/sql/avatica/`.|true|
 |`druid.sql.avatica.maxConnections`|Maximum number of open connections for the Avatica server. These are not HTTP connections, but are logical client connections that may span multiple HTTP connections.|50|
-|`druid.sql.avatica.maxRowsPerFrame`|Maximum number of rows to return in a single JDBC frame. Setting this property to -1 indicates that no row limit should be applied. Clients can optionally specify a row limit in their requests; if a client specifies a row limit, the lesser value of the client-provided limit and `maxRowsPerFrame` will be used.|100,000|
+|`druid.sql.avatica.maxRowsPerFrame`|Maximum number of rows to return in a single JDBC frame. Setting this property to -1 indicates that no row limit should be applied. Clients can optionally specify a row limit in their requests; if a client specifies a row limit, the lesser value of the client-provided limit and `maxRowsPerFrame` will be used.|5,000|
 |`druid.sql.avatica.maxStatementsPerConnection`|Maximum number of simultaneous open statements per Avatica client connection.|1|
 |`druid.sql.avatica.connectionIdleTimeout`|Avatica client connection idle timeout.|PT5M|
 |`druid.sql.http.enable`|Whether to enable JSON over HTTP querying at `/druid/v2/sql/`.|true|

--- a/sql/src/main/java/io/druid/sql/avatica/AvaticaServerConfig.java
+++ b/sql/src/main/java/io/druid/sql/avatica/AvaticaServerConfig.java
@@ -34,7 +34,7 @@ public class AvaticaServerConfig
   public Period connectionIdleTimeout = new Period("PT5M");
 
   @JsonProperty
-  public int maxRowsPerFrame = 100_000;
+  public int maxRowsPerFrame = 5000;
 
   public int getMaxConnections()
   {


### PR DESCRIPTION
The previous default of 100,000 was a bit excessive and could easily
lead to OOM errors on "select *" style queries.