### PR TITLE
Configurable index disabling for virtual columns

### DIFF
--- a/docs/querying/query-context-reference.md
+++ b/docs/querying/query-context-reference.md
@@ -72,6 +72,7 @@ Unless otherwise noted, the following parameters apply to all query types, and t
 |`sqlPlannerBloat`|`1000`|Calcite parameter which controls whether to merge two Project operators when inlining expressions causes complexity to increase. Implemented as a workaround to exception `There are not enough rules to produce a node with desired properties: convention=DRUID, sort=[]` thrown after rejecting the merge of two projects.|
 |`cloneQueryMode`|`excludeClones`| Indicates whether clone Historicals should be queried by brokers. Clone servers are created by the `cloneServers` Coordinator dynamic configuration. Possible values are `excludeClones`, `includeClones` and `preferClones`. `excludeClones` means that clone Historicals are not queried by the broker. `preferClones` indicates that when given a choice between the clone Historical and the original Historical which is being cloned, the broker chooses the clones. Historicals which are not involved in the cloning process will still be queried. `includeClones` means that broker queries any Historical without regarding clone status. This parameter only affects native queries. MSQ does not query Historicals directly.|
 |`realtimeSegmentsOnly` |`false`| When set to true, only query realtime segments. Historical segments are excluded. |
+|`maxVirtualColumnsForBitmapIndexing`|`Integer.MAX_VALUE`| Sets the virtual-column count threshold beyond which Druid stops using bitmap indexes for filters on virtual columns.|
 
 ## Parameters by query type
 

--- a/processing/src/main/java/org/apache/druid/query/QueryContext.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryContext.java
@@ -777,4 +777,9 @@ public class QueryContext
   {
     return getBoolean(QueryContexts.REALTIME_SEGMENTS_ONLY, QueryContexts.DEFAULT_REALTIME_SEGMENTS_ONLY);
   }
+
+  public int getMaxVirtualColumnsForBitmapIndexing()
+  {
+    return getInt(QueryContexts.CTX_MAX_VIRTUAL_COLUMNS_FOR_BITMAP, QueryContexts.DEFAULT_MAX_VIRTUAL_COLUMNS_FOR_BITMAP);
+  }
 }

--- a/processing/src/main/java/org/apache/druid/query/QueryContexts.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryContexts.java
@@ -142,6 +142,8 @@ public class QueryContexts
   public static final boolean DEFAULT_REALTIME_SEGMENTS_ONLY = false;
 
   public static final String CTX_PREPLANNED = "prePlanned";
+  public static final String CTX_MAX_VIRTUAL_COLUMNS_FOR_BITMAP = "maxVirtualColumnsForBitmapIndexing";
+
   public static final boolean DEFAULT_PREPLANNED = true;
 
   // Defaults
@@ -177,6 +179,7 @@ public class QueryContexts
   public static final boolean DEFAULT_USE_NESTED_FOR_UNKNOWN_TYPE_IN_SUBQUERY = false;
   public static final boolean DEFAULT_EXTENDED_FILTERED_SUM_REWRITE_ENABLED = true;
   public static final boolean DEFAULT_CTX_FULL_REPORT = false;
+  public static final int DEFAULT_MAX_VIRTUAL_COLUMNS_FOR_BITMAP = Integer.MAX_VALUE;
 
 
   @SuppressWarnings("unused") // Used by Jackson serialization

--- a/processing/src/main/java/org/apache/druid/segment/VirtualColumnBitmapDisablingIndexSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/VirtualColumnBitmapDisablingIndexSelector.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment;
+
+import org.apache.druid.collections.bitmap.BitmapFactory;
+import org.apache.druid.query.filter.ColumnIndexSelector;
+import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.column.ColumnHolder;
+import org.apache.druid.segment.column.ColumnIndexSupplier;
+import org.apache.druid.segment.column.SelectableColumn;
+import org.apache.druid.segment.selector.settable.SettableColumnValueSelector;
+import org.apache.druid.segment.serde.NoIndexesColumnIndexSupplier;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+public final class VirtualColumnBitmapDisablingIndexSelector implements ColumnIndexSelector
+{
+  private static final ColumnIndexSupplier NO_INDEXES = NoIndexesColumnIndexSupplier.getInstance();
+  private final ColumnIndexSelector delegate;
+  private final VirtualColumns virtualColumns;
+
+
+  public VirtualColumnBitmapDisablingIndexSelector(
+      final ColumnIndexSelector delegate,
+      final VirtualColumns virtualColumns
+  )
+  {
+    this.delegate = Objects.requireNonNull(delegate, "delegate");
+    this.virtualColumns = Objects.requireNonNull(virtualColumns, "virtualColumns");
+  }
+
+  @Override
+  public int getNumRows()
+  {
+    return delegate.getNumRows();
+  }
+
+  @Override
+  public BitmapFactory getBitmapFactory()
+  {
+    return delegate.getBitmapFactory();
+  }
+
+  @Override
+  @Nullable
+  public ColumnHolder getColumnHolder(final String columnName)
+  {
+    final ColumnHolder holder = delegate.getColumnHolder(columnName);
+    if (holder == null || !isVirtual(columnName)) {
+      return holder;
+    }
+
+    // force no indexes even if callers go via getColumnHolder().
+    return new ColumnHolder()
+    {
+      @Override
+      public ColumnCapabilities getCapabilities()
+      {
+        return holder.getCapabilities();
+      }
+
+      @Override
+      public int getLength()
+      {
+        return holder.getLength();
+      }
+
+      @Override
+      public SelectableColumn getColumn()
+      {
+        return holder.getColumn();
+      }
+
+      @Override
+      public ColumnIndexSupplier getIndexSupplier()
+      {
+        return NO_INDEXES;
+      }
+
+      @Override
+      public SettableColumnValueSelector makeNewSettableColumnValueSelector()
+      {
+        return holder.makeNewSettableColumnValueSelector();
+      }
+    };
+  }
+
+  @Override
+  @Nullable
+  public ColumnIndexSupplier getIndexSupplier(final String column)
+  {
+    if (column.isEmpty()) {
+      return null;
+    }
+
+    // Only disable indexes for virtual columns
+    if (isVirtual(column)) {
+      return NO_INDEXES;
+    }
+    return delegate.getIndexSupplier(column);
+  }
+
+
+  private boolean isVirtual(final String columnName)
+  {
+    return virtualColumns.getVirtualColumn(columnName) != null;
+  }
+}

--- a/processing/src/test/java/org/apache/druid/segment/filter/FilterBundleVCBitmapIndexDisablingTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/FilterBundleVCBitmapIndexDisablingTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.filter;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.collections.bitmap.BitmapFactory;
+import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.query.DefaultBitmapResultFactory;
+import org.apache.druid.query.filter.ColumnIndexSelector;
+import org.apache.druid.query.filter.EqualityFilter;
+import org.apache.druid.query.filter.Filter;
+import org.apache.druid.query.filter.FilterBundle;
+import org.apache.druid.segment.ColumnCache;
+import org.apache.druid.segment.QueryableIndex;
+import org.apache.druid.segment.TestIndex;
+import org.apache.druid.segment.VirtualColumnBitmapDisablingIndexSelector;
+import org.apache.druid.segment.VirtualColumns;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class FilterBundleVCBitmapIndexDisablingTest extends InitializedNullHandlingTest
+{
+
+  @Test
+  public void testVCBitmapIndexEnabled()
+  {
+    final VirtualColumns virtualColumns = VirtualColumns.create(ImmutableList.of(
+        new ExpressionVirtualColumn("v1",
+                                    "countryName", ColumnType.STRING,
+                                    ExprMacroTable.nil()
+        )
+    ));
+    final QueryableIndex index = TestIndex.getMMappedWikipediaIndex();
+    BitmapFactory bitmapFactory = index.getBitmapFactoryForDimensions();
+
+    try (Closer closer = Closer.create()) {
+      ColumnCache columnCache = new ColumnCache(index, virtualColumns, closer);
+      VirtualColumnBitmapDisablingIndexSelector selector = new VirtualColumnBitmapDisablingIndexSelector(columnCache,
+                                                                                                         virtualColumns
+      );
+
+      final FilterBundle filterBundleIndexEnabled = makeFilterBundle(new AndFilter(ImmutableList.of(
+          new EqualityFilter("v1", ColumnType.STRING, "United States", null),
+          new EqualityFilter("countryName",
+                             ColumnType.STRING,
+                             "United States",
+                             null
+          )
+      )), columnCache, bitmapFactory);
+
+      final FilterBundle filterBundleIndexDisabled = makeFilterBundle(new AndFilter(ImmutableList.of(
+          new EqualityFilter("v1", ColumnType.STRING, "United States", null),
+          new EqualityFilter("countryName",
+                             ColumnType.STRING,
+                             "United States",
+                             null
+          )
+      )), selector, bitmapFactory);
+
+      Assert.assertEquals(2, filterBundleIndexEnabled.getIndex().getIndexInfo().getIndexes().size());
+      Assert.assertEquals("v1 = United States", filterBundleIndexEnabled.getIndex().getIndexInfo().getIndexes().get(0).getFilter());
+      Assert.assertEquals("countryName = United States", filterBundleIndexEnabled.getIndex().getIndexInfo().getIndexes().get(1).getFilter());
+
+      Assert.assertNull(filterBundleIndexDisabled.getIndex().getIndexInfo().getIndexes());
+      Assert.assertEquals("countryName = United States", filterBundleIndexDisabled.getIndex().getIndexInfo().getFilter());
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+  }
+
+  protected FilterBundle makeFilterBundle(
+      final Filter filter,
+      ColumnIndexSelector selector,
+      BitmapFactory bitmapFactory
+  )
+  {
+    return new FilterBundle.Builder(filter, selector, false).build(new DefaultBitmapResultFactory(bitmapFactory),
+                                                                   selector.getNumRows(),
+                                                                   selector.getNumRows(),
+                                                                   false
+    );
+  }
+}

--- a/processing/src/test/java/org/apache/druid/segment/filter/VirtualColumnBitmapDisablingIndexSelectorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/VirtualColumnBitmapDisablingIndexSelectorTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.filter;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.query.filter.ColumnIndexSelector;
+import org.apache.druid.segment.ColumnCache;
+import org.apache.druid.segment.QueryableIndex;
+import org.apache.druid.segment.TestIndex;
+import org.apache.druid.segment.VirtualColumnBitmapDisablingIndexSelector;
+import org.apache.druid.segment.VirtualColumns;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.serde.NoIndexesColumnIndexSupplier;
+import org.apache.druid.segment.serde.StringUtf8ColumnIndexSupplier;
+import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.junit.Test;
+
+import java.util.Objects;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+public class VirtualColumnBitmapDisablingIndexSelectorTest extends InitializedNullHandlingTest
+{
+  @Test
+  public void testNative_disablesIndexSupplierForVirtualColumnsOnly() throws Exception
+  {
+    final QueryableIndex index = TestIndex.getMMappedWikipediaIndex();
+
+    final VirtualColumns virtualColumns = VirtualColumns.create(ImmutableList.of(new ExpressionVirtualColumn(
+                                                                                     "v0",
+                                                                                     "countryName",
+                                                                                     ColumnType.STRING,
+                                                                                     ExprMacroTable.nil()
+                                                                                 ),
+                                                                                 new ExpressionVirtualColumn("v1",
+                                                                                                             "cityName",
+                                                                                                             ColumnType.STRING,
+                                                                                                             ExprMacroTable.nil()
+                                                                                 )
+    ));
+
+    try (Closer closer = Closer.create()) {
+      final ColumnCache columnCache = new ColumnCache(index, virtualColumns, closer);
+
+      assertEquals(StringUtf8ColumnIndexSupplier.class,
+                   Objects.requireNonNull(columnCache.getIndexSupplier("v0")).getClass()
+      );
+      assertEquals(StringUtf8ColumnIndexSupplier.class,
+                   Objects.requireNonNull(columnCache.getIndexSupplier("v1")).getClass()
+      );
+
+      final ColumnIndexSelector vcIndexDisabled = new VirtualColumnBitmapDisablingIndexSelector(columnCache,
+                                                                                                virtualColumns
+      );
+
+      assertSame(NoIndexesColumnIndexSupplier.getInstance(), vcIndexDisabled.getIndexSupplier("v0"));
+      assertSame(NoIndexesColumnIndexSupplier.getInstance(), vcIndexDisabled.getIndexSupplier("v1"));
+
+      assertEquals(
+          StringUtf8ColumnIndexSupplier.class,
+          Objects.requireNonNull(vcIndexDisabled.getIndexSupplier("countryName")).getClass()
+      );
+      assertEquals(
+          StringUtf8ColumnIndexSupplier.class,
+          Objects.requireNonNull(vcIndexDisabled.getIndexSupplier("cityName")).getClass()
+      );
+    }
+  }
+}

--- a/sql/src/test/java/org/apache/druid/sql/calcite/VcBitmapIndexDisablingSqlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/VcBitmapIndexDisablingSqlTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.query.Query;
+import org.apache.druid.query.QueryContexts;
+import org.apache.druid.segment.ColumnCache;
+import org.apache.druid.segment.QueryableIndex;
+import org.apache.druid.segment.TestIndex;
+import org.apache.druid.segment.VirtualColumnBitmapDisablingIndexSelector;
+import org.apache.druid.segment.VirtualColumns;
+import org.apache.druid.segment.serde.NoIndexesColumnIndexSupplier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+
+public class VcBitmapIndexDisablingSqlTest extends BaseCalciteQueryTest
+{
+  @Test
+  public void testSqlPlannedQueryVirtualColumnsHaveNoIndexSupplierWhenDisabled()
+  {
+    final Map<String, Object> ctx = ImmutableMap.<String, Object>builder()
+                                                .putAll(QUERY_CONTEXT_DEFAULT)
+                                                .put(
+                                                    QueryContexts.CTX_MAX_VIRTUAL_COLUMNS_FOR_BITMAP,
+                                                    0
+                                                )
+                                                .build();
+
+    final String sql = "SELECT countryName + '' AS v0 FROM wikipedia LIMIT 1";
+
+    testBuilder()
+        .queryContext(ctx)
+        .sql(sql)
+        .expectedResults((s, queryResults) -> {
+          final List<Query<?>> planned = queryResults.recordedQueries;
+          Assertions.assertFalse(planned.isEmpty());
+
+          final QueryableIndex index = TestIndex.getMMappedWikipediaIndex();
+
+          for (Query<?> q : planned) {
+            final VirtualColumns vcs = q.getVirtualColumns();
+            if (vcs == null || vcs.isEmpty()) {
+              continue;
+            }
+
+            try (var closer = Closer.create()) {
+              final var columnCache = new
+                  ColumnCache(index, vcs, closer);
+              final var selector = new VirtualColumnBitmapDisablingIndexSelector(columnCache, vcs);
+
+              Assertions.assertSame(NoIndexesColumnIndexSupplier.getInstance(), selector.getIndexSupplier("v0"));
+              return;
+            }
+            catch (Exception e) {
+              throw new RuntimeException(e);
+            }
+          }
+
+          fail("SQL did not plan any query with virtualColumns");
+        })
+        .run();
+  }
+}


### PR DESCRIPTION
### Description

In some of our environments we observed a significant query performance regression after upgrading to Druid 29.0. This regression appears to be related to the virtual column bitmap indexing optimization introduced in https://github.com/apache/druid/pull/15585 and https://github.com/apache/druid/pull/15633.

While the change improves performance for many cases by enabling bitmap index creation for expression-based virtual columns, we found that in certain workloads the index computation becomes unexpectedly expensive. In our deployments, building these indices accounted for more than 90% of the CPU usage on Historical nodes during query execution, leading to severe degradation in overall query latency.

For one representative workload, the average query runtime increased from 10.01 seconds to 150.18 seconds compared to earlier versions. Once expression-based virtual column bitmap index creation was disabled, the regression disappeared and query performance returned to expected levels.

This PR addresses this issue by preventing the optimization from triggering in scenarios where the cost of index computation outweighs its benefit, avoiding major regressions in affected environments.

Added a new query context parameter, `maxVirtualColumnsForBitmapIndexing` (default: `Integer.MAX_VALUE`), which sets the virtual-column count threshold beyond which Druid stops using bitmap indexes for filters on virtual columns.

#### Release note

Added a safeguard to skip virtual-column bitmap indexing when it is likely to be counterproductive, falling back to non-indexed filtering to preserve expected performance. 

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.