### PR TITLE
Set druid.announcer.skipSegmentAnnouncementOnZk to true by default

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -794,7 +794,7 @@ If you want to turn off the batch data segment announcer, you can add a property
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.announcer.skipSegmentAnnouncementOnZk`|Skip announcing segments to ZooKeeper. Note that the batch server view will not work if this is set to true.|false|
+|`druid.announcer.skipSegmentAnnouncementOnZk`|Skip announcing segments to ZooKeeper. Note that the batch server view will not work if this is set to true.|true|
 
 ### JavaScript
 

--- a/server/src/main/java/org/apache/druid/server/initialization/BatchDataSegmentAnnouncerConfig.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/BatchDataSegmentAnnouncerConfig.java
@@ -46,7 +46,7 @@ public class BatchDataSegmentAnnouncerConfig
   private boolean skipDimensionsAndMetrics = false;
 
   @JsonProperty
-  private boolean skipSegmentAnnouncementOnZk = false;
+  private boolean skipSegmentAnnouncementOnZk = true;
 
   public int getSegmentsPerNode()
   {


### PR DESCRIPTION
Set skipSegmentAnnouncementOnZk to true by default

### Description
We have seen cases where a large number of watches in ZooKeeper causes performance issues. While there have been improvements, such as [#17482](https://github.com/apache/druid/pull/17482), simply setting the`druid.announcer.skipSegmentAnnouncementOnZk` configuration to `true` can significantly reduce unnecessary ZooKeeper watchers. Most users should already be using HTTP segment discovery, as it has been the default since v25. Therefore, switching the default value of this flag to true would benefit the community, as many users may not be aware of this configuration and have not overridden it to true.

#### Release note
The default value of `druid.announcer.skipSegmentAnnouncementOnZk` is now `true`, which means that Druid will no longer announce segments on ZooKeeper. As a result, ZooKeeper segment discovery will no longer work. (Since Druid v25, HTTP segment discovery has been the default instead of ZooKeeper segment discovery.) If you are already using HTTP segment discovery prior to this upgrade, no action is required. However, if you are upgrading from a cluster that still uses ZooKeeper segment discovery (i.e., version <25), or if you choose to continue using ZooKeeper segment discovery (by setting `druid.serverview.type` to `batch`), you must override `druid.announcer.skipSegmentAnnouncementOnZk` and set it to `false`.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
