### PR TITLE
Fix 'occured' -> 'occurred' typos

### DIFF
--- a/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sync/CacheNotifier.java
+++ b/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sync/CacheNotifier.java
@@ -87,7 +87,7 @@ public class CacheNotifier
           return;
         }
         catch (Throwable t) {
-          LOG.makeAlert(t, callerName + ": Error occured while handling updates.").emit();
+          LOG.makeAlert(t, callerName + ": Error occurred while handling updates.").emit();
         }
       }
     });

--- a/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sync/CatalogUpdateReceiver.java
+++ b/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sync/CatalogUpdateReceiver.java
@@ -85,7 +85,7 @@ public class CatalogUpdateReceiver
               LOG.debug("Scheduled catalog refresh is done");
             }
             catch (Throwable t) {
-              LOG.makeAlert(t, "Error occured while refreshing catalog.").emit();
+              LOG.makeAlert(t, "Error occurred while refreshing catalog.").emit();
             }
           }
       );

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerClient.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerClient.java
@@ -81,7 +81,7 @@ public interface ControllerClient extends Closeable
   ) throws IOException;
 
   /**
-   * Client side method to inform the controller that the error has occured in the given worker.
+   * Client side method to inform the controller that the error has occurred in the given worker.
    */
   void postWorkerError(MSQErrorReport errorWrapper) throws IOException;
 


### PR DESCRIPTION
Minor spelling correction across three Java files — `occured` → `occurred`.

Two of the three fixes are in user-visible alert messages emitted from catch blocks:

- `extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sync/CacheNotifier.java` — `"Error occurred while handling updates."`
- `extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sync/CatalogUpdateReceiver.java` — `"Error occurred while refreshing catalog."`

The third is in a Javadoc comment on `ControllerClient.postWorkerError`.

No functional changes.