### PR TITLE
Fix another race in getWorkerFor.

### DIFF
--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestWorkerClient.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestWorkerClient.java
@@ -63,7 +63,8 @@ public class MSQTestWorkerClient implements WorkerClient
   {
     final Stopwatch stopwatch = Stopwatch.createStarted();
 
-    // Wait for the worker to exist
+    // Wait for the worker to exist. It may not have been created or started up yet, especially if this is
+    // a worker trying to contact another worker.
     WorkerRunRef workerRunRef;
     while ((workerRunRef = inMemoryWorkers.computeIfAbsent(workerTaskId, this::newWorker)) == null
            || !workerRunRef.hasWorker()) {


### PR DESCRIPTION
This patch is covering another case, beyond the one covered in #18910. There was still a race when multiple workers were running and all trying to contact each other, if worker A tried to contact worker B before worker B had been set up.

The fix is to have newWorker return null rather than throw an error in the base class, and update getWorkerFor to retry on null.