### PR TITLE
Provisioning support for ZooKeeper Authorization

### DIFF
--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -42,6 +42,9 @@ We recommend just setting the base ZK path and the ZK service host, but all ZK p
 |--------|-----------|-------|
 |`druid.zk.paths.base`|Base Zookeeper path.|`/druid`|
 |`druid.zk.service.host`|The ZooKeeper hosts to connect to. This is a REQUIRED property and therefore a host address must be supplied.|none|
+|`druid.zk.service.user`|The username to authenticate with ZooKeeper. This is an optional property.|none|
+|`druid.zk.service.pwd`|The [Password Provider](../operations/password-provider.html) or the string password to authenticate with ZooKeeper. This is an optional property.|none|
+|`druid.zk.service.authScheme`|digest is the only authentication scheme supported. |digest|
 
 #### Zookeeper Behavior
 

--- a/server/src/main/java/io/druid/curator/CuratorConfig.java
+++ b/server/src/main/java/io/druid/curator/CuratorConfig.java
@@ -19,10 +19,13 @@
 
 package io.druid.curator;
 
+import javax.validation.constraints.Min;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 
-import javax.validation.constraints.Min;
+import io.druid.metadata.DefaultPasswordProvider;
+import io.druid.metadata.PasswordProvider;
 
 /**
  */
@@ -40,6 +43,15 @@ public class CuratorConfig
 
   @JsonProperty("acl")
   private boolean enableAcl = false;
+
+  @JsonProperty("user")
+  private String zkUser;
+
+  @JsonProperty("pwd")
+  private PasswordProvider zkPwd = new DefaultPasswordProvider("");
+
+  @JsonProperty("authScheme")
+  private String authScheme = "digest";
 
   public String getZkHosts()
   {
@@ -82,4 +94,20 @@ public class CuratorConfig
     Preconditions.checkNotNull(enableAcl, "enableAcl");
     this.enableAcl = enableAcl;
   }
+
+  public String getZkUser()
+  {
+    return zkUser;
+  }
+
+  public String getZkPwd()
+  {
+    return zkPwd.getPassword();
+  }
+
+  public String getAuthScheme()
+  {
+    return authScheme;
+  }
+
 }

--- a/server/src/test/java/io/druid/curator/CuratorConfigTest.java
+++ b/server/src/test/java/io/druid/curator/CuratorConfigTest.java
@@ -19,9 +19,10 @@
 
 package io.druid.curator;
 
-import io.druid.guice.JsonConfigTesterBase;
 import org.junit.Assert;
 import org.junit.Test;
+
+import io.druid.guice.JsonConfigTesterBase;
 
 public class CuratorConfigTest extends JsonConfigTesterBase<CuratorConfig>
 {
@@ -30,10 +31,16 @@ public class CuratorConfigTest extends JsonConfigTesterBase<CuratorConfig>
   {
     propertyValues.put(getPropertyKey("host"), "fooHost");
     propertyValues.put(getPropertyKey("acl"), "true");
+    propertyValues.put(getPropertyKey("user"), "test-zk-user");
+    propertyValues.put(getPropertyKey("pwd"), "test-zk-pwd");
+    propertyValues.put(getPropertyKey("authScheme"), "auth");
     testProperties.putAll(propertyValues);
     configProvider.inject(testProperties, configurator);
     CuratorConfig config = configProvider.get().get();
     Assert.assertEquals("fooHost", config.getZkHosts());
     Assert.assertEquals(true, config.getEnableAcl());
+    Assert.assertEquals("test-zk-user", config.getZkUser());
+    Assert.assertEquals("test-zk-pwd", config.getZkPwd());
+    Assert.assertEquals("auth", config.getAuthScheme());
   }
 }


### PR DESCRIPTION

The patch fix enables Druid nodes to authenticate with ZooKeeper using username, paasword, auth schemes as supported by the ZooKeeper.

The issue is discussed and addressed through discussion here: https://github.com/druid-io/druid/issues/5641