### PR TITLE
fix: correct typo in SeekableStreamIndexTaskRunner log message

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
@@ -811,7 +811,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
         // (1) catch all exceptions while reading from kafka
         if (Throwables.getRootCause(e) instanceof InterruptedException) {
           // Suppress InterruptedException stack trace to avoid flooding the logs
-          log.error("Encounted InterrupedException in run() before persisting");
+          log.error("Encountered InterruptedException in run() before persisting");
         } else {
           log.error(e, "Encountered exception in run() before persisting.");
         }


### PR DESCRIPTION
### Description

Two adjacent typos on one log line in `SeekableStreamIndexTaskRunner.java`:

```diff
-          log.error("Encounted InterrupedException in run() before persisting");
+          log.error("Encountered InterruptedException in run() before persisting");
```

- `Encounted` → `Encountered`
- `InterrupedException` → `InterruptedException`

Log-string-only change, no behaviour change.

Fixes #19189

### This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description. (N/A — log-only typo)

### Key changed/added classes in this PR

- `SeekableStreamIndexTaskRunner`