### PR TITLE
SQL: Remove unused escalator, authConfig from various classes.

### DIFF
--- a/benchmarks/src/main/java/io/druid/benchmark/query/SqlBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/query/SqlBenchmark.java
@@ -37,7 +37,6 @@ import io.druid.query.dimension.DefaultDimensionSpec;
 import io.druid.query.dimension.DimensionSpec;
 import io.druid.query.groupby.GroupByQuery;
 import io.druid.segment.QueryableIndex;
-import io.druid.server.security.AuthConfig;
 import io.druid.server.security.AuthTestUtils;
 import io.druid.server.security.NoopEscalator;
 import io.druid.sql.calcite.planner.DruidPlanner;
@@ -118,9 +117,7 @@ public class SqlBenchmark
         CalciteTests.createOperatorTable(),
         CalciteTests.createExprMacroTable(),
         plannerConfig,
-        new AuthConfig(),
         AuthTestUtils.TEST_AUTHORIZER_MAPPER,
-        new NoopEscalator(),
         CalciteTests.getJsonMapper()
     );
     groupByQuery = GroupByQuery
@@ -182,7 +179,10 @@ public class SqlBenchmark
   public void queryPlanner(Blackhole blackhole) throws Exception
   {
     try (final DruidPlanner planner = plannerFactory.createPlanner(null)) {
-      final PlannerResult plannerResult = planner.plan(sqlQuery);
+      final PlannerResult plannerResult = planner.plan(
+          sqlQuery,
+          NoopEscalator.getInstance().createEscalatedAuthenticationResult()
+      );
       final List<Object[]> results = plannerResult.run().toList();
       blackhole.consume(results);
     }

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/sql/QuantileSqlAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/sql/QuantileSqlAggregatorTest.java
@@ -47,7 +47,6 @@ import io.druid.segment.column.ValueType;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.virtual.ExpressionVirtualColumn;
 import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
-import io.druid.server.security.AuthConfig;
 import io.druid.server.security.AuthTestUtils;
 import io.druid.server.security.NoopEscalator;
 import io.druid.sql.calcite.filtration.Filtration;
@@ -137,9 +136,7 @@ public class QuantileSqlAggregatorTest extends CalciteTestBase
         operatorTable,
         CalciteTests.createExprMacroTable(),
         plannerConfig,
-        new AuthConfig(),
         AuthTestUtils.TEST_AUTHORIZER_MAPPER,
-        new NoopEscalator(),
         CalciteTests.getJsonMapper()
     );
   }
@@ -167,7 +164,10 @@ public class QuantileSqlAggregatorTest extends CalciteTestBase
                          + "APPROX_QUANTILE(cnt, 0.5)\n"
                          + "FROM foo";
 
-      final PlannerResult plannerResult = planner.plan(sql);
+      final PlannerResult plannerResult = planner.plan(
+          sql,
+          NoopEscalator.getInstance().createEscalatedAuthenticationResult()
+      );
 
       // Verify results
       final List<Object[]> results = plannerResult.run().toList();
@@ -249,7 +249,10 @@ public class QuantileSqlAggregatorTest extends CalciteTestBase
                          + "APPROX_QUANTILE(hist_m1, 0.999) FILTER(WHERE dim1 = 'abc')\n"
                          + "FROM foo";
 
-      final PlannerResult plannerResult = planner.plan(sql);
+      final PlannerResult plannerResult = planner.plan(
+          sql,
+          NoopEscalator.getInstance().createEscalatedAuthenticationResult()
+      );
 
       // Verify results
       final List<Object[]> results = plannerResult.run().toList();
@@ -302,7 +305,10 @@ public class QuantileSqlAggregatorTest extends CalciteTestBase
       final String sql = "SELECT AVG(x), APPROX_QUANTILE(x, 0.98)\n"
                          + "FROM (SELECT dim2, SUM(m1) AS x FROM foo GROUP BY dim2)";
 
-      final PlannerResult plannerResult = planner.plan(sql);
+      final PlannerResult plannerResult = planner.plan(
+          sql,
+          NoopEscalator.getInstance().createEscalatedAuthenticationResult()
+      );
 
       // Verify results
       final List<Object[]> results = plannerResult.run().toList();

--- a/server/src/test/java/io/druid/server/security/EscalatorTest.java
+++ b/server/src/test/java/io/druid/server/security/EscalatorTest.java
@@ -19,47 +19,23 @@
 
 package io.druid.server.security;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import io.druid.java.util.http.client.HttpClient;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.druid.segment.TestHelper;
+import org.junit.Assert;
+import org.junit.Test;
 
-public class NoopEscalator implements Escalator
+public class EscalatorTest
 {
-  private static final NoopEscalator INSTANCE = new NoopEscalator();
-
-  @JsonCreator
-  public static NoopEscalator getInstance()
+  @Test
+  public void testSerde() throws Exception
   {
-    return INSTANCE;
-  }
-
-  @Override
-  public HttpClient createEscalatedClient(HttpClient baseClient)
-  {
-    return baseClient;
-  }
-
-  @Override
-  public AuthenticationResult createEscalatedAuthenticationResult()
-  {
-    return AllowAllAuthenticator.ALLOW_ALL_RESULT;
-  }
-
-  @Override
-  public boolean equals(final Object obj)
-  {
-    //noinspection ObjectEquality
-    return obj.getClass() == getClass();
-  }
-
-  @Override
-  public int hashCode()
-  {
-    return 0;
-  }
-
-  @Override
-  public String toString()
-  {
-    return "NoopEscalator{}";
+    final ObjectMapper objectMapper = TestHelper.makeJsonMapper();
+    Assert.assertEquals(
+        NoopEscalator.getInstance(),
+        objectMapper.readValue(
+            objectMapper.writeValueAsString(NoopEscalator.getInstance()),
+            Escalator.class
+        )
+    );
   }
 }

--- a/sql/src/main/java/io/druid/sql/avatica/DruidMeta.java
+++ b/sql/src/main/java/io/druid/sql/avatica/DruidMeta.java
@@ -34,7 +34,6 @@ import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.logger.Logger;
-import io.druid.server.security.AuthConfig;
 import io.druid.server.security.AuthenticationResult;
 import io.druid.server.security.Authenticator;
 import io.druid.server.security.AuthenticatorMapper;
@@ -67,7 +66,6 @@ public class DruidMeta extends MetaImpl
   private final PlannerFactory plannerFactory;
   private final ScheduledExecutorService exec;
   private final AvaticaServerConfig config;
-  private final AuthConfig authConfig;
   private final List<Authenticator> authenticators;
 
   // Used to track logical connections.
@@ -81,14 +79,12 @@ public class DruidMeta extends MetaImpl
   public DruidMeta(
       final PlannerFactory plannerFactory,
       final AvaticaServerConfig config,
-      final AuthConfig authConfig,
       final Injector injector
   )
   {
     super(null);
     this.plannerFactory = Preconditions.checkNotNull(plannerFactory, "plannerFactory");
     this.config = config;
-    this.authConfig = authConfig;
     this.exec = Executors.newSingleThreadScheduledExecutor(
         new ThreadFactoryBuilder()
             .setNameFormat(StringUtils.format("DruidMeta@%s-ScheduledExecutor", Integer.toHexString(hashCode())))
@@ -183,7 +179,8 @@ public class DruidMeta extends MetaImpl
     if (authenticationResult == null) {
       throw new ForbiddenException("Authentication failed.");
     }
-    final Signature signature = druidStatement.prepare(plannerFactory, sql, maxRowCount, authenticationResult).getSignature();
+    final Signature signature = druidStatement.prepare(plannerFactory, sql, maxRowCount, authenticationResult)
+                                              .getSignature();
     final Frame firstFrame = druidStatement.execute()
                                            .nextFrame(
                                                DruidStatement.START_OFFSET,

--- a/sql/src/main/java/io/druid/sql/avatica/DruidStatement.java
+++ b/sql/src/main/java/io/druid/sql/avatica/DruidStatement.java
@@ -162,7 +162,7 @@ public class DruidStatement implements Closeable
     try (final DruidPlanner planner = plannerFactory.createPlanner(queryContext)) {
       synchronized (lock) {
         ensure(State.NEW);
-        this.plannerResult = planner.plan(query, null, authenticationResult);
+        this.plannerResult = planner.plan(query, authenticationResult);
         this.maxRowCount = maxRowCount;
         this.query = query;
         this.signature = Meta.Signature.create(

--- a/sql/src/main/java/io/druid/sql/calcite/planner/DruidPlanner.java
+++ b/sql/src/main/java/io/druid/sql/calcite/planner/DruidPlanner.java
@@ -20,11 +20,13 @@
 package io.druid.sql.calcite.planner;
 
 import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
+import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.guava.Sequences;
 import io.druid.server.security.Access;
@@ -32,7 +34,6 @@ import io.druid.server.security.AuthConfig;
 import io.druid.server.security.AuthenticationResult;
 import io.druid.server.security.AuthorizationUtils;
 import io.druid.server.security.AuthorizerMapper;
-import io.druid.server.security.Escalator;
 import io.druid.server.security.ForbiddenException;
 import io.druid.sql.calcite.rel.DruidConvention;
 import io.druid.sql.calcite.rel.DruidRel;
@@ -61,6 +62,7 @@ import org.apache.calcite.tools.RelConversionException;
 import org.apache.calcite.tools.ValidationException;
 import org.apache.calcite.util.Pair;
 
+import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import java.io.Closeable;
 import java.util.ArrayList;
@@ -72,33 +74,44 @@ public class DruidPlanner implements Closeable
   private final Planner planner;
   private final PlannerContext plannerContext;
   private final AuthorizerMapper authorizerMapper;
-  private final Escalator escalator;
 
-  public DruidPlanner(
+  DruidPlanner(
       final Planner planner,
       final PlannerContext plannerContext,
-      final AuthorizerMapper authorizerMapper,
-      final Escalator escalator
+      final AuthorizerMapper authorizerMapper
   )
   {
     this.planner = planner;
     this.plannerContext = plannerContext;
     this.authorizerMapper = authorizerMapper;
-    this.escalator = escalator;
-  }
-
-  public PlannerResult plan(final String sql) throws SqlParseException, ValidationException, RelConversionException
-  {
-    AuthenticationResult authenticationResult = escalator.createEscalatedAuthenticationResult();
-    return plan(sql, null, authenticationResult);
   }
 
   public PlannerResult plan(
       final String sql,
-      final HttpServletRequest request,
+      final HttpServletRequest request
+  ) throws SqlParseException, ValidationException, RelConversionException, ForbiddenException
+  {
+    return plan(sql, Preconditions.checkNotNull(request, "request"), null);
+  }
+
+  public PlannerResult plan(
+      final String sql,
       final AuthenticationResult authenticationResult
   ) throws SqlParseException, ValidationException, RelConversionException, ForbiddenException
   {
+    return plan(sql, null, Preconditions.checkNotNull(authenticationResult, "authenticationResult"));
+  }
+
+  private PlannerResult plan(
+      final String sql,
+      @Nullable final HttpServletRequest request,
+      @Nullable final AuthenticationResult authenticationResult
+  ) throws SqlParseException, ValidationException, RelConversionException, ForbiddenException
+  {
+    if (authenticationResult != null && request != null) {
+      throw new ISE("Cannot specify both 'request' and 'authenticationResult'");
+    }
+
     SqlExplain explain = null;
     SqlNode parsed = planner.parse(sql);
     if (parsed.getKind() == SqlKind.EXPLAIN) {
@@ -137,8 +150,8 @@ public class DruidPlanner implements Closeable
   private PlannerResult planWithDruidConvention(
       final SqlExplain explain,
       final RelRoot root,
-      final HttpServletRequest request,
-      final AuthenticationResult authenticationResult
+      @Nullable final HttpServletRequest request,
+      @Nullable final AuthenticationResult authenticationResult
   ) throws RelConversionException, ForbiddenException
   {
     final DruidRel<?> druidRel = (DruidRel<?>) planner.transform(

--- a/sql/src/main/java/io/druid/sql/calcite/planner/PlannerFactory.java
+++ b/sql/src/main/java/io/druid/sql/calcite/planner/PlannerFactory.java
@@ -24,9 +24,7 @@ import com.google.inject.Inject;
 import io.druid.guice.annotations.Json;
 import io.druid.math.expr.ExprMacroTable;
 import io.druid.server.QueryLifecycleFactory;
-import io.druid.server.security.AuthConfig;
 import io.druid.server.security.AuthorizerMapper;
-import io.druid.server.security.Escalator;
 import io.druid.sql.calcite.rel.QueryMaker;
 import io.druid.sql.calcite.schema.DruidSchema;
 import org.apache.calcite.avatica.util.Casing;
@@ -64,10 +62,7 @@ public class PlannerFactory
   private final ExprMacroTable macroTable;
   private final PlannerConfig plannerConfig;
   private final ObjectMapper jsonMapper;
-
-  private final AuthConfig authConfig;
   private final AuthorizerMapper authorizerMapper;
-  private final Escalator escalator;
 
   @Inject
   public PlannerFactory(
@@ -76,9 +71,7 @@ public class PlannerFactory
       final DruidOperatorTable operatorTable,
       final ExprMacroTable macroTable,
       final PlannerConfig plannerConfig,
-      final AuthConfig authConfig,
       final AuthorizerMapper authorizerMapper,
-      final Escalator escalator,
       final @Json ObjectMapper jsonMapper
   )
   {
@@ -87,9 +80,7 @@ public class PlannerFactory
     this.operatorTable = operatorTable;
     this.macroTable = macroTable;
     this.plannerConfig = plannerConfig;
-    this.authConfig = authConfig;
     this.authorizerMapper = authorizerMapper;
-    this.escalator = escalator;
     this.jsonMapper = jsonMapper;
   }
 
@@ -151,8 +142,7 @@ public class PlannerFactory
     return new DruidPlanner(
         Frameworks.getPlanner(frameworkConfig),
         plannerContext,
-        authorizerMapper,
-        escalator
+        authorizerMapper
     );
   }
 }

--- a/sql/src/main/java/io/druid/sql/http/SqlResource.java
+++ b/sql/src/main/java/io/druid/sql/http/SqlResource.java
@@ -85,7 +85,7 @@ public class SqlResource
     final DateTimeZone timeZone;
 
     try (final DruidPlanner planner = plannerFactory.createPlanner(sqlQuery.getContext())) {
-      plannerResult = planner.plan(sqlQuery.getQuery(), req, null);
+      plannerResult = planner.plan(sqlQuery.getQuery(), req);
       timeZone = planner.getPlannerContext().getTimeZone();
 
       // Remember which columns are time-typed, so we can emit ISO8601 instead of millis values.

--- a/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
+++ b/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
@@ -41,12 +41,10 @@ import io.druid.java.util.common.Pair;
 import io.druid.java.util.common.StringUtils;
 import io.druid.math.expr.ExprMacroTable;
 import io.druid.server.DruidNode;
-import io.druid.server.security.AuthConfig;
 import io.druid.server.security.AuthTestUtils;
 import io.druid.server.security.AuthenticatorMapper;
 import io.druid.server.security.AuthorizerMapper;
 import io.druid.server.security.Escalator;
-import io.druid.server.security.NoopEscalator;
 import io.druid.sql.calcite.planner.Calcites;
 import io.druid.sql.calcite.planner.DruidOperatorTable;
 import io.druid.sql.calcite.planner.PlannerConfig;
@@ -160,13 +158,10 @@ public class DruidAvaticaHandlerTest extends CalciteTestBase
             operatorTable,
             macroTable,
             plannerConfig,
-            new AuthConfig(),
             CalciteTests.TEST_AUTHORIZER_MAPPER,
-            CalciteTests.TEST_AUTHENTICATOR_ESCALATOR,
             CalciteTests.getJsonMapper()
         ),
         AVATICA_CONFIG,
-        new AuthConfig(),
         injector
     );
     final DruidAvaticaHandler handler = new DruidAvaticaHandler(
@@ -744,13 +739,10 @@ public class DruidAvaticaHandlerTest extends CalciteTestBase
             operatorTable,
             macroTable,
             plannerConfig,
-            new AuthConfig(),
             AuthTestUtils.TEST_AUTHORIZER_MAPPER,
-            new NoopEscalator(),
             CalciteTests.getJsonMapper()
         ),
         smallFrameConfig,
-        new AuthConfig(),
         injector
     )
     {

--- a/sql/src/test/java/io/druid/sql/avatica/DruidStatementTest.java
+++ b/sql/src/test/java/io/druid/sql/avatica/DruidStatementTest.java
@@ -24,9 +24,7 @@ import com.google.common.collect.Lists;
 import io.druid.java.util.common.DateTimes;
 import io.druid.math.expr.ExprMacroTable;
 import io.druid.server.security.AllowAllAuthenticator;
-import io.druid.server.security.AuthConfig;
 import io.druid.server.security.AuthTestUtils;
-import io.druid.server.security.NoopEscalator;
 import io.druid.sql.calcite.planner.DruidOperatorTable;
 import io.druid.sql.calcite.planner.PlannerConfig;
 import io.druid.sql.calcite.planner.PlannerFactory;
@@ -74,9 +72,7 @@ public class DruidStatementTest extends CalciteTestBase
         operatorTable,
         macroTable,
         plannerConfig,
-        new AuthConfig(),
         AuthTestUtils.TEST_AUTHORIZER_MAPPER,
-        new NoopEscalator(),
         CalciteTests.getJsonMapper()
     );
   }

--- a/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
@@ -84,7 +84,6 @@ import io.druid.query.topn.TopNQueryBuilder;
 import io.druid.segment.column.Column;
 import io.druid.segment.column.ValueType;
 import io.druid.segment.virtual.ExpressionVirtualColumn;
-import io.druid.server.security.AuthConfig;
 import io.druid.server.security.AuthenticationResult;
 import io.druid.server.security.ForbiddenException;
 import io.druid.sql.calcite.filtration.Filtration;
@@ -6484,7 +6483,7 @@ public class CalciteQueryTest extends CalciteTestBase
       final AuthenticationResult authenticationResult
   ) throws Exception
   {
-    final InProcessViewManager viewManager = new InProcessViewManager();
+    final InProcessViewManager viewManager = new InProcessViewManager(CalciteTests.TEST_AUTHENTICATOR_ESCALATOR);
     final DruidSchema druidSchema = CalciteTests.createMockSchema(walker, plannerConfig, viewManager);
     final DruidOperatorTable operatorTable = CalciteTests.createOperatorTable();
     final ExprMacroTable macroTable = CalciteTests.createExprMacroTable();
@@ -6495,9 +6494,7 @@ public class CalciteQueryTest extends CalciteTestBase
         operatorTable,
         macroTable,
         plannerConfig,
-        new AuthConfig(),
         CalciteTests.TEST_AUTHORIZER_MAPPER,
-        CalciteTests.TEST_AUTHENTICATOR_ESCALATOR,
         CalciteTests.getJsonMapper()
     );
 
@@ -6515,7 +6512,7 @@ public class CalciteQueryTest extends CalciteTestBase
     );
 
     try (DruidPlanner planner = plannerFactory.createPlanner(queryContext)) {
-      final PlannerResult plan = planner.plan(sql, null, authenticationResult);
+      final PlannerResult plan = planner.plan(sql, authenticationResult);
       return plan.run().toList();
     }
   }

--- a/sql/src/test/java/io/druid/sql/calcite/http/SqlResourceTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/http/SqlResourceTest.java
@@ -32,7 +32,6 @@ import io.druid.query.ResourceLimitExceededException;
 import io.druid.server.security.AllowAllAuthenticator;
 import io.druid.server.security.AuthConfig;
 import io.druid.server.security.AuthTestUtils;
-import io.druid.server.security.NoopEscalator;
 import io.druid.sql.calcite.planner.DruidOperatorTable;
 import io.druid.sql.calcite.planner.PlannerConfig;
 import io.druid.sql.calcite.planner.PlannerContext;
@@ -108,9 +107,7 @@ public class SqlResourceTest extends CalciteTestBase
             operatorTable,
             macroTable,
             plannerConfig,
-            new AuthConfig(),
             AuthTestUtils.TEST_AUTHORIZER_MAPPER,
-            new NoopEscalator(),
             CalciteTests.getJsonMapper()
         )
     );


### PR DESCRIPTION
DruidPlanner.plan is responsible for checking authorization, so these objects
weren't needed in as many places as they were injected.