### PR TITLE
Update tasks api to handle task deserialization failure

### DIFF
--- a/api/src/main/java/io/druid/indexer/TaskInfo.java
+++ b/api/src/main/java/io/druid/indexer/TaskInfo.java
@@ -20,6 +20,8 @@ package io.druid.indexer;
 
 import org.joda.time.DateTime;
 
+import javax.annotation.Nullable;
+
 /**
  * This class is used to store task info from runner query and cache in OverlordResource
  */
@@ -29,9 +31,16 @@ public class TaskInfo<EntryType>
   private final DateTime createdTime;
   private final TaskStatus status;
   private final String dataSource;
+  @Nullable
   private final EntryType task;
 
-  public TaskInfo(String id, DateTime createdTime, TaskStatus status, String dataSource, EntryType task)
+  public TaskInfo(
+      String id,
+      DateTime createdTime,
+      TaskStatus status,
+      String dataSource,
+      @Nullable EntryType task
+  )
   {
     this.id = id;
     this.createdTime = createdTime;
@@ -60,6 +69,7 @@ public class TaskInfo<EntryType>
     return dataSource;
   }
 
+  @Nullable
   public EntryType getTask()
   {
     return task;

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/http/OverlordResource.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/http/OverlordResource.java
@@ -602,7 +602,7 @@ public class OverlordResource
 
     Function<TaskInfo<Task>, TaskStatusPlus> completeTaskTransformFunc = taskInfo -> new TaskStatusPlus(
         taskInfo.getId(),
-        taskInfo.getTask().getType(),
+        taskInfo.getTask() == null ? null : taskInfo.getTask().getType(),
         taskInfo.getCreatedTime(),
         // Would be nice to include the real queue insertion time, but the
         // TaskStorage API doesn't yet allow it.
@@ -637,7 +637,7 @@ public class OverlordResource
         allActiveTasks.add(
             new AnyTask(
                 task.getId(),
-                task.getTask().getType(),
+                task.getTask() == null ? null : task.getTask().getType(),
                 SettableFuture.create(),
                 task.getDataSource(),
                 null,
@@ -958,7 +958,7 @@ public class OverlordResource
     if (type != null) {
       optionalTypeFilteredList = collectionToFilter
           .stream()
-          .filter(task -> task.getType().equals(type))
+          .filter(task -> type.equals(task.getType()))
           .collect(Collectors.toList());
     }
     if (dataSource != null) {

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/http/OverlordResourceTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/http/OverlordResourceTest.java
@@ -742,6 +742,46 @@ public class OverlordResourceTest
   }
 
   @Test
+  public void testGetNullCompleteTask()
+  {
+    expectAuthorizationTokenCheck();
+    EasyMock.expect(taskStorageQueryAdapter.getRecentlyCompletedTaskInfo(null, null, null)).andStubReturn(
+        ImmutableList.of(
+            new TaskInfo(
+                "id_1",
+                DateTime.now(ISOChronology.getInstanceUTC()),
+                TaskStatus.success("id_1"),
+                "allow",
+                null
+            ),
+            new TaskInfo(
+                "id_2",
+                DateTime.now(ISOChronology.getInstanceUTC()),
+                TaskStatus.success("id_2"),
+                "deny",
+                getTaskWithIdAndDatasource("id_2", "deny")
+            ),
+            new TaskInfo(
+                "id_3",
+                DateTime.now(ISOChronology.getInstanceUTC()),
+                TaskStatus.success("id_3"),
+                "allow",
+                getTaskWithIdAndDatasource("id_3", "allow")
+            )
+        )
+    );
+    EasyMock.replay(taskRunner, taskMaster, taskStorageQueryAdapter, indexerMetadataStorageAdapter, req);
+    List<TaskStatusPlus> responseObjects = (List<TaskStatusPlus>) overlordResource
+        .getTasks("complete", null, null, null, null, req)
+        .getEntity();
+    Assert.assertEquals(2, responseObjects.size());
+    Assert.assertEquals("id_1", responseObjects.get(0).getId());
+    TaskStatusPlus tsp = responseObjects.get(0);
+    Assert.assertEquals(null, tsp.getType());
+    Assert.assertTrue("DataSource Check", "allow".equals(responseObjects.get(0).getDataSource()));
+  }
+
+  @Test
   public void testGetTasksNegativeState()
   {
     EasyMock.replay(taskRunner, taskMaster, taskStorageQueryAdapter, indexerMetadataStorageAdapter, req);


### PR DESCRIPTION
If task payload fails to deserialize json to Java, make the task null and handle null task in OverlordResource instead of returning 500 error on `tasks` api. If an old task type is deleted, the tasks api should ignore that task type, but still return rest of the tasks and any information it can get about the deleted task type. `IOException` is caught and handled in `TaskInfoMapper` in `SQLMetadataStorageActionHandler` for the `payload` parsing error and task attribute is set to null for `TaskInfo`.