### PR TITLE
Move to the org.lz4 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -555,9 +555,9 @@
                 <version>2.0.1</version>
             </dependency>
             <dependency>
-                <groupId>net.jpountz.lz4</groupId>
-                <artifactId>lz4</artifactId>
-                <version>1.3.0</version>
+                <groupId>org.lz4</groupId>
+                <artifactId>lz4-java</artifactId>
+                <version>1.4.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.protobuf</groupId>

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -95,8 +95,8 @@
             <artifactId>rhino</artifactId>
         </dependency>
         <dependency>
-            <groupId>net.jpountz.lz4</groupId>
-            <artifactId>lz4</artifactId>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mapdb</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -146,8 +146,8 @@
             <artifactId>spymemcached</artifactId>
         </dependency>
         <dependency>
-            <groupId>net.jpountz.lz4</groupId>
-            <artifactId>lz4</artifactId>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
Hi all,

I would like to change the `net.jpountz.lz4` dependency to `org.lz4` and bump the version. Currently the `org.lz4` version of Spark is at 1.4.0 and causes Java classpath problems. 

Please refer to: https://github.com/lz4/lz4-java/blob/master/CHANGES.md#140 _groupId and artifactId have been changed from net.jpountz.lz4 and lz4 to org.lz4 and lz4-java, respectively. (Rei Odaira)_

Cheers, Fokko
