### PR TITLE
KubernetesTaskRunnerDynamicConfig printing

### DIFF
--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/DefaultKubernetesTaskRunnerDynamicConfig.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/DefaultKubernetesTaskRunnerDynamicConfig.java
@@ -100,7 +100,7 @@ public class DefaultKubernetesTaskRunnerDynamicConfig implements KubernetesTaskR
   {
     return "DefaultKubernetesTaskRunnerDynamicConfig{" +
            "podTemplateSelectStrategy=" + podTemplateSelectStrategy +
-           "capacity=" + capacity +
+           ", capacity=" + capacity +
            '}';
   }
 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes toString() printing in `DefaultKubernetesTaskRunnerDynamicConfig`


<hr>

##### Key changed/added classes in this PR
 * `DefaultKubernetesTaskRunnerDynamicConfig`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.