### PR TITLE
feat: log total bytes gathered when max scatter-gather bytes limit is reached

### DIFF
--- a/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
+++ b/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
@@ -437,11 +437,14 @@ public class DirectDruidClient<T> implements QueryRunner<T>
 
         private void checkTotalBytesLimit(long bytes)
         {
-          if (maxScatterGatherBytes < Long.MAX_VALUE && totalBytesGathered.addAndGet(bytes) > maxScatterGatherBytes) {
+          final long currentTotalBytesGathered = totalBytesGathered.addAndGet(bytes);
+          if (currentTotalBytesGathered > maxScatterGatherBytes) {
             String msg = StringUtils.format(
-                "Query[%s] url[%s] max scatter-gather bytes limit reached.",
+                "Query[%s] url[%s] total bytes gathered[%,d] exceeds maxScatterGatherBytes[%,d]",
                 query.getId(),
-                url
+                url,
+                currentTotalBytesGathered,
+                maxScatterGatherBytes
             );
             setupResponseReadFailure(msg, null);
             throw new ResourceLimitExceededException(msg);

--- a/server/src/test/java/org/apache/druid/query/QueryRunnerBasedOnClusteredClientTestBase.java
+++ b/server/src/test/java/org/apache/druid/query/QueryRunnerBasedOnClusteredClientTestBase.java
@@ -42,7 +42,6 @@ import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
-import org.apache.druid.query.context.ConcurrentResponseContext;
 import org.apache.druid.query.context.ResponseContext;
 import org.apache.druid.query.timeseries.TimeseriesResultValue;
 import org.apache.druid.query.topn.TopNQueryConfig;
@@ -228,9 +227,7 @@ public abstract class QueryRunnerBasedOnClusteredClientTestBase
 
   protected static ResponseContext responseContext()
   {
-    final ResponseContext responseContext = ConcurrentResponseContext.createEmpty();
-    responseContext.initializeRemainingResponses();
-    return responseContext;
+    return DirectDruidClient.makeResponseContextForQuery();
   }
 
   protected static DataSegment newSegment(


### PR DESCRIPTION
Fixes #18840.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

log total bytes gathered when max scatter-gather bytes limit is reached

#### Release note

<hr> log total bytes gathered when max scatter-gather bytes limit is reached

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.