### PR TITLE
drop segment selection through cost balancer

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/BalancerStrategy.java
+++ b/server/src/main/java/io/druid/server/coordinator/BalancerStrategy.java
@@ -21,7 +21,9 @@ package io.druid.server.coordinator;
 
 import io.druid.timeline.DataSegment;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.NavigableSet;
 
 public interface BalancerStrategy
 {
@@ -30,6 +32,11 @@ public interface BalancerStrategy
   ServerHolder findNewSegmentHomeReplicator(DataSegment proposalSegment, List<ServerHolder> serverHolders);
 
   BalancerSegmentHolder pickSegmentToMove(List<ServerHolder> serverHolders);
+
+  default Iterator<ServerHolder> pickServersToDrop(DataSegment toDropSegment, NavigableSet<ServerHolder> serverHolders)
+  {
+    return serverHolders.descendingIterator();
+  }
 
   void emitStats(String tier, CoordinatorStats stats, List<ServerHolder> serverHolderList);
 }

--- a/server/src/main/java/io/druid/server/coordinator/rules/LoadRule.java
+++ b/server/src/main/java/io/druid/server/coordinator/rules/LoadRule.java
@@ -19,8 +19,9 @@
 
 package io.druid.server.coordinator.rules;
 
-import io.druid.java.util.emitter.EmittingLogger;
 import io.druid.java.util.common.IAE;
+import io.druid.java.util.emitter.EmittingLogger;
+import io.druid.server.coordinator.BalancerStrategy;
 import io.druid.server.coordinator.CoordinatorStats;
 import io.druid.server.coordinator.DruidCluster;
 import io.druid.server.coordinator.DruidCoordinator;
@@ -39,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Objects;
+import java.util.TreeSet;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -209,7 +211,7 @@ public abstract class LoadRule implements Rule
   }
 
   /**
-   * @param stats {@link CoordinatorStats} to accumulate assignment statistics.
+   * @param stats      {@link CoordinatorStats} to accumulate assignment statistics.
    * @param tierToSkip if not null, this tier will be skipped from doing assignment, use when primary replica was
    *                   assigned.
    */
@@ -320,7 +322,7 @@ public abstract class LoadRule implements Rule
       } else {
         final int currentReplicantsInTier = entry.getIntValue();
         final int numToDrop = currentReplicantsInTier - targetReplicants.getOrDefault(tier, 0);
-        numDropped = dropForTier(numToDrop, holders, segment);
+        numDropped = dropForTier(numToDrop, holders, segment, params.getBalancerStrategy());
       }
 
       stats.addToTieredStat(DROPPED_COUNT, tier, numDropped);
@@ -346,13 +348,17 @@ public abstract class LoadRule implements Rule
   private static int dropForTier(
       final int numToDrop,
       final NavigableSet<ServerHolder> holdersInTier,
-      final DataSegment segment
+      final DataSegment segment,
+      final BalancerStrategy balancerStrategy
   )
   {
     int numDropped = 0;
 
-    // Use the reverse order to get the holders with least available size first.
-    final Iterator<ServerHolder> iterator = holdersInTier.descendingIterator();
+    final NavigableSet<ServerHolder> isServingSubset =
+        holdersInTier.stream().filter(s -> s.isServingSegment(segment)).collect(Collectors.toCollection(TreeSet::new));
+
+    final Iterator<ServerHolder> iterator = balancerStrategy.pickServersToDrop(segment, isServingSubset);
+
     while (numDropped < numToDrop) {
       if (!iterator.hasNext()) {
         log.warn("Wtf, holder was null?  I have no servers serving [%s]?", segment.getIdentifier());

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorRuleRunnerTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorRuleRunnerTest.java
@@ -22,6 +22,7 @@ package io.druid.server.coordinator;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.druid.client.DruidServer;
@@ -761,9 +762,9 @@ public class DruidCoordinatorRuleRunnerTest
         ImmutableMap.of(
             "hot",
             Stream.of(
-                    new ServerHolder(
-                        server1.toImmutableDruidServer(),
-                        mockPeon
+                new ServerHolder(
+                    server1.toImmutableDruidServer(),
+                    mockPeon
                 )
             ).collect(Collectors.toCollection(() -> new TreeSet<>(Collections.reverseOrder()))),
             "normal",
@@ -942,6 +943,7 @@ public class DruidCoordinatorRuleRunnerTest
 
     LoadQueuePeon anotherMockPeon = EasyMock.createMock(LoadQueuePeon.class);
     EasyMock.expect(anotherMockPeon.getLoadQueueSize()).andReturn(10L).atLeastOnce();
+    EasyMock.expect(anotherMockPeon.getSegmentsToLoad()).andReturn(Sets.newHashSet()).anyTimes();
     EasyMock.replay(anotherMockPeon);
 
     DruidCluster druidCluster = new DruidCluster(

--- a/server/src/test/java/io/druid/server/coordinator/rules/LoadRuleTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/rules/LoadRuleTest.java
@@ -286,6 +286,9 @@ public class LoadRuleTest
     final LoadQueuePeon mockPeon = createEmptyPeon();
     mockPeon.dropSegment(EasyMock.anyObject(), EasyMock.anyObject());
     EasyMock.expectLastCall().atLeastOnce();
+    EasyMock.expect(mockBalancerStrategy.pickServersToDrop(EasyMock.anyObject(), EasyMock.anyObject()))
+            .andDelegateTo(balancerStrategy)
+            .times(2);
     EasyMock.replay(throttler, mockPeon, mockBalancerStrategy);
 
     LoadRule rule = createLoadRule(ImmutableMap.of(
@@ -430,7 +433,9 @@ public class LoadRuleTest
     final LoadQueuePeon mockPeon = createEmptyPeon();
     mockPeon.dropSegment(EasyMock.anyObject(), EasyMock.anyObject());
     EasyMock.expectLastCall().atLeastOnce();
-
+    EasyMock.expect(mockBalancerStrategy.pickServersToDrop(EasyMock.anyObject(), EasyMock.anyObject()))
+            .andDelegateTo(balancerStrategy)
+            .times(1);
     EasyMock.replay(throttler, mockPeon, mockBalancerStrategy);
 
     LoadRule rule = createLoadRule(ImmutableMap.of(


### PR DESCRIPTION
Fixes issues that occur due to load rule segment drop does not use the segment balancer, one of the issues described in #5521. 

Drop segment will now use the balancer to get an iterator of `ServerHolder` objects which can be consumed to get the best candidate servers to drop segments from.