### PR TITLE
SegmentMetadataQuery: Fix default interval handling.

### DIFF
--- a/processing/src/main/java/io/druid/query/Druids.java
+++ b/processing/src/main/java/io/druid/query/Druids.java
@@ -591,6 +591,7 @@ public class Druids
     private EnumSet<SegmentMetadataQuery.AnalysisType> analysisTypes;
     private Boolean merge;
     private Boolean lenientAggregatorMerge;
+    private Boolean usingDefaultInterval;
     private Map<String, Object> context;
 
     public SegmentMetadataQueryBuilder()
@@ -601,6 +602,7 @@ public class Druids
       analysisTypes = null;
       merge = null;
       lenientAggregatorMerge = null;
+      usingDefaultInterval = null;
       context = null;
     }
 
@@ -613,7 +615,7 @@ public class Druids
           merge,
           context,
           analysisTypes,
-          false,
+          usingDefaultInterval,
           lenientAggregatorMerge
       );
     }
@@ -627,6 +629,7 @@ public class Druids
           .analysisTypes(query.getAnalysisTypes())
           .merge(query.isMerge())
           .lenientAggregatorMerge(query.isLenientAggregatorMerge())
+          .usingDefaultInterval(query.isUsingDefaultInterval())
           .context(query.getContext());
     }
 
@@ -693,6 +696,12 @@ public class Druids
     public SegmentMetadataQueryBuilder lenientAggregatorMerge(boolean lenientAggregatorMerge)
     {
       this.lenientAggregatorMerge = lenientAggregatorMerge;
+      return this;
+    }
+
+    public SegmentMetadataQueryBuilder usingDefaultInterval(boolean usingDefaultInterval)
+    {
+      this.usingDefaultInterval = usingDefaultInterval;
       return this;
     }
 

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
@@ -40,7 +40,6 @@ import io.druid.query.metadata.metadata.SegmentMetadataQuery;
 import io.druid.query.spec.LegacySegmentSpec;
 import io.druid.segment.column.ValueType;
 import io.druid.timeline.LogicalSegment;
-import org.joda.time.Interval;
 import org.joda.time.Period;
 import org.junit.Assert;
 import org.junit.Test;
@@ -293,16 +292,16 @@ public class SegmentMetadataQueryQueryToolChestTest
                 "2000-01-09/P1D"
             )
             .stream()
-            .map(interval -> (LogicalSegment) () -> new Interval(interval))
+            .map(interval -> (LogicalSegment) () -> Intervals.of(interval))
             .collect(Collectors.toList())
     );
 
     Assert.assertEquals(Period.weeks(1), config.getDefaultHistory());
     Assert.assertEquals(
         ImmutableList.of(
-            new Interval("2000-01-04/P1D"),
-            new Interval("2000-01-09/P1D"),
-            new Interval("2000-01-09/P1D")
+            Intervals.of("2000-01-04/P1D"),
+            Intervals.of("2000-01-09/P1D"),
+            Intervals.of("2000-01-09/P1D")
         ),
         filteredSegments.stream().map(LogicalSegment::getInterval).collect(Collectors.toList())
     );

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Maps;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.Intervals;
 import io.druid.query.CacheStrategy;
+import io.druid.query.Druids;
 import io.druid.query.TableDataSource;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.DoubleMaxAggregatorFactory;
@@ -38,10 +39,15 @@ import io.druid.query.metadata.metadata.SegmentAnalysis;
 import io.druid.query.metadata.metadata.SegmentMetadataQuery;
 import io.druid.query.spec.LegacySegmentSpec;
 import io.druid.segment.column.ValueType;
+import io.druid.timeline.LogicalSegment;
+import org.joda.time.Interval;
+import org.joda.time.Period;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class SegmentMetadataQueryQueryToolChestTest
 {
@@ -268,6 +274,37 @@ public class SegmentMetadataQueryQueryToolChestTest
             mergeLenient(analysis1, analysis2),
             mergeLenient(analysis1, analysis2)
         ).getAggregators()
+    );
+  }
+
+  @Test
+  public void testFilterSegments()
+  {
+    final SegmentMetadataQueryConfig config = new SegmentMetadataQueryConfig();
+    final SegmentMetadataQueryQueryToolChest toolChest = new SegmentMetadataQueryQueryToolChest(config);
+
+    final List<LogicalSegment> filteredSegments = toolChest.filterSegments(
+        Druids.newSegmentMetadataQueryBuilder().dataSource("foo").merge(true).build(),
+        ImmutableList
+            .of(
+                "2000-01-01/P1D",
+                "2000-01-04/P1D",
+                "2000-01-09/P1D",
+                "2000-01-09/P1D"
+            )
+            .stream()
+            .map(interval -> (LogicalSegment) () -> new Interval(interval))
+            .collect(Collectors.toList())
+    );
+
+    Assert.assertEquals(Period.weeks(1), config.getDefaultHistory());
+    Assert.assertEquals(
+        ImmutableList.of(
+            new Interval("2000-01-04/P1D"),
+            new Interval("2000-01-09/P1D"),
+            new Interval("2000-01-09/P1D")
+        ),
+        filteredSegments.stream().map(LogicalSegment::getInterval).collect(Collectors.toList())
     );
   }
 

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
@@ -895,6 +895,9 @@ public class SegmentMetadataQueryTest
 
     // test serialize and deserialize
     Assert.assertEquals(query, MAPPER.readValue(MAPPER.writeValueAsString(query), Query.class));
+
+    // test copy
+    Assert.assertEquals(query, Druids.SegmentMetadataQueryBuilder.copy((SegmentMetadataQuery) query).build());
   }
 
   @Test


### PR DESCRIPTION
PR #4131 introduced a new copy builder for segmentMetadata that did
not retain the value of usingDefaultInterval. This led to it being
dropped and the default-interval handling not working as expected.
Instead of using the default 1 week history when intervals are not
provided, the segmentMetadata query would query _all_ segments,
incurring an unexpected performance hit.

This patch fixes the bug and adds a test for the copy builder.