### PR TITLE
Fixed: PostgreSQL 18+ no longer needs the data folder in the volume

### DIFF
--- a/distribution/docker/docker-compose.yml
+++ b/distribution/docker/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - metadata_data:/var/lib/postgresql/data
+      - metadata_data:/var/lib/postgresql
     environment:
       - POSTGRES_PASSWORD=FoolishPassword
       - POSTGRES_USER=druid


### PR DESCRIPTION
Change the PostgreSQL data volume path in docker-compose due to changes in PostgreSQL 18+.

### Description

In version 18+, PostgreSQL suggests a single mount at /var/lib/postgresql.  See also https://github.com/docker-library/postgres/pull/1259

#### Release note
Fixed: PostgreSQL 18+ no longer needs the data folder in the volume

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.