### PR TITLE
fix detection for catalog DuplicateKeyException when overwriting table definitions

### DIFF
--- a/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/storage/sql/DbUtils.java
+++ b/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/storage/sql/DbUtils.java
@@ -21,6 +21,8 @@ package org.apache.druid.catalog.storage.sql;
 
 import org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException;
 
+import java.sql.SQLIntegrityConstraintViolationException;
+
 public class DbUtils
 {
   // Move to SqlMetadataConnector and its subclasses
@@ -31,13 +33,7 @@ public class DbUtils
       return false;
     }
 
-    // Use class names to avoid compile-time dependencies.
-    // Derby implementation
-    if (cause.getClass().getSimpleName().equals("DerbySQLIntegrityConstraintViolationException")) {
-      return true;
-    }
-    // MySQL implementation
-    if (cause.getClass().getSimpleName().equals("MySQLIntegrityConstraintViolationException")) {
+    if (cause instanceof SQLIntegrityConstraintViolationException) {
       return true;
     }
 


### PR DESCRIPTION
Changes to just detect `instance of SQLIntegrityConstraintViolationException` instead of looking for implementation specific classnames. Derby exceptions use this as a base type, and https://dev.mysql.com/doc/connector-j/en/connector-j-exceptions-changes.html shows that mysql just this directly in more recent connector versions