### PR TITLE
fix flaky SegmentLocalCacheManagerConcurrencyTest

### DIFF
--- a/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerConcurrencyTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerConcurrencyTest.java
@@ -428,6 +428,7 @@ class SegmentLocalCacheManagerConcurrencyTest
     Assertions.assertEquals(0, location2.getActiveWeakHolds());
     Assertions.assertTrue(4 >= location.getWeakEntryCount());
     Assertions.assertTrue(4 >= location2.getWeakEntryCount());
+    // 5 because __drop path
     Assertions.assertTrue(5 >= location.getPath().listFiles().length);
     Assertions.assertTrue(5 >= location2.getPath().listFiles().length);
     Assertions.assertEquals(location.getStats().getEvictionCount(), location.getStats().getUnmountCount());


### PR DESCRIPTION
flaky caused by test not being updated in #18696 (the extra __drop directory can appear in the location)