### PR TITLE
Fix for when Hadoop dataSource inputSpec is specified multiple times.

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopIngestionSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopIngestionSpec.java
@@ -36,6 +36,7 @@ import io.druid.timeline.partition.PartitionChunk;
 import org.joda.time.Interval;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -150,20 +151,19 @@ public class HadoopIngestionSpec extends IngestionSpec<HadoopIOConfig, HadoopTun
     String ingestionSpec = "ingestionSpec";
 
     Map<String, Object> pathSpec = spec.getIOConfig().getPathSpec();
-    Map<String, Object> datasourcePathSpec = null;
+    List<Map<String, Object>> datasourcePathSpecs = new ArrayList<>();
     if (pathSpec.get(type).equals(dataSource)) {
-      datasourcePathSpec = pathSpec;
+      datasourcePathSpecs.add(pathSpec);
     } else if (pathSpec.get(type).equals(multi)) {
       List<Map<String, Object>> childPathSpecs = (List<Map<String, Object>>) pathSpec.get(children);
       for (Map<String, Object> childPathSpec : childPathSpecs) {
         if (childPathSpec.get(type).equals(dataSource)) {
-          datasourcePathSpec = childPathSpec;
-          break;
+          datasourcePathSpecs.add(childPathSpec);
         }
       }
     }
 
-    if (datasourcePathSpec != null) {
+    for (Map<String, Object> datasourcePathSpec : datasourcePathSpecs) {
       Map<String, Object> ingestionSpecMap = (Map<String, Object>) datasourcePathSpec.get(ingestionSpec);
       DatasourceIngestionSpec ingestionSpecObj = jsonMapper.convertValue(
           ingestionSpecMap,

--- a/indexing-hadoop/src/test/java/io/druid/indexer/HadoopIngestionSpecUpdateDatasourcePathSpecSegmentsTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/HadoopIngestionSpecUpdateDatasourcePathSpecSegmentsTest.java
@@ -51,9 +51,12 @@ import java.util.Map;
  */
 public class HadoopIngestionSpecUpdateDatasourcePathSpecSegmentsTest
 {
-  private final String testDatasource = "test";
-  private final Interval testDatasourceInterval = Intervals.of("1970/3000");
-  private final Interval testDatasourceIntervalPartial = Intervals.of("2050/3000");
+  private static final String testDatasource = "test";
+  private static final String testDatasource2 = "test2";
+  private static final Interval testDatasourceInterval = Intervals.of("1970/3000");
+  private static final Interval testDatasourceInterval2 = Intervals.of("2000/2001");
+  private static final Interval testDatasourceIntervalPartial = Intervals.of("2050/3000");
+
   private final ObjectMapper jsonMapper;
 
   public HadoopIngestionSpecUpdateDatasourcePathSpecSegmentsTest()
@@ -67,7 +70,7 @@ public class HadoopIngestionSpecUpdateDatasourcePathSpecSegmentsTest
   }
 
   private static final DataSegment SEGMENT = new DataSegment(
-      "test1",
+      testDatasource,
       Intervals.of("2000/3000"),
       "ver",
       ImmutableMap.<String, Object>of(
@@ -75,6 +78,21 @@ public class HadoopIngestionSpecUpdateDatasourcePathSpecSegmentsTest
           "path", "/tmp/index1.zip"
       ),
       ImmutableList.of("host"),
+      ImmutableList.of("visited_sum", "unique_hosts"),
+      NoneShardSpec.instance(),
+      9,
+      2
+  );
+
+  private static final DataSegment SEGMENT2 = new DataSegment(
+      testDatasource2,
+      Intervals.of("2000/3000"),
+      "ver2",
+      ImmutableMap.<String, Object>of(
+          "type", "local",
+          "path", "/tmp/index2.zip"
+      ),
+      ImmutableList.of("host2"),
       ImmutableList.of("visited_sum", "unique_hosts"),
       NoneShardSpec.instance(),
       9,
@@ -218,6 +236,23 @@ public class HadoopIngestionSpecUpdateDatasourcePathSpecSegmentsTest
                 ),
                 null,
                 false
+            ),
+            new DatasourcePathSpec(
+                jsonMapper,
+                null,
+                new DatasourceIngestionSpec(
+                    testDatasource2,
+                    testDatasourceInterval2,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    false,
+                    null
+                ),
+                null,
+                false
             )
         )
     );
@@ -228,6 +263,10 @@ public class HadoopIngestionSpecUpdateDatasourcePathSpecSegmentsTest
     Assert.assertEquals(
         ImmutableList.of(WindowedDataSegment.of(SEGMENT)),
         ((DatasourcePathSpec) ((MultiplePathSpec) config.getPathSpec()).getChildren().get(1)).getSegments()
+    );
+    Assert.assertEquals(
+        ImmutableList.of(new WindowedDataSegment(SEGMENT2, testDatasourceInterval2)),
+        ((DatasourcePathSpec) ((MultiplePathSpec) config.getPathSpec()).getChildren().get(2)).getSegments()
     );
   }
 
@@ -264,9 +303,21 @@ public class HadoopIngestionSpecUpdateDatasourcePathSpecSegmentsTest
     );
 
     UsedSegmentLister segmentLister = EasyMock.createMock(UsedSegmentLister.class);
+
     EasyMock.expect(
-        segmentLister.getUsedSegmentsForIntervals(testDatasource, Lists.newArrayList(jobInterval))
+        segmentLister.getUsedSegmentsForIntervals(
+            testDatasource,
+            Lists.newArrayList(jobInterval != null ? jobInterval.overlap(testDatasourceInterval) : null)
+        )
     ).andReturn(ImmutableList.of(SEGMENT));
+
+    EasyMock.expect(
+        segmentLister.getUsedSegmentsForIntervals(
+            testDatasource2,
+            Lists.newArrayList(jobInterval != null ? jobInterval.overlap(testDatasourceInterval2) : null)
+        )
+    ).andReturn(ImmutableList.of(SEGMENT2));
+
     EasyMock.replay(segmentLister);
 
     spec = HadoopIngestionSpec.updateSegmentListIfDatasourcePathSpecIsUsed(spec, jsonMapper, segmentLister);


### PR DESCRIPTION
This feature was introduced in #5717 but it didn't work in production
because this magical rewriter code wasn't also modified. Now, it is.

I even tested it this time.