### PR TITLE
Skip normal authentication for JDBC requests in Router

### DIFF
--- a/integration-tests/docker/broker.conf
+++ b/integration-tests/docker/broker.conf
@@ -34,6 +34,8 @@ command=java
   -Ddruid.escalator.authorizerName=basic
   -Ddruid.auth.authorizers="[\"basic\"]"
   -Ddruid.auth.authorizer.basic.type=basic
+  -Ddruid.sql.enable=true
+  -Ddruid.sql.avatica.enable=true
   -cp /shared/docker/lib/*
   io.druid.cli.Main server broker
 redirect_stderr=true

--- a/integration-tests/docker/router.conf
+++ b/integration-tests/docker/router.conf
@@ -23,6 +23,8 @@ command=java
   -Ddruid.escalator.authorizerName=basic
   -Ddruid.auth.authorizers="[\"basic\"]"
   -Ddruid.auth.authorizer.basic.type=basic
+  -Ddruid.sql.enable=true
+  -Ddruid.sql.avatica.enable=true
   -cp /shared/docker/lib/*
   io.druid.cli.Main server router
 redirect_stderr=true

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -99,6 +99,16 @@
 
         <!-- Tests -->
         <dependency>
+            <groupId>org.apache.calcite.avatica</groupId>
+            <artifactId>avatica</artifactId>
+            <version>1.10.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.calcite.avatica</groupId>
+            <artifactId>avatica-server</artifactId>
+            <version>1.10.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
         </dependency>

--- a/services/src/main/java/io/druid/cli/RouterJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/RouterJettyServerInitializer.java
@@ -52,7 +52,9 @@ public class RouterJettyServerInitializer implements JettyServerInitializer
 {
   private static List<String> UNSECURED_PATHS = Lists.newArrayList(
       "/status/health",
-      // JDBC authentication uses the JDBC connection context instead of HTTP headers, skip the normal auth checks
+      // JDBC authentication uses the JDBC connection context instead of HTTP headers, skip the normal auth checks.
+      // The router will keep the connection context in the forwarded message, and the broker is responsible for
+      // performing the auth checks.
       DruidAvaticaHandler.AVATICA_PATH
   );
 

--- a/services/src/main/java/io/druid/cli/RouterJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/RouterJettyServerInitializer.java
@@ -37,6 +37,7 @@ import io.druid.server.router.Router;
 import io.druid.server.security.AuthenticationUtils;
 import io.druid.server.security.Authenticator;
 import io.druid.server.security.AuthenticatorMapper;
+import io.druid.sql.avatica.DruidAvaticaHandler;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.HandlerList;
@@ -50,7 +51,9 @@ import java.util.List;
 public class RouterJettyServerInitializer implements JettyServerInitializer
 {
   private static List<String> UNSECURED_PATHS = Lists.newArrayList(
-      "/status/health"
+      "/status/health",
+      // JDBC authentication uses the JDBC connection context instead of HTTP headers, skip the normal auth checks
+      DruidAvaticaHandler.AVATICA_PATH
   );
 
   private final DruidHttpClientConfig routerHttpClientConfig;

--- a/sql/src/main/java/io/druid/sql/avatica/DruidAvaticaHandler.java
+++ b/sql/src/main/java/io/druid/sql/avatica/DruidAvaticaHandler.java
@@ -35,7 +35,7 @@ import java.lang.reflect.InvocationTargetException;
 
 public class DruidAvaticaHandler extends AvaticaJsonHandler
 {
-  static final String AVATICA_PATH = "/druid/v2/sql/avatica/";
+  public static final String AVATICA_PATH = "/druid/v2/sql/avatica/";
 
   @Inject
   public DruidAvaticaHandler(


### PR DESCRIPTION
Authentication for JDBC requests should use credentials stored in the JDBC connection context instead of the HTTP headers.

On the broker, DruidAvaticaHandler handles JDBC requests separately from the normal authentication checking filters.

On the router, JDBC requests currently go through the normal authentication checking filter which is extraneous/incorrect.

This PR sets the Avatica path as "unsecured" on the Router, deferring the authentication check to the broker where authentication will occur using the JDBC connection context.