### PR TITLE
perf: Speed up VersionedIntervalTimeline operations

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineBenchmark.java
@@ -26,6 +26,7 @@ import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.GranularityType;
 import org.apache.druid.timeline.partition.NumberedOverwriteShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
+import org.apache.druid.timeline.partition.PartitionChunk;
 import org.apache.druid.timeline.partition.PartitionIds;
 import org.apache.druid.timeline.partition.ShardSpec;
 import org.joda.time.DateTime;
@@ -53,7 +54,7 @@ import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
 @State(Scope.Benchmark)
-@Fork(value = 1, jvmArgsAppend = {"-XX:+UseG1GC"})
+@Fork(value = 1, jvmArgsAppend = {"-XX:+UseG1GC", "-Xmx4g"})
 @Warmup(iterations = 10)
 @Measurement(iterations = 10)
 @BenchmarkMode({Mode.Throughput})
@@ -73,7 +74,7 @@ public class VersionedIntervalTimelineBenchmark
   @Param({"false", "true"})
   private boolean useSegmentLock;
 
-  @Param({"MONTH", "DAY"})
+  @Param({"MONTH", "DAY", "HOUR", "MINUTE"})
   private GranularityType segmentGranularity;
 
   private List<Interval> intervals;
@@ -216,22 +217,49 @@ public class VersionedIntervalTimelineBenchmark
     }
   }
 
+  /**
+   * Measures the cost of draining 10% of the timeline in one shot by rebuilding the timeline fresh
+   * each invocation. This is the "bulk removal" case — use {@link Mode#AverageTime} so the result
+   * is interpretable as "seconds per full 10%-drain" rather than a near-zero throughput figure.
+   */
   @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
   public void benchRemove(Blackhole blackhole)
   {
     final List<DataSegment> segmentsCopy = new ArrayList<>(segments);
-    final SegmentTimeline timeline = SegmentTimeline.forSegments(segmentsCopy);
+    final SegmentTimeline localTimeline = SegmentTimeline.forSegments(segmentsCopy);
     final int numTests = (int) (segmentsCopy.size() * 0.1);
     for (int i = 0; i < numTests; i++) {
       final DataSegment segment = segmentsCopy.remove(ThreadLocalRandom.current().nextInt(segmentsCopy.size()));
       blackhole.consume(
-          timeline.remove(
+          localTimeline.remove(
               segment.getInterval(),
               segment.getVersion(),
               segment.getShardSpec().createChunk(segment)
           )
       );
     }
+  }
+
+  /**
+   * Measures per-remove throughput against the pre-built timeline. One invocation = one remove + one
+   * re-add to keep the timeline stable.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.Throughput)
+  public void benchRemoveWithReplacement(Blackhole blackhole)
+  {
+    final DataSegment segment = segments.get(ThreadLocalRandom.current().nextInt(segments.size()));
+    final PartitionChunk<DataSegment> chunk = segment.getShardSpec().createChunk(segment);
+    final PartitionChunk<DataSegment> removed = timeline.remove(
+        segment.getInterval(),
+        segment.getVersion(),
+        chunk
+    );
+    if (removed != null) {
+      timeline.add(segment.getInterval(), segment.getVersion(), chunk);
+    }
+    blackhole.consume(removed);
   }
 
   @Benchmark
@@ -243,6 +271,26 @@ public class VersionedIntervalTimelineBenchmark
         intervals.get(intervalIndex + 2).getEnd()
     );
     blackhole.consume(timeline.lookup(queryInterval));
+  }
+
+  /**
+   * Looks up a single-interval window — the case that benefits most from the O(log N + K) range scan since only a
+   * tiny fraction of the timeline is touched regardless of overall size.
+   */
+  @Benchmark
+  public void benchLookupSingleInterval(Blackhole blackhole)
+  {
+    final int intervalIndex = ThreadLocalRandom.current().nextInt(intervals.size());
+    blackhole.consume(timeline.lookup(intervals.get(intervalIndex)));
+  }
+
+  /**
+   * Full-range lookup — scans all segments regardless of optimization; provides an upper-bound baseline.
+   */
+  @Benchmark
+  public void benchLookupFullRange(Blackhole blackhole)
+  {
+    blackhole.consume(timeline.lookup(TOTAL_INTERVAL));
   }
 
   @Benchmark

--- a/processing/src/main/java/org/apache/druid/timeline/VersionedIntervalTimeline.java
+++ b/processing/src/main/java/org/apache/druid/timeline/VersionedIntervalTimeline.java
@@ -88,7 +88,10 @@ public class VersionedIntervalTimeline<VersionType, ObjectType extends Overshado
       Comparators.intervalsByStartThenEnd()
   );
   // true interval -> version -> timelineEntry
-  private final Map<Interval, TreeMap<VersionType, TimelineEntry>> allTimelineEntries = new HashMap<>();
+  // NavigableMap so the private remove() can range-scan for overlapping intervals instead of a full O(N) pass.
+  private final NavigableMap<Interval, TreeMap<VersionType, TimelineEntry>> allTimelineEntries = new TreeMap<>(
+      Comparators.intervalsByStartThenEnd()
+  );
   private final AtomicInteger numObjects = new AtomicInteger();
 
   private final Comparator<? super VersionType> versionComparator;
@@ -118,7 +121,7 @@ public class VersionedIntervalTimeline<VersionType, ObjectType extends Overshado
                .iterator();
   }
 
-  public Map<Interval, TreeMap<VersionType, TimelineEntry>> getAllTimelineEntries()
+  public NavigableMap<Interval, TreeMap<VersionType, TimelineEntry>> getAllTimelineEntries()
   {
     return allTimelineEntries;
   }
@@ -715,7 +718,11 @@ public class VersionedIntervalTimeline<VersionType, ObjectType extends Overshado
   {
     timeline.remove(interval);
 
-    for (Entry<Interval, TreeMap<VersionType, TimelineEntry>> versionEntry : allTimelineEntries.entrySet()) {
+    // Use headMap to skip entries whose start >= interval.end (those can never overlap), then filter for actual overlap.
+    // Reduces the scan to O(M) where M is the # of intervals with start < interval.end.
+    final Interval headBound = new Interval(interval.getEnd(), interval.getEnd());
+    for (Entry<Interval, TreeMap<VersionType, TimelineEntry>> versionEntry :
+        allTimelineEntries.headMap(headBound, false).entrySet()) {
       if (versionEntry.getKey().overlap(interval) != null) {
         if (incompleteOk) {
           add(timeline, versionEntry.getKey(), versionEntry.getValue().lastEntry().getValue());
@@ -747,8 +754,27 @@ public class VersionedIntervalTimeline<VersionType, ObjectType extends Overshado
       timeline = completePartitionsTimeline;
     }
 
-    for (Entry<Interval, TimelineEntry> entry : timeline.entrySet()) {
+    // Both completePartitionsTimeline and incompletePartitionsTimeline contain non-overlapping adjusted intervals
+    // sorted by (start, end). To find entries overlapping [interval.start, interval.end) we only need to scan
+    // the range [floorKey(interval.start), first key with start >= interval.end). The floor handles the one
+    // entry that may have started before interval.start but still extends into the query window.
+    final Interval searchStart = new Interval(interval.getStart(), DateTimes.MAX);
+    Interval startKey = timeline.floorKey(searchStart);
+    if (startKey == null) {
+      // No entry starts at or before interval.start; begin from the first entry in the map.
+      startKey = timeline.isEmpty() ? null : timeline.firstKey();
+    }
+    if (startKey == null) {
+      return retVal;
+    }
+
+    for (Entry<Interval, TimelineEntry> entry : timeline.tailMap(startKey, true).entrySet()) {
       Interval timelineInterval = entry.getKey();
+      // All entries from here forward start at or after startKey.start. Once we reach an entry whose
+      // start is at or past the query end, there can be no more overlaps.
+      if (timelineInterval.getStartMillis() >= interval.getEndMillis()) {
+        break;
+      }
       TimelineEntry val = entry.getValue();
 
       // exclude empty partition holders (i.e. tombstones) since they do not add value


### PR DESCRIPTION
<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

We have observed severe performance degradation in the VersionedIntervalTimeline when ingesting datasource at the `MINUTE` segment grain. Due to query runners needing to acquire an exclusive lock [here](https://github.com/apache/druid/blob/master/server/src/main/java/org/apache/druid/client/BrokerServerView.java#L377-L379) on the query hot-path, if frequent segment add/remove callbacks that touch many intervals occur, the volume + latency of each of these timeline operations can cause the BrokerServerView lock to stall indefinitely, preventing queries from running. This giant lock in BrokerServerView is IMO another issue that should be dealt with in a separate change (at the very least, should change this lock granularity to per-datasource).

This patch speeds up a few timeline operations to significantly increase timeline throughput to minimize contention on the BrokerServerView lock.

#### Results

Params: `numInitialRootGenSegmentsPerInterval=10`, `numNonRootGenerations=1`, `useSegmentLock=false`

### benchLookup

| Granularity | Intervals | Baseline (ops/s) | Optimized (ops/s) | Speedup |
|---|---|---|---|---|
| DAY | 365 | 401,045 | 1,704,230 | **4.2x** |
| HOUR | 8,760 | 19,265 | 960,835 | **49.9x** |
| MINUTE | 525,600 | 68 | 243,950 | **3,588x** |

### benchRemoveWithReplacement (not much here in normal values)

| Granularity | Intervals | Baseline (ops/s) | Optimized (ops/s) | Speedup |
|---|---|---|---|---|
| DAY | 365 | 581,271 | 662,742 | **~1x (no visible change)** |
| HOUR | 8,760 | 19,427 | 19,136 | **~1x (no visible change)** |
| MINUTE | 525,600 | 45 | 264 | **5.9x** |


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Speed up VersionedIntervalTimeline operations

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.