### PR TITLE
Revert "Missing "Loader=yaml.FullLoader" parameter in generate-binary-license and generate-binary-notice py scripts"

### DIFF
--- a/distribution/bin/generate-binary-license.py
+++ b/distribution/bin/generate-binary-license.py
@@ -137,7 +137,7 @@ def generate_license(apache_license_v2, license_yaml):
     # Print Apache license first.
     print_outfile(apache_license_v2)
     with open(license_yaml, encoding='utf-8') as registry_file:
-        licenses_list = list(yaml.load_all(registry_file, Loader=yaml.FullLoader))
+        licenses_list = list(yaml.load_all(registry_file))
 
     # Group licenses by license_name, license_category, and then module.
     licenses_map = {}

--- a/distribution/bin/generate-binary-notice.py
+++ b/distribution/bin/generate-binary-notice.py
@@ -57,7 +57,7 @@ def generate_notice(source_notice, dependences_yaml):
     # Print Apache license first.
     print_outfile(source_notice)
     with open(dependences_yaml, encoding='utf-8') as registry_file:
-        dependencies = list(yaml.load_all(registry_file, Loader=yaml.FullLoader))
+        dependencies = list(yaml.load_all(registry_file))
 
     # Group dependencies by module
     modules_map = defaultdict(list)


### PR DESCRIPTION
Reverts apache/druid#11815

K8S integration test is failing, seeing if temporarily reverting this PR will fix the issue