### PR TITLE
revert coordinator lambda conversion to fix error

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
@@ -691,58 +691,63 @@ public class DruidCoordinator
       super(
           ImmutableList.of(
               new DruidCoordinatorSegmentInfoLoader(DruidCoordinator.this),
-              params -> {
-                // Display info about all historical servers
-                Iterable<ImmutableDruidServer> servers = FunctionalIterable
-                    .create(serverInventoryView.getInventory())
-                    .filter(DruidServer::segmentReplicatable)
-                    .transform(DruidServer::toImmutableDruidServer);
+              new DruidCoordinatorHelper()
+              {
+                @Override
+                public DruidCoordinatorRuntimeParams run(DruidCoordinatorRuntimeParams params)
+                {
+                  // Display info about all historical servers
+                  Iterable<ImmutableDruidServer> servers = FunctionalIterable
+                      .create(serverInventoryView.getInventory())
+                      .filter(DruidServer::segmentReplicatable)
+                      .transform(DruidServer::toImmutableDruidServer);
 
-                if (log.isDebugEnabled()) {
-                  log.debug("Servers");
-                  for (ImmutableDruidServer druidServer : servers) {
-                    log.debug("  %s", druidServer);
-                    log.debug("    -- DataSources");
-                    for (ImmutableDruidDataSource druidDataSource : druidServer.getDataSources()) {
-                      log.debug("    %s", druidDataSource);
+                  if (log.isDebugEnabled()) {
+                    log.debug("Servers");
+                    for (ImmutableDruidServer druidServer : servers) {
+                      log.debug("  %s", druidServer);
+                      log.debug("    -- DataSources");
+                      for (ImmutableDruidDataSource druidDataSource : druidServer.getDataSources()) {
+                        log.debug("    %s", druidDataSource);
+                      }
                     }
                   }
-                }
 
-                // Find all historical servers, group them by subType and sort by ascending usage
-                final DruidCluster cluster = new DruidCluster();
-                for (ImmutableDruidServer server : servers) {
-                  if (!loadManagementPeons.containsKey(server.getName())) {
-                    LoadQueuePeon loadQueuePeon = taskMaster.giveMePeon(server);
-                    loadQueuePeon.start();
-                    log.info("Created LoadQueuePeon for server[%s].", server.getName());
+                  // Find all historical servers, group them by subType and sort by ascending usage
+                  final DruidCluster cluster = new DruidCluster();
+                  for (ImmutableDruidServer server : servers) {
+                    if (!loadManagementPeons.containsKey(server.getName())) {
+                      LoadQueuePeon loadQueuePeon = taskMaster.giveMePeon(server);
+                      loadQueuePeon.start();
+                      log.info("Created LoadQueuePeon for server[%s].", server.getName());
 
-                    loadManagementPeons.put(server.getName(), loadQueuePeon);
+                      loadManagementPeons.put(server.getName(), loadQueuePeon);
+                    }
+
+                    cluster.add(new ServerHolder(server, loadManagementPeons.get(server.getName())));
                   }
 
-                  cluster.add(new ServerHolder(server, loadManagementPeons.get(server.getName())));
-                }
+                  segmentReplicantLookup = SegmentReplicantLookup.make(cluster);
 
-                segmentReplicantLookup = SegmentReplicantLookup.make(cluster);
+                  // Stop peons for servers that aren't there anymore.
+                  final Set<String> disappeared = Sets.newHashSet(loadManagementPeons.keySet());
+                  for (ImmutableDruidServer server : servers) {
+                    disappeared.remove(server.getName());
+                  }
+                  for (String name : disappeared) {
+                    log.info("Removing listener for server[%s] which is no longer there.", name);
+                    LoadQueuePeon peon = loadManagementPeons.remove(name);
+                    peon.stop();
+                  }
 
-                // Stop peons for servers that aren't there anymore.
-                final Set<String> disappeared = Sets.newHashSet(loadManagementPeons.keySet());
-                for (ImmutableDruidServer server : servers) {
-                  disappeared.remove(server.getName());
+                  return params.buildFromExisting()
+                               .withDruidCluster(cluster)
+                               .withDatabaseRuleManager(metadataRuleManager)
+                               .withLoadManagementPeons(loadManagementPeons)
+                               .withSegmentReplicantLookup(segmentReplicantLookup)
+                               .withBalancerReferenceTimestamp(DateTimes.nowUtc())
+                               .build();
                 }
-                for (String name : disappeared) {
-                  log.info("Removing listener for server[%s] which is no longer there.", name);
-                  LoadQueuePeon peon = loadManagementPeons.remove(name);
-                  peon.stop();
-                }
-
-                return params.buildFromExisting()
-                             .withDruidCluster(cluster)
-                             .withDatabaseRuleManager(metadataRuleManager)
-                             .withLoadManagementPeons(loadManagementPeons)
-                             .withSegmentReplicantLookup(segmentReplicantLookup)
-                             .withBalancerReferenceTimestamp(DateTimes.nowUtc())
-                             .build();
               },
               new DruidCoordinatorRuleRunner(DruidCoordinator.this),
               new DruidCoordinatorCleanupUnneeded(DruidCoordinator.this),


### PR DESCRIPTION
We have encountered this issue on some installations where the coordinator will explode with an error of the following form: 
```
    2018-04-05T05:18:59,883 ERROR [LeaderSelector[/demo/coordinator/_COORDINATOR]] org.apache.curator.framework.listen.ListenerContainer - Listener (io.druid.curator.discovery.CuratorDruidLeaderSelector$1@1e7f19b4) threw an exception
java.lang.VerifyError: Bad type on operand stack
Exception Details:
  Location:
    io/druid/server/coordinator/DruidCoordinator$CoordinatorHistoricalManagerRunnable.<init>(Lio/druid/server/coordinator/DruidCoordinator;I)V @16: invokedynamic
  Reason:
    Type uninitializedThis (current frame, stack[3]) is not assignable to 'io/druid/server/coordinator/DruidCoordinator$CoordinatorHistoricalManagerRunnable'
  Current Frame:
    bci: @16
    flags: { flagThisUninit }
    locals: { uninitializedThis, 'io/druid/server/coordinator/DruidCoordinator', integer }
    stack: { uninitializedThis, 'io/druid/server/coordinator/DruidCoordinator', 'io/druid/server/coordinator/helper/DruidCoordinatorSegmentInfoLoader', uninitializedThis }
  Bytecode:
    0x0000000: 2a2b b500 012a 2bbb 0002 592b b700 032a
    0x0000010: ba00 0400 00bb 0005 592b b700 06bb 0007
    0x0000020: 592b b700 08bb 0009 592b b700 0abb 000b
    0x0000030: 592b b700 0cbb 000d 592b b700 0eb8 000f
    0x0000040: 1cb7 0010 b1

    at io.druid.server.coordinator.DruidCoordinator.becomeLeader(DruidCoordinator.java:516) ~[druid-server-0.12.0-iap5.jar:0.12.0-iap5]
    at io.druid.server.coordinator.DruidCoordinator.access$000(DruidCoordinator.java:95) ~[druid-server-0.12.0-iap5.jar:0.12.0-iap5]
    at io.druid.server.coordinator.DruidCoordinator$1.becomeLeader(DruidCoordinator.java:471) ~[druid-server-0.12.0-iap5.jar:0.12.0-iap5]
    at io.druid.curator.discovery.CuratorDruidLeaderSelector$1.isLeader(CuratorDruidLeaderSelector.java:98) ~[druid-server-0.12.0-iap5.jar:0.12.0-iap5]
    at org.apache.curator.framework.recipes.leader.LeaderLatch$9.apply(LeaderLatch.java:665) ~[curator-recipes-4.0.0.jar:4.0.0]
    at org.apache.curator.framework.recipes.leader.LeaderLatch$9.apply(LeaderLatch.java:661) ~[curator-recipes-4.0.0.jar:4.0.0]
    at org.apache.curator.framework.listen.ListenerContainer$1.run(ListenerContainer.java:93) [curator-framework-4.0.0.jar:4.0.0]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_152]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_152]
    at java.lang.Thread.run(Thread.java:748) [?:1.8.0_152]
```
It appears related to [this change](https://github.com/druid-io/druid/pull/5528/files#diff-87398cf804a130e66498c79706348296L701). Note that this doesn't happen on all coordinator installations with this patch, as some seem to be functioning correctly. We haven't isolated the steps or environment to reproduce this exactly, it is likely related to some combination of jvm versions and possibly which extensions are loaded, as it isn't happening on all installations. It may be a jvm bug related to lambda this binding affecting some versions? 

Regardless, it seems best to revert this change  until we can determine the cause and ensure it doesn't happen anymore.