### PR TITLE
Let MySQLConnector accept all UTF charsets and recommend utf8mb4

### DIFF
--- a/docs/content/development/extensions-core/mysql.md
+++ b/docs/content/development/extensions-core/mysql.md
@@ -29,8 +29,8 @@ Make sure to [include](../../operations/including-extensions.html) `mysql-metada
   Paste the following snippet into the mysql prompt:
 
   ```sql
-  -- create a druid database, make sure to use utf8 as encoding
-  CREATE DATABASE druid DEFAULT CHARACTER SET utf8;
+  -- create a druid database, make sure to use utf8mb4 as encoding
+  CREATE DATABASE druid DEFAULT CHARACTER SET utf8mb4;
 
   -- create a druid user, and grant it all permission on the database we just created
   GRANT ALL ON druid.* TO 'druid'@'localhost' IDENTIFIED BY 'diurd';

--- a/extensions-core/mysql-metadata-storage/src/main/java/io/druid/metadata/storage/mysql/MySQLConnector.java
+++ b/extensions-core/mysql-metadata-storage/src/main/java/io/druid/metadata/storage/mysql/MySQLConnector.java
@@ -24,7 +24,6 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.mysql.jdbc.exceptions.MySQLTransientException;
-
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.logger.Logger;
@@ -35,7 +34,7 @@ import org.apache.commons.dbcp2.BasicDataSource;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.tweak.HandleCallback;
-import org.skife.jdbi.v2.util.BooleanMapper;
+import org.skife.jdbi.v2.util.StringMapper;
 
 import java.io.File;
 import java.sql.SQLException;
@@ -163,17 +162,19 @@ public class MySQLConnector extends SQLMetadataConnector
   @Override
   public boolean tableExists(Handle handle, String tableName)
   {
-    // ensure database defaults to utf8, otherwise bail
-    boolean isUtf8 = handle
-        .createQuery("SELECT @@character_set_database = 'utf8'")
-        .map(BooleanMapper.FIRST)
+    String databaseCharset = handle
+        .createQuery("SELECT @@character_set_database")
+        .map(StringMapper.FIRST)
         .first();
 
-    if (!isUtf8) {
+    if (!databaseCharset.matches("utf.*")) {
       throw new ISE(
-          "Database default character set is not UTF-8." + System.lineSeparator()
-          + "  Druid requires its MySQL database to be created using UTF-8 as default character set."
+          "Druid requires its MySQL database to be created with an UTF charset, found `%1$s`.%n" +
+          "The recommended charset is `utf8mb4`.",
+          databaseCharset
       );
+    } else if (!"utf8mb4".equals(databaseCharset)) {
+      log.warn("The current database charset `%1$s` does not match the recommended charset `utf8mb4`", databaseCharset);
     }
 
     return !handle.createQuery("SHOW tables LIKE :tableName")

--- a/extensions-core/mysql-metadata-storage/src/main/java/io/druid/metadata/storage/mysql/MySQLConnector.java
+++ b/extensions-core/mysql-metadata-storage/src/main/java/io/druid/metadata/storage/mysql/MySQLConnector.java
@@ -167,10 +167,10 @@ public class MySQLConnector extends SQLMetadataConnector
         .map(StringMapper.FIRST)
         .first();
 
-    if (!databaseCharset.matches("utf.*")) {
+    if (!databaseCharset.matches("utf8.*")) {
       throw new ISE(
-          "Druid requires its MySQL database to be created with an UTF charset, found `%1$s`.%n" +
-          "The recommended charset is `utf8mb4`.",
+          "Druid requires its MySQL database to be created with an UTF8 charset, found `%1$s`. "
+          + "The recommended charset is `utf8mb4`.",
           databaseCharset
       );
     } else if (!"utf8mb4".equals(databaseCharset)) {


### PR DESCRIPTION
Allow and prefer utf8mb4 character set in mysql metadata storage.

Upgrade Instructions:
Use ALTER DATABASE and ALTER TABLE as described in https://dev.mysql.com/doc/refman/5.7/en/charset-unicode-conversion.html

Closes #5377