### PR TITLE
fix: Change auth from WRITE to READ for specGetAll

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResource.java
@@ -201,10 +201,20 @@ public class SupervisorResource
   {
     return asLeaderWithSupervisorManager(
         manager -> {
-          Set<String> authorizedSupervisorIds = filterAuthorizedSupervisorIds(
-              req,
-              manager,
-              manager.getSupervisorIds()
+          Function<String, Iterable<ResourceAction>> readRaGenerator = supervisorId -> {
+            Optional<SupervisorSpec> supervisorSpecOptional = manager.getSupervisorSpec(supervisorId);
+            return supervisorSpecOptional
+                .transform(spec -> SPEC_DATASOURCE_READ_RA_GENERATOR.apply(new VersionedSupervisorSpec(spec, null)))
+                .orNull();
+          };
+
+          Set<String> authorizedSupervisorIds = Sets.newHashSet(
+              AuthorizationUtils.filterAuthorizedResources(
+                  req,
+                  manager.getSupervisorIds(),
+                  readRaGenerator,
+                  authorizerMapper
+              )
           );
           final boolean includeFull = full != null;
           final boolean includeState = state != null && state;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResource.java
@@ -201,20 +201,11 @@ public class SupervisorResource
   {
     return asLeaderWithSupervisorManager(
         manager -> {
-          Function<String, Iterable<ResourceAction>> readRaGenerator = supervisorId -> {
-            Optional<SupervisorSpec> supervisorSpecOptional = manager.getSupervisorSpec(supervisorId);
-            return supervisorSpecOptional
-                .transform(spec -> SPEC_DATASOURCE_READ_RA_GENERATOR.apply(new VersionedSupervisorSpec(spec, null)))
-                .orNull();
-          };
-
-          Set<String> authorizedSupervisorIds = Sets.newHashSet(
-              AuthorizationUtils.filterAuthorizedResources(
+          Set<String> authorizedSupervisorIds = filterAuthorizedSupervisorIds(
                   req,
+                  manager,
                   manager.getSupervisorIds(),
-                  readRaGenerator,
-                  authorizerMapper
-              )
+                  AuthorizationUtils.DATASOURCE_READ_RA_GENERATOR
           );
           final boolean includeFull = full != null;
           final boolean includeState = state != null && state;
@@ -509,7 +500,8 @@ public class SupervisorResource
           Set<String> authorizedSupervisorIds = filterAuthorizedSupervisorIds(
               req,
               manager,
-              manager.getSupervisorIds()
+              manager.getSupervisorIds(),
+              AuthorizationUtils.DATASOURCE_WRITE_RA_GENERATOR
           );
 
           for (final String supervisorId : authorizedSupervisorIds) {
@@ -652,7 +644,8 @@ public class SupervisorResource
   private Set<String> filterAuthorizedSupervisorIds(
       final HttpServletRequest req,
       SupervisorManager manager,
-      Collection<String> supervisorIds
+      Collection<String> supervisorIds,
+      Function<String, ResourceAction> authorizationFn
   )
   {
     Function<String, Iterable<ResourceAction>> raGenerator = supervisorId -> {
@@ -660,7 +653,7 @@ public class SupervisorResource
       if (supervisorSpecOptional.isPresent()) {
         return Iterables.transform(
             supervisorSpecOptional.get().getDataSources(),
-            AuthorizationUtils.DATASOURCE_WRITE_RA_GENERATOR
+            authorizationFn
         );
       } else {
         return null;
@@ -710,7 +703,8 @@ public class SupervisorResource
           Set<String> authorizedSupervisorIds = filterAuthorizedSupervisorIds(
               req,
               manager,
-              manager.getSupervisorIds()
+              manager.getSupervisorIds(),
+              AuthorizationUtils.DATASOURCE_WRITE_RA_GENERATOR
           );
 
           for (final String supervisorId : authorizedSupervisorIds) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResource.java
@@ -202,10 +202,10 @@ public class SupervisorResource
     return asLeaderWithSupervisorManager(
         manager -> {
           Set<String> authorizedSupervisorIds = filterAuthorizedSupervisorIds(
-                  req,
-                  manager,
-                  manager.getSupervisorIds(),
-                  AuthorizationUtils.DATASOURCE_READ_RA_GENERATOR
+              req,
+              manager,
+              manager.getSupervisorIds(),
+              AuthorizationUtils.DATASOURCE_READ_RA_GENERATOR
           );
           final boolean includeFull = full != null;
           final boolean includeState = state != null && state;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
@@ -342,6 +342,25 @@ public class SupervisorResourceTest extends EasyMockSupport
   }
 
   @Test
+  public void testSpecGetAllWithPartialAuthorizationForReadAccess()
+  {
+    EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.of(supervisorManager));
+    EasyMock.expect(supervisorManager.getSupervisorIds()).andReturn(SUPERVISOR_IDS).atLeastOnce();
+    EasyMock.expect(supervisorManager.getSupervisorSpec(SPEC1.getId())).andReturn(Optional.of(SPEC1));
+    EasyMock.expect(supervisorManager.getSupervisorSpec(SPEC2.getId())).andReturn(Optional.of(SPEC2));
+    setupMockRequestForUser("notDruid");
+    replayAll();
+
+    Response response = supervisorResource.specGetAll(null, null, null, request);
+    verifyAll();
+
+    Assert.assertEquals(200, response.getStatus());
+    // Only id1 (datasource1) should be returned since user lacks READ access to datasource2
+    Set<String> returnedIds = (Set<String>) response.getEntity();
+    Assert.assertEquals(ImmutableSet.of("id1"), returnedIds);
+  }
+
+  @Test
   public void testSpecGetAllFull()
   {
     SupervisorStateManager.State state1 = SupervisorStateManager.BasicState.RUNNING;


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

The current implementation of specGetAll is unnecessarily restrictive as it uses [DATASOURCE_WRITE_RA_GENERATOR](https://github.com/apache/druid/blob/master/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResource.java#L653) for authorization. This PR changes the Authorization to only require READ. This issue was surfaced after testing out the endpoint with the [Read Only Authorizer](https://github.com/apache/druid/pull/19243) enabled. Since the history endpoint already returns the list of all Supervisors with Read access this change makes the authorization consistent across the two endpoints

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...
specGetAll returns an empty list for Supervisors when read only authorization is enabled

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `SupervisorResource`
 * `SupervisorResourceTest`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.