### PR TITLE
KafkaIndexTask remove branch with unreachable code

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIndexTask.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIndexTask.java
@@ -849,17 +849,13 @@ public class KafkaIndexTask extends AbstractTask implements ChatHandler
       }
 
       for (SegmentsAndMetadata handedOff : handedOffList) {
-        if (handedOff == null) {
-          log.warn("Handoff failed for segments %s", handedOff.getSegments());
-        } else {
-          log.info(
-              "Handoff completed for segments[%s] with metadata[%s].",
-              Joiner.on(", ").join(
-                  handedOff.getSegments().stream().map(DataSegment::getIdentifier).collect(Collectors.toList())
-              ),
-              Preconditions.checkNotNull(handedOff.getCommitMetadata(), "commitMetadata")
-          );
-        }
+        log.info(
+            "Handoff completed for segments[%s] with metadata[%s].",
+            Joiner.on(", ").join(
+                handedOff.getSegments().stream().map(DataSegment::getIdentifier).collect(Collectors.toList())
+            ),
+            Preconditions.checkNotNull(handedOff.getCommitMetadata(), "commitMetadata")
+        );
       }
     }
     catch (InterruptedException | RejectedExecutionException e) {


### PR DESCRIPTION
Removes bogus `null` check that would explode with a NPE if true condition actually happened. It looks like the code modified in this PR was maybe [modeled after this one](https://github.com/clintropolis/druid/blob/ae56462b9a86e6d92407e07296c7672a09addba4/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIndexTask.java#L1222), but because of [this check in the logic path](https://github.com/clintropolis/druid/blob/ae56462b9a86e6d92407e07296c7672a09addba4/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaIndexTask.java#L362) the condition shouldn't be able to happen here as far as I can tell. I'm not actually sure if `driver.publish` will return `null` either, so maybe some more aggressive cleanup could be done here.