### PR TITLE
fix JettyTest would fail if JettyWithResponseFilterEnabledTest ran before it

### DIFF
--- a/server/src/test/java/org/apache/druid/server/initialization/JettyTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/JettyTest.java
@@ -105,6 +105,14 @@ public class JettyTest extends BaseJettyTest
   private LatchedRequestStateHolder latchedRequestState;
 
   @Override
+  public void setProperties()
+  {
+    // call super.setProperties first in case it is setting the same property as this class
+    super.setProperties();
+    System.setProperty("druid.server.http.showDetailedJettyErrors", "true");
+  }
+
+  @Override
   protected Injector setupInjector()
   {
     TLSServerConfig tlsConfig;

--- a/server/src/test/java/org/apache/druid/server/initialization/JettyWithResponseFilterEnabledTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/JettyWithResponseFilterEnabledTest.java
@@ -27,8 +27,9 @@ public class JettyWithResponseFilterEnabledTest extends JettyTest
   @Override
   public void setProperties()
   {
-    System.setProperty("druid.server.http.showDetailedJettyErrors", "false");
+    // call super.setProperties first in case it is setting the same property as this class
     super.setProperties();
+    System.setProperty("druid.server.http.showDetailedJettyErrors", "false");
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

this change ensures that `JettyTest` is setting the properties it needs in case some other test overwrites them
It also changes up the ordering of the call for `setProperties` to call super's first in case super is setting the same property as the class setting it.

I could have changed the `JettyWithResponseFilterEnabledTest` to clean up after itself, but some other test could come in and do a similar change and break `JettyTest` again. By making `JettyTest` in charge of its own dependencies it is a more resilient test.


<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `JettyTest`
 * `JettyWithResponseFilterEnabledTest`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [X] been self-reviewed.
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
