### PR TITLE
fix: Fix CacheKeyBuilder to correctly handle empty Cacheable keys

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/cache/CacheKeyBuilder.java
+++ b/processing/src/main/java/org/apache/druid/query/cache/CacheKeyBuilder.java
@@ -33,7 +33,6 @@ import javax.annotation.Nullable;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -103,15 +102,18 @@ public class CacheKeyBuilder
     return buffer.array();
   }
 
+  @Nullable
   private static byte[] cacheableToByteArray(@Nullable Cacheable cacheable)
   {
     if (cacheable == null) {
       return EMPTY_BYTES;
-    } else {
-      final byte[] key = cacheable.getCacheKey();
-      Preconditions.checkArgument(!Arrays.equals(key, EMPTY_BYTES), "cache key is equal to the empty key");
-      return key;
     }
+    final byte[] key = cacheable.getCacheKey();
+    if (key == null) {
+      return null;
+    }
+    Preconditions.checkArgument(key.length > 0, "cache key is equal to the empty key");
+    return key;
   }
 
   private static byte[] stringCollectionToByteArray(
@@ -269,12 +271,12 @@ public class CacheKeyBuilder
 
   public CacheKeyBuilder appendCacheable(@Nullable Cacheable input)
   {
-    byte[] cacheableToByteArray = cacheableToByteArray(input);
-    if (cacheableToByteArray == null) {
+    final byte[] bytes = cacheableToByteArray(input);
+    if (bytes == null) {
       invalidKey = true;
       return this;
     }
-    appendItem(CACHEABLE_KEY, cacheableToByteArray);
+    appendItem(CACHEABLE_KEY, bytes);
     return this;
   }
 

--- a/processing/src/test/java/org/apache/druid/query/cache/CacheKeyBuilderTest.java
+++ b/processing/src/test/java/org/apache/druid/query/cache/CacheKeyBuilderTest.java
@@ -297,6 +297,28 @@ public class CacheKeyBuilderTest
   }
 
   @Test
+  public void testAppendCacheableWithNullInput()
+  {
+    final byte[] key = new CacheKeyBuilder((byte) 10)
+        .appendCacheable(null)
+        .build();
+
+    Assert.assertNotNull("appendCacheable(null) should not invalidate the key", key);
+  }
+
+  @Test
+  public void testAppendCacheableWithUncacheableObject()
+  {
+    final Cacheable uncacheable = () -> null;
+
+    final byte[] key = new CacheKeyBuilder((byte) 10)
+        .appendCacheable(uncacheable)
+        .build();
+
+    Assert.assertNull("appendCacheable with getCacheKey()==null should invalidate the key", key);
+  }
+
+  @Test
   public void testIgnoringOrder()
   {
     byte[] actual = new CacheKeyBuilder((byte) 10)


### PR DESCRIPTION
**Bug**
CacheKeyBuilder.appendCacheable had a dead-code bug in its null check. The helper method cacheableToByteArray() returns EMPTY_BYTES (not null) when the input Cacheable is null, so the original guard if (cacheableToByteArray == null) could never match that case. Meanwhile, Cacheable.getCacheKey() is declared @Nullable and multiple production classes (e.g., RestrictedDataSource, UnnestDataSource, ExternalDataSource) return null from it to signal "uncacheable." That path happened to work only by coincidence — cacheableToByteArray() returned null implicitly when getCacheKey() returned null, and the == null check caught it.

**Fix**
Refactored cacheableToByteArray to make null handling explicit:

- cacheable == null (absent component) -> returns EMPTY_BYTES, key stays valid. This preserves backward compatibility with production callers that pass nullable fields like query.getDimensionsFilter() or JoinDataSource.leftFilter.
- cacheable.getCacheKey() == null (uncacheable object) -> returns null, which causes appendCacheable to set invalidKey = true and build() returns null.
- cacheable.getCacheKey() returns an empty array -> throws IllegalArgumentException (unchanged behavior).

Also simplified the empty-key check from Arrays.equals(key, EMPTY_BYTES) to key.length > 0.

**Tests**
Added two new test cases in CacheKeyBuilderTest:

- testAppendCacheableWithNullInput — verifies that appendCacheable(null) does not invalidate the key.
- testAppendCacheableWithUncacheableObject — verifies that appending a Cacheable whose getCacheKey() returns null causes build() to return null.

Could some committer help to review this PR?
cc @agile @trotter @mcroydon @StFS 
