### PR TITLE
fix: INTERVAL n WEEK resolves to seven days instead of one hour

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
@@ -129,9 +129,10 @@ public class DruidPlanner implements Closeable
     engine.validateContext(plannerContext.queryContextMap());
     planner.skipParse();
     final SqlNode parsed = plannerContext.getSqlNode();
-    // Work around CALCITE-6391 (fixed in Calcite 1.38) by rewriting any
-    // INTERVAL ... WEEK literals before they reach Calcite's buggy
-    // SqlIntervalQualifier.evaluateIntervalLiteralAsWeek path.
+    // Work around CALCITE-6581 (fixed in Calcite 1.38) by rewriting any
+    // INTERVAL ... WEEK and INTERVAL ... QUARTER literals before they reach
+    // Calcite's buggy SqlIntervalQualifier.evaluateIntervalLiteralAs{Week,Quarter}
+    // paths.
     final SqlNode weekRewritten = parsed.accept(new SqlIntervalWeekRewriteShuttle());
     final SqlNode root = rewriteParameters(weekRewritten == null ? parsed : weekRewritten);
     hook.captureSqlNode(root);

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
@@ -128,7 +128,12 @@ public class DruidPlanner implements Closeable
     // Validate query context.
     engine.validateContext(plannerContext.queryContextMap());
     planner.skipParse();
-    final SqlNode root = rewriteParameters(plannerContext.getSqlNode());
+    final SqlNode parsed = plannerContext.getSqlNode();
+    // Work around CALCITE-6391 (fixed in Calcite 1.38) by rewriting any
+    // INTERVAL ... WEEK literals before they reach Calcite's buggy
+    // SqlIntervalQualifier.evaluateIntervalLiteralAsWeek path.
+    final SqlNode weekRewritten = parsed.accept(new SqlIntervalWeekRewriteShuttle());
+    final SqlNode root = rewriteParameters(weekRewritten == null ? parsed : weekRewritten);
     hook.captureSqlNode(root);
     handler = createHandler(root);
     handler.validate();

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/SqlIntervalWeekRewriteShuttle.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/SqlIntervalWeekRewriteShuttle.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.planner;
+
+import org.apache.calcite.avatica.util.TimeUnit;
+import org.apache.calcite.avatica.util.TimeUnitRange;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIntervalLiteral;
+import org.apache.calcite.sql.SqlIntervalQualifier;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.util.SqlShuttle;
+
+import java.math.BigDecimal;
+
+/**
+ * Workaround for a Calcite 1.37.0 bug in which {@code INTERVAL n WEEK} is
+ * incorrectly converted to {@code n} hours instead of {@code n * 7} days.
+ *
+ * <p>The bug is in {@code SqlIntervalQualifier.evaluateIntervalLiteralAsWeek},
+ * which packages the WEEK value into a year-month shaped int array
+ * ({@code [sign, 0, week]}) even though {@code SqlIntervalQualifier.typeName()}
+ * reports WEEK intervals as {@link org.apache.calcite.sql.type.SqlTypeName#INTERVAL_DAY}.
+ * Downstream, {@code SqlParserUtil.intervalToMillis} interprets that array as
+ * {@code [sign, day, hour, minute, second, ms]}, so the week value lands in
+ * the hour slot. The bug was fixed upstream in Calcite 1.38.0
+ * (<a href="https://issues.apache.org/jira/browse/CALCITE-6391">CALCITE-6391</a>),
+ * but Druid is still on Calcite 1.37.0, so we work around it by rewriting any
+ * {@code WEEK} interval in the parsed {@link SqlNode} tree to an equivalent
+ * {@code DAY} interval whose value has been multiplied by seven.
+ *
+ * <p>Two parsed forms reach this shuttle:
+ * <ul>
+ *   <li>Quoted: {@code INTERVAL '1' WEEK} parses to a {@link SqlIntervalLiteral}
+ *       with a WEEK qualifier. We replace it with a {@link SqlIntervalLiteral}
+ *       containing the original numeric value multiplied by seven and a
+ *       {@link TimeUnit#DAY} qualifier.</li>
+ *   <li>Unquoted: {@code INTERVAL 1 WEEK} parses to
+ *       {@code SqlStdOperatorTable.INTERVAL.createCall(pos, n, qualifier)}.
+ *       We rewrite the call so the numeric operand becomes
+ *       {@code MULTIPLY(n, 7)} and the qualifier becomes {@code DAY}.</li>
+ * </ul>
+ *
+ * <p>This rewrite preserves the semantics of {@code TimeUnitRange.WEEK} while
+ * avoiding the buggy code path inside Calcite. Druid still treats WEEK as a
+ * day-time (millisecond) interval in arithmetic, which matches the expectation
+ * documented in the issue: {@code INTERVAL '1' WEEK} should add seven days.
+ */
+public class SqlIntervalWeekRewriteShuttle extends SqlShuttle
+{
+  private static final BigDecimal SEVEN = BigDecimal.valueOf(7);
+
+  @Override
+  public SqlNode visit(SqlLiteral literal)
+  {
+    if (literal instanceof SqlIntervalLiteral) {
+      final SqlIntervalLiteral intervalLiteral = (SqlIntervalLiteral) literal;
+      final SqlIntervalLiteral.IntervalValue value =
+          (SqlIntervalLiteral.IntervalValue) intervalLiteral.getValue();
+      if (value != null && isPlainWeek(value.getIntervalQualifier())) {
+        final String multiplied = multiplyByWeek(value.getIntervalLiteral());
+        if (multiplied != null) {
+          return SqlLiteral.createInterval(
+              value.getSign(),
+              multiplied,
+              new SqlIntervalQualifier(TimeUnit.DAY, null, value.getIntervalQualifier().getParserPosition()),
+              literal.getParserPosition()
+          );
+        }
+      }
+    }
+    return literal;
+  }
+
+  @Override
+  public SqlNode visit(SqlCall call)
+  {
+    if (call.getOperator() == SqlStdOperatorTable.INTERVAL && call.operandCount() == 2) {
+      final SqlNode qualifierNode = call.operand(1);
+      if (qualifierNode instanceof SqlIntervalQualifier
+          && isPlainWeek((SqlIntervalQualifier) qualifierNode)) {
+        // First, recurse into the numeric operand so any nested rewrites still happen.
+        final SqlNode rewrittenNumeric = call.operand(0).accept(this);
+        final SqlNode numeric = rewrittenNumeric == null ? call.operand(0) : rewrittenNumeric;
+        final SqlParserPos pos = call.getParserPosition();
+        final SqlNode multipliedNumeric = SqlStdOperatorTable.MULTIPLY.createCall(
+            pos,
+            numeric,
+            SqlLiteral.createExactNumeric("7", pos)
+        );
+        final SqlIntervalQualifier dayQualifier =
+            new SqlIntervalQualifier(TimeUnit.DAY, null, qualifierNode.getParserPosition());
+        return SqlStdOperatorTable.INTERVAL.createCall(pos, multipliedNumeric, dayQualifier);
+      }
+    }
+    return super.visit(call);
+  }
+
+  private static boolean isPlainWeek(SqlIntervalQualifier qualifier)
+  {
+    // Only the bare WEEK qualifier is affected. WEEK(SUNDAY)..WEEK(SATURDAY) and
+    // ISOWEEK use a non-null timeFrameName and are handled differently in Calcite.
+    return qualifier != null
+           && qualifier.timeUnitRange == TimeUnitRange.WEEK
+           && qualifier.timeFrameName == null;
+  }
+
+  /**
+   * Multiplies the integer string value of a WEEK interval literal by seven.
+   * Returns null if the value is not a plain non-negative integer literal,
+   * which means it does not match Calcite's WEEK interval grammar and would
+   * fail validation anyway.
+   */
+  private static String multiplyByWeek(String intervalStr)
+  {
+    if (intervalStr == null || intervalStr.isEmpty()) {
+      return null;
+    }
+    for (int i = 0; i < intervalStr.length(); i++) {
+      final char c = intervalStr.charAt(i);
+      if (c < '0' || c > '9') {
+        return null;
+      }
+    }
+    return new BigDecimal(intervalStr).multiply(SEVEN).toString();
+  }
+}

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/SqlIntervalWeekRewriteShuttle.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/SqlIntervalWeekRewriteShuttle.java
@@ -33,41 +33,61 @@ import org.apache.calcite.sql.util.SqlShuttle;
 import java.math.BigDecimal;
 
 /**
- * Workaround for a Calcite 1.37.0 bug in which {@code INTERVAL n WEEK} is
- * incorrectly converted to {@code n} hours instead of {@code n * 7} days.
+ * Workaround for Calcite 1.37.0 bugs in which {@code INTERVAL n WEEK} is
+ * incorrectly converted to {@code n} hours instead of {@code n * 7} days,
+ * and {@code INTERVAL n QUARTER} is incorrectly converted to {@code n} months
+ * instead of {@code n * 3} months.
  *
- * <p>The bug is in {@code SqlIntervalQualifier.evaluateIntervalLiteralAsWeek},
- * which packages the WEEK value into a year-month shaped int array
- * ({@code [sign, 0, week]}) even though {@code SqlIntervalQualifier.typeName()}
- * reports WEEK intervals as {@link org.apache.calcite.sql.type.SqlTypeName#INTERVAL_DAY}.
- * Downstream, {@code SqlParserUtil.intervalToMillis} interprets that array as
- * {@code [sign, day, hour, minute, second, ms]}, so the week value lands in
- * the hour slot. The bug was fixed upstream in Calcite 1.38.0
- * (<a href="https://issues.apache.org/jira/browse/CALCITE-6391">CALCITE-6391</a>),
- * but Druid is still on Calcite 1.37.0, so we work around it by rewriting any
- * {@code WEEK} interval in the parsed {@link SqlNode} tree to an equivalent
- * {@code DAY} interval whose value has been multiplied by seven.
+ * <p>Both bugs live in {@code SqlIntervalQualifier}:
+ * <ul>
+ *   <li>{@code evaluateIntervalLiteralAsWeek} packages the WEEK value into a
+ *       year-month shaped int array ({@code [sign, 0, week]}) even though
+ *       {@code SqlIntervalQualifier.typeName()} reports WEEK intervals as
+ *       {@link org.apache.calcite.sql.type.SqlTypeName#INTERVAL_DAY}. Downstream,
+ *       {@code SqlParserUtil.intervalToMillis} interprets that array as
+ *       {@code [sign, day, hour, minute, second, ms]}, so the week value lands
+ *       in the hour slot.</li>
+ *   <li>{@code evaluateIntervalLiteralAsQuarter} packages the QUARTER value
+ *       into a year-month shaped int array ({@code [sign, 0, quarter]}) without
+ *       multiplying by three, so {@code intervalToMonths} reads
+ *       {@code 12*0 + 1*quarter = quarter} months when it should read
+ *       {@code 3*quarter} months.</li>
+ * </ul>
  *
- * <p>Two parsed forms reach this shuttle:
+ * <p>Both bugs were fixed upstream in Calcite 1.38.0
+ * (<a href="https://issues.apache.org/jira/browse/CALCITE-6581">CALCITE-6581</a>),
+ * but Druid is still on Calcite 1.37.0, so we work around them by rewriting any
+ * affected interval in the parsed {@link SqlNode} tree to an equivalent
+ * interval in a unit that Calcite 1.37 handles correctly:
+ * <ul>
+ *   <li>{@code WEEK} is rewritten to {@code DAY} with the value multiplied by seven.</li>
+ *   <li>{@code QUARTER} is rewritten to {@code MONTH} with the value multiplied by three.</li>
+ * </ul>
+ *
+ * <p>Two parsed forms reach this shuttle for each affected unit:
  * <ul>
  *   <li>Quoted: {@code INTERVAL '1' WEEK} parses to a {@link SqlIntervalLiteral}
  *       with a WEEK qualifier. We replace it with a {@link SqlIntervalLiteral}
- *       containing the original numeric value multiplied by seven and a
- *       {@link TimeUnit#DAY} qualifier.</li>
+ *       containing the original numeric value multiplied by the appropriate
+ *       factor and a {@link TimeUnit#DAY} (or {@link TimeUnit#MONTH}) qualifier.</li>
  *   <li>Unquoted: {@code INTERVAL 1 WEEK} parses to
  *       {@code SqlStdOperatorTable.INTERVAL.createCall(pos, n, qualifier)}.
  *       We rewrite the call so the numeric operand becomes
- *       {@code MULTIPLY(n, 7)} and the qualifier becomes {@code DAY}.</li>
+ *       {@code MULTIPLY(n, factor)} and the qualifier becomes the appropriate
+ *       base unit.</li>
  * </ul>
  *
- * <p>This rewrite preserves the semantics of {@code TimeUnitRange.WEEK} while
- * avoiding the buggy code path inside Calcite. Druid still treats WEEK as a
- * day-time (millisecond) interval in arithmetic, which matches the expectation
- * documented in the issue: {@code INTERVAL '1' WEEK} should add seven days.
+ * <p>This rewrite preserves the semantics of {@code TimeUnitRange.WEEK} and
+ * {@code TimeUnitRange.QUARTER} while avoiding the buggy code paths inside
+ * Calcite. {@code WEEK(SUNDAY)..WEEK(SATURDAY)} and {@code ISOWEEK} qualifiers
+ * carry a non-null {@code timeFrameName} and are handled differently in
+ * Calcite, so the shuttle leaves them alone and only touches the bare
+ * {@code WEEK} form that is broken in 1.37.
  */
 public class SqlIntervalWeekRewriteShuttle extends SqlShuttle
 {
   private static final BigDecimal SEVEN = BigDecimal.valueOf(7);
+  private static final BigDecimal THREE = BigDecimal.valueOf(3);
 
   @Override
   public SqlNode visit(SqlLiteral literal)
@@ -76,15 +96,28 @@ public class SqlIntervalWeekRewriteShuttle extends SqlShuttle
       final SqlIntervalLiteral intervalLiteral = (SqlIntervalLiteral) literal;
       final SqlIntervalLiteral.IntervalValue value =
           (SqlIntervalLiteral.IntervalValue) intervalLiteral.getValue();
-      if (value != null && isPlainWeek(value.getIntervalQualifier())) {
-        final String multiplied = multiplyByWeek(value.getIntervalLiteral());
-        if (multiplied != null) {
-          return SqlLiteral.createInterval(
-              value.getSign(),
-              multiplied,
-              new SqlIntervalQualifier(TimeUnit.DAY, null, value.getIntervalQualifier().getParserPosition()),
-              literal.getParserPosition()
-          );
+      if (value != null) {
+        final SqlIntervalQualifier qualifier = value.getIntervalQualifier();
+        if (isPlainWeek(qualifier)) {
+          final String multiplied = multiplyLiteral(value.getIntervalLiteral(), SEVEN);
+          if (multiplied != null) {
+            return SqlLiteral.createInterval(
+                value.getSign(),
+                multiplied,
+                new SqlIntervalQualifier(TimeUnit.DAY, null, qualifier.getParserPosition()),
+                literal.getParserPosition()
+            );
+          }
+        } else if (isPlainQuarter(qualifier)) {
+          final String multiplied = multiplyLiteral(value.getIntervalLiteral(), THREE);
+          if (multiplied != null) {
+            return SqlLiteral.createInterval(
+                value.getSign(),
+                multiplied,
+                new SqlIntervalQualifier(TimeUnit.MONTH, null, qualifier.getParserPosition()),
+                literal.getParserPosition()
+            );
+          }
         }
       }
     }
@@ -96,23 +129,37 @@ public class SqlIntervalWeekRewriteShuttle extends SqlShuttle
   {
     if (call.getOperator() == SqlStdOperatorTable.INTERVAL && call.operandCount() == 2) {
       final SqlNode qualifierNode = call.operand(1);
-      if (qualifierNode instanceof SqlIntervalQualifier
-          && isPlainWeek((SqlIntervalQualifier) qualifierNode)) {
-        // First, recurse into the numeric operand so any nested rewrites still happen.
-        final SqlNode rewrittenNumeric = call.operand(0).accept(this);
-        final SqlNode numeric = rewrittenNumeric == null ? call.operand(0) : rewrittenNumeric;
-        final SqlParserPos pos = call.getParserPosition();
-        final SqlNode multipliedNumeric = SqlStdOperatorTable.MULTIPLY.createCall(
-            pos,
-            numeric,
-            SqlLiteral.createExactNumeric("7", pos)
-        );
-        final SqlIntervalQualifier dayQualifier =
-            new SqlIntervalQualifier(TimeUnit.DAY, null, qualifierNode.getParserPosition());
-        return SqlStdOperatorTable.INTERVAL.createCall(pos, multipliedNumeric, dayQualifier);
+      if (qualifierNode instanceof SqlIntervalQualifier) {
+        final SqlIntervalQualifier qualifier = (SqlIntervalQualifier) qualifierNode;
+        if (isPlainWeek(qualifier)) {
+          return rewriteIntervalCall(call, qualifier, "7", TimeUnit.DAY);
+        } else if (isPlainQuarter(qualifier)) {
+          return rewriteIntervalCall(call, qualifier, "3", TimeUnit.MONTH);
+        }
       }
     }
     return super.visit(call);
+  }
+
+  private SqlNode rewriteIntervalCall(
+      SqlCall call,
+      SqlIntervalQualifier qualifier,
+      String factor,
+      TimeUnit rewrittenUnit
+  )
+  {
+    // First, recurse into the numeric operand so any nested rewrites still happen.
+    final SqlNode rewrittenNumeric = call.operand(0).accept(this);
+    final SqlNode numeric = rewrittenNumeric == null ? call.operand(0) : rewrittenNumeric;
+    final SqlParserPos pos = call.getParserPosition();
+    final SqlNode multipliedNumeric = SqlStdOperatorTable.MULTIPLY.createCall(
+        pos,
+        numeric,
+        SqlLiteral.createExactNumeric(factor, pos)
+    );
+    final SqlIntervalQualifier rewrittenQualifier =
+        new SqlIntervalQualifier(rewrittenUnit, null, qualifier.getParserPosition());
+    return SqlStdOperatorTable.INTERVAL.createCall(pos, multipliedNumeric, rewrittenQualifier);
   }
 
   private static boolean isPlainWeek(SqlIntervalQualifier qualifier)
@@ -124,13 +171,21 @@ public class SqlIntervalWeekRewriteShuttle extends SqlShuttle
            && qualifier.timeFrameName == null;
   }
 
+  private static boolean isPlainQuarter(SqlIntervalQualifier qualifier)
+  {
+    // Only the bare QUARTER qualifier is affected.
+    return qualifier != null
+           && qualifier.timeUnitRange == TimeUnitRange.QUARTER
+           && qualifier.timeFrameName == null;
+  }
+
   /**
-   * Multiplies the integer string value of a WEEK interval literal by seven.
+   * Multiplies the integer string value of an interval literal by a factor.
    * Returns null if the value is not a plain non-negative integer literal,
-   * which means it does not match Calcite's WEEK interval grammar and would
-   * fail validation anyway.
+   * which means it does not match Calcite's WEEK/QUARTER interval grammar and
+   * would fail validation anyway.
    */
-  private static String multiplyByWeek(String intervalStr)
+  private static String multiplyLiteral(String intervalStr, BigDecimal factor)
   {
     if (intervalStr == null || intervalStr.isEmpty()) {
       return null;
@@ -141,6 +196,6 @@ public class SqlIntervalWeekRewriteShuttle extends SqlShuttle
         return null;
       }
     }
-    return new BigDecimal(intervalStr).multiply(SEVEN).toString();
+    return new BigDecimal(intervalStr).multiply(factor).toString();
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -6647,6 +6647,42 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  /**
+   * Regression test for <a href="https://github.com/apache/druid/issues/18665">#18665</a>:
+   * {@code INTERVAL '1' WEEK} previously folded to one hour instead of seven days because
+   * Calcite 1.37.0 mishandles the WEEK qualifier. The interval narrowing below proves the
+   * fix lands the equality on {@code 2000-01-08} (one week after {@code 2000-01-01})
+   * rather than {@code 2000-01-01T01:00:00}.
+   */
+  @Test
+  public void testIntervalWeekResolution()
+  {
+    testQuery(
+        "SELECT COUNT(*) FROM druid.foo WHERE "
+        + "__time = TIMESTAMP '2000-01-01 00:00:00' OR "
+        + "__time = TIMESTAMP '2000-01-01 00:00:00' + INTERVAL '1' WEEK OR "
+        + "__time = TIMESTAMP '2000-01-01 00:00:00' + INTERVAL 2 WEEK",
+        ImmutableList.of(
+            Druids.newTimeseriesQueryBuilder()
+                  .dataSource(CalciteTests.DATASOURCE1)
+                  .intervals(
+                      querySegmentSpec(
+                          Intervals.of("2000-01-01/2000-01-01T00:00:00.001"),
+                          Intervals.of("2000-01-08/2000-01-08T00:00:00.001"),
+                          Intervals.of("2000-01-15/2000-01-15T00:00:00.001")
+                      )
+                  )
+                  .granularity(Granularities.ALL)
+                  .aggregators(aggregators(new CountAggregatorFactory("a0")))
+                  .context(QUERY_CONTEXT_DEFAULT)
+                  .build()
+        ),
+        ImmutableList.of(
+            new Object[]{1L}
+        )
+    );
+  }
+
   @Test
   public void testCountStarWithComplexDisjointTimeFilter()
   {

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -6683,6 +6683,43 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  /**
+   * Regression test for the companion bug to {@link #testIntervalWeekResolution()}:
+   * {@code INTERVAL '1' QUARTER} previously folded to one month instead of three months
+   * because Calcite 1.37.0 mishandles the QUARTER qualifier (packages the value into a
+   * year-month array without multiplying by three). The interval narrowing below proves
+   * the fix lands the equality on {@code 2000-04-01} (three months after
+   * {@code 2000-01-01}) and {@code 2000-07-01} (six months after {@code 2000-01-01}).
+   */
+  @Test
+  public void testIntervalQuarterResolution()
+  {
+    testQuery(
+        "SELECT COUNT(*) FROM druid.foo WHERE "
+        + "__time = TIMESTAMP '2000-01-01 00:00:00' OR "
+        + "__time = TIMESTAMP '2000-01-01 00:00:00' + INTERVAL '1' QUARTER OR "
+        + "__time = TIMESTAMP '2000-01-01 00:00:00' + INTERVAL 2 QUARTER",
+        ImmutableList.of(
+            Druids.newTimeseriesQueryBuilder()
+                  .dataSource(CalciteTests.DATASOURCE1)
+                  .intervals(
+                      querySegmentSpec(
+                          Intervals.of("2000-01-01/2000-01-01T00:00:00.001"),
+                          Intervals.of("2000-04-01/2000-04-01T00:00:00.001"),
+                          Intervals.of("2000-07-01/2000-07-01T00:00:00.001")
+                      )
+                  )
+                  .granularity(Granularities.ALL)
+                  .aggregators(aggregators(new CountAggregatorFactory("a0")))
+                  .context(QUERY_CONTEXT_DEFAULT)
+                  .build()
+        ),
+        ImmutableList.of(
+            new Object[]{1L}
+        )
+    );
+  }
+
   @Test
   public void testCountStarWithComplexDisjointTimeFilter()
   {

--- a/sql/src/test/java/org/apache/druid/sql/calcite/planner/SqlIntervalWeekRewriteShuttleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/planner/SqlIntervalWeekRewriteShuttleTest.java
@@ -40,7 +40,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Verifies that {@link SqlIntervalWeekRewriteShuttle} rewrites
  * {@code INTERVAL ... WEEK} into the equivalent {@code INTERVAL ... DAY}
- * with the value multiplied by seven, working around CALCITE-6391.
+ * with the value multiplied by seven, and {@code INTERVAL ... QUARTER} into
+ * the equivalent {@code INTERVAL ... MONTH} with the value multiplied by three,
+ * working around CALCITE-6581.
  */
 public class SqlIntervalWeekRewriteShuttleTest extends CalciteTestBase
 {
@@ -174,38 +176,139 @@ public class SqlIntervalWeekRewriteShuttleTest extends CalciteTestBase
   }
 
   @Test
+  public void testQuotedSingleQuarterLiteralBecomesThreeMonths()
+  {
+    final SqlNode original = SqlLiteral.createInterval(
+        1,
+        "1",
+        new SqlIntervalQualifier(TimeUnit.QUARTER, null, SqlParserPos.ZERO),
+        SqlParserPos.ZERO
+    );
+
+    final SqlNode rewritten = original.accept(shuttle);
+    assertNotSame(original, rewritten);
+    assertTrue(rewritten instanceof SqlIntervalLiteral);
+    final SqlIntervalLiteral.IntervalValue value =
+        (SqlIntervalLiteral.IntervalValue) ((SqlIntervalLiteral) rewritten).getValue();
+    assertEquals("3", value.getIntervalLiteral());
+    assertEquals(TimeUnitRange.MONTH, value.getIntervalQualifier().timeUnitRange);
+    assertEquals(1, value.getSign());
+  }
+
+  @Test
+  public void testQuotedMultiQuarterLiteralIsMultipliedByThree()
+  {
+    final SqlNode original = SqlLiteral.createInterval(
+        1,
+        "4",
+        new SqlIntervalQualifier(TimeUnit.QUARTER, null, SqlParserPos.ZERO),
+        SqlParserPos.ZERO
+    );
+
+    final SqlNode rewritten = original.accept(shuttle);
+    final SqlIntervalLiteral.IntervalValue value =
+        (SqlIntervalLiteral.IntervalValue) ((SqlIntervalLiteral) rewritten).getValue();
+    assertEquals("12", value.getIntervalLiteral());
+    assertEquals(TimeUnitRange.MONTH, value.getIntervalQualifier().timeUnitRange);
+  }
+
+  @Test
+  public void testNegativeQuotedQuarterLiteralPreservesSign()
+  {
+    final SqlNode original = SqlLiteral.createInterval(
+        -1,
+        "2",
+        new SqlIntervalQualifier(TimeUnit.QUARTER, null, SqlParserPos.ZERO),
+        SqlParserPos.ZERO
+    );
+
+    final SqlNode rewritten = original.accept(shuttle);
+    final SqlIntervalLiteral.IntervalValue value =
+        (SqlIntervalLiteral.IntervalValue) ((SqlIntervalLiteral) rewritten).getValue();
+    assertEquals("6", value.getIntervalLiteral());
+    assertEquals(TimeUnitRange.MONTH, value.getIntervalQualifier().timeUnitRange);
+    assertEquals(-1, value.getSign());
+  }
+
+  @Test
+  public void testUnquotedQuarterIntervalCallBecomesMultiplyMonthCall()
+  {
+    // Mirrors what Druid's parser produces for `INTERVAL 1 QUARTER`:
+    //   SqlStdOperatorTable.INTERVAL.createCall(pos, n, qualifier)
+    final SqlNode original = SqlStdOperatorTable.INTERVAL.createCall(
+        SqlParserPos.ZERO,
+        SqlLiteral.createExactNumeric("2", SqlParserPos.ZERO),
+        new SqlIntervalQualifier(TimeUnit.QUARTER, null, SqlParserPos.ZERO)
+    );
+
+    final SqlNode rewritten = original.accept(shuttle);
+    assertNotSame(original, rewritten);
+    assertTrue(rewritten instanceof SqlBasicCall);
+    final SqlBasicCall rewrittenCall = (SqlBasicCall) rewritten;
+    assertSame(SqlStdOperatorTable.INTERVAL, rewrittenCall.getOperator());
+
+    // Operand 0 should be (numeric * 3).
+    final SqlNode numeric = rewrittenCall.operand(0);
+    assertTrue(numeric instanceof SqlBasicCall);
+    final SqlBasicCall numericCall = (SqlBasicCall) numeric;
+    assertSame(SqlStdOperatorTable.MULTIPLY, numericCall.getOperator());
+    assertEquals(2, numericCall.operandCount());
+    assertEquals("3", ((SqlLiteral) numericCall.operand(1)).toValue());
+
+    // Operand 1 should now be a MONTH qualifier.
+    final SqlNode qualifier = rewrittenCall.operand(1);
+    assertTrue(qualifier instanceof SqlIntervalQualifier);
+    assertEquals(TimeUnitRange.MONTH, ((SqlIntervalQualifier) qualifier).timeUnitRange);
+  }
+
+  @Test
   public void testParsedWeekIntervalIsRewritten() throws Exception
   {
     // End-to-end check using the actual parser, both forms.
-    assertParsedWeekIsRewritten("SELECT TIMESTAMP '1970-01-01 00:00:00' + INTERVAL '1' WEEK");
-    assertParsedWeekIsRewritten("SELECT TIMESTAMP '1970-01-01 00:00:00' + INTERVAL 1 WEEK");
-    assertParsedWeekIsRewritten("SELECT TIMESTAMP '1970-01-01 00:00:00' + INTERVAL 2 WEEK");
+    assertParsedUnitIsRewritten("SELECT TIMESTAMP '1970-01-01 00:00:00' + INTERVAL '1' WEEK", TimeUnitRange.WEEK);
+    assertParsedUnitIsRewritten("SELECT TIMESTAMP '1970-01-01 00:00:00' + INTERVAL 1 WEEK", TimeUnitRange.WEEK);
+    assertParsedUnitIsRewritten("SELECT TIMESTAMP '1970-01-01 00:00:00' + INTERVAL 2 WEEK", TimeUnitRange.WEEK);
   }
 
-  private void assertParsedWeekIsRewritten(String sql) throws Exception
+  @Test
+  public void testParsedQuarterIntervalIsRewritten() throws Exception
+  {
+    // End-to-end check using the actual parser, both forms.
+    assertParsedUnitIsRewritten("SELECT TIMESTAMP '1970-01-01 00:00:00' + INTERVAL '1' QUARTER", TimeUnitRange.QUARTER);
+    assertParsedUnitIsRewritten("SELECT TIMESTAMP '1970-01-01 00:00:00' + INTERVAL 1 QUARTER", TimeUnitRange.QUARTER);
+    assertParsedUnitIsRewritten("SELECT TIMESTAMP '1970-01-01 00:00:00' + INTERVAL 2 QUARTER", TimeUnitRange.QUARTER);
+  }
+
+  private void assertParsedUnitIsRewritten(String sql, TimeUnitRange unit) throws Exception
   {
     final SqlNode parsed = SqlParser.create(sql).parseQuery();
     final SqlNode rewritten = parsed.accept(shuttle);
-    final WeekFinder finder = new WeekFinder();
+    final UnitFinder finder = new UnitFinder(unit);
     rewritten.accept(finder);
     assertTrue(
         !finder.found,
-        "Rewritten tree for [" + sql + "] should not contain a WEEK qualifier, but it did."
+        "Rewritten tree for [" + sql + "] should not contain a " + unit + " qualifier, but it did."
     );
   }
 
   /**
-   * SqlShuttle that records whether it visited any plain WEEK
-   * {@link SqlIntervalQualifier}.
+   * SqlShuttle that records whether it visited any plain
+   * {@link SqlIntervalQualifier} for the given unit (with null timeFrameName).
    */
-  private static class WeekFinder extends org.apache.calcite.sql.util.SqlShuttle
+  private static class UnitFinder extends org.apache.calcite.sql.util.SqlShuttle
   {
+    private final TimeUnitRange targetUnit;
     boolean found;
+
+    UnitFinder(TimeUnitRange targetUnit)
+    {
+      this.targetUnit = targetUnit;
+    }
 
     @Override
     public SqlNode visit(SqlIntervalQualifier intervalQualifier)
     {
-      if (intervalQualifier.timeUnitRange == TimeUnitRange.WEEK
+      if (intervalQualifier.timeUnitRange == targetUnit
           && intervalQualifier.timeFrameName == null) {
         found = true;
       }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/planner/SqlIntervalWeekRewriteShuttleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/planner/SqlIntervalWeekRewriteShuttleTest.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.planner;
+
+import org.apache.calcite.avatica.util.TimeUnit;
+import org.apache.calcite.avatica.util.TimeUnitRange;
+import org.apache.calcite.sql.SqlBasicCall;
+import org.apache.calcite.sql.SqlIntervalLiteral;
+import org.apache.calcite.sql.SqlIntervalQualifier;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.druid.sql.calcite.util.CalciteTestBase;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that {@link SqlIntervalWeekRewriteShuttle} rewrites
+ * {@code INTERVAL ... WEEK} into the equivalent {@code INTERVAL ... DAY}
+ * with the value multiplied by seven, working around CALCITE-6391.
+ */
+public class SqlIntervalWeekRewriteShuttleTest extends CalciteTestBase
+{
+  private final SqlIntervalWeekRewriteShuttle shuttle = new SqlIntervalWeekRewriteShuttle();
+
+  @Test
+  public void testQuotedSingleWeekLiteralBecomesSevenDays()
+  {
+    final SqlNode original = SqlLiteral.createInterval(
+        1,
+        "1",
+        new SqlIntervalQualifier(TimeUnit.WEEK, null, SqlParserPos.ZERO),
+        SqlParserPos.ZERO
+    );
+
+    final SqlNode rewritten = original.accept(shuttle);
+    assertNotSame(original, rewritten);
+    assertTrue(rewritten instanceof SqlIntervalLiteral);
+    final SqlIntervalLiteral.IntervalValue value =
+        (SqlIntervalLiteral.IntervalValue) ((SqlIntervalLiteral) rewritten).getValue();
+    assertEquals("7", value.getIntervalLiteral());
+    assertEquals(TimeUnitRange.DAY, value.getIntervalQualifier().timeUnitRange);
+    assertEquals(1, value.getSign());
+  }
+
+  @Test
+  public void testQuotedMultiWeekLiteralIsMultipliedBySeven()
+  {
+    final SqlNode original = SqlLiteral.createInterval(
+        1,
+        "3",
+        new SqlIntervalQualifier(TimeUnit.WEEK, null, SqlParserPos.ZERO),
+        SqlParserPos.ZERO
+    );
+
+    final SqlNode rewritten = original.accept(shuttle);
+    final SqlIntervalLiteral.IntervalValue value =
+        (SqlIntervalLiteral.IntervalValue) ((SqlIntervalLiteral) rewritten).getValue();
+    assertEquals("21", value.getIntervalLiteral());
+    assertEquals(TimeUnitRange.DAY, value.getIntervalQualifier().timeUnitRange);
+  }
+
+  @Test
+  public void testNegativeQuotedWeekLiteralPreservesSign()
+  {
+    final SqlNode original = SqlLiteral.createInterval(
+        -1,
+        "2",
+        new SqlIntervalQualifier(TimeUnit.WEEK, null, SqlParserPos.ZERO),
+        SqlParserPos.ZERO
+    );
+
+    final SqlNode rewritten = original.accept(shuttle);
+    final SqlIntervalLiteral.IntervalValue value =
+        (SqlIntervalLiteral.IntervalValue) ((SqlIntervalLiteral) rewritten).getValue();
+    assertEquals("14", value.getIntervalLiteral());
+    assertEquals(TimeUnitRange.DAY, value.getIntervalQualifier().timeUnitRange);
+    assertEquals(-1, value.getSign());
+  }
+
+  @Test
+  public void testDayLiteralIsLeftUntouched()
+  {
+    final SqlNode original = SqlLiteral.createInterval(
+        1,
+        "1",
+        new SqlIntervalQualifier(TimeUnit.DAY, null, SqlParserPos.ZERO),
+        SqlParserPos.ZERO
+    );
+
+    final SqlNode rewritten = original.accept(shuttle);
+    assertSame(original, rewritten);
+  }
+
+  @Test
+  public void testMonthLiteralIsLeftUntouched()
+  {
+    final SqlNode original = SqlLiteral.createInterval(
+        1,
+        "5",
+        new SqlIntervalQualifier(TimeUnit.MONTH, null, SqlParserPos.ZERO),
+        SqlParserPos.ZERO
+    );
+
+    final SqlNode rewritten = original.accept(shuttle);
+    assertSame(original, rewritten);
+  }
+
+  @Test
+  public void testUnquotedWeekIntervalCallBecomesMultiplyDayCall()
+  {
+    // Mirrors what Druid's parser produces for `INTERVAL 1 WEEK`:
+    //   SqlStdOperatorTable.INTERVAL.createCall(pos, n, qualifier)
+    final SqlNode original = SqlStdOperatorTable.INTERVAL.createCall(
+        SqlParserPos.ZERO,
+        SqlLiteral.createExactNumeric("1", SqlParserPos.ZERO),
+        new SqlIntervalQualifier(TimeUnit.WEEK, null, SqlParserPos.ZERO)
+    );
+
+    final SqlNode rewritten = original.accept(shuttle);
+    assertNotSame(original, rewritten);
+    assertTrue(rewritten instanceof SqlBasicCall);
+    final SqlBasicCall rewrittenCall = (SqlBasicCall) rewritten;
+    assertSame(SqlStdOperatorTable.INTERVAL, rewrittenCall.getOperator());
+
+    // Operand 0 should be (numeric * 7).
+    final SqlNode numeric = rewrittenCall.operand(0);
+    assertTrue(numeric instanceof SqlBasicCall);
+    final SqlBasicCall numericCall = (SqlBasicCall) numeric;
+    assertSame(SqlStdOperatorTable.MULTIPLY, numericCall.getOperator());
+    assertEquals(2, numericCall.operandCount());
+    assertEquals("7", ((SqlLiteral) numericCall.operand(1)).toValue());
+
+    // Operand 1 should now be a DAY qualifier.
+    final SqlNode qualifier = rewrittenCall.operand(1);
+    assertTrue(qualifier instanceof SqlIntervalQualifier);
+    assertEquals(TimeUnitRange.DAY, ((SqlIntervalQualifier) qualifier).timeUnitRange);
+  }
+
+  @Test
+  public void testUnquotedDayIntervalCallIsLeftUntouched()
+  {
+    final SqlNode original = SqlStdOperatorTable.INTERVAL.createCall(
+        SqlParserPos.ZERO,
+        SqlLiteral.createExactNumeric("1", SqlParserPos.ZERO),
+        new SqlIntervalQualifier(TimeUnit.DAY, null, SqlParserPos.ZERO)
+    );
+
+    final SqlNode rewritten = original.accept(shuttle);
+    assertSame(original, rewritten);
+  }
+
+  @Test
+  public void testParsedWeekIntervalIsRewritten() throws Exception
+  {
+    // End-to-end check using the actual parser, both forms.
+    assertParsedWeekIsRewritten("SELECT TIMESTAMP '1970-01-01 00:00:00' + INTERVAL '1' WEEK");
+    assertParsedWeekIsRewritten("SELECT TIMESTAMP '1970-01-01 00:00:00' + INTERVAL 1 WEEK");
+    assertParsedWeekIsRewritten("SELECT TIMESTAMP '1970-01-01 00:00:00' + INTERVAL 2 WEEK");
+  }
+
+  private void assertParsedWeekIsRewritten(String sql) throws Exception
+  {
+    final SqlNode parsed = SqlParser.create(sql).parseQuery();
+    final SqlNode rewritten = parsed.accept(shuttle);
+    final WeekFinder finder = new WeekFinder();
+    rewritten.accept(finder);
+    assertTrue(
+        !finder.found,
+        "Rewritten tree for [" + sql + "] should not contain a WEEK qualifier, but it did."
+    );
+  }
+
+  /**
+   * SqlShuttle that records whether it visited any plain WEEK
+   * {@link SqlIntervalQualifier}.
+   */
+  private static class WeekFinder extends org.apache.calcite.sql.util.SqlShuttle
+  {
+    boolean found;
+
+    @Override
+    public SqlNode visit(SqlIntervalQualifier intervalQualifier)
+    {
+      if (intervalQualifier.timeUnitRange == TimeUnitRange.WEEK
+          && intervalQualifier.timeFrameName == null) {
+        found = true;
+      }
+      return intervalQualifier;
+    }
+  }
+}


### PR DESCRIPTION
Fixes #18665.

### Description

`INTERVAL '1' WEEK` (and the unquoted `INTERVAL 1 WEEK`) was resolving to one hour instead of seven days. The repro from #18665 makes the symptom obvious:

```sql
SELECT
  MILLIS_TO_TIMESTAMP(0) + INTERVAL 1 WEEK,
  MILLIS_TO_TIMESTAMP(0) + INTERVAL 2 WEEK
```

was returning `1970-01-01T01:00:00`, `1970-01-01T02:00:00` (one and two hours) instead of the expected `1970-01-08`, `1970-01-15`.

Per @gianm's review, `INTERVAL n QUARTER` is broken in Calcite 1.37.0 in the same way, so this PR also covers QUARTER.

#### Root cause

The bugs live in Calcite 1.37.0:

  - `SqlIntervalQualifier.evaluateIntervalLiteralAsWeek` packages a WEEK literal into a year-month shaped int array (`[sign, 0, week]`), even though `SqlIntervalQualifier.typeName()` reports a WEEK qualifier as `INTERVAL_DAY`. The downstream `SqlParserUtil.intervalToMillis` loop walks `ret[1..]` as `[day, hour, minute, second, ms]`, so the week count lands in the hour slot. `INTERVAL '1' WEEK` therefore becomes `1 * 3_600_000 ms = 1 hour`.
  - `SqlIntervalQualifier.evaluateIntervalLiteralAsQuarter` packages a QUARTER literal into the same year-month shaped array (`[sign, 0, quarter]`) without multiplying by three. `SqlParserUtil.intervalToMonths` reads `12 * 0 + 1 * quarter = quarter` months instead of `3 * quarter` months. `INTERVAL '1' QUARTER` therefore becomes one month.

Both bugs were fixed upstream as [CALCITE-6581](https://issues.apache.org/jira/browse/CALCITE-6581) in Calcite 1.38. Druid is still on Calcite 1.37, so we work around them inside the planner instead of upgrading Calcite in this PR.

#### Fixed the bug ...

Added `SqlIntervalWeekRewriteShuttle`, an `SqlShuttle` that walks the parsed `SqlNode` tree before validation and rewrites the affected parsed forms into equivalent intervals in a unit Calcite 1.37 handles correctly:

  - `INTERVAL '1' WEEK` parses to a `SqlIntervalLiteral` with a WEEK qualifier. The shuttle replaces it with a `SqlIntervalLiteral` whose value has been multiplied by seven and whose qualifier is now DAY.
  - `INTERVAL 1 WEEK` parses to `SqlStdOperatorTable.INTERVAL.createCall(pos, n, qualifier)`. The shuttle rewrites the call so the numeric operand becomes `MULTIPLY(n, 7)` and the qualifier becomes DAY.
  - `INTERVAL '1' QUARTER` and `INTERVAL 1 QUARTER` are rewritten the same way, using MONTH and a factor of three.

`WEEK(SUNDAY)..WEEK(SATURDAY)` and `ISOWEEK` qualifiers carry a non-null `timeFrameName` and are handled differently in Calcite, so the shuttle leaves them alone and only touches the bare `WEEK` / `QUARTER` forms that are broken in 1.37.

The shuttle is invoked in `DruidPlanner.validate` right before `rewriteParameters`, alongside the existing `SqlParameterizerShuttle` pass. It runs once per validate call and is a no-op for any tree that does not contain a WEEK or QUARTER interval.

This shuttle is a temporary workaround and should be removed when Druid upgrades to Calcite 1.38+.

#### Tests

  - `SqlIntervalWeekRewriteShuttleTest` exercises the shuttle directly against constructed `SqlIntervalLiteral` and `SqlCall` nodes for WEEK, QUARTER, DAY and MONTH (positive, negative, multi-unit), and against parsed queries that use both quoted and unquoted week and quarter intervals.
  - `CalciteQueryTest#testIntervalWeekResolution` is the end-to-end regression test from #18665. Without the fix it produces an interval narrowing on `2000-01-01T01:00:00.001` / `2000-01-01T02:00:00.001` (the bug); with the fix it correctly narrows to `2000-01-08` and `2000-01-15`.
  - `CalciteQueryTest#testIntervalQuarterResolution` is the companion regression for QUARTER: `INTERVAL '1' QUARTER` narrows to `2000-04-01` (three months later) and `INTERVAL 2 QUARTER` to `2000-07-01`.

I verified the bug is reachable by temporarily disabling the shuttle and watching the regression tests fail with exactly the actual-vs-expected from the issue. Re-enabling the shuttle makes them pass.

I also re-ran the surrounding test classes to make sure the rewrite did not regress any existing INTERVAL behavior:

  - `CalciteQueryTest` (441 tests)
  - `CalciteSelectQueryTest` (67 tests)
  - `CalciteJoinQueryTest` (594 tests)
  - `CalciteSubqueryTest` (54 tests)
  - `CalciteParameterQueryTest` (20 tests)
  - `CalciteInsertDmlTest` / `CalciteReplaceDmlTest` (107 tests)
  - `ExpressionsTest` (54 tests)
  - `DruidSqlParserUtilsTest` (57 tests)
  - `SqlQuidemTest` (10 tests)

All green. `mvn -pl sql -am verify -DskipTests=true` (checkstyle, forbiddenapis, animal-sniffer) and `mvn -pl sql -P rat verify -DskipTests=true` (license headers) also pass.

#### Release note

Fixed an issue where `INTERVAL n WEEK` in SQL queries resolved to `n` hours instead of `n * 7` days, and `INTERVAL n QUARTER` resolved to `n` months instead of `n * 3` months. `MILLIS_TO_TIMESTAMP(0) + INTERVAL '1' WEEK` now correctly returns `1970-01-08`, and `INTERVAL '1' QUARTER` adds three months, matching the SQL standard and other databases.

<hr>

##### Key changed/added classes in this PR
 * `SqlIntervalWeekRewriteShuttle` (new, covers WEEK and QUARTER)
 * `DruidPlanner` (calls the shuttle in `validate`)
 * `SqlIntervalWeekRewriteShuttleTest` (new)
 * `CalciteQueryTest` (regression tests `testIntervalWeekResolution` and `testIntervalQuarterResolution`)

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] a release note entry in the PR description.
