### PR TITLE
Include indexing task logs in the tarball when the web-console test fails

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -197,7 +197,7 @@ jobs:
 
       - name: Tar druid logs
         if: ${{ failure() && steps.web-console-test.conclusion == 'failure' }}
-        run: tar cvzf ./druid-logs.tgz -C ./distribution/target/apache-druid-*-SNAPSHOT/ log
+        run: tar cvzf ./druid-logs.tgz -C ./distribution/target/apache-druid-*-SNAPSHOT/ log -C ./var druid/indexing-logs
 
       - name: Upload druid logs to GitHub
         if: ${{ failure() && steps.web-console-test.conclusion == 'failure' }}


### PR DESCRIPTION
Cherry-picked from https://github.com/apache/druid/pull/18732/commits/51c5f8503694c4de540350985ff024b0205f81c4

When the web-console e2e test fails, the static-checks workflow currently uploads only the service logs in the tarball. While debugging a recent issue, the root cause turned out to be in the indexing logs. Including those logs in the tarball will make it easier to diagnose web-console test failures.

The artifact including the indexing-logs can be downloaded from https://github.com/apache/druid/actions/runs/19223275180/job/54945127755.
