### PR TITLE
Add capability to ingest record offset and partition using KafkaInputFormat

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputFormat.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputFormat.java
@@ -44,6 +44,7 @@ public class KafkaInputFormat implements InputFormat
   private static final String DEFAULT_HEADER_COLUMN_PREFIX = "kafka.header.";
   private static final String DEFAULT_TIMESTAMP_COLUMN_NAME = "kafka.timestamp";
   private static final String DEFAULT_TOPIC_COLUMN_NAME = "kafka.topic";
+  private static final String DEFAULT_PARTITION_COLUMN_NAME = "kafka.partition";
   private static final String DEFAULT_OFFSET_COLUMN_NAME = "kafka.offset";
   private static final String DEFAULT_KEY_COLUMN_NAME = "kafka.key";
   public static final String DEFAULT_AUTO_TIMESTAMP_STRING = "__kif_auto_timestamp";
@@ -60,6 +61,7 @@ public class KafkaInputFormat implements InputFormat
   private final String keyColumnName;
   private final String timestampColumnName;
   private final String topicColumnName;
+  private final String partitionColumnName;
   private final String offsetColumnName;
 
   public KafkaInputFormat(
@@ -70,6 +72,7 @@ public class KafkaInputFormat implements InputFormat
       @JsonProperty("keyColumnName") @Nullable String keyColumnName,
       @JsonProperty("timestampColumnName") @Nullable String timestampColumnName,
       @JsonProperty("topicColumnName") @Nullable String topicColumnName,
+      @JsonProperty("partitionColumnName") @Nullable String partitionColumnName,
       @JsonProperty("offsetColumnName") @Nullable String offsetColumnName
   )
   {
@@ -80,6 +83,7 @@ public class KafkaInputFormat implements InputFormat
     this.keyColumnName = keyColumnName != null ? keyColumnName : DEFAULT_KEY_COLUMN_NAME;
     this.timestampColumnName = timestampColumnName != null ? timestampColumnName : DEFAULT_TIMESTAMP_COLUMN_NAME;
     this.topicColumnName = topicColumnName != null ? topicColumnName : DEFAULT_TOPIC_COLUMN_NAME;
+    this.partitionColumnName = Configs.valueOrDefault(partitionColumnName, DEFAULT_PARTITION_COLUMN_NAME);
     this.offsetColumnName = Configs.valueOrDefault(offsetColumnName, DEFAULT_OFFSET_COLUMN_NAME);
   }
 
@@ -134,6 +138,7 @@ public class KafkaInputFormat implements InputFormat
         keyColumnName,
         timestampColumnName,
         topicColumnName,
+        partitionColumnName,
         offsetColumnName
     );
   }
@@ -188,6 +193,13 @@ public class KafkaInputFormat implements InputFormat
 
   @Nullable
   @JsonProperty
+  public String getPartitionColumnName()
+  {
+    return partitionColumnName;
+  }
+
+  @Nullable
+  @JsonProperty
   public String getOffsetColumnName()
   {
     return offsetColumnName;
@@ -210,6 +222,7 @@ public class KafkaInputFormat implements InputFormat
            && Objects.equals(keyColumnName, that.keyColumnName)
            && Objects.equals(timestampColumnName, that.timestampColumnName)
            && Objects.equals(topicColumnName, that.topicColumnName)
+           && Objects.equals(partitionColumnName, that.partitionColumnName)
            && Objects.equals(offsetColumnName, that.offsetColumnName);
   }
 
@@ -224,6 +237,7 @@ public class KafkaInputFormat implements InputFormat
         keyColumnName,
         timestampColumnName,
         topicColumnName,
+        partitionColumnName,
         offsetColumnName
     );
   }

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputReader.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputReader.java
@@ -56,6 +56,7 @@ public class KafkaInputReader implements InputEntityReader
   private final String keyColumnName;
   private final String timestampColumnName;
   private final String topicColumnName;
+  private final String partitionColumnName;
   private final String offsetColumnName;
 
   /**
@@ -76,6 +77,7 @@ public class KafkaInputReader implements InputEntityReader
       String keyColumnName,
       String timestampColumnName,
       String topicColumnName,
+      String partitionColumnName,
       String offsetColumnName
   )
   {
@@ -87,6 +89,7 @@ public class KafkaInputReader implements InputEntityReader
     this.keyColumnName = keyColumnName;
     this.timestampColumnName = timestampColumnName;
     this.topicColumnName = topicColumnName;
+    this.partitionColumnName = partitionColumnName;
     this.offsetColumnName = offsetColumnName;
   }
 
@@ -134,7 +137,7 @@ public class KafkaInputReader implements InputEntityReader
 
     // Add kafka record topic to the mergelist, only if the key doesn't already exist
     mergedHeaderMap.putIfAbsent(topicColumnName, record.getRecord().topic());
-
+    mergedHeaderMap.putIfAbsent(partitionColumnName, record.getRecord().partition());
     mergedHeaderMap.putIfAbsent(offsetColumnName, record.getRecord().offset());
 
     return mergedHeaderMap;

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
@@ -145,6 +145,7 @@ public class KafkaInputFormatTest
         "kafka.newkey.key",
         "kafka.newts.timestamp",
         "kafka.newtopic.topic",
+        "kafka.new.partition",
         "kafka.new.offset"
     );
   }
@@ -185,6 +186,7 @@ public class KafkaInputFormatTest
         "kafka.newkey.key",
         "kafka.newts.timestamp",
         "kafka.newtopic.topic",
+        "kafka.new.partition",
         "kafka.new.offset"
     );
     Assert.assertEquals(format, kif);
@@ -421,7 +423,8 @@ public class KafkaInputFormatTest
             false,
             false
         ),
-        "kafka.newheader.", "kafka.newkey.", "kafka.newts.", "kafka.newtopic.", "kafka.new.offset"
+        "kafka.newheader.", "kafka.newkey.", "kafka.newts.", "kafka.newtopic.",
+        "kafka.new.partition", "kafka.new.offset"
     );
 
     final InputEntityReader reader = localFormat.createReader(
@@ -650,6 +653,7 @@ public class KafkaInputFormatTest
                 "foo",
                 "kafka.newts.timestamp",
                 "kafka.newkey.key",
+                "kafka.new.partition",
                 "root_baz",
                 "o",
                 "bar",
@@ -718,6 +722,7 @@ public class KafkaInputFormatTest
         "kafka.newkey.key",
         "kafka.newts.timestamp",
         "kafka.newtopic.topic",
+        "kafka.new.partition",
         "kafka.new.offset"
     );
 
@@ -817,6 +822,7 @@ public class KafkaInputFormatTest
         "kafka.newkey.key",
         "kafka.newts.timestamp",
         "kafka.newtopic.topic",
+        "kafka.new.partition",
         "kafka.new.offset"
     );
 
@@ -918,6 +924,7 @@ public class KafkaInputFormatTest
                 "foo",
                 "kafka.newts.timestamp",
                 "kafka.newkey.key",
+                "kafka.new.partition",
                 "root_baz",
                 "o",
                 "path_omg",

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -172,7 +172,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
       new KafkaStringHeaderFormat(null),
       INPUT_FORMAT,
       INPUT_FORMAT,
-      "kafka.testheader.", "kafka.key", "kafka.timestamp", "kafka.topic", "kafka.offset"
+      "kafka.testheader.", "kafka.key", "kafka.timestamp", "kafka.topic", "kafka.partition", "kafka.offset"
   );
 
   private static TestingCluster zkServer;

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaIOConfigBuilder.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaIOConfigBuilder.java
@@ -62,6 +62,7 @@ public class KafkaIOConfigBuilder extends SupervisorIOConfigBuilder<KafkaIOConfi
         null,
         null,
         null,
+        null,
         null
     );
     return this;


### PR DESCRIPTION
### Usage

Ingesting the record offset as a column can allow us to write a `transformSpec` which filters on it.
This strategy can be used to ingest data for a certain offset range in Kafka, which is particularly useful when trying to recover some missing data.

### Changes

- Add optional fields `offsetColumnName` and `partitionColumnName` to `KafkaInputFormat`
- Add default names for these columns as `kafka.offset` and `kafka.partition` respectively

### Pending

- Add embedded test

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.