### PR TITLE
msq: fix 'occured' -> 'occurred' in ControllerClient Javadoc

### DIFF
--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerClient.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerClient.java
@@ -81,7 +81,7 @@ public interface ControllerClient extends Closeable
   ) throws IOException;
 
   /**
-   * Client side method to inform the controller that the error has occured in the given worker.
+   * Client side method to inform the controller that the error has occurred in the given worker.
    */
   void postWorkerError(MSQErrorReport errorWrapper) throws IOException;
 


### PR DESCRIPTION
Javadoc in `multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerClient.java` line 84 reads `error has occured`. Fixed to `occurred`. Comment-only change.