### PR TITLE
ignore brokers in broker views

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
@@ -350,6 +350,12 @@ public class DruidSchema extends AbstractSchema
   @VisibleForTesting
   void addSegment(final DruidServerMetadata server, final DataSegment segment)
   {
+    if (server.getType().equals(ServerType.BROKER)) {
+      // in theory we could just filter this to ensure we don't put ourselves in here, to make dope broker tree
+      // query topologies, but for now just skip all brokers, so we don't create some sort of wild infinite metadata
+      // loop...
+      return;
+    }
     synchronized (lock) {
       final Map<SegmentId, AvailableSegmentMetadata> knownSegments = segmentMetadataInfo.get(segment.getDataSource());
       AvailableSegmentMetadata segmentMetadata = knownSegments != null ? knownSegments.get(segment.getId()) : null;
@@ -428,6 +434,10 @@ public class DruidSchema extends AbstractSchema
   @VisibleForTesting
   void removeServerSegment(final DruidServerMetadata server, final DataSegment segment)
   {
+    if (server.getType().equals(ServerType.BROKER)) {
+      // cheese it
+      return;
+    }
     synchronized (lock) {
       log.debug("Segment[%s] is gone from server[%s]", segment.getId(), server.getName());
       final Map<SegmentId, AvailableSegmentMetadata> knownSegments = segmentMetadataInfo.get(segment.getDataSource());

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/DruidSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/DruidSchemaTest.java
@@ -57,6 +57,7 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.DataSegment.PruneSpecsHolder;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.LinearShardSpec;
+import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -418,4 +419,35 @@ public class DruidSchemaTest extends CalciteTestBase
     Assert.assertEquals(0L, currentMetadata.isRealtime());
   }
 
+  @Test
+  public void testAvailableSegmentFromBrokerIsIgnored()
+  {
+
+    Assert.assertEquals(4, schema.getTotalSegments());
+
+    DruidServerMetadata metadata = new DruidServerMetadata(
+        "broker",
+        "localhost:0",
+        null,
+        1000L,
+        ServerType.BROKER,
+        "broken",
+        0
+    );
+
+    DataSegment segment = new DataSegment(
+        "test",
+        Intervals.of("2011-04-01/2011-04-11"),
+        "v1",
+        ImmutableMap.of(),
+        ImmutableList.of(),
+        ImmutableList.of(),
+        NoneShardSpec.instance(),
+        1,
+        100L
+    );
+    schema.addSegment(metadata, segment);
+    Assert.assertEquals(4, schema.getTotalSegments());
+
+  }
 }


### PR DESCRIPTION
### Description
This PR fixes a fun issue introduced by #9971, which added the ability for realtime tasks and brokers to load broadcast segments, which is totally neat, but, was missing a couple of pieces. The missing piece being fixed here is for `BrokerServerView` and `DruidSchema` to ignore brokers so that they don't try to query themselves infinitely, or get metadata from themselves infinitely (well, at least until jetty gets really really sad).

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `BrokerServerView`
 * `DruidSchema`
