### PR TITLE
Add unsecuredPaths variable

### DIFF
--- a/docs/content/configuration/broker.md
+++ b/docs/content/configuration/broker.md
@@ -49,7 +49,7 @@ Druid uses Jetty to serve HTTP requests.
 |`druid.broker.http.unusedConnectionTimeout`|The timeout for idle connections in connection pool. This timeout should be less than `druid.broker.http.readTimeout`. Set this timeout = ~90% of `druid.broker.http.readTimeout`|`PT4M`|
 |`druid.server.http.maxQueryTimeout`|Maximum allowed value (in milliseconds) for `timeout` parameter. See [query-context](../querying/query-context.html) to know more about `timeout`. Query is rejected if the query context `timeout` is greater than this value. |Long.MAX_VALUE|
 |`druid.server.http.maxRequestHeaderSize`|Maximum size of a request header in bytes. Larger headers consume more memory and can make a server more vulnerable to denial of service attacks. |8 * 1024|
-
+|`druid.server.http.unsecuredPaths`|List of paths to which authorization checks will not be applied. |["/*"]|
 
 #### Retry Policy
 

--- a/docs/content/configuration/historical.md
+++ b/docs/content/configuration/historical.md
@@ -58,6 +58,7 @@ Druid uses Jetty to serve HTTP requests.
 |`druid.server.http.unannouncePropogationDelay`|How long to wait for zookeeper unannouncements to propgate before shutting down Jetty. This is a minimum and `druid.server.http.gracefulShutdownTimeout` does not start counting down until after this period elapses.|`PT0s` (do not wait)|
 |`druid.server.http.maxQueryTimeout`|Maximum allowed value (in milliseconds) for `timeout` parameter. See [query-context](query-context.html) to know more about `timeout`. Query is rejected if the query context `timeout` is greater than this value. |Long.MAX_VALUE|
 |`druid.server.http.maxRequestHeaderSize`|Maximum size of a request header in bytes. Larger headers consume more memory and can make a server more vulnerable to denial of service attacks.|8 * 1024|
+|`druid.server.http.unsecuredPaths`|List of paths to which authorization checks will not be applied. |["/*"]|
 
 #### Processing
 

--- a/server/src/main/java/io/druid/server/initialization/ServerConfig.java
+++ b/server/src/main/java/io/druid/server/initialization/ServerConfig.java
@@ -20,10 +20,13 @@
 package io.druid.server.initialization;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import org.joda.time.Period;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -67,6 +70,10 @@ public class ServerConfig
   @JsonProperty
   @NotNull
   private Period unannouncePropogationDelay = Period.ZERO;
+
+  @JsonProperty
+  @NotNull
+  private List<String> unsecuredPaths = ImmutableList.of("/*");
 
   public int getNumThreads()
   {
@@ -118,6 +125,11 @@ public class ServerConfig
     return unannouncePropogationDelay;
   }
 
+  public List<String> getUnsecuredPaths()
+  {
+    return unsecuredPaths;
+  }
+
   @Override
   public boolean equals(Object o)
   {
@@ -129,15 +141,16 @@ public class ServerConfig
     }
     ServerConfig that = (ServerConfig) o;
     return numThreads == that.numThreads &&
-           queueSize == that.queueSize &&
-           enableRequestLimit == that.enableRequestLimit &&
-           defaultQueryTimeout == that.defaultQueryTimeout &&
-           maxScatterGatherBytes == that.maxScatterGatherBytes &&
-           maxQueryTimeout == that.maxQueryTimeout &&
-           maxRequestHeaderSize == that.maxRequestHeaderSize &&
-           Objects.equals(maxIdleTime, that.maxIdleTime) &&
-           Objects.equals(gracefulShutdownTimeout, that.gracefulShutdownTimeout) &&
-           Objects.equals(unannouncePropogationDelay, that.unannouncePropogationDelay);
+        queueSize == that.queueSize &&
+        enableRequestLimit == that.enableRequestLimit &&
+        defaultQueryTimeout == that.defaultQueryTimeout &&
+        maxScatterGatherBytes == that.maxScatterGatherBytes &&
+        maxQueryTimeout == that.maxQueryTimeout &&
+        maxRequestHeaderSize == that.maxRequestHeaderSize &&
+        Objects.equals(maxIdleTime, that.maxIdleTime) &&
+        Objects.equals(gracefulShutdownTimeout, that.gracefulShutdownTimeout) &&
+        Objects.equals(unannouncePropogationDelay, that.unannouncePropogationDelay) &&
+        Objects.equals(unsecuredPaths, that.unsecuredPaths);
   }
 
   @Override
@@ -154,7 +167,8 @@ public class ServerConfig
         maxQueryTimeout,
         maxRequestHeaderSize,
         gracefulShutdownTimeout,
-        unannouncePropogationDelay
+        unannouncePropogationDelay,
+        unsecuredPaths
     );
   }
 
@@ -162,16 +176,17 @@ public class ServerConfig
   public String toString()
   {
     return "ServerConfig{" +
-           "numThreads=" + numThreads +
-           ", queueSize=" + queueSize +
-           ", enableRequestLimit=" + enableRequestLimit +
-           ", maxIdleTime=" + maxIdleTime +
-           ", defaultQueryTimeout=" + defaultQueryTimeout +
-           ", maxScatterGatherBytes=" + maxScatterGatherBytes +
-           ", maxQueryTimeout=" + maxQueryTimeout +
-           ", maxRequestHeaderSize=" + maxRequestHeaderSize +
-           ", gracefulShutdownTimeout=" + gracefulShutdownTimeout +
-           ", unannouncePropogationDelay=" + unannouncePropogationDelay +
-           '}';
+        "numThreads=" + numThreads +
+        ", queueSize=" + queueSize +
+        ", enableRequestLimit=" + enableRequestLimit +
+        ", maxIdleTime=" + maxIdleTime +
+        ", defaultQueryTimeout=" + defaultQueryTimeout +
+        ", maxScatterGatherBytes=" + maxScatterGatherBytes +
+        ", maxQueryTimeout=" + maxQueryTimeout +
+        ", maxRequestHeaderSize=" + maxRequestHeaderSize +
+        ", gracefulShutdownTimeout=" + gracefulShutdownTimeout +
+        ", unannouncePropogationDelay=" + unannouncePropogationDelay +
+        ", unsecuredPaths=" + unsecuredPaths +
+        '}';
   }
 }

--- a/services/src/main/java/io/druid/cli/QueryJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/QueryJettyServerInitializer.java
@@ -98,6 +98,8 @@ public class QueryJettyServerInitializer implements JettyServerInitializer
     List<Authenticator> authenticators = null;
     AuthenticationUtils.addSecuritySanityCheckFilter(root, jsonMapper);
 
+    UNSECURED_PATHS.addAll(serverConfig.getUnsecuredPaths());
+
     // perform no-op authorization for these resources
     AuthenticationUtils.addNoopAuthorizationFilters(root, UNSECURED_PATHS);
     AuthenticationUtils.addNoopAuthorizationFilters(root, authConfig.getUnsecuredPaths());


### PR DESCRIPTION
@gianm We have a custom broker resource which handles certain queries. After upgrading Druid broker to 0.11.0 , queries are failing because they aren't added to UnSecuredPaths List