### PR TITLE
Reduce number of metadata transaction retries

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -1010,7 +1010,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
                       0,
                       MAX_INITIALIZATION_RETRIES,
                       null,
-                      null
+                      StringUtils.format("Failed to initialize supervisor[%s]", supervisorId)
                   );
                 }
                 catch (Exception e2) {

--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
@@ -67,7 +67,8 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
   private static final String PAYLOAD_TYPE = "BLOB";
   private static final String COLLATION = "";
 
-  static final int DEFAULT_MAX_TRIES = 10;
+  static final int QUIET_RETRIES = 2;
+  static final int DEFAULT_MAX_TRIES = 3;
 
   private final Supplier<MetadataStorageConnectorConfig> config;
   private final Supplier<MetadataStorageTablesConfig> tablesConfigSupplier;
@@ -154,7 +155,13 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
   )
   {
     try {
-      return RetryUtils.retry(() -> getDBI().withHandle(callback), myShouldRetry, DEFAULT_MAX_TRIES);
+      return RetryUtils.retry(
+          () -> getDBI().withHandle(callback),
+          myShouldRetry,
+          null,
+          DEFAULT_MAX_TRIES,
+          "Metadata transaction failed"
+      );
     }
     catch (Exception e) {
       Throwables.propagateIfPossible(e);
@@ -170,7 +177,14 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
   public <T> T retryTransaction(final TransactionCallback<T> callback, final int quietTries, final int maxTries)
   {
     try {
-      return RetryUtils.retry(() -> getDBI().inTransaction(TransactionIsolationLevel.READ_COMMITTED, callback), shouldRetry, quietTries, maxTries);
+      return RetryUtils.retry(
+          () -> getDBI().inTransaction(TransactionIsolationLevel.READ_COMMITTED, callback),
+          shouldRetry,
+          quietTries,
+          maxTries,
+          null,
+          "Metadata write transaction failed"
+      );
     }
     catch (Exception e) {
       Throwables.propagateIfPossible(e);
@@ -897,7 +911,9 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
           () -> getDBI().inTransaction(TransactionIsolationLevel.READ_COMMITTED, callback),
           shouldRetry,
           quietTries,
-          maxTries
+          maxTries,
+          null,
+          "Metadata read transaction failed"
       );
     }
     catch (Exception e) {

--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
@@ -377,7 +377,7 @@ public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, Log
           }
           return tasks;
         },
-        3,
+        SQLMetadataConnector.QUIET_RETRIES,
         SQLMetadataConnector.DEFAULT_MAX_TRIES
     );
   }
@@ -436,7 +436,7 @@ public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, Log
           }
           return taskMetadataInfos;
         },
-        3,
+        SQLMetadataConnector.QUIET_RETRIES,
         SQLMetadataConnector.DEFAULT_MAX_TRIES
     );
   }
@@ -840,7 +840,7 @@ public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, Log
 
           return addLock(handle, entryId, newLock);
         },
-        3,
+        SQLMetadataConnector.QUIET_RETRIES,
         SQLMetadataConnector.DEFAULT_MAX_TRIES
     );
   }
@@ -849,16 +849,7 @@ public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, Log
   public void removeLock(final long lockId)
   {
     connector.retryWithHandle(
-        new HandleCallback<Void>()
-        {
-          @Override
-          public Void withHandle(Handle handle)
-          {
-            removeLock(handle, lockId);
-
-            return null;
-          }
-        }
+        handle -> removeLock(handle, lockId)
     );
   }
 

--- a/server/src/main/java/org/apache/druid/metadata/segment/SqlSegmentMetadataTransactionFactory.java
+++ b/server/src/main/java/org/apache/druid/metadata/segment/SqlSegmentMetadataTransactionFactory.java
@@ -40,8 +40,8 @@ import org.skife.jdbi.v2.TransactionStatus;
  */
 public class SqlSegmentMetadataTransactionFactory implements SegmentMetadataTransactionFactory
 {
-  private static final int QUIET_RETRIES = 3;
-  private static final int MAX_RETRIES = 10;
+  private static final int QUIET_RETRIES = 2;
+  private static final int MAX_RETRIES = 3;
 
   private final ObjectMapper jsonMapper;
   private final MetadataStorageTablesConfig tablesConfig;

--- a/server/src/main/java/org/apache/druid/metadata/segment/cache/HeapMemorySegmentMetadataCache.java
+++ b/server/src/main/java/org/apache/druid/metadata/segment/cache/HeapMemorySegmentMetadataCache.java
@@ -73,8 +73,8 @@ public class HeapMemorySegmentMetadataCache implements SegmentMetadataCache
 {
   private static final EmittingLogger log = new EmittingLogger(HeapMemorySegmentMetadataCache.class);
 
-  private static final int SQL_MAX_RETRIES = 10;
-  private static final int SQL_QUIET_RETRIES = 3;
+  private static final int SQL_MAX_RETRIES = 3;
+  private static final int SQL_QUIET_RETRIES = 2;
 
   /**
    * Maximum time to wait for cache to be ready.


### PR DESCRIPTION
### Description

Metadata transactions initiated by `IndexerSQLMetadataStorageCoordinator` and `MetadataTaskStorage`
typically hold the `TaskLockbox.giant` lock while the transaction is in progress.
If there is a transient failure, the transaction is retried up to 10 times which typically spans a period of over 5 minutes.

This eventually leads to a very late failure while causing the Overlord threads to be stuck due to the giant lock.

### Changes

- Reduce quiet retries to 2
- Reduce max retries to 3. It is best to fail early and noisily. If a retry is needed, it should be done at a higher layer.
- Include retry messages where possible

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
