### PR TITLE
Set the default latchable emitter timeout to 20 seconds in `ForcePushDownNestedQueryTest`

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/ForcePushDownNestedQueryTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/ForcePushDownNestedQueryTest.java
@@ -40,6 +40,7 @@ import org.apache.druid.query.groupby.having.OrHavingSpec;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.testing.embedded.EmbeddedClusterApis;
+import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
 import org.apache.druid.testing.embedded.msq.EmbeddedMSQApis;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
@@ -62,6 +63,12 @@ public class ForcePushDownNestedQueryTest extends QueryTestBase
 {
   private final String interval = "2015-09-12/2015-09-13";
   private final Map<String, Object> forcePushDownNestedContext = Map.of("forcePushDownNestedQuery", "true");
+
+  @Override
+  protected EmbeddedDruidCluster createCluster()
+  {
+    return super.createCluster().useDefaultTimeoutForLatchableEmitter(20);
+  }
 
   @Override
   public void beforeAll() throws IOException

--- a/server/src/test/java/org/apache/druid/server/metrics/LatchableEmitter.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/LatchableEmitter.java
@@ -126,7 +126,7 @@ public class LatchableEmitter extends StubServiceEmitter
     try {
       final long awaitTime = timeoutMillis >= 0 ? timeoutMillis : Long.MAX_VALUE;
       if (!waitCondition.countDownLatch.await(awaitTime, TimeUnit.MILLISECONDS)) {
-        throw new ISE("Timed out waiting for event");
+        throw new ISE("Timed out waiting for event after [%,d]ms", awaitTime);
       }
     }
     catch (InterruptedException e) {
@@ -152,7 +152,7 @@ public class LatchableEmitter extends StubServiceEmitter
     try {
       final long awaitTime = timeoutMillis >= 0 ? timeoutMillis : Long.MAX_VALUE;
       if (!waitCondition.countDownLatch.await(awaitTime, TimeUnit.MILLISECONDS)) {
-        throw new ISE("Timed out waiting for next event");
+        throw new ISE("Timed out waiting for next event after [%,d]ms", awaitTime);
       }
     }
     catch (InterruptedException e) {


### PR DESCRIPTION
- The `ForcePushDownNestedQueryTest` is occasionally flaky on master because the MSQ query in `loadWikipediaTable()` can take longer than the default 10 second timeout to finish and for segments to be loaded and available. Other tests such as `QueryVirtualStorageTest` and `EmbeddedDurableShuffleStorageTest` use a 20 second timeout for similar loads, so increasing the timeout here to 20 seconds should address the flakiness. See the [failed](https://productionresultssa19.blob.core.windows.net/actions-results/8a3b9883-9ea6-4cd0-8bc3-1488a1574788/workflow-job-run-1068f1c4-ce65-5618-8001-cf2bca9a5cdc/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-12-05T18%3A39%3A28Z&sig=zPTboCxyzgjf82V%2BcXOhQ2Ero7tq57HAE3r3PYQRYQc%3D&ske=2025-12-06T02%3A40%3A02Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-12-05T14%3A40%3A02Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2025-12-05T18%3A29%3A23Z&sv=2025-11-05) run: https://github.com/apache/druid/actions/runs/19955328339/job/57225328413
- Include the timeout value in the error message so the timeout is apparent without needing to inspect the stack trace