### PR TITLE
Switching single-dim to hashed in example

### DIFF
--- a/docs/ingestion/native-batch-simple-task.md
+++ b/docs/ingestion/native-batch-simple-task.md
@@ -91,7 +91,7 @@ A sample task is shown below:
       "type" : "index",
       "partitionsSpec": {
         "type": "hashed",
-        "partitionDimensions": "country",
+        "partitionDimensions": ["country"],
         "targetRowsPerSegment": 5000000
       }
     }


### PR DESCRIPTION
### Description
Switched the example to `hashed` partitioning, as single_dim is not supported in the simple index ingestion.