### PR TITLE
Fix quidem.filter comma handling.

### DIFF
--- a/sql/src/test/java/org/apache/druid/quidem/DruidQuidemTestBase.java
+++ b/sql/src/test/java/org/apache/druid/quidem/DruidQuidemTestBase.java
@@ -185,7 +185,7 @@ public abstract class DruidQuidemTestBase
       final FileSystem fileSystem = FileSystems.getDefault();
       for (String filterGlob : filterStr.split(",")) {
         if (!filterGlob.endsWith("*") && !filterGlob.endsWith(IQ_SUFFIX)) {
-          filterGlob = filterStr + IQ_SUFFIX;
+          filterGlob = filterGlob + IQ_SUFFIX;
         }
         filterMatchers.add(fileSystem.getPathMatcher("glob:" + filterGlob));
       }


### PR DESCRIPTION
When we add a missing `.iq` suffix to an individual quidem file, we need to do it on `filterGlob`, not `filterStr`.