### PR TITLE
Add repository url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,9 @@
         <caffeine.version>2.5.5</caffeine.version>
         <!-- When upgrading ZK, edit docs and integration tests as well (integration-tests/docker-base/setup.sh) -->
         <zookeeper.version>3.4.11</zookeeper.version>
+        <repoOrgId>org-apache-id</repoOrgId>
+        <repoOrgName>org-apache-name</repoOrgName>
+        <repoOrgUrl>https://repository.apache.org/content/repositories/public/</repoOrgUrl>
     </properties>
 
     <modules>
@@ -147,6 +150,14 @@
         <!-- distribution packaging -->
         <module>distribution</module>
     </modules>
+
+  <repositories>
+    <repository>
+        <id>${repoOrgId}</id>
+        <name>${repoOrgName}</name>
+        <url>${repoOrgUrl}</url>
+    </repository>
+  </repositories>
 
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
snapshot build fails to find dependent artifacts.
Add repoistory URL to resolved dependencies