### PR TITLE
Fix loadstatus?full double counting expected segments

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
@@ -252,6 +252,7 @@ public class DruidCoordinator
                   .computeIfAbsent(tier, ignored -> new Object2LongOpenHashMap<>())
                   .addTo(segment.getDataSource(), Math.max(ruleReplicants - currentReplicants, 0));
             });
+        break; // only the first matching rule applies
       }
     }
 


### PR DESCRIPTION
If more than one load rule applies to a segment, the first one that applies will take effect and the remainder will be ignored. However, the logic in `getReplicationStatus()` used by loadstatus?full was such that it would calculate expected segments based on all the rules that applied, leading to counts based on segments being expected to be also loaded according to lesser priority rules. Hence, if you had something like this:

Segments:
2018-01-01/2018-01-02
2018-01-02/2018-01-03
2017-01-01/2017-01-02

And your load rules were:
- Load interval 2018-01-01/P1M in hot tier
- Load forever in cold tier

`loadstatus?full` would show: `{"hot":{"datasource":0},"cold":{"datasource":2}}`

Test took about a hundred times longer than the fix.

Recommend for backport to 0.12.1 since a broken loadstatus potentially affects monitoring and rolling update scripting and the fix is low risk.