### PR TITLE
Security - add anonymous authenticator

### DIFF
--- a/docs/content/configuration/auth.md
+++ b/docs/content/configuration/auth.md
@@ -29,11 +29,35 @@ A request will pass through all Authenticators in the chain, until one of the Au
 
 If no Authenticator in the chain successfully authenticated a request or sent an HTTP error response, an HTTP error response will be sent at the end of the chain.
 
-Druid includes a built-in Authenticator, used for the default unsecured configuration.
+Druid includes two built-in Authenticators, one of which is used for the default unsecured configuration.
 
 ### AllowAll Authenticator
 
 This built-in Authenticator authenticates all requests, and always directs them to an Authorizer named "allowAll". It is not intended to be used for anything other than the default unsecured configuration.
+
+### Anonymous Authenticator
+
+This built-in Authenticator authenticates all requests, and directs them to an Authorizer specified in the configuration by the user. It is intended to be used for adding a default level of access.
+The Anonymous Authenticator would be added to the end of the authentication chain so if a user sends a request which fails the first part of the chain, the request will succeed or fail depending on how the Authorizer linked to the Anonymous Authenticator is configured.
+
+|Property|Description|Default|Required|
+|--------|-----------|-------|--------|
+|`druid.auth.authenticator.<authenticatorName>.authorizerName`|Authorizer that requests should be directed to.|N/A|Yes|
+|`druid.auth.authenticator.<authenticatorName>.identity`|The identity of the requester.|defaultUser|No|
+
+To use the Anonymous Authenticator, add an authenticator with type `anonymous` to the authenticatorChain.
+
+For example, the following enables the Anonymous Authenticator with the `druid-basic-security` extension:
+
+```
+druid.auth.authenticatorChain=["basic", "anonymous"]
+
+druid.auth.authenticator.anonymous.type=anonymous
+druid.auth.authenticator.anonymous.identity=defaultUser
+druid.auth.authenticator.anonymous.authorizerName=myBasicAuthorizer
+
+# ... usual configs for basic authentication would go here ...
+```
 
 ## Escalator
 The `druid.escalator.type` property determines what authentication scheme should be used for internal Druid cluster communications (such as when a broker node communicates with historical nodes for query processing).

--- a/docs/content/configuration/auth.md
+++ b/docs/content/configuration/auth.md
@@ -37,8 +37,8 @@ This built-in Authenticator authenticates all requests, and always directs them 
 
 ### Anonymous Authenticator
 
-This built-in Authenticator authenticates all requests, and directs them to an Authorizer specified in the configuration by the user. It is intended to be used for adding a default level of access.
-The Anonymous Authenticator would be added to the end of the authentication chain so if a user sends a request which fails the first part of the chain, the request will succeed or fail depending on how the Authorizer linked to the Anonymous Authenticator is configured.
+This built-in Authenticator authenticates all requests, and directs them to an Authorizer specified in the configuration by the user. It is intended to be used for adding a default level of access so 
+the Anonymous Authenticator should be added to the end of the authentication chain. A request that reaches the Anonymous Authenticator at the end of the chain will succeed or fail depending on how the Authorizer linked to the Anonymous Authenticator is configured.
 
 |Property|Description|Default|Required|
 |--------|-----------|-------|--------|

--- a/server/src/main/java/io/druid/server/security/AnonymousAuthenticator.java
+++ b/server/src/main/java/io/druid/server/security/AnonymousAuthenticator.java
@@ -41,9 +41,6 @@ import java.util.Map;
 public class AnonymousAuthenticator implements Authenticator
 {
   private final AuthenticationResult anonymousResult;
-  private final String name;
-  private final String authorizerName;
-  private final String identity;
   private final String DEFAULT_IDENTITY = "defaultUser";
 
   @JsonCreator
@@ -53,13 +50,10 @@ public class AnonymousAuthenticator implements Authenticator
       @JsonProperty("identity") String identity
   )
   {
-    this.name = name;
-    this.authorizerName = authorizerName;
-    this.identity = identity == null ? DEFAULT_IDENTITY : identity;
     this.anonymousResult = new AuthenticationResult(
-      this.identity,
-      this.authorizerName,
-      this.name,
+      identity == null ? DEFAULT_IDENTITY : identity,
+      authorizerName,
+      name,
       null
     );
   }

--- a/server/src/main/java/io/druid/server/security/AnonymousAuthenticator.java
+++ b/server/src/main/java/io/druid/server/security/AnonymousAuthenticator.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.security;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Map;
+
+/**
+ * Authenticates all requests and directs them to an authorizer.
+ */
+@JsonTypeName("anonymous")
+public class AnonymousAuthenticator implements Authenticator
+{
+  private final AuthenticationResult anonymousResult;
+  private final String name;
+  private final String authorizerName;
+  private final String identity;
+  private final String DEFAULT_IDENTITY = "defaultUser";
+
+  @JsonCreator
+  public AnonymousAuthenticator(
+      @JsonProperty("name") String name,
+      @JsonProperty("authorizerName") String authorizerName,
+      @JsonProperty("identity") String identity
+  )
+  {
+    this.name = name;
+    this.authorizerName = authorizerName;
+    this.identity = identity == null ? DEFAULT_IDENTITY : identity;
+    this.anonymousResult = new AuthenticationResult(
+      this.identity,
+      this.authorizerName,
+      this.name,
+      null
+    );
+  }
+
+  @Override
+  public Class<? extends Filter> getFilterClass()
+  {
+    return null;
+  }
+
+  @Override
+  public Map<String, String> getInitParameters()
+  {
+    return null;
+  }
+
+  @Override
+  public String getPath()
+  {
+    return "/*";
+  }
+
+  @Override
+  public EnumSet<DispatcherType> getDispatcherType()
+  {
+    return null;
+  }
+
+  @Override
+  public Filter getFilter()
+  {
+    return new Filter()
+    {
+      @Override
+      public void init(FilterConfig filterConfig)
+      {
+
+      }
+
+      @Override
+      public void doFilter(
+          ServletRequest request, ServletResponse response, FilterChain chain
+      ) throws IOException, ServletException
+      {
+        request.setAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT, anonymousResult);
+        chain.doFilter(request, response);
+      }
+
+      @Override
+      public void destroy()
+      {
+
+      }
+    };
+  }
+
+  @Override
+  public String getAuthChallengeHeader()
+  {
+    return null;
+  }
+
+  @Override
+  public AuthenticationResult authenticateJDBCContext(Map<String, Object> context)
+  {
+    return anonymousResult;
+  }
+}

--- a/server/src/main/java/io/druid/server/security/AuthConfig.java
+++ b/server/src/main/java/io/druid/server/security/AuthConfig.java
@@ -42,6 +42,8 @@ public class AuthConfig
 
   public static final String ALLOW_ALL_NAME = "allowAll";
 
+  public static final String ANONYMOUS_NAME = "anonymous";
+
   public AuthConfig()
   {
     this(null, null, null, false);

--- a/server/src/main/java/io/druid/server/security/Authenticator.java
+++ b/server/src/main/java/io/druid/server/security/Authenticator.java
@@ -33,6 +33,7 @@ import java.util.Map;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes(value = {
     @JsonSubTypes.Type(name = AuthConfig.ALLOW_ALL_NAME, value = AllowAllAuthenticator.class),
+    @JsonSubTypes.Type(name = AuthConfig.ANONYMOUS_NAME, value = AnonymousAuthenticator.class),
 })
 /**
  * This interface is essentially a ServletFilterHolder with additional requirements on the getFilter() method contract, plus:


### PR DESCRIPTION
Anonymous authenticator will authenticate all requests and then direct them to an authorizer. See #5821 (This pull request will probably replace 5821). This anonymous authenticator is similar to allowAll authenticator in that it will authenticate every request but the anonymous authenticator will point to a custom authorizer (such as the basic authorizer in the config below).

**Example usage in common.runtime.properties**
```
druid.auth.authenticatorChain=["MyBasicAuthenticator","anonymous"]

druid.auth.authenticator.MyBasicAuthenticator.type=basic
druid.auth.authenticator.MyBasicAuthenticator.initialAdminPassword=password1
druid.auth.authenticator.MyBasicAuthenticator.initialInternalClientPassword=password2
druid.auth.authenticator.MyBasicAuthenticator.authorizerName=MyBasicAuthorizer

druid.auth.authenticator.anonymous.type=anonymous
druid.auth.authenticator.anonymous.authorizerName=MyBasicAuthorizer
druid.auth.authenticator.anonymous.identity=tester

# Escalator
druid.escalator.type=basic
druid.escalator.internalClientUsername=druid_system
druid.escalator.internalClientPassword=password2
druid.escalator.authorizerName=MyBasicAuthorizer

druid.auth.authorizers=["MyBasicAuthorizer"]
druid.auth.authorizer.MyBasicAuthorizer.type=basic
```
The anonymous authenticator would be added to the end of the authentication chain so if a user sends a request which fails the first part of the chain, the request will succeed or fail depending on the authorizer linked to the anonymous authenticator and how it's configured.
