### PR TITLE
HdfsDataSegmentPusher: Close tmpIndexFile before copying it.

### DIFF
--- a/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsDataSegmentPusher.java
+++ b/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsDataSegmentPusher.java
@@ -125,8 +125,11 @@ public class HdfsDataSegmentPusher implements DataSegmentPusher
 
     final long size;
     final DataSegment dataSegment;
-    try (FSDataOutputStream out = fs.create(tmpIndexFile)) {
-      size = CompressionUtils.zip(inDir, out);
+    try {
+      try (FSDataOutputStream out = fs.create(tmpIndexFile)) {
+        size = CompressionUtils.zip(inDir, out);
+      }
+
       final String uniquePrefix = useUniquePath ? DataSegmentPusher.generateUniquePath() + "_" : "";
       final Path outIndexFile = new Path(StringUtils.format(
           "%s/%s/%d_%sindex.zip",


### PR DESCRIPTION
It seems that copy-before-close works OK on HDFS, but it doesn't work
on all filesystems. In particular, we observed this not working properly
with Google Cloud Storage. And anyway, it's better hygiene to close files
before attempting to copy them somewhere else.