### PR TITLE
Increase code coverage for `DirectDruidClientTest`

### DIFF
--- a/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
+++ b/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
@@ -560,11 +560,9 @@ public class DirectDruidClient<T> implements QueryRunner<T>
 
         Runnable checkRunnable = () -> {
           try {
-            log.info("GRRRR1 cacnelQuery");
             if (!responseFuture.isDone()) {
               log.error("Error cancelling query[%s]", query);
             }
-            log.info("GRRRR2 cacnelQuery");
             StatusResponseHolder response = responseFuture.get(30, TimeUnit.SECONDS);
             if (response.getStatus().getCode() >= 500) {
               log.error("Error cancelling query[%s]: queriable node returned status[%d] [%s].",
@@ -580,14 +578,12 @@ public class DirectDruidClient<T> implements QueryRunner<T>
             log.error(e, "Timed out cancelling query[%s]", query);
           }
         };
-        log.info("GRRRYAY INNER submit to cancel executor");
         queryCancellationExecutor.schedule(checkRunnable, 5, TimeUnit.SECONDS);
       }
       catch (IOException e) {
         log.error(e, "Error cancelling query[%s]", query);
       }
     };
-    log.info("GRRRYAY OUTER submit to cancel executor");
     queryCancellationExecutor.submit(cancelRunnable);
   }
 

--- a/server/src/test/java/org/apache/druid/client/TestHttpClient.java
+++ b/server/src/test/java/org/apache/druid/client/TestHttpClient.java
@@ -69,32 +69,37 @@ public class TestHttpClient implements HttpClient
   private final ObjectMapper objectMapper;
   @Nullable
   private final ListenableFuture future;
-  private final long timeoutMillis;
+  private final long responseDelayMillis;
 
   public TestHttpClient(ObjectMapper objectMapper)
   {
     this.objectMapper = objectMapper;
     this.future = null;
-    this.timeoutMillis = -1;
-  }
-
-  public TestHttpClient(ObjectMapper objectMapper, long timeoutMillis)
-  {
-    this.objectMapper = objectMapper;
-    this.future = null;
-    this.timeoutMillis = timeoutMillis;
+    this.responseDelayMillis = -1;
   }
 
   public TestHttpClient(ObjectMapper objectMapper, ListenableFuture future)
   {
     this.objectMapper = objectMapper;
     this.future = future;
-    this.timeoutMillis = -1;
+    this.responseDelayMillis = -1;
+  }
+
+  public TestHttpClient(ObjectMapper objectMapper, long responseDelayMillis)
+  {
+    this.objectMapper = objectMapper;
+    this.future = null;
+    this.responseDelayMillis = responseDelayMillis;
   }
 
   public void addServerAndRunner(DruidServer server, SimpleServerManager serverManager)
   {
     servers.put(computeUrl(server), serverManager);
+  }
+
+  public void addUrlAndRunner(URL queryId, SimpleServerManager serverManager)
+  {
+    servers.put(queryId, serverManager);
   }
 
   @Nullable
@@ -156,8 +161,8 @@ public class TestHttpClient implements HttpClient
       response.setContent(
           HeapChannelBufferFactory.getInstance().getBuffer(serializedContent, 0, serializedContent.length)
       );
-      if (timeoutMillis > 0) {
-        Thread.sleep(timeoutMillis);
+      if (responseDelayMillis > 0) {
+        Thread.sleep(responseDelayMillis);
       }
       final ClientResponse<Intermediate> intermClientResponse = handler.handleResponse(response, NOOP_TRAFFIC_COP);
       final ClientResponse<Final> finalClientResponse = handler.done(intermClientResponse);

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/BlockingExecutorService.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/BlockingExecutorService.java
@@ -248,7 +248,7 @@ public class BlockingExecutorService implements ExecutorService
         future.complete(result);
       }
       catch (Exception e) {
-        throw new ISE("Error while executing task", e);
+        throw new ISE(e, "Error[%s] while executing task", e.getMessage());
       }
     }
   }


### PR DESCRIPTION
Test-only change:
- Increases test coverage for the DirectDruidClient class from 57%, 35%, 16% to 76%, 73%, 52% for method / line / branch coverage respectively. We can add more tests as we evolve the code and/or do bug fixes.
- Replaces mocks with more concrete classes and test helpers, allowing the internals of the class, including `HttpResponseHandler` to be exercised.
- Also added a test for https://github.com/apache/druid/pull/18841 for which coverage had to be skipped

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.