### PR TITLE
MSQFaultsTest: Merge TooManyInputFiles test cases.

### DIFF
--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQFaultsTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQFaultsTest.java
@@ -470,38 +470,6 @@ public class MSQFaultsTest extends MSQTestBase
   @Test
   public void testTooManyInputFiles() throws IOException
   {
-    RowSignature dummyRowSignature = RowSignature.builder().add("__time", ColumnType.LONG).build();
-
-    final int numFiles = 100000;
-
-    final File toRead = getResourceAsTemporaryFile("/wikipedia-sampled.json");
-    final String toReadFileNameAsJson = queryFramework().queryJsonMapper().writeValueAsString(toRead.getAbsolutePath());
-
-    String externalFiles = String.join(", ", Collections.nCopies(numFiles, toReadFileNameAsJson));
-
-    testIngestQuery()
-        .setSql(StringUtils.format(
-            "insert into foo1 SELECT\n"
-            + "  floor(TIME_PARSE(\"timestamp\") to day) AS __time\n"
-            + "FROM TABLE(\n"
-            + "  EXTERN(\n"
-            + "    '{ \"files\": [%s],\"type\":\"local\"}',\n"
-            + "    '{\"type\": \"csv\", \"hasHeaderRow\": true}',\n"
-            + "    '[{\"name\": \"timestamp\", \"type\": \"string\"}]'\n"
-            + "  )\n"
-            + ") PARTITIONED by day",
-            externalFiles
-        ))
-        .setQueryContext(Map.of("maxNumTasks", 8))
-        .setExpectedDataSource("foo1")
-        .setExpectedRowSignature(dummyRowSignature)
-        .setExpectedMSQFault(new TooManyInputFilesFault(numFiles, Limits.DEFAULT_MAX_INPUT_FILES_PER_WORKER, 10))
-        .verifyResults();
-  }
-
-  @Test
-  public void testTooManyInputFilesWithLowContextLimit() throws IOException
-  {
     final RowSignature dummyRowSignature = RowSignature.builder().addTimeColumn().build();
 
     final int numFiles = 100;
@@ -513,7 +481,7 @@ public class MSQFaultsTest extends MSQTestBase
 
     final Map<String, Object> context =
         ImmutableMap.<String, Object>builder()
-                    .putAll(DEFAULT_MSQ_CONTEXT)
+                    .put(MultiStageQueryContext.CTX_MAX_NUM_TASKS, 8)
                     .put(MultiStageQueryContext.CTX_MAX_INPUT_FILES_PER_WORKER, maxInputFilesPerWorker)
                     .build();
 


### PR DESCRIPTION
It isn't really necessary to have both testTooManyInputFiles and testTooManyPartitionsWithLowContextLimit. The former test case takes over 30s and the latter takes less than a second. This patch merges them into a single test case that uses the maxPartitions context parameter to lower the threshold required for failure.