### PR TITLE
Fix authorization check in supervisor history API

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/overlord/supervisor/SupervisorResource.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/supervisor/SupervisorResource.java
@@ -235,7 +235,7 @@ public class SupervisorResource
                   }
                 }
             );
-            return Response.ok(supervisorHistory).build();
+            return Response.ok(authorizedSupervisorHistory).build();
           }
         }
     );


### PR DESCRIPTION
Fixes the issue reported here: https://github.com/druid-io/druid/pull/4818#pullrequestreview-100875144, where the unfiltered history results were returned instead of the auth-filtered results.