### PR TITLE
Enforce optimal IndexedInts iteration

### DIFF
--- a/.idea/inspectionProfiles/Druid.xml
+++ b/.idea/inspectionProfiles/Druid.xml
@@ -103,6 +103,13 @@
       <option name="m_reportCollectionMethods" value="true" />
       <option name="m_ignorePrivateMethods" value="false" />
     </inspection_tool>
+    <inspection_tool class="SSBasedInspection" enabled="true" level="ERROR" enabled_by_default="true">
+      <searchConfiguration name="Suboptimal IndexedInts iteration" text="$x$ &lt; $y$.size()" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="x" within="" contains="" />
+        <constraint name="y" nameOfExprType="IndexedInts" exprTypeWithinHierarchy="true" within="" contains="" />
+      </searchConfiguration>
+    </inspection_tool>
     <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
       <option name="processCode" value="true" />
       <option name="processLiterals" value="true" />

--- a/benchmarks/src/main/java/io/druid/benchmark/CompressedVSizeColumnarMultiIntsBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/CompressedVSizeColumnarMultiIntsBenchmark.java
@@ -152,7 +152,7 @@ public class CompressedVSizeColumnarMultiIntsBenchmark
   {
     for (int i = filter.nextSetBit(0); i >= 0; i = filter.nextSetBit(i + 1)) {
       IndexedInts row = uncompressed.get(i);
-      for (int j = 0; j < row.size(); j++) {
+      for (int j = 0, rowSize = row.size(); j < rowSize; j++) {
         blackhole.consume(row.get(j));
       }
     }
@@ -165,7 +165,7 @@ public class CompressedVSizeColumnarMultiIntsBenchmark
   {
     for (int i = filter.nextSetBit(0); i >= 0; i = filter.nextSetBit(i + 1)) {
       IndexedInts row = compressed.get(i);
-      for (int j = 0; j < row.size(); j++) {
+      for (int j = 0, rowSize = row.size(); j < rowSize; j++) {
         blackhole.consume(row.get(j));
       }
     }

--- a/extensions-contrib/distinctcount/src/main/java/io/druid/query/aggregation/distinctcount/DistinctCountAggregator.java
+++ b/extensions-contrib/distinctcount/src/main/java/io/druid/query/aggregation/distinctcount/DistinctCountAggregator.java
@@ -43,7 +43,7 @@ public class DistinctCountAggregator implements Aggregator
   public void aggregate()
   {
     IndexedInts row = selector.getRow();
-    for (int i = 0; i < row.size(); i++) {
+    for (int i = 0, rowSize = row.size(); i < rowSize; i++) {
       int index = row.get(i);
       mutableBitmap.add(index);
     }

--- a/extensions-contrib/distinctcount/src/main/java/io/druid/query/aggregation/distinctcount/DistinctCountBufferAggregator.java
+++ b/extensions-contrib/distinctcount/src/main/java/io/druid/query/aggregation/distinctcount/DistinctCountBufferAggregator.java
@@ -53,7 +53,7 @@ public class DistinctCountBufferAggregator implements BufferAggregator
   {
     MutableBitmap mutableBitmap = getMutableBitmap(position);
     IndexedInts row = selector.getRow();
-    for (int i = 0; i < row.size(); i++) {
+    for (int i = 0, rowSize = row.size(); i < rowSize; i++) {
       int index = row.get(i);
       mutableBitmap.add(index);
     }

--- a/processing/src/main/java/io/druid/query/aggregation/cardinality/types/StringCardinalityAggregatorColumnSelectorStrategy.java
+++ b/processing/src/main/java/io/druid/query/aggregation/cardinality/types/StringCardinalityAggregatorColumnSelectorStrategy.java
@@ -62,7 +62,7 @@ public class StringCardinalityAggregatorColumnSelectorStrategy implements Cardin
   public void hashValues(DimensionSelector dimSelector, HyperLogLogCollector collector)
   {
     IndexedInts row = dimSelector.getRow();
-    for (int i = 0; i < row.size(); i++) {
+    for (int i = 0, rowSize = row.size(); i < rowSize; i++) {
       int index = row.get(i);
       final String value = dimSelector.lookupName(index);
       collector.add(CardinalityAggregator.hashFn.hashUnencodedChars(nullToSpecial(value)).asBytes());

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryEngine.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryEngine.java
@@ -190,12 +190,13 @@ public class GroupByQueryEngine
 
         final DimensionSelector dimSelector = dims.get(0);
         final IndexedInts row = dimSelector.getRow();
-        if (row == null || row.size() == 0) {
+        final int rowSize = row.size();
+        if (rowSize == 0) {
           ByteBuffer newKey = key.duplicate();
           newKey.putInt(MISSING_VALUE);
           unaggregatedBuffers = updateValues(newKey, dims.subList(1, dims.size()));
         } else {
-          for (int i = 0; i < row.size(); i++) {
+          for (int i = 0; i < rowSize; i++) {
             ByteBuffer newKey = key.duplicate();
             int dimValue = row.get(i);
             newKey.putInt(dimValue);

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
@@ -639,12 +639,13 @@ public class GroupByQueryEngineV2
       }
 
       while (!cursor.isDone()) {
-        if (multiValues.size() == 0) {
+        int multiValuesSize = multiValues.size();
+        if (multiValuesSize == 0) {
           if (!grouper.aggregate(GroupByColumnSelectorStrategy.GROUP_BY_MISSING_VALUE).isOk()) {
             return;
           }
         } else {
-          for (; nextValIndex < multiValues.size(); nextValIndex++) {
+          for (; nextValIndex < multiValuesSize; nextValIndex++) {
             if (!grouper.aggregate(multiValues.get(nextValIndex)).isOk()) {
               return;
             }

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/column/DictionaryBuildingStringGroupByColumnSelectorStrategy.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/column/DictionaryBuildingStringGroupByColumnSelectorStrategy.java
@@ -75,7 +75,7 @@ public class DictionaryBuildingStringGroupByColumnSelectorStrategy extends Strin
     }
     int rowSize = row.size();
     newRow.ensureSize(rowSize);
-    for (int i = 0; i < row.size(); i++) {
+    for (int i = 0; i < rowSize; i++) {
       final String value = dimSelector.lookupName(row.get(i));
       final int dictId = reverseDictionary.getInt(value);
       if (dictId < 0) {

--- a/processing/src/main/java/io/druid/query/metadata/SegmentAnalyzer.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentAnalyzer.java
@@ -276,9 +276,9 @@ public class SegmentAnalyzer
               }
               long current = accumulated;
               while (!cursor.isDone()) {
-                final IndexedInts vals = selector.getRow();
-                for (int i = 0; i < vals.size(); ++i) {
-                  final String dimVal = selector.lookupName(vals.get(i));
+                final IndexedInts row = selector.getRow();
+                for (int i = 0, rowSize = row.size(); i < rowSize; ++i) {
+                  final String dimVal = selector.lookupName(row.get(i));
                   if (dimVal != null && !dimVal.isEmpty()) {
                     current += StringUtils.estimatedBinaryLengthAsUTF8(dimVal);
                   }

--- a/processing/src/main/java/io/druid/query/search/SearchQueryRunner.java
+++ b/processing/src/main/java/io/druid/query/search/SearchQueryRunner.java
@@ -127,9 +127,9 @@ public class SearchQueryRunner implements QueryRunner<Result<SearchResultValue>>
     )
     {
       if (selector != null && !isNilSelector(selector)) {
-        final IndexedInts vals = selector.getRow();
-        for (int i = 0; i < vals.size(); ++i) {
-          final String dimVal = selector.lookupName(vals.get(i));
+        final IndexedInts row = selector.getRow();
+        for (int i = 0, rowSize = row.size(); i < rowSize; ++i) {
+          final String dimVal = selector.lookupName(row.get(i));
           if (searchQuerySpec.accept(dimVal)) {
             set.addTo(new SearchHit(outputName, Strings.nullToEmpty(dimVal)), 1);
             if (set.size() >= limit) {

--- a/processing/src/main/java/io/druid/query/topn/types/StringTopNColumnSelectorStrategy.java
+++ b/processing/src/main/java/io/druid/query/topn/types/StringTopNColumnSelectorStrategy.java
@@ -132,7 +132,7 @@ public class StringTopNColumnSelectorStrategy
     long processedRows = 0;
     while (!cursor.isDone()) {
       final IndexedInts dimValues = selector.getRow();
-      for (int i = 0; i < dimValues.size(); ++i) {
+      for (int i = 0, size = dimValues.size(); i < size; ++i) {
         final int dimIndex = dimValues.get(i);
         Aggregator[] theAggregators = rowSelector[dimIndex];
         if (theAggregators == null) {
@@ -165,7 +165,7 @@ public class StringTopNColumnSelectorStrategy
     long processedRows = 0;
     while (!cursor.isDone()) {
       final IndexedInts dimValues = selector.getRow();
-      for (int i = 0; i < dimValues.size(); ++i) {
+      for (int i = 0, size = dimValues.size(); i < size; ++i) {
         final int dimIndex = dimValues.get(i);
         final String key = selector.lookupName(dimIndex);
 

--- a/processing/src/main/java/io/druid/segment/DimensionSelector.java
+++ b/processing/src/main/java/io/druid/segment/DimensionSelector.java
@@ -167,16 +167,17 @@ public interface DimensionSelector extends ColumnValueSelector, HotLoopCallee
   default Object defaultGetObject()
   {
     IndexedInts row = getRow();
-    if (row.size() == 0) {
+    int rowSize = row.size();
+    if (rowSize == 0) {
       return null;
-    }
-    if (row.size() == 1) {
+    } else if (rowSize == 1) {
       return lookupName(row.get(0));
+    } else {
+      final String[] strings = new String[rowSize];
+      for (int i = 0; i < rowSize; i++) {
+        strings[i] = lookupName(row.get(i));
+      }
+      return strings;
     }
-    final String[] strings = new String[row.size()];
-    for (int i = 0; i < row.size(); i++) {
-      strings[i] = lookupName(row.get(i));
-    }
-    return strings;
   }
 }

--- a/processing/src/main/java/io/druid/segment/data/CompressedVSizeColumnarMultiIntsSupplier.java
+++ b/processing/src/main/java/io/druid/segment/data/CompressedVSizeColumnarMultiIntsSupplier.java
@@ -109,7 +109,7 @@ public class CompressedVSizeColumnarMultiIntsSupplier implements WritableSupplie
     while (objects.hasNext()) {
       IndexedInts next = objects.next();
       offsetList.add(offset);
-      for (int i = 0; i < next.size(); i++) {
+      for (int i = 0, size = next.size(); i < size; i++) {
         values.add(next.get(i));
       }
       offset += next.size();

--- a/processing/src/main/java/io/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSupplier.java
+++ b/processing/src/main/java/io/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSupplier.java
@@ -91,7 +91,7 @@ public class V3CompressedVSizeColumnarMultiIntsSupplier implements WritableSuppl
     while (objects.hasNext()) {
       IndexedInts next = objects.next();
       offsetList.add(offset);
-      for (int i = 0; i < next.size(); i++) {
+      for (int i = 0, size = next.size(); i < size; i++) {
         values.add(next.get(i));
       }
       offset += next.size();

--- a/processing/src/test/java/io/druid/segment/data/CompressedColumnarIntsSupplierTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedColumnarIntsSupplierTest.java
@@ -205,7 +205,7 @@ public class CompressedColumnarIntsSupplierTest extends CompressionStrategyTest
 
         try {
           for (int i = 0; i < numRuns; ++i) {
-            for (int j = 0; j < columnarInts.size(); ++j) {
+            for (int j = 0, size = columnarInts.size(); j < size; ++j) {
               final long val = vals[j];
               final long indexedVal = columnarInts.get(j);
               if (Longs.compare(val, indexedVal) != 0) {
@@ -285,7 +285,7 @@ public class CompressedColumnarIntsSupplierTest extends CompressionStrategyTest
 
     // sequential access
     int[] indices = new int[vals.length];
-    for (int i = 0; i < columnarInts.size(); ++i) {
+    for (int i = 0, size = columnarInts.size(); i < size; ++i) {
       Assert.assertEquals(vals[i], columnarInts.get(i), 0.0);
       indices[i] = i;
     }

--- a/processing/src/test/java/io/druid/segment/data/CompressedVSizeColumnarIntsSupplierTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedVSizeColumnarIntsSupplierTest.java
@@ -282,7 +282,7 @@ public class CompressedVSizeColumnarIntsSupplierTest extends CompressionStrategy
 
         try {
           for (int i = 0; i < numRuns; ++i) {
-            for (int j = 0; j < columnarInts.size(); ++j) {
+            for (int j = 0, size = columnarInts.size(); j < size; ++j) {
               final long val = vals[j];
               final long indexedVal = columnarInts.get(j);
               if (Longs.compare(val, indexedVal) != 0) {
@@ -362,7 +362,7 @@ public class CompressedVSizeColumnarIntsSupplierTest extends CompressionStrategy
 
     // sequential access of every element
     int[] indices = new int[vals.length];
-    for (int i = 0; i < columnarInts.size(); ++i) {
+    for (int i = 0, size = columnarInts.size(); i < size; ++i) {
       final int expected = vals[i];
       final int actual = columnarInts.get(i);
       Assert.assertEquals(expected, actual);

--- a/processing/src/test/java/io/druid/segment/data/CompressedVSizeColumnarMultiIntsSupplierTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedVSizeColumnarMultiIntsSupplierTest.java
@@ -107,7 +107,7 @@ public class CompressedVSizeColumnarMultiIntsSupplierTest
       final IndexedInts vSizeIndexedInts = iterator.next();
 
       Assert.assertEquals(ints.length, vSizeIndexedInts.size());
-      for (int i = 0; i < vSizeIndexedInts.size(); i++) {
+      for (int i = 0, size = vSizeIndexedInts.size(); i < size; i++) {
         Assert.assertEquals(ints[i], vSizeIndexedInts.get(i));
       }
       row++;

--- a/processing/src/test/java/io/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSerializerTest.java
+++ b/processing/src/test/java/io/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSerializerTest.java
@@ -155,7 +155,7 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
         for (int i = 0; i < vals.size(); ++i) {
           IndexedInts subVals = columnarMultiInts.get(i);
           assertEquals(subVals.size(), vals.get(i).length);
-          for (int j = 0; j < subVals.size(); ++j) {
+          for (int j = 0, size = subVals.size(); j < size; ++j) {
             assertEquals(subVals.get(j), vals.get(i)[j]);
           }
         }
@@ -278,7 +278,7 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
       for (int i = 0; i < vals.size(); ++i) {
         IndexedInts subVals = columnarMultiInts.get(i);
         assertEquals(subVals.size(), vals.get(i).length);
-        for (int j = 0; j < subVals.size(); ++j) {
+        for (int j = 0, size = subVals.size(); j < size; ++j) {
           assertEquals(subVals.get(j), vals.get(i)[j]);
         }
       }

--- a/server/src/main/java/io/druid/segment/realtime/firehose/IngestSegmentFirehose.java
+++ b/server/src/main/java/io/druid/segment/realtime/firehose/IngestSegmentFirehose.java
@@ -21,7 +21,6 @@ package io.druid.segment.realtime.firehose;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.druid.data.input.Firehose;
 import io.druid.data.input.InputRow;
@@ -49,6 +48,7 @@ import io.druid.utils.Runnables;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -139,12 +139,13 @@ public class IngestSegmentFirehose implements Firehose
                                           final DimensionSelector selector = dimSelector.getValue();
                                           final IndexedInts vals = selector.getRow();
 
-                                          if (vals.size() == 1) {
+                                          int valsSize = vals.size();
+                                          if (valsSize == 1) {
                                             final String dimVal = selector.lookupName(vals.get(0));
                                             theEvent.put(dim, dimVal);
-                                          } else {
-                                            List<String> dimVals = Lists.newArrayList();
-                                            for (int i = 0; i < vals.size(); ++i) {
+                                          } else if (valsSize > 1) {
+                                            List<String> dimVals = new ArrayList<>(valsSize);
+                                            for (int i = 0; i < valsSize; ++i) {
                                               dimVals.add(selector.lookupName(vals.get(i)));
                                             }
                                             theEvent.put(dim, dimVals);


### PR DESCRIPTION
`IndexedInts` are usually iterated in some other loop, i. e. it's a nested, not a top level loop. So it should pay off to carefully write those loops.