### PR TITLE
fix(protobuf-core): re-introduce the load-by-file-path/url protobuf descriptors

### DIFF
--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/FileBasedProtobufBytesDecoderTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/FileBasedProtobufBytesDecoderTest.java
@@ -70,7 +70,7 @@ public class FileBasedProtobufBytesDecoderTest
   }
 
   @Test
-  public void tesDescriptorUrl()
+  public void testDescriptorUrl()
   {
     File descFile = new File("src/test/resources/proto_test_event.desc");
     String path = descFile.getAbsoluteFile().toString();
@@ -134,7 +134,7 @@ public class FileBasedProtobufBytesDecoderTest
     );
 
     assertEquals(
-        "Cannot read descriptor file: [file:/nonexist.desc]",
+        "Failed to initialize descriptor at [file:/nonexist.desc]",
         ex.getMessage()
     );
   }


### PR DESCRIPTION
### Description

Druid 35.0.0 broke URL path loading for protobufs. Reintroduce this feature.

#### Release note

Reintroduce URI protobuf descriptor files loading.

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [ ] been tested in a test Druid cluster.