### PR TITLE
Timeseries results are incoherent for case interval is out of range and case false filter.

### DIFF
--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesQuery.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesQuery.java
@@ -46,6 +46,7 @@ import java.util.Objects;
 public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
 {
   static final String CTX_GRAND_TOTAL = "grandTotal";
+  public static final String SKIP_EMPTY_BUCKETS = "skipEmptyBuckets";
 
   private final VirtualColumns virtualColumns;
   private final DimFilter dimFilter;
@@ -126,7 +127,7 @@ public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
 
   public boolean isSkipEmptyBuckets()
   {
-    return getContextBoolean("skipEmptyBuckets", false);
+    return getContextBoolean(SKIP_EMPTY_BUCKETS, false);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
@@ -28,6 +28,9 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.inject.Inject;
+import io.druid.data.input.MapBasedRow;
+import io.druid.java.util.common.DateTimes;
+import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.granularity.Granularity;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.guava.Sequences;
@@ -41,10 +44,12 @@ import io.druid.query.QueryToolChest;
 import io.druid.query.Result;
 import io.druid.query.ResultGranularTimestampComparator;
 import io.druid.query.ResultMergeQueryRunner;
+import io.druid.query.aggregation.Aggregator;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.MetricManipulationFn;
 import io.druid.query.aggregation.PostAggregator;
 import io.druid.query.cache.CacheKeyBuilder;
+import io.druid.query.groupby.RowBasedColumnSelectorFactory;
 import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
@@ -131,70 +136,93 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
       }
     };
 
-    return new QueryRunner<Result<TimeseriesResultValue>>()
-    {
-      @Override
-      public Sequence<Result<TimeseriesResultValue>> run(
-          final QueryPlus<Result<TimeseriesResultValue>> queryPlus,
-          final Map<String, Object> responseContext
-      )
-      {
-        final TimeseriesQuery query = (TimeseriesQuery) queryPlus.getQuery();
-        final Sequence<Result<TimeseriesResultValue>> baseResults = resultMergeQueryRunner.run(
-            queryPlus.withQuery(
-                queryPlus.getQuery()
-                         .withOverriddenContext(
-                             ImmutableMap.of(TimeseriesQuery.CTX_GRAND_TOTAL, false)
-                         )
-            ),
-            responseContext
+    return (queryPlus, responseContext) -> {
+      final TimeseriesQuery query = (TimeseriesQuery) queryPlus.getQuery();
+      final Sequence<Result<TimeseriesResultValue>> baseResults = resultMergeQueryRunner.run(
+          queryPlus.withQuery(
+              queryPlus.getQuery()
+                       .withOverriddenContext(
+                           ImmutableMap.of(TimeseriesQuery.CTX_GRAND_TOTAL, false)
+                       )
+          ),
+          responseContext
+      );
+
+      final Sequence<Result<TimeseriesResultValue>> finalSequence;
+
+      if (query.getGranularity().equals(Granularities.ALL) && !query.isSkipEmptyBuckets() && baseResults.toList()
+                                                                                                         .isEmpty()) {
+        Result<TimeseriesResultValue> retVal = getNullTimeseriesResultValue(query);
+        finalSequence = Sequences.simple(Collections.singletonList(retVal));
+      } else {
+        finalSequence = baseResults;
+      }
+
+      if (query.isGrandTotal()) {
+        // Accumulate grand totals while iterating the sequence.
+        final Object[] grandTotals = new Object[query.getAggregatorSpecs().size()];
+        final Sequence<Result<TimeseriesResultValue>> mappedSequence = Sequences.map(
+            finalSequence,
+            resultValue -> {
+              for (int i = 0; i < query.getAggregatorSpecs().size(); i++) {
+                final AggregatorFactory aggregatorFactory = query.getAggregatorSpecs().get(i);
+                final Object value = resultValue.getValue().getMetric(aggregatorFactory.getName());
+                if (grandTotals[i] == null) {
+                  grandTotals[i] = value;
+                } else {
+                  grandTotals[i] = aggregatorFactory.combine(grandTotals[i], value);
+                }
+              }
+              return resultValue;
+            }
         );
 
-        if (query.isGrandTotal()) {
-          // Accumulate grand totals while iterating the sequence.
-          final Object[] grandTotals = new Object[query.getAggregatorSpecs().size()];
-          final Sequence<Result<TimeseriesResultValue>> mappedSequence = Sequences.map(
-              baseResults,
-              resultValue -> {
-                for (int i = 0; i < query.getAggregatorSpecs().size(); i++) {
-                  final AggregatorFactory aggregatorFactory = query.getAggregatorSpecs().get(i);
-                  final Object value = resultValue.getValue().getMetric(aggregatorFactory.getName());
-                  if (grandTotals[i] == null) {
-                    grandTotals[i] = value;
-                  } else {
-                    grandTotals[i] = aggregatorFactory.combine(grandTotals[i], value);
-                  }
-                }
-                return resultValue;
-              }
-          );
+        return Sequences.concat(
+            ImmutableList.of(
+                mappedSequence,
+                Sequences.simple(
+                    () -> {
+                      final Map<String, Object> totalsMap = new HashMap<>();
 
-          return Sequences.concat(
-              ImmutableList.of(
-                  mappedSequence,
-                  Sequences.simple(
-                      () -> {
-                        final Map<String, Object> totalsMap = new HashMap<>();
-
-                        for (int i = 0; i < query.getAggregatorSpecs().size(); i++) {
-                          totalsMap.put(query.getAggregatorSpecs().get(i).getName(), grandTotals[i]);
-                        }
-
-                        final Result<TimeseriesResultValue> result = new Result<>(
-                            null,
-                            new TimeseriesResultValue(totalsMap)
-                        );
-
-                        return Collections.singletonList(result).iterator();
+                      for (int i = 0; i < query.getAggregatorSpecs().size(); i++) {
+                        totalsMap.put(query.getAggregatorSpecs().get(i).getName(), grandTotals[i]);
                       }
-                  )
-              )
-          );
-        } else {
-          return baseResults;
-        }
+
+                      final Result<TimeseriesResultValue> result = new Result<>(
+                          null,
+                          new TimeseriesResultValue(totalsMap)
+                      );
+
+                      return Collections.singletonList(result).iterator();
+                    }
+                )
+            )
+        );
+      } else {
+        return finalSequence;
       }
     };
+  }
+
+  private Result<TimeseriesResultValue> getNullTimeseriesResultValue(TimeseriesQuery query)
+  {
+    List<AggregatorFactory> aggregatorSpecs = query.getAggregatorSpecs();
+    Aggregator[] aggregators = new Aggregator[aggregatorSpecs.size()];
+    String[] aggregatorNames = new String[aggregatorSpecs.size()];
+    for (int i = 0; i < aggregatorSpecs.size(); i++) {
+      aggregators[i] = aggregatorSpecs.get(i)
+                                      .factorize(RowBasedColumnSelectorFactory.create(() -> new MapBasedRow(
+                                          null,
+                                          null
+                                      ), null));
+      aggregatorNames[i] = aggregatorSpecs.get(i).getName();
+    }
+    TimeseriesResultBuilder bob = new TimeseriesResultBuilder(DateTimes.EPOCH);
+    for (int i = 0; i < aggregatorSpecs.size(); i++) {
+      bob.addMetric(aggregatorNames[i], aggregators[i]);
+      aggregators[i].close();
+    }
+    return bob.build();
   }
 
   @Override
@@ -246,25 +274,20 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
       @Override
       public Function<Result<TimeseriesResultValue>, Object> prepareForCache(boolean isResultLevelCache)
       {
-        return new Function<Result<TimeseriesResultValue>, Object>()
-        {
-          @Override
-          public Object apply(final Result<TimeseriesResultValue> input)
-          {
-            TimeseriesResultValue results = input.getValue();
-            final List<Object> retVal = Lists.newArrayListWithCapacity(1 + aggs.size());
+        return input -> {
+          TimeseriesResultValue results = input.getValue();
+          final List<Object> retVal = Lists.newArrayListWithCapacity(1 + aggs.size());
 
-            retVal.add(input.getTimestamp().getMillis());
-            for (AggregatorFactory agg : aggs) {
-              retVal.add(results.getMetric(agg.getName()));
-            }
-            if (isResultLevelCache) {
-              for (PostAggregator postAgg : query.getPostAggregatorSpecs()) {
-                retVal.add(results.getMetric(postAgg.getName()));
-              }
-            }
-            return retVal;
+          retVal.add(input.getTimestamp().getMillis());
+          for (AggregatorFactory agg : aggs) {
+            retVal.add(results.getMetric(agg.getName()));
           }
+          if (isResultLevelCache) {
+            for (PostAggregator postAgg : query.getPostAggregatorSpecs()) {
+              retVal.add(results.getMetric(postAgg.getName()));
+            }
+          }
+          return retVal;
         };
       }
 
@@ -297,7 +320,7 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
               }
             }
 
-            return new Result<TimeseriesResultValue>(
+            return new Result<>(
                 timestamp,
                 new TimeseriesResultValue(retVal)
             );
@@ -311,20 +334,13 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
   public QueryRunner<Result<TimeseriesResultValue>> preMergeQueryDecoration(final QueryRunner<Result<TimeseriesResultValue>> runner)
   {
     return intervalChunkingQueryRunnerDecorator.decorate(
-        new QueryRunner<Result<TimeseriesResultValue>>()
-        {
-          @Override
-          public Sequence<Result<TimeseriesResultValue>> run(
-              QueryPlus<Result<TimeseriesResultValue>> queryPlus, Map<String, Object> responseContext
-          )
-          {
-            TimeseriesQuery timeseriesQuery = (TimeseriesQuery) queryPlus.getQuery();
-            if (timeseriesQuery.getDimensionsFilter() != null) {
-              timeseriesQuery = timeseriesQuery.withDimFilter(timeseriesQuery.getDimensionsFilter().optimize());
-              queryPlus = queryPlus.withQuery(timeseriesQuery);
-            }
-            return runner.run(queryPlus, responseContext);
+        (queryPlus, responseContext) -> {
+          TimeseriesQuery timeseriesQuery = (TimeseriesQuery) queryPlus.getQuery();
+          if (timeseriesQuery.getDimensionsFilter() != null) {
+            timeseriesQuery = timeseriesQuery.withDimFilter(timeseriesQuery.getDimensionsFilter().optimize());
+            queryPlus = queryPlus.withQuery(timeseriesQuery);
           }
+          return runner.run(queryPlus, responseContext);
         }, this);
   }
 
@@ -348,31 +364,26 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
       final TimeseriesQuery query, final MetricManipulationFn fn, final boolean calculatePostAggs
   )
   {
-    return new Function<Result<TimeseriesResultValue>, Result<TimeseriesResultValue>>()
-    {
-      @Override
-      public Result<TimeseriesResultValue> apply(Result<TimeseriesResultValue> result)
-      {
-        final TimeseriesResultValue holder = result.getValue();
-        final Map<String, Object> values = Maps.newHashMap(holder.getBaseObject());
-        if (calculatePostAggs && !query.getPostAggregatorSpecs().isEmpty()) {
-          // put non finalized aggregators for calculating dependent post Aggregators
-          for (AggregatorFactory agg : query.getAggregatorSpecs()) {
-            values.put(agg.getName(), holder.getMetric(agg.getName()));
-          }
-          for (PostAggregator postAgg : query.getPostAggregatorSpecs()) {
-            values.put(postAgg.getName(), postAgg.compute(values));
-          }
-        }
+    return result -> {
+      final TimeseriesResultValue holder = result.getValue();
+      final Map<String, Object> values = Maps.newHashMap(holder.getBaseObject());
+      if (calculatePostAggs && !query.getPostAggregatorSpecs().isEmpty()) {
+        // put non finalized aggregators for calculating dependent post Aggregators
         for (AggregatorFactory agg : query.getAggregatorSpecs()) {
-          values.put(agg.getName(), fn.manipulate(agg, holder.getMetric(agg.getName())));
+          values.put(agg.getName(), holder.getMetric(agg.getName()));
         }
-
-        return new Result<TimeseriesResultValue>(
-            result.getTimestamp(),
-            new TimeseriesResultValue(values)
-        );
+        for (PostAggregator postAgg : query.getPostAggregatorSpecs()) {
+          values.put(postAgg.getName(), postAgg.compute(values));
+        }
       }
+      for (AggregatorFactory agg : query.getAggregatorSpecs()) {
+        values.put(agg.getName(), fn.manipulate(agg, holder.getMetric(agg.getName())));
+      }
+
+      return new Result<>(
+          result.getTimestamp(),
+          new TimeseriesResultValue(values)
+      );
     };
   }
 }

--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
@@ -150,10 +150,10 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
 
       final Sequence<Result<TimeseriesResultValue>> finalSequence;
 
-      if (query.getGranularity().equals(Granularities.ALL) && !query.isSkipEmptyBuckets() && baseResults.toList()
-                                                                                                         .isEmpty()) {
-        Result<TimeseriesResultValue> retVal = getNullTimeseriesResultValue(query);
-        finalSequence = Sequences.simple(Collections.singletonList(retVal));
+      if (query.getGranularity().equals(Granularities.ALL) && !query.isSkipEmptyBuckets()) {
+        //Usally it is NOT Okay to materilize results via toList(), but Granularity is ALL thus we have only one record
+        finalSequence = baseResults.toList().isEmpty() ? Sequences.simple(Collections.singletonList(
+            getNullTimeseriesResultValue(query))) : baseResults;
       } else {
         finalSequence = baseResults;
       }

--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
@@ -151,7 +151,7 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
       final Sequence<Result<TimeseriesResultValue>> finalSequence;
 
       if (query.getGranularity().equals(Granularities.ALL) && !query.isSkipEmptyBuckets()) {
-        //Usally it is NOT Okay to materilize results via toList(), but Granularity is ALL thus we have only one record
+        //Usally it is NOT Okay to materialize results via toList(), but Granularity is ALL thus we have only one record
         finalSequence = baseResults.toList().isEmpty() ? Sequences.simple(Collections.singletonList(
             getNullTimeseriesResultValue(query))) : baseResults;
       } else {

--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
@@ -152,8 +152,9 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
 
       if (query.getGranularity().equals(Granularities.ALL) && !query.isSkipEmptyBuckets()) {
         //Usally it is NOT Okay to materialize results via toList(), but Granularity is ALL thus we have only one record
-        finalSequence = baseResults.toList().isEmpty() ? Sequences.simple(Collections.singletonList(
-            getNullTimeseriesResultValue(query))) : baseResults;
+        final List<Result<TimeseriesResultValue>> val = baseResults.toList();
+        finalSequence = val.isEmpty() ? Sequences.simple(Collections.singletonList(
+            getNullTimeseriesResultValue(query))) : Sequences.simple(val);
       } else {
         finalSequence = baseResults;
       }

--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
@@ -217,7 +217,8 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
                                       ), null));
       aggregatorNames[i] = aggregatorSpecs.get(i).getName();
     }
-    TimeseriesResultBuilder bob = new TimeseriesResultBuilder(DateTimes.EPOCH);
+    final DateTime start = query.getIntervals().isEmpty() ? DateTimes.EPOCH : query.getIntervals().get(0).getStart();
+    TimeseriesResultBuilder bob = new TimeseriesResultBuilder(start);
     for (int i = 0; i < aggregatorSpecs.size(); i++) {
       bob.addMetric(aggregatorNames[i], aggregators[i]);
       aggregators[i].close();

--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryRunnerFactory.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryRunnerFactory.java
@@ -21,18 +21,34 @@ package io.druid.query.timeseries;
 
 import com.google.inject.Inject;
 import io.druid.java.util.common.ISE;
+import io.druid.java.util.common.granularity.Granularity;
 import io.druid.java.util.common.guava.Sequence;
+import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.ChainedExecutionQueryRunner;
 import io.druid.query.Query;
+import io.druid.query.QueryMetrics;
 import io.druid.query.QueryPlus;
 import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerFactory;
 import io.druid.query.QueryToolChest;
 import io.druid.query.QueryWatcher;
 import io.druid.query.Result;
+import io.druid.query.filter.Filter;
+import io.druid.query.groupby.RowBasedColumnSelectorFactory;
+import io.druid.segment.Capabilities;
+import io.druid.segment.ColumnSelectorFactory;
+import io.druid.segment.Cursor;
+import io.druid.segment.Metadata;
 import io.druid.segment.Segment;
 import io.druid.segment.StorageAdapter;
+import io.druid.segment.VirtualColumns;
+import io.druid.segment.column.ColumnCapabilities;
+import io.druid.segment.data.Indexed;
+import org.joda.time.DateTime;
+import org.joda.time.Interval;
 
+import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
@@ -68,7 +84,13 @@ public class TimeseriesQueryRunnerFactory
       ExecutorService queryExecutor, Iterable<QueryRunner<Result<TimeseriesResultValue>>> queryRunners
   )
   {
-    return new ChainedExecutionQueryRunner<Result<TimeseriesResultValue>>(
+    if (!queryRunners.iterator().hasNext()) {
+      return (queryPlus, responseContext) -> {
+        TimeseriesQuery ts = (TimeseriesQuery) queryPlus.getQuery();
+        return engine.process(ts, EmptyStorageAdapter.INSTANCE);
+      };
+    }
+    return new ChainedExecutionQueryRunner<>(
         queryExecutor, queryWatcher, queryRunners
     );
   }
@@ -102,6 +124,170 @@ public class TimeseriesQueryRunnerFactory
       }
 
       return engine.process((TimeseriesQuery) input, adapter);
+    }
+  }
+
+  private static class EmptyStorageAdapter implements StorageAdapter
+  {
+    static final EmptyStorageAdapter INSTANCE = new EmptyStorageAdapter();
+
+    private EmptyStorageAdapter() {}
+
+    @Override
+    public String getSegmentIdentifier()
+    {
+      return null;
+    }
+
+    @Override
+    public Interval getInterval()
+    {
+      return null;
+    }
+
+    @Override
+    public Indexed<String> getAvailableDimensions()
+    {
+      return null;
+    }
+
+    @Override
+    public Iterable<String> getAvailableMetrics()
+    {
+      return null;
+    }
+
+    @Override
+    public int getDimensionCardinality(String column)
+    {
+      return 0;
+    }
+
+    @Override
+    public DateTime getMinTime()
+    {
+      return null;
+    }
+
+    @Override
+    public DateTime getMaxTime()
+    {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Comparable getMinValue(String column)
+    {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Comparable getMaxValue(String column)
+    {
+      return null;
+    }
+
+    @Override
+    public Capabilities getCapabilities()
+    {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public ColumnCapabilities getColumnCapabilities(String column)
+    {
+      return null;
+    }
+
+    @Override
+    public String getColumnTypeName(String column)
+    {
+      return null;
+    }
+
+    @Override
+    public int getNumRows()
+    {
+      return 0;
+    }
+
+    @Override
+    public DateTime getMaxIngestedEventTime()
+    {
+      return null;
+    }
+
+    @Override
+    public Metadata getMetadata()
+    {
+      return null;
+    }
+
+    @Override
+    public Sequence<Cursor> makeCursors(
+        @Nullable Filter filter,
+        Interval interval,
+        VirtualColumns virtualColumns,
+        Granularity gran,
+        boolean descending,
+        @Nullable QueryMetrics<?> queryMetrics
+    )
+    {
+      return Sequences.simple(Collections.singletonList(new Cursor()
+      {
+        private ColumnSelectorFactory columnSelectorFactory = RowBasedColumnSelectorFactory.create(() -> null, null);
+
+        @Override
+        public ColumnSelectorFactory getColumnSelectorFactory()
+        {
+          return columnSelectorFactory;
+        }
+
+        @Override
+        public DateTime getTime()
+        {
+          return null;
+        }
+
+        @Override
+        public void advance()
+        {
+
+        }
+
+        @Override
+        public void advanceUninterruptibly()
+        {
+
+        }
+
+        @Override
+        public void advanceTo(int offset)
+        {
+
+        }
+
+        @Override
+        public boolean isDone()
+        {
+          return true;
+        }
+
+        @Override
+        public boolean isDoneOrInterrupted()
+        {
+          return true;
+        }
+
+        @Override
+        public void reset()
+        {
+
+        }
+      }));
     }
   }
 }

--- a/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerTest.java
@@ -486,6 +486,56 @@ public class TimeseriesQueryRunnerTest
   }
 
   @Test
+  public void testTimeseriesIntervalOutOfRanges()
+  {
+    TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
+                                  .dataSource(QueryRunnerTestHelper.dataSource)
+                                  .granularity(QueryRunnerTestHelper.allGran)
+                                  .intervals(QueryRunnerTestHelper.emptyInterval)
+                                  .aggregators(
+                                      Arrays.asList(
+                                          QueryRunnerTestHelper.rowsCount,
+                                          QueryRunnerTestHelper.indexLongSum
+                                      )
+                                  )
+                                  .postAggregators(QueryRunnerTestHelper.addRowsIndexConstant)
+                                  .descending(descending)
+                                  .context(ImmutableMap.of(TimeseriesQuery.SKIP_EMPTY_BUCKETS, false))
+                                  .build();
+    List<Result<TimeseriesResultValue>> expectedResults = new ArrayList<>();
+
+    expectedResults.add(
+        new Result<>(
+            QueryRunnerTestHelper.emptyInterval.getIntervals().get(0).getStart(),
+            new TimeseriesResultValue(
+                ImmutableMap.of(
+                    "rows",
+                    0l,
+                    "index",
+                    0l,
+                    QueryRunnerTestHelper.addRowsIndexConstantMetric,
+                    1.0
+                )
+            )
+        )
+    );
+
+    // Must create a toolChest so we can run mergeResults (which applies grand totals).
+    QueryToolChest<Result<TimeseriesResultValue>, TimeseriesQuery> toolChest = new TimeseriesQueryQueryToolChest(
+        QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
+    );
+
+    // Must wrapped in a results finalizer to stop the runner's builtin finalizer from being called.
+    final FinalizeResultsQueryRunner finalRunner = new FinalizeResultsQueryRunner(
+        toolChest.mergeResults(runner),
+        toolChest
+    );
+
+    final List results = finalRunner.run(QueryPlus.wrap(query), CONTEXT).toList();
+    TestHelper.assertExpectedResults(expectedResults, results);
+  }
+
+  @Test
   public void testTimeseriesWithVirtualColumn()
   {
     TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()

--- a/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerTest.java
@@ -510,9 +510,9 @@ public class TimeseriesQueryRunnerTest
             new TimeseriesResultValue(
                 ImmutableMap.of(
                     "rows",
-                    0l,
+                    0L,
                     "index",
-                    0l,
+                    0L,
                     QueryRunnerTestHelper.addRowsIndexConstantMetric,
                     1.0
                 )

--- a/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerTest.java
@@ -520,7 +520,7 @@ public class TimeseriesQueryRunnerTest
         )
     );
 
-    // Must create a toolChest so we can run mergeResults (which applies grand totals).
+    // Must create a toolChest so we can run mergeResults (which creates the zeroed-out row).
     QueryToolChest<Result<TimeseriesResultValue>, TimeseriesQuery> toolChest = new TimeseriesQueryQueryToolChest(
         QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
     );

--- a/server/src/main/java/io/druid/client/CachingClusteredClient.java
+++ b/server/src/main/java/io/druid/client/CachingClusteredClient.java
@@ -67,6 +67,9 @@ import io.druid.query.SegmentDescriptor;
 import io.druid.query.aggregation.MetricManipulatorFns;
 import io.druid.query.filter.DimFilterUtils;
 import io.druid.query.spec.MultipleSpecificSegmentSpec;
+import io.druid.query.timeseries.TimeseriesQuery;
+import io.druid.query.timeseries.TimeseriesQueryRunnerFactory;
+import io.druid.query.timeseries.TimeseriesResultValue;
 import io.druid.server.QueryResource;
 import io.druid.server.coordination.DruidServerMetadata;
 import io.druid.timeline.DataSegment;
@@ -277,6 +280,10 @@ public class CachingClusteredClient implements QuerySegmentWalker
         }
       }
 
+      if (segments.isEmpty() && query instanceof TimeseriesQuery) {
+        final TimeseriesQueryRunnerFactory.EmptyQueryRunner emptyQueryRunner = new TimeseriesQueryRunnerFactory.EmptyQueryRunner();
+        return (Sequence<T>) emptyQueryRunner.run((QueryPlus<Result<TimeseriesResultValue>>) queryPlus, responseContext);
+      }
       final List<Pair<Interval, byte[]>> alreadyCachedResults = pruneSegmentsWithCachedResults(queryCacheKey, segments);
       final SortedMap<DruidServer, List<SegmentDescriptor>> segmentsByServer = groupSegmentsByServer(segments);
       return new LazySequence<>(() -> {

--- a/server/src/main/java/io/druid/client/CachingClusteredClient.java
+++ b/server/src/main/java/io/druid/client/CachingClusteredClient.java
@@ -67,9 +67,6 @@ import io.druid.query.SegmentDescriptor;
 import io.druid.query.aggregation.MetricManipulatorFns;
 import io.druid.query.filter.DimFilterUtils;
 import io.druid.query.spec.MultipleSpecificSegmentSpec;
-import io.druid.query.timeseries.TimeseriesQuery;
-import io.druid.query.timeseries.TimeseriesQueryRunnerFactory;
-import io.druid.query.timeseries.TimeseriesResultValue;
 import io.druid.server.QueryResource;
 import io.druid.server.coordination.DruidServerMetadata;
 import io.druid.timeline.DataSegment;
@@ -280,10 +277,6 @@ public class CachingClusteredClient implements QuerySegmentWalker
         }
       }
 
-      if (segments.isEmpty() && query instanceof TimeseriesQuery) {
-        final TimeseriesQueryRunnerFactory.EmptyQueryRunner emptyQueryRunner = new TimeseriesQueryRunnerFactory.EmptyQueryRunner();
-        return (Sequence<T>) emptyQueryRunner.run((QueryPlus<Result<TimeseriesResultValue>>) queryPlus, responseContext);
-      }
       final List<Pair<Interval, byte[]>> alreadyCachedResults = pruneSegmentsWithCachedResults(queryCacheKey, segments);
       final SortedMap<DruidServer, List<SegmentDescriptor>> segmentsByServer = groupSegmentsByServer(segments);
       return new LazySequence<>(() -> {

--- a/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
@@ -301,7 +301,15 @@ public class CalciteQueryTest extends CalciteTestBase
             new Object[]{11.0, 0.0}
         )
     );
+
+    testQuery(
+        "SELECT COUNT(*) FROM foo WHERE dim1 = 'nonexistent' GROUP BY FLOOR(__time TO DAY)",
+        null,
+        ImmutableList.of()
+    );
   }
+
+
 
   @Test
   public void testSelectTrimFamily() throws Exception

--- a/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
@@ -276,6 +276,33 @@ public class CalciteQueryTest extends CalciteTestBase
     );
   }
 
+
+  @Test
+  public void testSelectCountStart() throws Exception
+  {
+    testQuery(
+        PLANNER_CONFIG_DEFAULT,
+        QUERY_CONTEXT_DONT_SKIP_EMPTY_BUCKETS,
+        "SELECT exp(count(*)) + 10, sum(m2)  FROM druid.foo WHERE  dim2 = 0",
+        CalciteTests.REGULAR_USER_AUTH_RESULT,
+        null,
+        ImmutableList.of(
+            new Object[]{11.0, 0.0}
+        )
+    );
+
+    testQuery(
+        PLANNER_CONFIG_DEFAULT,
+        QUERY_CONTEXT_DONT_SKIP_EMPTY_BUCKETS,
+        "SELECT exp(count(*)) + 10, sum(m2)  FROM druid.foo WHERE  __time >= TIMESTAMP '2999-01-01 00:00:00'",
+        CalciteTests.REGULAR_USER_AUTH_RESULT,
+        null,
+        ImmutableList.of(
+            new Object[]{11.0, 0.0}
+        )
+    );
+  }
+
   @Test
   public void testSelectTrimFamily() throws Exception
   {


### PR DESCRIPTION
**Issue**
Timeseries results are incoherent for case interval is out of range and case  filter  matching zero rows.
IMO intervals and filters need to behave the same thus if user  issue a query with `SkipEmptyBuckets=false` with count aggregator result must be the similar.
Please look at the unit test to understand the issue (FYI it is not a SQL issue but SQL is a good way to express the issue).
~~**Fix**~~
~~TBH Am no sure what is the best way to fix this. I have added some add some nasty checks for the broker side that returns an empty query runner that does the trick but it make the code looks odd.
For the Histroical side i was able to added as part of the Timeseries Internal Query processing logic.
_Am still thinking about a better way to fix this_, the reason i am submitting this PR is to collect feedback/suggestions  please let me know if you see a better way to fix this.~~
**Fix V2** I have taken the route suggested by @gianm  and add the the check to mergeResutls.
The new patch checks for empty results for case Granularity ALL and NoSkipping of empty buckets. 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/druid-io/druid/5649)
<!-- Reviewable:end -->

