### PR TITLE
Fix coordinator loadStatus performance

### DIFF
--- a/benchmarks/src/main/java/io/druid/benchmark/LoadStatusBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/LoadStatusBenchmark.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.benchmark;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import io.druid.java.util.common.StringUtils;
+import io.druid.timeline.DataSegment;
+import io.druid.timeline.partition.NoneShardSpec;
+import org.joda.time.Interval;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 15)
+@Measurement(iterations = 30)
+public class LoadStatusBenchmark
+{
+  // Number of total data segments
+  @Param({"10000"})
+  int totalSegmentsCount;
+
+  @Param({"true", "false"})
+  private boolean serverHasAllSegments;
+
+  private Set<DataSegment> datasourceSegments;
+  private Collection<DataSegment> serverSegments;
+
+  @Setup(Level.Invocation)
+  public void setup() throws IOException
+  {
+    Map<String, DataSegment> immutableDatasourceSegmentsMap;
+    ConcurrentHashMap<String, DataSegment> serverSegmentsMap;
+
+    HashMap<String, DataSegment> datasourceSegmentsMap = Maps.newHashMap();
+    serverSegmentsMap = new ConcurrentHashMap<>();
+
+    for (int i = 0; i < totalSegmentsCount; i++) {
+      DataSegment segment = new DataSegment(
+          "benchmarkDatasource",
+          new Interval(StringUtils.format("%s-01-01/%s-12-31", i + 1970, i + 1970)),
+          "1",
+          null,
+          null,
+          null,
+          NoneShardSpec.instance(),
+          1,
+          1
+      );
+
+      datasourceSegmentsMap.put(segment.getIdentifier(), segment);
+
+      if (serverHasAllSegments || i % 2 == 0) {
+        serverSegmentsMap.put(segment.getIdentifier(), segment);
+      }
+    }
+
+    immutableDatasourceSegmentsMap = ImmutableMap.copyOf(datasourceSegmentsMap);
+
+    datasourceSegments = Sets.newHashSet(immutableDatasourceSegmentsMap.values());
+    serverSegments = Collections.unmodifiableCollection(serverSegmentsMap.values());
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void oldVersion(Blackhole blackhole)
+  {
+    datasourceSegments.removeAll(serverSegments);
+    blackhole.consume(datasourceSegments);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void newVersion(Blackhole blackhole)
+  {
+    for (DataSegment segment : serverSegments) {
+      datasourceSegments.remove(segment);
+    }
+    blackhole.consume(datasourceSegments);
+  }
+}

--- a/benchmarks/src/main/java/io/druid/benchmark/LoadStatusBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/LoadStatusBenchmark.java
@@ -66,7 +66,7 @@ public class LoadStatusBenchmark
   private Collection<DataSegment> serverSegments;
 
   @Setup(Level.Invocation)
-  public void setup() throws IOException
+  public void setup()
   {
     Map<String, DataSegment> immutableDatasourceSegmentsMap;
     ConcurrentHashMap<String, DataSegment> serverSegmentsMap;

--- a/benchmarks/src/main/java/io/druid/benchmark/LoadStatusBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/LoadStatusBenchmark.java
@@ -22,6 +22,7 @@ package io.druid.benchmark;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.StringUtils;
 import io.druid.timeline.DataSegment;
 import io.druid.timeline.partition.NoneShardSpec;
@@ -76,7 +77,7 @@ public class LoadStatusBenchmark
     for (int i = 0; i < totalSegmentsCount; i++) {
       DataSegment segment = new DataSegment(
           "benchmarkDatasource",
-          new Interval(StringUtils.format("%s-01-01/%s-12-31", i + 1970, i + 1970)),
+          Intervals.of(StringUtils.format("%s-01-01/%s-12-31", i + 1970, i + 1970)),
           "1",
           null,
           null,

--- a/benchmarks/src/main/java/io/druid/benchmark/LoadStatusBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/LoadStatusBenchmark.java
@@ -26,7 +26,6 @@ import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.StringUtils;
 import io.druid.timeline.DataSegment;
 import io.druid.timeline.partition.NoneShardSpec;
-import org.joda.time.Interval;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;

--- a/benchmarks/src/main/java/io/druid/benchmark/LoadStatusBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/LoadStatusBenchmark.java
@@ -40,7 +40,6 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;

--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
@@ -297,6 +297,8 @@ public class DruidCoordinator
       for (DruidServer druidServer : serverInventoryView.getInventory()) {
         final DruidDataSource loadedView = druidServer.getDataSource(dataSource.getName());
         if (loadedView != null) {
+          // This does not use segments.removeAll(loadedView.getSegments()) for performance reasons.
+          // Please see https://github.com/druid-io/druid/pull/5632 and LoadStatusBenchmark for more info.
           for (DataSegment serverSegment : loadedView.getSegments()) {
             segments.remove(serverSegment);
           }

--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
@@ -297,7 +297,9 @@ public class DruidCoordinator
       for (DruidServer druidServer : serverInventoryView.getInventory()) {
         final DruidDataSource loadedView = druidServer.getDataSource(dataSource.getName());
         if (loadedView != null) {
-          segments.removeAll(loadedView.getSegments());
+          for (DataSegment serverSegment : loadedView.getSegments()) {
+            segments.remove(serverSegment);
+          }
         }
       }
       final int unloadedSegmentSize = segments.size();


### PR DESCRIPTION
`getLoadStatus()` in `DruidCoordinator` determines how many segments need to be loaded per-datasource by retrieving the list of all segments from metadata, then asks each server for its segment inventory and removes the server segments from the set returned from metadata:

```
      // remove loaded segments
      for (DruidServer druidServer : serverInventoryView.getInventory()) {
        final DruidDataSource loadedView = druidServer.getDataSource(dataSource.getName());
        if (loadedView != null) {
          segments.removeAll(loadedView.getSegments());
        }
      }
```

The current code can perform badly when a server has the entire set of segments for a datasource.

This is the code for `AbstractSet.removeAll()`:
```
    public boolean removeAll(Collection<?> c) {
        Objects.requireNonNull(c);
        boolean modified = false;

        if (size() > c.size()) {
            for (Iterator<?> i = c.iterator(); i.hasNext(); )
                modified |= remove(i.next());
        } else {
            for (Iterator<?> i = iterator(); i.hasNext(); ) {
                if (c.contains(i.next())) {
                    i.remove();
                    modified = true;
                }
            }
        }
        return modified;
    }
```

In that situation, the else block will be used, and this is a problem because `loadedView.getSegments()` is the values collection of a ConcurrentHashMap, and its contains() method does a full traversal of the map:

```
  public Collection<DataSegment> getSegments()
  {
    return Collections.unmodifiableCollection(idToSegmentMap.values());
  }

...
    public static <T> Collection<T> unmodifiableCollection(Collection<? extends T> c) {
        return new UnmodifiableCollection<>(c);
    }
    public boolean contains(Object o)   {return c.contains(o);}
...
    static final class ValuesView<K,V> extends CollectionView<K,V,V>
        implements Collection<V>, java.io.Serializable {

        ValuesView(ConcurrentHashMap<K,V> map) { super(map); }

        public final boolean contains(Object o) {
            return map.containsValue(o);
        }
...
    /**
     * Returns {@code true} if this map maps one or more keys to the
     * specified value. Note: This method may require a full traversal
     * of the map, and is much slower than method {@code containsKey}.
     *
     * @param value value whose presence in this map is to be tested
     * @return {@code true} if this map maps one or more keys to the
     *         specified value
     * @throws NullPointerException if the specified value is null
     */
    public boolean containsValue(Object value) {
        if (value == null)
            throw new NullPointerException();
        Node<K,V>[] t;
        if ((t = table) != null) {
            Traverser<K,V> it = new Traverser<K,V>(t, t.length, 0, t.length);
            for (Node<K,V> p; (p = it.advance()) != null; ) {
                V v;
                if ((v = p.val) == value || (v != null && value.equals(v)))
                    return true;
            }
        }
        return false;
    }
...

```

The following benchmark (included in the PR) shows this behavior:

```
Benchmark                       (serverHasAllSegments)  (totalSegmentsCount)  Mode  Cnt        Score       Error  Units
LoadStatusBenchmark.newVersion                    true                 10000  avgt   50      387.188 ±     4.991  us/op
LoadStatusBenchmark.newVersion                   false                 10000  avgt   50      227.884 ±     2.444  us/op
LoadStatusBenchmark.oldVersion                    true                 10000  avgt   50  1581777.362 ± 38030.835  us/op
LoadStatusBenchmark.oldVersion                   false                 10000  avgt   50      244.024 ±     2.923  us/op
```