### PR TITLE
fix vsf load wait metric in ChannelCounters snapshot

### DIFF
--- a/multi-stage-query/src/main/java/org/apache/druid/msq/counters/ChannelCounters.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/counters/ChannelCounters.java
@@ -365,7 +365,7 @@ public class ChannelCounters implements QueryCounter
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public long[] getLoadWait()
     {
-      return loadTime;
+      return loadWait;
     }
 
     @JsonProperty
@@ -392,6 +392,7 @@ public class ChannelCounters implements QueryCounter
              && Arrays.equals(totalFiles, snapshot.totalFiles)
              && Arrays.equals(loadBytes, snapshot.loadBytes)
              && Arrays.equals(loadTime, snapshot.loadTime)
+             && Arrays.equals(loadWait, snapshot.loadWait)
              && Arrays.equals(loadFiles, snapshot.loadFiles);
     }
 
@@ -405,6 +406,7 @@ public class ChannelCounters implements QueryCounter
       result = 31 * result + Arrays.hashCode(totalFiles);
       result = 31 * result + Arrays.hashCode(loadBytes);
       result = 31 * result + Arrays.hashCode(loadTime);
+      result = 31 * result + Arrays.hashCode(loadWait);
       result = 31 * result + Arrays.hashCode(loadFiles);
       return result;
     }
@@ -420,6 +422,7 @@ public class ChannelCounters implements QueryCounter
              ", totalFiles=" + Arrays.toString(totalFiles) +
              ", loadBytes=" + Arrays.toString(loadBytes) +
              ", loadTime=" + Arrays.toString(loadTime) +
+             ", loadWait=" + Arrays.toString(loadWait) +
              ", loadFiles=" + Arrays.toString(loadFiles) +
              '}';
     }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/counters/ChannelCountersTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/counters/ChannelCountersTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.counters;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class ChannelCountersTest
+{
+  @Test
+  void testSnapshotEqualsAndHashcode()
+  {
+    EqualsVerifier.forClass(ChannelCounters.Snapshot.class).usingGetClass().verify();
+  }
+}


### PR DESCRIPTION
Fixes a mistake in #18971, which was returning `loadTime` instead of `loadWait`, which was also missing from `equals`, `hashCode` and `toString`