### PR TITLE
CompressionUtils: Make gzipInputStream public once again.

### DIFF
--- a/java-util/src/main/java/io/druid/java/util/common/CompressionUtils.java
+++ b/java-util/src/main/java/io/druid/java/util/common/CompressionUtils.java
@@ -318,8 +318,10 @@ public class CompressionUtils
    * @param in The raw input stream
    *
    * @return A GZIPInputStream that can handle concatenated gzip streams in the input
+   *
+   * @see #decompress(InputStream, String) which should be used instead for streams coming from files
    */
-  private static GZIPInputStream gzipInputStream(final InputStream in) throws IOException
+  public static GZIPInputStream gzipInputStream(final InputStream in) throws IOException
   {
     return new GZIPInputStream(
         new FilterInputStream(in)


### PR DESCRIPTION
But add a reference to "decompress" and mention that it's preferred
when reading from streams that come from files.

Follow up to #5586.