### PR TITLE
add dump-segment tool mode to dump v10 segment metadata

### DIFF
--- a/examples/bin/dump-segment
+++ b/examples/bin/dump-segment
@@ -1,0 +1,32 @@
+#!/bin/bash -eu
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+PWD="$(pwd)"
+WHEREAMI="$(dirname "$0")"
+WHATAMI="dump-segment"
+CONFDIR="$WHEREAMI/../conf/druid/tools/"
+MAIN_CLASS="org.apache.druid.cli.Main tools dump-segment"
+
+cd "$WHEREAMI/.."
+
+CLASS_PATH="$CONFDIR"/"$WHATAMI":"$CONFDIR"/_common:"$CONFDIR"/../_common:"$WHEREAMI/../lib/*"
+
+exec "$WHEREAMI"/run-java \
+    `cat "$CONFDIR"/"$WHATAMI"/jvm.config | xargs` \
+    -cp  $CLASS_PATH $MAIN_CLASS `echo "${@:1}"`

--- a/examples/conf/druid/tools/_common/common.runtime.properties
+++ b/examples/conf/druid/tools/_common/common.runtime.properties
@@ -1,0 +1,2 @@
+## common tool extensions
+druid.extensions.loadList=["druid-datasketches"]

--- a/examples/conf/druid/tools/_common/log4j2.xml
+++ b/examples/conf/druid/tools/_common/log4j2.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Licensed to the Apache Software Foundation (ASF) under one
+ ~ or more contributor license agreements.  See the NOTICE file
+ ~ distributed with this work for additional information
+ ~ regarding copyright ownership.  The ASF licenses this file
+ ~ to you under the Apache License, Version 2.0 (the
+ ~ "License"); you may not use this file except in compliance
+ ~ with the License.  You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+-->
+<Configuration status="WARN">
+  <Loggers>
+    <Root level="OFF">
+      <!-- logging is disabled so tools can have their output piped to other stuff  -->
+    </Root>
+  </Loggers>
+</Configuration>

--- a/examples/conf/druid/tools/dump-segment/jvm.config
+++ b/examples/conf/druid/tools/dump-segment/jvm.config
@@ -1,0 +1,4 @@
+-server
+-XX:+ExitOnOutOfMemoryError
+-Duser.timezone=UTC
+-Dfile.encoding=UTF-8


### PR DESCRIPTION
### Description
Since there is no longer a `meta.smoosh` in v10 segments, this PR adds an option to the dump segment tool to show v10 metadata. As a convenience to make this easy to run, I have added a `bin/dump-segment` to druid packaging, so its really easy to run against segments if you have a druid installation handy. Output is just the serialized json of the stored metadata, and can be piped into jq. For example:

```
$ ./bin/dump-segment --dump metadata_v10 -d ~/workspace/data/druid/segmentsCache/wikipedia-v10-no-rollup_2016-06-27T00\:00\:00.000Z_2016-06-28T00\:00\:00.000Z_2025-12-31T22\:19\:27.478Z/druid.segment | jq .
{
  "containers": [
    {
      "startOffset": 0,
      "size": 7069778
    }
  ],
  "files": {
    "__base/__time": {
      "container": 0,
      "startOffset": 0,
      "size": 120208
    },
    "__base/added": {
      "container": 0,
      "startOffset": 4241057,
      "size": 14
    },
...
```

or like do fancy jq stuff like show biggest internal files or whatever

```
$ ./bin/dump-segment --dump metadata_v10 -d ~/workspace/data/druid/segmentsCache/wikip10-no-rollup_2016-06-27T00\:00\:00.000Z_2016-06-28T00\:00\:00.000Z_2025-12-31T22\:19\:27.478Z/druid.segment | jq '.files | to_entries | map({file:.key, size:.value.size}) | sort_by(.size) | reverse'
[
  {
    "file": "__base/diffUrl.__stringDictionary",
    "size": 1908699
  },
  {
    "file": "__base/comment.__stringDictionary",
    "size": 1001152
  },
  {
    "file": "__base/page.__stringDictionary",
    "size": 732776
  },
  {
    "file": "__base/diffUrl.__valueIndexes",
    "size": 635276
  },
  {
    "file": "__base/page.__valueIndexes",
    "size": 586076
  },
  {
...
```
