### PR TITLE
Web console: defensive coding around dayjs

### DIFF
--- a/web-console/src/utils/date.ts
+++ b/web-console/src/utils/date.ts
@@ -106,5 +106,9 @@ export function formatDate(value: string) {
     LocalStorageKeys.WEB_CONSOLE_CONFIGS,
   );
   const showLocalTime = webConsoleConfig?.showLocalTime;
-  return showLocalTime ? dayjs(value).format(DATE_FORMAT) : dayjs(value).toISOString();
+  try {
+    return showLocalTime ? dayjs(value).format(DATE_FORMAT) : dayjs(value).toISOString();
+  } catch {
+    return value;
+  }
 }


### PR DESCRIPTION
This is a quick and dirty fix for a bug that is affecting me right now.

Segment view crashes if there are segments with 5 digit year start/end dates (far future data).

This bug was introduced in #18455. basically `dayjs(value).toISOString()` will throw if `value` is an unparsable date like (`12025-11-06T20:43:44.172Z`). So it needs to be wrapped in a try catch or some other check. In the task view this was coded more defensively:

<img width="651" height="381" alt="image" src="https://github.com/user-attachments/assets/c99ca07f-2a7a-4f56-8d82-1ca61cf5fb87" />

But in the segments view this will throw.
I made a quick and dirty fix that I verified works.

I am not utilizing `day.isValid()` in my fix because I believe there might be a way to achieve the functionality desired in #18455 without importing dayjs at all which would save an import. Will look into it after I can access the segment view in my cluster.

Also I want to look into wrapping the table of every view in a React error boundary