### PR TITLE
Fix supervisor tombstone auth handling

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/overlord/supervisor/SupervisorManager.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/supervisor/SupervisorManager.java
@@ -71,6 +71,7 @@ public class SupervisorManager
     Preconditions.checkState(started, "SupervisorManager not started");
     Preconditions.checkNotNull(spec, "spec");
     Preconditions.checkNotNull(spec.getId(), "spec.getId()");
+    Preconditions.checkNotNull(spec.getDataSources(), "spec.getDatasources()");
 
     synchronized (lock) {
       Preconditions.checkState(started, "SupervisorManager not started");
@@ -197,7 +198,7 @@ public class SupervisorManager
     }
 
     if (writeTombstone) {
-      metadataSupervisorManager.insert(id, new NoopSupervisorSpec()); // where NoopSupervisorSpec is a tombstone
+      metadataSupervisorManager.insert(id, new NoopSupervisorSpec(null, pair.rhs.getDataSources())); // where NoopSupervisorSpec is a tombstone
     }
     pair.lhs.stop(true);
     supervisors.remove(id);
@@ -232,7 +233,7 @@ public class SupervisorManager
     catch (Exception e) {
       // Supervisor creation or start failed write tombstone only when trying to start a new supervisor
       if (persistSpec) {
-        metadataSupervisorManager.insert(id, new NoopSupervisorSpec());
+        metadataSupervisorManager.insert(id, new NoopSupervisorSpec(null, spec.getDataSources()));
       }
       throw Throwables.propagate(e);
     }

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/supervisor/SupervisorResource.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/supervisor/SupervisorResource.java
@@ -47,6 +47,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -65,7 +66,7 @@ public class SupervisorResource
           return null;
         }
         if (supervisorSpec.getSpec().getDataSources() == null) {
-          return null;
+          return new ArrayList<>();
         }
         return Iterables.transform(
             supervisorSpec.getSpec().getDataSources(),

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -288,7 +289,7 @@ public class SupervisorManagerTest extends EasyMockSupport
     @Override
     public List<String> getDataSources()
     {
-      return null;
+      return new ArrayList<>();
     }
 
   }

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
@@ -19,6 +19,7 @@
 
 package io.druid.indexing.overlord.supervisor;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -287,6 +288,10 @@ public class SupervisorResourceTest extends EasyMockSupport
         new VersionedSupervisorSpec(
             new TestSupervisorSpec("id1", null, Arrays.asList("datasource1")),
             "v2"
+        ),
+        new VersionedSupervisorSpec(
+            new NoopSupervisorSpec(null, Arrays.asList("datasource1")),
+            "tombstone"
         )
     );
     List<VersionedSupervisorSpec> versions2 = ImmutableList.of(
@@ -297,11 +302,42 @@ public class SupervisorResourceTest extends EasyMockSupport
         new VersionedSupervisorSpec(
             new TestSupervisorSpec("id2", null, Arrays.asList("datasource2")),
             "v2"
+        ),
+        new VersionedSupervisorSpec(
+            new NoopSupervisorSpec(null, Arrays.asList("datasource2")),
+            "tombstone"
+        ),
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id2", null, Arrays.asList("datasource2")),
+            "v3"
+        )
+    );
+    List<VersionedSupervisorSpec> versions3 = ImmutableList.of(
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id2", null, Arrays.asList("datasource3")),
+            "v1"
+        ),
+        new VersionedSupervisorSpec(
+            new NoopSupervisorSpec(null, null),
+            "tombstone"
+        ),
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id2", null, Arrays.asList("datasource3")),
+            "v2"
+        ),
+        new VersionedSupervisorSpec(
+            new NoopSupervisorSpec(null, null),
+            "tombstone"
+        ),
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id2", null, Arrays.asList("datasource3")),
+            "v3"
         )
     );
     Map<String, List<VersionedSupervisorSpec>> history = Maps.newHashMap();
     history.put("id1", versions1);
     history.put("id2", versions2);
+    history.put("id3", versions3);
 
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.of(supervisorManager)).times(2);
     EasyMock.expect(supervisorManager.getSupervisorHistory()).andReturn(history);
@@ -344,6 +380,10 @@ public class SupervisorResourceTest extends EasyMockSupport
         new VersionedSupervisorSpec(
             new TestSupervisorSpec("id1", null, Arrays.asList("datasource1")),
             "v2"
+        ),
+        new VersionedSupervisorSpec(
+            new NoopSupervisorSpec(null, Arrays.asList("datasource1")),
+            "tombstone"
         )
     );
     List<VersionedSupervisorSpec> versions2 = ImmutableList.of(
@@ -354,12 +394,62 @@ public class SupervisorResourceTest extends EasyMockSupport
         new VersionedSupervisorSpec(
             new TestSupervisorSpec("id2", null, Arrays.asList("datasource2")),
             "v2"
+        ),
+        new VersionedSupervisorSpec(
+            new NoopSupervisorSpec(null, Arrays.asList("datasource2")),
+            "tombstone"
+        )
+    );
+    List<VersionedSupervisorSpec> versions3 = ImmutableList.of(
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id2", null, Arrays.asList("datasource2")),
+            "v1"
+        ),
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id2", null, Arrays.asList("datasource2")),
+            "v2"
+        ),
+        new VersionedSupervisorSpec(
+            new NoopSupervisorSpec(null, Arrays.asList("datasource2")),
+            "tombstone"
+        ),
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id3", null, Arrays.asList("datasource3")),
+            "v1"
+        ),
+        new VersionedSupervisorSpec(
+            new NoopSupervisorSpec(null, Arrays.asList("datasource3")),
+            "tombstone"
+        )
+    );
+    List<VersionedSupervisorSpec> versions4 = ImmutableList.of(
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id2", null, Arrays.asList("datasource2")),
+            "v1"
+        ),
+        new VersionedSupervisorSpec(
+            new NoopSupervisorSpec(null, null),
+            "tombstone"
+        ),
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id2", null, Arrays.asList("datasource2")),
+            "v2"
+        ),
+        new VersionedSupervisorSpec(
+            new NoopSupervisorSpec(null, null),
+            "tombstone"
+        ),
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id2", null, Arrays.asList("datasource2")),
+            "v3"
         )
     );
 
     Map<String, List<VersionedSupervisorSpec>> history = Maps.newHashMap();
     history.put("id1", versions1);
     history.put("id2", versions2);
+    history.put("id3", versions3);
+    history.put("id4", versions4);
 
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.of(supervisorManager)).times(2);
     EasyMock.expect(supervisorManager.getSupervisorHistory()).andReturn(history);
@@ -379,6 +469,32 @@ public class SupervisorResourceTest extends EasyMockSupport
 
     Map<String, List<VersionedSupervisorSpec>> filteredHistory = Maps.newHashMap();
     filteredHistory.put("id1", versions1);
+    filteredHistory.put(
+        "id3",
+        ImmutableList.of(
+            new VersionedSupervisorSpec(
+                new TestSupervisorSpec("id3", null, Arrays.asList("datasource3")),
+                "v1"
+            ),
+            new VersionedSupervisorSpec(
+                new NoopSupervisorSpec(null, Arrays.asList("datasource3")),
+                "tombstone"
+            )
+        )
+    );
+    filteredHistory.put(
+        "id4",
+        ImmutableList.of(
+            new VersionedSupervisorSpec(
+                new NoopSupervisorSpec(null, null),
+                "tombstone"
+            ),
+            new VersionedSupervisorSpec(
+                new NoopSupervisorSpec(null, null),
+                "tombstone"
+            )
+        )
+    );
 
     Assert.assertEquals(200, response.getStatus());
     Assert.assertEquals(filteredHistory, response.getEntity());
@@ -403,6 +519,10 @@ public class SupervisorResourceTest extends EasyMockSupport
             "v1"
         ),
         new VersionedSupervisorSpec(
+            new NoopSupervisorSpec(null, Arrays.asList("datasource1")),
+            "tombstone"
+        ),
+        new VersionedSupervisorSpec(
             new TestSupervisorSpec("id1", null, Arrays.asList("datasource1")),
             "v2"
         )
@@ -411,6 +531,10 @@ public class SupervisorResourceTest extends EasyMockSupport
         new VersionedSupervisorSpec(
             new TestSupervisorSpec("id2", null, Arrays.asList("datasource2")),
             "v1"
+        ),
+        new VersionedSupervisorSpec(
+            new NoopSupervisorSpec(null, Arrays.asList("datasource2")),
+            "tombstone"
         ),
         new VersionedSupervisorSpec(
             new TestSupervisorSpec("id2", null, Arrays.asList("datasource2")),
@@ -465,6 +589,10 @@ public class SupervisorResourceTest extends EasyMockSupport
             "v1"
         ),
         new VersionedSupervisorSpec(
+            new NoopSupervisorSpec(null, Arrays.asList("datasource3")),
+            "tombstone"
+        ),
+        new VersionedSupervisorSpec(
             new TestSupervisorSpec("id1", null, Arrays.asList("datasource1")),
             "v2"
         )
@@ -473,6 +601,10 @@ public class SupervisorResourceTest extends EasyMockSupport
         new VersionedSupervisorSpec(
             new TestSupervisorSpec("id2", null, Arrays.asList("datasource2")),
             "v1"
+        ),
+        new VersionedSupervisorSpec(
+            new NoopSupervisorSpec(null, Arrays.asList("datasource2")),
+            "tombstone"
         ),
         new VersionedSupervisorSpec(
             new TestSupervisorSpec("id2", null, Arrays.asList("datasource2")),
@@ -485,8 +617,24 @@ public class SupervisorResourceTest extends EasyMockSupport
             "v1"
         ),
         new VersionedSupervisorSpec(
+            new NoopSupervisorSpec(null, null),
+            "tombstone"
+        ),
+        new VersionedSupervisorSpec(
             new TestSupervisorSpec("id3", null, Arrays.asList("datasource2")),
             "v2"
+        ),
+        new VersionedSupervisorSpec(
+            new NoopSupervisorSpec(null, null),
+            "tombstone"
+        ),
+        new VersionedSupervisorSpec(
+            new TestSupervisorSpec("id3", null, Arrays.asList("datasource3")),
+            "v2"
+        ),
+        new VersionedSupervisorSpec(
+            new NoopSupervisorSpec(null, Arrays.asList("datasource3")),
+            "tombstone"
         )
     );
     Map<String, List<VersionedSupervisorSpec>> history = Maps.newHashMap();
@@ -521,6 +669,22 @@ public class SupervisorResourceTest extends EasyMockSupport
             new VersionedSupervisorSpec(
                 new TestSupervisorSpec("id3", null, Arrays.asList("datasource3")),
                 "v1"
+            ),
+            new VersionedSupervisorSpec(
+                new NoopSupervisorSpec(null, null),
+                "tombstone"
+            ),
+            new VersionedSupervisorSpec(
+                new NoopSupervisorSpec(null, null),
+                "tombstone"
+            ),
+            new VersionedSupervisorSpec(
+                new TestSupervisorSpec("id3", null, Arrays.asList("datasource3")),
+                "v2"
+            ),
+            new VersionedSupervisorSpec(
+                new NoopSupervisorSpec(null, Arrays.asList("datasource3")),
+                "tombstone"
             )
         ),
         response.getEntity()
@@ -572,6 +736,23 @@ public class SupervisorResourceTest extends EasyMockSupport
 
     Assert.assertEquals(503, response.getStatus());
     verifyAll();
+  }
+
+  @Test
+  public void testNoopSupervisorSpecSerde() throws Exception
+  {
+    ObjectMapper mapper = new ObjectMapper();
+    String oldSpec = "{\"type\":\"NoopSupervisorSpec\",\"id\":null,\"dataSources\":null}";
+    NoopSupervisorSpec expectedSpec = new NoopSupervisorSpec(null, null);
+    NoopSupervisorSpec deserializedSpec = mapper.readValue(oldSpec, NoopSupervisorSpec.class);
+    Assert.assertEquals(expectedSpec, deserializedSpec);
+
+    NoopSupervisorSpec spec1 = new NoopSupervisorSpec("abcd", Lists.newArrayList("defg"));
+    NoopSupervisorSpec spec2 = mapper.readValue(
+        mapper.writeValueAsBytes(spec1),
+        NoopSupervisorSpec.class
+    );
+    Assert.assertEquals(spec1, spec2);
   }
 
   private static class TestSupervisorSpec implements SupervisorSpec


### PR DESCRIPTION
#5501 resulted in "tombstone" NoopSupervisorSpecs being filtered out of the spec histories. 

This PR adjusts NoopSupervisorSpecs so that they record the datasource list of the previous running spec, for authorization purposes.

NoopSupervisorSpecs created before this change will have a null datasource list and will be visible to all users, for backwards compatibility.