### PR TITLE
Kafka version update - indexing service

### DIFF
--- a/extensions-core/kafka-indexing-service/pom.xml
+++ b/extensions-core/kafka-indexing-service/pom.xml
@@ -34,7 +34,7 @@
   </parent>
 
   <properties>
-    <apache.kafka.version>2.1.0</apache.kafka.version>
+    <apache.kafka.version>2.2.1</apache.kafka.version>
   </properties>
 
   <dependencies>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3059,7 +3059,7 @@ libraries:
 ---
 
 name: Apache Kafka
-version: 2.1.0
+version: 2.2.1
 license_category: binary
 module: extensions/druid-kafka-indexing-service
 license_name: Apache License version 2.0


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid (incubating) be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->


<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/incubator-druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

https://issues.apache.org/jira/browse/KAFKA-7755

>Since 2.1.0 Kafka clients are supporting multiple DNS resolved IP addresses if the first one fails. This change has been introduced by https://issues.apache.org/jira/browse/KAFKA-6863. However this DNS resolution is now performed only one time by the clients. This is not a problem if all brokers have fixed IP addresses, however this is definitely an issue when Kafka brokers are run on top of Kubernetes. Indeed, new Kubernetes pods will receive another IP address, so as soon as all brokers will have been restarted clients won't be able to reconnect to any broker.

Currently only way to force re-resolution on the druid is side is by terminating kafka supervisors and resubmitting them, if you run a cluster ingesting from kafka on k8s

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

Fix versions are available 2.1.1 and above, this PR updates it to 2.2.1
