### PR TITLE
Fix add-milestone GHA job

### DIFF
--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -20,7 +20,7 @@
 name: "PR Merged"
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 jobs:


### PR DESCRIPTION
A GitHub action to auto-add milestones were added in https://github.com/apache/druid/pull/18935

As @kgyrtkirk noted in this [comment](https://github.com/apache/druid/pull/18935#issuecomment-3780550138), this check is failing with a 403 error for [all](https://github.com/apache/druid/pull/19052) PRs coming from forks once they are merged into master:
```json
{"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/issues/issues#update-an-issue","status":"403"}
``` 

Given the 403, it does indicate a permissions issue likely with the GitHub token used for this. Trying `pull_request_target` instead of `pull_request` similar to the existing [labeler](https://github.com/apache/druid/blob/master/.github/workflows/labeler.yml#L26) action which uses the same. Since this specific add-milestone check doesn't export any credentials, I believe using `pull_request_target` should be okay. Hopefully, with the elevated base token, this should work. 🤞 