### PR TITLE
feat: emit identity dimension on router query/time metric

### DIFF
--- a/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -770,12 +770,12 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
         failedQueryCount.incrementAndGet();
       }
 
+      AuthenticationResult authenticationResult = AuthorizationUtils.authenticationResultFromRequest(req);
+
       // As router is simply a proxy, we don't make an effort to construct the error code from the exception ourselves.
       // We rely on broker to set this for us if the error occurs downstream.
       // Otherwise, if there's a router/client error, we log this as an unknown error.
-      emitQueryTime(requestTimeNs, success, sqlQueryId, queryId, statusCode);
-
-      AuthenticationResult authenticationResult = AuthorizationUtils.authenticationResultFromRequest(req);
+      emitQueryTime(requestTimeNs, success, sqlQueryId, queryId, statusCode, authenticationResult);
 
       //noinspection VariableNotUsedInsideIf
       if (sqlQueryId != null) {
@@ -863,8 +863,8 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       // We rely on broker to set this for us if the error occurs downstream. 
       // Otherwise, if there's a router/client error, we log this as an unknown error.
       final int statusCode = determineStatusCode(false, response.getStatus());
-      emitQueryTime(requestTimeNs, false, sqlQueryId, queryId, statusCode);
       AuthenticationResult authenticationResult = AuthorizationUtils.authenticationResultFromRequest(req);
+      emitQueryTime(requestTimeNs, false, sqlQueryId, queryId, statusCode, authenticationResult);
 
       //noinspection VariableNotUsedInsideIf
       if (sqlQueryId != null) {
@@ -940,7 +940,8 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
         boolean success,
         @Nullable String sqlQueryId,
         @Nullable String queryId,
-        int statusCode
+        int statusCode,
+        AuthenticationResult authenticationResult
     )
     {
       QueryMetrics queryMetrics;
@@ -962,6 +963,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       }
       queryMetrics.success(success);
       queryMetrics.statusCode(statusCode);
+      queryMetrics.identity(authenticationResult.getIdentity());
       queryMetrics.reportQueryTime(requestTimeNs).emit(emitter);
     }
   }

--- a/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
+++ b/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
@@ -51,11 +51,14 @@ import org.apache.druid.java.util.common.jackson.JacksonUtils;
 import org.apache.druid.java.util.common.lifecycle.Lifecycle;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;
 import org.apache.druid.query.DefaultGenericQueryMetricsFactory;
+import org.apache.druid.query.DefaultQueryMetrics;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.query.Druids;
+import org.apache.druid.query.GenericQueryMetricsFactory;
 import org.apache.druid.query.MapQueryToolChestWarehouse;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryException;
+import org.apache.druid.query.QueryMetrics;
 import org.apache.druid.query.aggregation.FilteredAggregatorFactory;
 import org.apache.druid.query.aggregation.any.StringAnyAggregatorFactory;
 import org.apache.druid.query.filter.SelectorDimFilter;
@@ -467,6 +470,41 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
     verifyServletCallsForQuery(query, true, false, hostFinder, properties, true);
   }
 
+  /**
+   * A {@link GenericQueryMetricsFactory} that overrides no-op dimensions (e.g. identity) so tests can assert on them.
+   */
+  private static GenericQueryMetricsFactory makeRouterTestOverrideEmittingFactory()
+  {
+    return new GenericQueryMetricsFactory()
+    {
+      private DefaultQueryMetrics makeOverridingMetrics()
+      {
+        return new DefaultQueryMetrics()
+        {
+          @Override
+          public void identity(String identity)
+          {
+            setDimension("identity", identity);
+          }
+        };
+      }
+
+      @Override
+      public QueryMetrics<Query<?>> makeMetrics(Query<?> query)
+      {
+        DefaultQueryMetrics metrics = makeOverridingMetrics();
+        metrics.query(query);
+        return metrics;
+      }
+
+      @Override
+      public QueryMetrics<Query<?>> makeMetrics()
+      {
+        return makeOverridingMetrics();
+      }
+    };
+  }
+
   @Test
   public void testMetricsEmittedWithErrorStatusCodeButNoResultException()
   {
@@ -510,7 +548,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
         null,
         stubServiceEmitter,
         NoopRequestLogger.instance(),
-        new DefaultGenericQueryMetricsFactory(),
+        makeRouterTestOverrideEmittingFactory(),
         new AuthenticatorMapper(ImmutableMap.of()),
         new Properties(),
         new ServerConfig()
@@ -529,6 +567,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
         stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE)
     );
     Assert.assertEquals("false", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("success"));
+    Assert.assertEquals("testUser", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("identity"));
   }
 
   @Test
@@ -581,7 +620,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
         null,
         stubServiceEmitter,
         NoopRequestLogger.instance(),
-        new DefaultGenericQueryMetricsFactory(),
+        makeRouterTestOverrideEmittingFactory(),
         new AuthenticatorMapper(ImmutableMap.of()),
         new Properties(),
         new ServerConfig()
@@ -600,6 +639,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
         stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE)
     );
     Assert.assertEquals("false", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("success"));
+    Assert.assertEquals("testUser", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("identity"));
   }
 
   @Test
@@ -634,7 +674,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
         null,
         stubServiceEmitter,
         NoopRequestLogger.instance(),
-        new DefaultGenericQueryMetricsFactory(),
+        makeRouterTestOverrideEmittingFactory(),
         new AuthenticatorMapper(ImmutableMap.of()),
         new Properties(),
         new ServerConfig()
@@ -654,6 +694,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
         stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE)
     );
     Assert.assertEquals("false", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("success"));
+    Assert.assertEquals("testUser", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("identity"));
   }
 
 


### PR DESCRIPTION
<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

We currently don't emit identity in query metrics on the router. This fixes that.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Emit identity dimension on router query/time metric


<hr>


<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.