### PR TITLE
Override isNull in LongsColumnWithNulls and FloatsColumnWithNulls

### DIFF
--- a/processing/src/main/java/io/druid/segment/column/FloatsColumnWithNulls.java
+++ b/processing/src/main/java/io/druid/segment/column/FloatsColumnWithNulls.java
@@ -45,6 +45,12 @@ class FloatsColumnWithNulls extends FloatsColumn
   }
 
   @Override
+  public boolean isNull(int rowNum)
+  {
+    return nullValueBitmap.get(rowNum);
+  }
+
+  @Override
   public void inspectRuntimeShape(RuntimeShapeInspector inspector)
   {
     super.inspectRuntimeShape(inspector);

--- a/processing/src/main/java/io/druid/segment/column/LongsColumnWithNulls.java
+++ b/processing/src/main/java/io/druid/segment/column/LongsColumnWithNulls.java
@@ -45,6 +45,12 @@ class LongsColumnWithNulls extends LongsColumn
   }
 
   @Override
+  public boolean isNull(int rowNum)
+  {
+    return nullValueBitmap.get(rowNum);
+  }
+
+  @Override
   public void inspectRuntimeShape(RuntimeShapeInspector inspector)
   {
     super.inspectRuntimeShape(inspector);


### PR DESCRIPTION
Noticed this while poking at some other things. As far as I can tell, this is necessary in order to actually make use of `nullValueBitmap` and handle nulls, and I think was just an oversight in the original PR. @nishantmonu51 is this correct?