### PR TITLE
update jedis-mock test dependency

### DIFF
--- a/extensions-contrib/redis-cache/pom.xml
+++ b/extensions-contrib/redis-cache/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>com.github.fppt</groupId>
             <artifactId>jedis-mock</artifactId>
-            <version>1.0.11</version>
+            <version>1.1.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Fixes #XXXX.

### Description

This is a small maintenance update that bumps the jedis-mock test dependency from version 1.0.11 to 1.1.12.

As the maintainer of jedis-mock, I am submitting this to ensure Druid uses the most accurate and up-to-date version of the library. Since 1.0.11, a significant number of bug fixes and behavioral corrections have been made, resulting in jedis-mock more closely mimicking actual Redis semantics. Updating to 1.1.12 ensures Druid tests benefit from these improvements and remain aligned with realistic Redis behavior.

#### Changes

Updated jedis-mock test dependency from 1.0.11 → 1.1.12.

No production code changes; this affects test scope only.

### Release note

This PR updates the jedis-mock test-only dependency to version 1.1.12, bringing in numerous upstream fixes and more accurate Redis behavior for Druid’s test suite. No impact on end users.

<hr>
Key changed/added classes in this PR

(None — test dependency update only)

<hr>

This PR has:

* [X] been self-reviewed.
* [ ] added documentation for new or modified features or behaviors.
* [X] a release note entry in the PR description.
* [ ] added Javadocs for most classes and all non-trivial methods.
* [ ] added or updated version, license, or notice information in licenses.yaml
* [ ] added comments explaining the "why" where needed.
* [ ] added or updated tests as needed.
* [ ] been tested in a test Druid cluster.