### PR TITLE
fix: Added all possible exceptions to MySQLInputSourceDatabaseConnectorTest

### DIFF
--- a/extensions-core/mysql-metadata-storage/pom.xml
+++ b/extensions-core/mysql-metadata-storage/pom.xml
@@ -121,6 +121,12 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/input/MySQLInputSourceDatabaseConnectorTest.java
+++ b/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/input/MySQLInputSourceDatabaseConnectorTest.java
@@ -41,6 +41,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Set;
 
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.containsString;
+
 @RunWith(MockitoJUnitRunner.class)
 public class MySQLInputSourceDatabaseConnectorTest
 {
@@ -167,7 +170,12 @@ public class MySQLInputSourceDatabaseConnectorTest
 
     JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of(""));
 
-    expectedException.expectMessage("The property [password] is not in the allowed list");
+    expectedException.expectMessage(
+        anyOf(
+            containsString("The property [password] is not in the allowed list"),
+            containsString("The property [user] is not in the allowed list")
+        )
+    );
     expectedException.expect(IllegalArgumentException.class);
 
     new MySQLInputSourceDatabaseConnector(
@@ -241,7 +249,12 @@ public class MySQLInputSourceDatabaseConnectorTest
 
     JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of("none", "nonenone"));
 
-    expectedException.expectMessage("The property [password] is not in the allowed list");
+    expectedException.expectMessage(
+          anyOf(
+                  containsString("The property [password] is not in the allowed list"),
+                  containsString("The property [user] is not in the allowed list")
+          )
+    );
     expectedException.expect(IllegalArgumentException.class);
 
     new MySQLInputSourceDatabaseConnector(
@@ -291,7 +304,12 @@ public class MySQLInputSourceDatabaseConnectorTest
 
     JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of("user", "nonenone"));
 
-    expectedException.expectMessage("The property [password] is not in the allowed list");
+    expectedException.expectMessage(
+          anyOf(
+                  containsString("The property [password] is not in the allowed list"),
+                  containsString("The property [keyonly] is not in the allowed list")
+          )
+    );
     expectedException.expect(IllegalArgumentException.class);
 
     new MySQLInputSourceDatabaseConnector(

--- a/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/input/MySQLInputSourceDatabaseConnectorTest.java
+++ b/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/input/MySQLInputSourceDatabaseConnectorTest.java
@@ -29,6 +29,7 @@ import org.apache.druid.metadata.MetadataStorageConnectorConfig;
 import org.apache.druid.metadata.storage.mysql.MySQLConnectorDriverConfig;
 import org.apache.druid.metadata.storage.mysql.MySQLMetadataStorageModule;
 import org.apache.druid.server.initialization.JdbcAccessSecurityConfig;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -40,9 +41,6 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Set;
-
-import static org.hamcrest.CoreMatchers.anyOf;
-import static org.hamcrest.CoreMatchers.containsString;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MySQLInputSourceDatabaseConnectorTest
@@ -171,9 +169,9 @@ public class MySQLInputSourceDatabaseConnectorTest
     JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of(""));
 
     expectedException.expectMessage(
-        anyOf(
-            containsString("The property [password] is not in the allowed list"),
-            containsString("The property [user] is not in the allowed list")
+        CoreMatchers.anyOf(
+            CoreMatchers.containsString("The property [password] is not in the allowed list"),
+            CoreMatchers.containsString("The property [user] is not in the allowed list")
         )
     );
     expectedException.expect(IllegalArgumentException.class);
@@ -250,10 +248,10 @@ public class MySQLInputSourceDatabaseConnectorTest
     JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of("none", "nonenone"));
 
     expectedException.expectMessage(
-          anyOf(
-                  containsString("The property [password] is not in the allowed list"),
-                  containsString("The property [user] is not in the allowed list")
-          )
+        CoreMatchers.anyOf(
+            CoreMatchers.containsString("The property [password] is not in the allowed list"),
+            CoreMatchers.containsString("The property [user] is not in the allowed list")
+        )
     );
     expectedException.expect(IllegalArgumentException.class);
 
@@ -305,10 +303,10 @@ public class MySQLInputSourceDatabaseConnectorTest
     JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of("user", "nonenone"));
 
     expectedException.expectMessage(
-          anyOf(
-                  containsString("The property [password] is not in the allowed list"),
-                  containsString("The property [keyonly] is not in the allowed list")
-          )
+        CoreMatchers.anyOf(
+            CoreMatchers.containsString("The property [password] is not in the allowed list"),
+            CoreMatchers.containsString("The property [keyonly] is not in the allowed list")
+        )
     );
     expectedException.expect(IllegalArgumentException.class);
 


### PR DESCRIPTION
### Description
The following tests in `MySQLInputSourceDatabaseConnectorTest.java` have some nondeterminism due to how properties are checked in [`ConnectionUriUtils.java`](https://github.com/apache/druid/blob/9106cb049692722866e66e42b28bd0f8f7898ab5/processing/src/main/java/org/apache/druid/utils/ConnectionUriUtils.java#L58):
- org.apache.druid.metadata.input.MySQLInputSourceDatabaseConnectorTest.testFailWhenNoAllowlistAndHaveProperty
- org.apache.druid.metadata.input.MySQLInputSourceDatabaseConnectorTest.testFailOnlyInvalidProperty
- org.apache.druid.metadata.input.MySQLInputSourceDatabaseConnectorTest.testFailValidAndInvalidPropertyMariadb

This PR proposes a fix to ensure the tests are robust to nondeterministic behaviors with different JVM and future updates to it.

### Problem
When a `MySQLInputSourceDatabaseConnector` is created, [`validateConfig`](https://github.com/apache/druid/blob/9106cb049692722866e66e42b28bd0f8f7898ab5/server/src/main/java/org/apache/druid/metadata/SQLInputSourceDatabaseConnector.java#L77) is called which then calls [`ConnectionUriUtils.throwIfPropertiesAreNotAllowed`](https://github.com/apache/druid/blob/9106cb049692722866e66e42b28bd0f8f7898ab5/processing/src/main/java/org/apache/druid/utils/ConnectionUriUtils.java#L58). The util function `throwIfPropertiesAreNotAllowed` tests membership using these `Set`s and throws an exception on the first element that is not in the `allowedProperties` `Set`. However, if there is more than one element not in the `allowedProperties` `Set`, then there may be multiple possible exception messages since a specific ordering of these elements is not guaranteed. 

As a result, the tests can fail as such: 

```
[ERROR] org.apache.druid.metadata.input.MySQLInputSourceDatabaseConnectorTest.testFailWhenNoAllowlistAndHaveProperty
[ERROR]   Run 1: MySQLInputSourceDatabaseConnectorTest.testFailWhenNoAllowlistAndHaveProperty 
Expected: (exception with message a string containing "The property [password] is not in the allowed list" and an instance of java.lang.IllegalArgumentException)                                                                                                                                     
     but: exception with message a string containing "The property [password] is not in the allowed list" message was "The property [user] is not in the allowed list []"                                                                                                                             
Stacktrace was: java.lang.IllegalArgumentException: The property [user] is not in the allowed list []                                              
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:445)                                                              
        at org.apache.druid.utils.ConnectionUriUtils.throwIfPropertiesAreNotAllowed(ConnectionUriUtils.java:69)                                    
        at org.apache.druid.metadata.SQLInputSourceDatabaseConnector.validateConfigs(SQLInputSourceDatabaseConnector.java:99)                      
        at org.apache.druid.metadata.SQLInputSourceDatabaseConnector.getDatasource(SQLInputSourceDatabaseConnector.java:77)                        
        at org.apache.druid.metadata.input.MySQLInputSourceDatabaseConnector.<init>(MySQLInputSourceDatabaseConnector.java:57)                     
        at org.apache.druid.metadata.input.MySQLInputSourceDatabaseConnectorTest.testFailWhenNoAllowlistAndHaveProperty(MySQLInputSourceDatabaseConnectorTest.java:173)                                                                                                        
```

### Solution
To fix `org.apache.druid.metadata.input.MySQLInputSourceDatabaseConnectorTest.testFailWhenNoAllowlistAndHaveProperty` and `org.apache.druid.metadata.input.MySQLInputSourceDatabaseConnectorTest.testFailOnlyInvalidProperty`, I enumerated all the possible error messages using:

```
expectedException.expectMessage(
        anyOf(
                containsString("The property [password] is not in the allowed list"),
                containsString("The property [user] is not in the allowed list")
        )
);
```
These values are found here:
<img width="1079" height="447" alt="Screenshot 2025-11-04 003655" src="https://github.com/user-attachments/assets/9ebd9b6c-bd0a-429f-8238-0a55320ac9af" />



To fix `org.apache.druid.metadata.input.MySQLInputSourceDatabaseConnectorTest.testFailValidAndInvalidPropertyMariadb`, I enumerated all the possible error messages using:

```
expectedException.expectMessage(
        anyOf(
                containsString("The property [password] is not in the allowed list"),
                containsString("The property [keyonly] is not in the allowed list")
        )
);
```

These values are found here:
<img width="1070" height="440" alt="Screenshot 2025-11-04 005634" src="https://github.com/user-attachments/assets/0dc72e3f-c2ca-4bf8-92bb-25a8ad20b803" />


---

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
