### PR TITLE
Update `dependency-check` to v12

### DIFF
--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -116,9 +116,9 @@ jobs:
   security_vulnerabilities:
     if: github.repository == 'apache/druid'
     name: security vulnerabilities
-    strategy:
-      fail-fast: false
     runs-on: ubuntu-latest
+    env:
+      NIST_NVD_API_KEY: ${{ secrets.NIST_NVD_API_KEY }}
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4

--- a/pom.xml
+++ b/pom.xml
@@ -1823,8 +1823,9 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>7.4.4</version>
+                <version>12.1.3</version>
                 <configuration>
+                    <nvdApiKeyEnvironmentVariable>NIST_NVD_API_KEY</nvdApiKeyEnvironmentVariable>
                     <failBuildOnCVSS>7</failBuildOnCVSS>
                     <skipProvidedScope>true</skipProvidedScope>
                     <skipSystemScope>true</skipSystemScope>  <!-- avoid error when processing jdk.tools:jdk.tools:jar:1.8:system -->


### PR DESCRIPTION
### Description

This PR updates `dependency-check` to v12. If we get an NVD API key added to this project (as GH secret), it should become quite quick.

<hr>

This PR has:

- [x] been self-reviewed.
