### PR TITLE
Forbid slashes in datasource names.

### DIFF
--- a/server/src/main/java/io/druid/segment/indexing/DataSchema.java
+++ b/server/src/main/java/io/druid/segment/indexing/DataSchema.java
@@ -73,6 +73,7 @@ public class DataSchema
     this.transformSpec = transformSpec == null ? TransformSpec.NONE : transformSpec;
 
     Preconditions.checkArgument(!Strings.isNullOrEmpty(dataSource), "dataSource cannot be null or empty. Please provide a dataSource.");
+    Preconditions.checkArgument(!dataSource.contains("/"), "dataSource cannot contain the '/' character.");
     this.dataSource = dataSource;
 
     if (granularitySpec == null) {


### PR DESCRIPTION
They are bad because datasources are used as paths on filesystems,
and slashes invariably make things get stored improperly.