### PR TITLE
Improved failure messages for MSQCompactionRunner.

### DIFF
--- a/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQCompactionRunner.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQCompactionRunner.java
@@ -730,23 +730,23 @@ public class MSQCompactionRunner implements CompactionRunner
       }
       try {
         if (task.isReady(toolbox.getTaskActionClient())) {
-          log.info("Running MSQControllerTask[%d]: %s", taskCnt, json);
+          log.info("Running MSQControllerTask number[%d]: %s", taskCnt, json);
           final TaskStatus taskStatus = task.run(toolbox);
           if (!taskStatus.isSuccess()) {
             failCnt++;
-            log.warn("Failed to run MSQControllerTask[%d]: %s", taskCnt, taskStatus.getErrorMsg());
+            log.warn("Failed to run MSQControllerTask number[%d]: %s", taskCnt, taskStatus.getErrorMsg());
             if (firstFailure == null) {
               firstFailure = taskStatus;
             }
           }
         } else {
           failCnt++;
-          log.warn("MSQControllerTask[%d] is not ready.", taskCnt);
+          log.warn("MSQControllerTask number[%d] is not ready.", taskCnt);
         }
       }
       catch (Exception e) {
         failCnt++;
-        log.warn(e, "Failed to run MSQControllerTask[%d].", taskCnt);
+        log.warn(e, "Failed to run MSQControllerTask number[%d].", taskCnt);
       }
     }
 


### PR DESCRIPTION
Include the first failure message in the task status itself, so it is not necessary to fetch task logs to see the error message.

Also, don't log the entire task JSON for failed subtasks. It is logged once when a subtask is initially run, and that's enough.