### PR TITLE
Implement Interval toString optimisation

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/DefaultQueryMetricsBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/DefaultQueryMetricsBenchmark.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark.query;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.java.util.common.FastIntervalStringFormatter;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.java.util.emitter.core.NoopEmitter;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.query.DefaultQueryMetrics;
+import org.apache.druid.query.DruidMetrics;
+import org.apache.druid.query.Query;
+import org.apache.druid.query.aggregation.CountAggregatorFactory;
+import org.apache.druid.query.dimension.DefaultDimensionSpec;
+import org.apache.druid.query.groupby.GroupByQuery;
+import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
+import org.joda.time.Interval;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 15)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class DefaultQueryMetricsBenchmark
+{
+
+  private GroupByQuery query;
+  private ServiceEmitter emitter;
+
+  private DefaultQueryMetrics<Query<?>> baseline;
+  private DefaultQueryMetrics<Query<?>> withoutInterval;
+  private DefaultQueryMetrics<Query<?>> withCustomIntervalToString;
+
+  @Setup(Level.Trial)
+  public void setup()
+  {
+    ImmutableList<Interval> intervals = ImmutableList.of(
+        Intervals.of("2020-01-01/2020-01-08"),
+        Intervals.of("2020-01-15/2020-01-22")
+    );
+    query = GroupByQuery
+        .builder()
+        .setDataSource("ds")
+        .setQuerySegmentSpec(new MultipleIntervalSegmentSpec(intervals))
+        .setDimensions(new DefaultDimensionSpec("dim", null))
+        .setAggregatorSpecs(ImmutableList.of(new CountAggregatorFactory("cnt")))
+        .setGranularity(Granularities.ALL)
+        .build();
+
+    emitter = new ServiceEmitter("bench", "localhost", new NoopEmitter());
+
+    baseline = new DefaultQueryMetrics<Query<?>>()
+    {
+      @Override
+      public void interval(Query<?> q)
+      {
+        setDimension(DruidMetrics.INTERVAL, q.getIntervals().stream().map(Interval::toString).toArray(String[]::new));
+      }
+    };
+
+    withoutInterval = new DefaultQueryMetrics<Query<?>>()
+    {
+      @Override
+      public void interval(Query<?> q)
+      {
+        // Emit nothing
+      }
+    };
+
+    withCustomIntervalToString = new DefaultQueryMetrics<Query<?>>()
+    {
+      @Override
+      public void interval(Query<?> q)
+      {
+        setDimension(DruidMetrics.INTERVAL, q.getIntervals().stream().map(FastIntervalStringFormatter::format).toArray(String[]::new));
+      }
+    };
+  }
+
+  @Benchmark
+  public void baselineMetrics(Blackhole bh)
+  {
+    baseline.query(query);
+    baseline.reportQueryTime(1);
+    baseline.emit(emitter);
+    bh.consume(baseline);
+  }
+
+  @Benchmark
+  public void withoutIntervalDimension(Blackhole bh)
+  {
+    withoutInterval.query(query);
+    withoutInterval.reportQueryTime(1);
+    withoutInterval.emit(emitter);
+    bh.consume(withoutInterval);
+  }
+
+  @Benchmark
+  public void withCustomIntervalToStringDimension(Blackhole bh)
+  {
+    withCustomIntervalToString.query(query);
+    withCustomIntervalToString.reportQueryTime(1);
+    withCustomIntervalToString.emit(emitter);
+    bh.consume(withCustomIntervalToString);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/java/util/common/FastIntervalStringFormatter.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/FastIntervalStringFormatter.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.java.util.common;
+
+import org.joda.time.Interval;
+import org.joda.time.chrono.ISOChronology;
+
+import java.util.Objects;
+
+public final class FastIntervalStringFormatter
+{
+  private static final int MILLIS_PER_SECOND = 1000;
+  private static final int SECONDS_PER_MINUTE = 60;
+  private static final int MINUTES_PER_HOUR = 60;
+  private static final int HOURS_PER_DAY = 24;
+  private static final int SECONDS_PER_HOUR = SECONDS_PER_MINUTE * MINUTES_PER_HOUR;
+  private static final int SECONDS_PER_DAY = SECONDS_PER_HOUR * HOURS_PER_DAY;
+  private static final int MILLIS_PER_DAY = SECONDS_PER_DAY * MILLIS_PER_SECOND;
+  // Year starts with march. March has 31, April has 30 ....(31, 30, 31, 30, 31) = 153 days. After that, the pattern repeats.
+  private static final int DAYS_IN_FIVE_MONTHS = 153;
+  private static final int DAYS_IN_YEAR = 365;
+
+  private static final String ETERNITY_STRING = Intervals.ETERNITY.toString();
+
+  private static final int ERA = 5;
+  // 2000-03-01T00:00:00.000Z
+  private static final long ERA_START_MILLIS = 951868800000L;
+  // 2400-02-29T23:59:59.999Z
+  private static final long ERA_END_MILLIS = 13574649599999L;
+  // Used to shift to 0000-03-01
+  private static final int RESET_OFFSET = 719468;
+  private static final int DAYS_PER_ERA = 146097;
+  private static final int YEARS_PER_ERA = 400;
+  private static final int ERA_DAYS_OFFSET = ERA * DAYS_PER_ERA;
+  // Used to get our target year interval (2000-2400)
+  private static final int ERA_OFFSET = ERA * YEARS_PER_ERA;
+
+  /**
+   * Tries to use optimised format if the interval is within [2000-03-01T00:00:00.000Z, 2400-02-29T23:59:59.999Z].
+   * Will fall back to {@link Interval#toString()} if the interval is not within the range or not in UTC timezone.
+   *
+   * @param interval The interval to convert to a string.
+   * @return A string representation of the interval.
+   */
+  public static String format(Interval interval)
+  {
+    if (Intervals.isEternity(interval)) {
+      return ETERNITY_STRING;
+    }
+    if (!Objects.equals(interval.getChronology(), ISOChronology.getInstanceUTC()) || interval.getStartMillis() < ERA_START_MILLIS || interval.getEndMillis() > ERA_END_MILLIS) {
+      return interval.toString();
+    }
+    StringBuilder sb = new StringBuilder(49);
+    formatIntervalFromMillis(sb, interval.getStartMillis());
+    sb.append("/");
+    formatIntervalFromMillis(sb, interval.getEndMillis());
+    return sb.toString();
+  }
+
+  private static void formatIntervalFromMillis(StringBuilder sb, long millis)
+  {
+    formatDateFromMillis(sb, millis);
+    formatTimeFromMillis(sb, millis);
+  }
+
+  /**
+   * Uses a variation of <a href="https://howardhinnant.github.io/date_algorithms.html#civil_from_days">Howard Hinnant's civil_from_days algorithm</a>
+   * to convert the milliseconds since epoch to a string representation of the date.
+   * <p>
+   * <p>
+   * Assumptions/Variation:
+   *
+   * <ul>
+   * <li>We fix era to be 5 since we know the dates will be within [2000-03-01T00:00:00.000Z, 2400-02-29T23:59:59.999Z]</li>
+   * <li>We omit any negative dates checks.</li>
+   * </ul>
+   *
+   * <p>
+   * <p>
+   * An Era is a 400-year cycle. Dates repeat every 400 years. We shift the days to be since 0000-03-01 to simplify calculations.
+   * We then calculate the internal year, month, and day of the year and shift it back to a civil calendar date.
+   *
+   */
+  private static void formatDateFromMillis(StringBuilder sb, long millis)
+  {
+
+    final int daysSinceEpoch = (int) (millis / MILLIS_PER_DAY);
+    // Shift days to be since 0000-03-01
+    int z = daysSinceEpoch + RESET_OFFSET;
+    int dayOfEra = z - ERA_DAYS_OFFSET;
+    int yearOfEra = (dayOfEra - dayOfEra / 1460 + dayOfEra / 36524 - dayOfEra / 146096) / DAYS_IN_YEAR;
+    int year = (yearOfEra + ERA_OFFSET);
+    int dayOfYear = dayOfEra - (DAYS_IN_YEAR * yearOfEra + yearOfEra / 4 - yearOfEra / 100);
+    int mp = (5 * dayOfYear + 2) / DAYS_IN_FIVE_MONTHS;
+    int day = dayOfYear - (DAYS_IN_FIVE_MONTHS * mp + 2) / 5 + 1;
+    int month = mp + (mp < 10 ? 3 : -9);
+    year += (month <= 2) ? 1 : 0;
+    sb.append(year);
+    sb.append('-');
+    appendPadded(sb, month, false);
+    sb.append('-');
+    appendPadded(sb, day, false);
+  }
+
+  private static void formatTimeFromMillis(StringBuilder sb, long millis)
+  {
+    final int millisOfDay = (int) (millis % MILLIS_PER_DAY);
+
+    // Time within the day
+    int totalSeconds = millisOfDay / MILLIS_PER_SECOND;
+    int milli = millisOfDay % MILLIS_PER_SECOND;
+    int hour = totalSeconds / SECONDS_PER_HOUR;
+    totalSeconds -= hour * SECONDS_PER_HOUR;
+    int minute = totalSeconds / SECONDS_PER_MINUTE;
+    int second = totalSeconds - minute * SECONDS_PER_MINUTE;
+
+    sb.append('T');
+    appendPadded(sb, hour, false);
+    sb.append(':');
+    appendPadded(sb, minute, false);
+    sb.append(':');
+    appendPadded(sb, second, false);
+    sb.append('.');
+    appendPadded(sb, milli, true);
+    sb.append('Z');
+  }
+
+  /**
+   * Appends the value to the StringBuilder, padded with zeros to the left. Only supports length 2 or 3.
+   */
+  private static void appendPadded(StringBuilder sb, int value, boolean isWidth3)
+  {
+    if (value < 10) {
+      sb.append('0');
+    }
+    if (isWidth3 && value < 100) {
+      sb.append('0');
+    }
+    sb.append(value);
+  }
+
+  private FastIntervalStringFormatter()
+  {
+  }
+}

--- a/processing/src/main/java/org/apache/druid/query/DefaultQueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/DefaultQueryMetrics.java
@@ -22,6 +22,7 @@ package org.apache.druid.query;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import org.apache.druid.collections.bitmap.BitmapFactory;
+import org.apache.druid.java.util.common.FastIntervalStringFormatter;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
@@ -65,7 +66,8 @@ public class DefaultQueryMetrics<QueryType extends Query<?>> implements QueryMet
 
   public static String[] getIntervalsAsStringArray(Collection<Interval> intervals)
   {
-    return intervals.stream().map(Interval::toString).toArray(String[]::new);
+    return intervals.stream().map(FastIntervalStringFormatter::format).toArray(String[]::new);
+
   }
 
   protected void checkModifiedFromOwnerThread()

--- a/processing/src/test/java/org/apache/druid/java/util/common/FastIntervalStringFormatterTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/FastIntervalStringFormatterTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.java.util.common;
+
+import org.joda.time.Interval;
+import org.joda.time.chrono.ISOChronology;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class FastIntervalStringFormatterTest
+{
+  @Test
+  public void testStringFormatterFormat()
+  {
+    final Interval[] validIntervals = new Interval[]{
+        // Boundary values
+        Intervals.of("2000-03-01T00:00:00.000Z/2000-03-02T00:00:00.000Z"),
+        Intervals.of("2000-03-02T00:00:00.000Z/2000-03-03T00:00:00.000Z"),
+        Intervals.of("2400-02-27T00:00:00.000Z/2400-02-28T00:00:00.000Z"),
+        Intervals.of("2400-02-28T00:00:00.000Z/2400-02-29T00:00:00.000Z"),
+
+        // Random values
+        Intervals.of("2005-03-14T01:33:43.029Z/2005-04-17T12:34:56.789Z"),
+        Intervals.of("2021-03-14T01:33:43.029Z/2021-03-15T12:34:56.789Z"),
+        Intervals.of("2022-12-03T01:33:43.029Z/2022-12-04T00:00:00.000Z"),
+        Intervals.of("2044-03-14T05:26:45.499Z/2096-05-17T18:11:06.330Z"),
+        Intervals.of("2004-09-05T19:02:12.560Z/2023-12-15T20:46:55.109Z"),
+        Intervals.of("2079-01-25T23:04:55.554Z/2090-11-25T22:15:54.088Z"),
+        Intervals.of("2017-03-17T07:43:03.784Z/2082-11-18T08:34:39.805Z"),
+        Intervals.of("2065-08-17T09:11:31.589Z/2096-01-03T17:21:08.502Z"),
+        Intervals.of("2012-11-17T07:39:30.856Z/2070-06-25T14:35:44.060Z"),
+        Intervals.of("2013-02-17T15:22:08.427Z/2073-08-31T16:56:23.603Z"),
+        Intervals.of("2073-02-10T23:47:58.800Z/2099-03-11T19:08:38.458Z"),
+        Intervals.of("2035-08-09T12:33:43.951Z/2076-12-08T23:59:50.690Z"),
+        Intervals.of("2030-01-22T18:39:08.566Z/2092-02-15T02:40:52.702Z"),
+        };
+
+    for (Interval interval : validIntervals) {
+      Assert.assertEquals(interval.toString(), FastIntervalStringFormatter.format(interval));
+    }
+  }
+
+  @Test
+  public void testStringFormatterFormat_Eternity()
+  {
+    Assert.assertEquals(Intervals.ETERNITY.toString(), FastIntervalStringFormatter.format(Intervals.ETERNITY));
+  }
+
+  @Test
+  public void testStringFormatterFormat_FallbackValues()
+  {
+    Interval intervalMock = Mockito.mock(Interval.class);
+
+    Mockito.when(intervalMock.getChronology())
+           .thenReturn(ISOChronology.getInstance(DateTimes.inferTzFromString("Asia/Shanghai")));
+    Mockito.when(intervalMock.getStartMillis()).thenReturn(951868810000L); // Valid start
+    Mockito.when(intervalMock.getEndMillis()).thenReturn(951868820000L); // Valid end
+
+    String dummyString = "DUMMY_STRING";
+    Mockito.when(intervalMock.toString()).thenReturn(dummyString);
+
+    String out = FastIntervalStringFormatter.format(intervalMock);
+
+    Assert.assertEquals(dummyString, out);
+
+    final Interval[] fallbackIntervals = new Interval[]{
+        // Boundary values
+        Intervals.of("2000-02-28T00:00:00.000Z/2000-02-29T00:00:00.000Z"),
+        Intervals.of("2000-02-29T00:00:00.000Z/2000-03-01T00:00:00.000Z"),
+        Intervals.of("2400-02-29T00:00:00.000Z/2400-03-01T00:00:00.000Z"),
+        Intervals.of("2400-03-01T00:00:00.000Z/2400-03-02T00:00:00.000Z"),
+
+        // Random values
+        Intervals.of("1966-09-21T14:29:42.757Z/1999-09-18T16:59:47.466Z"),
+        Intervals.of("1985-04-16T03:03:37.833Z/2000-01-21T04:12:01.011Z"),
+        Intervals.of("1982-02-02T07:20:40.659Z/1990-06-01T09:58:13.053Z"),
+        Intervals.of("1954-11-07T14:38:33.857Z/1972-09-27T04:52:42.821Z"),
+        Intervals.of("1977-08-10T18:45:18.676Z/1983-05-13T07:00:59.266Z"),
+        Intervals.of("2429-02-19T08:27:26.173Z/2568-02-16T06:53:16.887Z"),
+        Intervals.of("2447-07-10T12:48:18.234Z/2489-08-24T01:22:00.056Z"),
+        };
+
+    for (Interval interval : fallbackIntervals) {
+      Assert.assertEquals(interval.toString(), FastIntervalStringFormatter.format(interval));
+    }
+  }
+}


### PR DESCRIPTION
This PR implements an optimisation for the Interval.toString method.

Based on the flame graph before optimisation, we can see that the toString method takes up a significant amount of the running time (~16%). After the optimisation, the optimised format method only accounts for ~4% of the running time.

We use the algorithm found [here](https://howardhinnant.github.io/date_algorithms.html#civil_from_days) in order to optimise the toString method. 

The implementation differs slightly as we know Druid's intervals. As such the following tweaks have been made:

- We fix era to be 5 since we know the dates will be within [2000-03-01T00:00:00.000Z, 2400-02-29T23:59:59.999Z]
- We omit any negative dates checks.

Any dates which do not fall within the era or doesn't have UTC timezone will use `Interval.toString()` as the fallback.

```
Benchmark                                                              Mode  Cnt  Score   Error  Units
DefaultQueryMetricsBenchmark.baselineMetrics                           avgt   40  1.207 ± 0.022  us/op
DefaultQueryMetricsBenchmark.withCustomIntervalToStringDimension       avgt   40  0.413 ± 0.010  us/op
```

Note: I do agree that the algorithm is difficult to understand and there are magic numbers still existing. I did my best to refactor most of the numbers to variables if they were constants and I've also tried to maintain the same structure as the algorithm provided in order to make it easier to understand. 

## Flame Graph before Optimisation
<img width="2830" height="1274" alt="image" src="https://github.com/user-attachments/assets/bd61ead5-8798-4624-bcf8-4dfed9e071a4" />

## Flame Graph after Optimisation
<img width="3000" height="1492" alt="image" src="https://github.com/user-attachments/assets/3470432b-cb4e-48a5-b8dc-af805495f49e" />

