### PR TITLE
Update jsonpath dependency

### DIFF
--- a/api/src/test/java/io/druid/data/input/impl/JSONParseSpecTest.java
+++ b/api/src/test/java/io/druid/data/input/impl/JSONParseSpecTest.java
@@ -80,6 +80,31 @@ public class JSONParseSpecTest
   }
 
   @Test
+  public void testParseRowWithConditional()
+  {
+    final JSONParseSpec parseSpec = new JSONParseSpec(
+        new TimestampSpec("timestamp", "iso", null),
+        new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("foo")), null, null),
+        new JSONPathSpec(
+            true,
+            ImmutableList.of(
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "foo", "$.maybe_object.foo")
+            )
+        ),
+        null
+    );
+
+    final Map<String, Object> expected = new HashMap<>();
+    expected.put("foo", null);
+
+    final Parser<String, Object> parser = parseSpec.makeParser();
+    final Map<String, Object> parsedRow = parser.parseToMap("{\"something_else\": {\"foo\": \"test\"}}");
+
+    Assert.assertNotNull(parsedRow);
+    Assert.assertEquals(expected, parsedRow);
+  }
+
+  @Test
   public void testSerde() throws IOException
   {
     HashMap<String, Boolean> feature = new HashMap<String, Boolean>();

--- a/api/src/test/java/io/druid/data/input/impl/JSONParseSpecTest.java
+++ b/api/src/test/java/io/druid/data/input/impl/JSONParseSpecTest.java
@@ -30,6 +30,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -88,14 +89,16 @@ public class JSONParseSpecTest
         new JSONPathSpec(
             true,
             ImmutableList.of(
-                new JSONPathFieldSpec(JSONPathFieldType.PATH, "foo", "$.maybe_object.foo")
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "foo", "$.[?(@.maybe_object)].maybe_object.foo.test"),
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "bar", "$.[?(@.something_else)].something_else.foo")
             )
         ),
         null
     );
 
     final Map<String, Object> expected = new HashMap<>();
-    expected.put("foo", null);
+    expected.put("foo", new ArrayList());
+    expected.put("bar", Arrays.asList("test"));
 
     final Parser<String, Object> parser = parseSpec.makeParser();
     final Map<String, Object> parsedRow = parser.parseToMap("{\"something_else\": {\"foo\": \"test\"}}");

--- a/java-util/pom.xml
+++ b/java-util/pom.xml
@@ -92,12 +92,6 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>net.minidev</groupId>
-                    <artifactId>json-smart</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.thisptr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -635,7 +635,7 @@
             <dependency>
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path</artifactId>
-                <version>2.1.0</version>
+                <version>2.3.0</version>
             </dependency>
             <dependency>
                 <groupId>net.thisptr</groupId>


### PR DESCRIPTION
- Add a unit test containing a JSONPath conditional
- Update the JSONPath library and no longer exclude the json-smart dependency.
- I believe the original reason for excluding this has been fixed: https://github.com/json-path/JsonPath/pull/315