### PR TITLE
Disable flaky ingestion test

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/docker/IngestionBackwardCompatibilityDockerTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/docker/IngestionBackwardCompatibilityDockerTest.java
@@ -36,6 +36,7 @@ import org.apache.druid.testing.embedded.indexing.IngestionSmokeTest;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 
 /**
  * Runs some basic ingestion tests using Coordinator and Overlord at version
@@ -83,6 +84,13 @@ public class IngestionBackwardCompatibilityDockerTest extends IngestionSmokeTest
     Assertions.assertFalse(
         overlord.bindings().overlordLeaderSelector().isLeader()
     );
+  }
+
+  @Override
+  @Disabled("Disabled due to flakiness after segment drops")
+  public void test_runIndexTask_andKillData()
+  {
+    super.test_runIndexTask_andKillData();
   }
 
   @Override

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/IngestionSmokeTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/IngestionSmokeTest.java
@@ -60,7 +60,6 @@ import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -150,7 +149,6 @@ public class IngestionSmokeTest extends EmbeddedClusterTestBase
   }
 
   @Test
-  @Disabled("Disabled due to flakiness after segment drops")
   public void test_runIndexTask_andKillData()
   {
     final int numSegments = 10;


### PR DESCRIPTION
There have been reports of flakiness for `test_runIndexTask_andKillData` where the broker doesn't reflect the state of the unused segments after the kill command.

A follow up PR will be raised after this that will :
1. Emit a metric once the data source is marked for dropoping
2. This embedded test waits for that event to show up before attempting to run this flaky query.