### PR TITLE
Fix containerFriendly networking in DinD/VM environments

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/KafkaSchemaRegistryResource.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/KafkaSchemaRegistryResource.java
@@ -50,7 +50,9 @@ public class KafkaSchemaRegistryResource extends TestcontainerResource<RedpandaC
   protected RedpandaContainer createContainer()
   {
     return new RedpandaContainer(SCHEMA_REGISTRY_IMAGE)
-        .dependsOn(kafkaResource.getContainer());
+        .dependsOn(kafkaResource.getContainer())
+        // Enable host.docker.internal on Linux (Docker Desktop provides this automatically)
+        .withExtraHost("host.docker.internal", "host-gateway");
   }
 
   @Override

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/k8s/K3sClusterResource.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/k8s/K3sClusterResource.java
@@ -135,7 +135,9 @@ public class K3sClusterResource extends TestcontainerResource<K3sContainer>
   protected K3sContainer createContainer()
   {
     Objects.requireNonNull(druidImageName, "No Druid image specified");
-    final K3sContainer container = new K3sContainer(DockerImageName.parse(K3S_IMAGE_NAME));
+    final K3sContainer container = new K3sContainer(DockerImageName.parse(K3S_IMAGE_NAME))
+        // Enable host.docker.internal on Linux (Docker Desktop provides this automatically)
+        .withExtraHost("host.docker.internal", "host-gateway");
 
     final List<String> portBindings = new ArrayList<>();
     for (K3sDruidService service : services) {

--- a/extensions-core/druid-testcontainers/src/main/java/org/apache/druid/testing/DruidContainer.java
+++ b/extensions-core/druid-testcontainers/src/main/java/org/apache/druid/testing/DruidContainer.java
@@ -109,6 +109,9 @@ public class DruidContainer extends GenericContainer<DruidContainer>
         port -> port + ":" + port
     ).collect(Collectors.toList());
     setPortBindings(portBindings);
+
+    // Enable host.docker.internal on Linux (Docker Desktop provides this automatically)
+    withExtraHost("host.docker.internal", "host-gateway");
   }
 
   /**

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResource.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResource.java
@@ -65,22 +65,19 @@ public class KafkaResource extends TestcontainerResource<KafkaContainer>
   @Override
   protected KafkaContainer createContainer()
   {
-    // The result of getBootstrapServers() is the first entry in KafkaContainer.advertisedListeners.
-    // Override getBootstrapServers() to ensure that both DruidContainers and
-    // EmbeddedDruidServers can connect to the Kafka brokers.
-    return new KafkaContainer(KAFKA_IMAGE) {
-      @Override
-      public String getBootstrapServers()
-      {
-        return cluster.getEmbeddedHostname().useInHostAndPort(super.getBootstrapServers());
-      }
-    };
+    return new KafkaContainer(KAFKA_IMAGE)
+        // Enable host.docker.internal on Linux (Docker Desktop provides this automatically)
+        .withExtraHost("host.docker.internal", "host-gateway");
   }
 
+  /**
+   * Returns the Kafka bootstrap server URL, transformed using the cluster's
+   * embedded hostname so it's reachable from both embedded and containerized services.
+   */
   public String getBootstrapServerUrl()
   {
     ensureRunning();
-    return getContainer().getBootstrapServers();
+    return cluster.getEmbeddedHostname().useInHostAndPort(getContainer().getBootstrapServers());
   }
 
   public Map<String, Object> consumerProperties()


### PR DESCRIPTION
### Description

Embedded tests that rely on using `useContainerFriendlyHostname()` would fail in non-containerized environments since `InetAddress.getLocalHost().getHostAddress()` returns the IP associated with the machine's hostname in /etc/hosts or DNS. In cloud CI environments this often returns an internal/corporate network IP which isn't routable from inside the container's isolated network bridge. Switching to `host.docker.internal` fixes this as this yields the host of the Docker gateway relative to the requesting process' execution context (running in the host or in the container).

Scenarios:
1. **WORKING:** Embedded JVM test running on the host contacting a container (e.g. Kafka) running inside Docker.
   - Embedded JVM process would do a `connect(InetAddress.getLocalHost().getHostAddress():<docker gateway port>)` which would resolve to `connect(localhost:<docker gateway port>)`.
   - Docker gateway would then proxy the request to the container process listening on another port.
   - This scenario works fine, since `InetAddress.getLocalHost().getHostAddress()` actually resolves to what we want. `host.docker.internal` will also resolve to localhost in this scenario.

2. **WORKING:** Container contacting another container

3. **NOT WORKING:** Container (e.g. Kafka) wants to reply to that embedded JVM process. 
   - It too calls`InetAddress.getLocalHost().getHostAddress()`, but since they are using separate network namespaces, this resolves to `localhost` as well (incorrect). Instead, resolving to `DockerClientFactory.dockerHostIpAddress()` will yield the host of the Docker gateway, which then can proxy the request back to the intended embedded JVM process.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note

Fix containerFriendly networking in DinD/Linux native environments for embedded tests.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.