### PR TITLE
HttpRemoteTaskRunnerV2

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/hrtr/HttpRemoteTaskRunnerV2ScaleTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/hrtr/HttpRemoteTaskRunnerV2ScaleTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.testing.embedded.indexing.hrtr;
+
+import org.apache.druid.common.utils.IdUtils;
+import org.apache.druid.indexing.common.task.NoopTask;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.testing.embedded.EmbeddedBroker;
+import org.apache.druid.testing.embedded.EmbeddedCoordinator;
+import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
+import org.apache.druid.testing.embedded.EmbeddedHistorical;
+import org.apache.druid.testing.embedded.EmbeddedIndexer;
+import org.apache.druid.testing.embedded.EmbeddedOverlord;
+import org.apache.druid.testing.embedded.EmbeddedRouter;
+import org.apache.druid.testing.embedded.junit5.EmbeddedClusterTestBase;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * Scale test for HttpRemoteTaskRunnerV2 with large number of tasks with varying priorities and runtime durations.
+ */
+public class HttpRemoteTaskRunnerV2ScaleTest extends EmbeddedClusterTestBase
+{
+  private static final Logger log = new Logger(HttpRemoteTaskRunnerV2ScaleTest.class);
+  private static final int NUM_TASKS = 5_000;
+  private static final int NUM_WORKERS = 10;
+  private static final int WORKER_CAPACITY = 50;
+  private static final int TASK_RUN_TIME_MS = 100;
+
+  private final EmbeddedOverlord overlord = new EmbeddedOverlord()
+      .addProperty("druid.indexer.runner.type", "httpRemoteV2")
+      .addProperty("druid.indexer.runner.pendingTasksRunnerNumThreads", String.valueOf(Runtime.getRuntime().availableProcessors()));
+
+  private final EmbeddedIndexer[] indexers = new EmbeddedIndexer[NUM_WORKERS];
+
+  @Override
+  public EmbeddedDruidCluster createCluster()
+  {
+    for (int i = 0; i < NUM_WORKERS; i++) {
+      indexers[i] = new EmbeddedIndexer()
+          .addProperty("druid.worker.capacity", String.valueOf(WORKER_CAPACITY))
+          .addProperty("druid.segment.handoff.pollDuration", "PT0.1s")
+          .addProperty("druid.plaintextPort", String.valueOf(8100 + i));
+    }
+
+    EmbeddedDruidCluster cluster = EmbeddedDruidCluster.withEmbeddedDerbyAndZookeeper()
+                                                       .useLatchableEmitter()
+                                                       .useDefaultTimeoutForLatchableEmitter(240)
+                                                       .addServer(new EmbeddedCoordinator())
+                                                       .addServer(overlord);
+
+    for (EmbeddedIndexer indexer : indexers) {
+      cluster.addServer(indexer);
+    }
+
+    return cluster
+        .addServer(new EmbeddedHistorical())
+        .addServer(new EmbeddedBroker())
+        .addServer(new EmbeddedRouter());
+  }
+
+  @Test
+  public void test_scaleWithManyTasks()
+  {
+    log.info("Creating [%d] tasks...", NUM_TASKS);
+    List<NoopTask> tasks = createTasks(NUM_TASKS);
+
+    long startTime = System.currentTimeMillis();
+    List<String> taskIds = new ArrayList<>();
+    double totalTime = 0;
+    for (NoopTask task : tasks) {
+      String taskId = task.getId();
+      taskIds.add(taskId);
+      long t0 = System.nanoTime();
+      cluster.callApi().onLeaderOverlord(o -> o.runTask(taskId, task));
+      long t1 = System.nanoTime();
+      totalTime += t1 - t0;
+    }
+
+    int successCount = 0;
+    int failureCount = 0;
+    int reportInterval = NUM_TASKS / 10; // Report every 10%
+
+    log.info("Waiting for tasks to complete...");
+    for (int i = 0; i < taskIds.size(); i++) {
+      String taskId = taskIds.get(i);
+      try {
+        cluster.callApi().waitForTaskToSucceed(taskId, overlord);
+        ++successCount;
+        if ((i + 1) % reportInterval == 0) {
+          log.info("Progress: %d/%d tasks completed (%.1f%%)", i + 1, NUM_TASKS, ((i + 1) * 100.0) / NUM_TASKS);
+        }
+      }
+      catch (AssertionError e) {
+        ++failureCount;
+        log.error("Task %s failed: %s", taskId, e.getMessage());
+      }
+    }
+
+    long endTime = System.currentTimeMillis();
+    long durationMs = endTime - startTime;
+
+    double tasksPerSecond = (NUM_TASKS * 1000.0) / durationMs;
+    log.info("All tasks submitted in [%d] ms", System.currentTimeMillis() - startTime);
+    log.info("Avg task submission time: [%f] ns", totalTime / NUM_TASKS);
+    log.info(
+        "Task runner completed %d/%d tasks in %dms (%.2f tasks/sec)%n",
+        successCount,
+        NUM_TASKS,
+        durationMs,
+        tasksPerSecond
+    );
+
+    Assertions.assertEquals(NUM_TASKS, successCount, "All tasks should succeed");
+    Assertions.assertEquals(0, failureCount, "No tasks should fail");
+  }
+
+  private List<NoopTask> createTasks(int numTasks)
+  {
+    List<NoopTask> tasks = new ArrayList<>();
+    Random random = new Random(12345);
+
+    for (int i = 0; i < numTasks; i++) {
+      int priority = random.nextInt(101);
+      String taskId = IdUtils.getRandomIdWithPrefix(dataSource);
+
+      Map<String, Object> context = new HashMap<>();
+      context.put("priority", priority);
+      tasks.add(new NoopTask(taskId, null, dataSource, TASK_RUN_TIME_MS, 0, context));
+    }
+
+    return tasks;
+  }
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunnerV2.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunnerV2.java
@@ -1,0 +1,1971 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord.hrtr;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.base.Supplier;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListenableScheduledFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import org.apache.druid.concurrent.LifecycleLock;
+import org.apache.druid.discovery.DiscoveryDruidNode;
+import org.apache.druid.discovery.DruidNodeDiscovery;
+import org.apache.druid.discovery.DruidNodeDiscoveryProvider;
+import org.apache.druid.discovery.WorkerNodeService;
+import org.apache.druid.indexer.RunnerTaskState;
+import org.apache.druid.indexer.TaskLocation;
+import org.apache.druid.indexer.TaskState;
+import org.apache.druid.indexer.TaskStatus;
+import org.apache.druid.indexing.common.task.IndexTaskUtils;
+import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.indexing.overlord.ImmutableWorkerInfo;
+import org.apache.druid.indexing.overlord.RemoteTaskRunnerWorkItem;
+import org.apache.druid.indexing.overlord.TaskRunnerListener;
+import org.apache.druid.indexing.overlord.TaskRunnerUtils;
+import org.apache.druid.indexing.overlord.TaskRunnerWorkItem;
+import org.apache.druid.indexing.overlord.TaskStorage;
+import org.apache.druid.indexing.overlord.WorkerTaskRunner;
+import org.apache.druid.indexing.overlord.autoscaling.ProvisioningService;
+import org.apache.druid.indexing.overlord.autoscaling.ProvisioningStrategy;
+import org.apache.druid.indexing.overlord.autoscaling.ScalingStats;
+import org.apache.druid.indexing.overlord.config.HttpRemoteTaskRunnerConfig;
+import org.apache.druid.indexing.overlord.config.WorkerTaskRunnerConfig;
+import org.apache.druid.indexing.overlord.setup.DefaultWorkerBehaviorConfig;
+import org.apache.druid.indexing.overlord.setup.WorkerBehaviorConfig;
+import org.apache.druid.indexing.overlord.setup.WorkerSelectStrategy;
+import org.apache.druid.indexing.worker.TaskAnnouncement;
+import org.apache.druid.indexing.worker.Worker;
+import org.apache.druid.indexing.worker.config.WorkerConfig;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.Pair;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.java.util.common.concurrent.ScheduledExecutors;
+import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
+import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
+import org.apache.druid.java.util.emitter.EmittingLogger;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.apache.druid.java.util.http.client.HttpClient;
+import org.apache.druid.java.util.http.client.Request;
+import org.apache.druid.java.util.http.client.response.InputStreamResponseHandler;
+import org.apache.druid.query.DruidMetrics;
+import org.apache.druid.tasklogs.TaskLogStreamer;
+import org.jboss.netty.handler.codec.http.HttpMethod;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+import org.joda.time.Period;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+/**
+ * TODO: add a more descriptive title
+ */
+public class HttpRemoteTaskRunnerV2 implements WorkerTaskRunner, TaskLogStreamer, WorkerHolder.Listener
+{
+  private static final EmittingLogger log = new EmittingLogger(HttpRemoteTaskRunnerV2.class);
+
+  public static final String TASK_DISCOVERED_COUNT = "task/discovered/count";
+  private static final int FIND_WORKER_BACKOFF_DELAY_MILLIS = 10_000;
+  private static final int FIND_WORKER_BACKOFF_RETRIES = 4;
+
+  private final LifecycleLock lifecycleLock = new LifecycleLock();
+
+  // Executor for assigning pending tasks to workers.
+  private final ExecutorService pendingTasksExec;
+
+  // All known tasks, TaskID -> HttpRemoteTaskRunnerWorkItem
+  // This is a ConcurrentMap as some of the reads are done without holding the lock.
+  private final ConcurrentHashMap<String, HttpRemoteTaskRunnerWorkItem> tasks = new ConcurrentHashMap<>();
+
+  private final PriorityBlockingQueue<PendingTaskQueueItem> pendingTasks = new PriorityBlockingQueue<>();
+
+  // All discovered workers, "host:port" -> WorkerHolder
+  private final ConcurrentHashMap<String, WorkerHolder> workers = new ConcurrentHashMap<>();
+
+  // Executor for syncing state of each worker.
+  private final ScheduledExecutorService workersSyncExec;
+
+  // Internal worker state counters
+  private final AtomicLong blackListedWorkersCount = new AtomicLong(0);
+
+  // Executor to complete cleanup of workers which have disappeared.
+  private final ListeningScheduledExecutorService cleanupExec;
+  private final ConcurrentMap<String, ScheduledFuture> removedWorkerCleanups = new ConcurrentHashMap<>();
+
+  // Lock for synchronizing worker state transitions to minimize races between scheduling/accounting/adhoc worker routines
+  private final Object workerStateLock = new Object();
+  // Lock for waiting/notifying on task state transitions
+  private final Object taskStateLock = new Object();
+
+  // task runner listeners
+  private final CopyOnWriteArrayList<Pair<TaskRunnerListener, Executor>> listeners = new CopyOnWriteArrayList<>();
+
+  private final ProvisioningStrategy<WorkerTaskRunner> provisioningStrategy;
+  private ProvisioningService provisioningService;
+
+  private final DruidNodeDiscoveryProvider druidNodeDiscoveryProvider;
+  private final HttpClient httpClient;
+  private final ObjectMapper objectMapper;
+
+  private final Supplier<WorkerBehaviorConfig> workerConfigRef;
+  private final HttpRemoteTaskRunnerConfig config;
+
+  private final TaskStorage taskStorage;
+  private final ServiceEmitter emitter;
+
+  private volatile DruidNodeDiscovery.Listener nodeDiscoveryListener;
+
+  public HttpRemoteTaskRunnerV2(
+      ObjectMapper objectMapper,
+      HttpRemoteTaskRunnerConfig config,
+      HttpClient httpClient,
+      Supplier<WorkerBehaviorConfig> workerConfigRef,
+      ProvisioningStrategy<WorkerTaskRunner> provisioningStrategy,
+      DruidNodeDiscoveryProvider druidNodeDiscoveryProvider,
+      TaskStorage taskStorage,
+      ServiceEmitter emitter
+  )
+  {
+    this.objectMapper = objectMapper;
+    this.config = config;
+    this.httpClient = httpClient;
+    this.druidNodeDiscoveryProvider = druidNodeDiscoveryProvider;
+    this.taskStorage = taskStorage;
+    this.workerConfigRef = workerConfigRef;
+    this.emitter = emitter;
+
+    this.pendingTasksExec = Execs.multiThreaded(
+        config.getPendingTasksRunnerNumThreads(),
+        "hrtr-pending-tasks-runner-%d"
+    );
+
+    this.workersSyncExec = ScheduledExecutors.fixed(
+        config.getWorkerSyncNumThreads(),
+        "HttpRemoteTaskRunnerV2-worker-sync-%d"
+    );
+
+    this.cleanupExec = MoreExecutors.listeningDecorator(
+        ScheduledExecutors.fixed(1, "HttpRemoteTaskRunnerV2-Worker-Cleanup-%d")
+    );
+
+    this.provisioningStrategy = provisioningStrategy;
+  }
+
+  @Override
+  @LifecycleStart
+  public void start()
+  {
+    if (!lifecycleLock.canStart()) {
+      return;
+    }
+
+    try {
+      log.info("Starting...");
+
+      startWorkersHandling();
+
+      ScheduledExecutors.scheduleAtFixedRate(
+          cleanupExec,
+          Period.ZERO.toStandardDuration(),
+          config.getWorkerBlackListCleanupPeriod().toStandardDuration(),
+          this::checkAndRemoveWorkersFromBlackList
+      );
+
+      provisioningService = provisioningStrategy.makeProvisioningService(this);
+
+      scheduleSyncMonitoring();
+
+      startPendingTaskHandling();
+
+      lifecycleLock.started();
+
+      log.info("Started.");
+    }
+    catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    finally {
+      lifecycleLock.exitStart();
+    }
+  }
+
+  /**
+   * Must not be used outside of this class and {@link HttpRemoteTaskRunnerResource}
+   */
+  Map<String, ImmutableWorkerInfo> getWorkersEligibleToRunTasks()
+  {
+    return Maps.transformEntries(
+        Maps.filterEntries(
+            workers,
+            input -> input.getValue().getState() == WorkerHolder.State.READY &&
+                     input.getValue().isInitialized() &&
+                     input.getValue().isEnabled()
+        ),
+        (String key, WorkerHolder value) -> value.toImmutable()
+    );
+  }
+
+  @GuardedBy("workerStateLock")
+  private ImmutableWorkerInfo findWorkerToRunTask(Task task)
+  {
+    WorkerBehaviorConfig workerConfig = workerConfigRef.get();
+    WorkerSelectStrategy strategy;
+    if (workerConfig == null || workerConfig.getSelectStrategy() == null) {
+      strategy = WorkerBehaviorConfig.DEFAULT_STRATEGY;
+      log.debug("No worker selection strategy set. Using default of [%s]", strategy.getClass().getSimpleName());
+    } else {
+      strategy = workerConfig.getSelectStrategy();
+    }
+
+    return strategy.findWorkerForTask(
+        config,
+        ImmutableMap.copyOf(getWorkersEligibleToRunTasks()),
+        task
+    );
+  }
+
+  private boolean runTaskOnWorker(
+      final String taskId,
+      final String workerHost
+  ) throws InterruptedException
+  {
+    log.info("Assigning task[%s] to worker[%s]", taskId, workerHost);
+
+    final HttpRemoteTaskRunnerWorkItem workItem = tasks.get(taskId);
+    final WorkerHolder workerHolder = workers.get(workerHost);
+
+    Preconditions.checkState(workItem != null, "No task item found for task[%s]", taskId);
+
+    // Worker was removed, gracefully bail
+    if (workerHolder == null) {
+      log.warn("No worker found for host[%s]", workerHost);
+      return false;
+    }
+
+    Preconditions.checkState(
+        workerHolder.getState() == WorkerHolder.State.PENDING_ASSIGN,
+        "Found invalid state[%s] for worker[%s], expected state[%s]",
+        workerHolder.getState(),
+        workerHost,
+        WorkerHolder.State.PENDING_ASSIGN
+    );
+
+    if (workerHolder.assignTask(workItem.getTask())) {
+      // Don't assign new tasks until the task we just assigned is actually running
+      // on a worker - this avoids overflowing a worker with tasks
+      long waitMs = config.getTaskAssignmentTimeout().toStandardDuration().getMillis();
+      long waitStart = System.currentTimeMillis();
+      boolean isTaskAssignmentTimedOut = false;
+
+      final AtomicBoolean taskStartedOnWorker = new AtomicBoolean(false);
+      synchronized (taskStateLock) {
+        while (!taskStartedOnWorker.get()) {
+          tasks.compute(
+              taskId,
+              (key, taskEntry) -> {
+                if (taskEntry != null && taskEntry.isRunningOnWorker(workerHolder.getWorker())) {
+                  taskStartedOnWorker.set(true);
+                }
+                return taskEntry;
+              }
+          );
+
+          long remaining = waitMs - (System.currentTimeMillis() - waitStart);
+          if (remaining > 0) {
+            taskStateLock.wait(remaining);
+          } else {
+            isTaskAssignmentTimedOut = true;
+            break;
+          }
+        }
+      }
+
+      if (isTaskAssignmentTimedOut) {
+        log.makeAlert(
+            "Task assignment timed out on worker[%s], never ran task[%s] in timeout[%s]!",
+            workerHost,
+            taskId,
+            config.getTaskAssignmentTimeout()
+        ).emit();
+
+        throw new ISE(
+            "Task assignment timed out on worker[%s], never ran task[%s] in timeout[%s]! See overlord and middleManager/indexer logs for more details.",
+            workerHost,
+            taskId,
+            config.getTaskAssignmentTimeout()
+        );
+      }
+
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  // CAUTION: This method calls RemoteTaskRunnerWorkItem.setResult(..) which results in TaskQueue.notifyStatus() being called
+  // because that is attached by TaskQueue to task result future. So, this method must not be called with "statusLock"
+  // held. See https://github.com/apache/druid/issues/6201
+  private void taskComplete(
+      String taskId,
+      String workerHost,
+      TaskStatus taskStatus
+  )
+  {
+    Preconditions.checkState(!Thread.holdsLock(workerStateLock), "Current thread must not hold workerStateLock.");
+    Preconditions.checkState(!Thread.holdsLock(taskStateLock), "Current thread must not hold taskStateLock.");
+
+    AtomicBoolean taskCompleted = new AtomicBoolean(false);
+
+    tasks.compute(
+        taskId,
+        (key, taskEntry) -> {
+          Preconditions.checkState(taskEntry != null, "Expected task[%s] to exist", taskId);
+          if (taskEntry.getResult().isDone()) {
+            // This is not the first complete event.
+            try {
+              TaskState lastKnownState = taskEntry.getResult().get().getStatusCode();
+              if (taskStatus.getStatusCode() != lastKnownState) {
+                log.warn(
+                    "The state of the new task complete event is different from its last known state. "
+                    + "New state[%s], last known state[%s]",
+                    taskStatus.getStatusCode(),
+                    lastKnownState
+                );
+              }
+            }
+            catch (InterruptedException e) {
+              log.warn(e, "Interrupted while getting the last known task status.");
+              Thread.currentThread().interrupt();
+            }
+            catch (ExecutionException e) {
+              // This case should not really happen.
+              log.warn(e, "Failed to get the last known task status. Ignoring this failure.");
+            }
+          } else {
+            // Notify interested parties
+            taskEntry.setResult(taskStatus);
+            taskCompleted.set(true);
+          }
+
+          return taskEntry;
+        }
+    );
+
+    if (workerHost != null) {
+      synchronized (workerStateLock) {
+        workers.compute(
+            workerHost,
+            (key, workerHolder) -> {
+              if (workerHolder != null) {
+                log.info(
+                    "Worker[%s] completed task[%s] with status[%s]",
+                    workerHolder.getWorker().getHost(),
+                    taskStatus.getId(),
+                    taskStatus.getStatusCode()
+                );
+                // Worker is done with this task
+                workerHolder.setLastCompletedTaskTime(DateTimes.nowUtc());
+                blacklistWorkerIfNeeded(taskStatus, workerHolder);
+              } else {
+                log.warn("Could not find worker[%s]", workerHost);
+              }
+              return workerHolder;
+            }
+        );
+      }
+    }
+
+    // Notify listeners outside both tasks/workers critical sections to avoid deadlock
+    if (taskCompleted.get()) {
+      TaskRunnerUtils.notifyStatusChanged(listeners, taskStatus.getId(), taskStatus);
+    }
+
+    // Notify interested parties that a worker is potentially free and/or a task status updated
+    notifyWatchers();
+  }
+
+  private void startWorkersHandling() throws InterruptedException
+  {
+    final CountDownLatch workerViewInitialized = new CountDownLatch(1);
+    DruidNodeDiscovery druidNodeDiscovery =
+        druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY);
+    this.nodeDiscoveryListener = new DruidNodeDiscovery.Listener()
+    {
+      @Override
+      public void nodesAdded(Collection<DiscoveryDruidNode> nodes)
+      {
+        nodes.forEach(node -> addWorker(toWorker(node)));
+      }
+
+      @Override
+      public void nodesRemoved(Collection<DiscoveryDruidNode> nodes)
+      {
+        nodes.forEach(node -> removeWorker(toWorker(node)));
+      }
+
+      @Override
+      public void nodeViewInitialized()
+      {
+        //CountDownLatch.countDown() does nothing when count has already reached 0.
+        workerViewInitialized.countDown();
+      }
+
+      @Override
+      public void nodeViewInitializedTimedOut()
+      {
+        nodeViewInitialized();
+      }
+    };
+
+    druidNodeDiscovery.registerListener(nodeDiscoveryListener);
+
+    long workerDiscoveryStartTime = System.currentTimeMillis();
+    while (!workerViewInitialized.await(30, TimeUnit.SECONDS)) {
+      if (System.currentTimeMillis() - workerDiscoveryStartTime > TimeUnit.MINUTES.toMillis(5)) {
+        throw new ISE("Couldn't discover workers.");
+      } else {
+        log.info("Waiting for worker discovery...");
+      }
+    }
+    log.info("Discovered [%d] workers.", workers.size());
+
+    // Wait till all worker state is synced so that we know which worker is running/completed what tasks or else
+    // We would start assigning tasks which are pretty soon going to be reported by discovered workers.
+    workers.forEach((workerHost, workerEntry) -> {
+      try {
+        workerEntry.waitForInitialization();
+      }
+      catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    });
+    log.info("Workers have synced state successfully.");
+  }
+
+  private Worker toWorker(DiscoveryDruidNode node)
+  {
+    final WorkerNodeService workerNodeService = node.getService(
+        WorkerNodeService.DISCOVERY_SERVICE_KEY,
+        WorkerNodeService.class
+    );
+    if (workerNodeService == null) {
+      // this shouldn't typically happen, but just in case it does, make a dummy worker to allow the callbacks to
+      // continue since addWorker/removeWorker only need worker.getHost()
+      return new Worker(
+          node.getDruidNode().getServiceScheme(),
+          node.getDruidNode().getHostAndPortToUse(),
+          null,
+          0,
+          "",
+          WorkerConfig.DEFAULT_CATEGORY
+      );
+    }
+    return new Worker(
+        node.getDruidNode().getServiceScheme(),
+        node.getDruidNode().getHostAndPortToUse(),
+        workerNodeService.getIp(),
+        workerNodeService.getCapacity(),
+        workerNodeService.getVersion(),
+        workerNodeService.getCategory()
+    );
+  }
+
+  @VisibleForTesting
+  void addWorker(final Worker worker)
+  {
+    log.info("Adding worker[%s]", worker.getHost());
+    synchronized (workerStateLock) {
+      workers.compute(
+          worker.getHost(), (key, workerEntry) -> {
+            cancelWorkerCleanup(worker.getHost());
+
+            // There cannot be any new tasks assigned to this worker as the entry has not been published yet.
+            // That being said, there can be callbacks in taskAddedOrUpdated() where some task suddenly begins running
+            // on this worker. That method still blocks on this key lock, so it will occur strictly before/after this insertion.
+            if (workerEntry == null) {
+              log.info("Unrecognized worker[%s], rebuilding task mapping", worker.getHost());
+              final List<TaskAnnouncement> expectedAnnouncements = new ArrayList<>();
+              // It might be a worker that existed before, temporarily went away and came back. We might have a set of
+              // tasks that we think are running on this worker. Provide that information to WorkerHolder that
+              // manages the task syncing with that worker.
+              tasks.forEach((taskId, taskEntry) -> {
+                if (taskEntry.isRunningOnWorker(worker)) {
+                  // This announcement is only used to notify when a task has disappeared on the worker
+                  // So it is okay to set the dataSource and taskResource to null as they will not be used
+                  expectedAnnouncements.add(
+                      TaskAnnouncement.create(
+                          taskEntry.getTaskId(),
+                          taskEntry.getTaskType(),
+                          null,
+                          TaskStatus.running(taskEntry.getTaskId()),
+                          taskEntry.getLocation(),
+                          null
+                      )
+                  );
+                }
+              });
+
+              workerEntry = createWorkerHolder(
+                  objectMapper,
+                  httpClient,
+                  config,
+                  workersSyncExec,
+                  this,
+                  worker,
+                  expectedAnnouncements
+              );
+              workerEntry.start();
+            } else {
+              log.info("Worker[%s] already exists", worker.getHost());
+            }
+            return workerEntry;
+          }
+      );
+
+      // Notify any waiters that there is a new worker available
+      workerStateLock.notifyAll();
+    }
+  }
+
+  protected WorkerHolder createWorkerHolder(
+      ObjectMapper objectMapper,
+      HttpClient httpClient,
+      HttpRemoteTaskRunnerConfig config,
+      ScheduledExecutorService workersSyncExec,
+      WorkerHolder.Listener listener,
+      Worker worker,
+      List<TaskAnnouncement> knownAnnouncements
+  )
+  {
+    return new WorkerHolder(objectMapper, httpClient, config, workersSyncExec, listener, worker, knownAnnouncements);
+  }
+
+  @VisibleForTesting
+  void removeWorker(final Worker worker)
+  {
+    // Acquire workerLock to ensure atomicity between worker removal and competing scheduling routines
+    final WorkerHolder workerEntry;
+    synchronized (workerStateLock) {
+      workerEntry = workers.remove(worker.getHost());
+    }
+
+    // Perform the cleanup operations outside the lock to avoid excessive locking/deadlock
+    if (workerEntry != null) {
+      log.info("Removing worker[%s]", worker.getHost());
+      try {
+        workerEntry.stop();
+        scheduleTasksCleanupForWorker(worker.getHost());
+      }
+      catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    } else {
+      log.warn("Asked to remove a non-existent worker[%s]", worker.getHost());
+    }
+  }
+
+  private void cancelWorkerCleanup(String workerHost)
+  {
+    ScheduledFuture previousCleanup = removedWorkerCleanups.remove(workerHost);
+    if (previousCleanup != null) {
+      log.info("Cancelling worker[%s] scheduled task cleanup", workerHost);
+      previousCleanup.cancel(false);
+    }
+  }
+
+  private void scheduleTasksCleanupForWorker(final String workerHostAndPort)
+  {
+    cancelWorkerCleanup(workerHostAndPort);
+
+    final ListenableScheduledFuture<?> cleanupTask = cleanupExec.schedule(
+        () -> {
+          log.info("Running scheduled cleanup for worker[%s]", workerHostAndPort);
+          try {
+            final Set<HttpRemoteTaskRunnerWorkItem> tasksToFail = new HashSet<>();
+            tasks.forEach((taskId, taskEntry) -> {
+              if (taskEntry.getState().inProgress()) {
+                if (taskEntry.getWorker() != null && taskEntry.getWorker().getHost().equals(workerHostAndPort)) {
+                  tasksToFail.add(taskEntry);
+                }
+              }
+            });
+
+            for (HttpRemoteTaskRunnerWorkItem taskItem : tasksToFail) {
+              if (!taskItem.getResult().isDone()) {
+                log.warn(
+                    "Failing task[%s] because worker[%s] disappeared and did not report within cleanup timeout[%s]",
+                    taskItem.getTaskId(),
+                    workerHostAndPort,
+                    config.getTaskCleanupTimeout()
+                );
+                // taskComplete(..) must be called outside workerStatusLock, see comments on method.
+                taskComplete(
+                    taskItem.getTaskId(),
+                    null,
+                    TaskStatus.failure(
+                        taskItem.getTaskId(),
+                        StringUtils.format(
+                            "The worker that this task was assigned disappeared and "
+                            + "did not report cleanup within timeout[%s]. "
+                            + "See overlord and middleManager/indexer logs for more details.",
+                            config.getTaskCleanupTimeout()
+                        )
+                    )
+                );
+              }
+            }
+          }
+          catch (Exception e) {
+            log.makeAlert(e, "Exception while cleaning up worker[%s]", workerHostAndPort).emit();
+            throw new RuntimeException(e);
+          }
+        },
+        config.getTaskCleanupTimeout().toStandardDuration().getMillis(),
+        TimeUnit.MILLISECONDS
+    );
+
+    removedWorkerCleanups.put(workerHostAndPort, cleanupTask);
+
+    // Remove this entry from removedWorkerCleanups when done, if it's actually the one in there.
+    Futures.addCallback(
+        cleanupTask,
+        new FutureCallback<Object>()
+        {
+          @Override
+          public void onSuccess(Object result)
+          {
+            removedWorkerCleanups.remove(workerHostAndPort, cleanupTask);
+          }
+
+          @Override
+          public void onFailure(Throwable t)
+          {
+            removedWorkerCleanups.remove(workerHostAndPort, cleanupTask);
+          }
+        },
+        MoreExecutors.directExecutor()
+    );
+  }
+
+  private void scheduleSyncMonitoring()
+  {
+    workersSyncExec.scheduleAtFixedRate(
+        () -> {
+          log.debug("Running worker sync monitoring");
+
+          try {
+            syncMonitoring();
+          }
+          catch (Exception ex) {
+            log.makeAlert(ex, "Exception in worker sync monitoring").emit();
+          }
+        },
+        1,
+        5,
+        TimeUnit.MINUTES
+    );
+  }
+
+  @VisibleForTesting
+  void syncMonitoring()
+  {
+    // Ensure that the collection is not being modified during iteration. Iterate over a copy
+    final Set<Map.Entry<String, WorkerHolder>> workerEntrySet = ImmutableSet.copyOf(workers.entrySet());
+    for (Map.Entry<String, WorkerHolder> e : workerEntrySet) {
+      WorkerHolder workerHolder = e.getValue();
+      if (workerHolder.getUnderlyingSyncer().needsReset()) {
+        // TODO: do we want to make this remove/add atomic (e.g. acquire workerLock before)
+        if (workers.containsKey(e.getKey())) {
+          log.makeAlert(
+              "Worker[%s] is not syncing properly. Current state is [%s]. Resetting it.",
+              workerHolder.getWorker().getHost(),
+              workerHolder.getUnderlyingSyncer().getDebugInfo()
+          ).emit();
+          removeWorker(workerHolder.getWorker());
+          addWorker(workerHolder.getWorker());
+        }
+      }
+    }
+  }
+
+  /**
+   * This method returns the debugging information exposed by {@link HttpRemoteTaskRunnerResource} and meant
+   * for that use only. It must not be used for any other purpose.
+   */
+  Map<String, Object> getWorkerSyncerDebugInfo()
+  {
+    Preconditions.checkArgument(lifecycleLock.awaitStarted(1, TimeUnit.MILLISECONDS));
+
+    Map<String, Object> result = Maps.newHashMapWithExpectedSize(workers.size());
+    for (Map.Entry<String, WorkerHolder> e : ImmutableSet.copyOf(workers.entrySet())) {
+      WorkerHolder serverHolder = e.getValue();
+      result.put(
+          e.getKey(),
+          serverHolder.getUnderlyingSyncer().getDebugInfo()
+      );
+    }
+    return result;
+  }
+
+  private void checkAndRemoveWorkersFromBlackList()
+  {
+    final AtomicBoolean shouldRunPendingTasks = new AtomicBoolean(false);
+
+    synchronized (workerStateLock) {
+      for (final String workerHost : workers.keySet()) {
+        workers.computeIfPresent(
+            workerHost,
+            (workerHostKey, workerEntry) -> {
+              if (workerEntry.getState() == WorkerHolder.State.BLACKLISTED) {
+                if (shouldRemoveNodeFromBlackList(workerEntry)) {
+                  log.debug("Removing worker[%s] from blacklist", workerHost);
+                  workerEntry.resetContinuouslyFailedTasksCount();
+                  workerEntry.setBlacklistedUntil(null);
+                  workerEntry.setState(WorkerHolder.State.READY);
+                  shouldRunPendingTasks.set(true);
+                } else {
+                  log.debug("Skipping removal of worker[%s] from blacklist", workerHost);
+                }
+              }
+              return workerEntry;
+            }
+        );
+      }
+
+      if (shouldRunPendingTasks.get()) {
+        workerStateLock.notifyAll();
+      }
+    }
+  }
+
+  /**
+   * This method should be called under the corresponding worker key lock.
+   */
+  private boolean shouldRemoveNodeFromBlackList(WorkerHolder workerHolder)
+  {
+    if (blackListedWorkersCount.get() > workers.size() * (config.getMaxPercentageBlacklistWorkers() / 100.0)) {
+      log.info(
+          "Removing [%s] from blacklist because percentage of blacklisted workers exceeds [%d]",
+          workerHolder.getWorker(),
+          config.getMaxPercentageBlacklistWorkers()
+      );
+
+      return true;
+    }
+
+    DateTime blacklistedUntil = workerHolder.getBlacklistedUntil();
+    if (blacklistedUntil == null) {
+      // Blacklisted without an expiry time - should not happen, but remove from blacklist
+      log.warn("Worker[%s] is blacklisted but has no blacklistedUntil time set. Removing from blacklist.",
+               workerHolder.getWorker());
+      return true;
+    }
+
+    long remainingMillis = blacklistedUntil.getMillis() - System.currentTimeMillis();
+    if (remainingMillis <= 0) {
+      log.info("Removing [%s] from blacklist because backoff time elapsed", workerHolder.getWorker());
+      return true;
+    }
+
+    log.info("[%s] still blacklisted for [%,ds]", workerHolder.getWorker(), remainingMillis / 1000);
+    return false;
+  }
+
+  /**
+   * This method should be called under the corresponding worker key lock.
+   */
+  private void blacklistWorkerIfNeeded(TaskStatus taskStatus, WorkerHolder workerHolder)
+  {
+    if (taskStatus.isSuccess()) {
+      workerHolder.resetContinuouslyFailedTasksCount();
+      if (workerHolder.getState() == WorkerHolder.State.BLACKLISTED) {
+        workerHolder.setBlacklistedUntil(null);
+        workerHolder.setState(WorkerHolder.State.READY);
+        blackListedWorkersCount.decrementAndGet();
+        log.info(
+            "Worker[%s] removed from blacklist because task[%s] finished with SUCCESS",
+            workerHolder.getWorker(),
+            taskStatus.getId()
+        );
+      }
+    } else if (taskStatus.isFailure()) {
+      workerHolder.incrementContinuouslyFailedTasksCount();
+    }
+
+    if (workerHolder.getContinuouslyFailedTasksCount() > config.getMaxRetriesBeforeBlacklist() &&
+        blackListedWorkersCount.get() <= workers.size() * (config.getMaxPercentageBlacklistWorkers() / 100.0) - 1) {
+      // If worker is active, blacklist it
+      if (workerHolder.getState() == WorkerHolder.State.READY
+          || workerHolder.getState() == WorkerHolder.State.PENDING_ASSIGN) {
+        workerHolder.setBlacklistedUntil(DateTimes.nowUtc().plus(config.getWorkerBlackListBackoffTime()));
+        workerHolder.setState(WorkerHolder.State.BLACKLISTED);
+        blackListedWorkersCount.incrementAndGet();
+        log.info(
+            "Blacklisting worker[%s] until [%s] after [%,d] failed tasks in a row.",
+            workerHolder.getWorker(),
+            workerHolder.getBlacklistedUntil(),
+            workerHolder.getContinuouslyFailedTasksCount()
+        );
+      }
+    }
+  }
+
+  @Override
+  public Collection<ImmutableWorkerInfo> getWorkers()
+  {
+    return workers.values().stream().map(WorkerHolder::toImmutable).collect(Collectors.toList());
+  }
+
+  @Override
+  public Collection<Worker> getLazyWorkers()
+  {
+    // Want this synchronized with lazy-worker routine
+    synchronized (workerStateLock) {
+      return workers.values()
+                    .stream()
+                    .filter(w -> w.getState() == WorkerHolder.State.LAZY)
+                    .map(WorkerHolder::getWorker)
+                    .collect(Collectors.toList());
+    }
+  }
+
+  @Override
+  public Collection<Worker> markWorkersLazy(Predicate<ImmutableWorkerInfo> isLazyWorker, int maxLazyWorkers)
+  {
+    // Search for new workers to mark lazy.
+    // Status lock is used to prevent any tasks being assigned to workers while we mark them lazy
+    synchronized (workerStateLock) {
+      AtomicInteger numMarkedLazy = new AtomicInteger(getLazyWorkers().size());
+      workers.forEach((workerHostKey, workerHolder) -> {
+        if (numMarkedLazy.get() >= maxLazyWorkers) {
+          return;
+        }
+        try {
+          if (isWorkerOkForMarkingLazy(workerHolder) && isLazyWorker.apply(workerHolder.toImmutable())) {
+            log.info("Marking worker[%s] as lazy", workerHolder.getWorker().getHost());
+            workerHolder.setState(WorkerHolder.State.LAZY);
+            numMarkedLazy.incrementAndGet();
+          }
+        }
+        catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      });
+
+      log.info("Marked [%d] workers as lazy", numMarkedLazy.get());
+      return getLazyWorkers();
+    }
+  }
+
+  @GuardedBy("workerStateLock")
+  private boolean isWorkerOkForMarkingLazy(WorkerHolder workerHolder)
+  {
+    // Check that worker is not already lazy, and does not have any in-flight tasks being assigned to it.
+    if (workerHolder.getState() == WorkerHolder.State.LAZY
+        || workerHolder.getState() == WorkerHolder.State.PENDING_ASSIGN) {
+      log.debug(
+          "Skipping marking worker[%s] with incompatiable state[%s]",
+          workerHolder.getWorker().getHost(),
+          workerHolder.getState()
+      );
+      return false;
+    }
+
+    // Check that worker has no in-flight/running tasks associated with it
+    final AtomicBoolean inProgress = new AtomicBoolean(false);
+    tasks.forEach((taskId, taskEntry) -> {
+      if (taskEntry.getState().inProgress()) {
+        if (taskEntry.getWorker() != null && taskEntry.getWorker()
+                                                      .getHost()
+                                                      .equals(workerHolder.getWorker().getHost())) {
+          inProgress.set(true);
+        }
+      }
+    });
+    return !inProgress.get();
+  }
+
+  @Override
+  public WorkerTaskRunnerConfig getConfig()
+  {
+    return config;
+  }
+
+  @Override
+  public Collection<Task> getPendingTaskPayloads()
+  {
+    return tasks.values()
+                .stream()
+                .filter(item -> item.getState().isPending())
+                .map(HttpRemoteTaskRunnerWorkItem::getTask)
+                .collect(Collectors.toList());
+  }
+
+  @Override
+  public Optional<InputStream> streamTaskLog(String taskId, long offset) throws IOException
+  {
+    HttpRemoteTaskRunnerWorkItem taskRunnerWorkItem = tasks.get(taskId);
+    Worker worker = null;
+    if (taskRunnerWorkItem != null && taskRunnerWorkItem.getState() != HttpRemoteTaskRunnerWorkItem.State.COMPLETE) {
+      worker = taskRunnerWorkItem.getWorker();
+    }
+
+    if (worker == null || !workers.containsKey(worker.getHost())) {
+      // Worker is not running this task, it might be available in deep storage
+      return Optional.absent();
+    } else {
+      // Worker is still running this task
+      final URL url = TaskRunnerUtils.makeWorkerURL(
+          worker,
+          "/druid/worker/v1/task/%s/log?offset=%s",
+          taskId,
+          Long.toString(offset)
+      );
+
+      try {
+        return Optional.of(httpClient.go(
+            new Request(HttpMethod.GET, url),
+            new InputStreamResponseHandler()
+        ).get());
+      }
+      catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      catch (ExecutionException e) {
+        // Unwrap if possible
+        Throwables.propagateIfPossible(e.getCause(), IOException.class);
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  @Override
+  public Optional<InputStream> streamTaskReports(String taskId) throws IOException
+  {
+    HttpRemoteTaskRunnerWorkItem taskRunnerWorkItem = tasks.get(taskId);
+    Worker worker = null;
+    if (taskRunnerWorkItem != null && taskRunnerWorkItem.getState() != HttpRemoteTaskRunnerWorkItem.State.COMPLETE) {
+      worker = taskRunnerWorkItem.getWorker();
+    }
+
+    if (worker == null || !workers.containsKey(worker.getHost())) {
+      // Worker is not running this task, it might be available in deep storage
+      return Optional.absent();
+    } else {
+      // Worker is still running this task
+      TaskLocation taskLocation = taskRunnerWorkItem.getLocation();
+
+      if (TaskLocation.unknown().equals(taskLocation)) {
+        // No location known for this task. It may have not been assigned a location yet.
+        return Optional.absent();
+      }
+
+      final URL url = TaskRunnerUtils.makeTaskLocationURL(
+          taskLocation,
+          "/druid/worker/v1/chat/%s/liveReports",
+          taskId
+      );
+
+      try {
+        return Optional.of(httpClient.go(
+            new Request(HttpMethod.GET, url),
+            new InputStreamResponseHandler()
+        ).get());
+      }
+      catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      catch (ExecutionException e) {
+        // Unwrap if possible
+        Throwables.propagateIfPossible(e.getCause(), IOException.class);
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  @Override
+  public List<Pair<Task, ListenableFuture<TaskStatus>>> restore()
+  {
+    return ImmutableList.of();
+  }
+
+  @Override
+  public void registerListener(TaskRunnerListener listener, Executor executor)
+  {
+    for (Pair<TaskRunnerListener, Executor> pair : listeners) {
+      if (pair.lhs.getListenerId().equals(listener.getListenerId())) {
+        throw new ISE("Listener [%s] already registered", listener.getListenerId());
+      }
+    }
+
+    final Pair<TaskRunnerListener, Executor> listenerPair = Pair.of(listener, executor);
+
+    tasks.forEach((taskId, taskEntry) -> {
+      if (taskEntry.getState() == HttpRemoteTaskRunnerWorkItem.State.RUNNING) {
+        TaskRunnerUtils.notifyLocationChanged(
+            ImmutableList.of(listenerPair),
+            taskId,
+            taskEntry.getLocation()
+        );
+      }
+    });
+
+    log.info("Registered listener [%s]", listener.getListenerId());
+    listeners.add(listenerPair);
+  }
+
+  @Override
+  public void unregisterListener(String listenerId)
+  {
+    for (Pair<TaskRunnerListener, Executor> pair : listeners) {
+      if (pair.lhs.getListenerId().equals(listenerId)) {
+        listeners.remove(pair);
+        log.info("Unregistered listener [%s]", listenerId);
+        return;
+      }
+    }
+  }
+
+  @Override
+  public ListenableFuture<TaskStatus> run(Task task)
+  {
+    Preconditions.checkState(lifecycleLock.awaitStarted(1, TimeUnit.MILLISECONDS), "TaskRunner not started.");
+
+    AtomicReference<ListenableFuture<TaskStatus>> taskFuture = new AtomicReference<>();
+
+    log.info("Adding task[%s]", task.getId());
+
+    tasks.compute(
+        task.getId(), (id, entry) -> {
+          // Task already exists, but in case it was discovered from a worker on start()
+          // and TaskAnnouncement does not have Task instance, add it.
+          if (entry != null) {
+            if (entry.getTask() == null) {
+              entry.setTask(task);
+            }
+          } else {
+            entry = new HttpRemoteTaskRunnerWorkItem(
+                task.getId(),
+                null,
+                null,
+                task,
+                task.getType(),
+                HttpRemoteTaskRunnerWorkItem.State.PENDING
+            );
+            pendingTasks.offer(new PendingTaskQueueItem(task));
+          }
+
+          taskFuture.set(entry.getResult());
+          return entry;
+        }
+    );
+
+    return taskFuture.get();
+  }
+
+  private void startPendingTaskHandling()
+  {
+    for (int i = 0; i < config.getPendingTasksRunnerNumThreads(); i++) {
+      pendingTasksExec.submit(
+          () -> {
+            try {
+              if (!lifecycleLock.awaitStarted()) {
+                log.makeAlert("Lifecycle not started, PendingTaskExecution loop will not run.").emit();
+                return;
+              }
+
+              pendingTasksExecutionLoop();
+            }
+            catch (Throwable t) {
+              log.makeAlert(t, "Error while waiting for lifecycle start. PendingTaskExecution loop will not run")
+                 .emit();
+            }
+            finally {
+              log.info("PendingTaskExecution loop exited.");
+            }
+          }
+      );
+    }
+  }
+
+  @VisibleForTesting
+  void pendingTasksExecutionLoop()
+  {
+    while (!Thread.interrupted() && lifecycleLock.awaitStarted(1, TimeUnit.MILLISECONDS)) {
+      try {
+        final PendingTaskQueueItem taskItem = pendingTasks.poll(1, TimeUnit.MINUTES);
+        if (taskItem == null) {
+          log.info("Found no available tasks. Waiting for tasks to assign.");
+          continue;
+        }
+        final String taskId = taskItem.getTask().getId();
+
+        ImmutableWorkerInfo workerToAssign;
+        int workerFetchRetries = 0;
+
+        synchronized (workerStateLock) {
+          do {
+            workerToAssign = findWorkerToRunTask(taskItem.getTask());
+            if (workerToAssign == null) {
+              log.warn("No workers available to run task[%s]. Waiting", taskId);
+              workerStateLock.wait(FIND_WORKER_BACKOFF_DELAY_MILLIS); // yield the lock and wait a bit
+            }
+          } while (workerToAssign == null && workerFetchRetries++ < FIND_WORKER_BACKOFF_RETRIES);
+
+          // Exhausted worker assignment retries, let's backoff a bit
+          if (workerToAssign == null) {
+            log.warn("Failed to find workers available to run task[%s]. Sending to back of queue", taskId);
+            pendingTasks.put(taskItem.withFreshSequenceNumber());
+            continue;
+          }
+
+          // Mark this worker as unassignable while task is being assigned
+          workers.compute(
+              workerToAssign.getWorker().getHost(), (key, entry) -> {
+                Preconditions.checkState(
+                    entry != null,
+                    "Expected selected worker[%s] to be available",
+                    entry.getWorker().getHost()
+                );
+                Preconditions.checkState(
+                    entry.getState() == WorkerHolder.State.READY,
+                    "Expected worker[%s] state to be READY, got [%s]",
+                    entry.getWorker().getHost(),
+                    entry.getState()
+                );
+
+                entry.setState(WorkerHolder.State.PENDING_ASSIGN);
+                return entry;
+              }
+          );
+
+          // Mark this task as pending worker assign
+          tasks.compute(
+              taskId,
+              (key, entry) -> {
+                Preconditions.checkState(entry != null, "Expected task[%s] to be in tasks set", taskId);
+                Preconditions.checkState(
+                    entry.getState() == HttpRemoteTaskRunnerWorkItem.State.PENDING,
+                    "Expected task[%s] state to be PENDING, got state[%s]",
+                    taskId,
+                    entry.getState()
+                );
+
+                entry.setState(HttpRemoteTaskRunnerWorkItem.State.PENDING_WORKER_ASSIGN);
+                return entry;
+              }
+          );
+        }
+
+        final String workerHost = workerToAssign.getWorker().getHost();
+        try {
+          if (!runTaskOnWorker(taskId, workerHost)) {
+            log.warn("Failed to assign task[%s] to worker[%s]. Sending to back of queue", taskId, workerHost);
+            pendingTasks.put(taskItem.withFreshSequenceNumber());
+          } else {
+            log.info("Assigned task[%s] to worker[%s]", taskId, workerHost);
+          }
+        }
+        catch (InterruptedException ex) {
+          log.info("Got InterruptedException while assigning task[%s].", taskId);
+          throw ex;
+        }
+        catch (Throwable th) {
+          log.makeAlert(th, "Exception while trying to assign task")
+             .addData("taskId", taskId)
+             .emit();
+
+          // taskComplete(..) must be called outside workerStatusLock, see comments on method.
+          taskComplete(
+              taskId,
+              null,
+              TaskStatus.failure(
+                  taskId,
+                  StringUtils.format(
+                      "Failed to assign this task to worker[%s]. See overlord logs for more details.",
+                      workerHost
+                  )
+              )
+          );
+        }
+        finally {
+          // Allow the worker to accept tasks again
+          synchronized (workerStateLock) {
+            workers.compute(
+                workerHost,
+                (key, entry) -> {
+                  if (entry == null) {
+                    log.warn("Could not find worker[%s]", workerHost);
+                  } else {
+                    // Only reset the worker status if PENDING_ASSIGN
+                    // If LAZY/BLACKLISTED, either the worker is getting trashed eminently or will be auto-reset.
+                    entry.compareAndExchangeState(WorkerHolder.State.PENDING_ASSIGN, WorkerHolder.State.READY);
+                  }
+                  return entry;
+                }
+            );
+          }
+
+          notifyWatchers();
+        }
+      }
+      catch (InterruptedException e) {
+        log.warn("Interrupted, stopping pending task execution loop.");
+        Thread.currentThread().interrupt();
+      }
+      catch (Throwable th) {
+        log.makeAlert(th, "Unknown Exception while trying to assign tasks.").emit();
+      }
+    }
+
+    log.warn("Pending tasks execution loop exited");
+  }
+
+  @Override
+  public void shutdown(String taskId, String reason)
+  {
+    log.info("Shutdown task[%s] because [%s]", taskId, reason);
+
+    AtomicReference<WorkerHolder> workerHolderRunningTaskRef = new AtomicReference<>();
+    final AtomicBoolean wasComplete = new AtomicBoolean(false);
+    tasks.compute(
+        taskId,
+        (key, entry) -> {
+          if (entry != null) {
+            if (entry.getState() == HttpRemoteTaskRunnerWorkItem.State.RUNNING) {
+              workerHolderRunningTaskRef.set(workers.get(entry.getWorker().getHost()));
+            } else if (entry.getState() == HttpRemoteTaskRunnerWorkItem.State.COMPLETE) {
+              wasComplete.set(true);
+              entry = null; // delete the entry
+            }
+          } else {
+            log.debug("Asked to shutdown task[%s], but task not found. Already cleaned up.", taskId);
+          }
+          return entry;
+        }
+    );
+
+    if (workerHolderRunningTaskRef.get() != null) {
+      log.debug(
+          "Got shutdown request for task[%s]. Asking worker[%s] to kill it.",
+          taskId,
+          workerHolderRunningTaskRef.get().getWorker().getHost()
+      );
+      workerHolderRunningTaskRef.get().shutdownTask(taskId);
+    } else if (wasComplete.get()) {
+      log.debug("Task[%s] already completed, no shutdown needed.", taskId);
+    } else {
+      log.debug("Task[%s] not found or not running, no shutdown needed.", taskId);
+    }
+  }
+
+  @Override
+  @LifecycleStop
+  public void stop()
+  {
+    if (!lifecycleLock.canStop()) {
+      throw new ISE("can't stop.");
+    }
+
+    try {
+      log.info("Stopping...");
+
+      if (provisioningService != null) {
+        provisioningService.close();
+      }
+      pendingTasksExec.shutdownNow();
+      workersSyncExec.shutdownNow();
+      cleanupExec.shutdown();
+
+      log.info("Removing listener");
+      DruidNodeDiscovery druidNodeDiscovery =
+          druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY);
+      druidNodeDiscovery.removeListener(nodeDiscoveryListener);
+
+      log.info("Stopping worker holders");
+      workers.forEach((workerHost, workerHolder) -> {
+        try {
+          workerHolder.stop();
+        }
+        catch (Exception e) {
+          log.error(e, e.getMessage());
+        }
+      });
+    }
+    finally {
+      lifecycleLock.exitStop();
+    }
+
+    log.info("Stopped.");
+  }
+
+  @Override
+  public Collection<? extends TaskRunnerWorkItem> getRunningTasks()
+  {
+    return tasks.values()
+                .stream()
+                .filter(item -> item.getState() == HttpRemoteTaskRunnerWorkItem.State.RUNNING)
+                .collect(Collectors.toList());
+  }
+
+  @Override
+  public Collection<? extends TaskRunnerWorkItem> getPendingTasks()
+  {
+    return tasks.values()
+                .stream()
+                .filter(item -> item.getState().isPending())
+                .collect(Collectors.toList());
+  }
+
+  @Override
+  public Collection<? extends TaskRunnerWorkItem> getKnownTasks()
+  {
+    return ImmutableList.copyOf(tasks.values());
+  }
+
+  public Collection<? extends TaskRunnerWorkItem> getCompletedTasks()
+  {
+    return tasks.values()
+                .stream()
+                .filter(item -> item.getState() == HttpRemoteTaskRunnerWorkItem.State.COMPLETE)
+                .collect(Collectors.toList());
+  }
+
+  @Nullable
+  @Override
+  public RunnerTaskState getRunnerTaskState(String taskId)
+  {
+    final HttpRemoteTaskRunnerWorkItem workItem = tasks.get(taskId);
+    if (workItem == null) {
+      return null;
+    } else {
+      return workItem.getState().toRunnerTaskState();
+    }
+  }
+
+  @Override
+  public TaskLocation getTaskLocation(String taskId)
+  {
+    final HttpRemoteTaskRunnerWorkItem workItem = tasks.get(taskId);
+    if (workItem == null) {
+      return TaskLocation.unknown();
+    } else {
+      return workItem.getLocation();
+    }
+  }
+
+  public Collection<ImmutableWorkerInfo> getBlackListedWorkers()
+  {
+    return workers.values()
+                  .stream()
+                  .filter(w -> w.getState() == WorkerHolder.State.BLACKLISTED)
+                  .map(WorkerHolder::toImmutable)
+                  .collect(Collectors.toList());
+  }
+
+  @Override
+  public Optional<ScalingStats> getScalingStats()
+  {
+    return Optional.fromNullable(provisioningService.getStats());
+  }
+
+  @Override
+  public void taskAddedOrUpdated(final TaskAnnouncement announcement, final WorkerHolder workerHolder)
+  {
+    final String taskId = announcement.getTaskId();
+    final Worker worker = workerHolder.getWorker();
+
+    log.debug(
+        "Worker[%s] wrote status[%s] for task[%s] on [%s]",
+        worker.getHost(),
+        announcement.getTaskStatus().getStatusCode(),
+        taskId,
+        announcement.getTaskLocation()
+    );
+
+    final AtomicBoolean shouldShutdownTask = new AtomicBoolean(false);
+    final AtomicBoolean isTaskCompleted = new AtomicBoolean(false);
+
+    tasks.compute(
+        taskId,
+        (key, taskEntry) -> {
+          if (taskEntry == null) {
+            // Try to find information about it in the TaskStorage
+            Optional<TaskStatus> knownStatusInStorage = taskStorage.getStatus(taskId);
+
+            if (knownStatusInStorage.isPresent()) {
+              switch (knownStatusInStorage.get().getStatusCode()) {
+                case RUNNING:
+                  taskEntry = new HttpRemoteTaskRunnerWorkItem(
+                      taskId,
+                      worker,
+                      TaskLocation.unknown(),
+                      null,
+                      announcement.getTaskType(),
+                      HttpRemoteTaskRunnerWorkItem.State.RUNNING
+                  );
+                  final ServiceMetricEvent.Builder metricBuilder = new ServiceMetricEvent.Builder();
+                  metricBuilder.setDimension(DruidMetrics.TASK_ID, taskId);
+                  emitter.emit(metricBuilder.setMetric(TASK_DISCOVERED_COUNT, 1L));
+                  break;
+                case SUCCESS:
+                case FAILED:
+                  if (!announcement.getTaskStatus().isComplete()) {
+                    log.info(
+                        "Worker[%s] reported status for completed, known from taskStorage, task[%s]. Ignored.",
+                        worker.getHost(),
+                        taskId
+                    );
+                  }
+                  break;
+                default:
+                  log.makeAlert(
+                      "Found unrecognized state[%s] of task[%s] in taskStorage. Notification[%s] from worker[%s] is ignored.",
+                      knownStatusInStorage.get().getStatusCode(),
+                      taskId,
+                      announcement,
+                      worker.getHost()
+                  ).emit();
+              }
+            } else {
+              log.warn(
+                  "Worker[%s] reported status[%s] for unknown task[%s]. Ignored.",
+                  worker.getHost(),
+                  announcement.getStatus(),
+                  taskId
+              );
+            }
+          }
+
+          if (taskEntry == null) {
+            if (!announcement.getTaskStatus().isComplete()) {
+              shouldShutdownTask.set(true);
+            }
+          } else {
+            switch (announcement.getTaskStatus().getStatusCode()) {
+              case RUNNING:
+                switch (taskEntry.getState()) {
+                  case PENDING:
+                  case PENDING_WORKER_ASSIGN:
+                    taskEntry.setWorker(worker);
+                    taskEntry.setState(HttpRemoteTaskRunnerWorkItem.State.RUNNING);
+                    log.info("Task[%s] started RUNNING on worker[%s].", taskId, worker.getHost());
+
+                    final ServiceMetricEvent.Builder metricBuilder = new ServiceMetricEvent.Builder();
+                    IndexTaskUtils.setTaskDimensions(metricBuilder, taskEntry.getTask());
+                    emitter.emit(metricBuilder.setMetric(
+                                     "task/pending/time",
+                                     new Duration(taskEntry.getCreatedTime(), DateTimes.nowUtc()).getMillis()
+                                 )
+                    );
+
+                    // fall through
+                  case RUNNING:
+                    if (worker.getHost().equals(taskEntry.getWorker().getHost())) {
+                      if (!announcement.getTaskLocation().equals(taskEntry.getLocation())) {
+                        log.info(
+                            "Task[%s] location changed on worker[%s]. new location[%s].",
+                            taskId,
+                            worker.getHost(),
+                            announcement.getTaskLocation()
+                        );
+                        taskEntry.setLocation(announcement.getTaskLocation());
+                        TaskRunnerUtils.notifyLocationChanged(listeners, taskId, announcement.getTaskLocation());
+                      }
+                    } else {
+                      log.warn(
+                          "Found worker[%s] running task[%s] which is being run by another worker[%s]. Notification ignored.",
+                          worker.getHost(),
+                          taskId,
+                          taskEntry.getWorker().getHost()
+                      );
+                      shouldShutdownTask.set(true);
+                    }
+                    break;
+                  case COMPLETE:
+                    log.warn(
+                        "Worker[%s] reported status for completed task[%s]. Ignored.",
+                        worker.getHost(),
+                        taskId
+                    );
+                    shouldShutdownTask.set(true);
+                    break;
+                  default:
+                    log.makeAlert(
+                        "Found unrecognized state[%s] of task[%s]. Notification[%s] from worker[%s] is ignored.",
+                        taskEntry.getState(),
+                        taskId,
+                        announcement,
+                        worker.getHost()
+                    ).emit();
+                }
+                break;
+              case FAILED:
+              case SUCCESS:
+                switch (taskEntry.getState()) {
+                  case PENDING:
+                  case PENDING_WORKER_ASSIGN:
+                    taskEntry.setWorker(worker);
+                    taskEntry.setState(HttpRemoteTaskRunnerWorkItem.State.RUNNING);
+                    log.info("Task[%s] finished on worker[%s].", taskId, worker.getHost());
+                    // fall through
+                  case RUNNING:
+                    if (worker.getHost().equals(taskEntry.getWorker().getHost())) {
+                      if (!announcement.getTaskLocation().equals(taskEntry.getLocation())) {
+                        log.info(
+                            "Task[%s] location changed on worker[%s]. new location[%s].",
+                            taskId,
+                            worker.getHost(),
+                            announcement.getTaskLocation()
+                        );
+                        taskEntry.setLocation(announcement.getTaskLocation());
+                        TaskRunnerUtils.notifyLocationChanged(listeners, taskId, announcement.getTaskLocation());
+                      }
+
+                      isTaskCompleted.set(true);
+                    } else {
+                      log.warn(
+                          "Worker[%s] reported completed task[%s] which is being run by another worker[%s]. Notification ignored.",
+                          worker.getHost(),
+                          taskId,
+                          taskEntry.getWorker().getHost()
+                      );
+                    }
+                    break;
+                  case COMPLETE:
+                    // this can happen when a worker is restarted and reports its list of completed tasks again.
+                    break;
+                  default:
+                    log.makeAlert(
+                        "Found unrecognized state[%s] of task[%s]. Notification[%s] from worker[%s] is ignored.",
+                        taskEntry.getState(),
+                        taskId,
+                        announcement,
+                        worker.getHost()
+                    ).emit();
+                }
+                break;
+              default:
+                log.makeAlert(
+                    "Worker[%s] reported unrecognized state[%s] for task[%s].",
+                    worker.getHost(),
+                    announcement.getTaskStatus().getStatusCode(),
+                    taskId
+                ).emit();
+            }
+          }
+          return taskEntry;
+        }
+    );
+
+    if (isTaskCompleted.get()) {
+      // taskComplete(..) must be called outside statusLock, see comments on method.
+      taskComplete(taskId, worker.getHost(), announcement.getTaskStatus());
+    }
+
+    if (shouldShutdownTask.get()) {
+      log.warn("Killing task[%s] on worker[%s]", taskId, worker.getHost());
+      workerHolder.shutdownTask(taskId);
+    }
+
+    // Notify interested parties
+    notifyWatchers();
+  }
+
+  @Override
+  public void stateChanged(boolean enabled, WorkerHolder workerHolder)
+  {
+    notifyWatchers();
+  }
+
+  private void notifyWatchers()
+  {
+    synchronized (workerStateLock) {
+      workerStateLock.notifyAll();
+    }
+    synchronized (taskStateLock) {
+      taskStateLock.notifyAll();
+    }
+  }
+
+  @Override
+  public Map<String, Long> getTotalTaskSlotCount()
+  {
+    Map<String, Long> totalPeons = new HashMap<>();
+    for (ImmutableWorkerInfo worker : getWorkers()) {
+      String workerCategory = worker.getWorker().getCategory();
+      int workerCapacity = worker.getWorker().getCapacity();
+      totalPeons.compute(
+          workerCategory,
+          (category, totalCapacity) -> totalCapacity == null ? workerCapacity : totalCapacity + workerCapacity
+      );
+    }
+
+    return totalPeons;
+  }
+
+  @Override
+  public Map<String, Long> getIdleTaskSlotCount()
+  {
+    Map<String, Long> totalIdlePeons = new HashMap<>();
+    for (ImmutableWorkerInfo worker : getWorkersEligibleToRunTasks().values()) {
+      String workerCategory = worker.getWorker().getCategory();
+      int workerAvailableCapacity = worker.getAvailableCapacity();
+      totalIdlePeons.compute(
+          workerCategory,
+          (category, availableCapacity) -> availableCapacity == null
+                                           ? workerAvailableCapacity
+                                           : availableCapacity + workerAvailableCapacity
+      );
+    }
+
+    return totalIdlePeons;
+  }
+
+  @Override
+  public Map<String, Long> getUsedTaskSlotCount()
+  {
+    Map<String, Long> totalUsedPeons = new HashMap<>();
+    for (ImmutableWorkerInfo worker : getWorkers()) {
+      String workerCategory = worker.getWorker().getCategory();
+      int workerUsedCapacity = worker.getCurrCapacityUsed();
+      totalUsedPeons.compute(
+          workerCategory,
+          (category, usedCapacity) -> usedCapacity == null ? workerUsedCapacity : usedCapacity + workerUsedCapacity
+      );
+    }
+
+    return totalUsedPeons;
+  }
+
+  @Override
+  public Map<String, Long> getLazyTaskSlotCount()
+  {
+    Map<String, Long> totalLazyPeons = new HashMap<>();
+    for (Worker worker : getLazyWorkers()) {
+      String workerCategory = worker.getCategory();
+      int workerLazyPeons = worker.getCapacity();
+      totalLazyPeons.compute(
+          workerCategory,
+          (category, lazyPeons) -> lazyPeons == null ? workerLazyPeons : lazyPeons + workerLazyPeons
+      );
+    }
+
+    return totalLazyPeons;
+  }
+
+  @Override
+  public Map<String, Long> getBlacklistedTaskSlotCount()
+  {
+    Map<String, Long> totalBlacklistedPeons = new HashMap<>();
+    for (ImmutableWorkerInfo worker : getBlackListedWorkers()) {
+      String workerCategory = worker.getWorker().getCategory();
+      int workerBlacklistedPeons = worker.getWorker().getCapacity();
+      totalBlacklistedPeons.compute(
+          workerCategory,
+          (category, blacklistedPeons) -> blacklistedPeons == null
+                                          ? workerBlacklistedPeons
+                                          : blacklistedPeons + workerBlacklistedPeons
+      );
+    }
+
+    return totalBlacklistedPeons;
+  }
+
+  @Override
+  public int getTotalCapacity()
+  {
+    return getWorkers().stream().mapToInt(workerInfo -> workerInfo.getWorker().getCapacity()).sum();
+  }
+
+
+  /**
+   * Retrieves the maximum capacity of the task runner when autoscaling is enabled.*
+   *
+   * @return The maximum capacity as an integer value. Returns -1 if the maximum
+   * capacity cannot be determined or if autoscaling is not enabled.
+   */
+  @Override
+  public int getMaximumCapacityWithAutoscale()
+  {
+    int maximumCapacity = -1;
+    WorkerBehaviorConfig workerBehaviorConfig = workerConfigRef.get();
+    if (workerBehaviorConfig == null) {
+      // Auto scale not setup
+      log.debug("Cannot calculate maximum worker capacity as worker behavior config is not configured");
+    } else if (workerBehaviorConfig instanceof DefaultWorkerBehaviorConfig) {
+      DefaultWorkerBehaviorConfig defaultWorkerBehaviorConfig = (DefaultWorkerBehaviorConfig) workerBehaviorConfig;
+      if (defaultWorkerBehaviorConfig.getAutoScaler() == null) {
+        // Auto scale not setup
+        log.debug("Cannot calculate maximum worker capacity as auto scaler not configured");
+      } else {
+        int maxWorker = defaultWorkerBehaviorConfig.getAutoScaler().getMaxNumWorkers();
+        int expectedWorkerCapacity = provisioningStrategy.getExpectedWorkerCapacity(getWorkers());
+        maximumCapacity = expectedWorkerCapacity == -1 ? -1 : maxWorker * expectedWorkerCapacity;
+      }
+    }
+    return maximumCapacity;
+  }
+
+  @Override
+  public int getUsedCapacity()
+  {
+    return getWorkers().stream().mapToInt(ImmutableWorkerInfo::getCurrCapacityUsed).sum();
+  }
+
+  private static class HttpRemoteTaskRunnerWorkItem extends RemoteTaskRunnerWorkItem
+  {
+    enum State
+    {
+      // Task has been given to HRTR, but a worker to run this task hasn't been identified yet.
+      PENDING(0, true, RunnerTaskState.PENDING),
+
+      // A Worker has been identified to run this task, but request to run task hasn't been made to worker yet
+      // or worker hasn't acknowledged the task yet.
+      PENDING_WORKER_ASSIGN(1, true, RunnerTaskState.PENDING),
+
+      RUNNING(2, false, RunnerTaskState.RUNNING),
+      COMPLETE(3, false, RunnerTaskState.NONE);
+
+      private final int index;
+      private final boolean isPending;
+      private final RunnerTaskState runnerTaskState;
+
+      State(int index, boolean isPending, RunnerTaskState runnerTaskState)
+      {
+        this.index = index;
+        this.isPending = isPending;
+        this.runnerTaskState = runnerTaskState;
+      }
+
+      boolean isPending()
+      {
+        return isPending;
+      }
+
+      boolean inProgress()
+      {
+        return isPending || runnerTaskState == RunnerTaskState.RUNNING;
+      }
+
+      RunnerTaskState toRunnerTaskState()
+      {
+        return runnerTaskState;
+      }
+    }
+
+    private volatile Task task;
+    private volatile State state;
+
+    HttpRemoteTaskRunnerWorkItem(
+        String taskId,
+        Worker worker,
+        TaskLocation location,
+        @Nullable Task task,
+        String taskType,
+        State state
+    )
+    {
+      super(taskId, task == null ? null : task.getType(), worker, location, task == null ? null : task.getDataSource());
+      this.state = Preconditions.checkNotNull(state);
+      Preconditions.checkArgument(task == null || taskType == null || taskType.equals(task.getType()));
+
+      // It is possible to have it null when the TaskRunner is just started and discovered this taskId from a worker,
+      // notifications don't contain whole Task instance but just metadata about the task.
+      this.task = task;
+    }
+
+    public boolean isRunningOnWorker(Worker candidateWorker)
+    {
+      return getState() == State.RUNNING &&
+             getWorker() != null &&
+             Objects.equal(getWorker().getHost(), candidateWorker.getHost());
+    }
+
+    public Task getTask()
+    {
+      return task;
+    }
+
+    public void setTask(Task task)
+    {
+      this.task = task;
+      if (getTaskType() == null) {
+        setTaskType(task.getType());
+      } else {
+        Preconditions.checkArgument(getTaskType().equals(task.getType()));
+      }
+    }
+
+    @JsonProperty
+    public State getState()
+    {
+      return state;
+    }
+
+    @Override
+    public void setResult(TaskStatus status)
+    {
+      setState(State.COMPLETE);
+      super.setResult(status);
+    }
+
+    public void setState(State state)
+    {
+      Preconditions.checkArgument(
+          state.index - this.state.index > 0,
+          "Invalid state transition from [%s] to [%s]",
+          this.state,
+          state
+      );
+
+      setStateUnconditionally(state);
+    }
+
+    private void setStateUnconditionally(State state)
+    {
+      if (log.isDebugEnabled()) {
+        // Exception is logged to know what led to this call.
+        log.debug(
+            new RuntimeException("Stacktrace..."),
+            "Setting task[%s] work item state from [%s] to [%s].",
+            getTaskId(),
+            this.state,
+            state
+        );
+      }
+      this.state = state;
+    }
+  }
+
+  private static class PendingTaskQueueItem implements Comparable<PendingTaskQueueItem>
+  {
+    private static final AtomicLong SEQUENCE_GENERATOR = new AtomicLong(0);
+
+    private final Task task;
+    private final long sequenceNumber;
+
+    PendingTaskQueueItem(Task task)
+    {
+      this(task, SEQUENCE_GENERATOR.getAndIncrement());
+    }
+
+    @VisibleForTesting
+    PendingTaskQueueItem(Task task, long sequenceNumber)
+    {
+      this.task = task;
+      this.sequenceNumber = sequenceNumber;
+    }
+
+    public Task getTask()
+    {
+      return task;
+    }
+
+    /**
+     * Creates a new PendingTaskQueueItem for the same task with a fresh sequence number.
+     * This is used when requeueing a task to ensure it goes to the back of the queue
+     * for its priority level.
+     */
+    public PendingTaskQueueItem withFreshSequenceNumber()
+    {
+      return new PendingTaskQueueItem(task, SEQUENCE_GENERATOR.getAndIncrement());
+    }
+
+    /**
+     * Compares this item to another for priority queue ordering.
+     * Items are ordered by:
+     * 1. Task priority (higher priority first - note the reversed comparison)
+     * 2. Sequence number (lower sequence number first - FIFO)
+     */
+    @Override
+    public int compareTo(PendingTaskQueueItem other)
+    {
+      int priorityComparison = Integer.compare(other.task.getPriority(), this.task.getPriority());
+      if (priorityComparison != 0) {
+        return priorityComparison;
+      }
+      return Long.compare(this.sequenceNumber, other.sequenceNumber);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      PendingTaskQueueItem that = (PendingTaskQueueItem) o;
+      return sequenceNumber == that.sequenceNumber && task.equals(that.task);
+    }
+
+    @Override
+    public int hashCode()
+    {
+      return Objects.hashCode(task, sequenceNumber);
+    }
+  }
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunnerV2Factory.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunnerV2Factory.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord.hrtr;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Supplier;
+import com.google.inject.Inject;
+import org.apache.druid.discovery.DruidNodeDiscoveryProvider;
+import org.apache.druid.guice.annotations.EscalatedGlobal;
+import org.apache.druid.guice.annotations.Smile;
+import org.apache.druid.indexing.overlord.TaskRunnerFactory;
+import org.apache.druid.indexing.overlord.TaskStorage;
+import org.apache.druid.indexing.overlord.autoscaling.NoopProvisioningStrategy;
+import org.apache.druid.indexing.overlord.autoscaling.ProvisioningSchedulerConfig;
+import org.apache.druid.indexing.overlord.autoscaling.ProvisioningStrategy;
+import org.apache.druid.indexing.overlord.config.HttpRemoteTaskRunnerConfig;
+import org.apache.druid.indexing.overlord.setup.WorkerBehaviorConfig;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.java.util.http.client.HttpClient;
+
+/**
+ *
+ */
+public class HttpRemoteTaskRunnerV2Factory implements TaskRunnerFactory<HttpRemoteTaskRunnerV2>
+{
+  public static final String TYPE_NAME = "httpRemoteV2";
+
+  private final ObjectMapper smileMapper;
+  private final HttpRemoteTaskRunnerConfig httpRemoteTaskRunnerConfig;
+  private final HttpClient httpClient;
+  private final Supplier<WorkerBehaviorConfig> workerConfigRef;
+  private final ProvisioningSchedulerConfig provisioningSchedulerConfig;
+  private final ProvisioningStrategy provisioningStrategy;
+  private final DruidNodeDiscoveryProvider druidNodeDiscoveryProvider;
+  private final TaskStorage taskStorage;
+  private final ServiceEmitter emitter;
+  private HttpRemoteTaskRunnerV2 runner;
+
+  @Inject
+  public HttpRemoteTaskRunnerV2Factory(
+      @Smile final ObjectMapper smileMapper,
+      final HttpRemoteTaskRunnerConfig httpRemoteTaskRunnerConfig,
+      @EscalatedGlobal final HttpClient httpClient,
+      final Supplier<WorkerBehaviorConfig> workerConfigRef,
+      final ProvisioningSchedulerConfig provisioningSchedulerConfig,
+      final ProvisioningStrategy provisioningStrategy,
+      final DruidNodeDiscoveryProvider druidNodeDiscoveryProvider,
+      final TaskStorage taskStorage,
+      final ServiceEmitter emitter
+  )
+  {
+    this.smileMapper = smileMapper;
+    this.httpRemoteTaskRunnerConfig = httpRemoteTaskRunnerConfig;
+    this.httpClient = httpClient;
+    this.workerConfigRef = workerConfigRef;
+    this.provisioningSchedulerConfig = provisioningSchedulerConfig;
+    this.provisioningStrategy = provisioningStrategy;
+    this.druidNodeDiscoveryProvider = druidNodeDiscoveryProvider;
+    this.taskStorage = taskStorage;
+    this.emitter = emitter;
+  }
+
+  @Override
+  public HttpRemoteTaskRunnerV2 build()
+  {
+    runner = new HttpRemoteTaskRunnerV2(
+        smileMapper,
+        httpRemoteTaskRunnerConfig,
+        httpClient,
+        workerConfigRef,
+        provisioningSchedulerConfig.isDoAutoscale() ? provisioningStrategy : new NoopProvisioningStrategy<>(),
+        druidNodeDiscoveryProvider,
+        taskStorage,
+        emitter
+    );
+    return runner;
+  }
+
+  @Override
+  public HttpRemoteTaskRunnerV2 get()
+  {
+    return runner;
+  }
+}

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunnerV2Test.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunnerV2Test.java
@@ -1,0 +1,2613 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord.hrtr;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.Futures;
+import org.apache.druid.common.guava.DSuppliers;
+import org.apache.druid.concurrent.LifecycleLock;
+import org.apache.druid.discovery.DiscoveryDruidNode;
+import org.apache.druid.discovery.DruidNodeDiscovery;
+import org.apache.druid.discovery.DruidNodeDiscoveryProvider;
+import org.apache.druid.discovery.NodeRole;
+import org.apache.druid.discovery.WorkerNodeService;
+import org.apache.druid.indexer.TaskLocation;
+import org.apache.druid.indexer.TaskState;
+import org.apache.druid.indexer.TaskStatus;
+import org.apache.druid.indexing.common.task.NoopTask;
+import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.indexing.overlord.ImmutableWorkerInfo;
+import org.apache.druid.indexing.overlord.TaskRunnerListener;
+import org.apache.druid.indexing.overlord.TaskRunnerWorkItem;
+import org.apache.druid.indexing.overlord.TaskStorage;
+import org.apache.druid.indexing.overlord.TestProvisioningStrategy;
+import org.apache.druid.indexing.overlord.autoscaling.NoopProvisioningStrategy;
+import org.apache.druid.indexing.overlord.autoscaling.ProvisioningService;
+import org.apache.druid.indexing.overlord.autoscaling.ProvisioningStrategy;
+import org.apache.druid.indexing.overlord.config.HttpRemoteTaskRunnerConfig;
+import org.apache.druid.indexing.overlord.setup.DefaultWorkerBehaviorConfig;
+import org.apache.druid.indexing.overlord.setup.EqualDistributionWorkerSelectStrategy;
+import org.apache.druid.indexing.worker.TaskAnnouncement;
+import org.apache.druid.indexing.worker.Worker;
+import org.apache.druid.indexing.worker.config.WorkerConfig;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.java.util.emitter.EmittingLogger;
+import org.apache.druid.java.util.http.client.HttpClient;
+import org.apache.druid.java.util.http.client.response.StatusResponseHolder;
+import org.apache.druid.segment.TestHelper;
+import org.apache.druid.server.DruidNode;
+import org.apache.druid.server.coordination.ChangeRequestHttpSyncer;
+import org.apache.druid.server.metrics.NoopServiceEmitter;
+import org.easymock.EasyMock;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.joda.time.Period;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import static org.easymock.EasyMock.isA;
+
+/**
+ *
+ */
+public class HttpRemoteTaskRunnerV2Test
+{
+  @Before
+  public void setup()
+  {
+    EmittingLogger.registerEmitter(new NoopServiceEmitter());
+  }
+
+  /*
+  Simulates startup of Overlord and Workers being discovered with no previously known tasks. Fresh tasks are given
+  and expected to be completed.
+   */
+  @Test(timeout = 60_000L)
+  public void testFreshStart() throws Exception
+  {
+    TestDruidNodeDiscovery druidNodeDiscovery = new TestDruidNodeDiscovery();
+    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY))
+            .andReturn(druidNodeDiscovery);
+    EasyMock.replay(druidNodeDiscoveryProvider);
+
+    HttpRemoteTaskRunnerV2 taskRunner = newHttpTaskRunnerInstance(
+        druidNodeDiscoveryProvider,
+        new NoopProvisioningStrategy<>()
+    );
+
+    taskRunner.start();
+
+    DiscoveryDruidNode druidNode1 = new DiscoveryDruidNode(
+        new DruidNode("service", "host1", false, 8080, null, true, false),
+        NodeRole.MIDDLE_MANAGER,
+        ImmutableMap.of(
+            WorkerNodeService.DISCOVERY_SERVICE_KEY, new WorkerNodeService("ip1", 2, "0", WorkerConfig.DEFAULT_CATEGORY)
+        )
+    );
+
+    DiscoveryDruidNode druidNode2 = new DiscoveryDruidNode(
+        new DruidNode("service", "host2", false, 8080, null, true, false),
+        NodeRole.MIDDLE_MANAGER,
+        ImmutableMap.of(
+            WorkerNodeService.DISCOVERY_SERVICE_KEY, new WorkerNodeService("ip2", 2, "0", WorkerConfig.DEFAULT_CATEGORY)
+        )
+    );
+
+    druidNodeDiscovery.getListeners().get(0).nodesAdded(ImmutableList.of(druidNode1, druidNode2));
+
+    int numTasks = 8;
+    List<Future<TaskStatus>> futures = new ArrayList<>();
+    for (int i = 0; i < numTasks; i++) {
+      futures.add(taskRunner.run(NoopTask.create()));
+    }
+
+    for (Future<TaskStatus> future : futures) {
+      Assert.assertTrue(future.get().isSuccess());
+    }
+
+    Assert.assertEquals(numTasks, taskRunner.getKnownTasks().size());
+    Assert.assertEquals(numTasks, taskRunner.getCompletedTasks().size());
+    Assert.assertEquals(4, taskRunner.getTotalCapacity());
+    Assert.assertEquals(-1, taskRunner.getMaximumCapacityWithAutoscale());
+    Assert.assertEquals(0, taskRunner.getUsedCapacity());
+  }
+
+  @Test(timeout = 60_000L)
+  public void testFreshStart_nodeDiscoveryTimedOut() throws Exception
+  {
+    TestDruidNodeDiscovery druidNodeDiscovery = new TestDruidNodeDiscovery(true);
+    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY))
+            .andReturn(druidNodeDiscovery);
+    EasyMock.replay(druidNodeDiscoveryProvider);
+
+    HttpRemoteTaskRunnerV2 taskRunner = newHttpTaskRunnerInstance(
+        druidNodeDiscoveryProvider,
+        new NoopProvisioningStrategy<>()
+    );
+
+    taskRunner.start();
+
+    DiscoveryDruidNode druidNode1 = new DiscoveryDruidNode(
+        new DruidNode("service", "host1", false, 8080, null, true, false),
+        NodeRole.MIDDLE_MANAGER,
+        ImmutableMap.of(
+            WorkerNodeService.DISCOVERY_SERVICE_KEY, new WorkerNodeService("ip1", 2, "0", WorkerConfig.DEFAULT_CATEGORY)
+        )
+    );
+
+    DiscoveryDruidNode druidNode2 = new DiscoveryDruidNode(
+        new DruidNode("service", "host2", false, 8080, null, true, false),
+        NodeRole.MIDDLE_MANAGER,
+        ImmutableMap.of(
+            WorkerNodeService.DISCOVERY_SERVICE_KEY, new WorkerNodeService("ip2", 2, "0", WorkerConfig.DEFAULT_CATEGORY)
+        )
+    );
+
+    druidNodeDiscovery.getListeners().get(0).nodesAdded(ImmutableList.of(druidNode1, druidNode2));
+
+    int numTasks = 8;
+    List<Future<TaskStatus>> futures = new ArrayList<>();
+    for (int i = 0; i < numTasks; i++) {
+      futures.add(taskRunner.run(NoopTask.create()));
+    }
+
+    for (Future<TaskStatus> future : futures) {
+      Assert.assertTrue(future.get().isSuccess());
+    }
+
+    Assert.assertEquals(numTasks, taskRunner.getKnownTasks().size());
+    Assert.assertEquals(numTasks, taskRunner.getCompletedTasks().size());
+    Assert.assertEquals(4, taskRunner.getTotalCapacity());
+    Assert.assertEquals(0, taskRunner.getUsedCapacity());
+  }
+
+  /*
+  Simulates startup of Overlord. Overlord is then stopped and is expected to close down certain things.
+   */
+  @Test(timeout = 60_000L)
+  public void testFreshStartAndStop()
+  {
+    TestDruidNodeDiscovery druidNodeDiscovery = new TestDruidNodeDiscovery();
+    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY))
+            .andReturn(druidNodeDiscovery).times(2);
+    ProvisioningStrategy provisioningStrategy = EasyMock.createMock(ProvisioningStrategy.class);
+    ProvisioningService provisioningService = EasyMock.createNiceMock(ProvisioningService.class);
+    EasyMock.expect(provisioningStrategy.makeProvisioningService(isA(HttpRemoteTaskRunnerV2.class)))
+            .andReturn(provisioningService);
+    provisioningService.close();
+    EasyMock.expectLastCall();
+    EasyMock.replay(druidNodeDiscoveryProvider, provisioningStrategy, provisioningService);
+
+    DiscoveryDruidNode druidNode1 = new DiscoveryDruidNode(
+        new DruidNode("service", "host1", false, 8080, null, true, false),
+        NodeRole.MIDDLE_MANAGER,
+        ImmutableMap.of(
+            WorkerNodeService.DISCOVERY_SERVICE_KEY, new WorkerNodeService("ip1", 2, "0", WorkerConfig.DEFAULT_CATEGORY)
+        )
+    );
+
+    DiscoveryDruidNode druidNode2 = new DiscoveryDruidNode(
+        new DruidNode("service", "host2", false, 8080, null, true, false),
+        NodeRole.MIDDLE_MANAGER,
+        ImmutableMap.of(
+            WorkerNodeService.DISCOVERY_SERVICE_KEY, new WorkerNodeService("ip2", 2, "0", WorkerConfig.DEFAULT_CATEGORY)
+        )
+    );
+
+    HttpRemoteTaskRunnerV2 taskRunner = newHttpTaskRunnerInstance(
+        druidNodeDiscoveryProvider,
+        provisioningStrategy
+    );
+
+    taskRunner.start();
+    druidNodeDiscovery.getListeners().get(0).nodesAdded(ImmutableList.of(druidNode1, druidNode2));
+
+    // Verify workers were added
+    Assert.assertEquals(2, taskRunner.getWorkers().size());
+
+    taskRunner.stop();
+    Assert.assertTrue(druidNodeDiscovery.getListeners().isEmpty());
+
+    EasyMock.verify(druidNodeDiscoveryProvider, provisioningStrategy, provisioningService);
+  }
+
+  /*
+  Simulates startup of Overlord with no provisoner. Overlord is then stopped and is expected to close down certain
+  things.
+   */
+  @Test(timeout = 60_000L)
+  public void testFreshStartAndStopNoProvisioner()
+  {
+    TestDruidNodeDiscovery druidNodeDiscovery = new TestDruidNodeDiscovery();
+    ProvisioningStrategy provisioningStrategy = EasyMock.createMock(ProvisioningStrategy.class);
+
+    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY))
+            .andReturn(druidNodeDiscovery).times(2);
+    EasyMock.expect(provisioningStrategy.makeProvisioningService(isA(HttpRemoteTaskRunnerV2.class)))
+            .andReturn(null);
+    EasyMock.expectLastCall();
+    EasyMock.replay(druidNodeDiscoveryProvider, provisioningStrategy);
+
+    HttpRemoteTaskRunnerV2 taskRunner = new HttpRemoteTaskRunnerV2(
+        TestHelper.makeJsonMapper(),
+        new HttpRemoteTaskRunnerConfig()
+        {
+          @Override
+          public int getPendingTasksRunnerNumThreads()
+          {
+            return 3;
+          }
+        },
+        EasyMock.createNiceMock(HttpClient.class),
+        DSuppliers.of(new AtomicReference<>(DefaultWorkerBehaviorConfig.defaultConfig())),
+        provisioningStrategy,
+        druidNodeDiscoveryProvider,
+        EasyMock.createNiceMock(TaskStorage.class),
+        new NoopServiceEmitter()
+    )
+    {
+      @Override
+      protected WorkerHolder createWorkerHolder(
+          ObjectMapper smileMapper,
+          HttpClient httpClient,
+          HttpRemoteTaskRunnerConfig config,
+          ScheduledExecutorService workersSyncExec,
+          WorkerHolder.Listener listener,
+          Worker worker,
+          List<TaskAnnouncement> knownAnnouncements
+      )
+      {
+        return HttpRemoteTaskRunnerV2Test.createWorkerHolder(
+            smileMapper,
+            httpClient,
+            config,
+            workersSyncExec,
+            listener,
+            worker,
+            ImmutableList.of(),
+            ImmutableList.of(),
+            ImmutableMap.of(),
+            new AtomicInteger(),
+            ImmutableSet.of()
+        );
+      }
+    };
+
+    taskRunner.start();
+    taskRunner.stop();
+    EasyMock.verify(druidNodeDiscoveryProvider, provisioningStrategy);
+  }
+
+  /*
+  Simulates one task not getting acknowledged to be running after assigning it to a worker. But, other tasks are
+  successfully assigned to other worker and get completed.
+   */
+  @Test(timeout = 60_000L)
+  public void testOneStuckTaskAssignmentDoesntBlockOthers() throws Exception
+  {
+    TestDruidNodeDiscovery druidNodeDiscovery = new TestDruidNodeDiscovery();
+    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY))
+            .andReturn(druidNodeDiscovery);
+    EasyMock.replay(druidNodeDiscoveryProvider);
+
+    Task task1 = NoopTask.create();
+    Task task2 = NoopTask.create();
+    Task task3 = NoopTask.create();
+
+    HttpRemoteTaskRunnerV2 taskRunner = new HttpRemoteTaskRunnerV2(
+        TestHelper.makeJsonMapper(),
+        new HttpRemoteTaskRunnerConfig()
+        {
+          @Override
+          public int getPendingTasksRunnerNumThreads()
+          {
+            return 3;
+          }
+        },
+        EasyMock.createNiceMock(HttpClient.class),
+        DSuppliers.of(new AtomicReference<>(DefaultWorkerBehaviorConfig.defaultConfig())),
+        new NoopProvisioningStrategy<>(),
+        druidNodeDiscoveryProvider,
+        EasyMock.createNiceMock(TaskStorage.class),
+        new NoopServiceEmitter()
+    )
+    {
+      @Override
+      protected WorkerHolder createWorkerHolder(
+          ObjectMapper smileMapper,
+          HttpClient httpClient,
+          HttpRemoteTaskRunnerConfig config,
+          ScheduledExecutorService workersSyncExec,
+          WorkerHolder.Listener listener,
+          Worker worker,
+          List<TaskAnnouncement> knownAnnouncements
+      )
+      {
+        return HttpRemoteTaskRunnerV2Test.createWorkerHolder(
+            smileMapper,
+            httpClient,
+            config,
+            workersSyncExec,
+            listener,
+            worker,
+            ImmutableList.of(),
+            ImmutableList.of(),
+            ImmutableMap.of(task1, ImmutableList.of()), //no announcements would be received for task1
+            new AtomicInteger(),
+            ImmutableSet.of()
+        );
+      }
+    };
+
+    taskRunner.start();
+
+    DiscoveryDruidNode druidNode1 = new DiscoveryDruidNode(
+        new DruidNode("service", "host1", false, 8080, null, true, false),
+        NodeRole.MIDDLE_MANAGER,
+        ImmutableMap.of(
+            WorkerNodeService.DISCOVERY_SERVICE_KEY, new WorkerNodeService("ip1", 2, "0", WorkerConfig.DEFAULT_CATEGORY)
+        )
+    );
+
+    DiscoveryDruidNode druidNode2 = new DiscoveryDruidNode(
+        new DruidNode("service", "host2", false, 8080, null, true, false),
+        NodeRole.MIDDLE_MANAGER,
+        ImmutableMap.of(
+            WorkerNodeService.DISCOVERY_SERVICE_KEY, new WorkerNodeService("ip2", 2, "0", WorkerConfig.DEFAULT_CATEGORY)
+        )
+    );
+
+    druidNodeDiscovery.getListeners().get(0).nodesAdded(ImmutableList.of(druidNode1, druidNode2));
+
+    taskRunner.run(task1);
+    Future<TaskStatus> future2 = taskRunner.run(task2);
+    Future<TaskStatus> future3 = taskRunner.run(task3);
+
+    Assert.assertTrue(future2.get().isSuccess());
+    Assert.assertTrue(future3.get().isSuccess());
+
+    Assert.assertEquals(task1.getId(), Iterables.getOnlyElement(taskRunner.getPendingTasks()).getTaskId());
+  }
+
+  /*
+  Simulates restart of the Overlord where taskRunner, on start, discovers workers with prexisting tasks.
+   */
+  @Test(timeout = 60_000L)
+  public void testTaskRunnerRestart() throws Exception
+  {
+    TestDruidNodeDiscovery druidNodeDiscovery = new TestDruidNodeDiscovery();
+    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY))
+            .andReturn(druidNodeDiscovery);
+    EasyMock.replay(druidNodeDiscoveryProvider);
+
+    ConcurrentMap<String, CustomFunction> workerHolders = new ConcurrentHashMap<>();
+
+    Task task1 = NoopTask.create();
+    Task task2 = NoopTask.create();
+    Task task3 = NoopTask.create();
+    Task task4 = NoopTask.create();
+    Task task5 = NoopTask.create();
+
+    TaskStorage taskStorageMock = EasyMock.createStrictMock(TaskStorage.class);
+    EasyMock.expect(taskStorageMock.getStatus(task1.getId())).andReturn(Optional.absent());
+    EasyMock.expect(taskStorageMock.getStatus(task2.getId())).andReturn(Optional.absent()).times(2);
+    EasyMock.expect(taskStorageMock.getStatus(task3.getId())).andReturn(Optional.of(TaskStatus.running(task3.getId())));
+    EasyMock.expect(taskStorageMock.getStatus(task4.getId())).andReturn(Optional.of(TaskStatus.running(task4.getId())));
+    EasyMock.expect(taskStorageMock.getStatus(task5.getId())).andReturn(Optional.of(TaskStatus.success(task5.getId())));
+    EasyMock.replay(taskStorageMock);
+
+    HttpRemoteTaskRunnerV2 taskRunner = new HttpRemoteTaskRunnerV2(
+        TestHelper.makeJsonMapper(),
+        new HttpRemoteTaskRunnerConfig()
+        {
+          @Override
+          public int getPendingTasksRunnerNumThreads()
+          {
+            return 3;
+          }
+        },
+        EasyMock.createNiceMock(HttpClient.class),
+        DSuppliers.of(new AtomicReference<>(DefaultWorkerBehaviorConfig.defaultConfig())),
+        new NoopProvisioningStrategy<>(),
+        druidNodeDiscoveryProvider,
+        taskStorageMock,
+        new NoopServiceEmitter()
+    )
+    {
+      @Override
+      protected WorkerHolder createWorkerHolder(
+          ObjectMapper smileMapper,
+          HttpClient httpClient,
+          HttpRemoteTaskRunnerConfig config,
+          ScheduledExecutorService workersSyncExec,
+          WorkerHolder.Listener listener,
+          Worker worker,
+          List<TaskAnnouncement> knownAnnouncements
+      )
+      {
+        if (workerHolders.containsKey(worker.getHost())) {
+          return workerHolders.get(worker.getHost()).apply(
+              smileMapper,
+              httpClient,
+              config,
+              workersSyncExec,
+              listener,
+              worker,
+              knownAnnouncements
+          );
+        } else {
+          throw new ISE("No WorkerHolder for [%s].", worker.getHost());
+        }
+      }
+    };
+
+    taskRunner.start();
+
+    DiscoveryDruidNode druidNode = new DiscoveryDruidNode(
+        new DruidNode("service", "host", false, 1234, null, true, false),
+        NodeRole.MIDDLE_MANAGER,
+        ImmutableMap.of(
+            WorkerNodeService.DISCOVERY_SERVICE_KEY, new WorkerNodeService("ip1", 2, "0", WorkerConfig.DEFAULT_CATEGORY)
+        )
+    );
+
+    AtomicInteger ticks = new AtomicInteger();
+    Set<String> taskShutdowns = new HashSet<>();
+
+    workerHolders.put(
+        "host:1234",
+        (mapper, httpClient, config, exec, listener, worker, knownAnnouncements) -> createWorkerHolder(
+            mapper,
+            httpClient,
+            config,
+            exec,
+            listener,
+            worker,
+            knownAnnouncements,
+            ImmutableList.of(
+                TaskAnnouncement.create(
+                    task1,
+                    TaskStatus.success(task1.getId()),
+                    TaskLocation.create("host", 1234, 1235)
+                ),
+                TaskAnnouncement.create(
+                    task2,
+                    TaskStatus.running(task2.getId()),
+                    TaskLocation.create("host", 1234, 1235)
+                ),
+                TaskAnnouncement.create(
+                    task2,
+                    TaskStatus.success(task2.getId()),
+                    TaskLocation.create("host", 1234, 1235)
+                ),
+                TaskAnnouncement.create(
+                    task3,
+                    TaskStatus.success(task3.getId()),
+                    TaskLocation.create("host", 1234, 1235)
+                ),
+                TaskAnnouncement.create(
+                    task4,
+                    TaskStatus.running(task4.getId()),
+                    TaskLocation.create("host", 1234, 1235)
+                ),
+                TaskAnnouncement.create(
+                    task5,
+                    TaskStatus.running(task5.getId()),
+                    TaskLocation.create("host", 1234, 1235)
+                )
+            ),
+            ImmutableMap.of(),
+            ticks,
+            taskShutdowns
+        )
+    );
+
+    druidNodeDiscovery.getListeners().get(0).nodesAdded(
+        ImmutableList.of(
+            druidNode
+        )
+    );
+
+    while (ticks.get() < 1) {
+      Thread.sleep(100);
+    }
+
+    EasyMock.verify(taskStorageMock);
+
+    Assert.assertEquals(ImmutableSet.of(task2.getId(), task5.getId()), taskShutdowns);
+    Assert.assertTrue(taskRunner.getPendingTasks().isEmpty());
+
+    TaskRunnerWorkItem item = Iterables.getOnlyElement(taskRunner.getRunningTasks());
+    Assert.assertEquals(task4.getId(), item.getTaskId());
+
+    Assert.assertTrue(taskRunner.run(task3).get().isSuccess());
+
+    Assert.assertEquals(2, taskRunner.getKnownTasks().size());
+
+  }
+
+  @Test(timeout = 60_000L)
+  public void testWorkerDisapperAndReappearBeforeItsCleanup() throws Exception
+  {
+    TestDruidNodeDiscovery druidNodeDiscovery = new TestDruidNodeDiscovery();
+    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY))
+            .andReturn(druidNodeDiscovery);
+    EasyMock.replay(druidNodeDiscoveryProvider);
+
+    ConcurrentMap<String, CustomFunction> workerHolders = new ConcurrentHashMap<>();
+
+    HttpRemoteTaskRunnerV2 taskRunner = new HttpRemoteTaskRunnerV2(
+        TestHelper.makeJsonMapper(),
+        new HttpRemoteTaskRunnerConfig()
+        {
+          @Override
+          public int getPendingTasksRunnerNumThreads()
+          {
+            return 3;
+          }
+        },
+        EasyMock.createNiceMock(HttpClient.class),
+        DSuppliers.of(new AtomicReference<>(DefaultWorkerBehaviorConfig.defaultConfig())),
+        new NoopProvisioningStrategy<>(),
+        druidNodeDiscoveryProvider,
+        EasyMock.createNiceMock(TaskStorage.class),
+        new NoopServiceEmitter()
+    )
+    {
+      @Override
+      protected WorkerHolder createWorkerHolder(
+          ObjectMapper smileMapper,
+          HttpClient httpClient,
+          HttpRemoteTaskRunnerConfig config,
+          ScheduledExecutorService workersSyncExec,
+          WorkerHolder.Listener listener,
+          Worker worker,
+          List<TaskAnnouncement> knownAnnouncements
+      )
+      {
+        if (workerHolders.containsKey(worker.getHost())) {
+          return workerHolders.get(worker.getHost()).apply(
+              smileMapper,
+              httpClient,
+              config,
+              workersSyncExec,
+              listener,
+              worker,
+              knownAnnouncements
+          );
+        } else {
+          throw new ISE("No WorkerHolder for [%s].", worker.getHost());
+        }
+      }
+    };
+
+    taskRunner.start();
+
+    Task task1 = NoopTask.create();
+    Task task2 = NoopTask.create();
+
+    DiscoveryDruidNode druidNode = new DiscoveryDruidNode(
+        new DruidNode("service", "host", false, 1234, null, true, false),
+        NodeRole.MIDDLE_MANAGER,
+        ImmutableMap.of(
+            WorkerNodeService.DISCOVERY_SERVICE_KEY, new WorkerNodeService("ip1", 2, "0", WorkerConfig.DEFAULT_CATEGORY)
+        )
+    );
+
+    workerHolders.put(
+        "host:1234",
+        (mapper, httpClient, config, exec, listener, worker, knownAnnouncements) -> createWorkerHolder(
+            mapper,
+            httpClient,
+            config,
+            exec,
+            listener,
+            worker,
+            knownAnnouncements,
+            ImmutableList.of(),
+            ImmutableMap.of(
+                task1, ImmutableList.of(
+                    TaskAnnouncement.create(
+                        task1,
+                        TaskStatus.running(task1.getId()),
+                        TaskLocation.unknown()
+                    ),
+                    TaskAnnouncement.create(
+                        task1,
+                        TaskStatus.running(task1.getId()),
+                        TaskLocation.create("host", 1234, 1235)
+                    ),
+                    TaskAnnouncement.create(
+                        task1,
+                        TaskStatus.success(task1.getId()),
+                        TaskLocation.create("host", 1234, 1235)
+                    )
+                ),
+                task2, ImmutableList.of(
+                    TaskAnnouncement.create(
+                        task2,
+                        TaskStatus.running(task2.getId()),
+                        TaskLocation.unknown()
+                    ),
+                    TaskAnnouncement.create(
+                        task2,
+                        TaskStatus.running(task2.getId()),
+                        TaskLocation.create("host", 1234, 1235)
+                    )
+                )
+            ),
+            new AtomicInteger(),
+            ImmutableSet.of()
+        )
+    );
+
+    druidNodeDiscovery.getListeners().get(0).nodesAdded(
+        ImmutableList.of(
+            druidNode
+        )
+    );
+
+    Future<TaskStatus> future1 = taskRunner.run(task1);
+    Future<TaskStatus> future2 = taskRunner.run(task2);
+
+    while (taskRunner.getPendingTasks().size() > 0) {
+      Thread.sleep(100);
+    }
+
+    druidNodeDiscovery.getListeners().get(0).nodesRemoved(
+        ImmutableList.of(
+            druidNode
+        )
+    );
+
+    workerHolders.put(
+        "host:1234",
+        (mapper, httpClient, config, exec, listener, worker, knownAnnouncements) -> createWorkerHolder(
+            mapper,
+            httpClient,
+            config,
+            exec,
+            listener,
+            worker,
+            knownAnnouncements,
+            ImmutableList.of(
+                TaskAnnouncement.create(
+                    task2,
+                    TaskStatus.running(task2.getId()),
+                    TaskLocation.create("host", 1234, 1235)
+                ),
+                TaskAnnouncement.create(
+                    task2,
+                    TaskStatus.success(task2.getId()),
+                    TaskLocation.create("host", 1234, 1235)
+                )
+
+            ),
+            ImmutableMap.of(),
+            new AtomicInteger(),
+            ImmutableSet.of()
+        )
+    );
+
+    druidNodeDiscovery.getListeners().get(0).nodesAdded(
+        ImmutableList.of(
+            druidNode
+        )
+    );
+
+    Assert.assertTrue(future1.get().isSuccess());
+    Assert.assertTrue(future2.get().isSuccess());
+  }
+
+  @Test(timeout = 60_000L)
+  public void testWorkerDisapperAndReappearAfterItsCleanup() throws Exception
+  {
+    TestDruidNodeDiscovery druidNodeDiscovery = new TestDruidNodeDiscovery();
+    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY))
+            .andReturn(druidNodeDiscovery);
+    EasyMock.replay(druidNodeDiscoveryProvider);
+
+    ConcurrentMap<String, CustomFunction> workerHolders = new ConcurrentHashMap<>();
+
+    HttpRemoteTaskRunnerV2 taskRunner = new HttpRemoteTaskRunnerV2(
+        TestHelper.makeJsonMapper(),
+        new HttpRemoteTaskRunnerConfig()
+        {
+          @Override
+          public Period getTaskCleanupTimeout()
+          {
+            return Period.millis(1);
+          }
+        },
+        EasyMock.createNiceMock(HttpClient.class),
+        DSuppliers.of(new AtomicReference<>(DefaultWorkerBehaviorConfig.defaultConfig())),
+        new NoopProvisioningStrategy<>(),
+        druidNodeDiscoveryProvider,
+        EasyMock.createNiceMock(TaskStorage.class),
+        new NoopServiceEmitter()
+    )
+    {
+      @Override
+      protected WorkerHolder createWorkerHolder(
+          ObjectMapper smileMapper,
+          HttpClient httpClient,
+          HttpRemoteTaskRunnerConfig config,
+          ScheduledExecutorService workersSyncExec,
+          WorkerHolder.Listener listener,
+          Worker worker,
+          List<TaskAnnouncement> knownAnnouncements
+      )
+      {
+        if (workerHolders.containsKey(worker.getHost())) {
+          return workerHolders.get(worker.getHost()).apply(
+              smileMapper,
+              httpClient,
+              config,
+              workersSyncExec,
+              listener,
+              worker,
+              knownAnnouncements
+          );
+        } else {
+          throw new ISE("No WorkerHolder for [%s].", worker.getHost());
+        }
+      }
+    };
+
+    taskRunner.start();
+
+    Task task1 = NoopTask.create();
+    Task task2 = NoopTask.create();
+
+    DiscoveryDruidNode druidNode = new DiscoveryDruidNode(
+        new DruidNode("service", "host", false, 1234, null, true, false),
+        NodeRole.MIDDLE_MANAGER,
+        ImmutableMap.of(
+            WorkerNodeService.DISCOVERY_SERVICE_KEY,
+            new WorkerNodeService("ip1", 2, "0", WorkerConfig.DEFAULT_CATEGORY)
+        )
+    );
+
+    workerHolders.put(
+        "host:1234",
+        (mapper, httpClient, config, exec, listener, worker, knownAnnouncements) -> createWorkerHolder(
+            mapper,
+            httpClient,
+            config,
+            exec,
+            listener,
+            worker,
+            knownAnnouncements,
+            ImmutableList.of(),
+            ImmutableMap.of(
+                task1, ImmutableList.of(
+                    TaskAnnouncement.create(
+                        task1,
+                        TaskStatus.running(task1.getId()),
+                        TaskLocation.unknown()
+                    ),
+                    TaskAnnouncement.create(
+                        task1,
+                        TaskStatus.running(task1.getId()),
+                        TaskLocation.create("host", 1234, 1235)
+                    )
+                ),
+                task2, ImmutableList.of(
+                    TaskAnnouncement.create(
+                        task2,
+                        TaskStatus.running(task2.getId()),
+                        TaskLocation.unknown()
+                    ),
+                    TaskAnnouncement.create(
+                        task2,
+                        TaskStatus.running(task2.getId()),
+                        TaskLocation.create("host", 1234, 1235)
+                    )
+                )
+            ),
+            new AtomicInteger(),
+            ImmutableSet.of()
+        )
+    );
+
+    druidNodeDiscovery.getListeners().get(0).nodesAdded(
+        ImmutableList.of(
+            druidNode
+        )
+    );
+
+    Future<TaskStatus> future1 = taskRunner.run(task1);
+    Future<TaskStatus> future2 = taskRunner.run(task2);
+
+    while (taskRunner.getPendingTasks().size() > 0) {
+      Thread.sleep(100);
+    }
+
+    druidNodeDiscovery.getListeners().get(0).nodesRemoved(
+        ImmutableList.of(
+            druidNode
+        )
+    );
+
+    Assert.assertTrue(future1.get().isFailure());
+    Assert.assertTrue(future2.get().isFailure());
+    Assert.assertNotNull(future1.get().getErrorMsg());
+    Assert.assertNotNull(future2.get().getErrorMsg());
+    Assert.assertTrue(
+        future1.get().getErrorMsg().startsWith(
+            "The worker that this task was assigned disappeared and did not report cleanup within timeout"
+        )
+    );
+    Assert.assertTrue(
+        future2.get().getErrorMsg().startsWith(
+            "The worker that this task was assigned disappeared and did not report cleanup within timeout"
+        )
+    );
+
+    AtomicInteger ticks = new AtomicInteger();
+    Set<String> actualShutdowns = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    workerHolders.put(
+        "host:1234",
+        (mapper, httpClient, config, exec, listener, worker, knownAnnouncements) -> createWorkerHolder(
+            mapper,
+            httpClient,
+            config,
+            exec,
+            listener,
+            worker,
+            knownAnnouncements,
+            ImmutableList.of(
+                TaskAnnouncement.create(
+                    task1,
+                    TaskStatus.success(task1.getId()),
+                    TaskLocation.create("host", 1234, 1235)
+                ),
+                TaskAnnouncement.create(
+                    task2,
+                    TaskStatus.running(task2.getId()),
+                    TaskLocation.create("host", 1234, 1235)
+                )
+            ),
+            ImmutableMap.of(),
+            ticks,
+            actualShutdowns
+        )
+    );
+
+    druidNodeDiscovery.getListeners().get(0).nodesAdded(
+        ImmutableList.of(
+            druidNode
+        )
+    );
+
+    while (ticks.get() < 1) {
+      Thread.sleep(100);
+    }
+
+    Assert.assertEquals(ImmutableSet.of(task2.getId()), actualShutdowns);
+    Assert.assertTrue(taskRunner.run(task1).get().isFailure());
+    Assert.assertTrue(taskRunner.run(task2).get().isFailure());
+  }
+
+  @Test(timeout = 60_000L)
+  public void testMarkWorkersLazy() throws Exception
+  {
+    TestDruidNodeDiscovery druidNodeDiscovery = new TestDruidNodeDiscovery();
+    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY))
+            .andReturn(druidNodeDiscovery);
+    EasyMock.replay(druidNodeDiscoveryProvider);
+
+    Task task1 = NoopTask.create();
+    Task task2 = NoopTask.create();
+    String additionalWorkerCategory = "category2";
+
+    ConcurrentMap<String, CustomFunction> workerHolders = new ConcurrentHashMap<>();
+
+    HttpRemoteTaskRunnerV2 taskRunner = new HttpRemoteTaskRunnerV2(
+        TestHelper.makeJsonMapper(),
+        new HttpRemoteTaskRunnerConfig()
+        {
+          @Override
+          public int getPendingTasksRunnerNumThreads()
+          {
+            return 3;
+          }
+        },
+        EasyMock.createNiceMock(HttpClient.class),
+        DSuppliers.of(new AtomicReference<>(DefaultWorkerBehaviorConfig.defaultConfig())),
+        new NoopProvisioningStrategy<>(),
+        druidNodeDiscoveryProvider,
+        EasyMock.createNiceMock(TaskStorage.class),
+        new NoopServiceEmitter()
+    )
+    {
+      @Override
+      protected WorkerHolder createWorkerHolder(
+          ObjectMapper smileMapper,
+          HttpClient httpClient,
+          HttpRemoteTaskRunnerConfig config,
+          ScheduledExecutorService workersSyncExec,
+          WorkerHolder.Listener listener,
+          Worker worker,
+          List<TaskAnnouncement> knownAnnouncements
+      )
+      {
+        if (workerHolders.containsKey(worker.getHost())) {
+          return workerHolders.get(worker.getHost()).apply(
+              smileMapper,
+              httpClient,
+              config,
+              workersSyncExec,
+              listener,
+              worker,
+              knownAnnouncements
+          );
+        } else {
+          throw new ISE("No WorkerHolder for [%s].", worker.getHost());
+        }
+      }
+    };
+
+    taskRunner.start();
+
+    Assert.assertTrue(taskRunner.getTotalTaskSlotCount().isEmpty());
+    Assert.assertTrue(taskRunner.getIdleTaskSlotCount().isEmpty());
+    Assert.assertTrue(taskRunner.getUsedTaskSlotCount().isEmpty());
+
+    AtomicInteger ticks = new AtomicInteger();
+
+    DiscoveryDruidNode druidNode1 = new DiscoveryDruidNode(
+        new DruidNode("service", "host1", false, 8080, null, true, false),
+        NodeRole.MIDDLE_MANAGER,
+        ImmutableMap.of(
+            WorkerNodeService.DISCOVERY_SERVICE_KEY, new WorkerNodeService("ip1", 1, "0", WorkerConfig.DEFAULT_CATEGORY)
+        )
+    );
+
+    workerHolders.put(
+        "host1:8080",
+        (mapper, httpClient, config, exec, listener, worker, knownAnnouncements) -> createWorkerHolder(
+            mapper,
+            httpClient,
+            config,
+            exec,
+            listener,
+            worker,
+            knownAnnouncements,
+            ImmutableList.of(),
+            ImmutableMap.of(
+                task1, ImmutableList.of(
+                    TaskAnnouncement.create(
+                        task1,
+                        TaskStatus.running(task1.getId()),
+                        TaskLocation.unknown()
+                    ),
+                    TaskAnnouncement.create(
+                        task1,
+                        TaskStatus.running(task1.getId()),
+                        TaskLocation.create("host1", 8080, -1)
+                    )
+                )
+            ),
+            ticks,
+            ImmutableSet.of()
+        )
+    );
+
+    druidNodeDiscovery.getListeners().get(0).nodesAdded(ImmutableList.of(druidNode1));
+
+    Assert.assertEquals(1, taskRunner.getTotalTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
+    Assert.assertEquals(1, taskRunner.getIdleTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
+    Assert.assertEquals(0, taskRunner.getUsedTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
+
+    taskRunner.run(task1);
+
+    while (ticks.get() < 1) {
+      Thread.sleep(100);
+    }
+
+    Assert.assertEquals(1, taskRunner.getTotalTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
+    Assert.assertEquals(0, taskRunner.getIdleTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
+    Assert.assertEquals(1, taskRunner.getUsedTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
+
+    DiscoveryDruidNode druidNode2 = new DiscoveryDruidNode(
+        new DruidNode("service", "host2", false, 8080, null, true, false),
+        NodeRole.MIDDLE_MANAGER,
+        ImmutableMap.of(
+            WorkerNodeService.DISCOVERY_SERVICE_KEY,
+            new WorkerNodeService("ip2", 1, "0", additionalWorkerCategory)
+        )
+    );
+
+    workerHolders.put(
+        "host2:8080",
+        (mapper, httpClient, config, exec, listener, worker, knownAnnouncements) -> createWorkerHolder(
+            mapper,
+            httpClient,
+            config,
+            exec,
+            listener,
+            worker,
+            knownAnnouncements,
+            ImmutableList.of(),
+            ImmutableMap.of(task2, ImmutableList.of()),
+            ticks,
+            ImmutableSet.of()
+        )
+    );
+
+    druidNodeDiscovery.getListeners().get(0).nodesAdded(ImmutableList.of(druidNode2));
+
+    Assert.assertEquals(1, taskRunner.getTotalTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
+    Assert.assertEquals(1, taskRunner.getTotalTaskSlotCount().get(additionalWorkerCategory).longValue());
+    Assert.assertEquals(0, taskRunner.getIdleTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
+    Assert.assertEquals(1, taskRunner.getIdleTaskSlotCount().get(additionalWorkerCategory).longValue());
+    Assert.assertEquals(1, taskRunner.getUsedTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
+    Assert.assertEquals(0, taskRunner.getUsedTaskSlotCount().get(additionalWorkerCategory).longValue());
+
+    taskRunner.run(task2);
+
+    while (ticks.get() < 2) {
+      Thread.sleep(100);
+    }
+
+    Assert.assertEquals(1, taskRunner.getTotalTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
+    Assert.assertEquals(1, taskRunner.getTotalTaskSlotCount().get(additionalWorkerCategory).longValue());
+    Assert.assertEquals(0, taskRunner.getIdleTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
+    Assert.assertFalse(taskRunner.getIdleTaskSlotCount().containsKey(additionalWorkerCategory));
+    Assert.assertEquals(1, taskRunner.getUsedTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
+    Assert.assertEquals(0, taskRunner.getUsedTaskSlotCount().get(additionalWorkerCategory).longValue());
+
+    DiscoveryDruidNode druidNode3 = new DiscoveryDruidNode(
+        new DruidNode("service", "host3", false, 8080, null, true, false),
+        NodeRole.MIDDLE_MANAGER,
+        ImmutableMap.of(
+            WorkerNodeService.DISCOVERY_SERVICE_KEY,
+            new WorkerNodeService("ip2", 1, "0", WorkerConfig.DEFAULT_CATEGORY)
+        )
+    );
+
+    workerHolders.put(
+        "host3:8080",
+        (mapper, httpClient, config, exec, listener, worker, knownAnnouncements) -> createWorkerHolder(
+            mapper,
+            httpClient,
+            config,
+            exec,
+            listener,
+            worker,
+            knownAnnouncements,
+            ImmutableList.of(),
+            ImmutableMap.of(),
+            new AtomicInteger(),
+            ImmutableSet.of()
+        )
+    );
+
+    druidNodeDiscovery.getListeners().get(0).nodesAdded(ImmutableList.of(druidNode3));
+
+    Assert.assertEquals(2, taskRunner.getTotalTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
+    Assert.assertEquals(1, taskRunner.getTotalTaskSlotCount().get(additionalWorkerCategory).longValue());
+    Assert.assertEquals(1, taskRunner.getIdleTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
+    Assert.assertFalse(taskRunner.getIdleTaskSlotCount().containsKey(additionalWorkerCategory));
+    Assert.assertEquals(1, taskRunner.getUsedTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
+    Assert.assertEquals(0, taskRunner.getUsedTaskSlotCount().get(additionalWorkerCategory).longValue());
+    Assert.assertFalse(taskRunner.getLazyTaskSlotCount().containsKey(WorkerConfig.DEFAULT_CATEGORY));
+    Assert.assertFalse(taskRunner.getLazyTaskSlotCount().containsKey(additionalWorkerCategory));
+
+    Assert.assertEquals(task1.getId(), Iterables.getOnlyElement(taskRunner.getRunningTasks()).getTaskId());
+    Assert.assertEquals(task2.getId(), Iterables.getOnlyElement(taskRunner.getPendingTasks()).getTaskId());
+
+    Assert.assertEquals(
+        Collections.emptyList(),
+        taskRunner.markWorkersLazy(Predicates.alwaysTrue(), 0)
+    );
+
+    Assert.assertEquals(
+        "host3:8080",
+        Iterables.getOnlyElement(taskRunner.markWorkersLazy(Predicates.alwaysTrue(), 1))
+                 .getHost()
+    );
+
+    Assert.assertEquals(
+        "host3:8080",
+        Iterables.getOnlyElement(taskRunner.markWorkersLazy(Predicates.alwaysTrue(), Integer.MAX_VALUE))
+                 .getHost()
+    );
+
+    Assert.assertEquals(2, taskRunner.getTotalTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
+    Assert.assertEquals(1, taskRunner.getTotalTaskSlotCount().get(additionalWorkerCategory).longValue());
+    Assert.assertEquals(0, taskRunner.getIdleTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
+    Assert.assertFalse(taskRunner.getIdleTaskSlotCount().containsKey(additionalWorkerCategory));
+    Assert.assertEquals(1, taskRunner.getUsedTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
+    Assert.assertEquals(0, taskRunner.getUsedTaskSlotCount().get(additionalWorkerCategory).longValue());
+    Assert.assertEquals(1, taskRunner.getLazyTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
+    Assert.assertFalse(taskRunner.getLazyTaskSlotCount().containsKey(additionalWorkerCategory));
+  }
+
+  /*
+   * Task goes PENDING -> RUNNING -> SUCCESS and few more useless notifications in between.
+   */
+  @Test(timeout = 60_000L)
+  public void testTaskAddedOrUpdated1() throws Exception
+  {
+    Task task = NoopTask.create();
+    List<Object> listenerNotificationsAccumulator = new ArrayList<>();
+
+    Worker worker = new Worker("http", "worker", "127.0.0.1", 1, "v1", WorkerConfig.DEFAULT_CATEGORY);
+    WorkerHolder workerHolder = EasyMock.createMock(WorkerHolder.class);
+    EasyMock.expect(workerHolder.getWorker())
+            .andReturn(worker)
+            .anyTimes();
+    EasyMock.expect(workerHolder.getState()).andReturn(WorkerHolder.State.READY).anyTimes();
+    EasyMock.expect(workerHolder.isInitialized()).andReturn(true).anyTimes();
+    EasyMock.expect(workerHolder.isEnabled()).andReturn(true).anyTimes();
+    EasyMock.expect(workerHolder.toImmutable())
+            .andReturn(new ImmutableWorkerInfo(worker, 0, ImmutableSet.of(), ImmutableSet.of(), DateTimes.nowUtc()))
+            .anyTimes();
+    workerHolder.setLastCompletedTaskTime(EasyMock.anyObject());
+    workerHolder.setState(EasyMock.anyObject());
+    workerHolder.resetContinuouslyFailedTasksCount();
+    EasyMock.expect(workerHolder.getContinuouslyFailedTasksCount()).andReturn(0);
+    workerHolder.start();
+    EasyMock.expectLastCall();
+    EasyMock.replay(workerHolder);
+
+    HttpRemoteTaskRunnerV2 taskRunner = createTaskRunnerForTestTaskAddedOrUpdated(
+        EasyMock.createStrictMock(TaskStorage.class),
+        listenerNotificationsAccumulator,
+        worker,
+        workerHolder
+    );
+
+    // Register the mock worker using the proper API
+    taskRunner.addWorker(worker);
+
+    Future<TaskStatus> future = taskRunner.run(task);
+    Assert.assertEquals(task.getId(), Iterables.getOnlyElement(taskRunner.getPendingTasks()).getTaskId());
+
+    // RUNNING notification from worker
+    taskRunner.taskAddedOrUpdated(
+        TaskAnnouncement.create(
+            task,
+            TaskStatus.running(task.getId()),
+            TaskLocation.create("worker", 1000, 1001)
+        ), workerHolder
+    );
+    Assert.assertEquals(task.getId(), Iterables.getOnlyElement(taskRunner.getRunningTasks()).getTaskId());
+
+    // Another RUNNING notification from worker, notifying change in location
+    taskRunner.taskAddedOrUpdated(
+        TaskAnnouncement.create(
+            task,
+            TaskStatus.running(task.getId()),
+            TaskLocation.create("worker", 1, 2)
+        ), workerHolder
+    );
+    Assert.assertEquals(task.getId(), Iterables.getOnlyElement(taskRunner.getRunningTasks()).getTaskId());
+
+    // Redundant RUNNING notification from worker, ignored
+    taskRunner.taskAddedOrUpdated(
+        TaskAnnouncement.create(
+            task,
+            TaskStatus.running(task.getId()),
+            TaskLocation.create("worker", 1, 2)
+        ), workerHolder
+    );
+    Assert.assertEquals(task.getId(), Iterables.getOnlyElement(taskRunner.getRunningTasks()).getTaskId());
+
+    // Another "rogue-worker" reports running it, and gets asked to shutdown the task
+    WorkerHolder rogueWorkerHolder = EasyMock.createMock(WorkerHolder.class);
+    EasyMock.expect(rogueWorkerHolder.getWorker())
+            .andReturn(new Worker("http", "rogue-worker", "127.0.0.1", 5, "v1", WorkerConfig.DEFAULT_CATEGORY))
+            .anyTimes();
+    rogueWorkerHolder.shutdownTask(task.getId());
+    EasyMock.replay(rogueWorkerHolder);
+    taskRunner.taskAddedOrUpdated(
+        TaskAnnouncement.create(
+            task,
+            TaskStatus.running(task.getId()),
+            TaskLocation.create("rogue-worker", 1, 2)
+        ), rogueWorkerHolder
+    );
+    Assert.assertEquals(task.getId(), Iterables.getOnlyElement(taskRunner.getRunningTasks()).getTaskId());
+    EasyMock.verify(rogueWorkerHolder);
+
+    // "rogue-worker" reports FAILURE for the task, ignored
+    rogueWorkerHolder = EasyMock.createMock(WorkerHolder.class);
+    EasyMock.expect(rogueWorkerHolder.getWorker())
+            .andReturn(new Worker("http", "rogue-worker", "127.0.0.1", 5, "v1", WorkerConfig.DEFAULT_CATEGORY))
+            .anyTimes();
+    EasyMock.replay(rogueWorkerHolder);
+    taskRunner.taskAddedOrUpdated(
+        TaskAnnouncement.create(
+            task,
+            TaskStatus.failure(task.getId(), "Dummy task status failure err message"),
+            TaskLocation.create("rogue-worker", 1, 2)
+        ), rogueWorkerHolder
+    );
+    Assert.assertEquals(task.getId(), Iterables.getOnlyElement(taskRunner.getRunningTasks()).getTaskId());
+    EasyMock.verify(rogueWorkerHolder);
+
+    // workers sends SUCCESS notification, task is marked SUCCESS now.
+    taskRunner.taskAddedOrUpdated(
+        TaskAnnouncement.create(
+            task,
+            TaskStatus.success(task.getId()),
+            TaskLocation.create("worker", 1, 2)
+        ), workerHolder
+    );
+    Assert.assertEquals(task.getId(), Iterables.getOnlyElement(taskRunner.getCompletedTasks()).getTaskId());
+    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+
+    // "rogue-worker" reports running it, and gets asked to shutdown the task
+    rogueWorkerHolder = EasyMock.createMock(WorkerHolder.class);
+    EasyMock.expect(rogueWorkerHolder.getWorker())
+            .andReturn(new Worker("http", "rogue-worker", "127.0.0.1", 5, "v1", WorkerConfig.DEFAULT_CATEGORY))
+            .anyTimes();
+    rogueWorkerHolder.shutdownTask(task.getId());
+    EasyMock.replay(rogueWorkerHolder);
+    taskRunner.taskAddedOrUpdated(
+        TaskAnnouncement.create(
+            task,
+            TaskStatus.running(task.getId()),
+            TaskLocation.create("rogue-worker", 1, 2)
+        ), rogueWorkerHolder
+    );
+    Assert.assertEquals(task.getId(), Iterables.getOnlyElement(taskRunner.getCompletedTasks()).getTaskId());
+    EasyMock.verify(rogueWorkerHolder);
+
+    // "rogue-worker" reports FAILURE for the tasks, ignored
+    rogueWorkerHolder = EasyMock.createMock(WorkerHolder.class);
+    EasyMock.expect(rogueWorkerHolder.getWorker())
+            .andReturn(new Worker("http", "rogue-worker", "127.0.0.1", 5, "v1", WorkerConfig.DEFAULT_CATEGORY))
+            .anyTimes();
+    EasyMock.replay(rogueWorkerHolder);
+    taskRunner.taskAddedOrUpdated(
+        TaskAnnouncement.create(
+            task,
+            TaskStatus.failure(task.getId(), "Dummy task status failure for testing"),
+            TaskLocation.create("rogue-worker", 1, 2)
+        ), rogueWorkerHolder
+    );
+    Assert.assertEquals(task.getId(), Iterables.getOnlyElement(taskRunner.getCompletedTasks()).getTaskId());
+    EasyMock.verify(rogueWorkerHolder);
+
+    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+
+    EasyMock.verify(workerHolder);
+
+    Assert.assertEquals(
+        ImmutableList.of(
+            ImmutableList.of(task.getId(), TaskLocation.create("worker", 1000, 1001)),
+            ImmutableList.of(task.getId(), TaskLocation.create("worker", 1, 2)),
+            ImmutableList.of(task.getId(), TaskStatus.success(task.getId()))
+        ),
+        listenerNotificationsAccumulator
+    );
+  }
+
+  /*
+   * Task goes from PENDING -> SUCCESS . Happens when TaskRunner is given task but a worker reported it being already
+   * completed with SUCCESS.
+   */
+  @Test(timeout = 60_000L)
+  public void testTaskAddedOrUpdated2() throws Exception
+  {
+    Task task = NoopTask.create();
+    List<Object> listenerNotificationsAccumulator = new ArrayList<>();
+
+    Worker worker = new Worker("http", "localhost", "127.0.0.1", 1, "v1", WorkerConfig.DEFAULT_CATEGORY);
+
+    WorkerHolder workerHolder = EasyMock.createMock(WorkerHolder.class);
+    EasyMock.expect(workerHolder.getWorker()).andReturn(worker).anyTimes();
+    EasyMock.expect(workerHolder.getState()).andReturn(WorkerHolder.State.READY).anyTimes();
+    EasyMock.expect(workerHolder.isInitialized()).andReturn(true).anyTimes();
+    EasyMock.expect(workerHolder.isEnabled()).andReturn(true).anyTimes();
+    EasyMock.expect(workerHolder.toImmutable())
+            .andReturn(new ImmutableWorkerInfo(worker, 0, ImmutableSet.of(), ImmutableSet.of(), DateTimes.nowUtc()))
+            .anyTimes();
+    workerHolder.setState(EasyMock.anyObject());
+    EasyMock.expectLastCall().anyTimes();
+    workerHolder.setLastCompletedTaskTime(EasyMock.anyObject());
+    workerHolder.resetContinuouslyFailedTasksCount();
+    EasyMock.expect(workerHolder.getContinuouslyFailedTasksCount()).andReturn(0);
+    EasyMock.expect(workerHolder.getBlacklistedUntil()).andReturn(null);
+    EasyMock.expectLastCall().anyTimes();
+    workerHolder.start();
+    EasyMock.expectLastCall();
+    EasyMock.replay(workerHolder);
+
+    HttpRemoteTaskRunnerV2 taskRunner = createTaskRunnerForTestTaskAddedOrUpdated(
+        EasyMock.createStrictMock(TaskStorage.class),
+        listenerNotificationsAccumulator,
+        worker,
+        workerHolder
+    );
+
+    // Register the mock worker using the proper API
+    taskRunner.addWorker(worker);
+
+    Future<TaskStatus> future = taskRunner.run(task);
+    Assert.assertEquals(task.getId(), Iterables.getOnlyElement(taskRunner.getPendingTasks()).getTaskId());
+
+    taskRunner.taskAddedOrUpdated(
+        TaskAnnouncement.create(
+            task,
+            TaskStatus.success(task.getId()),
+            TaskLocation.create("worker", 1, 2)
+        ), workerHolder
+    );
+    Assert.assertEquals(task.getId(), Iterables.getOnlyElement(taskRunner.getCompletedTasks()).getTaskId());
+
+    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+
+    EasyMock.verify(workerHolder);
+
+    Assert.assertEquals(
+        ImmutableList.of(
+            ImmutableList.of(task.getId(), TaskLocation.create("worker", 1, 2)),
+            ImmutableList.of(task.getId(), TaskStatus.success(task.getId()))
+        ),
+        listenerNotificationsAccumulator
+    );
+  }
+
+  /*
+   * Notifications received for tasks not known to TaskRunner maybe known to TaskStorage.
+   * This could happen when TaskRunner starts and workers reports running/completed tasks on them.
+   */
+  @Test(timeout = 60_000L)
+  public void testTaskAddedOrUpdated3()
+  {
+    Task task1 = NoopTask.create();
+    Task task2 = NoopTask.create();
+    Task task3 = NoopTask.create();
+    Task task4 = NoopTask.create();
+    Task task5 = NoopTask.create();
+    Task task6 = NoopTask.create();
+
+    TaskStorage taskStorage = EasyMock.createMock(TaskStorage.class);
+    EasyMock.expect(taskStorage.getStatus(task1.getId())).andReturn(Optional.of(TaskStatus.running(task1.getId())));
+    EasyMock.expect(taskStorage.getStatus(task2.getId())).andReturn(Optional.of(TaskStatus.running(task2.getId())));
+    EasyMock.expect(taskStorage.getStatus(task3.getId())).andReturn(Optional.of(TaskStatus.success(task3.getId())));
+    EasyMock.expect(taskStorage.getStatus(task4.getId())).andReturn(Optional.of(TaskStatus.success(task4.getId())));
+    EasyMock.expect(taskStorage.getStatus(task5.getId())).andReturn(Optional.absent());
+    EasyMock.expect(taskStorage.getStatus(task6.getId())).andReturn(Optional.absent());
+    EasyMock.replay(taskStorage);
+
+    List<Object> listenerNotificationsAccumulator = new ArrayList<>();
+
+    Worker worker = new Worker("http", "localhost", "127.0.0.1", 1, "v1", WorkerConfig.DEFAULT_CATEGORY);
+
+    WorkerHolder workerHolder = EasyMock.createMock(WorkerHolder.class);
+    EasyMock.expect(workerHolder.getWorker()).andReturn(worker).anyTimes();
+    EasyMock.expect(workerHolder.getState()).andReturn(WorkerHolder.State.READY).anyTimes();
+    EasyMock.expect(workerHolder.isInitialized()).andReturn(true).anyTimes();
+    EasyMock.expect(workerHolder.isEnabled()).andReturn(true).anyTimes();
+    EasyMock.expect(workerHolder.toImmutable())
+            .andReturn(new ImmutableWorkerInfo(worker, 0, ImmutableSet.of(), ImmutableSet.of(), DateTimes.nowUtc()))
+            .anyTimes();
+    workerHolder.setState(EasyMock.anyObject());
+    EasyMock.expectLastCall().anyTimes();
+    workerHolder.setLastCompletedTaskTime(EasyMock.anyObject());
+    EasyMock.expectLastCall().anyTimes();
+    workerHolder.resetContinuouslyFailedTasksCount();
+    EasyMock.expectLastCall().anyTimes();
+    EasyMock.expect(workerHolder.getContinuouslyFailedTasksCount()).andReturn(0);
+    EasyMock.expect(workerHolder.getBlacklistedUntil()).andReturn(null);
+    EasyMock.expectLastCall().anyTimes();
+    workerHolder.shutdownTask(task3.getId());
+    workerHolder.shutdownTask(task5.getId());
+    workerHolder.start();
+    EasyMock.expectLastCall();
+    EasyMock.replay(workerHolder);
+
+    HttpRemoteTaskRunnerV2 taskRunner =
+        createTaskRunnerForTestTaskAddedOrUpdated(taskStorage, listenerNotificationsAccumulator, worker, workerHolder);
+
+    // Register the mock worker using the proper API
+    taskRunner.addWorker(worker);
+
+    Assert.assertEquals(0, taskRunner.getKnownTasks().size());
+
+    taskRunner.taskAddedOrUpdated(
+        TaskAnnouncement.create(
+            task1,
+            TaskStatus.running(task1.getId()),
+            TaskLocation.create("worker", 1, 2)
+        ), workerHolder
+    );
+
+    taskRunner.taskAddedOrUpdated(
+        TaskAnnouncement.create(
+            task2,
+            TaskStatus.success(task2.getId()),
+            TaskLocation.create("worker", 3, 4)
+        ), workerHolder
+    );
+
+    taskRunner.taskAddedOrUpdated(
+        TaskAnnouncement.create(
+            task3,
+            TaskStatus.running(task3.getId()),
+            TaskLocation.create("worker", 5, 6)
+        ), workerHolder
+    );
+
+    taskRunner.taskAddedOrUpdated(
+        TaskAnnouncement.create(
+            task4,
+            TaskStatus.success(task4.getId()),
+            TaskLocation.create("worker", 7, 8)
+        ), workerHolder
+    );
+
+    taskRunner.taskAddedOrUpdated(
+        TaskAnnouncement.create(
+            task5,
+            TaskStatus.running(task5.getId()),
+            TaskLocation.create("worker", 9, 10)
+        ), workerHolder
+    );
+
+    taskRunner.taskAddedOrUpdated(
+        TaskAnnouncement.create(
+            task6,
+            TaskStatus.success(task6.getId()),
+            TaskLocation.create("worker", 11, 12)
+        ), workerHolder
+    );
+
+    EasyMock.verify(workerHolder, taskStorage);
+
+    Assert.assertEquals(
+        ImmutableList.of(
+            ImmutableList.of(task1.getId(), TaskLocation.create("worker", 1, 2)),
+            ImmutableList.of(task2.getId(), TaskLocation.create("worker", 3, 4)),
+            ImmutableList.of(task2.getId(), TaskStatus.success(task2.getId()))
+        ),
+        listenerNotificationsAccumulator
+    );
+  }
+
+  @Test(timeout = 60_000L)
+  public void testTimeoutInAssigningTasks() throws Exception
+  {
+    TestDruidNodeDiscovery druidNodeDiscovery = new TestDruidNodeDiscovery();
+    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY))
+            .andReturn(druidNodeDiscovery);
+    EasyMock.replay(druidNodeDiscoveryProvider);
+
+    HttpRemoteTaskRunnerV2 taskRunner = new HttpRemoteTaskRunnerV2(
+        TestHelper.makeJsonMapper(),
+        new HttpRemoteTaskRunnerConfig()
+        {
+          @Override
+          public int getPendingTasksRunnerNumThreads()
+          {
+            return 1;
+          }
+
+          @Override
+          public Period getTaskAssignmentTimeout()
+          {
+            return new Period("PT1S");
+          }
+        },
+        EasyMock.createNiceMock(HttpClient.class),
+        DSuppliers.of(new AtomicReference<>(DefaultWorkerBehaviorConfig.defaultConfig())),
+        new NoopProvisioningStrategy<>(),
+        druidNodeDiscoveryProvider,
+        EasyMock.createNiceMock(TaskStorage.class),
+        new NoopServiceEmitter()
+    )
+    {
+      @Override
+      protected WorkerHolder createWorkerHolder(
+          ObjectMapper smileMapper,
+          HttpClient httpClient,
+          HttpRemoteTaskRunnerConfig config,
+          ScheduledExecutorService workersSyncExec,
+          WorkerHolder.Listener listener,
+          Worker worker,
+          List<TaskAnnouncement> knownAnnouncements
+      )
+      {
+        return new WorkerHolder(
+            smileMapper,
+            httpClient,
+            config,
+            workersSyncExec,
+            listener,
+            worker,
+            ImmutableList.of()
+        )
+        {
+          @Override
+          public void start()
+          {
+            disabled.set(false);
+          }
+
+          @Override
+          public void stop()
+          {
+          }
+
+          @Override
+          public boolean isInitialized()
+          {
+            return true;
+          }
+
+          @Override
+          public void waitForInitialization()
+          {
+          }
+
+          @Override
+          public boolean assignTask(Task task)
+          {
+            // Always returns true
+            return true;
+          }
+
+          @Override
+          public void shutdownTask(String taskId)
+          {
+          }
+        };
+      }
+    };
+
+    taskRunner.start();
+
+    DiscoveryDruidNode druidNode1 = new DiscoveryDruidNode(
+        new DruidNode("service", "host1", false, 8080, null, true, false),
+        NodeRole.MIDDLE_MANAGER,
+        ImmutableMap.of(
+            WorkerNodeService.DISCOVERY_SERVICE_KEY, new WorkerNodeService("ip1", 2, "0", WorkerConfig.DEFAULT_CATEGORY)
+        )
+    );
+
+    druidNodeDiscovery.getListeners().get(0).nodesAdded(ImmutableList.of(druidNode1));
+
+    Future<TaskStatus> future = taskRunner.run(NoopTask.create());
+    Assert.assertTrue(future.get().isFailure());
+    Assert.assertNotNull(future.get().getErrorMsg());
+    Assert.assertTrue(
+        future.get().getErrorMsg().startsWith("Failed to assign this task")
+    );
+  }
+
+  @Test(timeout = 60_000L)
+  public void testExceptionThrownInAssigningTasks() throws Exception
+  {
+    TestDruidNodeDiscovery druidNodeDiscovery = new TestDruidNodeDiscovery();
+    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY))
+            .andReturn(druidNodeDiscovery);
+    EasyMock.replay(druidNodeDiscoveryProvider);
+
+    HttpRemoteTaskRunnerV2 taskRunner = new HttpRemoteTaskRunnerV2(
+        TestHelper.makeJsonMapper(),
+        new HttpRemoteTaskRunnerConfig()
+        {
+          @Override
+          public int getPendingTasksRunnerNumThreads()
+          {
+            return 1;
+          }
+
+          @Override
+          public Period getTaskAssignmentTimeout()
+          {
+            return new Period("PT1S");
+          }
+        },
+        EasyMock.createNiceMock(HttpClient.class),
+        DSuppliers.of(new AtomicReference<>(DefaultWorkerBehaviorConfig.defaultConfig())),
+        new NoopProvisioningStrategy<>(),
+        druidNodeDiscoveryProvider,
+        EasyMock.createNiceMock(TaskStorage.class),
+        new NoopServiceEmitter()
+    )
+    {
+      @Override
+      protected WorkerHolder createWorkerHolder(
+          ObjectMapper smileMapper,
+          HttpClient httpClient,
+          HttpRemoteTaskRunnerConfig config,
+          ScheduledExecutorService workersSyncExec,
+          WorkerHolder.Listener listener,
+          Worker worker,
+          List<TaskAnnouncement> knownAnnouncements
+      )
+      {
+        return new WorkerHolder(
+            smileMapper,
+            httpClient,
+            config,
+            workersSyncExec,
+            listener,
+            worker,
+            ImmutableList.of()
+        )
+        {
+          @Override
+          public void start()
+          {
+            disabled.set(false);
+          }
+
+          @Override
+          public void stop()
+          {
+          }
+
+          @Override
+          public boolean isInitialized()
+          {
+            return true;
+          }
+
+          @Override
+          public void waitForInitialization()
+          {
+          }
+
+          @Override
+          public boolean assignTask(Task task)
+          {
+            throw new RuntimeException("Assign failure test");
+          }
+
+          @Override
+          public void shutdownTask(String taskId)
+          {
+          }
+        };
+      }
+    };
+
+    taskRunner.start();
+
+    DiscoveryDruidNode druidNode1 = new DiscoveryDruidNode(
+        new DruidNode("service", "host1", false, 8080, null, true, false),
+        NodeRole.MIDDLE_MANAGER,
+        ImmutableMap.of(
+            WorkerNodeService.DISCOVERY_SERVICE_KEY, new WorkerNodeService("ip1", 2, "0", WorkerConfig.DEFAULT_CATEGORY)
+        )
+    );
+
+    druidNodeDiscovery.getListeners().get(0).nodesAdded(ImmutableList.of(druidNode1));
+
+    Future<TaskStatus> future = taskRunner.run(NoopTask.create());
+    Assert.assertTrue(future.get().isFailure());
+    Assert.assertNotNull(future.get().getErrorMsg());
+    Assert.assertTrue(
+        StringUtils.format("Actual message is: %s", future.get().getErrorMsg()),
+        future.get().getErrorMsg().startsWith("Failed to assign this task")
+    );
+  }
+
+  /**
+   * Validate the internal state of tasks within the task runner
+   * when shutdown is called on pending / running tasks and completed tasks
+   */
+  @Test(timeout = 60_000L)
+  public void testShutdown()
+  {
+    List<Object> listenerNotificationsAccumulator = new ArrayList<>();
+    HttpRemoteTaskRunnerV2 taskRunner = createTaskRunnerForTestTaskAddedOrUpdated(
+        EasyMock.createStrictMock(TaskStorage.class),
+        listenerNotificationsAccumulator
+    );
+
+    Worker worker = new Worker("http", "localhost", "127.0.0.1", 1, "v1", WorkerConfig.DEFAULT_CATEGORY);
+
+    WorkerHolder workerHolder = EasyMock.createMock(WorkerHolder.class);
+    EasyMock.expect(workerHolder.getWorker()).andReturn(worker).anyTimes();
+    EasyMock.expect(workerHolder.getState()).andReturn(WorkerHolder.State.READY).anyTimes();
+    workerHolder.setLastCompletedTaskTime(EasyMock.anyObject());
+    EasyMock.expectLastCall().anyTimes();
+    workerHolder.resetContinuouslyFailedTasksCount();
+    EasyMock.expectLastCall().anyTimes();
+    workerHolder.incrementContinuouslyFailedTasksCount();
+    EasyMock.expectLastCall().anyTimes();
+    workerHolder.setBlacklistedUntil(EasyMock.anyObject());
+    EasyMock.expectLastCall().anyTimes();
+    EasyMock.replay(workerHolder);
+
+    taskRunner.start();
+
+    Task pendingTask = NoopTask.create();
+    taskRunner.run(pendingTask);
+    // Pending task is not cleaned up immediately
+    taskRunner.shutdown(pendingTask.getId(), "Forced shutdown");
+    Assert.assertTrue(taskRunner.getKnownTasks()
+                                .stream()
+                                .map(TaskRunnerWorkItem::getTaskId)
+                                .collect(Collectors.toSet())
+                                .contains(pendingTask.getId())
+    );
+
+    Task completedTask = NoopTask.create();
+    taskRunner.run(completedTask);
+    taskRunner.taskAddedOrUpdated(
+        TaskAnnouncement.create(
+            completedTask,
+            TaskStatus.success(completedTask.getId()),
+            TaskLocation.create("worker", 1, 2)
+        ), workerHolder
+    );
+    Assert.assertEquals(completedTask.getId(), Iterables.getOnlyElement(taskRunner.getCompletedTasks()).getTaskId());
+    TestDruidNodeDiscovery druidNodeDiscovery = new TestDruidNodeDiscovery();
+    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY))
+            .andReturn(druidNodeDiscovery);
+    EasyMock.replay(druidNodeDiscoveryProvider);
+
+
+    // Completed tasks are cleaned up when shutdown is invokded on them (by TaskQueue)
+    taskRunner.shutdown(completedTask.getId(), "Cleanup");
+    Assert.assertFalse(taskRunner.getKnownTasks()
+                                 .stream()
+                                 .map(TaskRunnerWorkItem::getTaskId)
+                                 .collect(Collectors.toSet())
+                                 .contains(completedTask.getId())
+    );
+
+  }
+
+  @Test(timeout = 60_000L)
+  public void testSyncMonitoring_finiteIteration()
+  {
+    TestDruidNodeDiscovery druidNodeDiscovery = new TestDruidNodeDiscovery();
+    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY))
+            .andReturn(druidNodeDiscovery);
+    EasyMock.replay(druidNodeDiscoveryProvider);
+
+    HttpRemoteTaskRunnerV2 taskRunner = new HttpRemoteTaskRunnerV2(
+        TestHelper.makeJsonMapper(),
+        new HttpRemoteTaskRunnerConfig(),
+        EasyMock.createNiceMock(HttpClient.class),
+        DSuppliers.of(new AtomicReference<>(DefaultWorkerBehaviorConfig.defaultConfig())),
+        new NoopProvisioningStrategy<>(),
+        druidNodeDiscoveryProvider,
+        EasyMock.createMock(TaskStorage.class),
+        new NoopServiceEmitter()
+    )
+    {
+      @Override
+      protected WorkerHolder createWorkerHolder(
+          ObjectMapper smileMapper,
+          HttpClient httpClient,
+          HttpRemoteTaskRunnerConfig config,
+          ScheduledExecutorService workersSyncExec,
+          WorkerHolder.Listener listener,
+          Worker worker,
+          List<TaskAnnouncement> knownAnnouncements
+      )
+      {
+        return createNonSyncingWorkerHolder(worker);
+      }
+    };
+
+    taskRunner.start();
+    taskRunner.addWorker(createWorker("abc"));
+    taskRunner.addWorker(createWorker("xyz"));
+    taskRunner.addWorker(createWorker("lol"));
+    Assert.assertEquals(3, taskRunner.getWorkerSyncerDebugInfo().size());
+    taskRunner.syncMonitoring();
+    Assert.assertEquals(3, taskRunner.getWorkerSyncerDebugInfo().size());
+  }
+
+  @Test(timeout = 60_000L)
+  public void testGetMaximumCapacity_noWorkerConfig()
+  {
+    TestDruidNodeDiscovery druidNodeDiscovery = new TestDruidNodeDiscovery();
+    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY))
+            .andReturn(druidNodeDiscovery);
+    EasyMock.replay(druidNodeDiscoveryProvider);
+
+    HttpRemoteTaskRunnerV2 taskRunner = new HttpRemoteTaskRunnerV2(
+        TestHelper.makeJsonMapper(),
+        new HttpRemoteTaskRunnerConfig(),
+        EasyMock.createNiceMock(HttpClient.class),
+        DSuppliers.of(new AtomicReference<>(null)),
+        new TestProvisioningStrategy<>(),
+        druidNodeDiscoveryProvider,
+        EasyMock.createMock(TaskStorage.class),
+        new NoopServiceEmitter()
+    );
+    Assert.assertEquals(-1, taskRunner.getMaximumCapacityWithAutoscale());
+  }
+
+  @Test(timeout = 60_000L)
+  public void testGetMaximumCapacity_noAutoScaler()
+  {
+    TestDruidNodeDiscovery druidNodeDiscovery = new TestDruidNodeDiscovery();
+    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY))
+            .andReturn(druidNodeDiscovery);
+    EasyMock.replay(druidNodeDiscoveryProvider);
+
+    HttpRemoteTaskRunnerV2 taskRunner = new HttpRemoteTaskRunnerV2(
+        TestHelper.makeJsonMapper(),
+        new HttpRemoteTaskRunnerConfig(),
+        EasyMock.createNiceMock(HttpClient.class),
+        DSuppliers.of(new AtomicReference<>(new DefaultWorkerBehaviorConfig(
+            new EqualDistributionWorkerSelectStrategy(
+                null,
+                null
+            ), null
+        ))),
+        new TestProvisioningStrategy<>(),
+        druidNodeDiscoveryProvider,
+        EasyMock.createMock(TaskStorage.class),
+        new NoopServiceEmitter()
+    );
+    Assert.assertEquals(-1, taskRunner.getMaximumCapacityWithAutoscale());
+  }
+
+  @Test(timeout = 60_000L)
+  public void testGetMaximumCapacity_withAutoScaler()
+  {
+    TestDruidNodeDiscovery druidNodeDiscovery = new TestDruidNodeDiscovery();
+    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY))
+            .andReturn(druidNodeDiscovery);
+    EasyMock.replay(druidNodeDiscoveryProvider);
+
+    HttpRemoteTaskRunnerV2 taskRunner = new HttpRemoteTaskRunnerV2(
+        TestHelper.makeJsonMapper(),
+        new HttpRemoteTaskRunnerConfig(),
+        EasyMock.createNiceMock(HttpClient.class),
+        DSuppliers.of(new AtomicReference<>(DefaultWorkerBehaviorConfig.defaultConfig())),
+        new TestProvisioningStrategy<>(),
+        druidNodeDiscoveryProvider,
+        EasyMock.createMock(TaskStorage.class),
+        new NoopServiceEmitter()
+    );
+    // Default autoscaler has max workers of 0
+    Assert.assertEquals(0, taskRunner.getMaximumCapacityWithAutoscale());
+  }
+
+  @Test(timeout = 60_000L)
+  public void testTaskPriorityAssignmentOrdering() throws Exception
+  {
+    TestDruidNodeDiscovery druidNodeDiscovery = new TestDruidNodeDiscovery();
+    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY))
+            .andReturn(druidNodeDiscovery);
+    EasyMock.replay(druidNodeDiscoveryProvider);
+
+    List<String> taskAssignmentOrder = Collections.synchronizedList(new ArrayList<>());
+    ConcurrentMap<String, CustomFunction> workerHolders = new ConcurrentHashMap<>();
+    CountDownLatch startPollingLatch = new CountDownLatch(1);
+
+    HttpRemoteTaskRunnerV2 taskRunner = new HttpRemoteTaskRunnerV2(
+        TestHelper.makeJsonMapper(),
+        new HttpRemoteTaskRunnerConfig()
+        {
+          @Override
+          public int getPendingTasksRunnerNumThreads()
+          {
+            return 1; // Ensure sequential processing from queue
+          }
+        },
+        EasyMock.createNiceMock(HttpClient.class),
+        DSuppliers.of(new AtomicReference<>(DefaultWorkerBehaviorConfig.defaultConfig())),
+        new NoopProvisioningStrategy<>(),
+        druidNodeDiscoveryProvider,
+        EasyMock.createNiceMock(TaskStorage.class),
+        new NoopServiceEmitter()
+    )
+    {
+      @Override
+      protected WorkerHolder createWorkerHolder(
+          ObjectMapper smileMapper,
+          HttpClient httpClient,
+          HttpRemoteTaskRunnerConfig config,
+          ScheduledExecutorService workersSyncExec,
+          WorkerHolder.Listener listener,
+          Worker worker,
+          List<TaskAnnouncement> knownAnnouncements
+      )
+      {
+        if (workerHolders.containsKey(worker.getHost())) {
+          return workerHolders.get(worker.getHost()).apply(
+              smileMapper,
+              httpClient,
+              config,
+              workersSyncExec,
+              listener,
+              worker,
+              knownAnnouncements
+          );
+        }
+        return createWorkerHolder(
+            smileMapper,
+            httpClient,
+            config,
+            workersSyncExec,
+            listener,
+            worker,
+            knownAnnouncements
+        );
+      }
+
+      @Override
+      void pendingTasksExecutionLoop()
+      {
+        try {
+          startPollingLatch.await();
+        }
+        catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return;
+        }
+        super.pendingTasksExecutionLoop();
+      }
+    };
+
+    Task lowPriorityTask = NoopTask.ofPriority(0);
+    Task mediumPriorityTask = NoopTask.ofPriority(50);
+    Task highPriorityTask = NoopTask.ofPriority(100);
+
+    workerHolders.put(
+        "host1:8080",
+        (mapper, httpClient, config, exec, listener, worker, knownAnnouncements) ->
+            createWorkerHolderWithOrderTracking(
+                mapper,
+                httpClient,
+                config,
+                exec,
+                listener,
+                worker,
+                knownAnnouncements,
+                taskAssignmentOrder
+            )
+    );
+
+    taskRunner.start();
+
+    Thread.sleep(100);
+
+    Future<TaskStatus> lowFuture = taskRunner.run(lowPriorityTask);
+    Future<TaskStatus> mediumFuture = taskRunner.run(mediumPriorityTask);
+    Future<TaskStatus> highFuture = taskRunner.run(highPriorityTask);
+
+    startPollingLatch.countDown();
+
+    DiscoveryDruidNode druidNode = new DiscoveryDruidNode(
+        new DruidNode("service", "host1", false, 8080, null, true, false),
+        NodeRole.MIDDLE_MANAGER,
+        ImmutableMap.of(
+            WorkerNodeService.DISCOVERY_SERVICE_KEY, new WorkerNodeService("ip1", 1, "0", WorkerConfig.DEFAULT_CATEGORY)
+        )
+    );
+    druidNodeDiscovery.getListeners().get(0).nodesAdded(ImmutableList.of(druidNode));
+
+    Assert.assertTrue(highFuture.get().isSuccess());
+    Assert.assertTrue(mediumFuture.get().isSuccess());
+    Assert.assertTrue(lowFuture.get().isSuccess());
+
+    Assert.assertEquals(
+        List.of(highPriorityTask.getId(), mediumPriorityTask.getId(), lowPriorityTask.getId()),
+        taskAssignmentOrder
+    );
+
+    Assert.assertEquals(3, taskRunner.getKnownTasks().size());
+    Assert.assertEquals(3, taskRunner.getCompletedTasks().size());
+  }
+
+  public static HttpRemoteTaskRunnerV2 createTaskRunnerForTestTaskAddedOrUpdated(
+      TaskStorage taskStorage,
+      List<Object> listenerNotificationsAccumulator
+  )
+  {
+    return createTaskRunnerForTestTaskAddedOrUpdated(taskStorage, listenerNotificationsAccumulator, null, null);
+  }
+
+  public static HttpRemoteTaskRunnerV2 createTaskRunnerForTestTaskAddedOrUpdated(
+      TaskStorage taskStorage,
+      List<Object> listenerNotificationsAccumulator,
+      Worker mockWorker,
+      WorkerHolder mockWorkerHolder
+  )
+  {
+    TestDruidNodeDiscovery druidNodeDiscovery = new TestDruidNodeDiscovery();
+    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY))
+            .andReturn(druidNodeDiscovery);
+    EasyMock.replay(druidNodeDiscoveryProvider);
+
+    // Create HttpClient mock that returns a successful status response for worker syncing
+    HttpClient httpClient = EasyMock.createNiceMock(HttpClient.class);
+    EasyMock.expect(httpClient.go(
+        EasyMock.anyObject(),
+        EasyMock.anyObject(),
+        EasyMock.anyObject()
+    )).andReturn(Futures.immediateFuture(
+        new StatusResponseHolder(HttpResponseStatus.OK, new StringBuilder())
+    )).anyTimes();
+    EasyMock.replay(httpClient);
+
+    HttpRemoteTaskRunnerV2 taskRunner = new HttpRemoteTaskRunnerV2(
+        TestHelper.makeJsonMapper(),
+        new HttpRemoteTaskRunnerConfig()
+        {
+          @Override
+          public int getPendingTasksRunnerNumThreads()
+          {
+            return 3;
+          }
+        },
+        httpClient,
+        DSuppliers.of(new AtomicReference<>(DefaultWorkerBehaviorConfig.defaultConfig())),
+        new NoopProvisioningStrategy<>(),
+        druidNodeDiscoveryProvider,
+        taskStorage,
+        new NoopServiceEmitter()
+    )
+    {
+      @Override
+      protected WorkerHolder createWorkerHolder(
+          ObjectMapper smileMapper,
+          HttpClient httpClient,
+          HttpRemoteTaskRunnerConfig config,
+          ScheduledExecutorService workersSyncExec,
+          WorkerHolder.Listener listener,
+          Worker worker,
+          List<TaskAnnouncement> knownAnnouncements
+      )
+      {
+        if (mockWorker != null && mockWorkerHolder != null && worker.getHost().equals(mockWorker.getHost())) {
+          return mockWorkerHolder;
+        }
+        return super.createWorkerHolder(
+            smileMapper,
+            httpClient,
+            config,
+            workersSyncExec,
+            listener,
+            worker,
+            knownAnnouncements
+        );
+      }
+    };
+
+    taskRunner.start();
+
+    if (listenerNotificationsAccumulator != null) {
+      taskRunner.registerListener(
+          new TaskRunnerListener()
+          {
+            @Override
+            public String getListenerId()
+            {
+              return "test-listener";
+            }
+
+            @Override
+            public void locationChanged(String taskId, TaskLocation newLocation)
+            {
+              listenerNotificationsAccumulator.add(ImmutableList.of(taskId, newLocation));
+            }
+
+            @Override
+            public void statusChanged(String taskId, TaskStatus status)
+            {
+              listenerNotificationsAccumulator.add(ImmutableList.of(taskId, status));
+            }
+          },
+          Execs.directExecutor()
+      );
+    }
+
+    return taskRunner;
+  }
+
+  private Worker createWorker(String host)
+  {
+    Worker worker = EasyMock.createMock(Worker.class);
+    EasyMock.expect(worker.getHost()).andReturn(host).anyTimes();
+    EasyMock.replay(worker);
+    return worker;
+  }
+
+  private WorkerHolder createNonSyncingWorkerHolder(Worker worker)
+  {
+    ChangeRequestHttpSyncer syncer = EasyMock.createMock(ChangeRequestHttpSyncer.class);
+    EasyMock.expect(syncer.needsReset()).andReturn(true).anyTimes();
+    EasyMock.expect(syncer.getDebugInfo()).andReturn(Collections.emptyMap()).anyTimes();
+    WorkerHolder workerHolder = EasyMock.createMock(WorkerHolder.class);
+    EasyMock.expect(workerHolder.getUnderlyingSyncer()).andReturn(syncer).anyTimes();
+    EasyMock.expect(workerHolder.getWorker()).andReturn(worker).anyTimes();
+    workerHolder.start();
+    EasyMock.expectLastCall();
+    workerHolder.stop();
+    EasyMock.expectLastCall();
+    EasyMock.replay(syncer, workerHolder);
+    return workerHolder;
+  }
+
+  private static WorkerHolder createWorkerHolder(
+      ObjectMapper smileMapper,
+      HttpClient httpClient,
+      HttpRemoteTaskRunnerConfig config,
+      ScheduledExecutorService workersSyncExec,
+      WorkerHolder.Listener listener,
+      Worker worker,
+      List<TaskAnnouncement> knownAnnouncements,
+
+      // simulates task announcements received from worker on first sync call for the tasks that are already
+      // running/completed on the worker.
+      List<TaskAnnouncement> preExistingTaskAnnouncements,
+
+      // defines behavior for what to do when a particular task is assigned
+      Map<Task, List<TaskAnnouncement>> toBeAssignedTasks,
+
+      // incremented on each runnable completion in workersSyncExec, useful for deterministically watching that some
+      // work completed
+      AtomicInteger ticks,
+
+      // Updated each time a shutdown(taskId) call is received, useful for asserting that expected shutdowns indeed
+      // happened.
+      Set<String> actualShutdowns
+  )
+  {
+    return new WorkerHolder(smileMapper, httpClient, config, workersSyncExec, listener, worker, knownAnnouncements)
+    {
+      private final String workerHost;
+      private final int workerPort;
+      private final LifecycleLock startStopLock = new LifecycleLock();
+
+      {
+        String hostAndPort = worker.getHost();
+        int colonIndex = hostAndPort.indexOf(':');
+        if (colonIndex == -1) {
+          throw new IAE("Invalid host and port: [%s]", colonIndex);
+        }
+        workerHost = hostAndPort.substring(0, colonIndex);
+        workerPort = Integer.parseInt(hostAndPort.substring(colonIndex + 1));
+      }
+
+      @Override
+      public void start()
+      {
+        synchronized (startStopLock) {
+          if (!startStopLock.canStart()) {
+            throw new ISE("Can't start worker[%s:%s].", workerHost, workerPort);
+          }
+          try {
+            disabled.set(false);
+
+            if (!preExistingTaskAnnouncements.isEmpty()) {
+              workersSyncExec.execute(
+                  () -> {
+                    for (TaskAnnouncement announcement : preExistingTaskAnnouncements) {
+                      tasksSnapshotRef.get().put(announcement.getTaskId(), announcement);
+                      listener.taskAddedOrUpdated(announcement, this);
+                    }
+                    ticks.incrementAndGet();
+                  }
+              );
+            }
+            startStopLock.started();
+          }
+          finally {
+            startStopLock.exitStart();
+          }
+        }
+      }
+
+      @Override
+      public void stop()
+      {
+        synchronized (startStopLock) {
+          if (!startStopLock.canStop()) {
+            throw new ISE("Can't stop worker[%s:%s].", workerHost, workerPort);
+          }
+          try {
+          }
+          finally {
+            startStopLock.exitStop();
+          }
+        }
+      }
+
+      @Override
+      public boolean isInitialized()
+      {
+        return true;
+      }
+
+      @Override
+      public void waitForInitialization()
+      {
+      }
+
+      @Override
+      public boolean assignTask(Task task)
+      {
+        // artificial sleeps are introduced to simulate some latency.
+
+        try {
+          Thread.sleep(500);
+        }
+        catch (InterruptedException ex) {
+          throw new RuntimeException(ex);
+        }
+
+        if (toImmutable().getCurrCapacityUsed() > worker.getCapacity()) {
+          throw new ISE("Got assigned tasks more than capacity.");
+        }
+
+        final List<TaskAnnouncement> announcements;
+        if (toBeAssignedTasks.containsKey(task)) {
+          announcements = toBeAssignedTasks.get(task);
+        } else {
+          // no behavior specified for the task, so do default behavior of completing the task
+          announcements = new ArrayList<>();
+          announcements.add(
+              TaskAnnouncement.create(
+                  task,
+                  TaskStatus.running(task.getId()),
+                  TaskLocation.unknown()
+              )
+          );
+          announcements.add(
+              TaskAnnouncement.create(
+                  task,
+                  TaskStatus.running(task.getId()),
+                  TaskLocation.create(workerHost, workerPort, -1)
+              )
+          );
+          announcements.add(
+              TaskAnnouncement.create(
+                  task,
+                  TaskStatus.success(task.getId()),
+                  TaskLocation.create(workerHost, workerPort, -1)
+              )
+          );
+        }
+
+        workersSyncExec.execute(
+            () -> {
+              for (TaskAnnouncement announcement : announcements) {
+                try {
+                  Thread.sleep(100);
+                }
+                catch (InterruptedException ex) {
+                  throw new RuntimeException(ex);
+                }
+
+                tasksSnapshotRef.get().put(announcement.getTaskId(), announcement);
+                listener.taskAddedOrUpdated(announcement, this);
+              }
+
+              ticks.incrementAndGet();
+            }
+        );
+        return true;
+      }
+
+      @Override
+      public void shutdownTask(String taskId)
+      {
+        actualShutdowns.add(taskId);
+      }
+    };
+  }
+
+  /**
+   * Creates a WorkerHolder that tracks the order in which tasks are assigned.
+   */
+  private static WorkerHolder createWorkerHolderWithOrderTracking(
+      ObjectMapper smileMapper,
+      HttpClient httpClient,
+      HttpRemoteTaskRunnerConfig config,
+      ScheduledExecutorService workersSyncExec,
+      WorkerHolder.Listener listener,
+      Worker worker,
+      List<TaskAnnouncement> knownAnnouncements,
+      List<String> taskAssignmentOrder
+  )
+  {
+    return new WorkerHolder(smileMapper, httpClient, config, workersSyncExec, listener, worker, knownAnnouncements)
+    {
+      private final String workerHost;
+      private final int workerPort;
+      private final LifecycleLock startStopLock = new LifecycleLock();
+
+      {
+        String hostAndPort = worker.getHost();
+        int colonIndex = hostAndPort.indexOf(':');
+        if (colonIndex == -1) {
+          throw new IAE("Invalid host and port: [%s]", colonIndex);
+        }
+        workerHost = hostAndPort.substring(0, colonIndex);
+        workerPort = Integer.parseInt(hostAndPort.substring(colonIndex + 1));
+      }
+
+      @Override
+      public void start()
+      {
+        synchronized (startStopLock) {
+          if (!startStopLock.canStart()) {
+            throw new ISE("Can't start worker[%s:%s].", workerHost, workerPort);
+          }
+          try {
+            disabled.set(false);
+            startStopLock.started();
+          }
+          finally {
+            startStopLock.exitStart();
+          }
+        }
+      }
+
+      @Override
+      public void stop()
+      {
+        synchronized (startStopLock) {
+          if (!startStopLock.canStop()) {
+            throw new ISE("Can't stop worker[%s:%s].", workerHost, workerPort);
+          }
+          try {
+          }
+          finally {
+            startStopLock.exitStop();
+          }
+        }
+      }
+
+      @Override
+      public boolean isInitialized()
+      {
+        return true;
+      }
+
+      @Override
+      public void waitForInitialization()
+      {
+      }
+
+      @Override
+      public boolean assignTask(Task task)
+      {
+        // Track the order of task assignments
+        taskAssignmentOrder.add(task.getId());
+
+        try {
+          Thread.sleep(500);
+        }
+        catch (InterruptedException ex) {
+          throw new RuntimeException(ex);
+        }
+
+        if (toImmutable().getCurrCapacityUsed() > worker.getCapacity()) {
+          throw new ISE("Got assigned tasks more than capacity.");
+        }
+
+        // Default behavior: complete the task successfully
+        List<TaskAnnouncement> announcements = new ArrayList<>();
+        announcements.add(
+            TaskAnnouncement.create(
+                task,
+                TaskStatus.running(task.getId()),
+                TaskLocation.unknown()
+            )
+        );
+        announcements.add(
+            TaskAnnouncement.create(
+                task,
+                TaskStatus.running(task.getId()),
+                TaskLocation.create(workerHost, workerPort, -1)
+            )
+        );
+        announcements.add(
+            TaskAnnouncement.create(
+                task,
+                TaskStatus.success(task.getId()),
+                TaskLocation.create(workerHost, workerPort, -1)
+            )
+        );
+
+        workersSyncExec.execute(
+            () -> {
+              for (TaskAnnouncement announcement : announcements) {
+                try {
+                  Thread.sleep(100);
+                }
+                catch (InterruptedException ex) {
+                  throw new RuntimeException(ex);
+                }
+
+                tasksSnapshotRef.get().put(announcement.getTaskId(), announcement);
+                listener.taskAddedOrUpdated(announcement, this);
+              }
+            }
+        );
+        return true;
+      }
+
+      @Override
+      public void shutdownTask(String taskId)
+      {
+        // No-op for this test
+      }
+    };
+  }
+
+  public static class TestDruidNodeDiscovery implements DruidNodeDiscovery
+  {
+    private final boolean timedOut;
+    private List<Listener> listeners;
+
+
+    public TestDruidNodeDiscovery()
+    {
+      this(false);
+    }
+
+    public TestDruidNodeDiscovery(boolean timedOut)
+    {
+      listeners = new ArrayList<>();
+      this.timedOut = timedOut;
+    }
+
+    @Override
+    public Collection<DiscoveryDruidNode> getAllNodes()
+    {
+      throw new UnsupportedOperationException("Not Implemented.");
+    }
+
+    @Override
+    public void registerListener(Listener listener)
+    {
+      listener.nodesAdded(ImmutableList.of());
+      if (timedOut) {
+        listener.nodeViewInitializedTimedOut();
+      } else {
+        listener.nodeViewInitialized();
+      }
+      listeners.add(listener);
+    }
+
+    @Override
+    public void removeListener(Listener listener)
+    {
+      listeners.remove(listener);
+    }
+
+    public List<Listener> getListeners()
+    {
+      return listeners;
+    }
+  }
+
+  public interface CustomFunction
+  {
+    WorkerHolder apply(
+        ObjectMapper smileMapper,
+        HttpClient httpClient,
+        HttpRemoteTaskRunnerConfig config,
+        ScheduledExecutorService workersSyncExec,
+        WorkerHolder.Listener listener,
+        Worker worker,
+        List<TaskAnnouncement> knownAnnouncements
+    );
+  }
+
+  private static HttpRemoteTaskRunnerV2 newHttpTaskRunnerInstance(
+      DruidNodeDiscoveryProvider druidNodeDiscoveryProvider,
+      ProvisioningStrategy provisioningStrategy
+  )
+  {
+    return new HttpRemoteTaskRunnerV2(
+        TestHelper.makeJsonMapper(),
+        new HttpRemoteTaskRunnerConfig()
+        {
+          @Override
+          public int getPendingTasksRunnerNumThreads()
+          {
+            return 3;
+          }
+        },
+        EasyMock.createNiceMock(HttpClient.class),
+        DSuppliers.of(new AtomicReference<>(DefaultWorkerBehaviorConfig.defaultConfig())),
+        provisioningStrategy,
+        druidNodeDiscoveryProvider,
+        EasyMock.createNiceMock(TaskStorage.class),
+        new NoopServiceEmitter()
+    )
+    {
+      @Override
+      protected WorkerHolder createWorkerHolder(
+          ObjectMapper smileMapper,
+          HttpClient httpClient,
+          HttpRemoteTaskRunnerConfig config,
+          ScheduledExecutorService workersSyncExec,
+          WorkerHolder.Listener listener,
+          Worker worker,
+          List<TaskAnnouncement> knownAnnouncements
+      )
+      {
+        return HttpRemoteTaskRunnerV2Test.createWorkerHolder(
+            smileMapper,
+            httpClient,
+            config,
+            workersSyncExec,
+            listener,
+            worker,
+            ImmutableList.of(),
+            ImmutableList.of(),
+            ImmutableMap.of(),
+            new AtomicInteger(),
+            ImmutableSet.of()
+        );
+      }
+    };
+  }
+}

--- a/services/src/main/java/org/apache/druid/cli/CliOverlord.java
+++ b/services/src/main/java/org/apache/druid/cli/CliOverlord.java
@@ -98,6 +98,7 @@ import org.apache.druid.indexing.overlord.duty.TaskLogAutoCleanerConfig;
 import org.apache.druid.indexing.overlord.duty.UnusedSegmentsKiller;
 import org.apache.druid.indexing.overlord.hrtr.HttpRemoteTaskRunnerFactory;
 import org.apache.druid.indexing.overlord.hrtr.HttpRemoteTaskRunnerResource;
+import org.apache.druid.indexing.overlord.hrtr.HttpRemoteTaskRunnerV2Factory;
 import org.apache.druid.indexing.overlord.http.OverlordCompactionResource;
 import org.apache.druid.indexing.overlord.http.OverlordDataSourcesResource;
 import org.apache.druid.indexing.overlord.http.OverlordRedirectInfo;
@@ -392,6 +393,11 @@ public class CliOverlord extends ServerRunnable
                      .to(HttpRemoteTaskRunnerFactory.class)
                      .in(LazySingleton.class);
                 binder.bind(HttpRemoteTaskRunnerFactory.class).in(LazySingleton.class);
+
+                biddy.addBinding(HttpRemoteTaskRunnerV2Factory.TYPE_NAME)
+                     .to(HttpRemoteTaskRunnerV2Factory.class)
+                     .in(LazySingleton.class);
+                binder.bind(HttpRemoteTaskRunnerV2Factory.class).in(LazySingleton.class);
 
                 JacksonConfigProvider.bind(binder, WorkerBehaviorConfig.CONFIG_KEY, WorkerBehaviorConfig.class, null);
                 JacksonConfigProvider.bind(


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

Still a draft.

I've seen on the giant lock in `HttpRemoteTaskRunner` cause severe performance degradation under heavy load(200-500ms per acquisition with 1000s of activeTasks can slow down the startPendingTasks loop in TaskQueue). This leads to scheduling delays, which leads to more lag, which auto-scales more tasks, ..., etc. The runner also has a few (un)documented races abundant in the code. This overhead also slows down query tasks under load (e.g. MSQE and others) which utilize the scheduler for execution.

I'm attempting a rewrite of this class to optimize for throughput and safety.

Apart from the performance improvements/bug fixes, this will also include some new features:
- Simpler code. The old task runner had old, legacy ZK references dangling around as well as a pretty complicated scheduling loop.
- Task priority-based scheduling onto workers (e.g. prioritize realtime tasks for scheduling), follows a simple priority-based fair-queueing policy. 

I would ultimately like to make this the default `HttpRemoteTaskRunner` and have it run in all tests/production clusters, etc. as I think that would help catch more bugs/issues. 

#### Performance Testing

Test results thus far have shown ~100-300ms speed up per task runner operation (`add()`, etc.). Over 1000s of tasks, this amounts to minutes of delay saved.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
