### PR TITLE
Coordinator fix balance to try to move max segments instead of up to max segments

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorBalancer.java
+++ b/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorBalancer.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.NavigableSet;
 import java.util.SortedSet;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 /**
  */
@@ -123,22 +124,27 @@ public class DruidCoordinatorBalancer implements DruidCoordinatorHelper
 
     final int maxToLoad = params.getCoordinatorDynamicConfig().getMaxSegmentsInNodeLoadingQueue();
     long unmoved = 0L;
-    for (int iter = 0; iter < maxSegmentsToMove; iter++) {
-      if (maxToLoad > 0) {
-        toMoveTo.removeIf(s -> s.getNumberOfSegmentsInQueue() >= maxToLoad);
-      }
+    for (int moved = 0; moved < maxSegmentsToMove;) {
       final BalancerSegmentHolder segmentToMove = strategy.pickSegmentToMove(toMoveFrom);
 
       if (segmentToMove != null && params.getAvailableSegments().contains(segmentToMove.getSegment())) {
-        final ServerHolder destinationHolder = strategy.findNewSegmentHomeBalancer(segmentToMove.getSegment(), toMoveTo);
+        final List<ServerHolder> toMoveToWithLoadQueueCapacity =
+            toMoveTo.stream()
+                    .filter(s -> s.getNumberOfSegmentsInQueue() < maxToLoad)
+                    .collect(Collectors.toList());
+        final ServerHolder destinationHolder =
+            strategy.findNewSegmentHomeBalancer(segmentToMove.getSegment(), toMoveToWithLoadQueueCapacity);
 
         if (destinationHolder != null) {
           moveSegment(segmentToMove, destinationHolder.getServer(), params);
+          moved++;
         } else {
-          ++unmoved;
+          log.info("Segment [%s] is 'optimally' placed.", segmentToMove.getSegment().getIdentifier());
+          unmoved++;
         }
       }
     }
+
     if (unmoved == maxSegmentsToMove) {
       // Cluster should be alive and constantly adjusting
       log.info("No good moves found in tier [%s]", tier);

--- a/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorBalancer.java
+++ b/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorBalancer.java
@@ -124,7 +124,7 @@ public class DruidCoordinatorBalancer implements DruidCoordinatorHelper
 
     final int maxToLoad = params.getCoordinatorDynamicConfig().getMaxSegmentsInNodeLoadingQueue();
     long unmoved = 0L;
-    for (int moved = 0; moved < maxSegmentsToMove;) {
+    for (int moved = 0; (moved + unmoved) < maxSegmentsToMove;) {
       final BalancerSegmentHolder segmentToMove = strategy.pickSegmentToMove(toMoveFrom);
 
       if (segmentToMove != null && params.getAvailableSegments().contains(segmentToMove.getSegment())) {

--- a/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorBalancer.java
+++ b/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorBalancer.java
@@ -130,8 +130,9 @@ public class DruidCoordinatorBalancer implements DruidCoordinatorHelper
       if (segmentToMove != null && params.getAvailableSegments().contains(segmentToMove.getSegment())) {
         final List<ServerHolder> toMoveToWithLoadQueueCapacity =
             toMoveTo.stream()
-                    .filter(s -> s.getNumberOfSegmentsInQueue() < maxToLoad)
+                    .filter(s -> maxToLoad <= 0 || s.getNumberOfSegmentsInQueue() < maxToLoad)
                     .collect(Collectors.toList());
+
         final ServerHolder destinationHolder =
             strategy.findNewSegmentHomeBalancer(segmentToMove.getSegment(), toMoveToWithLoadQueueCapacity);
 


### PR DESCRIPTION
Due to behavior of `CostBalancerStrategy.pickSegmentToMove` potentially returning `null` for a segment to move, `DruidCoordinatorBalancer` may not attempt to move `maxSegmentsToMove` every balancer run, also throwing off `unmoved` tracking and missing out on `No good moves...` log messages. Balancer will now always attempt to move `maxSegmentsToMove` ensuring that `moved + unmoved` add up.