### PR TITLE
better error messaging when parseSpec is missing timestampSpec or dimensionSpec

### DIFF
--- a/api/src/main/java/io/druid/data/input/impl/ParseSpec.java
+++ b/api/src/main/java/io/druid/data/input/impl/ParseSpec.java
@@ -22,6 +22,7 @@ package io.druid.data.input.impl;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.common.base.Preconditions;
 import io.druid.guice.annotations.ExtensionPoint;
 import io.druid.guice.annotations.PublicApi;
 import io.druid.java.util.common.parsers.Parser;
@@ -47,8 +48,8 @@ public abstract class ParseSpec
 
   protected ParseSpec(TimestampSpec timestampSpec, DimensionsSpec dimensionsSpec)
   {
-    this.timestampSpec = timestampSpec;
-    this.dimensionsSpec = dimensionsSpec;
+    this.timestampSpec = Preconditions.checkNotNull(timestampSpec, "parseSpec requires timestampSpec");
+    this.dimensionsSpec = Preconditions.checkNotNull(dimensionsSpec, "parseSpec requires dimensionSpec");
   }
 
   @JsonProperty

--- a/api/src/test/java/io/druid/data/input/impl/ParseSpecTest.java
+++ b/api/src/test/java/io/druid/data/input/impl/ParseSpecTest.java
@@ -21,13 +21,18 @@ package io.druid.data.input.impl;
 
 import com.google.common.collect.Lists;
 import io.druid.java.util.common.parsers.ParseException;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 import java.util.Collections;
 
 public class ParseSpecTest
 {
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
   @Test(expected = ParseException.class)
   public void testDuplicateNames() throws Exception
   {
@@ -89,6 +94,48 @@ public class ParseSpecTest
             Lists.newArrayList("B", "B"),
             Lists.<SpatialDimensionSchema>newArrayList()
         ),
+        ",",
+        null,
+        Arrays.asList("a", "B"),
+        false,
+        0
+    );
+  }
+
+  @Test
+  public void testDefaultTimestampSpec() throws Exception
+  {
+    expectedException.expect(NullPointerException.class);
+    expectedException.expectMessage("parseSpec requires timestampSpec");
+    @SuppressWarnings("unused") // expected exception
+    final ParseSpec spec = new DelimitedParseSpec(
+        null,
+        new DimensionsSpec(
+            DimensionsSpec.getDefaultSchemas(Collections.singletonList("a")),
+            Lists.newArrayList("B", "B"),
+            Lists.<SpatialDimensionSchema>newArrayList()
+        ),
+        ",",
+        null,
+        Arrays.asList("a", "B"),
+        false,
+        0
+    );
+  }
+
+  @Test
+  public void testDimensionSpecRequired() throws Exception
+  {
+    expectedException.expect(NullPointerException.class);
+    expectedException.expectMessage("parseSpec requires dimensionSpec");
+    @SuppressWarnings("unused") // expected exception
+    final ParseSpec spec = new DelimitedParseSpec(
+        new TimestampSpec(
+            "timestamp",
+            "auto",
+            null
+        ),
+        null,
         ",",
         null,
         Arrays.asList("a", "B"),


### PR DESCRIPTION
Add checks to `ParseSpec` constructor to give more friendly errors when misconfigured. 

Instead of a generic `NullPointerException`
```
2018-02-28T06:30:39,928 ERROR [task-runner-0-priority-0] io.druid.indexing.overlord.ThreadPoolTaskRunner - Exception while running task[KafkaIndexTask{id=index_kafka_some_task_id, type=index_kafka, dataSource=some_datasource}]
java.lang.NullPointerException
    at io.druid.data.input.impl.MapInputRowParser.parse(MapInputRowParser.java:50) ~[druid-api-0.11.0-iap5.jar:0.11.0-iap5]
    at io.druid.data.input.impl.StringInputRowParser.parseMap(StringInputRowParser.java:151) ~[druid-api-0.11.0-iap5.jar:0.11.0-iap5]
    at io.druid.data.input.impl.StringInputRowParser.parse(StringInputRowParser.java:77) ~[druid-api-0.11.0-iap5.jar:0.11.0-iap5]
    at io.druid.segment.transform.TransformingStringInputRowParser.parse(TransformingStringInputRowParser.java:48) ~[druid-processing-0.11.0-
    ...
```

error will now have messaging to help diagnose the reason
```
2018-02-28T11:14:41,980 ERROR [task-runner-0-priority-0] io.druid.indexing.overlord.ThreadPoolTaskRunner - Exception while running task[KafkaIndexTask{id=index_kafka_some_task_id, type=index_kafka, dataSource=some_datasource}]
java.lang.IllegalArgumentException: Instantiation of [simple type, class io.druid.data.input.impl.JSONParseSpec] value failed: parseSpec requires dimensionSpec
    at com.fasterxml.jackson.databind.ObjectMapper._convert(ObjectMapper.java:2774) ~[jackson-databind-2.4.6.jar:2.4.6]
    at com.fasterxml.jackson.databind.ObjectMapper.convertValue(ObjectMapper.java:2700) ~[jackson-databind-2.4.6.jar:2.4.6]
    at io.druid.segment.indexing.DataSchema.getParser(DataSchema.java:122) ~[classes/:?]
    at io.druid.indexing.common.task.IndexTask.generateAndPublishSegments(IndexTask.java:655) ~[classes/:?]
    at io.druid.indexing.common.task.IndexTask.run(IndexTask.java:264) ~[classes/:?]
```