### PR TITLE
Disable centralized schema metadata query

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/schema/CentralizedSchemaMetadataQueryDisabledTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/schema/CentralizedSchemaMetadataQueryDisabledTest.java
@@ -23,6 +23,7 @@ import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
 import org.apache.druid.testing.embedded.compact.CompactionSparseColumnTest;
 import org.apache.druid.testing.embedded.compact.CompactionTaskTest;
 import org.apache.druid.testing.embedded.indexing.KafkaDataFormatsTest;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 
 /**
@@ -46,6 +47,7 @@ public class CentralizedSchemaMetadataQueryDisabledTest
   }
 
   @Nested
+  @Disabled("Disabled due to test crossing timeouts")
   public class CompactionSparseColumn extends CompactionSparseColumnTest
   {
     @Override
@@ -56,6 +58,7 @@ public class CentralizedSchemaMetadataQueryDisabledTest
   }
 
   @Nested
+  @Disabled("Disabled due to test crossing timeouts")
   public class CompactionTask extends CompactionTaskTest
   {
     @Override
@@ -66,6 +69,7 @@ public class CentralizedSchemaMetadataQueryDisabledTest
   }
 
   @Nested
+  @Disabled("Disabled due to test crossing timeouts")
   public class KafkaDataFormats extends KafkaDataFormatsTest
   {
     @Override


### PR DESCRIPTION
Disabling this test due to timeouts on PRs (example) -  https://github.com/apache/druid/actions/runs/18542849607/job/52854335085?pr=18553

A proper fix will be investigated and implemented later.
