### PR TITLE
Add virtualStorageFabricEvictImmediately config.

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderConfig.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderConfig.java
@@ -77,8 +77,13 @@ public class SegmentLoaderConfig
   @JsonProperty("virtualStorageLoadThreads")
   private int virtualStorageLoadThreads = 2 * runtimeInfo.getAvailableProcessors();
 
-  @JsonProperty("virtualStorageFabricEvictImmediately")
-  private boolean virtualStorageFabricEvictImmediately = false;
+  /**
+   * When enabled, weakly-held cache entries are evicted immediately upon release of all holds, rather than
+   * waiting for space pressure to trigger eviction. This setting is not intended to be configured directly by
+   * administrators. Instead, it is expected to be set when appropriate via {@link #setVirtualStorage}.
+   */
+  @JsonProperty("virtualStorageFabricEvictImmediatelyOnHoldRelease")
+  private boolean virtualStorageFabricEvictImmediatelyOnHoldRelease = false;
 
   private long combinedMaxSize = 0;
 
@@ -157,9 +162,9 @@ public class SegmentLoaderConfig
     return virtualStorageLoadThreads;
   }
 
-  public boolean isVirtualStorageFabricEvictImmediately()
+  public boolean isVirtualStorageFabricEvictImmediatelyOnHoldRelease()
   {
-    return virtualStorageFabricEvictImmediately;
+    return virtualStorageFabricEvictImmediatelyOnHoldRelease;
   }
 
   public SegmentLoaderConfig withLocations(List<StorageLocationConfig> locations)
@@ -169,6 +174,19 @@ public class SegmentLoaderConfig
     retVal.deleteOnRemove = this.deleteOnRemove;
     retVal.infoDir = this.infoDir;
     return retVal;
+  }
+
+  /**
+   * Sets {@link #virtualStorage} and {@link #virtualStorageFabricEvictImmediatelyOnHoldRelease}.
+   */
+  public SegmentLoaderConfig setVirtualStorage(
+      boolean virtualStorage,
+      boolean virtualStorageFabricEvictImmediatelyOnHoldRelease
+  )
+  {
+    this.virtualStorage = virtualStorage;
+    this.virtualStorageFabricEvictImmediatelyOnHoldRelease = virtualStorageFabricEvictImmediatelyOnHoldRelease;
+    return this;
   }
 
   /**
@@ -203,7 +221,7 @@ public class SegmentLoaderConfig
            ", statusQueueMaxSize=" + statusQueueMaxSize +
            ", useVirtualStorageFabric=" + virtualStorage +
            ", virtualStorageFabricLoadThreads=" + virtualStorageLoadThreads +
-           ", virtualStorageFabricEvictImmediately=" + virtualStorageFabricEvictImmediately +
+           ", virtualStorageFabricEvictImmediatelyOnHoldRelease=" + virtualStorageFabricEvictImmediatelyOnHoldRelease +
            ", combinedMaxSize=" + combinedMaxSize +
            '}';
   }

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
@@ -145,9 +145,9 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
       if (config.getNumThreadsToLoadSegmentsIntoPageCacheOnBootstrap() > 0) {
         throw DruidException.defensive("Invalid configuration: virtualStorage is incompatible with numThreadsToLoadSegmentsIntoPageCacheOnBootstrap");
       }
-      if (config.isVirtualStorageFabricEvictImmediately()) {
+      if (config.isVirtualStorageFabricEvictImmediatelyOnHoldRelease()) {
         for (StorageLocation location : locations) {
-          location.setEvictImmediately(true);
+          location.setEvictImmediatelyOnHoldRelease(true);
         }
       }
       virtualStorageLoadOnDemandExec =
@@ -496,9 +496,9 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
   public void load(final DataSegment dataSegment) throws SegmentLoadingException
   {
     if (config.isVirtualStorage()) {
-      if (config.isVirtualStorageFabricEvictImmediately()) {
+      if (config.isVirtualStorageFabricEvictImmediatelyOnHoldRelease()) {
         throw DruidException.defensive(
-            "load() should not be called when virtualStorageFabricEvictImmediately is enabled"
+            "load() should not be called when virtualStorageFabricEvictImmediatelyOnHoldRelease is enabled"
         );
       }
       // virtual storage doesn't do anything with loading immediately, but check to see if the segment is already cached
@@ -542,9 +542,9 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
   ) throws SegmentLoadingException
   {
     if (config.isVirtualStorage()) {
-      if (config.isVirtualStorageFabricEvictImmediately()) {
+      if (config.isVirtualStorageFabricEvictImmediatelyOnHoldRelease()) {
         throw DruidException.defensive(
-            "bootstrap() should not be called when virtualStorageFabricEvictImmediately is enabled"
+            "bootstrap() should not be called when virtualStorageFabricEvictImmediatelyOnHoldRelease is enabled"
         );
       }
       // during bootstrap, check if the segment exists in a location and mount it, getCachedSegments already
@@ -1046,7 +1046,7 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
           unmount();
         }
 
-        if (config.isVirtualStorageFabricEvictImmediately()) {
+        if (config.isVirtualStorageFabricEvictImmediatelyOnHoldRelease()) {
           setDeleteInfoFileOnUnmount();
         }
       }

--- a/server/src/test/java/org/apache/druid/segment/loading/SegmentLoaderConfigTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/SegmentLoaderConfigTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.loading;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SegmentLoaderConfigTest
+{
+  @Test
+  public void testSetVirtualStorage()
+  {
+    final SegmentLoaderConfig config = new SegmentLoaderConfig();
+
+    // Verify default values
+    Assert.assertFalse(config.isVirtualStorage());
+    Assert.assertFalse(config.isVirtualStorageFabricEvictImmediatelyOnHoldRelease());
+
+    // Set both to true
+    config.setVirtualStorage(true, true);
+
+    // Verify both fields are set
+    Assert.assertTrue(config.isVirtualStorage());
+    Assert.assertTrue(config.isVirtualStorageFabricEvictImmediatelyOnHoldRelease());
+  }
+}

--- a/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerTest.java
@@ -1197,7 +1197,7 @@ public class SegmentLocalCacheManagerTest extends InitializedNullHandlingTest
       }
 
       @Override
-      public boolean isVirtualStorageFabricEvictImmediately()
+      public boolean isVirtualStorageFabricEvictImmediatelyOnHoldRelease()
       {
         return true;
       }


### PR DESCRIPTION
The purpose of this config is to enable using SegmentLocalCacheManager for loading segments on MSQ worker tasks, where segments are not assigned by load/drop rules, and where there is not generally a specific maxSize configured for the local cache. We need to evict segments immediately so local disks don't fill up.

The main changes:

1) In StorageLocation, update the `releaseHold` runnable to check for `evictImmediately`. If it is set, unmount the cache entry if all holds have been released.

2) In SegmentLocalCacheManager, when `evictImmediately` is set, `mount` sets an `onUnmount` handler to delete the info file.