### PR TITLE
WorkerImpl: Skip null dimensions when emitting metrics.

### DIFF
--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
@@ -230,16 +230,21 @@ public class WorkerImpl implements Worker
       cpuTimeNs += tracker.totalCpu();
     }
 
-    final Set<String> datasources = (Set<String>) queryMetricDimensions.get(DruidMetrics.DATASOURCE);
-    final Set<Interval> intervals = (Set<Interval>) queryMetricDimensions.get(DruidMetrics.INTERVAL);
-
     final MSQMetricEventBuilder metricBuilder = new MSQMetricEventBuilder();
-    metricBuilder.setDimension(DruidMetrics.DATASOURCE, DefaultQueryMetrics.getTableNamesAsString(datasources))
-                 .setDimension(DruidMetrics.INTERVAL, DefaultQueryMetrics.getIntervalsAsStringArray(intervals))
-                 .setDimension(DruidMetrics.DURATION, BaseQuery.calculateDuration(intervals))
-                 .setDimension(DruidMetrics.SUCCESS, success)
-                 .setMetric("query/time", time);
 
+    final Set<String> datasources = (Set<String>) queryMetricDimensions.get(DruidMetrics.DATASOURCE);
+    if (datasources != null) {
+      metricBuilder.setDimension(DruidMetrics.DATASOURCE, DefaultQueryMetrics.getTableNamesAsString(datasources));
+    }
+
+    final Set<Interval> intervals = (Set<Interval>) queryMetricDimensions.get(DruidMetrics.INTERVAL);
+    if (intervals != null) {
+      metricBuilder.setDimension(DruidMetrics.INTERVAL, DefaultQueryMetrics.getIntervalsAsStringArray(intervals));
+      metricBuilder.setDimension(DruidMetrics.DURATION, BaseQuery.calculateDuration(intervals));
+    }
+
+    metricBuilder.setDimension(DruidMetrics.SUCCESS, success);
+    metricBuilder.setMetric("query/time", time);
     context.emitMetric(metricBuilder);
 
     metricBuilder.setMetric("query/cpu/time", TimeUnit.NANOSECONDS.toMicros(cpuTimeNs));


### PR DESCRIPTION
If a query ends without a worker ever receiving a work order (perhaps due to failure), the call to DefaultQueryMetrics.getTableNamesAsString would throw a NullPointerException.

This patch updates metric emitting logic to skip dimensions that are not available at the time the query completes.