### PR TITLE
Update version to include project prefix

### DIFF
--- a/embedded-tests/pom.xml
+++ b/embedded-tests/pom.xml
@@ -363,7 +363,7 @@
     <dependency>
       <groupId>org.apache.druid.extensions</groupId>
       <artifactId>simple-client-sslcontext</artifactId>
-      <version>${parent.version}</version>
+      <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- Pin protobuf-java-util to the version from druid-protobuf-extensions to satisfy


### PR DESCRIPTION
Noticed [this warning](https://github.com/apache/druid/actions/runs/23161089568/job/67288816092#step:6:311) in our builds. This PR adds the `project` prefix to the version so Maven is happy again.

<hr>

This PR has:

- [x] been self-reviewed.