### PR TITLE
Improve error message when column's serialized size exceed the smoosher’s maximum

### DIFF
--- a/processing/src/main/java/org/apache/druid/java/util/common/io/smoosh/FileSmoosher.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/io/smoosh/FileSmoosher.java
@@ -23,6 +23,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Ints;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.IOE;
@@ -158,7 +159,13 @@ public class FileSmoosher implements SegmentFileBuilder
   public SmooshedWriter addWithSmooshedWriter(final String name, final long size) throws IOException
   {
     if (size > maxChunkSize) {
-      throw new IAE("Asked to add buffers[%,d] larger than configured max[%,d]", size, maxChunkSize);
+      throw DruidException.forPersona(DruidException.Persona.ADMIN)
+                          .ofCategory(DruidException.Category.RUNTIME_FAILURE)
+                          .build("Serialized buffer size[%,d] for column[%s] exceeds the maximum[%,d]. "
+                                  + "Consider adjusting the tuningConfig - for example, reduce maxRowsPerSegment, "
+                                  + "or partition your data further.",
+                                  size, name, maxChunkSize
+                          );
     }
 
     // If current writer is in use then create a new SmooshedWriter which


### PR DESCRIPTION
When the serialized size of a column exceeds 2 GB (the smoosher’s maximum) due to large blobs in a specific column, the ingestion task fails with the following stack trace - it doesn't indicate the problematic column:
```
java.lang.RuntimeException: org.apache.druid.java.util.common.IAE: Asked to add buffers[2,171,458,617] larger than configured max[2,147,483,647]
	at org.apache.druid.segment.realtime.appenderator.StreamAppenderator.mergeAndPush(StreamAppenderator.java:1015) ~[druid-server-32.0.1.jar:32.0.1]
	at org.apache.druid.segment.realtime.appenderator.StreamAppenderator.lambda$push$1(StreamAppenderator.java:826) ~[druid-server-32.0.1.jar:32.0.1]
	at com.google.common.util.concurrent.AbstractTransformFuture$TransformFuture.doTransform(AbstractTransformFuture.java:252) ~[guava-32.0.1-jre.jar:?]
	at com.google.common.util.concurrent.AbstractTransformFuture$TransformFuture.doTransform(AbstractTransformFuture.java:242) ~[guava-32.0.1-jre.jar:?]
	at com.google.common.util.concurrent.AbstractTransformFuture.run(AbstractTransformFuture.java:123) [guava-32.0.1-jre.jar:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.base/java.lang.Thread.run(Thread.java:840) [?:?]
Caused by: org.apache.druid.java.util.common.IAE: Asked to add buffers[2,171,458,617] larger than configured max[2,147,483,647]
	at org.apache.druid.java.util.common.io.smoosh.FileSmoosher.addWithSmooshedWriter(FileSmoosher.java:176) ~[druid-processing-32.0.1.jar:32.0.1]
	at org.apache.druid.segment.IndexMergerV9.makeColumn(IndexMergerV9.java:788) ~[druid-processing-32.0.1.jar:32.0.1]
	at org.apache.druid.segment.IndexMergerV9.makeIndexFiles(IndexMergerV9.java:291) ~[druid-processing-32.0.1.jar:32.0.1]
	at org.apache.druid.segment.IndexMergerV9.merge(IndexMergerV9.java:1359) ~[druid-processing-32.0.1.jar:32.0.1]
	at org.apache.druid.segment.IndexMergerV9.multiphaseMerge(IndexMergerV9.java:1177) ~[druid-processing-32.0.1.jar:32.0.1]
	at org.apache.druid.segment.IndexMergerV9.mergeQueryableIndex(IndexMergerV9.java:1119) ~[druid-processing-32.0.1.jar:32.0.1]
	at org.apache.druid.segment.realtime.appenderator.StreamAppenderator.mergeAndPush(StreamAppenderator.java:957) ~[druid-server-32.0.1.jar:32.0.1]
```

With this patch, the DruidException message includes the column name along with a few remediation suggestions as follows:
```
Serialized buffer size[10] for column[foo] exceeds the maximum[5]. Consider adjusting the tuningConfig - for example, reduce maxRowsPerSegment, or partition your data further.
```
<img width="2844" height="860" alt="CleanShot 2025-12-18 at 20 03 32@2x" src="https://github.com/user-attachments/assets/d33b7e4b-3028-426f-ba9a-a34dd2b11363" />



This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.