### PR TITLE
Adjust integration test configurations

### DIFF
--- a/integration-tests/docker/broker.conf
+++ b/integration-tests/docker/broker.conf
@@ -1,10 +1,10 @@
 [program:druid-broker]
 command=java
   -server
-  -Xmx1g
-  -Xms1g
-  -XX:NewSize=500m
-  -XX:MaxNewSize=500m
+  -Xmx512m
+  -Xms512m
+  -XX:NewSize=256m
+  -XX:MaxNewSize=256m
   -XX:+UseConcMarkSweepGC
   -XX:+PrintGCDetails
   -XX:+PrintGCTimeStamps
@@ -12,7 +12,7 @@ command=java
   -Dfile.encoding=UTF-8
   -Ddruid.host=%(ENV_HOST_IP)s
   -Ddruid.zk.service.host=druid-zookeeper-kafka
-  -Ddruid.processing.buffer.sizeBytes=75000000
+  -Ddruid.processing.buffer.sizeBytes=25000000
   -Ddruid.server.http.numThreads=100
   -Ddruid.processing.numThreads=1
   -Ddruid.broker.http.numConnections=30

--- a/integration-tests/docker/historical.conf
+++ b/integration-tests/docker/historical.conf
@@ -1,10 +1,10 @@
 [program:druid-historical]
 command=java
   -server
-  -Xmx1500m
-  -Xms1500m
-  -XX:NewSize=750m
-  -XX:MaxNewSize=750m
+  -Xmx512m
+  -Xms512m
+  -XX:NewSize=256m
+  -XX:MaxNewSize=256m
   -XX:+UseConcMarkSweepGC
   -XX:+PrintGCDetails
   -XX:+PrintGCTimeStamps
@@ -14,8 +14,8 @@ command=java
   -Ddruid.zk.service.host=druid-zookeeper-kafka
   -Ddruid.s3.accessKey=AKIAIMKECRUYKDQGR6YQ
   -Ddruid.s3.secretKey=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
-  -Ddruid.processing.buffer.sizeBytes=75000000
-  -Ddruid.processing.numThreads=3
+  -Ddruid.processing.buffer.sizeBytes=25000000
+  -Ddruid.processing.numThreads=2
   -Ddruid.server.http.numThreads=100
   -Ddruid.segmentCache.locations="[{\"path\":\"/shared/druid/indexCache\",\"maxSize\":5000000000}]"
   -Ddruid.server.maxSize=5000000000

--- a/integration-tests/docker/middlemanager.conf
+++ b/integration-tests/docker/middlemanager.conf
@@ -10,11 +10,11 @@ command=java
   -Dfile.encoding=UTF-8
   -Ddruid.host=%(ENV_HOST_IP)s
   -Ddruid.zk.service.host=druid-zookeeper-kafka
-  -Ddruid.worker.capacity=8
+  -Ddruid.worker.capacity=3
   -Ddruid.indexer.logs.directory=/shared/tasklogs
   -Ddruid.storage.storageDirectory=/shared/storage
   -Ddruid.indexer.runner.javaOpts=-server -Xmx256m -Xms256m -XX:NewSize=128m -XX:MaxNewSize=128m -XX:+UseConcMarkSweepGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps
-  -Ddruid.indexer.fork.property.druid.processing.buffer.sizeBytes=75000000
+  -Ddruid.indexer.fork.property.druid.processing.buffer.sizeBytes=25000000
   -Ddruid.indexer.fork.property.druid.processing.numThreads=1
   -Ddruid.indexer.fork.server.http.numThreads=100
   -Ddruid.s3.accessKey=AKIAIMKECRUYKDQGR6YQ

--- a/integration-tests/docker/router.conf
+++ b/integration-tests/docker/router.conf
@@ -1,7 +1,7 @@
 [program:druid-router]
 command=java
   -server
-  -Xmx1g
+  -Xmx128m
   -XX:+UseConcMarkSweepGC
   -XX:+PrintGCDetails
   -XX:+PrintGCTimeStamps


### PR DESCRIPTION
Integration tests seem to be failing quite often lately, this is an attempt to reduce footprint of docker containers and hopefully help success rate. This is suspected to be an issue of some sort of resource starvation by the rate which we see zk session timeout messages in logs
```
2018-03-28T12:29:22,123 WARN [main-SendThread(172.17.0.1:2181)] org.apache.zookeeper.ClientCnxn - Client session timed out, have not heard from server in 20077ms for sessionid 0x1626c8f101f0007
```
found by picking a failing PR at random, as well as other various sorts of timeout messages.

This is likely more CPU driven than memory, given [docs on travis build environment](https://docs.travis-ci.com/user/reference/overview/), but I was also able to reproduce these types of log messages by running docker engine with a low total memory allocation in my local environment. If reducing jvm memory alone does not appear to help in travis environment, we could investigate limits on [docker containers themselves](https://docs.docker.com/config/containers/resource_constraints/#understand-the-risks-of-running-out-of-memory).

We should also ensure that integration tests pass multiple times on this PR before merging.