### PR TITLE
MSQ: Controller result batching, consolidated lifecycle.

### DIFF
--- a/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/ControllerThreadPool.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/ControllerThreadPool.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.dart.controller;
+
+import com.google.common.util.concurrent.ListeningExecutorService;
+import org.apache.druid.guice.ManageLifecycle;
+import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
+import org.apache.druid.msq.dart.guice.DartControllerConfig;
+import org.apache.druid.msq.exec.Controller;
+
+/**
+ * Thread pool for running {@link Controller}. Number of threads is equal to
+ * {@link DartControllerConfig#getConcurrentQueries()}, which limits the number of concurrent controllers.
+ */
+@ManageLifecycle
+public class ControllerThreadPool
+{
+  private final ListeningExecutorService executorService;
+
+  public ControllerThreadPool(final ListeningExecutorService executorService)
+  {
+    this.executorService = executorService;
+  }
+
+  public ListeningExecutorService getExecutorService()
+  {
+    return executorService;
+  }
+
+  @LifecycleStop
+  public void stop()
+  {
+    executorService.shutdown();
+  }
+}

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/CaptureReportQueryListener.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/CaptureReportQueryListener.java
@@ -19,13 +19,12 @@
 
 package org.apache.druid.msq.exec;
 
-import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.msq.indexing.report.MSQResultsReport;
+import org.apache.druid.frame.read.FrameReader;
 import org.apache.druid.msq.indexing.report.MSQTaskReportPayload;
+import org.apache.druid.query.rowsandcols.RowsAndColumns;
 
 import javax.annotation.Nullable;
-import java.util.List;
 
 /**
  * A {@link QueryListener} wrapper that captures the report from {@link #onQueryComplete(MSQTaskReportPayload)}.
@@ -40,6 +39,14 @@ public class CaptureReportQueryListener implements QueryListener
   public CaptureReportQueryListener(final QueryListener delegate)
   {
     this.delegate = delegate;
+  }
+
+  /**
+   * Whether this listener has captured a report. Will be true if the query has completed, false otherwise.
+   */
+  public boolean hasReport()
+  {
+    return report != null;
   }
 
   /**
@@ -61,18 +68,15 @@ public class CaptureReportQueryListener implements QueryListener
   }
 
   @Override
-  public void onResultsStart(
-      final List<MSQResultsReport.ColumnAndType> signature,
-      @Nullable final List<SqlTypeName> sqlTypeNames
-  )
+  public void onResultsStart(final FrameReader frameReader)
   {
-    delegate.onResultsStart(signature, sqlTypeNames);
+    delegate.onResultsStart(frameReader);
   }
 
   @Override
-  public boolean onResultRow(final Object[] row)
+  public boolean onResultBatch(RowsAndColumns rac)
   {
-    return delegate.onResultRow(row);
+    return delegate.onResultBatch(rac);
   }
 
   @Override

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -2839,9 +2839,6 @@ public class ControllerImpl implements Controller
         final ControllerQueryResultsReader resultsReader = new ControllerQueryResultsReader(
             resultsChannel,
             queryDef.getFinalStageDefinition().getFrameReader(),
-            querySpec.getColumnMappings(),
-            resultsContext,
-            context.jsonMapper(),
             queryListener
         );
 

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/QueryListener.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/QueryListener.java
@@ -19,12 +19,10 @@
 
 package org.apache.druid.msq.exec;
 
-import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.frame.read.FrameReader;
 import org.apache.druid.msq.indexing.report.MSQResultsReport;
 import org.apache.druid.msq.indexing.report.MSQTaskReportPayload;
-
-import javax.annotation.Nullable;
-import java.util.List;
+import org.apache.druid.query.rowsandcols.RowsAndColumns;
 
 /**
  * Object passed to {@link Controller#run(QueryListener)} to enable retrieval of results, status, counters, etc.
@@ -39,27 +37,21 @@ public interface QueryListener
   /**
    * Called when results start coming in.
    *
-   * @param signature    signature of results
-   * @param sqlTypeNames SQL type names of results; same length as the signature
+   * @param frameReader reader for frames that will be passed to {@link #onResultBatch(RowsAndColumns)}
    */
-  void onResultsStart(
-      List<MSQResultsReport.ColumnAndType> signature,
-      @Nullable List<SqlTypeName> sqlTypeNames
-  );
+  void onResultsStart(FrameReader frameReader);
 
   /**
-   * Called for each result row. Follows a call to {@link #onResultsStart(List, List)}.
-   *
-   * @param row result row
+   * Called for each result batch. Follows a call to {@link #onResultsStart}.
    *
    * @return whether the controller should keep reading results
    */
-  boolean onResultRow(Object[] row);
+  boolean onResultBatch(RowsAndColumns rac);
 
   /**
-   * Called after the last result has been delivered by {@link #onResultRow(Object[])}. Only called if results are
-   * actually complete. If results are truncated due to {@link #readResults()} or {@link #onResultRow(Object[])}
-   * returning false, this method is not called.
+   * Called after the last result has been delivered by {@link #onResultBatch(RowsAndColumns)}. Only called if results
+   * are actually complete. If results are truncated due to {@link #readResults()} or
+   * {@link #onResultBatch(RowsAndColumns)} returning false, this method is not called.
    */
   void onResultsComplete();
 

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/SequenceQueryListener.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/SequenceQueryListener.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.exec;
+
+import org.apache.druid.common.guava.FutureUtils;
+import org.apache.druid.frame.channel.BlockingQueueFrameChannel;
+import org.apache.druid.frame.channel.FrameChannelSequence;
+import org.apache.druid.frame.channel.WritableFrameChannel;
+import org.apache.druid.frame.read.FrameReader;
+import org.apache.druid.java.util.common.guava.Sequence;
+import org.apache.druid.msq.indexing.report.MSQTaskReportPayload;
+import org.apache.druid.query.rowsandcols.RowsAndColumns;
+
+import java.io.IOException;
+
+/**
+ * Listener that provides a {@link Sequence} of {@link RowsAndColumns}, via {@link #getSequence()}.
+ */
+public class SequenceQueryListener implements QueryListener
+{
+  private static final int DEFAULT_CAPACITY = 2;
+
+  private final BlockingQueueFrameChannel channel;
+  private volatile FrameReader frameReader;
+
+  public SequenceQueryListener()
+  {
+    this(DEFAULT_CAPACITY);
+  }
+
+  public SequenceQueryListener(final int bufferSize)
+  {
+    this.channel = new BlockingQueueFrameChannel(bufferSize);
+  }
+
+  /**
+   * Returns a {@link Sequence} of {@link RowsAndColumns} read from the channel. The sequence performs blocking
+   * reads; it should be consumed from a thread that is allowed to block.
+   */
+  public Sequence<RowsAndColumns> getSequence()
+  {
+    return new FrameChannelSequence(channel.readable());
+  }
+
+  /**
+   * Returns the {@link FrameReader} set by {@link #onResultsStart(FrameReader)}.
+   */
+  public FrameReader getFrameReader()
+  {
+    return frameReader;
+  }
+
+  @Override
+  public boolean readResults()
+  {
+    return true;
+  }
+
+  @Override
+  public void onResultsStart(final FrameReader frameReader)
+  {
+    this.frameReader = frameReader;
+  }
+
+  @Override
+  public boolean onResultBatch(final RowsAndColumns rac)
+  {
+    try {
+      final WritableFrameChannel writable = channel.writable();
+
+      // Blocking write.
+      FutureUtils.getUnchecked(writable.writabilityFuture(), false);
+      writable.write(rac);
+      return true;
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void onResultsComplete()
+  {
+    // Nothing to do. We'll close the writable channel in onQueryComplete.
+  }
+
+  @Override
+  public void onQueryComplete(final MSQTaskReportPayload report)
+  {
+    try {
+      final WritableFrameChannel writable = channel.writable();
+
+      if (!writable.isClosed()) {
+        if (!report.getStatus().getStatus().isSuccess()) {
+          writable.fail(report.getStatus().getErrorReport().toDruidException());
+        }
+
+        writable.close();
+      }
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQControllerTask.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQControllerTask.java
@@ -269,12 +269,15 @@ public class MSQControllerTask extends AbstractTask implements ClientTaskQuery, 
         injector.getInstance(MSQTaskQueryKitSpecFactory.class)
     );
 
+    final ResultsContext resultsContext = new ResultsContext(getSqlTypeNames(), getSqlResultsContext());
     final TaskReportQueryListener queryListener = new TaskReportQueryListener(
         () -> toolbox.getTaskReportFileWriter().openReportOutputStream(getId()),
         toolbox.getJsonMapper(),
         getId(),
         getContext(),
-        querySpec.getDestination().getRowsInTaskReport()
+        querySpec.getDestination().getRowsInTaskReport(),
+        querySpec.getColumnMappings(),
+        resultsContext
     );
 
     controller.run(queryListener);

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/util/SqlStatementResourceHelper.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/util/SqlStatementResourceHelper.java
@@ -304,7 +304,7 @@ public class SqlStatementResourceHelper
     ));
   }
 
-  public static Sequence<Object[]> getResultSequence(
+  public static Iterator<Object[]> getResultIterator(
       final Frame resultsFrame,
       final FrameReader resultFrameReader,
       final ColumnMappings resultColumnMappings,
@@ -321,7 +321,7 @@ public class SqlStatementResourceHelper
                             .map(mapping -> columnSelectorFactory.makeColumnValueSelector(mapping.getQueryColumn()))
                             .collect(Collectors.toList());
 
-    final Iterable<Object[]> retVal = () -> new Iterator<>()
+    return new Iterator<>()
     {
       @Override
       public boolean hasNext()
@@ -356,7 +356,19 @@ public class SqlStatementResourceHelper
         return row;
       }
     };
-    return Sequences.simple(retVal);
+  }
+
+  public static Sequence<Object[]> getResultSequence(
+      final Frame resultsFrame,
+      final FrameReader resultFrameReader,
+      final ColumnMappings resultColumnMappings,
+      final ResultsContext resultsContext,
+      final ObjectMapper jsonMapper
+  )
+  {
+    return Sequences.simple(
+        () -> getResultIterator(resultsFrame, resultFrameReader, resultColumnMappings, resultsContext, jsonMapper)
+    );
   }
 
   @Nullable

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/TaskReportQueryListenerTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/TaskReportQueryListenerTest.java
@@ -26,22 +26,31 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.frame.Frame;
+import org.apache.druid.frame.FrameType;
+import org.apache.druid.frame.read.FrameReader;
+import org.apache.druid.frame.testutil.FrameSequenceBuilder;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.report.TaskContextReport;
 import org.apache.druid.indexer.report.TaskReport;
+import org.apache.druid.java.util.common.guava.Sequences;
 import org.apache.druid.msq.counters.CounterSnapshotsTree;
 import org.apache.druid.msq.exec.Limits;
+import org.apache.druid.msq.exec.ResultsContext;
 import org.apache.druid.msq.guice.MSQIndexingModule;
 import org.apache.druid.msq.indexing.destination.DurableStorageMSQDestination;
 import org.apache.druid.msq.indexing.destination.TaskReportMSQDestination;
-import org.apache.druid.msq.indexing.report.MSQResultsReport;
 import org.apache.druid.msq.indexing.report.MSQStagesReport;
 import org.apache.druid.msq.indexing.report.MSQStatusReport;
 import org.apache.druid.msq.indexing.report.MSQTaskReport;
 import org.apache.druid.msq.indexing.report.MSQTaskReportPayload;
 import org.apache.druid.msq.indexing.report.MSQTaskReportTest;
+import org.apache.druid.segment.RowAdapter;
+import org.apache.druid.segment.RowBasedCursorFactory;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.sql.calcite.planner.ColumnMappings;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -52,6 +61,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -59,30 +70,60 @@ public class TaskReportQueryListenerTest
 {
   private static final String TASK_ID = "mytask";
   private static final Map<String, Object> TASK_CONTEXT = ImmutableMap.of("foo", "bar");
-  private static final List<MSQResultsReport.ColumnAndType> SIGNATURE = ImmutableList.of(
-      new MSQResultsReport.ColumnAndType("x", ColumnType.STRING)
-  );
+  private static final RowSignature SIGNATURE = RowSignature.builder()
+                                                            .add("x", ColumnType.STRING)
+                                                            .build();
   private static final List<SqlTypeName> SQL_TYPE_NAMES = ImmutableList.of(SqlTypeName.VARCHAR);
   private static final ObjectMapper JSON_MAPPER =
       TestHelper.makeJsonMapper().registerModules(new MSQIndexingModule().getJacksonModules());
 
   private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
+  /**
+   * Creates a Frame containing the given rows using the test signature.
+   */
+  private Frame createFrame(final List<Map<String, Object>> rows)
+  {
+    final RowBasedCursorFactory<Map<String, Object>> cursorFactory = new RowBasedCursorFactory<>(
+        Sequences.simple(rows),
+        new MapRowAdapter(SIGNATURE),
+        SIGNATURE
+    );
+
+    return FrameSequenceBuilder.fromCursorFactory(cursorFactory)
+                               .frameType(FrameType.latestRowBased())
+                               .maxRowsPerFrame(Integer.MAX_VALUE)
+                               .frames()
+                               .toList()
+                               .get(0);
+  }
+
   @Test
   public void test_taskReportDestination() throws IOException
   {
+    final FrameReader frameReader = FrameReader.create(SIGNATURE);
+    final ResultsContext resultsContext = new ResultsContext(SQL_TYPE_NAMES, null);
+
     final TaskReportQueryListener listener = new TaskReportQueryListener(
         Suppliers.ofInstance(baos)::get,
         JSON_MAPPER,
         TASK_ID,
         TASK_CONTEXT,
-        TaskReportMSQDestination.instance().getRowsInTaskReport()
+        TaskReportMSQDestination.instance().getRowsInTaskReport(),
+        ColumnMappings.identity(SIGNATURE),
+        resultsContext
     );
 
     Assert.assertTrue(listener.readResults());
-    listener.onResultsStart(SIGNATURE, SQL_TYPE_NAMES);
-    Assert.assertTrue(listener.onResultRow(new Object[]{"foo"}));
-    Assert.assertTrue(listener.onResultRow(new Object[]{"bar"}));
+    listener.onResultsStart(frameReader);
+
+    // Create a frame with two rows
+    final Frame frame = createFrame(ImmutableList.of(
+        ImmutableMap.of("x", "foo"),
+        ImmutableMap.of("x", "bar")
+    ));
+    Assert.assertTrue(listener.onResultBatch(frame.asRAC()));
+
     listener.onResultsComplete();
     listener.onQueryComplete(
         new MSQTaskReportPayload(
@@ -139,20 +180,40 @@ public class TaskReportQueryListenerTest
   @Test
   public void test_durableDestination() throws IOException
   {
+    final FrameReader frameReader = FrameReader.create(SIGNATURE);
+    final ResultsContext resultsContext = new ResultsContext(SQL_TYPE_NAMES, null);
+
     final TaskReportQueryListener listener = new TaskReportQueryListener(
         Suppliers.ofInstance(baos)::get,
         JSON_MAPPER,
         TASK_ID,
         TASK_CONTEXT,
-        DurableStorageMSQDestination.instance().getRowsInTaskReport()
+        DurableStorageMSQDestination.instance().getRowsInTaskReport(),
+        ColumnMappings.identity(SIGNATURE),
+        resultsContext
     );
 
     Assert.assertTrue(listener.readResults());
-    listener.onResultsStart(SIGNATURE, SQL_TYPE_NAMES);
-    for (int i = 0; i < Limits.MAX_SELECT_RESULT_ROWS - 1; i++) {
-      Assert.assertTrue("row #" + i, listener.onResultRow(new Object[]{"foo"}));
+    listener.onResultsStart(frameReader);
+
+    // Create frames with rows up to MAX_SELECT_RESULT_ROWS
+    final int batchSize = 100;
+    int rowsAdded = 0;
+    boolean keepGoing = true;
+
+    while (keepGoing && rowsAdded < Limits.MAX_SELECT_RESULT_ROWS) {
+      final int rowsToAdd = (int) Math.min(batchSize, Limits.MAX_SELECT_RESULT_ROWS - rowsAdded);
+      final List<Map<String, Object>> rows = IntStream.range(0, rowsToAdd)
+                                                       .mapToObj(i -> ImmutableMap.<String, Object>of("x", "foo"))
+                                                       .collect(Collectors.toList());
+      final Frame frame = createFrame(rows);
+      keepGoing = listener.onResultBatch(frame.asRAC());
+      rowsAdded += rowsToAdd;
     }
-    Assert.assertFalse(listener.onResultRow(new Object[]{"foo"}));
+
+    // Should have stopped accepting results after MAX_SELECT_RESULT_ROWS
+    Assert.assertFalse(keepGoing);
+
     listener.onQueryComplete(
         new MSQTaskReportPayload(
             new MSQStatusReport(
@@ -202,5 +263,30 @@ public class TaskReportQueryListenerTest
 
     Assert.assertTrue(report.getPayload().getResults().isResultsTruncated());
     Assert.assertEquals(TaskState.SUCCESS, report.getPayload().getStatus().getStatus());
+  }
+
+  /**
+   * Simple RowAdapter for Map-based rows.
+   */
+  private static class MapRowAdapter implements RowAdapter<Map<String, Object>>
+  {
+    private final RowSignature signature;
+
+    MapRowAdapter(final RowSignature signature)
+    {
+      this.signature = signature;
+    }
+
+    @Override
+    public ToLongFunction<Map<String, Object>> timestampFunction()
+    {
+      return row -> 0L;
+    }
+
+    @Override
+    public Function<Map<String, Object>, Object> columnFunction(final String columnName)
+    {
+      return row -> row.get(columnName);
+    }
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/NoopQueryListener.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/NoopQueryListener.java
@@ -19,13 +19,10 @@
 
 package org.apache.druid.msq.test;
 
-import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.frame.read.FrameReader;
 import org.apache.druid.msq.exec.QueryListener;
-import org.apache.druid.msq.indexing.report.MSQResultsReport;
 import org.apache.druid.msq.indexing.report.MSQTaskReportPayload;
-
-import javax.annotation.Nullable;
-import java.util.List;
+import org.apache.druid.query.rowsandcols.RowsAndColumns;
 
 public class NoopQueryListener implements QueryListener
 {
@@ -36,13 +33,13 @@ public class NoopQueryListener implements QueryListener
   }
 
   @Override
-  public void onResultsStart(List<MSQResultsReport.ColumnAndType> signature, @Nullable List<SqlTypeName> sqlTypeNames)
+  public void onResultsStart(final FrameReader frameReader)
   {
     // Do nothing.
   }
 
   @Override
-  public boolean onResultRow(Object[] row)
+  public boolean onResultBatch(RowsAndColumns rac)
   {
     return true;
   }

--- a/processing/src/main/java/org/apache/druid/frame/channel/BlockingQueueFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/BlockingQueueFrameChannel.java
@@ -173,6 +173,8 @@ public class BlockingQueueFrameChannel
           // If this happens, it's a bug, potentially due to incorrectly using this class with multiple writers.
           throw new ISE("Could not write error to channel");
         }
+
+        notifyReader();
       }
     }
 


### PR DESCRIPTION
Main changes:

1) QueryListener is changed to deal in RowsAndColumns rather than
   individual rows.

2) Logic for converting Frames to SQL-formatted rows is moved into
   TaskReportQueryListener, out of QueryResultsReader.

3) DartQueryMaker's streaming mode (fullReport = false) is adjusted
   to use SequenceQueryListener + FrameChannelSequence.

4) Controller register/deregister and execution lifecycle related logic
   is consolidated and moved into ControllerHolder#runAsync, to simplify
   DartQueryMaker.