### PR TITLE
Revert a change in #18136

### DIFF
--- a/server/src/main/java/org/apache/druid/client/selector/AbstractTierSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/client/selector/AbstractTierSelectorStrategy.java
@@ -34,7 +34,7 @@ import java.util.Set;
  */
 public abstract class AbstractTierSelectorStrategy implements TierSelectorStrategy
 {
-  protected final ServerSelectorStrategy serverSelectorStrategy;
+  private final ServerSelectorStrategy serverSelectorStrategy;
 
   public AbstractTierSelectorStrategy(ServerSelectorStrategy serverSelectorStrategy)
   {


### PR DESCRIPTION
### Description

Solve the comment: https://github.com/apache/druid/pull/18136#discussion_r2193461359

This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
