### PR TITLE
Do not log sensitive property value if JsonConfigurator fails to parse

### DIFF
--- a/core/src/main/java/org/apache/druid/guice/JsonConfigurator.java
+++ b/core/src/main/java/org/apache/druid/guice/JsonConfigurator.java
@@ -102,7 +102,7 @@ public class JsonConfigurator
         catch (IOException e) {
           // Do not log exception message or the property value as it might
           // expose sensitive information
-          log.info("Unable to parse [%s] as a json object, using as is.", prop);
+          log.info("Unable to parse value of property [%s] as a json object, using as is.", prop);
           value = propValue;
         }
         hieraricalPutValue(propertyPrefix, prop, prop.substring(propertyBase.length()), value, jsonMap);


### PR DESCRIPTION
### Description

If a password or other sensitive information starting with a `{` or `[` character
is specified as a property value, `JsonConfigurator` tries to parse it as a json
object and fails. The subsequent logs expose this sensitive information.

For example, a password starting with `[` such as below
```
druid.escalator.internalClientPassword=[%thisisreallymypassword
```
would produce the following logs
```
2021-10-08T04:06:38,334 INFO [main] org.apache.druid.guice.JsonConfigurator - Unable to parse [druid.escalator.internalClientPassword]=[[%thisisreallymypassword] as a json object, using as is.
com.fasterxml.jackson.core.JsonParseException: Unexpected character (‘%’ (code 37)): expected a valid value (JSON String, Number, Array, Object or token ‘null’, ‘true’ or ‘false’)
 at [Source: (String)“[%thisisreallymypassword”; line: 1, column: 3]
```

This PR avoids logging the property value as well as the exception message as these
might contain the sensitive information (e.g. password) which could not be parsed.


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
