### PR TITLE
skip unnecessary aggregate(..) calls with LimitedBufferHashGrouper

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/AbstractBufferHashGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/AbstractBufferHashGrouper.java
@@ -76,13 +76,12 @@ public abstract class AbstractBufferHashGrouper<KeyType> implements Grouper<KeyT
   /**
    * Called to check if it's possible to skip aggregation for a row.
    *
-   * @param bucketWasUsed Was the row a new entry in the hash table?
    * @param bucketOffset  Offset of the bucket containing this row's entry in the hash table,
    *                      within the buffer returned by hashTable.getTableBuffer()
    *
    * @return true if aggregation can be skipped, false otherwise.
    */
-  public abstract boolean canSkipAggregate(boolean bucketWasUsed, int bucketOffset);
+  public abstract boolean canSkipAggregate(int bucketOffset);
 
   /**
    * Called after a row is aggregated. An implementing BufferHashGrouper class can use this to update
@@ -154,7 +153,7 @@ public abstract class AbstractBufferHashGrouper<KeyType> implements Grouper<KeyT
       newBucketHook(bucketStartOffset);
     }
 
-    if (canSkipAggregate(bucketWasUsed, bucketStartOffset)) {
+    if (canSkipAggregate(bucketStartOffset)) {
       return AggregateResult.ok();
     }
 

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/BufferHashGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/BufferHashGrouper.java
@@ -244,7 +244,7 @@ public class BufferHashGrouper<KeyType> extends AbstractBufferHashGrouper<KeyTyp
   }
 
   @Override
-  public boolean canSkipAggregate(boolean bucketWasUsed, int bucketOffset)
+  public boolean canSkipAggregate(int bucketOffset)
   {
     return false;
   }

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedBufferHashGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedBufferHashGrouper.java
@@ -152,7 +152,7 @@ public class LimitedBufferHashGrouper<KeyType> extends AbstractBufferHashGrouper
   }
 
   @Override
-  public boolean canSkipAggregate(boolean bucketWasUsed, int bucketOffset)
+  public boolean canSkipAggregate(int bucketOffset)
   {
     return !sortHasNonGroupingFields && heapIndexUpdater.getHeapIndexForOffset(bucketOffset) < 0;
   }


### PR DESCRIPTION
### Description

This is a short patch removing unnecessary work done during execution of groupBy query with limit push down. When limit is pushed down to merge phase in the groupBy query processing , `aggregate(..)` is called for all aggregators whenever a new bucket is added to the underlying hash table. This is unnecessary when `sortHasNonGroupingFields=false` and newly added bucket did not find a place in the min-max-heap .  With `sortHasNonGroupingFields=false`, that row's position in overall ordering can never change so it is ok to skip the `aggregate(..)` calls. this improves performance for cases where you have large number of buckets with multiple complex aggregators.

No behavior change is introduced in this PR.

<hr>

This PR has:
- [X] been self-reviewed.
- [X] been tested in a test Druid cluster.
<hr>
