### PR TITLE
Update defaultHadoopCoordinates in documentation.

### DIFF
--- a/docs/content/configuration/indexing-service.md
+++ b/docs/content/configuration/indexing-service.md
@@ -340,7 +340,7 @@ Additional peon configs include:
 |`druid.peon.mode`|Choices are "local" and "remote". Setting this to local means you intend to run the peon as a standalone node (Not recommended).|remote|
 |`druid.indexer.task.baseDir`|Base temporary working directory.|`System.getProperty("java.io.tmpdir")`|
 |`druid.indexer.task.baseTaskDir`|Base temporary working directory for tasks.|`${druid.indexer.task.baseDir}/persistent/tasks`|
-|`druid.indexer.task.defaultHadoopCoordinates`|Hadoop version to use with HadoopIndexTasks that do not request a particular version.|org.apache.hadoop:hadoop-client:2.3.0|
+|`druid.indexer.task.defaultHadoopCoordinates`|Hadoop version to use with HadoopIndexTasks that do not request a particular version.|org.apache.hadoop:hadoop-client:2.8.3|
 |`druid.indexer.task.defaultRowFlushBoundary`|Highest row count before persisting to disk. Used for indexing generating tasks.|75000|
 |`druid.indexer.task.directoryLockTimeout`|Wait this long for zombie peons to exit before giving up on their replacements.|PT10M|
 |`druid.indexer.task.gracefulShutdownTimeout`|Wait this long on middleManager restart for restorable tasks to gracefully exit.|PT5M|

--- a/docs/content/operations/other-hadoop.md
+++ b/docs/content/operations/other-hadoop.md
@@ -69,7 +69,7 @@ classloader.
 2. Batch ingestion uses jars from `hadoop-dependencies/` to submit Map/Reduce jobs (location customizable via the
 `druid.extensions.hadoopDependenciesDir` runtime property; see [Configuration](../configuration/index.html)).
 
-`hadoop-client:2.3.0` is the default version of the Hadoop client bundled with Druid for both purposes. This works with
+`hadoop-client:2.8.3` is the default version of the Hadoop client bundled with Druid for both purposes. This works with
 many Hadoop distributions (the version does not necessarily need to match), but if you run into issues, you can instead
 have Druid load libraries that exactly match your distribution. To do this, either copy the jars from your Hadoop
 cluster, or use the `pull-deps` tool to download the jars from a Maven repository.

--- a/docs/content/querying/lookups.md
+++ b/docs/content/querying/lookups.md
@@ -332,7 +332,7 @@ The return value will be the json representation of the factory.
 ```
 
 # Configuration
-See the [coordinator configuration guilde](../configuration/coordinator.html) for coordinator configuration
+See the [coordinator configuration guide](../configuration/coordinator.html) for coordinator configuration.
 
 To configure a Broker / Router / Historical / Peon to announce itself as part of a lookup tier, use the `druid.zk.paths.lookupTier` property.
 

--- a/examples/conf-quickstart/druid/middleManager/runtime.properties
+++ b/examples/conf-quickstart/druid/middleManager/runtime.properties
@@ -17,4 +17,3 @@ druid.indexer.fork.property.druid.processing.numThreads=2
 
 # Hadoop indexing
 druid.indexer.task.hadoopWorkingPath=var/druid/hadoop-tmp
-druid.indexer.task.defaultHadoopCoordinates=["org.apache.hadoop:hadoop-client:2.7.3"]

--- a/examples/conf/druid/middleManager/runtime.properties
+++ b/examples/conf/druid/middleManager/runtime.properties
@@ -17,4 +17,3 @@ druid.indexer.fork.property.druid.processing.numThreads=2
 
 # Hadoop indexing
 druid.indexer.task.hadoopWorkingPath=var/druid/hadoop-tmp
-druid.indexer.task.defaultHadoopCoordinates=["org.apache.hadoop:hadoop-client:2.7.3"]

--- a/services/src/main/java/io/druid/cli/PullDependencies.java
+++ b/services/src/main/java/io/druid/cli/PullDependencies.java
@@ -167,7 +167,7 @@ public class PullDependencies implements Runnable
 
   @Option(
       name = "--no-default-hadoop",
-      description = "Don't pull down the default hadoop coordinate, i.e., org.apache.hadoop:hadoop-client:2.3.0. If `-h` option is supplied, then default hadoop coordinate will not be downloaded.",
+      description = "Don't pull down the default hadoop coordinate, i.e., org.apache.hadoop:hadoop-client:2.8.3. If `-h` option is supplied, then default hadoop coordinate will not be downloaded.",
       required = false)
   public boolean noDefaultHadoop = false;
 


### PR DESCRIPTION
https://github.com/druid-io/druid/pull/5382 has updated `defaultHadoopCoordinates` to `2.8.3`. However, relevant documentation has not been updated (as a matter of fact it also has not been updated when upgrading from `2.3.0` to `2.7.3`).   This patch fixes it. 

Also, in a891a44 I am suggesting to remove `defaultHadoopCoordinates` from example config files. Please read my commit message for more detailed argumentation. 