### PR TITLE
Fix flaky QueryVirtualStorageTest

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/QueryVirtualStorageTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/QueryVirtualStorageTest.java
@@ -117,7 +117,7 @@ class QueryVirtualStorageTest extends EmbeddedClusterTestBase
     return EmbeddedDruidCluster
         .withEmbeddedDerbyAndZookeeper()
         .useLatchableEmitter()
-        .useDefaultTimeoutForLatchableEmitter(20)
+        .useDefaultTimeoutForLatchableEmitter(30)
         .addResource(storageResource)
         .addCommonProperty("druid.msq.dart.enabled", "true")
         .addCommonProperty("druid.storage.zip", "false")


### PR DESCRIPTION
Fix flaky QueryVirtualStorageTest

### Description

- QueryVirtualStorageTest: Still seeing timeout with 20seconds, bumping up to 30 seconds 
```
Error:  Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 34.09 s <<< FAILURE! -- in org.apache.druid.testing.embedded.query.QueryVirtualStorageTest
Error:  org.apache.druid.testing.embedded.query.QueryVirtualStorageTest -- Time elapsed: 34.09 s <<< ERROR!
org.apache.druid.java.util.common.ISE: Timed out waiting for event after [20,000]ms
	at org.apache.druid.server.metrics.LatchableEmitter.waitForEvent(LatchableEmitter.java:130)
	at org.apache.druid.server.metrics.LatchableEmitter.waitForEvent(LatchableEmitter.java:175)
	at org.apache.druid.testing.embedded.EmbeddedClusterApis.waitForTaskToFinish(EmbeddedClusterApis.java:242)
	at org.apache.druid.testing.embedded.EmbeddedClusterApis.waitForTaskToSucceed(EmbeddedClusterApis.java:214)
	at org.apache.druid.testing.embedded.msq.EmbeddedMSQApis.runTaskSqlAndGetReport(EmbeddedMSQApis.java:143)
	at org.apache.druid.testing.embedded.query.QueryVirtualStorageTest.loadWikiData(QueryVirtualStorageTest.java:423)
	at org.apache.druid.testing.embedded.query.QueryVirtualStorageTest.loadData(QueryVirtualStorageTest.java:143)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```

- QueryVirtualStorageTest: handle null loadWait in DART report assertion

ChannelCounters.Snapshot.getLoadWait() is Nullable — it returns null when all values are zero, which can happens when
segment load wait time is sub-millisecond (the internal nanosecond value is converted to milliseconds via
TimeUnit.NANOSECONDS.toMillis, truncating tiny waits to zero). On fast machines (i.e. with a lot of cores) or when the executor has free threads, the wait is effectively zero, causing a NullPointerException when the test accessed getLoadWait()[0] unconditionally.

Updated the assertion to tolerate the null case, since zero wait time is a legitimate outcome:
```
Assertions.assertTrue(
    segmentChannelCounters.getLoadWait() == null
    || segmentChannelCounters.getLoadWait()[0] >= 0
);
```

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.