### PR TITLE
Increase event emit timeout for CentralizedSchemaMetadataQueryDisabledTest

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/schema/CentralizedSchemaMetadataQueryDisabledTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/schema/CentralizedSchemaMetadataQueryDisabledTest.java
@@ -39,7 +39,8 @@ public class CentralizedSchemaMetadataQueryDisabledTest
            .addCommonProperty("druid.centralizedDatasourceSchema.backFillPeriod", "500")
            .addCommonProperty("druid.coordinator.segmentMetadata.disableSegmentMetadataQueries", "true")
            .addCommonProperty("druid.coordinator.segmentMetadata.metadataRefreshPeriod", "PT0.1s")
-           .addCommonProperty("druid.manager.segments.useIncrementalCache", "always");
+           .addCommonProperty("druid.manager.segments.useIncrementalCache", "always")
+           .useDefaultTimeoutForLatchableEmitter(60);
 
     return cluster;
   }
@@ -60,8 +61,7 @@ public class CentralizedSchemaMetadataQueryDisabledTest
     @Override
     protected EmbeddedDruidCluster createCluster()
     {
-      return configureCluster(super.createCluster())
-          .useDefaultTimeoutForLatchableEmitter(60);
+      return configureCluster(super.createCluster());
     }
   }
 


### PR DESCRIPTION
<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
