### PR TITLE
fix vsf load time to be actual load time and not include wait time

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
@@ -793,7 +793,7 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
                     entry.referenceProvider,
                     entry.dataSegment.getSize(),
                     waitTime,
-                    System.nanoTime() - startTime
+                    System.nanoTime() - execStartTime
                 );
               }
           );


### PR DESCRIPTION
Fixes the `query/load/time` metrics introduced in #18727 to not include `query/load/wait`, which was a mistake. Not quite sure how to write a test for this without doing some gross stuff that i don't much want to do