### PR TITLE
Default caffeine cache size

### DIFF
--- a/docs/content/configuration/caching.md
+++ b/docs/content/configuration/caching.md
@@ -49,7 +49,7 @@ Below are the configuration options known to this module:
 |`runtime.properties`|Description|Default|
 |--------------------|-----------|-------|
 |`druid.cache.type`| Set this to `caffeine` or leave out parameter|`caffeine`|
-|`druid.cache.sizeInBytes`|The maximum size of the cache in bytes on heap.|None (unlimited)|
+|`druid.cache.sizeInBytes`|The maximum size of the cache in bytes on heap.|min(1GB, Runtime.maxMemory / 10)|
 |`druid.cache.expireAfter`|The time (in ms) after an access for which a cache entry may be expired|None (no time limit)|
 |`druid.cache.cacheExecutorFactory`|The executor factory to use for Caffeine maintenance. One of `COMMON_FJP`, `SINGLE_THREAD`, or `SAME_THREAD`|ForkJoinPool common pool (`COMMON_FJP`)|
 |`druid.cache.evictOnClose`|If a close of a namespace (ex: removing a segment from a node) should cause an eager eviction of associated cache values|`false`|

--- a/server/src/main/java/io/druid/client/cache/CaffeineCache.java
+++ b/server/src/main/java/io/druid/client/cache/CaffeineCache.java
@@ -43,6 +43,7 @@ public class CaffeineCache implements io.druid.client.cache.Cache
 {
   private static final Logger log = new Logger(CaffeineCache.class);
   private static final int FIXED_COST = 8; // Minimum cost in "weight" per entry;
+  private static final int MAX_DEFAULT_BYTES = 1024 * 1024;
   private static final LZ4Factory LZ4_FACTORY = LZ4Factory.fastestInstance();
   private static final LZ4FastDecompressor LZ4_DECOMPRESSOR = LZ4_FACTORY.fastDecompressor();
   private static final LZ4Compressor LZ4_COMPRESSOR = LZ4_FACTORY.fastCompressor();
@@ -50,7 +51,6 @@ public class CaffeineCache implements io.druid.client.cache.Cache
   private final Cache<NamedKey, byte[]> cache;
   private final AtomicReference<CacheStats> priorStats = new AtomicReference<>(CacheStats.empty());
   private final CaffeineCacheConfig config;
-
 
   public static CaffeineCache create(final CaffeineCacheConfig config)
   {
@@ -66,14 +66,16 @@ public class CaffeineCache implements io.druid.client.cache.Cache
           .expireAfterAccess(config.getExpireAfter(), TimeUnit.MILLISECONDS);
     }
     if (config.getSizeInBytes() >= 0) {
-      builder
-          .maximumWeight(config.getSizeInBytes())
-          .weigher((NamedKey key, byte[] value) -> value.length
-                                                   + key.key.length
-                                                   + key.namespace.length() * Character.BYTES
-                                                   + FIXED_COST);
+      builder.maximumWeight(config.getSizeInBytes());
+    } else {
+      builder.maximumWeight(Math.min(MAX_DEFAULT_BYTES, Runtime.getRuntime().maxMemory() / 10));
     }
-    builder.executor(executor);
+    builder
+        .weigher((NamedKey key, byte[] value) -> value.length
+                                                    + key.key.length
+                                                    + key.namespace.length() * Character.BYTES
+                                                    + FIXED_COST)
+           .executor(executor);
     return new CaffeineCache(builder.build(), config);
   }
 

--- a/server/src/main/java/io/druid/client/cache/CaffeineCache.java
+++ b/server/src/main/java/io/druid/client/cache/CaffeineCache.java
@@ -72,10 +72,10 @@ public class CaffeineCache implements io.druid.client.cache.Cache
     }
     builder
         .weigher((NamedKey key, byte[] value) -> value.length
-                                                    + key.key.length
-                                                    + key.namespace.length() * Character.BYTES
-                                                    + FIXED_COST)
-           .executor(executor);
+                                                 + key.key.length
+                                                 + key.namespace.length() * Character.BYTES
+                                                 + FIXED_COST)
+        .executor(executor);
     return new CaffeineCache(builder.build(), config);
   }
 

--- a/server/src/main/java/io/druid/client/cache/CaffeineCache.java
+++ b/server/src/main/java/io/druid/client/cache/CaffeineCache.java
@@ -43,7 +43,7 @@ public class CaffeineCache implements io.druid.client.cache.Cache
 {
   private static final Logger log = new Logger(CaffeineCache.class);
   private static final int FIXED_COST = 8; // Minimum cost in "weight" per entry;
-  private static final int MAX_DEFAULT_BYTES = 1024 * 1024;
+  private static final int MAX_DEFAULT_BYTES = 1024 * 1024 * 1024;
   private static final LZ4Factory LZ4_FACTORY = LZ4Factory.fastestInstance();
   private static final LZ4FastDecompressor LZ4_DECOMPRESSOR = LZ4_FACTORY.fastDecompressor();
   private static final LZ4Compressor LZ4_COMPRESSOR = LZ4_FACTORY.fastCompressor();

--- a/server/src/test/java/io/druid/client/cache/CaffeineCacheTest.java
+++ b/server/src/test/java/io/druid/client/cache/CaffeineCacheTest.java
@@ -360,19 +360,19 @@ public class CaffeineCacheTest
 
     CacheStats stats = cache.getStats();
     Assert.assertEquals(0L, stats.getNumEntries());
-    Assert.assertEquals(-1L, stats.getSizeInBytes());
+    Assert.assertEquals(0L, stats.getSizeInBytes());
 
     cache.put(key1, val1);
 
     stats = cache.getStats();
     Assert.assertEquals(1L, stats.getNumEntries());
-    Assert.assertEquals(-1L, stats.getSizeInBytes());
+    Assert.assertEquals(0L, stats.getSizeInBytes());
 
     cache.put(key2, val2);
 
     stats = cache.getStats();
     Assert.assertEquals(2L, stats.getNumEntries());
-    Assert.assertEquals(-1L, stats.getSizeInBytes());
+    Assert.assertEquals(0L, stats.getSizeInBytes());
   }
 
   @Test

--- a/server/src/test/java/io/druid/client/cache/CaffeineCacheTest.java
+++ b/server/src/test/java/io/druid/client/cache/CaffeineCacheTest.java
@@ -366,13 +366,13 @@ public class CaffeineCacheTest
 
     stats = cache.getStats();
     Assert.assertEquals(1L, stats.getNumEntries());
-    Assert.assertEquals(0L, stats.getSizeInBytes());
+    Assert.assertEquals(34L, stats.getSizeInBytes());
 
     cache.put(key2, val2);
 
     stats = cache.getStats();
     Assert.assertEquals(2L, stats.getNumEntries());
-    Assert.assertEquals(0L, stats.getSizeInBytes());
+    Assert.assertEquals(68L, stats.getSizeInBytes());
   }
 
   @Test
@@ -461,7 +461,7 @@ public class CaffeineCacheTest
     caffeineCacheConfigJsonConfigProvider.inject(properties, configurator);
     final CaffeineCacheConfig config = caffeineCacheConfigJsonConfigProvider.get().get();
     Assert.assertEquals(-1, config.getExpireAfter());
-    Assert.assertEquals(-1, config.getSizeInBytes());
+    Assert.assertEquals(-1L, config.getSizeInBytes());
     Assert.assertEquals(ForkJoinPool.commonPool(), config.createExecutor());
   }
 


### PR DESCRIPTION
- Set a default size for caffeine cache - min(1GB, Runtime.maxMemory / 10).
- Update documentation.

For further info, please see discussion here: https://groups.google.com/forum/#!topic/druid-user/U0q_fHJtUwo