### PR TITLE
Prometheus config for mergebuffer used bytes

### DIFF
--- a/extensions-contrib/prometheus-emitter/src/main/resources/defaultMetrics.json
+++ b/extensions-contrib/prometheus-emitter/src/main/resources/defaultMetrics.json
@@ -51,7 +51,7 @@
   "mergeBuffer/acquisitionTimeNs": { "dimensions":  [], "type":  "timer", "help":  "Total time in nanoseconds to acquire merge buffer for groupBy queries."},
   "mergeBuffer/maxAcquisitionTimeNs": { "dimensions":  [], "type":  "timer", "help":  "Maximum time in nanoseconds to acquire merge buffer for any single groupBy query within the emission period."},
   "mergeBuffer/bytesUsed" : { "dimensions":  [], "type":  "gauge", "help":  "Total number of bytes used by merge buffers to process groupBy queries."},
-  "mergeBuffer/maxBytesUsed" : { "dimensions":  [], "type":  "gauge", "help":  "Maximum number of bytes used by merge buffers for any single GroupBy query within the emission period."},
+  "mergeBuffer/maxBytesUsed" : { "dimensions":  [], "type":  "gauge", "help":  "Maximum number of bytes used by merge buffers for any single groupBy query within the emission period."},
   "mergeBuffer/queries": { "dimensions":  [], "type":  "gauge", "help":  "Number of groupBy queries that acquired a batch of buffers from the merge buffer pool."},
   "groupBy/spilledQueries": { "dimensions":  [], "type":  "gauge", "help":  "Number of groupBy queries that have spilled onto the disk."},
   "groupBy/maxSpilledBytes": { "dimensions":  [], "type":  "gauge", "help":  "Maximum number of bytes spilled to disk by any single groupBy query within the emission period."},


### PR DESCRIPTION
### Description

This PR change is inspired by #18970. 
Add the newly introduced merge buffer used bytes metrics introduced in #18731 to the prometheus config.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `defaultMetrics.json`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.