### PR TITLE
Get rid of dominant task duration in cost-based autoscaler

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/WeightedCostFunction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/WeightedCostFunction.java
@@ -29,12 +29,7 @@ import org.apache.druid.java.util.common.logger.Logger;
 public class WeightedCostFunction
 {
   private static final Logger log = new Logger(WeightedCostFunction.class);
-  /**
-   * The lag severity at which lagBusyFactor reaches 1.0 (full idle suppression).
-   * lagSeverity is defined as lagPerPartition / highLagThreshold.
-   * At severity=1 (threshold), lagBusyFactor=0. At severity=MAX, lagBusyFactor=1.0.
-   */
-  private static final int LAG_AMPLIFICATION_MAX_SEVERITY = 5;
+  private static final double LAG_AMPLIFICATION_MULTIPLIER = 0.2;
 
   /**
    * Computes cost for a given task count using compute time metrics.
@@ -73,12 +68,19 @@ public class WeightedCostFunction
       }
     } else {
       // Lag recovery time is decreasing by adding tasks and increasing by ejecting tasks.
+      // In case of increasing lag, we apply an amplification factor to reflect the urgency of addressing lag.
       // Caution: we rely only on the metrics, the real issues may be absolutely different, up to hardware failure.
-      lagRecoveryTime = metrics.getAggregateLag() / (proposedTaskCount * avgProcessingRate);
+      if (metrics.getAggregateLag() <= 0) {
+        lagRecoveryTime = 0;
+      } else {
+        final double lagPerPartition = metrics.getAggregateLag() / metrics.getPartitionCount();
+        final double amplification = Math.max(1.0, 1.0 + LAG_AMPLIFICATION_MULTIPLIER * Math.log(lagPerPartition));
+        lagRecoveryTime = metrics.getAggregateLag() * amplification / (proposedTaskCount * avgProcessingRate);
+      }
     }
 
-    final double predictedIdleRatio = estimateIdleRatio(metrics, proposedTaskCount, config.getHighLagThreshold());
-    final double idleCost = proposedTaskCount * metrics.getTaskDurationSeconds() * predictedIdleRatio;
+    final double predictedIdleRatio = estimateIdleRatio(metrics, proposedTaskCount);
+    final double idleCost = proposedTaskCount * predictedIdleRatio;
     final double lagCost = config.getLagWeight() * lagRecoveryTime;
     final double weightedIdleCost = config.getIdleWeight() * idleCost;
     final double cost = lagCost + weightedIdleCost;
@@ -97,17 +99,13 @@ public class WeightedCostFunction
   }
 
   /**
-   * Estimates the idle ratio for a proposed task count.
-   * Includes lag-based adjustment to suppress predicted idle when lag exceeds the threshold,
-   * encouraging scale-up when there is real work to do.
-   * The algorithm is adjusted with {@code computeExtraPPTIncrease}, so they may work in tandem, when enabled.
+   * Estimates the idle ratio for a proposed task count with linear prediction.
    *
    * @param metrics   current system metrics containing idle ratio and task count
    * @param taskCount target task count to estimate an idle ratio for
    * @return estimated idle ratio in range [0.0, 1.0]
    */
-  @SuppressWarnings("ExtractMethodRecommender")
-  private double estimateIdleRatio(CostMetrics metrics, int taskCount, int highLagThreshold)
+  private double estimateIdleRatio(CostMetrics metrics, int taskCount)
   {
     final double currentPollIdleRatio = metrics.getPollIdleRatio();
 
@@ -126,17 +124,8 @@ public class WeightedCostFunction
     final double taskRatio = (double) taskCount / currentTaskCount;
     final double linearPrediction = Math.max(0.0, Math.min(1.0, 1.0 - busyFraction / taskRatio));
 
-    final double lagPerPartition = metrics.getAggregateLag() / metrics.getPartitionCount();
-    double lagBusyFactor = 0.;
-
-    // Lag-amplified idle decay using ln(lagSeverity) / ln(maxSeverity).
-    if (highLagThreshold > 0 && lagPerPartition >= highLagThreshold) {
-      final double lagSeverity = lagPerPartition / highLagThreshold;
-      lagBusyFactor = Math.min(1.0, Math.log(lagSeverity) / Math.log(LAG_AMPLIFICATION_MAX_SEVERITY));
-    }
-
     // Clamp to valid range [0, 1]
-    return Math.max(0.0, linearPrediction * (1.0 - lagBusyFactor));
+    return Math.max(0.0, linearPrediction);
   }
 
 }


### PR DESCRIPTION
Also, this patch replaces idle decay with logarithmic lag acceleration, providing smoother and less complicating scaling logic under loaded lag conditions.

Example under the hood.

<details>

Plot provides information about the scale-up aggressiveness from 1 task, having a 500k total lag.
 
**p** = partition count
**rate** = processing rate, given from metrics
**idle** = `poll-avg-idle` metric

<img width="900" height="750" alt="image" src="https://github.com/user-attachments/assets/7c4e5110-470f-4352-b63a-4c063a8a9b7a" />

</details>