### PR TITLE
Fix inefficient available segment cache population in SQLMetadataSegmentManager

### DIFF
--- a/server/src/main/java/io/druid/client/DruidDataSource.java
+++ b/server/src/main/java/io/druid/client/DruidDataSource.java
@@ -85,6 +85,14 @@ public class DruidDataSource
     return new ImmutableDruidDataSource(name, properties, idToSegmentMap);
   }
 
+  // For performance reasons, make sure we check for the existence of a segment using containsSegment(),
+  // which performs a key-based lookup, instead of calling contains() on the collection returned by
+  // dataSource.getSegments(). In Map values collections, the contains() method is a linear scan.
+  public boolean containsSegment(DataSegment segment)
+  {
+    return idToSegmentMap.containsKey(segment.getIdentifier());
+  }
+
   @Override
   public String toString()
   {

--- a/server/src/main/java/io/druid/metadata/SQLMetadataSegmentManager.java
+++ b/server/src/main/java/io/druid/metadata/SQLMetadataSegmentManager.java
@@ -475,7 +475,10 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
           }
         }
 
-        if (!dataSource.getSegments().contains(segment)) {
+        // For performance reasons, make sure we check for the existence of a segment using containsSegment(),
+        // which performs a key-based lookup, instead of calling contains() on the collection returned by
+        // dataSource.getSegments(). In Map values collections, the contains() method is a linear scan.
+        if (!dataSource.containsSegment(segment)) {
           dataSource.addSegment(segment);
         }
       }


### PR DESCRIPTION
In the poll() method, when SQLMetadataSegmentManager updates its cache of available segments, it checks if a datasource already has a segment using:

```
     if (!dataSource.getSegments().contains(segment)) {	
```

The `getSegments()` call returns a collection of the values of the idToSegmentMap inside `dataSource`, which is a ConcurrentSkipListMap:

```
  private final ConcurrentSkipListMap<String, DataSegment> idToSegmentMap;

...

  public Collection<DataSegment> getSegments()
  {
    return Collections.unmodifiableCollection(idToSegmentMap.values());
  }
```

The contains() method on the map values collection is a linear scan:

```
/**
     * Returns {@code true} if this map maps one or more keys to the
     * specified value.  This operation requires time linear in the
     * map size. Additionally, it is possible for the map to change
     * during execution of this method, in which case the returned
     * result may be inaccurate.
     *
     * @param value value whose presence in this map is to be tested
     * @return {@code true} if a mapping to {@code value} exists;
     *         {@code false} otherwise
     * @throws NullPointerException if the specified value is null
     */
    public boolean containsValue(Object value) {
        if (value == null)
            throw new NullPointerException();
        for (Node<K,V> n = findFirst(); n != null; n = n.next) {
            V v = n.getValidValue();
            if (v != null && value.equals(v))
                return true;
        }
        return false;
    }
```

This PR adjusts the segment existence check to use a key-based lookup on the `idToSegmentMap` of the `dataSource`.
