### PR TITLE
run openrewrite on jdk 21

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: '21'
           cache: 'maven'
 
       - name: maven install


### PR DESCRIPTION
maybe fix CI failures of the form

```
Error:  Failed to execute goal org.openrewrite.maven:rewrite-maven-plugin:5.42.0:dryRun (default-cli) on project druid: 
Error:  The plugin org.openrewrite.maven:rewrite-maven-plugin:5.42.0 has unmet prerequisites: 
Error:  	Required Java version 21 is not met by current version: 17.0.17
```