### PR TITLE
[Backport] Supress hadoop shaded jetty cve that is not exploitable in druid

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -143,6 +143,7 @@
     <cve>CVE-2024-29131</cve> <!--  This seems to be a legitimate vulnerability. We would need to go to hadoop-client 3.4 which required aws sdk v2 dependency work to finish -->
     <cve>CVE-2024-22201</cve> <!--  This seems to be a legitimate vulnerability. We would need to go to a hadoop-client which was not yet released  -->
     <cve>CVE-2025-52999</cve> <!--  This is vulneraability in all versions of hadoop-client-runtime and has not been fixed by hadoop yet -->
+    <cve>CVE-2024-9823</cve> <!-- This is in hadoop's shadded jetty. no version of hadoop has updated to fixed version. It is a jetty server vuln, which should not be exploitable in hadoop client code -->
   </suppress>
 
   <!-- those are false positives, no other tools report any of those CVEs in the hadoop package -->


### PR DESCRIPTION
Backport of #18354 to 34.0.0.