### PR TITLE
Web console: fix supervisor redirect

### DIFF
--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -143,7 +143,7 @@ import {
   updateSchemaWithSample,
   upgradeSpec,
 } from '../../druid-models';
-import { getSpecDatasourceName, getSpecSupervisorId } from '../../helpers';
+import { getSpecSupervisorId } from '../../helpers';
 import { getLink } from '../../links';
 import { Api, AppToaster, UrlBaser } from '../../singletons';
 import {
@@ -3740,7 +3740,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
       intent: Intent.SUCCESS,
     });
 
-    const supervisorId = getSpecDatasourceName(spec);
+    const supervisorId = getSpecSupervisorId(spec);
     if (supervisorId) {
       setTimeout(() => {
         goToView('supervisors', TableFilters.eq({ supervisor_id: supervisorId }));


### PR DESCRIPTION
All credit for spotting (and fixing) this bug goes to Claude Code:

The prompt:

```
There was a change in Druid that made it possible to have multiple supervisors write to the same datasource (aka. table). Previously a supervisor had a `supervisor_id` and a `datasource` but they were always the same. As 
such some code might have been written to refer to the `datasource` instead of the `supervisor_id` as it was actually intended. Scan the code and highlight any potential issues where the supervisor_id and datasource are 
conflated. 
```

Thanks AI.