### PR TITLE
Snappy decompression support

### DIFF
--- a/java-util/src/main/java/io/druid/java/util/common/CompressionUtils.java
+++ b/java-util/src/main/java/io/druid/java/util/common/CompressionUtils.java
@@ -29,6 +29,7 @@ import com.google.common.io.Files;
 import io.druid.java.util.common.io.NativeIO;
 import io.druid.java.util.common.logger.Logger;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
+import org.apache.commons.compress.compressors.snappy.FramedSnappyCompressorInputStream;
 import org.apache.commons.compress.compressors.xz.XZCompressorInputStream;
 
 import java.io.BufferedInputStream;
@@ -56,6 +57,7 @@ public class CompressionUtils
   private static final String GZ_SUFFIX = ".gz";
   private static final String XZ_SUFFIX = ".xz";
   private static final String ZIP_SUFFIX = ".zip";
+  private static final String SNAPPY_SUFFIX = ".sz";
 
   /**
    * Zip the contents of directory into the file indicated by outputZipFile. Sub directories are skipped
@@ -536,6 +538,8 @@ public class CompressionUtils
       return new BZip2CompressorInputStream(in, true);
     } else if (fileName.endsWith(XZ_SUFFIX)) {
       return new XZCompressorInputStream(in, true);
+    } else if (fileName.endsWith(SNAPPY_SUFFIX)) {
+      return new FramedSnappyCompressorInputStream(in);
     } else if (fileName.endsWith(ZIP_SUFFIX)) {
       // This reads the first file in the archive.
       final ZipInputStream zipIn = new ZipInputStream(in, StandardCharsets.UTF_8);

--- a/java-util/src/test/java/io/druid/java/util/common/CompressionUtilsTest.java
+++ b/java-util/src/test/java/io/druid/java/util/common/CompressionUtilsTest.java
@@ -26,6 +26,7 @@ import com.google.common.io.ByteSource;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
+import org.apache.commons.compress.compressors.snappy.FramedSnappyCompressorOutputStream;
 import org.apache.commons.compress.compressors.xz.XZCompressorOutputStream;
 import org.junit.Assert;
 import org.junit.Before;
@@ -271,6 +272,20 @@ public class CompressionUtilsTest
       ByteStreams.copy(new FileInputStream(testFile), out);
     }
     try (final InputStream inputStream = CompressionUtils.decompress(new FileInputStream(xzFile), xzFile.getName())) {
+      assertGoodDataStream(inputStream);
+    }
+  }
+
+  @Test
+  public void testDecompressSnappy() throws IOException
+  {
+    final File tmpDir = temporaryFolder.newFolder("testDecompressSnappy");
+    final File snappyFile = new File(tmpDir, testFile.getName() + ".sz");
+    Assert.assertFalse(snappyFile.exists());
+    try (final OutputStream out = new FramedSnappyCompressorOutputStream(new FileOutputStream(snappyFile))) {
+      ByteStreams.copy(new FileInputStream(testFile), out);
+    }
+    try (final InputStream inputStream = CompressionUtils.decompress(new FileInputStream(snappyFile), snappyFile.getName())) {
       assertGoodDataStream(inputStream);
     }
   }


### PR DESCRIPTION
Support decompression of files using Google's Snappy algorithm.

This only supports files compressed with the Snappy framing format
described here: https://github.com/google/snappy/blob/master/framing_format.txt