### PR TITLE
SegmentManager: Close references on failure of getSegmentsBundle.

### DIFF
--- a/server/src/main/java/org/apache/druid/server/SegmentManager.java
+++ b/server/src/main/java/org/apache/druid/server/SegmentManager.java
@@ -149,31 +149,47 @@ public class SegmentManager
       SegmentMapFunction segmentMapFunction
   )
   {
-    final ArrayList<SegmentReference> segmentReferences = new ArrayList<>();
-    final ArrayList<SegmentDescriptor> missingSegments = new ArrayList<>();
-    final ArrayList<DataSegmentAndDescriptor> loadableSegments = new ArrayList<>();
-    for (DataSegmentAndDescriptor segment : segments) {
-      final DataSegment dataSegment = segment.getDataSegment();
-      if (dataSegment == null) {
-        missingSegments.add(segment.getDescriptor());
-        continue;
+    // Closer to collect everything that needs to be cleaned up in the event of failure. If we make it
+    // out of this function, closing the segment references is the caller's responsibility.
+    final Closer safetyNet = Closer.create();
+    try {
+      final ArrayList<SegmentReference> segmentReferences = new ArrayList<>();
+      final ArrayList<SegmentDescriptor> missingSegments = new ArrayList<>();
+      final ArrayList<DataSegmentAndDescriptor> loadableSegments = new ArrayList<>();
+      for (final DataSegmentAndDescriptor segment : segments) {
+        final DataSegment dataSegment = segment.getDataSegment();
+        if (dataSegment == null) {
+          missingSegments.add(segment.getDescriptor());
+          continue;
+        }
+        final Optional<Segment> ref = acquireCachedSegment(dataSegment);
+        if (ref.isPresent()) {
+          try {
+            final Optional<Segment> mapped = segmentMapFunction.apply(ref).map(safetyNet::register);
+            segmentReferences.add(
+                new SegmentReference(
+                    segment.getDescriptor(),
+                    mapped,
+                    null
+                )
+            );
+          }
+          catch (Throwable t) {
+            // If applying the mapFn failed, attach the base segment to the closer and rethrow
+            ref.ifPresent(safetyNet::register);
+            throw t;
+          }
+        } else if (canLoadSegmentOnDemand(dataSegment)) {
+          loadableSegments.add(segment);
+        } else {
+          missingSegments.add(segment.getDescriptor());
+        }
       }
-      Optional<Segment> ref = acquireCachedSegment(dataSegment);
-      if (ref.isPresent()) {
-        segmentReferences.add(
-            new SegmentReference(
-                segment.getDescriptor(),
-                segmentMapFunction.apply(ref),
-                null
-            )
-        );
-      } else if (canLoadSegmentOnDemand(dataSegment)) {
-        loadableSegments.add(segment);
-      } else {
-        missingSegments.add(segment.getDescriptor());
-      }
+      return new LeafSegmentsBundle(segmentReferences, loadableSegments, missingSegments);
     }
-    return new LeafSegmentsBundle(segmentReferences, loadableSegments, missingSegments);
+    catch (Throwable t) {
+      throw CloseableUtils.closeAndWrapInCatch(t, safetyNet);
+    }
   }
 
   /**


### PR DESCRIPTION
Similar to the approach in ServerManager#getOrLoadBundleSegments, we use a safetyNet to close references if bundle creation fails.