### PR TITLE
Authorize spec history instead of current specs for supervisor history API

### DIFF
--- a/indexing-service/src/test/java/io/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
@@ -47,6 +47,7 @@ import org.junit.runner.RunWith;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -101,7 +102,7 @@ public class SupervisorResourceTest extends EasyMockSupport
   @Test
   public void testSpecPost() throws Exception
   {
-    SupervisorSpec spec = new TestSupervisorSpec("my-id", null) {
+    SupervisorSpec spec = new TestSupervisorSpec("my-id", null, null) {
 
       @Override
       public List<String> getDataSources()
@@ -140,7 +141,7 @@ public class SupervisorResourceTest extends EasyMockSupport
   public void testSpecGetAll() throws Exception
   {
     Set<String> supervisorIds = ImmutableSet.of("id1", "id2");
-    SupervisorSpec spec1 = new TestSupervisorSpec("id1", null) {
+    SupervisorSpec spec1 = new TestSupervisorSpec("id1", null, null) {
 
       @Override
       public List<String> getDataSources()
@@ -148,7 +149,7 @@ public class SupervisorResourceTest extends EasyMockSupport
         return Lists.newArrayList("datasource1");
       }
     };
-    SupervisorSpec spec2 = new TestSupervisorSpec("id2", null) {
+    SupervisorSpec spec2 = new TestSupervisorSpec("id2", null, null) {
 
       @Override
       public List<String> getDataSources()
@@ -188,7 +189,7 @@ public class SupervisorResourceTest extends EasyMockSupport
   @Test
   public void testSpecGet() throws Exception
   {
-    SupervisorSpec spec = new TestSupervisorSpec("my-id", null);
+    SupervisorSpec spec = new TestSupervisorSpec("my-id", null, null);
 
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.of(supervisorManager)).times(2);
     EasyMock.expect(supervisorManager.getSupervisorSpec("my-id")).andReturn(Optional.of(spec));
@@ -279,28 +280,34 @@ public class SupervisorResourceTest extends EasyMockSupport
   @Test
   public void testSpecGetAllHistory() throws Exception
   {
+    List<VersionedSupervisorSpec> versions1 = ImmutableList.of(
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id1", null, Arrays.asList("datasource1")),
+            "v1"
+        ),
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id1", null, Arrays.asList("datasource1")),
+            "v2"
+        )
+    );
+    List<VersionedSupervisorSpec> versions2 = ImmutableList.of(
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id2", null, Arrays.asList("datasource2")),
+            "v1"
+        ),
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id2", null, Arrays.asList("datasource2")),
+            "v2"
+        )
+    );
     Map<String, List<VersionedSupervisorSpec>> history = Maps.newHashMap();
-    history.put("id1", null);
-    history.put("id2", null);
+    history.put("id1", versions1);
+    history.put("id2", versions2);
 
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.of(supervisorManager)).times(2);
     EasyMock.expect(supervisorManager.getSupervisorHistory()).andReturn(history);
-    SupervisorSpec spec1 = new TestSupervisorSpec("id1", null) {
-
-      @Override
-      public List<String> getDataSources()
-      {
-        return Lists.newArrayList("datasource1");
-      }
-    };
-    SupervisorSpec spec2 = new TestSupervisorSpec("id2", null) {
-
-      @Override
-      public List<String> getDataSources()
-      {
-        return Lists.newArrayList("datasource2");
-      }
-    };
+    SupervisorSpec spec1 = new TestSupervisorSpec("id1", null, Arrays.asList("datasource1"));
+    SupervisorSpec spec2 = new TestSupervisorSpec("id2", null, Arrays.asList("datasource2"));
     EasyMock.expect(supervisorManager.getSupervisorSpec("id1")).andReturn(Optional.of(spec1)).atLeastOnce();
     EasyMock.expect(supervisorManager.getSupervisorSpec("id2")).andReturn(Optional.of(spec2)).atLeastOnce();
     EasyMock.expect(request.getAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED)).andReturn(null).atLeastOnce();
@@ -330,28 +337,35 @@ public class SupervisorResourceTest extends EasyMockSupport
   @Test
   public void testSpecGetAllHistoryWithAuthFailureFiltering() throws Exception
   {
+    List<VersionedSupervisorSpec> versions1 = ImmutableList.of(
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id1", null, Arrays.asList("datasource1")),
+            "v1"
+        ),
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id1", null, Arrays.asList("datasource1")),
+            "v2"
+        )
+    );
+    List<VersionedSupervisorSpec> versions2 = ImmutableList.of(
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id2", null, Arrays.asList("datasource2")),
+            "v1"
+        ),
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id2", null, Arrays.asList("datasource2")),
+            "v2"
+        )
+    );
+
     Map<String, List<VersionedSupervisorSpec>> history = Maps.newHashMap();
-    history.put("id1", null);
-    history.put("id2", null);
+    history.put("id1", versions1);
+    history.put("id2", versions2);
 
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.of(supervisorManager)).times(2);
     EasyMock.expect(supervisorManager.getSupervisorHistory()).andReturn(history);
-    SupervisorSpec spec1 = new TestSupervisorSpec("id1", null) {
-
-      @Override
-      public List<String> getDataSources()
-      {
-        return Lists.newArrayList("datasource1");
-      }
-    };
-    SupervisorSpec spec2 = new TestSupervisorSpec("id2", null) {
-
-      @Override
-      public List<String> getDataSources()
-      {
-        return Lists.newArrayList("datasource2");
-      }
-    };
+    SupervisorSpec spec1 = new TestSupervisorSpec("id1", null, Arrays.asList("datasource1"));
+    SupervisorSpec spec2 = new TestSupervisorSpec("id2", null, Arrays.asList("datasource2"));
     EasyMock.expect(supervisorManager.getSupervisorSpec("id1")).andReturn(Optional.of(spec1)).atLeastOnce();
     EasyMock.expect(supervisorManager.getSupervisorSpec("id2")).andReturn(Optional.of(spec2)).atLeastOnce();
     EasyMock.expect(request.getAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED)).andReturn(null).atLeastOnce();
@@ -365,7 +379,7 @@ public class SupervisorResourceTest extends EasyMockSupport
     Response response = supervisorResource.specGetAllHistory(request);
 
     Map<String, List<VersionedSupervisorSpec>> filteredHistory = Maps.newHashMap();
-    filteredHistory.put("id1", null);
+    filteredHistory.put("id1", versions1);
 
     Assert.assertEquals(200, response.getStatus());
     Assert.assertEquals(filteredHistory, response.getEntity());
@@ -384,24 +398,51 @@ public class SupervisorResourceTest extends EasyMockSupport
   @Test
   public void testSpecGetHistory() throws Exception
   {
-    List<VersionedSupervisorSpec> versions = ImmutableList.of(
-        new VersionedSupervisorSpec(null, "v1"),
-        new VersionedSupervisorSpec(null, "v2")
+    List<VersionedSupervisorSpec> versions1 = ImmutableList.of(
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id1", null, Arrays.asList("datasource1")),
+            "v1"
+        ),
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id1", null, Arrays.asList("datasource1")),
+            "v2"
+        )
+    );
+    List<VersionedSupervisorSpec> versions2 = ImmutableList.of(
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id2", null, Arrays.asList("datasource2")),
+            "v1"
+        ),
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id2", null, Arrays.asList("datasource2")),
+            "v2"
+        )
     );
     Map<String, List<VersionedSupervisorSpec>> history = Maps.newHashMap();
-    history.put("id1", versions);
-    history.put("id2", null);
+    history.put("id1", versions1);
+    history.put("id2", versions2);
 
-    EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.of(supervisorManager)).times(2);
-    EasyMock.expect(supervisorManager.getSupervisorHistory()).andReturn(history).times(2);
+    EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.of(supervisorManager)).times(3);
+    EasyMock.expect(supervisorManager.getSupervisorHistory()).andReturn(history).times(3);
+    EasyMock.expect(request.getAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED)).andReturn(null).atLeastOnce();
+    EasyMock.expect(request.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT)).andReturn(
+        new AuthenticationResult("druid", "druid", null)
+    ).atLeastOnce();
+    request.setAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED, true);
+    EasyMock.expectLastCall().anyTimes();
     replayAll();
 
-    Response response = supervisorResource.specGetHistory("id1");
+    Response response = supervisorResource.specGetHistory(request, "id1");
 
     Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(versions, response.getEntity());
+    Assert.assertEquals(versions1, response.getEntity());
 
-    response = supervisorResource.specGetHistory("id3");
+    response = supervisorResource.specGetHistory(request, "id2");
+
+    Assert.assertEquals(200, response.getStatus());
+    Assert.assertEquals(versions2, response.getEntity());
+
+    response = supervisorResource.specGetHistory(request, "id3");
 
     Assert.assertEquals(404, response.getStatus());
 
@@ -410,7 +451,92 @@ public class SupervisorResourceTest extends EasyMockSupport
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.<SupervisorManager>absent());
     replayAll();
 
-    response = supervisorResource.specGetHistory("id1");
+    response = supervisorResource.specGetHistory(request, "id1");
+    verifyAll();
+
+    Assert.assertEquals(503, response.getStatus());
+  }
+
+  @Test
+  public void testSpecGetHistoryWithAuthFailure() throws Exception
+  {
+    List<VersionedSupervisorSpec> versions1 = ImmutableList.of(
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id1", null, Arrays.asList("datasource1")),
+            "v1"
+        ),
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id1", null, Arrays.asList("datasource1")),
+            "v2"
+        )
+    );
+    List<VersionedSupervisorSpec> versions2 = ImmutableList.of(
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id2", null, Arrays.asList("datasource2")),
+            "v1"
+        ),
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id2", null, Arrays.asList("datasource2")),
+            "v2"
+        )
+    );
+    List<VersionedSupervisorSpec> versions3 = ImmutableList.of(
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id3", null, Arrays.asList("datasource3")),
+            "v1"
+        ),
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id3", null, Arrays.asList("datasource2")),
+            "v2"
+        )
+    );
+    Map<String, List<VersionedSupervisorSpec>> history = Maps.newHashMap();
+    history.put("id1", versions1);
+    history.put("id2", versions2);
+    history.put("id3", versions3);
+
+    EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.of(supervisorManager)).times(4);
+    EasyMock.expect(supervisorManager.getSupervisorHistory()).andReturn(history).times(4);
+    EasyMock.expect(request.getAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED)).andReturn(null).atLeastOnce();
+    EasyMock.expect(request.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT)).andReturn(
+        new AuthenticationResult("notdruid", "druid", null)
+    ).atLeastOnce();
+    request.setAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED, true);
+    EasyMock.expectLastCall().anyTimes();
+    replayAll();
+
+    Response response = supervisorResource.specGetHistory(request, "id1");
+
+    Assert.assertEquals(200, response.getStatus());
+    Assert.assertEquals(versions1, response.getEntity());
+
+    response = supervisorResource.specGetHistory(request, "id2");
+
+    // user is not authorized to access datasource2
+    Assert.assertEquals(404, response.getStatus());
+
+    response = supervisorResource.specGetHistory(request, "id3");
+    Assert.assertEquals(200, response.getStatus());
+    Assert.assertEquals(
+        ImmutableList.of(
+            new VersionedSupervisorSpec(
+                new TestSupervisorSpec("id3", null, Arrays.asList("datasource3")),
+                "v1"
+            )
+        ),
+        response.getEntity()
+    );
+
+    response = supervisorResource.specGetHistory(request, "id4");
+    Assert.assertEquals(404, response.getStatus());
+
+
+    resetAll();
+
+    EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.<SupervisorManager>absent());
+    replayAll();
+
+    response = supervisorResource.specGetHistory(request, "id1");
     verifyAll();
 
     Assert.assertEquals(503, response.getStatus());
@@ -453,11 +579,13 @@ public class SupervisorResourceTest extends EasyMockSupport
   {
     private final String id;
     private final Supervisor supervisor;
+    private final List<String> datasources;
 
-    public TestSupervisorSpec(String id, Supervisor supervisor)
+    public TestSupervisorSpec(String id, Supervisor supervisor, List<String> datasources)
     {
       this.id = id;
       this.supervisor = supervisor;
+      this.datasources = datasources;
     }
 
     @Override
@@ -475,7 +603,38 @@ public class SupervisorResourceTest extends EasyMockSupport
     @Override
     public List<String> getDataSources()
     {
-      return null;
+      return datasources;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      TestSupervisorSpec that = (TestSupervisorSpec) o;
+
+      if (getId() != null ? !getId().equals(that.getId()) : that.getId() != null) {
+        return false;
+      }
+      if (supervisor != null ? !supervisor.equals(that.supervisor) : that.supervisor != null) {
+        return false;
+      }
+      return datasources != null ? datasources.equals(that.datasources) : that.datasources == null;
+
+    }
+
+    @Override
+    public int hashCode()
+    {
+      int result = getId() != null ? getId().hashCode() : 0;
+      result = 31 * result + (supervisor != null ? supervisor.hashCode() : 0);
+      result = 31 * result + (datasources != null ? datasources.hashCode() : 0);
+      return result;
     }
   }
 }

--- a/server/src/main/java/io/druid/indexing/overlord/supervisor/VersionedSupervisorSpec.java
+++ b/server/src/main/java/io/druid/indexing/overlord/supervisor/VersionedSupervisorSpec.java
@@ -45,4 +45,31 @@ public class VersionedSupervisorSpec
   {
     return version;
   }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    VersionedSupervisorSpec that = (VersionedSupervisorSpec) o;
+
+    if (getSpec() != null ? !getSpec().equals(that.getSpec()) : that.getSpec() != null) {
+      return false;
+    }
+    return getVersion() != null ? getVersion().equals(that.getVersion()) : that.getVersion() == null;
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = getSpec() != null ? getSpec().hashCode() : 0;
+    result = 31 * result + (getVersion() != null ? getVersion().hashCode() : 0);
+    return result;
+  }
 }


### PR DESCRIPTION
The auth checks on the `/history` and `/{id}/history` endpoints in the SupervisorResource are incorrect, they filter based on the current specs of supervisors, instead of filtering the lists of spec history.

This PR fixes the checks so that they filter the spec history properly.