### PR TITLE
fix bug in SegmentLocalCacheManager to only attempt download in acquireSegment if virtual storage is enabled

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
@@ -336,6 +336,11 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
         if (retryAcquireExisting != null) {
           return retryAcquireExisting;
         }
+
+        if (!config.isVirtualStorage()) {
+          return AcquireSegmentAction.missingSegment();
+        }
+
         final Iterator<StorageLocation> iterator = strategy.getLocations();
         while (iterator.hasNext()) {
           final StorageLocation location = iterator.next();

--- a/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerTest.java
@@ -1048,6 +1048,31 @@ public class SegmentLocalCacheManagerTest extends InitializedNullHandlingTest
   }
 
   @Test
+  public void testGetSegmentAfterDroppedWithNoVirtualStorageEnabled() throws Exception
+  {
+    SegmentLocalCacheManager manager = makeDefaultManager(jsonMapper);
+
+    final DataSegment segmentToLoad = makeTestDataSegment(segmentDeepStorageDir);
+    createSegmentZipInLocation(segmentDeepStorageDir, TEST_DATA_RELATIVE_PATH);
+
+    manager.load(segmentToLoad);
+    Assert.assertNotNull(manager.getSegmentFiles(segmentToLoad));
+    manager.drop(segmentToLoad);
+    Assert.assertNull(manager.getSegmentFiles(segmentToLoad));
+
+    // ensure that if virtual storage is not enabled, we do not download the segment (callers might have a DataSegment
+    // reference which was originally cached and then dropped before attempting to acquire a segment. if virtual storage
+    // is not enabled, this should return a missing segment instead of downloading
+    AcquireSegmentAction segmentAction = manager.acquireSegment(segmentToLoad);
+    ReferenceCountedObjectProvider<Segment> referenceProvider = segmentAction.getSegmentFuture().get();
+    Optional<Segment> theSegment = referenceProvider.acquireReference();
+    Assert.assertFalse(theSegment.isPresent());
+    segmentAction.close();
+
+    Assert.assertNull(manager.getSegmentFiles(segmentToLoad));
+  }
+
+  @Test
   public void testIfTombstoneIsLoaded() throws IOException, SegmentLoadingException
   {
     final DataSegment tombstone = DataSegment.builder()


### PR DESCRIPTION
### Description
Not sure if I've seen this happen yet, but I think it could if the coordinator issued a drop command between the resolving the `DataSegment` from the timeline for a query and then actually calling `acquireSegment` on them. Added test to ensure that this call produces a missing segment response if virtual storage mode is not enabled.