### PR TITLE
Simple fix for ThreadPoolTaskRunner

### DIFF
--- a/api/src/main/java/io/druid/segment/loading/NoopDataSegmentArchiver.java
+++ b/api/src/main/java/io/druid/segment/loading/NoopDataSegmentArchiver.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.loading;
+
+import io.druid.timeline.DataSegment;
+
+import javax.annotation.Nullable;
+
+/**
+ * Mostly used for test purpose.
+ */
+public class NoopDataSegmentArchiver implements DataSegmentArchiver
+{
+  @Nullable
+  @Override
+  public DataSegment archive(DataSegment segment) throws SegmentLoadingException
+  {
+    return segment;
+  }
+
+  @Nullable
+  @Override
+  public DataSegment restore(DataSegment segment) throws SegmentLoadingException
+  {
+    return segment;
+  }
+}

--- a/api/src/main/java/io/druid/segment/loading/NoopDataSegmentKiller.java
+++ b/api/src/main/java/io/druid/segment/loading/NoopDataSegmentKiller.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.loading;
+
+import io.druid.timeline.DataSegment;
+
+import java.io.IOException;
+
+/**
+ * Mostly used for test purpose.
+ */
+public class NoopDataSegmentKiller implements DataSegmentKiller
+{
+  @Override
+  public void kill(DataSegment segments) throws SegmentLoadingException
+  {
+  }
+
+  @Override
+  public void killAll() throws IOException
+  {
+  }
+}

--- a/api/src/main/java/io/druid/segment/loading/NoopDataSegmentMover.java
+++ b/api/src/main/java/io/druid/segment/loading/NoopDataSegmentMover.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.loading;
+
+import io.druid.timeline.DataSegment;
+
+import java.util.Map;
+
+/**
+ * Mostly used for test purpose.
+ */
+public class NoopDataSegmentMover implements DataSegmentMover
+{
+  @Override
+  public DataSegment move(
+      DataSegment segment, Map<String, Object> targetLoadSpec
+  )
+  {
+    return segment;
+  }
+}

--- a/api/src/main/java/io/druid/segment/loading/NoopDataSegmentPusher.java
+++ b/api/src/main/java/io/druid/segment/loading/NoopDataSegmentPusher.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.loading;
+
+import com.google.common.collect.ImmutableMap;
+import io.druid.timeline.DataSegment;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Map;
+
+/**
+ * Mostly used for test purpose.
+ */
+public class NoopDataSegmentPusher implements DataSegmentPusher
+{
+  @Override
+  public String getPathForHadoop()
+  {
+    return "noop";
+  }
+
+  @Deprecated
+  @Override
+  public String getPathForHadoop(String dataSource)
+  {
+    return getPathForHadoop();
+  }
+
+  @Override
+  public DataSegment push(File file, DataSegment segment, boolean replaceExisting)
+  {
+    return segment;
+  }
+
+  @Override
+  public Map<String, Object> makeLoadSpec(URI uri)
+  {
+    return ImmutableMap.of();
+  }
+}

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/ThreadPoolTaskRunnerTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/ThreadPoolTaskRunnerTest.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.indexing.overlord;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import io.druid.indexer.TaskState;
+import io.druid.indexing.common.SegmentLoaderFactory;
+import io.druid.indexing.common.TaskStatus;
+import io.druid.indexing.common.TaskToolbox;
+import io.druid.indexing.common.TaskToolboxFactory;
+import io.druid.indexing.common.TestUtils;
+import io.druid.indexing.common.actions.TaskActionClient;
+import io.druid.indexing.common.actions.TaskActionClientFactory;
+import io.druid.indexing.common.config.TaskConfig;
+import io.druid.indexing.common.task.AbstractTask;
+import io.druid.indexing.common.task.NoopTask;
+import io.druid.java.util.emitter.service.ServiceEmitter;
+import io.druid.segment.loading.NoopDataSegmentArchiver;
+import io.druid.segment.loading.NoopDataSegmentKiller;
+import io.druid.segment.loading.NoopDataSegmentMover;
+import io.druid.segment.loading.NoopDataSegmentPusher;
+import io.druid.segment.loading.SegmentLoaderLocalCacheManager;
+import io.druid.server.DruidNode;
+import io.druid.server.coordination.NoopDataSegmentAnnouncer;
+import io.druid.server.initialization.ServerConfig;
+import io.druid.server.metrics.NoopServiceEmitter;
+import org.easymock.EasyMock;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class ThreadPoolTaskRunnerTest
+{
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private ThreadPoolTaskRunner runner;
+
+  @Before
+  public void setup() throws IOException
+  {
+    final TestUtils utils = new TestUtils();
+    final DruidNode node = new DruidNode("testServer", "testHost", 1000, null, true, false);
+    final TaskConfig taskConfig = new TaskConfig(
+        temporaryFolder.newFile().toString(),
+        null,
+        null,
+        50000,
+        null,
+        true,
+        null,
+        null
+    );
+    final ServiceEmitter emitter = new NoopServiceEmitter();
+    final TaskToolboxFactory toolboxFactory = new TaskToolboxFactory(
+        taskConfig,
+        EasyMock.createMock(TaskActionClientFactory.class),
+        emitter,
+        new NoopDataSegmentPusher(),
+        new NoopDataSegmentKiller(),
+        new NoopDataSegmentMover(),
+        new NoopDataSegmentArchiver(),
+        new NoopDataSegmentAnnouncer(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        new SegmentLoaderFactory(EasyMock.createMock(SegmentLoaderLocalCacheManager.class)),
+        utils.getTestObjectMapper(),
+        utils.getTestIndexIO(),
+        null,
+        null,
+        utils.getTestIndexMergerV9(),
+        null,
+        node,
+        null,
+        null
+    );
+    runner = new ThreadPoolTaskRunner(
+        toolboxFactory,
+        taskConfig,
+        emitter,
+        node,
+        new ServerConfig()
+    );
+  }
+
+  @After
+  public void teardown()
+  {
+    runner.stop();
+  }
+
+  @Test
+  public void testRun() throws ExecutionException, InterruptedException
+  {
+    Assert.assertEquals(
+        TaskState.SUCCESS,
+        runner.run(new NoopTask(null, null, 500L, 0, null, null, null)).get().getStatusCode()
+    );
+  }
+
+  @Test
+  public void testStop() throws ExecutionException, InterruptedException, TimeoutException
+  {
+    final ListenableFuture<TaskStatus> future = runner.run(
+        new NoopTask(null, null, Long.MAX_VALUE, 0, null, null, null) // infinite task
+    );
+    runner.stop();
+    Assert.assertEquals(
+        TaskState.FAILED,
+        future.get(1000, TimeUnit.MILLISECONDS).getStatusCode()
+    );
+  }
+
+  @Test
+  public void testStopWithRestorableTask() throws InterruptedException, ExecutionException, TimeoutException
+  {
+    final BooleanHolder holder = new BooleanHolder();
+    final ListenableFuture<TaskStatus> future = runner.run(
+        new RestorableTask(holder)
+    );
+    runner.stop();
+    Assert.assertEquals(
+        TaskState.SUCCESS,
+        future.get(1000, TimeUnit.MILLISECONDS).getStatusCode()
+    );
+    Assert.assertTrue(holder.get());
+  }
+
+  private class RestorableTask extends AbstractTask
+  {
+    private final BooleanHolder gracefullyStopped;
+
+    protected RestorableTask(BooleanHolder gracefullyStopped)
+    {
+      super("testId", "testDataSource", Collections.emptyMap());
+
+      this.gracefullyStopped = gracefullyStopped;
+    }
+
+    @Override
+    public String getType()
+    {
+      return "restorable";
+    }
+
+    @Override
+    public boolean isReady(TaskActionClient taskActionClient)
+    {
+      return true;
+    }
+
+    @Override
+    public TaskStatus run(TaskToolbox toolbox) throws InterruptedException
+    {
+      return TaskStatus.success(getId());
+    }
+
+    @Override
+    public boolean canRestore()
+    {
+      return true;
+    }
+
+    @Override
+    public void stopGracefully()
+    {
+      gracefullyStopped.set();
+    }
+  }
+
+  private static class BooleanHolder
+  {
+    private boolean value;
+
+    void set()
+    {
+      this.value = true;
+    }
+
+    boolean get()
+    {
+      return value;
+    }
+  }
+}

--- a/java-util/src/main/java/io/druid/java/util/common/Numbers.java
+++ b/java-util/src/main/java/io/druid/java/util/common/Numbers.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.java.util.common;
+
+public final class Numbers
+{
+  public static long parseLong(Object val)
+  {
+    if (val instanceof String) {
+      return Long.parseLong((String) val);
+    } else if (val instanceof Number) {
+      return ((Number) val).longValue();
+    } else {
+      throw new ISE("Unknown type [%s]", val.getClass());
+    }
+  }
+
+  public static int parseInt(Object val)
+  {
+    if (val instanceof String) {
+      return Integer.parseInt((String) val);
+    } else if (val instanceof Number) {
+      return ((Number) val).intValue();
+    } else {
+      throw new ISE("Unknown type [%s]", val.getClass());
+    }
+  }
+
+  public static boolean parseBoolean(Object val)
+  {
+    if (val instanceof String) {
+      return Boolean.parseBoolean((String) val);
+    } else if (val instanceof Boolean) {
+      return (boolean) val;
+    } else {
+      throw new ISE("Unknown type [%s]. Cannot parse!", val.getClass());
+    }
+  }
+
+  private Numbers()
+  {
+  }
+}

--- a/processing/src/main/java/io/druid/query/QueryContexts.java
+++ b/processing/src/main/java/io/druid/query/QueryContexts.java
@@ -23,7 +23,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import io.druid.guice.annotations.PublicApi;
 import io.druid.java.util.common.IAE;
-import io.druid.java.util.common.ISE;
+import io.druid.java.util.common.Numbers;
 
 @PublicApi
 public class QueryContexts
@@ -212,46 +212,23 @@ public class QueryContexts
 
   static <T> long parseLong(Query<T> query, String key, long defaultValue)
   {
-    Object val = query.getContextValue(key);
-    if (val == null) {
-      return defaultValue;
-    }
-    if (val instanceof String) {
-      return Long.parseLong((String) val);
-    } else if (val instanceof Number) {
-      return ((Number) val).longValue();
-    } else {
-      throw new ISE("Unknown type [%s]", val.getClass());
-    }
+    final Object val = query.getContextValue(key);
+    return val == null ? defaultValue : Numbers.parseLong(val);
   }
 
   static <T> int parseInt(Query<T> query, String key, int defaultValue)
   {
-    Object val = query.getContextValue(key);
-    if (val == null) {
-      return defaultValue;
-    }
-    if (val instanceof String) {
-      return Integer.parseInt((String) val);
-    } else if (val instanceof Number) {
-      return ((Number) val).intValue();
-    } else {
-      throw new ISE("Unknown type [%s]", val.getClass());
-    }
+    final Object val = query.getContextValue(key);
+    return val == null ? defaultValue : Numbers.parseInt(val);
   }
 
   static <T> boolean parseBoolean(Query<T> query, String key, boolean defaultValue)
   {
-    Object val = query.getContextValue(key);
-    if (val == null) {
-      return defaultValue;
-    }
-    if (val instanceof String) {
-      return Boolean.parseBoolean((String) val);
-    } else if (val instanceof Boolean) {
-      return (boolean) val;
-    } else {
-      throw new ISE("Unknown type [%s]. Cannot parse!", val.getClass());
-    }
+    final Object val = query.getContextValue(key);
+    return val == null ? defaultValue : Numbers.parseBoolean(val);
+  }
+
+  private QueryContexts()
+  {
   }
 }

--- a/server/src/main/java/io/druid/server/ClientQuerySegmentWalker.java
+++ b/server/src/main/java/io/druid/server/ClientQuerySegmentWalker.java
@@ -116,7 +116,7 @@ public class ClientQuerySegmentWalker implements QuerySegmentWalker
 
     return new FluentQueryRunnerBuilder<>(toolChest)
         .create(
-            new SetAndVerifyContextQueryRunner(
+            new SetAndVerifyContextQueryRunner<>(
                 serverConfig,
                 new RetryQueryRunner<>(
                     baseClientRunner,

--- a/server/src/main/java/io/druid/server/coordination/NoopDataSegmentAnnouncer.java
+++ b/server/src/main/java/io/druid/server/coordination/NoopDataSegmentAnnouncer.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.coordination;
+
+import io.druid.timeline.DataSegment;
+
+/**
+ * Mostly used for test purpose.
+ */
+public class NoopDataSegmentAnnouncer implements DataSegmentAnnouncer
+{
+  @Override
+  public void announceSegment(DataSegment segment)
+  {
+  }
+
+  @Override
+  public void unannounceSegment(DataSegment segment)
+  {
+  }
+
+  @Override
+  public void announceSegments(Iterable<DataSegment> segments)
+  {
+  }
+
+  @Override
+  public void unannounceSegments(Iterable<DataSegment> segments)
+  {
+  }
+}

--- a/server/src/main/java/io/druid/server/coordination/ServerManager.java
+++ b/server/src/main/java/io/druid/server/coordination/ServerManager.java
@@ -23,8 +23,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
-import io.druid.java.util.emitter.EmittingLogger;
-import io.druid.java.util.emitter.service.ServiceEmitter;
 import io.druid.client.CachingQueryRunner;
 import io.druid.client.cache.Cache;
 import io.druid.client.cache.CacheConfig;
@@ -33,6 +31,8 @@ import io.druid.guice.annotations.Processing;
 import io.druid.guice.annotations.Smile;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.guava.FunctionalIterable;
+import io.druid.java.util.emitter.EmittingLogger;
+import io.druid.java.util.emitter.service.ServiceEmitter;
 import io.druid.query.BySegmentQueryRunner;
 import io.druid.query.CPUTimeMetricQueryRunner;
 import io.druid.query.DataSource;
@@ -280,26 +280,26 @@ public class ServerManager implements QuerySegmentWalker
   {
     SpecificSegmentSpec segmentSpec = new SpecificSegmentSpec(segmentDescriptor);
     String segmentId = adapter.getIdentifier();
-    return new SetAndVerifyContextQueryRunner(
+    return new SetAndVerifyContextQueryRunner<>(
         serverConfig,
         CPUTimeMetricQueryRunner.safeBuild(
-            new SpecificSegmentQueryRunner<T>(
-                new MetricsEmittingQueryRunner<T>(
+            new SpecificSegmentQueryRunner<>(
+                new MetricsEmittingQueryRunner<>(
                     emitter,
                     toolChest,
-                    new BySegmentQueryRunner<T>(
+                    new BySegmentQueryRunner<>(
                         segmentId,
                         adapter.getDataInterval().getStart(),
-                        new CachingQueryRunner<T>(
+                        new CachingQueryRunner<>(
                             segmentId,
                             segmentDescriptor,
                             objectMapper,
                             cache,
                             toolChest,
-                            new MetricsEmittingQueryRunner<T>(
+                            new MetricsEmittingQueryRunner<>(
                                 emitter,
                                 toolChest,
-                                new ReferenceCountingSegmentQueryRunner<T>(factory, adapter, segmentDescriptor),
+                                new ReferenceCountingSegmentQueryRunner<>(factory, adapter, segmentDescriptor),
                                 QueryMetrics::reportSegmentTime,
                                 queryMetrics -> queryMetrics.segment(segmentId)
                             ),

--- a/services/src/main/java/io/druid/cli/CliRealtimeExample.java
+++ b/services/src/main/java/io/druid/cli/CliRealtimeExample.java
@@ -20,7 +20,6 @@
 package io.druid.cli;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Binder;
 import com.google.inject.Inject;
 import com.google.inject.Module;
@@ -37,15 +36,14 @@ import io.druid.guice.RealtimeModule;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.query.lookup.LookupModule;
 import io.druid.segment.loading.DataSegmentPusher;
+import io.druid.segment.loading.NoopDataSegmentPusher;
 import io.druid.server.coordination.DataSegmentAnnouncer;
+import io.druid.server.coordination.NoopDataSegmentAnnouncer;
 import io.druid.server.initialization.jetty.ChatHandlerServerModule;
 import io.druid.timeline.DataSegment;
 
-import java.io.File;
-import java.net.URI;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executor;
 
@@ -134,62 +132,6 @@ public class CliRealtimeExample extends ServerRunnable
     public boolean isSegmentLoadedByServer(String serverKey, DataSegment segment)
     {
       return false;
-    }
-  }
-
-  private static class NoopDataSegmentPusher implements DataSegmentPusher
-  {
-
-    @Override
-    public String getPathForHadoop()
-    {
-      return "noop";
-    }
-
-    @Deprecated
-    @Override
-    public String getPathForHadoop(String dataSource)
-    {
-      return getPathForHadoop();
-    }
-
-    @Override
-    public DataSegment push(File file, DataSegment segment, boolean replaceExisting)
-    {
-      return segment;
-    }
-
-    @Override
-    public Map<String, Object> makeLoadSpec(URI uri)
-    {
-      return ImmutableMap.of();
-    }
-  }
-
-  private static class NoopDataSegmentAnnouncer implements DataSegmentAnnouncer
-  {
-    @Override
-    public void announceSegment(DataSegment segment)
-    {
-      // do nothing
-    }
-
-    @Override
-    public void unannounceSegment(DataSegment segment)
-    {
-      // do nothing
-    }
-
-    @Override
-    public void announceSegments(Iterable<DataSegment> segments)
-    {
-      // do nothing
-    }
-
-    @Override
-    public void unannounceSegments(Iterable<DataSegment> segments)
-    {
-      // do nothing
     }
   }
 }


### PR DESCRIPTION
ThreadPoolTaskRunner is always supposed to run at most a single task. I removed collections to keep unnecessary states. I also tidied up codes and added a unit test for ThreadPoolTaskRunner.