### PR TITLE
add ServiceClientImpl retry on 401

### DIFF
--- a/server/src/main/java/org/apache/druid/rpc/StandardRetryPolicy.java
+++ b/server/src/main/java/org/apache/druid/rpc/StandardRetryPolicy.java
@@ -141,7 +141,8 @@ public class StandardRetryPolicy implements ServiceRetryPolicy
     return code == HttpResponseStatus.BAD_GATEWAY.getCode()
            || code == HttpResponseStatus.SERVICE_UNAVAILABLE.getCode()
            || code == HttpResponseStatus.GATEWAY_TIMEOUT.getCode()
-
+           // 401 can happen from things like expiration and might be retryable
+           || code == HttpResponseStatus.UNAUTHORIZED.getCode()
            // Technically shouldn't retry this last one, but servers sometimes return HTTP 500 for retryable errors.
            || code == HttpResponseStatus.INTERNAL_SERVER_ERROR.getCode();
   }

--- a/server/src/test/java/org/apache/druid/rpc/ServiceClientImplTest.java
+++ b/server/src/test/java/org/apache/druid/rpc/ServiceClientImplTest.java
@@ -715,6 +715,23 @@ public class ServiceClientImplTest
     );
   }
 
+  @Test
+  public void test_request_authErrorRetry() throws Exception
+  {
+    final RequestBuilder requestBuilder = new RequestBuilder(HttpMethod.GET, "/foo");
+    final ImmutableMap<String, String> expectedResponseObject = ImmutableMap.of("foo", "bar");
+
+    // Unauthorized response from SERVER1, then OK response.
+    stubLocatorCall(locations(SERVER1, SERVER2));
+    expectHttpCall(requestBuilder, SERVER1)
+        .thenReturn(errorResponse(HttpResponseStatus.UNAUTHORIZED, null, "unauthorized"))
+        .thenReturn(valueResponse(expectedResponseObject));
+
+    serviceClient = makeServiceClient(StandardRetryPolicy.unlimited());
+    final Map<String, String> response = doRequest(serviceClient, requestBuilder);
+    Assert.assertEquals(expectedResponseObject, response);
+  }
+
   private void stubLocatorCall(final ServiceLocations locations)
   {
     stubLocatorCall(Futures.immediateFuture(locations));


### PR DESCRIPTION
### Description
updates `StandardRetryPolicy` to retry on 401 unauthorized response, since it can result from things like credential expiration between the time that the client sent the request and the server processed it.