### PR TITLE
Update labeler GH action

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -32,6 +32,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v6
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
### Description

Updates the labeler GH action to [`v6`](https://github.com/actions/labeler/releases/tag/v6.0.0) to get rid of the deprecated node v20 warnings in the GH action runs.

Our current runner versions are `2.332.0` (higher than the required [`v2.327.1`](https://github.com/actions/runner/releases/tag/v2.327.1) for Node 24 support).

<hr>

This PR has:

- [x] been self-reviewed.
