### PR TITLE
fix sql planner for json_value with returning boolean to plan as long type output

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/NestedDataOperatorConversions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/NestedDataOperatorConversions.java
@@ -312,15 +312,15 @@ public class NestedDataOperatorConversions
         }
 
         RelDataType sqlType = cx.getValidator().getValidatedNodeType(call);
+        final SqlTypeName sqlTypeName = sqlType.getSqlTypeName();
         SqlOperator jsonValueOperator;
-        if (SqlTypeName.INT_TYPES.contains(sqlType.getSqlTypeName())) {
+        if (SqlTypeName.INT_TYPES.contains(sqlTypeName) || SqlTypeName.BOOLEAN_TYPES.contains(sqlTypeName)) {
           jsonValueOperator = JsonValueBigintOperatorConversion.FUNCTION;
-        } else if (SqlTypeName.DECIMAL.equals(sqlType.getSqlTypeName()) ||
-                   SqlTypeName.APPROX_TYPES.contains(sqlType.getSqlTypeName())) {
+        } else if (SqlTypeName.DECIMAL.equals(sqlTypeName) || SqlTypeName.APPROX_TYPES.contains(sqlTypeName)) {
           jsonValueOperator = JsonValueDoubleOperatorConversion.FUNCTION;
-        } else if (SqlTypeName.STRING_TYPES.contains(sqlType.getSqlTypeName())) {
+        } else if (SqlTypeName.STRING_TYPES.contains(sqlTypeName)) {
           jsonValueOperator = JsonValueVarcharOperatorConversion.FUNCTION;
-        } else if (SqlTypeName.ARRAY.equals(sqlType.getSqlTypeName())) {
+        } else if (SqlTypeName.ARRAY.equals(sqlTypeName)) {
           ColumnType elementType = Calcites.getColumnTypeForRelDataType(sqlType.getComponentType());
           switch (elementType.getType()) {
             case LONG:


### PR DESCRIPTION
Without this change, this query in the planner falls into the 'json_value_any' part of the convertlet that does not set the expected native druid type. The added test would fail with a class cast exception as a string matcher was being used to handle a selector that was not returning strings (exploring a change for this as a separate branch).