### PR TITLE
Adjust cost-based autoscaler algorithm

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -3403,7 +3403,6 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
         group.completionTimeout = DateTimes.nowUtc().plus(ioConfig.getCompletionTimeout());
         pendingCompletionTaskGroups.computeIfAbsent(groupId, k -> new CopyOnWriteArrayList<>()).add(group);
 
-
         boolean endOffsetsAreInvalid = false;
         for (Entry<PartitionIdType, SequenceOffsetType> entry : endOffsets.entrySet()) {
           if (entry.getValue().equals(getEndOfPartitionMarker())) {
@@ -3453,18 +3452,26 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
    * This method is invoked to determine whether a task count adjustment is needed
    * during a task rollover based on the recommendations from the task auto-scaler.
  */
+
   @VisibleForTesting
   void maybeScaleDuringTaskRollover()
   {
     if (taskAutoScaler != null && activelyReadingTaskGroups.isEmpty()) {
       int rolloverTaskCount = taskAutoScaler.computeTaskCountForRollover();
-      if (rolloverTaskCount > 0) {
+      if (rolloverTaskCount > 0 && rolloverTaskCount != getIoConfig().getTaskCount()) {
         log.info("Autoscaler recommends scaling down to [%d] tasks during rollover", rolloverTaskCount);
         changeTaskCountInIOConfig(rolloverTaskCount);
-        autoScalerConfig.setTaskCountStart(rolloverTaskCount);
         // Here force reset the supervisor state to be re-calculated on the next iteration of runInternal() call.
         // This seems the best way to inject task amount recalculation during the rollover.
         clearAllocationInfo();
+
+        ServiceMetricEvent.Builder event = ServiceMetricEvent
+            .builder()
+            .setDimension(DruidMetrics.SUPERVISOR_ID, supervisorId)
+            .setDimension(DruidMetrics.DATASOURCE, dataSource)
+            .setDimension(DruidMetrics.STREAM, getIoConfig().getStream());
+
+        emitter.emit(event.setMetric(AUTOSCALER_REQUIRED_TASKS_METRIC, rolloverTaskCount));
       }
     }
   }
@@ -4049,7 +4056,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
           builder.put(partitionId, makeSequenceNumber(sequence, useExclusiveStartSequenceNumberForNonFirstSequence()));
         }
       } else {
-        // if we don't have a startingOffset (first run or we had some previous failures and reset the sequences) then
+        // if we don't have a startingOffset (first run, or we had some previous failures and reset the sequences) then
         // get the sequence from metadata storage (if available) or Kafka/Kinesis (otherwise)
         OrderedSequenceNumber<SequenceOffsetType> offsetFromStorage = getOffsetFromStorageForPartition(
             partitionId,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfig.java
@@ -86,7 +86,7 @@ public abstract class SeekableStreamSupervisorIOConfig
     // Could be null
     this.autoScalerConfig = autoScalerConfig;
     this.autoScalerEnabled = autoScalerConfig != null && autoScalerConfig.getEnableTaskAutoScaler();
-    // if autoscaler is enabled then taskCount will be ignored here and initial taskCount will equal to taskCountStart/taskCountMin
+    // if autoscaler is enabled, then taskCount will be ignored here and initial taskCount will equal to taskCountStart/taskCountMin
     if (autoScalerEnabled) {
       final Integer startTaskCount = autoScalerConfig.getTaskCountStart();
       this.taskCount = startTaskCount != null ? startTaskCount : autoScalerConfig.getTaskCountMin();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/AutoScalerConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/AutoScalerConfig.java
@@ -41,7 +41,6 @@ public interface AutoScalerConfig
   int getTaskCountMax();
   int getTaskCountMin();
   Integer getTaskCountStart();
-  void setTaskCountStart(int taskCountStart);
   Double getStopTaskCountRatio();
   SupervisorTaskAutoScaler createAutoScaler(Supervisor supervisor, SupervisorSpec spec, ServiceEmitter emitter);
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScalerConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScalerConfig.java
@@ -158,12 +158,6 @@ public class CostBasedAutoScalerConfig implements AutoScalerConfig
   }
 
   @Override
-  public void setTaskCountStart(int taskCountStart)
-  {
-    this.taskCountStart = taskCountStart;
-  }
-
-  @Override
   @JsonProperty
   public long getMinTriggerScaleActionFrequencyMillis()
   {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/LagBasedAutoScalerConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/LagBasedAutoScalerConfig.java
@@ -184,12 +184,6 @@ public class LagBasedAutoScalerConfig implements AutoScalerConfig
   }
 
   @Override
-  public void setTaskCountStart(int taskCountStart)
-  {
-    this.taskCountStart = taskCountStart;
-  }
-
-  @Override
   public SupervisorTaskAutoScaler createAutoScaler(Supervisor supervisor, SupervisorSpec spec, ServiceEmitter emitter)
   {
     return new LagBasedAutoScaler((SeekableStreamSupervisor) supervisor, spec.getId(), this, spec, emitter);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfigTest.java
@@ -80,7 +80,7 @@ public class SeekableStreamSupervisorIOConfigTest
   }
 
   @Test
-  public void testAutoScalerEnabledTrueAndFalse()
+  public void testAutoScalerEnabledPreservesTaskCountWhenNonNull()
   {
     LagAggregator lagAggregator = mock(LagAggregator.class);
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorScaleDuringTaskRolloverTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorScaleDuringTaskRolloverTest.java
@@ -88,7 +88,7 @@ public class SeekableStreamSupervisorScaleDuringTaskRolloverTest extends Seekabl
     Assert.assertEquals(
         "Task count should not change when rolloverTaskCount <= 0",
         beforeTaskCount,
-        (int) supervisor.getIoConfig().getAutoScalerConfig().getTaskCountStart()
+        (int) supervisor.getIoConfig().getTaskCount()
     );
   }
 
@@ -116,7 +116,7 @@ public class SeekableStreamSupervisorScaleDuringTaskRolloverTest extends Seekabl
     Assert.assertEquals(
         "Task count should be updated to " + targetTaskCount + " when rolloverTaskCount > 0",
         targetTaskCount,
-        (int) supervisor.getIoConfig().getAutoScalerConfig().getTaskCountStart()
+        (int) supervisor.getIoConfig().getTaskCount()
     );
   }
 
@@ -144,7 +144,7 @@ public class SeekableStreamSupervisorScaleDuringTaskRolloverTest extends Seekabl
     Assert.assertEquals(
         "Task count should not change when rolloverTaskCount is 0",
         beforeTaskCount,
-        (int) supervisor.getIoConfig().getAutoScalerConfig().getTaskCountStart()
+        (int) supervisor.getIoConfig().getTaskCount()
     );
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorSpecTest.java
@@ -1457,7 +1457,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
           "stream",
           new JsonInputFormat(new JSONPathSpec(true, ImmutableList.of()), ImmutableMap.of(), false, false, false),
           1,
-          taskCount,
+          null, // autoscaler uses taskCountStart/taskCountMin for the initial value
           new Period("PT1H"),
           new Period("P1D"),
           new Period("PT30S"),
@@ -1478,7 +1478,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
           "stream",
           new JsonInputFormat(new JSONPathSpec(true, ImmutableList.of()), ImmutableMap.of(), false, false, false),
           1,
-          taskCount,
+          null, // autoscaler uses taskCountStart/taskCountMin for the initial value
           new Period("PT1H"),
           new Period("P1D"),
           new Period("PT30S"),

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScalerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScalerTest.java
@@ -38,7 +38,7 @@ import java.util.Map;
 import static org.apache.druid.indexing.common.stats.DropwizardRowIngestionMeters.FIFTEEN_MINUTE_NAME;
 import static org.apache.druid.indexing.common.stats.DropwizardRowIngestionMeters.FIVE_MINUTE_NAME;
 import static org.apache.druid.indexing.common.stats.DropwizardRowIngestionMeters.ONE_MINUTE_NAME;
-import static org.apache.druid.indexing.seekablestream.supervisor.autoscaler.CostBasedAutoScaler.LAG_ACTIVATION_THRESHOLD;
+import static org.apache.druid.indexing.seekablestream.supervisor.autoscaler.CostBasedAutoScaler.EXTRA_SCALING_LAG_PER_PARTITION_THRESHOLD;
 import static org.apache.druid.indexing.seekablestream.supervisor.autoscaler.CostBasedAutoScaler.computeExtraMaxPartitionsPerTaskIncrease;
 import static org.apache.druid.indexing.seekablestream.supervisor.autoscaler.CostBasedAutoScaler.computeValidTaskCounts;
 import static org.mockito.Mockito.when;
@@ -184,7 +184,7 @@ public class CostBasedAutoScalerTest
   {
     // No extra increase below the threshold
     Assert.assertEquals(0, computeExtraMaxPartitionsPerTaskIncrease(30L * 49_000L, 30, 3, 30));
-    Assert.assertEquals(4, computeExtraMaxPartitionsPerTaskIncrease(30L * LAG_ACTIVATION_THRESHOLD, 30, 3, 30));
+    Assert.assertEquals(4, computeExtraMaxPartitionsPerTaskIncrease(30L * EXTRA_SCALING_LAG_PER_PARTITION_THRESHOLD, 30, 3, 30));
 
     // More aggressive increase when the lag is high
     Assert.assertEquals(6, computeExtraMaxPartitionsPerTaskIncrease(30L * 300_000L, 30, 3, 30));


### PR DESCRIPTION
## Core ideas around the change
- Scale up more aggressively when per-partition lag is meaningful.
- Relax the PPT (partitions-per-task) increase limit based on lag severity and headroom.
- Keep behavior conservative near `taskCountMax` and avoid negative headroom effects.

## Key changes
- **Lag-proportional PPT relaxation**: add `rawExtra` when avg lag exceeds thresholds, plus a step function for higher lag.
- **Headroom-aware scaling**: multiply by `max(0, 1 - currentTasks/maxTasks)` to reduce aggressiveness near max and avoid negative scaling.
- **Lag-amplified idle decay**: when lag/partition exceeds the activation threshold, the lag-based busy factor is multiplied 
    by a ramped multiplier (1.0x at 50K to 2.0x at 500K) to reduce predicted idle more aggressively during high lag.

## Expected behavior (for example, 30 partitions, `taskCountMax`=30)
- 3 tasks: 50K lag/partition → 8 tasks; 300K → 15 tasks; 500K+ → 30 tasks.
- 10 tasks: 100K → 15; 300K → 30; 500K → 30.
- 20/25 tasks (PPT=1): scale-up capped only by `taskCountMax`.
Note: examples assume lag-dominant conditions (low/mide processing rate, low idle).

## Open questions / risks
- **Lag skew**: using `aggregateLag / partitionCount` can under-react if a few partitions are far behind. Consider max/percentile lag if available.

This PR has:

- [ ] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] been tested in a test Druid cluster.