### PR TITLE
DartControllerModule: Move ControllerThreadPool inside ActualModule.

### DIFF
--- a/multi-stage-query/src/main/java/org/apache/druid/msq/dart/guice/DartControllerModule.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/dart/guice/DartControllerModule.java
@@ -123,21 +123,21 @@ public class DartControllerModule implements DruidModule
     {
       return new DartMessageRelays(discoveryProvider, messageRelayFactory);
     }
-  }
 
-  @Provides
-  @Dart
-  @ManageLifecycle
-  public ControllerThreadPool makeControllerThreadPool(DartControllerConfig dartControllerConfig)
-  {
-    return new ControllerThreadPool(
-        MoreExecutors.listeningDecorator(
-            Execs.multiThreaded(
-                dartControllerConfig.getConcurrentQueries(),
-                "dart-controller-%s"
-            )
-        )
-    );
+    @Provides
+    @Dart
+    @ManageLifecycle
+    public ControllerThreadPool makeControllerThreadPool(DartControllerConfig dartControllerConfig)
+    {
+      return new ControllerThreadPool(
+          MoreExecutors.listeningDecorator(
+              Execs.multiThreaded(
+                  dartControllerConfig.getConcurrentQueries(),
+                  "dart-controller-%s"
+              )
+          )
+      );
+    }
   }
 
   @Override


### PR DESCRIPTION
It was at the incorrect level of indentation, so it was provided always, even when Dart was not enabled.