### PR TITLE
Increase timeout in ForcePushDownNestedQueryTest

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/ForcePushDownNestedQueryTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/ForcePushDownNestedQueryTest.java
@@ -67,7 +67,7 @@ public class ForcePushDownNestedQueryTest extends QueryTestBase
   @Override
   protected EmbeddedDruidCluster createCluster()
   {
-    return super.createCluster().useDefaultTimeoutForLatchableEmitter(20);
+    return super.createCluster().useDefaultTimeoutForLatchableEmitter(30);
   }
 
   @Override


### PR DESCRIPTION
Trying to address some recent flakiness in this new embedded test.
The timeout was recently increased to 20s (from the default 10s), but it still seems to be flaky.

https://github.com/apache/druid/actions/runs/19984107070/job/57315442102?pr=18820#step:6:8061

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.