### PR TITLE
Support AWS InternalError code retries

### DIFF
--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
@@ -96,7 +96,8 @@ public class S3Utils
         // This can happen sometimes when AWS isn't able to obtain the credentials for some service:
         // https://github.com/aws/aws-sdk-java/issues/2285
         return true;
-      } else if (e instanceof AmazonS3Exception && e.getMessage().contains("InternalError")) {
+      } else if (e instanceof AmazonS3Exception && ((AmazonS3Exception) e).getStatusCode() == 200 &&
+                 (e.getMessage().contains("InternalError") || e.getMessage().contains("SlowDown"))) {
         // This can happen sometimes when AWS returns a 200 response with internal error message
         // https://repost.aws/knowledge-center/s3-resolve-200-internalerror
         return true;


### PR DESCRIPTION
Supports AWS S3's InternalError retries, for more information about the error, please refer - https://repost.aws/knowledge-center/s3-resolve-200-internalerror 

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.