### PR TITLE
Bulk add to timeline in DataSourceCompactibleSegmentIterator.

### DIFF
--- a/processing/src/main/java/org/apache/druid/timeline/VersionedIntervalTimeline.java
+++ b/processing/src/main/java/org/apache/druid/timeline/VersionedIntervalTimeline.java
@@ -176,14 +176,20 @@ public class VersionedIntervalTimeline<VersionType, ObjectType extends Overshado
         .toSet();
   }
 
+  /**
+   * Add a single partition chunk entry to this timeline. Avoid calling this in a loop, since it
+   * is O(objects in holder) and can therefore creates O(N^2) situations. Instead use {@link #addAll(Iterator)}
+   * if you have many objects to add.
+   */
   public void add(final Interval interval, VersionType version, PartitionChunk<ObjectType> object)
   {
     addAll(Iterators.singletonIterator(new PartitionChunkEntry<>(interval, version, object)));
   }
 
-  public void addAll(
-      final Iterator<PartitionChunkEntry<VersionType, ObjectType>> objects
-  )
+  /**
+   * Adds partition chunk entries to this timeline.
+   */
+  public void addAll(final Iterator<PartitionChunkEntry<VersionType, ObjectType>> objects)
   {
     lock.writeLock().lock();
 


### PR DESCRIPTION
Calling "addAll" is more efficient than calling "add" in a loop, it is O(N) instead of O(N^2).