### PR TITLE
Fix task state leak due to interrupt race

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -731,6 +731,12 @@ public class TaskQueue
 
     // Save status to metadata store first, so if we crash while doing the rest of the shutdown, our successor
     // remembers that this task has completed.
+    //
+    // Clear the thread interrupt flag before the write so it can complete even during overlord shutdown.
+    // Without this, an interrupted thread would fail the write immediately (0 retries), leaving the task
+    // as active in the metadata store and causing it to appear stuck in WAITING indefinitely. The flag is
+    // restored in the finally block so the calling executor's shutdown handling is not affected.
+    final boolean wasInterrupted = Thread.interrupted();
     try {
       // The code block is only called when a task completes,
       // and we need to check to make sure the metadata store has the correct status stored.
@@ -748,6 +754,11 @@ public class TaskQueue
          .addData("task", task.getId())
          .addData("statusCode", taskStatus.getStatusCode())
          .emit();
+    }
+    finally {
+      if (wasInterrupted) {
+        Thread.currentThread().interrupt();
+      }
     }
 
     shutdownTaskOnRunner(task.getId(), reasonFormat, args);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
@@ -193,7 +193,7 @@ public class TaskQueueTest extends IngestionTestBase
   }
 
   @Test
-  public void testManageQueuedTasksDoesNothingWhenInactive() throws Exception
+  public void testManageQueuedTasksDoesNothingWhenInactive()
   {
     // Add a task to the queue while active
     final TestTask task = new TestTask("t1", Intervals.of("2021-01/P1M"));
@@ -638,6 +638,47 @@ public class TaskQueueTest extends IngestionTestBase
     Assert.assertFalse(taskInQueueAsString.contains(password));
 
     Assert.assertEquals(taskInStorageAsString, taskInQueueAsString);
+  }
+
+  @Test
+  public void testShutdownPersistsStatus_andRestoresInterruptFlag_whenThreadIsInterrupted()
+  {
+    // Regression test: notifyStatus() must persist terminal status to the metadata store even when the calling
+    // thread is interrupted (e.g., executor threads interrupted during overlord shutdown), and must restore
+    // the interrupt flag afterward so the calling executor's shutdown handling is not broken.
+    final HeapMemoryTaskStorage storage = new HeapMemoryTaskStorage(new TaskStorageConfig(null));
+    final TaskQueue queue = new TaskQueue(
+        new TaskLockConfig(),
+        new TaskQueueConfig(null, null, null, null, null, null),
+        new DefaultTaskConfig(),
+        storage,
+        new SimpleTaskRunner(serviceEmitter),
+        actionClientFactory,
+        getLockbox(),
+        serviceEmitter,
+        getObjectMapper(),
+        new NoopTaskContextEnricher()
+    );
+    queue.setActive(true);
+
+    final String reason = "Killing task for graceful shutdown";
+    final TestTask task = new TestTask("interrupt-test-task", Intervals.of("2021-01-01/P1D"));
+    queue.add(task);
+
+    Thread.currentThread().interrupt();
+    queue.shutdown(task.getId(), reason);
+
+    Assert.assertTrue(
+        "Thread interrupt flag must be restored after notifyStatus()",
+        Thread.currentThread().isInterrupted()
+    );
+    // Clear the interrupt so the test framework is not affected.
+    Thread.interrupted();
+
+    final Optional<TaskStatus> status = storage.getStatus(task.getId());
+    Assert.assertTrue(status.isPresent());
+    Assert.assertEquals(TaskState.FAILED, status.get().getStatusCode());
+    Assert.assertEquals(reason, status.get().getErrorMsg());
   }
 
   @Test


### PR DESCRIPTION
<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Saw this issue in our cluster where a task queue callback thread gets interrupted mid-persist. Since our DB connector propagates interruptions, we would fail to persist the task status callback, causing inconsistency between what's in memory (`FAILED`) and what's in DB (`RUNNING`). Since the in-memory task is complete, it is cleaned up. On the next sync, the `RUNNING` entry is pulled in, keeping it in the active tasks list as `WAITING`.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Fix WAITING task state leak due to interrupt race

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.