### PR TITLE
Final cost-based autoscaler knobs adjusments

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/WeightedCostFunction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/WeightedCostFunction.java
@@ -33,7 +33,7 @@ public class WeightedCostFunction
    * Multiplier for a lag amplification factor; it was carefully chosen
    * during extensive testing as the most balanced multiplier for high-lag recovery.
    */
-  private static final double LAG_AMPLIFICATION_MULTIPLIER = 0.05;
+  static final double LAG_AMPLIFICATION_MULTIPLIER = 0.05;
 
   /**
    * Computes cost for a given task count using compute time metrics.

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/WeightedCostFunctionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/WeightedCostFunctionTest.java
@@ -97,7 +97,7 @@ public class WeightedCostFunctionTest
     // aggregateLag = 100000 * 100 = 10,000,000; lagPerPartition = 100,000
     CostMetrics metrics = createMetrics(100000.0, 10, 100, 0.3);
     double aggregateLag = 100000.0 * 100;
-    double amplification = 1.0 + 0.2 * Math.log(aggregateLag / 100);
+    double amplification = 1.0 + WeightedCostFunction.LAG_AMPLIFICATION_MULTIPLIER * Math.log(aggregateLag / 100);
 
     double costCurrent = costFunction.computeCost(metrics, 10, lagOnlyConfig).totalCost();
     Assert.assertEquals("Cost of current tasks", aggregateLag * amplification / (10 * 1000.0), costCurrent, 0.1);
@@ -307,7 +307,7 @@ public class WeightedCostFunctionTest
 
     double aggregateLag = 150.0 * partitionCount;
     double lagPerPartition = aggregateLag / partitionCount;
-    double amplification = 1.0 + 0.2 * Math.log(lagPerPartition);
+    double amplification = 1.0 + WeightedCostFunction.LAG_AMPLIFICATION_MULTIPLIER * Math.log(lagPerPartition);
     double expected = aggregateLag * amplification / (proposedTaskCount * 1000.0);
 
     Assert.assertEquals("Lag amplification should increase lag recovery time", expected, costWithAmp, 0.0001);


### PR DESCRIPTION
This patch makes autoscaling during high lag even smoother, by reducing logarihmic mutliplier used a knob for that.
Old multiplier recommended to scale up too much tasks.
The result might be seen in the plot under the hood.

<details>

Plot conditions were taken from real scenario: ~5M lag, 100k processing rate, 48 partitions (10 and 24 partitions are present here for differential analysis purposes).

<img width="1800" height="750" alt="image" src="https://github.com/user-attachments/assets/916a9ab1-4e2d-4e75-81e3-bd2e8a63eae5" />

</details>

This PR has:

- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.