### PR TITLE
Fix metrics for inserting segments

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/common/actions/SegmentTransactionalInsertAction.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/actions/SegmentTransactionalInsertAction.java
@@ -135,6 +135,7 @@ public class SegmentTransactionalInsertAction implements TaskAction<SegmentPubli
       toolbox.getEmitter().emit(metricBuilder.build("segment/txn/failure", 1));
     }
 
+    // getSegments() should return an empty set if announceHistoricalSegments() failed
     for (DataSegment segment : retVal.getSegments()) {
       metricBuilder.setDimension(DruidMetrics.INTERVAL, segment.getInterval().toString());
       toolbox.getEmitter().emit(metricBuilder.build("segment/added/bytes", segment.getSize()));


### PR DESCRIPTION
Metrics should be collected no matter whether the insertion succeeds or not.

This was introduced in 0.12.0, so I labeled for 0.12.1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/druid-io/druid/5749)
<!-- Reviewable:end -->
