### PR TITLE
change default compaction task target size from 800MB to 400MB

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/DataSourceCompactionConfig.java
+++ b/server/src/main/java/io/druid/server/coordinator/DataSourceCompactionConfig.java
@@ -33,7 +33,7 @@ public class DataSourceCompactionConfig
 {
   // should be synchronized with Tasks.DEFAULT_MERGE_TASK_PRIORITY
   private static final int DEFAULT_COMPACTION_TASK_PRIORITY = 25;
-  private static final long DEFAULT_TARGET_COMPACTION_SIZE_BYTES = 800 * 1024 * 1024; // 800MB
+  private static final long DEFAULT_TARGET_COMPACTION_SIZE_BYTES = 400 * 1024 * 1024; // 400MB
   private static final int DEFAULT_NUM_TARGET_COMPACTION_SEGMENTS = 150;
   private static final Period DEFAULT_SKIP_OFFSET_FROM_LATEST = new Period("P1D");
 


### PR DESCRIPTION
This is to fall in line with recommendations in the docs ['Segments should generally be between 300MB-700MB in size'](http://druid.io/docs/0.12.1/operations/recommendations.html)