### PR TITLE
Deprecate spark2 profile in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1128,13 +1128,6 @@
 
     <profiles>
         <profile>
-            <id>spark2</id>
-            <properties>
-                <jackson.version>2.6.5</jackson.version>
-                <aws.sdk.version>1.11.143</aws.sdk.version>
-            </properties>
-        </profile>
-        <profile>
             <id>strict</id>
             <build>
                 <plugins>


### PR DESCRIPTION
Deprecated due to https://github.com/druid-io/druid/pull/5382