### PR TITLE
Timeseries: Epoch time instead of null for grandTotal.

### DIFF
--- a/docs/content/querying/timeseriesquery.md
+++ b/docs/content/querying/timeseriesquery.md
@@ -94,9 +94,9 @@ Druid can include an extra "grand totals" row as the last row of a timeseries re
 }
 ```
 
-The grand totals row will appear as the last row in the result array, and will have no timestamp. It will be the last
-row even if the query is run in "descending" mode. Post-aggregations in the grand totals row will be computed based
-upon the grand total aggregations.
+The grand totals row will appear as the last row in the result array, and will have the Unix epoch as its timestamp
+(1970-01-01T00:00:00Z). It will be the last row even if the query is run in "descending" mode. Post-aggregations in
+the grand totals row will be computed based upon the grand total aggregations.
 
 #### Zero-filling
 

--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.inject.Inject;
+import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.granularity.Granularity;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.guava.Sequences;
@@ -181,7 +182,7 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
                         }
 
                         final Result<TimeseriesResultValue> result = new Result<>(
-                            null,
+                            DateTimes.EPOCH,
                             new TimeseriesResultValue(totalsMap)
                         );
 

--- a/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryRunnerTest.java
@@ -453,7 +453,7 @@ public class TimeseriesQueryRunnerTest
 
     expectedResults.add(
         new Result<>(
-            null,
+            DateTimes.EPOCH,
             new TimeseriesResultValue(
                 ImmutableMap.of(
                     "rows",


### PR DESCRIPTION
May be friendlier to people who have written serde code that
assumes all timestamps are non-null.

This change was suggested by @b-slim on the dev sync today.

Follow up to #5640.