### PR TITLE
Add task action metrics, add taskId metric dimension.

### DIFF
--- a/docs/content/operations/metrics.md
+++ b/docs/content/operations/metrics.md
@@ -129,10 +129,12 @@ Note: If the JVM does not support CPU time measurement for the current thread, i
 
 |Metric|Description|Dimensions|Normal Value|
 |------|-----------|----------|------------|
-|`task/run/time`|Milliseconds taken to run task.|dataSource, taskType, taskStatus.|Varies.|
-|`segment/added/bytes`|Size in bytes of new segments created.|dataSource, taskType, interval.|Varies.|
-|`segment/moved/bytes`|Size in bytes of segments moved/archived via the Move Task.|dataSource, taskType, interval.|Varies.|
-|`segment/nuked/bytes`|Size in bytes of segments deleted via the Kill Task.|dataSource, taskType, interval.|Varies.|
+|`task/run/time`|Milliseconds taken to run a task.|dataSource, taskId, taskType, taskStatus.|Varies.|
+|`task/action/log/time`|Milliseconds taken to log a task action to the audit log.|dataSource, taskId, taskType|< 1000 (subsecond)|
+|`task/action/run/time`|Milliseconds taken to execute a task action.|dataSource, taskId, taskType|Varies from subsecond to a few sections, based on action type.|
+|`segment/added/bytes`|Size in bytes of new segments created.|dataSource, taskId, taskType, interval.|Varies.|
+|`segment/moved/bytes`|Size in bytes of segments moved/archived via the Move Task.|dataSource, taskId, taskType, interval.|Varies.|
+|`segment/nuked/bytes`|Size in bytes of segments deleted via the Kill Task.|dataSource, taskId, taskType, interval.|Varies.|
 
 ## Coordination
 

--- a/indexing-service/src/main/java/io/druid/indexing/common/actions/SegmentMetadataUpdateAction.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/actions/SegmentMetadataUpdateAction.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.ImmutableSet;
+import io.druid.indexing.common.task.IndexTaskUtils;
 import io.druid.indexing.common.task.Task;
 import io.druid.indexing.overlord.CriticalAction;
 import io.druid.java.util.common.ISE;
@@ -94,9 +95,8 @@ public class SegmentMetadataUpdateAction implements TaskAction<Void>
     }
 
     // Emit metrics
-    final ServiceMetricEvent.Builder metricBuilder = new ServiceMetricEvent.Builder()
-        .setDimension(DruidMetrics.DATASOURCE, task.getDataSource())
-        .setDimension(DruidMetrics.TASK_TYPE, task.getType());
+    final ServiceMetricEvent.Builder metricBuilder = new ServiceMetricEvent.Builder();
+    IndexTaskUtils.setTaskDimensions(metricBuilder, task);
 
     for (DataSegment segment : segments) {
       metricBuilder.setDimension(DruidMetrics.INTERVAL, segment.getInterval().toString());

--- a/indexing-service/src/main/java/io/druid/indexing/common/actions/SegmentNukeAction.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/actions/SegmentNukeAction.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.ImmutableSet;
+import io.druid.indexing.common.task.IndexTaskUtils;
 import io.druid.indexing.common.task.Task;
 import io.druid.indexing.overlord.CriticalAction;
 import io.druid.java.util.common.ISE;
@@ -94,9 +95,8 @@ public class SegmentNukeAction implements TaskAction<Void>
     }
 
     // Emit metrics
-    final ServiceMetricEvent.Builder metricBuilder = new ServiceMetricEvent.Builder()
-        .setDimension(DruidMetrics.DATASOURCE, task.getDataSource())
-        .setDimension(DruidMetrics.TASK_TYPE, task.getType());
+    final ServiceMetricEvent.Builder metricBuilder = new ServiceMetricEvent.Builder();
+    IndexTaskUtils.setTaskDimensions(metricBuilder, task);
 
     for (DataSegment segment : segments) {
       metricBuilder.setDimension(DruidMetrics.INTERVAL, segment.getInterval().toString());

--- a/indexing-service/src/main/java/io/druid/indexing/common/actions/SegmentTransactionalInsertAction.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/actions/SegmentTransactionalInsertAction.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.ImmutableSet;
+import io.druid.indexing.common.task.IndexTaskUtils;
 import io.druid.indexing.common.task.Task;
 import io.druid.indexing.overlord.CriticalAction;
 import io.druid.indexing.overlord.DataSourceMetadata;
@@ -126,9 +127,8 @@ public class SegmentTransactionalInsertAction implements TaskAction<SegmentPubli
 
     if (retVal.isSuccess()) {
       // Emit metrics
-      final ServiceMetricEvent.Builder metricBuilder = new ServiceMetricEvent.Builder()
-          .setDimension(DruidMetrics.DATASOURCE, task.getDataSource())
-          .setDimension(DruidMetrics.TASK_TYPE, task.getType());
+      final ServiceMetricEvent.Builder metricBuilder = new ServiceMetricEvent.Builder();
+      IndexTaskUtils.setTaskDimensions(metricBuilder, task);
 
       if (retVal.isSuccess()) {
         toolbox.getEmitter().emit(metricBuilder.build("segment/txn/success", 1));

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTaskUtils.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTaskUtils.java
@@ -19,6 +19,9 @@
 
 package io.druid.indexing.common.task;
 
+import io.druid.indexing.common.TaskStatus;
+import io.druid.java.util.emitter.service.ServiceMetricEvent;
+import io.druid.query.DruidMetrics;
 import io.druid.server.security.Access;
 import io.druid.server.security.Action;
 import io.druid.server.security.AuthorizationUtils;
@@ -74,5 +77,21 @@ public class IndexTaskUtils
     }
 
     return access;
+  }
+
+  public static void setTaskDimensions(final ServiceMetricEvent.Builder metricBuilder, final Task task)
+  {
+    metricBuilder.setDimension(DruidMetrics.TASK_ID, task.getId());
+    metricBuilder.setDimension(DruidMetrics.TASK_TYPE, task.getType());
+    metricBuilder.setDimension(DruidMetrics.DATASOURCE, task.getDataSource());
+  }
+
+  public static void setTaskStatusDimensions(
+      final ServiceMetricEvent.Builder metricBuilder,
+      final TaskStatus taskStatus
+  )
+  {
+    metricBuilder.setDimension(DruidMetrics.TASK_ID, taskStatus.getId());
+    metricBuilder.setDimension(DruidMetrics.TASK_STATUS, taskStatus.getStatusCode().toString());
   }
 }


### PR DESCRIPTION
Adds two new metrics: task/action/log/time and task/action/run/time. Also
adds taskId as a dimension, to give us the ability to drill down into metrics
for an individual task. Also standardizes metrics-attachment using two helper
methods in IndexTaskUtils.

This helps when debugging issues due to sluggish task action run time, which
can in turn indicate problems with the metadata store. It also aids in monitoring,
since high log or run times are leading indicators of a potential problem.