### PR TITLE
Make DruidPlanner constructor public again

### DIFF
--- a/sql/src/main/java/io/druid/sql/calcite/planner/DruidPlanner.java
+++ b/sql/src/main/java/io/druid/sql/calcite/planner/DruidPlanner.java
@@ -75,7 +75,7 @@ public class DruidPlanner implements Closeable
   private final PlannerContext plannerContext;
   private final AuthorizerMapper authorizerMapper;
 
-  DruidPlanner(
+  public DruidPlanner(
       final Planner planner,
       final PlannerContext plannerContext,
       final AuthorizerMapper authorizerMapper


### PR DESCRIPTION
DruidPlanner's constructor is currently package-private, extension classes (in the same package) cannot access the constructor because they're loaded by a different classloader