### PR TITLE
Add missing druid-services dependency jetty-io

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -248,6 +248,10 @@
             <artifactId>jdbi</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-io</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.graalvm.js</groupId>
             <artifactId>js-scriptengine</artifactId>
             <scope>runtime</scope>
@@ -320,11 +324,6 @@
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-io</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
A dependency on jetty-io was introduced in druid-services with PR https://github.com/apache/druid/pull/18699. This change adds that to the services pom file.