### PR TITLE
Log exceptions from FrameProcessor factories 

### DIFF
--- a/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/BaseLeafFrameProcessor.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/BaseLeafFrameProcessor.java
@@ -92,7 +92,7 @@ public abstract class BaseLeafFrameProcessor implements FrameProcessor<Object>
       }
       catch (Exception e) {
         // Did not want to load the segment for exception handling, hence adding the descriptor in the log to figure out failures.
-        log.error("Error processing segment descriptor: [%s]", baseInput.getSegment().getDescriptor());
+        log.error(e, "Error processing segment descriptor: [%s]", baseInput.getSegment().getDescriptor());
         throw e;
       }
     } else if (baseInput.hasDataServerQuery()) {


### PR DESCRIPTION
Minor follow up to https://github.com/apache/druid/pull/18513 to also log the exception in the worker. Currently, the exception is passed to the controller and doesn't seem to be logged anywhere in the worker.