### PR TITLE
Fix SQL Server select query in createInactiveStatusesSinceQuery() method.

### DIFF
--- a/server/src/main/java/io/druid/metadata/SQLServerMetadataStorageActionHandler.java
+++ b/server/src/main/java/io/druid/metadata/SQLServerMetadataStorageActionHandler.java
@@ -64,9 +64,7 @@ public class SQLServerMetadataStorageActionHandler<EntryType, StatusType, LogTyp
         + "ORDER BY created_date DESC",
         getEntryTable()
     );
-    if (maxNumStatuses != null) {
-      sql += " LIMIT :n";
-    }
+
     Query<Map<String, Object>> query = handle.createQuery(sql).bind("start", timestamp.toString());
 
     if (maxNumStatuses != null) {

--- a/server/src/main/java/io/druid/metadata/SQLServerMetadataStorageActionHandler.java
+++ b/server/src/main/java/io/druid/metadata/SQLServerMetadataStorageActionHandler.java
@@ -49,7 +49,7 @@ public class SQLServerMetadataStorageActionHandler<EntryType, StatusType, LogTyp
       Handle handle, DateTime timestamp, @Nullable Integer maxNumStatuses, @Nullable String datasource
   )
   {
-    String sql = maxNumStatuses == null ? "SELECT " : "SELECT TOP :n ";
+    String sql = maxNumStatuses == null ? "SELECT " : "SELECT TOP (:n) ";
 
     sql += StringUtils.format(
         "    id, "


### PR DESCRIPTION
SQL server does not support LIMIT N in select queries. Instead it has TOP N to limiting number of query results.
And TOP N is already added in the select statement as per maxNumStatuses value.