### PR TITLE
docs: fix typos in comments for separate(ly) and propagate

### DIFF
--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureUtils.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureUtils.java
@@ -43,7 +43,7 @@ public class AzureUtils
   static final String BLOB = "blob";
 
   // This logic is copied from RequestRetryOptions in the azure client. We still need this logic because some classes like
-  // RetryingInputEntity need a predicate function to tell whether to retry, seperate from the Azure client retries.
+  // RetryingInputEntity need a predicate function to tell whether to retry, separate from the Azure client retries.
   public static final Predicate<Throwable> AZURE_RETRY = e -> {
     if (e == null) {
       return false;

--- a/extensions-core/orc-extensions/src/main/java/org/apache/druid/data/input/orc/OrcInputFormat.java
+++ b/extensions-core/orc-extensions/src/main/java/org/apache/druid/data/input/orc/OrcInputFormat.java
@@ -57,7 +57,7 @@ public class OrcInputFormat extends NestedInputFormat
 
   private void initialize(Configuration conf)
   {
-    //Initializing seperately since during eager initialization, resolving
+    //Initializing separately since during eager initialization, resolving
     //namenode hostname throws an error if nodes are ephemeral
 
     // Ensure that FileSystem class level initialization happens with correct CL

--- a/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/ParquetInputFormat.java
+++ b/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/ParquetInputFormat.java
@@ -57,7 +57,7 @@ public class ParquetInputFormat extends NestedInputFormat
 
   private void initialize(Configuration conf)
   {
-    // Initializing seperately since during eager initialization, resolving
+    // Initializing separately since during eager initialization, resolving
     // namenode hostname throws an error if nodes are ephemeral
 
     // Ensure that FileSystem class level initialization happens with correct CL

--- a/processing/src/main/java/org/apache/druid/query/FrameBasedInlineDataSourceSerializer.java
+++ b/processing/src/main/java/org/apache/druid/query/FrameBasedInlineDataSourceSerializer.java
@@ -69,7 +69,7 @@ public class FrameBasedInlineDataSourceSerializer extends StdSerializer<FrameBas
       }
       catch (IOException e) {
         // Ideally, this shouldn't be reachable.
-        // Wrap the IO exception in the runtime exception and propogate it forward
+        // Wrap the IO exception in the runtime exception and propagate it forward
         List<String> elements = new ArrayList<>();
         for (Object o : row) {
           elements.add(o.toString());


### PR DESCRIPTION
Comment-only typo fixes:

- `ParquetInputFormat.java`, `OrcInputFormat.java`: `Initializing seperately` -> `Initializing separately`
- `AzureUtils.java`: `seperate from the Azure client retries` -> `separate from the Azure client retries`
- `FrameBasedInlineDataSourceSerializer.java`: `propogate it forward` -> `propagate it forward`

No behavior changes.