### PR TITLE
Fix docs to explain that WRITE permissions do not include READ

### DIFF
--- a/docs/operations/security-user-auth.md
+++ b/docs/operations/security-user-auth.md
@@ -50,11 +50,8 @@ In practice, most deployments will only need to define two classes of users:
 
 It is important to note that WRITE access to DATASOURCE grants a user broad access. For instance, such users will have access to the Druid file system, S3 buckets, and credentials, among other things. As such, the ability to add and manage datasources should be allocated selectively to administrators.   
 
-> Note: `WRITE` permission on a resource does not include `READ` permission as well.
-> For instance, a `DATASOURCE READ`-only user might be able to access an API or a
-> system schema record that a `DATASOURCE WRITE`-only user would not have access to.
-> If a user needs to have both `READ` and `WRITE` permissions on a resource,
-> grant them both explicitly.
+`WRITE` permission on a resource does not include `READ` permission. If a user requires both `READ` and `WRITE` permissions on a resource, you must grant them both explicitly. For instance, a user with only `DATASOURCE READ` permission
+might have access to an API or a system schema record that a user with `DATASOURCE WRITE` permission would not have access to.
 
 ## Default user accounts
 


### PR DESCRIPTION
### Description

WRITE permissions on any resource do not include READ permissions on the same resource.
For instance, the results of `sys.segments` are filtered by DATASOURCE READ access.
So a DATASOURCE WRITE-only user would see fewer results in a `sys.segments`
query than a DATASOURCE READ-only user.

This PR tries to clarify this distinction in the docs.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
