### PR TITLE
Timeseries: Add "grandTotal" option.

### DIFF
--- a/docs/content/querying/timeseriesquery.md
+++ b/docs/content/querying/timeseriesquery.md
@@ -56,7 +56,7 @@ There are 7 main parts to a timeseries query:
 |filter|See [Filters](../querying/filters.html)|no|
 |aggregations|See [Aggregations](../querying/aggregations.html)|no|
 |postAggregations|See [Post Aggregations](../querying/post-aggregations.html)|no|
-|context|See [Context](../querying/query-context.html)|no|
+|context|Can be used to modify query behavior, including [grand totals](#grand-totals) and [zero-filling](#zero-filling). See also [Context](../querying/query-context.html) for parameters that apply to all query types.|no|
 
 To pull it all together, the above query would return 2 data points, one for each day between 2012-01-01 and 2012-01-03, from the "sample\_datasource" table. Each data point would be the (long) sum of sample\_fieldName1, the (double) sum of sample\_fieldName2 and the (double) result of sample\_fieldName1 divided by sample\_fieldName2 for the filter set. The output looks like this:
 
@@ -72,6 +72,31 @@ To pull it all together, the above query would return 2 data points, one for eac
   }
 ]
 ```
+
+#### Grand totals
+
+Druid can include an extra "grand totals" row as the last row of a timeseries result set. To enable this, add
+`"grandTotal" : true` to your query context. For example:
+
+```json
+{
+  "queryType": "timeseries",
+  "dataSource": "sample_datasource",
+  "intervals": [ "2012-01-01T00:00:00.000/2012-01-03T00:00:00.000" ],
+  "granularity": "day",
+  "aggregations": [
+    { "type": "longSum", "name": "sample_name1", "fieldName": "sample_fieldName1" },
+    { "type": "doubleSum", "name": "sample_name2", "fieldName": "sample_fieldName2" }
+  ],
+  "context": {
+    "grandTotal": true
+  }
+}
+```
+
+The grand totals row will appear as the last row in the result array, and will have no timestamp. It will be the last
+row even if the query is run in "descending" mode. Post-aggregations in the grand totals row will be computed based
+upon the grand total aggregations.
 
 #### Zero-filling
 

--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesQuery.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesQuery.java
@@ -45,6 +45,8 @@ import java.util.Objects;
 @JsonTypeName("timeseries")
 public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
 {
+  static final String CTX_GRAND_TOTAL = "grandTotal";
+
   private final VirtualColumns virtualColumns;
   private final DimFilter dimFilter;
   private final List<AggregatorFactory> aggregatorSpecs;
@@ -117,6 +119,11 @@ public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
     return postAggregatorSpecs;
   }
 
+  public boolean isGrandTotal()
+  {
+    return getContextBoolean(CTX_GRAND_TOTAL, false);
+  }
+
   public boolean isSkipEmptyBuckets()
   {
     return getContextBoolean("skipEmptyBuckets", false);
@@ -155,16 +162,16 @@ public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
   public String toString()
   {
     return "TimeseriesQuery{" +
-        "dataSource='" + getDataSource() + '\'' +
-        ", querySegmentSpec=" + getQuerySegmentSpec() +
-        ", descending=" + isDescending() +
-        ", virtualColumns=" + virtualColumns +
-        ", dimFilter=" + dimFilter +
-        ", granularity='" + getGranularity() + '\'' +
-        ", aggregatorSpecs=" + aggregatorSpecs +
-        ", postAggregatorSpecs=" + postAggregatorSpecs +
-        ", context=" + getContext() +
-        '}';
+           "dataSource='" + getDataSource() + '\'' +
+           ", querySegmentSpec=" + getQuerySegmentSpec() +
+           ", descending=" + isDescending() +
+           ", virtualColumns=" + virtualColumns +
+           ", dimFilter=" + dimFilter +
+           ", granularity='" + getGranularity() + '\'' +
+           ", aggregatorSpecs=" + aggregatorSpecs +
+           ", postAggregatorSpecs=" + postAggregatorSpecs +
+           ", context=" + getContext() +
+           '}';
   }
 
   @Override
@@ -181,9 +188,9 @@ public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
     }
     final TimeseriesQuery that = (TimeseriesQuery) o;
     return Objects.equals(virtualColumns, that.virtualColumns) &&
-        Objects.equals(dimFilter, that.dimFilter) &&
-        Objects.equals(aggregatorSpecs, that.aggregatorSpecs) &&
-        Objects.equals(postAggregatorSpecs, that.postAggregatorSpecs);
+           Objects.equals(dimFilter, that.dimFilter) &&
+           Objects.equals(aggregatorSpecs, that.aggregatorSpecs) &&
+           Objects.equals(postAggregatorSpecs, that.postAggregatorSpecs);
   }
 
   @Override

--- a/processing/src/test/java/io/druid/segment/TestHelper.java
+++ b/processing/src/test/java/io/druid/segment/TestHelper.java
@@ -302,8 +302,8 @@ public class TestHelper
     // always generate exactly the same results (different merge ordering / float vs double)
     Assert.assertEquals(
         StringUtils.format("%s: timestamp", msg),
-        expected.getTimestamp().getMillis(),
-        actual.getTimestamp().getMillis()
+        expected.getTimestamp(),
+        actual.getTimestamp()
     );
 
     final Map<String, Object> expectedMap = ((MapBasedRow) expected).getEvent();


### PR DESCRIPTION
Adds a grandTotal option to timeseries queries. It saves the need for two queries when a UI wants to draw a timeseries but also wants to show the grand total, and also reduces cluster load (since the grand total is cheap to compute when piggybacked on the main query).

I'm not sure if the way I did this is best -- check out `mergeResults` in the tool chest. I'm open to other suggestions.

Similar to #5280, but it's for timeseries.