### PR TITLE
Perf: Remove redundant map lookups in CustomTierSelectorStrategy comparator

### DIFF
--- a/server/src/main/java/org/apache/druid/client/selector/CustomTierSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/client/selector/CustomTierSelectorStrategy.java
@@ -48,18 +48,23 @@ public class CustomTierSelectorStrategy extends AbstractTierSelectorStrategy
     }
 
     // Tiers with priorities explicitly specified in the custom priority list config always have higher priority than
-    // those not and those not specified fall back to use highest priority strategy among themselves
+    // those not and those not specified fall back to use the highest priority strategy among themselves
     this.comparator = (p1, p2) -> {
-      if (lookup.containsKey(p1) && lookup.containsKey(p2)) {
-        return Integer.compare(lookup.get(p1), lookup.get(p2));
-      } else if (lookup.containsKey(p1)) {
-        return -1;
-      } else if (lookup.containsKey(p2)) {
-        return 1;
-      } else {
-        // Fall back to use highest priority strategy
-        return Integer.compare(p2, p1);
+      final Integer rank1 = lookup.get(p1);
+      final Integer rank2 = lookup.get(p2);
+
+      if (rank1 != null && rank2 != null) {
+        return Integer.compare(rank1, rank2);
       }
+      if (rank1 != null) {
+        return -1;
+      }
+      if (rank2 != null) {
+        return 1;
+      }
+
+      // Fall back to highest priority first
+      return Integer.compare(p2, p1);
     };
   }
 


### PR DESCRIPTION
Avoid repeated `containsKey()` and `get()` calls by retrieving each map value once and using null checks instead. This reduces redundant lookups and simplifies the comparator logic.

This PR has:

- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.