### PR TITLE
Add "joda" option to timeFormat extractionFn.

### DIFF
--- a/docs/content/querying/dimensionspecs.md
+++ b/docs/content/querying/dimensionspecs.md
@@ -263,13 +263,18 @@ Note, if you are working with the `__time` dimension, you should consider using 
 [time extraction function instead](#time-format-extraction-function) instead,
 which works on time value directly as opposed to string values.
 
-Time formats are described in the
-[SimpleDateFormat documentation](http://icu-project.org/apiref/icu4j/com/ibm/icu/text/SimpleDateFormat.html)
+If "joda" is true, time formats are described in the [Joda DateTimeFormat documentation](http://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html).
+If "joda" is false (or unspecified) then formats are described in the [SimpleDateFormat documentation](http://icu-project.org/apiref/icu4j/com/ibm/icu/text/SimpleDateFormat.html).
+In general, we recommend setting "joda" to true since Joda format strings are more common in Druid APIs and since Joda handles certain edge cases (like weeks and weekyears near
+the start and end of calendar years) in a more ISO8601 compliant way.
+
+If a value cannot be parsed using the provided timeFormat, it will be returned as-is.
 
 ```json
 { "type" : "time",
   "timeFormat" : <input_format>,
-  "resultFormat" : <output_format> }
+  "resultFormat" : <output_format>,
+  "joda" : <true, false> }
 ```
 
 

--- a/java-util/src/main/java/io/druid/java/util/common/DateTimes.java
+++ b/java-util/src/main/java/io/druid/java/util/common/DateTimes.java
@@ -70,10 +70,16 @@ public final class DateTimes
     {
       return innerFormatter.parseDateTime(instant);
     }
+
+    public String print(final DateTime instant)
+    {
+      return innerFormatter.print(instant);
+    }
   }
 
   /**
    * Creates a {@link UtcFormatter} that wraps around a {@link DateTimeFormatter}.
+   *
    * @param formatter inner {@link DateTimeFormatter} used to parse {@link String}
    */
   public static UtcFormatter wrapFormatter(final DateTimeFormatter formatter)

--- a/processing/src/test/java/io/druid/query/extraction/TimeDimExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/TimeDimExtractionFnTest.java
@@ -25,6 +25,7 @@ import io.druid.jackson.DefaultObjectMapper;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Set;
 
 /**
@@ -41,19 +42,39 @@ public class TimeDimExtractionFnTest
   };
 
   @Test
-  public void testEmptyAndNullExtraction()
+  public void testEmptyNullAndUnparseableExtraction()
   {
-    ExtractionFn extractionFn = new TimeDimExtractionFn("MM/dd/yyyy", "MM/yyyy");
+    for (boolean joda : Arrays.asList(true, false)) {
+      ExtractionFn extractionFn = new TimeDimExtractionFn("MM/dd/yyyy", "MM/yyyy", joda);
 
-    Assert.assertNull(extractionFn.apply(null));
-    Assert.assertNull(extractionFn.apply(""));
+      Assert.assertNull(extractionFn.apply(null));
+      Assert.assertNull(extractionFn.apply(""));
+      Assert.assertEquals("foo", extractionFn.apply("foo"));
+    }
   }
 
   @Test
   public void testMonthExtraction()
   {
     Set<String> months = Sets.newHashSet();
-    ExtractionFn extractionFn = new TimeDimExtractionFn("MM/dd/yyyy", "MM/yyyy");
+    ExtractionFn extractionFn = new TimeDimExtractionFn("MM/dd/yyyy", "MM/yyyy", false);
+
+    for (String dim : dims) {
+      months.add(extractionFn.apply(dim));
+    }
+
+    Assert.assertEquals(months.size(), 4);
+    Assert.assertTrue(months.contains("01/2012"));
+    Assert.assertTrue(months.contains("03/2012"));
+    Assert.assertTrue(months.contains("05/2012"));
+    Assert.assertTrue(months.contains("12/2012"));
+  }
+
+  @Test
+  public void testMonthExtractionJoda()
+  {
+    Set<String> months = Sets.newHashSet();
+    ExtractionFn extractionFn = new TimeDimExtractionFn("MM/dd/yyyy", "MM/yyyy", true);
 
     for (String dim : dims) {
       months.add(extractionFn.apply(dim));
@@ -70,7 +91,7 @@ public class TimeDimExtractionFnTest
   public void testQuarterExtraction()
   {
     Set<String> quarters = Sets.newHashSet();
-    ExtractionFn extractionFn = new TimeDimExtractionFn("MM/dd/yyyy", "QQQ/yyyy");
+    ExtractionFn extractionFn = new TimeDimExtractionFn("MM/dd/yyyy", "QQQ/yyyy", false);
 
     for (String dim : dims) {
       quarters.add(extractionFn.apply(dim));
@@ -83,14 +104,36 @@ public class TimeDimExtractionFnTest
   }
 
   @Test
+  public void testWeeks()
+  {
+    final TimeDimExtractionFn weekFn = new TimeDimExtractionFn("yyyy-MM-dd", "YYYY-ww", false);
+    Assert.assertEquals("2016-01", weekFn.apply("2015-12-31"));
+    Assert.assertEquals("2016-01", weekFn.apply("2016-01-01"));
+    Assert.assertEquals("2017-01", weekFn.apply("2017-01-01"));
+    Assert.assertEquals("2018-01", weekFn.apply("2017-12-31"));
+    Assert.assertEquals("2018-01", weekFn.apply("2018-01-01"));
+  }
+
+  @Test
+  public void testWeeksJoda()
+  {
+    final TimeDimExtractionFn weekFn = new TimeDimExtractionFn("yyyy-MM-dd", "xxxx-ww", true);
+    Assert.assertEquals("2015-53", weekFn.apply("2015-12-31"));
+    Assert.assertEquals("2015-53", weekFn.apply("2016-01-01"));
+    Assert.assertEquals("2016-52", weekFn.apply("2017-01-01"));
+    Assert.assertEquals("2017-52", weekFn.apply("2017-12-31"));
+    Assert.assertEquals("2018-01", weekFn.apply("2018-01-01"));
+  }
+
+  @Test
   public void testSerde() throws Exception
   {
     final ObjectMapper objectMapper = new DefaultObjectMapper();
-    final String json = "{ \"type\" : \"time\", \"timeFormat\" : \"MM/dd/yyyy\", \"resultFormat\" : \"QQQ/yyyy\" }";
+    final String json = "{ \"type\" : \"time\", \"timeFormat\" : \"MM/dd/yyyy\", \"resultFormat\" : \"yyyy-MM-dd\", \"joda\" : true }";
     TimeDimExtractionFn extractionFn = (TimeDimExtractionFn) objectMapper.readValue(json, ExtractionFn.class);
 
     Assert.assertEquals("MM/dd/yyyy", extractionFn.getTimeFormat());
-    Assert.assertEquals("QQQ/yyyy", extractionFn.getResultFormat());
+    Assert.assertEquals("yyyy-MM-dd", extractionFn.getResultFormat());
 
     // round trip
     Assert.assertEquals(

--- a/processing/src/test/java/io/druid/segment/filter/SelectorFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/SelectorFilterTest.java
@@ -95,10 +95,10 @@ public class SelectorFilterTest extends BaseFilterTest
   @Test
   public void testWithTimeExtractionFnNull()
   {
-    assertFilterMatches(new SelectorDimFilter("dim0", null, new TimeDimExtractionFn("yyyy-mm-dd", "yyyy-mm")), ImmutableList.<String>of());
-    assertFilterMatches(new SelectorDimFilter("dim6", null, new TimeDimExtractionFn("yyyy-mm-dd", "yyyy-mm")), ImmutableList.<String>of("3", "4", "5"));
-    assertFilterMatches(new SelectorDimFilter("dim6", "2017-07", new TimeDimExtractionFn("yyyy-mm-dd", "yyyy-mm")), ImmutableList.<String>of("0", "1"));
-    assertFilterMatches(new SelectorDimFilter("dim6", "2017-05", new TimeDimExtractionFn("yyyy-mm-dd", "yyyy-mm")), ImmutableList.<String>of("2"));
+    assertFilterMatches(new SelectorDimFilter("dim0", null, new TimeDimExtractionFn("yyyy-MM-dd", "yyyy-MM", true)), ImmutableList.of());
+    assertFilterMatches(new SelectorDimFilter("dim6", null, new TimeDimExtractionFn("yyyy-MM-dd", "yyyy-MM", true)), ImmutableList.of("3", "4", "5"));
+    assertFilterMatches(new SelectorDimFilter("dim6", "2017-07", new TimeDimExtractionFn("yyyy-MM-dd", "yyyy-MM", true)), ImmutableList.of("0", "1"));
+    assertFilterMatches(new SelectorDimFilter("dim6", "2017-05", new TimeDimExtractionFn("yyyy-MM-dd", "yyyy-MM", true)), ImmutableList.of("2"));
   }
 
   @Test


### PR DESCRIPTION
Closes #5445 by introducing an ISO compliant "joda" option. (Also more consistent with the rest of Druid, where we generally use Joda time)