### PR TITLE
support throw duplicate row during realtime ingestion in RealtimePlumber

### DIFF
--- a/docs/content/ingestion/stream-pull.md
+++ b/docs/content/ingestion/stream-pull.md
@@ -156,6 +156,7 @@ The tuningConfig is optional and default parameters will be used if no tuningCon
 |handoffConditionTimeout|long|Milliseconds to wait for segment handoff. It must be >= 0, where 0 means to wait forever.|no (default == 0)|
 |alertTimeout|long|Milliseconds timeout after which an alert is created if the task isn't finished by then. This allows users to monitor tasks that are failing to finish and give up the worker slot for any unexpected errors.|no (default == 0)|
 |segmentWriteOutMediumFactory|String|Segment write-out medium to use when creating segments. See [Indexing Service Configuration](../configuration/indexing-service.html) page, "SegmentWriteOutMediumFactory" section for explanation and available options.|no (not specified by default, the value from `druid.peon.defaultSegmentWriteOutMediumFactory` is used)|
+|dedupColumn|String|the column to judge whether this row is already in this segment, if so, throw away this row. If it is String type column, to reduce heap cost, use long type hashcode of this column's value to judge whether this row is already ingested, so there maybe very small chance to throw away a row that is not ingested before.|no (default == null)|
 |indexSpec|Object|Tune how data is indexed. See below for more information.|no|
 
 Before enabling thread priority settings, users are highly encouraged to read the [original pull request](https://github.com/druid-io/druid/pull/984) and other documentation about proper use of `-XX:+UseThreadPriorities`. 

--- a/docs/content/operations/metrics.md
+++ b/docs/content/operations/metrics.md
@@ -107,6 +107,7 @@ These metrics are only available if the RealtimeMetricsMonitor is included in th
 |------|-----------|----------|------------|
 |`ingest/events/thrownAway`|Number of events rejected because they are outside the windowPeriod.|dataSource.|0|
 |`ingest/events/unparseable`|Number of events rejected because the events are unparseable.|dataSource.|0|
+|`ingest/events/duplicate`|Number of events rejected because the events are duplicated.|dataSource.|0|
 |`ingest/events/processed`|Number of events successfully processed per emission period.|dataSource.|Equal to your # of events per emission period.|
 |`ingest/rows/output`|Number of Druid rows persisted.|dataSource.|Your # of events with rollup.|
 |`ingest/persists/count`|Number of times persist occurred.|dataSource.|Depends on configuration.|

--- a/extensions-contrib/opentsdb-emitter/src/main/resources/defaultMetrics.json
+++ b/extensions-contrib/opentsdb-emitter/src/main/resources/defaultMetrics.json
@@ -54,6 +54,9 @@
   "ingest/events/unparseable": [
     "dataSource"
   ],
+  "ingest/events/duplicate": [
+    "dataSource"
+  ],
   "ingest/events/processed": [
     "dataSource"
   ],

--- a/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
@@ -32,6 +32,7 @@
 
   "ingest/events/thrownAway" : { "dimensions" : ["dataSource"], "type" : "count" },
   "ingest/events/unparseable" : { "dimensions" : ["dataSource"], "type" : "count" },
+  "ingest/events/duplicate" : { "dimensions" : ["dataSource"], "type" : "count" },
   "ingest/events/processed" : { "dimensions" : ["dataSource"], "type" : "count" },
   "ingest/rows/output" : { "dimensions" : ["dataSource"], "type" : "count" },
   "ingest/persist/count" : { "dimensions" : ["dataSource"], "type" : "count" },

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/RealtimeIndexTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/RealtimeIndexTaskTest.java
@@ -919,6 +919,7 @@ public class RealtimeIndexTaskTest
         reportParseExceptions,
         handoffTimeout,
         null,
+        null,
         null
     );
     return new RealtimeIndexTask(

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
@@ -554,6 +554,7 @@ public class TaskSerdeTest
                 true,
                 null,
                 null,
+                null,
                 null
             )
         ),

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLifecycleTest.java
@@ -1278,6 +1278,7 @@ public class TaskLifecycleTest
         null,
         null,
         null,
+        null,
         null
     );
     FireDepartment fireDepartment = new FireDepartment(dataSchema, realtimeIOConfig, realtimeTuningConfig);

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexAddResult.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexAddResult.java
@@ -30,6 +30,21 @@ public class IncrementalIndexAddResult
 
   @Nullable
   private final ParseException parseException;
+  @Nullable
+  private String reasonOfNotAdded;
+
+  public IncrementalIndexAddResult(
+      int rowCount,
+      long bytesInMemory,
+      @Nullable ParseException parseException,
+      @Nullable String reasonOfNotAdded
+  )
+  {
+    this.rowCount = rowCount;
+    this.bytesInMemory = bytesInMemory;
+    this.parseException = parseException;
+    this.reasonOfNotAdded = reasonOfNotAdded;
+  }
 
   public IncrementalIndexAddResult(
       int rowCount,
@@ -37,9 +52,7 @@ public class IncrementalIndexAddResult
       @Nullable ParseException parseException
   )
   {
-    this.rowCount = rowCount;
-    this.bytesInMemory = bytesInMemory;
-    this.parseException = parseException;
+    this(rowCount, bytesInMemory, parseException, null);
   }
 
   public int getRowCount()
@@ -56,5 +69,11 @@ public class IncrementalIndexAddResult
   public ParseException getParseException()
   {
     return parseException;
+  }
+
+  @Nullable
+  public String getReasonOfNotAdded()
+  {
+    return reasonOfNotAdded;
   }
 }

--- a/server/src/main/java/io/druid/segment/indexing/RealtimeTuningConfig.java
+++ b/server/src/main/java/io/druid/segment/indexing/RealtimeTuningConfig.java
@@ -53,6 +53,7 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
   private static final Boolean defaultReportParseExceptions = Boolean.FALSE;
   private static final long defaultHandoffConditionTimeout = 0;
   private static final long defaultAlertTimeout = 0;
+  private static final String defaultDedupColumn = null;
 
   private static File createNewBasePersistDirectory()
   {
@@ -87,7 +88,8 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
         defaultReportParseExceptions,
         defaultHandoffConditionTimeout,
         defaultAlertTimeout,
-        null
+        null,
+        defaultDedupColumn
     );
   }
 
@@ -108,6 +110,8 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
   private final long alertTimeout;
   @Nullable
   private final SegmentWriteOutMediumFactory segmentWriteOutMediumFactory;
+  @Nullable
+  private final String dedupColumn;
 
   @JsonCreator
   public RealtimeTuningConfig(
@@ -128,7 +132,8 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
       @JsonProperty("reportParseExceptions") Boolean reportParseExceptions,
       @JsonProperty("handoffConditionTimeout") Long handoffConditionTimeout,
       @JsonProperty("alertTimeout") Long alertTimeout,
-      @JsonProperty("segmentWriteOutMediumFactory") @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory
+      @JsonProperty("segmentWriteOutMediumFactory") @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory,
+      @JsonProperty("dedupColumn") @Nullable String dedupColumn
   )
   {
     this.maxRowsInMemory = maxRowsInMemory == null ? defaultMaxRowsInMemory : maxRowsInMemory;
@@ -160,6 +165,7 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
     this.alertTimeout = alertTimeout == null ? defaultAlertTimeout : alertTimeout;
     Preconditions.checkArgument(this.alertTimeout >= 0, "alertTimeout must be >= 0");
     this.segmentWriteOutMediumFactory = segmentWriteOutMediumFactory;
+    this.dedupColumn = dedupColumn == null ? defaultDedupColumn : dedupColumn;
   }
 
   @Override
@@ -276,6 +282,13 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
     return segmentWriteOutMediumFactory;
   }
 
+  @JsonProperty
+  @Nullable
+  public String getDedupColumn()
+  {
+    return dedupColumn;
+  }
+
   public RealtimeTuningConfig withVersioningPolicy(VersioningPolicy policy)
   {
     return new RealtimeTuningConfig(
@@ -295,7 +308,8 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
         reportParseExceptions,
         handoffConditionTimeout,
         alertTimeout,
-        segmentWriteOutMediumFactory
+        segmentWriteOutMediumFactory,
+        dedupColumn
     );
   }
 
@@ -318,7 +332,8 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
         reportParseExceptions,
         handoffConditionTimeout,
         alertTimeout,
-        segmentWriteOutMediumFactory
+        segmentWriteOutMediumFactory,
+        dedupColumn
     );
   }
 }

--- a/server/src/main/java/io/druid/segment/realtime/FireDepartmentMetrics.java
+++ b/server/src/main/java/io/druid/segment/realtime/FireDepartmentMetrics.java
@@ -31,6 +31,7 @@ public class FireDepartmentMetrics
   private final AtomicLong processedWithErrorsCount = new AtomicLong(0);
   private final AtomicLong thrownAwayCount = new AtomicLong(0);
   private final AtomicLong unparseableCount = new AtomicLong(0);
+  private final AtomicLong dedupCount = new AtomicLong(0);
   private final AtomicLong rowOutputCount = new AtomicLong(0);
   private final AtomicLong numPersists = new AtomicLong(0);
   private final AtomicLong persistTimeMillis = new AtomicLong(0);
@@ -58,6 +59,11 @@ public class FireDepartmentMetrics
   public void incrementThrownAway()
   {
     thrownAwayCount.incrementAndGet();
+  }
+
+  public void incrementDedup()
+  {
+    dedupCount.incrementAndGet();
   }
 
   public void incrementUnparseable()
@@ -145,6 +151,11 @@ public class FireDepartmentMetrics
     return unparseableCount.get();
   }
 
+  public long dedup()
+  {
+    return dedupCount.get();
+  }
+
   public long rowOutput()
   {
     return rowOutputCount.get();
@@ -217,6 +228,7 @@ public class FireDepartmentMetrics
     retVal.processedWithErrorsCount.set(processedWithErrorsCount.get());
     retVal.thrownAwayCount.set(thrownAwayCount.get());
     retVal.unparseableCount.set(unparseableCount.get());
+    retVal.dedupCount.set(dedupCount.get());
     retVal.rowOutputCount.set(rowOutputCount.get());
     retVal.numPersists.set(numPersists.get());
     retVal.persistTimeMillis.set(persistTimeMillis.get());
@@ -247,6 +259,7 @@ public class FireDepartmentMetrics
     thrownAwayCount.addAndGet(otherSnapshot.thrownAway());
     rowOutputCount.addAndGet(otherSnapshot.rowOutput());
     unparseableCount.addAndGet(otherSnapshot.unparseable());
+    dedupCount.addAndGet(otherSnapshot.dedup());
     numPersists.addAndGet(otherSnapshot.numPersists());
     persistTimeMillis.addAndGet(otherSnapshot.persistTimeMillis());
     persistBackPressureMillis.addAndGet(otherSnapshot.persistBackPressureMillis());

--- a/server/src/main/java/io/druid/segment/realtime/RealtimeMetricsMonitor.java
+++ b/server/src/main/java/io/druid/segment/realtime/RealtimeMetricsMonitor.java
@@ -80,6 +80,12 @@ public class RealtimeMetricsMonitor extends AbstractMonitor
         log.error("[%,d] Unparseable events! Turn on debug logging to see exception stack trace.", unparseable);
       }
       emitter.emit(builder.build("ingest/events/unparseable", unparseable));
+      final long dedup = metrics.dedup() - previous.dedup();
+      if (dedup > 0) {
+        log.warn("[%,d] duplicate events!", dedup);
+      }
+      emitter.emit(builder.build("ingest/events/duplicate", dedup));
+
       emitter.emit(builder.build("ingest/events/processed", metrics.processed() - previous.processed()));
       emitter.emit(builder.build("ingest/rows/output", metrics.rowOutput() - previous.rowOutput()));
       emitter.emit(builder.build("ingest/persists/count", metrics.numPersists() - previous.numPersists()));

--- a/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -355,7 +355,8 @@ public class AppenderatorImpl implements Appenderator
           identifier.getVersion(),
           tuningConfig.getMaxRowsInMemory(),
           TuningConfigs.getMaxBytesInMemoryOrDefault(tuningConfig.getMaxBytesInMemory()),
-          tuningConfig.isReportParseExceptions()
+          tuningConfig.isReportParseExceptions(),
+          null
       );
 
       try {
@@ -1027,6 +1028,7 @@ public class AppenderatorImpl implements Appenderator
             tuningConfig.getMaxRowsInMemory(),
             TuningConfigs.getMaxBytesInMemoryOrDefault(tuningConfig.getMaxBytesInMemory()),
             tuningConfig.isReportParseExceptions(),
+            null,
             hydrants
         );
         sinks.put(identifier, currSink);

--- a/server/src/main/java/io/druid/segment/realtime/plumber/Plumber.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/Plumber.java
@@ -24,10 +24,15 @@ import io.druid.data.input.Committer;
 import io.druid.data.input.InputRow;
 import io.druid.query.Query;
 import io.druid.query.QueryRunner;
+import io.druid.segment.incremental.IncrementalIndexAddResult;
 import io.druid.segment.incremental.IndexSizeExceededException;
 
 public interface Plumber
 {
+  IncrementalIndexAddResult THROWAWAY = new IncrementalIndexAddResult(-1, -1, null, "row too late");
+  IncrementalIndexAddResult NOT_WRITABLE = new IncrementalIndexAddResult(-1, -1, null, "not writable");
+  IncrementalIndexAddResult DUPLICATE = new IncrementalIndexAddResult(-2, -1, null, "duplicate row");
+
   /**
    * Perform any initial setup. Should be called before using any other methods, and should be paired
    * with a corresponding call to {@link #finishJob}.
@@ -40,10 +45,12 @@ public interface Plumber
    * @param row               the row to insert
    * @param committerSupplier supplier of a committer associated with all data that has been added, including this row
    *
-   * @return - positive numbers indicate how many summarized rows exist in the index for that timestamp,
+   * @return IncrementalIndexAddResult whose rowCount
+   * - positive numbers indicate how many summarized rows exist in the index for that timestamp,
    * -1 means a row was thrown away because it was too late
+   * -2 means a row was thrown away because it is duplicate
    */
-  int add(InputRow row, Supplier<Committer> committerSupplier) throws IndexSizeExceededException;
+  IncrementalIndexAddResult add(InputRow row, Supplier<Committer> committerSupplier) throws IndexSizeExceededException;
 
   <T> QueryRunner<T> getQueryRunner(Query<T> query);
 

--- a/server/src/main/java/io/druid/segment/realtime/plumber/Plumbers.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/Plumbers.java
@@ -26,6 +26,7 @@ import io.druid.data.input.InputRow;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.java.util.common.parsers.ParseException;
+import io.druid.segment.incremental.IncrementalIndexAddResult;
 import io.druid.segment.incremental.IndexSizeExceededException;
 import io.druid.segment.realtime.FireDepartmentMetrics;
 
@@ -66,9 +67,9 @@ public class Plumbers
       return;
     }
 
-    final int numRows;
+    final IncrementalIndexAddResult addResult;
     try {
-      numRows = plumber.add(inputRow, committerSupplier);
+      addResult = plumber.add(inputRow, committerSupplier);
     }
     catch (IndexSizeExceededException e) {
       // Shouldn't happen if this is only being called by a single thread.
@@ -76,9 +77,15 @@ public class Plumbers
       throw new ISE(e, "WTF?! Index size exceeded, this shouldn't happen. Bad Plumber!");
     }
 
-    if (numRows == -1) {
+    if (addResult.getRowCount() == -1) {
       metrics.incrementThrownAway();
-      log.debug("Discarded row[%s], considering thrownAway.", inputRow);
+      log.debug("Discarded row[%s], considering thrownAway due to %s.", inputRow, addResult.getReasonOfNotAdded());
+      return;
+    }
+
+    if (addResult.getRowCount() == -2) {
+      metrics.incrementDedup();
+      log.debug("Discarded row[%s], considering duplication.", inputRow);
       return;
     }
 

--- a/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -30,14 +30,11 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Ints;
-import io.druid.java.util.emitter.EmittingLogger;
-import io.druid.java.util.emitter.service.ServiceEmitter;
 import io.druid.client.cache.Cache;
 import io.druid.client.cache.CacheConfig;
 import io.druid.common.guava.ThreadRenamingCallable;
 import io.druid.common.guava.ThreadRenamingRunnable;
 import io.druid.common.utils.VMUtils;
-import io.druid.java.util.common.concurrent.Execs;
 import io.druid.concurrent.TaskThreadPriority;
 import io.druid.data.input.Committer;
 import io.druid.data.input.InputRow;
@@ -46,9 +43,12 @@ import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.Pair;
 import io.druid.java.util.common.StringUtils;
+import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.concurrent.ScheduledExecutors;
 import io.druid.java.util.common.granularity.Granularity;
 import io.druid.java.util.common.io.Closer;
+import io.druid.java.util.emitter.EmittingLogger;
+import io.druid.java.util.emitter.service.ServiceEmitter;
 import io.druid.query.Query;
 import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerFactoryConglomerate;
@@ -209,13 +209,13 @@ public class RealtimePlumber implements Plumber
   }
 
   @Override
-  public int add(InputRow row, Supplier<Committer> committerSupplier) throws IndexSizeExceededException
+  public IncrementalIndexAddResult add(InputRow row, Supplier<Committer> committerSupplier) throws IndexSizeExceededException
   {
     long messageTimestamp = row.getTimestampFromEpoch();
     final Sink sink = getSink(messageTimestamp);
     metrics.reportMessageMaxTimestamp(messageTimestamp);
     if (sink == null) {
-      return -1;
+      return Plumber.THROWAWAY;
     }
 
     final IncrementalIndexAddResult addResult = sink.add(row, false);
@@ -227,7 +227,7 @@ public class RealtimePlumber implements Plumber
       persist(committerSupplier.get());
     }
 
-    return addResult.getRowCount();
+    return addResult;
   }
 
   private Sink getSink(long timestamp)
@@ -257,7 +257,8 @@ public class RealtimePlumber implements Plumber
           versioningPolicy.getVersion(sinkInterval),
           config.getMaxRowsInMemory(),
           TuningConfigs.getMaxBytesInMemoryOrDefault(config.getMaxBytesInMemory()),
-          config.isReportParseExceptions()
+          config.isReportParseExceptions(),
+          config.getDedupColumn()
       );
       addSink(retVal);
 
@@ -508,6 +509,7 @@ public class RealtimePlumber implements Plumber
     shuttingDown = true;
 
     for (final Map.Entry<Long, Sink> entry : sinks.entrySet()) {
+      entry.getValue().clearDedupCache();
       persistAndMerge(entry.getKey(), entry.getValue());
     }
 
@@ -733,6 +735,7 @@ public class RealtimePlumber implements Plumber
           config.getMaxRowsInMemory(),
           TuningConfigs.getMaxBytesInMemoryOrDefault(config.getMaxBytesInMemory()),
           config.isReportParseExceptions(),
+          config.getDedupColumn(),
           hydrants
       );
       addSink(currSink);
@@ -757,6 +760,7 @@ public class RealtimePlumber implements Plumber
          .addData("interval", sink.getInterval())
          .emit();
     }
+    clearDedupCache();
   }
 
   protected void startPersistThread()
@@ -811,16 +815,33 @@ public class RealtimePlumber implements Plumber
     ScheduledExecutors.scheduleAtFixedRate(scheduledExecutor, initialDelay, rate, threadRenamingCallable);
   }
 
-  private void mergeAndPush()
+  private void clearDedupCache()
+  {
+    long minTimestamp = getAllowedMinTime().getMillis();
+
+    for (Map.Entry<Long, Sink> entry : sinks.entrySet()) {
+      final Long intervalStart = entry.getKey();
+      if (intervalStart < minTimestamp) {
+        entry.getValue().clearDedupCache();
+      }
+    }
+  }
+
+  private DateTime getAllowedMinTime()
   {
     final Granularity segmentGranularity = schema.getGranularitySpec().getSegmentGranularity();
     final Period windowPeriod = config.getWindowPeriod();
 
     final long windowMillis = windowPeriod.toStandardDuration().getMillis();
-    log.info("Starting merge and push.");
-    DateTime minTimestampAsDate = segmentGranularity.bucketStart(
+    return segmentGranularity.bucketStart(
         DateTimes.utc(Math.max(windowMillis, rejectionPolicy.getCurrMaxTime().getMillis()) - windowMillis)
     );
+  }
+
+  private void mergeAndPush()
+  {
+    log.info("Starting merge and push.");
+    DateTime minTimestampAsDate = getAllowedMinTime();
     long minTimestamp = minTimestampAsDate.getMillis();
 
     log.info(
@@ -835,6 +856,7 @@ public class RealtimePlumber implements Plumber
       if (intervalStart < minTimestamp) {
         log.info("Adding entry [%s] for merge and push.", entry);
         sinksToPush.add(entry);
+        entry.getValue().clearDedupCache();
       } else {
         log.info(
             "Skipping persist and merge for entry [%s] : Start time [%s] >= [%s] min timestamp required in this run. Segment will be picked up in a future run.",

--- a/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorPlumberTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorPlumberTest.java
@@ -80,6 +80,7 @@ public class AppenderatorPlumberTest
         false,
         null,
         null,
+        null,
         null
     );
 
@@ -111,17 +112,17 @@ public class AppenderatorPlumberTest
     commitMetadata.put("x", "1");
     Assert.assertEquals(
         1,
-        plumber.add(rows[0], null));        
+        plumber.add(rows[0], null).getRowCount());
 
     commitMetadata.put("x", "2");
     Assert.assertEquals(
         2,
-        plumber.add(rows[1], null));        
+        plumber.add(rows[1], null).getRowCount());
 
     commitMetadata.put("x", "3");
     Assert.assertEquals(
         3,
-        plumber.add(rows[2], null));
+        plumber.add(rows[2], null).getRowCount());
 
     
     Assert.assertEquals(1, plumber.getSegmentsView().size());

--- a/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorTester.java
+++ b/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorTester.java
@@ -159,6 +159,7 @@ public class AppenderatorTester implements AutoCloseable
         null,
         null,
         null,
+        null,
         null
     );
 

--- a/server/src/test/java/io/druid/segment/realtime/appenderator/DefaultOfflineAppenderatorFactoryTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/appenderator/DefaultOfflineAppenderatorFactoryTest.java
@@ -149,6 +149,7 @@ public class DefaultOfflineAppenderatorFactoryTest
         null,
         null,
         null,
+        null,
         null
     );
 

--- a/server/src/test/java/io/druid/segment/realtime/plumber/RealtimePlumberSchoolTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/plumber/RealtimePlumberSchoolTest.java
@@ -212,6 +212,7 @@ public class RealtimePlumberSchoolTest
         false,
         null,
         null,
+        null,
         null
     );
 
@@ -272,7 +273,8 @@ public class RealtimePlumberSchoolTest
         DateTimes.of("2014-12-01T12:34:56.789").toString(),
         tuningConfig.getMaxRowsInMemory(),
         TuningConfigs.getMaxBytesInMemoryOrDefault(tuningConfig.getMaxBytesInMemory()),
-        tuningConfig.isReportParseExceptions()
+        tuningConfig.isReportParseExceptions(),
+        tuningConfig.getDedupColumn()
     );
     plumber.getSinks().put(0L, sink);
     Assert.assertNull(plumber.startJob());
@@ -317,7 +319,8 @@ public class RealtimePlumberSchoolTest
         DateTimes.of("2014-12-01T12:34:56.789").toString(),
         tuningConfig.getMaxRowsInMemory(),
         TuningConfigs.getMaxBytesInMemoryOrDefault(tuningConfig.getMaxBytesInMemory()),
-        tuningConfig.isReportParseExceptions()
+        tuningConfig.isReportParseExceptions(),
+        tuningConfig.getDedupColumn()
     );
     plumber.getSinks().put(0L, sink);
     plumber.startJob();
@@ -372,7 +375,8 @@ public class RealtimePlumberSchoolTest
         DateTimes.of("2014-12-01T12:34:56.789").toString(),
         tuningConfig.getMaxRowsInMemory(),
         TuningConfigs.getMaxBytesInMemoryOrDefault(tuningConfig.getMaxBytesInMemory()),
-        tuningConfig.isReportParseExceptions()
+        tuningConfig.isReportParseExceptions(),
+        tuningConfig.getDedupColumn()
     );
     plumber2.getSinks().put(0L, sink);
     Assert.assertNull(plumber2.startJob());

--- a/services/src/test/java/io/druid/cli/validate/DruidJsonValidatorTest.java
+++ b/services/src/test/java/io/druid/cli/validate/DruidJsonValidatorTest.java
@@ -184,6 +184,7 @@ public class DruidJsonValidatorTest
                 true,
                 null,
                 null,
+                null,
                 null
             )
         ),


### PR DESCRIPTION
When pulling streaming data, we don't always ingest data without duplicate, like the upper streaming failover and write part of same data again.
So we add a config to allow to check duplicate row when ingest if we really want more accurate data.

how it works:
1. add a dedupColumn config in RealtimeTuningConfig, which is the primary key of the data
2. In RealtimePlumber, sink is bound to an interval, then maintain a Set inside the sink to hold all values of dedupColumn, so dedup doesn't happen across sinks
3. when sink.add(InputRow) called, check the value of dedupColumn of this inputRow whether it is in the Set, if so, reject with return rowCount as -2
4. RealtimeManager increase the ingest/events/duplicate count metric
5. the dedup Set is cleared when the sink is no longer writable:
  5.1 when mergeAndPush which is called at fix rate
  5.2 when got a new sink then try to clearDedupCache for the older sink in case merge process is slow in 5.1

Why need a primary key?
If we compare each columns to distinguish duplication, we need to setup a sink level timeAndDims which costs lots of heap memory.
Instead we ask user to prepare a 'pk' column as dedupColumn (usually, pk is built on several columns like {timestamp, user_id, item_id, order_id}) in their ETL process like in storm, spark, flink, user is glad to do so to gain the ability of dedup, 
Of course, 'pk' is no need to be in dimension list, it's only for dedup.

Limitation:
if the dedupColumn is string type column, whose value maybe md5, use it's long type hashcode (use BKDRHash algorithm) instead to judge whether it is a duplicate row, so there's very small change to throw away a row which is not duplicate. But I think it is worth to do this trade off to reduce heap cost to avoid OOM if maxRowsInMemory is a big number.