### PR TITLE
Remove stacktraces for RE failures on 

### DIFF
--- a/processing/src/main/java/org/apache/druid/java/util/metrics/cgroups/Cpu.java
+++ b/processing/src/main/java/org/apache/druid/java/util/metrics/cgroups/Cpu.java
@@ -77,7 +77,7 @@ public class Cpu
       }
     }
     catch (IOException | RuntimeException ex) {
-      LOG.noStackTrace().error(ex, "Unable to fetch cpu snapshot");
+      LOG.noStackTrace().warn(ex, "Unable to fetch CPU snapshot. Cgroup metrics will not be emitted.");
     }
 
 


### PR DESCRIPTION
Removes stack traces for `RE` exception thrown when calling `discover()` on a misconfigured cpu discoverer