### PR TITLE
Remove setParitionerClass call from SortableBytes

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/DeterminePartitionsJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/DeterminePartitionsJob.java
@@ -192,14 +192,13 @@ public class DeterminePartitionsJob implements Jobby
         config.addInputPaths(dimSelectionJob);
       }
 
-      SortableBytes.useSortableBytesAsMapOutputKey(dimSelectionJob);
+      SortableBytes.useSortableBytesAsMapOutputKey(dimSelectionJob, DeterminePartitionsDimSelectionPartitioner.class);
       dimSelectionJob.setMapOutputValueClass(Text.class);
       dimSelectionJob.setCombinerClass(DeterminePartitionsDimSelectionCombiner.class);
       dimSelectionJob.setReducerClass(DeterminePartitionsDimSelectionReducer.class);
       dimSelectionJob.setOutputKeyClass(BytesWritable.class);
       dimSelectionJob.setOutputValueClass(Text.class);
       dimSelectionJob.setOutputFormatClass(DeterminePartitionsDimSelectionOutputFormat.class);
-      dimSelectionJob.setPartitionerClass(DeterminePartitionsDimSelectionPartitioner.class);
       dimSelectionJob.setNumReduceTasks(config.getGranularitySpec().bucketIntervals().get().size());
       JobHelper.setupClasspath(
           JobHelper.distributedClassPath(config.getWorkingPath()),

--- a/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
@@ -172,7 +172,7 @@ public class IndexGeneratorJob implements Jobby
       job.setMapperClass(IndexGeneratorMapper.class);
       job.setMapOutputValueClass(BytesWritable.class);
 
-      SortableBytes.useSortableBytesAsMapOutputKey(job);
+      SortableBytes.useSortableBytesAsMapOutputKey(job, IndexGeneratorPartitioner.class);
 
       int numReducers = Iterables.size(config.getAllBuckets().get());
       if (numReducers == 0) {
@@ -185,7 +185,6 @@ public class IndexGeneratorJob implements Jobby
       }
 
       job.setNumReduceTasks(numReducers);
-      job.setPartitionerClass(IndexGeneratorPartitioner.class);
 
       setReducerClass(job);
       job.setOutputKeyClass(BytesWritable.class);

--- a/indexing-hadoop/src/main/java/io/druid/indexer/SortableBytes.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/SortableBytes.java
@@ -23,7 +23,6 @@ import io.druid.java.util.common.StringUtils;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.WritableComparator;
 import org.apache.hadoop.mapreduce.Job;
-import org.apache.hadoop.mapreduce.Partitioner;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -150,18 +149,6 @@ public class SortableBytes
       }
 
       return retVal;
-    }
-  }
-
-  public static class SortableBytesPartitioner extends Partitioner<BytesWritable, Object>
-  {
-    @Override
-    public int getPartition(BytesWritable bytesWritable, Object o, int numPartitions)
-    {
-      final byte[] bytes = bytesWritable.getBytes();
-      int length = ByteBuffer.wrap(bytes).getInt();
-
-      return (ByteBuffer.wrap(bytes, 4, length).hashCode() & Integer.MAX_VALUE) % numPartitions;
     }
   }
 }

--- a/indexing-hadoop/src/main/java/io/druid/indexer/SortableBytes.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/SortableBytes.java
@@ -98,7 +98,6 @@ public class SortableBytes
     job.setMapOutputKeyClass(BytesWritable.class);
     job.setGroupingComparatorClass(SortableBytesGroupingComparator.class);
     job.setSortComparatorClass(SortableBytesSortingComparator.class);
-    job.setPartitionerClass(SortableBytesPartitioner.class);
   }
 
   public static class SortableBytesGroupingComparator extends WritableComparator

--- a/indexing-hadoop/src/main/java/io/druid/indexer/SortableBytes.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/SortableBytes.java
@@ -23,6 +23,7 @@ import io.druid.java.util.common.StringUtils;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.WritableComparator;
 import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Partitioner;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -92,11 +93,12 @@ public class SortableBytes
     );
   }
 
-  public static void useSortableBytesAsMapOutputKey(Job job)
+  public static void useSortableBytesAsMapOutputKey(Job job, Class<? extends Partitioner> partitionerClass)
   {
     job.setMapOutputKeyClass(BytesWritable.class);
     job.setGroupingComparatorClass(SortableBytesGroupingComparator.class);
     job.setSortComparatorClass(SortableBytesSortingComparator.class);
+    job.setPartitionerClass(partitionerClass);
   }
 
   public static class SortableBytesGroupingComparator extends WritableComparator


### PR DESCRIPTION
Callers override the partitioner class themselves. So we should remove setting of the partitioner class from the method in SortableBytes class. 

The two cases where this method is used and the callers are then overwriting the values are:

`DetermineParitionJobs#run()
dimSelectionJob.setPartitionerClass(DeterminePartitionsDimSelectionPartitioner.class);
`

and 

`IndexGeneratorJor#run()
job.setPartitionerClass(IndexGeneratorPartitioner.class);
`

@jihoonson @gianm - could you guys please review when you get a chance. Thanks!