### PR TITLE
Store cause for invalid field exceptions

### DIFF
--- a/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ScanQueryFrameProcessor.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ScanQueryFrameProcessor.java
@@ -433,6 +433,7 @@ public class ScanQueryFrameProcessor extends BaseLeafFrameProcessor
       throw
           builder.source(ParseExceptionUtils.generateReadableInputSourceNameFromMappedSegment(this.segment)) // frame segment
                  .rowNumber(this.cursorOffset.getOffset() + 1)
+                 .cause(ffwe.getCause())
                  .build();
     }
     catch (Exception e) {

--- a/processing/src/main/java/org/apache/druid/frame/write/InvalidFieldException.java
+++ b/processing/src/main/java/org/apache/druid/frame/write/InvalidFieldException.java
@@ -122,6 +122,8 @@ public class InvalidFieldException extends RuntimeException
     private String source;
     @Nullable
     private String errorMsg;
+    @Nullable
+    private Throwable cause;
 
     public Builder()
     {
@@ -133,11 +135,16 @@ public class InvalidFieldException extends RuntimeException
       rowNumber = invalidFieldException.rowNumber;
       column = invalidFieldException.column;
       errorMsg = invalidFieldException.errorMsg;
+      cause = invalidFieldException.getCause();
     }
 
     public InvalidFieldException build()
     {
-      return new InvalidFieldException(source, column, rowNumber, errorMsg);
+      InvalidFieldException invalidFieldException = new InvalidFieldException(source, column, rowNumber, errorMsg);
+      if (cause != null) {
+        invalidFieldException.initCause(cause);
+      }
+      return invalidFieldException;
     }
 
     public Builder column(String val)
@@ -161,6 +168,12 @@ public class InvalidFieldException extends RuntimeException
     public Builder errorMsg(String val)
     {
       errorMsg = val;
+      return this;
+    }
+
+    public Builder cause(Throwable val)
+    {
+      cause = val;
       return this;
     }
   }

--- a/processing/src/main/java/org/apache/druid/frame/write/RowBasedFrameWriter.java
+++ b/processing/src/main/java/org/apache/druid/frame/write/RowBasedFrameWriter.java
@@ -310,6 +310,7 @@ public class RowBasedFrameWriter implements FrameWriter
       catch (Exception e) {
         throw InvalidFieldException.builder().column(signature.getColumnName(i))
                                    .errorMsg(e.getMessage())
+                                   .cause(e)
                                    .build();
       }
 

--- a/processing/src/test/java/org/apache/druid/frame/write/RowBasedFrameWriterTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/write/RowBasedFrameWriterTest.java
@@ -98,12 +98,14 @@ public class RowBasedFrameWriterTest extends InitializedNullHandlingTest
 
     final RowSignature signature = RowSignature.builder().add(colName, ColumnType.LONG).build();
 
+    RuntimeException realException = new RuntimeException(errorMsg);
+
     LongFieldWriter fieldWriter = EasyMock.mock(LongFieldWriter.class);
     EasyMock.expect(fieldWriter.writeTo(
         EasyMock.anyObject(),
         EasyMock.anyLong(),
         EasyMock.anyLong()
-    )).andThrow(new RuntimeException(errorMsg));
+    )).andThrow(realException);
 
     EasyMock.replay(fieldWriter);
 
@@ -128,5 +130,6 @@ public class RowBasedFrameWriterTest extends InitializedNullHandlingTest
         rowBasedFrameWriter::addSelection
     );
     Assert.assertEquals(expectedException, actualException);
+    Assert.assertEquals(realException, actualException.getCause());
   }
 }


### PR DESCRIPTION
An `InvalidFieldException` only stores the error message string. The exception should instead also store the exception as the cause to make it easier to debug.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
