### PR TITLE
feat: add disk-utilization-aware segment loading

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/CoordinatorDynamicConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/CoordinatorDynamicConfig.java
@@ -75,6 +75,7 @@ public class CoordinatorDynamicConfig
 
   private final Set<String> turboLoadingNodes;
   private final Map<String, String> cloneServers;
+  private final Map<String, Double> tierServerFillThreshold;
 
   /**
    * Stale pending segments belonging to the data sources in this list are not killed by {@code
@@ -126,7 +127,8 @@ public class CoordinatorDynamicConfig
       @JsonProperty("smartSegmentLoading") @Nullable Boolean smartSegmentLoading,
       @JsonProperty("debugDimensions") @Nullable Map<String, String> debugDimensions,
       @JsonProperty("turboLoadingNodes") @Nullable Set<String> turboLoadingNodes,
-      @JsonProperty("cloneServers") @Nullable Map<String, String> cloneServers
+      @JsonProperty("cloneServers") @Nullable Map<String, String> cloneServers,
+      @JsonProperty("tierServerFillThreshold") @Nullable Map<String, Double> tierServerFillThreshold
   )
   {
     this.markSegmentAsUnusedDelayMillis =
@@ -172,6 +174,7 @@ public class CoordinatorDynamicConfig
     this.validDebugDimensions = validateDebugDimensions(debugDimensions);
     this.turboLoadingNodes = Configs.valueOrDefault(turboLoadingNodes, Set.of());
     this.cloneServers = Configs.valueOrDefault(cloneServers, Map.of());
+    this.tierServerFillThreshold = Configs.valueOrDefault(tierServerFillThreshold, Map.of());
   }
 
   private Map<Dimension, String> validateDebugDimensions(Map<String, String> debugDimensions)
@@ -338,6 +341,12 @@ public class CoordinatorDynamicConfig
     return cloneServers;
   }
 
+  @JsonProperty
+  public Map<String, Double> getTierServerFillThreshold()
+  {
+    return tierServerFillThreshold;
+  }
+
   /**
    * List of servers to put in turbo-loading mode. These servers will use a larger thread pool to load
    * segments. This causes decreases the average time taken to load segments. However, this also means less resources
@@ -371,6 +380,7 @@ public class CoordinatorDynamicConfig
            ", replicateAfterLoadTimeout=" + replicateAfterLoadTimeout +
            ", turboLoadingNodes=" + turboLoadingNodes +
            ", cloneServers=" + cloneServers +
+           ", tierServerFillThreshold=" + tierServerFillThreshold +
            '}';
   }
 
@@ -407,7 +417,8 @@ public class CoordinatorDynamicConfig
            && Objects.equals(decommissioningNodes, that.decommissioningNodes)
            && Objects.equals(turboLoadingNodes, that.turboLoadingNodes)
            && Objects.equals(debugDimensions, that.debugDimensions)
-           && Objects.equals(cloneServers, that.cloneServers);
+           && Objects.equals(cloneServers, that.cloneServers)
+           && Objects.equals(tierServerFillThreshold, that.tierServerFillThreshold);
   }
 
   @Override
@@ -431,7 +442,8 @@ public class CoordinatorDynamicConfig
         pauseCoordination,
         debugDimensions,
         turboLoadingNodes,
-        cloneServers
+        cloneServers,
+        tierServerFillThreshold
     );
   }
 
@@ -488,6 +500,7 @@ public class CoordinatorDynamicConfig
     private Boolean smartSegmentLoading;
     private Set<String> turboLoadingNodes;
     private Map<String, String> cloneServers;
+    private Map<String, Double> tierServerFillThreshold;
 
     public Builder()
     {
@@ -512,7 +525,8 @@ public class CoordinatorDynamicConfig
         @JsonProperty("smartSegmentLoading") @Nullable Boolean smartSegmentLoading,
         @JsonProperty("debugDimensions") @Nullable Map<String, String> debugDimensions,
         @JsonProperty("turboLoadingNodes") @Nullable Set<String> turboLoadingNodes,
-        @JsonProperty("cloneServers") @Nullable Map<String, String> cloneServers
+        @JsonProperty("cloneServers") @Nullable Map<String, String> cloneServers,
+        @JsonProperty("tierServerFillThreshold") @Nullable Map<String, Double> tierServerFillThreshold
     )
     {
       this.markSegmentAsUnusedDelayMillis = markSegmentAsUnusedDelayMillis;
@@ -533,6 +547,7 @@ public class CoordinatorDynamicConfig
       this.debugDimensions = debugDimensions;
       this.turboLoadingNodes = turboLoadingNodes;
       this.cloneServers = cloneServers;
+      this.tierServerFillThreshold = tierServerFillThreshold;
     }
 
     public Builder withMarkSegmentAsUnusedDelayMillis(long leadingTimeMillis)
@@ -631,6 +646,12 @@ public class CoordinatorDynamicConfig
       return this;
     }
 
+    public Builder withTierServerFillThreshold(Map<String, Double> tierServerFillThreshold)
+    {
+      this.tierServerFillThreshold = tierServerFillThreshold;
+      return this;
+    }
+
     /**
      * Builds a CoordinatoryDynamicConfig using either the configured values, or
      * the default value if not configured.
@@ -658,7 +679,8 @@ public class CoordinatorDynamicConfig
           valueOrDefault(smartSegmentLoading, Defaults.SMART_SEGMENT_LOADING),
           debugDimensions,
           turboLoadingNodes,
-          cloneServers
+          cloneServers,
+          tierServerFillThreshold
       );
     }
 
@@ -690,7 +712,8 @@ public class CoordinatorDynamicConfig
           valueOrDefault(smartSegmentLoading, defaults.isSmartSegmentLoading()),
           valueOrDefault(debugDimensions, defaults.getDebugDimensions()),
           valueOrDefault(turboLoadingNodes, defaults.getTurboLoadingNodes()),
-          valueOrDefault(cloneServers, defaults.getCloneServers())
+          valueOrDefault(cloneServers, defaults.getCloneServers()),
+          valueOrDefault(tierServerFillThreshold, defaults.getTierServerFillThreshold())
       );
     }
   }

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
@@ -750,6 +750,7 @@ public class DruidCoordinator
               .withDataSourcesSnapshot(dataSourcesSnapshot)
               .withDynamicConfigs(metadataManager.configs().getCurrentDynamicConfig())
               .withCompactionConfig(metadataManager.configs().getCurrentCompactionConfig())
+              .withDefaultServerFillThreshold(config.getDefaultServerFillThreshold())
               .build();
           dutyGroup.run(params);
         } else {

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorRuntimeParams.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorRuntimeParams.java
@@ -203,6 +203,7 @@ public class DruidCoordinatorRuntimeParams
     private CoordinatorRunStats stats;
     private BalancerStrategy balancerStrategy;
     private Set<String> broadcastDatasources;
+    private double defaultServerFillThreshold = 1.0;
 
     private Builder()
     {
@@ -288,7 +289,9 @@ public class DruidCoordinatorRuntimeParams
           druidCluster,
           balancerStrategy,
           segmentLoadingConfig,
-          stats
+          stats,
+          coordinatorDynamicConfig,
+          defaultServerFillThreshold
       );
     }
 
@@ -337,6 +340,12 @@ public class DruidCoordinatorRuntimeParams
     public Builder withDynamicConfigs(CoordinatorDynamicConfig configs)
     {
       this.coordinatorDynamicConfig = configs;
+      return this;
+    }
+
+    public Builder withDefaultServerFillThreshold(double defaultServerFillThreshold)
+    {
+      this.defaultServerFillThreshold = defaultServerFillThreshold;
       return this;
     }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/ServerHolder.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/ServerHolder.java
@@ -254,6 +254,12 @@ public class ServerHolder implements Comparable<ServerHolder>
     return getMaxSize() - getSizeUsed();
   }
 
+  public double getFillFraction()
+  {
+    final long maxSize = getMaxSize();
+    return maxSize > 0 ? (double) getSizeUsed() / maxSize : 0.0;
+  }
+
   /**
    * Checks if the server can load the given segment.
    * <p>

--- a/server/src/main/java/org/apache/druid/server/coordinator/config/CoordinatorSegmentLoadConfigs.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/config/CoordinatorSegmentLoadConfigs.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.common.config.Configs;
+
+public class CoordinatorSegmentLoadConfigs
+{
+  /**
+   * Default fill-fraction threshold applied to all tiers with no per-tier override in
+   * {@link org.apache.druid.server.coordinator.CoordinatorDynamicConfig#getTierServerFillThreshold()}.
+   * Servers whose fill fraction ({@code sizeUsed / maxSize}) exceeds this value are deprioritized
+   * for segment assignment. {@code 1.0} means no threshold (current behavior).
+   */
+  @JsonProperty
+  private final double defaultServerFillThreshold;
+
+  @JsonCreator
+  public CoordinatorSegmentLoadConfigs(
+      @JsonProperty("defaultServerFillThreshold") Double defaultServerFillThreshold
+  )
+  {
+    this.defaultServerFillThreshold = Configs.valueOrDefault(defaultServerFillThreshold, 1.0);
+  }
+
+  public double getDefaultServerFillThreshold()
+  {
+    return defaultServerFillThreshold;
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/coordinator/config/DruidCoordinatorConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/config/DruidCoordinatorConfig.java
@@ -34,6 +34,7 @@ public class DruidCoordinatorConfig
   private final CoordinatorKillConfigs killConfigs;
   private final BalancerStrategyFactory balancerStrategyFactory;
   private final HttpLoadQueuePeonConfig httpLoadQueuePeonConfig;
+  private final CoordinatorSegmentLoadConfigs coordinatorSegmentLoadConfigs;
 
   @Inject
   public DruidCoordinatorConfig(
@@ -41,7 +42,8 @@ public class DruidCoordinatorConfig
       CoordinatorPeriodConfig periodConfig,
       CoordinatorKillConfigs killConfigs,
       BalancerStrategyFactory balancerStrategyFactory,
-      HttpLoadQueuePeonConfig httpLoadQueuePeonConfig
+      HttpLoadQueuePeonConfig httpLoadQueuePeonConfig,
+      CoordinatorSegmentLoadConfigs coordinatorSegmentLoadConfigs
   )
   {
     this.killConfigs = killConfigs;
@@ -49,6 +51,7 @@ public class DruidCoordinatorConfig
     this.periodConfig = periodConfig;
     this.balancerStrategyFactory = balancerStrategyFactory;
     this.httpLoadQueuePeonConfig = httpLoadQueuePeonConfig;
+    this.coordinatorSegmentLoadConfigs = coordinatorSegmentLoadConfigs;
 
     validateKillConfigs();
   }
@@ -86,6 +89,11 @@ public class DruidCoordinatorConfig
   public HttpLoadQueuePeonConfig getHttpLoadQueuePeonConfig()
   {
     return httpLoadQueuePeonConfig;
+  }
+
+  public double getDefaultServerFillThreshold()
+  {
+    return coordinatorSegmentLoadConfigs.getDefaultServerFillThreshold();
   }
 
   private void validateKillConfigs()

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/RoundRobinServerSelector.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/RoundRobinServerSelector.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.server.coordinator.loading;
 
+import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
 import org.apache.druid.server.coordinator.DruidCluster;
 import org.apache.druid.server.coordinator.ServerHolder;
 import org.apache.druid.timeline.DataSegment;
@@ -48,9 +49,13 @@ import java.util.Set;
 public class RoundRobinServerSelector
 {
   private final Map<String, CircularServerList> tierToServers = new HashMap<>();
+  private final CoordinatorDynamicConfig dynamicConfig;
+  private final double defaultServerFillThreshold;
 
-  public RoundRobinServerSelector(DruidCluster cluster)
+  public RoundRobinServerSelector(DruidCluster cluster, CoordinatorDynamicConfig dynamicConfig, double defaultServerFillThreshold)
   {
+    this.dynamicConfig = dynamicConfig;
+    this.defaultServerFillThreshold = defaultServerFillThreshold;
     cluster.getManagedHistoricals().forEach(
         (tier, servers) -> tierToServers.put(tier, new CircularServerList(servers))
     );
@@ -67,25 +72,46 @@ public class RoundRobinServerSelector
       return Collections.emptyIterator();
     }
 
-    return new EligibleServerIterator(segment, iterator);
+    return new EligibleServerIterator(
+        segment,
+        iterator,
+        dynamicConfig.getTierServerFillThreshold().getOrDefault(tier, defaultServerFillThreshold)
+    );
   }
 
   /**
    * Iterator over servers in a tier that are eligible to load a given segment.
+   * <p>
+   * Applies a fill-threshold preference: at construction time, scans all servers
+   * to determine if any eligible server is below the threshold. If so, only
+   * below-threshold servers are returned. If none qualify, the threshold is
+   * relaxed so all eligible servers are returned (fallback to original behavior).
+   * <p>
+   * The cursor advances through the circular list across calls so that
+   * subsequent invocations pick up where the last iterator left off.
    */
   private static class EligibleServerIterator implements Iterator<ServerHolder>
   {
     final CircularServerList delegate;
     final DataSegment segment;
+    final double effectiveFillThreshold;
 
     ServerHolder nextEligible;
     int remainingIterations;
 
-    EligibleServerIterator(DataSegment segment, CircularServerList delegate)
+    EligibleServerIterator(DataSegment segment, CircularServerList delegate, double fillThreshold)
     {
       this.delegate = delegate;
       this.segment = segment;
       this.remainingIterations = delegate.servers.size();
+
+      // Apply the threshold only if at least one eligible server is below it.
+      // Otherwise fall back: allow any eligible server (preference-with-fallback).
+      final boolean anyBelowThreshold = delegate.servers.stream()
+                                                        .anyMatch(s -> s.canLoadSegment(segment)
+                                                                       && s.getFillFraction() <= fillThreshold);
+      this.effectiveFillThreshold = anyBelowThreshold ? fillThreshold : Double.POSITIVE_INFINITY;
+
       nextEligible = search();
     }
 
@@ -112,7 +138,7 @@ public class RoundRobinServerSelector
     {
       while (remainingIterations-- > 0) {
         ServerHolder nextServer = delegate.peekNext();
-        if (nextServer.canLoadSegment(segment)) {
+        if (nextServer.canLoadSegment(segment) && nextServer.getFillFraction() <= effectiveFillThreshold) {
           return nextServer;
         } else {
           delegate.advanceCursor();

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentStatusInTier.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentStatusInTier.java
@@ -35,21 +35,28 @@ import java.util.NavigableSet;
 public class SegmentStatusInTier
 {
   private final DataSegment segment;
+  private final double fillThreshold;
 
   private final List<ServerHolder> eligibleLoadServers = new ArrayList<>();
+  private final List<ServerHolder> aboveThresholdLoadServers = new ArrayList<>();
   private final List<ServerHolder> eligibleDropServers = new ArrayList<>();
 
   private final Map<SegmentAction, List<ServerHolder>> serversWithQueuedActions = new HashMap<>();
 
-  public SegmentStatusInTier(DataSegment segment, NavigableSet<ServerHolder> historicals)
+  public SegmentStatusInTier(DataSegment segment, NavigableSet<ServerHolder> historicals, double fillThreshold)
   {
     this.segment = segment;
+    this.fillThreshold = fillThreshold;
     historicals.forEach(this::handleServer);
   }
 
+  /**
+   * Returns servers eligible to load the segment, preferring those below the
+   * fill threshold. Falls back to above-threshold servers if none qualify.
+   */
   public List<ServerHolder> getServersEligibleToLoad()
   {
-    return eligibleLoadServers;
+    return eligibleLoadServers.isEmpty() ? aboveThresholdLoadServers : eligibleLoadServers;
   }
 
   public List<ServerHolder> getServersEligibleToDrop()
@@ -68,7 +75,11 @@ public class SegmentStatusInTier
     if (server.isServingSegment(segment)) {
       eligibleDropServers.add(server);
     } else if (server.canLoadSegment(segment)) {
-      eligibleLoadServers.add(server);
+      if (server.getFillFraction() <= fillThreshold) {
+        eligibleLoadServers.add(server);
+      } else {
+        aboveThresholdLoadServers.add(server);
+      }
     } else if (action != null) {
       serversWithQueuedActions.computeIfAbsent(action, a -> new ArrayList<>())
                               .add(server);

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/StrategicSegmentAssigner.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/StrategicSegmentAssigner.java
@@ -22,6 +22,7 @@ package org.apache.druid.server.coordinator.loading;
 import com.google.common.collect.Sets;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import org.apache.druid.client.DruidServer;
+import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
 import org.apache.druid.server.coordinator.DruidCluster;
 import org.apache.druid.server.coordinator.ServerHolder;
 import org.apache.druid.server.coordinator.balancer.BalancerStrategy;
@@ -58,6 +59,8 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
   private final SegmentLoadQueueManager loadQueueManager;
   private final DruidCluster cluster;
   private final CoordinatorRunStats stats;
+  private final CoordinatorDynamicConfig dynamicConfig;
+  private final double defaultServerFillThreshold;
   private final SegmentReplicaCountMap replicaCountMap;
   private final ReplicationThrottler replicationThrottler;
   private final RoundRobinServerSelector serverSelector;
@@ -76,17 +79,23 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
       DruidCluster cluster,
       BalancerStrategy strategy,
       SegmentLoadingConfig loadingConfig,
-      CoordinatorRunStats stats
+      CoordinatorRunStats stats,
+      CoordinatorDynamicConfig dynamicConfig,
+      double defaultServerFillThreshold
   )
   {
     this.stats = stats;
     this.cluster = cluster;
     this.strategy = strategy;
     this.loadQueueManager = loadQueueManager;
+    this.dynamicConfig = dynamicConfig;
+    this.defaultServerFillThreshold = defaultServerFillThreshold;
     this.replicaCountMap = SegmentReplicaCountMap.create(cluster);
     this.replicationThrottler = createReplicationThrottler(cluster, loadingConfig);
     this.useRoundRobinAssignment = loadingConfig.isUseRoundRobinSegmentAssignment();
-    this.serverSelector = useRoundRobinAssignment ? new RoundRobinServerSelector(cluster) : null;
+    this.serverSelector = useRoundRobinAssignment
+                          ? new RoundRobinServerSelector(cluster, dynamicConfig, defaultServerFillThreshold)
+                          : null;
 
     cluster.getManagedHistoricals().forEach(
         (tier, historicals) -> tierToHistoricalCount.put(tier, historicals.size())
@@ -150,14 +159,24 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
       return false;
     }
 
-    // If the source server is not decommissioning, move can be skipped if the
-    // segment is already optimally placed
-    if (!sourceServer.isDecommissioning()) {
-      eligibleDestinationServers.add(sourceServer);
+    // Prefer servers below the fill threshold. Fall back to all eligible servers if none qualify.
+    final double fillThreshold = dynamicConfig.getTierServerFillThreshold()
+                                              .getOrDefault(tier, defaultServerFillThreshold);
+    List<ServerHolder> candidates = eligibleDestinationServers.stream()
+                                                              .filter(s -> s.getFillFraction() <= fillThreshold)
+                                                              .collect(Collectors.toList());
+    if (candidates.isEmpty()) {
+      candidates = eligibleDestinationServers;
+    }
+
+    // Allow "already optimally placed" only if the source is not above the fill threshold.
+    // If the source is over-threshold, force the move to drain it — do not add it to candidates.
+    if (!sourceServer.isDecommissioning() && sourceServer.getFillFraction() <= fillThreshold) {
+      candidates.add(sourceServer);
     }
 
     final ServerHolder destination =
-        strategy.findDestinationServerToMoveSegment(segment, sourceServer, eligibleDestinationServers);
+        strategy.findDestinationServerToMoveSegment(segment, sourceServer, candidates);
 
     if (destination == null || destination.getServer().equals(sourceServer.getServer())) {
       incrementSkipStat(Stats.Segments.MOVE_SKIPPED, "Optimally placed", segment, sourceServer);
@@ -276,7 +295,11 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
     }
 
     final SegmentStatusInTier segmentStatus =
-        new SegmentStatusInTier(segment, cluster.getManagedHistoricalsByTier(tier));
+        new SegmentStatusInTier(
+            segment,
+            cluster.getManagedHistoricalsByTier(tier),
+            dynamicConfig.getTierServerFillThreshold().getOrDefault(tier, defaultServerFillThreshold)
+        );
 
     // Cancel all moves in this tier if it does not need to have replicas
     if (shouldCancelMoves) {

--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorConfigTest.java
@@ -30,6 +30,7 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.server.coordinator.config.CoordinatorKillConfigs;
 import org.apache.druid.server.coordinator.config.CoordinatorPeriodConfig;
 import org.apache.druid.server.coordinator.config.CoordinatorRunConfig;
+import org.apache.druid.server.coordinator.config.CoordinatorSegmentLoadConfigs;
 import org.apache.druid.server.coordinator.config.DruidCoordinatorConfig;
 import org.apache.druid.server.coordinator.config.HttpLoadQueuePeonConfig;
 import org.apache.druid.server.coordinator.config.KillUnusedSegmentsConfig;
@@ -443,7 +444,8 @@ public class DruidCoordinatorConfigTest
             periodConfig,
             killConfig,
             null,
-            null
+            null,
+            new CoordinatorSegmentLoadConfigs(null)
         )
     );
 

--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
@@ -54,6 +54,7 @@ import org.apache.druid.server.coordinator.balancer.CostBalancerStrategyFactory;
 import org.apache.druid.server.coordinator.config.CoordinatorKillConfigs;
 import org.apache.druid.server.coordinator.config.CoordinatorPeriodConfig;
 import org.apache.druid.server.coordinator.config.CoordinatorRunConfig;
+import org.apache.druid.server.coordinator.config.CoordinatorSegmentLoadConfigs;
 import org.apache.druid.server.coordinator.config.DruidCoordinatorConfig;
 import org.apache.druid.server.coordinator.duty.CompactSegments;
 import org.apache.druid.server.coordinator.duty.CoordinatorCustomDuty;
@@ -146,7 +147,8 @@ public class DruidCoordinatorTest
         new CoordinatorPeriodConfig(null, null),
         CoordinatorKillConfigs.DEFAULT,
         new CostBalancerStrategyFactory(),
-        null
+        null,
+        new CoordinatorSegmentLoadConfigs(null)
     );
     druidNode = new DruidNode("hey", "what", false, 1234, null, true, false);
     scheduledExecutorFactory = ScheduledExecutors::fixed;

--- a/server/src/test/java/org/apache/druid/server/coordinator/loading/RoundRobinServerSelectorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/loading/RoundRobinServerSelectorTest.java
@@ -24,6 +24,7 @@ import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.segment.IndexIO;
 import org.apache.druid.segment.TestDataSource;
 import org.apache.druid.server.coordination.ServerType;
+import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
 import org.apache.druid.server.coordinator.DruidCluster;
 import org.apache.druid.server.coordinator.ServerHolder;
 import org.apache.druid.timeline.DataSegment;
@@ -64,7 +65,7 @@ public class RoundRobinServerSelectorTest
         .builder()
         .addTier(TIER, serverXL, serverM, serverXS, serverL)
         .build();
-    final RoundRobinServerSelector selector = new RoundRobinServerSelector(cluster);
+    final RoundRobinServerSelector selector = new RoundRobinServerSelector(cluster, CoordinatorDynamicConfig.builder().build(), 1.0);
 
     // Verify that only eligible servers are returned in order of available size
     Iterator<ServerHolder> pickedServers = selector.getServersInTierToLoadSegment(TIER, segment);
@@ -91,7 +92,7 @@ public class RoundRobinServerSelectorTest
         .builder()
         .addTier(TIER, serverXL, serverM, serverXS, serverL)
         .build();
-    final RoundRobinServerSelector selector = new RoundRobinServerSelector(cluster);
+    final RoundRobinServerSelector selector = new RoundRobinServerSelector(cluster, CoordinatorDynamicConfig.builder().build(), 1.0);
 
     // Verify that only eligible servers are returned in order of available size
     Iterator<ServerHolder> pickedServers = selector.getServersInTierToLoadSegment(TIER, segment);
@@ -113,7 +114,7 @@ public class RoundRobinServerSelectorTest
   public void testNoServersInTier()
   {
     DruidCluster cluster = DruidCluster.builder().addTier(TIER).build();
-    final RoundRobinServerSelector selector = new RoundRobinServerSelector(cluster);
+    final RoundRobinServerSelector selector = new RoundRobinServerSelector(cluster, CoordinatorDynamicConfig.builder().build(), 1.0);
 
     Iterator<ServerHolder> eligibleServers = selector.getServersInTierToLoadSegment(TIER, segment);
     Assert.assertFalse(eligibleServers.hasNext());
@@ -129,7 +130,7 @@ public class RoundRobinServerSelectorTest
         createHistorical("server3", 10),
         createHistorical("server4", 20)
     ).build();
-    final RoundRobinServerSelector selector = new RoundRobinServerSelector(cluster);
+    final RoundRobinServerSelector selector = new RoundRobinServerSelector(cluster, CoordinatorDynamicConfig.builder().build(), 1.0);
 
     // Verify that only eligible servers are returned in order of available size
     Iterator<ServerHolder> eligibleServers = selector.getServersInTierToLoadSegment(TIER, segment);

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBuilder.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBuilder.java
@@ -58,6 +58,7 @@ import org.apache.druid.server.coordinator.balancer.RandomBalancerStrategyFactor
 import org.apache.druid.server.coordinator.config.CoordinatorKillConfigs;
 import org.apache.druid.server.coordinator.config.CoordinatorPeriodConfig;
 import org.apache.druid.server.coordinator.config.CoordinatorRunConfig;
+import org.apache.druid.server.coordinator.config.CoordinatorSegmentLoadConfigs;
 import org.apache.druid.server.coordinator.config.DruidCoordinatorConfig;
 import org.apache.druid.server.coordinator.config.HttpLoadQueuePeonConfig;
 import org.apache.druid.server.coordinator.duty.CoordinatorCustomDutyGroups;
@@ -487,7 +488,8 @@ public class CoordinatorSimulationBuilder
           new CoordinatorPeriodConfig(null, null),
           CoordinatorKillConfigs.DEFAULT,
           createBalancerStrategy(balancerStrategy),
-          new HttpLoadQueuePeonConfig(null, null, null)
+          new HttpLoadQueuePeonConfig(null, null, null),
+          new CoordinatorSegmentLoadConfigs(null)
       );
 
       JacksonConfigManager jacksonConfigManager = mockConfigManager();

--- a/server/src/test/java/org/apache/druid/server/http/CoordinatorDynamicConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/CoordinatorDynamicConfigTest.java
@@ -279,6 +279,7 @@ public class CoordinatorDynamicConfigTest
         false,
         null,
         ImmutableSet.of("host1"),
+        null,
         null
     );
     Assert.assertTrue(config.getSpecificDataSourcesToKillUnusedSegmentsIn().isEmpty());
@@ -305,6 +306,7 @@ public class CoordinatorDynamicConfigTest
         false,
         null,
         ImmutableSet.of("host1"),
+        null,
         null
     );
     Assert.assertEquals(ImmutableSet.of("test1"), config.getSpecificDataSourcesToKillUnusedSegmentsIn());

--- a/services/src/main/java/org/apache/druid/cli/CliCoordinator.java
+++ b/services/src/main/java/org/apache/druid/cli/CliCoordinator.java
@@ -79,6 +79,7 @@ import org.apache.druid.server.coordinator.balancer.BalancerStrategyFactory;
 import org.apache.druid.server.coordinator.config.CoordinatorKillConfigs;
 import org.apache.druid.server.coordinator.config.CoordinatorPeriodConfig;
 import org.apache.druid.server.coordinator.config.CoordinatorRunConfig;
+import org.apache.druid.server.coordinator.config.CoordinatorSegmentLoadConfigs;
 import org.apache.druid.server.coordinator.config.DruidCoordinatorConfig;
 import org.apache.druid.server.coordinator.config.HttpLoadQueuePeonConfig;
 import org.apache.druid.server.coordinator.duty.CoordinatorCustomDuty;
@@ -196,6 +197,7 @@ public class CliCoordinator extends ServerRunnable
             JsonConfigProvider.bind(binder, "druid.coordinator.kill", CoordinatorKillConfigs.class);
             JsonConfigProvider.bind(binder, "druid.coordinator.period", CoordinatorPeriodConfig.class);
             JsonConfigProvider.bind(binder, "druid.coordinator.loadqueuepeon.http", HttpLoadQueuePeonConfig.class);
+            JsonConfigProvider.bind(binder, "druid.coordinator.segmentLoading", CoordinatorSegmentLoadConfigs.class);
             JsonConfigProvider.bind(binder, "druid.coordinator.balancer", BalancerStrategyFactory.class);
             JsonConfigProvider.bind(binder, "druid.coordinator.segment", CoordinatorSegmentWatcherConfig.class);
             JsonConfigProvider.bind(binder, "druid.coordinator.segmentMetadataCache", SegmentMetadataCacheConfig.class);


### PR DESCRIPTION
### Description

#### Problem

We have seen the following issue in our production clusters:

Tier `X` exhibits a persistent bimodal disk distribution: ~35 servers near 70% full (Group A) and ~35 servers at 99%+ (Group B). Two root causes prevent the coordinator segment balancing from correcting this:

1. **Round-robin initial placement** distributes new segments across all servers, continuously loading Group B servers that are already near-full.

2. **`CostBalancerStrategy` is purely temporal** — disk utilization plays no role in selecting a move destination server. This causes two problems:
   - Moves **from** Group B are never scheduled: the balancer adds the source server back to the candidate pool as a "stay in place" option, and the temporal cost function frequently scores it as optimal, marking the segment as "Optimally placed."
   - Moves **to** Group B are attempted and fail at runtime: the coordinator's snapshot of available disk space lags behind the historical's live state, so the balancer schedules a load to a server it believes has capacity, but the historical rejects it because the disk is full.

Together these create a feedback loop: new segments land on Group B, moves to drain Group B are never scheduled, moves to Group B fail, and the imbalance compounds over time (disks in Group B remain pinned at ~100%).

#### Solution

The core issues we are trying to solve are:

1. Minimize server disk utilization variance within a tier subject to segment temporal locality.
2. Prevent cases where we get into a state of severe disk imbalance.
3. Allow for an "off-ramp" in case we do get into a perpetual state of imbalance.
4. Create a tunable way to deterministically force data redistribution, while still allowing oversubscription in worst-case scenarios (e.g. auto-scaling is delayed).

#### Considerations

I considered 2 options:

1. Add a static/dynamic threshold to candidate server selection (e.g. don't assign to servers with >{threshold}% utilization).
3. Change `CostBalancerStrategy` to penalize high disk utilization in the cost function.

The core tradeoff is whether to allow Druid to oversubscribe a disk or not. Option #2 would permit oversubscription based on a heuristic — if the segment fits AND temporal locality gain outweighs the disk penalty — meaning it is less deterministic and has pathological cases where temporal value still outweighs the utilization penalty.

Option #1 is a harder limit that is more deterministic. I opted for a **preference-with-fallback** approach: prefer servers below a configurable utilization threshold, then fall back to current behavior if all servers exceed the threshold. This keeps temporal locality optimization within the set of "valid" servers, and avoids blocking segment loads entirely during oversubscription events (e.g. slow auto-scaling) where no
server is below the threshold.

Additionally, when selecting a move destination, the source server is only re-added to the candidate pool if it is itself below the threshold. This prevents the balancer from declaring a segment on a 99%-full server as "Optimally placed" and suppressing the drain move.

#### Configuration

**Static default**
`druid.coordinator.segmentLoading.defaultServerFillThreshold`
Default: `1.0` (disabled — preserves current behavior).

**Dynamic per-tier overrides**
```json
{ "tierServerFillThreshold": { "temp": 0.90 } }

The per-tier override takes precedence over the static default. If no override exists for a tier, the static default applies.
```

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Add disk-utilization-aware segment loading threshold to help balance segment load evenly

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
 - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.