### PR TITLE
Fix serde of UpdateLocationAction used by K8s-based tasks

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/UpdateLocationAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/UpdateLocationAction.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Optional;
+import org.apache.druid.error.InvalidInput;
 import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.TaskRunner;
@@ -42,6 +43,7 @@ public class UpdateLocationAction implements TaskAction<Void>
       @JsonProperty("location") TaskLocation location
   )
   {
+    InvalidInput.conditionalException(location != null, "No task location specified");
     this.location = location;
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/UpdateLocationActionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/UpdateLocationActionTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.indexing.common.actions;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Optional;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.Task;
@@ -81,5 +82,14 @@ public class UpdateLocationActionTest
     final String json = TestHelper.JSON_MAPPER.writeValueAsString(original);
     final TaskAction<?> deserialized = TestHelper.JSON_MAPPER.readValue(json, TaskAction.class);
     Assert.assertEquals(original, deserialized);
+  }
+
+  @Test
+  public void test_actionWithNullLocation_throwsException()
+  {
+    Assert.assertThrows(
+        DruidException.class,
+        () -> new UpdateLocationAction(null)
+    );
   }
 }


### PR DESCRIPTION
### Bug

`AbstractTask.setup()` fires an `UpdateLocationAction` when running a K8s-based encapsulated task to notify the Overlord of the task location. This object gets serialized incorrectly causing the location to be null.

### Fix

- Fix serialization of `UpdateLocationAction`
- Add test for serde
- Add null check and throw InvalidInput exception

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.