### PR TITLE
java 17 is now the recommended version

### DIFF
--- a/examples/bin/verify-java
+++ b/examples/bin/verify-java
@@ -28,14 +28,14 @@ sub fail_check {
     : "No Java runtime was detected on your system.";
 
   print STDERR <<"EOT";
-Druid requires Java 11 or 17. $current_version_text
+Druid requires Java 11 or 17(recommended). $current_version_text
 
 If you believe this check is in error, or you want to proceed with a potentially
 unsupported Java runtime, you can skip this check using an environment variable:
 
   export DRUID_SKIP_JAVA_CHECK=1
 
-Otherwise, install Java 11 or 17 in one of the following locations.
+Otherwise, install Java 11 or 17(recommended) in one of the following locations.
 
   * DRUID_JAVA_HOME
   * JAVA_HOME

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     </scm>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <aether.version>0.9.0.M2</aether.version>

--- a/quidem-ut/README.md
+++ b/quidem-ut/README.md
@@ -36,7 +36,7 @@ curl -s "https://get.sdkman.io" | bash
 # at the end of installation either open a new terminal; or follow the instructions at the end
 
 # install java&maven
-sdk install java 11.0.23-zulu
+sdk install java 17.0.12-zulu
 sdk install maven
 
 # run mvn to see if it works


### PR DESCRIPTION
Update to use 17 in a few places

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
