### PR TITLE
Fix incorrect build from source path in README.md and druid repo url.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ You can find more developers' resources in [`dev/`](dev) directory.
 1. Clone your fork of the GitHub repository
 
     ```sh
-    git clone git@github.com:<username>/druid.git
+    git clone git@github.com:<username>/incubator-druid.git
     ```
 
     replace `<username>` with your GitHub username.
@@ -100,7 +100,7 @@ You can find more developers' resources in [`dev/`](dev) directory.
     Go to your Druid fork main page
 
     ```
-    https://github.com/<username>/druid
+    https://github.com/<username>/incubator-druid
     ```
 
     If you recently pushed your changes GitHub will automatically pop up a

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Some committers and users are present in the channel `#druid` on the Apache Slac
 
 Please note that JDK 8 is required to build Druid.
 
-For instructions on building Druid from source, see [docs/content/development/build.md](docs/content/development/build.md)
+For instructions on building Druid from source, see [docs/development/build.md](docs/development/build.md)
 
 ### Contributing
 


### PR DESCRIPTION
Minor updates to URLs in READMEs to point to the correct path.
This time against master instead of `apache:0.16.0-incubating` in https://github.com/apache/incubator-druid/pull/8527.