### PR TITLE
add `prometheus-emitter` to distribution

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -427,6 +427,8 @@
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:druid-moving-average-query</argument>
                                         <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions.contrib:druid-momentsketch</argument>
+                                        <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:druid-tdigestsketch</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:gce-extensions</argument>


### PR DESCRIPTION
`prometheus` is de-facto monitoring stack in cloud native/container environment like Kubernetes.
It's very helpful if druid docker image ship with `prometheus-emitter` extension by default.

Signed-off-by: Đặng Minh Dũng <dungdm93@live.com>
