### PR TITLE
Improve cache cost to handle heterogenous historicals

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/CachingCostBalancerStrategy.java
+++ b/server/src/main/java/io/druid/server/coordinator/CachingCostBalancerStrategy.java
@@ -61,7 +61,11 @@ public class CachingCostBalancerStrategy extends CostBalancerStrategy
     // add segments that will be loaded to the cost
     cost += costCacheForLoadingSegments(server).computeCost(serverName, proposalSegment);
 
-    return cost;
+    if (server.getAvailableSize() <= 0) {
+      return Double.POSITIVE_INFINITY;
+    }
+
+    return cost * (server.getMaxSize() / server.getAvailableSize());
   }
 
   private ClusterCostCache costCacheForLoadingSegments(ServerHolder server)


### PR DESCRIPTION
Adding support for cache cost to handle heterogeneous clusters. Without this smaller size historicals get full a lot faster than bigger size historicals