### PR TITLE
Support for request logging in kafka emitter.

### DIFF
--- a/docs/content/development/extensions-contrib/kafka-emitter.md
+++ b/docs/content/development/extensions-contrib/kafka-emitter.md
@@ -22,6 +22,7 @@ All the configuration parameters for the Kafka emitter are under `druid.emitter.
 |`druid.emitter.kafka.bootstrap.servers`|Comma-separated Kafka broker. (`[hostname:port],[hostname:port]...`)|yes|none|
 |`druid.emitter.kafka.metric.topic`|Kafka topic name for emitter's target to emit service metric.|yes|none|
 |`druid.emitter.kafka.alert.topic`|Kafka topic name for emitter's target to emit alert.|yes|none|
+|`druid.emitter.kafka.request.topic`|Kafka topic name for emitter's target to emit request logs.|yes|none|
 |`druid.emitter.kafka.producer.config`|JSON formatted configuration which user want to set additional properties to Kafka producer.|no|none|
 |`druid.emitter.kafka.clusterName`|Optional value to specify name of your druid cluster. It can help make groups in your monitoring environment. |no|none|
 
@@ -31,5 +32,6 @@ All the configuration parameters for the Kafka emitter are under `druid.emitter.
 druid.emitter.kafka.bootstrap.servers=hostname1:9092,hostname2:9092
 druid.emitter.kafka.metric.topic=druid-metric
 druid.emitter.kafka.alert.topic=druid-alert
+druid.emitter.kafka.request.topic=druid-request
 druid.emitter.kafka.producer.config={"max.block.ms":10000}
 ```

--- a/extensions-contrib/kafka-emitter/pom.xml
+++ b/extensions-contrib/kafka-emitter/pom.xml
@@ -54,6 +54,12 @@
     </dependency>
     <dependency>
       <groupId>io.druid</groupId>
+      <artifactId>druid-server</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.druid</groupId>
       <artifactId>java-util</artifactId>
       <version>${project.parent.version}</version>
       <scope>provided</scope>

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/ClusterNameMixin.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/ClusterNameMixin.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.emitter.kafka;
+
+import com.fasterxml.jackson.databind.annotation.JsonAppend;
+
+@JsonAppend(
+    attrs = {
+        @JsonAppend.Attr(value = "clusterName")
+    }
+)
+public class ClusterNameMixin
+{
+}

--- a/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/io/druid/emitter/kafka/KafkaEmitterConfig.java
@@ -37,6 +37,8 @@ public class KafkaEmitterConfig
   private final String metricTopic;
   @JsonProperty("alert.topic")
   private final String alertTopic;
+  @JsonProperty("request.topic")
+  private final String requestTopic;
   @JsonProperty
   private final String clusterName;
   @JsonProperty("producer.config")
@@ -47,6 +49,7 @@ public class KafkaEmitterConfig
       @JsonProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG) String bootstrapServers,
       @JsonProperty("metric.topic") String metricTopic,
       @JsonProperty("alert.topic") String alertTopic,
+      @JsonProperty("request.topic") String requestTopic,
       @JsonProperty("clusterName") String clusterName,
       @JsonProperty("producer.config") @Nullable Map<String, String> kafkaProducerConfig
   )
@@ -54,6 +57,7 @@ public class KafkaEmitterConfig
     this.bootstrapServers = Preconditions.checkNotNull(bootstrapServers, "bootstrap.servers can not be null");
     this.metricTopic = Preconditions.checkNotNull(metricTopic, "metric.topic can not be null");
     this.alertTopic = Preconditions.checkNotNull(alertTopic, "alert.topic can not be null");
+    this.requestTopic = Preconditions.checkNotNull(requestTopic, "request.topic can not be null");
     this.clusterName = clusterName;
     this.kafkaProducerConfig = kafkaProducerConfig == null ? ImmutableMap.of() : kafkaProducerConfig;
   }
@@ -74,6 +78,12 @@ public class KafkaEmitterConfig
   public String getAlertTopic()
   {
     return alertTopic;
+  }
+
+  @JsonProperty
+  public String getRequestTopic()
+  {
+    return requestTopic;
   }
 
   @JsonProperty
@@ -109,6 +119,9 @@ public class KafkaEmitterConfig
     if (!getAlertTopic().equals(that.getAlertTopic())) {
       return false;
     }
+    if (!getRequestTopic().equals(that.getRequestTopic())) {
+      return false;
+    }
     if (getClusterName() != null ? !getClusterName().equals(that.getClusterName()) : that.getClusterName() != null) {
       return false;
     }
@@ -121,6 +134,7 @@ public class KafkaEmitterConfig
     int result = getBootstrapServers().hashCode();
     result = 31 * result + getMetricTopic().hashCode();
     result = 31 * result + getAlertTopic().hashCode();
+    result = 31 * result + getRequestTopic().hashCode();
     result = 31 * result + (getClusterName() != null ? getClusterName().hashCode() : 0);
     result = 31 * result + getKafkaProducerConfig().hashCode();
     return result;
@@ -133,6 +147,7 @@ public class KafkaEmitterConfig
            "bootstrap.servers='" + bootstrapServers + '\'' +
            ", metric.topic='" + metricTopic + '\'' +
            ", alert.topic='" + alertTopic + '\'' +
+           ", request.topic='" + requestTopic + '\'' +
            ", clusterName='" + clusterName + '\'' +
            ", Producer.config=" + kafkaProducerConfig +
            '}';

--- a/extensions-contrib/kafka-emitter/src/test/java/io/druid/emitter/kafka/KafkaEmitterConfigTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/io/druid/emitter/kafka/KafkaEmitterConfigTest.java
@@ -43,7 +43,7 @@ public class KafkaEmitterConfigTest
   public void testSerDeserKafkaEmitterConfig() throws IOException
   {
     KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", "metricTest",
-                                                                   "alertTest", "clusterNameTest",
+                                                                   "alertTest", "requestTest", "clusterNameTest",
                                                                    ImmutableMap.<String, String>builder()
                                                                        .put("testKey", "testValue").build()
     );
@@ -57,7 +57,7 @@ public class KafkaEmitterConfigTest
   public void testSerDeNotRequiredKafkaProducerConfig()
   {
     KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("localhost:9092", "metricTest",
-                                                                   "alertTest", "clusterNameTest",
+                                                                   "alertTest", "requestTest", "clusterNameTest",
                                                                    null
     );
     try {


### PR DESCRIPTION
This is an initial version of #5700 fix. Works as expected, rich request logs are emitted to dedicated kafka topic as complex JSON structure. But the overall design of the solution is ugly, kafka emitter needs to know too many details about emitted events to serialize them correctly. 

For ServiceMetricEvent and AlertEvents kafka emitter serializes map like structure of the event. But for ReqestLogEvent it does not work due to complex query and queryStats fields. So for the complex object like RequestLogEvent Jakson databind is used for serialization instead of Event.toMap method. 

In my opinion emitters should depend fully on Jakson databind for serialization instead of Event.toMap method. But it requires changes in ServiceMetricEvent and AlertEvents and I'm not sure about impact on another emitter implementations.

@dkhwangbo, @jihoonson What do you think? 