### PR TITLE
Coordinator slight optimization of load rule runner to skip drop if numToDrop is 0

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/rules/LoadRule.java
+++ b/server/src/main/java/io/druid/server/coordinator/rules/LoadRule.java
@@ -322,7 +322,11 @@ public abstract class LoadRule implements Rule
       } else {
         final int currentReplicantsInTier = entry.getIntValue();
         final int numToDrop = currentReplicantsInTier - targetReplicants.getOrDefault(tier, 0);
-        numDropped = dropForTier(numToDrop, holders, segment, params.getBalancerStrategy());
+        if (numToDrop > 0) {
+          numDropped = dropForTier(numToDrop, holders, segment, params.getBalancerStrategy());
+        } else {
+          numDropped = 0;
+        }
       }
 
       stats.addToTieredStat(DROPPED_COUNT, tier, numDropped);


### PR DESCRIPTION
This skips filtering the list of servers and the cost balancer `pickServersToDrop` that operates on that filtered list of servers that currently always happens even if we are not going to drop any segments.