### PR TITLE
Bump org.apache.commons:commons-lang3 from 3.18.0 to 3.19.0

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -667,13 +667,13 @@ name: Apache Commons Lang
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 3.18.0
+version: 3.19.0
 libraries:
   - org.apache.commons: commons-lang3
 notices:
   - commons-lang3: |
       Apache Commons Lang
-      Copyright 2001-2021 The Apache Software Foundation
+      Copyright 2001-2025 The Apache Software Foundation
 
       This product includes software developed at
       The Apache Software Foundation (https://www.apache.org/).

--- a/pom.xml
+++ b/pom.xml
@@ -345,7 +345,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.18.0</version>
+                <version>3.19.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Resurrects https://github.com/apache/druid/pull/18570 with updated license versions.