### PR TITLE
do not log the whole exception in CgroupUtil

### DIFF
--- a/processing/src/main/java/org/apache/druid/java/util/metrics/CgroupUtil.java
+++ b/processing/src/main/java/org/apache/druid/java/util/metrics/CgroupUtil.java
@@ -54,7 +54,7 @@ public class CgroupUtil
       return lines.stream().map(Longs::tryParse).filter(Objects::nonNull).findFirst().orElse(defaultValue);
     }
     catch (RuntimeException | IOException ex) {
-      LOG.warn(ex, "Unable to fetch %s", fileName);
+      LOG.noStackTrace().warn(ex, "Unable to fetch %s", fileName);
       return defaultValue;
     }
   }


### PR DESCRIPTION
We see these long exception stacks in CI and in local runs that just pollute the logs

```
2025-08-06T13:31:22,178 WARN [main] org.apache.druid.java.util.metrics.CgroupUtil - Unable to fetch cpu.shares
org.apache.druid.java.util.common.RE: Hierarchy for [cpu] not found
	at org.apache.druid.java.util.metrics.cgroups.ProcCgroupDiscoverer.getCgroupEntry(ProcCgroupDiscoverer.java:118) ~[druid-processing-2025.10.0-iap-SNAPSHOT.jar:2025.10.0-iap-SNAPSHOT]
	at org.apache.druid.java.util.metrics.cgroups.ProcCgroupDiscoverer.discover(ProcCgroupDiscoverer.java:79) ~[druid-processing-2025.10.0-iap-SNAPSHOT.jar:2025.10.0-iap-SNAPSHOT]
	at org.apache.druid.java.util.metrics.CgroupUtil.readLongValue(CgroupUtil.java:53) [druid-processing-2025.10.0-iap-SNAPSHOT.jar:2025.10.0-iap-SNAPSHOT]
	at org.apache.druid.java.util.metrics.cgroups.Cpu.snapshot(Cpu.java:85) [druid-processing-2025.10.0-iap-SNAPSHOT.jar:2025.10.0-iap-SNAPSHOT]
	at io.imply.druid.meter.VCpuMonitor.<init>(VCpuMonitor.java:117) [druid-server-2025.10.0-iap-SNAPSHOT.jar:2025.10.0-iap-SNAPSHOT]
	at io.imply.druid.meter.VCpuMonitor.<init>(VCpuMonitor.java:89) [druid-server-2025.10.0-iap-SNAPSHOT.jar:2025.10.0-iap-SNAPSHOT]
	at io.imply.druid.meter.VCpuMonitor.<init>(VCpuMonitor.java:71) [druid-server-2025.10.0-iap-SNAPSHOT.jar:2025.10.0-iap-SNAPSHOT]
	at io.imply.druid.meter.VCpuMonitor$$FastClassByGuice$$227833162.GUICE$TRAMPOLINE(<generated>) [?:2025.10.0-iap-SNAPSHOT]
	at io.imply.druid.meter.VCpuMonitor$$FastClassByGuice$$227833162.apply(<generated>) [?:2025.10.0-iap-SNAPSHOT]
	at com.google.inject.internal.DefaultConstructionProxyFactory$FastClassProxy.newInstance(DefaultConstructionProxyFactory.java:82) [guice-5.1.0.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:114) [guice-5.1.0.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91) [guice-5.1.0.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:300) [guice-5.1.0.jar:?]
	at com.google.inject.internal.InjectorImpl$1.get(InjectorImpl.java:1101) [guice-5.1.0.jar:?]
	at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1139) [guice-5.1.0.jar:?]
	at org.apache.druid.server.metrics.MetricsModule.getMonitorScheduler(MetricsModule.java:118) [druid-server-2025.10.0-iap-SNAPSHOT.jar:2025.10.0-iap-SNAPSHOT]
	at org.apache.druid.server.metrics.MetricsModule$$FastClassByGuice$$30335127.GUICE$TRAMPOLINE(<generated>) [?:2025.10.0-iap-SNAPSHOT]
	at org.apache.druid.server.metrics.MetricsModule$$FastClassByGuice$$30335127.apply(<generated>) [?:2025.10.0-iap-SNAPSHOT]
	at com.google.inject.internal.ProviderMethod$FastClassProviderMethod.doProvision(ProviderMethod.java:260) [guice-5.1.0.jar:?]
	at com.google.inject.internal.ProviderMethod.doProvision(ProviderMethod.java:171) [guice-5.1.0.jar:?]
	at com.google.inject.internal.InternalProviderInstanceBindingImpl$CyclicFactory.provision(InternalProviderInstanceBindingImpl.java:185) [guice-5.1.0.jar:?]
	at com.google.inject.internal.InternalProviderInstanceBindingImpl$CyclicFactory.get(InternalProviderInstanceBindingImpl.java:162) [guice-5.1.0.jar:?]
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40) [guice-5.1.0.jar:?]
	at org.apache.druid.guice.LifecycleScope$1.get(LifecycleScope.java:68) [druid-processing-2025.10.0-iap-SNAPSHOT.jar:2025.10.0-iap-SNAPSHOT]
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45) [guice-5.1.0.jar:?]
	at com.google.inject.internal.FactoryProxy.get(FactoryProxy.java:60) [guice-5.1.0.jar:?]
```

This change gets rid of this unnecessary logging. 