### PR TITLE
Fix race condition in standard ITs: wait for MySQL readiness before starting Druid services

### DIFF
--- a/integration-tests/docker/docker-compose.base.yml
+++ b/integration-tests/docker/docker-compose.base.yml
@@ -68,6 +68,11 @@ services:
       - ./service-supervisords/metadata-storage.conf:/usr/lib/druid/conf/metadata-storage.conf
     env_file:
       - ./environment-configs/common
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "--silent"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
 
 
 ### overlords

--- a/integration-tests/docker/docker-compose.cds-coordinator-metadata-query-disabled.yml
+++ b/integration-tests/docker/docker-compose.cds-coordinator-metadata-query-disabled.yml
@@ -42,9 +42,12 @@ services:
       - druid_coordinator_segmentMetadata_disableSegmentMetadataQueries=true
       - druid_manager_segments_useIncrementalCache=always
     depends_on:
-      - druid-overlord
-      - druid-metadata-storage
-      - druid-zookeeper-kafka
+      druid-overlord:
+        condition: service_started
+      druid-metadata-storage:
+        condition: service_healthy
+      druid-zookeeper-kafka:
+        condition: service_started
 
   druid-overlord:
     extends:
@@ -55,8 +58,10 @@ services:
       - druid_centralizedDatasourceSchema_enabled=true
       - druid_manager_segments_useIncrementalCache=always
     depends_on:
-      - druid-metadata-storage
-      - druid-zookeeper-kafka
+      druid-metadata-storage:
+        condition: service_healthy
+      druid-zookeeper-kafka:
+        condition: service_started
 
   druid-historical:
     extends:

--- a/integration-tests/docker/docker-compose.cds-task-schema-publish-disabled.yml
+++ b/integration-tests/docker/docker-compose.cds-task-schema-publish-disabled.yml
@@ -42,9 +42,12 @@ services:
       - druid_coordinator_segmentMetadata_metadataRefreshPeriod=PT15S
       - druid_manager_segments_useIncrementalCache=always
     depends_on:
-      - druid-overlord
-      - druid-metadata-storage
-      - druid-zookeeper-kafka
+      druid-overlord:
+        condition: service_started
+      druid-metadata-storage:
+        condition: service_healthy
+      druid-zookeeper-kafka:
+        condition: service_started
 
   druid-overlord:
     extends:
@@ -56,8 +59,10 @@ services:
       - druid_centralizedDatasourceSchema_taskSchemaPublishDisabled=true
       - druid_manager_segments_useIncrementalCache=always
     depends_on:
-      - druid-metadata-storage
-      - druid-zookeeper-kafka
+      druid-metadata-storage:
+        condition: service_healthy
+      druid-zookeeper-kafka:
+        condition: service_started
 
   druid-historical:
     extends:

--- a/integration-tests/docker/docker-compose.centralized-datasource-schema.yml
+++ b/integration-tests/docker/docker-compose.centralized-datasource-schema.yml
@@ -41,9 +41,12 @@ services:
       - druid_coordinator_segmentMetadata_metadataRefreshPeriod=PT15S
       - druid_manager_segments_useIncrementalCache=always
     depends_on:
-      - druid-overlord
-      - druid-metadata-storage
-      - druid-zookeeper-kafka
+      druid-overlord:
+        condition: service_started
+      druid-metadata-storage:
+        condition: service_healthy
+      druid-zookeeper-kafka:
+        condition: service_started
 
   druid-overlord:
     extends:
@@ -54,8 +57,10 @@ services:
       - druid_centralizedDatasourceSchema_enabled=true
       - druid_manager_segments_useIncrementalCache=always
     depends_on:
-      - druid-metadata-storage
-      - druid-zookeeper-kafka
+      druid-metadata-storage:
+        condition: service_healthy
+      druid-zookeeper-kafka:
+        condition: service_started
 
   druid-historical:
     extends:

--- a/integration-tests/docker/docker-compose.cli-indexer.yml
+++ b/integration-tests/docker/docker-compose.cli-indexer.yml
@@ -36,8 +36,10 @@ services:
     environment:
       - DRUID_INTEGRATION_TEST_GROUP=${DRUID_INTEGRATION_TEST_GROUP}
     depends_on:
-      - druid-metadata-storage
-      - druid-zookeeper-kafka
+      druid-metadata-storage:
+        condition: service_healthy
+      druid-zookeeper-kafka:
+        condition: service_started
 
   druid-coordinator:
     extends:
@@ -46,9 +48,12 @@ services:
     environment:
       - DRUID_INTEGRATION_TEST_GROUP=${DRUID_INTEGRATION_TEST_GROUP}
     depends_on:
-      - druid-overlord
-      - druid-metadata-storage
-      - druid-zookeeper-kafka
+      druid-overlord:
+        condition: service_started
+      druid-metadata-storage:
+        condition: service_healthy
+      druid-zookeeper-kafka:
+        condition: service_started
 
   druid-historical:
     extends:

--- a/integration-tests/docker/docker-compose.ldap-security.yml
+++ b/integration-tests/docker/docker-compose.ldap-security.yml
@@ -53,10 +53,14 @@ services:
     environment:
       - DRUID_INTEGRATION_TEST_GROUP=${DRUID_INTEGRATION_TEST_GROUP}
     depends_on:
-      - druid-openldap
-      - druid-metadata-storage
-      - druid-zookeeper-kafka
-      - druid-overlord
+      druid-openldap:
+        condition: service_started
+      druid-metadata-storage:
+        condition: service_healthy
+      druid-zookeeper-kafka:
+        condition: service_started
+      druid-overlord:
+        condition: service_started
 
   druid-overlord:
     extends:
@@ -68,9 +72,12 @@ services:
     environment:
       - DRUID_INTEGRATION_TEST_GROUP=${DRUID_INTEGRATION_TEST_GROUP}
     depends_on:
-      - druid-openldap
-      - druid-metadata-storage
-      - druid-zookeeper-kafka
+      druid-openldap:
+        condition: service_started
+      druid-metadata-storage:
+        condition: service_healthy
+      druid-zookeeper-kafka:
+        condition: service_started
 
   druid-historical:
     extends:

--- a/integration-tests/docker/docker-compose.query-error-test.yml
+++ b/integration-tests/docker/docker-compose.query-error-test.yml
@@ -36,8 +36,10 @@ services:
     environment:
       - DRUID_INTEGRATION_TEST_GROUP=${DRUID_INTEGRATION_TEST_GROUP}
     depends_on:
-      - druid-metadata-storage
-      - druid-zookeeper-kafka
+      druid-metadata-storage:
+        condition: service_healthy
+      druid-zookeeper-kafka:
+        condition: service_started
 
   druid-coordinator:
     extends:
@@ -46,9 +48,12 @@ services:
     environment:
       - DRUID_INTEGRATION_TEST_GROUP=${DRUID_INTEGRATION_TEST_GROUP}
     depends_on:
-      - druid-overlord
-      - druid-metadata-storage
-      - druid-zookeeper-kafka
+      druid-overlord:
+        condition: service_started
+      druid-metadata-storage:
+        condition: service_healthy
+      druid-zookeeper-kafka:
+        condition: service_started
 
   druid-broker:
     extends:

--- a/integration-tests/docker/docker-compose.query-retry-test.yml
+++ b/integration-tests/docker/docker-compose.query-retry-test.yml
@@ -36,8 +36,10 @@ services:
     environment:
       - DRUID_INTEGRATION_TEST_GROUP=${DRUID_INTEGRATION_TEST_GROUP}
     depends_on:
-      - druid-metadata-storage
-      - druid-zookeeper-kafka
+      druid-metadata-storage:
+        condition: service_healthy
+      druid-zookeeper-kafka:
+        condition: service_started
 
   druid-coordinator:
     extends:
@@ -46,9 +48,12 @@ services:
     environment:
       - DRUID_INTEGRATION_TEST_GROUP=${DRUID_INTEGRATION_TEST_GROUP}
     depends_on:
-      - druid-overlord
-      - druid-metadata-storage
-      - druid-zookeeper-kafka
+      druid-overlord:
+        condition: service_started
+      druid-metadata-storage:
+        condition: service_healthy
+      druid-zookeeper-kafka:
+        condition: service_started
 
   druid-broker:
     extends:

--- a/integration-tests/docker/docker-compose.yml
+++ b/integration-tests/docker/docker-compose.yml
@@ -36,9 +36,12 @@ services:
     environment:
       - DRUID_INTEGRATION_TEST_GROUP=${DRUID_INTEGRATION_TEST_GROUP}
     depends_on:
-      - druid-overlord
-      - druid-metadata-storage
-      - druid-zookeeper-kafka
+      druid-overlord:
+        condition: service_started
+      druid-metadata-storage:
+        condition: service_healthy
+      druid-zookeeper-kafka:
+        condition: service_started
 
   druid-overlord:
     extends:
@@ -47,8 +50,10 @@ services:
     environment:
       - DRUID_INTEGRATION_TEST_GROUP=${DRUID_INTEGRATION_TEST_GROUP}
     depends_on:
-      - druid-metadata-storage
-      - druid-zookeeper-kafka
+      druid-metadata-storage:
+        condition: service_healthy
+      druid-zookeeper-kafka:
+        condition: service_started
 
   druid-historical:
     extends:


### PR DESCRIPTION
### Description

This PR fixes a race condition in standard ITs, where we were not waiting for MySQL readiness before starting Druid services. This caused intermittent IT failures when MySQL took 20+ seconds to initialize while coordinator exhausted its retries sooner than that.

This PR adds Docker healthcheck to `druid-metadata-storage` and uses `condition: service_healthy` to ensure coordinator and overlord only start after MySQL is accepting connections.

<hr>

This PR has:

- [x] been self-reviewed.
