### PR TITLE
default IndexBuilder buildV10 to false

### DIFF
--- a/processing/src/test/java/org/apache/druid/segment/IndexBuilder.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexBuilder.java
@@ -143,7 +143,7 @@ public class IndexBuilder
   public IndexBuilder segmentWriteOutMediumFactory(SegmentWriteOutMediumFactory segmentWriteOutMediumFactory)
   {
     this.segmentWriteOutMediumFactory = segmentWriteOutMediumFactory;
-    this.indexMerger = new IndexMergerV9(jsonMapper, indexIO, segmentWriteOutMediumFactory, writeNullColumns);
+    this.indexMerger = makeIndexMerger();
     return this;
   }
 


### PR DESCRIPTION
### Description
This was a mistake in #18880 that sets incorrect default version for index merger in test index builder to v10