### PR TITLE
Fix NPE in PrefetchableTextFilesFirehoseFactory

### DIFF
--- a/api/src/main/java/io/druid/data/input/impl/prefetch/PrefetchConfig.java
+++ b/api/src/main/java/io/druid/data/input/impl/prefetch/PrefetchConfig.java
@@ -28,7 +28,6 @@ public class PrefetchConfig
   public static final long DEFAULT_MAX_CACHE_CAPACITY_BYTES = 1024 * 1024 * 1024; // 1GB
   public static final long DEFAULT_MAX_FETCH_CAPACITY_BYTES = 1024 * 1024 * 1024; // 1GB
   public static final long DEFAULT_FETCH_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(60);
-  public static final int DEFAULT_MAX_FETCH_RETRY = 3;
 
   // A roughly max size of total fetched objects, but the actual fetched size can be bigger. The reason is our current
   // client implementations for cloud storages like s3 don't support range scan yet, so we must download the whole file

--- a/api/src/main/java/io/druid/data/input/impl/prefetch/PrefetchableTextFilesFirehoseFactory.java
+++ b/api/src/main/java/io/druid/data/input/impl/prefetch/PrefetchableTextFilesFirehoseFactory.java
@@ -91,6 +91,8 @@ public abstract class PrefetchableTextFilesFirehoseFactory<T>
 {
   private static final Logger LOG = new Logger(PrefetchableTextFilesFirehoseFactory.class);
 
+  public static final int DEFAULT_MAX_FETCH_RETRY = 3;
+
   private final CacheManager<T> cacheManager;
   private final PrefetchConfig prefetchConfig;
 
@@ -114,7 +116,7 @@ public abstract class PrefetchableTextFilesFirehoseFactory<T>
     this.cacheManager = new CacheManager<>(
         prefetchConfig.getMaxCacheCapacityBytes()
     );
-    this.maxFetchRetry = maxFetchRetry;
+    this.maxFetchRetry = maxFetchRetry == null ? DEFAULT_MAX_FETCH_RETRY : maxFetchRetry;
   }
 
   @JsonProperty


### PR DESCRIPTION
If `maxFetchRetry` is null when creating a `PrefetchableTextFilesFirehoseFactory`, an NPE occurs.