### PR TITLE
fix NPE when buffersList contains null in SmooshedFileMapper

### DIFF
--- a/java-util/src/main/java/io/druid/java/util/common/io/smoosh/SmooshedFileMapper.java
+++ b/java-util/src/main/java/io/druid/java/util/common/io/smoosh/SmooshedFileMapper.java
@@ -19,7 +19,6 @@
 
 package io.druid.java.util.common.io.smoosh;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Closeables;
@@ -158,6 +157,8 @@ public class SmooshedFileMapper implements Closeable
       }
     }
     buffersList.clear();
-    Throwables.propagateIfPossible(thrown);
+    if (thrown != null) {
+      throw new RuntimeException(thrown);
+    }
   }
 }

--- a/java-util/src/main/java/io/druid/java/util/common/io/smoosh/SmooshedFileMapper.java
+++ b/java-util/src/main/java/io/druid/java/util/common/io/smoosh/SmooshedFileMapper.java
@@ -143,6 +143,9 @@ public class SmooshedFileMapper implements Closeable
   {
     Throwable thrown = null;
     for (MappedByteBuffer mappedByteBuffer : buffersList) {
+      if (mappedByteBuffer == null) {
+        continue;
+      }
       try {
         ByteBufferUtils.unmap(mappedByteBuffer);
       }
@@ -154,6 +157,7 @@ public class SmooshedFileMapper implements Closeable
         }
       }
     }
+    buffersList.clear();
     Throwables.propagateIfPossible(thrown);
   }
 }


### PR DESCRIPTION
when use Serialization v2, it has a chance to mapFile in second part directly without mapFile in the first part, then
`buffersList.add(null);`
if close SmooshedFileMapper at this moment, then NPE due to `ByteBufferUtils.unmap(mappedByteBuffer)` when mappedByteBuffer is null.