### PR TITLE
Fix flaky BrokerServerViewTest.

### DIFF
--- a/server/src/test/java/org/apache/druid/client/BrokerServerViewTest.java
+++ b/server/src/test/java/org/apache/druid/client/BrokerServerViewTest.java
@@ -555,7 +555,7 @@ public class BrokerServerViewTest extends CuratorTestBase
   public void testDifferentTierStrategiesForHistoricalAndRealtimeServers() throws Exception
   {
     segmentViewInitLatch = new CountDownLatch(1);
-    segmentAddedLatch = new CountDownLatch(6);
+    segmentAddedLatch = new CountDownLatch(7);
     segmentRemovedLatch = new CountDownLatch(0);
 
     // Setup a Broker with LowestPriority strategy for historicals and HighestPriority for realtime


### PR DESCRIPTION
The test testDifferentTierStrategiesForHistoricalAndRealtimeServers was flaky because it adds 7 segments but only waits for 6.