### PR TITLE
Add metrics and improve logging for row signature flapping.

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -462,9 +462,8 @@ These metrics are emitted by the Druid Coordinator in every run of the correspon
 |`segment/schemaCache/dataSource/removed`|Emitted when a datasource is removed from the Broker cache due to segments being marked as unused.|`dataSource`||
 |`segment/schemaCache/refresh/time`|Time taken to refresh segments in coordinator segment schema cache.|`dataSource`||
 |`segment/schemaCache/backfill/count`|Number of segments for which schema was back filled in the database.|`dataSource`||
-|`segment/schemaCache/rowSignature/initialized`|Emitted when a datasource row signature is initialized for the first time in the Broker's segment metadata cache.|`dataSource`||
 |`segment/schemaCache/rowSignature/changed`|Emitted when the cached row signature on the Broker's segment metadata cache for a datasource changes, indicating schema evolution or some form of flapping.|`dataSource`||
-|`segment/schemaCache/rowSignature/column/count`|Number of columns in the updated row signature for a datasource.|`dataSource`||
+|`segment/schemaCache/rowSignature/column/count`|Number of columns in the row signature on the Broker's segment metadata cache for a datasource when it's initialized or updated.|`dataSource`||
 |`segment/schemaCache/realtime/count`|Number of realtime segments for which schema is cached.||Depends on the number of realtime segments in the cluster.|
 |`segment/schemaCache/used/count`|Number of published used segments for which schema is cached.||Depends on the number of segments in the cluster.|
 |`segment/schemaCache/usedFingerprint/count`|Number of unique schema fingerprints cached for published used segments.||Depends on the number of distinct schema in the cluster.|

--- a/server/src/main/java/org/apache/druid/segment/metadata/Metric.java
+++ b/server/src/main/java/org/apache/druid/segment/metadata/Metric.java
@@ -53,7 +53,6 @@ public class Metric
   public static final String REFRESH_SKIPPED_TOMBSTONES = PREFIX + "refresh/tombstone/count";
   public static final String REFRESH_DURATION_MILLIS = PREFIX + "refresh/time";
   public static final String DATASOURCE_REMOVED = PREFIX + "dataSource/removed";
-  public static final String SCHEMA_ROW_SIGNATURE_INITIALIZED = PREFIX + "rowSignature/initialized";
   public static final String SCHEMA_ROW_SIGNATURE_CHANGED = PREFIX + "rowSignature/changed";
   public static final String SCHEMA_ROW_SIGNATURE_COLUMN_COUNT = PREFIX + "rowSignature/column/count";
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/BrokerSegmentMetadataCache.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/BrokerSegmentMetadataCache.java
@@ -370,7 +370,6 @@ public class BrokerSegmentMetadataCache extends AbstractSegmentMetadataCache<Phy
           dataSource, newColumnCount, newRowSignature
       );
 
-      emitMetric(Metric.SCHEMA_ROW_SIGNATURE_INITIALIZED, 1, builder);
       emitMetric(Metric.SCHEMA_ROW_SIGNATURE_COLUMN_COUNT, newColumnCount, builder);
       return;
     }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/BrokerSegmentMetadataCacheTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/BrokerSegmentMetadataCacheTest.java
@@ -431,10 +431,6 @@ public class BrokerSegmentMetadataCacheTest extends BrokerSegmentMetadataCacheTe
 
     refreshLatch.await(WAIT_TIMEOUT_SECS, TimeUnit.SECONDS);
 
-    emitter.verifyValue(Metric.SCHEMA_ROW_SIGNATURE_INITIALIZED, Map.of(DruidMetrics.DATASOURCE, "foo"), 1L);
-    emitter.verifyValue(Metric.SCHEMA_ROW_SIGNATURE_INITIALIZED, Map.of(DruidMetrics.DATASOURCE, "foo2"), 1L);
-    emitter.verifyValue(Metric.SCHEMA_ROW_SIGNATURE_INITIALIZED, Map.of(DruidMetrics.DATASOURCE, "some_datasource"), 1L);
-
     emitter.verifyValue(Metric.SCHEMA_ROW_SIGNATURE_COLUMN_COUNT, Map.of(DruidMetrics.DATASOURCE, "foo"), 6L);
     emitter.verifyValue(Metric.SCHEMA_ROW_SIGNATURE_COLUMN_COUNT, Map.of(DruidMetrics.DATASOURCE, "foo2"), 3L);
     emitter.verifyValue(Metric.SCHEMA_ROW_SIGNATURE_COLUMN_COUNT, Map.of(DruidMetrics.DATASOURCE, "some_datasource"), 9L);
@@ -833,7 +829,6 @@ public class BrokerSegmentMetadataCacheTest extends BrokerSegmentMetadataCacheTe
 
     Assert.assertTrue(addSegmentLatch.await(1, TimeUnit.SECONDS));
 
-    emitter.verifyValue(Metric.SCHEMA_ROW_SIGNATURE_INITIALIZED, Map.of(DruidMetrics.DATASOURCE, "foo"), 1L);
     emitter.verifyValue(Metric.SCHEMA_ROW_SIGNATURE_COLUMN_COUNT, Map.of(DruidMetrics.DATASOURCE, "foo"), 6L);
 
     Set<String> dataSources = segments.stream().map(DataSegment::getDataSource).collect(Collectors.toSet());
@@ -1000,10 +995,6 @@ public class BrokerSegmentMetadataCacheTest extends BrokerSegmentMetadataCacheTe
     // wait for get again, just to make sure table has been updated (latch counts down just before tables are updated)
     refreshLatch = new CountDownLatch(1);
     Assert.assertTrue(refreshLatch.await(WAIT_TIMEOUT_SECS, TimeUnit.SECONDS));
-
-    emitter.verifyValue(Metric.SCHEMA_ROW_SIGNATURE_INITIALIZED, Map.of(DruidMetrics.DATASOURCE, "foo"), 1L);
-    emitter.verifyValue(Metric.SCHEMA_ROW_SIGNATURE_INITIALIZED, Map.of(DruidMetrics.DATASOURCE, "foo2"), 1L);
-    emitter.verifyValue(Metric.SCHEMA_ROW_SIGNATURE_INITIALIZED, Map.of(DruidMetrics.DATASOURCE, "some_datasource"), 1L);
 
     emitter.verifyValue(Metric.SCHEMA_ROW_SIGNATURE_COLUMN_COUNT, Map.of(DruidMetrics.DATASOURCE, "foo"), 6L);
     emitter.verifyValue(Metric.SCHEMA_ROW_SIGNATURE_COLUMN_COUNT, Map.of(DruidMetrics.DATASOURCE, "foo2"), 3L);


### PR DESCRIPTION
We keep encountering different row signatures on the Brokers for the same datasource even when the schema has changed. We’ll need to root cause why the schema “flaps” periodically, but my current suspicion is that this originates on the ingestion path when data is sparse + complex<json> columns - when this happens the columns in the row signature gets reordered.

The side effect of this row signature flapping is that SQL queries can be planned into incorrect native queries until the broker’s schema cache eventually reconciles back to the “correct” signature. This leads to sporadic missing data.

To this end, add some metrics and improve logging to include dimension counts in the old vs new signatures (we have really large schemas, so the actual signature get truncated) whenever a row signature change occurs.

Release note
Add  `segment/schemaCache/rowSignature/changed` and `segment/schemaCache/rowSignature/column/count` metrics to get visibility into when the Broker's segment metadata cache's row signature for each datasource is initialized and updated.

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.