### PR TITLE
feat: add OpenLineage request logger extension

### DIFF
--- a/distribution/docker/environment
+++ b/distribution/docker/environment
@@ -27,7 +27,11 @@ DRUID_SINGLE_NODE_CONF=micro-quickstart
 
 druid_emitter_logging_logLevel=debug
 
-druid_extensions_loadList=["druid-histogram", "druid-datasketches", "druid-lookups-cached-global", "postgresql-metadata-storage"]
+druid_extensions_loadList=["druid-histogram", "druid-datasketches", "druid-lookups-cached-global", "postgresql-metadata-storage", "druid-multi-stage-query", "openlineage-emitter"]
+
+druid_request_logging_type=openlineage
+druid_request_logging_namespace=druid://local.docker.test
+druid_request_logging_transportType=CONSOLE
 
 druid_zk_service_host=zookeeper
 
@@ -48,4 +52,4 @@ druid_indexer_logs_directory=/opt/shared/indexing-logs
 druid_processing_numThreads=2
 druid_processing_numMergeBuffers=2
 
-DRUID_LOG4J=<?xml version="1.0" encoding="UTF-8" ?><Configuration status="WARN"><Appenders><Console name="Console" target="SYSTEM_OUT"><PatternLayout pattern="%d{ISO8601} %p [%t] %c - %m%n"/></Console></Appenders><Loggers><Root level="info"><AppenderRef ref="Console"/></Root><Logger name="org.apache.druid.jetty.RequestLog" additivity="false" level="DEBUG"><AppenderRef ref="Console"/></Logger></Loggers></Configuration>
+DRUID_LOG4J=<?xml version="1.0" encoding="UTF-8" ?><Configuration status="WARN"><Appenders><Console name="Console" target="SYSTEM_OUT"><PatternLayout pattern="%d{ISO8601} %p [%t] %c - %m%n"/></Console></Appenders><Loggers><Root level="info"><AppenderRef ref="Console"/></Root><Logger name="org.apache.druid.jetty.RequestLog" additivity="false" level="DEBUG"><AppenderRef ref="Console"/></Logger><Logger name="org.apache.druid.extensions.openlineage" additivity="false" level="DEBUG"><AppenderRef ref="Console"/></Logger></Loggers></Configuration>

--- a/distribution/docker/environment
+++ b/distribution/docker/environment
@@ -27,11 +27,7 @@ DRUID_SINGLE_NODE_CONF=micro-quickstart
 
 druid_emitter_logging_logLevel=debug
 
-druid_extensions_loadList=["druid-histogram", "druid-datasketches", "druid-lookups-cached-global", "postgresql-metadata-storage", "druid-multi-stage-query", "openlineage-emitter"]
-
-druid_request_logging_type=openlineage
-druid_request_logging_namespace=druid://local.docker.test
-druid_request_logging_transportType=CONSOLE
+druid_extensions_loadList=["druid-histogram", "druid-datasketches", "druid-lookups-cached-global", "postgresql-metadata-storage"]
 
 druid_zk_service_host=zookeeper
 
@@ -52,4 +48,4 @@ druid_indexer_logs_directory=/opt/shared/indexing-logs
 druid_processing_numThreads=2
 druid_processing_numMergeBuffers=2
 
-DRUID_LOG4J=<?xml version="1.0" encoding="UTF-8" ?><Configuration status="WARN"><Appenders><Console name="Console" target="SYSTEM_OUT"><PatternLayout pattern="%d{ISO8601} %p [%t] %c - %m%n"/></Console></Appenders><Loggers><Root level="info"><AppenderRef ref="Console"/></Root><Logger name="org.apache.druid.jetty.RequestLog" additivity="false" level="DEBUG"><AppenderRef ref="Console"/></Logger><Logger name="org.apache.druid.extensions.openlineage" additivity="false" level="DEBUG"><AppenderRef ref="Console"/></Logger></Loggers></Configuration>
+DRUID_LOG4J=<?xml version="1.0" encoding="UTF-8" ?><Configuration status="WARN"><Appenders><Console name="Console" target="SYSTEM_OUT"><PatternLayout pattern="%d{ISO8601} %p [%t] %c - %m%n"/></Console></Appenders><Loggers><Root level="info"><AppenderRef ref="Console"/></Root><Logger name="org.apache.druid.jetty.RequestLog" additivity="false" level="DEBUG"><AppenderRef ref="Console"/></Logger></Loggers></Configuration>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -404,6 +404,12 @@
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:kafka-emitter</argument>
                                         <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions.contrib:openlineage-emitter</argument>
+                                        <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions.contrib:materialized-view-maintenance</argument>
+                                        <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions.contrib:materialized-view-selection</argument>
+                                        <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:druid-opentsdb-emitter</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:druid-redis-cache</argument>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -406,10 +406,6 @@
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:openlineage-emitter</argument>
                                         <argument>-c</argument>
-                                        <argument>org.apache.druid.extensions.contrib:materialized-view-maintenance</argument>
-                                        <argument>-c</argument>
-                                        <argument>org.apache.druid.extensions.contrib:materialized-view-selection</argument>
-                                        <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:druid-opentsdb-emitter</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:druid-redis-cache</argument>

--- a/docs/configuration/extensions.md
+++ b/docs/configuration/extensions.md
@@ -93,6 +93,7 @@ All of these community extensions can be downloaded using [pull-deps](../operati
 |graphite-emitter|Graphite metrics emitter|[link](../development/extensions-contrib/graphite.md)|
 |statsd-emitter|StatsD metrics emitter|[link](../development/extensions-contrib/statsd.md)|
 |kafka-emitter|Kafka metrics emitter|[link](../development/extensions-contrib/kafka-emitter.md)|
+|openlineage-emitter|OpenLineage data lineage emitter|[link](../development/extensions-contrib/openlineage-emitter.md)|
 |druid-thrift-extensions|Support thrift ingestion |[link](../development/extensions-contrib/thrift.md)|
 |druid-opentsdb-emitter|OpenTSDB metrics emitter |[link](../development/extensions-contrib/opentsdb-emitter.md)|
 |druid-moving-average-query|Support for [Moving Average](https://en.wikipedia.org/wiki/Moving_average) and other Aggregate [Window Functions](https://en.wikibooks.org/wiki/Structured_Query_Language/Window_functions) in Druid queries.|[link](../development/extensions-contrib/moving-average-query.md)|

--- a/docs/development/extensions-contrib/openlineage-emitter.md
+++ b/docs/development/extensions-contrib/openlineage-emitter.md
@@ -1,0 +1,95 @@
+---
+id: openlineage-emitter
+title: "OpenLineage Emitter"
+---
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+To use this Apache Druid extension, [include](../../configuration/extensions.md#loading-extensions) `openlineage-emitter` in the extensions load list.
+
+## Introduction
+
+This extension emits [OpenLineage](https://openlineage.io) `RunEvent`s for each completed Druid query, enabling data lineage tracking with any OpenLineage-compatible backend such as [Marquez](https://marquezproject.ai).
+
+For SQL queries, the SQL text is parsed to extract input datasources (FROM clauses, JOINs, CTEs) and the output datasource (INSERT INTO). For native queries, table names are resolved from the datasource tree. Native sub-queries spawned by a SQL execution are deduplicated against the SQL-level event.
+
+:::note
+SQL table extraction relies on `calcite-core` being on the classpath, which is the case on Broker nodes. Native query lineage is available on all nodes.
+:::
+
+## Configuration
+
+All configuration parameters are under `druid.request.logging`.
+
+| Property | Description | Required | Default |
+|---|---|---|---|
+| `druid.request.logging.type` | Set to `openlineage` to enable this extension. | yes | — |
+| `druid.request.logging.namespace` | Namespace used for OpenLineage job and dataset URIs. Typically the Broker URL. | no | `druid://localhost` |
+| `druid.request.logging.transportType` | Where to send events. `CONSOLE` logs JSON to the Druid log; `HTTP` POSTs to an OpenLineage API endpoint. | no | `CONSOLE` |
+| `druid.request.logging.transportUrl` | OpenLineage API endpoint URL. Required when `transportType=HTTP`. | no | — |
+
+### Examples
+
+**Console (development)**
+
+```properties
+druid.request.logging.type=openlineage
+druid.request.logging.namespace=druid://broker.prod:8082
+```
+
+**HTTP (production)**
+
+```properties
+druid.request.logging.type=openlineage
+druid.request.logging.namespace=druid://broker.prod:8082
+druid.request.logging.transportType=HTTP
+druid.request.logging.transportUrl=http://marquez:5000/api/v1/lineage
+```
+
+**Combined with another logger using the `composing` provider**
+
+```properties
+druid.request.logging.type=composing
+druid.request.logging.loggerProviders[0].type=slf4j
+druid.request.logging.loggerProviders[1].type=openlineage
+druid.request.logging.loggerProviders[1].namespace=druid://broker.prod:8082
+druid.request.logging.loggerProviders[1].transportType=HTTP
+druid.request.logging.loggerProviders[1].transportUrl=http://marquez:5000/api/v1/lineage
+```
+
+## Event structure
+
+Each emitted event follows the [OpenLineage spec](https://openlineage.io/spec/2-0-2/OpenLineage.json) and includes the following facets.
+
+### Run facets
+
+| Facet | Description |
+|---|---|
+| `processing_engine` | Engine name (`druid`). Standard OpenLineage facet. |
+| `druid_query_context` | Query metadata: `identity` (authenticated user), `remoteAddress`, `queryType`, and `nativeQueryIds` (for SQL queries). |
+| `druid_query_statistics` | Execution stats: `durationMs`, `bytes`, `planningTimeMs`, `statusCode`. |
+| `errorMessage` | Exception message for failed queries. Standard OpenLineage facet. |
+
+### Job facets
+
+| Facet | Description |
+|---|---|
+| `jobType` | `processingType=BATCH`, `integration=DRUID`, `jobType=QUERY`. Standard OpenLineage facet. |
+| `sql` | Raw SQL text. Present on SQL queries only. Standard OpenLineage facet. |

--- a/docs/development/extensions-contrib/openlineage-emitter.md
+++ b/docs/development/extensions-contrib/openlineage-emitter.md
@@ -41,9 +41,10 @@ All configuration parameters are under `druid.request.logging`.
 | Property | Description | Required | Default |
 |---|---|---|---|
 | `druid.request.logging.type` | Set to `openlineage` to enable this extension. | yes | — |
-| `druid.request.logging.namespace` | Namespace used for OpenLineage job and dataset URIs. Typically the Broker URL. | no | `druid://localhost` |
+| `druid.request.logging.namespace` | Namespace used for OpenLineage job and dataset URIs. Typically the Broker URL. | no | `druid://<hostname>` |
 | `druid.request.logging.transportType` | Where to send events. `CONSOLE` logs JSON to the Druid log; `HTTP` POSTs to an OpenLineage API endpoint. | no | `CONSOLE` |
 | `druid.request.logging.transportUrl` | OpenLineage API endpoint URL. Required when `transportType=HTTP`. | no | — |
+| `druid.request.logging.excludedNativeQueryTypes` | Native query types to exclude from lineage emission. Internal broker queries like segment metadata lookups produce noisy, low-value events. | no | `["segmentMetadata", "dataSourceMetadata", "timeBoundary"]` |
 
 ### Examples
 
@@ -67,11 +68,7 @@ druid.request.logging.transportUrl=http://marquez:5000/api/v1/lineage
 
 ```properties
 druid.request.logging.type=composing
-druid.request.logging.loggerProviders[0].type=slf4j
-druid.request.logging.loggerProviders[1].type=openlineage
-druid.request.logging.loggerProviders[1].namespace=druid://broker.prod:8082
-druid.request.logging.loggerProviders[1].transportType=HTTP
-druid.request.logging.loggerProviders[1].transportUrl=http://marquez:5000/api/v1/lineage
+druid.request.logging.loggerProviders=[{"type":"slf4j"},{"type":"openlineage","namespace":"druid://broker.prod:8082","transportType":"HTTP","transportUrl":"http://marquez:5000/api/v1/lineage"}]
 ```
 
 ## Event structure

--- a/docs/development/extensions-contrib/openlineage-emitter.md
+++ b/docs/development/extensions-contrib/openlineage-emitter.md
@@ -28,7 +28,7 @@ To use this Apache Druid extension, [include](../../configuration/extensions.md#
 
 This extension emits [OpenLineage](https://openlineage.io) `RunEvent`s for each completed Druid query, enabling data lineage tracking with any OpenLineage-compatible backend such as [Marquez](https://marquezproject.ai).
 
-For SQL queries, the SQL text is parsed to extract input datasources (FROM clauses, JOINs, CTEs) and the output datasource (INSERT INTO). For native queries, table names are resolved from the datasource tree. Native sub-queries spawned by a SQL execution are deduplicated against the SQL-level event.
+For MSQ DML statements (`INSERT INTO` / `REPLACE INTO`), the output datasource is extracted from the SQL text and emitted as an output dataset. Input extraction from SQL is not performed — reliably resolving `FROM` / `JOIN` tables at the logger layer would duplicate planner work. For native queries, input table names are resolved from the datasource tree and emitted as input datasets. Native sub-queries spawned by a SQL execution carry a `sqlQueryId` in their context facet for correlation with the parent SQL event.
 
 :::note
 SQL table extraction relies on `calcite-core` being on the classpath, which is the case on Broker nodes. Native query lineage is available on all nodes.
@@ -48,9 +48,9 @@ All configuration parameters are under `druid.request.logging`.
 | `druid.request.logging.emitQueueCapacity` | Maximum number of events buffered in the async HTTP emit queue. Events are dropped (with a warning) when the queue is full. Only applies when `transportType=HTTP`. | no | `1000` |
 | `druid.request.logging.emitThreadCount` | Number of background threads used to POST events to the HTTP endpoint. Only applies when `transportType=HTTP`. | no | `1` |
 | `druid.request.logging.trustStorePath` | Path to the TrustStore file for HTTPS transport. Only applies when `transportType=HTTP`. | no | — |
-| `druid.request.logging.trustStorePassword` | Password for the TrustStore. Only applies when `transportType=HTTP`. | no | — |
+| `druid.request.logging.trustStorePassword` | Password for the TrustStore. Accepts a plain string or a [PasswordProvider](../../operations/password-provider.md) (e.g. an environment variable). Only applies when `transportType=HTTP`. | no | — |
 | `druid.request.logging.keyStorePath` | Path to the KeyStore file for mutual TLS. Only applies when `transportType=HTTP`. | no | — |
-| `druid.request.logging.keyStorePassword` | Password for the KeyStore. Only applies when `transportType=HTTP`. | no | — |
+| `druid.request.logging.keyStorePassword` | Password for the KeyStore. Accepts a plain string or a [PasswordProvider](../../operations/password-provider.md). Only applies when `transportType=HTTP`. | no | — |
 
 ### Examples
 
@@ -86,7 +86,7 @@ Each emitted event follows the [OpenLineage spec](https://openlineage.io/spec/2-
 | Facet | Description |
 |---|---|
 | `processing_engine` | Engine name (`druid`). Standard OpenLineage facet. |
-| `druid_query_context` | Query metadata: `identity` (authenticated user), `remoteAddress`, `queryType`, and `nativeQueryIds` (for SQL queries). |
+| `druid_query_context` | Query metadata: `identity` (authenticated user), `remoteAddress`, `queryType`, and `sqlQueryId` (on native sub-queries of SQL, for correlation with the parent SQL event). |
 | `druid_query_statistics` | Execution stats: `durationMs`, `bytes`, `planningTimeMs`, `statusCode`. |
 | `errorMessage` | Exception message for failed queries. Standard OpenLineage facet. |
 

--- a/docs/development/extensions-contrib/openlineage-emitter.md
+++ b/docs/development/extensions-contrib/openlineage-emitter.md
@@ -45,6 +45,12 @@ All configuration parameters are under `druid.request.logging`.
 | `druid.request.logging.transportType` | Where to send events. `CONSOLE` logs JSON to the Druid log; `HTTP` POSTs to an OpenLineage API endpoint. | no | `CONSOLE` |
 | `druid.request.logging.transportUrl` | OpenLineage API endpoint URL. Required when `transportType=HTTP`. | no | — |
 | `druid.request.logging.excludedNativeQueryTypes` | Native query types to exclude from lineage emission. Internal broker queries like segment metadata lookups produce noisy, low-value events. | no | `["segmentMetadata", "dataSourceMetadata", "timeBoundary"]` |
+| `druid.request.logging.emitQueueCapacity` | Maximum number of events buffered in the async HTTP emit queue. Events are dropped (with a warning) when the queue is full. Only applies when `transportType=HTTP`. | no | `1000` |
+| `druid.request.logging.emitThreadCount` | Number of background threads used to POST events to the HTTP endpoint. Only applies when `transportType=HTTP`. | no | `1` |
+| `druid.request.logging.trustStorePath` | Path to the TrustStore file for HTTPS transport. Only applies when `transportType=HTTP`. | no | — |
+| `druid.request.logging.trustStorePassword` | Password for the TrustStore. Only applies when `transportType=HTTP`. | no | — |
+| `druid.request.logging.keyStorePath` | Path to the KeyStore file for mutual TLS. Only applies when `transportType=HTTP`. | no | — |
+| `druid.request.logging.keyStorePassword` | Password for the KeyStore. Only applies when `transportType=HTTP`. | no | — |
 
 ### Examples
 

--- a/docs/development/extensions-contrib/openlineage-emitter.md
+++ b/docs/development/extensions-contrib/openlineage-emitter.md
@@ -31,7 +31,7 @@ This extension emits [OpenLineage](https://openlineage.io) `RunEvent`s for each 
 For MSQ DML statements (`INSERT INTO` / `REPLACE INTO`), the output datasource is extracted from the SQL text and emitted as an output dataset. Input extraction from SQL is not performed — reliably resolving `FROM` / `JOIN` tables at the logger layer would duplicate planner work. For native queries, input table names are resolved from the datasource tree and emitted as input datasets. Native sub-queries spawned by a SQL execution carry a `sqlQueryId` in their context facet for correlation with the parent SQL event.
 
 :::note
-SQL table extraction relies on `calcite-core` being on the classpath, which is the case on Broker nodes. Native query lineage is available on all nodes.
+MSQ DML output extraction relies on `calcite-core` being on the classpath, which is the case on Broker nodes. Native query lineage is available on all nodes.
 :::
 
 ## Configuration

--- a/extensions-contrib/openlineage-emitter/pom.xml
+++ b/extensions-contrib/openlineage-emitter/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.druid</groupId>
+    <artifactId>druid</artifactId>
+    <version>37.0.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <groupId>org.apache.druid.extensions.contrib</groupId>
+  <artifactId>openlineage-emitter</artifactId>
+  <name>openlineage-emitter</name>
+  <description>
+    OpenLineage data lineage emitter for Apache Druid. Captures table-level lineage from SQL
+    and native queries and emits OpenLineage RunEvents to a console or HTTP endpoint.
+
+    Configure via druid.request.logging.type=openlineage.
+    SQL table extraction uses the Calcite SQL parser; only available on Broker nodes.
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-processing</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-server</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.calcite</groupId>
+      <artifactId>calcite-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-processing</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-server</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/extensions-contrib/openlineage-emitter/pom.xml
+++ b/extensions-contrib/openlineage-emitter/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>37.0.0-SNAPSHOT</version>
+    <version>38.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/openlineage-emitter/pom.xml
+++ b/extensions-contrib/openlineage-emitter/pom.xml
@@ -60,6 +60,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.calcite.avatica</groupId>
+      <artifactId>avatica-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <scope>provided</scope>

--- a/extensions-contrib/openlineage-emitter/pom.xml
+++ b/extensions-contrib/openlineage-emitter/pom.xml
@@ -106,8 +106,13 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/extensions-contrib/openlineage-emitter/pom.xml
+++ b/extensions-contrib/openlineage-emitter/pom.xml
@@ -84,24 +84,30 @@
       <artifactId>jsr305</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.druid</groupId>
-      <artifactId>druid-processing</artifactId>
-      <version>${project.parent.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.druid</groupId>
-      <artifactId>druid-server</artifactId>
-      <version>${project.parent.version}</version>
-      <type>test-jar</type>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/extensions-contrib/openlineage-emitter/pom.xml
+++ b/extensions-contrib/openlineage-emitter/pom.xml
@@ -34,11 +34,12 @@
   <artifactId>openlineage-emitter</artifactId>
   <name>openlineage-emitter</name>
   <description>
-    OpenLineage data lineage emitter for Apache Druid. Captures table-level lineage from SQL
-    and native queries and emits OpenLineage RunEvents to a console or HTTP endpoint.
+    OpenLineage data lineage emitter for Apache Druid. Captures table-level lineage from
+    native and SQL queries and emits OpenLineage RunEvents to a console or HTTP endpoint.
 
     Configure via druid.request.logging.type=openlineage.
-    SQL table extraction uses the Calcite SQL parser; only available on Broker nodes.
+    Input datasources are resolved from the native query plan; the SQL parser (calcite-core,
+    present on Broker nodes) is used only to extract the output datasource of MSQ INSERT/REPLACE.
   </description>
 
   <dependencies>

--- a/extensions-contrib/openlineage-emitter/pom.xml
+++ b/extensions-contrib/openlineage-emitter/pom.xml
@@ -55,6 +55,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-sql</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.calcite</groupId>
       <artifactId>calcite-core</artifactId>
       <scope>provided</scope>

--- a/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
+++ b/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
@@ -64,8 +64,10 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * OpenLineage RunEvents for completed Druid queries.
@@ -96,8 +98,11 @@ public class OpenLineageRequestLogger implements RequestLogger
       .withQuotedCasing(Casing.UNCHANGED)
       .withQuoting(Quoting.DOUBLE_QUOTE);
 
-  private static final int EMIT_QUEUE_CAPACITY = 1000;
-  private static final int EMIT_THREAD_COUNT = 1;
+  static final int DEFAULT_EMIT_QUEUE_CAPACITY = 1000;
+  static final int DEFAULT_EMIT_THREAD_COUNT = 1;
+  private static final int DISCARD_WARNING_INTERVAL = 1000;
+
+  static final String UNKNOWN_QUERY_ID = "unknown-query-id";
 
   private final ObjectMapper jsonMapper;
   private final String namespace;
@@ -109,6 +114,7 @@ public class OpenLineageRequestLogger implements RequestLogger
   private final HttpClient httpClient;
   @Nullable
   private final ExecutorService emitExecutor;
+  private final AtomicLong discardedEventCount = new AtomicLong(0);
 
   public OpenLineageRequestLogger(
       ObjectMapper jsonMapper,
@@ -118,7 +124,8 @@ public class OpenLineageRequestLogger implements RequestLogger
       Set<String> excludedNativeQueryTypes
   )
   {
-    this(jsonMapper, namespace, transportType, transportUrl, excludedNativeQueryTypes, null);
+    this(jsonMapper, namespace, transportType, transportUrl, excludedNativeQueryTypes,
+         DEFAULT_EMIT_QUEUE_CAPACITY, DEFAULT_EMIT_THREAD_COUNT);
   }
 
   public OpenLineageRequestLogger(
@@ -127,6 +134,22 @@ public class OpenLineageRequestLogger implements RequestLogger
       OpenLineageRequestLoggerProvider.TransportType transportType,
       @Nullable String transportUrl,
       Set<String> excludedNativeQueryTypes,
+      int emitQueueCapacity,
+      int emitThreadCount
+  )
+  {
+    this(jsonMapper, namespace, transportType, transportUrl, excludedNativeQueryTypes,
+         emitQueueCapacity, emitThreadCount, null);
+  }
+
+  public OpenLineageRequestLogger(
+      ObjectMapper jsonMapper,
+      String namespace,
+      OpenLineageRequestLoggerProvider.TransportType transportType,
+      @Nullable String transportUrl,
+      Set<String> excludedNativeQueryTypes,
+      int emitQueueCapacity,
+      int emitThreadCount,
       @Nullable HttpClient httpClient
   )
   {
@@ -137,16 +160,16 @@ public class OpenLineageRequestLogger implements RequestLogger
     this.excludedNativeQueryTypes = excludedNativeQueryTypes;
     if (transportType == OpenLineageRequestLoggerProvider.TransportType.HTTP) {
       this.httpClient = httpClient != null ? httpClient : HttpClientBuilder.create().build();
-      // Bounded queue: if the queue is full, silently drop the event rather than blocking
-      // the query thread. Uses Druid's Execs for daemon thread naming conventions.
+      // Bounded queue: if the queue is full, drop the event rather than blocking the query thread.
+      // A warning is logged on the first drop and every DISCARD_WARNING_INTERVAL drops thereafter.
       this.emitExecutor = new ThreadPoolExecutor(
-          EMIT_THREAD_COUNT,
-          EMIT_THREAD_COUNT,
+          emitThreadCount,
+          emitThreadCount,
           60L,
           TimeUnit.SECONDS,
-          new ArrayBlockingQueue<>(EMIT_QUEUE_CAPACITY),
+          new ArrayBlockingQueue<>(emitQueueCapacity),
           Execs.makeThreadFactory("OpenLineageEmitter-%d"),
-          new ThreadPoolExecutor.DiscardPolicy()
+          new DiscardWithWarningPolicy(discardedEventCount)
       );
     } else {
       this.httpClient = null;
@@ -216,7 +239,8 @@ public class OpenLineageRequestLogger implements RequestLogger
     List<String> inputs = new ArrayList<>(new LinkedHashSet<>(requestLogLine.getQuery().getDataSource().getTableNames()));
     String queryId = requestLogLine.getQuery().getId();
     if (queryId == null) {
-      queryId = UUID.randomUUID().toString();
+      log.debug("Native query reached OpenLineage logger without a query ID");
+      queryId = UNKNOWN_QUERY_ID;
     }
 
     emit(buildRunEvent(queryId, null, queryType, requestLogLine, inputs, null));
@@ -450,7 +474,7 @@ public class OpenLineageRequestLogger implements RequestLogger
       if (transportType == OpenLineageRequestLoggerProvider.TransportType.HTTP) {
         emitExecutor.submit(() -> emitHttp(json));
       } else {
-        log.info("OpenLineage event: %s", json);
+        log.debug("OpenLineage event: %s", json);
       }
     }
     catch (IOException e) {
@@ -480,7 +504,8 @@ public class OpenLineageRequestLogger implements RequestLogger
     if (id != null) {
       return id.toString();
     }
-    return UUID.randomUUID().toString();
+    log.debug("SQL query reached OpenLineage logger without a query ID");
+    return UNKNOWN_QUERY_ID;
   }
 
   private void putLongStat(ObjectNode node, String targetKey, Map<String, Object> stats, String... sourceKeys)
@@ -498,6 +523,29 @@ public class OpenLineageRequestLogger implements RequestLogger
   {
     String v = OpenLineageRequestLogger.class.getPackage().getImplementationVersion();
     return v != null ? v : "unknown";
+  }
+
+  /**
+   * Rejection handler that discards events when the emit queue is full, but logs a warning
+   * on the first drop and every {@link #DISCARD_WARNING_INTERVAL} drops thereafter.
+   */
+  private static class DiscardWithWarningPolicy implements RejectedExecutionHandler
+  {
+    private final AtomicLong discardedCount;
+
+    DiscardWithWarningPolicy(AtomicLong discardedCount)
+    {
+      this.discardedCount = discardedCount;
+    }
+
+    @Override
+    public void rejectedExecution(Runnable r, ThreadPoolExecutor executor)
+    {
+      long count = discardedCount.incrementAndGet();
+      if (count == 1 || count % DISCARD_WARNING_INTERVAL == 0) {
+        log.warn("OpenLineage emit queue full, discarded [%,d] events total", count);
+      }
+    }
   }
 
 }

--- a/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
+++ b/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
@@ -99,21 +99,12 @@ public class OpenLineageRequestLogger implements RequestLogger
   private static final int EMIT_QUEUE_CAPACITY = 1000;
   private static final int EMIT_THREAD_COUNT = 1;
 
-  /**
-   * Internal broker query types that are automatically issued for schema discovery and metadata
-   * caching. These are not user-initiated and produce noisy, low-value lineage events.
-   */
-  private static final Set<String> INTERNAL_QUERY_TYPES = Set.of(
-      "segmentMetadata",
-      "dataSourceMetadata",
-      "timeBoundary"
-  );
-
   private final ObjectMapper jsonMapper;
   private final String namespace;
   private final OpenLineageRequestLoggerProvider.TransportType transportType;
   @Nullable
   private final String transportUrl;
+  private final Set<String> excludedNativeQueryTypes;
   @Nullable
   private final HttpClient httpClient;
   @Nullable
@@ -123,15 +114,29 @@ public class OpenLineageRequestLogger implements RequestLogger
       ObjectMapper jsonMapper,
       String namespace,
       OpenLineageRequestLoggerProvider.TransportType transportType,
-      @Nullable String transportUrl
+      @Nullable String transportUrl,
+      Set<String> excludedNativeQueryTypes
+  )
+  {
+    this(jsonMapper, namespace, transportType, transportUrl, excludedNativeQueryTypes, null);
+  }
+
+  public OpenLineageRequestLogger(
+      ObjectMapper jsonMapper,
+      String namespace,
+      OpenLineageRequestLoggerProvider.TransportType transportType,
+      @Nullable String transportUrl,
+      Set<String> excludedNativeQueryTypes,
+      @Nullable HttpClient httpClient
   )
   {
     this.jsonMapper = jsonMapper;
     this.namespace = namespace;
     this.transportType = transportType;
     this.transportUrl = transportUrl;
+    this.excludedNativeQueryTypes = excludedNativeQueryTypes;
     if (transportType == OpenLineageRequestLoggerProvider.TransportType.HTTP) {
-      this.httpClient = HttpClientBuilder.create().build();
+      this.httpClient = httpClient != null ? httpClient : HttpClientBuilder.create().build();
       // Bounded queue: if the queue is full, silently drop the event rather than blocking
       // the query thread. Uses Druid's Execs for daemon thread naming conventions.
       this.emitExecutor = new ThreadPoolExecutor(
@@ -204,7 +209,7 @@ public class OpenLineageRequestLogger implements RequestLogger
 
     String queryType = requestLogLine.getQuery().getType();
 
-    if (INTERNAL_QUERY_TYPES.contains(queryType)) {
+    if (excludedNativeQueryTypes.contains(queryType)) {
       return;
     }
 

--- a/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
+++ b/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
@@ -1,0 +1,414 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.extensions.openlineage;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.calcite.sql.SqlBasicCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlInsert;
+import org.apache.calcite.sql.SqlJoin;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOrderBy;
+import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.SqlWith;
+import org.apache.calcite.sql.SqlWithItem;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.query.BaseQuery;
+import org.apache.druid.server.RequestLogLine;
+import org.apache.druid.server.log.RequestLogger;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * OpenLineage RunEvents for completed Druid queries.
+ */
+public class OpenLineageRequestLogger implements RequestLogger
+{
+  private static final Logger log = new Logger(OpenLineageRequestLogger.class);
+
+  private static final String PRODUCER =
+      "https://github.com/apache/druid/extensions-contrib/openlineage-emitter";
+  private static final String SCHEMA_URL =
+      "https://openlineage.io/spec/2-0-2/OpenLineage.json";
+  private static final String ENGINE_FACET_SCHEMA_URL =
+      "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json";
+  private static final String ERROR_FACET_SCHEMA_URL =
+      "https://openlineage.io/spec/facets/1-0-0/ErrorMessageRunFacet.json";
+  private static final String JOB_TYPE_FACET_SCHEMA_URL =
+      "https://openlineage.io/spec/facets/2-0-2/JobTypeJobFacet.json";
+  private static final String SQL_FACET_SCHEMA_URL =
+      "https://openlineage.io/spec/facets/1-0-1/SQLJobFacet.json";
+
+  private final ObjectMapper jsonMapper;
+  private final String namespace;
+  private final OpenLineageRequestLoggerProvider.TransportType transportType;
+  @Nullable
+  private final String transportUrl;
+
+  public OpenLineageRequestLogger(
+      ObjectMapper jsonMapper,
+      String namespace,
+      OpenLineageRequestLoggerProvider.TransportType transportType,
+      @Nullable String transportUrl
+  )
+  {
+    this.jsonMapper = jsonMapper;
+    this.namespace = namespace;
+    this.transportType = transportType;
+    this.transportUrl = transportUrl;
+  }
+
+  @Override
+  public void logNativeQuery(RequestLogLine requestLogLine) throws IOException
+  {
+    // Skip native sub-queries of a SQL execution to avoid duplicating the SQL-level event.
+    if (requestLogLine.getQuery().getContextValue(BaseQuery.SQL_QUERY_ID) != null) {
+      return;
+    }
+
+    List<String> inputs = new ArrayList<>(requestLogLine.getQuery().getDataSource().getTableNames());
+    String queryId = requestLogLine.getQuery().getId();
+    if (queryId == null) {
+      queryId = UUID.randomUUID().toString();
+    }
+    String queryType = requestLogLine.getQuery().getType();
+
+    emit(buildRunEvent(queryId, null, queryType, requestLogLine, inputs, Optional.empty()));
+  }
+
+  @Override
+  public void logSqlQuery(RequestLogLine requestLogLine) throws IOException
+  {
+    String sql = requestLogLine.getSql();
+    List<String> inputs = new ArrayList<>();
+    Optional<String> output = Optional.empty();
+
+    if (sql != null) {
+      try {
+        SqlNode parsed = SqlParser.create(sql, SqlParser.config()).parseQuery();
+        inputs = extractInputs(parsed);
+        output = extractOutput(parsed);
+      }
+      catch (SqlParseException e) {
+        // Druid-specific SQL extensions (REPLACE, EXTERN, etc.) may not parse with the standard
+        // Calcite parser. Emit the event without table-level lineage rather than failing.
+        log.debug(
+            "OpenLineage: could not parse SQL for lineage extraction (query will still be emitted): %s",
+            e.getMessage()
+        );
+      }
+    }
+
+    String queryId = extractSqlQueryId(requestLogLine);
+    emit(buildRunEvent(queryId, sql, "sql", requestLogLine, inputs, output));
+  }
+
+  private ObjectNode buildRunEvent(
+      String queryId,
+      @Nullable String sql,
+      String queryType,
+      RequestLogLine requestLogLine,
+      List<String> inputs,
+      Optional<String> output
+  )
+  {
+    Map<String, Object> stats = requestLogLine.getQueryStats().getStats();
+    boolean success = Boolean.TRUE.equals(stats.get("success"));
+
+    ObjectNode event = jsonMapper.createObjectNode();
+    event.put("eventType", success ? "COMPLETE" : "FAIL");
+    event.put("eventTime", requestLogLine.getTimestamp().toInstant().toString());
+    event.put("producer", PRODUCER);
+    event.put("schemaURL", SCHEMA_URL);
+    event.set("run", buildRun(queryId, queryType, requestLogLine, stats, success));
+    event.set("job", buildJob(queryId, sql));
+    event.set("inputs", buildDatasets(inputs));
+    event.set("outputs", buildDatasets(output.map(List::of).orElse(List.of())));
+    return event;
+  }
+
+  private ObjectNode buildRun(
+      String queryId,
+      String queryType,
+      RequestLogLine requestLogLine,
+      Map<String, Object> stats,
+      boolean success
+  )
+  {
+    ObjectNode run = jsonMapper.createObjectNode();
+    run.put("runId", UUID.nameUUIDFromBytes(queryId.getBytes(StandardCharsets.UTF_8)).toString());
+
+    ObjectNode facets = jsonMapper.createObjectNode();
+
+    ObjectNode engineFacet = jsonMapper.createObjectNode();
+    engineFacet.put("_producer", PRODUCER);
+    engineFacet.put("_schemaURL", ENGINE_FACET_SCHEMA_URL);
+    engineFacet.put("name", "druid");
+    facets.set("processing_engine", engineFacet);
+
+    ObjectNode contextFacet = jsonMapper.createObjectNode();
+    contextFacet.put("_producer", PRODUCER);
+    contextFacet.put("queryType", queryType);
+    contextFacet.put("remoteAddress", requestLogLine.getRemoteAddr());
+    Object identity = stats.get("identity");
+    if (identity != null) {
+      contextFacet.put("identity", identity.toString());
+    }
+    Object nativeQueryIds = requestLogLine.getSqlQueryContext().get("nativeQueryIds");
+    if (nativeQueryIds != null) {
+      contextFacet.put("nativeQueryIds", nativeQueryIds.toString());
+    }
+    facets.set("druid_query_context", contextFacet);
+
+    ObjectNode statsFacet = jsonMapper.createObjectNode();
+    statsFacet.put("_producer", PRODUCER);
+    putLongStat(statsFacet, "durationMs", stats, "sqlQuery/time", "query/time");
+    putLongStat(statsFacet, "bytes", stats, "sqlQuery/bytes", "query/bytes");
+    putLongStat(statsFacet, "planningTimeMs", stats, "sqlQuery/planningTimeMs");
+    Object statusCode = stats.get("statusCode");
+    if (statusCode != null) {
+      statsFacet.put("statusCode", statusCode.toString());
+    }
+    facets.set("druid_query_statistics", statsFacet);
+
+    if (!success) {
+      Object exception = stats.get("exception");
+      if (exception != null) {
+        ObjectNode errorFacet = jsonMapper.createObjectNode();
+        errorFacet.put("_producer", PRODUCER);
+        errorFacet.put("_schemaURL", ERROR_FACET_SCHEMA_URL);
+        errorFacet.put("message", exception.toString());
+        errorFacet.put("programmingLanguage", "SQL");
+        facets.set("errorMessage", errorFacet);
+      }
+    }
+
+    run.set("facets", facets);
+    return run;
+  }
+
+  private ObjectNode buildJob(String queryId, @Nullable String sql)
+  {
+    ObjectNode job = jsonMapper.createObjectNode();
+    job.put("namespace", namespace);
+    job.put("name", queryId);
+
+    ObjectNode facets = jsonMapper.createObjectNode();
+
+    ObjectNode jobTypeFacet = jsonMapper.createObjectNode();
+    jobTypeFacet.put("_producer", PRODUCER);
+    jobTypeFacet.put("_schemaURL", JOB_TYPE_FACET_SCHEMA_URL);
+    jobTypeFacet.put("processingType", "BATCH");
+    jobTypeFacet.put("integration", "DRUID");
+    jobTypeFacet.put("jobType", "QUERY");
+    facets.set("jobType", jobTypeFacet);
+
+    if (sql != null) {
+      ObjectNode sqlFacet = jsonMapper.createObjectNode();
+      sqlFacet.put("_producer", PRODUCER);
+      sqlFacet.put("_schemaURL", SQL_FACET_SCHEMA_URL);
+      sqlFacet.put("query", sql);
+      facets.set("sql", sqlFacet);
+    }
+
+    job.set("facets", facets);
+    return job;
+  }
+
+  private ArrayNode buildDatasets(List<String> tableNames)
+  {
+    ArrayNode array = jsonMapper.createArrayNode();
+    for (String name : tableNames) {
+      ObjectNode node = jsonMapper.createObjectNode();
+      node.put("namespace", namespace);
+      node.put("name", name);
+      // Schema and columnLineage facets require Druid coordinator metadata lookups and are not
+      // populated here. Column-level lineage is a future enhancement.
+      node.set("facets", jsonMapper.createObjectNode());
+      array.add(node);
+    }
+    return array;
+  }
+
+  /**
+   * Extracts the names of input datasources referenced in FROM clauses.
+   * CTEs (WITH clause names) are excluded since they are not physical datasources.
+   */
+  private List<String> extractInputs(SqlNode root)
+  {
+    List<String> tables = new ArrayList<>();
+    if (root instanceof SqlWith) {
+      SqlWith with = (SqlWith) root;
+      Set<String> cteNames = new HashSet<>();
+      for (SqlNode item : with.withList) {
+        if (item instanceof SqlWithItem) {
+          cteNames.add(((SqlWithItem) item).name.getSimple());
+          collectFromClause(((SqlWithItem) item).query, tables, cteNames);
+        }
+      }
+      collectFromClause(with.body, tables, cteNames);
+    } else if (root instanceof SqlInsert) {
+      collectFromClause(((SqlInsert) root).getSource(), tables, Set.of());
+    } else {
+      collectFromClause(root, tables, Set.of());
+    }
+    return tables;
+  }
+
+  /**
+   * Extracts the output datasource name for INSERT statements. Returns empty for SELECT queries.
+   */
+  private Optional<String> extractOutput(SqlNode root)
+  {
+    if (root instanceof SqlInsert) {
+      SqlNode target = ((SqlInsert) root).getTargetTable();
+      if (target instanceof SqlIdentifier) {
+        return Optional.of(String.join(".", ((SqlIdentifier) target).names));
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Recursively walks a FROM clause node and appends physical table names to {@code tables}.
+   * CTE names in {@code excludeNames} are skipped.
+   */
+  private void collectFromClause(SqlNode from, List<String> tables, Set<String> excludeNames)
+  {
+    if (from == null) {
+      return;
+    }
+    if (from instanceof SqlIdentifier) {
+      String name = String.join(".", ((SqlIdentifier) from).names);
+      if (!excludeNames.contains(name)) {
+        tables.add(name);
+      }
+    } else if (from instanceof SqlJoin) {
+      SqlJoin join = (SqlJoin) from;
+      collectFromClause(join.getLeft(), tables, excludeNames);
+      collectFromClause(join.getRight(), tables, excludeNames);
+    } else if (from instanceof SqlSelect) {
+      collectFromClause(((SqlSelect) from).getFrom(), tables, excludeNames);
+    } else if (from instanceof SqlWith) {
+      SqlWith with = (SqlWith) from;
+      Set<String> innerExcludes = new HashSet<>(excludeNames);
+      for (SqlNode item : with.withList) {
+        if (item instanceof SqlWithItem) {
+          innerExcludes.add(((SqlWithItem) item).name.getSimple());
+          collectFromClause(((SqlWithItem) item).query, tables, innerExcludes);
+        }
+      }
+      collectFromClause(with.body, tables, innerExcludes);
+    } else if (from instanceof SqlOrderBy) {
+      collectFromClause(((SqlOrderBy) from).query, tables, excludeNames);
+    } else if (from instanceof SqlBasicCall) {
+      SqlBasicCall call = (SqlBasicCall) from;
+      if (call.getKind() == SqlKind.AS) {
+        collectFromClause(call.operand(0), tables, excludeNames);
+      } else {
+        for (SqlNode operand : call.getOperandList()) {
+          collectFromClause(operand, tables, excludeNames);
+        }
+      }
+    }
+  }
+
+  protected void emit(ObjectNode event)
+  {
+    try {
+      String json = jsonMapper.writeValueAsString(event);
+      if (transportType == OpenLineageRequestLoggerProvider.TransportType.HTTP) {
+        emitHttp(json);
+      } else {
+        log.info("OpenLineage event: %s", json);
+      }
+    }
+    catch (Exception e) {
+      log.error(e, "Failed to emit OpenLineage event");
+    }
+  }
+
+  private void emitHttp(String json)
+  {
+    try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+      HttpPost post = new HttpPost(transportUrl);
+      post.setEntity(new StringEntity(json, ContentType.APPLICATION_JSON));
+      try (CloseableHttpResponse response = httpClient.execute(post)) {
+        int statusCode = response.getStatusLine().getStatusCode();
+        if (statusCode >= 400) {
+          log.warn("OpenLineage endpoint [%s] returned HTTP %d", transportUrl, statusCode);
+        }
+      }
+    }
+    catch (Exception e) {
+      log.error(e, "Failed to POST OpenLineage event to [%s]", transportUrl);
+    }
+  }
+
+  private String extractSqlQueryId(RequestLogLine requestLogLine)
+  {
+    Object id = requestLogLine.getSqlQueryContext().get(BaseQuery.SQL_QUERY_ID);
+    if (id != null) {
+      return id.toString();
+    }
+    return UUID.randomUUID().toString();
+  }
+
+  private void putLongStat(ObjectNode node, String targetKey, Map<String, Object> stats, String... sourceKeys)
+  {
+    for (String key : sourceKeys) {
+      Object val = stats.get(key);
+      if (val instanceof Number) {
+        node.put(targetKey, ((Number) val).longValue());
+        return;
+      }
+    }
+  }
+
+  @Override
+  public String toString()
+  {
+    return "OpenLineageRequestLogger{" +
+           "namespace='" + namespace + '\'' +
+           ", transportType=" + transportType +
+           ", transportUrl='" + transportUrl + '\'' +
+           '}';
+  }
+}

--- a/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
+++ b/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
@@ -34,16 +34,17 @@ import org.apache.calcite.sql.SqlWith;
 import org.apache.calcite.sql.SqlWithItem;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
+import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.BaseQuery;
 import org.apache.druid.server.RequestLogLine;
 import org.apache.druid.server.log.RequestLogger;
-import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.HttpClientBuilder;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -81,6 +82,8 @@ public class OpenLineageRequestLogger implements RequestLogger
   private final OpenLineageRequestLoggerProvider.TransportType transportType;
   @Nullable
   private final String transportUrl;
+  @Nullable
+  private final HttpClient httpClient;
 
   public OpenLineageRequestLogger(
       ObjectMapper jsonMapper,
@@ -93,13 +96,45 @@ public class OpenLineageRequestLogger implements RequestLogger
     this.namespace = namespace;
     this.transportType = transportType;
     this.transportUrl = transportUrl;
+    this.httpClient = transportType == OpenLineageRequestLoggerProvider.TransportType.HTTP
+                      ? HttpClientBuilder.create().build()
+                      : null;
+  }
+
+  @LifecycleStart
+  @Override
+  public void start() throws Exception
+  {
+    if (transportType == OpenLineageRequestLoggerProvider.TransportType.HTTP && transportUrl == null) {
+      throw new IllegalStateException(
+          "druid.request.logging.transportUrl must be set when transportType=HTTP"
+      );
+    }
+    log.info(
+        "Started OpenLineage %s transport%s",
+        transportType == OpenLineageRequestLoggerProvider.TransportType.HTTP ? "HTTP" : "console",
+        transportType == OpenLineageRequestLoggerProvider.TransportType.HTTP ? " to [" + transportUrl + "]" : ""
+    );
+  }
+
+  @LifecycleStop
+  @Override
+  public void stop()
+  {
+    // HTTP client cleanup is handled by Druid lifecycle management
+    log.info("Stopped OpenLineage request logger");
   }
 
   @Override
   public void logNativeQuery(RequestLogLine requestLogLine) throws IOException
   {
+    // Skip if query failed to parse (query is null)
+    if (requestLogLine.getQuery() == null) {
+      return;
+    }
+
     // Skip native sub-queries of a SQL execution to avoid duplicating the SQL-level event.
-    if (requestLogLine.getQuery().getContextValue(BaseQuery.SQL_QUERY_ID) != null) {
+    if (requestLogLine.getQuery().getContext().get(BaseQuery.SQL_QUERY_ID) != null) {
       return;
     }
 
@@ -215,7 +250,9 @@ public class OpenLineageRequestLogger implements RequestLogger
         errorFacet.put("_producer", PRODUCER);
         errorFacet.put("_schemaURL", ERROR_FACET_SCHEMA_URL);
         errorFacet.put("message", exception.toString());
-        errorFacet.put("programmingLanguage", "SQL");
+        if ("sql".equals(queryType)) {
+          errorFacet.put("programmingLanguage", "SQL");
+        }
         facets.set("errorMessage", errorFacet);
       }
     }
@@ -367,18 +404,16 @@ public class OpenLineageRequestLogger implements RequestLogger
 
   private void emitHttp(String json)
   {
-    try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
-      HttpPost post = new HttpPost(transportUrl);
-      post.setEntity(new StringEntity(json, ContentType.APPLICATION_JSON));
-      try (CloseableHttpResponse response = httpClient.execute(post)) {
-        int statusCode = response.getStatusLine().getStatusCode();
-        if (statusCode >= 400) {
-          log.warn("OpenLineage endpoint [%s] returned HTTP %d", transportUrl, statusCode);
-        }
-      }
+    HttpPost post = new HttpPost(transportUrl);
+    post.setEntity(new StringEntity(json, ContentType.APPLICATION_JSON));
+    try {
+      httpClient.execute(post);
     }
     catch (Exception e) {
       log.error(e, "Failed to POST OpenLineage event to [%s]", transportUrl);
+    }
+    finally {
+      post.releaseConnection();
     }
   }
 

--- a/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
+++ b/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
@@ -22,6 +22,8 @@ package org.apache.druid.extensions.openlineage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.calcite.avatica.util.Casing;
+import org.apache.calcite.avatica.util.Quoting;
 import org.apache.calcite.sql.SqlBasicCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlInsert;
@@ -34,28 +36,36 @@ import org.apache.calcite.sql.SqlWith;
 import org.apache.calcite.sql.SqlWithItem;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.BaseQuery;
 import org.apache.druid.server.RequestLogLine;
 import org.apache.druid.server.log.RequestLogger;
+import org.apache.druid.utils.CloseableUtils;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
 
 import javax.annotation.Nullable;
+import java.io.Closeable;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * OpenLineage RunEvents for completed Druid queries.
@@ -77,6 +87,28 @@ public class OpenLineageRequestLogger implements RequestLogger
   private static final String SQL_FACET_SCHEMA_URL =
       "https://openlineage.io/spec/facets/1-0-1/SQLJobFacet.json";
 
+  // Standard Calcite parser (not Druid's custom parser): sufficient for table name extraction.
+  // Druid-specific syntax (REPLACE, EXTERN, etc.) falls through to the SqlParseException handler.
+  private static final SqlParser.Config SQL_PARSER_CONFIG = SqlParser
+      .config()
+      .withCaseSensitive(true)
+      .withUnquotedCasing(Casing.UNCHANGED)
+      .withQuotedCasing(Casing.UNCHANGED)
+      .withQuoting(Quoting.DOUBLE_QUOTE);
+
+  private static final int EMIT_QUEUE_CAPACITY = 1000;
+  private static final int EMIT_THREAD_COUNT = 1;
+
+  /**
+   * Internal broker query types that are automatically issued for schema discovery and metadata
+   * caching. These are not user-initiated and produce noisy, low-value lineage events.
+   */
+  private static final Set<String> INTERNAL_QUERY_TYPES = Set.of(
+      "segmentMetadata",
+      "dataSourceMetadata",
+      "timeBoundary"
+  );
+
   private final ObjectMapper jsonMapper;
   private final String namespace;
   private final OpenLineageRequestLoggerProvider.TransportType transportType;
@@ -84,6 +116,8 @@ public class OpenLineageRequestLogger implements RequestLogger
   private final String transportUrl;
   @Nullable
   private final HttpClient httpClient;
+  @Nullable
+  private final ExecutorService emitExecutor;
 
   public OpenLineageRequestLogger(
       ObjectMapper jsonMapper,
@@ -96,9 +130,23 @@ public class OpenLineageRequestLogger implements RequestLogger
     this.namespace = namespace;
     this.transportType = transportType;
     this.transportUrl = transportUrl;
-    this.httpClient = transportType == OpenLineageRequestLoggerProvider.TransportType.HTTP
-                      ? HttpClientBuilder.create().build()
-                      : null;
+    if (transportType == OpenLineageRequestLoggerProvider.TransportType.HTTP) {
+      this.httpClient = HttpClientBuilder.create().build();
+      // Bounded queue: if the queue is full, silently drop the event rather than blocking
+      // the query thread. Uses Druid's Execs for daemon thread naming conventions.
+      this.emitExecutor = new ThreadPoolExecutor(
+          EMIT_THREAD_COUNT,
+          EMIT_THREAD_COUNT,
+          60L,
+          TimeUnit.SECONDS,
+          new ArrayBlockingQueue<>(EMIT_QUEUE_CAPACITY),
+          Execs.makeThreadFactory("OpenLineageEmitter-%d"),
+          new ThreadPoolExecutor.DiscardPolicy()
+      );
+    } else {
+      this.httpClient = null;
+      this.emitExecutor = null;
+    }
   }
 
   @LifecycleStart
@@ -110,25 +158,41 @@ public class OpenLineageRequestLogger implements RequestLogger
           "druid.request.logging.transportUrl must be set when transportType=HTTP"
       );
     }
-    log.info(
-        "Started OpenLineage %s transport%s",
-        transportType == OpenLineageRequestLoggerProvider.TransportType.HTTP ? "HTTP" : "console",
-        transportType == OpenLineageRequestLoggerProvider.TransportType.HTTP ? " to [" + transportUrl + "]" : ""
-    );
+    if (transportType == OpenLineageRequestLoggerProvider.TransportType.HTTP) {
+      log.info("Started OpenLineage HTTP transport to [%s]", transportUrl);
+    } else {
+      log.info("Started OpenLineage console transport");
+    }
   }
 
   @LifecycleStop
   @Override
   public void stop()
   {
-    // HTTP client cleanup is handled by Druid lifecycle management
+    if (emitExecutor != null) {
+      emitExecutor.shutdown();
+      try {
+        if (!emitExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+          emitExecutor.shutdownNow();
+        }
+      }
+      catch (InterruptedException e) {
+        emitExecutor.shutdownNow();
+        Thread.currentThread().interrupt();
+      }
+    }
+    if (httpClient instanceof Closeable) {
+      CloseableUtils.closeAndSuppressExceptions(
+          (Closeable) httpClient,
+          e -> log.warn(e, "Failed to close OpenLineage HTTP client")
+      );
+    }
     log.info("Stopped OpenLineage request logger");
   }
 
   @Override
   public void logNativeQuery(RequestLogLine requestLogLine) throws IOException
   {
-    // Skip if query failed to parse (query is null)
     if (requestLogLine.getQuery() == null) {
       return;
     }
@@ -138,14 +202,19 @@ public class OpenLineageRequestLogger implements RequestLogger
       return;
     }
 
-    List<String> inputs = new ArrayList<>(requestLogLine.getQuery().getDataSource().getTableNames());
+    String queryType = requestLogLine.getQuery().getType();
+
+    if (INTERNAL_QUERY_TYPES.contains(queryType)) {
+      return;
+    }
+
+    List<String> inputs = new ArrayList<>(new LinkedHashSet<>(requestLogLine.getQuery().getDataSource().getTableNames()));
     String queryId = requestLogLine.getQuery().getId();
     if (queryId == null) {
       queryId = UUID.randomUUID().toString();
     }
-    String queryType = requestLogLine.getQuery().getType();
 
-    emit(buildRunEvent(queryId, null, queryType, requestLogLine, inputs, Optional.empty()));
+    emit(buildRunEvent(queryId, null, queryType, requestLogLine, inputs, null));
   }
 
   @Override
@@ -153,11 +222,11 @@ public class OpenLineageRequestLogger implements RequestLogger
   {
     String sql = requestLogLine.getSql();
     List<String> inputs = new ArrayList<>();
-    Optional<String> output = Optional.empty();
+    String output = null;
 
     if (sql != null) {
       try {
-        SqlNode parsed = SqlParser.create(sql, SqlParser.config()).parseQuery();
+        SqlNode parsed = SqlParser.create(sql, SQL_PARSER_CONFIG).parseQuery();
         inputs = extractInputs(parsed);
         output = extractOutput(parsed);
       }
@@ -172,7 +241,7 @@ public class OpenLineageRequestLogger implements RequestLogger
     }
 
     String queryId = extractSqlQueryId(requestLogLine);
-    emit(buildRunEvent(queryId, sql, "sql", requestLogLine, inputs, output));
+    emit(buildRunEvent(queryId, sql, "sql", requestLogLine, new ArrayList<>(new LinkedHashSet<>(inputs)), output));
   }
 
   private ObjectNode buildRunEvent(
@@ -181,7 +250,7 @@ public class OpenLineageRequestLogger implements RequestLogger
       String queryType,
       RequestLogLine requestLogLine,
       List<String> inputs,
-      Optional<String> output
+      @Nullable String output
   )
   {
     Map<String, Object> stats = requestLogLine.getQueryStats().getStats();
@@ -195,7 +264,7 @@ public class OpenLineageRequestLogger implements RequestLogger
     event.set("run", buildRun(queryId, queryType, requestLogLine, stats, success));
     event.set("job", buildJob(queryId, sql));
     event.set("inputs", buildDatasets(inputs));
-    event.set("outputs", buildDatasets(output.map(List::of).orElse(List.of())));
+    event.set("outputs", buildDatasets(output != null ? List.of(output) : List.of()));
     return event;
   }
 
@@ -212,14 +281,12 @@ public class OpenLineageRequestLogger implements RequestLogger
 
     ObjectNode facets = jsonMapper.createObjectNode();
 
-    ObjectNode engineFacet = jsonMapper.createObjectNode();
-    engineFacet.put("_producer", PRODUCER);
-    engineFacet.put("_schemaURL", ENGINE_FACET_SCHEMA_URL);
+    ObjectNode engineFacet = createFacet(ENGINE_FACET_SCHEMA_URL);
     engineFacet.put("name", "druid");
+    engineFacet.put("version", getDruidVersion());
     facets.set("processing_engine", engineFacet);
 
-    ObjectNode contextFacet = jsonMapper.createObjectNode();
-    contextFacet.put("_producer", PRODUCER);
+    ObjectNode contextFacet = createFacet(null);
     contextFacet.put("queryType", queryType);
     contextFacet.put("remoteAddress", requestLogLine.getRemoteAddr());
     Object identity = stats.get("identity");
@@ -232,8 +299,7 @@ public class OpenLineageRequestLogger implements RequestLogger
     }
     facets.set("druid_query_context", contextFacet);
 
-    ObjectNode statsFacet = jsonMapper.createObjectNode();
-    statsFacet.put("_producer", PRODUCER);
+    ObjectNode statsFacet = createFacet(null);
     putLongStat(statsFacet, "durationMs", stats, "sqlQuery/time", "query/time");
     putLongStat(statsFacet, "bytes", stats, "sqlQuery/bytes", "query/bytes");
     putLongStat(statsFacet, "planningTimeMs", stats, "sqlQuery/planningTimeMs");
@@ -246,9 +312,7 @@ public class OpenLineageRequestLogger implements RequestLogger
     if (!success) {
       Object exception = stats.get("exception");
       if (exception != null) {
-        ObjectNode errorFacet = jsonMapper.createObjectNode();
-        errorFacet.put("_producer", PRODUCER);
-        errorFacet.put("_schemaURL", ERROR_FACET_SCHEMA_URL);
+        ObjectNode errorFacet = createFacet(ERROR_FACET_SCHEMA_URL);
         errorFacet.put("message", exception.toString());
         if ("sql".equals(queryType)) {
           errorFacet.put("programmingLanguage", "SQL");
@@ -269,24 +333,30 @@ public class OpenLineageRequestLogger implements RequestLogger
 
     ObjectNode facets = jsonMapper.createObjectNode();
 
-    ObjectNode jobTypeFacet = jsonMapper.createObjectNode();
-    jobTypeFacet.put("_producer", PRODUCER);
-    jobTypeFacet.put("_schemaURL", JOB_TYPE_FACET_SCHEMA_URL);
+    ObjectNode jobTypeFacet = createFacet(JOB_TYPE_FACET_SCHEMA_URL);
     jobTypeFacet.put("processingType", "BATCH");
     jobTypeFacet.put("integration", "DRUID");
     jobTypeFacet.put("jobType", "QUERY");
     facets.set("jobType", jobTypeFacet);
 
     if (sql != null) {
-      ObjectNode sqlFacet = jsonMapper.createObjectNode();
-      sqlFacet.put("_producer", PRODUCER);
-      sqlFacet.put("_schemaURL", SQL_FACET_SCHEMA_URL);
+      ObjectNode sqlFacet = createFacet(SQL_FACET_SCHEMA_URL);
       sqlFacet.put("query", sql);
       facets.set("sql", sqlFacet);
     }
 
     job.set("facets", facets);
     return job;
+  }
+
+  private ObjectNode createFacet(@Nullable String schemaUrl)
+  {
+    ObjectNode facet = jsonMapper.createObjectNode();
+    facet.put("_producer", PRODUCER);
+    if (schemaUrl != null) {
+      facet.put("_schemaURL", schemaUrl);
+    }
+    return facet;
   }
 
   private ArrayNode buildDatasets(List<String> tableNames)
@@ -296,18 +366,12 @@ public class OpenLineageRequestLogger implements RequestLogger
       ObjectNode node = jsonMapper.createObjectNode();
       node.put("namespace", namespace);
       node.put("name", name);
-      // Schema and columnLineage facets require Druid coordinator metadata lookups and are not
-      // populated here. Column-level lineage is a future enhancement.
       node.set("facets", jsonMapper.createObjectNode());
       array.add(node);
     }
     return array;
   }
 
-  /**
-   * Extracts the names of input datasources referenced in FROM clauses.
-   * CTEs (WITH clause names) are excluded since they are not physical datasources.
-   */
   private List<String> extractInputs(SqlNode root)
   {
     List<String> tables = new ArrayList<>();
@@ -329,24 +393,18 @@ public class OpenLineageRequestLogger implements RequestLogger
     return tables;
   }
 
-  /**
-   * Extracts the output datasource name for INSERT statements. Returns empty for SELECT queries.
-   */
-  private Optional<String> extractOutput(SqlNode root)
+  @Nullable
+  private String extractOutput(SqlNode root)
   {
     if (root instanceof SqlInsert) {
       SqlNode target = ((SqlInsert) root).getTargetTable();
       if (target instanceof SqlIdentifier) {
-        return Optional.of(String.join(".", ((SqlIdentifier) target).names));
+        return String.join(".", ((SqlIdentifier) target).names);
       }
     }
-    return Optional.empty();
+    return null;
   }
 
-  /**
-   * Recursively walks a FROM clause node and appends physical table names to {@code tables}.
-   * CTE names in {@code excludeNames} are skipped.
-   */
   private void collectFromClause(SqlNode from, List<String> tables, Set<String> excludeNames)
   {
     if (from == null) {
@@ -375,15 +433,8 @@ public class OpenLineageRequestLogger implements RequestLogger
       collectFromClause(with.body, tables, innerExcludes);
     } else if (from instanceof SqlOrderBy) {
       collectFromClause(((SqlOrderBy) from).query, tables, excludeNames);
-    } else if (from instanceof SqlBasicCall) {
-      SqlBasicCall call = (SqlBasicCall) from;
-      if (call.getKind() == SqlKind.AS) {
-        collectFromClause(call.operand(0), tables, excludeNames);
-      } else {
-        for (SqlNode operand : call.getOperandList()) {
-          collectFromClause(operand, tables, excludeNames);
-        }
-      }
+    } else if (from instanceof SqlBasicCall && from.getKind() == SqlKind.AS) {
+      collectFromClause(((SqlBasicCall) from).operand(0), tables, excludeNames);
     }
   }
 
@@ -392,13 +443,13 @@ public class OpenLineageRequestLogger implements RequestLogger
     try {
       String json = jsonMapper.writeValueAsString(event);
       if (transportType == OpenLineageRequestLoggerProvider.TransportType.HTTP) {
-        emitHttp(json);
+        emitExecutor.submit(() -> emitHttp(json));
       } else {
         log.info("OpenLineage event: %s", json);
       }
     }
-    catch (Exception e) {
-      log.error(e, "Failed to emit OpenLineage event");
+    catch (IOException e) {
+      log.error(e, "Failed to serialize OpenLineage event");
     }
   }
 
@@ -407,9 +458,10 @@ public class OpenLineageRequestLogger implements RequestLogger
     HttpPost post = new HttpPost(transportUrl);
     post.setEntity(new StringEntity(json, ContentType.APPLICATION_JSON));
     try {
-      httpClient.execute(post);
+      org.apache.http.HttpResponse response = httpClient.execute(post);
+      EntityUtils.consumeQuietly(response.getEntity());
     }
-    catch (Exception e) {
+    catch (IOException e) {
       log.error(e, "Failed to POST OpenLineage event to [%s]", transportUrl);
     }
     finally {
@@ -437,13 +489,10 @@ public class OpenLineageRequestLogger implements RequestLogger
     }
   }
 
-  @Override
-  public String toString()
+  private static String getDruidVersion()
   {
-    return "OpenLineageRequestLogger{" +
-           "namespace='" + namespace + '\'' +
-           ", transportType=" + transportType +
-           ", transportUrl='" + transportUrl + '\'' +
-           '}';
+    String v = OpenLineageRequestLogger.class.getPackage().getImplementationVersion();
+    return v != null ? v : "unknown";
   }
+
 }

--- a/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
+++ b/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
@@ -68,7 +68,7 @@ public class OpenLineageRequestLogger implements RequestLogger
   private static final Logger log = new Logger(OpenLineageRequestLogger.class);
 
   private static final String PRODUCER =
-      "https://github.com/apache/druid/extensions-contrib/openlineage-emitter";
+      "https://github.com/apache/druid/tree/master/extensions-contrib/openlineage-emitter";
   private static final String SCHEMA_URL =
       "https://openlineage.io/spec/2-0-2/OpenLineage.json";
   private static final String ENGINE_FACET_SCHEMA_URL =
@@ -77,6 +77,15 @@ public class OpenLineageRequestLogger implements RequestLogger
       "https://openlineage.io/spec/facets/1-0-0/ErrorMessageRunFacet.json";
   private static final String JOB_TYPE_FACET_SCHEMA_URL =
       "https://openlineage.io/spec/facets/2-0-2/JobTypeJobFacet.json";
+  private static final String SQL_FACET_SCHEMA_URL =
+      "https://openlineage.io/spec/facets/1-0-1/SQLJobFacet.json";
+  // raw.githubusercontent.com so consumers can dereference the URL and receive JSON, not an HTML tree page.
+  private static final String CUSTOM_SCHEMA_BASE =
+      "https://raw.githubusercontent.com/apache/druid/master/extensions-contrib/openlineage-emitter"
+      + "/src/main/resources/openlineage-schema/";
+  private static final String CONTEXT_FACET_SCHEMA_URL = CUSTOM_SCHEMA_BASE + "DruidQueryContextRunFacet.json";
+  private static final String STATS_FACET_SCHEMA_URL = CUSTOM_SCHEMA_BASE + "DruidQueryStatisticsRunFacet.json";
+  static final int SQL_FACET_MAX_LENGTH = 64 * 1024;
   static final int DEFAULT_EMIT_QUEUE_CAPACITY = 1000;
   static final int DEFAULT_EMIT_THREAD_COUNT = 1;
   private static final int DISCARD_WARNING_INTERVAL = 1000;
@@ -253,8 +262,10 @@ public class OpenLineageRequestLogger implements RequestLogger
    * </ul>
    *
    * <p>For {@code INSERT INTO druid.foo} or {@code INSERT INTO catalog.druid.foo}, returns just
-   * {@code foo} — matching the planner's normalization to a bare datasource name. CTEs are
-   * unwrapped if present (e.g. {@code WITH x AS (...) INSERT INTO foo SELECT ...}).
+   * {@code foo} — matching the planner's normalization to a bare datasource name. CTEs in the
+   * Druid MSQ form {@code INSERT INTO foo WITH x AS (...) SELECT ...} are handled correctly
+   * because the target table is on the outer {@code SqlInsert} node; the CTE appears as the
+   * source, not as a wrapper around the statement.
    */
   @Nullable
   static String extractMsqOutputDatasource(String sql)
@@ -308,7 +319,7 @@ public class OpenLineageRequestLogger implements RequestLogger
     event.put("producer", PRODUCER);
     event.put("schemaURL", SCHEMA_URL);
     event.set("run", buildRun(queryId, queryType, requestLogLine, stats, success));
-    event.set("job", buildJob(queryId));
+    event.set("job", buildJob(queryId, requestLogLine.getSql()));
     event.set("inputs", buildDatasets(inputs));
     event.set("outputs", buildDatasets(output != null ? List.of(output) : List.of()));
     return event;
@@ -332,7 +343,7 @@ public class OpenLineageRequestLogger implements RequestLogger
     engineFacet.put("version", getDruidVersion());
     facets.set("processing_engine", engineFacet);
 
-    ObjectNode contextFacet = createFacet(null);
+    ObjectNode contextFacet = createFacet(CONTEXT_FACET_SCHEMA_URL);
     contextFacet.put("queryType", queryType);
     contextFacet.put("remoteAddress", requestLogLine.getRemoteAddr());
     Object identity = stats.get("identity");
@@ -347,7 +358,7 @@ public class OpenLineageRequestLogger implements RequestLogger
     }
     facets.set("druid_query_context", contextFacet);
 
-    ObjectNode statsFacet = createFacet(null);
+    ObjectNode statsFacet = createFacet(STATS_FACET_SCHEMA_URL);
     putLongStat(statsFacet, "durationMs", stats, "sqlQuery/time", "query/time");
     putLongStat(statsFacet, "bytes", stats, "sqlQuery/bytes", "query/bytes");
     putLongStat(statsFacet, "planningTimeMs", stats, "sqlQuery/planningTimeMs");
@@ -373,7 +384,7 @@ public class OpenLineageRequestLogger implements RequestLogger
     return run;
   }
 
-  private ObjectNode buildJob(String queryId)
+  private ObjectNode buildJob(String queryId, @Nullable String sql)
   {
     ObjectNode job = jsonMapper.createObjectNode();
     job.put("namespace", namespace);
@@ -386,6 +397,21 @@ public class OpenLineageRequestLogger implements RequestLogger
     jobTypeFacet.put("integration", "DRUID");
     jobTypeFacet.put("jobType", "QUERY");
     facets.set("jobType", jobTypeFacet);
+
+    if (sql != null) {
+      ObjectNode sqlFacet = createFacet(SQL_FACET_SCHEMA_URL);
+      if (sql.length() > SQL_FACET_MAX_LENGTH) {
+        log.warn(
+            "SQL text for query [%s] exceeds [%,d] bytes and will be truncated in the sql job facet",
+            queryId,
+            SQL_FACET_MAX_LENGTH
+        );
+        sqlFacet.put("query", sql.substring(0, SQL_FACET_MAX_LENGTH));
+      } else {
+        sqlFacet.put("query", sql);
+      }
+      facets.set("sql", sqlFacet);
+    }
 
     job.set("facets", facets);
     return job;

--- a/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
+++ b/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
@@ -22,21 +22,6 @@ package org.apache.druid.extensions.openlineage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.calcite.avatica.util.Casing;
-import org.apache.calcite.avatica.util.Quoting;
-import org.apache.calcite.sql.SqlBasicCall;
-import org.apache.calcite.sql.SqlCall;
-import org.apache.calcite.sql.SqlIdentifier;
-import org.apache.calcite.sql.SqlInsert;
-import org.apache.calcite.sql.SqlJoin;
-import org.apache.calcite.sql.SqlKind;
-import org.apache.calcite.sql.SqlNode;
-import org.apache.calcite.sql.SqlNodeList;
-import org.apache.calcite.sql.SqlSelect;
-import org.apache.calcite.sql.SqlWith;
-import org.apache.calcite.sql.SqlWithItem;
-import org.apache.calcite.sql.parser.SqlParseException;
-import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
@@ -49,6 +34,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 
 import javax.annotation.Nullable;
@@ -56,7 +42,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -68,8 +53,6 @@ import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * OpenLineage RunEvents for completed Druid queries.
@@ -88,27 +71,6 @@ public class OpenLineageRequestLogger implements RequestLogger
       "https://openlineage.io/spec/facets/1-0-0/ErrorMessageRunFacet.json";
   private static final String JOB_TYPE_FACET_SCHEMA_URL =
       "https://openlineage.io/spec/facets/2-0-2/JobTypeJobFacet.json";
-  private static final String SQL_FACET_SCHEMA_URL =
-      "https://openlineage.io/spec/facets/1-0-1/SQLJobFacet.json";
-
-  // Standard Calcite parser (not Druid's custom parser): sufficient for table name extraction.
-  // Druid-specific syntax (REPLACE, EXTERN, etc.) falls through to the SqlParseException handler.
-  private static final SqlParser.Config SQL_PARSER_CONFIG = SqlParser
-      .config()
-      .withCaseSensitive(true)
-      .withUnquotedCasing(Casing.UNCHANGED)
-      .withQuotedCasing(Casing.UNCHANGED)
-      .withQuoting(Quoting.DOUBLE_QUOTE);
-
-  // Matches INSERT INTO or REPLACE INTO when the standard Calcite parser fails (e.g. EXTERN,
-  // PARTITIONED BY). Captures the output table name; handles quoted and unquoted identifiers.
-  private static final Pattern WRITE_INTO_PATTERN =
-      Pattern.compile("(?i)^\\s*(?:INSERT|REPLACE)\\s+INTO\\s+\"?([^\"\\s]+)\"?");
-  // Extracts the SELECT subquery from INSERT INTO or REPLACE INTO for input lineage.
-  // Stops before PARTITIONED BY / CLUSTERED BY which are Druid-specific clauses.
-  private static final Pattern SELECT_FROM_WRITE_PATTERN =
-      Pattern.compile("(?is)\\b(SELECT\\s+.+?)(?:\\s+PARTITIONED\\s+BY|\\s+CLUSTERED\\s+BY|$)");
-
   static final int DEFAULT_EMIT_QUEUE_CAPACITY = 1000;
   static final int DEFAULT_EMIT_THREAD_COUNT = 1;
   private static final int DISCARD_WARNING_INTERVAL = 1000;
@@ -161,7 +123,7 @@ public class OpenLineageRequestLogger implements RequestLogger
       );
     }
     if (transportType == OpenLineageRequestLoggerProvider.TransportType.HTTP) {
-      this.httpClient = httpClient;
+      this.httpClient = httpClient != null ? httpClient : HttpClientBuilder.create().build();
       // Bounded queue: if the queue is full, drop the event rather than blocking the query thread.
       // A warning is logged on the first drop and every DISCARD_WARNING_INTERVAL drops thereafter.
       this.emitExecutor = new ThreadPoolExecutor(
@@ -225,11 +187,6 @@ public class OpenLineageRequestLogger implements RequestLogger
       return;
     }
 
-    // Skip native sub-queries of a SQL execution to avoid duplicating the SQL-level event.
-    if (requestLogLine.getQuery().getContext().get(BaseQuery.SQL_QUERY_ID) != null) {
-      return;
-    }
-
     String queryType = requestLogLine.getQuery().getType();
 
     if (excludedNativeQueryTypes.contains(queryType)) {
@@ -243,56 +200,27 @@ public class OpenLineageRequestLogger implements RequestLogger
       queryId = UNKNOWN_QUERY_ID;
     }
 
-    emit(buildRunEvent(queryId, null, queryType, requestLogLine, inputs, null));
+    emit(buildRunEvent(queryId, queryType, requestLogLine, inputs, null));
   }
 
+  /**
+   * SQL-level logging is a no-op. Lineage is emitted from the native query plan via
+   * {@link #logNativeQuery}, which has structured access to datasource references
+   * (JoinDataSource, UnionDataSource, etc.) without requiring SQL parsing.
+   *
+   * <p>For SQL queries, the broker converts SQL to native queries before execution.
+   * Each native sub-query calls {@link #logNativeQuery}, which extracts inputs from
+   * {@code query.getDataSource().getTableNames()}. The native events carry the parent
+   * SQL query ID in their context for correlation.
+   */
   @Override
   public void logSqlQuery(RequestLogLine requestLogLine) throws IOException
   {
-    String sql = requestLogLine.getSql();
-    List<String> inputs = new ArrayList<>();
-    String output = null;
-
-    if (sql != null) {
-      try {
-        SqlNode parsed = SqlParser.create(sql, SQL_PARSER_CONFIG).parseQuery();
-        inputs = extractInputs(parsed);
-        output = extractOutput(parsed);
-      }
-      catch (SqlParseException e) {
-        // Druid-specific SQL extensions (INSERT/REPLACE INTO with PARTITIONED BY, EXTERN, etc.)
-        // may not parse with the standard Calcite parser. Attempt to extract lineage via regex;
-        // for other unparseable statements, emit the event without table-level lineage.
-        Matcher writeMatcher = WRITE_INTO_PATTERN.matcher(sql);
-        if (writeMatcher.find()) {
-          output = writeMatcher.group(1);
-          // Also try to extract inputs from the SELECT subquery. EXTERN-sourced inputs will
-          // fail to re-parse and fall through with empty inputs, which is correct.
-          Matcher selectMatcher = SELECT_FROM_WRITE_PATTERN.matcher(sql);
-          if (selectMatcher.find()) {
-            try {
-              SqlNode selectNode = SqlParser.create(selectMatcher.group(1), SQL_PARSER_CONFIG).parseQuery();
-              inputs = extractInputs(selectNode);
-            }
-            catch (SqlParseException ignored) {
-              // EXTERN or other non-standard sources — inputs left empty
-            }
-          }
-        }
-        log.debug(
-            "OpenLineage: could not parse SQL with standard Calcite parser (query will still be emitted): %s",
-            e.getMessage()
-        );
-      }
-    }
-
-    String queryId = extractSqlQueryId(requestLogLine);
-    emit(buildRunEvent(queryId, sql, "sql", requestLogLine, new ArrayList<>(new LinkedHashSet<>(inputs)), output));
+    // No-op: lineage is emitted from native sub-queries.
   }
 
   private ObjectNode buildRunEvent(
       String queryId,
-      @Nullable String sql,
       String queryType,
       RequestLogLine requestLogLine,
       List<String> inputs,
@@ -308,7 +236,7 @@ public class OpenLineageRequestLogger implements RequestLogger
     event.put("producer", PRODUCER);
     event.put("schemaURL", SCHEMA_URL);
     event.set("run", buildRun(queryId, queryType, requestLogLine, stats, success));
-    event.set("job", buildJob(queryId, sql));
+    event.set("job", buildJob(queryId));
     event.set("inputs", buildDatasets(inputs));
     event.set("outputs", buildDatasets(output != null ? List.of(output) : List.of()));
     return event;
@@ -339,10 +267,11 @@ public class OpenLineageRequestLogger implements RequestLogger
     if (identity != null) {
       contextFacet.put("identity", identity.toString());
     }
-    Map<String, Object> sqlQueryContext = requestLogLine.getSqlQueryContext();
-    Object nativeQueryIds = sqlQueryContext != null ? sqlQueryContext.get("nativeQueryIds") : null;
-    if (nativeQueryIds != null) {
-      contextFacet.put("nativeQueryIds", nativeQueryIds.toString());
+    // For native sub-queries of SQL, include the parent SQL query ID for correlation.
+    Object sqlQueryId = requestLogLine.getQuery() != null
+        ? requestLogLine.getQuery().getContext().get(BaseQuery.SQL_QUERY_ID) : null;
+    if (sqlQueryId != null) {
+      contextFacet.put("sqlQueryId", sqlQueryId.toString());
     }
     facets.set("druid_query_context", contextFacet);
 
@@ -361,7 +290,7 @@ public class OpenLineageRequestLogger implements RequestLogger
       if (exception != null) {
         ObjectNode errorFacet = createFacet(ERROR_FACET_SCHEMA_URL);
         errorFacet.put("message", exception.toString());
-        if ("sql".equals(queryType)) {
+        if (sqlQueryId != null) {
           errorFacet.put("programmingLanguage", "SQL");
         }
         facets.set("errorMessage", errorFacet);
@@ -372,7 +301,7 @@ public class OpenLineageRequestLogger implements RequestLogger
     return run;
   }
 
-  private ObjectNode buildJob(String queryId, @Nullable String sql)
+  private ObjectNode buildJob(String queryId)
   {
     ObjectNode job = jsonMapper.createObjectNode();
     job.put("namespace", namespace);
@@ -385,12 +314,6 @@ public class OpenLineageRequestLogger implements RequestLogger
     jobTypeFacet.put("integration", "DRUID");
     jobTypeFacet.put("jobType", "QUERY");
     facets.set("jobType", jobTypeFacet);
-
-    if (sql != null) {
-      ObjectNode sqlFacet = createFacet(SQL_FACET_SCHEMA_URL);
-      sqlFacet.put("query", sql);
-      facets.set("sql", sqlFacet);
-    }
 
     job.set("facets", facets);
     return job;
@@ -419,119 +342,6 @@ public class OpenLineageRequestLogger implements RequestLogger
     return array;
   }
 
-  private List<String> extractInputs(SqlNode root)
-  {
-    List<String> tables = new ArrayList<>();
-    if (root instanceof SqlInsert) {
-      // For INSERT/REPLACE, only walk the source query — the target table is an output, not an input.
-      collectTableNames(((SqlInsert) root).getSource(), tables, Set.of());
-    } else {
-      collectTableNames(root, tables, Set.of());
-    }
-    return tables;
-  }
-
-  @Nullable
-  private String extractOutput(SqlNode root)
-  {
-    if (root instanceof SqlInsert) {
-      SqlNode target = ((SqlInsert) root).getTargetTable();
-      if (target instanceof SqlIdentifier) {
-        return String.join(".", ((SqlIdentifier) target).names);
-      }
-    }
-    return null;
-  }
-
-  /**
-   * Walks the SQL tree to collect table references from FROM clauses, JOINs, subqueries in
-   * WHERE/HAVING/SELECT, and set operations (UNION/INTERSECT/EXCEPT). CTE alias names are
-   * tracked in {@code excludeNames} to avoid reporting them as table inputs.
-   *
-   * <p>The walker distinguishes table-reference positions (FROM, JOIN) from column-reference
-   * positions (SELECT list, WHERE expressions) by collecting {@link SqlIdentifier} nodes only
-   * from known table-reference contexts, while recursing into all subqueries to find nested
-   * FROM clauses.
-   */
-  private void collectTableNames(SqlNode node, List<String> tables, Set<String> excludeNames)
-  {
-    if (node == null) {
-      return;
-    }
-    if (node instanceof SqlWith) {
-      SqlWith with = (SqlWith) node;
-      Set<String> innerExcludes = new HashSet<>(excludeNames);
-      for (SqlNode item : with.withList) {
-        if (item instanceof SqlWithItem) {
-          innerExcludes.add(((SqlWithItem) item).name.getSimple());
-          collectTableNames(((SqlWithItem) item).query, tables, innerExcludes);
-        }
-      }
-      collectTableNames(with.body, tables, innerExcludes);
-    } else if (node instanceof SqlNodeList) {
-      // Lists (e.g., SELECT list items): recurse into each element to find subqueries.
-      for (SqlNode item : (SqlNodeList) node) {
-        collectTableNames(item, tables, excludeNames);
-      }
-    } else if (node instanceof SqlSelect) {
-      SqlSelect select = (SqlSelect) node;
-      // FROM clause: identifiers here are table references.
-      collectFromPosition(select.getFrom(), tables, excludeNames);
-      // Recurse into WHERE, HAVING, and SELECT list to find nested subqueries.
-      collectTableNames(select.getWhere(), tables, excludeNames);
-      collectTableNames(select.getHaving(), tables, excludeNames);
-      collectTableNames(select.getSelectList(), tables, excludeNames);
-    } else if (node instanceof SqlCall) {
-      SqlCall call = (SqlCall) node;
-      if (call.getKind() == SqlKind.UNION || call.getKind() == SqlKind.INTERSECT || call.getKind() == SqlKind.EXCEPT) {
-        // Set operations: each operand is a SELECT whose FROM clause has table references.
-        for (SqlNode operand : call.getOperandList()) {
-          collectTableNames(operand, tables, excludeNames);
-        }
-      } else {
-        // Other expressions (AND, OR, IN, =, function calls, etc.): recurse to find subqueries.
-        for (SqlNode operand : call.getOperandList()) {
-          if (operand instanceof SqlSelect || operand instanceof SqlWith || operand instanceof SqlCall) {
-            collectTableNames(operand, tables, excludeNames);
-          }
-        }
-      }
-    }
-  }
-
-  /**
-   * Collects table names from a FROM-clause position, where {@link SqlIdentifier} nodes
-   * represent table references (not column references).
-   */
-  private void collectFromPosition(SqlNode node, List<String> tables, Set<String> excludeNames)
-  {
-    if (node == null) {
-      return;
-    }
-    if (node instanceof SqlIdentifier) {
-      String name = String.join(".", ((SqlIdentifier) node).names);
-      if (!excludeNames.contains(name)) {
-        tables.add(name);
-      }
-    } else if (node instanceof SqlJoin) {
-      SqlJoin join = (SqlJoin) node;
-      collectFromPosition(join.getLeft(), tables, excludeNames);
-      collectFromPosition(join.getRight(), tables, excludeNames);
-    } else if (node instanceof SqlSelect) {
-      // Subquery in FROM: recurse into the full select.
-      collectTableNames(node, tables, excludeNames);
-    } else if (node instanceof SqlBasicCall && node.getKind() == SqlKind.AS) {
-      // Alias: the table reference is the first operand.
-      collectFromPosition(((SqlBasicCall) node).operand(0), tables, excludeNames);
-    } else if (node instanceof SqlCall && node.getKind() == SqlKind.LATERAL) {
-      // LATERAL (subquery): the single operand is a SELECT whose tables we should collect.
-      // Other SqlCalls in FROM position (UNNEST, TABLE, etc.) are not table references —
-      // their operands are column expressions, not datasource names.
-      for (SqlNode operand : ((SqlCall) node).getOperandList()) {
-        collectFromPosition(operand, tables, excludeNames);
-      }
-    }
-  }
 
   protected void emit(ObjectNode event)
   {
@@ -570,17 +380,6 @@ public class OpenLineageRequestLogger implements RequestLogger
     finally {
       post.releaseConnection();
     }
-  }
-
-  private String extractSqlQueryId(RequestLogLine requestLogLine)
-  {
-    Map<String, Object> sqlQueryContext = requestLogLine.getSqlQueryContext();
-    Object id = sqlQueryContext != null ? sqlQueryContext.get(BaseQuery.SQL_QUERY_ID) : null;
-    if (id != null) {
-      return id.toString();
-    }
-    log.debug("SQL query reached OpenLineage logger without a query ID");
-    return UNKNOWN_QUERY_ID;
   }
 
   private void putLongStat(ObjectNode node, String targetKey, Map<String, Object> stats, String... sourceKeys)

--- a/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
+++ b/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
@@ -22,6 +22,10 @@ package org.apache.druid.extensions.openlineage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlInsert;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlWith;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
@@ -29,6 +33,8 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.BaseQuery;
 import org.apache.druid.server.RequestLogLine;
 import org.apache.druid.server.log.RequestLogger;
+import org.apache.druid.sql.calcite.parser.DruidSqlParser;
+import org.apache.druid.sql.calcite.parser.ExternalDestinationSqlIdentifier;
 import org.apache.druid.utils.CloseableUtils;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
@@ -53,8 +59,6 @@ import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * OpenLineage RunEvents for completed Druid queries.
@@ -78,11 +82,6 @@ public class OpenLineageRequestLogger implements RequestLogger
   private static final int DISCARD_WARNING_INTERVAL = 1000;
 
   static final String UNKNOWN_QUERY_ID = "unknown-query-id";
-
-  // Matches the output table of MSQ DML: INSERT INTO "foo" or REPLACE INTO foo
-  private static final Pattern MSQ_DML_OUTPUT_PATTERN = Pattern.compile(
-      "(?si)^\\s*(?:INSERT|REPLACE)\\s+INTO\\s+\"?([^\"\\s(,]+)\"?"
-  );
 
   private final ObjectMapper jsonMapper;
   private final String namespace;
@@ -217,8 +216,8 @@ public class OpenLineageRequestLogger implements RequestLogger
    *
    * <p>MSQ INSERT/REPLACE queries submit an MSQControllerTask and never produce a native
    * request-log event, so their output lineage must be captured here. The output datasource
-   * is extracted from the SQL text; inputs are not emitted because reliably extracting
-   * FROM/JOIN tables without a full SQL parser is out of scope for the logger layer.
+   * is extracted from the SQL AST via Druid's SQL parser; inputs are not emitted because
+   * reliably extracting FROM/JOIN tables in the logger layer would duplicate planner work.
    */
   @Override
   public void logSqlQuery(RequestLogLine requestLogLine) throws IOException
@@ -227,11 +226,10 @@ public class OpenLineageRequestLogger implements RequestLogger
     if (sql == null) {
       return;
     }
-    Matcher matcher = MSQ_DML_OUTPUT_PATTERN.matcher(sql);
-    if (!matcher.find()) {
+    String outputTable = extractMsqOutputDatasource(sql);
+    if (outputTable == null) {
       return;
     }
-    String outputTable = matcher.group(1);
 
     Map<String, Object> sqlContext = requestLogLine.getSqlQueryContext();
     String queryId = sqlContext != null ? (String) sqlContext.get("sqlQueryId") : null;
@@ -241,6 +239,56 @@ public class OpenLineageRequestLogger implements RequestLogger
     }
 
     emit(buildRunEvent(queryId, "msq", requestLogLine, List.of(), outputTable));
+  }
+
+  /**
+   * Extracts the output datasource name from an MSQ DML statement (INSERT INTO / REPLACE INTO)
+   * using Druid's SQL parser. Returns {@code null} for any input that is not a Druid
+   * INSERT/REPLACE into a regular datasource — including:
+   * <ul>
+   *   <li>SELECT and other non-DML statements</li>
+   *   <li>{@code INSERT INTO EXTERN(...) AS CSV ...} export statements (target parses as a
+   *       SqlCall, not a SqlIdentifier)</li>
+   *   <li>SQL that fails to parse</li>
+   * </ul>
+   *
+   * <p>For {@code INSERT INTO druid.foo} or {@code INSERT INTO catalog.druid.foo}, returns just
+   * {@code foo} — matching the planner's normalization to a bare datasource name. CTEs are
+   * unwrapped if present (e.g. {@code WITH x AS (...) INSERT INTO foo SELECT ...}).
+   */
+  @Nullable
+  static String extractMsqOutputDatasource(String sql)
+  {
+    try {
+      // allowSetStatements=true so that a Druid SET preamble (e.g. "SET sqlQueryId = '...'; INSERT
+      // INTO foo ...") doesn't cause the parse to throw. We only inspect the main statement.
+      SqlNode node = DruidSqlParser.parse(sql, true).getMainStatement();
+      // WITH ... INSERT/REPLACE wraps the ingest with a SqlWith; unwrap it.
+      if (node instanceof SqlWith) {
+        node = ((SqlWith) node).body;
+      }
+      // DruidSqlInsert and DruidSqlReplace both extend SqlInsert, so this covers both.
+      if (!(node instanceof SqlInsert)) {
+        return null;
+      }
+      SqlNode target = ((SqlInsert) node).getTargetTable();
+      // INSERT INTO EXTERN(...) AS CSV writes to a file, not a Druid datasource.
+      // ExternalDestinationSqlIdentifier extends SqlIdentifier, so check it explicitly.
+      if (target instanceof ExternalDestinationSqlIdentifier) {
+        return null;
+      }
+      if (!(target instanceof SqlIdentifier)) {
+        return null;
+      }
+      SqlIdentifier id = (SqlIdentifier) target;
+      // Druid's planner normalizes any schema/catalog prefix (e.g. "druid.foo",
+      // "catalog.druid.foo") to the bare datasource name. Match that here.
+      return id.names.isEmpty() ? null : id.names.get(id.names.size() - 1);
+    }
+    catch (Exception e) {
+      log.debug(e, "Failed to parse SQL for MSQ output datasource extraction; skipping output lineage");
+      return null;
+    }
   }
 
   private ObjectNode buildRunEvent(

--- a/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
+++ b/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
@@ -53,6 +53,8 @@ import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * OpenLineage RunEvents for completed Druid queries.
@@ -76,6 +78,11 @@ public class OpenLineageRequestLogger implements RequestLogger
   private static final int DISCARD_WARNING_INTERVAL = 1000;
 
   static final String UNKNOWN_QUERY_ID = "unknown-query-id";
+
+  // Matches the output table of MSQ DML: INSERT INTO "foo" or REPLACE INTO foo
+  private static final Pattern MSQ_DML_OUTPUT_PATTERN = Pattern.compile(
+      "(?si)^\\s*(?:INSERT|REPLACE)\\s+INTO\\s+\"?([^\"\\s(,]+)\"?"
+  );
 
   private final ObjectMapper jsonMapper;
   private final String namespace;
@@ -204,19 +211,36 @@ public class OpenLineageRequestLogger implements RequestLogger
   }
 
   /**
-   * SQL-level logging is a no-op. Lineage is emitted from the native query plan via
-   * {@link #logNativeQuery}, which has structured access to datasource references
-   * (JoinDataSource, UnionDataSource, etc.) without requiring SQL parsing.
+   * Emits lineage for MSQ DML statements (INSERT INTO / REPLACE INTO). For native-engine
+   * SQL SELECT queries, lineage is emitted from {@link #logNativeQuery} instead, which has
+   * structured access to datasource references without requiring SQL parsing.
    *
-   * <p>For SQL queries, the broker converts SQL to native queries before execution.
-   * Each native sub-query calls {@link #logNativeQuery}, which extracts inputs from
-   * {@code query.getDataSource().getTableNames()}. The native events carry the parent
-   * SQL query ID in their context for correlation.
+   * <p>MSQ INSERT/REPLACE queries submit an MSQControllerTask and never produce a native
+   * request-log event, so their output lineage must be captured here. The output datasource
+   * is extracted from the SQL text; inputs are not emitted because reliably extracting
+   * FROM/JOIN tables without a full SQL parser is out of scope for the logger layer.
    */
   @Override
   public void logSqlQuery(RequestLogLine requestLogLine) throws IOException
   {
-    // No-op: lineage is emitted from native sub-queries.
+    String sql = requestLogLine.getSql();
+    if (sql == null) {
+      return;
+    }
+    Matcher matcher = MSQ_DML_OUTPUT_PATTERN.matcher(sql);
+    if (!matcher.find()) {
+      return;
+    }
+    String outputTable = matcher.group(1);
+
+    Map<String, Object> sqlContext = requestLogLine.getSqlQueryContext();
+    String queryId = sqlContext != null ? (String) sqlContext.get("sqlQueryId") : null;
+    if (queryId == null) {
+      log.debug("MSQ SQL query reached OpenLineage logger without a sqlQueryId");
+      queryId = UNKNOWN_QUERY_ID;
+    }
+
+    emit(buildRunEvent(queryId, "msq", requestLogLine, List.of(), outputTable));
   }
 
   private ObjectNode buildRunEvent(

--- a/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
+++ b/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
@@ -49,7 +49,6 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 
 import javax.annotation.Nullable;
@@ -101,15 +100,13 @@ public class OpenLineageRequestLogger implements RequestLogger
       .withQuotedCasing(Casing.UNCHANGED)
       .withQuoting(Quoting.DOUBLE_QUOTE);
 
-  // Matches: INSERT INTO <table> ... (fallback when EXTERN prevents standard Calcite parsing)
-  // Handles both quoted ("table") and unquoted (table) identifiers.
-  private static final Pattern INSERT_INTO_PATTERN =
-      Pattern.compile("(?i)^\\s*INSERT\\s+INTO\\s+\"?([^\"\\s]+)\"?");
-  // Matches: REPLACE INTO <table> OVERWRITE ... (Druid-specific, not parseable by standard Calcite)
-  private static final Pattern REPLACE_INTO_PATTERN =
-      Pattern.compile("(?i)^\\s*REPLACE\\s+INTO\\s+\"?([^\"\\s]+)\"?");
-  // Extracts the SELECT subquery from a REPLACE INTO statement for input lineage
-  private static final Pattern REPLACE_SELECT_PATTERN =
+  // Matches INSERT INTO or REPLACE INTO when the standard Calcite parser fails (e.g. EXTERN,
+  // PARTITIONED BY). Captures the output table name; handles quoted and unquoted identifiers.
+  private static final Pattern WRITE_INTO_PATTERN =
+      Pattern.compile("(?i)^\\s*(?:INSERT|REPLACE)\\s+INTO\\s+\"?([^\"\\s]+)\"?");
+  // Extracts the SELECT subquery from INSERT INTO or REPLACE INTO for input lineage.
+  // Stops before PARTITIONED BY / CLUSTERED BY which are Druid-specific clauses.
+  private static final Pattern SELECT_FROM_WRITE_PATTERN =
       Pattern.compile("(?is)\\b(SELECT\\s+.+?)(?:\\s+PARTITIONED\\s+BY|\\s+CLUSTERED\\s+BY|$)");
 
   static final int DEFAULT_EMIT_QUEUE_CAPACITY = 1000;
@@ -139,21 +136,7 @@ public class OpenLineageRequestLogger implements RequestLogger
   )
   {
     this(jsonMapper, namespace, transportType, transportUrl, excludedNativeQueryTypes,
-         DEFAULT_EMIT_QUEUE_CAPACITY, DEFAULT_EMIT_THREAD_COUNT);
-  }
-
-  public OpenLineageRequestLogger(
-      ObjectMapper jsonMapper,
-      String namespace,
-      OpenLineageRequestLoggerProvider.TransportType transportType,
-      @Nullable String transportUrl,
-      Set<String> excludedNativeQueryTypes,
-      int emitQueueCapacity,
-      int emitThreadCount
-  )
-  {
-    this(jsonMapper, namespace, transportType, transportUrl, excludedNativeQueryTypes,
-         emitQueueCapacity, emitThreadCount, null);
+         DEFAULT_EMIT_QUEUE_CAPACITY, DEFAULT_EMIT_THREAD_COUNT, null);
   }
 
   public OpenLineageRequestLogger(
@@ -178,7 +161,7 @@ public class OpenLineageRequestLogger implements RequestLogger
       );
     }
     if (transportType == OpenLineageRequestLoggerProvider.TransportType.HTTP) {
-      this.httpClient = httpClient != null ? httpClient : HttpClientBuilder.create().build();
+      this.httpClient = httpClient;
       // Bounded queue: if the queue is full, drop the event rather than blocking the query thread.
       // A warning is logged on the first drop and every DISCARD_WARNING_INTERVAL drops thereafter.
       this.emitExecutor = new ThreadPoolExecutor(
@@ -277,16 +260,15 @@ public class OpenLineageRequestLogger implements RequestLogger
         output = extractOutput(parsed);
       }
       catch (SqlParseException e) {
-        // Druid-specific SQL extensions (REPLACE INTO, EXTERN, etc.) may not parse with the
-        // standard Calcite parser. Attempt to extract lineage via regex fallback;
+        // Druid-specific SQL extensions (INSERT/REPLACE INTO with PARTITIONED BY, EXTERN, etc.)
+        // may not parse with the standard Calcite parser. Attempt to extract lineage via regex;
         // for other unparseable statements, emit the event without table-level lineage.
-        Matcher insertMatcher = INSERT_INTO_PATTERN.matcher(sql);
-        if (insertMatcher.find()) {
-          output = insertMatcher.group(1);
-          // Also try to extract inputs from the SELECT subquery (handles PARTITIONED BY and
-          // other Druid-specific clauses that prevent full parsing). EXTERN-sourced inputs
-          // will fail to re-parse and fall through with empty inputs, which is correct.
-          Matcher selectMatcher = REPLACE_SELECT_PATTERN.matcher(sql);
+        Matcher writeMatcher = WRITE_INTO_PATTERN.matcher(sql);
+        if (writeMatcher.find()) {
+          output = writeMatcher.group(1);
+          // Also try to extract inputs from the SELECT subquery. EXTERN-sourced inputs will
+          // fail to re-parse and fall through with empty inputs, which is correct.
+          Matcher selectMatcher = SELECT_FROM_WRITE_PATTERN.matcher(sql);
           if (selectMatcher.find()) {
             try {
               SqlNode selectNode = SqlParser.create(selectMatcher.group(1), SQL_PARSER_CONFIG).parseQuery();
@@ -294,20 +276,6 @@ public class OpenLineageRequestLogger implements RequestLogger
             }
             catch (SqlParseException ignored) {
               // EXTERN or other non-standard sources — inputs left empty
-            }
-          }
-        }
-        Matcher m = REPLACE_INTO_PATTERN.matcher(sql);
-        if (m.find()) {
-          output = m.group(1);
-          Matcher selectMatcher = REPLACE_SELECT_PATTERN.matcher(sql);
-          if (selectMatcher.find()) {
-            try {
-              SqlNode selectNode = SqlParser.create(selectMatcher.group(1), SQL_PARSER_CONFIG).parseQuery();
-              inputs = extractInputs(selectNode);
-            }
-            catch (SqlParseException ignored) {
-              // fall through with empty inputs
             }
           }
         }
@@ -371,7 +339,8 @@ public class OpenLineageRequestLogger implements RequestLogger
     if (identity != null) {
       contextFacet.put("identity", identity.toString());
     }
-    Object nativeQueryIds = requestLogLine.getSqlQueryContext().get("nativeQueryIds");
+    Map<String, Object> sqlQueryContext = requestLogLine.getSqlQueryContext();
+    Object nativeQueryIds = sqlQueryContext != null ? sqlQueryContext.get("nativeQueryIds") : null;
     if (nativeQueryIds != null) {
       contextFacet.put("nativeQueryIds", nativeQueryIds.toString());
     }
@@ -554,8 +523,10 @@ public class OpenLineageRequestLogger implements RequestLogger
     } else if (node instanceof SqlBasicCall && node.getKind() == SqlKind.AS) {
       // Alias: the table reference is the first operand.
       collectFromPosition(((SqlBasicCall) node).operand(0), tables, excludeNames);
-    } else if (node instanceof SqlCall) {
-      // LATERAL, UNNEST, or other FROM-position nodes: walk operands.
+    } else if (node instanceof SqlCall && node.getKind() == SqlKind.LATERAL) {
+      // LATERAL (subquery): the single operand is a SELECT whose tables we should collect.
+      // Other SqlCalls in FROM position (UNNEST, TABLE, etc.) are not table references —
+      // their operands are column expressions, not datasource names.
       for (SqlNode operand : ((SqlCall) node).getOperandList()) {
         collectFromPosition(operand, tables, excludeNames);
       }
@@ -603,7 +574,8 @@ public class OpenLineageRequestLogger implements RequestLogger
 
   private String extractSqlQueryId(RequestLogLine requestLogLine)
   {
-    Object id = requestLogLine.getSqlQueryContext().get(BaseQuery.SQL_QUERY_ID);
+    Map<String, Object> sqlQueryContext = requestLogLine.getSqlQueryContext();
+    Object id = sqlQueryContext != null ? sqlQueryContext.get(BaseQuery.SQL_QUERY_ID) : null;
     if (id != null) {
       return id.toString();
     }

--- a/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
+++ b/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
@@ -54,8 +54,6 @@ import org.apache.http.util.EntityUtils;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -71,6 +69,8 @@ import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * OpenLineage RunEvents for completed Druid queries.
@@ -204,7 +204,7 @@ public class OpenLineageRequestLogger implements RequestLogger
   public void start()
   {
     log.info(
-        "Started OpenLineage {} transport{}",
+        "Started OpenLineage %s transport%s",
         transportType,
         transportUrl != null ? " to [" + transportUrl + "]" : ""
     );
@@ -278,38 +278,36 @@ public class OpenLineageRequestLogger implements RequestLogger
       }
       catch (SqlParseException e) {
         // Druid-specific SQL extensions (REPLACE INTO, EXTERN, etc.) may not parse with the
-        // standard Calcite parser. Attempt to extract lineage from REPLACE INTO via regex;
+        // standard Calcite parser. Attempt to extract lineage via regex fallback;
         // for other unparseable statements, emit the event without table-level lineage.
-        if (sql != null) {
-          Matcher insertMatcher = INSERT_INTO_PATTERN.matcher(sql);
-          if (insertMatcher.find()) {
-            output = insertMatcher.group(1);
-            // Also try to extract inputs from the SELECT subquery (handles PARTITIONED BY and
-            // other Druid-specific clauses that prevent full parsing). EXTERN-sourced inputs
-            // will fail to re-parse and fall through with empty inputs, which is correct.
-            Matcher selectMatcher = REPLACE_SELECT_PATTERN.matcher(sql);
-            if (selectMatcher.find()) {
-              try {
-                SqlNode selectNode = SqlParser.create(selectMatcher.group(1), SQL_PARSER_CONFIG).parseQuery();
-                inputs = extractInputs(selectNode);
-              }
-              catch (SqlParseException ignored) {
-                // EXTERN or other non-standard sources — inputs left empty
-              }
+        Matcher insertMatcher = INSERT_INTO_PATTERN.matcher(sql);
+        if (insertMatcher.find()) {
+          output = insertMatcher.group(1);
+          // Also try to extract inputs from the SELECT subquery (handles PARTITIONED BY and
+          // other Druid-specific clauses that prevent full parsing). EXTERN-sourced inputs
+          // will fail to re-parse and fall through with empty inputs, which is correct.
+          Matcher selectMatcher = REPLACE_SELECT_PATTERN.matcher(sql);
+          if (selectMatcher.find()) {
+            try {
+              SqlNode selectNode = SqlParser.create(selectMatcher.group(1), SQL_PARSER_CONFIG).parseQuery();
+              inputs = extractInputs(selectNode);
+            }
+            catch (SqlParseException ignored) {
+              // EXTERN or other non-standard sources — inputs left empty
             }
           }
-          Matcher m = REPLACE_INTO_PATTERN.matcher(sql);
-          if (m.find()) {
-            output = m.group(1);
-            Matcher selectMatcher = REPLACE_SELECT_PATTERN.matcher(sql);
-            if (selectMatcher.find()) {
-              try {
-                SqlNode selectNode = SqlParser.create(selectMatcher.group(1), SQL_PARSER_CONFIG).parseQuery();
-                inputs = extractInputs(selectNode);
-              }
-              catch (SqlParseException ignored) {
-                // fall through with empty inputs
-              }
+        }
+        Matcher m = REPLACE_INTO_PATTERN.matcher(sql);
+        if (m.find()) {
+          output = m.group(1);
+          Matcher selectMatcher = REPLACE_SELECT_PATTERN.matcher(sql);
+          if (selectMatcher.find()) {
+            try {
+              SqlNode selectNode = SqlParser.create(selectMatcher.group(1), SQL_PARSER_CONFIG).parseQuery();
+              inputs = extractInputs(selectNode);
+            }
+            catch (SqlParseException ignored) {
+              // fall through with empty inputs
             }
           }
         }

--- a/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
+++ b/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
@@ -89,6 +89,13 @@ public class OpenLineageRequestLogger implements RequestLogger
   static final int DEFAULT_EMIT_QUEUE_CAPACITY = 1000;
   static final int DEFAULT_EMIT_THREAD_COUNT = 1;
   private static final int DISCARD_WARNING_INTERVAL = 1000;
+  /**
+   * Number of attempts per event (1 initial + MAX_SEND_RETRIES retries).
+   * Delivery is at-most-once after all attempts are exhausted: if every attempt
+   * fails the event is dropped and a warning is logged.
+   */
+  static final int MAX_SEND_RETRIES = 2;
+  private static final long RETRY_SLEEP_MS = 500;
 
   static final String UNKNOWN_QUERY_ID = "unknown-query-id";
 
@@ -458,25 +465,70 @@ public class OpenLineageRequestLogger implements RequestLogger
 
   private void emitHttp(String json)
   {
-    HttpPost post = new HttpPost(transportUrl);
-    post.setEntity(new StringEntity(json, ContentType.APPLICATION_JSON));
-    try {
-      org.apache.http.HttpResponse response = httpClient.execute(post);
-      int statusCode = response.getStatusLine().getStatusCode();
-      if (statusCode < 200 || statusCode >= 300) {
-        log.warn(
-            "OpenLineage HTTP transport received non-2xx response [%d] from [%s]; event may have been dropped",
-            statusCode,
+    IOException lastException = null;
+    int lastStatusCode = -1;
+
+    for (int attempt = 0; attempt <= MAX_SEND_RETRIES; attempt++) {
+      if (attempt > 0) {
+        try {
+          Thread.sleep(RETRY_SLEEP_MS);
+        }
+        catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          log.warn("OpenLineage HTTP emit interrupted on retry [%d]; dropping event", attempt);
+          return;
+        }
+      }
+
+      HttpPost post = new HttpPost(transportUrl);
+      post.setEntity(new StringEntity(json, ContentType.APPLICATION_JSON));
+      try {
+        org.apache.http.HttpResponse response = httpClient.execute(post);
+        lastStatusCode = response.getStatusLine().getStatusCode();
+        EntityUtils.consumeQuietly(response.getEntity());
+        if (lastStatusCode >= 200 && lastStatusCode < 300) {
+          return; // success
+        }
+        // Non-2xx: retry (server-side error may be transient)
+        log.debug(
+            "OpenLineage HTTP attempt [%d/%d] received non-2xx [%d] from [%s]",
+            attempt + 1,
+            MAX_SEND_RETRIES + 1,
+            lastStatusCode,
+            transportUrl
+        );
+        lastException = null;
+      }
+      catch (IOException e) {
+        lastException = e;
+        log.debug(
+            e,
+            "OpenLineage HTTP attempt [%d/%d] failed posting to [%s]",
+            attempt + 1,
+            MAX_SEND_RETRIES + 1,
             transportUrl
         );
       }
-      EntityUtils.consumeQuietly(response.getEntity());
+      finally {
+        post.releaseConnection();
+      }
     }
-    catch (IOException e) {
-      log.error(e, "Failed to POST OpenLineage event to [%s]", transportUrl);
-    }
-    finally {
-      post.releaseConnection();
+
+    // All attempts exhausted — delivery guarantee is at-most-once.
+    if (lastException != null) {
+      log.warn(
+          lastException,
+          "OpenLineage event dropped: all [%d] attempts to POST to [%s] failed with an exception",
+          MAX_SEND_RETRIES + 1,
+          transportUrl
+      );
+    } else {
+      log.warn(
+          "OpenLineage event dropped: all [%d] attempts to POST to [%s] returned non-2xx status [%d]",
+          MAX_SEND_RETRIES + 1,
+          transportUrl,
+          lastStatusCode
+      );
     }
   }
 

--- a/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
+++ b/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLogger.java
@@ -25,12 +25,13 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.avatica.util.Quoting;
 import org.apache.calcite.sql.SqlBasicCall;
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlInsert;
 import org.apache.calcite.sql.SqlJoin;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
-import org.apache.calcite.sql.SqlOrderBy;
+import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.SqlWith;
 import org.apache.calcite.sql.SqlWithItem;
@@ -53,6 +54,8 @@ import org.apache.http.util.EntityUtils;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -97,6 +100,17 @@ public class OpenLineageRequestLogger implements RequestLogger
       .withUnquotedCasing(Casing.UNCHANGED)
       .withQuotedCasing(Casing.UNCHANGED)
       .withQuoting(Quoting.DOUBLE_QUOTE);
+
+  // Matches: INSERT INTO <table> ... (fallback when EXTERN prevents standard Calcite parsing)
+  // Handles both quoted ("table") and unquoted (table) identifiers.
+  private static final Pattern INSERT_INTO_PATTERN =
+      Pattern.compile("(?i)^\\s*INSERT\\s+INTO\\s+\"?([^\"\\s]+)\"?");
+  // Matches: REPLACE INTO <table> OVERWRITE ... (Druid-specific, not parseable by standard Calcite)
+  private static final Pattern REPLACE_INTO_PATTERN =
+      Pattern.compile("(?i)^\\s*REPLACE\\s+INTO\\s+\"?([^\"\\s]+)\"?");
+  // Extracts the SELECT subquery from a REPLACE INTO statement for input lineage
+  private static final Pattern REPLACE_SELECT_PATTERN =
+      Pattern.compile("(?is)\\b(SELECT\\s+.+?)(?:\\s+PARTITIONED\\s+BY|\\s+CLUSTERED\\s+BY|$)");
 
   static final int DEFAULT_EMIT_QUEUE_CAPACITY = 1000;
   static final int DEFAULT_EMIT_THREAD_COUNT = 1;
@@ -158,6 +172,11 @@ public class OpenLineageRequestLogger implements RequestLogger
     this.transportType = transportType;
     this.transportUrl = transportUrl;
     this.excludedNativeQueryTypes = excludedNativeQueryTypes;
+    if (transportType == OpenLineageRequestLoggerProvider.TransportType.HTTP && transportUrl == null) {
+      throw new IllegalStateException(
+          "druid.request.logging.transportUrl must be set when transportType=HTTP"
+      );
+    }
     if (transportType == OpenLineageRequestLoggerProvider.TransportType.HTTP) {
       this.httpClient = httpClient != null ? httpClient : HttpClientBuilder.create().build();
       // Bounded queue: if the queue is full, drop the event rather than blocking the query thread.
@@ -177,20 +196,18 @@ public class OpenLineageRequestLogger implements RequestLogger
     }
   }
 
+  // Note: ComposingRequestLogger does not delegate @LifecycleStart to sub-loggers, so this method
+  // may not be called when used in a composing configuration. HTTP URL validation is therefore
+  // performed in the constructor instead. This method is retained for direct lifecycle use.
   @LifecycleStart
   @Override
-  public void start() throws Exception
+  public void start()
   {
-    if (transportType == OpenLineageRequestLoggerProvider.TransportType.HTTP && transportUrl == null) {
-      throw new IllegalStateException(
-          "druid.request.logging.transportUrl must be set when transportType=HTTP"
-      );
-    }
-    if (transportType == OpenLineageRequestLoggerProvider.TransportType.HTTP) {
-      log.info("Started OpenLineage HTTP transport to [%s]", transportUrl);
-    } else {
-      log.info("Started OpenLineage console transport");
-    }
+    log.info(
+        "Started OpenLineage {} transport{}",
+        transportType,
+        transportUrl != null ? " to [" + transportUrl + "]" : ""
+    );
   }
 
   @LifecycleStop
@@ -260,10 +277,44 @@ public class OpenLineageRequestLogger implements RequestLogger
         output = extractOutput(parsed);
       }
       catch (SqlParseException e) {
-        // Druid-specific SQL extensions (REPLACE, EXTERN, etc.) may not parse with the standard
-        // Calcite parser. Emit the event without table-level lineage rather than failing.
+        // Druid-specific SQL extensions (REPLACE INTO, EXTERN, etc.) may not parse with the
+        // standard Calcite parser. Attempt to extract lineage from REPLACE INTO via regex;
+        // for other unparseable statements, emit the event without table-level lineage.
+        if (sql != null) {
+          Matcher insertMatcher = INSERT_INTO_PATTERN.matcher(sql);
+          if (insertMatcher.find()) {
+            output = insertMatcher.group(1);
+            // Also try to extract inputs from the SELECT subquery (handles PARTITIONED BY and
+            // other Druid-specific clauses that prevent full parsing). EXTERN-sourced inputs
+            // will fail to re-parse and fall through with empty inputs, which is correct.
+            Matcher selectMatcher = REPLACE_SELECT_PATTERN.matcher(sql);
+            if (selectMatcher.find()) {
+              try {
+                SqlNode selectNode = SqlParser.create(selectMatcher.group(1), SQL_PARSER_CONFIG).parseQuery();
+                inputs = extractInputs(selectNode);
+              }
+              catch (SqlParseException ignored) {
+                // EXTERN or other non-standard sources — inputs left empty
+              }
+            }
+          }
+          Matcher m = REPLACE_INTO_PATTERN.matcher(sql);
+          if (m.find()) {
+            output = m.group(1);
+            Matcher selectMatcher = REPLACE_SELECT_PATTERN.matcher(sql);
+            if (selectMatcher.find()) {
+              try {
+                SqlNode selectNode = SqlParser.create(selectMatcher.group(1), SQL_PARSER_CONFIG).parseQuery();
+                inputs = extractInputs(selectNode);
+              }
+              catch (SqlParseException ignored) {
+                // fall through with empty inputs
+              }
+            }
+          }
+        }
         log.debug(
-            "OpenLineage: could not parse SQL for lineage extraction (query will still be emitted): %s",
+            "OpenLineage: could not parse SQL with standard Calcite parser (query will still be emitted): %s",
             e.getMessage()
         );
       }
@@ -404,20 +455,11 @@ public class OpenLineageRequestLogger implements RequestLogger
   private List<String> extractInputs(SqlNode root)
   {
     List<String> tables = new ArrayList<>();
-    if (root instanceof SqlWith) {
-      SqlWith with = (SqlWith) root;
-      Set<String> cteNames = new HashSet<>();
-      for (SqlNode item : with.withList) {
-        if (item instanceof SqlWithItem) {
-          cteNames.add(((SqlWithItem) item).name.getSimple());
-          collectFromClause(((SqlWithItem) item).query, tables, cteNames);
-        }
-      }
-      collectFromClause(with.body, tables, cteNames);
-    } else if (root instanceof SqlInsert) {
-      collectFromClause(((SqlInsert) root).getSource(), tables, Set.of());
+    if (root instanceof SqlInsert) {
+      // For INSERT/REPLACE, only walk the source query — the target table is an output, not an input.
+      collectTableNames(((SqlInsert) root).getSource(), tables, Set.of());
     } else {
-      collectFromClause(root, tables, Set.of());
+      collectTableNames(root, tables, Set.of());
     }
     return tables;
   }
@@ -434,36 +476,91 @@ public class OpenLineageRequestLogger implements RequestLogger
     return null;
   }
 
-  private void collectFromClause(SqlNode from, List<String> tables, Set<String> excludeNames)
+  /**
+   * Walks the SQL tree to collect table references from FROM clauses, JOINs, subqueries in
+   * WHERE/HAVING/SELECT, and set operations (UNION/INTERSECT/EXCEPT). CTE alias names are
+   * tracked in {@code excludeNames} to avoid reporting them as table inputs.
+   *
+   * <p>The walker distinguishes table-reference positions (FROM, JOIN) from column-reference
+   * positions (SELECT list, WHERE expressions) by collecting {@link SqlIdentifier} nodes only
+   * from known table-reference contexts, while recursing into all subqueries to find nested
+   * FROM clauses.
+   */
+  private void collectTableNames(SqlNode node, List<String> tables, Set<String> excludeNames)
   {
-    if (from == null) {
+    if (node == null) {
       return;
     }
-    if (from instanceof SqlIdentifier) {
-      String name = String.join(".", ((SqlIdentifier) from).names);
-      if (!excludeNames.contains(name)) {
-        tables.add(name);
-      }
-    } else if (from instanceof SqlJoin) {
-      SqlJoin join = (SqlJoin) from;
-      collectFromClause(join.getLeft(), tables, excludeNames);
-      collectFromClause(join.getRight(), tables, excludeNames);
-    } else if (from instanceof SqlSelect) {
-      collectFromClause(((SqlSelect) from).getFrom(), tables, excludeNames);
-    } else if (from instanceof SqlWith) {
-      SqlWith with = (SqlWith) from;
+    if (node instanceof SqlWith) {
+      SqlWith with = (SqlWith) node;
       Set<String> innerExcludes = new HashSet<>(excludeNames);
       for (SqlNode item : with.withList) {
         if (item instanceof SqlWithItem) {
           innerExcludes.add(((SqlWithItem) item).name.getSimple());
-          collectFromClause(((SqlWithItem) item).query, tables, innerExcludes);
+          collectTableNames(((SqlWithItem) item).query, tables, innerExcludes);
         }
       }
-      collectFromClause(with.body, tables, innerExcludes);
-    } else if (from instanceof SqlOrderBy) {
-      collectFromClause(((SqlOrderBy) from).query, tables, excludeNames);
-    } else if (from instanceof SqlBasicCall && from.getKind() == SqlKind.AS) {
-      collectFromClause(((SqlBasicCall) from).operand(0), tables, excludeNames);
+      collectTableNames(with.body, tables, innerExcludes);
+    } else if (node instanceof SqlNodeList) {
+      // Lists (e.g., SELECT list items): recurse into each element to find subqueries.
+      for (SqlNode item : (SqlNodeList) node) {
+        collectTableNames(item, tables, excludeNames);
+      }
+    } else if (node instanceof SqlSelect) {
+      SqlSelect select = (SqlSelect) node;
+      // FROM clause: identifiers here are table references.
+      collectFromPosition(select.getFrom(), tables, excludeNames);
+      // Recurse into WHERE, HAVING, and SELECT list to find nested subqueries.
+      collectTableNames(select.getWhere(), tables, excludeNames);
+      collectTableNames(select.getHaving(), tables, excludeNames);
+      collectTableNames(select.getSelectList(), tables, excludeNames);
+    } else if (node instanceof SqlCall) {
+      SqlCall call = (SqlCall) node;
+      if (call.getKind() == SqlKind.UNION || call.getKind() == SqlKind.INTERSECT || call.getKind() == SqlKind.EXCEPT) {
+        // Set operations: each operand is a SELECT whose FROM clause has table references.
+        for (SqlNode operand : call.getOperandList()) {
+          collectTableNames(operand, tables, excludeNames);
+        }
+      } else {
+        // Other expressions (AND, OR, IN, =, function calls, etc.): recurse to find subqueries.
+        for (SqlNode operand : call.getOperandList()) {
+          if (operand instanceof SqlSelect || operand instanceof SqlWith || operand instanceof SqlCall) {
+            collectTableNames(operand, tables, excludeNames);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Collects table names from a FROM-clause position, where {@link SqlIdentifier} nodes
+   * represent table references (not column references).
+   */
+  private void collectFromPosition(SqlNode node, List<String> tables, Set<String> excludeNames)
+  {
+    if (node == null) {
+      return;
+    }
+    if (node instanceof SqlIdentifier) {
+      String name = String.join(".", ((SqlIdentifier) node).names);
+      if (!excludeNames.contains(name)) {
+        tables.add(name);
+      }
+    } else if (node instanceof SqlJoin) {
+      SqlJoin join = (SqlJoin) node;
+      collectFromPosition(join.getLeft(), tables, excludeNames);
+      collectFromPosition(join.getRight(), tables, excludeNames);
+    } else if (node instanceof SqlSelect) {
+      // Subquery in FROM: recurse into the full select.
+      collectTableNames(node, tables, excludeNames);
+    } else if (node instanceof SqlBasicCall && node.getKind() == SqlKind.AS) {
+      // Alias: the table reference is the first operand.
+      collectFromPosition(((SqlBasicCall) node).operand(0), tables, excludeNames);
+    } else if (node instanceof SqlCall) {
+      // LATERAL, UNNEST, or other FROM-position nodes: walk operands.
+      for (SqlNode operand : ((SqlCall) node).getOperandList()) {
+        collectFromPosition(operand, tables, excludeNames);
+      }
     }
   }
 
@@ -488,6 +585,14 @@ public class OpenLineageRequestLogger implements RequestLogger
     post.setEntity(new StringEntity(json, ContentType.APPLICATION_JSON));
     try {
       org.apache.http.HttpResponse response = httpClient.execute(post);
+      int statusCode = response.getStatusLine().getStatusCode();
+      if (statusCode < 200 || statusCode >= 300) {
+        log.warn(
+            "OpenLineage HTTP transport received non-2xx response [%d] from [%s]; event may have been dropped",
+            statusCode,
+            transportUrl
+        );
+      }
       EntityUtils.consumeQuietly(response.getEntity());
     }
     catch (IOException e) {

--- a/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerModule.java
+++ b/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerModule.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.extensions.openlineage;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.inject.Binder;
+import org.apache.druid.initialization.DruidModule;
+
+import java.util.Collections;
+import java.util.List;
+
+public class OpenLineageRequestLoggerModule implements DruidModule
+{
+  @Override
+  public void configure(Binder binder)
+  {
+  }
+
+  @Override
+  public List<? extends Module> getJacksonModules()
+  {
+    return Collections.singletonList(
+        new SimpleModule("OpenLineageRequestLoggerModule")
+            .registerSubtypes(OpenLineageRequestLoggerProvider.class)
+    );
+  }
+}

--- a/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerProvider.java
+++ b/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerProvider.java
@@ -25,11 +25,13 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.log.RequestLogger;
 import org.apache.druid.server.log.RequestLoggerProvider;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
+import java.util.Set;
 
 /**
  *  Configure logging type, namespace, transport type (http or default console), transportUrl in {@code runtime.properties} 
@@ -52,7 +54,7 @@ public class OpenLineageRequestLoggerProvider implements RequestLoggerProvider
 
   @JsonProperty
   @NotNull
-  private String namespace = "druid://localhost";
+  private String namespace = "druid://" + DruidNode.getDefaultHost();
 
   @JsonProperty
   @NotNull
@@ -62,10 +64,18 @@ public class OpenLineageRequestLoggerProvider implements RequestLoggerProvider
   @JsonProperty
   private String transportUrl;
 
+  @JsonProperty
+  @NotNull
+  private Set<String> excludedNativeQueryTypes = Set.of(
+      "segmentMetadata",
+      "dataSourceMetadata",
+      "timeBoundary"
+  );
+
   @Override
   public RequestLogger get()
   {
     log.debug("Creating OpenLineageRequestLogger [namespace=%s, transport=%s]", namespace, transportType);
-    return new OpenLineageRequestLogger(jsonMapper, namespace, transportType, transportUrl);
+    return new OpenLineageRequestLogger(jsonMapper, namespace, transportType, transportUrl, excludedNativeQueryTypes);
   }
 }

--- a/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerProvider.java
+++ b/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerProvider.java
@@ -68,14 +68,27 @@ public class OpenLineageRequestLoggerProvider implements RequestLoggerProvider
   @NotNull
   private Set<String> excludedNativeQueryTypes = Set.of(
       "segmentMetadata",
-      "dataSourceMetadata",
-      "timeBoundary"
+      "dataSourceMetadata"
   );
+
+  @JsonProperty
+  private int emitQueueCapacity = OpenLineageRequestLogger.DEFAULT_EMIT_QUEUE_CAPACITY;
+
+  @JsonProperty
+  private int emitThreadCount = OpenLineageRequestLogger.DEFAULT_EMIT_THREAD_COUNT;
 
   @Override
   public RequestLogger get()
   {
     log.debug("Creating OpenLineageRequestLogger [namespace=%s, transport=%s]", namespace, transportType);
-    return new OpenLineageRequestLogger(jsonMapper, namespace, transportType, transportUrl, excludedNativeQueryTypes);
+    return new OpenLineageRequestLogger(
+        jsonMapper,
+        namespace,
+        transportType,
+        transportUrl,
+        excludedNativeQueryTypes,
+        emitQueueCapacity,
+        emitThreadCount
+    );
   }
 }

--- a/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerProvider.java
+++ b/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerProvider.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.extensions.openlineage;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.guice.annotations.Json;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.server.log.RequestLogger;
+import org.apache.druid.server.log.RequestLoggerProvider;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
+/**
+ *  Configure logging type, namespace, transport type (http or default console), transportUrl in {@code runtime.properties} 
+ */
+@JsonTypeName("openlineage")
+public class OpenLineageRequestLoggerProvider implements RequestLoggerProvider
+{
+  private static final Logger log = new Logger(OpenLineageRequestLoggerProvider.class);
+
+  public enum TransportType
+  {
+    CONSOLE,
+    HTTP
+  }
+
+  @JacksonInject
+  @Json
+  @NotNull
+  private ObjectMapper jsonMapper;
+
+  @JsonProperty
+  @NotNull
+  private String namespace = "druid://localhost";
+
+  @JsonProperty
+  @NotNull
+  private TransportType transportType = TransportType.CONSOLE;
+
+  @Nullable
+  @JsonProperty
+  private String transportUrl;
+
+  @Override
+  public RequestLogger get()
+  {
+    if (transportType == TransportType.HTTP && transportUrl == null) {
+      throw new IllegalStateException(
+          "druid.request.logging.transportUrl must be set when transportType=HTTP"
+      );
+    }
+    OpenLineageRequestLogger logger = new OpenLineageRequestLogger(jsonMapper, namespace, transportType, transportUrl);
+    log.debug(new Exception("Stack trace"), "Creating %s at", logger);
+    return logger;
+  }
+}

--- a/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerProvider.java
+++ b/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerProvider.java
@@ -65,8 +65,7 @@ public class OpenLineageRequestLoggerProvider implements RequestLoggerProvider
   @Override
   public RequestLogger get()
   {
-    OpenLineageRequestLogger logger = new OpenLineageRequestLogger(jsonMapper, namespace, transportType, transportUrl);
-    log.debug(new Exception("Stack trace"), "Creating %s at", logger);
-    return logger;
+    log.debug("Creating OpenLineageRequestLogger [namespace=%s, transport=%s]", namespace, transportType);
+    return new OpenLineageRequestLogger(jsonMapper, namespace, transportType, transportUrl);
   }
 }

--- a/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerProvider.java
+++ b/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerProvider.java
@@ -65,11 +65,6 @@ public class OpenLineageRequestLoggerProvider implements RequestLoggerProvider
   @Override
   public RequestLogger get()
   {
-    if (transportType == TransportType.HTTP && transportUrl == null) {
-      throw new IllegalStateException(
-          "druid.request.logging.transportUrl must be set when transportType=HTTP"
-      );
-    }
     OpenLineageRequestLogger logger = new OpenLineageRequestLogger(jsonMapper, namespace, transportType, transportUrl);
     log.debug(new Exception("Stack trace"), "Creating %s at", logger);
     return logger;

--- a/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerProvider.java
+++ b/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerProvider.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.metadata.PasswordProvider;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.log.RequestLogger;
 import org.apache.druid.server.log.RequestLoggerProvider;
@@ -93,7 +94,7 @@ public class OpenLineageRequestLoggerProvider implements RequestLoggerProvider
 
   @Nullable
   @JsonProperty
-  private String trustStorePassword;
+  private PasswordProvider trustStorePassword;
 
   @Nullable
   @JsonProperty
@@ -101,7 +102,7 @@ public class OpenLineageRequestLoggerProvider implements RequestLoggerProvider
 
   @Nullable
   @JsonProperty
-  private String keyStorePassword;
+  private PasswordProvider keyStorePassword;
 
   @Override
   public RequestLogger get()
@@ -136,7 +137,9 @@ public class OpenLineageRequestLoggerProvider implements RequestLoggerProvider
       if (trustStorePath != null) {
         try (FileInputStream in = new FileInputStream(new File(trustStorePath))) {
           KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
-          trustStore.load(in, trustStorePassword != null ? trustStorePassword.toCharArray() : null);
+          // getPassword() may return null if the env var is unset; treat as no-password.
+          String rawTrustPw = trustStorePassword != null ? trustStorePassword.getPassword() : null;
+          trustStore.load(in, rawTrustPw != null ? rawTrustPw.toCharArray() : null);
           tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
           tmf.init(trustStore);
         }
@@ -145,9 +148,12 @@ public class OpenLineageRequestLoggerProvider implements RequestLoggerProvider
       if (keyStorePath != null) {
         try (FileInputStream in = new FileInputStream(new File(keyStorePath))) {
           KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
-          keyStore.load(in, keyStorePassword != null ? keyStorePassword.toCharArray() : null);
+          // Resolve once to avoid inconsistent values if the provider is dynamic.
+          String rawKeyPw = keyStorePassword != null ? keyStorePassword.getPassword() : null;
+          char[] keyPwChars = rawKeyPw != null ? rawKeyPw.toCharArray() : null;
+          keyStore.load(in, keyPwChars);
           kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-          kmf.init(keyStore, keyStorePassword != null ? keyStorePassword.toCharArray() : null);
+          kmf.init(keyStore, keyPwChars);
         }
       }
       SSLContext sslContext = SSLContext.getInstance("TLS");

--- a/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerProvider.java
+++ b/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerProvider.java
@@ -28,13 +28,22 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.log.RequestLogger;
 import org.apache.druid.server.log.RequestLoggerProvider;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.HttpClientBuilder;
 
 import javax.annotation.Nullable;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
 import javax.validation.constraints.NotNull;
+import java.io.File;
+import java.io.FileInputStream;
+import java.security.KeyStore;
 import java.util.Set;
 
 /**
- *  Configure logging type, namespace, transport type (http or default console), transportUrl in {@code runtime.properties} 
+ * Configure via {@code druid.request.logging.type=openlineage} in {@code runtime.properties}.
  */
 @JsonTypeName("openlineage")
 public class OpenLineageRequestLoggerProvider implements RequestLoggerProvider
@@ -78,10 +87,27 @@ public class OpenLineageRequestLoggerProvider implements RequestLoggerProvider
   @JsonProperty
   private int emitThreadCount = OpenLineageRequestLogger.DEFAULT_EMIT_THREAD_COUNT;
 
+  @Nullable
+  @JsonProperty
+  private String trustStorePath;
+
+  @Nullable
+  @JsonProperty
+  private String trustStorePassword;
+
+  @Nullable
+  @JsonProperty
+  private String keyStorePath;
+
+  @Nullable
+  @JsonProperty
+  private String keyStorePassword;
+
   @Override
   public RequestLogger get()
   {
     log.debug("Creating OpenLineageRequestLogger [namespace=%s, transport=%s]", namespace, transportType);
+    HttpClient httpClient = transportType == TransportType.HTTP ? buildHttpClient() : null;
     return new OpenLineageRequestLogger(
         jsonMapper,
         namespace,
@@ -89,7 +115,51 @@ public class OpenLineageRequestLoggerProvider implements RequestLoggerProvider
         transportUrl,
         excludedNativeQueryTypes,
         emitQueueCapacity,
-        emitThreadCount
+        emitThreadCount,
+        httpClient
     );
+  }
+
+  private HttpClient buildHttpClient()
+  {
+    RequestConfig requestConfig = RequestConfig.custom()
+                                               .setConnectTimeout(5000)
+                                               .setSocketTimeout(10000)
+                                               .setConnectionRequestTimeout(5000)
+                                               .build();
+    if (trustStorePath == null && keyStorePath == null) {
+      return HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build();
+    }
+    try {
+      HttpClientBuilder builder = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig);
+      TrustManagerFactory tmf = null;
+      if (trustStorePath != null) {
+        try (FileInputStream in = new FileInputStream(new File(trustStorePath))) {
+          KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+          trustStore.load(in, trustStorePassword != null ? trustStorePassword.toCharArray() : null);
+          tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+          tmf.init(trustStore);
+        }
+      }
+      KeyManagerFactory kmf = null;
+      if (keyStorePath != null) {
+        try (FileInputStream in = new FileInputStream(new File(keyStorePath))) {
+          KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+          keyStore.load(in, keyStorePassword != null ? keyStorePassword.toCharArray() : null);
+          kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+          kmf.init(keyStore, keyStorePassword != null ? keyStorePassword.toCharArray() : null);
+        }
+      }
+      SSLContext sslContext = SSLContext.getInstance("TLS");
+      sslContext.init(
+          kmf != null ? kmf.getKeyManagers() : null,
+          tmf != null ? tmf.getTrustManagers() : null,
+          null
+      );
+      return builder.setSSLContext(sslContext).build();
+    }
+    catch (Exception e) {
+      throw new IllegalStateException("Failed to configure TLS for OpenLineage HTTP transport", e);
+    }
   }
 }

--- a/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerProvider.java
+++ b/extensions-contrib/openlineage-emitter/src/main/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerProvider.java
@@ -68,7 +68,8 @@ public class OpenLineageRequestLoggerProvider implements RequestLoggerProvider
   @NotNull
   private Set<String> excludedNativeQueryTypes = Set.of(
       "segmentMetadata",
-      "dataSourceMetadata"
+      "dataSourceMetadata",
+      "timeBoundary"
   );
 
   @JsonProperty

--- a/extensions-contrib/openlineage-emitter/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
+++ b/extensions-contrib/openlineage-emitter/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.druid.extensions.openlineage.OpenLineageRequestLoggerModule

--- a/extensions-contrib/openlineage-emitter/src/main/resources/openlineage-schema/DruidQueryContextRunFacet.json
+++ b/extensions-contrib/openlineage-emitter/src/main/resources/openlineage-schema/DruidQueryContextRunFacet.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/apache/druid/master/extensions-contrib/openlineage-emitter/src/main/resources/openlineage-schema/DruidQueryContextRunFacet.json",
+  "title": "DruidQueryContextRunFacet",
+  "description": "Druid-specific run facet capturing query context metadata.",
+  "type": "object",
+  "allOf": [
+    {"$ref": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/definitions/RunFacet"}
+  ],
+  "properties": {
+    "queryType": {
+      "type": "string",
+      "description": "The Druid query type (e.g. 'groupBy', 'topN', 'scan', 'msq')."
+    },
+    "remoteAddress": {
+      "type": "string",
+      "description": "IP address of the client that submitted the query."
+    },
+    "identity": {
+      "type": "string",
+      "description": "Authenticated identity of the query submitter, if available."
+    },
+    "sqlQueryId": {
+      "type": "string",
+      "description": "For native sub-queries of SQL, the parent SQL query ID for correlation."
+    }
+  },
+  "required": ["queryType", "remoteAddress"]
+}

--- a/extensions-contrib/openlineage-emitter/src/main/resources/openlineage-schema/DruidQueryStatisticsRunFacet.json
+++ b/extensions-contrib/openlineage-emitter/src/main/resources/openlineage-schema/DruidQueryStatisticsRunFacet.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/apache/druid/master/extensions-contrib/openlineage-emitter/src/main/resources/openlineage-schema/DruidQueryStatisticsRunFacet.json",
+  "title": "DruidQueryStatisticsRunFacet",
+  "description": "Druid-specific run facet capturing query execution statistics.",
+  "type": "object",
+  "allOf": [
+    {"$ref": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/definitions/RunFacet"}
+  ],
+  "properties": {
+    "durationMs": {
+      "type": "integer",
+      "description": "Total query execution time in milliseconds."
+    },
+    "bytes": {
+      "type": "integer",
+      "description": "Number of bytes returned by the query."
+    },
+    "planningTimeMs": {
+      "type": "integer",
+      "description": "SQL planning time in milliseconds. Only present on SQL queries."
+    },
+    "statusCode": {
+      "type": "string",
+      "description": "HTTP status code of the query response."
+    }
+  }
+}

--- a/extensions-contrib/openlineage-emitter/src/test/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerTest.java
+++ b/extensions-contrib/openlineage-emitter/src/test/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerTest.java
@@ -330,7 +330,21 @@ public class OpenLineageRequestLoggerTest
     Field transportTypeField = OpenLineageRequestLoggerProvider.class.getDeclaredField("transportType");
     transportTypeField.setAccessible(true);
     transportTypeField.set(provider, OpenLineageRequestLoggerProvider.TransportType.HTTP);
-    provider.get();
+    // Validation moved to start() method for proper lifecycle management
+    OpenLineageRequestLogger logger = (OpenLineageRequestLogger) provider.get();
+    logger.start();
+  }
+
+  @Test
+  public void testNativeQueryWithNullQueryDoesNotCrash() throws Exception
+  {
+    // Simulate a native query parse failure where query is null
+    RequestLogLine logLine = RequestLogLine.forNative(null, TIMESTAMP, REMOTE_ADDR, new QueryStats(ImmutableMap.of()));
+
+    // Should not throw NPE, should return early without emitting event
+    logger.logNativeQuery(logLine);
+
+    Assert.assertEquals(0, capturedEvents.size());
   }
 
   private static RequestLogLine sqlLine(String sql, Map<String, Object> context, Map<String, Object> stats)

--- a/extensions-contrib/openlineage-emitter/src/test/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerTest.java
+++ b/extensions-contrib/openlineage-emitter/src/test/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerTest.java
@@ -1,0 +1,403 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.extensions.openlineage;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.query.BaseQuery;
+import org.apache.druid.query.DataSource;
+import org.apache.druid.query.Query;
+import org.apache.druid.query.TableDataSource;
+import org.apache.druid.query.filter.DimFilter;
+import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
+import org.apache.druid.query.spec.QuerySegmentSpec;
+import org.apache.druid.server.QueryStats;
+import org.apache.druid.server.RequestLogLine;
+import org.joda.time.DateTime;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class OpenLineageRequestLoggerTest
+{
+  private static final ObjectMapper MAPPER = new DefaultObjectMapper();
+  private static final String NAMESPACE = "druid://test:8082";
+  private static final DateTime TIMESTAMP = DateTimes.of("2024-01-01T00:00:00Z");
+  private static final String REMOTE_ADDR = "10.0.0.1";
+
+  private List<ObjectNode> capturedEvents;
+  private OpenLineageRequestLogger logger;
+
+  @Before
+  public void setUp()
+  {
+    capturedEvents = new ArrayList<>();
+    logger = new OpenLineageRequestLogger(
+        MAPPER,
+        NAMESPACE,
+        OpenLineageRequestLoggerProvider.TransportType.CONSOLE,
+        null
+    )
+    {
+      @Override
+      protected void emit(ObjectNode event)
+      {
+        capturedEvents.add(event);
+      }
+    };
+  }
+
+  @Test
+  public void testSqlQuerySimpleSelect() throws IOException
+  {
+    logger.logSqlQuery(sqlLine(
+        "SELECT * FROM \"kttm\"",
+        ImmutableMap.of("sqlQueryId", "qid-1"),
+        ImmutableMap.of("success", true, "sqlQuery/time", 200L, "sqlQuery/bytes", 1024L,
+                        "sqlQuery/planningTimeMs", 10L, "statusCode", "200", "identity", "alice")
+    ));
+
+    Assert.assertEquals(1, capturedEvents.size());
+    ObjectNode event = capturedEvents.get(0);
+
+    Assert.assertEquals("COMPLETE", event.get("eventType").asText());
+    Assert.assertEquals(NAMESPACE, event.get("job").get("namespace").asText());
+
+    JsonNode inputs = event.get("inputs");
+    Assert.assertEquals(1, inputs.size());
+    Assert.assertEquals("kttm", inputs.get(0).get("name").asText());
+    Assert.assertEquals(NAMESPACE, inputs.get(0).get("namespace").asText());
+
+    Assert.assertEquals(0, event.get("outputs").size());
+  }
+
+  @Test
+  public void testSqlQueryJoin() throws IOException
+  {
+    logger.logSqlQuery(sqlLine(
+        "SELECT a.\"x\" FROM \"tableA\" AS a JOIN \"tableB\" AS b ON a.\"id\" = b.\"id\"",
+        ImmutableMap.of("sqlQueryId", "qid-2"),
+        ImmutableMap.of("success", true)
+    ));
+
+    Assert.assertEquals(1, capturedEvents.size());
+    Set<String> names = inputNames(capturedEvents.get(0).get("inputs"));
+    Assert.assertTrue(names.contains("tableA"));
+    Assert.assertTrue(names.contains("tableB"));
+  }
+
+  @Test
+  public void testSqlQueryCteExcludesCteNames() throws IOException
+  {
+    // "cte" is a CTE name and must NOT appear as an input; "realTable" is the physical source
+    logger.logSqlQuery(sqlLine(
+        "WITH \"cte\" AS (SELECT * FROM \"realTable\") SELECT * FROM \"cte\"",
+        ImmutableMap.of("sqlQueryId", "qid-3"),
+        ImmutableMap.of("success", true)
+    ));
+
+    Assert.assertEquals(1, capturedEvents.size());
+    Set<String> names = inputNames(capturedEvents.get(0).get("inputs"));
+    Assert.assertTrue(names.contains("realTable"));
+    Assert.assertFalse(names.contains("cte"));
+  }
+
+  @Test
+  public void testSqlQueryInsert() throws IOException
+  {
+    logger.logSqlQuery(sqlLine(
+        "INSERT INTO \"outputTable\" SELECT * FROM \"inputTable\"",
+        ImmutableMap.of("sqlQueryId", "qid-4"),
+        ImmutableMap.of("success", true)
+    ));
+
+    Assert.assertEquals(1, capturedEvents.size());
+    ObjectNode event = capturedEvents.get(0);
+
+    Assert.assertTrue(inputNames(event.get("inputs")).contains("inputTable"));
+
+    JsonNode outputs = event.get("outputs");
+    Assert.assertEquals(1, outputs.size());
+    Assert.assertEquals("outputTable", outputs.get(0).get("name").asText());
+  }
+
+  @Test
+  public void testSqlQueryParseFailureStillEmitsEvent() throws IOException
+  {
+    // Druid-specific syntax (REPLACE INTO) doesn't parse with the standard Calcite parser;
+    // the event is still emitted, just without table-level lineage.
+    logger.logSqlQuery(sqlLine(
+        "REPLACE INTO \"ds\" OVERWRITE ALL SELECT * FROM \"src\" PARTITIONED BY ALL",
+        ImmutableMap.of("sqlQueryId", "qid-5"),
+        ImmutableMap.of("success", true)
+    ));
+
+    Assert.assertEquals(1, capturedEvents.size());
+    Assert.assertEquals(0, capturedEvents.get(0).get("inputs").size());
+    Assert.assertEquals(0, capturedEvents.get(0).get("outputs").size());
+  }
+
+  @Test
+  public void testSqlQueryFailedQueryHasErrorMessageFacet() throws IOException
+  {
+    logger.logSqlQuery(sqlLine(
+        "SELECT * FROM \"t\"",
+        ImmutableMap.of("sqlQueryId", "qid-6"),
+        ImmutableMap.of("success", false, "exception", "Query timed out")
+    ));
+
+    Assert.assertEquals(1, capturedEvents.size());
+    ObjectNode event = capturedEvents.get(0);
+
+    Assert.assertEquals("FAIL", event.get("eventType").asText());
+
+    JsonNode errorFacet = event.get("run").get("facets").get("errorMessage");
+    Assert.assertNotNull(errorFacet);
+    Assert.assertEquals("Query timed out", errorFacet.get("message").asText());
+    Assert.assertEquals("SQL", errorFacet.get("programmingLanguage").asText());
+  }
+
+  @Test
+  public void testSqlQueryNoErrorMessageFacetOnSuccess() throws IOException
+  {
+    logger.logSqlQuery(sqlLine(
+        "SELECT 1",
+        ImmutableMap.of("sqlQueryId", "qid-7"),
+        ImmutableMap.of("success", true)
+    ));
+
+    Assert.assertEquals(1, capturedEvents.size());
+    Assert.assertNull(capturedEvents.get(0).get("run").get("facets").get("errorMessage"));
+  }
+
+  @Test
+  public void testSqlQueryStatsFacets() throws IOException
+  {
+    logger.logSqlQuery(sqlLine(
+        "SELECT 1",
+        ImmutableMap.of("sqlQueryId", "qid-8"),
+        ImmutableMap.of(
+            "success", true,
+            "sqlQuery/time", 300L,
+            "sqlQuery/bytes", 2048L,
+            "sqlQuery/planningTimeMs", 25L,
+            "statusCode", "200",
+            "identity", "bob"
+        )
+    ));
+
+    Assert.assertEquals(1, capturedEvents.size());
+    JsonNode runFacets = capturedEvents.get(0).get("run").get("facets");
+
+    JsonNode stats = runFacets.get("druid_query_statistics");
+    Assert.assertEquals(300L, stats.get("durationMs").asLong());
+    Assert.assertEquals(2048L, stats.get("bytes").asLong());
+    Assert.assertEquals(25L, stats.get("planningTimeMs").asLong());
+    Assert.assertEquals("200", stats.get("statusCode").asText());
+
+    JsonNode ctx = runFacets.get("druid_query_context");
+    Assert.assertEquals("bob", ctx.get("identity").asText());
+    Assert.assertEquals(REMOTE_ADDR, ctx.get("remoteAddress").asText());
+    Assert.assertEquals("sql", ctx.get("queryType").asText());
+  }
+
+  @Test
+  public void testSqlQuerySqlFacetPresent() throws IOException
+  {
+    String sql = "SELECT * FROM \"t\"";
+    logger.logSqlQuery(sqlLine(
+        sql,
+        ImmutableMap.of("sqlQueryId", "qid-9"),
+        ImmutableMap.of("success", true)
+    ));
+
+    Assert.assertEquals(1, capturedEvents.size());
+    JsonNode sqlFacet = capturedEvents.get(0).get("job").get("facets").get("sql");
+    Assert.assertNotNull(sqlFacet);
+    Assert.assertEquals(sql, sqlFacet.get("query").asText());
+  }
+
+  @Test
+  public void testSqlQueryJobTypeFacet() throws IOException
+  {
+    logger.logSqlQuery(sqlLine(
+        "SELECT 1",
+        ImmutableMap.of("sqlQueryId", "qid-10"),
+        ImmutableMap.of("success", true)
+    ));
+
+    Assert.assertEquals(1, capturedEvents.size());
+    JsonNode jobType = capturedEvents.get(0).get("job").get("facets").get("jobType");
+    Assert.assertNotNull(jobType);
+    Assert.assertEquals("BATCH", jobType.get("processingType").asText());
+    Assert.assertEquals("DRUID", jobType.get("integration").asText());
+    Assert.assertEquals("QUERY", jobType.get("jobType").asText());
+  }
+
+  @Test
+  public void testSqlQueryProcessingEngineFacet() throws IOException
+  {
+    logger.logSqlQuery(sqlLine(
+        "SELECT 1",
+        ImmutableMap.of("sqlQueryId", "qid-11"),
+        ImmutableMap.of("success", true)
+    ));
+
+    Assert.assertEquals(1, capturedEvents.size());
+    JsonNode engine = capturedEvents.get(0).get("run").get("facets").get("processing_engine");
+    Assert.assertNotNull(engine);
+    Assert.assertEquals("druid", engine.get("name").asText());
+  }
+
+  @Test
+  public void testNativeQueryStandaloneEmitsEvent() throws IOException
+  {
+    TestQuery query = new TestQuery(new TableDataSource("myDatasource"), ImmutableMap.of("queryId", "native-qid-1"));
+    logger.logNativeQuery(nativeLine(query, ImmutableMap.of("success", true, "query/time", 50L)));
+
+    Assert.assertEquals(1, capturedEvents.size());
+    ObjectNode event = capturedEvents.get(0);
+
+    Assert.assertEquals("COMPLETE", event.get("eventType").asText());
+    Assert.assertTrue(inputNames(event.get("inputs")).contains("myDatasource"));
+  }
+
+  @Test
+  public void testNativeQuerySpawnedBySqlIsSkipped() throws IOException
+  {
+    // Queries with sqlQueryId in context are sub-queries of a SQL execution; skip to avoid duplicate events.
+    TestQuery query = new TestQuery(
+        new TableDataSource("myDatasource"),
+        ImmutableMap.of("queryId", "native-qid-2", BaseQuery.SQL_QUERY_ID, "parent-sql-id")
+    );
+    logger.logNativeQuery(nativeLine(query, ImmutableMap.of("success", true)));
+
+    Assert.assertEquals(0, capturedEvents.size());
+  }
+
+  @Test
+  public void testNativeQueryStatFallbackKeys() throws IOException
+  {
+    // Native queries report timing via "query/time" and "query/bytes", not the "sqlQuery/*" variants.
+    TestQuery query = new TestQuery(new TableDataSource("t"), ImmutableMap.of("queryId", "native-qid-3"));
+    logger.logNativeQuery(nativeLine(
+        query,
+        ImmutableMap.of("success", true, "query/time", 75L, "query/bytes", 512L)
+    ));
+
+    Assert.assertEquals(1, capturedEvents.size());
+    JsonNode stats = capturedEvents.get(0).get("run").get("facets").get("druid_query_statistics");
+    Assert.assertEquals(75L, stats.get("durationMs").asLong());
+    Assert.assertEquals(512L, stats.get("bytes").asLong());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testProviderHttpWithoutUrlThrows() throws Exception
+  {
+    OpenLineageRequestLoggerProvider provider = new OpenLineageRequestLoggerProvider();
+    Field transportTypeField = OpenLineageRequestLoggerProvider.class.getDeclaredField("transportType");
+    transportTypeField.setAccessible(true);
+    transportTypeField.set(provider, OpenLineageRequestLoggerProvider.TransportType.HTTP);
+    provider.get();
+  }
+
+  private static RequestLogLine sqlLine(String sql, Map<String, Object> context, Map<String, Object> stats)
+  {
+    return RequestLogLine.forSql(sql, context, TIMESTAMP, REMOTE_ADDR, new QueryStats(stats));
+  }
+
+  private static RequestLogLine nativeLine(Query<?> query, Map<String, Object> stats)
+  {
+    return RequestLogLine.forNative(query, TIMESTAMP, REMOTE_ADDR, new QueryStats(stats));
+  }
+
+  private static Set<String> inputNames(JsonNode inputs)
+  {
+    Set<String> names = new HashSet<>();
+    for (JsonNode input : inputs) {
+      names.add(input.get("name").asText());
+    }
+    return names;
+  }
+}
+
+@JsonTypeName("test")
+class TestQuery extends BaseQuery<Object>
+{
+  private static final QuerySegmentSpec DUMMY_SPEC = new MultipleIntervalSegmentSpec(
+      Collections.singletonList(Intervals.of("2024-01-01/2024-01-02"))
+  );
+
+  TestQuery(DataSource dataSource, Map<String, Object> context)
+  {
+    super(dataSource, DUMMY_SPEC, context);
+  }
+
+  @Override
+  public boolean hasFilters()
+  {
+    return false;
+  }
+
+  @Override
+  public DimFilter getFilter()
+  {
+    return null;
+  }
+
+  @Override
+  public String getType()
+  {
+    return "test";
+  }
+
+  @Override
+  public Query<Object> withQuerySegmentSpec(QuerySegmentSpec spec)
+  {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Query<Object> withDataSource(DataSource dataSource)
+  {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Query<Object> withOverriddenContext(Map<String, Object> contextOverride)
+  {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/extensions-contrib/openlineage-emitter/src/test/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerTest.java
+++ b/extensions-contrib/openlineage-emitter/src/test/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerTest.java
@@ -37,12 +37,11 @@ import org.apache.druid.query.spec.QuerySegmentSpec;
 import org.apache.druid.server.QueryStats;
 import org.apache.druid.server.RequestLogLine;
 import org.joda.time.DateTime;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -60,7 +59,7 @@ public class OpenLineageRequestLoggerTest
   private List<ObjectNode> capturedEvents;
   private OpenLineageRequestLogger logger;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     capturedEvents = new ArrayList<>();
@@ -80,31 +79,30 @@ public class OpenLineageRequestLoggerTest
   }
 
   @Test
-  public void testSqlQuerySimpleSelect() throws IOException
+  public void testSqlSimpleSelect() throws IOException
   {
     logger.logSqlQuery(sqlLine(
         "SELECT * FROM \"kttm\"",
         ImmutableMap.of("sqlQueryId", "qid-1"),
-        ImmutableMap.of("success", true, "sqlQuery/time", 200L, "sqlQuery/bytes", 1024L,
-                        "sqlQuery/planningTimeMs", 10L, "statusCode", "200", "identity", "alice")
+        ImmutableMap.of("success", true)
     ));
 
-    Assert.assertEquals(1, capturedEvents.size());
+    Assertions.assertEquals(1, capturedEvents.size());
     ObjectNode event = capturedEvents.get(0);
 
-    Assert.assertEquals("COMPLETE", event.get("eventType").asText());
-    Assert.assertEquals(NAMESPACE, event.get("job").get("namespace").asText());
+    Assertions.assertEquals("COMPLETE", event.get("eventType").asText());
+    Assertions.assertEquals(NAMESPACE, event.get("job").get("namespace").asText());
 
     JsonNode inputs = event.get("inputs");
-    Assert.assertEquals(1, inputs.size());
-    Assert.assertEquals("kttm", inputs.get(0).get("name").asText());
-    Assert.assertEquals(NAMESPACE, inputs.get(0).get("namespace").asText());
+    Assertions.assertEquals(1, inputs.size());
+    Assertions.assertEquals("kttm", inputs.get(0).get("name").asText());
+    Assertions.assertEquals(NAMESPACE, inputs.get(0).get("namespace").asText());
 
-    Assert.assertEquals(0, event.get("outputs").size());
+    Assertions.assertEquals(0, event.get("outputs").size());
   }
 
   @Test
-  public void testSqlQueryJoin() throws IOException
+  public void testSqlJoin() throws IOException
   {
     logger.logSqlQuery(sqlLine(
         "SELECT a.\"x\" FROM \"tableA\" AS a JOIN \"tableB\" AS b ON a.\"id\" = b.\"id\"",
@@ -112,30 +110,30 @@ public class OpenLineageRequestLoggerTest
         ImmutableMap.of("success", true)
     ));
 
-    Assert.assertEquals(1, capturedEvents.size());
-    Set<String> names = inputNames(capturedEvents.get(0).get("inputs"));
-    Assert.assertTrue(names.contains("tableA"));
-    Assert.assertTrue(names.contains("tableB"));
+    Assertions.assertEquals(1, capturedEvents.size());
+    Set<String> names = inputNames(capturedEvents.get(0));
+    Assertions.assertEquals(2, names.size());
+    Assertions.assertTrue(names.contains("tableA"));
+    Assertions.assertTrue(names.contains("tableB"));
   }
 
   @Test
-  public void testSqlQueryCteExcludesCteNames() throws IOException
+  public void testSqlCteExcludesCteNames() throws IOException
   {
-    // "cte" is a CTE name and must NOT appear as an input; "realTable" is the physical source
     logger.logSqlQuery(sqlLine(
         "WITH \"cte\" AS (SELECT * FROM \"realTable\") SELECT * FROM \"cte\"",
         ImmutableMap.of("sqlQueryId", "qid-3"),
         ImmutableMap.of("success", true)
     ));
 
-    Assert.assertEquals(1, capturedEvents.size());
-    Set<String> names = inputNames(capturedEvents.get(0).get("inputs"));
-    Assert.assertTrue(names.contains("realTable"));
-    Assert.assertFalse(names.contains("cte"));
+    Assertions.assertEquals(1, capturedEvents.size());
+    Set<String> names = inputNames(capturedEvents.get(0));
+    Assertions.assertTrue(names.contains("realTable"));
+    Assertions.assertFalse(names.contains("cte"));
   }
 
   @Test
-  public void testSqlQueryInsert() throws IOException
+  public void testSqlInsertExtractsInputAndOutput() throws IOException
   {
     logger.logSqlQuery(sqlLine(
         "INSERT INTO \"outputTable\" SELECT * FROM \"inputTable\"",
@@ -143,18 +141,18 @@ public class OpenLineageRequestLoggerTest
         ImmutableMap.of("success", true)
     ));
 
-    Assert.assertEquals(1, capturedEvents.size());
+    Assertions.assertEquals(1, capturedEvents.size());
     ObjectNode event = capturedEvents.get(0);
 
-    Assert.assertTrue(inputNames(event.get("inputs")).contains("inputTable"));
+    Assertions.assertTrue(inputNames(event).contains("inputTable"));
 
     JsonNode outputs = event.get("outputs");
-    Assert.assertEquals(1, outputs.size());
-    Assert.assertEquals("outputTable", outputs.get(0).get("name").asText());
+    Assertions.assertEquals(1, outputs.size());
+    Assertions.assertEquals("outputTable", outputs.get(0).get("name").asText());
   }
 
   @Test
-  public void testSqlQueryParseFailureStillEmitsEvent() throws IOException
+  public void testSqlParseFailureStillEmitsEvent() throws IOException
   {
     // Druid-specific syntax (REPLACE INTO) doesn't parse with the standard Calcite parser;
     // the event is still emitted, just without table-level lineage.
@@ -164,50 +162,19 @@ public class OpenLineageRequestLoggerTest
         ImmutableMap.of("success", true)
     ));
 
-    Assert.assertEquals(1, capturedEvents.size());
-    Assert.assertEquals(0, capturedEvents.get(0).get("inputs").size());
-    Assert.assertEquals(0, capturedEvents.get(0).get("outputs").size());
+    Assertions.assertEquals(1, capturedEvents.size());
+    Assertions.assertEquals(0, capturedEvents.get(0).get("inputs").size());
+    Assertions.assertEquals(0, capturedEvents.get(0).get("outputs").size());
+    Assertions.assertEquals("COMPLETE", capturedEvents.get(0).get("eventType").asText());
   }
 
   @Test
-  public void testSqlQueryFailedQueryHasErrorMessageFacet() throws IOException
+  public void testSqlQueryFacets() throws IOException
   {
+    String sql = "SELECT * FROM \"t\"";
     logger.logSqlQuery(sqlLine(
-        "SELECT * FROM \"t\"",
-        ImmutableMap.of("sqlQueryId", "qid-6"),
-        ImmutableMap.of("success", false, "exception", "Query timed out")
-    ));
-
-    Assert.assertEquals(1, capturedEvents.size());
-    ObjectNode event = capturedEvents.get(0);
-
-    Assert.assertEquals("FAIL", event.get("eventType").asText());
-
-    JsonNode errorFacet = event.get("run").get("facets").get("errorMessage");
-    Assert.assertNotNull(errorFacet);
-    Assert.assertEquals("Query timed out", errorFacet.get("message").asText());
-    Assert.assertEquals("SQL", errorFacet.get("programmingLanguage").asText());
-  }
-
-  @Test
-  public void testSqlQueryNoErrorMessageFacetOnSuccess() throws IOException
-  {
-    logger.logSqlQuery(sqlLine(
-        "SELECT 1",
-        ImmutableMap.of("sqlQueryId", "qid-7"),
-        ImmutableMap.of("success", true)
-    ));
-
-    Assert.assertEquals(1, capturedEvents.size());
-    Assert.assertNull(capturedEvents.get(0).get("run").get("facets").get("errorMessage"));
-  }
-
-  @Test
-  public void testSqlQueryStatsFacets() throws IOException
-  {
-    logger.logSqlQuery(sqlLine(
-        "SELECT 1",
-        ImmutableMap.of("sqlQueryId", "qid-8"),
+        sql,
+        ImmutableMap.of("sqlQueryId", "qid-facets", "nativeQueryIds", "[native-1, native-2]"),
         ImmutableMap.of(
             "success", true,
             "sqlQuery/time", 300L,
@@ -218,133 +185,130 @@ public class OpenLineageRequestLoggerTest
         )
     ));
 
-    Assert.assertEquals(1, capturedEvents.size());
-    JsonNode runFacets = capturedEvents.get(0).get("run").get("facets");
-
-    JsonNode stats = runFacets.get("druid_query_statistics");
-    Assert.assertEquals(300L, stats.get("durationMs").asLong());
-    Assert.assertEquals(2048L, stats.get("bytes").asLong());
-    Assert.assertEquals(25L, stats.get("planningTimeMs").asLong());
-    Assert.assertEquals("200", stats.get("statusCode").asText());
-
-    JsonNode ctx = runFacets.get("druid_query_context");
-    Assert.assertEquals("bob", ctx.get("identity").asText());
-    Assert.assertEquals(REMOTE_ADDR, ctx.get("remoteAddress").asText());
-    Assert.assertEquals("sql", ctx.get("queryType").asText());
-  }
-
-  @Test
-  public void testSqlQuerySqlFacetPresent() throws IOException
-  {
-    String sql = "SELECT * FROM \"t\"";
-    logger.logSqlQuery(sqlLine(
-        sql,
-        ImmutableMap.of("sqlQueryId", "qid-9"),
-        ImmutableMap.of("success", true)
-    ));
-
-    Assert.assertEquals(1, capturedEvents.size());
-    JsonNode sqlFacet = capturedEvents.get(0).get("job").get("facets").get("sql");
-    Assert.assertNotNull(sqlFacet);
-    Assert.assertEquals(sql, sqlFacet.get("query").asText());
-  }
-
-  @Test
-  public void testSqlQueryJobTypeFacet() throws IOException
-  {
-    logger.logSqlQuery(sqlLine(
-        "SELECT 1",
-        ImmutableMap.of("sqlQueryId", "qid-10"),
-        ImmutableMap.of("success", true)
-    ));
-
-    Assert.assertEquals(1, capturedEvents.size());
-    JsonNode jobType = capturedEvents.get(0).get("job").get("facets").get("jobType");
-    Assert.assertNotNull(jobType);
-    Assert.assertEquals("BATCH", jobType.get("processingType").asText());
-    Assert.assertEquals("DRUID", jobType.get("integration").asText());
-    Assert.assertEquals("QUERY", jobType.get("jobType").asText());
-  }
-
-  @Test
-  public void testSqlQueryProcessingEngineFacet() throws IOException
-  {
-    logger.logSqlQuery(sqlLine(
-        "SELECT 1",
-        ImmutableMap.of("sqlQueryId", "qid-11"),
-        ImmutableMap.of("success", true)
-    ));
-
-    Assert.assertEquals(1, capturedEvents.size());
-    JsonNode engine = capturedEvents.get(0).get("run").get("facets").get("processing_engine");
-    Assert.assertNotNull(engine);
-    Assert.assertEquals("druid", engine.get("name").asText());
-  }
-
-  @Test
-  public void testNativeQueryStandaloneEmitsEvent() throws IOException
-  {
-    TestQuery query = new TestQuery(new TableDataSource("myDatasource"), ImmutableMap.of("queryId", "native-qid-1"));
-    logger.logNativeQuery(nativeLine(query, ImmutableMap.of("success", true, "query/time", 50L)));
-
-    Assert.assertEquals(1, capturedEvents.size());
+    Assertions.assertEquals(1, capturedEvents.size());
     ObjectNode event = capturedEvents.get(0);
 
-    Assert.assertEquals("COMPLETE", event.get("eventType").asText());
-    Assert.assertTrue(inputNames(event.get("inputs")).contains("myDatasource"));
+    // OpenLineage envelope
+    Assertions.assertNotNull(event.get("schemaURL"));
+    Assertions.assertNotNull(event.get("producer"));
+    Assertions.assertEquals("2024-01-01T00:00:00.000Z", event.get("eventTime").asText());
+
+    // Job facets
+    JsonNode jobFacets = event.get("job").get("facets");
+    Assertions.assertEquals(sql, jobFacets.get("sql").get("query").asText());
+    Assertions.assertEquals("BATCH", jobFacets.get("jobType").get("processingType").asText());
+    Assertions.assertEquals("DRUID", jobFacets.get("jobType").get("integration").asText());
+    Assertions.assertEquals("QUERY", jobFacets.get("jobType").get("jobType").asText());
+
+    // Run facets
+    JsonNode runFacets = event.get("run").get("facets");
+    Assertions.assertEquals("druid", runFacets.get("processing_engine").get("name").asText());
+    Assertions.assertNotNull(runFacets.get("processing_engine").get("version"));
+
+    // Query context facet
+    JsonNode ctx = runFacets.get("druid_query_context");
+    Assertions.assertEquals("bob", ctx.get("identity").asText());
+    Assertions.assertEquals(REMOTE_ADDR, ctx.get("remoteAddress").asText());
+    Assertions.assertEquals("sql", ctx.get("queryType").asText());
+    Assertions.assertEquals("[native-1, native-2]", ctx.get("nativeQueryIds").asText());
+
+    // Statistics facet
+    JsonNode stats = runFacets.get("druid_query_statistics");
+    Assertions.assertEquals(300L, stats.get("durationMs").asLong());
+    Assertions.assertEquals(2048L, stats.get("bytes").asLong());
+    Assertions.assertEquals(25L, stats.get("planningTimeMs").asLong());
+    Assertions.assertEquals("200", stats.get("statusCode").asText());
+
+    // No error facet on success
+    Assertions.assertNull(runFacets.get("errorMessage"));
   }
 
   @Test
-  public void testNativeQuerySpawnedBySqlIsSkipped() throws IOException
+  public void testSqlQueryFailure() throws IOException
   {
-    // Queries with sqlQueryId in context are sub-queries of a SQL execution; skip to avoid duplicate events.
+    logger.logSqlQuery(sqlLine(
+        "SELECT * FROM \"t\"",
+        ImmutableMap.of("sqlQueryId", "qid-fail"),
+        ImmutableMap.of("success", false, "exception", "Query timed out")
+    ));
+
+    Assertions.assertEquals(1, capturedEvents.size());
+    ObjectNode event = capturedEvents.get(0);
+
+    Assertions.assertEquals("FAIL", event.get("eventType").asText());
+
+    JsonNode errorFacet = event.get("run").get("facets").get("errorMessage");
+    Assertions.assertNotNull(errorFacet);
+    Assertions.assertEquals("Query timed out", errorFacet.get("message").asText());
+    Assertions.assertEquals("SQL", errorFacet.get("programmingLanguage").asText());
+  }
+
+  @Test
+  public void testNativeQuery() throws IOException
+  {
+    TestQuery query = new TestQuery(
+        new TableDataSource("myDatasource"),
+        ImmutableMap.of("queryId", "native-qid-1")
+    );
+    logger.logNativeQuery(nativeLine(query, ImmutableMap.of("success", true, "query/time", 50L, "query/bytes", 512L)));
+
+    Assertions.assertEquals(1, capturedEvents.size());
+    ObjectNode event = capturedEvents.get(0);
+
+    Assertions.assertEquals("COMPLETE", event.get("eventType").asText());
+    Assertions.assertTrue(inputNames(event).contains("myDatasource"));
+
+    // Native queries use "query/time" and "query/bytes" stat keys (not "sqlQuery/*")
+    JsonNode stats = event.get("run").get("facets").get("druid_query_statistics");
+    Assertions.assertEquals(50L, stats.get("durationMs").asLong());
+    Assertions.assertEquals(512L, stats.get("bytes").asLong());
+
+    // No sql facet on native queries
+    Assertions.assertNull(event.get("job").get("facets").get("sql"));
+
+    // Query type reflects the native query type
+    Assertions.assertEquals("test", event.get("run").get("facets").get("druid_query_context").get("queryType").asText());
+  }
+
+  @Test
+  public void testNativeSubQueryOfSqlIsSkipped() throws IOException
+  {
+    // Queries with sqlQueryId in context are sub-queries of a SQL execution; skip to avoid
+    // duplicate events since the SQL-level event already captures the lineage.
     TestQuery query = new TestQuery(
         new TableDataSource("myDatasource"),
         ImmutableMap.of("queryId", "native-qid-2", BaseQuery.SQL_QUERY_ID, "parent-sql-id")
     );
     logger.logNativeQuery(nativeLine(query, ImmutableMap.of("success", true)));
 
-    Assert.assertEquals(0, capturedEvents.size());
+    Assertions.assertEquals(0, capturedEvents.size());
   }
 
   @Test
-  public void testNativeQueryStatFallbackKeys() throws IOException
+  public void testNativeQueryWithNullQueryDoesNotCrash() throws IOException
   {
-    // Native queries report timing via "query/time" and "query/bytes", not the "sqlQuery/*" variants.
-    TestQuery query = new TestQuery(new TableDataSource("t"), ImmutableMap.of("queryId", "native-qid-3"));
-    logger.logNativeQuery(nativeLine(
-        query,
-        ImmutableMap.of("success", true, "query/time", 75L, "query/bytes", 512L)
-    ));
+    RequestLogLine logLine = RequestLogLine.forNative(
+        null,
+        TIMESTAMP,
+        REMOTE_ADDR,
+        new QueryStats(ImmutableMap.of())
+    );
 
-    Assert.assertEquals(1, capturedEvents.size());
-    JsonNode stats = capturedEvents.get(0).get("run").get("facets").get("druid_query_statistics");
-    Assert.assertEquals(75L, stats.get("durationMs").asLong());
-    Assert.assertEquals(512L, stats.get("bytes").asLong());
-  }
-
-  @Test(expected = IllegalStateException.class)
-  public void testProviderHttpWithoutUrlThrows() throws Exception
-  {
-    OpenLineageRequestLoggerProvider provider = new OpenLineageRequestLoggerProvider();
-    Field transportTypeField = OpenLineageRequestLoggerProvider.class.getDeclaredField("transportType");
-    transportTypeField.setAccessible(true);
-    transportTypeField.set(provider, OpenLineageRequestLoggerProvider.TransportType.HTTP);
-    // Validation moved to start() method for proper lifecycle management
-    OpenLineageRequestLogger logger = (OpenLineageRequestLogger) provider.get();
-    logger.start();
-  }
-
-  @Test
-  public void testNativeQueryWithNullQueryDoesNotCrash() throws Exception
-  {
-    // Simulate a native query parse failure where query is null
-    RequestLogLine logLine = RequestLogLine.forNative(null, TIMESTAMP, REMOTE_ADDR, new QueryStats(ImmutableMap.of()));
-
-    // Should not throw NPE, should return early without emitting event
     logger.logNativeQuery(logLine);
 
-    Assert.assertEquals(0, capturedEvents.size());
+    Assertions.assertEquals(0, capturedEvents.size());
+  }
+
+  @Test
+  public void testStartThrowsWhenHttpWithoutUrl()
+  {
+    OpenLineageRequestLogger httpLogger = new OpenLineageRequestLogger(
+        MAPPER,
+        NAMESPACE,
+        OpenLineageRequestLoggerProvider.TransportType.HTTP,
+        null
+    );
+    Assertions.assertThrows(IllegalStateException.class, httpLogger::start);
   }
 
   private static RequestLogLine sqlLine(String sql, Map<String, Object> context, Map<String, Object> stats)
@@ -357,10 +321,10 @@ public class OpenLineageRequestLoggerTest
     return RequestLogLine.forNative(query, TIMESTAMP, REMOTE_ADDR, new QueryStats(stats));
   }
 
-  private static Set<String> inputNames(JsonNode inputs)
+  private static Set<String> inputNames(JsonNode event)
   {
     Set<String> names = new HashSet<>();
-    for (JsonNode input : inputs) {
+    for (JsonNode input : event.get("inputs")) {
       names.add(input.get("name").asText());
     }
     return names;

--- a/extensions-contrib/openlineage-emitter/src/test/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerTest.java
+++ b/extensions-contrib/openlineage-emitter/src/test/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerTest.java
@@ -49,12 +49,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+
 public class OpenLineageRequestLoggerTest
 {
   private static final ObjectMapper MAPPER = new DefaultObjectMapper();
   private static final String NAMESPACE = "druid://test:8082";
   private static final DateTime TIMESTAMP = DateTimes.of("2024-01-01T00:00:00Z");
   private static final String REMOTE_ADDR = "10.0.0.1";
+  private static final Set<String> DEFAULT_EXCLUDED_NATIVE_QUERY_TYPES = Set.of(
+      "segmentMetadata",
+      "dataSourceMetadata",
+      "timeBoundary"
+  );
 
   private List<ObjectNode> capturedEvents;
   private OpenLineageRequestLogger logger;
@@ -63,11 +69,17 @@ public class OpenLineageRequestLoggerTest
   public void setUp()
   {
     capturedEvents = new ArrayList<>();
-    logger = new OpenLineageRequestLogger(
+    logger = createLogger(DEFAULT_EXCLUDED_NATIVE_QUERY_TYPES);
+  }
+
+  private OpenLineageRequestLogger createLogger(Set<String> excludedNativeQueryTypes)
+  {
+    return new OpenLineageRequestLogger(
         MAPPER,
         NAMESPACE,
         OpenLineageRequestLoggerProvider.TransportType.CONSOLE,
-        null
+        null,
+        excludedNativeQueryTypes
     )
     {
       @Override
@@ -306,7 +318,8 @@ public class OpenLineageRequestLoggerTest
         MAPPER,
         NAMESPACE,
         OpenLineageRequestLoggerProvider.TransportType.HTTP,
-        null
+        null,
+        DEFAULT_EXCLUDED_NATIVE_QUERY_TYPES
     );
     Assertions.assertThrows(IllegalStateException.class, httpLogger::start);
   }

--- a/extensions-contrib/openlineage-emitter/src/test/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerTest.java
+++ b/extensions-contrib/openlineage-emitter/src/test/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerTest.java
@@ -91,10 +91,10 @@ public class OpenLineageRequestLoggerTest
     };
   }
 
-  // --- logSqlQuery is a no-op ---
+  // --- logSqlQuery: SELECT is no-op; MSQ DML emits ---
 
   @Test
-  public void testSqlQueryIsNoOp() throws IOException
+  public void testSqlSelectIsNoOp() throws IOException
   {
     logger.logSqlQuery(sqlLine(
         "SELECT * FROM \"kttm\"",
@@ -103,6 +103,71 @@ public class OpenLineageRequestLoggerTest
     ));
 
     Assertions.assertEquals(0, capturedEvents.size());
+  }
+
+  @Test
+  public void testMsqInsertEmitsOutputLineage() throws IOException
+  {
+    logger.logSqlQuery(sqlLine(
+        "INSERT INTO \"kttm-result\" SELECT * FROM \"kttm\"",
+        ImmutableMap.of("sqlQueryId", "msq-insert-1"),
+        ImmutableMap.of("success", true, "sqlQuery/time", 1200L, "sqlQuery/bytes", 4096L)
+    ));
+
+    Assertions.assertEquals(1, capturedEvents.size());
+    ObjectNode event = capturedEvents.get(0);
+
+    Assertions.assertEquals("COMPLETE", event.get("eventType").asText());
+    // Output table extracted from SQL
+    Assertions.assertEquals(1, event.get("outputs").size());
+    Assertions.assertEquals("kttm-result", event.get("outputs").get(0).get("name").asText());
+    // Inputs are empty — extracting FROM clause requires a full SQL parser
+    Assertions.assertEquals(0, event.get("inputs").size());
+    // queryType is msq
+    Assertions.assertEquals("msq", event.get("run").get("facets").get("druid_query_context").get("queryType").asText());
+    // stats
+    Assertions.assertEquals(1200L, event.get("run").get("facets").get("druid_query_statistics").get("durationMs").asLong());
+  }
+
+  @Test
+  public void testMsqReplaceEmitsOutputLineage() throws IOException
+  {
+    logger.logSqlQuery(sqlLine(
+        "REPLACE INTO \"kttm-result\" OVERWRITE ALL SELECT * FROM \"kttm\"",
+        ImmutableMap.of("sqlQueryId", "msq-replace-1"),
+        ImmutableMap.of("success", true)
+    ));
+
+    Assertions.assertEquals(1, capturedEvents.size());
+    Assertions.assertEquals("kttm-result", capturedEvents.get(0).get("outputs").get(0).get("name").asText());
+  }
+
+  @Test
+  public void testMsqInsertUnquotedTable() throws IOException
+  {
+    logger.logSqlQuery(sqlLine(
+        "INSERT INTO kttm_result SELECT count(*) FROM kttm",
+        ImmutableMap.of("sqlQueryId", "msq-unquoted-1"),
+        ImmutableMap.of("success", true)
+    ));
+
+    Assertions.assertEquals(1, capturedEvents.size());
+    Assertions.assertEquals("kttm_result", capturedEvents.get(0).get("outputs").get(0).get("name").asText());
+  }
+
+  @Test
+  public void testMsqInsertFailure() throws IOException
+  {
+    logger.logSqlQuery(sqlLine(
+        "INSERT INTO \"kttm-result\" SELECT * FROM \"kttm\"",
+        ImmutableMap.of("sqlQueryId", "msq-fail-1"),
+        ImmutableMap.of("success", false, "exception", "Task failed")
+    ));
+
+    Assertions.assertEquals(1, capturedEvents.size());
+    ObjectNode event = capturedEvents.get(0);
+    Assertions.assertEquals("FAIL", event.get("eventType").asText());
+    Assertions.assertEquals("Task failed", event.get("run").get("facets").get("errorMessage").get("message").asText());
   }
 
   // --- Native query tests ---

--- a/extensions-contrib/openlineage-emitter/src/test/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerTest.java
+++ b/extensions-contrib/openlineage-emitter/src/test/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerTest.java
@@ -175,6 +175,11 @@ public class OpenLineageRequestLoggerTest
     Assertions.assertEquals(0, event.get("inputs").size());
     // queryType is msq
     Assertions.assertEquals("msq", event.get("run").get("facets").get("druid_query_context").get("queryType").asText());
+    // sql facet present with the original SQL text
+    Assertions.assertEquals(
+        "INSERT INTO \"kttm-result\" SELECT * FROM \"kttm\"",
+        event.get("job").get("facets").get("sql").get("query").asText()
+    );
     // stats
     Assertions.assertEquals(1200L, event.get("run").get("facets").get("druid_query_statistics").get("durationMs").asLong());
   }
@@ -212,6 +217,35 @@ public class OpenLineageRequestLoggerTest
     logger.logSqlQuery(sqlLine(
         "INSERT INTO druid.kttm_result SELECT * FROM kttm",
         ImmutableMap.of("sqlQueryId", "msq-druid-schema-1"),
+        ImmutableMap.of("success", true)
+    ));
+
+    Assertions.assertEquals(1, capturedEvents.size());
+    Assertions.assertEquals("kttm_result", capturedEvents.get(0).get("outputs").get(0).get("name").asText());
+  }
+
+  @Test
+  public void testMsqInsertCteUnwrapped() throws IOException
+  {
+    // In Druid MSQ, CTEs appear as the source of the INSERT, not as a wrapper around it.
+    // The target table must still be extracted correctly from the outer SqlInsert node.
+    logger.logSqlQuery(sqlLine(
+        "INSERT INTO kttm_result WITH staged AS (SELECT * FROM kttm) SELECT * FROM staged",
+        ImmutableMap.of("sqlQueryId", "msq-cte-1"),
+        ImmutableMap.of("success", true)
+    ));
+
+    Assertions.assertEquals(1, capturedEvents.size());
+    Assertions.assertEquals("kttm_result", capturedEvents.get(0).get("outputs").get(0).get("name").asText());
+  }
+
+  @Test
+  public void testMsqInsertThreePartCatalogPrefix() throws IOException
+  {
+    // catalog.druid.foo → Druid normalizes to bare name "foo"; AST extraction matches.
+    logger.logSqlQuery(sqlLine(
+        "INSERT INTO catalog.druid.kttm_result SELECT * FROM kttm",
+        ImmutableMap.of("sqlQueryId", "msq-catalog-1"),
         ImmutableMap.of("success", true)
     ));
 

--- a/extensions-contrib/openlineage-emitter/src/test/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerTest.java
+++ b/extensions-contrib/openlineage-emitter/src/test/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerTest.java
@@ -106,6 +106,56 @@ public class OpenLineageRequestLoggerTest
   }
 
   @Test
+  public void testLogSqlQueryWithNullSql() throws IOException
+  {
+    logger.logSqlQuery(RequestLogLine.forSql(
+        null,
+        ImmutableMap.of(),
+        TIMESTAMP,
+        REMOTE_ADDR,
+        new QueryStats(ImmutableMap.of())
+    ));
+
+    Assertions.assertEquals(0, capturedEvents.size());
+  }
+
+  @Test
+  public void testMsqInsertMissingSqlQueryId() throws IOException
+  {
+    // No sqlQueryId in context → falls back to UNKNOWN_QUERY_ID
+    logger.logSqlQuery(sqlLine(
+        "INSERT INTO \"kttm-result\" SELECT * FROM \"kttm\"",
+        ImmutableMap.of(),
+        ImmutableMap.of("success", true)
+    ));
+
+    Assertions.assertEquals(1, capturedEvents.size());
+    Assertions.assertEquals(
+        OpenLineageRequestLogger.UNKNOWN_QUERY_ID,
+        capturedEvents.get(0).get("job").get("name").asText()
+    );
+  }
+
+  @Test
+  public void testMsqInsertNullContext() throws IOException
+  {
+    // Null sqlQueryContext → falls back to UNKNOWN_QUERY_ID
+    logger.logSqlQuery(RequestLogLine.forSql(
+        "INSERT INTO \"kttm-result\" SELECT * FROM \"kttm\"",
+        null,
+        TIMESTAMP,
+        REMOTE_ADDR,
+        new QueryStats(ImmutableMap.of("success", true))
+    ));
+
+    Assertions.assertEquals(1, capturedEvents.size());
+    Assertions.assertEquals(
+        OpenLineageRequestLogger.UNKNOWN_QUERY_ID,
+        capturedEvents.get(0).get("job").get("name").asText()
+    );
+  }
+
+  @Test
   public void testMsqInsertEmitsOutputLineage() throws IOException
   {
     logger.logSqlQuery(sqlLine(
@@ -384,6 +434,20 @@ public class OpenLineageRequestLoggerTest
         null,
         DEFAULT_EXCLUDED_NATIVE_QUERY_TYPES
     ));
+  }
+
+  @Test
+  public void testStopWithHttpTransport()
+  {
+    OpenLineageRequestLogger httpLogger = new OpenLineageRequestLogger(
+        MAPPER,
+        NAMESPACE,
+        OpenLineageRequestLoggerProvider.TransportType.HTTP,
+        "http://localhost:9999/api/v1/lineage",
+        DEFAULT_EXCLUDED_NATIVE_QUERY_TYPES
+    );
+    // Covers the executor-shutdown and httpClient-close branches in stop()
+    Assertions.assertDoesNotThrow(httpLogger::stop);
   }
 
   private static RequestLogLine sqlLine(String sql, Map<String, Object> context, Map<String, Object> stats)

--- a/extensions-contrib/openlineage-emitter/src/test/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerTest.java
+++ b/extensions-contrib/openlineage-emitter/src/test/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerTest.java
@@ -371,6 +371,22 @@ public class OpenLineageRequestLoggerTest
   }
 
   @Test
+  public void testSqlUnnestDoesNotAddColumnAsInput() throws IOException
+  {
+    // UNNEST operands are column references, not table names — they must not appear in inputs.
+    logger.logSqlQuery(sqlLine(
+        "SELECT a FROM \"myTable\", UNNEST(\"arrayCol\") AS u(a)",
+        ImmutableMap.of("sqlQueryId", "qid-unnest"),
+        ImmutableMap.of("success", true)
+    ));
+
+    Assertions.assertEquals(1, capturedEvents.size());
+    Set<String> names = inputNames(capturedEvents.get(0));
+    Assertions.assertTrue(names.contains("myTable"));
+    Assertions.assertFalse(names.contains("arrayCol"));
+  }
+
+  @Test
   public void testSqlUnionAll() throws IOException
   {
     logger.logSqlQuery(sqlLine(

--- a/extensions-contrib/openlineage-emitter/src/test/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerTest.java
+++ b/extensions-contrib/openlineage-emitter/src/test/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerTest.java
@@ -164,13 +164,72 @@ public class OpenLineageRequestLoggerTest
   }
 
   @Test
-  public void testSqlParseFailureStillEmitsEvent() throws IOException
+  public void testSqlReplaceIntoExtractsOutputAndInputs() throws IOException
   {
-    // Druid-specific syntax (REPLACE INTO) doesn't parse with the standard Calcite parser;
-    // the event is still emitted, just without table-level lineage.
+    // REPLACE INTO is Druid-specific and not parsed by standard Calcite; the regex fallback
+    // extracts the output table and re-parses the SELECT for inputs.
     logger.logSqlQuery(sqlLine(
-        "REPLACE INTO \"ds\" OVERWRITE ALL SELECT * FROM \"src\" PARTITIONED BY ALL",
+        "REPLACE INTO \"ds\" OVERWRITE ALL SELECT * FROM \"src\" PARTITIONED BY DAY",
         ImmutableMap.of("sqlQueryId", "qid-5"),
+        ImmutableMap.of("success", true)
+    ));
+
+    Assertions.assertEquals(1, capturedEvents.size());
+    ObjectNode event = capturedEvents.get(0);
+    Assertions.assertEquals("COMPLETE", event.get("eventType").asText());
+    Assertions.assertTrue(inputNames(event).contains("src"));
+    JsonNode outputs = event.get("outputs");
+    Assertions.assertEquals(1, outputs.size());
+    Assertions.assertEquals("ds", outputs.get(0).get("name").asText());
+  }
+
+  @Test
+  public void testSqlInsertIntoWithDruidSourceExtractsInputAndOutput() throws IOException
+  {
+    // INSERT INTO with PARTITIONED BY is unparseable by standard Calcite; regex fallback
+    // extracts the output table and re-parses the SELECT for inputs.
+    logger.logSqlQuery(sqlLine(
+        "INSERT INTO \"target\" SELECT * FROM \"source\" PARTITIONED BY DAY",
+        ImmutableMap.of("sqlQueryId", "qid-insert-partitioned"),
+        ImmutableMap.of("success", true)
+    ));
+
+    Assertions.assertEquals(1, capturedEvents.size());
+    ObjectNode event = capturedEvents.get(0);
+    Assertions.assertEquals("COMPLETE", event.get("eventType").asText());
+    Assertions.assertTrue(inputNames(event).contains("source"));
+    JsonNode outputs = event.get("outputs");
+    Assertions.assertEquals(1, outputs.size());
+    Assertions.assertEquals("target", outputs.get(0).get("name").asText());
+  }
+
+  @Test
+  public void testSqlInsertIntoWithExternExtractsOutputOnly() throws IOException
+  {
+    // INSERT INTO with EXTERN is unparseable by standard Calcite; the regex fallback
+    // extracts the output table only (EXTERN sources are external, not Druid datasets).
+    logger.logSqlQuery(sqlLine(
+        "INSERT INTO \"target\" SELECT * FROM TABLE(EXTERN('{\"type\":\"inline\",\"data\":\"\"}','{\"type\":\"json\"}')) PARTITIONED BY ALL",
+        ImmutableMap.of("sqlQueryId", "qid-extern"),
+        ImmutableMap.of("success", true)
+    ));
+
+    Assertions.assertEquals(1, capturedEvents.size());
+    ObjectNode event = capturedEvents.get(0);
+    Assertions.assertEquals("COMPLETE", event.get("eventType").asText());
+    Assertions.assertEquals(0, event.get("inputs").size());
+    JsonNode outputs = event.get("outputs");
+    Assertions.assertEquals(1, outputs.size());
+    Assertions.assertEquals("target", outputs.get(0).get("name").asText());
+  }
+
+  @Test
+  public void testSqlUnparsedStatementStillEmitsEvent() throws IOException
+  {
+    // Completely unparseable SQL still emits an event (without lineage) rather than failing.
+    logger.logSqlQuery(sqlLine(
+        "THIS IS NOT VALID SQL !!!",
+        ImmutableMap.of("sqlQueryId", "qid-bad"),
         ImmutableMap.of("success", true)
     ));
 
@@ -312,16 +371,62 @@ public class OpenLineageRequestLoggerTest
   }
 
   @Test
-  public void testStartThrowsWhenHttpWithoutUrl()
+  public void testSqlUnionAll() throws IOException
   {
-    OpenLineageRequestLogger httpLogger = new OpenLineageRequestLogger(
+    logger.logSqlQuery(sqlLine(
+        "SELECT * FROM \"tableA\" UNION ALL SELECT * FROM \"tableB\"",
+        ImmutableMap.of("sqlQueryId", "qid-union"),
+        ImmutableMap.of("success", true)
+    ));
+
+    Assertions.assertEquals(1, capturedEvents.size());
+    Set<String> names = inputNames(capturedEvents.get(0));
+    Assertions.assertTrue(names.contains("tableA"));
+    Assertions.assertTrue(names.contains("tableB"));
+  }
+
+  @Test
+  public void testSqlSubqueryInWhere() throws IOException
+  {
+    logger.logSqlQuery(sqlLine(
+        "SELECT * FROM \"outer\" WHERE \"x\" IN (SELECT \"y\" FROM \"inner\")",
+        ImmutableMap.of("sqlQueryId", "qid-subquery"),
+        ImmutableMap.of("success", true)
+    ));
+
+    Assertions.assertEquals(1, capturedEvents.size());
+    Set<String> names = inputNames(capturedEvents.get(0));
+    Assertions.assertTrue(names.contains("outer"));
+    Assertions.assertTrue(names.contains("inner"));
+  }
+
+  @Test
+  public void testSqlScalarSubqueryInSelect() throws IOException
+  {
+    logger.logSqlQuery(sqlLine(
+        "SELECT (SELECT COUNT(*) FROM \"counts\") AS cnt FROM \"main\"",
+        ImmutableMap.of("sqlQueryId", "qid-scalar"),
+        ImmutableMap.of("success", true)
+    ));
+
+    Assertions.assertEquals(1, capturedEvents.size());
+    Set<String> names = inputNames(capturedEvents.get(0));
+    Assertions.assertTrue(names.contains("main"));
+    Assertions.assertTrue(names.contains("counts"));
+  }
+
+  @Test
+  public void testConstructorThrowsWhenHttpWithoutUrl()
+  {
+    // HTTP URL validation is enforced at construction time so it fails fast during Guice wiring,
+    // even when ComposingRequestLogger does not delegate @LifecycleStart to sub-loggers.
+    Assertions.assertThrows(IllegalStateException.class, () -> new OpenLineageRequestLogger(
         MAPPER,
         NAMESPACE,
         OpenLineageRequestLoggerProvider.TransportType.HTTP,
         null,
         DEFAULT_EXCLUDED_NATIVE_QUERY_TYPES
-    );
-    Assertions.assertThrows(IllegalStateException.class, httpLogger::start);
+    ));
   }
 
   private static RequestLogLine sqlLine(String sql, Map<String, Object> context, Map<String, Object> stats)

--- a/extensions-contrib/openlineage-emitter/src/test/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerTest.java
+++ b/extensions-contrib/openlineage-emitter/src/test/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerTest.java
@@ -206,6 +206,49 @@ public class OpenLineageRequestLoggerTest
   }
 
   @Test
+  public void testMsqInsertDruidSchemaPrefix() throws IOException
+  {
+    // Druid normalizes "druid.foo" → "foo" — our AST extraction should match the planner.
+    logger.logSqlQuery(sqlLine(
+        "INSERT INTO druid.kttm_result SELECT * FROM kttm",
+        ImmutableMap.of("sqlQueryId", "msq-druid-schema-1"),
+        ImmutableMap.of("success", true)
+    ));
+
+    Assertions.assertEquals(1, capturedEvents.size());
+    Assertions.assertEquals("kttm_result", capturedEvents.get(0).get("outputs").get(0).get("name").asText());
+  }
+
+  @Test
+  public void testMsqInsertWithSetPreamble() throws IOException
+  {
+    // Druid SQL accepts SET statements before DML. We call DruidSqlParser with
+    // allowSetStatements=true; the SET is dropped and only the main INSERT is inspected.
+    logger.logSqlQuery(sqlLine(
+        "SET maxNumTasks = 2;\nINSERT INTO kttm_result SELECT * FROM kttm",
+        ImmutableMap.of("sqlQueryId", "msq-set-1"),
+        ImmutableMap.of("success", true)
+    ));
+
+    Assertions.assertEquals(1, capturedEvents.size());
+    Assertions.assertEquals("kttm_result", capturedEvents.get(0).get("outputs").get(0).get("name").asText());
+  }
+
+  @Test
+  public void testMsqInsertExternExportSkipped() throws IOException
+  {
+    // INSERT INTO EXTERN(...) AS CSV writes to a file, not a Druid datasource.
+    // The AST target is a SqlCall, not a SqlIdentifier; emit no event at all.
+    logger.logSqlQuery(sqlLine(
+        "INSERT INTO EXTERN(s3(bucket => 'x', prefix => 'y')) AS CSV SELECT * FROM kttm",
+        ImmutableMap.of("sqlQueryId", "msq-extern-1"),
+        ImmutableMap.of("success", true)
+    ));
+
+    Assertions.assertEquals(0, capturedEvents.size(), "EXTERN exports should not emit an output dataset");
+  }
+
+  @Test
   public void testMsqInsertFailure() throws IOException
   {
     logger.logSqlQuery(sqlLine(

--- a/extensions-contrib/openlineage-emitter/src/test/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerTest.java
+++ b/extensions-contrib/openlineage-emitter/src/test/java/org/apache/druid/extensions/openlineage/OpenLineageRequestLoggerTest.java
@@ -31,6 +31,7 @@ import org.apache.druid.query.BaseQuery;
 import org.apache.druid.query.DataSource;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.TableDataSource;
+import org.apache.druid.query.UnionDataSource;
 import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
 import org.apache.druid.query.spec.QuerySegmentSpec;
@@ -90,8 +91,10 @@ public class OpenLineageRequestLoggerTest
     };
   }
 
+  // --- logSqlQuery is a no-op ---
+
   @Test
-  public void testSqlSimpleSelect() throws IOException
+  public void testSqlQueryIsNoOp() throws IOException
   {
     logger.logSqlQuery(sqlLine(
         "SELECT * FROM \"kttm\"",
@@ -99,220 +102,10 @@ public class OpenLineageRequestLoggerTest
         ImmutableMap.of("success", true)
     ));
 
-    Assertions.assertEquals(1, capturedEvents.size());
-    ObjectNode event = capturedEvents.get(0);
-
-    Assertions.assertEquals("COMPLETE", event.get("eventType").asText());
-    Assertions.assertEquals(NAMESPACE, event.get("job").get("namespace").asText());
-
-    JsonNode inputs = event.get("inputs");
-    Assertions.assertEquals(1, inputs.size());
-    Assertions.assertEquals("kttm", inputs.get(0).get("name").asText());
-    Assertions.assertEquals(NAMESPACE, inputs.get(0).get("namespace").asText());
-
-    Assertions.assertEquals(0, event.get("outputs").size());
+    Assertions.assertEquals(0, capturedEvents.size());
   }
 
-  @Test
-  public void testSqlJoin() throws IOException
-  {
-    logger.logSqlQuery(sqlLine(
-        "SELECT a.\"x\" FROM \"tableA\" AS a JOIN \"tableB\" AS b ON a.\"id\" = b.\"id\"",
-        ImmutableMap.of("sqlQueryId", "qid-2"),
-        ImmutableMap.of("success", true)
-    ));
-
-    Assertions.assertEquals(1, capturedEvents.size());
-    Set<String> names = inputNames(capturedEvents.get(0));
-    Assertions.assertEquals(2, names.size());
-    Assertions.assertTrue(names.contains("tableA"));
-    Assertions.assertTrue(names.contains("tableB"));
-  }
-
-  @Test
-  public void testSqlCteExcludesCteNames() throws IOException
-  {
-    logger.logSqlQuery(sqlLine(
-        "WITH \"cte\" AS (SELECT * FROM \"realTable\") SELECT * FROM \"cte\"",
-        ImmutableMap.of("sqlQueryId", "qid-3"),
-        ImmutableMap.of("success", true)
-    ));
-
-    Assertions.assertEquals(1, capturedEvents.size());
-    Set<String> names = inputNames(capturedEvents.get(0));
-    Assertions.assertTrue(names.contains("realTable"));
-    Assertions.assertFalse(names.contains("cte"));
-  }
-
-  @Test
-  public void testSqlInsertExtractsInputAndOutput() throws IOException
-  {
-    logger.logSqlQuery(sqlLine(
-        "INSERT INTO \"outputTable\" SELECT * FROM \"inputTable\"",
-        ImmutableMap.of("sqlQueryId", "qid-4"),
-        ImmutableMap.of("success", true)
-    ));
-
-    Assertions.assertEquals(1, capturedEvents.size());
-    ObjectNode event = capturedEvents.get(0);
-
-    Assertions.assertTrue(inputNames(event).contains("inputTable"));
-
-    JsonNode outputs = event.get("outputs");
-    Assertions.assertEquals(1, outputs.size());
-    Assertions.assertEquals("outputTable", outputs.get(0).get("name").asText());
-  }
-
-  @Test
-  public void testSqlReplaceIntoExtractsOutputAndInputs() throws IOException
-  {
-    // REPLACE INTO is Druid-specific and not parsed by standard Calcite; the regex fallback
-    // extracts the output table and re-parses the SELECT for inputs.
-    logger.logSqlQuery(sqlLine(
-        "REPLACE INTO \"ds\" OVERWRITE ALL SELECT * FROM \"src\" PARTITIONED BY DAY",
-        ImmutableMap.of("sqlQueryId", "qid-5"),
-        ImmutableMap.of("success", true)
-    ));
-
-    Assertions.assertEquals(1, capturedEvents.size());
-    ObjectNode event = capturedEvents.get(0);
-    Assertions.assertEquals("COMPLETE", event.get("eventType").asText());
-    Assertions.assertTrue(inputNames(event).contains("src"));
-    JsonNode outputs = event.get("outputs");
-    Assertions.assertEquals(1, outputs.size());
-    Assertions.assertEquals("ds", outputs.get(0).get("name").asText());
-  }
-
-  @Test
-  public void testSqlInsertIntoWithDruidSourceExtractsInputAndOutput() throws IOException
-  {
-    // INSERT INTO with PARTITIONED BY is unparseable by standard Calcite; regex fallback
-    // extracts the output table and re-parses the SELECT for inputs.
-    logger.logSqlQuery(sqlLine(
-        "INSERT INTO \"target\" SELECT * FROM \"source\" PARTITIONED BY DAY",
-        ImmutableMap.of("sqlQueryId", "qid-insert-partitioned"),
-        ImmutableMap.of("success", true)
-    ));
-
-    Assertions.assertEquals(1, capturedEvents.size());
-    ObjectNode event = capturedEvents.get(0);
-    Assertions.assertEquals("COMPLETE", event.get("eventType").asText());
-    Assertions.assertTrue(inputNames(event).contains("source"));
-    JsonNode outputs = event.get("outputs");
-    Assertions.assertEquals(1, outputs.size());
-    Assertions.assertEquals("target", outputs.get(0).get("name").asText());
-  }
-
-  @Test
-  public void testSqlInsertIntoWithExternExtractsOutputOnly() throws IOException
-  {
-    // INSERT INTO with EXTERN is unparseable by standard Calcite; the regex fallback
-    // extracts the output table only (EXTERN sources are external, not Druid datasets).
-    logger.logSqlQuery(sqlLine(
-        "INSERT INTO \"target\" SELECT * FROM TABLE(EXTERN('{\"type\":\"inline\",\"data\":\"\"}','{\"type\":\"json\"}')) PARTITIONED BY ALL",
-        ImmutableMap.of("sqlQueryId", "qid-extern"),
-        ImmutableMap.of("success", true)
-    ));
-
-    Assertions.assertEquals(1, capturedEvents.size());
-    ObjectNode event = capturedEvents.get(0);
-    Assertions.assertEquals("COMPLETE", event.get("eventType").asText());
-    Assertions.assertEquals(0, event.get("inputs").size());
-    JsonNode outputs = event.get("outputs");
-    Assertions.assertEquals(1, outputs.size());
-    Assertions.assertEquals("target", outputs.get(0).get("name").asText());
-  }
-
-  @Test
-  public void testSqlUnparsedStatementStillEmitsEvent() throws IOException
-  {
-    // Completely unparseable SQL still emits an event (without lineage) rather than failing.
-    logger.logSqlQuery(sqlLine(
-        "THIS IS NOT VALID SQL !!!",
-        ImmutableMap.of("sqlQueryId", "qid-bad"),
-        ImmutableMap.of("success", true)
-    ));
-
-    Assertions.assertEquals(1, capturedEvents.size());
-    Assertions.assertEquals(0, capturedEvents.get(0).get("inputs").size());
-    Assertions.assertEquals(0, capturedEvents.get(0).get("outputs").size());
-    Assertions.assertEquals("COMPLETE", capturedEvents.get(0).get("eventType").asText());
-  }
-
-  @Test
-  public void testSqlQueryFacets() throws IOException
-  {
-    String sql = "SELECT * FROM \"t\"";
-    logger.logSqlQuery(sqlLine(
-        sql,
-        ImmutableMap.of("sqlQueryId", "qid-facets", "nativeQueryIds", "[native-1, native-2]"),
-        ImmutableMap.of(
-            "success", true,
-            "sqlQuery/time", 300L,
-            "sqlQuery/bytes", 2048L,
-            "sqlQuery/planningTimeMs", 25L,
-            "statusCode", "200",
-            "identity", "bob"
-        )
-    ));
-
-    Assertions.assertEquals(1, capturedEvents.size());
-    ObjectNode event = capturedEvents.get(0);
-
-    // OpenLineage envelope
-    Assertions.assertNotNull(event.get("schemaURL"));
-    Assertions.assertNotNull(event.get("producer"));
-    Assertions.assertEquals("2024-01-01T00:00:00.000Z", event.get("eventTime").asText());
-
-    // Job facets
-    JsonNode jobFacets = event.get("job").get("facets");
-    Assertions.assertEquals(sql, jobFacets.get("sql").get("query").asText());
-    Assertions.assertEquals("BATCH", jobFacets.get("jobType").get("processingType").asText());
-    Assertions.assertEquals("DRUID", jobFacets.get("jobType").get("integration").asText());
-    Assertions.assertEquals("QUERY", jobFacets.get("jobType").get("jobType").asText());
-
-    // Run facets
-    JsonNode runFacets = event.get("run").get("facets");
-    Assertions.assertEquals("druid", runFacets.get("processing_engine").get("name").asText());
-    Assertions.assertNotNull(runFacets.get("processing_engine").get("version"));
-
-    // Query context facet
-    JsonNode ctx = runFacets.get("druid_query_context");
-    Assertions.assertEquals("bob", ctx.get("identity").asText());
-    Assertions.assertEquals(REMOTE_ADDR, ctx.get("remoteAddress").asText());
-    Assertions.assertEquals("sql", ctx.get("queryType").asText());
-    Assertions.assertEquals("[native-1, native-2]", ctx.get("nativeQueryIds").asText());
-
-    // Statistics facet
-    JsonNode stats = runFacets.get("druid_query_statistics");
-    Assertions.assertEquals(300L, stats.get("durationMs").asLong());
-    Assertions.assertEquals(2048L, stats.get("bytes").asLong());
-    Assertions.assertEquals(25L, stats.get("planningTimeMs").asLong());
-    Assertions.assertEquals("200", stats.get("statusCode").asText());
-
-    // No error facet on success
-    Assertions.assertNull(runFacets.get("errorMessage"));
-  }
-
-  @Test
-  public void testSqlQueryFailure() throws IOException
-  {
-    logger.logSqlQuery(sqlLine(
-        "SELECT * FROM \"t\"",
-        ImmutableMap.of("sqlQueryId", "qid-fail"),
-        ImmutableMap.of("success", false, "exception", "Query timed out")
-    ));
-
-    Assertions.assertEquals(1, capturedEvents.size());
-    ObjectNode event = capturedEvents.get(0);
-
-    Assertions.assertEquals("FAIL", event.get("eventType").asText());
-
-    JsonNode errorFacet = event.get("run").get("facets").get("errorMessage");
-    Assertions.assertNotNull(errorFacet);
-    Assertions.assertEquals("Query timed out", errorFacet.get("message").asText());
-    Assertions.assertEquals("SQL", errorFacet.get("programmingLanguage").asText());
-  }
+  // --- Native query tests ---
 
   @Test
   public void testNativeQuery() throws IOException
@@ -329,7 +122,6 @@ public class OpenLineageRequestLoggerTest
     Assertions.assertEquals("COMPLETE", event.get("eventType").asText());
     Assertions.assertTrue(inputNames(event).contains("myDatasource"));
 
-    // Native queries use "query/time" and "query/bytes" stat keys (not "sqlQuery/*")
     JsonNode stats = event.get("run").get("facets").get("druid_query_statistics");
     Assertions.assertEquals(50L, stats.get("durationMs").asLong());
     Assertions.assertEquals(512L, stats.get("bytes").asLong());
@@ -342,17 +134,28 @@ public class OpenLineageRequestLoggerTest
   }
 
   @Test
-  public void testNativeSubQueryOfSqlIsSkipped() throws IOException
+  public void testNativeSubQueryOfSqlEmits() throws IOException
   {
-    // Queries with sqlQueryId in context are sub-queries of a SQL execution; skip to avoid
-    // duplicate events since the SQL-level event already captures the lineage.
+    // Native sub-queries of SQL emit events with the plain native queryType.
+    // SQL origin is indicated by sqlQueryId in the context facet.
     TestQuery query = new TestQuery(
         new TableDataSource("myDatasource"),
         ImmutableMap.of("queryId", "native-qid-2", BaseQuery.SQL_QUERY_ID, "parent-sql-id")
     );
     logger.logNativeQuery(nativeLine(query, ImmutableMap.of("success", true)));
 
-    Assertions.assertEquals(0, capturedEvents.size());
+    Assertions.assertEquals(1, capturedEvents.size());
+    ObjectNode event = capturedEvents.get(0);
+
+    // queryType is the plain native type, not prefixed with "sql/"
+    Assertions.assertEquals("test",
+        event.get("run").get("facets").get("druid_query_context").get("queryType").asText());
+
+    // sqlQueryId included for correlation with parent SQL
+    Assertions.assertEquals("parent-sql-id",
+        event.get("run").get("facets").get("druid_query_context").get("sqlQueryId").asText());
+
+    Assertions.assertTrue(inputNames(event).contains("myDatasource"));
   }
 
   @Test
@@ -371,71 +174,144 @@ public class OpenLineageRequestLoggerTest
   }
 
   @Test
-  public void testSqlUnnestDoesNotAddColumnAsInput() throws IOException
+  public void testNativeQueryExcludedType() throws IOException
   {
-    // UNNEST operands are column references, not table names — they must not appear in inputs.
-    logger.logSqlQuery(sqlLine(
-        "SELECT a FROM \"myTable\", UNNEST(\"arrayCol\") AS u(a)",
-        ImmutableMap.of("sqlQueryId", "qid-unnest"),
-        ImmutableMap.of("success", true)
-    ));
+    TestQuery query = new TestQuery(
+        new TableDataSource("myDatasource"),
+        ImmutableMap.of("queryId", "native-qid-excluded")
+    )
+    {
+      @Override
+      public String getType()
+      {
+        return "segmentMetadata";
+      }
+    };
+    logger.logNativeQuery(nativeLine(query, ImmutableMap.of("success", true)));
 
-    Assertions.assertEquals(1, capturedEvents.size());
-    Set<String> names = inputNames(capturedEvents.get(0));
-    Assertions.assertTrue(names.contains("myTable"));
-    Assertions.assertFalse(names.contains("arrayCol"));
+    Assertions.assertEquals(0, capturedEvents.size());
   }
 
   @Test
-  public void testSqlUnionAll() throws IOException
+  public void testNativeUnionDataSourceExtractsBothTables() throws IOException
   {
-    logger.logSqlQuery(sqlLine(
-        "SELECT * FROM \"tableA\" UNION ALL SELECT * FROM \"tableB\"",
-        ImmutableMap.of("sqlQueryId", "qid-union"),
-        ImmutableMap.of("success", true)
-    ));
+    // UnionDataSource.getTableNames() returns all member table names.
+    // JoinDataSource has the same behavior but requires complex construction (ExprMacroTable etc.),
+    // so we test UnionDataSource as the multi-table representative.
+    DataSource unionDs = new UnionDataSource(
+        List.of(new TableDataSource("leftTable"), new TableDataSource("rightTable"))
+    );
+    TestQuery query = new TestQuery(unionDs, ImmutableMap.of("queryId", "native-multi-1"));
+    logger.logNativeQuery(nativeLine(query, ImmutableMap.of("success", true)));
 
     Assertions.assertEquals(1, capturedEvents.size());
     Set<String> names = inputNames(capturedEvents.get(0));
-    Assertions.assertTrue(names.contains("tableA"));
-    Assertions.assertTrue(names.contains("tableB"));
+    Assertions.assertEquals(2, names.size());
+    Assertions.assertTrue(names.contains("leftTable"));
+    Assertions.assertTrue(names.contains("rightTable"));
   }
 
   @Test
-  public void testSqlSubqueryInWhere() throws IOException
+  public void testNativeQueryFacets() throws IOException
   {
-    logger.logSqlQuery(sqlLine(
-        "SELECT * FROM \"outer\" WHERE \"x\" IN (SELECT \"y\" FROM \"inner\")",
-        ImmutableMap.of("sqlQueryId", "qid-subquery"),
-        ImmutableMap.of("success", true)
-    ));
+    TestQuery query = new TestQuery(
+        new TableDataSource("t"),
+        ImmutableMap.of("queryId", "native-facets")
+    );
+    logger.logNativeQuery(nativeLine(query, ImmutableMap.of(
+        "success", true,
+        "query/time", 300L,
+        "query/bytes", 2048L,
+        "statusCode", "200",
+        "identity", "bob"
+    )));
 
     Assertions.assertEquals(1, capturedEvents.size());
-    Set<String> names = inputNames(capturedEvents.get(0));
-    Assertions.assertTrue(names.contains("outer"));
-    Assertions.assertTrue(names.contains("inner"));
+    ObjectNode event = capturedEvents.get(0);
+
+    // OpenLineage envelope
+    Assertions.assertNotNull(event.get("schemaURL"));
+    Assertions.assertNotNull(event.get("producer"));
+    Assertions.assertEquals("2024-01-01T00:00:00.000Z", event.get("eventTime").asText());
+
+    // Job facets — no SQL facet
+    JsonNode jobFacets = event.get("job").get("facets");
+    Assertions.assertNull(jobFacets.get("sql"));
+    Assertions.assertEquals("BATCH", jobFacets.get("jobType").get("processingType").asText());
+    Assertions.assertEquals("DRUID", jobFacets.get("jobType").get("integration").asText());
+    Assertions.assertEquals("QUERY", jobFacets.get("jobType").get("jobType").asText());
+
+    // Run facets
+    JsonNode runFacets = event.get("run").get("facets");
+    Assertions.assertEquals("druid", runFacets.get("processing_engine").get("name").asText());
+
+    // Query context facet
+    JsonNode ctx = runFacets.get("druid_query_context");
+    Assertions.assertEquals("bob", ctx.get("identity").asText());
+    Assertions.assertEquals(REMOTE_ADDR, ctx.get("remoteAddress").asText());
+    Assertions.assertEquals("test", ctx.get("queryType").asText());
+    Assertions.assertNull(ctx.get("sqlQueryId"));
+
+    // Statistics facet
+    JsonNode stats = runFacets.get("druid_query_statistics");
+    Assertions.assertEquals(300L, stats.get("durationMs").asLong());
+    Assertions.assertEquals(2048L, stats.get("bytes").asLong());
+    Assertions.assertEquals("200", stats.get("statusCode").asText());
+
+    // No error facet on success
+    Assertions.assertNull(runFacets.get("errorMessage"));
   }
 
   @Test
-  public void testSqlScalarSubqueryInSelect() throws IOException
+  public void testNativeQueryFailure() throws IOException
   {
-    logger.logSqlQuery(sqlLine(
-        "SELECT (SELECT COUNT(*) FROM \"counts\") AS cnt FROM \"main\"",
-        ImmutableMap.of("sqlQueryId", "qid-scalar"),
-        ImmutableMap.of("success", true)
-    ));
+    TestQuery query = new TestQuery(
+        new TableDataSource("t"),
+        ImmutableMap.of("queryId", "native-fail")
+    );
+    logger.logNativeQuery(nativeLine(query, ImmutableMap.of(
+        "success", false,
+        "exception", "Query timed out"
+    )));
 
     Assertions.assertEquals(1, capturedEvents.size());
-    Set<String> names = inputNames(capturedEvents.get(0));
-    Assertions.assertTrue(names.contains("main"));
-    Assertions.assertTrue(names.contains("counts"));
+    ObjectNode event = capturedEvents.get(0);
+
+    Assertions.assertEquals("FAIL", event.get("eventType").asText());
+
+    JsonNode errorFacet = event.get("run").get("facets").get("errorMessage");
+    Assertions.assertNotNull(errorFacet);
+    Assertions.assertEquals("Query timed out", errorFacet.get("message").asText());
+    // Native query — no "programmingLanguage" field
+    Assertions.assertNull(errorFacet.get("programmingLanguage"));
+  }
+
+  @Test
+  public void testNativeSqlSubQueryFailure() throws IOException
+  {
+    TestQuery query = new TestQuery(
+        new TableDataSource("t"),
+        ImmutableMap.of("queryId", "native-sql-fail", BaseQuery.SQL_QUERY_ID, "parent-sql")
+    );
+    logger.logNativeQuery(nativeLine(query, ImmutableMap.of(
+        "success", false,
+        "exception", "Query timed out"
+    )));
+
+    Assertions.assertEquals(1, capturedEvents.size());
+    ObjectNode event = capturedEvents.get(0);
+
+    Assertions.assertEquals("FAIL", event.get("eventType").asText());
+
+    JsonNode errorFacet = event.get("run").get("facets").get("errorMessage");
+    Assertions.assertNotNull(errorFacet);
+    // SQL-originated query — has "programmingLanguage"
+    Assertions.assertEquals("SQL", errorFacet.get("programmingLanguage").asText());
   }
 
   @Test
   public void testConstructorThrowsWhenHttpWithoutUrl()
   {
-    // HTTP URL validation is enforced at construction time so it fails fast during Guice wiring,
-    // even when ComposingRequestLogger does not delegate @LifecycleStart to sub-loggers.
     Assertions.assertThrows(IllegalStateException.class, () -> new OpenLineageRequestLogger(
         MAPPER,
         NAMESPACE,

--- a/pom.xml
+++ b/pom.xml
@@ -257,6 +257,8 @@
         <module>extensions-contrib/openlineage-emitter</module>
         <module>extensions-contrib/redis-cache</module>
         <module>extensions-contrib/opentsdb-emitter</module>
+        <module>extensions-contrib/materialized-view-maintenance</module>
+        <module>extensions-contrib/materialized-view-selection</module>
         <module>extensions-contrib/momentsketch</module>
         <module>extensions-contrib/moving-average-query</module>
         <module>extensions-contrib/tdigestsketch</module>

--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,7 @@
         <module>extensions-contrib/ambari-metrics-emitter</module>
         <module>extensions-contrib/sqlserver-metadata-storage</module>
         <module>extensions-contrib/kafka-emitter</module>
+        <module>extensions-contrib/openlineage-emitter</module>
         <module>extensions-contrib/redis-cache</module>
         <module>extensions-contrib/opentsdb-emitter</module>
         <module>extensions-contrib/momentsketch</module>

--- a/pom.xml
+++ b/pom.xml
@@ -257,8 +257,6 @@
         <module>extensions-contrib/openlineage-emitter</module>
         <module>extensions-contrib/redis-cache</module>
         <module>extensions-contrib/opentsdb-emitter</module>
-        <module>extensions-contrib/materialized-view-maintenance</module>
-        <module>extensions-contrib/materialized-view-selection</module>
         <module>extensions-contrib/momentsketch</module>
         <module>extensions-contrib/moving-average-query</module>
         <module>extensions-contrib/tdigestsketch</module>

--- a/website/.spelling
+++ b/website/.spelling
@@ -196,6 +196,7 @@ Lucene
 MapBD
 MapDB
 MariaDB
+Marquez
 MiddleManager
 MiddleManagers
 Montréal
@@ -211,6 +212,7 @@ OLAP
 OOMs
 OpenJDK
 OpenLDAP
+OpenLineage
 OpenTSDB
 OutputStream
 ParAccel

--- a/website/.spelling
+++ b/website/.spelling
@@ -214,6 +214,7 @@ OLAP
 OOMs
 OpenJDK
 OpenLDAP
+openlineage
 OpenLineage
 OpenTSDB
 OutputStream

--- a/website/.spelling
+++ b/website/.spelling
@@ -422,6 +422,7 @@ kubexit
 k8s
 laning
 lifecycle
+lineage
 localhost
 log4j
 log4j2

--- a/website/.spelling
+++ b/website/.spelling
@@ -62,6 +62,7 @@ CORS
 CNF
 CPUs
 CSVs
+CTEs
 CentralizedDatasourceSchema
 Ceph
 circledR
@@ -105,6 +106,7 @@ ECS
 EMR
 EMRFS
 ETL
+emits
 Elasticsearch
 Enums
 FIRST_VALUE
@@ -335,6 +337,7 @@ deepstore
 denormalization
 denormalize
 denormalized
+deduplicated
 deprioritization
 deprioritizes
 dequeued


### PR DESCRIPTION
### Description
Added `extensions-contrib/openlineage-emitter` as a contrib extension that uses the `RequestLogger` to transform and send lineage information to any [OpenLineage](https://openlineage.io)-compatible API.
For SQL queries, the SQL text is parsed with the Calcite parser to extract input datasources (FROM clauses, JOINs, CTEs) and output datasources (INSERT INTO). For native queries, table names are read from `DataSource.getTableNames()`. Native sub-queries spawned by a SQL execution are deduplicated against the SQL-level event.
Each event includes standard OpenLineage facets (`processing_engine`, `jobType`, `sql`,`errorMessage`) and custom Druid facets (`druid_query_context` with user identity and query metadata, `druid_query_statistics` with duration and bytes).

Transport is configurable: `CONSOLE` (default) logs JSON to the Druid log; `HTTP` POSTs to an OpenLineage endpoint such as [Marquez](https://marquezproject.ai). Can be combined with other loggers via the `composing` provider.

<img width="1251" height="387" alt="Screenshot 2026-05-13 at 3 21 30 PM" src="https://github.com/user-attachments/assets/725687da-6830-44fc-8413-8e938834fa3d" />

This PR has:

- [ ] been self-reviewed.
- [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.