### PR TITLE
Fix default CliIndexer TLS port

### DIFF
--- a/services/src/main/java/org/apache/druid/cli/CliIndexer.java
+++ b/services/src/main/java/org/apache/druid/cli/CliIndexer.java
@@ -100,7 +100,7 @@ public class CliIndexer extends ServerRunnable
           {
             binder.bindConstant().annotatedWith(Names.named("serviceName")).to("druid/indexer");
             binder.bindConstant().annotatedWith(Names.named("servicePort")).to(8091);
-            binder.bindConstant().annotatedWith(Names.named("tlsServicePort")).to(8091);
+            binder.bindConstant().annotatedWith(Names.named("tlsServicePort")).to(8291);
 
             IndexingServiceModuleHelper.configureTaskRunnerConfigs(binder);
 


### PR DESCRIPTION
This PR fixes the default TLS port for the CliIndexer process, which was incorrectly set to 8091, it should be 8291 instead.

This PR has:
- [x] been self-reviewed.