### PR TITLE
fix: hang in PeriodGranularity when using sub-day compound periods with imprecise timezone days

### DIFF
--- a/processing/src/main/java/org/apache/druid/java/util/common/granularity/PeriodGranularity.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/granularity/PeriodGranularity.java
@@ -600,6 +600,16 @@ public class PeriodGranularity extends Granularity implements JsonSerializable
         offset += millis;
       }
       return t - offset;
+    } else if (period.getYears() == 0 && period.getMonths() == 0 && period.getWeeks() == 0 && period.getDays() == 0) {
+      // If the period only contains hours, minutes, seconds, and millis,
+      // their duration is always precise even across daylight saving transitions.
+      // Therefore, we can safely convert the period to milliseconds.
+      final long millis = period.toStandardDuration().getMillis();
+      long offset = t % millis - origin % millis;
+      if (offset < 0) {
+        offset += millis;
+      }
+      return t - offset;
     } else {
       throw new UnsupportedOperationException(
           "Period cannot be converted to milliseconds as some fields mays vary in length with chronology " + chronology

--- a/processing/src/main/java/org/apache/druid/java/util/common/granularity/PeriodGranularity.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/granularity/PeriodGranularity.java
@@ -593,17 +593,10 @@ public class PeriodGranularity extends Granularity implements JsonSerializable
   {
     // toStandardDuration assumes days are always 24h, and hours are always 60 minutes,
     // which may not always be the case, e.g if there are daylight saving changes.
-    if (chronology.days().isPrecise() && chronology.hours().isPrecise()) {
-      final long millis = period.toStandardDuration().getMillis();
-      long offset = t % millis - origin % millis;
-      if (offset < 0) {
-        offset += millis;
-      }
-      return t - offset;
-    } else if (period.getYears() == 0 && period.getMonths() == 0 && period.getWeeks() == 0 && period.getDays() == 0) {
-      // If the period only contains hours, minutes, seconds, and millis,
-      // their duration is always precise even across daylight saving transitions.
-      // Therefore, we can safely convert the period to milliseconds.
+    // However, if the period only contains hours, minutes, seconds, and millis,
+    // their duration is always precise even across daylight saving transitions.
+    if ((chronology.days().isPrecise() && chronology.hours().isPrecise())
+        || (period.getYears() == 0 && period.getMonths() == 0 && period.getWeeks() == 0 && period.getDays() == 0)) {
       final long millis = period.toStandardDuration().getMillis();
       long offset = t % millis - origin % millis;
       if (offset < 0) {

--- a/processing/src/test/java/org/apache/druid/java/util/common/granularity/PeriodGranularityBugTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/granularity/PeriodGranularityBugTest.java
@@ -1,0 +1,25 @@
+package org.apache.druid.java.util.common.granularity;
+
+import org.joda.time.DateTimeZone;
+import org.joda.time.Period;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PeriodGranularityBugTest {
+    @Test(timeout = 5000)
+    public void testCompoundPeriodWithTimeZone() {
+        // America/New_York has DST, so days are imprecise
+        PeriodGranularity pg = new PeriodGranularity(new Period("PT1M1S"), null, DateTimeZone.forID("America/New_York"));
+        long time = 1704067200000L; // 2024-01-01T00:00:00Z
+        long start = System.currentTimeMillis();
+        long bucket = pg.bucketStart(time);
+        long end = System.currentTimeMillis();
+        
+        Assert.assertTrue("Should run quickly", (end - start) < 1000);
+        
+        // Let's also check if it returns the same as a non-compound period of same duration (PT61S)
+        PeriodGranularity pg2 = new PeriodGranularity(new Period("PT61S"), null, DateTimeZone.forID("America/New_York"));
+        long bucket2 = pg2.bucketStart(time);
+        Assert.assertEquals(bucket2, bucket);
+    }
+}

--- a/processing/src/test/java/org/apache/druid/java/util/common/granularity/PeriodGranularityBugTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/granularity/PeriodGranularityBugTest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.druid.java.util.common.granularity;
 
 import org.joda.time.DateTimeZone;
@@ -5,21 +24,24 @@ import org.joda.time.Period;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class PeriodGranularityBugTest {
-    @Test(timeout = 5000)
-    public void testCompoundPeriodWithTimeZone() {
-        // America/New_York has DST, so days are imprecise
-        PeriodGranularity pg = new PeriodGranularity(new Period("PT1M1S"), null, DateTimeZone.forID("America/New_York"));
-        long time = 1704067200000L; // 2024-01-01T00:00:00Z
-        long start = System.currentTimeMillis();
-        long bucket = pg.bucketStart(time);
-        long end = System.currentTimeMillis();
-        
-        Assert.assertTrue("Should run quickly", (end - start) < 1000);
-        
-        // Let's also check if it returns the same as a non-compound period of same duration (PT61S)
-        PeriodGranularity pg2 = new PeriodGranularity(new Period("PT61S"), null, DateTimeZone.forID("America/New_York"));
-        long bucket2 = pg2.bucketStart(time);
-        Assert.assertEquals(bucket2, bucket);
-    }
+public class PeriodGranularityBugTest
+{
+  @Test(timeout = 5000)
+  public void testCompoundPeriodWithTimeZone()
+  {
+    // America/New_York has DST, so days are imprecise
+    PeriodGranularity pg = new PeriodGranularity(new Period("PT1M1S"), null, DateTimeZone.forID("America/New_York"));
+    long time = 1704067200000L; // 2024-01-01T00:00:00Z
+    long start = System.currentTimeMillis();
+    long bucket = pg.bucketStart(time);
+    long end = System.currentTimeMillis();
+    
+    Assert.assertTrue("Should run quickly", (end - start) < 1000);
+    
+    // Let's also check if it returns the same as a non-compound period of same duration (PT61S)
+    PeriodGranularity pg2 = new PeriodGranularity(new Period("PT61S"), null, DateTimeZone.forID("America/New_York"));
+    long bucket2 = pg2.bucketStart(time);
+    Assert.assertEquals(bucket2, bucket);
+  }
 }
+

--- a/processing/src/test/java/org/apache/druid/java/util/common/granularity/PeriodGranularityBugTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/granularity/PeriodGranularityBugTest.java
@@ -19,7 +19,7 @@
 
 package org.apache.druid.java.util.common.granularity;
 
-import org.joda.time.DateTimeZone;
+import org.apache.druid.java.util.common.DateTimes;
 import org.joda.time.Period;
 import org.junit.Assert;
 import org.junit.Test;
@@ -30,7 +30,7 @@ public class PeriodGranularityBugTest
   public void testCompoundPeriodWithTimeZone()
   {
     // America/New_York has DST, so days are imprecise
-    PeriodGranularity pg = new PeriodGranularity(new Period("PT1M1S"), null, DateTimeZone.forID("America/New_York"));
+    PeriodGranularity pg = new PeriodGranularity(new Period("PT1M1S"), null, DateTimes.inferTzFromString("America/New_York"));
     long time = 1704067200000L; // 2024-01-01T00:00:00Z
     long start = System.currentTimeMillis();
     long bucket = pg.bucketStart(time);
@@ -39,7 +39,7 @@ public class PeriodGranularityBugTest
     Assert.assertTrue("Should run quickly", (end - start) < 1000);
     
     // Let's also check if it returns the same as a non-compound period of same duration (PT61S)
-    PeriodGranularity pg2 = new PeriodGranularity(new Period("PT61S"), null, DateTimeZone.forID("America/New_York"));
+    PeriodGranularity pg2 = new PeriodGranularity(new Period("PT61S"), null, DateTimes.inferTzFromString("America/New_York"));
     long bucket2 = pg2.bucketStart(time);
     Assert.assertEquals(bucket2, bucket);
   }


### PR DESCRIPTION
**This is my first real PR, and was largely assisted by AI, so please scrutinize heavily.**

Fixes a bug where timestamp_floor with compound time-only periods falls back to an infinite loop when the timezone has daylight saving time.

### Description
The issue is caused by how Druid's PeriodGranularity attempts to bucket timestamps when timezones and daylight saving time (DST) are involved. 

When trying to bucket timestamps using a compound period like PT1M1S, Druid first tries a fast-path (`truncateMillisPeriod`). It checks if the timezone has precise days and hours. Because timezones with DST (like `America/New_York`) observe daylight saving time, Druid incorrectly flags the timezone as imprecise for all period durations. It then falls back to a slow-path (`truncateCompoundPeriod`), which literally runs a while loop, adding the period duration starting from January 1st, 1970, until it reaches the target timestamp. This means it loops over 28 million times for every single row in the query, causing it to hang.

This PR updates the `truncateMillisPeriod` logic to check if the period contains any inherently imprecise components like years, months, weeks, or days. If the period only contains hours, minutes, seconds, or milliseconds, it will safely convert the period to milliseconds and use the fast-path modulo math, avoiding the infinite while loop completely.

A regression test `PeriodGranularityBugTest.java` is included to validate this fix.