### PR TITLE
Disable Msq Drill Window Test

### DIFF
--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQDrillWindowQueryTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQDrillWindowQueryTest.java
@@ -33,6 +33,7 @@ import org.apache.druid.sql.calcite.QueryTestBuilder;
 import org.apache.druid.sql.calcite.SqlTestFrameworkConfig;
 import org.apache.druid.sql.calcite.TempDirProducer;
 import org.apache.druid.sql.calcite.planner.PlannerCaptureHook;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;


### PR DESCRIPTION
Disables MSQ Drill Window tests due to excessive flakiness for now to avoid blocking development. Will be enabled after a debugging and addressing the root cause.

Error message:
```
2025-08-07T16:13:59.3626128Z Preparing 1 report as configured.
2025-08-07T16:14:01.6721255Z MSQDrillWindowQueryTest:1 | Expected that this testcase will fail - it might got fixed; or failure have changed?: unexpected exception type thrown; expected:<java.lang.AssertionError> but was:<org.apache.druid.java.util.common.ISE>0.07s
2025-08-07T16:14:19.0310605Z ℹ️ Posting with conclusion 'failure' to refs/heads/iow (sha: 85d9e3c89677428ab07ff237fce609c02a829536)
2025-08-07T16:14:19.0311947Z ##[endgroup]
2025-08-07T16:14:19.0312855Z ##[group]🚀 Publish results
2025-08-07T16:14:19.0315992Z ℹ️ - Unit Test Report - 288504 tests run, 269583 passed, 18920 skipped, 1 failed.
2025-08-07T16:14:19.0318561Z    🧪 - MSQDrillWindowQueryTest | Expected that this testcase will fail - it might got fixed; or failure have changed?: unexpected exception type thrown; expected:<java.lang.AssertionError> but was:<org.apache.druid.java.util.common.ISE>
2025-08-07T16:14:19.0348738Z ##[error]Expected that this testcase will fail - it might got fixed; or failure have changed?: unexpected exception type thrown; expected:<java.lang.AssertionError> but was:<org.apache.druid.java.util.common.ISE>
2025-08-07T16:14:19.0356212Z ##[error]❌ Tests reported 1 failures
```

Example failures:
https://github.com/apache/druid/actions/runs/16416105923/job/46384345651?pr=18302
https://github.com/apache/druid/actions/runs/16416105923/job/46382330738?pr=18302