### PR TITLE
Fix bug in basic authorizer auditing and add embedded test

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/auth/BasicAuthAuditTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/auth/BasicAuthAuditTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.testing.embedded.auth;
 
 import org.apache.druid.audit.AuditEntry;
+import org.apache.druid.audit.AuditManager;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.testing.embedded.EmbeddedBroker;
 import org.apache.druid.testing.embedded.EmbeddedCoordinator;
@@ -78,7 +79,11 @@ public class BasicAuthAuditTest extends EmbeddedClusterTestBase
     // Wait for all services to be synced
     Thread.sleep(100L);
 
-    final List<AuditEntry> entries = securityClient.getUpdateHistory();
+    final List<AuditEntry> entries = coordinator.bindings().getInstance(AuditManager.class).fetchAuditHistory(
+        "basic",
+        "basic.authorizer",
+        100
+    );
     Assertions.assertEquals(1, entries.size());
     Assertions.assertEquals(
         StringUtils.format("\"Create role[%s]\"", dataSource),

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/auth/SecurityClient.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/auth/SecurityClient.java
@@ -19,9 +19,7 @@
 
 package org.apache.druid.testing.embedded.auth;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.druid.audit.AuditEntry;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.rpc.RequestBuilder;
 import org.apache.druid.server.security.ResourceAction;
@@ -164,18 +162,6 @@ public class SecurityClient
         )
     );
     sendRequest(mapper -> request.jsonContent(mapper, permissions));
-  }
-
-  public List<AuditEntry> getUpdateHistory()
-  {
-    final RequestBuilder request = new RequestBuilder(
-        HttpMethod.GET,
-        StringUtils.format(
-            "%s/history",
-            AUTHORIZER_URL
-        )
-    );
-    return clients.onLeaderCoordinator(mapper -> request, new TypeReference<>() {});
   }
 
   private void sendRequest(Function<ObjectMapper, RequestBuilder> request)

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authorization/endpoint/BasicAuthorizerResource.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authorization/endpoint/BasicAuthorizerResource.java
@@ -24,7 +24,6 @@ import com.google.inject.Inject;
 import com.sun.jersey.spi.container.ResourceFilters;
 import org.apache.druid.audit.AuditEntry;
 import org.apache.druid.audit.AuditManager;
-import org.apache.druid.common.config.Configs;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.security.basic.BasicSecurityResourceFilter;
@@ -33,7 +32,6 @@ import org.apache.druid.server.security.AuthValidator;
 import org.apache.druid.server.security.AuthorizationUtils;
 import org.apache.druid.server.security.ResourceAction;
 
-import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -610,25 +608,6 @@ public class BasicAuthorizerResource
   {
     authValidator.validateAuthorizerName(authorizerName);
     return resourceHandler.getCachedGroupMappingMaps(authorizerName);
-  }
-
-  @GET
-  @Path("/db/{authorizerName}/history")
-  @Produces(MediaType.APPLICATION_JSON)
-  @ResourceFilters(BasicSecurityResourceFilter.class)
-  public Response getAuthorizerUpdateHistory(
-      @PathParam("authorizerName") String authorizerName,
-      @QueryParam("limit") @Nullable Integer limit
-  )
-  {
-    authValidator.validateAuthorizerName(authorizerName);
-    return Response.ok(
-        auditManager.fetchAuditHistory(
-            authorizerName,
-            "basic.authorizer",
-            Configs.valueOrDefault(limit, 100)
-        )
-    ).build();
   }
 
   /**


### PR DESCRIPTION
### Bug

#17916 introduced a bug where it creates audit log entries when a change made to authorizer roles and permissions are synced from the Coordinator to other services.
Audit logs should not be created in the `/listen` APIs and should be created only by the Coordinator.

### Fix

- Revert the changes made in #17916 
- Add embedded test to verify created audit entries

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.