### PR TITLE
fix: preserve GROUPING SET dimensions with single-value filter 

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/Grouping.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/Grouping.java
@@ -228,14 +228,42 @@ public class Grouping
     // Remove literal dimensions that did not appear in the projection. This is useful for queries
     // like "SELECT COUNT(*) FROM tbl GROUP BY 'dummy'" which some tools can generate, and for which we don't
     // actually want to include a dimension 'dummy'.
+    //
+    // However, non-literal dimensions (column references) used in any GROUPING SET should not be dropped,
+    // even if they are not in the projection. This ensures correct NULL value formatting.
+    // See: https://github.com/apache/druid/issues/13204
     final ImmutableBitSet aggregateProjectBits = RelOptUtil.InputFinder.bits(project.getProjects(), null);
     final int[] newDimIndexes = new int[dimensions.size()];
     boolean droppedDimensions = false;
 
+    // Collect all dimension indices referenced in any non-empty subtotal, but only when the subtotals
+    // spec has real effect (i.e. multiple grouping sets). A plain GROUP BY with a single group produces
+    // subtotals = [[0, 1, ...]] which has no effect and must not prevent literal dimensions from being dropped.
+    // See: https://github.com/apache/druid/issues/13204
+    final Set<Integer> dimensionsInSubtotals = new HashSet<>();
+    if (subtotals.hasEffect(dimensions.stream()
+                                      .map(DimensionExpression::toDimensionSpec)
+                                      .collect(Collectors.toList()))) {
+      for (IntList subtotal : subtotals.getSubtotals()) {
+        if (!subtotal.isEmpty()) {
+          for (int dimIndex : subtotal) {
+            dimensionsInSubtotals.add(dimIndex);
+          }
+        }
+      }
+    }
+
     for (int i = 0; i < dimensions.size(); i++) {
       final DimensionExpression dimension = dimensions.get(i);
-      if (plannerContext.parseExpression(dimension.getDruidExpression().getExpression()).isLiteral()
-          && !aggregateProjectBits.get(i)) {
+      final boolean isLiteral = plannerContext.parseExpression(
+          dimension.getDruidExpression().getExpression()
+      ).isLiteral();
+      final boolean isUsedInSubtotals = dimensionsInSubtotals.contains(i);
+
+      // Drop if it's a literal AND not in projection AND not used in any grouping set.
+      // Non-literal dimensions referenced in a GROUPING SET must be preserved so that
+      // subtotals which omit them correctly emit null.
+      if (isLiteral && !aggregateProjectBits.get(i) && !isUsedInSubtotals) {
         droppedDimensions = true;
         newDimIndexes[i] = -1;
       } else {

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -11662,6 +11662,11 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                 ColumnType.STRING
                             ),
                             expressionVirtualColumn(
+                                "v1",
+                                "'dummy'",
+                                ColumnType.STRING
+                            ),
+                            expressionVirtualColumn(
                                 "v2",
                                 "timestamp_floor(\"__time\",'P1M',null,'UTC')",
                                 ColumnType.LONG
@@ -11670,15 +11675,16 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         .setDimensions(
                             dimensions(
                                 new DefaultDimensionSpec("v0", "d0"),
+                                new DefaultDimensionSpec("v1", "d1", ColumnType.STRING),
                                 new DefaultDimensionSpec("v2", "d2", ColumnType.LONG)
                             )
                         )
                         .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
                         .setSubtotalsSpec(
                             ImmutableList.of(
-                                ImmutableList.of("d0", "d2"),
+                                ImmutableList.of("d0", "d1", "d2"),
                                 ImmutableList.of("d0"),
-                                ImmutableList.of(),
+                                ImmutableList.of("d1"),
                                 ImmutableList.of("d2")
                             )
                         )
@@ -11954,6 +11960,84 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         ),
         ImmutableList.of(
             new Object[]{"abc", null, 1L}
+        )
+    );
+  }
+
+  @Test
+  public void testGroupingSetsWithSingleValueFilter()
+  {
+    msqIncompatible();
+    testQuery(
+        "SELECT dim1, dim2, SUM(cnt)\n"
+        + "FROM druid.foo\n"
+        + "WHERE dim2 = 'a'\n"
+        + "GROUP BY GROUPING SETS ( (dim1, dim2), (dim1) )",
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(CalciteTests.DATASOURCE1)
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setGranularity(Granularities.ALL)
+                        .setDimensions(
+                            dimensions(
+                                new DefaultDimensionSpec("dim1", "d0", ColumnType.STRING),
+                                new DefaultDimensionSpec("dim2", "d1", ColumnType.STRING)
+                            )
+                        )
+                        .setDimFilter(equality("dim2", "a", ColumnType.STRING))
+                        .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
+                        .setSubtotalsSpec(
+                            ImmutableList.of(
+                                ImmutableList.of("d0", "d1"),
+                                ImmutableList.of("d0")
+                            )
+                        )
+                        .build()
+        ),
+        ImmutableList.of(
+            new Object[]{"", "a", 1L},
+            new Object[]{"1", "a", 1L},
+            new Object[]{"", null, 1L},
+            new Object[]{"1", null, 1L}
+        )
+    );
+  }
+
+  @Test
+  public void testGroupingSetsWithSingleValueFilterUsingIn()
+  {
+    msqIncompatible();
+    testQuery(
+        "SELECT dim1, dim2, SUM(cnt)\n"
+        + "FROM druid.foo\n"
+        + "WHERE dim2 IN ('a')\n"
+        + "GROUP BY GROUPING SETS ( (dim1, dim2), (dim1) )",
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(CalciteTests.DATASOURCE1)
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setGranularity(Granularities.ALL)
+                        .setDimensions(
+                            dimensions(
+                                new DefaultDimensionSpec("dim1", "d0", ColumnType.STRING),
+                                new DefaultDimensionSpec("dim2", "d1", ColumnType.STRING)
+                            )
+                        )
+                        .setDimFilter(equality("dim2", "a", ColumnType.STRING))
+                        .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
+                        .setSubtotalsSpec(
+                            ImmutableList.of(
+                                ImmutableList.of("d0", "d1"),
+                                ImmutableList.of("d0")
+                            )
+                        )
+                        .build()
+        ),
+        ImmutableList.of(
+            new Object[]{"", "a", 1L},
+            new Object[]{"1", "a", 1L},
+            new Object[]{"", null, 1L},
+            new Object[]{"1", null, 1L}
         )
     );
   }

--- a/sql/src/test/quidem/org.apache.druid.quidem.SqlQuidemTest/grouping_sets_single_value_filter.iq
+++ b/sql/src/test/quidem/org.apache.druid.quidem.SqlQuidemTest/grouping_sets_single_value_filter.iq
@@ -1,0 +1,118 @@
+!use druidtest:///
+!set outputformat mysql
+
+# GROUPING SETS with single-value equality filter should preserve dim2 in subtotals (fix for #13204)
+SELECT dim1, dim2, SUM(cnt)
+FROM druid.foo
+WHERE dim2 = 'a'
+GROUP BY GROUPING SETS ( (dim1, dim2), (dim1) );
++------+------+--------+
+| dim1 | dim2 | EXPR$2 |
++------+------+--------+
+|      | a    |      1 |
+|      |      |      1 |
+| 1    | a    |      1 |
+| 1    |      |      1 |
++------+------+--------+
+(4 rows)
+
+!ok
+{
+  "queryType" : "groupBy",
+  "dataSource" : {
+    "type" : "table",
+    "name" : "foo"
+  },
+  "intervals" : {
+    "type" : "intervals",
+    "intervals" : [ "-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z" ]
+  },
+  "filter" : {
+    "type" : "equals",
+    "column" : "dim2",
+    "matchValueType" : "STRING",
+    "matchValue" : "a"
+  },
+  "granularity" : {
+    "type" : "all"
+  },
+  "dimensions" : [ {
+    "type" : "default",
+    "dimension" : "dim1",
+    "outputName" : "d0",
+    "outputType" : "STRING"
+  }, {
+    "type" : "default",
+    "dimension" : "dim2",
+    "outputName" : "d1",
+    "outputType" : "STRING"
+  } ],
+  "aggregations" : [ {
+    "type" : "longSum",
+    "name" : "a0",
+    "fieldName" : "cnt"
+  } ],
+  "limitSpec" : {
+    "type" : "NoopLimitSpec"
+  },
+  "subtotalsSpec" : [ [ "d0", "d1" ], [ "d0" ] ]
+}
+!nativePlan
+
+# GROUPING SETS with single-value IN filter should behave identically to = filter (fix for #13204)
+SELECT dim1, dim2, SUM(cnt)
+FROM druid.foo
+WHERE dim2 IN ('a')
+GROUP BY GROUPING SETS ( (dim1, dim2), (dim1) );
++------+------+--------+
+| dim1 | dim2 | EXPR$2 |
++------+------+--------+
+|      | a    |      1 |
+|      |      |      1 |
+| 1    | a    |      1 |
+| 1    |      |      1 |
++------+------+--------+
+(4 rows)
+
+!ok
+{
+  "queryType" : "groupBy",
+  "dataSource" : {
+    "type" : "table",
+    "name" : "foo"
+  },
+  "intervals" : {
+    "type" : "intervals",
+    "intervals" : [ "-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z" ]
+  },
+  "filter" : {
+    "type" : "equals",
+    "column" : "dim2",
+    "matchValueType" : "STRING",
+    "matchValue" : "a"
+  },
+  "granularity" : {
+    "type" : "all"
+  },
+  "dimensions" : [ {
+    "type" : "default",
+    "dimension" : "dim1",
+    "outputName" : "d0",
+    "outputType" : "STRING"
+  }, {
+    "type" : "default",
+    "dimension" : "dim2",
+    "outputName" : "d1",
+    "outputType" : "STRING"
+  } ],
+  "aggregations" : [ {
+    "type" : "longSum",
+    "name" : "a0",
+    "fieldName" : "cnt"
+  } ],
+  "limitSpec" : {
+    "type" : "NoopLimitSpec"
+  },
+  "subtotalsSpec" : [ [ "d0", "d1" ], [ "d0" ] ]
+}
+!nativePlan


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #13204

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description



```sql
SELECT dim1, dim2, SUM(cnt)
FROM druid.foo
WHERE dim2 = 'a'
GROUP BY GROUPING SETS ( (dim1, dim2), (dim1) )
```

Before (incorrect):

```
dim1 | dim2 | SUM(cnt)
""   | a    | 1
"1"  | a    | 1
""   | a    | 1   -- should be null
"1"  | a    | 1   -- should be null
```

After (correct):

```
dim1 | dim2 | SUM(cnt)
""   | a    | 1
"1"  | a    | 1
""   | null | 1
"1"  | null | 1
```



Fixed Grouping.applyProject() to preserve non-literal dimensions (and literal dimensions referenced in non-empty
subtotals) when Subtotals.hasEffect() is true, preventing single-value filter dimensions from being dropped and
causing incorrect non-null values in GROUPING SET subtotal rows.



#### Release note

Fixed a bug where a SQL query using GROUPING SETS with a single-value WHERE filter on a grouped dimension would return
the filtered value instead of null in subtotal rows that exclude that dimension. For example, WHERE dim2 = 'a' GROUP 
BY GROUPING SETS ((dim1, dim2), (dim1)) now correctly returns null for dim2 in the (dim1) subtotal rows instead of
repeating 'a'.


<hr>



<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [ ] been tested in a test Druid cluster.