### PR TITLE
Add length checks to LDAPCredentialsValidator (#18959)

### DIFF
--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/validator/LDAPCredentialsValidator.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/validator/LDAPCredentialsValidator.java
@@ -153,6 +153,9 @@ public class LDAPCredentialsValidator implements CredentialsValidator
       char[] password
   )
   {
+    if (username.isEmpty() || password.length == 0) {
+      return null;
+    }
     final SearchResult userResult;
     final LdapName userDn;
     final Map<String, Object> contextMap = new HashMap<>();


### PR DESCRIPTION
### Description

Cherry-pick https://github.com/apache/druid/commit/79f149d8991802c7f005c2fea0b1d3586780750c to mainline.

#### Release note

Add username/password length checks to LDAPCredentialsValidator

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.