### PR TITLE
fix: Optimizes SpillingGrouper for high cardinality dimension(s) GroupBy with large memory footprint aggregators

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -2253,6 +2253,7 @@ Supported runtime properties:
 |`druid.query.groupBy.maxMergingDictionarySize`|Maximum amount of heap space (approximately) to use for per-query string dictionaries. When the dictionary exceeds this size, a spill to disk will be triggered. See [groupBy memory tuning and resource limits](../querying/groupbyquery.md#memory-tuning-and-resource-limits) for details.|100000000|
 |`druid.query.groupBy.maxOnDiskStorage`|Maximum amount of disk space to use, per-query, for spilling result sets to disk when either the merging buffer or the dictionary fills up. Queries that exceed this limit will fail. Set to zero to disable disk spilling.|0 (disabled)|
 |`druid.query.groupBy.maxSpillFileCount`|Maximum number of spill files allowed per GroupBy query. Queries that exceed this limit will fail. See [groupBy memory tuning and resource limits](../querying/groupbyquery.md#memory-tuning-and-resource-limits) for details.|Integer.MAX_VALUE (unlimited)|
+|`druid.query.groupBy.minSpillFileSize`|Minimum number of bytes that must accumulate across pending in-memory spill runs before they are flushed as a single file to disk. Smaller spills are batched in heap memory to avoid creating many tiny files. Higher values reduce file count but increase heap usage.|1048576 (1 MiB)|
 |`druid.query.groupBy.defaultOnDiskStorage`|Default amount of disk space to use, per-query, for spilling the result sets to disk when either the merging buffer or the dictionary fills up. Set to zero to disable disk spilling for queries which don't override `maxOnDiskStorage` in their context.|`druid.query.groupBy.maxOnDiskStorage`|
 
 Supported query contexts:
@@ -2263,6 +2264,7 @@ Supported query contexts:
 |`maxMergingDictionarySize`|Can be used to lower the value of `druid.query.groupBy.maxMergingDictionarySize` for this query.|
 |`maxOnDiskStorage`|Can be used to set `maxOnDiskStorage` to a value between 0 and `druid.query.groupBy.maxOnDiskStorage` for this query. If this query context override exceeds `druid.query.groupBy.maxOnDiskStorage`, the query will use `druid.query.groupBy.maxOnDiskStorage`. Omitting this from the query context will cause the query to use `druid.query.groupBy.defaultOnDiskStorage` for `maxOnDiskStorage`|
 |`maxSpillFileCount`|Can be used to override the value of `druid.query.groupBy.maxSpillFileCount` for this query.|
+|`minSpillFileSize`|Can be used to override the value of `druid.query.groupBy.minSpillFileSize` for this query.|
 
 ### Advanced configurations
 

--- a/docs/querying/groupbyquery.md
+++ b/docs/querying/groupbyquery.md
@@ -358,6 +358,7 @@ Supported runtime properties:
 |`druid.query.groupBy.maxMergingDictionarySize`|Maximum amount of heap space (approximately) to use for per-query string dictionaries. When the dictionary exceeds this size, a spill to disk will be triggered. If set to `0` (automatic), each query's dictionary uses 30% of the Java heap divided by `druid.processing.numMergeBuffers`, or 1GB, whichever is smaller.<br /><br />See [Memory tuning and resource limits](#memory-tuning-and-resource-limits) for details on changing this property.|0 (automatic)|
 |`druid.query.groupBy.maxOnDiskStorage`|Maximum amount of disk space to use, per-query, for spilling result sets to disk when either the merging buffer or the dictionary fills up. Queries that exceed this limit will fail. Set to zero to disable disk spilling.|0 (disabled)|
 |`druid.query.groupBy.maxSpillFileCount`|Maximum number of spill files allowed per GroupBy query. Queries that exceed this limit will fail.<br /><br />See [Memory tuning and resource limits](#memory-tuning-and-resource-limits) for details on changing this property.|Integer.MAX_VALUE (unlimited)|
+|`druid.query.groupBy.minSpillFileSize`|Minimum number of bytes that must accumulate across pending in-memory spill runs before they are flushed as a single file to disk. Smaller spills are batched in heap memory to avoid creating many tiny files. Higher values reduce file count but increase heap usage.|1048576 (1 MiB)|
 
 Supported query contexts:
 
@@ -365,6 +366,7 @@ Supported query contexts:
 |---|-----------|
 |`maxOnDiskStorage`|Can be used to lower the value of `druid.query.groupBy.maxOnDiskStorage` for this query.|
 |`maxSpillFileCount`|Can be used to override the value of `druid.query.groupBy.maxSpillFileCount` for this query.|
+|`minSpillFileSize`|Can be used to override the value of `druid.query.groupBy.minSpillFileSize` for this query.|
 
 ### Advanced configurations
 

--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryConfig.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryConfig.java
@@ -54,6 +54,7 @@ public class GroupByQueryConfig
   private static final String CTX_KEY_MAX_SELECTOR_DICTIONARY_SIZE = "maxSelectorDictionarySize";
   private static final String CTX_KEY_MAX_MERGING_DICTIONARY_SIZE = "maxMergingDictionarySize";
   private static final String CTX_KEY_MAX_SPILL_FILE_COUNT = "maxSpillFileCount";
+  private static final String CTX_KEY_MIN_SPILL_FILE_SIZE = "minSpillFileSize";
   private static final String CTX_KEY_FORCE_HASH_AGGREGATION = "forceHashAggregation";
   private static final String CTX_KEY_INTERMEDIATE_COMBINE_DEGREE = "intermediateCombineDegree";
   private static final String CTX_KEY_NUM_PARALLEL_COMBINE_THREADS = "numParallelCombineThreads";
@@ -103,6 +104,9 @@ public class GroupByQueryConfig
   @JsonProperty
   // Max on-disk temporary storage, per-query; when exceeded, the query fails
   private HumanReadableBytes maxOnDiskStorage = HumanReadableBytes.valueOf(0);
+
+  @JsonProperty
+  private HumanReadableBytes minSpillFileSize = HumanReadableBytes.valueOf(1024 * 1024L);
 
   @JsonProperty
   private HumanReadableBytes defaultOnDiskStorage = HumanReadableBytes.valueOf(-1);
@@ -251,6 +255,11 @@ public class GroupByQueryConfig
     return maxSpillFileCount;
   }
 
+  public long getMinSpillFileSize()
+  {
+    return minSpillFileSize.getBytes();
+  }
+
   /**
    * Mirror maxOnDiskStorage if defaultOnDiskStorage's default is not overridden by cluster operator.
    *
@@ -357,6 +366,11 @@ public class GroupByQueryConfig
         getMaxSpillFileCount()
     );
 
+    newConfig.minSpillFileSize = queryContext.getHumanReadableBytes(
+        CTX_KEY_MIN_SPILL_FILE_SIZE,
+        getMinSpillFileSize()
+    );
+
     newConfig.forcePushDownLimit = queryContext.getBoolean(CTX_KEY_FORCE_LIMIT_PUSH_DOWN, isForcePushDownLimit());
     newConfig.applyLimitPushDownToSegment = queryContext.getBoolean(
         CTX_KEY_APPLY_LIMIT_PUSH_DOWN_TO_SEGMENT,
@@ -400,6 +414,7 @@ public class GroupByQueryConfig
            ", bufferGrouperInitialBuckets=" + bufferGrouperInitialBuckets +
            ", maxMergingDictionarySize=" + maxMergingDictionarySize +
            ", maxOnDiskStorage=" + maxOnDiskStorage.getBytes() +
+           ", minSpillFileSize=" + minSpillFileSize.getBytes() +
            ", defaultOnDiskStorage=" + getDefaultOnDiskStorage().getBytes() + // use the getter because of special behavior for mirroring maxOnDiskStorage if defaultOnDiskStorage not explicitly set.
            ", forcePushDownLimit=" + forcePushDownLimit +
            ", forceHashAggregation=" + forceHashAggregation +

--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryConfig.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryConfig.java
@@ -106,6 +106,13 @@ public class GroupByQueryConfig
   private HumanReadableBytes maxOnDiskStorage = HumanReadableBytes.valueOf(0);
 
   @JsonProperty
+  // Minimum number of serialized bytes that must accumulate across pending in-memory spill runs before they are
+  // flushed as a single file to disk. Aggregators like ThetaSketch pre-allocate a large fixed buffer per row
+  // (e.g. ~131KB for ThetaSketch(K=16384)), causing the in-memory grouper to flush frequently. However, when
+  // each key has been seen only a few times, the sketch serializes to just a handful of bytes in compact form.
+  // Without batching, this produces thousands of tiny spill files. By accumulating runs in heap memory first
+  // and writing to disk only once this threshold is reached, we avoid that explosion in file count without any
+  // extra disk I/O for small spills.
   private HumanReadableBytes minSpillFileSize = HumanReadableBytes.valueOf(1024 * 1024L);
 
   @JsonProperty

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/ConcurrentGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/ConcurrentGrouper.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -452,7 +453,9 @@ public class ConcurrentGrouper<KeyType> implements Grouper<KeyType>
     }
     catch (ExecutionException e) {
       GuavaUtils.cancelAll(true, future, futures);
-      throw new RuntimeException(e.getCause());
+      Throwable cause = e.getCause();
+      Throwables.throwIfUnchecked(cause);
+      throw new RuntimeException(cause);
     }
   }
 

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/ConcurrentGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/ConcurrentGrouper.java
@@ -96,6 +96,7 @@ public class ConcurrentGrouper<KeyType> implements Grouper<KeyType>
   @Nullable
   private final ParallelCombiner<KeyType> parallelCombiner;
   private final boolean mergeThreadLocal;
+  private final long minSpillFileSize;
   private final GroupByStatsProvider.PerQueryStats perQueryStats;
 
   private volatile boolean initialized = false;
@@ -142,6 +143,7 @@ public class ConcurrentGrouper<KeyType> implements Grouper<KeyType>
         groupByQueryConfig.getIntermediateCombineDegree(),
         groupByQueryConfig.getNumParallelCombineThreads(),
         groupByQueryConfig.isMergeThreadLocal(),
+        groupByQueryConfig.getMinSpillFileSize(),
         perQueryStats
     );
   }
@@ -168,6 +170,7 @@ public class ConcurrentGrouper<KeyType> implements Grouper<KeyType>
       final int intermediateCombineDegree,
       final int numParallelCombineThreads,
       final boolean mergeThreadLocal,
+      final long minSpillFileSize,
       final GroupByStatsProvider.PerQueryStats perQueryStats
   )
   {
@@ -218,6 +221,7 @@ public class ConcurrentGrouper<KeyType> implements Grouper<KeyType>
     }
 
     this.mergeThreadLocal = mergeThreadLocal;
+    this.minSpillFileSize = minSpillFileSize;
     this.perQueryStats = perQueryStats;
   }
 
@@ -246,6 +250,7 @@ public class ConcurrentGrouper<KeyType> implements Grouper<KeyType>
                 limitSpec,
                 sortHasNonGroupingFields,
                 sliceSize,
+                minSpillFileSize,
                 perQueryStats
             );
             grouper.init();

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedTemporaryStorage.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedTemporaryStorage.java
@@ -56,6 +56,7 @@ public class LimitedTemporaryStorage implements Closeable
 
   private final AtomicLong bytesUsed = new AtomicLong();
   private final Set<File> files = new TreeSet<>();
+  private int nextFileIndex = 0;
 
   private volatile boolean closed = false;
 
@@ -105,7 +106,7 @@ public class LimitedTemporaryStorage implements Closeable
         createdStorageDirectory = true;
       }
 
-      final File theFile = new File(storageDirectory, StringUtils.format("%08d.tmp", files.size()));
+      final File theFile = new File(storageDirectory, StringUtils.format("%08d.tmp", nextFileIndex++));
       final EnumSet<StandardOpenOption> openOptions = EnumSet.of(
           StandardOpenOption.CREATE_NEW,
           StandardOpenOption.WRITE

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedTemporaryStorage.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedTemporaryStorage.java
@@ -125,12 +125,12 @@ public class LimitedTemporaryStorage implements Closeable
         final long fileSize = file.length();
         try {
           Files.delete(file.toPath());
+          bytesUsed.addAndGet(-fileSize);
         }
         catch (IOException e) {
           log.warn(e, "Cannot delete file: %s", file);
         }
         files.remove(file);
-        bytesUsed.addAndGet(-fileSize);
       }
     }
   }

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedTemporaryStorage.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedTemporaryStorage.java
@@ -122,6 +122,7 @@ public class LimitedTemporaryStorage implements Closeable
   {
     synchronized (files) {
       if (files.contains(file)) {
+        final long fileSize = file.length();
         try {
           Files.delete(file.toPath());
         }
@@ -129,6 +130,7 @@ public class LimitedTemporaryStorage implements Closeable
           log.warn(e, "Cannot delete file: %s", file);
         }
         files.remove(file);
+        bytesUsed.addAndGet(-fileSize);
       }
     }
   }

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedTemporaryStorage.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedTemporaryStorage.java
@@ -146,6 +146,14 @@ public class LimitedTemporaryStorage implements Closeable
     return bytesUsed.get();
   }
 
+  @VisibleForTesting
+  public int currentFileCount()
+  {
+    synchronized (files) {
+      return files.size();
+    }
+  }
+
   @Override
   public void close()
   {

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedTemporaryStorage.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedTemporaryStorage.java
@@ -163,8 +163,6 @@ public class LimitedTemporaryStorage implements Closeable
       }
       closed = true;
 
-      perQueryStatsContainer.spilledBytes(bytesUsed.get());
-
       bytesUsed.set(0);
 
       for (File file : ImmutableSet.copyOf(files)) {

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -282,6 +282,7 @@ public class RowBasedGrouperHelper
           limitSpec,
           sortHasNonGroupingFields,
           mergeBufferSize,
+          querySpecificConfig.getMinSpillFileSize(),
           perQueryStats
       );
     } else {

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouper.java
@@ -490,5 +490,9 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
       temporaryStorage.delete(file);
     }
     files.clear();
+    for (final File file : dictionaryFiles) {
+      temporaryStorage.delete(file);
+    }
+    dictionaryFiles.clear();
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouper.java
@@ -35,12 +35,14 @@ import org.apache.druid.java.util.common.jackson.JacksonUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.query.BaseQuery;
+import org.apache.druid.query.ResourceLimitExceededException;
 import org.apache.druid.query.aggregation.AggregatorAdapters;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.groupby.GroupByStatsProvider;
 import org.apache.druid.query.groupby.orderby.DefaultLimitSpec;
 import org.apache.druid.segment.ColumnSelectorFactory;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -72,6 +74,17 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
       "Maximum number of spill files reached for this query. Try raising druid.query.groupBy.maxSpillFileCount."
   );
 
+  /**
+   * Minimum number of serialized bytes that must accumulate across pending in-memory spill runs before they are
+   * flushed as a single file to disk. Aggregators like ThetaSketch pre-allocate a large fixed buffer per row
+   * (e.g. ~131KB for ThetaSketch(K=16384)), causing the in-memory grouper to flush frequently. However, when
+   * each key has been seen only a few times, the sketch serializes to just a handful of bytes in compact form.
+   * Without batching, this produces thousands of tiny spill files. By accumulating runs in heap memory first
+   * and writing to disk only once this threshold is reached, we avoid that explosion in file count without any
+   * extra disk I/O for small spills.
+   */
+  private static final long MIN_SPILL_FILE_BYTES = 1024 * 1024L; // 1MB
+
   private final AbstractBufferHashGrouper<KeyType> grouper;
   private final KeySerde<KeyType> keySerde;
   private final LimitedTemporaryStorage temporaryStorage;
@@ -84,6 +97,14 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
   private final List<File> files = new ArrayList<>();
   private final List<File> dictionaryFiles = new ArrayList<>();
   private final boolean sortHasNonGroupingFields;
+
+  // Pending spill runs not yet written to disk. Each entry is one buffer flush serialized as a
+  // LZ4-compressed JSON byte array — the same format as an on-disk spill file, so it can be
+  // re-read with the same read() path. Runs are held in heap memory and merged into a single
+  // sorted file only when pendingSpillBytes reaches MIN_SPILL_FILE_BYTES.
+  private final List<byte[]> pendingSpillRuns = new ArrayList<>();
+  private final Set<String> pendingDictionaryEntries = new HashSet<>();
+  private long pendingSpillBytes = 0;
 
   private boolean diskFull = false;
   private boolean maxFileCount = false;
@@ -225,6 +246,9 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
   public void reset()
   {
     grouper.reset();
+    pendingSpillRuns.clear();
+    pendingSpillBytes = 0;
+    pendingDictionaryEntries.clear();
     deleteFiles();
   }
 
@@ -235,6 +259,9 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
     perQueryStats.maxMergeBufferUsedBytes(getMaxMergeBufferUsedBytes());
     grouper.close();
     keySerde.reset();
+    pendingSpillRuns.clear();
+    pendingSpillBytes = 0;
+    pendingDictionaryEntries.clear();
     deleteFiles();
   }
 
@@ -293,6 +320,22 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
   @Override
   public CloseableIterator<Entry<KeyType>> iterator(final boolean sorted)
   {
+    // Flush any runs that did not reach MIN_SPILL_FILE_BYTES during the spill phase.
+    try {
+      flushPendingRunsToDisk();
+    }
+    catch (TemporaryStorageFullException e) {
+      diskFull = true;
+      throw new ResourceLimitExceededException(DISK_FULL.getReason());
+    }
+    catch (TemporaryStorageFileLimitException e) {
+      maxFileCount = true;
+      throw new ResourceLimitExceededException(MAX_FILE.getReason());
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
     final List<CloseableIterator<Entry<KeyType>>> iterators = new ArrayList<>(1 + files.size());
 
     iterators.add(grouper.iterator(sorted));
@@ -301,33 +344,7 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
     for (final File file : files) {
       final MappingIterator<Entry<KeyType>> fileIterator = read(file, keySerde.keyClazz());
 
-      iterators.add(
-          CloseableIterators.withEmptyBaggage(
-              Iterators.transform(
-                  fileIterator,
-                  new Function<>()
-                  {
-                    final ReusableEntry<KeyType> reusableEntry =
-                        ReusableEntry.create(keySerde, aggregatorFactories.length);
-
-                    @Override
-                    public Entry<KeyType> apply(Entry<KeyType> entry)
-                    {
-                      final Object[] deserializedValues = reusableEntry.getValues();
-                      for (int i = 0; i < deserializedValues.length; i++) {
-                        deserializedValues[i] = aggregatorFactories[i].deserialize(entry.getValues()[i]);
-                        if (deserializedValues[i] instanceof Integer) {
-                          // Hack to satisfy the groupBy unit tests; perhaps we could do better by adjusting Jackson config.
-                          deserializedValues[i] = ((Integer) deserializedValues[i]).longValue();
-                        }
-                      }
-                      reusableEntry.setKey(entry.getKey());
-                      return reusableEntry;
-                    }
-                  }
-              )
-          )
-      );
+      iterators.add(deserializeIterator(fileIterator));
       closer.register(fileIterator);
     }
 
@@ -345,12 +362,103 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
 
   private void spill() throws IOException
   {
+    // Stream directly to a temp file first, then check the file size. If the file is small
+    // (serialized size much smaller than the pre-allocated buffer, e.g. HLL sketches in List mode),
+    // read it back into memory for batching to avoid creating thousands of tiny disk files.
+    // If the file is already large enough, keep it on disk as-is.
+    final File file;
     try (CloseableIterator<Entry<KeyType>> iterator = grouper.iterator(true)) {
-      files.add(spill(iterator));
-      dictionaryFiles.add(spill(keySerde.getDictionary().iterator()));
-
-      grouper.reset();
+      file = spill(iterator);
     }
+    pendingDictionaryEntries.addAll(keySerde.getDictionary());
+    grouper.reset();
+
+    final long fileSize = file.length();
+    if (fileSize < MIN_SPILL_FILE_BYTES) {
+      pendingSpillRuns.add(Files.readAllBytes(file.toPath()));
+      pendingSpillBytes += fileSize;
+      temporaryStorage.delete(file);
+
+      if (pendingSpillBytes >= MIN_SPILL_FILE_BYTES) {
+        flushPendingRunsToDisk();
+      }
+    } else {
+      files.add(file);
+      dictionaryFiles.add(spill(pendingDictionaryEntries.iterator()));
+      pendingDictionaryEntries.clear();
+    }
+  }
+
+  /**
+   * Merge-sorts all pending in-memory spill runs and writes them as a single sorted file to disk.
+   * Each run is already individually sorted (from grouper.iterator(true)); this method merges them
+   * so the output file is fully sorted, as required by iterator()'s mergeSorted across files.
+   */
+  private void flushPendingRunsToDisk() throws IOException
+  {
+    if (pendingSpillRuns.isEmpty()) {
+      return;
+    }
+
+    final Comparator<Entry<KeyType>> sortComparator =
+        sortHasNonGroupingFields ? defaultOrderKeyObjComparator : keyObjComparator;
+
+    final List<MappingIterator<Entry<KeyType>>> readers = new ArrayList<>(pendingSpillRuns.size());
+    try {
+      for (final byte[] runBytes : pendingSpillRuns) {
+        readers.add(spillMapper.readValues(
+            spillMapper.getFactory().createParser(new LZ4BlockInputStream(new ByteArrayInputStream(runBytes))),
+            spillMapper.getTypeFactory().constructParametricType(ReusableEntry.class, keySerde.keyClazz())
+        ));
+      }
+      final List<CloseableIterator<Entry<KeyType>>> iterators = new ArrayList<>(readers.size());
+      for (final MappingIterator<Entry<KeyType>> reader : readers) {
+        iterators.add(deserializeIterator(reader));
+      }
+      files.add(spill(CloseableIterators.mergeSorted(iterators, sortComparator)));
+      dictionaryFiles.add(spill(pendingDictionaryEntries.iterator()));
+    }
+    finally {
+      for (final MappingIterator<Entry<KeyType>> reader : readers) {
+        try {
+          reader.close();
+        }
+        catch (IOException e) {
+          log.warn(e, "Failed to close reader while flushing pending spill runs");
+        }
+      }
+      pendingSpillRuns.clear();
+      pendingSpillBytes = 0;
+      pendingDictionaryEntries.clear();
+    }
+  }
+
+  private CloseableIterator<Entry<KeyType>> deserializeIterator(final Iterator<Entry<KeyType>> iterator)
+  {
+    return CloseableIterators.withEmptyBaggage(
+        Iterators.transform(
+            iterator,
+            new Function<>()
+            {
+              final ReusableEntry<KeyType> reusableEntry =
+                  ReusableEntry.create(keySerde, aggregatorFactories.length);
+
+              @Override
+              public Entry<KeyType> apply(Entry<KeyType> entry)
+              {
+                final Object[] deserializedValues = reusableEntry.getValues();
+                for (int i = 0; i < deserializedValues.length; i++) {
+                  deserializedValues[i] = aggregatorFactories[i].deserialize(entry.getValues()[i]);
+                  if (deserializedValues[i] instanceof Integer) {
+                    deserializedValues[i] = ((Integer) deserializedValues[i]).longValue();
+                  }
+                }
+                reusableEntry.setKey(entry.getKey());
+                return reusableEntry;
+              }
+            }
+        )
+    );
   }
 
   private <T> File spill(Iterator<T> iterator) throws IOException

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouper.java
@@ -309,6 +309,17 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
     this.spillingAllowed = spillingAllowed;
   }
 
+  /**
+   * Returns an iterator over all grouped entries, merging results from the in-memory grouper and
+   * any spill files on disk. When sorted is true, uses a merge-sorted iterator across all sources;
+   * when false, simply concatenates them.
+   *
+   * <p>In practice, sorted is always true. {@link RowBasedGrouperHelper} hardcodes
+   * {@code grouper.iterator(true)} because the merge layer above — CombiningIterator in
+   * {@link ConcurrentGrouper} and the broker merge — detects duplicate keys by comparing
+   * consecutive sorted entries. So sorted=true is required for merge correctness, not output
+   * ordering. The sorted=false path exists but is unreachable through any production query path.
+   */
   @Override
   public CloseableIterator<Entry<KeyType>> iterator(final boolean sorted)
   {
@@ -385,6 +396,16 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
    * Merge-sorts all pending in-memory spill runs and writes them as a single sorted file to disk.
    * Each run is already individually sorted (from grouper.iterator(true)); this method merges them
    * so the output file is fully sorted, as required by iterator()'s mergeSorted across files.
+   * <p>
+   * We always merge-sort rather than concatenating runs (regardless of sorted / sortHasNonGroupingFields flags).
+   * The processing cost is dominated by JSON deserialization and re-serialization; the merge-sort comparison itself
+   * is O(N log K) key comparisons and negligible relative to the serde overhead, so concatenation would save little.
+   * <p>
+   * An alternative approach of writing each pending run's raw byte[] sequentially into one file
+   * (avoiding serde entirely) was rejected because at read time each sub-stream would require its own
+   * LZ4BlockInputStream with an internal buffer. With large amount of small spills we can end up with large number of
+   * sub-streams, each with its own buffer, which can lead to OOM. By merging runs together, we ensure that the number
+   * of spill files (and thus sub-streams) is small regardless of spill pattern.
    */
   private void flushPendingRunsToDisk() throws IOException
   {

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouper.java
@@ -74,17 +74,6 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
       "Maximum number of spill files reached for this query. Try raising druid.query.groupBy.maxSpillFileCount."
   );
 
-  /**
-   * Minimum number of serialized bytes that must accumulate across pending in-memory spill runs before they are
-   * flushed as a single file to disk. Aggregators like ThetaSketch pre-allocate a large fixed buffer per row
-   * (e.g. ~131KB for ThetaSketch(K=16384)), causing the in-memory grouper to flush frequently. However, when
-   * each key has been seen only a few times, the sketch serializes to just a handful of bytes in compact form.
-   * Without batching, this produces thousands of tiny spill files. By accumulating runs in heap memory first
-   * and writing to disk only once this threshold is reached, we avoid that explosion in file count without any
-   * extra disk I/O for small spills.
-   */
-  private static final long MIN_SPILL_FILE_BYTES = 1024 * 1024L; // 1MB
-
   private final AbstractBufferHashGrouper<KeyType> grouper;
   private final KeySerde<KeyType> keySerde;
   private final LimitedTemporaryStorage temporaryStorage;
@@ -93,6 +82,7 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
   private final Comparator<Grouper.Entry<KeyType>> keyObjComparator;
   private final Comparator<Grouper.Entry<KeyType>> defaultOrderKeyObjComparator;
   private final GroupByStatsProvider.PerQueryStats perQueryStats;
+  private final long minSpillFileSize;
 
   private final List<File> files = new ArrayList<>();
   private final List<File> dictionaryFiles = new ArrayList<>();
@@ -101,7 +91,7 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
   // Pending spill runs not yet written to disk. Each entry is one buffer flush serialized as a
   // LZ4-compressed JSON byte array — the same format as an on-disk spill file, so it can be
   // re-read with the same read() path. Runs are held in heap memory and merged into a single
-  // sorted file only when pendingSpillBytes reaches MIN_SPILL_FILE_BYTES.
+  // sorted file only when pendingSpillBytes reaches minSpillFileSize.
   private final List<byte[]> pendingSpillRuns = new ArrayList<>();
   private final Set<String> pendingDictionaryEntries = new HashSet<>();
   private long pendingSpillBytes = 0;
@@ -124,6 +114,7 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
       final DefaultLimitSpec limitSpec,
       final boolean sortHasNonGroupingFields,
       final int mergeBufferSize,
+      final long minSpillFileSize,
       final GroupByStatsProvider.PerQueryStats perQueryStats
   )
   {
@@ -184,6 +175,7 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
     this.spillMapper = keySerde.decorateObjectMapper(spillMapper);
     this.spillingAllowed = spillingAllowed;
     this.sortHasNonGroupingFields = sortHasNonGroupingFields;
+    this.minSpillFileSize = minSpillFileSize;
     this.perQueryStats = perQueryStats;
   }
 
@@ -320,7 +312,7 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
   @Override
   public CloseableIterator<Entry<KeyType>> iterator(final boolean sorted)
   {
-    // Flush any runs that did not reach MIN_SPILL_FILE_BYTES during the spill phase.
+    // Flush any runs that did not reach minSpillFileSize during the spill phase.
     try {
       flushPendingRunsToDisk();
     }
@@ -374,12 +366,12 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
     grouper.reset();
 
     final long fileSize = file.length();
-    if (fileSize < MIN_SPILL_FILE_BYTES) {
+    if (fileSize < minSpillFileSize) {
       pendingSpillRuns.add(Files.readAllBytes(file.toPath()));
       pendingSpillBytes += fileSize;
       temporaryStorage.delete(file);
 
-      if (pendingSpillBytes >= MIN_SPILL_FILE_BYTES) {
+      if (pendingSpillBytes >= minSpillFileSize) {
         flushPendingRunsToDisk();
       }
     } else {

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouper.java
@@ -249,6 +249,15 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
   {
     perQueryStats.dictionarySize(getDictionarySizeEstimate());
     perQueryStats.maxMergeBufferUsedBytes(getMaxMergeBufferUsedBytes());
+    // Record spilled bytes before deleteFiles() decrements bytesUsed in temporaryStorage.
+    long spilledBytes = 0;
+    for (final File file : files) {
+      spilledBytes += file.length();
+    }
+    for (final File file : dictionaryFiles) {
+      spilledBytes += file.length();
+    }
+    perQueryStats.spilledBytes(spilledBytes);
     grouper.close();
     keySerde.reset();
     pendingSpillRuns.clear();

--- a/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/ConcurrentGrouperTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/ConcurrentGrouperTest.java
@@ -179,6 +179,7 @@ public class ConcurrentGrouperTest extends InitializedNullHandlingTest
           4,
           parallelCombineThreads,
           mergeThreadLocal,
+          1024 * 1024L,
           perQueryStats
       );
       closer.register(grouper);
@@ -257,6 +258,7 @@ public class ConcurrentGrouperTest extends InitializedNullHandlingTest
           4,
           parallelCombineThreads,
           mergeThreadLocal,
+          1024 * 1024L,
           perQueryStats
       );
       closer.register(grouper);

--- a/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouperTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouperTest.java
@@ -1,0 +1,384 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.groupby.epinephelinae;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.data.input.MapBasedRow;
+import org.apache.druid.java.util.common.parsers.CloseableIterator;
+import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.CountAggregatorFactory;
+import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
+import org.apache.druid.query.groupby.GroupByStatsProvider;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SpillingGrouperTest extends InitializedNullHandlingTest
+{
+  private static final AggregatorFactory[] AGGREGATOR_FACTORIES = new AggregatorFactory[]{
+      new LongSumAggregatorFactory("valueSum", "value"),
+      new CountAggregatorFactory("count")
+  };
+  private static final int KEY_SIZE = new IntKeySerde().keySize();
+  private static final float MAX_LOAD_FACTOR = 0.75f;
+  private static final int INITIAL_BUCKETS = 4;
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void testNoSpilling() throws IOException
+  {
+    final File storageDir = temporaryFolder.newFolder();
+    //  Only 3 keys with a 10,000-byte buffer. Everything fits in memory
+    try (SpillingGrouper<IntKey> grouper = makeGrouper(10000, storageDir, 1024 * 1024, 100)) {
+      for (int i = 0; i < 3; i++) {
+        Assert.assertTrue(grouper.aggregate(new IntKey(i)).isOk());
+      }
+
+      assertResultsCorrect(grouper, 3, 1);
+      Assert.assertEquals(0, storageDir.listFiles().length);
+    }
+  }
+
+  @Test
+  public void testSpillAndIterateSorted() throws IOException
+  {
+    final File storageDir = temporaryFolder.newFolder();
+    final int numKeys = 100;
+    // 100 unique keys force many spills since buffer is only 50 bytes. With iterator(true), results should be sorted ascending by key.
+    try (SpillingGrouper<IntKey> grouper = makeGrouper(50, storageDir, 1024 * 1024, 100)) {
+      for (int i = 0; i < numKeys; i++) {
+        Assert.assertTrue(grouper.aggregate(new IntKey(i)).isOk());
+      }
+
+      try (CloseableIterator<Grouper.Entry<IntKey>> iterator = grouper.iterator(true)) {
+        Assert.assertTrue("spilling should have occurred", storageDir.listFiles().length > 0);
+        int prevKey = -1;
+        int count = 0;
+        while (iterator.hasNext()) {
+          Grouper.Entry<IntKey> entry = iterator.next();
+          Assert.assertTrue(
+              "keys should be sorted ascending",
+              entry.getKey().intValue() > prevKey
+          );
+          prevKey = entry.getKey().intValue();
+          Assert.assertEquals(1L, entry.getValues()[0]);
+          Assert.assertEquals(1L, entry.getValues()[1]);
+          count++;
+        }
+        Assert.assertEquals(numKeys, count);
+      }
+    }
+  }
+
+  @Test
+  public void testSpillAndIterateUnsorted() throws IOException
+  {
+    final File storageDir = temporaryFolder.newFolder();
+    final int numKeys = 100;
+    // 100 unique keys force many spills since buffer is only 50 bytes. With iterator(false), results may be in any order, but all keys should be present with correct values.
+    try (SpillingGrouper<IntKey> grouper = makeGrouper(50, storageDir, 1024 * 1024, 100)) {
+      for (int i = 0; i < numKeys; i++) {
+        Assert.assertTrue(grouper.aggregate(new IntKey(i)).isOk());
+      }
+
+      assertResultsCorrect(grouper, numKeys, 1);
+      Assert.assertTrue("spilling should have occurred", storageDir.listFiles().length > 0);
+    }
+  }
+
+  @Test
+  public void testAggregatesDuplicateKeys() throws IOException
+  {
+    // SpillingGrouper doesn't combine across spills — duplicate keys from different spill files
+    // appear as separate entries in the sorted iterator. Verify that the total aggregate values
+    // per key sum to the expected amount across all entries.
+    final File storageDir = temporaryFolder.newFolder();
+    final int numKeys = 20;
+    final int duplicates = 5;
+    try (SpillingGrouper<IntKey> grouper = makeGrouper(50, storageDir, 1024 * 1024, 100)) {
+      for (int round = 0; round < duplicates; round++) {
+        for (int i = 0; i < numKeys; i++) {
+          Assert.assertTrue(grouper.aggregate(new IntKey(i)).isOk());
+        }
+      }
+
+      int totalEntries = 0;
+      final Map<Integer, Long> totalCounts = new HashMap<>();
+      try (CloseableIterator<Grouper.Entry<IntKey>> iterator = grouper.iterator(true)) {
+        Assert.assertTrue("spilling should have occurred", storageDir.listFiles().length > 0);
+        while (iterator.hasNext()) {
+          Grouper.Entry<IntKey> entry = iterator.next();
+          totalCounts.merge(entry.getKey().intValue(), (Long) entry.getValues()[1], Long::sum);
+          totalEntries++;
+        }
+      }
+      Assert.assertTrue(
+          "duplicate keys should exist across spills, so total entries (" + totalEntries
+          + ") should exceed unique key count (" + numKeys + ")",
+          totalEntries > numKeys
+      );
+      Assert.assertEquals(numKeys, totalCounts.size());
+      for (Map.Entry<Integer, Long> e : totalCounts.entrySet()) {
+        Assert.assertEquals(
+            "total count for key " + e.getKey(),
+            (long) duplicates,
+            (long) e.getValue()
+        );
+      }
+    }
+  }
+
+  @Test
+  public void testSmallSpillsAreBatched() throws IOException
+  {
+    final File storageDir = temporaryFolder.newFolder();
+    final int bufferSize = 50;
+    final int numKeys = 100;
+
+    int maxUsableEntries = computeMaxUsableEntries(bufferSize);
+    Assert.assertEquals(
+        "buffer should hold at most 1 entry, guaranteeing a spill on every key",
+        1,
+        maxUsableEntries
+    );
+
+    try (SpillingGrouper<IntKey> grouper = makeGrouper(bufferSize, storageDir, 1024 * 1024, 100)) {
+      for (int i = 0; i < numKeys; i++) {
+        Assert.assertTrue(grouper.aggregate(new IntKey(i)).isOk());
+      }
+
+      assertResultsCorrect(grouper, numKeys, 1);
+
+      File[] files = storageDir.listFiles();
+      Assert.assertNotNull(files);
+      Assert.assertEquals(
+          "all spills are tiny and should batch into a single data + dictionary file pair",
+          2,
+          files.length
+      );
+    }
+  }
+
+  @Test
+  public void testResetClearsPendingState() throws IOException
+  {
+    try (SpillingGrouper<IntKey> grouper = makeGrouper(50, temporaryFolder.newFolder(), 1024 * 1024, 100)) {
+      for (int i = 0; i < 50; i++) {
+        Assert.assertTrue(grouper.aggregate(new IntKey(i)).isOk());
+      }
+
+      grouper.reset();
+
+      for (int i = 1000; i < 1010; i++) {
+        Assert.assertTrue(grouper.aggregate(new IntKey(i)).isOk());
+      }
+
+      try (CloseableIterator<Grouper.Entry<IntKey>> iterator = grouper.iterator(true)) {
+        int count = 0;
+        while (iterator.hasNext()) {
+          Grouper.Entry<IntKey> entry = iterator.next();
+          Assert.assertTrue(
+              "keys should be >= 1000 after reset",
+              entry.getKey().intValue() >= 1000
+          );
+          count++;
+        }
+        Assert.assertEquals(10, count);
+      }
+    }
+  }
+
+  @Test
+  public void testDiskFull() throws IOException
+  {
+    try (SpillingGrouper<IntKey> grouper = makeGrouper(50, temporaryFolder.newFolder(), 100, 100)) {
+      AggregateResult lastResult = AggregateResult.ok();
+      for (int i = 0; i < 10000 && lastResult.isOk(); i++) {
+        lastResult = grouper.aggregate(new IntKey(i));
+      }
+
+      Assert.assertFalse("should have hit disk full", lastResult.isOk());
+      Assert.assertTrue(
+          "reason should mention disk space",
+          lastResult.getReason().contains("Not enough disk space")
+      );
+    }
+  }
+
+  @Test
+  public void testMaxSpillFileCount() throws IOException
+  {
+    // With batching, small spill files are created and immediately deleted, so the file count
+    // stays low. The limit is hit when flushPendingRunsToDisk() creates the merged data file
+    // (succeeds as file #1) then tries to create the dictionary file (fails because
+    // maxFileCount=1 is already reached). Need enough keys to accumulate >= 1MB of pending bytes.
+    //
+    // Without batching, the file limit would be hit on the 2nd spill — only a handful of keys
+    // would succeed. With batching, thousands of keys are processed before the flush triggers
+    // the limit. We assert keysAggregated > maxUsableEntries * 2 to prove batching was active.
+    final int bufferSize = 50;
+    final int maxUsableEntries = computeMaxUsableEntries(bufferSize);
+    try (SpillingGrouper<IntKey> grouper = makeGrouper(bufferSize, temporaryFolder.newFolder(), 10 * 1024 * 1024, 1)) {
+      AggregateResult lastResult = AggregateResult.ok();
+      int keysAggregated = 0;
+      for (int i = 0; i < 200_000 && lastResult.isOk(); i++) {
+        lastResult = grouper.aggregate(new IntKey(i));
+        if (lastResult.isOk()) {
+          keysAggregated++;
+        }
+      }
+
+      Assert.assertFalse("should have hit max file count", lastResult.isOk());
+      Assert.assertTrue(
+          "reason should mention spill file count",
+          lastResult.getReason().contains("Maximum number of spill files")
+      );
+      Assert.assertTrue(
+          "batching should allow many keys (" + keysAggregated + ") before hitting file limit;"
+          + " without batching only ~" + (maxUsableEntries * 2) + " would succeed",
+          keysAggregated > maxUsableEntries * 2
+      );
+    }
+  }
+
+  private SpillingGrouper<IntKey> makeGrouper(
+      int bufferSize,
+      File storageDir,
+      long maxStorageBytes,
+      int maxFileCount
+  )
+  {
+    final GroupByTestColumnSelectorFactory columnSelectorFactory = GrouperTestUtil.newColumnSelectorFactory();
+    columnSelectorFactory.setRow(new MapBasedRow(0, ImmutableMap.of("value", 1L)));
+
+    final SpillingGrouper<IntKey> grouper = new SpillingGrouper<>(
+        Suppliers.ofInstance(ByteBuffer.allocate(bufferSize)),
+        new IntKeySerdeFactory(),
+        columnSelectorFactory,
+        AGGREGATOR_FACTORIES,
+        Integer.MAX_VALUE,
+        MAX_LOAD_FACTOR,
+        INITIAL_BUCKETS,
+        new LimitedTemporaryStorage(
+            storageDir,
+            maxStorageBytes,
+            maxFileCount,
+            new GroupByStatsProvider.PerQueryStats()
+        ),
+        new ObjectMapper(),
+        true,
+        null,
+        false,
+        bufferSize,
+        new GroupByStatsProvider.PerQueryStats()
+    );
+    grouper.init();
+    return grouper;
+  }
+
+  private void assertResultsCorrect(
+      SpillingGrouper<IntKey> grouper,
+      int expectedKeys,
+      long expectedCountPerKey
+  ) throws IOException
+  {
+    final Map<Integer, Object[]> results = new HashMap<>();
+    try (CloseableIterator<Grouper.Entry<IntKey>> iterator = grouper.iterator(true)) {
+      while (iterator.hasNext()) {
+        Grouper.Entry<IntKey> entry = iterator.next();
+        int key = entry.getKey().intValue();
+        Object[] valuesCopy = new Object[entry.getValues().length];
+        System.arraycopy(entry.getValues(), 0, valuesCopy, 0, valuesCopy.length);
+        Assert.assertNull("duplicate key in results: " + key, results.put(key, valuesCopy));
+      }
+    }
+    Assert.assertEquals(expectedKeys, results.size());
+    for (Map.Entry<Integer, Object[]> e : results.entrySet()) {
+      Assert.assertEquals(
+          "valueSum for key " + e.getKey(),
+          expectedCountPerKey,
+          e.getValue()[0]
+      );
+      Assert.assertEquals(
+          "count for key " + e.getKey(),
+          expectedCountPerKey,
+          e.getValue()[1]
+      );
+    }
+  }
+
+  private static int computeMaxUsableEntries(int bufferSize)
+  {
+    int aggSize = 0;
+    for (AggregatorFactory factory : AGGREGATOR_FACTORIES) {
+      aggSize += factory.getMaxIntermediateSizeWithNulls();
+    }
+    int bucketSizeWithHash = Integer.BYTES + KEY_SIZE + aggSize;
+    int maxBuckets = Math.min(bufferSize / bucketSizeWithHash, INITIAL_BUCKETS);
+    return (int) (maxBuckets * MAX_LOAD_FACTOR);
+  }
+
+  static class IntKeySerdeFactory implements Grouper.KeySerdeFactory<IntKey>
+  {
+    @Override
+    public long getMaxDictionarySize()
+    {
+      return 0;
+    }
+
+    @Override
+    public Grouper.KeySerde<IntKey> factorize()
+    {
+      return new IntKeySerde();
+    }
+
+    @Override
+    public Grouper.KeySerde<IntKey> factorizeWithDictionary(List<String> dictionary)
+    {
+      return factorize();
+    }
+
+    @Override
+    public IntKey copyKey(IntKey key)
+    {
+      return new IntKey(key.intValue());
+    }
+
+    @Override
+    public Comparator<Grouper.Entry<IntKey>> objectComparator(boolean forceDefaultOrder)
+    {
+      return Comparator.comparingInt(o -> o.getKey().intValue());
+    }
+  }
+}

--- a/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouperTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouperTest.java
@@ -301,6 +301,7 @@ public class SpillingGrouperTest extends InitializedNullHandlingTest
         null,
         false,
         bufferSize,
+        1024 * 1024L,
         new GroupByStatsProvider.PerQueryStats()
     );
     grouper.init();

--- a/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouperTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouperTest.java
@@ -222,7 +222,7 @@ public class SpillingGrouperTest extends InitializedNullHandlingTest
   @Test
   public void testDiskFull() throws IOException
   {
-    try (SpillingGrouper<IntKey> grouper = makeGrouper(50, temporaryFolder.newFolder(), 100, 100)) {
+    try (SpillingGrouper<IntKey> grouper = makeGrouper(50, temporaryFolder.newFolder(), 10, 100)) {
       AggregateResult lastResult = AggregateResult.ok();
       for (int i = 0; i < 10000 && lastResult.isOk(); i++) {
         lastResult = grouper.aggregate(new IntKey(i));

--- a/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouperTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouperTest.java
@@ -191,6 +191,73 @@ public class SpillingGrouperTest extends InitializedNullHandlingTest
   }
 
   @Test
+  public void testDiskQuotaReclaimedWhenSmallSpillsDeleted() throws IOException
+  {
+    final File storageDir = temporaryFolder.newFolder();
+    final LimitedTemporaryStorage temporaryStorage =
+        new LimitedTemporaryStorage(storageDir, 1024 * 1024, 100, new GroupByStatsProvider.PerQueryStats());
+    final int bufferSize = 50;
+    final int numKeys = 100;
+
+    int maxUsableEntries = computeMaxUsableEntries(bufferSize);
+    Assert.assertEquals(
+        "buffer should hold at most 1 entry, guaranteeing a spill on every key",
+        1,
+        maxUsableEntries
+    );
+
+    try (SpillingGrouper<IntKey> grouper = makeGrouper(bufferSize, temporaryStorage)) {
+      for (int i = 0; i < numKeys; i++) {
+        Assert.assertTrue(grouper.aggregate(new IntKey(i)).isOk());
+      }
+
+      // Before iterator(): small spills were created and deleted during batching, so the
+      // temporary storage should have reclaimed their bytes. Only the final merged file(s)
+      // from flushPendingRunsToDisk() should remain on disk.
+      long sizeBeforeIterator = temporaryStorage.currentSize();
+      int fileCountBeforeIterator = temporaryStorage.currentFileCount();
+
+      // With a 50-byte buffer and 100 keys, many individual spills occur. Batching deletes
+      // each small temp file immediately, so the file count should be much less than numKeys.
+      Assert.assertTrue(
+          "file count (" + fileCountBeforeIterator + ") should be much less than numKeys (" + numKeys
+          + ") because small spill files are deleted after being read into memory",
+          fileCountBeforeIterator < numKeys
+      );
+
+      // The tracked bytes should reflect only the files still on disk, not the deleted ones.
+      long actualDiskBytes = 0;
+      File[] diskFiles = storageDir.listFiles();
+      Assert.assertNotNull(diskFiles);
+      for (File f : diskFiles) {
+        actualDiskBytes += f.length();
+      }
+      Assert.assertEquals(
+          "tracked bytes should match actual bytes on disk",
+          actualDiskBytes,
+          sizeBeforeIterator
+      );
+
+      // Calling iterator() flushes remaining pending runs; verify results are still correct.
+      assertResultsCorrect(grouper, numKeys, 1);
+
+      // After iterator, check that the final state is also consistent.
+      long sizeAfterIterator = temporaryStorage.currentSize();
+      long actualDiskBytesAfter = 0;
+      File[] diskFilesAfter = storageDir.listFiles();
+      Assert.assertNotNull(diskFilesAfter);
+      for (File f : diskFilesAfter) {
+        actualDiskBytesAfter += f.length();
+      }
+      Assert.assertEquals(
+          "tracked bytes should match actual bytes on disk after iterator",
+          actualDiskBytesAfter,
+          sizeAfterIterator
+      );
+    }
+  }
+
+  @Test
   public void testResetClearsPendingState() throws IOException
   {
     try (SpillingGrouper<IntKey> grouper = makeGrouper(50, temporaryFolder.newFolder(), 1024 * 1024, 100)) {
@@ -279,6 +346,17 @@ public class SpillingGrouperTest extends InitializedNullHandlingTest
       int maxFileCount
   )
   {
+    return makeGrouper(
+        bufferSize,
+        new LimitedTemporaryStorage(storageDir, maxStorageBytes, maxFileCount, new GroupByStatsProvider.PerQueryStats())
+    );
+  }
+
+  private SpillingGrouper<IntKey> makeGrouper(
+      int bufferSize,
+      LimitedTemporaryStorage temporaryStorage
+  )
+  {
     final GroupByTestColumnSelectorFactory columnSelectorFactory = GrouperTestUtil.newColumnSelectorFactory();
     columnSelectorFactory.setRow(new MapBasedRow(0, ImmutableMap.of("value", 1L)));
 
@@ -290,12 +368,7 @@ public class SpillingGrouperTest extends InitializedNullHandlingTest
         Integer.MAX_VALUE,
         MAX_LOAD_FACTOR,
         INITIAL_BUCKETS,
-        new LimitedTemporaryStorage(
-            storageDir,
-            maxStorageBytes,
-            maxFileCount,
-            new GroupByStatsProvider.PerQueryStats()
-        ),
+        temporaryStorage,
         new ObjectMapper(),
         true,
         null,


### PR DESCRIPTION
Optimizes SpillingGrouper for high cardinality dimension(s) GroupBy with large memory footprint aggregators

### Description

tldr; Batch small spill files in SpillingGrouper to reduce file count

**Problem**                                                   
                                                                                                                                                                                                                                                     
When aggregators like HLL sketches (or ThetaSketch) are used in groupBy queries, the BufferHashGrouper pre-allocates a large fixed-size buffer per group slot (e.g. ~64KB per slot for HLL with lgK=16). This causes the in-memory grouper to fill up quickly and spill frequently (as the number of unique grouping the BufferHashGrouper can store in memory is low). However, when each key has only been seen a few times (i.e. high cardinality dimension(s) GroupBy), the sketch serializes to a compact form of just a handful of bytes (HLL in List mode). The result is thousands of tiny spill files on disk — each one only a few KB despite the grouper buffer being full.                                                                                                                                                                                                    
                                                            
Large number of spill files can cause OOM when GroupBy merges spill files by opening all of them simultaneously. We previously prevent this by adding guardrail in https://github.com/apache/druid/pull/19141 which would fail the query. This PR fix the issue and will allow the query to succeed. 
  
**Fix**                                                                                                                                                                                                                                                
                                                            
Instead of writing every grouper flush directly to its own spill file, small flushes (serialized size < 1MB) are batched in heap memory. When the accumulated pending bytes reach the 1MB threshold, all pending runs are merge-sorted and written as a single consolidated file. Large flushes (>= 1MB) bypass batching and go directly to disk as before.
                                                                                                                                                                                                                                                     
The approach avoids holding the full serialized data in heap during the spill by streaming directly to a temp file first, then reading back only small files (< 1MB) into memory for batching. This prevents OOM risk when the serialized size happens to be close to the buffer size.


##### Key changed/added classes in this PR
All changes are in SpillingGrouper.java:                                                                                                                                                                                                           
  
  - spill(): Streams grouper contents to a temp file first. If the file is small (< MIN_SPILL_FILE_BYTES), reads it back into pendingSpillRuns and deletes the temp file. If large, keeps it on disk. Triggers flushPendingRunsToDisk() when accumulated pending bytes reach the threshold.            
  - flushPendingRunsToDisk() (new): Deserializes all pending in-memory runs, merge-sorts them (each run is individually sorted from grouper.iterator(true)), and writes the merged result as a single sorted spill file. Also writes a dictionary file for the accumulated dictionary entries.                                                                                                                                                                                                       
  - deserializeIterator() (new / refactor): Extracted the deserialization transform (deserialize aggregator values, Integer→Long coercion) that was previously inlined in iterator(). Now shared between iterator() and flushPendingRunsToDisk().
  - reset() / close(): Clear pending state (pendingSpillRuns, pendingSpillBytes, pendingDictionaryEntries).                                                                                                                                          
  - iterator(): Calls flushPendingRunsToDisk() before iteration to flush any runs that didn't reach the threshold during the spill phase.                                                                                                            
                                                                                                                                                                                                                                                     
**Memory overhead**                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                     
Peak additional heap usage is bounded by ~2 × MIN_SPILL_FILE_BYTES (2MB): up to 1MB of accumulated pending byte arrays plus one file being read back. The grouper buffer itself is an off-heap direct ByteBuffer and is reset before the read-back.

## Optimizations considered but not pursued                                                                                                                                                                                                        
   
### Combine duplicate keys during flush (`combineByKey`)                                                                                                                                                                                           
                                                            
During `flushPendingRunsToDisk()`, we tried deserializing all pending runs, combining entries with duplicate keys by merging their aggregator values (using `AggregatorFactory.combine()`), then serializing the deduplicated result. The idea was to reduce the output file size and the final merge fan-in.
                                                                                                                                                                                                                                                     
Flame graph analysis showed `combineByKey` itself consumed only 28 CPU samples — negligible overhead. However, **wall-clock time regressed from 180s to 190s** (+5.5%). The cause: even though the CPU cost of `combine()` itself was small, the synchronous deserialize-combine-reserialize pipeline added latency to the processing thread's critical path. The processing thread cannot ingest new rows while flushing, so any additional work during the flush directly extends the stall. In this workload, the keys had low duplication across the small runs, so `combineByKey` eliminated very few entries while paying the full deserialization cost for every entry.                                                             
                                  
### Reducing merge fan-in with cascaded intermediate merges                                                                                                                                                                                        
   
Instead of writing all pending runs as a single merged file, we considered a cascaded merge approach — progressively merging spill files on disk (similar to an external merge sort with bounded fan-in) to keep the final `iterator()` merge across a small number of large files. This was not pursued because the batching approach already achieves the same goal more simply: by accumulating small runs in memory and writing them as one file, the number of files at `iterator()` time is naturally reduced by orders of magnitude (e.g., from ~2,000 to ~dozens). Cascaded disk merges would add I/O amplification (each entry written to disk multiple times) for marginal additional fan-in reduction.                                   
                                                            
## Potential future improvements

### Reducing sketch initialization cost

Flame graph profiling shows that `HllSketchMergeBufferAggregatorHelper.createNewUnion()` accounts for **50.7% of the processing thread's CPU time** — the dominant bottleneck. Every time a new group slot is initialized in the `BufferHashGrouper`, `init()` calls `createNewUnion()` which copies a pre-built empty Union image (~65KB for lgK=16) into the buffer via `initializeEmptyUnion()`, then wraps it with `Union.writableWrap()`. During hash table growth (`adjustTableWhenFull()`), every existing slot is relocated via `relocate()`, which calls `createNewUnion()` again. With frequent spills, the grouper repeatedly fills, spills, resets, and re-initializes — multiplying the init cost.            
                                                            
Possible approaches:                                                                                                                                                                                                                               
   
  1. **Variable-size buffer slots in `BufferHashGrouper`**: Currently, `ByteBufferHashTable` uses fixed-width buckets (`bucketSizeWithHash = HASH_SIZE + keySize + aggregators.spaceNeeded()`), where `spaceNeeded()` is the *maximum* intermediate size. For HLL with lgK=16, this pre-allocates ~65KB per slot even when the sketch is in List mode (few distinct values, only a handful of bytes). If the hash table supported variable-width slots — starting small and growing on demand as sketches transition from List → Set → HLL mode — far more groups would fit in the buffer before spilling. This would dramatically reduce the number of spills and proportionally reduce `createNewUnion()` calls. However, this is a fundamental architectural change to `ByteBufferHashTable`, which relies on fixed-width contiguous buckets for O(1) offset calculation and linear probing.

  2. **Lazy sketch initialization**: Instead of initializing a full Union object when a new bucket is created, defer the expensive `createNewUnion()` call until the first aggregation value is actually merged. For groups that are spilled before receiving many values, this could avoid the full initialization cost entirely. The `BufferAggregator` interface would need to support deferred init — e.g., storing a sentinel in the buffer and lazily initializing on first `aggregate()` call.

## Benchmarks result
Before this PR:
```
Before Change
Benchmark                                                  (initialBuckets)  (numProcessingThreads)  (numSegments)  (queryGranularity)  (rowsPerSegment)  (schemaAndQuery)  (vectorize)  Mode  Cnt       Score       Error  Units
GroupByBenchmark.queryMultiQueryableIndexTTFR                            -1                       4              4                 all            100000           basic.A        force  avgt   15   42116.148 ±  2627.574  us/op
GroupByBenchmark.queryMultiQueryableIndexWithSerde                       -1                       4              4                 all            100000           basic.A        force  avgt   15  103143.571 ± 19105.285  us/op
GroupByBenchmark.queryMultiQueryableIndexWithSpilling                    -1                       4              4                 all            100000           basic.A        force  avgt   15  388720.771 ± 15675.278  us/op
GroupByBenchmark.queryMultiQueryableIndexWithSpillingTTFR                -1                       4              4                 all            100000           basic.A        force  avgt   15   95759.378 ±  1799.533  us/op
GroupByBenchmark.queryMultiQueryableIndexX                               -1                       4              4                 all            100000           basic.A        force  avgt   15   66064.295 ±  8078.106  us/op

New Benchmarks

bufferGrouperMaxSize=100 (spill size ~6 KB)
GroupByBenchmark.queryMultiQueryableIndexWithSmallSpilling                    -1                       4              4                 all            100000           basic.A        force  avgt   15  1422480.170 ± 73222.415  us/op
GroupByBenchmark.queryMultiQueryableIndexWithSmallSpillingTTFR                -1                       4              4                 all            100000           basic.A        force  avgt   15   938728.684 ± 54411.363  us/op

bufferGrouperMaxSize=70000 (spill size ~4 MB)
GroupByBenchmark.queryMultiQueryableIndexWithLargeSpilling                    -1                       4              4                 all           1000000           basic.A        force  avgt   15  5179514.738 ± 79378.483  us/op
GroupByBenchmark.queryMultiQueryableIndexWithLargeSpillingTTFR                -1                       4              4                 all           1000000           basic.A        force  avgt   15  1647320.687 ± 62434.948  us/op
```

After this PR:
```
Benchmark                                                  (initialBuckets)  (numProcessingThreads)  (numSegments)  (queryGranularity)  (rowsPerSegment)  (schemaAndQuery)  (vectorize)  Mode  Cnt       Score       Error  Units
GroupByBenchmark.queryMultiQueryableIndexTTFR                            -1                       4              4                 all            100000           basic.A        force  avgt   15   53740.436 ±  8723.658  us/op
GroupByBenchmark.queryMultiQueryableIndexWithSerde                       -1                       4              4                 all            100000           basic.A        force  avgt   15   99847.941 ±  5631.568  us/op
GroupByBenchmark.queryMultiQueryableIndexWithSpilling                    -1                       4              4                 all            100000           basic.A        force  avgt   15  372782.928 ± 31551.417  us/op
GroupByBenchmark.queryMultiQueryableIndexWithSpillingTTFR                -1                       4              4                 all            100000           basic.A        force  avgt   15  176957.932 ± 24544.399  us/op
GroupByBenchmark.queryMultiQueryableIndexX                               -1                       4              4                 all            100000           basic.A        force  avgt   15   75079.741 ± 23374.447  us/op


New Benchmarks

bufferGrouperMaxSize=100 (spill size ~6 KB)
GroupByBenchmark.queryMultiQueryableIndexWithSmallSpilling                    -1                       4              4                 all            100000           basic.A        force  avgt   15  843467.611 ± 81698.388  us/op
GroupByBenchmark.queryMultiQueryableIndexWithSmallSpillingTTFR                -1                       4              4                 all            100000           basic.A        force  avgt   15  618040.133 ± 64764.729  us/op

bufferGrouperMaxSize=70000 (spill size ~4 MB)
GroupByBenchmark.queryMultiQueryableIndexWithLargeSpilling                    -1                       4              4                 all           1000000           basic.A        force  avgt   15  4997633.779 ± 124961.464  us/op
GroupByBenchmark.queryMultiQueryableIndexWithLargeSpillingTTFR                -1                       4              4                 all           1000000           basic.A        force  avgt   15  2413843.500 ± 856006.565  us/op

```

The existing queryMultiQueryableIndexWithSpilling/queryMultiQueryableIndexWithSpillingTTFR uses bufferGrouperMaxSize=4000 which produce reasonable spills of ~200kb. I have also added new benchmarks with similar idea but producing spill files on extremes ends for size. queryMultiQueryableIndexWithSmallSpilling/queryMultiQueryableIndexWithSmallSpillingTTFR sets bufferGrouperMaxSize=100, producing spill size ~6 KB. This would result in more batching. queryMultiQueryableIndexWithLargeSpilling/queryMultiQueryableIndexWithLargeSpillingTTFR sets bufferGrouperMaxSize=70000, producing spill size ~4 MB. This would skip batching. These new benchmarks are not added to the PR since they are really the same as queryMultiQueryableIndexWithSpilling/queryMultiQueryableIndexWithSpillingTTFR just with different config values.

```
Non-spilling benchmarks (unchanged code path):

  ┌───────────────────────────────────┬────────────┬──────────┬───────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────┐   
  │             Benchmark             │   Before   │  After   │ Delta │                                                  Notes                                                   │
  ├───────────────────────────────────┼────────────┼──────────┼───────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────┤   
  │ queryMultiQueryableIndexX         │ 66,064 ±8K │ 67,746   │ +3%   │ No spilling. Within error bars. Noise.                                                                   │
  │                                   │            │ ±8K      │       │                                                                                                          │
  ├───────────────────────────────────┼────────────┼──────────┼───────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────┤   
  │ queryMultiQueryableIndexWithSerde │ 103,144    │ 87,389   │ -15%  │ No spilling. Looks like an improvement but the "before" had huge error bars (±19K). The "after" run just │   
  │                                   │ ±19K       │ ±2K      │       │  had less variance. Not attributable to the change.                                                      │   
  ├───────────────────────────────────┼────────────┼──────────┼───────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────┤   
  │ queryMultiQueryableIndexTTFR      │ 42,116     │ 41,499   │ -1%   │ No spilling. Identical within error bars.                                                                │
  │                                   │ ±2.6K      │ ±3K      │       │                                                                                                          │   
  └───────────────────────────────────┴────────────┴──────────┴───────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────┘
                                                                                                                                                                                     
  No real change, as expected — these don't hit the spill path.                                                                                                                      
  
  ---                                                                                                                                                                                
  Default spilling (bufferGrouperMaxSize=4000, spill size ~250KB — batching applies):
                                                                                                                                                                                     
  ┌──────────────────┬──────────┬──────────┬───────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
  │    Benchmark     │  Before  │  After   │ Delta │                                                            Notes                                                            │   
  ├──────────────────┼──────────┼──────────┼───────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ WithSpilling     │ 388,721  │ 343,351  │ -12%  │ Improvement. Each spill (~250KB) is under 1MB, so batching kicks in — many small spills are accumulated in memory and       │
  │                  │ ±16K     │ ±56K     │       │ merged into fewer disk files, reducing file I/O. Error bars overlap though, so the magnitude is uncertain.                  │
  ├──────────────────┼──────────┼──────────┼───────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤   
  │                  │          │          │       │ TTFR regression. Before: spill files are written individually during spill(), so they're ready to iterate immediately.      │
  │ WithSpillingTTFR │ 95,759   │ 170,717  │ +78%  │ After: small spills are held in memory, and iterator() calls flushPendingRunsToDisk() to merge-sort and write them before   │   
  │                  │ ±1.8K    │ ±24K     │       │ returning the first row. That extra flush delays the first row. Doesn't affect total query time since GroupBy materializes  │
  │                  │          │          │       │ all rows before returning.                                                                                                  │   
  └──────────────────┴──────────┴──────────┴───────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

  ---
  Small spilling (bufferGrouperMaxSize=100, spill size ~6KB — batching's sweet spot):

  ┌───────────────────────┬─────────────┬───────────┬───────┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
  │       Benchmark       │   Before    │   After   │ Delta │                                                       Notes                                                        │
  ├───────────────────────┼─────────────┼───────────┼───────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ WithSmallSpilling     │ 1,422,480   │ 843,468   │ -41%  │ Large win. Without batching: thousands of tiny ~6KB files created on disk. With batching: accumulated in memory,   │
  │                       │ ±73K        │ ±82K      │       │ merged into a handful of files. Eliminates massive filesystem overhead (open/write/close/seek per file).           │
  ├───────────────────────┼─────────────┼───────────┼───────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤   
  │                       │ 938,729     │ 618,040   │       │ Also faster. Even with the flushPendingRunsToDisk() cost in iterator(), the total work is far less than writing    │
  │ WithSmallSpillingTTFR │ ±54K        │ ±65K      │ -34%  │ thousands of individual files during spill(). The batching saves so much I/O that TTFR improves too despite the    │   
  │                       │             │           │       │ deferred flush.                                                                                                    │
  └───────────────────────┴─────────────┴───────────┴───────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘   
                                                         
  This is the target scenario. Aggregators like ThetaSketch that pre-allocate large buffers but serialize small produce exactly this pattern.                                        
  
  ---                                                                                                                                                                                
  Large spilling (bufferGrouperMaxSize=70000, spill size ~4MB — bypasses batching):

  ┌───────────────────────┬────────────┬────────────┬───────┬───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
  │       Benchmark       │   Before   │   After    │ Delta │                                                       Notes                                                       │
  ├───────────────────────┼────────────┼────────────┼───────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤    
  │ WithLargeSpilling     │ 5,179,515  │ 4,997,634  │ -4%   │ Within error bars. Each spill is ~4MB (>1MB threshold), so it goes directly to disk — the batching path is        │
  │                       │ ±79K       │ ±125K      │       │ skipped entirely. No change expected.                                                                             │    
  ├───────────────────────┼────────────┼────────────┼───────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤    
  │                       │ 1,647,321  │ 2,103,661  │       │ TTFR regression. Large spills bypass batching, but iterator() still calls flushPendingRunsToDisk() (which is a    │
  │ WithLargeSpillingTTFR │ ±62K       │ ±96K       │ +28%  │ no-op since pendingSpillRuns is empty). This shouldn't cause a 28% regression for a no-op call. More likely       │    
  │                       │            │            │       │ benchmark variance — the ±96K error bars are significant. Could also be environmental noise between runs.         │
  └───────────────────────┴────────────┴────────────┴───────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘    
         
```
                                                                                                                                                                                                                                                     
This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.