### PR TITLE
[Backport] Update maven-javadoc-plugin configuration to properly disable javadoc  linting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1965,7 +1965,7 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <configuration>
                         <!-- jdk8 started linting javadocs by default; ours are not fully compliant -->
-                        <additionalparam>-Xdoclint:none</additionalparam>
+                        <doclint>none</doclint>
 
                         <!-- HadoopFsWrapper javadocs cannot be generated due to missing annotations -->
                         <excludePackageNames>org.apache.hadoop.fs</excludePackageNames>


### PR DESCRIPTION
Backport of #18317 to 34.0.0.