### PR TITLE
Parallel strict compilation in static checks

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -67,12 +67,6 @@ jobs:
         if: ${{ matrix.java == '17' }}
         run: ./check_test_suite_test.py
 
-      - name: (openjdk17) strict compilation
-        if: ${{ matrix.java == '17' }}
-        # errorprone requires JDK 11+
-        # Strict compilation requires more than 2 GB
-        run: ${MVN} clean -DstrictCompile compile test-compile --fail-at-end ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
-
       - name: maven install
         if: ${{ matrix.java == '17' }}
         run: |
@@ -112,6 +106,23 @@ jobs:
       - name: spotbugs checks
         if: ${{ matrix.java == '17' }}
         run: ${MVN} spotbugs:check --fail-at-end -pl '!benchmarks'
+
+  strict-compilation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout branch
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'maven'
+
+      - name: (openjdk17) strict compilation
+        # errorprone requires JDK 11+
+        # Strict compilation requires more than 2 GB
+        run: ${MVN} clean -DstrictCompile compile test-compile --fail-at-end ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
 
   openrewrite:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Strict compilation takes a bit of time and could be run in parallel instead. 