### PR TITLE
MSQ: Save stack trace when rewriting faults.

### DIFF
--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -2930,37 +2930,34 @@ public class ControllerImpl implements Controller
       @Nullable final MSQErrorReport workerErrorReport
   )
   {
-
     if (workerErrorReport == null) {
       return null;
     } else if (workerErrorReport.getFault() instanceof InvalidNullByteFault) {
-      InvalidNullByteFault inbf = (InvalidNullByteFault) workerErrorReport.getFault();
-      return MSQErrorReport.fromException(
-          workerErrorReport.getTaskId(),
-          workerErrorReport.getHost(),
-          workerErrorReport.getStageNumber(),
-          InvalidNullByteException.builder()
-                                  .source(inbf.getSource())
-                                  .rowNumber(inbf.getRowNumber())
-                                  .column(inbf.getColumn())
-                                  .value(inbf.getValue())
-                                  .position(inbf.getPosition())
-                                  .build(),
-          querySpec.getColumnMappings()
+      final InvalidNullByteFault inbf = (InvalidNullByteFault) workerErrorReport.getFault();
+      return workerErrorReport.withFault(
+          MSQErrorReport.getFaultFromException(
+              InvalidNullByteException.builder()
+                                      .source(inbf.getSource())
+                                      .rowNumber(inbf.getRowNumber())
+                                      .column(inbf.getColumn())
+                                      .value(inbf.getValue())
+                                      .position(inbf.getPosition())
+                                      .build(),
+              querySpec.getColumnMappings()
+          )
       );
     } else if (workerErrorReport.getFault() instanceof InvalidFieldFault) {
-      InvalidFieldFault iff = (InvalidFieldFault) workerErrorReport.getFault();
-      return MSQErrorReport.fromException(
-          workerErrorReport.getTaskId(),
-          workerErrorReport.getHost(),
-          workerErrorReport.getStageNumber(),
-          InvalidFieldException.builder()
-                               .source(iff.getSource())
-                               .rowNumber(iff.getRowNumber())
-                               .column(iff.getColumn())
-                               .errorMsg(iff.getErrorMsg())
-                               .build(),
-          querySpec.getColumnMappings()
+      final InvalidFieldFault iff = (InvalidFieldFault) workerErrorReport.getFault();
+      return workerErrorReport.withFault(
+          MSQErrorReport.getFaultFromException(
+              InvalidFieldException.builder()
+                                   .source(iff.getSource())
+                                   .rowNumber(iff.getRowNumber())
+                                   .column(iff.getColumn())
+                                   .errorMsg(iff.getErrorMsg())
+                                   .build(),
+              querySpec.getColumnMappings()
+          )
       );
     } else {
       return workerErrorReport;

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/error/MSQErrorReport.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/error/MSQErrorReport.java
@@ -164,6 +164,14 @@ public class MSQErrorReport
     return druidException;
   }
 
+  /**
+   * Returns a copy of this error report with a new fault code.
+   */
+  public MSQErrorReport withFault(final MSQFault newFault)
+  {
+    return new MSQErrorReport(taskId, host, stageNumber, newFault, exceptionStackTrace);
+  }
+
   @Override
   public boolean equals(Object o)
   {


### PR DESCRIPTION
`ControllerImpl` has a function `mapQueryColumnNameToOutputColumnName` that rewrites faults to use the user-visible column names. However, the current implementation also replaces the `exceptionStackTrace`. The original trace from the worker is lost, replaced by a not-very-useful one from this function on the controller.

This patch changes the function so only the fault is rewritten, not the entire error report, so the original worker stack trace is preserved.