### PR TITLE
Set operator image.tag=v1.3.0 in embedded docker test

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/k8s/K3sClusterWithOperatorResource.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/k8s/K3sClusterWithOperatorResource.java
@@ -54,6 +54,7 @@ public class K3sClusterWithOperatorResource extends K3sClusterResource
   private static final String HELM_REPO_NAME = "datainfra";
   private static final String HELM_REPO_URL = "https://charts.datainfra.io";
   private static final String HELM_CHART_NAME = "datainfra/druid-operator";
+  private static final String OPERATOR_IMAGE_TAG = "v1.3.0";
   private static final String HELM_VERSION = "v3.13.1";
   private static final String HELM_PLATFORM = "linux-amd64";
   private static final String HELM_MOUNT_PATH = "/usr/local/bin/helm";
@@ -202,6 +203,7 @@ public class K3sClusterWithOperatorResource extends K3sClusterResource
           "--namespace", OPERATOR_NAMESPACE,
           "--create-namespace",
           "--set", "env.WATCH_NAMESPACE=" + DRUID_NAMESPACE,
+          "--set", "image.tag=" + OPERATOR_IMAGE_TAG,
           "--wait",
           "--timeout", "3m"
       );


### PR DESCRIPTION
### Description

The helm chart for druid-operator has been updated to v1.3.1

```java
> helm show chart datainfra/druid-operator
apiVersion: v2
appVersion: v1.3.1
description: Druid Kubernetes Operator
icon: https://www.apache.org/logos/res/druid/druid-1.png
name: druid-operator
type: application
version: 0.4.0
```

but `docker.io/datainfrahq/druid-operator/v1.3.1` does not exist yet causing CI to fail due to
```java
java.lang.RuntimeException: Failed to execute helm command
Caused by: java.lang.RuntimeException: Helm command failed: install druid-operator datainfra/druid-operator --namespace druid-operator-system --create-namespace --set env.WATCH_NAMESPACE=druid --wait --timeout 3m
```

in turn caused by
```java
E1009 08:25:18.769339      55 pod_workers.go:1300] "Error syncing pod, skipping" err="failed to \"StartContainer\" for \"manager\" with ErrImagePull: \"rpc error: code = NotFound desc = failed to pull and unpack image \\\"docker.io/datainfrahq/druid-operator:v1.3.1\\\": failed to resolve reference \\\"docker.io/datainfrahq/druid-operator:v1.3.1\\\": docker.io/datainfrahq/druid-operator:v1.3.1: not found\"" pod="druid-operator-system/druid-operator-76969cb75f-zrhnz" podUID="266446f2-71d0-451e-be94-98f48de2d2c6"
```

### Fix

Force set to use image `v1.3.0` until Docker image for `v1.3.1` is available

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
