### PR TITLE
Disable tests that use Helm charts.

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/k8s/KubernetesTaskRunnerCachingModeDockerTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/k8s/KubernetesTaskRunnerCachingModeDockerTest.java
@@ -19,11 +19,14 @@
 
 package org.apache.druid.testing.embedded.k8s;
 
+import org.junit.jupiter.api.Disabled;
+
 /**
  * Runs ingestion tests using SharedInformer caching mode.
  * Uses Fabric8 SharedInformers to maintain a local cache of Jobs and Pods,
  * reducing load on the Kubernetes API server.
  */
+@Disabled("requires charts.datainfra.io chart, see https://github.com/apache/druid/pull/19047")
 public class KubernetesTaskRunnerCachingModeDockerTest extends BaseKubernetesTaskRunnerDockerTest
 {
   @Override

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/k8s/KubernetesTaskRunnerDirectModeDockerTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/k8s/KubernetesTaskRunnerDirectModeDockerTest.java
@@ -19,10 +19,13 @@
 
 package org.apache.druid.testing.embedded.k8s;
 
+import org.junit.jupiter.api.Disabled;
+
 /**
  * Runs ingestion tests using direct K8s API interaction (default mode).
  * Each task makes direct API calls to the Kubernetes API server.
  */
+@Disabled("requires charts.datainfra.io chart, see https://github.com/apache/druid/pull/19047")
 public class KubernetesTaskRunnerDirectModeDockerTest extends BaseKubernetesTaskRunnerDockerTest
 {
   @Override


### PR DESCRIPTION
The helm charts are not currently available. There are discussions at the following two issues about making them available:

- https://github.com/datainfrahq/druid-operator/issues/250
- https://github.com/datainfrahq/druid-operator/issues/259

Ultimately, the way to fix this is to complete https://github.com/apache/druid/issues/18582 (officially release an Apache version of the helm charts) and then use that.