### PR TITLE
Increase timeout for Docker Test

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/docker/IngestionDockerTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/docker/IngestionDockerTest.java
@@ -52,7 +52,7 @@ public class IngestionDockerTest extends IngestionSmokeTest implements LatestIma
     overlord.addProperty("druid.plaintextPort", "7090");
 
     return cluster
-        .useDefaultTimeoutForLatchableEmitter(120)
+        .useDefaultTimeoutForLatchableEmitter(180)
         .useContainerFriendlyHostname()
         .addResource(containerOverlord)
         .addResource(containerCoordinator)


### PR DESCRIPTION
The `test_runIndexTask_andKillData` Docker test has been quite [flaky](https://github.com/apache/druid/actions/workflows/unit-and-integration-tests-unified.yml?query=is%3Afailure+event%3Apush) due to timeouts, often requiring multiple re-runs.

```
Error:  test_runIndexTask_andKillData  Time elapsed: 127.754 s  <<< ERROR!
org.apache.druid.java.util.common.ISE: Timed out waiting for event after [120,000]ms
```

We’ll need to inspect the Docker logs to identify the source of timeout/flakiness, but the logs appear to be missing because they get cleaned up after the test completes? In the meantime, try increasing the timeout from 2 minutes to 3 minutes to see if it reduces or eliminates the flakiness.
