### PR TITLE
Expose noop filter to users

### DIFF
--- a/docs/content/querying/filters.md
+++ b/docs/content/querying/filters.md
@@ -487,3 +487,11 @@ Filtering on a set of ISO 8601 intervals:
     ]
 }
 ```
+
+
+### Noop Filter
+The noop filter is a filter which applies no conditions to your query.  Useful if you need to disable other filters when queries are generated programatically. 
+
+```json
+{ "type" : "noop" }
+```

--- a/processing/src/main/java/io/druid/query/filter/DimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/DimFilter.java
@@ -42,7 +42,8 @@ import io.druid.java.util.common.Cacheable;
     @JsonSubTypes.Type(name = "bound", value = BoundDimFilter.class),
     @JsonSubTypes.Type(name = "interval", value = IntervalDimFilter.class),
     @JsonSubTypes.Type(name = "like", value = LikeDimFilter.class),
-    @JsonSubTypes.Type(name = "expression", value = ExpressionDimFilter.class)
+    @JsonSubTypes.Type(name = "expression", value = ExpressionDimFilter.class),
+    @JsonSubTypes.Type(name = "noop", value = NoopDimFilter.class)
 })
 public interface DimFilter extends Cacheable
 {


### PR DESCRIPTION
It would be useful to expose the noop filter to users. This allows a filter to be "switched off" without removing the filter property from the json.  This is useful when developing a query, or in tools which programmatically generate druid queries.  