### PR TITLE
docs: Update links

### DIFF
--- a/docs/design/zookeeper.md
+++ b/docs/design/zookeeper.md
@@ -40,7 +40,7 @@ The operations that happen over ZK are
 
 ## Coordinator Leader Election
 
-We use the Curator [LeaderLatch](https://curator.apache.org/curator-recipes/leader-latch.html) recipe to perform leader election at path
+We use the Curator [LeaderLatch](https://curator.apache.org/docs/recipes-leader-latch) recipe to perform leader election at path
 
 ```
 ${druid.zk.paths.coordinatorPath}/_COORDINATOR

--- a/docs/development/extensions-core/test-stats.md
+++ b/docs/development/extensions-core/test-stats.md
@@ -30,7 +30,7 @@ Make sure to include `druid-stats` extension in order to use these aggregators.
 
 ## Z-Score for two sample ztests post aggregator
 
-Please refer to [Making Sense of the Two-Proportions Test](https://www.isixsigma.com/tools-templates/hypothesis-testing/making-sense-two-proportions-test/) and [An Introduction to Statistics: Comparing Two Means](https://userweb.ucs.louisiana.edu/~jcb0773/Berry_statbook/427bookall-August2024.pdf) for more details.
+Please refer to [Making Sense of the Two-Proportions Test](https://www.isixsigma.com/hypothesis-testing/making-sense-two-proportions-test/) and [An Introduction to Statistics: Comparing Two Means](https://userweb.ucs.louisiana.edu/~jcb0773/Berry_statbook/427bookall-August2024.pdf) for more details.
 
 ```
 z = (p1 - p2) / S.E.  (assuming null hypothesis is true)

--- a/docs/multi-stage-query/examples.md
+++ b/docs/multi-stage-query/examples.md
@@ -29,7 +29,7 @@ This page describes SQL-based batch ingestion using the [multi-stage query task 
 These example queries show you some of the things you can do when modifying queries for your use case. Copy the example queries into the **Query** view of the web console and run them to see what they do.
 
 :::tip
-When you insert or replace data with SQL-based ingestion, set the context parameter `finalizeAggregations` to `false`. This context parameter is automatically set for you if you use the Druid console. If you use the API, you must explicitly set it. For an example, see [SQL-based ingestion API](../api-reference/sql-ingestion-api#sample-request). For details on aggregations, see [Rollup](./concepts.md#rollup).
+When you insert or replace data with SQL-based ingestion, set the context parameter `finalizeAggregations` to `false`. This context parameter is automatically set for you if you use the Druid console. If you use the API, you must explicitly set it. For an example, see [SQL-based ingestion API](../api-reference/sql-ingestion-api.md#sample-request). For details on aggregations, see [Rollup](./concepts.md#rollup).
 :::
 
 ## INSERT with no rollup

--- a/docs/querying/projections.md
+++ b/docs/querying/projections.md
@@ -249,36 +249,36 @@ To use compaction on a datasource that includes projections, you need to set the
 <Tabs>
   <TabItem value="Coordinator duties">
 
-```json
-{
-    "type": "catalog",
-    "dataSource": YOUR_DATASOURCE,
-    "engine": "native",
-    "skipOffsetFromLatest": "PT0H",
-    "taskPriority": 25,
-    "inputSegmentSizeBytes": 100000000000000,
-    "taskContext": null
-  }
-```
-
-</TabItem>
-  <TabItem value="Supervisors"> 
-  
   ```json
   {
-  "type": "autocompact",
-  "spec": {
-    "type": "catalog",
-    "dataSource": YOUR_DATASOURCE,
-    "engine": "native",
-    "skipOffsetFromLatest": "PT0H",
-    "taskPriority": 25,
-    "inputSegmentSizeBytes": 100000000000000,
-    "taskContext": null
-  },
-  "suspended": true
-}
-```
+      "type": "catalog",
+      "dataSource": YOUR_DATASOURCE,
+      "engine": "native",
+      "skipOffsetFromLatest": "PT0H",
+      "taskPriority": 25,
+      "inputSegmentSizeBytes": 100000000000000,
+      "taskContext": null
+  }
+  ```
+
+  </TabItem>
+  <TabItem value="Supervisors">
+
+  ```json
+  {
+      "type": "autocompact",
+      "spec": {
+        "type": "catalog",
+        "dataSource": YOUR_DATASOURCE,
+        "engine": "native",
+        "skipOffsetFromLatest": "PT0H",
+        "taskPriority": 25,
+        "inputSegmentSizeBytes": 100000000000000,
+        "taskContext": null
+      },
+      "suspended": true
+  }
+  ```
 
   </TabItem>
 </Tabs>

--- a/docs/querying/query-context-reference.md
+++ b/docs/querying/query-context-reference.md
@@ -34,7 +34,7 @@ This reference contains context parameters organized by their scope:
 To learn how to set the query context, see [Set query context](./query-context.md).
 
 For reference on query context parameters specific to Druid SQL, visit [SQL query context](sql-query-context.md). 
-For context parameters related to SQL-based ingestion, see the [SQL-based ingestion reference](../multi-stage-query/reference/#context-parameters).
+For context parameters related to SQL-based ingestion, see the [SQL-based ingestion reference](../multi-stage-query/reference.md#context-parameters).
 
 
 ## General parameters


### PR DESCRIPTION
Fixes some outdated links and standardizes internal link style.

Also fixes JSON spacing in projections.md that was triggering a Docusaurus error `Unexpected token, expected "}" (225:8)`