### PR TITLE
Log all the handlers for a stage before they start / stop.

### DIFF
--- a/processing/src/main/java/org/apache/druid/java/util/common/lifecycle/Lifecycle.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/lifecycle/Lifecycle.java
@@ -371,7 +371,7 @@ public class Lifecycle
             handler.stop();
           }
           catch (Exception e) {
-            log.warn(e, "Lifecycle [%s] encountered exception while stopping [%s]", name, handler);
+            log.warn(e, "Lifecycle [%s] encountered exception while stopping handler [%s]", name, handler);
             if (thrown == null) {
               thrown = e;
             } else {


### PR DESCRIPTION
This logs all handlers during the start and stop lifecycle stages. It’s useful for understanding the execution order ahead of time, especially to identify which handlers didn’t run when a service stops. For example, some handlers like `SupervisorManager.stop()` can take a while to stop, blocking other subsequent handlers from stopping if a certain timeout is exceeded.

A sample of the start lifecycle logs:
```log
2025-10-18T00:39:38,019 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle - Starting lifecycle [module] stage [NORMAL] for handlers [[LoggingEmitter, ServiceEmitter, org.apache.druid.curator.CuratorModule$1@3e89f5bc, org.apache.druid.curator.discovery.DiscoveryModule$5@259aec72, DerbyConnector, org.apache.druid.guice.JacksonConfigManagerModule$1@36d39655, ConfigManager, SQLAuditManager, JvmMonitor, MetadataTaskStorage, IndexerSQLMetadataStorageCoordinator, org.apache.druid.java.util.common.concurrent.ExecutorServices$1@26be0d23, org.apache.druid.java.util.common.concurrent.ExecutorServices$1@576b385d, SegmentAllocationQueue, SQLMetadataSupervisorManager, org.apache.druid.java.util.http.client.HttpClientInit$1@2560a7be, org.apache.druid.java.util.http.client.HttpClientInit$2@fabfc79, NettyHttpClient, CuratorDruidNodeDiscoveryProvider, TaskMaster, org.apache.druid.metadata.SqlSegmentsMetadataManagerProvider$1@59aa2fba, SqlSegmentsMetadataManagerV2, org.apache.druid.java.util.common.concurrent.ExecutorServices$1@578d5d02, OverlordCompactionScheduler, DiscoveryServiceLocator, org.apache.druid.java.util.common.concurrent.ExecutorServices$1@77f04d1a, DruidOverlord, BasicMonitorScheduler, HdfsStorageAuthentication, HdfsStorageAvailabilityChecker, org.apache.druid.java.util.http.client.HttpClientInit$1@27682fa9, org.apache.druid.java.util.http.client.HttpClientInit$2@2fb70301, NettyHttpClient, HttpServerInventoryView, CoordinatorServerView, org.apache.druid.metadata.SQLMetadataRuleManagerProvider$1@126f2eb8, SQLMetadataRuleManager, DiscoveryServiceLocator, org.apache.druid.java.util.common.concurrent.ExecutorServices$1@67823972, org.apache.druid.java.util.common.concurrent.ExecutorServices$1@1f1574c, CoordinatorDynamicConfigSyncer, DruidCoordinator]]
2025-10-18T00:39:38,023 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Starting lifecycle [LoggingEmitter#start]
```
A sample of the stop lifecycle logs:
```log
2025-10-18T00:41:46,863 INFO [Thread-57] org.apache.druid.java.util.common.lifecycle.Lifecycle - Stopping lifecycle [task-master] stage [NORMAL] for handlers [[org.apache.druid.indexing.overlord.DruidOverlord$1$2@111b1ea8, OverlordDutyExecutor, SupervisorManager, org.apache.druid.indexing.overlord.DruidOverlord$1$1@388e6093, TaskQueue, HttpRemoteTaskRunner]]
2025-10-18T00:41:46,871 INFO [Thread-57] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Stopping lifecyle [OverlordDutyExecutor#stop].
2025-10-18T00:41:46,871 INFO [Thread-57] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Stopping lifecyle [SupervisorManager#stop].
2025-10-18T00:41:46,872 INFO [Thread-57] org.apache.druid.indexing.overlord.supervisor.SupervisorManager - Stopping [6] supervisors
2025-10-18T00:41:46,877 INFO [Thread-57] org.apache.druid.indexing.overlord.supervisor.SupervisorManager - Waiting for [6] supervisors to shutdown
```


This PR has:

- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
