### PR TITLE
docs: fix 'seperate' typo in extension comments

### DIFF
--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureUtils.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureUtils.java
@@ -43,7 +43,7 @@ public class AzureUtils
   static final String BLOB = "blob";
 
   // This logic is copied from RequestRetryOptions in the azure client. We still need this logic because some classes like
-  // RetryingInputEntity need a predicate function to tell whether to retry, seperate from the Azure client retries.
+  // RetryingInputEntity need a predicate function to tell whether to retry, separate from the Azure client retries.
   public static final Predicate<Throwable> AZURE_RETRY = e -> {
     if (e == null) {
       return false;

--- a/extensions-core/orc-extensions/src/main/java/org/apache/druid/data/input/orc/OrcInputFormat.java
+++ b/extensions-core/orc-extensions/src/main/java/org/apache/druid/data/input/orc/OrcInputFormat.java
@@ -57,7 +57,7 @@ public class OrcInputFormat extends NestedInputFormat
 
   private void initialize(Configuration conf)
   {
-    //Initializing seperately since during eager initialization, resolving
+    //Initializing separately since during eager initialization, resolving
     //namenode hostname throws an error if nodes are ephemeral
 
     // Ensure that FileSystem class level initialization happens with correct CL

--- a/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/ParquetInputFormat.java
+++ b/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/ParquetInputFormat.java
@@ -57,7 +57,7 @@ public class ParquetInputFormat extends NestedInputFormat
 
   private void initialize(Configuration conf)
   {
-    // Initializing seperately since during eager initialization, resolving
+    // Initializing separately since during eager initialization, resolving
     // namenode hostname throws an error if nodes are ephemeral
 
     // Ensure that FileSystem class level initialization happens with correct CL


### PR DESCRIPTION
Three small comment-only typo fixes:

- `extensions-core/azure-extensions/.../AzureUtils.java`: `seperate` → `separate`
- `extensions-core/orc-extensions/.../OrcInputFormat.java`: `Initializing seperately` → `Initializing separately`
- `extensions-core/parquet-extensions/.../ParquetInputFormat.java`: `Initializing seperately` → `Initializing separately`

No functional change.