### PR TITLE
feat: add `restarted` field to supervisor update API response

### DIFF
--- a/docs/api-reference/supervisor-api.md
+++ b/docs/api-reference/supervisor-api.md
@@ -2508,10 +2508,15 @@ curl "http://ROUTER_IP:ROUTER_PORT/druid/indexer/v1/supervisor?skipRestartIfUnmo
 
   ```json
 {
-    "id": "social_media"
+    "id": "social_media",
+    "restarted": true
 }
   ```
 </details>
+
+The response includes the following fields:
+- `id`: The supervisor ID.
+- `restarted`: A boolean indicating whether the supervisor was restarted. When `skipRestartIfUnmodified` is set to `true` and the supervisor spec is unchanged, this field will be `false`; otherwise, it will be `true`.
 
 ### Suspend a running supervisor
 

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/docker/IngestionBackwardCompatibilityDockerTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/docker/IngestionBackwardCompatibilityDockerTest.java
@@ -37,6 +37,8 @@ import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 
+import java.util.Map;
+
 /**
  * Runs some basic ingestion tests using Coordinator and Overlord at version
  * {@link DruidContainer.Image#APACHE_31} and other services at current version
@@ -109,6 +111,13 @@ public class IngestionBackwardCompatibilityDockerTest extends IngestionSmokeTest
     catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  protected void validateSupervisorUpdateResponse(Map<String, String> startSupervisorResult, String supervisorId)
+  {
+    // Older Overlord versions did not include "restarted" in the API response.
+    Assertions.assertEquals(Map.of("id", supervisorId), startSupervisorResult);
   }
 
   @Override

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/IngestionSmokeTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/IngestionSmokeTest.java
@@ -297,7 +297,7 @@ public class IngestionSmokeTest extends EmbeddedClusterTestBase
     final Map<String, String> startSupervisorResult = cluster.callApi().onLeaderOverlord(
         o -> o.postSupervisor(kafkaSupervisorSpec)
     );
-    Assertions.assertEquals(Map.of("id", supervisorId), startSupervisorResult);
+    Assertions.assertEquals(Map.of("id", supervisorId, "restarted", "true"), startSupervisorResult);
 
     waitForSegmentsToBeQueryable(1);
 

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/IngestionSmokeTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/IngestionSmokeTest.java
@@ -297,7 +297,7 @@ public class IngestionSmokeTest extends EmbeddedClusterTestBase
     final Map<String, String> startSupervisorResult = cluster.callApi().onLeaderOverlord(
         o -> o.postSupervisor(kafkaSupervisorSpec)
     );
-    Assertions.assertEquals(Map.of("id", supervisorId, "restarted", "true"), startSupervisorResult);
+    validateSupervisorUpdateResponse(startSupervisorResult, supervisorId);
 
     waitForSegmentsToBeQueryable(1);
 
@@ -415,6 +415,11 @@ public class IngestionSmokeTest extends EmbeddedClusterTestBase
         event -> event.hasMetricName("segment/metadataCache/sync/time")
                       .hasService("druid/broker")
     );
+  }
+
+  protected void validateSupervisorUpdateResponse(Map<String, String> startSupervisorResult, String supervisorId)
+  {
+    Assertions.assertEquals(Map.of("id", supervisorId, "restarted", "true"), startSupervisorResult);
   }
 
   protected void waitForNextCoordinatorCacheSync()

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResource.java
@@ -166,7 +166,7 @@ public class SupervisorResource
           }
 
           if (Boolean.TRUE.equals(skipRestartIfUnmodified) && !manager.shouldUpdateSupervisor(spec)) {
-            return Response.ok(ImmutableMap.of("id", spec.getId())).build();
+            return Response.ok(ImmutableMap.of("id", spec.getId(), "restarted", false)).build();
           }
 
           manager.createOrUpdateAndStartSupervisor(spec);
@@ -183,7 +183,7 @@ public class SupervisorResource
                         .build()
           );
 
-          return Response.ok(ImmutableMap.of("id", spec.getId())).build();
+          return Response.ok(ImmutableMap.of("id", spec.getId(), "restarted", true)).build();
         }
     );
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
@@ -178,7 +178,7 @@ public class SupervisorResourceTest extends EasyMockSupport
     verifyAll();
 
     Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("id", "my-id"), response.getEntity());
+    Assert.assertEquals(ImmutableMap.of("id", "my-id", "restarted", true), response.getEntity());
     resetAll();
 
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.absent());
@@ -248,7 +248,7 @@ public class SupervisorResourceTest extends EasyMockSupport
     verifyAll();
 
     Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("id", "my-id"), response.getEntity());
+    Assert.assertEquals(ImmutableMap.of("id", "my-id", "restarted", false), response.getEntity());
 
     resetAll();
 
@@ -269,7 +269,7 @@ public class SupervisorResourceTest extends EasyMockSupport
     verifyAll();
 
     Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("id", "my-id"), response.getEntity());
+    Assert.assertEquals(ImmutableMap.of("id", "my-id", "restarted", true), response.getEntity());
   }
 
   @Test
@@ -300,7 +300,7 @@ public class SupervisorResourceTest extends EasyMockSupport
     verifyAll();
 
     Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("id", "my-id"), response.getEntity());
+    Assert.assertEquals(ImmutableMap.of("id", "my-id", "restarted", true), response.getEntity());
     resetAll();
 
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.absent());

--- a/server/src/test/java/org/apache/druid/rpc/indexing/OverlordClientImplTest.java
+++ b/server/src/test/java/org/apache/druid/rpc/indexing/OverlordClientImplTest.java
@@ -283,11 +283,11 @@ public class OverlordClientImplTest
             .jsonContent(jsonMapper, supervisorSpec),
         HttpResponseStatus.OK,
         ImmutableMap.of(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON),
-        jsonMapper.writeValueAsBytes(Map.of("id", supervisorId))
+        jsonMapper.writeValueAsBytes(Map.of("id", supervisorId, "restarted", true))
     );
 
     Assert.assertEquals(
-        Map.of("id", supervisorId),
+        Map.of("id", supervisorId, "restarted", true),
         overlordClient.postSupervisor(supervisorSpec).get()
     );
   }

--- a/server/src/test/java/org/apache/druid/rpc/indexing/OverlordClientImplTest.java
+++ b/server/src/test/java/org/apache/druid/rpc/indexing/OverlordClientImplTest.java
@@ -287,7 +287,7 @@ public class OverlordClientImplTest
     );
 
     Assert.assertEquals(
-        Map.of("id", supervisorId, "restarted", true),
+        Map.of("id", supervisorId, "restarted", "true"),
         overlordClient.postSupervisor(supervisorSpec).get()
     );
   }


### PR DESCRIPTION
  ## Summary
  Adds a `restarted` boolean field to the supervisor POST endpoint response to indicate whether the supervisor was actually restarted when `skipRestartIfUnmodified` is set to true.

  When using the `skipRestartIfUnmodified` parameter, callers had no way to determine from the response whether the supervisor was actually restarted or skipped. This should provide feedback to API callers about the supervisor restart status.

### Release note

  Adds a `restarted` boolean field to the supervisor POST endpoint response to indicate whether the supervisor was actually restarted.


This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.