### PR TITLE
Fix SQLMetadataSegmentManager to allow succesive start and stop

### DIFF
--- a/common/src/main/java/io/druid/concurrent/LifecycleLock.java
+++ b/common/src/main/java/io/druid/concurrent/LifecycleLock.java
@@ -175,13 +175,6 @@ public final class LifecycleLock
       }
     }
 
-    void reset()
-    {
-      if (!compareAndSetState(STOPPED, NOT_STARTED)) {
-        throw new IllegalMonitorStateException("Not called exitStop() before reset()");
-      }
-    }
-
     void exitStopAndReset()
     {
       if (!compareAndSetState(STOPPING, NOT_STARTED)) {
@@ -279,7 +272,7 @@ public final class LifecycleLock
    * LifecycleLock is used in a restartable object, this method must be called before exit from stop() on this object,
    * usually in a finally block.
    *
-   * @throws IllegalMonitorStateException if {@link #exitStop()} is not yet called on this LifecycleLock
+   * @throws IllegalMonitorStateException if {@link #canStop()} is not yet called on this LifecycleLock
    */
   public void exitStopAndReset()
   {

--- a/common/src/main/java/io/druid/concurrent/LifecycleLock.java
+++ b/common/src/main/java/io/druid/concurrent/LifecycleLock.java
@@ -181,13 +181,20 @@ public final class LifecycleLock
         throw new IllegalMonitorStateException("Not called exitStop() before reset()");
       }
     }
+
+    void exitStopAndReset()
+    {
+      if (!compareAndSetState(STOPPING, NOT_STARTED)) {
+        throw new IllegalMonitorStateException("Not called exitStop() before reset()");
+      }
+    }
   }
 
   private final Sync sync = new Sync();
 
   /**
    * Start latch, only one canStart() call in any thread on this LifecycleLock object could return true, if {@link
-   * #reset()} is not called in between.
+   * #exitStopAndReset()} is not called in between.
    */
   public boolean canStart()
   {
@@ -257,8 +264,8 @@ public final class LifecycleLock
   }
 
   /**
-   * If this LifecycleLock is used in a restartable object, which uses {@link #reset()}, exitStop() must be called
-   * before exit from stop() on this object, usually in a finally block.
+   * Finalizes stopping the the LifecycleLock. This method must be called before exit from stop() on this object,
+   * usually in a finally block. If you're using a restartable object, use {@link #exitStopAndReset()} instead.
    *
    * @throws IllegalMonitorStateException if {@link #canStop()} is not yet called on this LifecycleLock
    */
@@ -268,12 +275,14 @@ public final class LifecycleLock
   }
 
   /**
-   * Resets the LifecycleLock after {@link #exitStop()}, so that {@link #canStart()} could be called again.
+   * Finalizes stopping the LifecycleLock and resets it, so that {@link #canStart()} could be called again. If this
+   * LifecycleLock is used in a restartable object, this method must be called before exit from stop() on this object,
+   * usually in a finally block.
    *
    * @throws IllegalMonitorStateException if {@link #exitStop()} is not yet called on this LifecycleLock
    */
-  public void reset()
+  public void exitStopAndReset()
   {
-    sync.reset();
+    sync.exitStopAndReset();
   }
 }

--- a/common/src/test/java/io/druid/concurrent/LifecycleLockTest.java
+++ b/common/src/test/java/io/druid/concurrent/LifecycleLockTest.java
@@ -138,8 +138,7 @@ public class LifecycleLockTest
     lifecycleLock.started();
     lifecycleLock.exitStart();
     Assert.assertTrue(lifecycleLock.canStop());
-    lifecycleLock.exitStop();
-    lifecycleLock.reset();
+    lifecycleLock.exitStopAndReset();
     Assert.assertTrue(lifecycleLock.canStart());
   }
 

--- a/server/src/main/java/io/druid/metadata/SQLMetadataSegmentManager.java
+++ b/server/src/main/java/io/druid/metadata/SQLMetadataSegmentManager.java
@@ -170,7 +170,7 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
       exec = null;
     }
     finally {
-      lifecycleLock.exitStop();
+      lifecycleLock.exitStopAndReset();
     }
   }
 

--- a/server/src/main/java/io/druid/metadata/SQLMetadataSegmentManager.java
+++ b/server/src/main/java/io/druid/metadata/SQLMetadataSegmentManager.java
@@ -35,7 +35,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
 import io.druid.client.DruidDataSource;
 import io.druid.client.ImmutableDruidDataSource;
-import io.druid.concurrent.LifecycleLock;
 import io.druid.guice.ManageLifecycle;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.Intervals;
@@ -86,7 +85,10 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
   private static final Interner<DataSegment> DATA_SEGMENT_INTERNER = Interners.newWeakInterner();
   private static final EmittingLogger log = new EmittingLogger(SQLMetadataSegmentManager.class);
 
-  private final LifecycleLock lifecycleLock = new LifecycleLock();
+  // Use to synchronize start() and stop(). These methods should be synchronized to prevent from being called at the
+  // same time if two different threads are calling them. This might be possible if a druid coordinator gets and drops
+  // leadership repeatedly in quick succession.
+  private final Object lock = new Object();
 
   private final ObjectMapper jsonMapper;
   private final Supplier<MetadataSegmentManagerConfig> config;
@@ -96,6 +98,7 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
 
   private volatile ListeningScheduledExecutorService exec = null;
   private volatile ListenableFuture<?> future = null;
+  private volatile boolean started;
 
   @Inject
   public SQLMetadataSegmentManager(
@@ -116,11 +119,11 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
   @LifecycleStart
   public void start()
   {
-    if (!lifecycleLock.canStart()) {
-      return;
-    }
+    synchronized (lock) {
+      if (started) {
+        return;
+      }
 
-    try {
       exec = MoreExecutors.listeningDecorator(Execs.scheduledSingleThreaded("DatabaseSegmentManager-Exec--%d"));
 
       final Duration delay = config.get().getPollDuration().toStandardDuration();
@@ -143,10 +146,7 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
           delay.getMillis(),
           TimeUnit.MILLISECONDS
       );
-      lifecycleLock.started();
-    }
-    finally {
-      lifecycleLock.exitStart();
+      started = true;
     }
   }
 
@@ -154,10 +154,11 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
   @LifecycleStop
   public void stop()
   {
-    if (!lifecycleLock.canStop()) {
-      return;
-    }
-    try {
+    synchronized (lock) {
+      if (!started) {
+        return;
+      }
+
       final ConcurrentHashMap<String, DruidDataSource> emptyMap = new ConcurrentHashMap<>();
       ConcurrentHashMap<String, DruidDataSource> current;
       do {
@@ -168,9 +169,7 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
       future = null;
       exec.shutdownNow();
       exec = null;
-    }
-    finally {
-      lifecycleLock.exitStopAndReset();
+      started = false;
     }
   }
 
@@ -366,7 +365,7 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
   @Override
   public boolean isStarted()
   {
-    return lifecycleLock.isStarted();
+    return started;
   }
 
   @Override
@@ -420,7 +419,7 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
   public void poll()
   {
     try {
-      if (!lifecycleLock.isStarted()) {
+      if (!started) {
         return;
       }
 

--- a/server/src/test/java/io/druid/metadata/SQLMetadataRuleManagerTest.java
+++ b/server/src/test/java/io/druid/metadata/SQLMetadataRuleManagerTest.java
@@ -83,6 +83,16 @@ public class SQLMetadataRuleManagerTest
   }
 
   @Test
+  public void testMultipleStopAndStart()
+  {
+    // Simulate successive losing and getting the coordinator leadership
+    ruleManager.start();
+    ruleManager.stop();
+    ruleManager.start();
+    ruleManager.stop();
+  }
+
+  @Test
   public void testRuleInsert()
   {
     List<Rule> rules = Arrays.<Rule>asList(

--- a/server/src/test/java/io/druid/metadata/SQLMetadataSegmentManagerTest.java
+++ b/server/src/test/java/io/druid/metadata/SQLMetadataSegmentManagerTest.java
@@ -41,7 +41,7 @@ import org.junit.Test;
 import java.io.IOException;
 
 
-public class MetadataSegmentManagerTest
+public class SQLMetadataSegmentManagerTest
 {
   @Rule
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule = new TestDerbyConnector.DerbyConnectorRule();
@@ -229,5 +229,15 @@ public class MetadataSegmentManagerTest
 
     Assert.assertNull(manager.getInventoryValue(newDataSource));
     Assert.assertTrue(manager.removeSegment(newDataSource, newSegment.getIdentifier()));
+  }
+
+  @Test
+  public void testStopAndStart()
+  {
+    // Simulate successive losing and getting the coordinator leadership
+    manager.start();
+    manager.stop();
+    manager.start();
+    manager.stop();
   }
 }

--- a/server/src/test/java/io/druid/server/lookup/cache/LookupCoordinatorManagerTest.java
+++ b/server/src/test/java/io/druid/server/lookup/cache/LookupCoordinatorManagerTest.java
@@ -62,7 +62,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -1256,15 +1255,15 @@ public class LookupCoordinatorManagerTest
         lookupCoordinatorManagerConfig
     );
 
-    Assert.assertFalse(manager.lifecycleLock.awaitStarted(1, TimeUnit.MILLISECONDS));
+    Assert.assertFalse(manager.isStarted());
 
     manager.start();
-    Assert.assertTrue(manager.lifecycleLock.awaitStarted(1, TimeUnit.MILLISECONDS));
+    Assert.assertTrue(manager.awaitStarted(1));
     Assert.assertTrue(manager.backgroundManagerIsRunning());
     Assert.assertFalse(manager.waitForBackgroundTermination(10));
 
     manager.stop();
-    Assert.assertFalse(manager.lifecycleLock.awaitStarted(1, TimeUnit.MILLISECONDS));
+    Assert.assertFalse(manager.awaitStarted(1));
     Assert.assertTrue(manager.waitForBackgroundTermination(10));
     Assert.assertFalse(manager.backgroundManagerIsRunning());
 
@@ -1293,35 +1292,35 @@ public class LookupCoordinatorManagerTest
         lookupCoordinatorManagerConfig
     );
 
-    Assert.assertFalse(manager.lifecycleLock.awaitStarted(1, TimeUnit.MILLISECONDS));
+    Assert.assertFalse(manager.awaitStarted(1));
 
     manager.start();
-    Assert.assertTrue(manager.lifecycleLock.awaitStarted(1, TimeUnit.MILLISECONDS));
+    Assert.assertTrue(manager.awaitStarted(1));
     Assert.assertTrue(manager.backgroundManagerIsRunning());
     Assert.assertFalse(manager.waitForBackgroundTermination(10));
 
     manager.stop();
-    Assert.assertFalse(manager.lifecycleLock.awaitStarted(1, TimeUnit.MILLISECONDS));
+    Assert.assertFalse(manager.awaitStarted(1));
     Assert.assertTrue(manager.waitForBackgroundTermination(10));
     Assert.assertFalse(manager.backgroundManagerIsRunning());
 
     manager.start();
-    Assert.assertTrue(manager.lifecycleLock.awaitStarted(1, TimeUnit.MILLISECONDS));
+    Assert.assertTrue(manager.awaitStarted(1));
     Assert.assertTrue(manager.backgroundManagerIsRunning());
     Assert.assertFalse(manager.waitForBackgroundTermination(10));
 
     manager.stop();
-    Assert.assertFalse(manager.lifecycleLock.awaitStarted(1, TimeUnit.MILLISECONDS));
+    Assert.assertFalse(manager.awaitStarted(1));
     Assert.assertTrue(manager.waitForBackgroundTermination(10));
     Assert.assertFalse(manager.backgroundManagerIsRunning());
 
     manager.start();
-    Assert.assertTrue(manager.lifecycleLock.awaitStarted(1, TimeUnit.MILLISECONDS));
+    Assert.assertTrue(manager.awaitStarted(1));
     Assert.assertTrue(manager.backgroundManagerIsRunning());
     Assert.assertFalse(manager.waitForBackgroundTermination(10));
 
     manager.stop();
-    Assert.assertFalse(manager.lifecycleLock.awaitStarted(1, TimeUnit.MILLISECONDS));
+    Assert.assertFalse(manager.awaitStarted(1));
     Assert.assertTrue(manager.waitForBackgroundTermination(10));
     Assert.assertFalse(manager.backgroundManagerIsRunning());
 


### PR DESCRIPTION
SQLMetadataSegmentManager throws the below error if a coordinator loses the leadership before start() is called.

```
2018-03-29T00:14:55,098 INFO [Coordinator-Exec--0] io.druid.server.coordinator.DruidCoordinator - I am no longer the leader...
2018-03-29T00:14:55,098 WARN [Coordinator-Exec--0] io.druid.curator.discovery.CuratorServiceAnnouncer - Ignoring request to unannounce service[DruidNode{serviceName='druid/coordinator', host='ip-10-45-4-73.eu-central-1.compute.internal', port=-1, plaintextPort=-1, enablePlaintextPort=false, tlsPort=8281, enableTlsPort=true}]
2018-03-29T00:14:55,098 ERROR [Coordinator-Exec--0] io.druid.server.coordinator.DruidCoordinator - Caught exception, ignoring so that schedule keeps going.: {class=io.druid.server.coordinator.DruidCoordinator, exceptionType=class java.lang.IllegalMonitorStateException, exceptionMessage=Called canStop() before start()}
java.lang.IllegalMonitorStateException: Called canStop() before start()
    at io.druid.concurrent.LifecycleLock$Sync.canStop(LifecycleLock.java:166) ~[druid-common-0.12.0-iap3.jar:0.12.0-iap3]
    at io.druid.concurrent.LifecycleLock.canStop(LifecycleLock.java:256) ~[druid-common-0.12.0-iap3.jar:0.12.0-iap3]
    at io.druid.metadata.SQLMetadataSegmentManager.stop(SQLMetadataSegmentManager.java:159) ~[druid-server-0.12.0-iap3.jar:0.12.0-iap3]
    at io.druid.server.coordinator.DruidCoordinator.stopBeingLeader(DruidCoordinator.java:584) ~[druid-server-0.12.0-iap3.jar:0.12.0-iap3]
    at io.druid.server.coordinator.DruidCoordinator.access$100(DruidCoordinator.java:96) ~[druid-server-0.12.0-iap3.jar:0.12.0-iap3]
    at io.druid.server.coordinator.DruidCoordinator$CoordinatorRunnable.run(DruidCoordinator.java:631) [druid-server-0.12.0-iap3.jar:0.12.0-iap3]
    at io.druid.server.coordinator.DruidCoordinator$3.call(DruidCoordinator.java:554) [druid-server-0.12.0-iap3.jar:0.12.0-iap3]
    at io.druid.server.coordinator.DruidCoordinator$3.call(DruidCoordinator.java:547) [druid-server-0.12.0-iap3.jar:0.12.0-iap3]
    at io.druid.java.util.common.concurrent.ScheduledExecutors$2.run(ScheduledExecutors.java:102) [java-util-0.12.0-iap3.jar:0.12.0-iap3]
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_152]
    at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_152]
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) [?:1.8.0_152]
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) [?:1.8.0_152]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_152]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_152]
    at java.lang.Thread.run(Thread.java:748) [?:1.8.0_152]
```

I added `exitStopAndReset()` method to `LifecycleLock` instead of `reset()` because calling two methods separately (`exitStop()` and `reset()`) isn't done atomically. Also removed unnecessary synchronizations in `LookupCoordinatorManager`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/druid-io/druid/5554)
<!-- Reviewable:end -->
