### PR TITLE
[Backport] Make the HTTP client that lives beneath fabric8 KubernetesClient configurable

### DIFF
--- a/docs/development/extensions-core/k8s-jobs.md
+++ b/docs/development/extensions-core/k8s-jobs.md
@@ -856,3 +856,43 @@ To do this, set the following property.
 |`druid.indexer.runner.k8sAndWorker.runnerStrategy.taskType.default`| `String` (e.g., `k8s`, `worker`) | Specifies the default runner to use if no overrides apply. This setting ensures there is always a fallback runner available.|None|No|
 |`druid.indexer.runner.k8sAndWorker.runnerStrategy.taskType.overrides`| `JsonObject`(e.g., `{"index_kafka": "worker"}`)| Defines task-specific overrides for runner types. Each entry sets a task type to a specific runner, allowing fine control. |`{}`|No|
 
+### Experimental Fabric8 Http Client Configurations
+
+:::warning
+
+This section is experimental and subject to change. The Druid developer community intends on selecting a stable default HTTP client and configuration in the future, simplifying configuration and distribution packaging. This means that not all exposed HTTP clients and their configurations will be supported long term. If you opt in to using this experimental configuration, please provide feedback to the Druid developer community ([GitHub Issue](https://github.com/apache/druid/issues/18629) ... Apache mailing list: `dev@druid.apache.org`) on your experience to help guide our long term decisions.
+
+:::
+
+The extension uses [fabric8 KubernetesClient](https://github.com/fabric8io/kubernetes-client) to communicate with the Kubernetes API server. This client creates an
+underlying HTTP Client using a pluggable HTTP client library. By default, the client is [vert.x](https://github.com/fabric8io/kubernetes-client/tree/main/httpclient-vertx). The legacy default
+was [okhttp](https://github.com/fabric8io/kubernetes-client/tree/main/httpclient-okhttp).
+
+|Property| Possible Values |Description| Default |required|
+|--------|-----------------|-----------|---------|--------|
+|`druid.indexer.runner.k8sAndWorker.http.httpClientType`|`String` (e.g., `okhttp`, `vertx`, `javaStandardHttp`)|Specifies the HTTP client library to be used by the worker task runner for communication with worker nodes.|`vertx`|No|
+
+#### vert.x HTTP Client
+
+|Property| Possible Values |Description| Default |required|
+|--------|-----------------|-----------|---------|--------|
+|`druid.indexer.runner.k8sAndWorker.http.vertx.workerPoolSize`|`Integer`|...|20|No|
+|`druid.indexer.runner.k8sAndWorker.http.vertx.eventLoopPoolSize`|`Integer`|...|`2 * number cores`|No|
+|`druid.indexer.runner.k8sAndWorker.http.vertx.internalBlockingPoolSize`|`Integer`|...|20|No|
+
+#### OkHttp Client
+
+|Property| Possible Values |Description| Default |required|
+|--------|-----------------|-----------|---------|--------|
+|`druid.indexer.runner.k8sAndWorker.http.okhttp.useCustomDispatcherExecutor`|`Boolean`|Flag indicating if okhttp client will use a custom defined thread pool for okhttp http client request dispatcher|false|No|
+|`druid.indexer.runner.k8sAndWorker.http.okhttp.coreWorkerThreads`|`Integer`|The number of threads to keep in the pool, even if they are idle. Only applicable if `useCustomDispatcherExecutor` is true.|50|No|
+|`druid.indexer.runner.k8sAndWorker.http.okhttp.maxWorkerThreads`|`Integer`|Maximum number of threads in the custom thread pool for okhttp client request dispatcher. Must be greater than or equal to `druid.indexer.runner.k8sAndWorker.http.okhttp.coreWorkerThreads` Only applicable if `useCustomDispatcherExecutor` is true.|`druid.indexer.runner.k8sAndWorker.http.okhttp.coreWorkerThreads`|No|
+|`druid.indexer.runner.k8sAndWorker.http.okhttp.workerThreadKeepAliveTime`|`Long`|Idle timeout in seconds for non-core threads in the worker thread pool. Only applicable if `useCustomDispatcherExecutor` is true.|60|No|
+
+#### Native Java HTTP Client
+
+|Property| Possible Values |Description| Default |required|
+|--------|-----------------|-----------|---------|--------|
+|`druid.indexer.runner.k8sAndWorker.http.javaStandardHttp.coreWorkerThreads`|`Integer`|The number of threads to keep in the pool, even if they are idle.|20|No|
+|`druid.indexer.runner.k8sAndWorker.http.javaStandardHttp.maxWorkerThreads`|`Integer`|Maximum number of threads in the custom thread pool for okhttp client request dispatcher.|20|No|
+|`druid.indexer.runner.k8sAndWorker.http.javaStandardHttp.workerThreadKeepAliveTime`|`Long`|Idle timeout in seconds for non-core threads in the worker thread pool.|60|No|

--- a/extensions-core/kubernetes-overlord-extensions/pom.xml
+++ b/extensions-core/kubernetes-overlord-extensions/pom.xml
@@ -121,17 +121,26 @@
       <artifactId>kubernetes-client</artifactId>
       <version>${fabric8.version}</version>
       <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>io.fabric8</groupId>
-          <artifactId>kubernetes-httpclient-okhttp</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-httpclient-jdk</artifactId>
+      <version>${fabric8.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-httpclient-okhttp</artifactId>
+      <version>${fabric8.version}</version>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-httpclient-vertx</artifactId>
       <version>${fabric8.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>4.12.0</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesOverlordModule.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesOverlordModule.java
@@ -54,7 +54,13 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.lifecycle.Lifecycle;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.k8s.overlord.common.DruidKubernetesClient;
-import org.apache.druid.k8s.overlord.common.DruidKubernetesHttpClientConfig;
+import org.apache.druid.k8s.overlord.common.httpclient.DruidKubernetesHttpClientFactory;
+import org.apache.druid.k8s.overlord.common.httpclient.jdk.DruidKubernetesJdkHttpClientConfig;
+import org.apache.druid.k8s.overlord.common.httpclient.jdk.DruidKubernetesJdkHttpClientFactory;
+import org.apache.druid.k8s.overlord.common.httpclient.okhttp.DruidKubernetesOkHttpHttpClientConfig;
+import org.apache.druid.k8s.overlord.common.httpclient.okhttp.DruidKubernetesOkHttpHttpClientFactory;
+import org.apache.druid.k8s.overlord.common.httpclient.vertx.DruidKubernetesVertxHttpClientConfig;
+import org.apache.druid.k8s.overlord.common.httpclient.vertx.DruidKubernetesVertxHttpClientFactory;
 import org.apache.druid.k8s.overlord.execution.KubernetesTaskExecutionConfigResource;
 import org.apache.druid.k8s.overlord.execution.KubernetesTaskRunnerDynamicConfig;
 import org.apache.druid.k8s.overlord.runnerstrategy.RunnerStrategy;
@@ -79,7 +85,11 @@ public class KubernetesOverlordModule implements DruidModule
                                                                + ".k8sAndWorker";
   private static final String RUNNERSTRATEGY_PROPERTIES_FORMAT_STRING = K8SANDWORKER_PROPERTIES_PREFIX
                                                                         + ".runnerStrategy.%s";
-  private static final String HTTPCLIENT_PROPERITES_PREFIX = K8SANDWORKER_PROPERTIES_PREFIX + ".http";
+  private static final String K8SANDWORKER_HTTPCLIENT_PROPERTIES_PREFIX = K8SANDWORKER_PROPERTIES_PREFIX + ".http";
+  private static final String HTTPCLIENT_TYPE_PROPERTY = K8SANDWORKER_HTTPCLIENT_PROPERTIES_PREFIX + ".httpClientType";
+  private static final String VERTX_HTTPCLIENT_PROPERITES_PREFIX = K8SANDWORKER_HTTPCLIENT_PROPERTIES_PREFIX + "." + DruidKubernetesVertxHttpClientFactory.TYPE_NAME;
+  private static final String OKHTTP_HTTPCLIENT_PROPERITES_PREFIX = K8SANDWORKER_HTTPCLIENT_PROPERTIES_PREFIX + "." + DruidKubernetesOkHttpHttpClientFactory.TYPE_NAME;
+  public static final String JDK_HTTPCLIENT_PROPERITES_PREFIX = K8SANDWORKER_HTTPCLIENT_PROPERTIES_PREFIX + "." + DruidKubernetesJdkHttpClientFactory.TYPE_NAME;
 
   @Override
   public void configure(Binder binder)
@@ -114,14 +124,37 @@ public class KubernetesOverlordModule implements DruidModule
 
     Jerseys.addResource(binder, KubernetesTaskExecutionConfigResource.class);
 
-    JsonConfigProvider.bind(binder, HTTPCLIENT_PROPERITES_PREFIX, DruidKubernetesHttpClientConfig.class);
+    PolyBind.createChoiceWithDefault(
+        binder,
+        HTTPCLIENT_TYPE_PROPERTY,
+        Key.get(DruidKubernetesHttpClientFactory.class),
+        DruidKubernetesVertxHttpClientFactory.TYPE_NAME
+    );
+
+    final MapBinder<String, DruidKubernetesHttpClientFactory> factoryBinder =
+        PolyBind.optionBinder(binder, Key.get(DruidKubernetesHttpClientFactory.class));
+
+    factoryBinder.addBinding(DruidKubernetesVertxHttpClientFactory.TYPE_NAME)
+                 .toProvider(VertxHttpClientFactoryProvider.class)
+                 .in(LazySingleton.class);
+
+    factoryBinder.addBinding(DruidKubernetesOkHttpHttpClientFactory.TYPE_NAME)
+                 .toProvider(OkHttpHttpClientFactoryProvider.class)
+                 .in(LazySingleton.class);
+    factoryBinder.addBinding(DruidKubernetesJdkHttpClientFactory.TYPE_NAME)
+                 .toProvider(JdkHttpClientFactoryProvider.class)
+                 .in(LazySingleton.class);
+
+    JsonConfigProvider.bind(binder, VERTX_HTTPCLIENT_PROPERITES_PREFIX, DruidKubernetesVertxHttpClientConfig.class);
+    JsonConfigProvider.bind(binder, OKHTTP_HTTPCLIENT_PROPERITES_PREFIX, DruidKubernetesOkHttpHttpClientConfig.class);
+    JsonConfigProvider.bind(binder, JDK_HTTPCLIENT_PROPERITES_PREFIX, DruidKubernetesJdkHttpClientConfig.class);
   }
 
   @Provides
   @LazySingleton
   public DruidKubernetesClient makeKubernetesClient(
       KubernetesTaskRunnerConfig kubernetesTaskRunnerConfig,
-      DruidKubernetesHttpClientConfig httpClientConfig,
+      DruidKubernetesHttpClientFactory httpClientFactory,
       Lifecycle lifecycle
   )
   {
@@ -133,7 +166,7 @@ public class KubernetesOverlordModule implements DruidModule
       config.setHttpProxy(null);
     }
 
-    client = new DruidKubernetesClient(httpClientConfig, config);
+    client = new DruidKubernetesClient(httpClientFactory, config);
 
     lifecycle.addHandler(
         new Lifecycle.Handler()
@@ -278,6 +311,57 @@ public class KubernetesOverlordModule implements DruidModule
       provider.inject(props, configurator);
 
       return provider.get();
+    }
+  }
+
+  private static class VertxHttpClientFactoryProvider implements Provider<DruidKubernetesHttpClientFactory>
+  {
+    private DruidKubernetesVertxHttpClientConfig config;
+
+    @Inject
+    public void inject(DruidKubernetesVertxHttpClientConfig config)
+    {
+      this.config = config;  // Guice injects the Vertx-specific config
+    }
+
+    @Override
+    public DruidKubernetesHttpClientFactory get()
+    {
+      return new DruidKubernetesVertxHttpClientFactory(config);
+    }
+  }
+
+  private static class OkHttpHttpClientFactoryProvider implements Provider<DruidKubernetesHttpClientFactory>
+  {
+    private DruidKubernetesOkHttpHttpClientConfig config;
+
+    @Inject
+    public void inject(DruidKubernetesOkHttpHttpClientConfig config)
+    {
+      this.config = config;  // Guice injects the OkHttp-specific config
+    }
+
+    @Override
+    public DruidKubernetesHttpClientFactory get()
+    {
+      return new DruidKubernetesOkHttpHttpClientFactory(config);
+    }
+  }
+
+  private static class JdkHttpClientFactoryProvider implements Provider<DruidKubernetesHttpClientFactory>
+  {
+    private DruidKubernetesJdkHttpClientConfig config;
+
+    @Inject
+    public void inject(DruidKubernetesJdkHttpClientConfig config)
+    {
+      this.config = config;
+    }
+
+    @Override
+    public DruidKubernetesHttpClientFactory get()
+    {
+      return new DruidKubernetesJdkHttpClientFactory(config);
     }
   }
 }

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/DruidKubernetesClient.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/DruidKubernetesClient.java
@@ -22,15 +22,16 @@ package org.apache.druid.k8s.overlord.common;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import org.apache.druid.k8s.overlord.common.httpclient.DruidKubernetesHttpClientFactory;
 
 public class DruidKubernetesClient implements KubernetesClientApi
 {
   private final KubernetesClient kubernetesClient;
 
-  public DruidKubernetesClient(DruidKubernetesHttpClientConfig httpClientConfig, Config kubernetesClientConfig)
+  public DruidKubernetesClient(DruidKubernetesHttpClientFactory httpClientFactory, Config kubernetesClientConfig)
   {
     this.kubernetesClient = new KubernetesClientBuilder()
-        .withHttpClientFactory(new DruidKubernetesHttpClientFactory(httpClientConfig))
+        .withHttpClientFactory(httpClientFactory)
         .withConfig(kubernetesClientConfig)
         .build();
   }

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/DruidKubernetesHttpClientFactory.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/DruidKubernetesHttpClientFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.k8s.overlord.common.httpclient;
+
+import io.fabric8.kubernetes.client.http.HttpClient;
+
+public interface DruidKubernetesHttpClientFactory extends HttpClient.Factory
+{
+}

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/jdk/DruidKubernetesJdkHttpClientConfig.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/jdk/DruidKubernetesJdkHttpClientConfig.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.k8s.overlord.common.httpclient.jdk;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+public class DruidKubernetesJdkHttpClientConfig
+{
+
+  @JsonProperty
+  @Nullable
+  private Integer maxWorkerThreads = null;
+
+  @JsonProperty
+  private int coreWorkerThreads = 50;
+
+  @JsonProperty
+  private long workerThreadKeepAliveTime = 60L;
+
+  public int getMaxWorkerThreads()
+  {
+    if (maxWorkerThreads == null || maxWorkerThreads < coreWorkerThreads) {
+      return coreWorkerThreads;
+    } else {
+      return maxWorkerThreads;
+    }
+  }
+
+  public int getCoreWorkerThreads()
+  {
+    return coreWorkerThreads;
+  }
+
+  public long getWorkerThreadKeepAliveTime()
+  {
+    return workerThreadKeepAliveTime;
+  }
+
+}

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/jdk/DruidKubernetesJdkHttpClientFactory.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/jdk/DruidKubernetesJdkHttpClientFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.k8s.overlord.common.httpclient.jdk;
+
+import io.fabric8.kubernetes.client.jdkhttp.JdkHttpClientFactory;
+import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.k8s.overlord.common.httpclient.DruidKubernetesHttpClientFactory;
+
+import java.net.http.HttpClient;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class DruidKubernetesJdkHttpClientFactory extends JdkHttpClientFactory implements DruidKubernetesHttpClientFactory
+{
+  public static final String TYPE_NAME = "javaStandardHttp";
+  private final DruidKubernetesJdkHttpClientConfig config;
+
+  public DruidKubernetesJdkHttpClientFactory(DruidKubernetesJdkHttpClientConfig config)
+  {
+    super();
+    this.config = config;
+  }
+
+  @Override
+  protected HttpClient.Builder createNewHttpClientBuilder()
+  {
+    ExecutorService executorService = new ThreadPoolExecutor(
+        config.getCoreWorkerThreads(),
+        config.getMaxWorkerThreads(),
+        config.getWorkerThreadKeepAliveTime(),
+        TimeUnit.SECONDS,
+        new LinkedBlockingQueue<>(),
+        Execs.makeThreadFactory("JdkHttpClient-%d")
+    );
+    return HttpClient.newBuilder().executor(executorService);
+  }
+
+  @Override
+  protected void additionalConfig(HttpClient.Builder builder)
+  {
+  }
+}

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/okhttp/DruidKubernetesOkHttpHttpClientConfig.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/okhttp/DruidKubernetesOkHttpHttpClientConfig.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.k8s.overlord.common.httpclient.okhttp;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.Min;
+
+public class DruidKubernetesOkHttpHttpClientConfig
+{
+  @JsonProperty
+  private boolean useCustomDispatcherExecutor = false;
+
+  @JsonProperty
+  @Nullable
+  private Integer maxWorkerThreads = null;
+
+  @JsonProperty
+  @Min(1)
+  private int coreWorkerThreads = 50;
+
+  @JsonProperty
+  private long workerThreadKeepAliveTime = 60L;
+
+  public boolean isUseCustomDispatcherExecutor()
+  {
+    return useCustomDispatcherExecutor;
+  }
+
+  public int getMaxWorkerThreads()
+  {
+    if (maxWorkerThreads == null || maxWorkerThreads < coreWorkerThreads) {
+      return coreWorkerThreads;
+    } else {
+      return maxWorkerThreads;
+    }
+  }
+
+  public int getCoreWorkerThreads()
+  {
+    return coreWorkerThreads;
+  }
+
+  public long getWorkerThreadKeepAliveTime()
+  {
+    return workerThreadKeepAliveTime;
+  }
+
+}

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/okhttp/DruidKubernetesOkHttpHttpClientFactory.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/okhttp/DruidKubernetesOkHttpHttpClientFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.k8s.overlord.common.httpclient.okhttp;
+
+import io.fabric8.kubernetes.client.okhttp.OkHttpClientFactory;
+import okhttp3.Dispatcher;
+import okhttp3.OkHttpClient;
+import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.k8s.overlord.common.httpclient.DruidKubernetesHttpClientFactory;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class DruidKubernetesOkHttpHttpClientFactory extends OkHttpClientFactory implements DruidKubernetesHttpClientFactory
+{
+  public static final String TYPE_NAME = "okhttp";
+  private final DruidKubernetesOkHttpHttpClientConfig config;
+
+  public DruidKubernetesOkHttpHttpClientFactory(DruidKubernetesOkHttpHttpClientConfig config)
+  {
+    super();
+    this.config = config;
+  }
+
+  @Override
+  protected void additionalConfig(OkHttpClient.Builder builder)
+  {
+    if (config.isUseCustomDispatcherExecutor()) {
+      ExecutorService executorService = new ThreadPoolExecutor(
+          config.getCoreWorkerThreads(),
+          config.getMaxWorkerThreads(),
+          config.getWorkerThreadKeepAliveTime(),
+          TimeUnit.SECONDS,
+          new LinkedBlockingQueue<>(),
+          Execs.makeThreadFactory("OkHttpHttpClient-%d")
+      );
+      Dispatcher dispatcher = new Dispatcher(executorService);
+      dispatcher.setMaxRequests(config.getMaxWorkerThreads());
+      dispatcher.setMaxRequestsPerHost(config.getMaxWorkerThreads());
+      builder.dispatcher(dispatcher);
+    }
+  }
+}

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/vertx/DruidKubernetesVertxHttpClientConfig.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/vertx/DruidKubernetesVertxHttpClientConfig.java
@@ -17,12 +17,12 @@
  * under the License.
  */
 
-package org.apache.druid.k8s.overlord.common;
+package org.apache.druid.k8s.overlord.common.httpclient.vertx;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.vertx.core.VertxOptions;
 
-public class DruidKubernetesHttpClientConfig
+public class DruidKubernetesVertxHttpClientConfig
 {
   @JsonProperty
   private int workerPoolSize = VertxOptions.DEFAULT_WORKER_POOL_SIZE;

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/vertx/DruidKubernetesVertxHttpClientFactory.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/vertx/DruidKubernetesVertxHttpClientFactory.java
@@ -17,30 +17,31 @@
  * under the License.
  */
 
-package org.apache.druid.k8s.overlord.common;
+package org.apache.druid.k8s.overlord.common.httpclient.vertx;
 
-import io.fabric8.kubernetes.client.http.HttpClient;
 import io.fabric8.kubernetes.client.vertx.VertxHttpClientBuilder;
 import io.fabric8.kubernetes.client.vertx.VertxHttpClientFactory;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.file.FileSystemOptions;
 import io.vertx.core.spi.resolver.ResolverProvider;
+import org.apache.druid.k8s.overlord.common.httpclient.DruidKubernetesHttpClientFactory;
 
 /**
  * Similar to {@link VertxHttpClientFactory} but allows us to override thread pool configurations.
  */
-public class DruidKubernetesHttpClientFactory implements HttpClient.Factory
+public class DruidKubernetesVertxHttpClientFactory implements DruidKubernetesHttpClientFactory
 {
+  public static final String TYPE_NAME = "vertx";
   private final Vertx vertx;
 
-  public DruidKubernetesHttpClientFactory(final DruidKubernetesHttpClientConfig httpClientConfig)
+  public DruidKubernetesVertxHttpClientFactory(final DruidKubernetesVertxHttpClientConfig httpClientConfig)
   {
     this.vertx = createVertxInstance(httpClientConfig);
   }
 
   @Override
-  public VertxHttpClientBuilder<DruidKubernetesHttpClientFactory> newBuilder()
+  public VertxHttpClientBuilder<DruidKubernetesVertxHttpClientFactory> newBuilder()
   {
     return new VertxHttpClientBuilder<>(this, vertx);
   }
@@ -49,7 +50,7 @@ public class DruidKubernetesHttpClientFactory implements HttpClient.Factory
    * Adapted from fabric8 kubernetes-client 7.1.0. We bring this here so we can customize thread pool sizes
    * and force usage of daemon threads.
    */
-  private static Vertx createVertxInstance(final DruidKubernetesHttpClientConfig httpClientConfig)
+  private static Vertx createVertxInstance(final DruidKubernetesVertxHttpClientConfig httpClientConfig)
   {
     // fabric8 disables the async DNS resolver while creating Vertx.
     // I'm not sure if we really need to do this, but I'm keeping it to align behavior with upstream.

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerFactoryTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerFactoryTest.java
@@ -26,8 +26,9 @@ import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.k8s.overlord.common.DruidKubernetesClient;
-import org.apache.druid.k8s.overlord.common.DruidKubernetesHttpClientConfig;
 import org.apache.druid.k8s.overlord.common.K8sTaskId;
+import org.apache.druid.k8s.overlord.common.httpclient.vertx.DruidKubernetesVertxHttpClientConfig;
+import org.apache.druid.k8s.overlord.common.httpclient.vertx.DruidKubernetesVertxHttpClientFactory;
 import org.apache.druid.k8s.overlord.taskadapter.TaskAdapter;
 import org.apache.druid.tasklogs.NoopTaskLogs;
 import org.apache.druid.tasklogs.TaskLogs;
@@ -57,7 +58,7 @@ public class KubernetesTaskRunnerFactoryTest
         .build();
     taskLogs = new NoopTaskLogs();
     druidKubernetesClient =
-        new DruidKubernetesClient(new DruidKubernetesHttpClientConfig(), new ConfigBuilder().build());
+        new DruidKubernetesClient(new DruidKubernetesVertxHttpClientFactory(new DruidKubernetesVertxHttpClientConfig()), new ConfigBuilder().build());
     taskAdapter = new TestTaskAdapter();
   }
 

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/httpclient/jdk/DruidKubernetesJdkHttpClientConfigTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/httpclient/jdk/DruidKubernetesJdkHttpClientConfigTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.k8s.overlord.common.httpclient.jdk;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class DruidKubernetesJdkHttpClientConfigTest
+{
+  private static final ObjectMapper OBJECT_MAPPER = new DefaultObjectMapper();
+
+  @Test
+  public void testSerdeWithDefaults() throws IOException
+  {
+    String json = "{}";
+    DruidKubernetesJdkHttpClientConfig config = OBJECT_MAPPER.readValue(
+        json,
+        DruidKubernetesJdkHttpClientConfig.class
+    );
+
+    Assert.assertEquals(50, config.getCoreWorkerThreads());
+    Assert.assertEquals(50, config.getMaxWorkerThreads());
+    Assert.assertEquals(60L, config.getWorkerThreadKeepAliveTime());
+
+    String serialized = OBJECT_MAPPER.writeValueAsString(config);
+    DruidKubernetesJdkHttpClientConfig deserialized = OBJECT_MAPPER.readValue(
+        serialized,
+        DruidKubernetesJdkHttpClientConfig.class
+    );
+
+    Assert.assertEquals(config.getCoreWorkerThreads(), deserialized.getCoreWorkerThreads());
+    Assert.assertEquals(config.getMaxWorkerThreads(), deserialized.getMaxWorkerThreads());
+    Assert.assertEquals(config.getWorkerThreadKeepAliveTime(), deserialized.getWorkerThreadKeepAliveTime());
+  }
+
+  @Test
+  public void testSerdeWithAllFieldsSet() throws IOException
+  {
+    String json = "{\n"
+                  + "  \"maxWorkerThreads\": 80,\n"
+                  + "  \"coreWorkerThreads\": 30,\n"
+                  + "  \"workerThreadKeepAliveTime\": 120\n"
+                  + "}";
+
+    DruidKubernetesJdkHttpClientConfig config = OBJECT_MAPPER.readValue(
+        json,
+        DruidKubernetesJdkHttpClientConfig.class
+    );
+
+    Assert.assertEquals(30, config.getCoreWorkerThreads());
+    Assert.assertEquals(80, config.getMaxWorkerThreads());
+    Assert.assertEquals(120L, config.getWorkerThreadKeepAliveTime());
+
+    String serialized = OBJECT_MAPPER.writeValueAsString(config);
+    DruidKubernetesJdkHttpClientConfig deserialized = OBJECT_MAPPER.readValue(
+        serialized,
+        DruidKubernetesJdkHttpClientConfig.class
+    );
+
+    Assert.assertEquals(config.getCoreWorkerThreads(), deserialized.getCoreWorkerThreads());
+    Assert.assertEquals(config.getMaxWorkerThreads(), deserialized.getMaxWorkerThreads());
+    Assert.assertEquals(config.getWorkerThreadKeepAliveTime(), deserialized.getWorkerThreadKeepAliveTime());
+  }
+
+  @Test
+  public void testSerdeWithNullMaxWorkerThreads() throws IOException
+  {
+    String json = "{\n"
+                  + "  \"maxWorkerThreads\": null,\n"
+                  + "  \"coreWorkerThreads\": 40,\n"
+                  + "  \"workerThreadKeepAliveTime\": 90\n"
+                  + "}";
+
+    DruidKubernetesJdkHttpClientConfig config = OBJECT_MAPPER.readValue(
+        json,
+        DruidKubernetesJdkHttpClientConfig.class
+    );
+
+    Assert.assertEquals(40, config.getCoreWorkerThreads());
+    Assert.assertEquals(40, config.getMaxWorkerThreads());
+    Assert.assertEquals(90L, config.getWorkerThreadKeepAliveTime());
+
+    String serialized = OBJECT_MAPPER.writeValueAsString(config);
+    DruidKubernetesJdkHttpClientConfig deserialized = OBJECT_MAPPER.readValue(
+        serialized,
+        DruidKubernetesJdkHttpClientConfig.class
+    );
+
+    Assert.assertEquals(config.getCoreWorkerThreads(), deserialized.getCoreWorkerThreads());
+    Assert.assertEquals(config.getMaxWorkerThreads(), deserialized.getMaxWorkerThreads());
+    Assert.assertEquals(config.getWorkerThreadKeepAliveTime(), deserialized.getWorkerThreadKeepAliveTime());
+  }
+
+  @Test
+  public void testMaxWorkerThreadsLogic()
+  {
+    DruidKubernetesJdkHttpClientConfig config = new DruidKubernetesJdkHttpClientConfig();
+
+    Assert.assertEquals(50, config.getMaxWorkerThreads());
+  }
+
+  @Test
+  public void testMaxWorkerThreadsGreaterThanCore() throws IOException
+  {
+    String json = "{\n"
+                  + "  \"maxWorkerThreads\": 100,\n"
+                  + "  \"coreWorkerThreads\": 30\n"
+                  + "}";
+
+    DruidKubernetesJdkHttpClientConfig config = OBJECT_MAPPER.readValue(
+        json,
+        DruidKubernetesJdkHttpClientConfig.class
+    );
+
+    Assert.assertEquals(30, config.getCoreWorkerThreads());
+    Assert.assertEquals(100, config.getMaxWorkerThreads());
+  }
+
+  @Test
+  public void testMaxWorkerThreadsLessThanCore() throws IOException
+  {
+    String json = "{\n"
+                  + "  \"maxWorkerThreads\": 20,\n"
+                  + "  \"coreWorkerThreads\": 30\n"
+                  + "}";
+
+    DruidKubernetesJdkHttpClientConfig config = OBJECT_MAPPER.readValue(
+        json,
+        DruidKubernetesJdkHttpClientConfig.class
+    );
+
+    Assert.assertEquals(30, config.getCoreWorkerThreads());
+    Assert.assertEquals(30, config.getMaxWorkerThreads());
+  }
+}

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/httpclient/okhttp/DruidKubernetesOkHttpHttpClientConfigTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/httpclient/okhttp/DruidKubernetesOkHttpHttpClientConfigTest.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.k8s.overlord.common.httpclient.okhttp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class DruidKubernetesOkHttpHttpClientConfigTest
+{
+  private static final ObjectMapper OBJECT_MAPPER = new DefaultObjectMapper();
+
+  @Test
+  public void testSerdeWithDefaults() throws IOException
+  {
+    String json = "{}";
+    DruidKubernetesOkHttpHttpClientConfig config = OBJECT_MAPPER.readValue(
+        json,
+        DruidKubernetesOkHttpHttpClientConfig.class
+    );
+
+    Assert.assertFalse(config.isUseCustomDispatcherExecutor());
+    Assert.assertEquals(50, config.getCoreWorkerThreads());
+    Assert.assertEquals(50, config.getMaxWorkerThreads());
+    Assert.assertEquals(60L, config.getWorkerThreadKeepAliveTime());
+
+    String serialized = OBJECT_MAPPER.writeValueAsString(config);
+    DruidKubernetesOkHttpHttpClientConfig deserialized = OBJECT_MAPPER.readValue(
+        serialized,
+        DruidKubernetesOkHttpHttpClientConfig.class
+    );
+
+    Assert.assertEquals(config.isUseCustomDispatcherExecutor(), deserialized.isUseCustomDispatcherExecutor());
+    Assert.assertEquals(config.getCoreWorkerThreads(), deserialized.getCoreWorkerThreads());
+    Assert.assertEquals(config.getMaxWorkerThreads(), deserialized.getMaxWorkerThreads());
+    Assert.assertEquals(config.getWorkerThreadKeepAliveTime(), deserialized.getWorkerThreadKeepAliveTime());
+  }
+
+  @Test
+  public void testSerdeWithAllFieldsSet() throws IOException
+  {
+    String json = "{\n"
+                  + "  \"useCustomDispatcherExecutor\": false,\n"
+                  + "  \"maxWorkerThreads\": 99,\n"
+                  + "  \"coreWorkerThreads\": 30,\n"
+                  + "  \"workerThreadKeepAliveTime\": 120\n"
+                  + "}";
+
+    DruidKubernetesOkHttpHttpClientConfig config = OBJECT_MAPPER.readValue(
+        json,
+        DruidKubernetesOkHttpHttpClientConfig.class
+    );
+
+    Assert.assertFalse(config.isUseCustomDispatcherExecutor());
+    Assert.assertEquals(30, config.getCoreWorkerThreads());
+    Assert.assertEquals(99, config.getMaxWorkerThreads());
+    Assert.assertEquals(120L, config.getWorkerThreadKeepAliveTime());
+
+    String serialized = OBJECT_MAPPER.writeValueAsString(config);
+    DruidKubernetesOkHttpHttpClientConfig deserialized = OBJECT_MAPPER.readValue(
+        serialized,
+        DruidKubernetesOkHttpHttpClientConfig.class
+    );
+
+    Assert.assertEquals(config.isUseCustomDispatcherExecutor(), deserialized.isUseCustomDispatcherExecutor());
+    Assert.assertEquals(config.getCoreWorkerThreads(), deserialized.getCoreWorkerThreads());
+    Assert.assertEquals(config.getMaxWorkerThreads(), deserialized.getMaxWorkerThreads());
+    Assert.assertEquals(config.getWorkerThreadKeepAliveTime(), deserialized.getWorkerThreadKeepAliveTime());
+  }
+
+  @Test
+  public void testSerdeWithNullMaxWorkerThreads() throws IOException
+  {
+    String json = "{\n"
+                  + "  \"useCustomDispatcherExecutor\": true,\n"
+                  + "  \"maxWorkerThreads\": null,\n"
+                  + "  \"coreWorkerThreads\": 40,\n"
+                  + "  \"workerThreadKeepAliveTime\": 90\n"
+                  + "}";
+
+    DruidKubernetesOkHttpHttpClientConfig config = OBJECT_MAPPER.readValue(
+        json,
+        DruidKubernetesOkHttpHttpClientConfig.class
+    );
+
+    Assert.assertTrue(config.isUseCustomDispatcherExecutor());
+    Assert.assertEquals(40, config.getCoreWorkerThreads());
+    Assert.assertEquals(40, config.getMaxWorkerThreads());
+    Assert.assertEquals(90L, config.getWorkerThreadKeepAliveTime());
+
+    String serialized = OBJECT_MAPPER.writeValueAsString(config);
+    DruidKubernetesOkHttpHttpClientConfig deserialized = OBJECT_MAPPER.readValue(
+        serialized,
+        DruidKubernetesOkHttpHttpClientConfig.class
+    );
+
+    Assert.assertEquals(config.isUseCustomDispatcherExecutor(), deserialized.isUseCustomDispatcherExecutor());
+    Assert.assertEquals(config.getCoreWorkerThreads(), deserialized.getCoreWorkerThreads());
+    Assert.assertEquals(config.getMaxWorkerThreads(), deserialized.getMaxWorkerThreads());
+    Assert.assertEquals(config.getWorkerThreadKeepAliveTime(), deserialized.getWorkerThreadKeepAliveTime());
+  }
+
+  @Test
+  public void testMaxWorkerThreadsLogic()
+  {
+    DruidKubernetesOkHttpHttpClientConfig config = new DruidKubernetesOkHttpHttpClientConfig();
+
+    Assert.assertEquals(50, config.getMaxWorkerThreads());
+  }
+
+  @Test
+  public void testMaxWorkerThreadsGreaterThanCore() throws IOException
+  {
+    String json = "{\n"
+                  + "  \"maxWorkerThreads\": 100,\n"
+                  + "  \"coreWorkerThreads\": 30\n"
+                  + "}";
+
+    DruidKubernetesOkHttpHttpClientConfig config = OBJECT_MAPPER.readValue(
+        json,
+        DruidKubernetesOkHttpHttpClientConfig.class
+    );
+
+    Assert.assertEquals(30, config.getCoreWorkerThreads());
+    Assert.assertEquals(100, config.getMaxWorkerThreads());
+  }
+
+  @Test
+  public void testMaxWorkerThreadsLessThanCore() throws IOException
+  {
+    String json = "{\n"
+                  + "  \"maxWorkerThreads\": 20,\n"
+                  + "  \"coreWorkerThreads\": 30\n"
+                  + "}";
+
+    DruidKubernetesOkHttpHttpClientConfig config = OBJECT_MAPPER.readValue(
+        json,
+        DruidKubernetesOkHttpHttpClientConfig.class
+    );
+
+    Assert.assertEquals(30, config.getCoreWorkerThreads());
+    Assert.assertEquals(30, config.getMaxWorkerThreads());
+  }
+}

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/DruidPeonClientIntegrationTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/DruidPeonClientIntegrationTest.java
@@ -35,7 +35,6 @@ import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexTuningConfig;
 import org.apache.druid.k8s.overlord.KubernetesTaskRunnerConfig;
 import org.apache.druid.k8s.overlord.common.DruidKubernetesClient;
-import org.apache.druid.k8s.overlord.common.DruidKubernetesHttpClientConfig;
 import org.apache.druid.k8s.overlord.common.JobResponse;
 import org.apache.druid.k8s.overlord.common.K8sTaskId;
 import org.apache.druid.k8s.overlord.common.K8sTestUtils;
@@ -43,6 +42,8 @@ import org.apache.druid.k8s.overlord.common.KubernetesClientApi;
 import org.apache.druid.k8s.overlord.common.KubernetesPeonClient;
 import org.apache.druid.k8s.overlord.common.PeonCommandContext;
 import org.apache.druid.k8s.overlord.common.PeonPhase;
+import org.apache.druid.k8s.overlord.common.httpclient.vertx.DruidKubernetesVertxHttpClientConfig;
+import org.apache.druid.k8s.overlord.common.httpclient.vertx.DruidKubernetesVertxHttpClientFactory;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.log.StartupLoggingConfig;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
@@ -87,7 +88,7 @@ public class DruidPeonClientIntegrationTest
         new NamedType(ParallelIndexTuningConfig.class, "index_parallel"),
         new NamedType(IndexTask.IndexTuningConfig.class, "index")
     );
-    k8sClient = new DruidKubernetesClient(new DruidKubernetesHttpClientConfig(), new ConfigBuilder().build());
+    k8sClient = new DruidKubernetesClient(new DruidKubernetesVertxHttpClientFactory(new DruidKubernetesVertxHttpClientConfig()), new ConfigBuilder().build());
     peonClient = new KubernetesPeonClient(k8sClient, "default", false, new NoopServiceEmitter());
     druidNode = new DruidNode(
         "test",

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -886,6 +886,8 @@ libraries:
   - io.fabric8: kubernetes-model-scheduling
   - io.fabric8: kubernetes-model-storageclass
   - io.fabric8: kubernetes-httpclient-vertx
+  - io.fabric8: kubernetes-httpclient-jdk
+  - io.fabric8: kubernetes-httpclient-okhttp
 ---
 
 name: vertx

--- a/website/.spelling
+++ b/website/.spelling
@@ -175,6 +175,7 @@ Kerberos
 KeyStores
 Kinesis
 Kubernetes
+KubernetesClient
 Lakehouse
 LDAPS
 LRU
@@ -343,6 +344,7 @@ endpointConfig
 enum
 expectedType
 expr
+fabric8
 failover
 failovers
 featureSpec
@@ -455,6 +457,7 @@ numerics
 numShards
 parameterize
 objectGlob
+okhttp
 parameterized
 parse_json
 parseable
@@ -624,6 +627,7 @@ vectorizeVirtualColumns
 versioned
 versioning
 virtualColumns
+vert.x
 w.r.t.
 walkthrough
 whitelist


### PR DESCRIPTION
Backport of #18540 to 35.0.0.