### PR TITLE
Web console: show completed Dart queries (adapt to work in #18923)

### DIFF
--- a/web-console/script/druid
+++ b/web-console/script/druid
@@ -69,6 +69,7 @@ function _build_distribution() {
     && rm conf/druid/auto/_common/common.runtime.properties.bak \
     && echo -e "\n\ndruid.server.http.allowedHttpMethods=[\"HEAD\"]" >> conf/druid/auto/_common/common.runtime.properties \
     && echo -e "\n\ndruid.export.storage.baseDir=/" >> conf/druid/auto/_common/common.runtime.properties \
+    && echo -e "\n\ndruid.sql.planner.enableSysQueriesTable=true" >> conf/druid/auto/_common/common.runtime.properties \
     && echo -e "\n\ndruid.msq.dart.enabled=true" >> conf/druid/auto/_common/common.runtime.properties \
     && echo -e "\n\ndruid.msq.dart.controller.maxRetainedReportCount=100" >> conf/druid/auto/_common/common.runtime.properties \
     && echo -e "\n\ndruid.msq.dart.controller.maxRetainedReportDuration=PT3600S" >> conf/druid/auto/_common/common.runtime.properties \

--- a/web-console/src/druid-models/dart/dart-query-entry.ts
+++ b/web-console/src/druid-models/dart/dart-query-entry.ts
@@ -24,5 +24,5 @@ export interface DartQueryEntry {
   authenticator: string;
   identity: string;
   startTime: string;
-  state: 'ACCEPTED' | 'RUNNING' | 'CANCELED';
+  state: 'ACCEPTED' | 'RUNNING' | 'CANCELED' | 'SUCCESS' | 'FAILED';
 }

--- a/web-console/src/views/workbench-view/current-dart-panel/current-dart-panel.tsx
+++ b/web-console/src/views/workbench-view/current-dart-panel/current-dart-panel.tsx
@@ -38,7 +38,11 @@ function stateToIconAndColor(status: DartQueryEntry['state']): [IconName, string
     case 'RUNNING':
       return [IconNames.REFRESH, '#2167d5'];
     case 'ACCEPTED':
-      return [IconNames.CIRCLE, '#8d8d8d'];
+      return [IconNames.CIRCLE, '#d5631a'];
+    case 'SUCCESS':
+      return [IconNames.TICK_CIRCLE, '#57d500'];
+    case 'FAILED':
+      return [IconNames.DELETE, '#9f0d0a'];
     case 'CANCELED':
       return [IconNames.DISABLE, '#8d8d8d'];
     default:
@@ -61,8 +65,9 @@ export const CurrentDartPanel = React.memo(function CurrentViberPanel(
   const [dartQueryEntriesState, queryManager] = useQueryManager<number, DartQueryEntry[]>({
     query: useStore(WORK_STATE_STORE, getMsqDartVersion),
     processQuery: async (_, signal) => {
-      return (await Api.instance.get('/druid/v2/sql/queries', { signal })).data
-        .queries as DartQueryEntry[];
+      return (
+        await Api.instance.get('/druid/v2/sql/queries?includeComplete', { signal })
+      ).data.queries.reverse() as DartQueryEntry[];
     },
   });
 

--- a/web-console/src/views/workbench-view/execution-details-pane-loader/execution-details-pane-loader.tsx
+++ b/web-console/src/views/workbench-view/execution-details-pane-loader/execution-details-pane-loader.tsx
@@ -33,6 +33,8 @@ async function getDartExecution(sqlQueryId: string, signal: AbortSignal): Promis
     { signal },
   );
 
+  if (!data.report) throw new Error('Query not started yet');
+
   return Execution.fromDartReport(data.report).changeSqlQuery(data.query.sql);
 }
 


### PR DESCRIPTION
This PR addapts the web console to the change in #18923

<img width="266" height="145" alt="image" src="https://github.com/user-attachments/assets/e3040137-1f11-4cca-a143-75fb30c845cb" />
