### PR TITLE
Fix HTTP OPTIONS request auth handling

### DIFF
--- a/docs/content/configuration/auth.md
+++ b/docs/content/configuration/auth.md
@@ -10,7 +10,7 @@ layout: doc_page
 |`druid.escalator.type`|String|Type of the Escalator that should be used for internal Druid communications. This Escalator must use an authentication scheme that is supported by an Authenticator in `druid.auth.authenticationChain`.|"noop"|no|
 |`druid.auth.authorizers`|JSON List of Strings|List of Authorizer type names |["allowAll"]|no|
 |`druid.auth.unsecuredPaths`| List of Strings|List of paths for which security checks will not be performed. All requests to these paths will be allowed.|[]|no|
-|`druid.auth.allowUnauthenticatedHttpOptions`|Boolean|If true, skip authentication checks for HTTP OPTIONS requests. This is needed for certain use cases, such as supporting CORS pre-flight requests. Note that disabling authentication checks for OPTIONS requests will allow unauthenticated users to determine what Druid endpoints are valid (by checking if the OPTIONS request returns a 200 instead of 404), so the authentication checks should not be disabled unless necessary. |false|no|
+|`druid.auth.allowUnauthenticatedHttpOptions`|Boolean|If true, skip authentication checks for HTTP OPTIONS requests. This is needed for certain use cases, such as supporting CORS pre-flight requests. Note that disabling authentication checks for OPTIONS requests will allow unauthenticated users to determine what Druid endpoints are valid (by checking if the OPTIONS request returns a 200 instead of 404), so enabling this option may reveal information about server configuration, including information about what extensions are loaded (if those extensions add endpoints).|false|no|
 
 ## Enabling Authentication/Authorization
 

--- a/docs/content/configuration/auth.md
+++ b/docs/content/configuration/auth.md
@@ -10,6 +10,7 @@ layout: doc_page
 |`druid.escalator.type`|String|Type of the Escalator that should be used for internal Druid communications. This Escalator must use an authentication scheme that is supported by an Authenticator in `druid.auth.authenticationChain`.|"noop"|no|
 |`druid.auth.authorizers`|JSON List of Strings|List of Authorizer type names |["allowAll"]|no|
 |`druid.auth.unsecuredPaths`| List of Strings|List of paths for which security checks will not be performed. All requests to these paths will be allowed.|[]|no|
+|`druid.auth.allowUnauthenticatedHttpOptions`|Boolean|If true, skip authentication checks for HTTP OPTIONS requests. This is needed for certain use cases, such as supporting CORS pre-flight requests. Note that disabling authentication checks for OPTIONS requests will allow unauthenticated users to determine what Druid endpoints are valid (by checking if the OPTIONS request returns a 200 instead of 404), so the authentication checks should not be disabled unless necessary. |false|no|
 
 ## Enabling Authentication/Authorization
 

--- a/integration-tests/src/test/java/io/druid/tests/security/ITBasicAuthConfigurationTest.java
+++ b/integration-tests/src/test/java/io/druid/tests/security/ITBasicAuthConfigurationTest.java
@@ -224,6 +224,18 @@ public class ITBasicAuthConfigurationTest
     
     LOG.info("Testing Avatica query on router with incorrect credentials.");
     testAvaticaAuthFailure(routerUrl);
+
+    LOG.info("Checking OPTIONS requests on services...");
+    testOptionsRequests(adminClient);
+  }
+
+  private void testOptionsRequests(HttpClient httpClient)
+  {
+    makeRequest(httpClient, HttpMethod.OPTIONS, config.getCoordinatorUrl() + "/status", null);
+    makeRequest(httpClient, HttpMethod.OPTIONS, config.getIndexerUrl() + "/status", null);
+    makeRequest(httpClient, HttpMethod.OPTIONS, config.getBrokerUrl() + "/status", null);
+    makeRequest(httpClient, HttpMethod.OPTIONS, config.getHistoricalUrl() + "/status", null);
+    makeRequest(httpClient, HttpMethod.OPTIONS, config.getRouterUrl() + "/status", null);
   }
 
   private void checkUnsecuredCoordinatorLoadQueuePath(HttpClient client)

--- a/server/src/main/java/io/druid/server/security/AllowOptionsResourceFilter.java
+++ b/server/src/main/java/io/druid/server/security/AllowOptionsResourceFilter.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.security;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.HttpMethod;
+import java.io.IOException;
+
+public class AllowOptionsResourceFilter implements Filter
+{
+  private final boolean allowUnauthenticatedHttpOptions;
+
+  public AllowOptionsResourceFilter(
+      boolean allowUnauthenticatedHttpOptions
+  )
+  {
+    this.allowUnauthenticatedHttpOptions = allowUnauthenticatedHttpOptions;
+  }
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException
+  {
+
+  }
+
+  @Override
+  public void doFilter(
+      ServletRequest request, ServletResponse response, FilterChain chain
+  ) throws IOException, ServletException
+  {
+    HttpServletRequest httpReq = (HttpServletRequest) request;
+
+    // Druid itself doesn't explictly handle OPTIONS requests, no resource handler will authorize such requests.
+    // so this filter catches all OPTIONS requests and authorizes them.
+    if (HttpMethod.OPTIONS.equals(httpReq.getMethod())) {
+      if (allowUnauthenticatedHttpOptions) {
+        httpReq.setAttribute(
+            AuthConfig.DRUID_AUTHENTICATION_RESULT,
+            new AuthenticationResult(AuthConfig.ALLOW_ALL_NAME, AuthConfig.ALLOW_ALL_NAME, null)
+        );
+      }
+
+      httpReq.setAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED, true);
+    }
+
+    chain.doFilter(request, response);
+  }
+
+  @Override
+  public void destroy()
+  {
+
+  }
+}

--- a/server/src/main/java/io/druid/server/security/AllowOptionsResourceFilter.java
+++ b/server/src/main/java/io/druid/server/security/AllowOptionsResourceFilter.java
@@ -57,17 +57,17 @@ public class AllowOptionsResourceFilter implements Filter
     // Druid itself doesn't explictly handle OPTIONS requests, no resource handler will authorize such requests.
     // so this filter catches all OPTIONS requests and authorizes them.
     if (HttpMethod.OPTIONS.equals(httpReq.getMethod())) {
-      if (allowUnauthenticatedHttpOptions) {
+      if (httpReq.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT) == null) {
         // If the request already had credentials and authenticated successfully, keep the authenticated identity.
         // Otherwise, allow the unauthenticated request.
-        if (httpReq.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT) == null) {
+        if (allowUnauthenticatedHttpOptions) {
           httpReq.setAttribute(
               AuthConfig.DRUID_AUTHENTICATION_RESULT,
               new AuthenticationResult(AuthConfig.ALLOW_ALL_NAME, AuthConfig.ALLOW_ALL_NAME, null)
           );
+        } else {
+          ((HttpServletResponse) response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
         }
-      } else {
-        ((HttpServletResponse) response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
       }
 
       httpReq.setAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED, true);

--- a/server/src/main/java/io/druid/server/security/AuthConfig.java
+++ b/server/src/main/java/io/druid/server/security/AuthConfig.java
@@ -44,7 +44,7 @@ public class AuthConfig
 
   public AuthConfig()
   {
-    this(null, null, null, null);
+    this(null, null, null, false);
   }
 
   @JsonCreator
@@ -52,15 +52,13 @@ public class AuthConfig
       @JsonProperty("authenticatorChain") List<String> authenticationChain,
       @JsonProperty("authorizers") List<String> authorizers,
       @JsonProperty("unsecuredPaths") List<String> unsecuredPaths,
-      @JsonProperty("allowUnauthenticatedHttpOptions") Boolean allowUnauthenticatedHttpOptions
+      @JsonProperty("allowUnauthenticatedHttpOptions") boolean allowUnauthenticatedHttpOptions
   )
   {
     this.authenticatorChain = authenticationChain;
     this.authorizers = authorizers;
     this.unsecuredPaths = unsecuredPaths == null ? Collections.emptyList() : unsecuredPaths;
-    this.allowUnauthenticatedHttpOptions = allowUnauthenticatedHttpOptions == null
-                                            ? false
-                                            : allowUnauthenticatedHttpOptions;
+    this.allowUnauthenticatedHttpOptions = allowUnauthenticatedHttpOptions;
   }
 
   @JsonProperty

--- a/server/src/main/java/io/druid/server/security/AuthConfig.java
+++ b/server/src/main/java/io/druid/server/security/AuthConfig.java
@@ -44,19 +44,23 @@ public class AuthConfig
 
   public AuthConfig()
   {
-    this(null, null, null);
+    this(null, null, null, null);
   }
 
   @JsonCreator
   public AuthConfig(
       @JsonProperty("authenticatorChain") List<String> authenticationChain,
       @JsonProperty("authorizers") List<String> authorizers,
-      @JsonProperty("unsecuredPaths") List<String> unsecuredPaths
+      @JsonProperty("unsecuredPaths") List<String> unsecuredPaths,
+      @JsonProperty("allowUnauthenticatedHttpOptions") Boolean allowUnauthenticatedHttpOptions
   )
   {
     this.authenticatorChain = authenticationChain;
     this.authorizers = authorizers;
     this.unsecuredPaths = unsecuredPaths == null ? Collections.emptyList() : unsecuredPaths;
+    this.allowUnauthenticatedHttpOptions = allowUnauthenticatedHttpOptions == null
+                                            ? false
+                                            : allowUnauthenticatedHttpOptions;
   }
 
   @JsonProperty
@@ -67,6 +71,9 @@ public class AuthConfig
 
   @JsonProperty
   private final List<String> unsecuredPaths;
+
+  @JsonProperty
+  private final boolean allowUnauthenticatedHttpOptions;
 
   public List<String> getAuthenticatorChain()
   {
@@ -83,14 +90,9 @@ public class AuthConfig
     return unsecuredPaths;
   }
 
-  @Override
-  public String toString()
+  public boolean isAllowUnauthenticatedHttpOptions()
   {
-    return "AuthConfig{" +
-           "authenticatorChain='" + authenticatorChain + '\'' +
-           ", authorizers='" + authorizers + '\'' +
-           ", unsecuredPaths='" + unsecuredPaths + '\'' +
-           '}';
+    return allowUnauthenticatedHttpOptions;
   }
 
   @Override
@@ -103,14 +105,31 @@ public class AuthConfig
       return false;
     }
     AuthConfig that = (AuthConfig) o;
-    return Objects.equals(authenticatorChain, that.authenticatorChain) &&
-           Objects.equals(authorizers, that.authorizers) &&
-           Objects.equals(unsecuredPaths, that.unsecuredPaths);
+    return isAllowUnauthenticatedHttpOptions() == that.isAllowUnauthenticatedHttpOptions() &&
+           Objects.equals(getAuthenticatorChain(), that.getAuthenticatorChain()) &&
+           Objects.equals(getAuthorizers(), that.getAuthorizers()) &&
+           Objects.equals(getUnsecuredPaths(), that.getUnsecuredPaths());
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(authenticatorChain, authorizers, unsecuredPaths);
+    return Objects.hash(
+        getAuthenticatorChain(),
+        getAuthorizers(),
+        getUnsecuredPaths(),
+        isAllowUnauthenticatedHttpOptions()
+    );
+  }
+
+  @Override
+  public String toString()
+  {
+    return "AuthConfig{" +
+           "authenticatorChain=" + authenticatorChain +
+           ", authorizers=" + authorizers +
+           ", unsecuredPaths=" + unsecuredPaths +
+           ", allowUnauthenticatedHttpOptions=" + allowUnauthenticatedHttpOptions +
+           '}';
   }
 }

--- a/server/src/main/java/io/druid/server/security/AuthenticationUtils.java
+++ b/server/src/main/java/io/druid/server/security/AuthenticationUtils.java
@@ -27,6 +27,16 @@ import java.util.List;
 
 public class AuthenticationUtils
 {
+  public static void addAllowOptionsFilter(ServletContextHandler root, boolean allowUnauthenticatedHttpOptions)
+  {
+    FilterHolder holder = new FilterHolder(new AllowOptionsResourceFilter(allowUnauthenticatedHttpOptions));
+    root.addFilter(
+        holder,
+        "/*",
+        null
+    );
+  }
+
   public static void addAuthenticationFilterChain(
       ServletContextHandler root,
       List<Authenticator> authenticators

--- a/services/src/main/java/io/druid/cli/CliOverlord.java
+++ b/services/src/main/java/io/druid/cli/CliOverlord.java
@@ -344,10 +344,10 @@ public class CliOverlord extends ServerRunnable
       AuthenticationUtils.addNoopAuthorizationFilters(root, UNSECURED_PATHS);
       AuthenticationUtils.addNoopAuthorizationFilters(root, authConfig.getUnsecuredPaths());
 
-      AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isAllowUnauthenticatedHttpOptions());
-
       authenticators = authenticatorMapper.getAuthenticatorChain();
       AuthenticationUtils.addAuthenticationFilterChain(root, authenticators);
+
+      AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isAllowUnauthenticatedHttpOptions());
 
       JettyServerInitUtils.addExtensionFilters(root, injector);
 

--- a/services/src/main/java/io/druid/cli/CliOverlord.java
+++ b/services/src/main/java/io/druid/cli/CliOverlord.java
@@ -344,6 +344,8 @@ public class CliOverlord extends ServerRunnable
       AuthenticationUtils.addNoopAuthorizationFilters(root, UNSECURED_PATHS);
       AuthenticationUtils.addNoopAuthorizationFilters(root, authConfig.getUnsecuredPaths());
 
+      AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isAllowUnauthenticatedHttpOptions());
+
       authenticators = authenticatorMapper.getAuthenticatorChain();
       AuthenticationUtils.addAuthenticationFilterChain(root, authenticators);
 

--- a/services/src/main/java/io/druid/cli/CoordinatorJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/CoordinatorJettyServerInitializer.java
@@ -125,11 +125,12 @@ class CoordinatorJettyServerInitializer implements JettyServerInitializer
       AuthenticationUtils.addNoopAuthorizationFilters(root, CliOverlord.UNSECURED_PATHS);
     }
 
+    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isAllowUnauthenticatedHttpOptions());
+
     authenticators = authenticatorMapper.getAuthenticatorChain();
     AuthenticationUtils.addAuthenticationFilterChain(root, authenticators);
 
     JettyServerInitUtils.addExtensionFilters(root, injector);
-
 
     // Check that requests were authorized before sending responses
     AuthenticationUtils.addPreResponseAuthorizationCheckFilter(

--- a/services/src/main/java/io/druid/cli/CoordinatorJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/CoordinatorJettyServerInitializer.java
@@ -125,10 +125,10 @@ class CoordinatorJettyServerInitializer implements JettyServerInitializer
       AuthenticationUtils.addNoopAuthorizationFilters(root, CliOverlord.UNSECURED_PATHS);
     }
 
-    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isAllowUnauthenticatedHttpOptions());
-
     authenticators = authenticatorMapper.getAuthenticatorChain();
     AuthenticationUtils.addAuthenticationFilterChain(root, authenticators);
+
+    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isAllowUnauthenticatedHttpOptions());
 
     JettyServerInitUtils.addExtensionFilters(root, injector);
 

--- a/services/src/main/java/io/druid/cli/MiddleManagerJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/MiddleManagerJettyServerInitializer.java
@@ -78,9 +78,10 @@ class MiddleManagerJettyServerInitializer implements JettyServerInitializer
     AuthenticationUtils.addNoopAuthorizationFilters(root, UNSECURED_PATHS);
     AuthenticationUtils.addNoopAuthorizationFilters(root, authConfig.getUnsecuredPaths());
 
+    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isAllowUnauthenticatedHttpOptions());
+
     authenticators = authenticatorMapper.getAuthenticatorChain();
     AuthenticationUtils.addAuthenticationFilterChain(root, authenticators);
-
 
     JettyServerInitUtils.addExtensionFilters(root, injector);
 

--- a/services/src/main/java/io/druid/cli/MiddleManagerJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/MiddleManagerJettyServerInitializer.java
@@ -78,10 +78,10 @@ class MiddleManagerJettyServerInitializer implements JettyServerInitializer
     AuthenticationUtils.addNoopAuthorizationFilters(root, UNSECURED_PATHS);
     AuthenticationUtils.addNoopAuthorizationFilters(root, authConfig.getUnsecuredPaths());
 
-    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isAllowUnauthenticatedHttpOptions());
-
     authenticators = authenticatorMapper.getAuthenticatorChain();
     AuthenticationUtils.addAuthenticationFilterChain(root, authenticators);
+
+    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isAllowUnauthenticatedHttpOptions());
 
     JettyServerInitUtils.addExtensionFilters(root, injector);
 

--- a/services/src/main/java/io/druid/cli/QueryJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/QueryJettyServerInitializer.java
@@ -102,6 +102,8 @@ public class QueryJettyServerInitializer implements JettyServerInitializer
     AuthenticationUtils.addNoopAuthorizationFilters(root, UNSECURED_PATHS);
     AuthenticationUtils.addNoopAuthorizationFilters(root, authConfig.getUnsecuredPaths());
 
+    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isAllowUnauthenticatedHttpOptions());
+
     authenticators = authenticatorMapper.getAuthenticatorChain();
     AuthenticationUtils.addAuthenticationFilterChain(root, authenticators);
 

--- a/services/src/main/java/io/druid/cli/QueryJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/QueryJettyServerInitializer.java
@@ -102,10 +102,10 @@ public class QueryJettyServerInitializer implements JettyServerInitializer
     AuthenticationUtils.addNoopAuthorizationFilters(root, UNSECURED_PATHS);
     AuthenticationUtils.addNoopAuthorizationFilters(root, authConfig.getUnsecuredPaths());
 
-    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isAllowUnauthenticatedHttpOptions());
-
     authenticators = authenticatorMapper.getAuthenticatorChain();
     AuthenticationUtils.addAuthenticationFilterChain(root, authenticators);
+
+    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isAllowUnauthenticatedHttpOptions());
 
     JettyServerInitUtils.addExtensionFilters(root, injector);
 

--- a/services/src/main/java/io/druid/cli/RouterJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/RouterJettyServerInitializer.java
@@ -111,10 +111,10 @@ public class RouterJettyServerInitializer implements JettyServerInitializer
     AuthenticationUtils.addNoopAuthorizationFilters(root, UNSECURED_PATHS);
     AuthenticationUtils.addNoopAuthorizationFilters(root, authConfig.getUnsecuredPaths());
 
-    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isAllowUnauthenticatedHttpOptions());
-
     final List<Authenticator> authenticators = authenticatorMapper.getAuthenticatorChain();
     AuthenticationUtils.addAuthenticationFilterChain(root, authenticators);
+
+    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isAllowUnauthenticatedHttpOptions());
 
     JettyServerInitUtils.addExtensionFilters(root, injector);
 

--- a/services/src/main/java/io/druid/cli/RouterJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/RouterJettyServerInitializer.java
@@ -111,6 +111,8 @@ public class RouterJettyServerInitializer implements JettyServerInitializer
     AuthenticationUtils.addNoopAuthorizationFilters(root, UNSECURED_PATHS);
     AuthenticationUtils.addNoopAuthorizationFilters(root, authConfig.getUnsecuredPaths());
 
+    AuthenticationUtils.addAllowOptionsFilter(root, authConfig.isAllowUnauthenticatedHttpOptions());
+
     final List<Authenticator> authenticators = authenticatorMapper.getAuthenticatorChain();
     AuthenticationUtils.addAuthenticationFilterChain(root, authenticators);
 


### PR DESCRIPTION
Fixes #5588 

This PR sets the AUTHORIZATION_CHECKED flag to true for all HTTP OPTIONS requests. This is handled in a new servlet filter (Druid has no explicit OPTIONS method handlers on its endpoints).

It seems that CORS pre-flight OPTIONS requests do not generally contain credentials headers:
- https://stackoverflow.com/questions/15734031/why-does-the-preflight-options-request-of-an-authenticated-cors-request-work-in  
- https://fetch.spec.whatwg.org/#cors-preflight-request
- https://bugzilla.mozilla.org/show_bug.cgi?id=778548

So a `disableHttpOptionsAuthentication` config is added to disable authentication checks on OPTIONS requests (authentication is required by default) to support CORS use cases.