### PR TITLE
Web console: fix typo in forceGuaranteedRollup tooltip

### DIFF
--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -1561,7 +1561,6 @@ export function getPartitionRelatedTuningSpecFormFields(
           type: 'boolean',
           info: (
             <>
-              <p>Does not currently work with parallel ingestion</p>
               <p>
                 Forces guaranteeing the perfect rollup. The perfect rollup optimizes the total size
                 of generated segments and querying time while indexing time will be increased. If


### PR DESCRIPTION
This has not been updated since 0.15.

The warning does not apply in 0.16.