### PR TITLE
feat: MSQ: Log full stack trace when "debug" is set.

### DIFF
--- a/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/DartControllerContext.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/DartControllerContext.java
@@ -254,4 +254,10 @@ public class DartControllerContext implements ControllerContext
         DEFAULT_TARGET_PARTITIONS_PER_WORKER
     );
   }
+
+  @Override
+  public boolean isDebug()
+  {
+    return context.isDebug();
+  }
 }

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/dart/worker/DartWorkerContext.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/dart/worker/DartWorkerContext.java
@@ -275,6 +275,12 @@ public class DartWorkerContext implements WorkerContext
   }
 
   @Override
+  public boolean isDebug()
+  {
+    return queryContext.isDebug();
+  }
+
+  @Override
   public DruidNode selfNode()
   {
     return selfNode;

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerContext.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerContext.java
@@ -135,4 +135,9 @@ public interface ControllerContext
    * shuffle specs that have {@link ShuffleSpec#isAdjustable()} set to true.
    */
   int targetPartitionsPerWorker();
+
+  /**
+   * Whether the controller should log full stack traces on error.
+   */
+  boolean isDebug();
 }

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -487,11 +487,11 @@ public class ControllerImpl implements Controller
 
       // Log the errors we encountered.
       if (controllerError != null) {
-        log.warn("Controller: %s", MSQTasks.errorReportToLogMessage(controllerError));
+        log.warn("Controller: %s", MSQTasks.errorReportToLogMessage(controllerError, context.isDebug()));
       }
 
       if (workerError != null) {
-        log.warn("Worker: %s", MSQTasks.errorReportToLogMessage(workerError));
+        log.warn("Worker: %s", MSQTasks.errorReportToLogMessage(workerError, context.isDebug()));
       }
     }
     if (queryKernel != null && queryKernel.isSuccess()) {

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/MSQTasks.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/MSQTasks.java
@@ -203,9 +203,10 @@ public class MSQTasks
   }
 
   /**
-   * Returns a string form of a {@link MSQErrorReport} suitable for logging.
+   * Returns a string form of a {@link MSQErrorReport} suitable for logging. When {@code forceFullStackTrace} is true,
+   * the full stack trace is always included (when available), regardless of fault type.
    */
-  static String errorReportToLogMessage(final MSQErrorReport errorReport)
+  static String errorReportToLogMessage(final MSQErrorReport errorReport, final boolean forceFullStackTrace)
   {
     final StringBuilder logMessage = new StringBuilder("Work failed");
 
@@ -222,7 +223,7 @@ public class MSQTasks
     logMessage.append(": ").append(MSQFaultUtils.generateMessageWithErrorCode(errorReport.getFault()));
 
     if (errorReport.getExceptionStackTrace() != null) {
-      if (logFullStackTrace(errorReport.getFault())) {
+      if (forceFullStackTrace || logFullStackTrace(errorReport.getFault())) {
         logMessage.append('\n').append(errorReport.getExceptionStackTrace());
       } else {
         // Log first line only (error class, message) for known faults, to avoid polluting logs.

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerContext.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerContext.java
@@ -116,6 +116,11 @@ public interface WorkerContext extends Closeable
    */
   boolean includeAllCounters();
 
+  /**
+   * Whether to log full stack traces for all errors.
+   */
+  boolean isDebug();
+
   @Override
   void close();
 }

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
@@ -195,7 +195,7 @@ public class WorkerImpl implements Worker
 
       if (maybeErrorReport.isPresent()) {
         final MSQErrorReport errorReport = maybeErrorReport.get();
-        final String logMessage = MSQTasks.errorReportToLogMessage(errorReport);
+        final String logMessage = MSQTasks.errorReportToLogMessage(errorReport, context.isDebug());
         log.warn("%s", logMessage);
 
         // Inform controller of any errors that occur, unless we were canceled. This prevents attempting to contact

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerControllerContext.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerControllerContext.java
@@ -259,6 +259,12 @@ public class IndexerControllerContext implements ControllerContext
     );
   }
 
+  @Override
+  public boolean isDebug()
+  {
+    return taskQuerySpecContext.isDebug();
+  }
+
   /**
    * Helper method for {@link #queryKernelConfig(MSQSpec)}. Also used in tests.
    */

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerWorkerContext.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerWorkerContext.java
@@ -93,6 +93,7 @@ public class IndexerWorkerContext implements WorkerContext
   private final int maxConcurrentStages;
   private final boolean liveReportCounters;
   private final boolean includeAllCounters;
+  private final boolean debug;
   private final int threadCount;
 
   // Written under synchronized(this) using double-checked locking.
@@ -134,6 +135,7 @@ public class IndexerWorkerContext implements WorkerContext
     );
     this.liveReportCounters = MultiStageQueryContext.getLiveReportCounters(queryContext, DEFAULT_LIVE_REPORT_COUNTERS);
     this.includeAllCounters = MultiStageQueryContext.getIncludeAllCounters(queryContext);
+    this.debug = queryContext.isDebug();
     
     // Compute thread count once in constructor
     final int baseThreadCount = memoryIntrospector.numProcessingThreads();
@@ -325,6 +327,12 @@ public class IndexerWorkerContext implements WorkerContext
   public boolean includeAllCounters()
   {
     return includeAllCounters;
+  }
+
+  @Override
+  public boolean isDebug()
+  {
+    return debug;
   }
 
   public ServiceLocator controllerLocator()

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/error/DruidExceptionFault.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/error/DruidExceptionFault.java
@@ -106,6 +106,7 @@ public class DruidExceptionFault extends BaseMSQFault
     return DruidException.forPersona(personaEnum)
                          .ofCategory(categoryEnum)
                          .withErrorCode(druidErrorCode)
+                         .wasDeserialized()
                          .build(getErrorMessage())
                          .withContext(context);
   }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestControllerContext.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestControllerContext.java
@@ -486,6 +486,12 @@ public class MSQTestControllerContext implements ControllerContext, DartControll
   }
 
   @Override
+  public boolean isDebug()
+  {
+    return true;
+  }
+
+  @Override
   public ControllerContext newContext(QueryContext context)
   {
     this.queryContext = this.queryContext.override(context);

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestWorkerContext.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestWorkerContext.java
@@ -207,6 +207,12 @@ public class MSQTestWorkerContext implements WorkerContext
   }
 
   @Override
+  public boolean isDebug()
+  {
+    return true;
+  }
+
+  @Override
   public void close()
   {
     try {

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/TestDartControllerContextFactoryImpl.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/TestDartControllerContextFactoryImpl.java
@@ -108,6 +108,12 @@ public class TestDartControllerContextFactoryImpl extends DartControllerContextF
       {
         serviceEmitter.emit(metricBuilder.build("controller", queryId()));
       }
+
+      @Override
+      public boolean isDebug()
+      {
+        return true;
+      }
     };
   }
 

--- a/processing/src/main/java/org/apache/druid/error/DruidException.java
+++ b/processing/src/main/java/org/apache/druid/error/DruidException.java
@@ -477,7 +477,7 @@ public class DruidException extends RuntimeException
      *
      * @return the builder
      */
-    DruidExceptionBuilder wasDeserialized()
+    public DruidExceptionBuilder wasDeserialized()
     {
       this.deserialized = true;
       return this;


### PR DESCRIPTION
Typically controllers and workers only log the full stack trace for unknown faults and for DruidExceptions that have a non-USER persona. The rationale is to avoid log spam. However, sometimes it is useful to see them. This patch changes things so the full stack traces are logged when the "debug" flag is set in the context.

Test contexts are also updated such that the full stack trace is always logged in tests.

Finally, this patch also calls "wasDeserialized()" on the DruidException builder when re-creating DruidExceptions on the controller. This avoids having a stack trace assigned that isn't useful.