### PR TITLE
Update to jetty 9.4; Enable request decompression

### DIFF
--- a/docs/content/operations/http-compression.md
+++ b/docs/content/operations/http-compression.md
@@ -1,0 +1,13 @@
+---
+layout: doc_page
+---
+# HTTP Compression
+
+Druid supports http request decompression and response compression, to use this, http request header `Content-Encoding:gzip` and  `Accept-Encoding:gzip` is needed to be set.
+
+# General Configuration
+
+|Property|Description|Default|
+|--------|-----------|-------|
+|`druid.server.http.compressionLevel`|The compression level. Value should be between [-1,9], -1 for default level, 0 for no compression.|-1 (default compression level)|
+|`druid.server.http.inflateBufferSize`|The buffer size used by gzip decoder. Set to 0 to disable request decompression.|4096|

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <fastutil.version>8.1.0</fastutil.version>
         <guava.version>16.0.1</guava.version>
         <guice.version>4.1.0</guice.version>
-        <jetty.version>9.3.19.v20170502</jetty.version>
+        <jetty.version>9.4.10.v20180503</jetty.version>
         <jersey.version>1.19.3</jersey.version>
         <!-- jackson 2.7.x causes injection error and 2.8.x can't be used because avatica is using 2.6.3 -->
         <jackson.version>2.6.7</jackson.version>

--- a/server/src/main/java/io/druid/server/AsyncQueryForwardingServlet.java
+++ b/server/src/main/java/io/druid/server/AsyncQueryForwardingServlet.java
@@ -51,6 +51,7 @@ import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.client.api.Result;
 import org.eclipse.jetty.client.util.BytesContentProvider;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.proxy.AsyncProxyServlet;
 
@@ -300,7 +301,9 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
     if (query != null) {
       final ObjectMapper objectMapper = (ObjectMapper) clientRequest.getAttribute(OBJECTMAPPER_ATTRIBUTE);
       try {
-        proxyRequest.content(new BytesContentProvider(objectMapper.writeValueAsBytes(query)));
+        byte[] bytes = objectMapper.writeValueAsBytes(query);
+        proxyRequest.content(new BytesContentProvider(bytes));
+        proxyRequest.getHeaders().put(HttpHeader.CONTENT_LENGTH, String.valueOf(bytes.length));
       }
       catch (JsonProcessingException e) {
         Throwables.propagate(e);

--- a/server/src/main/java/io/druid/server/initialization/ServerConfig.java
+++ b/server/src/main/java/io/druid/server/initialization/ServerConfig.java
@@ -22,14 +22,19 @@ package io.druid.server.initialization;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.joda.time.Period;
 
+import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import java.util.Objects;
+import java.util.zip.Deflater;
 
 /**
  */
 public class ServerConfig
 {
+
+  public static final int DEFAULT_GZIP_INFLATE_BUFFER_SIZE = 4096;
+
   @JsonProperty
   @Min(1)
   private int numThreads = Math.max(10, (Runtime.getRuntime().availableProcessors() * 17) / 16 + 2) + 30;
@@ -67,6 +72,15 @@ public class ServerConfig
   @JsonProperty
   @NotNull
   private Period unannouncePropogationDelay = Period.ZERO;
+
+  @JsonProperty
+  @Min(0)
+  private int inflateBufferSize = DEFAULT_GZIP_INFLATE_BUFFER_SIZE;
+
+  @JsonProperty
+  @Min(-1)
+  @Max(9)
+  private int compressionLevel = Deflater.DEFAULT_COMPRESSION;
 
   public int getNumThreads()
   {
@@ -118,6 +132,17 @@ public class ServerConfig
     return unannouncePropogationDelay;
   }
 
+  public int getInflateBufferSize()
+  {
+    return inflateBufferSize;
+  }
+
+  public int getCompressionLevel()
+  {
+    return compressionLevel;
+  }
+
+
   @Override
   public boolean equals(Object o)
   {
@@ -135,6 +160,8 @@ public class ServerConfig
            maxScatterGatherBytes == that.maxScatterGatherBytes &&
            maxQueryTimeout == that.maxQueryTimeout &&
            maxRequestHeaderSize == that.maxRequestHeaderSize &&
+           inflateBufferSize == that.inflateBufferSize &&
+           compressionLevel == that.compressionLevel &&
            Objects.equals(maxIdleTime, that.maxIdleTime) &&
            Objects.equals(gracefulShutdownTimeout, that.gracefulShutdownTimeout) &&
            Objects.equals(unannouncePropogationDelay, that.unannouncePropogationDelay);
@@ -154,7 +181,9 @@ public class ServerConfig
         maxQueryTimeout,
         maxRequestHeaderSize,
         gracefulShutdownTimeout,
-        unannouncePropogationDelay
+        unannouncePropogationDelay,
+        inflateBufferSize,
+        compressionLevel
     );
   }
 
@@ -172,6 +201,8 @@ public class ServerConfig
            ", maxRequestHeaderSize=" + maxRequestHeaderSize +
            ", gracefulShutdownTimeout=" + gracefulShutdownTimeout +
            ", unannouncePropogationDelay=" + unannouncePropogationDelay +
+           ", inflateBufferSize=" + inflateBufferSize +
+           ", compressionLevel=" + compressionLevel +
            '}';
   }
 }

--- a/server/src/main/java/io/druid/server/initialization/jetty/JettyServerInitUtils.java
+++ b/server/src/main/java/io/druid/server/initialization/jetty/JettyServerInitUtils.java
@@ -22,9 +22,7 @@ package io.druid.server.initialization.jetty;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
-
 import io.druid.java.util.common.ISE;
-
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.handler.RequestLogHandler;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
@@ -38,11 +36,13 @@ public class JettyServerInitUtils
 {
   private static final String[] GZIP_METHODS = new String[]{HttpMethod.GET, HttpMethod.POST};
 
-  public static GzipHandler wrapWithDefaultGzipHandler(final Handler handler)
+  public static GzipHandler wrapWithDefaultGzipHandler(final Handler handler, int inflateBufferSize, int compressionLevel)
   {
     GzipHandler gzipHandler = new GzipHandler();
     gzipHandler.setMinGzipSize(0);
     gzipHandler.setIncludedMethods(GZIP_METHODS);
+    gzipHandler.setInflateBufferSize(inflateBufferSize);
+    gzipHandler.setCompressionLevel(compressionLevel);
 
     // We don't actually have any precomputed .gz resources, and checking for them inside jars is expensive.
     gzipHandler.setCheckGzExists(false);

--- a/server/src/test/java/io/druid/server/AsyncManagementForwardingServletTest.java
+++ b/server/src/test/java/io/druid/server/AsyncManagementForwardingServletTest.java
@@ -436,7 +436,7 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
       JettyServerInitUtils.addExtensionFilters(root, injector);
 
       final HandlerList handlerList = new HandlerList();
-      handlerList.setHandlers(new Handler[]{JettyServerInitUtils.wrapWithDefaultGzipHandler(root)});
+      handlerList.setHandlers(new Handler[]{JettyServerInitUtils.wrapWithDefaultGzipHandler(root, 4096, -1)});
       server.setHandler(handlerList);
     }
   }

--- a/server/src/test/java/io/druid/server/AsyncQueryForwardingServletTest.java
+++ b/server/src/test/java/io/druid/server/AsyncQueryForwardingServletTest.java
@@ -364,7 +364,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
       root.addFilter(GuiceFilter.class, "/exception/*", null);
 
       final HandlerList handlerList = new HandlerList();
-      handlerList.setHandlers(new Handler[]{JettyServerInitUtils.wrapWithDefaultGzipHandler(root)});
+      handlerList.setHandlers(new Handler[]{JettyServerInitUtils.wrapWithDefaultGzipHandler(root, 4096, -1)});
       server.setHandler(handlerList);
     }
   }

--- a/server/src/test/java/io/druid/server/initialization/BaseJettyTest.java
+++ b/server/src/test/java/io/druid/server/initialization/BaseJettyTest.java
@@ -52,6 +52,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -66,6 +67,8 @@ import java.util.concurrent.TimeUnit;
 
 public abstract class BaseJettyTest
 {
+  protected static final String DEFAULT_RESPONSE_CONTENT = "hello";
+
   protected Lifecycle lifecycle;
   protected HttpClient client;
   protected Server server;
@@ -142,7 +145,7 @@ public abstract class BaseJettyTest
       root.addFilter(GuiceFilter.class, "/*", null);
 
       final HandlerList handlerList = new HandlerList();
-      handlerList.setHandlers(new Handler[]{JettyServerInitUtils.wrapWithDefaultGzipHandler(root)});
+      handlerList.setHandlers(new Handler[]{JettyServerInitUtils.wrapWithDefaultGzipHandler(root, 4096, -1)});
       server.setHandler(handlerList);
     }
 
@@ -165,33 +168,46 @@ public abstract class BaseJettyTest
       catch (InterruptedException e) {
         //
       }
-      return Response.ok("hello").build();
+      return Response.ok(DEFAULT_RESPONSE_CONTENT).build();
     }
   }
 
   @Path("/default")
   public static class DefaultResource
   {
+
     @DELETE
     @Path("{resource}")
     @Produces(MediaType.APPLICATION_JSON)
     public Response delete()
     {
-      return Response.ok("hello").build();
+      return Response.ok(DEFAULT_RESPONSE_CONTENT).build();
     }
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Response get()
     {
-      return Response.ok("hello").build();
+      return Response.ok(DEFAULT_RESPONSE_CONTENT).build();
     }
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     public Response post()
     {
-      return Response.ok("hello").build();
+      return Response.ok(DEFAULT_RESPONSE_CONTENT).build();
+    }
+  }
+
+  @Path("/return")
+  public static class DirectlyReturnResource
+  {
+    @POST
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response postText(String text)
+    {
+      return Response.ok(text).build();
     }
   }
 

--- a/services/src/main/java/io/druid/cli/CliOverlord.java
+++ b/services/src/main/java/io/druid/cli/CliOverlord.java
@@ -90,6 +90,7 @@ import io.druid.server.audit.AuditManagerProvider;
 import io.druid.server.coordinator.CoordinatorOverlordServiceConfig;
 import io.druid.server.http.RedirectFilter;
 import io.druid.server.http.RedirectInfo;
+import io.druid.server.initialization.ServerConfig;
 import io.druid.server.initialization.jetty.JettyServerInitUtils;
 import io.druid.server.initialization.jetty.JettyServerInitializer;
 import io.druid.server.security.AuthConfig;
@@ -307,11 +308,13 @@ public class CliOverlord extends ServerRunnable
   private static class OverlordJettyServerInitializer implements JettyServerInitializer
   {
     private final AuthConfig authConfig;
+    private final ServerConfig serverConfig;
 
     @Inject
-    OverlordJettyServerInitializer(AuthConfig authConfig)
+    OverlordJettyServerInitializer(AuthConfig authConfig, ServerConfig serverConfig)
     {
       this.authConfig = authConfig;
+      this.serverConfig = serverConfig;
     }
 
     @Override
@@ -373,7 +376,11 @@ public class CliOverlord extends ServerRunnable
       handlerList.setHandlers(
           new Handler[]{
               JettyServerInitUtils.getJettyRequestLogHandler(),
-              JettyServerInitUtils.wrapWithDefaultGzipHandler(root)
+              JettyServerInitUtils.wrapWithDefaultGzipHandler(
+                  root,
+                  serverConfig.getInflateBufferSize(),
+                  serverConfig.getCompressionLevel()
+              )
           }
       );
 

--- a/services/src/main/java/io/druid/cli/CoordinatorJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/CoordinatorJettyServerInitializer.java
@@ -30,6 +30,7 @@ import io.druid.java.util.common.logger.Logger;
 import io.druid.server.coordinator.DruidCoordinatorConfig;
 import io.druid.server.http.OverlordProxyServlet;
 import io.druid.server.http.RedirectFilter;
+import io.druid.server.initialization.ServerConfig;
 import io.druid.server.initialization.jetty.JettyServerInitUtils;
 import io.druid.server.initialization.jetty.JettyServerInitializer;
 import io.druid.server.security.AuthConfig;
@@ -72,13 +73,15 @@ class CoordinatorJettyServerInitializer implements JettyServerInitializer
   private final DruidCoordinatorConfig config;
   private final boolean beOverlord;
   private final AuthConfig authConfig;
+  private final ServerConfig serverConfig;
 
   @Inject
-  CoordinatorJettyServerInitializer(DruidCoordinatorConfig config, Properties properties, AuthConfig authConfig)
+  CoordinatorJettyServerInitializer(DruidCoordinatorConfig config, Properties properties, AuthConfig authConfig, ServerConfig serverConfig)
   {
     this.config = config;
     this.beOverlord = CliCoordinator.isOverlord(properties);
     this.authConfig = authConfig;
+    this.serverConfig = serverConfig;
   }
 
   @Override
@@ -165,7 +168,11 @@ class CoordinatorJettyServerInitializer implements JettyServerInitializer
     handlerList.setHandlers(
         new Handler[]{
             JettyServerInitUtils.getJettyRequestLogHandler(),
-            JettyServerInitUtils.wrapWithDefaultGzipHandler(root)
+            JettyServerInitUtils.wrapWithDefaultGzipHandler(
+                root,
+                serverConfig.getInflateBufferSize(),
+                serverConfig.getCompressionLevel()
+            )
         }
     );
 

--- a/services/src/main/java/io/druid/cli/MiddleManagerJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/MiddleManagerJettyServerInitializer.java
@@ -27,6 +27,7 @@ import com.google.inject.Key;
 import com.google.inject.servlet.GuiceFilter;
 import io.druid.guice.annotations.Json;
 import io.druid.java.util.common.logger.Logger;
+import io.druid.server.initialization.ServerConfig;
 import io.druid.server.initialization.jetty.JettyServerInitUtils;
 import io.druid.server.initialization.jetty.JettyServerInitializer;
 import io.druid.server.security.AuthConfig;
@@ -49,17 +50,19 @@ class MiddleManagerJettyServerInitializer implements JettyServerInitializer
 {
   private static Logger log = new Logger(MiddleManagerJettyServerInitializer.class);
 
-  private static List<String> UNSECURED_PATHS = Lists.newArrayList(
-      "/status/health"
-  );
-
+  private final ServerConfig serverConfig;
   private final AuthConfig authConfig;
 
   @Inject
-  public MiddleManagerJettyServerInitializer(AuthConfig authConfig)
+  public MiddleManagerJettyServerInitializer(ServerConfig serverConfig, AuthConfig authConfig)
   {
+    this.serverConfig = serverConfig;
     this.authConfig = authConfig;
   }
+
+  private static List<String> UNSECURED_PATHS = Lists.newArrayList(
+      "/status/health"
+  );
 
   @Override
   public void initialize(Server server, Injector injector)
@@ -97,7 +100,11 @@ class MiddleManagerJettyServerInitializer implements JettyServerInitializer
     handlerList.setHandlers(
         new Handler[]{
             JettyServerInitUtils.getJettyRequestLogHandler(),
-            JettyServerInitUtils.wrapWithDefaultGzipHandler(root),
+            JettyServerInitUtils.wrapWithDefaultGzipHandler(
+                root,
+                serverConfig.getInflateBufferSize(),
+                serverConfig.getCompressionLevel()
+            ),
             new DefaultHandler()
         }
     );

--- a/services/src/main/java/io/druid/cli/QueryJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/QueryJettyServerInitializer.java
@@ -130,7 +130,11 @@ public class QueryJettyServerInitializer implements JettyServerInitializer
     }
 
     // Add Gzip handler at the very end
-    handlerList.addHandler(JettyServerInitUtils.wrapWithDefaultGzipHandler(root));
+    handlerList.addHandler(JettyServerInitUtils.wrapWithDefaultGzipHandler(
+        root,
+        serverConfig.getInflateBufferSize(),
+        serverConfig.getCompressionLevel()
+    ));
 
     final StatisticsHandler statisticsHandler = new StatisticsHandler();
     statisticsHandler.setHandler(handlerList);

--- a/services/src/main/java/io/druid/cli/RouterJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/RouterJettyServerInitializer.java
@@ -30,6 +30,7 @@ import io.druid.guice.annotations.Json;
 import io.druid.guice.http.DruidHttpClientConfig;
 import io.druid.server.AsyncManagementForwardingServlet;
 import io.druid.server.AsyncQueryForwardingServlet;
+import io.druid.server.initialization.ServerConfig;
 import io.druid.server.initialization.jetty.JettyServerInitUtils;
 import io.druid.server.initialization.jetty.JettyServerInitializer;
 import io.druid.server.router.ManagementProxyConfig;
@@ -65,6 +66,7 @@ public class RouterJettyServerInitializer implements JettyServerInitializer
   private final AsyncQueryForwardingServlet asyncQueryForwardingServlet;
   private final AsyncManagementForwardingServlet asyncManagementForwardingServlet;
   private final AuthConfig authConfig;
+  private final ServerConfig serverConfig;
 
   @Inject
   public RouterJettyServerInitializer(
@@ -73,7 +75,8 @@ public class RouterJettyServerInitializer implements JettyServerInitializer
       ManagementProxyConfig managementProxyConfig,
       AsyncQueryForwardingServlet asyncQueryForwardingServlet,
       AsyncManagementForwardingServlet asyncManagementForwardingServlet,
-      AuthConfig authConfig
+      AuthConfig authConfig,
+      ServerConfig serverConfig
   )
   {
     this.routerHttpClientConfig = routerHttpClientConfig;
@@ -82,6 +85,7 @@ public class RouterJettyServerInitializer implements JettyServerInitializer
     this.asyncQueryForwardingServlet = asyncQueryForwardingServlet;
     this.asyncManagementForwardingServlet = asyncManagementForwardingServlet;
     this.authConfig = authConfig;
+    this.serverConfig = serverConfig;
   }
 
   @Override
@@ -132,7 +136,11 @@ public class RouterJettyServerInitializer implements JettyServerInitializer
     handlerList.setHandlers(
         new Handler[]{
             JettyServerInitUtils.getJettyRequestLogHandler(),
-            JettyServerInitUtils.wrapWithDefaultGzipHandler(root)
+            JettyServerInitUtils.wrapWithDefaultGzipHandler(
+                root,
+                serverConfig.getInflateBufferSize(),
+                serverConfig.getCompressionLevel()
+            )
         }
     );
     server.setHandler(handlerList);


### PR DESCRIPTION
Automatic request decompression is implemented since [Jetty-964](https://github.com/eclipse/jetty.project/pull/964)，to use this feature, a dependency upgrading of jetty from 9.3 to 9.4 is needed.