### PR TITLE
[Backport] fix issue with projection schema deserialization from existing v9 segment metadata

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/projections/ProjectionSchema.java
+++ b/processing/src/main/java/org/apache/druid/segment/projections/ProjectionSchema.java
@@ -21,6 +21,7 @@ package org.apache.druid.segment.projections;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.OptBoolean;
 import org.apache.druid.data.input.impl.AggregateProjectionSpec;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.query.OrderBy;
@@ -38,7 +39,7 @@ import java.util.List;
  *
  * For V10 segment format {@link org.apache.druid.segment.file.SegmentFileMetadata}
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", requireTypeIdForSubtypes = OptBoolean.FALSE)
 @JsonSubTypes(value = {
     @JsonSubTypes.Type(name = AggregateProjectionSpec.TYPE_NAME, value = AggregateProjectionSchema.class),
     @JsonSubTypes.Type(name = TableProjectionSchema.TYPE_NAME, value = TableProjectionSchema.class),

--- a/processing/src/test/java/org/apache/druid/segment/AggregateProjectionMetadataTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/AggregateProjectionMetadataTest.java
@@ -72,8 +72,56 @@ class AggregateProjectionMetadataTest extends InitializedNullHandlingTest
         spec,
         JSON_MAPPER.readValue(JSON_MAPPER.writeValueAsString(spec), AggregateProjectionMetadata.class)
     );
+    String legacy = "{\n"
+                    + "  \"type\" : \"aggregate\",\n"
+                    + "  \"schema\" : {\n"
+                    + "    \"name\" : \"some_projection\",\n"
+                    + "    \"timeColumnName\" : \"time\",\n"
+                    + "    \"filter\" : {\n"
+                    + "      \"type\" : \"equals\",\n"
+                    + "      \"column\" : \"a\",\n"
+                    + "      \"matchValueType\" : \"STRING\",\n"
+                    + "      \"matchValue\" : \"a\"\n"
+                    + "    },\n"
+                    + "    \"virtualColumns\" : [ {\n"
+                    + "      \"type\" : \"expression\",\n"
+                    + "      \"name\" : \"time\",\n"
+                    + "      \"expression\" : \"timestamp_floor(__time,'PT1H',null,'UTC')\",\n"
+                    + "      \"outputType\" : \"LONG\"\n"
+                    + "    } ],\n"
+                    + "    \"groupingColumns\" : [ \"a\", \"b\", \"time\", \"c\", \"d\" ],\n"
+                    + "    \"aggregators\" : [ {\n"
+                    + "      \"type\" : \"count\",\n"
+                    + "      \"name\" : \"count\"\n"
+                    + "    }, {\n"
+                    + "      \"type\" : \"longSum\",\n"
+                    + "      \"name\" : \"e\",\n"
+                    + "      \"fieldName\" : \"e\"\n"
+                    + "    } ],\n"
+                    + "    \"ordering\" : [ {\n"
+                    + "      \"columnName\" : \"a\",\n"
+                    + "      \"order\" : \"ascending\"\n"
+                    + "    }, {\n"
+                    + "      \"columnName\" : \"b\",\n"
+                    + "      \"order\" : \"ascending\"\n"
+                    + "    }, {\n"
+                    + "      \"columnName\" : \"time\",\n"
+                    + "      \"order\" : \"ascending\"\n"
+                    + "    }, {\n"
+                    + "      \"columnName\" : \"c\",\n"
+                    + "      \"order\" : \"ascending\"\n"
+                    + "    }, {\n"
+                    + "      \"columnName\" : \"d\",\n"
+                    + "      \"order\" : \"ascending\"\n"
+                    + "    } ]\n"
+                    + "  },\n"
+                    + "  \"numRows\" : 12345\n"
+                    + "}";
+    Assertions.assertEquals(
+        spec,
+        JSON_MAPPER.readValue(legacy, AggregateProjectionMetadata.class)
+    );
   }
-
 
   @Test
   void testComparator()


### PR DESCRIPTION
Backport of #18916 to 36.0.0.