### PR TITLE
Proper handling of the exceptions from auto persisting in AppenderatorImpl.add()

### DIFF
--- a/common/src/main/java/io/druid/common/guava/ThreadRenamingCallable.java
+++ b/common/src/main/java/io/druid/common/guava/ThreadRenamingCallable.java
@@ -35,7 +35,7 @@ public abstract class ThreadRenamingCallable<T> implements Callable<T>
   }
 
   @Override
-  public final T call()
+  public final T call() throws Exception
   {
     final Thread currThread = Thread.currentThread();
     String currName = currThread.getName();
@@ -48,5 +48,5 @@ public abstract class ThreadRenamingCallable<T> implements Callable<T>
     }
   }
 
-  public abstract T doCall();
+  public abstract T doCall() throws Exception;
 }


### PR DESCRIPTION
`AppenderatorImpl.add()` can optionally call `persistAll()` if needed. The actual persisting task is executed in background and `persistAll()` returns a `Future` for the background task. The exceptions from this `Future` is not currently being handled properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/druid-io/druid/5932)
<!-- Reviewable:end -->
