### PR TITLE
lz4j: use safeDecompressor instead of fastDecompressor

### DIFF
--- a/server/src/main/java/org/apache/druid/client/cache/LZ4Transcoder.java
+++ b/server/src/main/java/org/apache/druid/client/cache/LZ4Transcoder.java
@@ -21,7 +21,7 @@ package org.apache.druid.client.cache;
 
 import net.jpountz.lz4.LZ4Compressor;
 import net.jpountz.lz4.LZ4Factory;
-import net.jpountz.lz4.LZ4FastDecompressor;
+import net.jpountz.lz4.LZ4SafeDecompressor;
 import net.spy.memcached.transcoders.SerializingTranscoder;
 
 import java.nio.ByteBuffer;
@@ -66,12 +66,12 @@ public class LZ4Transcoder extends SerializingTranscoder
   {
     byte[] out = null;
     if (in != null) {
-      LZ4FastDecompressor decompressor = lz4Factory.fastDecompressor();
+      LZ4SafeDecompressor decompressor = lz4Factory.safeDecompressor();
 
       int size = ByteBuffer.wrap(in).getInt();
 
       out = new byte[size];
-      decompressor.decompress(in, Integer.BYTES, out, 0, out.length);
+      decompressor.decompress(in, Integer.BYTES, in.length - Integer.BYTES, out, 0, out.length);
     }
     return out == null ? null : out;
   }


### PR DESCRIPTION
* the fastDecompressor method is deprecated
* according to lz4 apidoc-s the `fast` could be even slower

https://github.com/yawkat/lz4-java/blob/384ade4e11ca33002e600449682e5ebb63b85ac8/src/java/net/jpountz/lz4/LZ4Factory.java#L82-L89