### PR TITLE
Concurrent loading segment cache

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
@@ -232,8 +232,8 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
     final CountDownLatch latch = new CountDownLatch(segmentsToLoad.length);
 
     // If there is no dedicated bootstrap executor, perform the loading sequentially on the current thread.
-    final boolean isLoadingSegmentCacheFromDiskWithoutBootstrapExecutor = loadOnBootstrapExec == null;
-    final ExecutorService executorService = isLoadingSegmentCacheFromDiskWithoutBootstrapExecutor
+    final boolean isLoadingSegmentsSequentially = loadOnBootstrapExec == null;
+    final ExecutorService executorService = isLoadingSegmentsSequentially
                                             ? MoreExecutors.newDirectExecutorService()
                                             : loadOnBootstrapExec;
 
@@ -269,7 +269,8 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
     stopwatch.stop();
     log.info("Loaded [%d/%d] cached segments in [%d]ms.", cachedSegments.size(), segmentsToLoad.length, stopwatch.millisElapsed());
 
-    if (isLoadingSegmentCacheFromDiskWithoutBootstrapExecutor) {
+    if (isLoadingSegmentsSequentially) {
+      // Shutdown the direct executor service we created previously in this method.
       executorService.shutdown();
     }
 


### PR DESCRIPTION
### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Concurrent loading of cached segments during startup

Previously, we are using 1 thread to run `SegmentLocalCacheManager#getCachedSegments`. We may take quite a bit of time if the number of segments is large. 

We can do better by multithreading using `loadOnBootstrapExec`, and speed up segment retrieval. 

#### Refactoring
- Create segmentsToLoad array via extracted method: `retrieveSegmentMetadataFiles`.
- Extract logic to load segments into `addFilesToCachedSegments`

#### Log Changes
- Add stopwatch to report time taken to load cached segments.
- Removed log "Loading segment cache file [%d/%d][%s]." to remove log clutter, stopwatch will help to handle this better. (It was annoying to navigate ~100k lines of this when looking through logs)

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Speed up load of cached segments during Historical startup.

<hr>

##### Key changed/added classes in this PR
 * `SegmentLocalCacheManager`
 * `SegmentCacheManager` + Relevant implementations.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
