### PR TITLE
fix: MSQ workers closing each other in tests.

### DIFF
--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestControllerContext.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestControllerContext.java
@@ -470,7 +470,7 @@ public class MSQTestControllerContext implements ControllerContext, DartControll
   @Override
   public WorkerClient newWorkerClient()
   {
-    return new MSQTestWorkerClient(inMemoryWorkers, mapper);
+    return new MSQTestWorkerClient(inMemoryWorkers, mapper, true);
   }
 
   @Override

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestWorkerClient.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestWorkerClient.java
@@ -49,12 +49,18 @@ public class MSQTestWorkerClient implements WorkerClient
 
   protected final Map<String, WorkerRunRef> inMemoryWorkers;
   private final ObjectMapper objectMapper;
+  private final boolean closeWorkersOnClose;
   private final AtomicBoolean closed = new AtomicBoolean();
 
-  public MSQTestWorkerClient(Map<String, WorkerRunRef> inMemoryWorkers, ObjectMapper objectMapper)
+  public MSQTestWorkerClient(
+      Map<String, WorkerRunRef> inMemoryWorkers,
+      ObjectMapper objectMapper,
+      boolean closeWorkersOnClose
+  )
   {
     this.inMemoryWorkers = inMemoryWorkers;
     this.objectMapper = objectMapper;
+    this.closeWorkersOnClose = closeWorkersOnClose;
   }
 
   @Override
@@ -191,7 +197,7 @@ public class MSQTestWorkerClient implements WorkerClient
   @Override
   public void close()
   {
-    if (closed.compareAndSet(false, true)) {
+    if (closed.compareAndSet(false, true) && closeWorkersOnClose) {
       inMemoryWorkers.forEach((k, v) -> v.cancel());
     }
   }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestWorkerContext.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestWorkerContext.java
@@ -161,7 +161,7 @@ public class MSQTestWorkerContext implements WorkerContext
   @Override
   public WorkerClient makeWorkerClient()
   {
-    return new MSQTestWorkerClient(inMemoryWorkers, mapper);
+    return new MSQTestWorkerClient(inMemoryWorkers, mapper, false);
   }
 
   @Override

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/TestDartControllerContextFactoryImpl.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/TestDartControllerContextFactoryImpl.java
@@ -116,7 +116,7 @@ public class TestDartControllerContextFactoryImpl extends DartControllerContextF
 
     public DartTestWorkerClient()
     {
-      super(workerMap, jsonMapper);
+      super(workerMap, jsonMapper, true);
     }
 
     @Override


### PR DESCRIPTION
The MSQTestWorkerClient has logic in close() to cancel any still-running workers. This logic should only run on the controller version of the worker client, not the worker-to-worker client. When it runs on the worker-to-worker client, it can cause spurious test failures.