### PR TITLE
Revert "Use CoordinatorClient for fetching tier lookup (#18142)"

### DIFF
--- a/server/src/main/java/org/apache/druid/client/coordinator/CoordinatorClient.java
+++ b/server/src/main/java/org/apache/druid/client/coordinator/CoordinatorClient.java
@@ -23,7 +23,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.druid.client.BootstrapSegmentsResponse;
 import org.apache.druid.client.ImmutableSegmentLoadInfo;
 import org.apache.druid.query.SegmentDescriptor;
-import org.apache.druid.query.lookup.LookupExtractorFactoryContainer;
 import org.apache.druid.rpc.ServiceRetryPolicy;
 import org.apache.druid.segment.metadata.DataSourceInformation;
 import org.apache.druid.server.compaction.CompactionStatusResponse;
@@ -33,7 +32,6 @@ import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 public interface CoordinatorClient
@@ -103,13 +101,4 @@ public interface CoordinatorClient
    * API: {@code POST /druid/coordinator/v1/config}
    */
   ListenableFuture<Void> updateCoordinatorDynamicConfig(CoordinatorDynamicConfig dynamicConfig);
-
-  /**
-   * Gets the lookup configuration for a tier.
-   * <p>
-   * API: {@code GET /druid/coordinator/v1/lookups/config/<tier>}
-   *
-   * @param tier The name of the tier for which the lookup configuration is to be fetched.
-   */
-  ListenableFuture<Map<String, LookupExtractorFactoryContainer>> fetchLookupsForTier(String tier);
 }

--- a/server/src/main/java/org/apache/druid/client/coordinator/CoordinatorClientImpl.java
+++ b/server/src/main/java/org/apache/druid/client/coordinator/CoordinatorClientImpl.java
@@ -30,11 +30,8 @@ import org.apache.druid.common.guava.FutureUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.jackson.JacksonUtils;
 import org.apache.druid.java.util.http.client.response.BytesFullResponseHandler;
-import org.apache.druid.java.util.http.client.response.BytesFullResponseHolder;
 import org.apache.druid.java.util.http.client.response.InputStreamResponseHandler;
 import org.apache.druid.query.SegmentDescriptor;
-import org.apache.druid.query.lookup.LookupExtractorFactoryContainer;
-import org.apache.druid.query.lookup.LookupUtils;
 import org.apache.druid.rpc.IgnoreHttpResponseHandler;
 import org.apache.druid.rpc.RequestBuilder;
 import org.apache.druid.rpc.ServiceClient;
@@ -50,7 +47,6 @@ import org.joda.time.Interval;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 public class CoordinatorClientImpl implements CoordinatorClient
@@ -252,38 +248,6 @@ public class CoordinatorClientImpl implements CoordinatorClient
         new RequestBuilder(HttpMethod.POST, "/druid/coordinator/v1/config")
             .jsonContent(jsonMapper, dynamicConfig),
         IgnoreHttpResponseHandler.INSTANCE
-    );
-  }
-
-  @Override
-  public ListenableFuture<Map<String, LookupExtractorFactoryContainer>> fetchLookupsForTier(
-      String tier
-  )
-  {
-    final String path = StringUtils.format(
-        "/druid/coordinator/v1/lookups/config/%s?detailed=true",
-        StringUtils.urlEncode(tier)
-    );
-
-    return FutureUtils.transform(
-        client.asyncRequest(
-            new RequestBuilder(HttpMethod.GET, path),
-            new BytesFullResponseHandler()
-        ),
-        this::extractLookupFactory
-    );
-  }
-
-  private Map<String, LookupExtractorFactoryContainer> extractLookupFactory(BytesFullResponseHolder holder)
-  {
-    Map<String, Object> lookupNameToGenericConfig = JacksonUtils.readValue(
-        jsonMapper,
-        holder.getContent(),
-        new TypeReference<>() {}
-    );
-    return LookupUtils.tryConvertObjectMapToLookupConfigMap(
-        lookupNameToGenericConfig,
-        jsonMapper
     );
   }
 }

--- a/server/src/main/java/org/apache/druid/client/coordinator/NoopCoordinatorClient.java
+++ b/server/src/main/java/org/apache/druid/client/coordinator/NoopCoordinatorClient.java
@@ -23,7 +23,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.druid.client.BootstrapSegmentsResponse;
 import org.apache.druid.client.ImmutableSegmentLoadInfo;
 import org.apache.druid.query.SegmentDescriptor;
-import org.apache.druid.query.lookup.LookupExtractorFactoryContainer;
 import org.apache.druid.rpc.ServiceRetryPolicy;
 import org.apache.druid.segment.metadata.DataSourceInformation;
 import org.apache.druid.server.compaction.CompactionStatusResponse;
@@ -33,7 +32,6 @@ import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 public class NoopCoordinatorClient implements CoordinatorClient
@@ -101,14 +99,6 @@ public class NoopCoordinatorClient implements CoordinatorClient
 
   @Override
   public ListenableFuture<Void> updateCoordinatorDynamicConfig(CoordinatorDynamicConfig dynamicConfig)
-  {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public ListenableFuture<Map<String, LookupExtractorFactoryContainer>> fetchLookupsForTier(
-      String tier
-  )
   {
     throw new UnsupportedOperationException();
   }

--- a/server/src/main/java/org/apache/druid/query/lookup/LookupReferencesManager.java
+++ b/server/src/main/java/org/apache/druid/query/lookup/LookupReferencesManager.java
@@ -20,31 +20,34 @@
 package org.apache.druid.query.lookup;
 
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import org.apache.commons.lang3.mutable.MutableBoolean;
-import org.apache.druid.client.coordinator.CoordinatorClient;
-import org.apache.druid.common.guava.FutureUtils;
+import org.apache.druid.client.coordinator.Coordinator;
 import org.apache.druid.concurrent.LifecycleLock;
+import org.apache.druid.discovery.DruidLeaderClient;
 import org.apache.druid.guice.ManageLifecycle;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.java.util.common.IOE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.RetryUtils;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.emitter.EmittingLogger;
-import org.apache.druid.rpc.HttpResponseException;
+import org.apache.druid.java.util.http.client.response.StringFullResponseHolder;
 import org.apache.druid.server.lookup.cache.LookupLoadingSpec;
 import org.apache.druid.server.metrics.DataSourceTaskIdHolder;
+import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
 import javax.annotation.Nullable;
@@ -75,7 +78,7 @@ import java.util.stream.Collectors;
  * This class provide a basic {@link LookupExtractorFactory} references manager. It allows basic operations fetching,
  * listing, adding and deleting of {@link LookupExtractor} objects, and can take periodic snap shot of the loaded lookup
  * extractor specifications in order to bootstrap nodes after restart.
- * <p>
+ *
  * It also implements {@link LookupExtractorFactoryContainerProvider}, to supply queries and indexing transformations
  * with a reference to a {@link LookupExtractorFactoryContainer}. This class is a companion of
  * {@link org.apache.druid.server.lookup.cache.LookupCoordinatorManager}, which communicates with
@@ -85,6 +88,9 @@ import java.util.stream.Collectors;
 public class LookupReferencesManager implements LookupExtractorFactoryContainerProvider
 {
   private static final EmittingLogger LOG = new EmittingLogger(LookupReferencesManager.class);
+
+  private static final TypeReference<Map<String, Object>> LOOKUPS_ALL_GENERIC_REFERENCE =
+      new TypeReference<>() {};
 
   // Lookups state (loaded/to-be-loaded/to-be-dropped etc) is managed by immutable LookupUpdateState instance.
   // Any update to state is done by creating updated LookupUpdateState instance and atomically setting that
@@ -105,7 +111,9 @@ public class LookupReferencesManager implements LookupExtractorFactoryContainerP
   //for unit testing only
   private final boolean testMode;
 
-  private final CoordinatorClient coordinatorClient;
+  private final DruidLeaderClient druidLeaderClient;
+
+  private final ObjectMapper jsonMapper;
 
   private final LookupListeningAnnouncerConfig lookupListeningAnnouncerConfig;
 
@@ -117,18 +125,18 @@ public class LookupReferencesManager implements LookupExtractorFactoryContainerP
   public LookupReferencesManager(
       LookupConfig lookupConfig,
       @Json ObjectMapper objectMapper,
-      CoordinatorClient coordinatorClient,
+      @Coordinator DruidLeaderClient druidLeaderClient,
       LookupListeningAnnouncerConfig lookupListeningAnnouncerConfig
   )
   {
-    this(lookupConfig, objectMapper, coordinatorClient, lookupListeningAnnouncerConfig, false);
+    this(lookupConfig, objectMapper, druidLeaderClient, lookupListeningAnnouncerConfig, false);
   }
 
   @VisibleForTesting
   LookupReferencesManager(
       LookupConfig lookupConfig,
       ObjectMapper objectMapper,
-      CoordinatorClient coordinatorClient,
+      DruidLeaderClient druidLeaderClient,
       LookupListeningAnnouncerConfig lookupListeningAnnouncerConfig,
       boolean testMode
   )
@@ -138,7 +146,8 @@ public class LookupReferencesManager implements LookupExtractorFactoryContainerP
     } else {
       this.lookupSnapshotTaker = new LookupSnapshotTaker(objectMapper, lookupConfig.getSnapshotWorkingDir());
     }
-    this.coordinatorClient = coordinatorClient;
+    this.druidLeaderClient = druidLeaderClient;
+    this.jsonMapper = objectMapper;
     this.lookupListeningAnnouncerConfig = lookupListeningAnnouncerConfig;
     this.lookupConfig = lookupConfig;
     this.testMode = testMode;
@@ -277,11 +286,7 @@ public class LookupReferencesManager implements LookupExtractorFactoryContainerP
     if (lookupLoadingSpec.getMode() == LookupLoadingSpec.Mode.NONE ||
         (lookupLoadingSpec.getMode() == LookupLoadingSpec.Mode.ONLY_REQUIRED
          && !lookupLoadingSpec.getLookupsToLoad().contains(lookupName))) {
-      LOG.info(
-          "Skipping notice to add lookup[%s] since current lookup loading mode[%s] does not allow it.",
-          lookupName,
-          lookupLoadingSpec.getMode()
-      );
+      LOG.info("Skipping notice to add lookup [%s] since current lookup loading mode [%s] does not allow it.", lookupName, lookupLoadingSpec.getMode());
       return;
     }
     addNotice(new LoadNotice(lookupName, lookupExtractorFactoryContainer, lookupConfig.getLookupStartRetries()));
@@ -396,8 +401,7 @@ public class LookupReferencesManager implements LookupExtractorFactoryContainerP
       lookupBeanList = getLookupsList();
       if (lookupLoadingSpec.getMode() == LookupLoadingSpec.Mode.ONLY_REQUIRED && lookupBeanList != null) {
         lookupBeanList = lookupBeanList.stream()
-                                       .filter(lookupBean -> lookupLoadingSpec.getLookupsToLoad()
-                                                                              .contains(lookupBean.getName()))
+                                       .filter(lookupBean -> lookupLoadingSpec.getLookupsToLoad().contains(lookupBean.getName()))
                                        .collect(Collectors.toList());
       }
     }
@@ -433,6 +437,7 @@ public class LookupReferencesManager implements LookupExtractorFactoryContainerP
    * Returns a list of lookups from the coordinator if the coordinator is available. If it's not available, returns null.
    *
    * @param tier lookup tier name
+   *
    * @return list of LookupBean objects, or null
    */
   @Nullable
@@ -471,24 +476,37 @@ public class LookupReferencesManager implements LookupExtractorFactoryContainerP
 
   @Nullable
   private Map<String, LookupExtractorFactoryContainer> tryGetLookupListFromCoordinator(String tier)
+      throws IOException, InterruptedException
   {
-    try {
-      return FutureUtils.getUnchecked(coordinatorClient.fetchLookupsForTier(tier), true);
+    final StringFullResponseHolder response = fetchLookupsForTier(tier);
+    if (response.getStatus().equals(HttpResponseStatus.NOT_FOUND)) {
+      LOG.warn("No lookups found for tier [%s], response [%s]", tier, response);
+      return null;
+    } else if (!response.getStatus().equals(HttpResponseStatus.OK)) {
+      throw new IOE(
+          "Error while fetching lookup code from Coordinator with status[%s] and content[%s]",
+          response.getStatus(),
+          response.getContent()
+      );
     }
-    catch (Exception e) {
-      Throwable rootCause = Throwables.getRootCause(e);
-      if (rootCause instanceof HttpResponseException) {
-        final HttpResponseException httpException = (HttpResponseException) rootCause;
-        if (httpException.getResponse().getStatus().equals(HttpResponseStatus.NOT_FOUND)) {
-          LOG.info(
-              "No lookups found for tier [%s], status [%s]",
-              tier,
-              httpException.getResponse().getStatus()
-          );
-          return null;
-        }
-      }
-      throw e;
+
+    // Older version of getSpecificTier returns a list of lookup names.
+    // Lookup loading is performed via snapshot if older version is present.
+    // This check is only for backward compatibility and should be removed in a future release
+    if (response.getContent().startsWith("[")) {
+      LOG.info(
+          "Failed to retrieve lookup information from coordinator, " +
+          "because coordinator appears to be running on older Druid version. " +
+          "Attempting to load lookups using snapshot instead"
+      );
+      return null;
+    } else {
+      Map<String, Object> lookupNameToGenericConfig =
+          jsonMapper.readValue(response.getContent(), LOOKUPS_ALL_GENERIC_REFERENCE);
+      return LookupUtils.tryConvertObjectMapToLookupConfigMap(
+          lookupNameToGenericConfig,
+          jsonMapper
+      );
     }
   }
 
@@ -610,6 +628,15 @@ public class LookupReferencesManager implements LookupExtractorFactoryContainerP
     }
   }
 
+  private StringFullResponseHolder fetchLookupsForTier(String tier) throws InterruptedException, IOException
+  {
+    return druidLeaderClient.go(
+        druidLeaderClient.makeRequest(
+            HttpMethod.GET,
+            StringUtils.format("/druid/coordinator/v1/lookups/config/%s?detailed=true", tier)
+        )
+    );
+  }
   private void dropContainer(LookupExtractorFactoryContainer container, String lookupName)
   {
     if (container != null) {
@@ -624,12 +651,10 @@ public class LookupReferencesManager implements LookupExtractorFactoryContainerP
       }
     }
   }
-
   @VisibleForTesting
   interface Notice
   {
-    void handle(Map<String, LookupExtractorFactoryContainer> lookupMap, LookupReferencesManager manager)
-        throws Exception;
+    void handle(Map<String, LookupExtractorFactoryContainer> lookupMap, LookupReferencesManager manager) throws Exception;
   }
 
   private static class LoadNotice implements Notice
@@ -716,7 +741,6 @@ public class LookupReferencesManager implements LookupExtractorFactoryContainerP
         }
       });
     }
-
     @Override
     public String toString()
     {

--- a/server/src/test/java/org/apache/druid/client/coordinator/CoordinatorClientImplTest.java
+++ b/server/src/test/java/org/apache/druid/client/coordinator/CoordinatorClientImplTest.java
@@ -29,16 +29,12 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.Injector;
 import org.apache.druid.client.BootstrapSegmentsResponse;
 import org.apache.druid.client.ImmutableSegmentLoadInfo;
-import org.apache.druid.common.guava.FutureUtils;
 import org.apache.druid.guice.StartupInjectorBuilder;
 import org.apache.druid.initialization.CoreInjectorBuilder;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.SegmentDescriptor;
-import org.apache.druid.query.lookup.LookupExtractorFactory;
-import org.apache.druid.query.lookup.LookupExtractorFactoryContainer;
-import org.apache.druid.query.lookup.MapLookupExtractorFactory;
 import org.apache.druid.rpc.MockServiceClient;
 import org.apache.druid.rpc.RequestBuilder;
 import org.apache.druid.segment.column.ColumnType;
@@ -99,10 +95,7 @@ public class CoordinatorClientImplTest
     jsonMapper.setInjectableValues(
         new InjectableValues.Std(ImmutableMap.of(
             DataSegment.PruneSpecsHolder.class.getName(),
-            DataSegment.PruneSpecsHolder.DEFAULT
-        ))
-    );
-    jsonMapper.registerSubtypes(MapLookupExtractorFactory.class);
+            DataSegment.PruneSpecsHolder.DEFAULT)));
     serviceClient = new MockServiceClient();
     coordinatorClient = new CoordinatorClientImpl(serviceClient, jsonMapper);
   }
@@ -151,10 +144,7 @@ public class CoordinatorClientImplTest
                    .build();
 
     serviceClient.expectAndRespond(
-        new RequestBuilder(
-            HttpMethod.GET,
-            "/druid/coordinator/v1/metadata/datasources/xyz/segments/def?includeUnused=false"
-        ),
+        new RequestBuilder(HttpMethod.GET, "/druid/coordinator/v1/metadata/datasources/xyz/segments/def?includeUnused=false"),
         HttpResponseStatus.OK,
         ImmutableMap.of(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON),
         jsonMapper.writeValueAsBytes(segment)
@@ -355,13 +345,10 @@ public class CoordinatorClientImplTest
                    .size(1)
                    .build(),
         serverMetadataSet
-    );
+        );
 
     serviceClient.expectAndRespond(
-        new RequestBuilder(
-            HttpMethod.GET,
-            "/druid/coordinator/v1/datasources/xyz/intervals/2001-01-01T00:00:00.000Z_2002-01-01T00:00:00.000Z/serverview?full"
-        ),
+        new RequestBuilder(HttpMethod.GET, "/druid/coordinator/v1/datasources/xyz/intervals/2001-01-01T00:00:00.000Z_2002-01-01T00:00:00.000Z/serverview?full"),
         HttpResponseStatus.OK,
         ImmutableMap.of(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON),
         jsonMapper.writeValueAsBytes(Collections.singletonList(immutableSegmentLoadInfo1))
@@ -379,10 +366,7 @@ public class CoordinatorClientImplTest
     );
 
     serviceClient.expectAndRespond(
-        new RequestBuilder(
-            HttpMethod.GET,
-            "/druid/coordinator/v1/datasources/xyz/intervals/2501-01-01T00:00:00.000Z_2502-01-01T00:00:00.000Z/serverview?full"
-        ),
+        new RequestBuilder(HttpMethod.GET, "/druid/coordinator/v1/datasources/xyz/intervals/2501-01-01T00:00:00.000Z_2502-01-01T00:00:00.000Z/serverview?full"),
         HttpResponseStatus.OK,
         ImmutableMap.of(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON),
         jsonMapper.writeValueAsBytes(Collections.singletonList(immutableSegmentLoadInfo2))
@@ -486,36 +470,5 @@ public class CoordinatorClientImplTest
     );
 
     Assert.assertNull(coordinatorClient.updateCoordinatorDynamicConfig(config).get());
-  }
-
-  @Test
-  public void test_fetchLookupsForTier_detailedEnabled() throws Exception
-  {
-    LookupExtractorFactory lookupData = new MapLookupExtractorFactory(
-        Map.of(
-            "77483", "United States",
-            "77484", "India"
-        ),
-        true
-    );
-    LookupExtractorFactoryContainer lookupDataContainer = new LookupExtractorFactoryContainer("v0", lookupData);
-    Map<String, LookupExtractorFactoryContainer> lookups = Map.of(
-        "default_tier", lookupDataContainer
-    );
-
-    serviceClient.expectAndRespond(
-        new RequestBuilder(
-            HttpMethod.GET,
-            "/druid/coordinator/v1/lookups/config/default_tier?detailed=true"
-        ),
-        HttpResponseStatus.OK,
-        Map.of(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON),
-        DefaultObjectMapper.INSTANCE.writeValueAsBytes(lookups)
-    );
-
-    Assert.assertEquals(
-        lookups,
-        FutureUtils.getUnchecked(coordinatorClient.fetchLookupsForTier("default_tier"), true)
-    );
   }
 }

--- a/server/src/test/java/org/apache/druid/query/lookup/LookupReferencesManagerTest.java
+++ b/server/src/test/java/org/apache/druid/query/lookup/LookupReferencesManagerTest.java
@@ -22,18 +22,18 @@ package org.apache.druid.query.lookup;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.util.concurrent.Futures;
-import org.apache.druid.client.coordinator.CoordinatorClientImpl;
+import org.apache.druid.discovery.DruidLeaderClient;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.emitter.EmittingLogger;
+import org.apache.druid.java.util.http.client.Request;
 import org.apache.druid.java.util.http.client.response.StringFullResponseHolder;
-import org.apache.druid.rpc.HttpResponseException;
 import org.apache.druid.server.lookup.cache.LookupLoadingSpec;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.easymock.EasyMock;
-import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
+import org.jboss.netty.buffer.BigEndianHeapChannelBuffer;
+import org.jboss.netty.handler.codec.http.HttpMethod;
+import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
-import org.jboss.netty.handler.codec.http.HttpVersion;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -41,6 +41,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
@@ -59,7 +60,7 @@ public class LookupReferencesManagerTest
   LookupExtractorFactory lookupExtractorFactory;
   LookupExtractorFactoryContainer container;
   ObjectMapper mapper = new DefaultObjectMapper();
-  private CoordinatorClientImpl coordinatorClient;
+  private DruidLeaderClient druidLeaderClient;
   private LookupListeningAnnouncerConfig config;
 
   @Before
@@ -67,7 +68,7 @@ public class LookupReferencesManagerTest
   {
     EmittingLogger.registerEmitter(new NoopServiceEmitter());
 
-    coordinatorClient = EasyMock.createMock(CoordinatorClientImpl.class);
+    druidLeaderClient = EasyMock.createMock(DruidLeaderClient.class);
 
     config = EasyMock.createMock(LookupListeningAnnouncerConfig.class);
     EasyMock.expect(config.getLookupLoadingSpec()).andReturn(LookupLoadingSpec.ALL).anyTimes();
@@ -80,29 +81,50 @@ public class LookupReferencesManagerTest
     );
     container = new LookupExtractorFactoryContainer("v0", lookupExtractorFactory);
     mapper.registerSubtypes(MapLookupExtractorFactory.class);
+    String temporaryPath = temporaryFolder.newFolder().getAbsolutePath();
     lookupReferencesManager = new LookupReferencesManager(
         new LookupConfig(temporaryFolder.newFolder().getAbsolutePath()),
         mapper,
-        coordinatorClient,
+        druidLeaderClient,
         config,
         true
     );
   }
 
+  private static HttpResponse newEmptyResponse(final HttpResponseStatus status)
+  {
+    final HttpResponse response = EasyMock.createNiceMock(HttpResponse.class);
+    EasyMock.expect(response.getStatus()).andReturn(status).anyTimes();
+    EasyMock.expect(response.getContent()).andReturn(new BigEndianHeapChannelBuffer(0));
+    EasyMock.replay(response);
+    return response;
+  }
+
   @Test
-  public void testStartStop() throws IOException
+  public void testStartStop() throws InterruptedException, IOException
   {
     lookupReferencesManager = new LookupReferencesManager(
         new LookupConfig(null),
-        mapper, coordinatorClient, config
+        mapper, druidLeaderClient, config
     );
 
-    Map<String, LookupExtractorFactoryContainer> lookupMap = new HashMap<>();
+    Map<String, Object> lookupMap = new HashMap<>();
     lookupMap.put("testMockForStartStop", container);
+    String strResult = mapper.writeValueAsString(lookupMap);
+    Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     EasyMock.expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     EasyMock.replay(config);
-    EasyMock.expect(coordinatorClient.fetchLookupsForTier(LOOKUP_TIER)).andReturn(Futures.immediateFuture(lookupMap));
-    EasyMock.replay(coordinatorClient);
+    EasyMock.expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
+            .andReturn(request);
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
+        newEmptyResponse(HttpResponseStatus.OK),
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
+    EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
+    EasyMock.replay(druidLeaderClient);
     Assert.assertFalse(lookupReferencesManager.lifecycleLock.awaitStarted(1, TimeUnit.MICROSECONDS));
     Assert.assertNull(lookupReferencesManager.mainThread);
     Assert.assertNull(lookupReferencesManager.stateRef.get());
@@ -150,12 +172,23 @@ public class LookupReferencesManagerTest
     EasyMock.expect(lookupExtractorFactory.isInitialized()).andReturn(true).anyTimes();
     EasyMock.replay(lookupExtractorFactory);
 
-    Map<String, LookupExtractorFactoryContainer> lookupMap = new HashMap<>();
+    Map<String, Object> lookupMap = new HashMap<>();
     lookupMap.put("testMockForAddGetRemove", container);
+    String strResult = mapper.writeValueAsString(lookupMap);
+    Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     EasyMock.expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     EasyMock.replay(config);
-    EasyMock.expect(coordinatorClient.fetchLookupsForTier(LOOKUP_TIER)).andReturn(Futures.immediateFuture(lookupMap));
-    EasyMock.replay(coordinatorClient);
+    EasyMock.expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
+            .andReturn(request);
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
+        newEmptyResponse(HttpResponseStatus.OK),
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
+    EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
+    EasyMock.replay(druidLeaderClient);
     lookupReferencesManager.start();
     Assert.assertEquals(Optional.empty(), lookupReferencesManager.get("test"));
 
@@ -182,12 +215,23 @@ public class LookupReferencesManagerTest
     EasyMock.expect(lookupExtractorFactory.isInitialized()).andReturn(true).anyTimes();
     EasyMock.replay(lookupExtractorFactory);
 
-    Map<String, LookupExtractorFactoryContainer> lookupMap = new HashMap<>();
+    Map<String, Object> lookupMap = new HashMap<>();
     lookupMap.put("testMockForAddGetRemove", container);
+    String strResult = mapper.writeValueAsString(lookupMap);
+    Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     EasyMock.expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     EasyMock.replay(config);
-    EasyMock.expect(coordinatorClient.fetchLookupsForTier(LOOKUP_TIER)).andReturn(Futures.immediateFuture(lookupMap));
-    EasyMock.replay(coordinatorClient);
+    EasyMock.expect(druidLeaderClient.makeRequest(
+                HttpMethod.GET,
+                "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+            ))
+            .andReturn(request);
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
+        newEmptyResponse(HttpResponseStatus.OK),
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
+    EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
+    EasyMock.replay(druidLeaderClient);
     lookupReferencesManager.start();
     Assert.assertEquals(Optional.empty(), lookupReferencesManager.get("test"));
 
@@ -228,12 +272,23 @@ public class LookupReferencesManagerTest
     EasyMock.expect(lookupExtractorFactory.isInitialized()).andReturn(true).anyTimes();
     EasyMock.replay(lookupExtractorFactory);
 
-    Map<String, LookupExtractorFactoryContainer> lookupMap = new HashMap<>();
+    Map<String, Object> lookupMap = new HashMap<>();
     lookupMap.put("testMockForAddGetRemove", container);
+    String strResult = mapper.writeValueAsString(lookupMap);
+    Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     EasyMock.expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     EasyMock.replay(config);
-    EasyMock.expect(coordinatorClient.fetchLookupsForTier(LOOKUP_TIER)).andReturn(Futures.immediateFuture(lookupMap));
-    EasyMock.replay(coordinatorClient);
+    EasyMock.expect(druidLeaderClient.makeRequest(
+                HttpMethod.GET,
+                "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+            ))
+            .andReturn(request);
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
+        newEmptyResponse(HttpResponseStatus.OK),
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
+    EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
+    EasyMock.replay(druidLeaderClient);
     lookupReferencesManager.start();
     Assert.assertEquals(Optional.empty(), lookupReferencesManager.get("test"));
 
@@ -263,7 +318,6 @@ public class LookupReferencesManagerTest
 
     Assert.assertEquals(Optional.empty(), lookupReferencesManager.get("test"));
   }
-
   @Test
   public void testCloseIsCalledAfterStopping() throws Exception
   {
@@ -272,12 +326,23 @@ public class LookupReferencesManagerTest
     EasyMock.expect(lookupExtractorFactory.close()).andReturn(true).once();
     EasyMock.expect(lookupExtractorFactory.isInitialized()).andReturn(true).anyTimes();
     EasyMock.replay(lookupExtractorFactory);
-    Map<String, LookupExtractorFactoryContainer> lookupMap = new HashMap<>();
+    Map<String, Object> lookupMap = new HashMap<>();
     lookupMap.put("testMockForCloseIsCalledAfterStopping", container);
+    String strResult = mapper.writeValueAsString(lookupMap);
+    Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     EasyMock.expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     EasyMock.replay(config);
-    EasyMock.expect(coordinatorClient.fetchLookupsForTier(LOOKUP_TIER)).andReturn(Futures.immediateFuture(lookupMap));
-    EasyMock.replay(coordinatorClient);
+    EasyMock.expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
+            .andReturn(request);
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
+        newEmptyResponse(HttpResponseStatus.OK),
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
+    EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
+    EasyMock.replay(druidLeaderClient);
     lookupReferencesManager.start();
     lookupReferencesManager.add("testMock", new LookupExtractorFactoryContainer("0", lookupExtractorFactory));
     lookupReferencesManager.handlePendingNotices();
@@ -295,12 +360,23 @@ public class LookupReferencesManagerTest
     EasyMock.expect(lookupExtractorFactory.destroy()).andReturn(true).once();
     EasyMock.replay(lookupExtractorFactory);
 
-    Map<String, LookupExtractorFactoryContainer> lookupMap = new HashMap<>();
+    Map<String, Object> lookupMap = new HashMap<>();
     lookupMap.put("testMockForDestroyIsCalledAfterRemove", container);
+    String strResult = mapper.writeValueAsString(lookupMap);
+    Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     EasyMock.expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     EasyMock.replay(config);
-    EasyMock.expect(coordinatorClient.fetchLookupsForTier(LOOKUP_TIER)).andReturn(Futures.immediateFuture(lookupMap));
-    EasyMock.replay(coordinatorClient);
+    EasyMock.expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
+            .andReturn(request);
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
+        newEmptyResponse(HttpResponseStatus.OK),
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
+    EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
+    EasyMock.replay(druidLeaderClient);
     LookupExtractorFactoryContainer container = new LookupExtractorFactoryContainer("0", lookupExtractorFactory);
     lookupReferencesManager.start();
     lookupReferencesManager.add("testMock", container);
@@ -315,12 +391,23 @@ public class LookupReferencesManagerTest
   @Test
   public void testGetNotThere() throws Exception
   {
-    Map<String, LookupExtractorFactoryContainer> lookupMap = new HashMap<>();
+    Map<String, Object> lookupMap = new HashMap<>();
     lookupMap.put("testMockForGetNotThere", container);
+    String strResult = mapper.writeValueAsString(lookupMap);
+    Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     EasyMock.expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     EasyMock.replay(config);
-    EasyMock.expect(coordinatorClient.fetchLookupsForTier(LOOKUP_TIER)).andReturn(Futures.immediateFuture(lookupMap));
-    EasyMock.replay(coordinatorClient);
+    EasyMock.expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
+            .andReturn(request);
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
+        newEmptyResponse(HttpResponseStatus.OK),
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
+    EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
+    EasyMock.replay(druidLeaderClient);
     lookupReferencesManager.start();
     Assert.assertEquals(Optional.empty(), lookupReferencesManager.get("notThere"));
   }
@@ -337,12 +424,23 @@ public class LookupReferencesManagerTest
     EasyMock.expect(lookupExtractorFactory2.start()).andReturn(true).once();
 
     EasyMock.replay(lookupExtractorFactory1, lookupExtractorFactory2);
-    Map<String, LookupExtractorFactoryContainer> lookupMap = new HashMap<>();
+    Map<String, Object> lookupMap = new HashMap<>();
     lookupMap.put("testMockForUpdateWithHigherVersion", container);
+    String strResult = mapper.writeValueAsString(lookupMap);
+    Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     EasyMock.expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     EasyMock.replay(config);
-    EasyMock.expect(coordinatorClient.fetchLookupsForTier(LOOKUP_TIER)).andReturn(Futures.immediateFuture(lookupMap));
-    EasyMock.replay(coordinatorClient);
+    EasyMock.expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
+            .andReturn(request);
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
+        newEmptyResponse(HttpResponseStatus.OK),
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
+    EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
+    EasyMock.replay(druidLeaderClient);
     lookupReferencesManager.start();
     lookupReferencesManager.add("testName", new LookupExtractorFactoryContainer("1", lookupExtractorFactory1));
     lookupReferencesManager.handlePendingNotices();
@@ -362,12 +460,23 @@ public class LookupReferencesManagerTest
     LookupExtractorFactory lookupExtractorFactory2 = EasyMock.createNiceMock(LookupExtractorFactory.class);
 
     EasyMock.replay(lookupExtractorFactory1, lookupExtractorFactory2);
-    Map<String, LookupExtractorFactoryContainer> lookupMap = new HashMap<>();
+    Map<String, Object> lookupMap = new HashMap<>();
     lookupMap.put("testMockForUpdateWithLowerVersion", container);
+    String strResult = mapper.writeValueAsString(lookupMap);
+    Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     EasyMock.expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     EasyMock.replay(config);
-    EasyMock.expect(coordinatorClient.fetchLookupsForTier(LOOKUP_TIER)).andReturn(Futures.immediateFuture(lookupMap));
-    EasyMock.replay(coordinatorClient);
+    EasyMock.expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
+            .andReturn(request);
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
+        newEmptyResponse(HttpResponseStatus.OK),
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
+    EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
+    EasyMock.replay(druidLeaderClient);
     lookupReferencesManager.start();
     lookupReferencesManager.add("testName", new LookupExtractorFactoryContainer("1", lookupExtractorFactory1));
     lookupReferencesManager.handlePendingNotices();
@@ -385,27 +494,48 @@ public class LookupReferencesManagerTest
     EasyMock.expect(lookupExtractorFactory1.start()).andReturn(true).once();
     EasyMock.expect(lookupExtractorFactory1.isInitialized()).andReturn(false).anyTimes();
     EasyMock.replay(lookupExtractorFactory1);
-    Map<String, LookupExtractorFactoryContainer> lookupMap = new HashMap<>();
+    Map<String, Object> lookupMap = new HashMap<>();
+    String strResult = mapper.writeValueAsString(lookupMap);
+    Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     EasyMock.expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     EasyMock.replay(config);
-    EasyMock.expect(coordinatorClient.fetchLookupsForTier(LOOKUP_TIER)).andReturn(Futures.immediateFuture(lookupMap));
-    EasyMock.replay(coordinatorClient);
+    EasyMock.expect(druidLeaderClient.makeRequest(
+                HttpMethod.GET,
+                "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+            ))
+            .andReturn(request);
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
+        newEmptyResponse(HttpResponseStatus.OK),
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
+    EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
+    EasyMock.replay(druidLeaderClient);
     lookupReferencesManager.start();
     lookupReferencesManager.add("testName", new LookupExtractorFactoryContainer("1", lookupExtractorFactory1));
     lookupReferencesManager.handlePendingNotices();
     Assert.assertTrue(lookupReferencesManager.get("testName").isPresent());
     EasyMock.verify(lookupExtractorFactory1);
   }
-
   @Test
   public void testRemoveNonExisting() throws Exception
   {
-    Map<String, LookupExtractorFactoryContainer> lookupMap = new HashMap<>();
+    Map<String, Object> lookupMap = new HashMap<>();
     lookupMap.put("testMockForRemoveNonExisting", container);
+    String strResult = mapper.writeValueAsString(lookupMap);
+    Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     EasyMock.expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     EasyMock.replay(config);
-    EasyMock.expect(coordinatorClient.fetchLookupsForTier(LOOKUP_TIER)).andReturn(Futures.immediateFuture(lookupMap));
-    EasyMock.replay(coordinatorClient);
+    EasyMock.expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
+            .andReturn(request);
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
+        newEmptyResponse(HttpResponseStatus.OK),
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
+    EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
+    EasyMock.replay(druidLeaderClient);
     lookupReferencesManager.start();
     lookupReferencesManager.remove("test", null);
     lookupReferencesManager.handlePendingNotices();
@@ -423,11 +553,20 @@ public class LookupReferencesManagerTest
         "0",
         new MapLookupExtractorFactory(ImmutableMap.of("key2", "value2"), true)
     );
-    Map<String, LookupExtractorFactoryContainer> lookupMap = new HashMap<>();
+    Map<String, Object> lookupMap = new HashMap<>();
+    String strResult = mapper.writeValueAsString(lookupMap);
+    Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     EasyMock.expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     EasyMock.replay(config);
-    EasyMock.expect(coordinatorClient.fetchLookupsForTier(LOOKUP_TIER)).andReturn(Futures.immediateFuture(lookupMap));
-    EasyMock.replay(coordinatorClient);
+    EasyMock.expect(
+        druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true")
+    ).andReturn(request);
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
+        newEmptyResponse(HttpResponseStatus.OK),
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
+    EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
+    EasyMock.replay(druidLeaderClient);
     lookupReferencesManager.start();
     lookupReferencesManager.add("one", container1);
     lookupReferencesManager.add("two", container2);
@@ -437,7 +576,7 @@ public class LookupReferencesManagerTest
 
     Assert.assertEquals(
         ImmutableSet.of("one", "two"),
-        (lookupReferencesManager).getAllLookupNames()
+        ((LookupExtractorFactoryContainerProvider) lookupReferencesManager).getAllLookupNames()
     );
   }
 
@@ -480,11 +619,22 @@ public class LookupReferencesManagerTest
             ), true
         )
     );
-    Map<String, LookupExtractorFactoryContainer> lookupMap = new HashMap<>();
+    Map<String, Object> lookupMap = new HashMap<>();
+    String strResult = mapper.writeValueAsString(lookupMap);
+    Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     EasyMock.expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     EasyMock.replay(config);
-    EasyMock.expect(coordinatorClient.fetchLookupsForTier(LOOKUP_TIER)).andReturn(Futures.immediateFuture(lookupMap));
-    EasyMock.replay(coordinatorClient);
+    EasyMock.expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
+            .andReturn(request);
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
+        newEmptyResponse(HttpResponseStatus.OK),
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
+    EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
+    EasyMock.replay(druidLeaderClient);
     lookupReferencesManager.start();
     lookupReferencesManager.add("one", container1);
     lookupReferencesManager.add("two", container2);
@@ -510,14 +660,25 @@ public class LookupReferencesManagerTest
   {
     LookupReferencesManager lookupReferencesManager = new LookupReferencesManager(
         new LookupConfig(temporaryFolder.newFolder().getAbsolutePath()),
-        mapper, coordinatorClient, config
+        mapper, druidLeaderClient, config
     );
-    Map<String, LookupExtractorFactoryContainer> lookupMap = new HashMap<>();
+    Map<String, Object> lookupMap = new HashMap<>();
     lookupMap.put("testMockForRealModeWithMainThread", container);
+    String strResult = mapper.writeValueAsString(lookupMap);
+    Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     EasyMock.expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     EasyMock.replay(config);
-    EasyMock.expect(coordinatorClient.fetchLookupsForTier(LOOKUP_TIER)).andReturn(Futures.immediateFuture(lookupMap));
-    EasyMock.replay(coordinatorClient);
+    EasyMock.expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
+            .andReturn(request);
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
+        newEmptyResponse(HttpResponseStatus.OK),
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
+    EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
+    EasyMock.replay(druidLeaderClient);
     lookupReferencesManager.start();
     Assert.assertTrue(lookupReferencesManager.mainThread.isAlive());
 
@@ -588,14 +749,25 @@ public class LookupReferencesManagerTest
             ), true
         )
     );
-    Map<String, LookupExtractorFactoryContainer> lookupMap = new HashMap<>();
+    Map<String, Object> lookupMap = new HashMap<>();
     lookupMap.put("testLookup1", container1);
     lookupMap.put("testLookup2", container2);
     lookupMap.put("testLookup3", container3);
+    String strResult = mapper.writeValueAsString(lookupMap);
+    Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     EasyMock.expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     EasyMock.replay(config);
-    EasyMock.expect(coordinatorClient.fetchLookupsForTier(LOOKUP_TIER)).andReturn(Futures.immediateFuture(lookupMap));
-    EasyMock.replay(coordinatorClient);
+    EasyMock.expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
+            .andReturn(request);
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
+        newEmptyResponse(HttpResponseStatus.OK),
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
+    EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
+    EasyMock.replay(druidLeaderClient);
 
     lookupReferencesManager.start();
     Assert.assertEquals(Optional.of(container1), lookupReferencesManager.get("testLookup1"));
@@ -624,16 +796,27 @@ public class LookupReferencesManagerTest
         )
     );
     EasyMock.reset(config);
-    EasyMock.reset(coordinatorClient);
+    EasyMock.reset(druidLeaderClient);
     Map<String, LookupExtractorFactoryContainer> lookupMap = new HashMap<>();
     lookupMap.put("testLookup1", container1);
     lookupMap.put("testLookup2", container2);
     lookupMap.put("testLookup3", container3);
+    String strResult = mapper.writeValueAsString(lookupMap);
+    Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     EasyMock.expect(config.getLookupTier()).andReturn(LOOKUP_TIER);
     EasyMock.expect(config.getLookupLoadingSpec()).andReturn(lookupLoadingSpec);
     EasyMock.replay(config);
-    EasyMock.expect(coordinatorClient.fetchLookupsForTier(LOOKUP_TIER)).andReturn(Futures.immediateFuture(lookupMap));
-    EasyMock.replay(coordinatorClient);
+    EasyMock.expect(druidLeaderClient.makeRequest(
+                HttpMethod.GET,
+                "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+            ))
+            .andReturn(request);
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
+        newEmptyResponse(HttpResponseStatus.OK),
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
+    EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
+    EasyMock.replay(druidLeaderClient);
 
     lookupReferencesManager.start();
     return lookupMap;
@@ -661,9 +844,7 @@ public class LookupReferencesManagerTest
   public void testCoordinatorLoadSubsetOfLookups() throws Exception
   {
     Map<String, LookupExtractorFactoryContainer> lookupMap =
-        getLookupMapForSelectiveLoadingOfLookups(
-            LookupLoadingSpec.loadOnly(ImmutableSet.of("testLookup1", "testLookup2"))
-        );
+        getLookupMapForSelectiveLoadingOfLookups(LookupLoadingSpec.loadOnly(ImmutableSet.of("testLookup1", "testLookup2")));
     Assert.assertEquals(Optional.of(lookupMap.get("testLookup1")), lookupReferencesManager.get("testLookup1"));
     Assert.assertEquals(Optional.of(lookupMap.get("testLookup2")), lookupReferencesManager.get("testLookup2"));
     Assert.assertFalse(lookupReferencesManager.get("testLookup3").isPresent());
@@ -722,15 +903,21 @@ public class LookupReferencesManagerTest
     lookupReferencesManager = new LookupReferencesManager(
         lookupConfig,
         mapper,
-        coordinatorClient,
+        druidLeaderClient,
         config
     );
 
+    Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     EasyMock.expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     EasyMock.replay(config);
-
-    EasyMock.expect(coordinatorClient.fetchLookupsForTier(LOOKUP_TIER)).andThrow(new RuntimeException()).anyTimes();
-    EasyMock.replay(coordinatorClient);
+    EasyMock.expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
+            .andReturn(request)
+            .anyTimes();
+    EasyMock.expect(druidLeaderClient.go(request)).andThrow(new IllegalStateException()).anyTimes();
+    EasyMock.replay(druidLeaderClient);
 
     lookupReferencesManager.start();
     lookupReferencesManager.add("testMockForLoadLookupOnCoordinatorFailure", container);
@@ -748,26 +935,23 @@ public class LookupReferencesManagerTest
     lookupReferencesManager = new LookupReferencesManager(
         lookupConfig,
         mapper,
-        coordinatorClient,
+        druidLeaderClient,
         config,
         true
     );
     EasyMock.reset(config);
-    EasyMock.reset(coordinatorClient);
+    EasyMock.reset(druidLeaderClient);
     EasyMock.expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     EasyMock.expect(config.getLookupLoadingSpec()).andReturn(LookupLoadingSpec.ALL).anyTimes();
     EasyMock.replay(config);
-    EasyMock.expect(coordinatorClient.fetchLookupsForTier(LOOKUP_TIER)).andReturn(
-        Futures.immediateFailedFuture(
-            new HttpResponseException(
-                new StringFullResponseHolder(
-                    new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_FOUND),
-                    StandardCharsets.UTF_8
-                )
-            )
-        )
-    ).anyTimes();
-    EasyMock.replay(coordinatorClient);
+    EasyMock.expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
+            .andReturn(request)
+            .anyTimes();
+    EasyMock.expect(druidLeaderClient.go(request)).andThrow(new IllegalStateException()).anyTimes();
+    EasyMock.replay(druidLeaderClient);
     lookupReferencesManager.start();
     Assert.assertEquals(
         Optional.of(container),
@@ -789,15 +973,26 @@ public class LookupReferencesManagerTest
     LookupReferencesManager lookupReferencesManager = new LookupReferencesManager(
         lookupConfig,
         mapper,
-        coordinatorClient,
+        druidLeaderClient,
         config
     );
-    Map<String, LookupExtractorFactoryContainer> lookupMap = new HashMap<>();
+    Map<String, Object> lookupMap = new HashMap<>();
     lookupMap.put("testMockForDisableLookupSync", container);
+    String strResult = mapper.writeValueAsString(lookupMap);
+    Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     EasyMock.expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     EasyMock.replay(config);
+    EasyMock.expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
+            .andReturn(request);
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
+        newEmptyResponse(HttpResponseStatus.OK),
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
+    EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
 
-    EasyMock.expect(coordinatorClient.fetchLookupsForTier(LOOKUP_TIER)).andReturn(Futures.immediateFuture(lookupMap));
     lookupReferencesManager.start();
     Assert.assertEquals(Optional.empty(), lookupReferencesManager.get("testMockForDisableLookupSync"));
   }


### PR DESCRIPTION
This reverts commit 6b3cb50cdd8fc8c3dd9db2b55351758634c975a5.

### Description

Unblocking issues where cachedNamespace failed to load by brokers.

Stack trace for blocked threads - 

```
"main" #1 prio=5 os_prio=31 cpu=3520.56ms elapsed=363.89s tid=0x000000014c80dc00 nid=0x2203 waiting on condition  [0x000000016f295000]
   java.lang.Thread.State: WAITING (parking)
	at jdk.internal.misc.Unsafe.park(java.base@17.0.11/Native Method)
	- parking to wait for  <0x00000006062c63e8> (a com.google.common.util.concurrent.AbstractTransformFuture$TransformFuture)
	at java.util.concurrent.locks.LockSupport.park(java.base@17.0.11/LockSupport.java:211)
	at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:561)
	at com.google.common.util.concurrent.FluentFuture$TrustedFuture.get(FluentFuture.java:91)
	at org.apache.druid.common.guava.FutureUtils.get(FutureUtils.java:52)
	at org.apache.druid.common.guava.FutureUtils.getUnchecked(FutureUtils.java:76)
	at org.apache.druid.query.lookup.LookupReferencesManager.tryGetLookupListFromCoordinator(LookupReferencesManager.java:476)
	at org.apache.druid.query.lookup.LookupReferencesManager.lambda$getLookupListFromCoordinator$5(LookupReferencesManager.java:453)
	at org.apache.druid.query.lookup.LookupReferencesManager$$Lambda$931/0x000000a001976cd0.perform(Unknown Source)
	at org.apache.druid.java.util.common.RetryUtils.retry(RetryUtils.java:129)
	at org.apache.druid.java.util.common.RetryUtils.retry(RetryUtils.java:81)
	at org.apache.druid.java.util.common.RetryUtils.retry(RetryUtils.java:163)
	at org.apache.druid.java.util.common.RetryUtils.retry(RetryUtils.java:153)
	at org.apache.druid.query.lookup.LookupReferencesManager.getLookupListFromCoordinator(LookupReferencesManager.java:443)
	at org.apache.druid.query.lookup.LookupReferencesManager.getLookupsList(LookupReferencesManager.java:421)
	at org.apache.druid.query.lookup.LookupReferencesManager.loadLookupsAndInitStateRef(LookupReferencesManager.java:396)
	at org.apache.druid.query.lookup.LookupReferencesManager.start(LookupReferencesManager.java:162)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(java.base@17.0.11/Native Method)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(java.base@17.0.11/NativeMethodAccessorImpl.java:77)
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(java.base@17.0.11/DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(java.base@17.0.11/Method.java:568)
	at org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler.start(Lifecycle.java:446)
	at org.apache.druid.java.util.common.lifecycle.Lifecycle.start(Lifecycle.java:341)
	at org.apache.druid.guice.LifecycleModule$2.start(LifecycleModule.java:152)
	at org.apache.druid.cli.GuiceRunnable.initLifecycle(GuiceRunnable.java:148)
	at org.apache.druid.cli.GuiceRunnable.initLifecycle(GuiceRunnable.java:106)
	at org.apache.druid.cli.ServerRunnable.run(ServerRunnable.java:67)
	at org.apache.druid.cli.Main.main(Main.java:112)
```

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
