### PR TITLE
Bump Apache Parquet to 1.10.0

### DIFF
--- a/extensions-contrib/parquet-extensions/pom.xml
+++ b/extensions-contrib/parquet-extensions/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-avro</artifactId>
-            <version>1.8.3</version>
+            <version>1.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.xerial.snappy</groupId>

--- a/extensions-contrib/parquet-extensions/pom.xml
+++ b/extensions-contrib/parquet-extensions/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-avro</artifactId>
-            <version>1.8.2</version>
+            <version>1.8.3</version>
         </dependency>
         <dependency>
             <groupId>org.xerial.snappy</groupId>


### PR DESCRIPTION
Hi all,

I'd like to bump Parquet to 1.10.0. This is a minor upgrade and fixes some issues with the statistics of the Parquet file format: https://github.com/apache/parquet-mr/blob/master/CHANGES.md

I'm working on porting the indexing process to Spark: https://github.com/Fokko/druid-indexing-on-spark. Currently not yet working, but I expect a first version in a couple of weeks.

Cheers, Fokko