### PR TITLE
Lazy init of fullyQualifiedStorageDirectory in HDFS pusher

### DIFF
--- a/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsDataSegmentPusher.java
+++ b/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsDataSegmentPusher.java
@@ -232,6 +232,9 @@ public class HdfsDataSegmentPusher implements DataSegmentPusher
     );
   }
 
+
+  // We lazily initialiize fullQualifiedStorageDirectory to avoid potential issues with Hadoop namenode HA.
+  // Please see https://github.com/druid-io/druid/pull/5684
   private void initFullyQualifiedStorageDirectory()
   {
     try {

--- a/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsDataSegmentPusher.java
+++ b/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsDataSegmentPusher.java
@@ -20,6 +20,8 @@
 package io.druid.storage.hdfs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteSink;
 import com.google.common.io.ByteSource;
@@ -53,8 +55,10 @@ public class HdfsDataSegmentPusher implements DataSegmentPusher
 
   private final Configuration hadoopConfig;
   private final ObjectMapper jsonMapper;
-  private final Path storageDir;
-  private String fullyQualifiedStorageDirectory;
+
+  // We lazily initialize fullQualifiedStorageDirectory to avoid potential issues with Hadoop namenode HA.
+  // Please see https://github.com/druid-io/druid/pull/5684
+  private final Supplier<String> fullyQualifiedStorageDirectory;
 
   @Inject
   public HdfsDataSegmentPusher(
@@ -65,7 +69,20 @@ public class HdfsDataSegmentPusher implements DataSegmentPusher
   {
     this.hadoopConfig = hadoopConfig;
     this.jsonMapper = jsonMapper;
-    this.storageDir = new Path(config.getStorageDirectory());
+    Path storageDir = new Path(config.getStorageDirectory());
+    this.fullyQualifiedStorageDirectory = Suppliers.memoize(
+        () -> {
+          try {
+            return FileSystem.newInstance(storageDir.toUri(), hadoopConfig)
+                             .makeQualified(storageDir)
+                             .toUri()
+                             .toString();
+          }
+          catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        }
+    );
 
     log.info("Configured HDFS as deep storage");
   }
@@ -80,28 +97,24 @@ public class HdfsDataSegmentPusher implements DataSegmentPusher
   @Override
   public String getPathForHadoop()
   {
-    initFullyQualifiedStorageDirectory();
-
-    return fullyQualifiedStorageDirectory;
+    return fullyQualifiedStorageDirectory.get();
   }
 
   @Override
   public DataSegment push(File inDir, DataSegment segment, boolean replaceExisting) throws IOException
   {
-    initFullyQualifiedStorageDirectory();
-
     final String storageDir = this.getStorageDir(segment);
 
     log.info(
         "Copying segment[%s] to HDFS at location[%s/%s]",
         segment.getIdentifier(),
-        fullyQualifiedStorageDirectory,
+        fullyQualifiedStorageDirectory.get(),
         storageDir
     );
 
     Path tmpIndexFile = new Path(StringUtils.format(
         "%s/%s/%s/%s_index.zip",
-        fullyQualifiedStorageDirectory,
+        fullyQualifiedStorageDirectory.get(),
         segment.getDataSource(),
         UUIDUtils.generateUuid(),
         segment.getShardSpec().getPartitionNum()
@@ -117,13 +130,13 @@ public class HdfsDataSegmentPusher implements DataSegmentPusher
       size = CompressionUtils.zip(inDir, out);
       final Path outIndexFile = new Path(StringUtils.format(
           "%s/%s/%d_index.zip",
-          fullyQualifiedStorageDirectory,
+          fullyQualifiedStorageDirectory.get(),
           storageDir,
           segment.getShardSpec().getPartitionNum()
       ));
       final Path outDescriptorFile = new Path(StringUtils.format(
           "%s/%s/%d_descriptor.json",
-          fullyQualifiedStorageDirectory,
+          fullyQualifiedStorageDirectory.get(),
           storageDir,
           segment.getShardSpec().getPartitionNum()
       ));
@@ -230,23 +243,5 @@ public class HdfsDataSegmentPusher implements DataSegmentPusher
         dataSegment.getShardSpec().getPartitionNum(),
         indexName
     );
-  }
-
-
-  // We lazily initialiize fullQualifiedStorageDirectory to avoid potential issues with Hadoop namenode HA.
-  // Please see https://github.com/druid-io/druid/pull/5684
-  private void initFullyQualifiedStorageDirectory()
-  {
-    try {
-      if (fullyQualifiedStorageDirectory == null) {
-        fullyQualifiedStorageDirectory = FileSystem.newInstance(storageDir.toUri(), hadoopConfig)
-                                                   .makeQualified(storageDir)
-                                                   .toUri()
-                                                   .toString();
-      }
-    }
-    catch (Exception e) {
-      throw new RuntimeException(e);
-    }
   }
 }

--- a/extensions-core/hdfs-storage/src/test/java/io/druid/storage/hdfs/HdfsDataSegmentPusherTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/io/druid/storage/hdfs/HdfsDataSegmentPusherTest.java
@@ -107,7 +107,7 @@ public class HdfsDataSegmentPusherTest
   @Test
   public void testPushWithBadScheme() throws Exception
   {
-    expectedException.expect(IOException.class);
+    expectedException.expect(RuntimeException.class);
     expectedException.expectMessage("No FileSystem for scheme");
     testUsingScheme("xyzzy");
 


### PR DESCRIPTION
Some users have encountered issues when running Druid 0.12.0 against a Hadoop cluster with namenode HA enabled, where the mapper encounters an UnknownHostException when it tries to interpret the logical nameservice string as a hostname (e.g.: https://github.com/druid-io/druid/issues/5552). The users encountering issue also report that their hadoop ingestion was working in Druid 0.10.0 with the same hadoop configs.

In a local test environment, I was able to run a hadoop ingestion task successfully using namenode HA (https://github.com/druid-io/druid/issues/5552#issuecomment-383743216), so this issue might be a misconfiguration in some cases.

However, in another case, we observed this issue in a customer environment where the Hadoop .xml files in the Druid classpath were correctly configured for namenode HA, but the mapper failed to pick up the configurations. The root cause was unclear. 

Given that the mapper does not actually need the DataSegmentPusher, this PR is a workaround that lazily evaluates the the `fullyQualifiedStorageDirectory` variable in HdfsDataSegmentPusher, to unblock users who are encountering this issue, until a more complete understanding of the issue is reached.

I suspect that these users did not encounter issues in 0.10.0 because in that version HadoopDruidIndexerConfig did not have the DataSegmentPusher as a field (see https://github.com/druid-io/druid/pull/4116).



