### PR TITLE
Load rules should honor partial overlap

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/rules/Rules.java
+++ b/server/src/main/java/io/druid/server/coordinator/rules/Rules.java
@@ -27,13 +27,13 @@ public class Rules
 {
   public static boolean eligibleForLoad(Interval src, Interval target)
   {
-    return src.contains(target);
+    return src.overlaps(target);
   }
 
   public static boolean eligibleForLoad(Period period, Interval interval, DateTime referenceTimestamp)
   {
     final Interval currInterval = new Interval(period, referenceTimestamp);
-    return currInterval.overlaps(interval) && interval.getStartMillis() >= currInterval.getStartMillis();
+    return eligibleForLoad(currInterval, interval);
   }
 
   private Rules() {}

--- a/server/src/test/java/io/druid/server/coordinator/rules/PeriodLoadRuleTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/rules/PeriodLoadRuleTest.java
@@ -83,6 +83,31 @@ public class PeriodLoadRuleTest
   }
 
   @Test
+  public void testAppliesToPartialOverlap()
+  {
+    DateTime now = DateTimes.of("2012-12-31T01:00:00");
+    PeriodLoadRule rule = new PeriodLoadRule(
+            new Period("P1M"),
+            ImmutableMap.<String, Integer>of("", 0)
+    );
+
+    Assert.assertTrue(
+            rule.appliesTo(
+                    builder.interval(new Interval(now.minusWeeks(1), now.plusWeeks(1))).build(),
+                    now
+            )
+    );
+    Assert.assertTrue(
+            rule.appliesTo(
+                    builder.interval(
+                            new Interval(now.minusMonths(1).minusWeeks(1), now.minusMonths(1).plusWeeks(1))
+                    ).build(),
+                    now
+            )
+    );
+  }
+
+  @Test
   public void testSerdeNullTieredReplicants() throws Exception
   {
     PeriodLoadRule rule = new PeriodLoadRule(


### PR DESCRIPTION
Load rules should load segments that partially overlap with rule window,
instead of loading only segments that fully overlap. Otherwise, valid data is
skipped and result produced is incorrect.