### PR TITLE
Fix LoadRule drop segment replica unexpected when concurrent coordinator duties conflicted

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/LoadRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/LoadRule.java
@@ -403,10 +403,18 @@ public abstract class LoadRule implements Rule
       final String tier = entry.getKey();
 
       final NavigableSet<ServerHolder> holders = druidCluster.getHistoricalsByTier(tier);
-
+      final int targetReplicant = targetReplicants.getOrDefault(tier, 0);
       final int numDropped;
       if (holders == null) {
         log.makeAlert("No holders found for tier[%s]", tier).emit();
+        numDropped = 0;
+      } else if (targetReplicant > 0 && params.getSegmentReplicantLookup().isUnloadingInProcess(tier, segment.getId())) {
+        log.debug(
+            "segment[%s] is unloading in tier[%s], target replicant[%d], skip drop rule",
+            segment.getId(),
+            tier,
+            targetReplicant
+        );
         numDropped = 0;
       } else {
         final int currentReplicantsInTier = entry.getIntValue();


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->
LoadRule may drop all the segment replica unexpected! 

When LoadRule drops segment or BalanceSegments moves segment, the actual work will be done by asking LoadQueuePeon to load or drop segment asynchronously. This surely cause concurrent conflict problem. 

For example, when BalanceSegments moves segment, it will first mark the segment to drop on fromServer and ask toServer to load, when load work done, the fromServer does drop work. If the LoadRule happens to check segment replica count after the load work done and before the drop occur, the  LoadRule will find there is  one segment to drop, it will then pick one server to drop the segment, mostly the fromServer will not be picked as it marked the segment to drop and so has smaller cost -- if you use CostBalancerStrategy. Then when the fromServer does drop, two replica will totally dropped! Especially when the tier config to one replica, there will be none segment replica serving!

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

### Approach
To solve the concurrent problem, we can make a snapshot of the unloading segments. If one segment is unloading in tier, the LoadRule should not drop the segment in the tier at this time.

<hr>

##### Key changed/added classes in this PR
 * `LoadRule`
 * `UpdateCoordinatorStateAndPrepareCluster`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
