### PR TITLE
fix: Console handling for tables without intervals.

### DIFF
--- a/web-console/src/druid-models/stages/stages.ts
+++ b/web-console/src/druid-models/stages/stages.ts
@@ -70,7 +70,7 @@ export type StageInput =
   | {
       type: 'table';
       dataSource: string;
-      intervals: string[];
+      intervals?: string[];
     }
   | {
       type: 'external';

--- a/web-console/src/views/workbench-view/execution-stages-pane/execution-stages-pane.tsx
+++ b/web-console/src/views/workbench-view/execution-stages-pane/execution-stages-pane.tsx
@@ -76,7 +76,7 @@ function summarizeTableInput(tableStageInput: StageInput): string {
   if (tableStageInput.type !== 'table') return '';
   return assemble(
     `Datasource: ${tableStageInput.dataSource}`,
-    `Interval: ${tableStageInput.intervals.join('; ')}`,
+    tableStageInput.intervals && `Interval: ${tableStageInput.intervals.join('; ')}`,
   ).join('\n');
 }
 


### PR DESCRIPTION
Since #19264, the "intervals" field is omitted from table specs when it is ETERNITY (i.e. no time filter). This caused a crash in the web console, which is fixed by this patch.