### PR TITLE
Fix race in getWorkerFor in MSQ tests.

### DIFF
--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerRunRef.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerRunRef.java
@@ -93,6 +93,14 @@ public class WorkerRunRef
   }
 
   /**
+   * Returns true if the worker reference has been set (i.e., {@link #run} has been called).
+   */
+  public boolean hasWorker()
+  {
+    return workerRef.get() != null;
+  }
+
+  /**
    * Cancel the worker. Interrupts the worker if currently running.
    */
   public void cancel()

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestControllerContext.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestControllerContext.java
@@ -211,8 +211,8 @@ public class MSQTestControllerContext implements ControllerContext, DartControll
           )
       );
       final WorkerRunRef workerRunRef = new WorkerRunRef();
-      ListenableFuture<?> future = workerRunRef.run(worker, EXECUTOR);
       inMemoryWorkers.put(task.getId(), workerRunRef);
+      ListenableFuture<?> future = workerRunRef.run(worker, EXECUTOR);
       statusMap.put(task.getId(), TaskStatus.running(task.getId()));
 
       Futures.addCallback(future, new FutureCallback<Object>()


### PR DESCRIPTION
In certain tests, there can be a race between starting a worker and trying to contact it. When this race trips, you get an error "Not implemented" from newWorker. This patch addresses it by ensuring that we wait for workers to start running when trying to contact them.