### PR TITLE
Reduce nesting in `SegmentLocalCacheManager.addFilesToCachedSegments`

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
@@ -255,7 +255,6 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
   private void addFilesToCachedSegments(File file, AtomicInteger ignored, List<DataSegment> cachedSegments) throws IOException
   {
     final DataSegment segment = jsonMapper.readValue(file, DataSegment.class);
-
     if (!segment.getId().toString().equals(file.getName())) {
       log.warn("Ignoring cache file[%s] for segment[%s].", file.getPath(), segment.getId());
       ignored.incrementAndGet();


### PR DESCRIPTION
### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Add an early return for the if-else block

Before
```
boolean removeInfo = false;
if (!segment.getId().toString().equals(file.getName())) {  
  // Do something without changing removeInfo
} else {  
  removeInfo = true; 
  // All processing logic nested inside the else block, may change removeInfo...
}

if (removeInfo) {
  // Do something... then returns
}
```

After:
```
if (!segment.getId().toString().equals(file.getName())) {  
  // Early Return
}

// Declare removeInfo = true and move on.
```

No functional changes; this is a pure readability improvement

##### Key changed/added classes in this PR
 * `SegmentLocalCacheManager`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.