### PR TITLE
docs: fix typo in catalog endpoint

### DIFF
--- a/docs/development/extensions-core/catalog.md
+++ b/docs/development/extensions-core/catalog.md
@@ -403,7 +403,7 @@ Retrieve a list of table names in the schema.
 
 ##### URL
 
-`GET` `/druid/coordinator/v1/catalog/schemas/{schema}/table`
+`GET` `/druid/coordinator/v1/catalog/schemas/{schema}/tables`
 
 ##### Responses
 


### PR DESCRIPTION
Fixes the endpoint from `/table` to `/tables`. The corresponding example uses the correct endpoint.