### PR TITLE
Fix two VectorAggregator null checks.

### DIFF
--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramVectorAggregator.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramVectorAggregator.java
@@ -75,11 +75,12 @@ public class ApproximateHistogramVectorAggregator implements VectorAggregator
     final boolean[] isValueNull = selector.getNullVector();
 
     for (int i = 0; i < numRows; i++) {
-      if (isValueNull != null && isValueNull[i]) {
+      final int row = rows != null ? rows[i] : i;
+      if (isValueNull != null && isValueNull[row]) {
         continue;
       }
       final int position = positions[i] + positionOffset;
-      innerAggregator.aggregate(buf, position, vector[rows != null ? rows[i] : i]);
+      innerAggregator.aggregate(buf, position, vector[row]);
     }
   }
 

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramVectorAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramVectorAggregatorTest.java
@@ -111,6 +111,32 @@ public class ApproximateHistogramVectorAggregatorTest
   }
 
   @Test
+  public void testAggregateMultiPositionsWithNullsAndRowsIndirection()
+  {
+    // field_1 has a null vector where index 10 is null (value 45).
+    // By using rows indirection to map loop index 0 -> row 10, we verify the null check
+    // correctly skips the null row.
+    ApproximateHistogramAggregatorFactory factory = buildHistogramAggFactory("field_1");
+    final int size = factory.getMaxIntermediateSize();
+    ByteBuffer byteBuffer = ByteBuffer.allocate(size * 2);
+    VectorAggregator vectorAggregator = factory.factorizeVector(vectorColumnSelectorFactory);
+    final int[] positions = new int[]{0, size};
+    vectorAggregator.init(byteBuffer, positions[0]);
+    vectorAggregator.init(byteBuffer, positions[1]);
+
+    // rows[0]=10 (null row, value 45), rows[1]=0 (non-null, value 23)
+    // Position 0 should skip the null; position 1 should get value 23.
+    vectorAggregator.aggregate(byteBuffer, 2, positions, new int[]{10, 0}, 0);
+
+    ApproximateHistogram h0 = (ApproximateHistogram) vectorAggregator.get(byteBuffer, 0);
+    Assert.assertEquals(0, h0.count());
+
+    ApproximateHistogram h1 = (ApproximateHistogram) vectorAggregator.get(byteBuffer, size);
+    Assert.assertArrayEquals(new float[]{23}, h1.positions(), 0.1f);
+    Assert.assertArrayEquals(new long[]{1}, h1.bins());
+  }
+
+  @Test
   public void testAggregateMultiPositions()
   {
     ApproximateHistogramAggregatorFactory factory = buildHistogramAggFactory("field_2");

--- a/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanVectorAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanVectorAggregator.java
@@ -73,18 +73,12 @@ public class DoubleMeanVectorAggregator implements VectorAggregator
     final double[] vector = selector.getDoubleVector();
     final boolean[] nulls = selector.getNullVector();
 
-    if (nulls != null) {
-      for (int j = 0; j < numRows; j++) {
-        if (!nulls[j]) {
-          final double val = vector[rows != null ? rows[j] : j];
-          DoubleMeanHolder.update(buf, positions[j] + positionOffset, val);
-        }
+    for (int i = 0; i < numRows; i++) {
+      final int row = rows != null ? rows[i] : i;
+      if (nulls != null && nulls[row]) {
+        continue;
       }
-    } else {
-      for (int i = 0; i < numRows; i++) {
-        final double val = vector[rows != null ? rows[i] : i];
-        DoubleMeanHolder.update(buf, positions[i] + positionOffset, val);
-      }
+      DoubleMeanHolder.update(buf, positions[i] + positionOffset, vector[row]);
     }
   }
 


### PR DESCRIPTION
When "rows" is nonnull, we need to use it to index into the null vector and data vector. The prior code was using it for the data vector, but not the null vector.