### PR TITLE
ArrayAggregation: Use long to avoid overflow

### DIFF
--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/BufferArrayGrouper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/BufferArrayGrouper.java
@@ -61,7 +61,7 @@ public class BufferArrayGrouper implements IntGrouper
   private ByteBuffer usedFlagBuffer;
   private ByteBuffer valBuffer;
 
-  static int requiredBufferCapacity(
+  static long requiredBufferCapacity(
       int cardinality,
       AggregatorFactory[] aggregatorFactories
   )
@@ -72,7 +72,7 @@ public class BufferArrayGrouper implements IntGrouper
                                  .sum();
 
     return getUsedFlagBufferCapacity(cardinalityWithMissingValue) +  // total used flags size
-           cardinalityWithMissingValue * recordSize;                 // total values size
+        (long) cardinalityWithMissingValue * recordSize;                 // total values size
   }
 
   /**

--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
@@ -219,7 +219,7 @@ public class GroupByQueryEngineV2
       final AggregatorFactory[] aggregatorFactories = query
           .getAggregatorSpecs()
           .toArray(new AggregatorFactory[query.getAggregatorSpecs().size()]);
-      final int requiredBufferCapacity = BufferArrayGrouper.requiredBufferCapacity(
+      final long requiredBufferCapacity = BufferArrayGrouper.requiredBufferCapacity(
           cardinality,
           aggregatorFactories
       );

--- a/processing/src/test/java/io/druid/query/groupby/epinephelinae/BufferArrayGrouperTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/epinephelinae/BufferArrayGrouperTest.java
@@ -86,4 +86,21 @@ public class BufferArrayGrouperTest
     grouper.init();
     return grouper;
   }
+
+  @Test
+  public void testRequiredBufferCapacity()
+  {
+    int[] cardinalityArray = new int[] {1, 10, Integer.MAX_VALUE - 1};
+    AggregatorFactory[] aggregatorFactories = new AggregatorFactory[] {
+        new LongSumAggregatorFactory("sum", "sum")
+    };
+
+    long[] requiredSizes = new long[] {17, 90, 16911433721L};
+
+    for (int i = 0; i < cardinalityArray.length; i++) {
+      Assert.assertEquals(requiredSizes[i], BufferArrayGrouper.requiredBufferCapacity(
+          cardinalityArray[i],
+          aggregatorFactories));
+    }
+  }
 }


### PR DESCRIPTION
@jihoonson  Nasty bug, overflow error can be easily overlooked. Fix for https://github.com/druid-io/druid/issues/5203
