### PR TITLE
Fix NullPointerException when in DeterminePartitionsJob for Hadoop 3.0 and later versions

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/DetermineHashedPartitionsJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/DetermineHashedPartitionsJob.java
@@ -440,7 +440,7 @@ public class DetermineHashedPartitionsJob implements Jobby
     public int getPartition(LongWritable interval, BytesWritable text, int numPartitions)
     {
 
-      if ("local".equals(config.get("mapred.job.tracker")) || determineIntervals) {
+      if ("local".equals(JobHelper.getJobTrackerAddress(config)) || determineIntervals) {
         return 0;
       } else {
         return reducerLookup.get(interval);

--- a/indexing-hadoop/src/main/java/io/druid/indexer/DeterminePartitionsJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/DeterminePartitionsJob.java
@@ -485,7 +485,8 @@ public class DeterminePartitionsJob implements Jobby
       final ByteBuffer bytes = ByteBuffer.wrap(bytesWritable.getBytes());
       bytes.position(4); // Skip length added by SortableBytes
       final int index = bytes.getInt();
-      if (config.get("mapred.job.tracker").equals("local")) {
+      String jobTrackerAddress = JobHelper.getJobTrackerAddress(config);
+      if ("local".equals(jobTrackerAddress)) {
         return index % numPartitions;
       } else {
         if (index >= numPartitions) {

--- a/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/IndexGeneratorJob.java
@@ -535,7 +535,7 @@ public class IndexGeneratorJob implements Jobby
       final ByteBuffer bytes = ByteBuffer.wrap(bytesWritable.getBytes());
       bytes.position(4); // Skip length added by SortableBytes
       int shardNum = bytes.getInt();
-      if ("local".equals(config.get("mapreduce.jobtracker.address")) || "local".equals(config.get("mapred.job.tracker"))) {
+      if ("local".equals(JobHelper.getJobTrackerAddress(config))) {
         return shardNum % numPartitions;
       } else {
         if (shardNum >= numPartitions) {

--- a/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/JobHelper.java
@@ -831,4 +831,14 @@ public class JobHelper
       throw Throwables.propagate(e);
     }
   }
+
+  public static String getJobTrackerAddress(Configuration config)
+  {
+    String jobTrackerAddress = config.get("mapred.job.tracker");
+    if (jobTrackerAddress == null) {
+      // New Property name for Hadoop 3.0 and later versions
+      jobTrackerAddress = config.get("mapreduce.jobtracker.address");
+    }
+    return jobTrackerAddress;
+  }
 }


### PR DESCRIPTION
In DeterminePartitonsJob -
config.get("mapred.job.tracker").equals("local") throws NPE as the
property name is changed in hadoop 3.0 to mapreduce.jobtracker.address

This patch extracts the logic to fetch jobTrackerAddress in JobHelper
and reuses it when needed.