### PR TITLE
Upgrade compiler version to JDK 17

### DIFF
--- a/.github/scripts/strict-compilation.sh
+++ b/.github/scripts/strict-compilation.sh
@@ -18,4 +18,4 @@
 set -e
 set -x
 
-mvn -B clean -DstrictCompile -pl '!embedded-tests' compile test-compile --fail-at-end -P skip-tests -Dweb.console.skip=true -T1C
+mvn -B clean -DstrictCompile compile test-compile --fail-at-end -P skip-tests -Dweb.console.skip=true -T1C

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Find articles written by community members and a calendar of upcoming events on 
 
 ### Building from source
 
-Please note that JDK 11 or JDK 17 is required to build Druid.
+Please note that JDK 17 or JDK 21 is required to build Druid.
 
 See the latest [build guide](https://druid.apache.org/docs/latest/development/build.html) for instructions on building Apache Druid from source.
 

--- a/embedded-tests/pom.xml
+++ b/embedded-tests/pom.xml
@@ -29,9 +29,6 @@
 
   <properties>
     <surefire.rerunFailingTestsCount>0</surefire.rerunFailingTestsCount>
-    <!--  Hadoop relies upon JDK 11 language level which breaks when upgraded to anything higher, but we can use 17 in \
-    embedded-tests, which supports more features such as multiline text block literal delimiter (""")  -->
-    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <parent>
@@ -557,14 +554,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.11.0</version>
-        <configuration>
-          <release>${maven.compiler.release}</release> <!-- forced for this module -->
-        </configuration>
-      </plugin>
       <!-- Skip this module from jacoco coverage as it contains only tests -->
       <plugin>
         <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,12 +70,7 @@
     </scm>
 
     <properties>
-        <!--  java 11 is no longer supported, but for backward compatibility reasons we plan to stay on 11 until druid37, see https://github.com/apache/druid/pull/18759.
-          Note for upgrade:
-          - remove the maven-compiler-plugin in embedded-tests
-          - remove exclusion of embedded-tests in strict compilation check
-          -->
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <aether.version>0.9.0.M2</aether.version>


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fully deprecates JDK 11 per https://github.com/apache/druid/pull/18759#issuecomment-3554561707. Ideally v37 can remove JDK 17 support altogether and JDK 25 will be the newer supported version (with JDK 21 being deprecated).

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Upgrade compiler version to JDK 17. This removes compiler compatibility for indexing-hadoop (no longer supported extension).


<hr>


<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.