### PR TITLE
PartitionHolder: Early return from isComplete when we find an end.

### DIFF
--- a/common/src/main/java/io/druid/timeline/partition/PartitionHolder.java
+++ b/common/src/main/java/io/druid/timeline/partition/PartitionHolder.java
@@ -96,6 +96,10 @@ public class PartitionHolder<T> implements Iterable<PartitionChunk<T>>
       return false;
     }
 
+    if (curr.isEnd()) {
+      return true;
+    }
+
     while (iter.hasNext()) {
       PartitionChunk<T> next = iter.next();
       if (!curr.abuts(next)) {
@@ -103,7 +107,7 @@ public class PartitionHolder<T> implements Iterable<PartitionChunk<T>>
       }
 
       if (next.isEnd()) {
-        endSeen = true;
+        return true;
       }
       curr = next;
     }

--- a/common/src/main/java/io/druid/timeline/partition/PartitionHolder.java
+++ b/common/src/main/java/io/druid/timeline/partition/PartitionHolder.java
@@ -90,7 +90,6 @@ public class PartitionHolder<T> implements Iterable<PartitionChunk<T>>
     Iterator<PartitionChunk<T>> iter = holderSet.iterator();
 
     PartitionChunk<T> curr = iter.next();
-    boolean endSeen = curr.isEnd();
 
     if (!curr.isStart()) {
       return false;
@@ -112,7 +111,7 @@ public class PartitionHolder<T> implements Iterable<PartitionChunk<T>>
       curr = next;
     }
 
-    return endSeen;
+    return false;
   }
 
   public PartitionChunk<T> getChunk(final int partitionNum)


### PR DESCRIPTION
Holders are complete if they have a start, sequence of abutting objects, and
then an end. There isn't any reason to check whether or not the objects _after_
the end are abutting (the extensible set).

This is really a performance patch, since behavior shouldn't be changing. The
extensible shardSpecs (where we could have shards after the end) are always
abutting each other anyway. Performance doesn't usually matter much in this
function, but it can when there are thousands of segments per time chunk.