### PR TITLE
Enhance Compaction task to be able to write to a different/new datasource

### DIFF
--- a/.idea/inspectionProfiles/Druid.xml
+++ b/.idea/inspectionProfiles/Druid.xml
@@ -39,9 +39,13 @@
       <option name="SUGGEST_NULLABLE_ANNOTATIONS" value="false" />
       <option name="DONT_REPORT_TRUE_ASSERT_STATEMENTS" value="true" />
     </inspection_tool>
+    <inspection_tool class="ConstantValue" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="DONT_REPORT_TRUE_ASSERT_STATEMENTS" value="true" />
+    </inspection_tool>
     <inspection_tool class="Contract" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="CopyConstructorMissesField" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="CovariantEquals" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="DataFlowIssueMerged" />
     <inspection_tool class="DuplicateBooleanBranch" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="DuplicateCondition" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="ignoreSideEffectConditions" value="true" />
@@ -59,6 +63,7 @@
     <inspection_tool class="EqualsUsesNonFinalVariable" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="EqualsWhichDoesntCheckParameterClass" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="EqualsWithItself" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="FieldAccessNotGuarded" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="FieldCanBeLocal" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="EXCLUDE_ANNOS">
@@ -70,7 +75,6 @@
       </option>
       <option name="IGNORE_FIELDS_USED_IN_MULTIPLE_METHODS" value="true" />
     </inspection_tool>
-    <inspection_tool class="FieldMayBeFinal" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="FinalStaticMethod" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="FlowJSError" enabled="false" level="Non-TeamCity Error" enabled_by_default="false" />
     <inspection_tool class="ForCanBeForeach" enabled="true" level="WARNING" enabled_by_default="true">
@@ -82,7 +86,6 @@
       <option name="ignoreUntypedCollections" value="false" />
     </inspection_tool>
     <inspection_tool class="ForLoopThatDoesntUseLoopVariable" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="Guava" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="HashCodeUsesNonFinalVariable" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ImplicitArrayToString" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="IndexOfReplaceableByContains" enabled="true" level="ERROR" enabled_by_default="true" />
@@ -111,6 +114,24 @@
     <inspection_tool class="LengthOneStringInIndexOf" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ListIndexOfReplaceableByContains" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="MalformedFormatString" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="classNames">
+        <list>
+          <option value="org.apache.druid.java.util.common.StringUtils" />
+          <option value="org.apache.druid.java.util.common.logger.Logger" />
+        </list>
+      </option>
+      <option name="methodNames">
+        <list>
+          <option value="trace" />
+          <option value="debug" />
+          <option value="info" />
+          <option value="warn" />
+          <option value="error" />
+          <option value="wtf" />
+          <option value="format" />
+          <option value="nonStrictFormat" />
+        </list>
+      </option>
       <option name="additionalClasses" value="org.apache.druid.java.util.common.StringUtils,org.apache.druid.java.util.common.logger.Logger" />
       <option name="additionalMethods" value="trace,debug,info,warn,error,wtf,format,nonStrictFormat" />
     </inspection_tool>
@@ -154,6 +175,7 @@
     </inspection_tool>
     <inspection_tool class="ObjectEqualsNull" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ObjectToString" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="OptionalOfNullableMisuseMerged" />
     <inspection_tool class="OverwrittenKey" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="PointlessIndexOfComparison" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="PrimitiveArrayArgumentToVariableArgMethod" enabled="true" level="ERROR" enabled_by_default="true" />
@@ -177,105 +199,6 @@
       <option name="m_ignorePrivateMethods" value="false" />
     </inspection_tool>
     <inspection_tool class="SSBasedInspection" enabled="true" level="ERROR" enabled_by_default="true">
-      <searchConfiguration name="Suboptimal IndexedInts iteration" text="$x$ &lt; $y$.size()" recursive="false" caseInsensitive="true" type="JAVA">
-        <constraint name="__context__" target="true" within="" contains="" />
-        <constraint name="x" within="" contains="" />
-        <constraint name="y" nameOfExprType="IndexedInts" exprTypeWithinHierarchy="true" within="" contains="" />
-      </searchConfiguration>
-      <searchConfiguration name="Lists.newArrayList() with a single argument. Use Collections.singletonList() instead" created="1532737126203" text="Lists.newArrayList($x$)" recursive="false" caseInsensitive="true" type="JAVA">
-        <constraint name="x" nameOfExprType="java\.lang\.Iterable|java\.util\.Iterator|Object\[\]" exprTypeWithinHierarchy="true" negateName="true" negateExprType="true" within="" contains="" />
-        <constraint name="__context__" target="true" within="" contains="" />
-      </searchConfiguration>
-      <searchConfiguration name="Math.abs(rnd.nextInt()) doensn't guarantee positive result. Use nextInt() &amp; Integer.MAX_VALUE or nextInt(Integer.MAX_VALUE)" created="1535067616084" text="$Math$.abs($x$.nextInt())" recursive="false" caseInsensitive="true" type="JAVA">
-        <constraint name="__context__" target="true" within="" contains="" />
-        <constraint name="x" nameOfFormalType="java\.util\.Random" exprTypeWithinHierarchy="true" formalTypeWithinHierarchy="true" within="" contains="" />
-        <constraint name="Math" within="" contains="" />
-      </searchConfiguration>
-      <searchConfiguration name="Math.abs(rnd.nextLong()) doesn't guarantee positive result. Use nextLong() &amp; Long.MAX_VALUE" created="1535067616084" text="$Math$.abs($x$.nextLong())" recursive="false" caseInsensitive="true" type="JAVA">
-        <constraint name="__context__" target="true" within="" contains="" />
-        <constraint name="x" nameOfFormalType="java\.util\.Random" exprTypeWithinHierarchy="true" formalTypeWithinHierarchy="true" within="" contains="" />
-        <constraint name="Math" within="" contains="" />
-      </searchConfiguration>
-      <searchConfiguration name="Use nextInt(bound) instead" created="1535068047572" text="$x$.nextInt() % $a$" recursive="false" caseInsensitive="true" type="JAVA">
-        <constraint name="__context__" target="true" within="" contains="" />
-        <constraint name="x" nameOfFormalType="java\.util\.Random" exprTypeWithinHierarchy="true" formalTypeWithinHierarchy="true" within="" contains="" />
-        <constraint name="a" within="" contains="" />
-      </searchConfiguration>
-      <searchConfiguration name="Use ZKPaths.makePath() with many arguments" created="1537504371779" text="org.apache.curator.utils.ZKPaths.makePath(org.apache.curator.utils.ZKPaths.makePath($x$, $y$), $z$)" recursive="false" caseInsensitive="true" type="JAVA">
-        <constraint name="__context__" target="true" within="" contains="" />
-        <constraint name="x" within="" contains="" />
-        <constraint name="y" within="" contains="" />
-        <constraint name="z" within="" contains="" />
-      </searchConfiguration>
-      <searchConfiguration name="Use RE (a Druid's class)" created="1539352150701" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$))" recursive="false" caseInsensitive="true" type="JAVA">
-        <constraint name="__context__" target="true" within="" contains="" />
-        <constraint name="E" regexp="java\.lang\.RuntimeException" within="" contains="" />
-        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
-      </searchConfiguration>
-      <searchConfiguration name="Use RE (a Druid's class) with cause" created="1539353059868" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$),$y$)" recursive="false" caseInsensitive="true" type="JAVA">
-        <constraint name="__context__" target="true" within="" contains="" />
-        <constraint name="E" regexp="java\.lang\.RuntimeException" within="" contains="" />
-        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
-        <constraint name="y" minCount="0" maxCount="2147483647" within="" contains="" />
-      </searchConfiguration>
-      <searchConfiguration name="Use ISE (a Druid's class)" created="1539353519594" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$))" recursive="false" caseInsensitive="true" type="JAVA">
-        <constraint name="__context__" target="true" within="" contains="" />
-        <constraint name="E" regexp="java\.lang\.IllegalStateException" within="" contains="" />
-        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
-      </searchConfiguration>
-      <searchConfiguration name="Use ISE (a Druid's class) with cause" created="1539353595734" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$),$y$)" recursive="false" caseInsensitive="true" type="JAVA">
-        <constraint name="__context__" target="true" within="" contains="" />
-        <constraint name="E" regexp="java\.lang\.IllegalStateException" within="" contains="" />
-        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
-        <constraint name="y" minCount="0" maxCount="2147483647" within="" contains="" />
-      </searchConfiguration>
-      <searchConfiguration name="Use IAE (a Druid's class)" created="1539353691746" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$))" recursive="false" caseInsensitive="true" type="JAVA">
-        <constraint name="__context__" target="true" within="" contains="" />
-        <constraint name="E" regexp="java\.lang\.IllegalArgumentException" within="" contains="" />
-        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
-      </searchConfiguration>
-      <searchConfiguration name="Use IAE (a Druid's class) with cause" created="1539353766336" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$),$y$)" recursive="false" caseInsensitive="true" type="JAVA">
-        <constraint name="__context__" target="true" within="" contains="" />
-        <constraint name="E" regexp="java\.lang\.IllegalArgumentException" within="" contains="" />
-        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
-        <constraint name="y" minCount="0" maxCount="2147483647" within="" contains="" />
-      </searchConfiguration>
-      <searchConfiguration name="Use IOE (a Druid's class)" created="1539353913074" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$))" recursive="false" caseInsensitive="true" type="JAVA">
-        <constraint name="__context__" target="true" within="" contains="" />
-        <constraint name="E" regexp="java\.io\.IOException" within="" contains="" />
-        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
-      </searchConfiguration>
-      <searchConfiguration name="Use IOE (a Druid's class) with cause" created="1539354009031" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$),$y$)" recursive="false" caseInsensitive="true" type="JAVA">
-        <constraint name="__context__" target="true" within="" contains="" />
-        <constraint name="E" regexp="java\.io\.IOException" within="" contains="" />
-        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
-        <constraint name="y" minCount="0" maxCount="2147483647" within="" contains="" />
-      </searchConfiguration>
-      <searchConfiguration name="Use UOE (a Druid's class)" created="1539354091201" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$))" recursive="false" caseInsensitive="true" type="JAVA">
-        <constraint name="__context__" target="true" within="" contains="" />
-        <constraint name="E" regexp="java\.lang\.UnsupportedOperationException" within="" contains="" />
-        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
-      </searchConfiguration>
-      <searchConfiguration name="Use TypeReference&lt;List&lt;...&gt;&gt; instead" created="1539884261626" text="TypeReference&lt;ArrayList&lt;$E$&gt;&gt;" recursive="false" caseInsensitive="true" type="JAVA">
-        <constraint name="__context__" target="true" within="" contains="" />
-        <constraint name="E" within="" contains="" />
-      </searchConfiguration>
-      <searchConfiguration name="Use TypeReference&lt;Map&lt;...&gt;&gt; instead" created="1539884261626" text="TypeReference&lt;HashMap&lt;$K$, $V$&gt;&gt;" recursive="false" caseInsensitive="true" type="JAVA">
-        <constraint name="__context__" target="true" within="" contains="" />
-        <constraint name="K" within="" contains="" />
-        <constraint name="V" within="" contains="" />
-      </searchConfiguration>
-      <searchConfiguration name="Use TypeReference&lt;Set&lt;...&gt;&gt; instead" created="1539884261626" text="TypeReference&lt;HashSet&lt;$E$&gt;&gt;" recursive="false" caseInsensitive="true" type="JAVA">
-        <constraint name="__context__" target="true" within="" contains="" />
-        <constraint name="E" within="" contains="" />
-      </searchConfiguration>
-      <searchConfiguration name="Concurrent maps should be assigned into variables of ConcurrentMap type or more specific" text="Map&lt;$K$, $V$&gt; $x$ = $y$;" recursive="true" caseInsensitive="true" type="JAVA">
-        <constraint name="__context__" target="true" within="" contains="" />
-        <constraint name="K" within="" contains="" />
-        <constraint name="V" within="" contains="" />
-        <constraint name="x" within="" contains="" />
-        <constraint name="y" nameOfExprType="java\.util\.concurrent\.ConcurrentMap" exprTypeWithinHierarchy="true" within="" contains="" />
-      </searchConfiguration>
       <searchConfiguration name="A ConcurrentHashMap on which compute() is called should be assinged into variables of ConcurrentHashMap type, not ConcurrentMap" text="$x$.compute($y$, $z$)" recursive="true" caseInsensitive="true" type="JAVA">
         <constraint name="__context__" target="true" within="" contains="" />
         <constraint name="x" nameOfExprType="java\.util\.concurrent\.ConcurrentMap" within="" contains="" />
@@ -301,11 +224,46 @@
         <constraint name="b" within="" contains="" />
         <constraint name="c" within="" contains="" />
       </searchConfiguration>
-      <searchConfiguration name="No need to wrap a collection as unmodifiable before addAll()" text="$c$.addAll(Collections.$unmodifiableMethod$($c2$))" recursive="true" caseInsensitive="true" type="JAVA">
+      <searchConfiguration name="Assign an ExecutorService instance to an ExecutorService variable, not an Executor variable" text="$x$ = $y$;" recursive="true" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" within="" contains="" />
+        <constraint name="x" nameOfExprType="java\.util\.concurrent\.Executor" within="" contains="" />
+        <constraint name="y" nameOfExprType="java\.util\.concurrent\.ExecutorService" exprTypeWithinHierarchy="true" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Concurrent maps should be assigned into variables of ConcurrentMap type or more specific" text="Map&lt;$K$, $V$&gt; $x$ = $y$;" recursive="true" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="K" within="" contains="" />
+        <constraint name="V" within="" contains="" />
+        <constraint name="x" within="" contains="" />
+        <constraint name="y" nameOfExprType="java\.util\.concurrent\.ConcurrentMap" exprTypeWithinHierarchy="true" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Create a simple ExecutorService (not scheduled)" text="$x$ = $y$;" recursive="true" caseInsensitive="true" type="JAVA" pattern_context="default">
+        <constraint name="__context__" within="" contains="" />
+        <constraint name="x" nameOfExprType="java\.util\.concurrent\.ExecutorService" within="" contains="" />
+        <constraint name="y" nameOfExprType="java\.util\.concurrent\.ScheduledExecutorService" exprTypeWithinHierarchy="true" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Intialize an ExecutorService instance to an ExecutorService variable, not an Executor variable" text="Executor $x$ = $y$;" recursive="true" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" within="" contains="" />
+        <constraint name="x" within="" contains="" />
+        <constraint name="y" nameOfExprType="java\.util\.concurrent\.ExecutorService" exprTypeWithinHierarchy="true" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Lists.newArrayList() with a single argument. Use Collections.singletonList() instead" created="1532737126203" text="Lists.newArrayList($x$)" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="x" nameOfExprType="java\.lang\.Iterable|java\.util\.Iterator|Object\[\]" exprTypeWithinHierarchy="true" negateName="true" negateExprType="true" within="" contains="" />
+        <constraint name="__context__" target="true" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Math.abs(rnd.nextInt()) doensn't guarantee positive result. Use nextInt() &amp; Integer.MAX_VALUE or nextInt(Integer.MAX_VALUE)" created="1535067616084" text="$Math$.abs($x$.nextInt())" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="x" nameOfFormalType="java\.util\.Random" exprTypeWithinHierarchy="true" formalTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="Math" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Math.abs(rnd.nextLong()) doesn't guarantee positive result. Use nextLong() &amp; Long.MAX_VALUE" created="1535067616084" text="$Math$.abs($x$.nextLong())" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="x" nameOfFormalType="java\.util\.Random" exprTypeWithinHierarchy="true" formalTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="Math" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="new Collection(Arrays.asList()), or some utility from CollectionUtils (or create an utility)" text="Stream.of($x$).collect($c$())" recursive="true" caseInsensitive="true" type="JAVA">
         <constraint name="__context__" target="true" within="" contains="" />
         <constraint name="c" within="" contains="" />
-        <constraint name="unmodifiableMethod" regexp="unmodifiable.*" within="" contains="" />
-        <constraint name="c2" within="" contains="" />
+        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
       </searchConfiguration>
       <searchConfiguration name="No need to copy a collection as immutable before addAll()" text="$m$.addAll($ImmutableCollection$.copyOf($x$))" recursive="true" caseInsensitive="true" type="JAVA">
         <constraint name="__context__" target="true" within="" contains="" />
@@ -313,22 +271,23 @@
         <constraint name="x" maxCount="2147483647" within="" contains="" />
         <constraint name="ImmutableCollection" regexp="Immutable.*" within="" contains="" />
       </searchConfiguration>
-      <searchConfiguration name="No need to wrap a map as unmodifiable before putAll()" text="$m$.putAll(Collections.$unmodifiableMapMethod$($m2$))" recursive="true" caseInsensitive="true" type="JAVA">
-        <constraint name="__context__" target="true" within="" contains="" />
-        <constraint name="m" within="" contains="" />
-        <constraint name="m2" within="" contains="" />
-        <constraint name="unmodifiableMapMethod" regexp="unmodifiable.*" within="" contains="" />
-      </searchConfiguration>
       <searchConfiguration name="No need to copy a map to immutable before putAll()" text="$m$.putAll($ImmutableMap$.copyOf($x$))" recursive="true" caseInsensitive="true" type="JAVA">
         <constraint name="__context__" target="true" within="" contains="" />
         <constraint name="m" within="" contains="" />
         <constraint name="x" maxCount="2147483647" within="" contains="" />
         <constraint name="ImmutableMap" regexp="Immutable.*" within="" contains="" />
       </searchConfiguration>
-      <searchConfiguration name="Use map.putIfAbsent(k,v) or map.computeIfAbsent(k,v) where appropriate instead of containsKey() + put(). If computing v is expensive or has side effects use map.computeIfAbsent() instead" created="1558868694225" text="if (!$m$.containsKey($k$)) {&#10;    $m$.put($k$, $v$);&#10;}" recursive="false" caseInsensitive="true" type="JAVA">
+      <searchConfiguration name="No need to wrap a collection as unmodifiable before addAll()" text="$c$.addAll(Collections.$unmodifiableMethod$($c2$))" recursive="true" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="c" within="" contains="" />
+        <constraint name="unmodifiableMethod" regexp="unmodifiable.*" within="" contains="" />
+        <constraint name="c2" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="No need to wrap a map as unmodifiable before putAll()" text="$m$.putAll(Collections.$unmodifiableMapMethod$($m2$))" recursive="true" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
         <constraint name="m" within="" contains="" />
-        <constraint name="k" within="" contains="" />
-        <constraint name="v" within="" contains="" />
+        <constraint name="m2" within="" contains="" />
+        <constraint name="unmodifiableMapMethod" regexp="unmodifiable.*" within="" contains="" />
       </searchConfiguration>
       <searchConfiguration name="Prohibit Thread.getState() != TERMINATED antipattern" text="$t$.getState()!=Thread.State.$state$" recursive="true" caseInsensitive="true" type="JAVA">
         <constraint name="t" within="" contains="" />
@@ -338,16 +297,10 @@
         <constraint name="t" within="" contains="" />
         <constraint name="state" within="" contains="" />
       </searchConfiguration>
-      <searchConfiguration name="Use CollectionUtils.mapValues(Map&lt;K,V&gt;, Function&lt;V,V2&gt;)" text="$x$.entrySet().stream().collect(Collectors.toMap($k$ -&gt; $k$.getKey(), $y$))" recursive="true" caseInsensitive="true" type="JAVA">
-        <constraint name="x" within="" contains="" />
-        <constraint name="y" within="" contains="" />
-        <constraint name="k" within="" contains="" />
+      <searchConfiguration name="Suboptimal IndexedInts iteration" text="$x$ &lt; $y$.size()" recursive="false" caseInsensitive="true" type="JAVA">
         <constraint name="__context__" target="true" within="" contains="" />
-      </searchConfiguration>
-      <searchConfiguration name="Use CollectionUtils.mapValues(Map&lt;k,v&gt;, Function&lt;v,v2&gt;)" text="$x$.entrySet().stream().collect(Collectors.toMap(Entry::getKey, $y$))" recursive="true" caseInsensitive="true" type="JAVA">
         <constraint name="x" within="" contains="" />
-        <constraint name="y" within="" contains="" />
-        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="y" nameOfExprType="IndexedInts" exprTypeWithinHierarchy="true" within="" contains="" />
       </searchConfiguration>
       <searchConfiguration name="Use CollectionUtils.mapKeys(Map&lt;K,V&gt;, Function&lt;K,K2&gt;)" text="$x$.entrySet().stream().collect(Collectors.toMap($y$, $v$ -&gt; $v$.getValue()))" recursive="true" caseInsensitive="true" type="JAVA">
         <constraint name="x" within="" contains="" />
@@ -360,10 +313,16 @@
         <constraint name="y" within="" contains="" />
         <constraint name="__context__" target="true" within="" contains="" />
       </searchConfiguration>
-      <searchConfiguration name="new Collection(Arrays.asList()), or some utility from CollectionUtils (or create an utility)" text="Stream.of($x$).collect($c$())" recursive="true" caseInsensitive="true" type="JAVA">
+      <searchConfiguration name="Use CollectionUtils.mapValues(Map&lt;K,V&gt;, Function&lt;V,V2&gt;)" text="$x$.entrySet().stream().collect(Collectors.toMap($k$ -&gt; $k$.getKey(), $y$))" recursive="true" caseInsensitive="true" type="JAVA">
+        <constraint name="x" within="" contains="" />
+        <constraint name="y" within="" contains="" />
+        <constraint name="k" within="" contains="" />
         <constraint name="__context__" target="true" within="" contains="" />
-        <constraint name="c" within="" contains="" />
-        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use CollectionUtils.mapValues(Map&lt;k,v&gt;, Function&lt;v,v2&gt;)" text="$x$.entrySet().stream().collect(Collectors.toMap(Entry::getKey, $y$))" recursive="true" caseInsensitive="true" type="JAVA">
+        <constraint name="x" within="" contains="" />
+        <constraint name="y" within="" contains="" />
+        <constraint name="__context__" target="true" within="" contains="" />
       </searchConfiguration>
       <searchConfiguration name="Use computeIfAbsent(...).somethingElse(...) chain instead" text="$m$.putIfAbsent($k$, $l$);&#10;$m$.get($k$).$x$($y$);" recursive="true" caseInsensitive="true" type="JAVA">
         <constraint name="__context__" target="true" within="" contains="" />
@@ -373,27 +332,7 @@
         <constraint name="l" within="" contains="" />
         <constraint name="y" minCount="0" maxCount="2147483647" within="" contains="" />
       </searchConfiguration>
-      <searchConfiguration name="Assign an ExecutorService instance to an ExecutorService variable, not an Executor variable" text="$x$ = $y$;" recursive="true" caseInsensitive="true" type="JAVA" >
-        <constraint name="__context__" within="" contains="" />
-        <constraint name="x" nameOfExprType="java\.util\.concurrent\.Executor" within="" contains="" />
-        <constraint name="y" nameOfExprType="java\.util\.concurrent\.ExecutorService" exprTypeWithinHierarchy="true" within="" contains="" />
-      </searchConfiguration>
-      <searchConfiguration name="Intialize an ExecutorService instance to an ExecutorService variable, not an Executor variable" text="Executor $x$ = $y$;" recursive="true" caseInsensitive="true" type="JAVA" >
-        <constraint name="__context__" within="" contains="" />
-        <constraint name="x"  within="" contains="" />
-        <constraint name="y" nameOfExprType="java\.util\.concurrent\.ExecutorService" exprTypeWithinHierarchy="true"  within="" contains="" />
-      </searchConfiguration>
-      <searchConfiguration name="Create a simple ExecutorService (not scheduled)" text="$x$ = $y$;" recursive="true" caseInsensitive="true" type="JAVA" pattern_context="default">
-        <constraint name="__context__" within="" contains="" />
-        <constraint name="x" nameOfExprType="java\.util\.concurrent\.ExecutorService" within="" contains="" />
-        <constraint name="y" nameOfExprType="java\.util\.concurrent\.ScheduledExecutorService" exprTypeWithinHierarchy="true" within="" contains="" />
-      </searchConfiguration>
       <searchConfiguration name="Use equals on Pattern.toString()" text="$a$.equals($b$)" recursive="true" caseInsensitive="true" type="JAVA" pattern_context="default">
-        <constraint name="__context__" within="" contains="" />
-        <constraint name="a" nameOfExprType="Pattern" within="" contains="" />
-        <constraint name="b" within="" contains="" />
-      </searchConfiguration>
-      <searchConfiguration name="Use Objects.equals() on Pattern.toString()" text="java.util.Objects.equals($a$, $b$)" recursive="true" caseInsensitive="true" type="JAVA" pattern_context="default">
         <constraint name="__context__" within="" contains="" />
         <constraint name="a" nameOfExprType="Pattern" within="" contains="" />
         <constraint name="b" within="" contains="" />
@@ -402,10 +341,93 @@
         <constraint name="__context__" within="" contains="" />
         <constraint name="a" nameOfExprType="java\.util\.regex\.Pattern" within="" contains="" />
       </searchConfiguration>
+      <searchConfiguration name="Use IAE (a Druid's class)" created="1539353691746" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$))" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="E" regexp="java\.lang\.IllegalArgumentException" within="" contains="" />
+        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use IAE (a Druid's class) with cause" created="1539353766336" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$),$y$)" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="E" regexp="java\.lang\.IllegalArgumentException" within="" contains="" />
+        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
+        <constraint name="y" minCount="0" maxCount="2147483647" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use IOE (a Druid's class)" created="1539353913074" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$))" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="E" regexp="java\.io\.IOException" within="" contains="" />
+        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use IOE (a Druid's class) with cause" created="1539354009031" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$),$y$)" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="E" regexp="java\.io\.IOException" within="" contains="" />
+        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
+        <constraint name="y" minCount="0" maxCount="2147483647" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use ISE (a Druid's class)" created="1539353519594" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$))" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="E" regexp="java\.lang\.IllegalStateException" within="" contains="" />
+        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use ISE (a Druid's class) with cause" created="1539353595734" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$),$y$)" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="E" regexp="java\.lang\.IllegalStateException" within="" contains="" />
+        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
+        <constraint name="y" minCount="0" maxCount="2147483647" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use map.putIfAbsent(k,v) or map.computeIfAbsent(k,v) where appropriate instead of containsKey() + put(). If computing v is expensive or has side effects use map.computeIfAbsent() instead" created="1558868694225" text="if (!$m$.containsKey($k$)) {&#10;    $m$.put($k$, $v$);&#10;}" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="m" within="" contains="" />
+        <constraint name="k" within="" contains="" />
+        <constraint name="v" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use nextInt(bound) instead" created="1535068047572" text="$x$.nextInt() % $a$" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="x" nameOfFormalType="java\.util\.Random" exprTypeWithinHierarchy="true" formalTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="a" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use Objects.equals() on Pattern.toString()" text="java.util.Objects.equals($a$, $b$)" recursive="true" caseInsensitive="true" type="JAVA" pattern_context="default">
+        <constraint name="__context__" within="" contains="" />
+        <constraint name="a" nameOfExprType="Pattern" within="" contains="" />
+        <constraint name="b" within="" contains="" />
+      </searchConfiguration>
       <searchConfiguration name="Use Objects.hash() on Pattern.toString() instead" text="java.util.Objects.hash($b$,$a$)" recursive="true" caseInsensitive="true" type="JAVA" pattern_context="default">
         <constraint name="__context__" within="" contains="" />
         <constraint name="a" nameOfExprType="java\.util\.regex\.Pattern" within="" contains="" />
         <constraint name="b" minCount="0" maxCount="2147483647" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use RE (a Druid's class)" created="1539352150701" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$))" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="E" regexp="java\.lang\.RuntimeException" within="" contains="" />
+        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use RE (a Druid's class) with cause" created="1539353059868" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$),$y$)" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="E" regexp="java\.lang\.RuntimeException" within="" contains="" />
+        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
+        <constraint name="y" minCount="0" maxCount="2147483647" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use TypeReference&lt;List&lt;...&gt;&gt; instead" created="1539884261626" text="TypeReference&lt;ArrayList&lt;$E$&gt;&gt;" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="E" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use TypeReference&lt;Map&lt;...&gt;&gt; instead" created="1539884261626" text="TypeReference&lt;HashMap&lt;$K$, $V$&gt;&gt;" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="K" within="" contains="" />
+        <constraint name="V" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use TypeReference&lt;Set&lt;...&gt;&gt; instead" created="1539884261626" text="TypeReference&lt;HashSet&lt;$E$&gt;&gt;" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="E" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use UOE (a Druid's class)" created="1539354091201" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$))" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="E" regexp="java\.lang\.UnsupportedOperationException" within="" contains="" />
+        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use ZKPaths.makePath() with many arguments" created="1537504371779" text="org.apache.curator.utils.ZKPaths.makePath(org.apache.curator.utils.ZKPaths.makePath($x$, $y$), $z$)" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="x" within="" contains="" />
+        <constraint name="y" within="" contains="" />
+        <constraint name="z" within="" contains="" />
       </searchConfiguration>
     </inspection_tool>
     <inspection_tool class="SimplifyStreamApiCallChains" enabled="true" level="ERROR" enabled_by_default="true" />
@@ -427,6 +449,7 @@
     <inspection_tool class="StringEquality" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="StringEqualsCharSequence" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="StringTokenizerDelimiter" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="Stylelint" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="SubtractionInCompareTo" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="SuspiciousArrayCast" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SuspiciousArrayMethodCall" enabled="true" level="ERROR" enabled_by_default="true" />
@@ -481,8 +504,8 @@
     <inspection_tool class="XmlHighlighting" enabled="true" level="Non-TeamCity Warning" enabled_by_default="true" />
     <inspection_tool class="XmlInvalidId" enabled="true" level="Non-TeamCity Error" enabled_by_default="true" />
     <inspection_tool class="XmlPathReference" enabled="true" level="Non-TeamCity Error" enabled_by_default="true" />
-    <inspection_tool class="unused" enabled="true" level="WARNING" enabled_by_default="true" isSelected="false">
-      <scope name="UnusedInspectionsScope" level="ERROR" enabled="true" isSelected="false">
+    <inspection_tool class="unused" enabled="true" level="WARNING" enabled_by_default="true" checkParameterExcludingHierarchy="false">
+      <scope name="UnusedInspectionsScope" level="ERROR" enabled="true" checkParameterExcludingHierarchy="false">
         <option name="LOCAL_VARIABLE" value="true" />
         <option name="FIELD" value="true" />
         <option name="METHOD" value="true" />
@@ -493,6 +516,7 @@
         <option name="ADD_APPLET_TO_ENTRIES" value="true" />
         <option name="ADD_SERVLET_TO_ENTRIES" value="true" />
         <option name="ADD_NONJAVA_TO_ENTRIES" value="true" />
+        <option name="selected" value="true" />
       </scope>
       <option name="LOCAL_VARIABLE" value="true" />
       <option name="FIELD" value="true" />
@@ -504,6 +528,7 @@
       <option name="ADD_APPLET_TO_ENTRIES" value="true" />
       <option name="ADD_SERVLET_TO_ENTRIES" value="true" />
       <option name="ADD_NONJAVA_TO_ENTRIES" value="true" />
+      <option name="selected" value="true" />
     </inspection_tool>
   </profile>
 </component>

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/CompactionTaskTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/CompactionTaskTest.java
@@ -87,7 +87,7 @@ public class CompactionTaskTest extends CompactionTestBase
       () -> TaskBuilder
           .ofTypeCompact()
           .context("storeCompactionState", true)
-          .ioConfig(new CompactionIntervalSpec(Intervals.of("2013-08-31/2013-09-02"), null), false);
+          .ioConfig(new CompactionIntervalSpec(Intervals.of("2013-08-31/2013-09-02"), null, null), false);
   private static final Supplier<TaskBuilder.Compact> PARALLEL_COMPACTION_TASK =
       () -> COMPACTION_TASK.get().tuningConfig(
           t -> t.withPartitionsSpec(new HashedPartitionsSpec(null, null, null))
@@ -98,7 +98,7 @@ public class CompactionTaskTest extends CompactionTestBase
       () -> TaskBuilder
           .ofTypeCompact()
           .context("storeCompactionState", true)
-          .ioConfig(new CompactionIntervalSpec(Intervals.of("2013-08-31/2013-09-02"), null), true);
+          .ioConfig(new CompactionIntervalSpec(Intervals.of("2013-08-31/2013-09-02"), null, null), true);
 
   private static final Supplier<TaskBuilder.Index> INDEX_TASK_WITH_TIMESTAMP =
       () -> MoreResources.Task.INDEX_TASK_WITH_AGGREGATORS.get().dimensions(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionInputSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionInputSpec.java
@@ -51,4 +51,9 @@ public interface CompactionInputSpec
    * @param latestSegments       most recent published segments in the interval returned by {@link #findInterval}
    */
   boolean validateSegments(LockGranularity lockGranularityInUse, List<DataSegment> latestSegments);
+
+  /**
+   * Return the datasource to be used as input to the compaction task.
+   */
+  String getDataSource();
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionIntervalSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionIntervalSpec.java
@@ -43,11 +43,14 @@ public class CompactionIntervalSpec implements CompactionInputSpec
   private final Interval interval;
   @Nullable
   private final String sha256OfSortedSegmentIds;
+  @Nullable
+  private final String dataSource;
 
   @JsonCreator
   public CompactionIntervalSpec(
       @JsonProperty("interval") Interval interval,
-      @JsonProperty("sha256OfSortedSegmentIds") @Nullable String sha256OfSortedSegmentIds
+      @JsonProperty("sha256OfSortedSegmentIds") @Nullable String sha256OfSortedSegmentIds,
+      @JsonProperty("dataSource") @Nullable String dataSource
   )
   {
     if (interval != null && interval.toDurationMillis() == 0) {
@@ -55,6 +58,7 @@ public class CompactionIntervalSpec implements CompactionInputSpec
     }
     this.interval = interval;
     this.sha256OfSortedSegmentIds = sha256OfSortedSegmentIds;
+    this.dataSource = dataSource;
   }
 
   @JsonProperty
@@ -68,6 +72,14 @@ public class CompactionIntervalSpec implements CompactionInputSpec
   public String getSha256OfSortedSegmentIds()
   {
     return sha256OfSortedSegmentIds;
+  }
+
+  @Override
+  @Nullable
+  @JsonProperty
+  public String getDataSource()
+  {
+    return dataSource;
   }
 
   @Override
@@ -97,21 +109,19 @@ public class CompactionIntervalSpec implements CompactionInputSpec
   @Override
   public boolean equals(Object o)
   {
-    if (this == o) {
-      return true;
-    }
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
     CompactionIntervalSpec that = (CompactionIntervalSpec) o;
     return Objects.equals(interval, that.interval) &&
-           Objects.equals(sha256OfSortedSegmentIds, that.sha256OfSortedSegmentIds);
+           Objects.equals(sha256OfSortedSegmentIds, that.sha256OfSortedSegmentIds) &&
+           Objects.equals(dataSource, that.dataSource);
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(interval, sha256OfSortedSegmentIds);
+    return Objects.hash(interval, sha256OfSortedSegmentIds, dataSource);
   }
 
   @Override
@@ -119,7 +129,8 @@ public class CompactionIntervalSpec implements CompactionInputSpec
   {
     return "CompactionIntervalSpec{" +
            "interval=" + interval +
-           ", sha256OfSegmentIds='" + sha256OfSortedSegmentIds + '\'' +
+           ", sha256OfSortedSegmentIds='" + sha256OfSortedSegmentIds + '\'' +
+           ", dataSource='" + dataSource + '\'' +
            '}';
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/SpecificSegmentsSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/SpecificSegmentsSpec.java
@@ -28,6 +28,7 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.joda.time.Interval;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -39,18 +40,26 @@ public class SpecificSegmentsSpec implements CompactionInputSpec
 
   private final List<String> segments;
 
+  @Nullable
+  private final String dataSource;
+
   public static SpecificSegmentsSpec fromSegments(List<DataSegment> segments)
   {
     Preconditions.checkArgument(!segments.isEmpty(), "Empty segment list");
     return new SpecificSegmentsSpec(
-        segments.stream().map(segment -> segment.getId().toString()).collect(Collectors.toList())
+        segments.stream().map(segment -> segment.getId().toString()).collect(Collectors.toList()),
+        null
     );
   }
 
   @JsonCreator
-  public SpecificSegmentsSpec(@JsonProperty("segments") List<String> segments)
+  public SpecificSegmentsSpec(
+      @JsonProperty("segments") List<String> segments,
+      @JsonProperty("dataSource") @Nullable String dataSource
+  )
   {
     this.segments = segments;
+    this.dataSource = dataSource;
     // Sort segments to use in validateSegments.
     Collections.sort(this.segments);
   }
@@ -59,6 +68,14 @@ public class SpecificSegmentsSpec implements CompactionInputSpec
   public List<String> getSegments()
   {
     return segments;
+  }
+
+  @Override
+  @Nullable
+  @JsonProperty
+  public String getDataSource()
+  {
+    return dataSource;
   }
 
   @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientCompactionTaskQuerySerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientCompactionTaskQuerySerdeTest.java
@@ -341,7 +341,7 @@ public class ClientCompactionTaskQuerySerdeTest
         "datasource",
         new SegmentCacheManagerFactory(TestIndex.INDEX_IO, MAPPER)
     )
-        .inputSpec(new CompactionIntervalSpec(Intervals.of("2019/2020"), "testSha256OfSortedSegmentIds"), true)
+        .inputSpec(new CompactionIntervalSpec(Intervals.of("2019/2020"), "testSha256OfSortedSegmentIds", null), true)
         .tuningConfig(
             TuningConfigBuilder
                 .forParallelIndexTask()

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionInputSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionInputSpecTest.java
@@ -53,12 +53,14 @@ public class CompactionInputSpecTest
         new Object[]{
             new CompactionIntervalSpec(
                 INTERVAL,
-                SegmentUtils.hashIds(SEGMENTS)
+                SegmentUtils.hashIds(SEGMENTS),
+                null
             )
         },
         new Object[]{
             new SpecificSegmentsSpec(
-                SEGMENTS.stream().map(segment -> segment.getId().toString()).collect(Collectors.toList())
+                SEGMENTS.stream().map(segment -> segment.getId().toString()).collect(Collectors.toList()),
+                null
             )
         }
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskParallelRunTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskParallelRunTest.java
@@ -178,7 +178,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
         getSegmentCacheManagerFactory()
     );
     final CompactionTask compactionTask = builder
-        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null))
+        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null, null))
         .tuningConfig(AbstractParallelIndexSupervisorTaskTest.DEFAULT_TUNING_CONFIG_FOR_PARALLEL_INDEXING)
         .build();
 
@@ -230,7 +230,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
         getSegmentCacheManagerFactory()
     );
     final CompactionTask compactionTask = builder
-        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null))
+        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null, null))
         .tuningConfig(newTuningConfig(new HashedPartitionsSpec(null, 3, null), 2, true))
         .build();
 
@@ -293,7 +293,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
         getSegmentCacheManagerFactory()
     );
     final CompactionTask compactionTask = builder
-        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null))
+        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null, null))
         .tuningConfig(newTuningConfig(new SingleDimensionPartitionsSpec(7, null, "dim", false), 2, true))
         .build();
 
@@ -342,7 +342,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     );
 
     final CompactionTask compactionTask = builder
-        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null))
+        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null, null))
         .tuningConfig(newTuningConfig(new SingleDimensionPartitionsSpec(7, null, "dim", false), 2, true))
         .dimensionsSpec(new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("ts", "dim"))))
         .metricsSpec(new AggregatorFactory[]{new LongSumAggregatorFactory("val", "val")})
@@ -396,7 +396,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
         getSegmentCacheManagerFactory()
     );
     final CompactionTask compactionTask = builder
-        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null))
+        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null, null))
         .tuningConfig(newTuningConfig(
             new DimensionRangePartitionsSpec(7, null, Arrays.asList("dim1", "dim2"), false),
             2,
@@ -447,7 +447,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
         getSegmentCacheManagerFactory()
     );
     final CompactionTask compactionTask = builder
-        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null))
+        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null, null))
         .tuningConfig(newTuningConfig(new SingleDimensionPartitionsSpec(7, null, "dim", false), 1, true))
         .build();
 
@@ -495,7 +495,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
         getSegmentCacheManagerFactory()
     );
     final CompactionTask compactionTask = builder
-        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null))
+        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null, null))
         .tuningConfig(newTuningConfig(
             new DimensionRangePartitionsSpec(7, null, Arrays.asList("dim1", "dim2"), false),
             1,
@@ -543,7 +543,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
         getSegmentCacheManagerFactory()
     );
     final CompactionTask compactionTask = builder
-        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null))
+        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null, null))
         .tuningConfig(AbstractParallelIndexSupervisorTaskTest.DEFAULT_TUNING_CONFIG_FOR_PARALLEL_INDEXING)
         .context(ImmutableMap.of(Tasks.STORE_COMPACTION_STATE_KEY, false))
         .build();
@@ -573,7 +573,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
         getSegmentCacheManagerFactory()
     );
     final CompactionTask compactionTask = builder
-        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null))
+        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null, null))
         .tuningConfig(AbstractParallelIndexSupervisorTaskTest.DEFAULT_TUNING_CONFIG_FOR_PARALLEL_INDEXING)
         .transformSpec(new CompactionTransformSpec(new SelectorDimFilter("dim", "a", null)))
         .build();
@@ -624,7 +624,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
         getSegmentCacheManagerFactory()
     );
     final CompactionTask compactionTask = builder
-        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null))
+        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null, null))
         .tuningConfig(AbstractParallelIndexSupervisorTaskTest.DEFAULT_TUNING_CONFIG_FOR_PARALLEL_INDEXING)
         .metricsSpec(new AggregatorFactory[]{
             new CountAggregatorFactory("cnt"),
@@ -679,7 +679,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
         getSegmentCacheManagerFactory()
     );
     final CompactionTask compactionTask = builder
-        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null))
+        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null, null))
         .tuningConfig(AbstractParallelIndexSupervisorTaskTest.DEFAULT_TUNING_CONFIG_FOR_PARALLEL_INDEXING)
         .build();
 
@@ -728,7 +728,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
         getSegmentCacheManagerFactory()
     );
     final CompactionTask compactionTask = builder
-        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null))
+        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null, null))
         .tuningConfig(AbstractParallelIndexSupervisorTaskTest.DEFAULT_TUNING_CONFIG_FOR_PARALLEL_INDEXING)
         .build();
 
@@ -820,7 +820,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     );
     final CompactionTask compactionTask = builder
         // Set the dropExisting flag to true in the IOConfig of the compaction task
-        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null), true)
+        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null, null), true)
         .tuningConfig(AbstractParallelIndexSupervisorTaskTest.DEFAULT_TUNING_CONFIG_FOR_PARALLEL_INDEXING)
         .granularitySpec(new ClientCompactionTaskGranularitySpec(Granularities.MINUTE, null, null))
         .build();
@@ -865,7 +865,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
         getSegmentCacheManagerFactory()
     );
     final CompactionTask compactionTask = builder
-        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null))
+        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null, null))
         .tuningConfig(AbstractParallelIndexSupervisorTaskTest.DEFAULT_TUNING_CONFIG_FOR_PARALLEL_INDEXING)
         .granularitySpec(new ClientCompactionTaskGranularitySpec(Granularities.MINUTE, null, null))
         .build();
@@ -906,7 +906,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
         getSegmentCacheManagerFactory()
     );
     final CompactionTask compactionTask = builder
-        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null))
+        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null, null))
         .tuningConfig(AbstractParallelIndexSupervisorTaskTest.DEFAULT_TUNING_CONFIG_FOR_PARALLEL_INDEXING)
         .build();
 
@@ -959,7 +959,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
                                .aggregators(new LongSumAggregatorFactory("val", "val"))
                                .build();
     final CompactionTask compactionTask = builder
-        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null))
+        .inputSpec(new CompactionIntervalSpec(INTERVAL_TO_INDEX, null, null))
         .tuningConfig(AbstractParallelIndexSupervisorTaskTest.DEFAULT_TUNING_CONFIG_FOR_PARALLEL_INDEXING)
         .projections(
             ImmutableList.of(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunTest.java
@@ -679,7 +679,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
     final CompactionTask compactionTask1 = compactionTaskBuilder()
         .ioConfig(
             new CompactionIOConfig(
-                new CompactionIntervalSpec(Intervals.of("2014-01-01/2014-01-02"), null),
+                new CompactionIntervalSpec(Intervals.of("2014-01-01/2014-01-02"), null, null),
                 false,
                 null
             )
@@ -709,7 +709,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
     final CompactionTask compactionTask1 = compactionTaskBuilder()
         .ioConfig(
             new CompactionIOConfig(
-                new CompactionIntervalSpec(Intervals.of("2014-01-01/2014-01-02"), null),
+                new CompactionIntervalSpec(Intervals.of("2014-01-01/2014-01-02"), null, null),
                 true,
                 null
             )
@@ -1111,7 +1111,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
     final CompactionTask partialCompactionTask = compactionTaskBuilder()
         .segmentGranularity(Granularities.MINUTE)
         // Set dropExisting to true
-        .inputSpec(new CompactionIntervalSpec(compactionPartialInterval, null), true)
+        .inputSpec(new CompactionIntervalSpec(compactionPartialInterval, null, null), true)
         .build();
     final Pair<TaskStatus, DataSegmentsWithSchemas> partialCompactionResult = runTask(partialCompactionTask);
     verifySchema(partialCompactionResult.rhs);
@@ -1173,7 +1173,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
     final CompactionTask fullCompactionTask = compactionTaskBuilder()
         .segmentGranularity(null)
         // Set dropExisting to true
-        .inputSpec(new CompactionIntervalSpec(Intervals.of("2014-01-01/2014-01-02"), null), true)
+        .inputSpec(new CompactionIntervalSpec(Intervals.of("2014-01-01/2014-01-02"), null, null), true)
         .build();
 
     // **** FULL COMPACTION ****
@@ -1263,7 +1263,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
     final CompactionTask partialCompactionTask = compactionTaskBuilder()
         .segmentGranularity(Granularities.MINUTE)
         // Set dropExisting to true
-        .inputSpec(new CompactionIntervalSpec(compactionPartialInterval, null), true)
+        .inputSpec(new CompactionIntervalSpec(compactionPartialInterval, null, null), true)
         .build();
     final Pair<TaskStatus, DataSegmentsWithSchemas> partialCompactionResult = runTask(partialCompactionTask);
     verifySchema(partialCompactionResult.rhs);
@@ -1317,7 +1317,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
         .segmentGranularity(null)
         // Set dropExisting to true
         // last 59 minutes of our 01, should be all tombstones
-        .inputSpec(new CompactionIntervalSpec(Intervals.of("2014-01-01T01:01:00/2014-01-01T02:00:00"), null), true)
+        .inputSpec(new CompactionIntervalSpec(Intervals.of("2014-01-01T01:01:00/2014-01-01T02:00:00"), null, null), true)
         .build();
 
     // **** Compaction over tombstones ****
@@ -1355,7 +1355,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
     final CompactionTask partialCompactionTask = compactionTaskBuilder()
         .segmentGranularity(Granularities.MINUTE)
         // Set dropExisting to false
-        .inputSpec(new CompactionIntervalSpec(partialInterval, null), false)
+        .inputSpec(new CompactionIntervalSpec(partialInterval, null, null), false)
         .build();
 
     final Pair<TaskStatus, DataSegmentsWithSchemas> partialCompactionResult = runTask(partialCompactionTask);
@@ -1377,7 +1377,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
     final CompactionTask fullCompactionTask = compactionTaskBuilder()
         .segmentGranularity(null)
         // Set dropExisting to false
-        .inputSpec(new CompactionIntervalSpec(Intervals.of("2014-01-01/2014-01-02"), null), false)
+        .inputSpec(new CompactionIntervalSpec(Intervals.of("2014-01-01/2014-01-02"), null, null), false)
         .build();
 
     final Pair<TaskStatus, DataSegmentsWithSchemas> fullCompactionResult = runTask(fullCompactionTask);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
@@ -375,7 +375,7 @@ public class CompactionTaskTest
         DATA_SOURCE,
         segmentCacheManagerFactory
     );
-    builder.inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS)));
+    builder.inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS), null));
     builder.tuningConfig(createTuningConfig());
     builder.segmentGranularity(Granularities.HOUR);
     final CompactionTask taskCreatedWithSegmentGranularity = builder.build();
@@ -384,7 +384,7 @@ public class CompactionTaskTest
         DATA_SOURCE,
         segmentCacheManagerFactory
     );
-    builder2.inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS)));
+    builder2.inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS), null));
     builder2.tuningConfig(createTuningConfig());
     builder2.granularitySpec(new ClientCompactionTaskGranularitySpec(Granularities.HOUR, Granularities.DAY, null));
     final CompactionTask taskCreatedWithGranularitySpec = builder2.build();
@@ -401,7 +401,7 @@ public class CompactionTaskTest
         DATA_SOURCE,
         segmentCacheManagerFactory
     );
-    builder.inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS)));
+    builder.inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS), null));
     builder.tuningConfig(createTuningConfig());
     builder.segmentGranularity(Granularities.HOUR);
     builder.granularitySpec(new ClientCompactionTaskGranularitySpec(Granularities.MINUTE, Granularities.DAY, null));
@@ -431,7 +431,7 @@ public class CompactionTaskTest
         DATA_SOURCE,
         segmentCacheManagerFactory
     );
-    builder.inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS)));
+    builder.inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS), null));
     builder.tuningConfig(createTuningConfig());
     builder.transformSpec(transformSpec);
     final CompactionTask taskCreatedWithTransformSpec = builder.build();
@@ -449,7 +449,7 @@ public class CompactionTaskTest
         DATA_SOURCE,
         segmentCacheManagerFactory
     );
-    builder.inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS)));
+    builder.inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS), null));
     builder.tuningConfig(createTuningConfig());
     builder.metricsSpec(aggregatorFactories);
     final CompactionTask taskCreatedWithTransformSpec = builder.build();
@@ -466,7 +466,7 @@ public class CompactionTaskTest
         DATA_SOURCE,
         segmentCacheManagerFactory
     );
-    builder.inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS)));
+    builder.inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS), null));
     builder.tuningConfig(createTuningConfig());
     builder.segmentGranularity(Granularities.HOUR);
     builder.granularitySpec(new ClientCompactionTaskGranularitySpec(null, Granularities.DAY, null));
@@ -494,7 +494,7 @@ public class CompactionTaskTest
         DATA_SOURCE,
         segmentCacheManagerFactory
     );
-    builder.inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS)));
+    builder.inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS), null));
     builder.tuningConfig(createTuningConfig());
     builder.segmentGranularity(Granularities.HOUR);
     builder.granularitySpec(new ClientCompactionTaskGranularitySpec(Granularities.HOUR, Granularities.DAY, null));
@@ -511,7 +511,7 @@ public class CompactionTaskTest
     );
     final CompactionTask task = builder
         .inputSpec(
-            new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS))
+            new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS), null)
         )
         .tuningConfig(createTuningConfig())
         .context(ImmutableMap.of("testKey", "testContext"))
@@ -666,7 +666,7 @@ public class CompactionTaskTest
     );
     final CompactionTask task = builder
         .inputSpec(
-            new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS))
+            new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS), null)
         )
         .tuningConfig(createTuningConfig())
         .context(ImmutableMap.of("testKey", "testContext"))
@@ -770,7 +770,7 @@ public class CompactionTaskTest
   {
     final SegmentProvider provider = new SegmentProvider(
         "datasource",
-        new CompactionIntervalSpec(Intervals.of("2021-01-01/P1D"), null)
+        new CompactionIntervalSpec(Intervals.of("2021-01-01/P1D"), null, null)
     );
 
     expectedException.expect(IllegalStateException.class);
@@ -784,9 +784,10 @@ public class CompactionTaskTest
   public void testCreateIngestionSchema() throws IOException
   {
     final Map<Interval, DataSchema> dataSchemasForIntervals = CompactionTask.createDataSchemasForIntervals(
+        DATA_SOURCE,
         toolbox,
         LockGranularity.TIME_CHUNK,
-        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null)),
+        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null, null)),
         null,
         null,
         null,
@@ -847,9 +848,10 @@ public class CompactionTaskTest
         .build();
 
     final Map<Interval, DataSchema> dataSchemasForIntervals = CompactionTask.createDataSchemasForIntervals(
+        DATA_SOURCE,
         toolbox,
         LockGranularity.TIME_CHUNK,
-        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null)),
+        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null, null)),
         null,
         null,
         null,
@@ -911,9 +913,10 @@ public class CompactionTaskTest
         .build();
 
     final Map<Interval, DataSchema> dataSchemasForIntervals = CompactionTask.createDataSchemasForIntervals(
+        DATA_SOURCE,
         toolbox,
         LockGranularity.TIME_CHUNK,
-        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null)),
+        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null, null)),
         null,
         null,
         null,
@@ -976,9 +979,10 @@ public class CompactionTaskTest
         .build();
 
     final Map<Interval, DataSchema> dataSchemasForIntervals = CompactionTask.createDataSchemasForIntervals(
+        DATA_SOURCE,
         toolbox,
         LockGranularity.TIME_CHUNK,
-        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null)),
+        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null, null)),
         null,
         null,
         null,
@@ -1048,9 +1052,10 @@ public class CompactionTaskTest
     );
 
     final Map<Interval, DataSchema> dataSchemasForIntervals = CompactionTask.createDataSchemasForIntervals(
+        DATA_SOURCE,
         toolbox,
         LockGranularity.TIME_CHUNK,
-        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null)),
+        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null, null)),
         customSpec,
         null,
         null,
@@ -1100,9 +1105,10 @@ public class CompactionTaskTest
     };
 
     final Map<Interval, DataSchema> dataSchemasForIntervals = CompactionTask.createDataSchemasForIntervals(
+        DATA_SOURCE,
         toolbox,
         LockGranularity.TIME_CHUNK,
-        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null)),
+        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null, null)),
         null,
         null,
         customMetricsSpec,
@@ -1145,9 +1151,10 @@ public class CompactionTaskTest
   public void testCreateIngestionSchemaWithCustomSegments() throws IOException
   {
     final Map<Interval, DataSchema> dataSchemasForIntervals = CompactionTask.createDataSchemasForIntervals(
+        DATA_SOURCE,
         toolbox,
         LockGranularity.TIME_CHUNK,
-        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null)),
+        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null, null)),
         null,
         null,
         null,
@@ -1197,6 +1204,7 @@ public class CompactionTaskTest
     // Remove one segment in the middle
     segments.remove(segments.size() / 2);
     final Map<Interval, DataSchema> dataSchemasForIntervals = CompactionTask.createDataSchemasForIntervals(
+        DATA_SOURCE,
         toolbox,
         LockGranularity.TIME_CHUNK,
         new SegmentProvider(DATA_SOURCE, SpecificSegmentsSpec.fromSegments(segments)),
@@ -1229,6 +1237,7 @@ public class CompactionTaskTest
     indexIO.removeMetadata(Iterables.getFirst(indexIO.getQueryableIndexMap().keySet(), null));
     final List<DataSegment> segments = new ArrayList<>(SEGMENTS);
     final Map<Interval, DataSchema> dataSchemasForIntervals = CompactionTask.createDataSchemasForIntervals(
+        DATA_SOURCE,
         toolbox,
         LockGranularity.TIME_CHUNK,
         new SegmentProvider(DATA_SOURCE, SpecificSegmentsSpec.fromSegments(segments)),
@@ -1272,9 +1281,10 @@ public class CompactionTaskTest
   public void testSegmentGranularityAndNullQueryGranularity() throws IOException
   {
     final Map<Interval, DataSchema> dataSchemasForIntervals = CompactionTask.createDataSchemasForIntervals(
+        DATA_SOURCE,
         toolbox,
         LockGranularity.TIME_CHUNK,
-        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null)),
+        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null, null)),
         null,
         null,
         null,
@@ -1318,9 +1328,10 @@ public class CompactionTaskTest
   public void testQueryGranularityAndNullSegmentGranularity() throws IOException
   {
     final Map<Interval, DataSchema> dataSchemasForIntervals = CompactionTask.createDataSchemasForIntervals(
+        DATA_SOURCE,
         toolbox,
         LockGranularity.TIME_CHUNK,
-        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null)),
+        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null, null)),
         null,
         null,
         null,
@@ -1361,9 +1372,10 @@ public class CompactionTaskTest
   public void testQueryGranularityAndSegmentGranularityNonNull() throws IOException
   {
     final Map<Interval, DataSchema> dataSchemasForIntervals = CompactionTask.createDataSchemasForIntervals(
+        DATA_SOURCE,
         toolbox,
         LockGranularity.TIME_CHUNK,
-        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null)),
+        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null, null)),
         null,
         null,
         null,
@@ -1414,9 +1426,10 @@ public class CompactionTaskTest
   public void testNullGranularitySpec() throws IOException
   {
     final Map<Interval, DataSchema> dataSchemasForIntervals = CompactionTask.createDataSchemasForIntervals(
+        DATA_SOURCE,
         toolbox,
         LockGranularity.TIME_CHUNK,
-        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null)),
+        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null, null)),
         null,
         null,
         null,
@@ -1461,9 +1474,10 @@ public class CompactionTaskTest
       throws IOException
   {
     final Map<Interval, DataSchema> dataSchemasForIntervals = CompactionTask.createDataSchemasForIntervals(
+        DATA_SOURCE,
         toolbox,
         LockGranularity.TIME_CHUNK,
-        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null)),
+        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null, null)),
         null,
         null,
         null,
@@ -1508,9 +1522,10 @@ public class CompactionTaskTest
       throws IOException
   {
     final Map<Interval, DataSchema> dataSchemasForIntervals = CompactionTask.createDataSchemasForIntervals(
+        DATA_SOURCE,
         toolbox,
         LockGranularity.TIME_CHUNK,
-        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null)),
+        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null, null)),
         null,
         null,
         null,
@@ -1540,9 +1555,10 @@ public class CompactionTaskTest
       throws IOException
   {
     final Map<Interval, DataSchema> dataSchemasForIntervals = CompactionTask.createDataSchemasForIntervals(
+        DATA_SOURCE,
         toolbox,
         LockGranularity.TIME_CHUNK,
-        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null)),
+        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null, null)),
         null,
         null,
         null,
@@ -1574,9 +1590,10 @@ public class CompactionTaskTest
       throws IOException
   {
     final Map<Interval, DataSchema> dataSchemasForIntervals = CompactionTask.createDataSchemasForIntervals(
+        DATA_SOURCE,
         toolbox,
         LockGranularity.TIME_CHUNK,
-        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null)),
+        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null, null)),
         null,
         null,
         null,
@@ -1598,7 +1615,7 @@ public class CompactionTaskTest
         DATA_SOURCE,
         segmentCacheManagerFactory
     );
-    builder.inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS)));
+    builder.inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS), null));
     builder.compactionRunner(new TestMSQCompactionRunner());
     final CompactionTask compactionTask = builder.build();
     // granularitySpec=null should assume a possible rollup
@@ -1612,7 +1629,7 @@ public class CompactionTaskTest
         DATA_SOURCE,
         segmentCacheManagerFactory
     );
-    builder.inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS)));
+    builder.inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS), null));
     builder.compactionRunner(new TestMSQCompactionRunner());
     builder.tuningConfig(TuningConfigBuilder.forCompactionTask()
                                             .withForceGuaranteedRollup(true)
@@ -1636,7 +1653,7 @@ public class CompactionTaskTest
         DATA_SOURCE,
         segmentCacheManagerFactory
     );
-    builder.inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS)));
+    builder.inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS), null));
     builder.compactionRunner(new TestMSQCompactionRunner());
     builder.granularitySpec(new ClientCompactionTaskGranularitySpec(null, null, true));
 
@@ -1654,7 +1671,7 @@ public class CompactionTaskTest
         DATA_SOURCE,
         segmentCacheManagerFactory
     );
-    builder.inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS)));
+    builder.inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, SegmentUtils.hashIds(SEGMENTS), null));
     builder.compactionRunner(new TestMSQCompactionRunner());
 
     DimensionSchema stringDim = new StringDimensionSchema("string_dim_1", null, null);

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQCompactionRunnerTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQCompactionRunnerTest.java
@@ -688,7 +688,7 @@ public class MSQCompactionRunnerTest
     context.putAll(contextParams);
 
     builder
-        .inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, null))
+        .inputSpec(new CompactionIntervalSpec(COMPACTION_INTERVAL, null, null))
         .tuningConfig(createTuningConfig(
             indexSpec,
             partitionsSpec == null ? new DynamicPartitionsSpec(100, null) : partitionsSpec


### PR DESCRIPTION
Enhance Compaction task to be able to write to a different/new datasource

### Description

Compaction tasks, unlike reindexing (which is native batch + druid input source), are great as they allow user to only specific specs that is needed and can automatically infer unspecified specs from existing segments of the input datasource. For example, if a user doesn't want to change the metrics, they don't have to set the metricsSpec and the Compaction task will correctly create metricsSpec from existing segments. 

A limitation of Compaction tasks is that the datasource the task is writing to and reading from has to be the same datasource. There are multiple use cases where we may want to write to a different datasource. For example:
1. You have an existing datasource A with all your data. You want to overwrite the datasource with a new ingestionSpec modifying x dimensions and y metrics. Before you do, you want to create a backup in case anything goes wrong. You may want to use a Compaction task to read from datasource A and write to datasource A_temp (exact copy without any change in specs) to test out the new ingestionSpec.
2. You have an existing datasource A with all your data. You may want to do a periodic backup (clone of the table at that state in time). You may want to use a Compaction task to read from datasource A and write to datasource A_20250429 (exact copy without any change in specs). This can be used for audit purpose or as a backup in case an accidental and/or malicious drop/overwrite/modification happen to the datasource A.
3. You have an existing datasource A with all your data. You have some queries that is not performant on this datasource due to the low rollup ratio (i.e. this datasource has a requirement for fine granularity and/or large number of dimensions). You may want to use a Compaction task to read from datasource A and write to datasource A_optimizedForSomeGroupBy (exact copy with change in dimensionSpec and/or granularitySpec) to power this query. In this case, you wouldn't need to specific the metricsSpec as you are not changing the metricsSpec.

This PR adds a new Property to the Compaction task `inputSpec`. The new field is `dataSource`. This new field is not required. When not set, the Compaction task will read and write to the same datasource given by the top-most level `dataSource` field. When set, the Compaction task will read from inputSpec's `dataSource` and write to the top-most level `dataSource` field. I think it make sense for this new field to be in the Compaction task `inputSpec` as the `inputSpec` purpose is specifying the input of the task. 

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
