### PR TITLE
Optimize chunkedCopy for sequential writes

### DIFF
--- a/java-util/src/test/java/io/druid/java/util/common/io/NativeIOTest.java
+++ b/java-util/src/test/java/io/druid/java/util/common/io/NativeIOTest.java
@@ -58,7 +58,7 @@ public class NativeIOTest
   @Test
   public void testDisabledFadviseChunkedCopy() throws Exception
   {
-    boolean possible = NativeIO.getFadvisePossible();
+    boolean possible = NativeIO.isFadvisePossible();
 
     NativeIO.setFadvisePossible(false);
     File f = tempFolder.newFile();
@@ -70,6 +70,24 @@ public class NativeIOTest
     byte[] data = Files.readAllBytes(f.toPath());
 
     NativeIO.setFadvisePossible(possible);
+    Assert.assertTrue(Arrays.equals(bytes, data));
+  }
+
+  @Test
+  public void testDisabledSyncFileRangePossible() throws Exception
+  {
+    boolean possible = NativeIO.isSyncFileRangePossible();
+
+    NativeIO.setSyncFileRangePossible(false);
+    File f = tempFolder.newFile();
+    byte[] bytes = new byte[]{(byte) 0x8, (byte) 0x9};
+
+    ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
+    NativeIO.chunkedCopy(bis, f);
+
+    byte[] data = Files.readAllBytes(f.toPath());
+
+    NativeIO.setSyncFileRangePossible(possible);
     Assert.assertTrue(Arrays.equals(bytes, data));
   }
 


### PR DESCRIPTION
NativeIO.chunkedCopy fsyncs its writebuffer directly and
requires an O_DIRECT RandomAccessFile. By allowing the
kernel to start writing while filling the buffer the writes
will be more constant. In addition the O_DIRECT flag is not
required anymore and this will work faster in case fadvise
is not supported on some system.

This is based on Linus' post here:
http://lkml.iu.edu/hypermail/linux/kernel/1005.2/01845.html

@drcrallen @b-slim 

Benchmarks on a 8GB, 4 CPU Machine, HDD backed:

1. Allocate 1GB file `fallocate -l 1GB dummy.img`
2. Check pagecache:
```
[centos@druid-build druid]$ vmtouch -v /tmp/dummy.img
/tmp/dummy.img
[                                                            ] 0/262144

           Files: 1
     Directories: 0
  Resident Pages: 0/262144  0/1G  0%
         Elapsed: 0.008541 seconds
```
3. Load source file into pagecache
```
[centos@druid-build druid]$ vmtouch -t /tmp/dummy.img
           Files: 1
     Directories: 0
   Touched Pages: 262144 (1G)
         Elapsed: 1.0545 seconds
```
4. Benchmark 20 runs *current* behavior (report is in milliseconds)
```
[centos@druid-build tmp]$ time java -cp druid-services-directio-selfcontained.jar:. Benchmark dummy.img dummy.img.cp
Starting copy from dummy.img to dummy.img.cp
Copy No: 0
Copy No: 1
Copy No: 2
Copy No: 3
Copy No: 4
Copy No: 5
Copy No: 6
Copy No: 7
Copy No: 8
Copy No: 9
Copy No: 10
Copy No: 11
Copy No: 12
Copy No: 13
Copy No: 14
Copy No: 15
Copy No: 16
Copy No: 17
Copy No: 18
Copy No: 19
Min: 20916
Max: 25299
Median: 23468.0
Mean: 23392.65
SD: 1343.1131746803767
```
5. Check pagecache
```
[centos@druid-build druid]$ vmtouch -v /tmp/dummy.img.cp
/tmp/dummy.img.cp
[                                                            ] 0/262144

           Files: 1
     Directories: 0
  Resident Pages: 0/262144  0/1G  0%
         Elapsed: 0.009043 seconds
```

6. benchmark *this PR*
```
[centos@druid-build tmp]$ time java -cp druid-services-nativeio-selfcontained.jar:. Benchmark dummy.img dummy.img.cp
Starting copy from dummy.img to dummy.img.cp
Copy No: 0
Copy No: 1
Copy No: 2
Copy No: 3
Copy No: 4
Copy No: 5
Copy No: 6
Copy No: 7
Copy No: 8
Copy No: 9
Copy No: 10
Copy No: 11
Copy No: 12
Copy No: 13
Copy No: 14
Copy No: 15
Copy No: 16
Copy No: 17
Copy No: 18
Copy No: 19
Min: 20039
Max: 25308
Median: 21817.0
Mean: 22353.15
SD: 1400.4327902473578

real	7m27.222s
user	0m12.803s
sys	0m33.998s
```
7. Check pagecache
```
[centos@druid-build druid]$ vmtouch -v /tmp/dummy.img.cp
/tmp/dummy.img.cp
[                                                            ] 0/262144

           Files: 1
     Directories: 0
  Resident Pages: 0/262144  0/1G  0%
         Elapsed: 0.007807 seconds
```