### PR TITLE
Fix IT

### DIFF
--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG JDK_VERSION=17-slim-buster
+ARG JDK_VERSION=17-slim-bullseye
 FROM openjdk:$JDK_VERSION as druidbase
 
 # Bundle everything into one script so cleanup can reduce image size.
@@ -27,7 +27,6 @@ ARG ZK_VERSION
 ARG APACHE_ARCHIVE_MIRROR_HOST=https://downloads.apache.org
 RUN APACHE_ARCHIVE_MIRROR_HOST=${APACHE_ARCHIVE_MIRROR_HOST} /root/base-setup.sh && rm -f /root/base-setup.sh
 
-
 FROM druidbase
 ARG MYSQL_VERSION
 ARG MARIA_VERSION
@@ -36,14 +35,6 @@ ARG CONFLUENT_VERSION
 
 # Verify Java version
 RUN java -version
-
-RUN echo "[mysqld]\ncharacter-set-server=utf8\ncollation-server=utf8_bin\n" >> /etc/mysql/my.cnf
-
-# Setup metadata store
-# touch is needed because OverlayFS's copy-up operation breaks POSIX standards. See https://github.com/docker/for-linux/issues/72.
-RUN find /var/lib/mysql -type f -exec touch {} \; && /etc/init.d/mysql start \
-      && echo "CREATE USER 'druid'@'%' IDENTIFIED BY 'diurd'; GRANT ALL ON druid.* TO 'druid'@'%'; CREATE database druid DEFAULT CHARACTER SET utf8mb4;" | mysql -u root \
-      && /etc/init.d/mysql stop
 
 # Add Druid scripts and jars
 ADD bin/* /usr/local/druid/bin/
@@ -65,11 +56,17 @@ RUN if [ "$MYSQL_DRIVER_CLASSNAME" = "com.mysql.jdbc.Driver" ] ; \
 RUN wget -q "https://packages.confluent.io/maven/io/confluent/kafka-protobuf-provider/$CONFLUENT_VERSION/kafka-protobuf-provider-$CONFLUENT_VERSION.jar" \
     -O /usr/local/druid/lib/kafka-protobuf-provider.jar
 
-# Add sample data
-# touch is needed because OverlayFS's copy-up operation breaks POSIX standards. See https://github.com/docker/for-linux/issues/72.
-RUN find /var/lib/mysql -type f -exec touch {} \; && service mysql start \
-      && /usr/local/druid/bin/run-java -cp "/usr/local/druid/lib/*" -Ddruid.extensions.directory=/usr/local/druid/extensions -Ddruid.extensions.loadList='["mysql-metadata-storage"]' -Ddruid.metadata.storage.type=mysql -Ddruid.metadata.mysql.driver.driverClassName=$MYSQL_DRIVER_CLASSNAME org.apache.druid.cli.Main tools metadata-init --connectURI="jdbc:mysql://localhost:3306/druid" --user=druid --password=diurd \
-      && /etc/init.d/mysql stop
+# Setup metadata store
+ADD run-mysql.sh /run-mysql.sh
+RUN echo "[mysqld]\ncharacter-set-server=utf8\ncollation-server=utf8_bin\n" >> /etc/mysql/my.cnf
+RUN mkdir -p /run/mysqld && chown mysql:mysql /run/mysqld
+RUN ( \
+    bash /run-mysql.sh; \
+    echo "CREATE USER 'druid'@'%' IDENTIFIED BY 'diurd'; GRANT ALL ON druid.* TO 'druid'@'%'; CREATE database druid DEFAULT CHARACTER SET utf8mb4;" | mysql -u root; \
+    /usr/local/druid/bin/run-java -cp "/usr/local/druid/lib/*" -Ddruid.extensions.directory=/usr/local/druid/extensions -Ddruid.extensions.loadList='["mysql-metadata-storage"]' -Ddruid.metadata.storage.type=mysql -Ddruid.metadata.mysql.driver.driverClassName=$MYSQL_DRIVER_CLASSNAME org.apache.druid.cli.Main tools metadata-init --connectURI="jdbc:mysql://localhost:3306/druid" --user=druid --password=diurd; \
+    mysqladmin shutdown \
+    )
+
 ADD test-data /test-data
 
 # Setup supervisord
@@ -77,9 +74,6 @@ ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Add druid configuration setup script
 ADD druid.sh /druid.sh
-
-# mysql
-ADD run-mysql.sh /run-mysql.sh
 
 # internal docker_ip:9092 endpoint is used to access Kafka from other Docker containers
 # external docker ip:9093 endpoint is used to access Kafka from test code

--- a/integration-tests/docker/run-mysql.sh
+++ b/integration-tests/docker/run-mysql.sh
@@ -15,4 +15,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find /var/lib/mysql -type f -exec touch {} \; && /usr/bin/pidproxy /var/run/mysqld/mysqld.pid /usr/bin/mysqld_safe --bind-address=0.0.0.0
+(mysqld --bind-address=0.0.0.0 || true) & # there might already be a mysqld running, so we ignore the error
+/usr/bin/pidproxy /var/run/mysqld/mysqld.pid /usr/bin/mysqld_safe --bind-address=0.0.0.0
+echo "Waiting for MySQL to be ready...";
+for i in {30..0}; do
+  mysqladmin ping --silent && break;
+  sleep 1; \
+done; \
+if [ "$i" = 0 ]; then
+  echo "MySQL did not start"; exit 1;
+fi;

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -569,6 +569,7 @@
                 <start.hadoop.docker>false</start.hadoop.docker>
                 <docker.run.skip>false</docker.run.skip>
                 <docker.build.skip>false</docker.build.skip>
+                <docker.build.skipMavenBuild>false</docker.build.skipMavenBuild>
                 <docker.build.hadoop>false</docker.build.hadoop>
                 <it.indexer>middleManager</it.indexer>
                 <override.config.path />
@@ -598,6 +599,7 @@
                                         <DRUID_INTEGRATION_TEST_OVERRIDE_CONFIG_PATH>${override.config.path}</DRUID_INTEGRATION_TEST_OVERRIDE_CONFIG_PATH>
                                         <DRUID_INTEGRATION_TEST_RESOURCE_FILE_DIR_PATH>${resource.file.dir.path}</DRUID_INTEGRATION_TEST_RESOURCE_FILE_DIR_PATH>
                                         <DRUID_INTEGRATION_TEST_SKIP_BUILD_DOCKER>${docker.build.skip}</DRUID_INTEGRATION_TEST_SKIP_BUILD_DOCKER>
+                                        <DRUID_INTEGRATION_TEST_SKIP_MAVEN_BUILD_DOCKER>${docker.build.skipMavenBuild}</DRUID_INTEGRATION_TEST_SKIP_MAVEN_BUILD_DOCKER>
                                         <DRUID_INTEGRATION_TEST_SKIP_RUN_DOCKER>${docker.run.skip}</DRUID_INTEGRATION_TEST_SKIP_RUN_DOCKER>
                                         <DRUID_INTEGRATION_TEST_INDEXER>${it.indexer}</DRUID_INTEGRATION_TEST_INDEXER>
                                         <MYSQL_VERSION>${mysql.version}</MYSQL_VERSION>

--- a/integration-tests/script/copy_resources_template.sh
+++ b/integration-tests/script/copy_resources_template.sh
@@ -28,14 +28,21 @@ rm -rf $SHARED_DIR/docker
 mkdir -p $SHARED_DIR
 cp -R docker $SHARED_DIR/docker
 
-pushd ../
-rm -rf distribution/target/apache-druid-$DRUID_VERSION-integration-test-bin
-# using parallel build here may not yield significant speedups
-mvn -B -Pskip-static-checks,skip-tests -Dweb.console.skip=true install -Pintegration-test
-mv distribution/target/apache-druid-$DRUID_VERSION-integration-test-bin/bin $SHARED_DIR/docker/bin
-mv distribution/target/apache-druid-$DRUID_VERSION-integration-test-bin/lib $SHARED_DIR/docker/lib
-mv distribution/target/apache-druid-$DRUID_VERSION-integration-test-bin/extensions $SHARED_DIR/docker/extensions
-popd
+if [ -z "$DRUID_INTEGRATION_TEST_SKIP_MAVEN_BUILD_DOCKER" ] || [ "$DRUID_INTEGRATION_TEST_SKIP_MAVEN_BUILD_DOCKER" = "false" ]
+then
+  pushd ../
+  rm -rf distribution/target/apache-druid-$DRUID_VERSION-integration-test-bin
+  # using parallel build here may not yield significant speedups
+  mvn -B -Pskip-static-checks,skip-tests -Dweb.console.skip=true install -Pintegration-test
+  mv distribution/target/apache-druid-$DRUID_VERSION-integration-test-bin/bin $SHARED_DIR/docker/bin
+  mv distribution/target/apache-druid-$DRUID_VERSION-integration-test-bin/lib $SHARED_DIR/docker/lib
+  mv distribution/target/apache-druid-$DRUID_VERSION-integration-test-bin/extensions $SHARED_DIR/docker/extensions
+  popd
+else
+  cp -R ../distribution/target/apache-druid-$DRUID_VERSION-integration-test-bin/bin $SHARED_DIR/docker/bin
+  cp -R ../distribution/target/apache-druid-$DRUID_VERSION-integration-test-bin/lib $SHARED_DIR/docker/lib
+  cp -R ../distribution/target/apache-druid-$DRUID_VERSION-integration-test-bin/extensions $SHARED_DIR/docker/extensions
+fi
 
 # Make directoriess if they dont exist
 mkdir -p $SHARED_DIR/hadoop_xml

--- a/integration-tests/script/docker_build_containers.sh
+++ b/integration-tests/script/docker_build_containers.sh
@@ -29,7 +29,7 @@ else
   11 | 17 | 21)
     echo "Build druid-cluster with Java $DRUID_INTEGRATION_TEST_JVM_RUNTIME"
     docker build -t druid/cluster \
-      --build-arg JDK_VERSION=$DRUID_INTEGRATION_TEST_JVM_RUNTIME-slim-buster \
+      --build-arg JDK_VERSION=$DRUID_INTEGRATION_TEST_JVM_RUNTIME-slim-bullseye \
       --build-arg ZK_VERSION \
       --build-arg KAFKA_VERSION \
       --build-arg CONFLUENT_VERSION \


### PR DESCRIPTION
A few changes to IT:
- update to use `openjdk:17-slim-bullseye`
- some modification to `run-mysql.sh`, since the new slim bullseye image doesn’t include mysql service.
- in `druid/cluster` docker entrypoint, skip `setupData` for druid services. 
- add a new `docker.build.skipMavenBuild` parameter for running IT test. This avoids duplicated maven build. To use:
  - `mvn package -Pintegration-test -DskipTests -Dcyclonedx.skip=true -Dforbiddenapis.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dmaven.javadoc.skip=true -Pskip-static-checks -T1.0C`
  - then
`mvn --no-snapshot-updates verify -pl integration-tests -P integration-tests -Dgroups=security -Doverride.config.path=../../integration-tests/docker/environment-configs/test-groups/prepopulated-data -Ddocker.build.skipMavenBuild=true
`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
