### PR TITLE
Web console: Lookup values should use the default engine

### DIFF
--- a/web-console/src/dialogs/lookup-table-action-dialog/lookup-values-table/lookup-values-table.tsx
+++ b/web-console/src/dialogs/lookup-table-action-dialog/lookup-values-table/lookup-values-table.tsx
@@ -45,7 +45,6 @@ export const LookupValuesTable = React.memo(function LookupValuesTable(
       return await queryDruidSql<LookupRow>(
         {
           query: `SELECT "k", "v" FROM ${N('lookup').table(lookupId)} LIMIT 5000`,
-          context: { engine: 'native' },
         },
         signal,
       );


### PR DESCRIPTION
Go a little bit too excited with https://github.com/apache/druid/pull/18857. Undoing this one line