### PR TITLE
Specify PostgreSQL version 17.6 in distribution's docker-compose.yml

### DIFF
--- a/distribution/docker/docker-compose.yml
+++ b/distribution/docker/docker-compose.yml
@@ -31,7 +31,7 @@ volumes:
 services:
   postgres:
     container_name: postgres
-    image: postgres:latest
+    image: postgres:17.6
     ports:
       - "5432:5432"
     volumes:


### PR DESCRIPTION
Container with the latest version of PostgreSQL (18.0 at the moment of this commit)
doesn't start due to the some problems of PostgreSQL on docker itself on the new version.

This patch establishes PostgreSQL version 17.6 in docker-compose.yml as stable, temporarily.

Detailed error log may be found under the spoiler
<details>

```
Error: in 18+, these Docker images are configured to store database data in a
format which is compatible with "pg_ctlcluster" (specifically, using
major-version-specific directory names). This better reflects how
PostgreSQL itself works, and how upgrades are to be performed.

See also https://github.com/docker-library/postgres/pull/1259

Counter to that, there appears to be PostgreSQL data in:
  /var/lib/postgresql/data

This is usually the result of upgrading the Docker image without
upgrading the underlying database using "pg_upgrade" (which requires both
versions).

The suggested container configuration for 18+ is to place a single mount
at /var/lib/postgresql which will then place PostgreSQL data in a
subdirectory, allowing usage of "pg_upgrade --link" without mount point
boundary issues.

See https://github.com/docker-library/postgres/issues/37 for a (long)
discussion around this process, and suggestions for how to do so.
```

</details>

This PR has:

- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.