### PR TITLE
Fix HTTP OPTIONS request auth handling

### DIFF
--- a/docs/content/configuration/auth.md
+++ b/docs/content/configuration/auth.md
@@ -10,7 +10,7 @@ layout: doc_page
 |`druid.escalator.type`|String|Type of the Escalator that should be used for internal Druid communications. This Escalator must use an authentication scheme that is supported by an Authenticator in `druid.auth.authenticationChain`.|"noop"|no|
 |`druid.auth.authorizers`|JSON List of Strings|List of Authorizer type names |["allowAll"]|no|
 |`druid.auth.unsecuredPaths`| List of Strings|List of paths for which security checks will not be performed. All requests to these paths will be allowed.|[]|no|
-|`druid.auth.requireHttpOptionsAuthentication`|Boolean|If false, skip authentication checks for HTTP OPTIONS requests. Note that disabling authentication checks for OPTIONS requests will allow unauthenticated users to determine what Druid endpoints are valid, and this may leak sensitive information (for example, the `/druid/indexer/v1//task/{taskid}` endpoint on the Overlord and `/druid/coordinator/v1/datasources` endpoints on the Coordinator contain resource names), so the authentication checks should not be disabled unless truly necessary. |true|no|
+|`druid.auth.disableHttpOptionsAuthentication`|Boolean|If true, skip authentication checks for HTTP OPTIONS requests. Note that disabling authentication checks for OPTIONS requests will allow unauthenticated users to determine what Druid endpoints are valid, and this may leak sensitive information (for example, the `/druid/indexer/v1//task/{taskid}` endpoint on the Overlord and `/druid/coordinator/v1/datasources` endpoints on the Coordinator contain resource names), so the authentication checks should not be disabled unless truly necessary. |false|no|
 
 ## Enabling Authentication/Authorization
 

--- a/docs/content/configuration/auth.md
+++ b/docs/content/configuration/auth.md
@@ -10,6 +10,7 @@ layout: doc_page
 |`druid.escalator.type`|String|Type of the Escalator that should be used for internal Druid communications. This Escalator must use an authentication scheme that is supported by an Authenticator in `druid.auth.authenticationChain`.|"noop"|no|
 |`druid.auth.authorizers`|JSON List of Strings|List of Authorizer type names |["allowAll"]|no|
 |`druid.auth.unsecuredPaths`| List of Strings|List of paths for which security checks will not be performed. All requests to these paths will be allowed.|[]|no|
+|`druid.auth.requireHttpOptionsAuthentication`|Boolean|If false, skip authentication checks for HTTP OPTIONS requests. Note that disabling authentication checks for OPTIONS requests will allow unauthenticated users to determine what Druid endpoints are valid, and this may leak sensitive information (for example, the `/druid/indexer/v1//task/{taskid}` endpoint on the Overlord and `/druid/coordinator/v1/datasources` endpoints on the Coordinator contain resource names), so the authentication checks should not be disabled unless truly necessary. |true|no|
 
 ## Enabling Authentication/Authorization
 

--- a/integration-tests/src/test/java/io/druid/tests/security/ITBasicAuthConfigurationTest.java
+++ b/integration-tests/src/test/java/io/druid/tests/security/ITBasicAuthConfigurationTest.java
@@ -224,6 +224,18 @@ public class ITBasicAuthConfigurationTest
     
     LOG.info("Testing Avatica query on router with incorrect credentials.");
     testAvaticaAuthFailure(routerUrl);
+
+    LOG.info("Checking OPTIONS requests on services...");
+    testOptionsRequests(adminClient);
+  }
+
+  private void testOptionsRequests(HttpClient httpClient)
+  {
+    makeRequest(httpClient, HttpMethod.OPTIONS, config.getCoordinatorUrl() + "/status", null);
+    makeRequest(httpClient, HttpMethod.OPTIONS, config.getIndexerUrl() + "/status", null);
+    makeRequest(httpClient, HttpMethod.OPTIONS, config.getBrokerUrl() + "/status", null);
+    makeRequest(httpClient, HttpMethod.OPTIONS, config.getHistoricalUrl() + "/status", null);
+    makeRequest(httpClient, HttpMethod.OPTIONS, config.getRouterUrl() + "/status", null);
   }
 
   private void checkUnsecuredCoordinatorLoadQueuePath(HttpClient client)

--- a/server/src/main/java/io/druid/server/security/AllowOptionsResourceFilter.java
+++ b/server/src/main/java/io/druid/server/security/AllowOptionsResourceFilter.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.security;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.HttpMethod;
+import java.io.IOException;
+
+public class AllowOptionsResourceFilter implements Filter
+{
+  private final boolean requireAuthentication;
+
+  public AllowOptionsResourceFilter(
+      boolean requireAuthentication
+  )
+  {
+    this.requireAuthentication = requireAuthentication;
+  }
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException
+  {
+
+  }
+
+  @Override
+  public void doFilter(
+      ServletRequest request, ServletResponse response, FilterChain chain
+  ) throws IOException, ServletException
+  {
+    HttpServletRequest httpReq = (HttpServletRequest) request;
+
+    // Druid itself doesn't explictly handle OPTIONS requests, no resource handler will authorize such requests.
+    // so this filter catches all OPTIONS requests and authorizes them.
+    if (HttpMethod.OPTIONS.equals(httpReq.getMethod())) {
+      if (!requireAuthentication) {
+        httpReq.setAttribute(
+            AuthConfig.DRUID_AUTHENTICATION_RESULT,
+            new AuthenticationResult(AuthConfig.ALLOW_ALL_NAME, AuthConfig.ALLOW_ALL_NAME, null)
+        );
+      }
+
+      httpReq.setAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED, true);
+    }
+
+    chain.doFilter(request, response);
+  }
+
+  @Override
+  public void destroy()
+  {
+
+  }
+}

--- a/server/src/main/java/io/druid/server/security/AllowOptionsResourceFilter.java
+++ b/server/src/main/java/io/druid/server/security/AllowOptionsResourceFilter.java
@@ -31,13 +31,13 @@ import java.io.IOException;
 
 public class AllowOptionsResourceFilter implements Filter
 {
-  private final boolean requireAuthentication;
+  private final boolean disableAuthentication;
 
   public AllowOptionsResourceFilter(
-      boolean requireAuthentication
+      boolean disableAuthentication
   )
   {
-    this.requireAuthentication = requireAuthentication;
+    this.disableAuthentication = disableAuthentication;
   }
 
   @Override
@@ -56,7 +56,7 @@ public class AllowOptionsResourceFilter implements Filter
     // Druid itself doesn't explictly handle OPTIONS requests, no resource handler will authorize such requests.
     // so this filter catches all OPTIONS requests and authorizes them.
     if (HttpMethod.OPTIONS.equals(httpReq.getMethod())) {
-      if (!requireAuthentication) {
+      if (disableAuthentication) {
         httpReq.setAttribute(
             AuthConfig.DRUID_AUTHENTICATION_RESULT,
             new AuthenticationResult(AuthConfig.ALLOW_ALL_NAME, AuthConfig.ALLOW_ALL_NAME, null)

--- a/server/src/main/java/io/druid/server/security/AuthConfig.java
+++ b/server/src/main/java/io/druid/server/security/AuthConfig.java
@@ -44,19 +44,23 @@ public class AuthConfig
 
   public AuthConfig()
   {
-    this(null, null, null);
+    this(null, null, null, null);
   }
 
   @JsonCreator
   public AuthConfig(
       @JsonProperty("authenticatorChain") List<String> authenticationChain,
       @JsonProperty("authorizers") List<String> authorizers,
-      @JsonProperty("unsecuredPaths") List<String> unsecuredPaths
+      @JsonProperty("unsecuredPaths") List<String> unsecuredPaths,
+      @JsonProperty("requireHttpOptionsAuthentication") Boolean requireHttpOptionsAuthentication
   )
   {
     this.authenticatorChain = authenticationChain;
     this.authorizers = authorizers;
     this.unsecuredPaths = unsecuredPaths == null ? Collections.emptyList() : unsecuredPaths;
+    this.requireHttpOptionsAuthentication = requireHttpOptionsAuthentication == null
+                                            ? true
+                                            : requireHttpOptionsAuthentication;
   }
 
   @JsonProperty
@@ -67,6 +71,9 @@ public class AuthConfig
 
   @JsonProperty
   private final List<String> unsecuredPaths;
+
+  @JsonProperty
+  private final boolean requireHttpOptionsAuthentication;
 
   public List<String> getAuthenticatorChain()
   {
@@ -83,14 +90,9 @@ public class AuthConfig
     return unsecuredPaths;
   }
 
-  @Override
-  public String toString()
+  public boolean isRequireHttpOptionsAuthentication()
   {
-    return "AuthConfig{" +
-           "authenticatorChain='" + authenticatorChain + '\'' +
-           ", authorizers='" + authorizers + '\'' +
-           ", unsecuredPaths='" + unsecuredPaths + '\'' +
-           '}';
+    return requireHttpOptionsAuthentication;
   }
 
   @Override
@@ -103,14 +105,31 @@ public class AuthConfig
       return false;
     }
     AuthConfig that = (AuthConfig) o;
-    return Objects.equals(authenticatorChain, that.authenticatorChain) &&
-           Objects.equals(authorizers, that.authorizers) &&
-           Objects.equals(unsecuredPaths, that.unsecuredPaths);
+    return isRequireHttpOptionsAuthentication() == that.isRequireHttpOptionsAuthentication() &&
+           Objects.equals(getAuthenticatorChain(), that.getAuthenticatorChain()) &&
+           Objects.equals(getAuthorizers(), that.getAuthorizers()) &&
+           Objects.equals(getUnsecuredPaths(), that.getUnsecuredPaths());
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(authenticatorChain, authorizers, unsecuredPaths);
+    return Objects.hash(
+        getAuthenticatorChain(),
+        getAuthorizers(),
+        getUnsecuredPaths(),
+        isRequireHttpOptionsAuthentication()
+    );
+  }
+
+  @Override
+  public String toString()
+  {
+    return "AuthConfig{" +
+           "authenticatorChain=" + authenticatorChain +
+           ", authorizers=" + authorizers +
+           ", unsecuredPaths=" + unsecuredPaths +
+           ", requireHttpOptionsAuthentication=" + requireHttpOptionsAuthentication +
+           '}';
   }
 }

--- a/server/src/main/java/io/druid/server/security/AuthConfig.java
+++ b/server/src/main/java/io/druid/server/security/AuthConfig.java
@@ -52,15 +52,15 @@ public class AuthConfig
       @JsonProperty("authenticatorChain") List<String> authenticationChain,
       @JsonProperty("authorizers") List<String> authorizers,
       @JsonProperty("unsecuredPaths") List<String> unsecuredPaths,
-      @JsonProperty("requireHttpOptionsAuthentication") Boolean requireHttpOptionsAuthentication
+      @JsonProperty("disableHttpOptionsAuthentication") Boolean disableHttpOptionsAuthentication
   )
   {
     this.authenticatorChain = authenticationChain;
     this.authorizers = authorizers;
     this.unsecuredPaths = unsecuredPaths == null ? Collections.emptyList() : unsecuredPaths;
-    this.requireHttpOptionsAuthentication = requireHttpOptionsAuthentication == null
-                                            ? true
-                                            : requireHttpOptionsAuthentication;
+    this.disableHttpOptionsAuthentication = disableHttpOptionsAuthentication == null
+                                            ? false
+                                            : disableHttpOptionsAuthentication;
   }
 
   @JsonProperty
@@ -73,7 +73,7 @@ public class AuthConfig
   private final List<String> unsecuredPaths;
 
   @JsonProperty
-  private final boolean requireHttpOptionsAuthentication;
+  private final boolean disableHttpOptionsAuthentication;
 
   public List<String> getAuthenticatorChain()
   {
@@ -90,9 +90,9 @@ public class AuthConfig
     return unsecuredPaths;
   }
 
-  public boolean isRequireHttpOptionsAuthentication()
+  public boolean isDisableHttpOptionsAuthentication()
   {
-    return requireHttpOptionsAuthentication;
+    return disableHttpOptionsAuthentication;
   }
 
   @Override
@@ -105,7 +105,7 @@ public class AuthConfig
       return false;
     }
     AuthConfig that = (AuthConfig) o;
-    return isRequireHttpOptionsAuthentication() == that.isRequireHttpOptionsAuthentication() &&
+    return isDisableHttpOptionsAuthentication() == that.isDisableHttpOptionsAuthentication() &&
            Objects.equals(getAuthenticatorChain(), that.getAuthenticatorChain()) &&
            Objects.equals(getAuthorizers(), that.getAuthorizers()) &&
            Objects.equals(getUnsecuredPaths(), that.getUnsecuredPaths());
@@ -118,7 +118,7 @@ public class AuthConfig
         getAuthenticatorChain(),
         getAuthorizers(),
         getUnsecuredPaths(),
-        isRequireHttpOptionsAuthentication()
+        isDisableHttpOptionsAuthentication()
     );
   }
 
@@ -129,7 +129,7 @@ public class AuthConfig
            "authenticatorChain=" + authenticatorChain +
            ", authorizers=" + authorizers +
            ", unsecuredPaths=" + unsecuredPaths +
-           ", requireHttpOptionsAuthentication=" + requireHttpOptionsAuthentication +
+           ", disableHttpOptionsAuthentication=" + disableHttpOptionsAuthentication +
            '}';
   }
 }

--- a/server/src/main/java/io/druid/server/security/AuthenticationUtils.java
+++ b/server/src/main/java/io/druid/server/security/AuthenticationUtils.java
@@ -27,9 +27,9 @@ import java.util.List;
 
 public class AuthenticationUtils
 {
-  public static void addAllowOptionsFilter(ServletContextHandler root, boolean requireHttpOptionsAuthentication)
+  public static void addAllowOptionsFilter(ServletContextHandler root, boolean disableHttpOptionsAuthentication)
   {
-    FilterHolder holder = new FilterHolder(new AllowOptionsResourceFilter(requireHttpOptionsAuthentication));
+    FilterHolder holder = new FilterHolder(new AllowOptionsResourceFilter(disableHttpOptionsAuthentication));
     root.addFilter(
         holder,
         "/*",

--- a/server/src/main/java/io/druid/server/security/AuthenticationUtils.java
+++ b/server/src/main/java/io/druid/server/security/AuthenticationUtils.java
@@ -27,6 +27,16 @@ import java.util.List;
 
 public class AuthenticationUtils
 {
+  public static void addAllowOptionsFilter(ServletContextHandler root, boolean requireHttpOptionsAuthentication)
+  {
+    FilterHolder holder = new FilterHolder(new AllowOptionsResourceFilter(requireHttpOptionsAuthentication));
+    root.addFilter(
+        holder,
+        "/*",
+        null
+    );
+  }
+
   public static void addAuthenticationFilterChain(
       ServletContextHandler root,
       List<Authenticator> authenticators

--- a/services/src/main/java/io/druid/cli/CliOverlord.java
+++ b/services/src/main/java/io/druid/cli/CliOverlord.java
@@ -344,7 +344,7 @@ public class CliOverlord extends ServerRunnable
       AuthenticationUtils.addNoopAuthorizationFilters(root, UNSECURED_PATHS);
       AuthenticationUtils.addNoopAuthorizationFilters(root, authConfig.getUnsecuredPaths());
 
-      AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isRequireHttpOptionsAuthentication());
+      AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isDisableHttpOptionsAuthentication());
 
       authenticators = authenticatorMapper.getAuthenticatorChain();
       AuthenticationUtils.addAuthenticationFilterChain(root, authenticators);

--- a/services/src/main/java/io/druid/cli/CliOverlord.java
+++ b/services/src/main/java/io/druid/cli/CliOverlord.java
@@ -344,6 +344,8 @@ public class CliOverlord extends ServerRunnable
       AuthenticationUtils.addNoopAuthorizationFilters(root, UNSECURED_PATHS);
       AuthenticationUtils.addNoopAuthorizationFilters(root, authConfig.getUnsecuredPaths());
 
+      AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isRequireHttpOptionsAuthentication());
+
       authenticators = authenticatorMapper.getAuthenticatorChain();
       AuthenticationUtils.addAuthenticationFilterChain(root, authenticators);
 

--- a/services/src/main/java/io/druid/cli/CoordinatorJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/CoordinatorJettyServerInitializer.java
@@ -125,11 +125,12 @@ class CoordinatorJettyServerInitializer implements JettyServerInitializer
       AuthenticationUtils.addNoopAuthorizationFilters(root, CliOverlord.UNSECURED_PATHS);
     }
 
+    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isRequireHttpOptionsAuthentication());
+
     authenticators = authenticatorMapper.getAuthenticatorChain();
     AuthenticationUtils.addAuthenticationFilterChain(root, authenticators);
 
     JettyServerInitUtils.addExtensionFilters(root, injector);
-
 
     // Check that requests were authorized before sending responses
     AuthenticationUtils.addPreResponseAuthorizationCheckFilter(

--- a/services/src/main/java/io/druid/cli/CoordinatorJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/CoordinatorJettyServerInitializer.java
@@ -125,7 +125,7 @@ class CoordinatorJettyServerInitializer implements JettyServerInitializer
       AuthenticationUtils.addNoopAuthorizationFilters(root, CliOverlord.UNSECURED_PATHS);
     }
 
-    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isRequireHttpOptionsAuthentication());
+    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isDisableHttpOptionsAuthentication());
 
     authenticators = authenticatorMapper.getAuthenticatorChain();
     AuthenticationUtils.addAuthenticationFilterChain(root, authenticators);

--- a/services/src/main/java/io/druid/cli/MiddleManagerJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/MiddleManagerJettyServerInitializer.java
@@ -78,9 +78,10 @@ class MiddleManagerJettyServerInitializer implements JettyServerInitializer
     AuthenticationUtils.addNoopAuthorizationFilters(root, UNSECURED_PATHS);
     AuthenticationUtils.addNoopAuthorizationFilters(root, authConfig.getUnsecuredPaths());
 
+    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isRequireHttpOptionsAuthentication());
+
     authenticators = authenticatorMapper.getAuthenticatorChain();
     AuthenticationUtils.addAuthenticationFilterChain(root, authenticators);
-
 
     JettyServerInitUtils.addExtensionFilters(root, injector);
 

--- a/services/src/main/java/io/druid/cli/MiddleManagerJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/MiddleManagerJettyServerInitializer.java
@@ -78,7 +78,7 @@ class MiddleManagerJettyServerInitializer implements JettyServerInitializer
     AuthenticationUtils.addNoopAuthorizationFilters(root, UNSECURED_PATHS);
     AuthenticationUtils.addNoopAuthorizationFilters(root, authConfig.getUnsecuredPaths());
 
-    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isRequireHttpOptionsAuthentication());
+    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isDisableHttpOptionsAuthentication());
 
     authenticators = authenticatorMapper.getAuthenticatorChain();
     AuthenticationUtils.addAuthenticationFilterChain(root, authenticators);

--- a/services/src/main/java/io/druid/cli/QueryJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/QueryJettyServerInitializer.java
@@ -102,7 +102,7 @@ public class QueryJettyServerInitializer implements JettyServerInitializer
     AuthenticationUtils.addNoopAuthorizationFilters(root, UNSECURED_PATHS);
     AuthenticationUtils.addNoopAuthorizationFilters(root, authConfig.getUnsecuredPaths());
 
-    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isRequireHttpOptionsAuthentication());
+    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isDisableHttpOptionsAuthentication());
 
     authenticators = authenticatorMapper.getAuthenticatorChain();
     AuthenticationUtils.addAuthenticationFilterChain(root, authenticators);

--- a/services/src/main/java/io/druid/cli/QueryJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/QueryJettyServerInitializer.java
@@ -102,6 +102,8 @@ public class QueryJettyServerInitializer implements JettyServerInitializer
     AuthenticationUtils.addNoopAuthorizationFilters(root, UNSECURED_PATHS);
     AuthenticationUtils.addNoopAuthorizationFilters(root, authConfig.getUnsecuredPaths());
 
+    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isRequireHttpOptionsAuthentication());
+
     authenticators = authenticatorMapper.getAuthenticatorChain();
     AuthenticationUtils.addAuthenticationFilterChain(root, authenticators);
 

--- a/services/src/main/java/io/druid/cli/RouterJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/RouterJettyServerInitializer.java
@@ -111,6 +111,8 @@ public class RouterJettyServerInitializer implements JettyServerInitializer
     AuthenticationUtils.addNoopAuthorizationFilters(root, UNSECURED_PATHS);
     AuthenticationUtils.addNoopAuthorizationFilters(root, authConfig.getUnsecuredPaths());
 
+    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isRequireHttpOptionsAuthentication());
+
     final List<Authenticator> authenticators = authenticatorMapper.getAuthenticatorChain();
     AuthenticationUtils.addAuthenticationFilterChain(root, authenticators);
 

--- a/services/src/main/java/io/druid/cli/RouterJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/RouterJettyServerInitializer.java
@@ -111,7 +111,7 @@ public class RouterJettyServerInitializer implements JettyServerInitializer
     AuthenticationUtils.addNoopAuthorizationFilters(root, UNSECURED_PATHS);
     AuthenticationUtils.addNoopAuthorizationFilters(root, authConfig.getUnsecuredPaths());
 
-    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isRequireHttpOptionsAuthentication());
+    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isDisableHttpOptionsAuthentication());
 
     final List<Authenticator> authenticators = authenticatorMapper.getAuthenticatorChain();
     AuthenticationUtils.addAuthenticationFilterChain(root, authenticators);


### PR DESCRIPTION
Fixes #5588 

This PR sets the AUTHORIZATION_CHECKED flag to true for all HTTP OPTIONS requests. This is handled in a new servlet filter (Druid has no explicit OPTIONS method handlers on its endpoints).

It seems that CORS pre-flight OPTIONS requests do not generally contain credentials headers:
- https://stackoverflow.com/questions/15734031/why-does-the-preflight-options-request-of-an-authenticated-cors-request-work-in  
- https://fetch.spec.whatwg.org/#cors-preflight-request
- https://bugzilla.mozilla.org/show_bug.cgi?id=778548

So a `disableHttpOptionsAuthentication` config is added to disable authentication checks on OPTIONS requests (authentication is required by default) to support CORS use cases.