### PR TITLE
Add configurable clientAuthenticationMethod to druid-pac4j OIDC configuration

### DIFF
--- a/docs/development/extensions-core/druid-pac4j.md
+++ b/docs/development/extensions-core/druid-pac4j.md
@@ -55,6 +55,7 @@ druid.auth.authenticator.jwt.type=jwt
 |`druid.auth.pac4j.oidc.discoveryURI`|discovery URI for fetching OP metadata [see this](http://openid.net/specs/openid-connect-discovery-1_0.html).|none|Yes|
 |`druid.auth.pac4j.oidc.oidcClaim`|[claim](https://openid.net/specs/openid-connect-core-1_0.html#Claims) that will be extracted from the ID Token after validation.|name|No|
 |`druid.auth.pac4j.oidc.scope`| scope is used by an application during authentication to authorize access to a user's details.|`openid profile email`|No|
+|`druid.auth.pac4j.oidc.clientAuthenticationMethod`|The client authentication method to use when communicating with the OIDC provider. Supported values: `client_secret_basic`, `client_secret_post`, `client_secret_jwt`, `private_key_jwt`, `none`. If not specified, pac4j will auto-detect the method from the provider's discovery document. Set this explicitly if you need to use a specific method (e.g., when your provider advertises multiple methods but you want to use a particular one).|Auto-detected from provider|No|
 
 :::info
 Users must set a strong passphrase to ensure that an attacker is not able to guess it simply by brute force.

--- a/extensions-core/druid-pac4j/src/main/java/org/apache/druid/security/pac4j/OIDCConfig.java
+++ b/extensions-core/druid-pac4j/src/main/java/org/apache/druid/security/pac4j/OIDCConfig.java
@@ -44,13 +44,17 @@ public class OIDCConfig
   @JsonProperty
   private final String scope;
 
+  @JsonProperty
+  private final String clientAuthenticationMethod;
+
   @JsonCreator
   public OIDCConfig(
       @JsonProperty("clientID") String clientID,
       @JsonProperty("clientSecret") PasswordProvider clientSecret,
       @JsonProperty("discoveryURI") String discoveryURI,
       @JsonProperty("oidcClaim") String oidcClaim,
-      @JsonProperty("scope") @Nullable String scope
+      @JsonProperty("scope") @Nullable String scope,
+      @JsonProperty("clientAuthenticationMethod") @Nullable String clientAuthenticationMethod
   )
   {
     this.clientID = Preconditions.checkNotNull(clientID, "null clientID");
@@ -58,6 +62,7 @@ public class OIDCConfig
     this.discoveryURI = Preconditions.checkNotNull(discoveryURI, "null discoveryURI");
     this.oidcClaim = oidcClaim == null ? DEFAULT_SCOPE : oidcClaim;
     this.scope = scope;
+    this.clientAuthenticationMethod = clientAuthenticationMethod;
   }
 
   @JsonProperty
@@ -88,5 +93,11 @@ public class OIDCConfig
   public String getScope()
   {
     return scope;
+  }
+
+  @JsonProperty
+  public String getClientAuthenticationMethod()
+  {
+    return clientAuthenticationMethod;
   }
 }

--- a/extensions-core/druid-pac4j/src/main/java/org/apache/druid/security/pac4j/Pac4jAuthenticator.java
+++ b/extensions-core/druid-pac4j/src/main/java/org/apache/druid/security/pac4j/Pac4jAuthenticator.java
@@ -27,6 +27,7 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.primitives.Ints;
 import com.google.inject.Provider;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import org.apache.druid.server.security.AuthenticationResult;
 import org.apache.druid.server.security.Authenticator;
@@ -132,6 +133,10 @@ public class Pac4jAuthenticator implements Authenticator
     oidcConf.setSecret(oidcConfig.getClientSecret().getPassword());
     oidcConf.setDiscoveryURI(oidcConfig.getDiscoveryURI());
     oidcConf.setScope(oidcConfig.getScope());
+    if (oidcConfig.getClientAuthenticationMethod() != null) {
+      oidcConf.setClientAuthenticationMethod(
+          ClientAuthenticationMethod.parse(oidcConfig.getClientAuthenticationMethod()));
+    }
     oidcConf.setExpireSessionWithToken(true);
     oidcConf.setUseNonce(true);
     oidcConf.setReadTimeout(Ints.checkedCast(pac4jCommonConfig.getReadTimeout().getMillis()));

--- a/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/OIDCConfigTest.java
+++ b/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/OIDCConfigTest.java
@@ -46,6 +46,7 @@ public class OIDCConfigTest
     Assert.assertEquals("testdiscoveryuri", conf.getDiscoveryURI());
     Assert.assertEquals("name", conf.getOidcClaim());
     Assert.assertEquals("testscope", conf.getScope());
+    Assert.assertNull(conf.getClientAuthenticationMethod());
   }
 
   @Test
@@ -71,5 +72,32 @@ public class OIDCConfigTest
     Assert.assertEquals("testdiscoveryuri", conf.getDiscoveryURI());
     Assert.assertEquals("email", conf.getOidcClaim());
     Assert.assertEquals("testscope", conf.getScope());
+  }
+
+  @Test
+  public void testSerdeWithClientAuthenticationMethod() throws Exception
+  {
+    ObjectMapper jsonMapper = new ObjectMapper();
+
+    String jsonStr = "{\n"
+                     + "  \"clientID\": \"testid\",\n"
+                     + "  \"clientSecret\": \"testsecret\",\n"
+                     + "  \"discoveryURI\": \"testdiscoveryuri\",\n"
+                     + "  \"oidcClaim\": \"email\",\n"
+                     + "  \"scope\": \"testscope\",\n"
+                     + "  \"clientAuthenticationMethod\": \"client_secret_post\"\n"
+                     + "}\n";
+
+    OIDCConfig conf = jsonMapper.readValue(
+        jsonMapper.writeValueAsString(jsonMapper.readValue(jsonStr, OIDCConfig.class)),
+        OIDCConfig.class
+    );
+
+    Assert.assertEquals("testid", conf.getClientID());
+    Assert.assertEquals("testsecret", conf.getClientSecret().getPassword());
+    Assert.assertEquals("testdiscoveryuri", conf.getDiscoveryURI());
+    Assert.assertEquals("email", conf.getOidcClaim());
+    Assert.assertEquals("testscope", conf.getScope());
+    Assert.assertEquals("client_secret_post", conf.getClientAuthenticationMethod());
   }
 }


### PR DESCRIPTION
Fixes #19019.

### Description

This PR adds an optional `clientAuthenticationMethod` configuration parameter to the druid-pac4j OIDC authentication extension, allowing users to explicitly specify the client authentication method to use with their OIDC provider.

#### Problem: Breaking change with pac4j 5.7.3 upgrade

The upgrade of pac4j to 5.7.3 in Druid 35 introduced support for the `private_key_jwt` client authentication method (added in pac4j 5.7.0).
This created a breaking change for some OIDC deployments:
- pac4j 4.5.7 (Druid 34.0.0): When auto-detecting the authentication method from an OIDC provider's discovery document, pac4j would not recognize `private_key_jwt` and would fall back to the next available method like `client_secret_basic`.

- pac4j 5.7.3 (Druid 35.0.1): pac4j now recognizes `private_key_jwt` in the `SUPPORTED_METHODS` set. When an OIDC provider (e.g., Keycloak) advertises `["private_key_jwt", "client_secret_basic", ...]`, pac4j selects `private_key_jwt` as the first supported method. However, if `privateKeyJwtConfig` is not configured in the code, authentication fails with: `"privateKeyJwtConfig cannot be null"`

This affects users whose OIDC providers advertise `private_key_jwt` but who want to use simpler authentication methods like `client_secret_basic` or `client_secret_post`.

#### Solution: Explicit configuration parameter

Added a new optional `clientAuthenticationMethod` field to `OIDCConfig` that:
- Allows users to explicitly specify which client authentication method to use
- Bypasses pac4j's auto-detection logic when set
- Maintains full backward compatibility (null/not specified = use pac4j auto-detection)

The implementation:
1. Added `clientAuthenticationMethod` field to `OIDCConfig` with JSON serialization
2. Modified `Pac4jAuthenticator` to call `oidcConf.setClientAuthenticationMethod()` when the parameter is provided
3. Uses `ClientAuthenticationMethod.parse()` from nimbus library to parse the method string
4. Added test coverage in `OIDCConfigTest`

#### Design decisions

- String-based configuration: Used a String type rather than an enum to maintain flexibility as new authentication methods are added to the OIDC spec and pac4j library
- Optional parameter: Made it nullable/optional to preserve backward compatibility and allow users who are satisfied with auto-detection to continue using it
- No default value: Explicitly choosing not to set a default value ensures existing deployments continue their current behavior

#### Release note

Users of the druid-pac4j OIDC authentication extension can now explicitly configure their preferred client authentication method using the new optional `clientAuthenticationMethod` parameter. This resolves compatibility issues introduced with pac4j 5.7.3 where OIDC providers advertising `private_key_jwt` (such as Keycloak) would cause authentication failures when the asymmetric JWT method was not configured.

Supported values include: `client_secret_basic`, `client_secret_post`, `client_secret_jwt`, `private_key_jwt`, and `none`. If not specified, pac4j will continue to use its auto-detection behavior.

#### Key changed/added classes in this PR
- OIDCConfig - Added clientAuthenticationMethod field with getter
- Pac4jAuthenticator - Added logic to set client authentication method when configured
- OIDCConfigTest - Added test for new configuration parameter

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.