### PR TITLE
fix: Try to fix flakes in LookupCoordinatorManagerTest

### DIFF
--- a/server/src/test/java/org/apache/druid/server/lookup/cache/LookupCoordinatorManagerTest.java
+++ b/server/src/test/java/org/apache/druid/server/lookup/cache/LookupCoordinatorManagerTest.java
@@ -506,7 +506,7 @@ public class LookupCoordinatorManagerTest
   }
 
   @Test
-  public void testUpdateLookupsFailsUnitialized()
+  public void testUpdateLookupsFailsUnitialized() throws Exception
   {
     final LookupCoordinatorManager manager = new LookupCoordinatorManager(
         client,
@@ -523,11 +523,17 @@ public class LookupCoordinatorManagerTest
       }
     };
     manager.start();
-    Assert.assertThrows(ISE.class, () -> manager.updateLookups(TIERED_LOOKUP_MAP_V0, auditInfo));
+    try {
+      Assert.assertThrows(ISE.class, () -> manager.updateLookups(TIERED_LOOKUP_MAP_V0, auditInfo));
+    }
+    finally {
+      manager.stop();
+      manager.waitForBackgroundTermination(10);
+    }
   }
 
   @Test
-  public void testUpdateLookupsInitialization()
+  public void testUpdateLookupsInitialization() throws Exception
   {
     final LookupCoordinatorManager manager = new LookupCoordinatorManager(
         client,
@@ -544,21 +550,26 @@ public class LookupCoordinatorManagerTest
       }
     };
     manager.start();
-
-    EasyMock.reset(configManager);
-    EasyMock.expect(
-        configManager.set(
-                        EasyMock.eq(LookupCoordinatorManager.LOOKUP_CONFIG_KEY),
-                        EasyMock.eq(EMPTY_TIERED_LOOKUP),
-                        EasyMock.eq(auditInfo)
-                    )).andReturn(SetResult.ok()).once();
-    EasyMock.replay(configManager);
-    manager.updateLookups(EMPTY_TIERED_LOOKUP, auditInfo);
-    EasyMock.verify(configManager);
+    try {
+      EasyMock.reset(configManager);
+      EasyMock.expect(
+          configManager.set(
+                          EasyMock.eq(LookupCoordinatorManager.LOOKUP_CONFIG_KEY),
+                          EasyMock.eq(EMPTY_TIERED_LOOKUP),
+                          EasyMock.eq(auditInfo)
+                      )).andReturn(SetResult.ok()).once();
+      EasyMock.replay(configManager);
+      manager.updateLookups(EMPTY_TIERED_LOOKUP, auditInfo);
+      EasyMock.verify(configManager);
+    }
+    finally {
+      manager.stop();
+      manager.waitForBackgroundTermination(10);
+    }
   }
 
   @Test
-  public void testUpdateLookupAdds()
+  public void testUpdateLookupAdds() throws Exception
   {
     final LookupCoordinatorManager manager = new LookupCoordinatorManager(
         client,
@@ -575,20 +586,25 @@ public class LookupCoordinatorManagerTest
       }
     };
     manager.start();
-
-    EasyMock.reset(configManager);
-    EasyMock.expect(configManager.set(
-                        EasyMock.eq(LookupCoordinatorManager.LOOKUP_CONFIG_KEY),
-                        EasyMock.eq(TIERED_LOOKUP_MAP_V0),
-                        EasyMock.eq(auditInfo)
-                    )).andReturn(SetResult.ok()).once();
-    EasyMock.replay(configManager);
-    manager.updateLookup(LOOKUP_TIER, SINGLE_LOOKUP_NAME, SINGLE_LOOKUP_SPEC_V0, auditInfo);
-    EasyMock.verify(configManager);
+    try {
+      EasyMock.reset(configManager);
+      EasyMock.expect(configManager.set(
+                          EasyMock.eq(LookupCoordinatorManager.LOOKUP_CONFIG_KEY),
+                          EasyMock.eq(TIERED_LOOKUP_MAP_V0),
+                          EasyMock.eq(auditInfo)
+                      )).andReturn(SetResult.ok()).once();
+      EasyMock.replay(configManager);
+      manager.updateLookup(LOOKUP_TIER, SINGLE_LOOKUP_NAME, SINGLE_LOOKUP_SPEC_V0, auditInfo);
+      EasyMock.verify(configManager);
+    }
+    finally {
+      manager.stop();
+      manager.waitForBackgroundTermination(10);
+    }
   }
 
   @Test
-  public void testUpdateLookupsAddsNewLookup()
+  public void testUpdateLookupsAddsNewLookup() throws Exception
   {
     final LookupExtractorFactoryMapContainer ignore = new LookupExtractorFactoryMapContainer(
         "v0",
@@ -619,38 +635,44 @@ public class LookupCoordinatorManagerTest
       }
     };
     manager.start();
-    final LookupExtractorFactoryMapContainer newSpec = new LookupExtractorFactoryMapContainer(
-        "v1",
-        ImmutableMap.of("prop", "new")
-    );
-    EasyMock.reset(configManager);
-    EasyMock.expect(
-        configManager.set(
-            EasyMock.eq(LookupCoordinatorManager.LOOKUP_CONFIG_KEY),
-            EasyMock.eq(ImmutableMap.<String, Map<String, LookupExtractorFactoryMapContainer>>of(
-                            LOOKUP_TIER + "1", ImmutableMap.of(
-                                "foo1", ignore,
-                                "foo2", newSpec
-                            ),
-                            LOOKUP_TIER + "2", ImmutableMap.of("ignore", ignore)
-                        )),
-            EasyMock.eq(auditInfo)
-        )
-    ).andReturn(SetResult.ok()).once();
-    EasyMock.replay(configManager);
-    Assert.assertTrue(
-        manager.updateLookups(
-            ImmutableMap.of(
-                LOOKUP_TIER + "1", ImmutableMap.of(
-                    "foo2",
-                    newSpec
-                )
-            ), auditInfo));
-    EasyMock.verify(configManager);
+    try {
+      final LookupExtractorFactoryMapContainer newSpec = new LookupExtractorFactoryMapContainer(
+          "v1",
+          ImmutableMap.of("prop", "new")
+      );
+      EasyMock.reset(configManager);
+      EasyMock.expect(
+          configManager.set(
+              EasyMock.eq(LookupCoordinatorManager.LOOKUP_CONFIG_KEY),
+              EasyMock.eq(ImmutableMap.<String, Map<String, LookupExtractorFactoryMapContainer>>of(
+                              LOOKUP_TIER + "1", ImmutableMap.of(
+                                  "foo1", ignore,
+                                  "foo2", newSpec
+                              ),
+                              LOOKUP_TIER + "2", ImmutableMap.of("ignore", ignore)
+                          )),
+              EasyMock.eq(auditInfo)
+          )
+      ).andReturn(SetResult.ok()).once();
+      EasyMock.replay(configManager);
+      Assert.assertTrue(
+          manager.updateLookups(
+              ImmutableMap.of(
+                  LOOKUP_TIER + "1", ImmutableMap.of(
+                      "foo2",
+                      newSpec
+                  )
+              ), auditInfo));
+      EasyMock.verify(configManager);
+    }
+    finally {
+      manager.stop();
+      manager.waitForBackgroundTermination(10);
+    }
   }
 
   @Test
-  public void testUpdateLookupsOnlyUpdatesToTier()
+  public void testUpdateLookupsOnlyUpdatesToTier() throws Exception
   {
     final LookupExtractorFactoryMapContainer ignore = new LookupExtractorFactoryMapContainer(
         "v0",
@@ -681,91 +703,103 @@ public class LookupCoordinatorManagerTest
       }
     };
     manager.start();
-    final LookupExtractorFactoryMapContainer newSpec = new LookupExtractorFactoryMapContainer(
-        "v1",
-        ImmutableMap.of("prop", "new")
-    );
-    EasyMock.reset(configManager);
-    EasyMock.expect(
-        configManager.set(
-            EasyMock.eq(LookupCoordinatorManager.LOOKUP_CONFIG_KEY),
-            EasyMock.eq(ImmutableMap.<String, Map<String, LookupExtractorFactoryMapContainer>>of(
-                            LOOKUP_TIER + "1", ImmutableMap.of("foo", newSpec),
-                            LOOKUP_TIER + "2", ImmutableMap.of("ignore", ignore)
-                        )),
-            EasyMock.eq(auditInfo)
-        )
-    ).andReturn(SetResult.ok()).once();
-    EasyMock.replay(configManager);
-    Assert.assertTrue(
-        manager.updateLookups(
-            ImmutableMap.of(
-                LOOKUP_TIER + "1", ImmutableMap.of(
-                    "foo",
-                    newSpec
-                )
-            ), auditInfo));
-    EasyMock.verify(configManager);
-  }
-
-  @Test
-  public void testUpdateLookupsUpdates()
-  {
-    final LookupCoordinatorManager manager = new LookupCoordinatorManager(
-        client,
-        druidNodeDiscoveryProvider,
-        mapper,
-        configManager,
-        lookupCoordinatorManagerConfig
-    )
-    {
-      @Override
-      public Map<String, Map<String, LookupExtractorFactoryMapContainer>> getKnownLookups()
-      {
-        return TIERED_LOOKUP_MAP_V0;
-      }
-    };
-    manager.start();
-    EasyMock.reset(configManager);
-    EasyMock.expect(configManager.set(
-                        EasyMock.eq(LookupCoordinatorManager.LOOKUP_CONFIG_KEY),
-                        EasyMock.eq(TIERED_LOOKUP_MAP_V1),
-                        EasyMock.eq(auditInfo)
-                    )).andReturn(SetResult.ok()).once();
-    EasyMock.replay(configManager);
-    manager.updateLookups(TIERED_LOOKUP_MAP_V1, auditInfo);
-    EasyMock.verify(configManager);
-  }
-
-  @Test
-  public void testUpdateLookupFailsSameVersionUpdates()
-  {
-    final LookupCoordinatorManager manager = new LookupCoordinatorManager(
-        client,
-        druidNodeDiscoveryProvider,
-        mapper,
-        configManager,
-        lookupCoordinatorManagerConfig
-    )
-    {
-      @Override
-      public Map<String, Map<String, LookupExtractorFactoryMapContainer>> getKnownLookups()
-      {
-        return TIERED_LOOKUP_MAP_V0;
-      }
-    };
-    manager.start();
-
     try {
-      manager.updateLookups(TIERED_LOOKUP_MAP_V0, auditInfo);
-      Assert.fail();
+      final LookupExtractorFactoryMapContainer newSpec = new LookupExtractorFactoryMapContainer(
+          "v1",
+          ImmutableMap.of("prop", "new")
+      );
+      EasyMock.reset(configManager);
+      EasyMock.expect(
+          configManager.set(
+              EasyMock.eq(LookupCoordinatorManager.LOOKUP_CONFIG_KEY),
+              EasyMock.eq(ImmutableMap.<String, Map<String, LookupExtractorFactoryMapContainer>>of(
+                              LOOKUP_TIER + "1", ImmutableMap.of("foo", newSpec),
+                              LOOKUP_TIER + "2", ImmutableMap.of("ignore", ignore)
+                          )),
+              EasyMock.eq(auditInfo)
+          )
+      ).andReturn(SetResult.ok()).once();
+      EasyMock.replay(configManager);
+      Assert.assertTrue(
+          manager.updateLookups(
+              ImmutableMap.of(
+                  LOOKUP_TIER + "1", ImmutableMap.of(
+                      "foo",
+                      newSpec
+                  )
+              ), auditInfo));
+      EasyMock.verify(configManager);
     }
-    catch (IAE ex) {
+    finally {
+      manager.stop();
+      manager.waitForBackgroundTermination(10);
     }
   }
 
   @Test
-  public void testUpdateLookupsAddsNewTier()
+  public void testUpdateLookupsUpdates() throws Exception
+  {
+    final LookupCoordinatorManager manager = new LookupCoordinatorManager(
+        client,
+        druidNodeDiscoveryProvider,
+        mapper,
+        configManager,
+        lookupCoordinatorManagerConfig
+    )
+    {
+      @Override
+      public Map<String, Map<String, LookupExtractorFactoryMapContainer>> getKnownLookups()
+      {
+        return TIERED_LOOKUP_MAP_V0;
+      }
+    };
+    manager.start();
+    try {
+      EasyMock.reset(configManager);
+      EasyMock.expect(configManager.set(
+                          EasyMock.eq(LookupCoordinatorManager.LOOKUP_CONFIG_KEY),
+                          EasyMock.eq(TIERED_LOOKUP_MAP_V1),
+                          EasyMock.eq(auditInfo)
+                      )).andReturn(SetResult.ok()).once();
+      EasyMock.replay(configManager);
+      manager.updateLookups(TIERED_LOOKUP_MAP_V1, auditInfo);
+      EasyMock.verify(configManager);
+    }
+    finally {
+      manager.stop();
+      manager.waitForBackgroundTermination(10);
+    }
+  }
+
+  @Test
+  public void testUpdateLookupFailsSameVersionUpdates() throws Exception
+  {
+    final LookupCoordinatorManager manager = new LookupCoordinatorManager(
+        client,
+        druidNodeDiscoveryProvider,
+        mapper,
+        configManager,
+        lookupCoordinatorManagerConfig
+    )
+    {
+      @Override
+      public Map<String, Map<String, LookupExtractorFactoryMapContainer>> getKnownLookups()
+      {
+        return TIERED_LOOKUP_MAP_V0;
+      }
+    };
+    manager.start();
+    try {
+      Assert.assertThrows(IAE.class, () -> manager.updateLookups(TIERED_LOOKUP_MAP_V0, auditInfo));
+    }
+    finally {
+      manager.stop();
+      manager.waitForBackgroundTermination(10);
+    }
+  }
+
+  @Test
+  public void testUpdateLookupsAddsNewTier() throws Exception
   {
     final LookupExtractorFactoryMapContainer ignore = new LookupExtractorFactoryMapContainer(
         "v0",
@@ -790,33 +824,39 @@ public class LookupCoordinatorManagerTest
       }
     };
     manager.start();
-    final LookupExtractorFactoryMapContainer newSpec = new LookupExtractorFactoryMapContainer(
-        "v1",
-        ImmutableMap.of("prop", "new")
-    );
-    EasyMock.reset(configManager);
-    EasyMock.expect(
-        configManager.set(
-            EasyMock.eq(LookupCoordinatorManager.LOOKUP_CONFIG_KEY),
-            EasyMock.eq(ImmutableMap.<String, Map<String, LookupExtractorFactoryMapContainer>>of(
-                            LOOKUP_TIER + "1", ImmutableMap.of("foo", newSpec),
-                            LOOKUP_TIER + "2", ImmutableMap.of("ignore", ignore)
-                        )),
-            EasyMock.eq(auditInfo)
-        )
-    ).andReturn(SetResult.ok()).once();
-    EasyMock.replay(configManager);
-    Assert.assertTrue(manager.updateLookups(ImmutableMap.of(
-                                                LOOKUP_TIER + "1", ImmutableMap.of(
-                                                    "foo",
-                                                    newSpec
-                                                )
-                                            ), auditInfo));
-    EasyMock.verify(configManager);
+    try {
+      final LookupExtractorFactoryMapContainer newSpec = new LookupExtractorFactoryMapContainer(
+          "v1",
+          ImmutableMap.of("prop", "new")
+      );
+      EasyMock.reset(configManager);
+      EasyMock.expect(
+          configManager.set(
+              EasyMock.eq(LookupCoordinatorManager.LOOKUP_CONFIG_KEY),
+              EasyMock.eq(ImmutableMap.<String, Map<String, LookupExtractorFactoryMapContainer>>of(
+                              LOOKUP_TIER + "1", ImmutableMap.of("foo", newSpec),
+                              LOOKUP_TIER + "2", ImmutableMap.of("ignore", ignore)
+                          )),
+              EasyMock.eq(auditInfo)
+          )
+      ).andReturn(SetResult.ok()).once();
+      EasyMock.replay(configManager);
+      Assert.assertTrue(manager.updateLookups(ImmutableMap.of(
+                                                  LOOKUP_TIER + "1", ImmutableMap.of(
+                                                      "foo",
+                                                      newSpec
+                                                  )
+                                              ), auditInfo));
+      EasyMock.verify(configManager);
+    }
+    finally {
+      manager.stop();
+      manager.waitForBackgroundTermination(10);
+    }
   }
 
   @Test
-  public void testDeleteTier()
+  public void testDeleteTier() throws Exception
   {
     final LookupExtractorFactoryMapContainer foo1 = new LookupExtractorFactoryMapContainer(
         "v0",
@@ -845,23 +885,29 @@ public class LookupCoordinatorManagerTest
       }
     };
     manager.start();
-    EasyMock.reset(configManager);
-    EasyMock.expect(
-        configManager.set(
-            EasyMock.eq(LookupCoordinatorManager.LOOKUP_CONFIG_KEY),
-            EasyMock.eq(
-                ImmutableMap.<String, Map<String, LookupExtractorFactoryMapContainer>>of()
-            ),
-            EasyMock.eq(auditInfo)
-        )
-    ).andReturn(SetResult.ok()).once();
-    EasyMock.replay(configManager);
-    Assert.assertTrue(manager.deleteTier(LOOKUP_TIER, auditInfo));
-    EasyMock.verify(configManager);
+    try {
+      EasyMock.reset(configManager);
+      EasyMock.expect(
+          configManager.set(
+              EasyMock.eq(LookupCoordinatorManager.LOOKUP_CONFIG_KEY),
+              EasyMock.eq(
+                  ImmutableMap.<String, Map<String, LookupExtractorFactoryMapContainer>>of()
+              ),
+              EasyMock.eq(auditInfo)
+          )
+      ).andReturn(SetResult.ok()).once();
+      EasyMock.replay(configManager);
+      Assert.assertTrue(manager.deleteTier(LOOKUP_TIER, auditInfo));
+      EasyMock.verify(configManager);
+    }
+    finally {
+      manager.stop();
+      manager.waitForBackgroundTermination(10);
+    }
   }
 
   @Test
-  public void testDeleteLookup()
+  public void testDeleteLookup() throws Exception
   {
     final LookupExtractorFactoryMapContainer ignore = new LookupExtractorFactoryMapContainer(
         "v0",
@@ -890,28 +936,34 @@ public class LookupCoordinatorManagerTest
       }
     };
     manager.start();
-    EasyMock.reset(configManager);
-    EasyMock.expect(
-        configManager.set(
-            EasyMock.eq(LookupCoordinatorManager.LOOKUP_CONFIG_KEY),
-            EasyMock.eq(
-                ImmutableMap.of(
-                    LOOKUP_TIER, ImmutableMap.of(
-                        "ignore", ignore
-                    )
-                )
-            ),
-            EasyMock.eq(auditInfo)
-        )
-    ).andReturn(SetResult.ok()).once();
-    EasyMock.replay(configManager);
-    Assert.assertTrue(manager.deleteLookup(LOOKUP_TIER, "foo", auditInfo));
-    EasyMock.verify(configManager);
+    try {
+      EasyMock.reset(configManager);
+      EasyMock.expect(
+          configManager.set(
+              EasyMock.eq(LookupCoordinatorManager.LOOKUP_CONFIG_KEY),
+              EasyMock.eq(
+                  ImmutableMap.of(
+                      LOOKUP_TIER, ImmutableMap.of(
+                          "ignore", ignore
+                      )
+                  )
+              ),
+              EasyMock.eq(auditInfo)
+          )
+      ).andReturn(SetResult.ok()).once();
+      EasyMock.replay(configManager);
+      Assert.assertTrue(manager.deleteLookup(LOOKUP_TIER, "foo", auditInfo));
+      EasyMock.verify(configManager);
+    }
+    finally {
+      manager.stop();
+      manager.waitForBackgroundTermination(10);
+    }
   }
 
 
   @Test
-  public void testDeleteLastLookup()
+  public void testDeleteLastLookup() throws Exception
   {
     final LookupExtractorFactoryMapContainer lookup = new LookupExtractorFactoryMapContainer(
         "v0",
@@ -934,23 +986,29 @@ public class LookupCoordinatorManagerTest
       }
     };
     manager.start();
-    EasyMock.reset(configManager);
-    EasyMock.expect(
-        configManager.set(
-            EasyMock.eq(LookupCoordinatorManager.LOOKUP_CONFIG_KEY),
-            EasyMock.eq(
-                ImmutableMap.<String, Map<String, LookupExtractorFactoryMapContainer>>of()
-            ),
-            EasyMock.eq(auditInfo)
-        )
-    ).andReturn(SetResult.ok()).once();
-    EasyMock.replay(configManager);
-    Assert.assertTrue(manager.deleteLookup(LOOKUP_TIER, "foo", auditInfo));
-    EasyMock.verify(configManager);
+    try {
+      EasyMock.reset(configManager);
+      EasyMock.expect(
+          configManager.set(
+              EasyMock.eq(LookupCoordinatorManager.LOOKUP_CONFIG_KEY),
+              EasyMock.eq(
+                  ImmutableMap.<String, Map<String, LookupExtractorFactoryMapContainer>>of()
+              ),
+              EasyMock.eq(auditInfo)
+          )
+      ).andReturn(SetResult.ok()).once();
+      EasyMock.replay(configManager);
+      Assert.assertTrue(manager.deleteLookup(LOOKUP_TIER, "foo", auditInfo));
+      EasyMock.verify(configManager);
+    }
+    finally {
+      manager.stop();
+      manager.waitForBackgroundTermination(10);
+    }
   }
 
   @Test
-  public void testDeleteLookupIgnoresMissing()
+  public void testDeleteLookupIgnoresMissing() throws Exception
   {
     final LookupExtractorFactoryMapContainer ignore = new LookupExtractorFactoryMapContainer(
         "v0",
@@ -974,11 +1032,17 @@ public class LookupCoordinatorManagerTest
       }
     };
     manager.start();
-    Assert.assertFalse(manager.deleteLookup(LOOKUP_TIER, "foo", auditInfo));
+    try {
+      Assert.assertFalse(manager.deleteLookup(LOOKUP_TIER, "foo", auditInfo));
+    }
+    finally {
+      manager.stop();
+      manager.waitForBackgroundTermination(10);
+    }
   }
 
   @Test
-  public void testDeleteLookupIgnoresNotReady()
+  public void testDeleteLookupIgnoresNotReady() throws Exception
   {
     final LookupCoordinatorManager manager = new LookupCoordinatorManager(
         client,
@@ -995,7 +1059,13 @@ public class LookupCoordinatorManagerTest
       }
     };
     manager.start();
-    Assert.assertFalse(manager.deleteLookup(LOOKUP_TIER, "foo", auditInfo));
+    try {
+      Assert.assertFalse(manager.deleteLookup(LOOKUP_TIER, "foo", auditInfo));
+    }
+    finally {
+      manager.stop();
+      manager.waitForBackgroundTermination(10);
+    }
   }
 
   @Test
@@ -1182,19 +1252,24 @@ public class LookupCoordinatorManagerTest
     Assert.assertTrue(manager.knownOldState.get().isEmpty());
 
     manager.start();
+    try {
+      Map<HostAndPort, LookupsState<LookupExtractorFactoryMapContainer>> expectedKnownState = ImmutableMap.of(
+          host1.getHostAndPort(),
+          host1UpdatedState,
+          host2.getHostAndPort(),
+          host2UpdatedState
+      );
 
-    Map<HostAndPort, LookupsState<LookupExtractorFactoryMapContainer>> expectedKnownState = ImmutableMap.of(
-        host1.getHostAndPort(),
-        host1UpdatedState,
-        host2.getHostAndPort(),
-        host2UpdatedState
-    );
+      while (!expectedKnownState.equals(manager.knownOldState.get())) {
+        Thread.sleep(100);
+      }
 
-    while (!expectedKnownState.equals(manager.knownOldState.get())) {
-      Thread.sleep(100);
+      EasyMock.verify(lookupNodeDiscovery, configManager, lookupsCommunicator);
     }
-
-    EasyMock.verify(lookupNodeDiscovery, configManager, lookupsCommunicator);
+    finally {
+      manager.stop();
+      manager.waitForBackgroundTermination(60_000);
+    }
   }
 
   @Test
@@ -1365,7 +1440,7 @@ public class LookupCoordinatorManagerTest
   }
 
   @Test
-  public void testLookupDiscoverAll()
+  public void testLookupDiscoverAll() throws Exception
   {
     final Set<String> fakeChildren = ImmutableSet.of("tier1", "tier2");
     EasyMock.reset(lookupNodeDiscovery);
@@ -1383,12 +1458,18 @@ public class LookupCoordinatorManagerTest
     );
 
     manager.start();
-    Assert.assertEquals(fakeChildren, manager.discoverTiers());
-    EasyMock.verify(lookupNodeDiscovery);
+    try {
+      Assert.assertEquals(fakeChildren, manager.discoverTiers());
+      EasyMock.verify(lookupNodeDiscovery);
+    }
+    finally {
+      manager.stop();
+      manager.waitForBackgroundTermination(10);
+    }
   }
 
   @Test
-  public void testDiscoverNodesInTier()
+  public void testDiscoverNodesInTier() throws Exception
   {
     EasyMock.reset(lookupNodeDiscovery);
     EasyMock.expect(lookupNodeDiscovery.getNodesInTier("tier"))
@@ -1410,19 +1491,25 @@ public class LookupCoordinatorManagerTest
     );
 
     manager.start();
-    Assert.assertEquals(
-        ImmutableSet.of(
-            HostAndPort.fromParts("h1", 8080),
-            HostAndPort.fromParts("h2", 8080)
-        ),
-        ImmutableSet.copyOf(manager.discoverNodesInTier("tier"))
-    );
-    EasyMock.verify(lookupNodeDiscovery);
+    try {
+      Assert.assertEquals(
+          ImmutableSet.of(
+              HostAndPort.fromParts("h1", 8080),
+              HostAndPort.fromParts("h2", 8080)
+          ),
+          ImmutableSet.copyOf(manager.discoverNodesInTier("tier"))
+      );
+      EasyMock.verify(lookupNodeDiscovery);
+    }
+    finally {
+      manager.stop();
+      manager.waitForBackgroundTermination(10);
+    }
   }
 
   //tests that lookups stored in db from 0.10.0 are converted and restored.
   @Test
-  public void testBackwardCompatibilityMigration()
+  public void testBackwardCompatibilityMigration() throws Exception
   {
     EasyMock.reset(configManager);
 
@@ -1484,6 +1571,12 @@ public class LookupCoordinatorManagerTest
         }
     );
     manager.start();
-    EasyMock.verify(configManager);
+    try {
+      EasyMock.verify(configManager);
+    }
+    finally {
+      manager.stop();
+      manager.waitForBackgroundTermination(10);
+    }
   }
 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

Noticed `LookupCoordinatorManagerTest` as being pretty flakey when looking at CI runs and then running locally on loops. About every ~200 iterations I would get a test fail on the assertion in the teardown. With the proposed change I was able to get multiple runs above 3k iterations without a failure and gave up on waiting.

#### Analysis and solution notes 
  - LookupCoordinatorManagerTest has 17 tests that call manager.start() (which spawns a ScheduledExecutorService running lookupManagementLoop() in the background) but never call manager.stop(). When the background loop fires after EasyMock expectations are exhausted, it throws, which gets caught and emitted as an alert via EmittingLogger. The @After teardown then fails its assertEquals(0, SERVICE_EMITTER.getNumEmittedEvents()) assertion.
  - Wraps post-start() logic in each affected test with try/finally blocks that call manager.stop() and manager.waitForBackgroundTermination().                                                                                                                                                                
                                                                                                                                                                                                                                                                                                               
The per-test try/finally pattern was chosen over a centralized teardown approach (e.g. a class-level field stopped in @After) because each test constructs its manager differently (varying constructors, overridden methods, and config) making a shared field seem maybe awkward. try/finally keeps the lifecycle visible right where start() is called. 

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `LookupCoordinatorManagerTest`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.