### PR TITLE
Fix negative Kafka partition lag caused by inconsistent current/latest offsets

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisor.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisor.java
@@ -506,9 +506,11 @@ public class KafkaSupervisor extends SeekableStreamSupervisor<KafkaTopicPartitio
   }
 
   /**
-   * Fetches the latest offsets from the Kafka stream and updates the map
-   * {@link #latestSequenceFromStream}. The actual lag is computed lazily in
-   * {@link #getPartitionRecordLag}.
+   * Fetches latest stream offsets, combines with the highest ingested offsets into a snapshot,
+   * and atomically updates {@link #offsetSnapshotRef}.
+   * <p>
+   * Lag is computed consistently from the snapshot in downstream methods.
+   * </p>
    */
   @Override
   protected void updatePartitionLagFromStream()

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/OffsetSnapshot.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/OffsetSnapshot.java
@@ -39,7 +39,7 @@ import java.util.Objects;
  * <p>
  * By publishing both maps together as a single atomic snapshot (using {@link java.util.concurrent.atomic.AtomicReference}),
  * readers (such as lag metrics and supervisor status) always observe a coherent and consistent view.
- * This produces stable and monotonic lag trends, avoiding artifacts like temporary negative lags.
+ * This produces stable, non-negative lag values over time, avoiding artifacts like temporary negative lags.
  *
  * <p>
  * This class is generic and can be reused by all seekable-stream supervisors (Kafka, Kinesis, etc.).

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/OffsetSnapshotTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/OffsetSnapshotTest.java
@@ -38,9 +38,9 @@ public class OffsetSnapshotTest
     );
 
     Assert.assertTrue(snapshot.getHighestIngestedOffsets().isEmpty());
-    Assert.assertSame(ImmutableMap.of(), snapshot.getHighestIngestedOffsets());
+    Assert.assertEquals(ImmutableMap.of(), snapshot.getHighestIngestedOffsets());
     Assert.assertTrue(snapshot.getLatestOffsetsFromStream().isEmpty());
-    Assert.assertSame(ImmutableMap.of(), snapshot.getLatestOffsetsFromStream());
+    Assert.assertEquals(ImmutableMap.of(), snapshot.getLatestOffsetsFromStream());
   }
 
   @Test
@@ -49,9 +49,9 @@ public class OffsetSnapshotTest
     OffsetSnapshot<Integer, Long> snapshot = OffsetSnapshot.of(null, null);
 
     Assert.assertTrue(snapshot.getHighestIngestedOffsets().isEmpty());
-    Assert.assertSame(ImmutableMap.of(), snapshot.getHighestIngestedOffsets());
+    Assert.assertEquals(ImmutableMap.of(), snapshot.getHighestIngestedOffsets());
     Assert.assertTrue(snapshot.getLatestOffsetsFromStream().isEmpty());
-    Assert.assertSame(ImmutableMap.of(), snapshot.getLatestOffsetsFromStream());
+    Assert.assertEquals(ImmutableMap.of(), snapshot.getLatestOffsetsFromStream());
   }
 
   @Test
@@ -62,7 +62,7 @@ public class OffsetSnapshotTest
     OffsetSnapshot<Integer, Long> snapshot = OffsetSnapshot.of(null, endOffsets);
 
     Assert.assertTrue(snapshot.getHighestIngestedOffsets().isEmpty());
-    Assert.assertSame(ImmutableMap.of(), snapshot.getHighestIngestedOffsets());
+    Assert.assertEquals(ImmutableMap.of(), snapshot.getHighestIngestedOffsets());
     Assert.assertEquals(endOffsets, snapshot.getLatestOffsetsFromStream());
   }
 
@@ -75,7 +75,7 @@ public class OffsetSnapshotTest
 
     Assert.assertEquals(currentOffsets, snapshot.getHighestIngestedOffsets());
     Assert.assertTrue(snapshot.getLatestOffsetsFromStream().isEmpty());
-    Assert.assertSame(ImmutableMap.of(), snapshot.getLatestOffsetsFromStream());
+    Assert.assertEquals(ImmutableMap.of(), snapshot.getLatestOffsetsFromStream());
   }
 
   @Test


### PR DESCRIPTION
# Motivation

We operate a Druid deployment with more than 500 nodes.

In real-time ingestion scenarios, a monitoring process queries the cluster every minute to retrieve the `ingest/kafka/partitionLag` metric. If the lag remains unhealthy for more than five minutes, alerts are triggered.

In our production environment, this metric periodically becomes **negative**, even when the cluster is fully healthy. These false alerts create unnecessary operational load and frequently wake the on-call team during off-hours. At the same time, we cannot suppress negative-lag alerts entirely, since in some situations negative lag can indicate real ingestion problems.

For a large-scale, 24×7 real-time ingestion pipeline, **accurate and consistent lag metrics are essential to avoid unnecessary nighttime wake-ups while still ensuring that real issues are detected promptly**.


---

# Problem Description

<img width="1255" height="839" alt="negative_lag" src="https://github.com/user-attachments/assets/3b193544-984d-4d62-9387-06d0100b79f7" />


In the current implementation, the Druid supervisor maintains two volatile data structures:

* The latest Kafka `end_offset` for each partition
* The latest task-reported `current_offset` for each partition

The supervisor periodically updates these values (every 30 seconds):

1. Querying all tasks in parallel  to update `current_offset`.
   This step waits for all HTTP requests to complete and each request has a timeout of two minutes.
2. Querying Kafka cluster to refresh `end_offset`.

On the other hand, a separate periodic task (every minute) computes:

```
lag = end_offset - current_offset
```

Because the two updates are not atomic, intermediate inconsistent states may occur.

### Intermediate State Leading to Negative Lag

If one task becomes heavily loaded or experiences other delays during Step 1, it may take significantly longer to return its offset. In this situation, the supervisor continues waiting for that slow task while the other tasks have already responded. 

During this waiting period:

* Many `current_offset` values already have been updated to new values.
* The `end_offset` values remain stale because Step 2 has not executed yet.

If a monitoring request arrives in this intermediate window, the supervisor computes lag using:

* **Partially updated `current_offset`**
* **Stale `end_offset`**

This produces negative lag values.

This issue repeats as long as at least one task remains slow. Large clusters with many partitions and many Kafka-indexing tasks are more likely to experience this scenario.

---

# Example Scenario

1. Initial state: `end_offset = 10000`, `current_offset = 0`.
2. After consumption: latest Kafka `end_offset = 30000`, and all tasks have consumed up to `20000`.
3. During Step 1, 49 tasks respond quickly, and their `current_offset` is updated to `20000`.
   One task is slow, causing Step 1 to remain in the awaiting state.
4. The in-memory `end_offset` stays at the old value `10000`.
5. If a metric query occurs at this point, the supervisor calculates:

   ```
   10000 - 20000 = -10000
   ```
6. Because the periodic update logic repeats, this situation can persist across multiple cycles.

---

# Proposed Changes

Replace the two volatile structures storing `current_offset` and `end_offset` with `AtomicReference` containers that hold both values as a single immutable state object. The supervisor will update these references as atomic units, ensuring that lag computation always observes a consistent snapshot.

This eliminates inconsistent intermediate states and prevents negative lag due to partial updates.

---

# Rationale

* Ensures consistent reads between related fields.
* No behavioral changes other than removing negative lag caused by inconsistent state.

---

# Operational Impact

* Improved accuracy of Kafka lag metrics in large clusters.
* Reduces false alerts in monitoring systems.

---

# Test Plan

* This change does not add new feature. We only need to make sure existing tests still pass. 
* All current tests pass successfully.

---
This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.



