### PR TITLE
ChannelCounters: Store segment load/wait time in nanos.

### DIFF
--- a/multi-stage-query/src/main/java/org/apache/druid/msq/counters/ChannelCounters.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/counters/ChannelCounters.java
@@ -62,9 +62,15 @@ public class ChannelCounters implements QueryCounter
   @GuardedBy("this")
   private final LongList loadBytes = new LongArrayList();
 
+  /**
+   * Segment load time. Stored here in nanos, snapshotted in millis.
+   */
   @GuardedBy("this")
   private final LongList loadTime = new LongArrayList();
 
+  /**
+   * Segment load waiting time. Stored here in nanos, snapshotted in millis.
+   */
   @GuardedBy("this")
   private final LongList loadWait = new LongArrayList();
 
@@ -99,8 +105,8 @@ public class ChannelCounters implements QueryCounter
       addLoad(
           NO_PARTITION,
           loadResult.getLoadSizeBytes(),
-          TimeUnit.NANOSECONDS.toMillis(loadResult.getLoadTimeNanos()),
-          TimeUnit.NANOSECONDS.toMillis(loadResult.getWaitTimeNanos()),
+          loadResult.getLoadTimeNanos(),
+          loadResult.getWaitTimeNanos(),
           1
       );
     }
@@ -242,6 +248,20 @@ public class ChannelCounters implements QueryCounter
     ) {
       return null;
     } else {
+      if (loadTimeArray != null) {
+        // Stored as nanoseconds, snapshotted as milliseconds.
+        for (int i = 0; i < loadTimeArray.length; i++) {
+          loadTimeArray[i] = TimeUnit.NANOSECONDS.toMillis(loadTimeArray[i]);
+        }
+      }
+
+      if (loadWaitArray != null) {
+        // Stored as nanoseconds, snapshotted as milliseconds.
+        for (int i = 0; i < loadWaitArray.length; i++) {
+          loadWaitArray[i] = TimeUnit.NANOSECONDS.toMillis(loadWaitArray[i]);
+        }
+      }
+
       return new Snapshot(
           rowsArray,
           bytesArray,


### PR DESCRIPTION
This patch changes the loadTime and loadWait such that they are accumulated in nanoseconds and snapshotted in milliseconds. Snapshots are in the same units they were before (milliseconds), but by using nanoseconds for accumulation, we avoid accumulating rounding errors.

This fixes some flakiness in QueryVirtualStorageTest, which asserts that the loadWait is > 0. If the test runs quickly enough that the individual waits are always sub-ms, this would end up zero due to rounding errors.