### PR TITLE
add method getRequiredColumns for DimFilter

### DIFF
--- a/extensions-contrib/materialized-view-selection/src/main/java/io/druid/query/materializedview/MaterializedViewUtils.java
+++ b/extensions-contrib/materialized-view-selection/src/main/java/io/druid/query/materializedview/MaterializedViewUtils.java
@@ -48,10 +48,9 @@ public class MaterializedViewUtils
   public static Set<String> getRequiredFields(Query query)
   {
     Set<String> dimensions = new HashSet<>();
-    Set<String> dimsInFilter = query.getFilter().getRequiredColumns();
-    if (dimsInFilter != null) {
-      dimensions.addAll(dimsInFilter);
-    }
+    Set<String> dimsInFilter = null == query.getFilter() ? new HashSet<String>() : query.getFilter().getRequiredColumns();
+    dimensions.addAll(dimsInFilter);
+
     if (query instanceof TopNQuery) {
       TopNQuery q = (TopNQuery) query;
       dimensions.addAll(extractFieldsFromAggregations(q.getAggregatorSpecs()));

--- a/extensions-contrib/materialized-view-selection/src/main/java/io/druid/query/materializedview/MaterializedViewUtils.java
+++ b/extensions-contrib/materialized-view-selection/src/main/java/io/druid/query/materializedview/MaterializedViewUtils.java
@@ -20,24 +20,12 @@
 package io.druid.query.materializedview;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.JodaUtils;
 import io.druid.query.Query;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.FilteredAggregatorFactory;
 import io.druid.query.dimension.DimensionSpec;
-import io.druid.query.filter.AndDimFilter;
-import io.druid.query.filter.BoundDimFilter;
-import io.druid.query.filter.DimFilter;
-import io.druid.query.filter.InDimFilter;
-import io.druid.query.filter.IntervalDimFilter;
-import io.druid.query.filter.LikeDimFilter;
-import io.druid.query.filter.NotDimFilter;
-import io.druid.query.filter.OrDimFilter;
-import io.druid.query.filter.RegexDimFilter;
-import io.druid.query.filter.SearchQueryDimFilter;
-import io.druid.query.filter.SelectorDimFilter;
 import io.druid.query.groupby.GroupByQuery;
 import io.druid.query.timeseries.TimeseriesQuery;
 import io.druid.query.topn.TopNQuery;
@@ -60,7 +48,7 @@ public class MaterializedViewUtils
   public static Set<String> getRequiredFields(Query query)
   {
     Set<String> dimensions = new HashSet<>();
-    Set<String> dimsInFilter = getDimensionsInFilter(query.getFilter());
+    Set<String> dimsInFilter = query.getFilter().getRequiredColumns();
     if (dimsInFilter != null) {
       dimensions.addAll(dimsInFilter);
     }
@@ -90,56 +78,11 @@ public class MaterializedViewUtils
     for (AggregatorFactory agg : aggs) {
       if (agg instanceof FilteredAggregatorFactory) {
         FilteredAggregatorFactory fagg = (FilteredAggregatorFactory) agg;
-        ret.addAll(getDimensionsInFilter(fagg.getFilter()));
+        ret.addAll(fagg.getFilter().getRequiredColumns());
       }
       ret.addAll(agg.requiredFields());
     }
     return ret;
-  }
-
-  private static Set<String> getDimensionsInFilter(DimFilter dimFilter)
-  {
-    if (dimFilter instanceof AndDimFilter) {
-      AndDimFilter d = (AndDimFilter) dimFilter;
-      Set<String> ret = new HashSet<>();
-      for (DimFilter filter : d.getFields()) {
-        ret.addAll(getDimensionsInFilter(filter));
-      }
-      return ret;
-    } else if (dimFilter instanceof OrDimFilter) {
-      OrDimFilter d = (OrDimFilter) dimFilter;
-      Set<String> ret = new HashSet<>();
-      for (DimFilter filter : d.getFields()) {
-        ret.addAll(getDimensionsInFilter(filter));
-      }
-      return ret;
-    } else if (dimFilter instanceof NotDimFilter) {
-      NotDimFilter d = (NotDimFilter) dimFilter;
-      return getDimensionsInFilter(d.getField());
-    } else if (dimFilter instanceof BoundDimFilter) {
-      BoundDimFilter d = (BoundDimFilter) dimFilter;
-      return Sets.newHashSet(d.getDimension());
-    } else if (dimFilter instanceof InDimFilter) {
-      InDimFilter d = (InDimFilter) dimFilter;
-      return Sets.newHashSet(d.getDimension());
-    } else if (dimFilter instanceof IntervalDimFilter) {
-      IntervalDimFilter d = (IntervalDimFilter) dimFilter;
-      return Sets.newHashSet(d.getDimension());
-    } else if (dimFilter instanceof LikeDimFilter) {
-      LikeDimFilter d = (LikeDimFilter) dimFilter;
-      return Sets.newHashSet(d.getDimension());
-    } else if (dimFilter instanceof RegexDimFilter) {
-      RegexDimFilter d = (RegexDimFilter) dimFilter;
-      return Sets.newHashSet(d.getDimension());
-    } else if (dimFilter instanceof SearchQueryDimFilter) {
-      SearchQueryDimFilter d = (SearchQueryDimFilter) dimFilter;
-      return Sets.newHashSet(d.getDimension());
-    } else if (dimFilter instanceof SelectorDimFilter) {
-      SelectorDimFilter d = (SelectorDimFilter) dimFilter;
-      return Sets.newHashSet(d.getDimension());
-    } else {
-      return null;
-    }
   }
 
   /**

--- a/processing/src/main/java/io/druid/query/filter/AndDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/AndDimFilter.java
@@ -24,12 +24,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.RangeSet;
+import com.google.common.collect.Sets;
 import com.google.common.collect.TreeRangeSet;
 import io.druid.java.util.common.StringUtils;
 import io.druid.segment.filter.AndFilter;
 import io.druid.segment.filter.Filters;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 /**
@@ -95,6 +97,15 @@ public class AndDimFilter implements DimFilter
       }
     }
     return retSet;
+  }
+
+  @Override
+  public HashSet<String> getRequiredColumns()
+  {
+    HashSet<String> requiredColumns = Sets.newHashSet();
+    fields.stream()
+        .forEach(field -> requiredColumns.addAll(field.getRequiredColumns()));
+    return requiredColumns;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/BoundDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/BoundDimFilter.java
@@ -26,6 +26,7 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
+import com.google.common.collect.Sets;
 import com.google.common.collect.TreeRangeSet;
 import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Floats;
@@ -40,6 +41,7 @@ import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.ByteBuffer;
+import java.util.HashSet;
 import java.util.Objects;
 
 public class BoundDimFilter implements DimFilter
@@ -244,6 +246,12 @@ public class BoundDimFilter implements DimFilter
     }
     retSet.add(range);
     return retSet;
+  }
+
+  @Override
+  public HashSet<String> getRequiredColumns()
+  {
+    return Sets.newHashSet(dimension);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/ColumnComparisonDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/ColumnComparisonDimFilter.java
@@ -24,11 +24,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.RangeSet;
+import com.google.common.collect.Sets;
 import io.druid.query.cache.CacheKeyBuilder;
 import io.druid.query.dimension.DimensionSpec;
 import io.druid.segment.filter.ColumnComparisonFilter;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  */
@@ -101,6 +104,15 @@ public class ColumnComparisonDimFilter implements DimFilter
   public RangeSet<String> getDimensionRangeSet(String dimension)
   {
     return null;
+  }
+
+  @Override
+  public HashSet<String> getRequiredColumns()
+  {
+    return Sets.newHashSet(dimensions.stream()
+        .map(DimensionSpec::getDimension)
+        .collect(Collectors.toSet())
+    );
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/DimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/DimFilter.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.collect.RangeSet;
 import io.druid.java.util.common.Cacheable;
 
+import java.util.HashSet;
+
 /**
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -75,4 +77,9 @@ public interface DimFilter extends Cacheable
    * determine for this DimFilter.
    */
   RangeSet<String> getDimensionRangeSet(String dimension);
+
+  /**
+   * @return a HashSet that represents all columns' name which the DimFilter required to do filter.
+   */
+  HashSet<String> getRequiredColumns();
 }

--- a/processing/src/main/java/io/druid/query/filter/ExpressionDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/ExpressionDimFilter.java
@@ -23,12 +23,14 @@ import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.RangeSet;
+import com.google.common.collect.Sets;
 import io.druid.math.expr.Expr;
 import io.druid.math.expr.ExprMacroTable;
 import io.druid.math.expr.Parser;
 import io.druid.query.cache.CacheKeyBuilder;
 import io.druid.segment.filter.ExpressionFilter;
 
+import java.util.HashSet;
 import java.util.Objects;
 
 public class ExpressionDimFilter implements DimFilter
@@ -68,6 +70,12 @@ public class ExpressionDimFilter implements DimFilter
   public RangeSet<String> getDimensionRangeSet(final String dimension)
   {
     return null;
+  }
+
+  @Override
+  public HashSet<String> getRequiredColumns()
+  {
+    return Sets.newHashSet(Parser.findRequiredBindings(parsed));
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/ExtractionDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/ExtractionDimFilter.java
@@ -23,10 +23,12 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.RangeSet;
+import com.google.common.collect.Sets;
 import io.druid.java.util.common.StringUtils;
 import io.druid.query.extraction.ExtractionFn;
 
 import java.nio.ByteBuffer;
+import java.util.HashSet;
 
 /**
  * This class is deprecated, use SelectorDimFilter instead: {@link SelectorDimFilter}
@@ -108,6 +110,12 @@ public class ExtractionDimFilter implements DimFilter
   public RangeSet<String> getDimensionRangeSet(String dimension)
   {
     return null;
+  }
+
+  @Override
+  public HashSet<String> getRequiredColumns()
+  {
+    return Sets.newHashSet(dimension);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/InDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/InDimFilter.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
+import com.google.common.collect.Sets;
 import com.google.common.collect.TreeRangeSet;
 import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Floats;
@@ -48,6 +49,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -213,6 +215,12 @@ public class InDimFilter implements DimFilter
       retSet.add(Range.singleton(Strings.nullToEmpty(value)));
     }
     return retSet;
+  }
+
+  @Override
+  public HashSet<String> getRequiredColumns()
+  {
+    return Sets.newHashSet(dimension);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/IntervalDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/IntervalDimFilter.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.RangeSet;
+import com.google.common.collect.Sets;
 import com.google.common.primitives.Longs;
 import io.druid.java.util.common.JodaUtils;
 import io.druid.java.util.common.Pair;
@@ -34,6 +35,7 @@ import org.joda.time.Interval;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 public class IntervalDimFilter implements DimFilter
@@ -120,6 +122,12 @@ public class IntervalDimFilter implements DimFilter
   public RangeSet<String> getDimensionRangeSet(String dimension)
   {
     return convertedFilter.getDimensionRangeSet(dimension);
+  }
+
+  @Override
+  public HashSet<String> getRequiredColumns()
+  {
+    return Sets.newHashSet(dimension);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/JavaScriptDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/JavaScriptDimFilter.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.RangeSet;
+import com.google.common.collect.Sets;
 import io.druid.java.util.common.StringUtils;
 import io.druid.js.JavaScriptConfig;
 import io.druid.query.extraction.ExtractionFn;
@@ -34,6 +35,7 @@ import org.mozilla.javascript.Function;
 import org.mozilla.javascript.ScriptableObject;
 
 import java.nio.ByteBuffer;
+import java.util.HashSet;
 
 public class JavaScriptDimFilter implements DimFilter
 {
@@ -132,6 +134,12 @@ public class JavaScriptDimFilter implements DimFilter
   public RangeSet<String> getDimensionRangeSet(String dimension)
   {
     return null;
+  }
+
+  @Override
+  public HashSet<String> getRequiredColumns()
+  {
+    return Sets.newHashSet(dimension);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/LikeDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/LikeDimFilter.java
@@ -25,6 +25,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
 import com.google.common.collect.RangeSet;
+import com.google.common.collect.Sets;
 import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.Chars;
 import io.druid.java.util.common.StringUtils;
@@ -34,6 +35,7 @@ import io.druid.segment.filter.LikeFilter;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
+import java.util.HashSet;
 import java.util.regex.Pattern;
 
 public class LikeDimFilter implements DimFilter
@@ -304,6 +306,12 @@ public class LikeDimFilter implements DimFilter
   public RangeSet<String> getDimensionRangeSet(String dimension)
   {
     return null;
+  }
+
+  @Override
+  public HashSet<String> getRequiredColumns()
+  {
+    return Sets.newHashSet(dimension);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/NotDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/NotDimFilter.java
@@ -27,6 +27,7 @@ import com.google.common.collect.RangeSet;
 import io.druid.segment.filter.NotFilter;
 
 import java.nio.ByteBuffer;
+import java.util.HashSet;
 import java.util.List;
 
 /**
@@ -98,6 +99,12 @@ public class NotDimFilter implements DimFilter
     }
     RangeSet<String> rangeSet = field.getDimensionRangeSet(dimension);
     return rangeSet == null ? null : rangeSet.complement();
+  }
+
+  @Override
+  public HashSet<String> getRequiredColumns()
+  {
+    return field.getRequiredColumns();
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/OrDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/OrDimFilter.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.RangeSet;
+import com.google.common.collect.Sets;
 import com.google.common.collect.TreeRangeSet;
 import io.druid.java.util.common.StringUtils;
 import io.druid.segment.filter.Filters;
@@ -31,6 +32,7 @@ import io.druid.segment.filter.OrFilter;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 /**
@@ -103,6 +105,15 @@ public class OrDimFilter implements DimFilter
       }
     }
     return retSet;
+  }
+
+  @Override
+  public HashSet<String> getRequiredColumns()
+  {
+    HashSet<String> requiredColumns = Sets.newHashSet();
+    fields.stream()
+        .forEach(field -> requiredColumns.addAll(field.getRequiredColumns()));
+    return requiredColumns;
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/RegexDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/RegexDimFilter.java
@@ -23,11 +23,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.RangeSet;
+import com.google.common.collect.Sets;
 import io.druid.java.util.common.StringUtils;
 import io.druid.query.extraction.ExtractionFn;
 import io.druid.segment.filter.RegexFilter;
 
 import java.nio.ByteBuffer;
+import java.util.HashSet;
 import java.util.regex.Pattern;
 
 /**
@@ -106,6 +108,12 @@ public class RegexDimFilter implements DimFilter
   public RangeSet<String> getDimensionRangeSet(String dimension)
   {
     return null;
+  }
+
+  @Override
+  public HashSet<String> getRequiredColumns()
+  {
+    return Sets.newHashSet(dimension);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/SearchQueryDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/SearchQueryDimFilter.java
@@ -22,12 +22,14 @@ package io.druid.query.filter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.RangeSet;
+import com.google.common.collect.Sets;
 import io.druid.java.util.common.StringUtils;
 import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.search.SearchQuerySpec;
 import io.druid.segment.filter.SearchQueryFilter;
 
 import java.nio.ByteBuffer;
+import java.util.HashSet;
 
 /**
  */
@@ -102,6 +104,12 @@ public class SearchQueryDimFilter implements DimFilter
   public RangeSet<String> getDimensionRangeSet(String dimension)
   {
     return null;
+  }
+
+  @Override
+  public HashSet<String> getRequiredColumns()
+  {
+    return Sets.newHashSet(dimension);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/SelectorDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/SelectorDimFilter.java
@@ -28,6 +28,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
+import com.google.common.collect.Sets;
 import com.google.common.collect.TreeRangeSet;
 import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Floats;
@@ -38,6 +39,7 @@ import io.druid.segment.filter.DimensionPredicateFilter;
 import io.druid.segment.filter.SelectorFilter;
 
 import java.nio.ByteBuffer;
+import java.util.HashSet;
 import java.util.Objects;
 
 /**
@@ -190,6 +192,12 @@ public class SelectorDimFilter implements DimFilter
     RangeSet<String> retSet = TreeRangeSet.create();
     retSet.add(Range.singleton(Strings.nullToEmpty(value)));
     return retSet;
+  }
+
+  @Override
+  public HashSet<String> getRequiredColumns()
+  {
+    return Sets.newHashSet(dimension);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/filter/SpatialDimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/SpatialDimFilter.java
@@ -22,11 +22,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.RangeSet;
+import com.google.common.collect.Sets;
 import io.druid.collections.spatial.search.Bound;
 import io.druid.java.util.common.StringUtils;
 import io.druid.segment.filter.SpatialFilter;
 
 import java.nio.ByteBuffer;
+import java.util.HashSet;
 
 /**
  */
@@ -90,6 +92,12 @@ public class SpatialDimFilter implements DimFilter
   public RangeSet<String> getDimensionRangeSet(String dimension)
   {
     return null;
+  }
+
+  @Override
+  public HashSet<String> getRequiredColumns()
+  {
+    return Sets.newHashSet(dimension);
   }
 
   @Override

--- a/processing/src/test/java/io/druid/query/filter/AndDimFilterTest.java
+++ b/processing/src/test/java/io/druid/query/filter/AndDimFilterTest.java
@@ -16,45 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package io.druid.query.filter;
 
-import com.google.common.collect.RangeSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.junit.Assert;
+import org.junit.Test;
 
-import java.nio.ByteBuffer;
-import java.util.HashSet;
-
-/**
- */
-public class NoopDimFilter implements DimFilter
+public class AndDimFilterTest
 {
-  @Override
-  public byte[] getCacheKey()
-  {        
-    return ByteBuffer.allocate(1).put(DimFilterUtils.NOOP_CACHE_ID).array();
-  }
-
-  @Override
-  public DimFilter optimize()
+  @Test
+  public void testGetRequiredColumns()
   {
-    return this;
-  }
-
-  @Override
-  public Filter toFilter()
-  {
-    return null;
-  }
-
-  @Override
-  public RangeSet<String> getDimensionRangeSet(String dimension)
-  {
-    return null;
-  }
-
-  @Override
-  public HashSet<String> getRequiredColumns()
-  {
-    return null;
+    AndDimFilter andDimFilter = new AndDimFilter(
+        Lists.newArrayList(
+            new SelectorDimFilter("a", "d", null),
+            new SelectorDimFilter("b", "d", null),
+            new SelectorDimFilter("c", "d", null)
+        )
+    );
+    Assert.assertEquals(andDimFilter.getRequiredColumns(), Sets.newHashSet("a", "b", "c"));
   }
 }

--- a/processing/src/test/java/io/druid/query/filter/BoundDimFilterTest.java
+++ b/processing/src/test/java/io/druid/query/filter/BoundDimFilterTest.java
@@ -42,6 +42,7 @@ package io.druid.query.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import io.druid.guice.GuiceInjectors;
@@ -127,5 +128,12 @@ public class BoundDimFilterTest
     BoundDimFilter boundDimFilterWithExtract = new BoundDimFilter("dimension", "12", "15", null, null, true, extractionFn, StringComparators.ALPHANUMERIC);
 
     Assert.assertNotEquals(boundDimFilter.hashCode(), boundDimFilterWithExtract.hashCode());
+  }
+
+  @Test
+  public void testGetRequiredColumns()
+  {
+    BoundDimFilter boundDimFilter = new BoundDimFilter("dimension", "12", "15", null, null, true, null, StringComparators.ALPHANUMERIC);
+    Assert.assertEquals(boundDimFilter.getRequiredColumns(), Sets.newHashSet("dimension"));
   }
 }

--- a/processing/src/test/java/io/druid/query/filter/ColumnComparisonDimFilterTest.java
+++ b/processing/src/test/java/io/druid/query/filter/ColumnComparisonDimFilterTest.java
@@ -20,6 +20,7 @@
 package io.druid.query.filter;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 import io.druid.query.dimension.DefaultDimensionSpec;
 import org.junit.Assert;
 import org.junit.Test;
@@ -86,5 +87,17 @@ public class ColumnComparisonDimFilterTest
         columnComparisonDimFilter2.hashCode(),
         columnComparisonDimFilter3.hashCode()
     );
+  }
+
+  @Test
+  public void testGetRequiredColumns()
+  {
+    ColumnComparisonDimFilter columnComparisonDimFilter = new ColumnComparisonDimFilter(
+        ImmutableList.of(
+            DefaultDimensionSpec.of("abc"),
+            DefaultDimensionSpec.of("d")
+        )
+    );
+    Assert.assertEquals(columnComparisonDimFilter.getRequiredColumns(), Sets.newHashSet("abc", "d"));
   }
 }

--- a/processing/src/test/java/io/druid/query/filter/IntervalDimFilterTest.java
+++ b/processing/src/test/java/io/druid/query/filter/IntervalDimFilterTest.java
@@ -20,6 +20,7 @@
 package io.druid.query.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Sets;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import io.druid.guice.GuiceInjectors;
@@ -229,5 +230,19 @@ public class IntervalDimFilterTest
         null
     );
     Assert.assertNotEquals(intervalFilter1, intervalFilter5);
+  }
+
+  @Test
+  public void testGetRequiredColumns()
+  {
+    DimFilter intervalFilter = new IntervalDimFilter(
+        Column.TIME_COLUMN_NAME,
+        Arrays.asList(
+            Intervals.of("1970-01-01T00:00:00.001Z/1970-01-01T00:00:00.004Z"),
+            Intervals.of("1975-01-01T00:00:00.001Z/1980-01-01T00:00:00.004Z")
+        ),
+        null
+    );
+    Assert.assertEquals(intervalFilter.getRequiredColumns(), Sets.newHashSet(Column.TIME_COLUMN_NAME));
   }
 }

--- a/processing/src/test/java/io/druid/query/filter/JavaScriptDimFilterTest.java
+++ b/processing/src/test/java/io/druid/query/filter/JavaScriptDimFilterTest.java
@@ -19,6 +19,7 @@
 
 package io.druid.query.filter;
 
+import com.google.common.collect.Sets;
 import io.druid.js.JavaScriptConfig;
 import io.druid.query.extraction.RegexDimExtractionFn;
 import io.druid.segment.filter.JavaScriptFilter;
@@ -104,5 +105,12 @@ public class JavaScriptDimFilterTest
     expectedException.expectMessage("JavaScript is disabled");
     javaScriptDimFilter.toFilter();
     Assert.assertTrue(false);
+  }
+
+  @Test
+  public void testGetRequiredColumns()
+  {
+    JavaScriptDimFilter javaScriptDimFilter = new JavaScriptDimFilter("dim", FN1, null, new JavaScriptConfig(false));
+    Assert.assertEquals(javaScriptDimFilter.getRequiredColumns(), Sets.newHashSet("dim"));
   }
 }

--- a/processing/src/test/java/io/druid/query/filter/LikeDimFilterTest.java
+++ b/processing/src/test/java/io/druid/query/filter/LikeDimFilterTest.java
@@ -20,6 +20,7 @@
 package io.druid.query.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Sets;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.query.extraction.SubstringDimExtractionFn;
 import org.junit.Assert;
@@ -59,5 +60,12 @@ public class LikeDimFilterTest
     Assert.assertNotEquals(filter, filter3);
     Assert.assertEquals(filter.hashCode(), filter2.hashCode());
     Assert.assertNotEquals(filter.hashCode(), filter3.hashCode());
+  }
+
+  @Test
+  public void testGetRequiredColumns()
+  {
+    final DimFilter filter = new LikeDimFilter("foo", "bar%", "@", new SubstringDimExtractionFn(1, 2));
+    Assert.assertEquals(filter.getRequiredColumns(), Sets.newHashSet("foo"));
   }
 }

--- a/processing/src/test/java/io/druid/query/filter/SelectorDimFilterTest.java
+++ b/processing/src/test/java/io/druid/query/filter/SelectorDimFilterTest.java
@@ -19,6 +19,7 @@
 
 package io.druid.query.filter;
 
+import com.google.common.collect.Sets;
 import io.druid.query.extraction.RegexDimExtractionFn;
 import org.junit.Assert;
 import org.junit.Test;
@@ -74,5 +75,12 @@ public class SelectorDimFilterTest
         )
     );
     Assert.assertEquals(selectorDimFilter, filter.optimize());
+  }
+
+  @Test
+  public void testGetRequiredColumns()
+  {
+    SelectorDimFilter selectorDimFilter = new SelectorDimFilter("abc", "d", null);
+    Assert.assertEquals(selectorDimFilter.getRequiredColumns(), Sets.newHashSet("abc"));
   }
 }

--- a/processing/src/test/java/io/druid/segment/filter/ExpressionFilterTest.java
+++ b/processing/src/test/java/io/druid/segment/filter/ExpressionFilterTest.java
@@ -22,6 +22,7 @@ package io.druid.segment.filter;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.data.input.impl.FloatDimensionSchema;
@@ -39,6 +40,7 @@ import io.druid.segment.IndexBuilder;
 import io.druid.segment.StorageAdapter;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -198,6 +200,18 @@ public class ExpressionFilterTest extends BaseFilterTest
     assertFilterMatches(EDF("missing > 2"), ImmutableList.of());
     assertFilterMatches(EDF("missing > 2.0"), ImmutableList.of());
     assertFilterMatches(EDF("like(missing, '1%')"), ImmutableList.of());
+  }
+
+  @Test
+  public void testGetRequiredColumn()
+  {
+    Assert.assertEquals(EDF("like(dim1, '1%')").getRequiredColumns(), Sets.newHashSet("dim1"));
+    Assert.assertEquals(EDF("dim2 == '1'").getRequiredColumns(), Sets.newHashSet("dim2"));
+    Assert.assertEquals(EDF("dim3 < '2'").getRequiredColumns(), Sets.newHashSet("dim3"));
+    Assert.assertEquals(EDF("dim4 == ''").getRequiredColumns(), Sets.newHashSet("dim4"));
+    Assert.assertEquals(EDF("1 + 1").getRequiredColumns(), Sets.newHashSet());
+    Assert.assertEquals(EDF("dim0 == dim3").getRequiredColumns(), Sets.newHashSet("dim0", "dim3"));
+    Assert.assertEquals(EDF("missing == ''").getRequiredColumns(), Sets.newHashSet("missing"));
   }
 
   private static ExpressionDimFilter EDF(final String expression)


### PR DESCRIPTION
In order to get required columns in materialized-view feature, it's better to add a method to DimFilter which returns all required column names.
see issue #5710
