### PR TITLE
Add explicit mention of pending drop of java 11 support

### DIFF
--- a/docs/release-info/release-notes.md
+++ b/docs/release-info/release-notes.md
@@ -57,6 +57,10 @@ For tips about how to write a good release note, see [Release notes](https://git
 
 This section contains important information about new and existing features.
 
+### Java 11 support
+
+Java 11 support has been deprecated since Druid 32.0, and official support will be removed as early as Druid 35.0.0
+
 ### Hadoop-based ingestion
 
 Hadoop-based ingestion has been deprecated since Druid 32.0 and will be removed as early as Druid 35.0.0. 


### PR DESCRIPTION
Add explicit top line mention of java 11 support being deprecated and dropped as soon as Druid 35. As with hadoop, we want to leave no doubt of pending removal in upcoming release. This will give users time to plan starting now rather than when the see the d35 release notes