### PR TITLE
Web console: make detail archive opening more robust

### DIFF
--- a/web-console/src/utils/download-query-detail-archive.ts
+++ b/web-console/src/utils/download-query-detail-archive.ts
@@ -18,6 +18,11 @@
 
 import * as JSONBig from 'json-bigint-native';
 
+import type {
+  AsyncStatusResponse,
+  MsqTaskPayloadResponse,
+  MsqTaskReportResponse,
+} from '../druid-models';
 import { Api } from '../singletons';
 
 import { downloadFile } from './download';
@@ -26,9 +31,9 @@ export interface QueryDetailArchive {
   id: string;
   detailArchiveVersion: number;
   status?: any;
-  reports?: any;
-  payload?: any;
-  statementsStatus?: any;
+  reports?: MsqTaskReportResponse;
+  payload?: MsqTaskPayloadResponse;
+  statementsStatus?: AsyncStatusResponse;
   serverStatus?: any;
 }
 

--- a/web-console/src/views/workbench-view/execution-submit-dialog/execution-submit-dialog.tsx
+++ b/web-console/src/views/workbench-view/execution-submit-dialog/execution-submit-dialog.tsx
@@ -82,9 +82,27 @@ export const ExecutionSubmitDialog = React.memo(function ExecutionSubmitDialog(
     if (typeof detailArchiveVersion === 'number') {
       try {
         if (detailArchiveVersion === 2) {
-          execution = Execution.fromTaskReport(parsed.reports)
-            .updateWithTaskPayload(parsed.payload)
-            .updateWithAsyncStatus(parsed.statementsStatus);
+          if (parsed.reports) {
+            execution = Execution.fromTaskReport(parsed.reports);
+          }
+
+          if (parsed.statementsStatus) {
+            execution = execution
+              ? execution.updateWithAsyncStatus(parsed.statementsStatus)
+              : Execution.fromAsyncStatus(parsed.statementsStatus);
+          }
+
+          if (!execution) {
+            AppToaster.show({
+              intent: Intent.DANGER,
+              message: `Not enough information to decode detail archive`,
+            });
+            return;
+          }
+
+          if (parsed.payload) {
+            execution = execution.updateWithTaskPayload(parsed.payload);
+          }
         } else {
           AppToaster.show({
             intent: Intent.DANGER,
@@ -97,6 +115,7 @@ export const ExecutionSubmitDialog = React.memo(function ExecutionSubmitDialog(
           intent: Intent.DANGER,
           message: `Could not decode profile: ${e.message}`,
         });
+        console.log(e); // Log out the error to the console in case we want to debug this further. This is very much a power user feature.
         return;
       }
     } else if (typeof (parsed as any).multiStageQuery === 'object') {


### PR DESCRIPTION
Allow the detail opening dialog to handle cases where not all fields are set on the detail archive (this is possible as the detail archive is generated in a "best effort" approach).

Specifically I came across this issue when opening a detail archive that did not have `statementsStatus` set. It crashed.

Note: the workaround for now is to manually edit the archive JSON to add `statementsStatus: {}` (or whatever is missing) at the top level