### PR TITLE
Suppress CVE-2025-49128 for jackson-core shaded in hadoop-client-runtime

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -142,7 +142,8 @@
     <cve>CVE-2024-47561</cve> <!--  This seems to be a legitimate vulnerability. We would need to go to hadoop-client 3.4 which required aws sdk v2 dependency work to finish -->
     <cve>CVE-2024-29131</cve> <!--  This seems to be a legitimate vulnerability. We would need to go to hadoop-client 3.4 which required aws sdk v2 dependency work to finish -->
     <cve>CVE-2024-22201</cve> <!--  This seems to be a legitimate vulnerability. We would need to go to a hadoop-client which was not yet released  -->
-    <cve>CVE-2025-52999</cve> <!--  This is vulneraability in all versions of hadoop-client-runtime and has not been fixed by hadoop yet -->
+    <cve>CVE-2025-52999</cve> <!--  This is vulnerability in all versions of hadoop-client-runtime and has not been fixed by hadoop yet -->
+    <cve>CVE-2025-49128</cve> <!--  jackson-core is shaded inside hadoop-client-runtime at an older version; Druid's standalone jackson-core is 2.19.2 which is not affected. No fix available in hadoop-client 3.3.x yet -->
     <cve>CVE-2024-9823</cve> <!-- This is in hadoop's shadded jetty. no version of hadoop has updated to fixed version. It is a jetty server vuln, which should not be exploitable in hadoop client code -->
     <cve>CVE-2025-27821</cve> <!-- native hdfs vulnerability -->
     <cve>CVE-2025-5115</cve> <!-- netty issue in shaded hadoop -->


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description
Adds an OWASP dependency-check suppression for CVE-2025-49128, which is flagged against the
jackson-core copy shaded inside `hadoop-client-runtime-3.3.6.jar`.

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->


#### Why this is suppressed

* Druid's standalone `jackson-core` is already at **2.19.2** (managed via `jackson-bom`), which is
not affected by this CVE. The flag originates from an older jackson-core version shaded internally
inside `hadoop-client-runtime-3.3.6.jar`. There is no fix available in the Hadoop 3.3.x line yet,
making this unavoidable without a major Hadoop upgrade.

* CVE-2025-52999 (also flagged against the same shaded copy) was already suppressed in the same
block — this change brings CVE-2025-49128 in line with that existing suppression. It also fixes a typo in that entry.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
* Suppress CVE-2025-49128 for `jackson-core` shaded inside `hadoop-client-runtime`. Druid's own `jackson-core` is unaffected at `2.19.2`.
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
- `owasp-dependency-check-suppressions.xml`: Added `CVE-2025-49128` to the `hadoop-client-runtime-3.3.6.jar`
  suppression block, alongside fixing a typo the existing `CVE-2025-52999` entry.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [X] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.