### PR TITLE
Faster bucket search in ByteBufferHashTable

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/ByteBufferHashTableBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/ByteBufferHashTableBenchmark.java
@@ -115,7 +115,7 @@ public class ByteBufferHashTableBenchmark
       ByteBuffer keyBuffer = insertedKeysBuffer.slice();
       insertedKeysBuffer.clear(); // Reset limit for next iteration
 
-      int keyHash = Groupers.smear(keyBuffer.getInt(0)) & 0x7FFFFFFF;
+      int keyHash = Groupers.smear(keyBuffer.getInt(0)) & Groupers.USED_FLAG_MASK;
       insertedKeyHashes[i] = keyHash;
 
       int bucket = hashTable.findBucket0(true, keyBuffer, keyHash);
@@ -150,7 +150,7 @@ public class ByteBufferHashTableBenchmark
       lookupKeys[i] = lookupKeysBuffer.slice();
       lookupKeysBuffer.clear();
 
-      lookupKeyHashes[i] = Groupers.smear(lookupKeys[i].getInt(0)) & 0x7FFFFFFF;
+      lookupKeyHashes[i] = Groupers.smear(lookupKeys[i].getInt(0)) & Groupers.USED_FLAG_MASK;
     }
 
     // Fill the rest with existing keys (copy from insertedKeysBuffer)

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/ByteBufferHashTable.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/ByteBufferHashTable.java
@@ -202,7 +202,7 @@ public class ByteBufferHashTable
         keyBuffer.limit(entryBuffer.position() + HASH_SIZE + keySize);
         keyBuffer.position(entryBuffer.position() + HASH_SIZE);
 
-        final int keyHash = entryBuffer.getInt(entryBuffer.position()) & 0x7fffffff;
+        final int keyHash = entryBuffer.getInt(entryBuffer.position()) & Groupers.USED_FLAG_MASK;
         final int newBucket = findBucket(true, newBuckets, newTableBuffer, keyBuffer, keyHash);
 
         if (newBucket < 0) {
@@ -308,7 +308,7 @@ public class ByteBufferHashTable
       final int bucketOffset = bucket * bucketSizeWithHash;
       final int storedHashWithUsedFlag = targetTableBuffer.getInt(bucketOffset);
 
-      if ((storedHashWithUsedFlag & 0x80000000) == 0) {
+      if ((storedHashWithUsedFlag & Groupers.USED_FLAG_BIT) == 0) {
         // Found unused bucket before finding our key
         return allowNewBucket ? bucket : -1;
       }

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/Groupers.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/Groupers.java
@@ -48,7 +48,17 @@ public class Groupers
       + "for details."
   );
 
-  private static final int USED_FLAG_MASK = 0x7fffffff;
+  /**
+   * Mask to clear the used flag bit from a hash value. Used when reading a hash from a bucket
+   * to recover the original hash without the used flag.
+   */
+  public static final int USED_FLAG_MASK = 0x7fffffff;
+
+  /**
+   * Bit that indicates a bucket is used in the hash table. This is the sign bit (highest bit)
+   * of the hash value stored in each bucket.
+   */
+  public static final int USED_FLAG_BIT = 0x80000000;
 
   private static final int C1 = 0xcc9e2d51;
   private static final int C2 = 0x1b873593;
@@ -93,7 +103,7 @@ public class Groupers
 
   static int getUsedFlag(int keyHash)
   {
-    return keyHash | 0x80000000;
+    return keyHash | USED_FLAG_BIT;
   }
 
   public static ByteBuffer getSlice(ByteBuffer buffer, int sliceSize, int i)

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedBufferHashGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedBufferHashGrouper.java
@@ -544,7 +544,7 @@ public class LimitedBufferHashGrouper<KeyType> extends AbstractBufferHashGrouper
           keyBuffer.position(entryBuffer.position() + HASH_SIZE);
 
           // Put the entry in the new hash table
-          final int keyHash = entryBuffer.getInt(entryBuffer.position()) & 0x7fffffff;
+          final int keyHash = entryBuffer.getInt(entryBuffer.position()) & Groupers.USED_FLAG_MASK;
           final int newBucket = findBucket(true, maxBuckets, newTableBuffer, keyBuffer, keyHash);
 
           if (newBucket < 0) {


### PR DESCRIPTION
### Description

Adds hash code comparison for large enough keys to `ByteBufferHashTable#findBucket()`. Also, changes key comparison to use long/int/byte instead of byte-only comparison (thus, the comparison is now closer to `HashTableUtils#memoryEquals()` used in `MemoryOpenHashTable`). These changes are aimed to speed-up bucket search in `ByteBufferHashTable`, especially in high-collision cases.

#### Microbenchmarks

Environment: Ryzen 7900x, Ubuntu 24.04, OpenJDK 64-bit 17.0.17

Before:
```
Benchmark                                (keySize)  Mode  Cnt   Score   Error  Units
ByteBufferHashTableBenchmark.findBucket          8  avgt    5  19.965 ± 0.212  ns/op
ByteBufferHashTableBenchmark.findBucket         16  avgt    5  26.816 ± 1.282  ns/op
ByteBufferHashTableBenchmark.findBucket         32  avgt    5  36.174 ± 0.337  ns/op
ByteBufferHashTableBenchmark.findBucket         64  avgt    5  49.581 ± 0.482  ns/op
ByteBufferHashTableBenchmark.findBucket        128  avgt    5  72.990 ± 1.429  ns/op
```

After:
```
Benchmark                                (keySize)  Mode  Cnt   Score   Error  Units
ByteBufferHashTableBenchmark.findBucket          8  avgt    5   5.502 ± 0.338  ns/op
ByteBufferHashTableBenchmark.findBucket         16  avgt    5  11.830 ± 0.046  ns/op
ByteBufferHashTableBenchmark.findBucket         32  avgt    5  15.965 ± 0.135  ns/op
ByteBufferHashTableBenchmark.findBucket         64  avgt    5  20.522 ± 0.069  ns/op
ByteBufferHashTableBenchmark.findBucket        128  avgt    5  29.035 ± 1.806  ns/op
```

#### Release note

Speed-up bucket search in hash table used by GROUP BY

<hr>

##### Key changed/added classes in this PR
 * `ByteBufferHashTable`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.