### PR TITLE
correct overlord console header. Because it's not the coordinator con…

### DIFF
--- a/indexing-service/src/main/resources/indexer_static/console.html
+++ b/indexing-service/src/main/resources/indexer_static/console.html
@@ -36,7 +36,7 @@
 
 <body>
 <div class="container">
-    <div class="heading">Coordinator Console</div>
+    <div class="heading">Overlord Console</div>
     <div class="supervisors_section" style="display: none;">
     <h2>Supervisors</h2>
     <table id="supervisorsTable"></table>


### PR DESCRIPTION
…sole, it's the overlord console.