### PR TITLE
[Proposal] Add default user to basic security extension

### DIFF
--- a/extensions-core/druid-basic-security/src/test/java/io/druid/security/authentication/CoordinatorBasicAuthenticatorMetadataStorageUpdaterTest.java
+++ b/extensions-core/druid-basic-security/src/test/java/io/druid/security/authentication/CoordinatorBasicAuthenticatorMetadataStorageUpdaterTest.java
@@ -76,6 +76,7 @@ public class CoordinatorBasicAuthenticatorMetadataStorageUpdaterTest
                     null,
                     null,
                     null,
+                    null,
                     null
                 )
             )

--- a/extensions-core/druid-basic-security/src/test/java/io/druid/security/authentication/CoordinatorBasicAuthenticatorResourceTest.java
+++ b/extensions-core/druid-basic-security/src/test/java/io/druid/security/authentication/CoordinatorBasicAuthenticatorResourceTest.java
@@ -87,6 +87,7 @@ public class CoordinatorBasicAuthenticatorResourceTest
                 "druid",
                 null,
                 null,
+                null,
                 null
             ),
             AUTHENTICATOR_NAME2,
@@ -96,6 +97,7 @@ public class CoordinatorBasicAuthenticatorResourceTest
                 "test",
                 "druid",
                 "druid",
+                null,
                 null,
                 null,
                 null


### PR DESCRIPTION
The druid-basic-security extension locks everything down by default. This change gives access to a default user if the Druid request has no authorization header. The user's name is configurable and will default to "defaultUser".

The authorization API would still need to be used to create a user with the above name, a role and a permission. For example, a permission could be read only for datasources.

Comments welcome.