### PR TITLE
Web console: don't send lookups to sampler

### DIFF
--- a/web-console/src/utils/sampler.spec.ts
+++ b/web-console/src/utils/sampler.spec.ts
@@ -17,7 +17,7 @@
  */
 
 import type { SampleResponse } from './sampler';
-import { guessDimensionsFromSampleResponse } from './sampler';
+import { changeLookupInExpressionsSampling, guessDimensionsFromSampleResponse } from './sampler';
 
 describe('sampler', () => {
   describe('getInferredDimensionsFromSampleResponse', () => {
@@ -128,6 +128,52 @@ describe('sampler', () => {
           },
         ]
       `);
+    });
+  });
+
+  describe('changeLookupInExpressionsSampling', () => {
+    it('does nothing when there is nothing to do', () => {
+      expect(changeLookupInExpressionsSampling(`concat("x", 'lol')`)).toEqual(`concat("x", 'lol')`);
+    });
+
+    it('works with a SQL parsable expression', () => {
+      expect(
+        changeLookupInExpressionsSampling(`concat(lookup("x", 'lookup_name'), 'lol')`),
+      ).toEqual(
+        `concat(concat('lookup_name', '[', "x", '] -- This is a placeholder, lookups are not supported in sampling'), 'lol')`,
+      );
+
+      expect(
+        changeLookupInExpressionsSampling(`concat(lookup("x", 'lookup_name', 'fallback'), 'lol')`),
+      ).toEqual(
+        `concat(nvl(concat('lookup_name', '[', "x", '] -- This is a placeholder, lookups are not supported in sampling'), 'fallback'), 'lol')`,
+      );
+
+      expect(
+        changeLookupInExpressionsSampling(
+          `concat(lookup("x", 'lookup_name', 'fallback', '?'), 'lol')`,
+        ),
+      ).toEqual(`concat(null, 'lol')`);
+    });
+
+    it('works with a non-SQL parsable expression', () => {
+      expect(
+        changeLookupInExpressionsSampling(`concat(lookup("x", 'lookup_name'), 'lol')^`),
+      ).toEqual(
+        `concat(concat('lookup_name','[',"x",'] -- This is a placeholder, lookups are not supported in sampling'), 'lol')^`,
+      );
+
+      expect(
+        changeLookupInExpressionsSampling(`concat(lookup("x", 'lookup_name', 'fallback'), 'lol')^`),
+      ).toEqual(
+        `concat(nvl(concat('lookup_name','[',"x",'] -- This is a placeholder, lookups are not supported in sampling'),'fallback'), 'lol')^`,
+      );
+
+      expect(
+        changeLookupInExpressionsSampling(
+          `concat(lookup("x", 'lookup_name', 'fallback', '?'), 'lol')^`,
+        ),
+      ).toEqual(`concat(null, 'lol')^`);
     });
   });
 });


### PR DESCRIPTION
Instead of sending transform expressions containing lookups to the sampler, which is guaranteed to give an error of lookup not found due to lookups not being loaded on the overlord, change the transform to a placeholder so it does not block the flow:

![image](https://github.com/apache/druid/assets/177816/3057f880-b356-49d9-89e3-04be403ad74d)

![image](https://github.com/apache/druid/assets/177816/34d4aba5-7dc4-46d1-99fa-9ef7fe77bc60)

![image](https://github.com/apache/druid/assets/177816/13bcd524-6244-479f-8539-8853677416aa)

