### PR TITLE
fix error message for MSQ TooManyInputFilesFault

### DIFF
--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/QueryValidator.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/QueryValidator.java
@@ -19,20 +19,13 @@
 
 package org.apache.druid.msq.exec;
 
-import com.google.common.math.IntMath;
-import com.google.common.primitives.Ints;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.msq.indexing.error.MSQException;
 import org.apache.druid.msq.indexing.error.TooManyClusteredByColumnsFault;
 import org.apache.druid.msq.indexing.error.TooManyColumnsFault;
-import org.apache.druid.msq.indexing.error.TooManyInputFilesFault;
 import org.apache.druid.msq.indexing.error.TooManyWorkersFault;
-import org.apache.druid.msq.input.InputSlice;
 import org.apache.druid.msq.kernel.QueryDefinition;
 import org.apache.druid.msq.kernel.StageDefinition;
-import org.apache.druid.msq.kernel.WorkOrder;
-
-import java.math.RoundingMode;
 
 public class QueryValidator
 {
@@ -66,24 +59,6 @@ public class QueryValidator
       } else if (numWorkers <= 0) {
         throw new ISE("Number of workers must be greater than 0");
       }
-    }
-  }
-
-  /**
-   * Validate that a {@link WorkOrder} falls within the {@link Limits#MAX_INPUT_FILES_PER_WORKER} limit.
-   */
-  public static void validateWorkOrder(final WorkOrder order)
-  {
-    final int numInputFiles = Ints.checkedCast(order.getInputs().stream().mapToLong(InputSlice::fileCount).sum());
-
-    if (numInputFiles > Limits.MAX_INPUT_FILES_PER_WORKER) {
-      throw new MSQException(
-          new TooManyInputFilesFault(
-              numInputFiles,
-              Limits.MAX_INPUT_FILES_PER_WORKER,
-              IntMath.divide(numInputFiles, Limits.MAX_INPUT_FILES_PER_WORKER, RoundingMode.CEILING)
-          )
-      );
     }
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQFaultsTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQFaultsTest.java
@@ -472,7 +472,7 @@ public class MSQFaultsTest extends MSQTestBase
   {
     RowSignature dummyRowSignature = RowSignature.builder().add("__time", ColumnType.LONG).build();
 
-    final int numFiles = 20000;
+    final int numFiles = 100000;
 
     final File toRead = getResourceAsTemporaryFile("/wikipedia-sampled.json");
     final String toReadFileNameAsJson = queryFramework().queryJsonMapper().writeValueAsString(toRead.getAbsolutePath());
@@ -492,9 +492,10 @@ public class MSQFaultsTest extends MSQTestBase
             + ") PARTITIONED by day",
             externalFiles
         ))
+        .setQueryContext(Map.of("maxNumTasks", 8))
         .setExpectedDataSource("foo1")
         .setExpectedRowSignature(dummyRowSignature)
-        .setExpectedMSQFault(new TooManyInputFilesFault(numFiles, Limits.MAX_INPUT_FILES_PER_WORKER, 2))
+        .setExpectedMSQFault(new TooManyInputFilesFault(numFiles, Limits.MAX_INPUT_FILES_PER_WORKER, 10))
         .verifyResults();
   }
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/QueryValidatorTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/QueryValidatorTest.java
@@ -26,16 +26,13 @@ import org.apache.druid.msq.kernel.QueryDefinition;
 import org.apache.druid.msq.kernel.QueryDefinitionBuilder;
 import org.apache.druid.msq.kernel.StageDefinition;
 import org.apache.druid.msq.kernel.StageDefinitionBuilder;
-import org.apache.druid.msq.kernel.WorkOrder;
 import org.apache.druid.msq.querykit.common.OffsetLimitStageProcessor;
-import org.apache.druid.msq.util.MultiStageQueryContext;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.util.Collections;
 import java.util.UUID;
 import java.util.stream.IntStream;
 
@@ -93,37 +90,6 @@ public class QueryValidatorTest
         Limits.MAX_FRAME_COLUMNS
     ));
     QueryValidator.validateQueryDef(createQueryDefinition(Limits.MAX_FRAME_COLUMNS + 1, 1));
-  }
-
-  @Test
-  public void testMoreInputFiles()
-  {
-    int numWorkers = 3;
-    int inputFiles = numWorkers * Limits.MAX_INPUT_FILES_PER_WORKER + 1;
-
-    final WorkOrder workOrder = new WorkOrder(
-        createQueryDefinition(inputFiles, numWorkers),
-        0,
-        0,
-        Collections.singletonList(() -> inputFiles), // Slice with a large number of inputFiles
-        null,
-        null,
-        null,
-        null
-    );
-
-    expectedException.expect(MSQException.class);
-    expectedException.expectMessage(StringUtils.format(
-        "Too many input files/segments [%d] encountered. Maximum input files/segments per worker is set to [%d]. Try"
-        + " breaking your query up into smaller queries, or increasing the number of workers to at least [%d] by"
-        + " setting %s in your query context",
-        inputFiles,
-        Limits.MAX_INPUT_FILES_PER_WORKER,
-        numWorkers + 1,
-        MultiStageQueryContext.CTX_MAX_NUM_TASKS
-    ));
-
-    QueryValidator.validateWorkOrder(workOrder);
   }
 
   public static QueryDefinition createQueryDefinition(int numColumns, int numWorkers)


### PR DESCRIPTION
### Description
This PR fixes an issue with MSQ input file validation that results in creating a`TooManyInputFilesFault ` from the number of an individual worker instead of totals across all workers. This lead to incorrect error messaging, since the error message advises on the minimum number of workers required to run the work order, so by only considering a single workers inputs it would advise to have at least the number of workers required to run _that workers inputs_, even though the number of actual workers might far exceed that.

For example, the adjusted test in this PR has 8 workers to run 100k inputs, before the changes in this PR the error message would be something like:
```
Too many input files/segments [14286] encountered. Maximum input files/segments per worker is set to [10000]. Try breaking your query up into smaller queries, or increasing the number of workers to at least [2] by...
```
The number of files is less than the 100k total for the job, and the "... increasing the number of workers to at least [2] ..." isn't helpful because we already have 8 workers.
