### PR TITLE
fix: Optimize nullable numeric aggregation for Pooled TopN

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/aggregation/NullableNumericAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/NullableNumericAggregatorFactory.java
@@ -24,11 +24,16 @@ import com.google.common.base.Preconditions;
 import org.apache.druid.guice.annotations.ExtensionPoint;
 import org.apache.druid.segment.BaseNullableColumnValueSelector;
 import org.apache.druid.segment.BaseObjectColumnValueSelector;
+import org.apache.druid.segment.ColumnInspector;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.ColumnValueSelector;
+import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.Types;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
 import org.apache.druid.segment.vector.VectorValueSelector;
+
+import javax.annotation.Nullable;
 
 /**
  * Abstract superclass for null-aware numeric aggregators.
@@ -63,7 +68,7 @@ public abstract class NullableNumericAggregatorFactory<T extends BaseNullableCol
   {
     T selector = selector(columnSelectorFactory);
     Aggregator aggregator = factorize(columnSelectorFactory, selector);
-    if (this.forceNotNullable()) {
+    if (!useNullableNumericAggregators(columnSelectorFactory)) {
       return aggregator;
     }
     return new NullableNumericAggregator(aggregator, makeNullSelector(selector, columnSelectorFactory));
@@ -74,7 +79,7 @@ public abstract class NullableNumericAggregatorFactory<T extends BaseNullableCol
   {
     T selector = selector(columnSelectorFactory);
     BufferAggregator aggregator = factorizeBuffered(columnSelectorFactory, selector);
-    if (this.forceNotNullable()) {
+    if (!useNullableNumericAggregators(columnSelectorFactory)) {
       return aggregator;
     }
     return new NullableNumericBufferAggregator(aggregator, makeNullSelector(selector, columnSelectorFactory));
@@ -86,7 +91,7 @@ public abstract class NullableNumericAggregatorFactory<T extends BaseNullableCol
     Preconditions.checkState(canVectorize(columnSelectorFactory), "Cannot vectorize");
     VectorValueSelector selector = vectorSelector(columnSelectorFactory);
     VectorAggregator aggregator = factorizeVector(columnSelectorFactory, selector);
-    if (this.forceNotNullable()) {
+    if (!useNullableNumericAggregators(columnSelectorFactory)) {
       return aggregator;
     }
     return new NullableNumericVectorAggregator(aggregator, selector);
@@ -109,6 +114,27 @@ public abstract class NullableNumericAggregatorFactory<T extends BaseNullableCol
       return getMaxIntermediateSize();
     }
     return getMaxIntermediateSize() + Byte.BYTES;
+  }
+
+  private boolean useNullableNumericAggregators(ColumnInspector columnInspector)
+  {
+    if (forceNotNullable()) {
+      return false;
+    }
+
+    final String inputColumn = getInputColumn();
+    if (inputColumn == null) {
+      return true;
+    }
+
+    final ColumnCapabilities capabilities = columnInspector.getColumnCapabilities(inputColumn);
+    return !(Types.isNumeric(capabilities) && capabilities.hasNulls().isFalse());
+  }
+
+  @Nullable
+  protected String getInputColumn()
+  {
+    return null;
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/query/aggregation/NullableNumericAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/NullableNumericAggregatorFactory.java
@@ -68,7 +68,7 @@ public abstract class NullableNumericAggregatorFactory<T extends BaseNullableCol
   {
     T selector = selector(columnSelectorFactory);
     Aggregator aggregator = factorize(columnSelectorFactory, selector);
-    if (!useNullableNumericAggregators(columnSelectorFactory)) {
+    if (forceNotNullable()) {
       return aggregator;
     }
     return new NullableNumericAggregator(aggregator, makeNullSelector(selector, columnSelectorFactory));
@@ -79,7 +79,7 @@ public abstract class NullableNumericAggregatorFactory<T extends BaseNullableCol
   {
     T selector = selector(columnSelectorFactory);
     BufferAggregator aggregator = factorizeBuffered(columnSelectorFactory, selector);
-    if (!useNullableNumericAggregators(columnSelectorFactory)) {
+    if (forceNotNullable()) {
       return aggregator;
     }
     return new NullableNumericBufferAggregator(aggregator, makeNullSelector(selector, columnSelectorFactory));
@@ -91,10 +91,33 @@ public abstract class NullableNumericAggregatorFactory<T extends BaseNullableCol
     Preconditions.checkState(canVectorize(columnSelectorFactory), "Cannot vectorize");
     VectorValueSelector selector = vectorSelector(columnSelectorFactory);
     VectorAggregator aggregator = factorizeVector(columnSelectorFactory, selector);
-    if (!useNullableNumericAggregators(columnSelectorFactory)) {
+    if (forceNotNullable()) {
       return aggregator;
     }
     return new NullableNumericVectorAggregator(aggregator, selector);
+  }
+
+  /**
+   * Factorizes a buffer aggregator for Pooled TopN. Unlike general aggregation engines, Pooled TopN creates aggregate
+   * state only after a dimension value is seen. If the input column is known to be numeric and non-null, the nullable
+   * wrapper cannot affect the result, so TopN may skip it to keep hot-loop specialization effective.
+   */
+  public final BufferAggregator factorizeBufferedForPooledTopN(ColumnSelectorFactory columnSelectorFactory)
+  {
+    T selector = selector(columnSelectorFactory);
+    BufferAggregator aggregator = factorizeBuffered(columnSelectorFactory, selector);
+    if (!useNullableNumericAggregatorsForPooledTopN(columnSelectorFactory)) {
+      return aggregator;
+    }
+    return new NullableNumericBufferAggregator(aggregator, makeNullSelector(selector, columnSelectorFactory));
+  }
+
+  public final int getMaxIntermediateSizeWithNullsForPooledTopN(ColumnInspector columnInspector)
+  {
+    if (!useNullableNumericAggregatorsForPooledTopN(columnInspector)) {
+      return getMaxIntermediateSize();
+    }
+    return getMaxIntermediateSizeWithNulls();
   }
 
   @Override
@@ -116,7 +139,7 @@ public abstract class NullableNumericAggregatorFactory<T extends BaseNullableCol
     return getMaxIntermediateSize() + Byte.BYTES;
   }
 
-  private boolean useNullableNumericAggregators(ColumnInspector columnInspector)
+  private boolean useNullableNumericAggregatorsForPooledTopN(ColumnInspector columnInspector)
   {
     if (forceNotNullable()) {
       return false;

--- a/processing/src/main/java/org/apache/druid/query/aggregation/NullableNumericAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/NullableNumericAggregatorFactory.java
@@ -68,7 +68,7 @@ public abstract class NullableNumericAggregatorFactory<T extends BaseNullableCol
   {
     T selector = selector(columnSelectorFactory);
     Aggregator aggregator = factorize(columnSelectorFactory, selector);
-    if (forceNotNullable()) {
+    if (this.forceNotNullable()) {
       return aggregator;
     }
     return new NullableNumericAggregator(aggregator, makeNullSelector(selector, columnSelectorFactory));
@@ -79,7 +79,7 @@ public abstract class NullableNumericAggregatorFactory<T extends BaseNullableCol
   {
     T selector = selector(columnSelectorFactory);
     BufferAggregator aggregator = factorizeBuffered(columnSelectorFactory, selector);
-    if (forceNotNullable()) {
+    if (this.forceNotNullable()) {
       return aggregator;
     }
     return new NullableNumericBufferAggregator(aggregator, makeNullSelector(selector, columnSelectorFactory));
@@ -91,7 +91,7 @@ public abstract class NullableNumericAggregatorFactory<T extends BaseNullableCol
     Preconditions.checkState(canVectorize(columnSelectorFactory), "Cannot vectorize");
     VectorValueSelector selector = vectorSelector(columnSelectorFactory);
     VectorAggregator aggregator = factorizeVector(columnSelectorFactory, selector);
-    if (forceNotNullable()) {
+    if (this.forceNotNullable()) {
       return aggregator;
     }
     return new NullableNumericVectorAggregator(aggregator, selector);
@@ -141,7 +141,7 @@ public abstract class NullableNumericAggregatorFactory<T extends BaseNullableCol
 
   private boolean useNullableNumericAggregatorsForPooledTopN(ColumnInspector columnInspector)
   {
-    if (forceNotNullable()) {
+    if (this.forceNotNullable()) {
       return false;
     }
 

--- a/processing/src/main/java/org/apache/druid/query/aggregation/SimpleDoubleAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/SimpleDoubleAggregatorFactory.java
@@ -135,6 +135,13 @@ public abstract class SimpleDoubleAggregatorFactory extends NullableNumericAggre
   }
 
   @Override
+  @Nullable
+  protected String getInputColumn()
+  {
+    return expression == null ? fieldName : null;
+  }
+
+  @Override
   public Object deserialize(Object object)
   {
     // handle "NaN" / "Infinity" values serialized as strings in JSON

--- a/processing/src/main/java/org/apache/druid/query/aggregation/SimpleFloatAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/SimpleFloatAggregatorFactory.java
@@ -125,6 +125,13 @@ public abstract class SimpleFloatAggregatorFactory extends NullableNumericAggreg
   }
 
   @Override
+  @Nullable
+  protected String getInputColumn()
+  {
+    return expression == null ? fieldName : null;
+  }
+
+  @Override
   public Object deserialize(Object object)
   {
     // handle "NaN" / "Infinity" values serialized as strings in JSON

--- a/processing/src/main/java/org/apache/druid/query/aggregation/SimpleLongAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/SimpleLongAggregatorFactory.java
@@ -131,6 +131,13 @@ public abstract class SimpleLongAggregatorFactory extends NullableNumericAggrega
   }
 
   @Override
+  @Nullable
+  protected String getInputColumn()
+  {
+    return expression == null ? fieldName : null;
+  }
+
+  @Override
   public Object deserialize(Object object)
   {
     return object;

--- a/processing/src/main/java/org/apache/druid/query/topn/PooledTopNAlgorithm.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/PooledTopNAlgorithm.java
@@ -361,7 +361,7 @@ public class PooledTopNAlgorithm
     for (AggregatorFactory spec : aggregatorSpecs) {
       if (spec instanceof NullableNumericAggregatorFactory) {
         aggregators[aggregatorIndex] =
-            ((NullableNumericAggregatorFactory) spec).factorizeBufferedForPooledTopN(cursor.getColumnSelectorFactory());
+            ((NullableNumericAggregatorFactory<?>) spec).factorizeBufferedForPooledTopN(cursor.getColumnSelectorFactory());
       } else {
         aggregators[aggregatorIndex] = spec.factorizeBuffered(cursor.getColumnSelectorFactory());
       }

--- a/processing/src/main/java/org/apache/druid/query/topn/PooledTopNAlgorithm.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/PooledTopNAlgorithm.java
@@ -27,11 +27,14 @@ import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.query.BaseQuery;
 import org.apache.druid.query.ColumnSelectorPlus;
 import org.apache.druid.query.CursorGranularizer;
+import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.BufferAggregator;
+import org.apache.druid.query.aggregation.NullableNumericAggregatorFactory;
 import org.apache.druid.query.aggregation.SimpleDoubleBufferAggregator;
 import org.apache.druid.query.monomorphicprocessing.SpecializationService;
 import org.apache.druid.query.monomorphicprocessing.SpecializationState;
 import org.apache.druid.query.monomorphicprocessing.StringRuntimeShape;
+import org.apache.druid.segment.ColumnInspector;
 import org.apache.druid.segment.Cursor;
 import org.apache.druid.segment.DimensionSelector;
 import org.apache.druid.segment.FilteredOffset;
@@ -259,7 +262,10 @@ public class PooledTopNAlgorithm
       int numBytesPerRecord = 0;
 
       for (int i = 0; i < query.getAggregatorSpecs().size(); ++i) {
-        aggregatorSizes[i] = query.getAggregatorSpecs().get(i).getMaxIntermediateSizeWithNulls();
+        aggregatorSizes[i] = getMaxIntermediateSizeWithNullsForPooledTopN(
+            cursor.getColumnSelectorFactory(),
+            query.getAggregatorSpecs().get(i)
+        );
         numBytesPerRecord += aggregatorSizes[i];
       }
 
@@ -329,7 +335,39 @@ public class PooledTopNAlgorithm
   @Override
   protected BufferAggregator[] makeDimValAggregateStore(PooledTopNParams params)
   {
-    return makeBufferAggregators(params.getCursor(), query.getAggregatorSpecs());
+    return makeBufferAggregatorsForPooledTopN(params.getCursor(), query.getAggregatorSpecs());
+  }
+
+  private static int getMaxIntermediateSizeWithNullsForPooledTopN(
+      ColumnInspector columnInspector,
+      AggregatorFactory aggregatorFactory
+  )
+  {
+    if (aggregatorFactory instanceof NullableNumericAggregatorFactory) {
+      return ((NullableNumericAggregatorFactory) aggregatorFactory).getMaxIntermediateSizeWithNullsForPooledTopN(
+          columnInspector
+      );
+    }
+    return aggregatorFactory.getMaxIntermediateSizeWithNulls();
+  }
+
+  private static BufferAggregator[] makeBufferAggregatorsForPooledTopN(
+      Cursor cursor,
+      List<AggregatorFactory> aggregatorSpecs
+  )
+  {
+    BufferAggregator[] aggregators = new BufferAggregator[aggregatorSpecs.size()];
+    int aggregatorIndex = 0;
+    for (AggregatorFactory spec : aggregatorSpecs) {
+      if (spec instanceof NullableNumericAggregatorFactory) {
+        aggregators[aggregatorIndex] =
+            ((NullableNumericAggregatorFactory) spec).factorizeBufferedForPooledTopN(cursor.getColumnSelectorFactory());
+      } else {
+        aggregators[aggregatorIndex] = spec.factorizeBuffered(cursor.getColumnSelectorFactory());
+      }
+      ++aggregatorIndex;
+    }
+    return aggregators;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/topn/PooledTopNAlgorithm.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/PooledTopNAlgorithm.java
@@ -344,7 +344,7 @@ public class PooledTopNAlgorithm
   )
   {
     if (aggregatorFactory instanceof NullableNumericAggregatorFactory) {
-      return ((NullableNumericAggregatorFactory) aggregatorFactory).getMaxIntermediateSizeWithNullsForPooledTopN(
+      return ((NullableNumericAggregatorFactory<?>) aggregatorFactory).getMaxIntermediateSizeWithNullsForPooledTopN(
           columnInspector
       );
     }

--- a/processing/src/main/java/org/apache/druid/query/topn/PooledTopNAlgorithm.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/PooledTopNAlgorithm.java
@@ -338,7 +338,7 @@ public class PooledTopNAlgorithm
     return makeBufferAggregatorsForPooledTopN(params.getCursor(), query.getAggregatorSpecs());
   }
 
-  private static int getMaxIntermediateSizeWithNullsForPooledTopN(
+  static int getMaxIntermediateSizeWithNullsForPooledTopN(
       ColumnInspector columnInspector,
       AggregatorFactory aggregatorFactory
   )

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQueryEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQueryEngine.java
@@ -172,7 +172,10 @@ public class TopNQueryEngine
 
     int numBytesPerRecord = 0;
     for (AggregatorFactory aggregatorFactory : query.getAggregatorSpecs()) {
-      numBytesPerRecord += aggregatorFactory.getMaxIntermediateSizeWithNulls();
+      numBytesPerRecord += PooledTopNAlgorithm.getMaxIntermediateSizeWithNullsForPooledTopN(
+          cursorInspector.getColumnInspector(),
+          aggregatorFactory
+      );
     }
 
     final TopNAlgorithmSelector selector = new TopNAlgorithmSelector(

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQueryEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQueryEngine.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.query.topn;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
 import org.apache.druid.collections.NonBlockingPool;
@@ -157,7 +158,8 @@ public class TopNQueryEngine
   /**
    * Choose the best {@link TopNAlgorithm} for the given query.
    */
-  private TopNMapFn getMapFn(
+  @VisibleForTesting
+  TopNMapFn getMapFn(
       final TopNQuery query,
       final TopNCursorInspector cursorInspector,
       final @Nullable TopNQueryMetrics queryMetrics

--- a/processing/src/test/java/org/apache/druid/query/aggregation/DoubleSumAggregatorTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/DoubleSumAggregatorTest.java
@@ -162,6 +162,28 @@ public class DoubleSumAggregatorTest
   }
 
   @Test
+  public void testPooledTopNUsesNullableBufferAggregatorWhenInputNullsAreUnknown()
+  {
+    ColumnSelectorFactory selectorFactory = EasyMock.createMock(ColumnSelectorFactory.class);
+    TestDoubleColumnSelectorImpl selector = new TestDoubleColumnSelectorImpl(new double[]{1.0d});
+    ColumnCapabilitiesImpl capabilities =
+        ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.DOUBLE);
+    DoubleSumAggregatorFactory factory = new DoubleSumAggregatorFactory("sum", "metric");
+    EasyMock.expect(selectorFactory.makeColumnValueSelector("metric")).andReturn(selector);
+    EasyMock.expect(selectorFactory.getColumnCapabilities("metric")).andReturn(capabilities).times(4);
+    EasyMock.replay(selectorFactory);
+
+    BufferAggregator aggregator = factory.factorizeBufferedForPooledTopN(selectorFactory);
+
+    Assertions.assertTrue(aggregator instanceof NullableNumericBufferAggregator);
+    Assertions.assertEquals(
+        Double.BYTES + Byte.BYTES,
+        factory.getMaxIntermediateSizeWithNullsForPooledTopN(selectorFactory)
+    );
+    EasyMock.verify(selectorFactory);
+  }
+
+  @Test
   public void testUsesNullableAggregatorWhenInputNullsAreUnknown()
   {
     ColumnSelectorFactory selectorFactory = EasyMock.createMock(ColumnSelectorFactory.class);

--- a/processing/src/test/java/org/apache/druid/query/aggregation/DoubleSumAggregatorTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/DoubleSumAggregatorTest.java
@@ -19,9 +19,14 @@
 
 package org.apache.druid.query.aggregation;
 
+import org.apache.druid.segment.ColumnSelectorFactory;
+import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
+import org.apache.druid.segment.column.ColumnType;
+import org.easymock.EasyMock;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.nio.ByteBuffer;
 import java.util.Comparator;
 
 /**
@@ -72,5 +77,79 @@ public class DoubleSumAggregatorTest
     Assertions.assertEquals(0, comp.compare(first, first));
     Assertions.assertEquals(0, comp.compare(agg.get(), agg.get()));
     Assertions.assertEquals(1, comp.compare(agg.get(), first));
+  }
+
+  @Test
+  public void testSkipsNullableBufferAggregatorWhenInputHasNoNulls()
+  {
+    ColumnSelectorFactory selectorFactory = EasyMock.createMock(ColumnSelectorFactory.class);
+    TestDoubleColumnSelectorImpl selector = new TestDoubleColumnSelectorImpl(new double[]{1.0d});
+    ColumnCapabilitiesImpl capabilities =
+        ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.DOUBLE).setHasNulls(false);
+    EasyMock.expect(selectorFactory.makeColumnValueSelector("metric")).andReturn(selector);
+    EasyMock.expect(selectorFactory.getColumnCapabilities("metric")).andReturn(capabilities).times(2);
+    EasyMock.replay(selectorFactory);
+
+    BufferAggregator aggregator = new DoubleSumAggregatorFactory("sum", "metric").factorizeBuffered(selectorFactory);
+
+    Assertions.assertTrue(aggregator instanceof DoubleSumBufferAggregator);
+    ByteBuffer buffer = ByteBuffer.allocate(Double.BYTES);
+    aggregator.init(buffer, 0);
+    aggregator.aggregate(buffer, 0);
+    Assertions.assertEquals(1.0d, aggregator.getDouble(buffer, 0), 0.0d);
+    EasyMock.verify(selectorFactory);
+  }
+
+  @Test
+  public void testSkipsNullableAggregatorWhenInputHasNoNulls()
+  {
+    ColumnSelectorFactory selectorFactory = EasyMock.createMock(ColumnSelectorFactory.class);
+    TestDoubleColumnSelectorImpl selector = new TestDoubleColumnSelectorImpl(new double[]{1.0d});
+    ColumnCapabilitiesImpl capabilities =
+        ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.DOUBLE).setHasNulls(false);
+    EasyMock.expect(selectorFactory.makeColumnValueSelector("metric")).andReturn(selector);
+    EasyMock.expect(selectorFactory.getColumnCapabilities("metric")).andReturn(capabilities).times(2);
+    EasyMock.replay(selectorFactory);
+
+    Aggregator aggregator = new DoubleSumAggregatorFactory("sum", "metric").factorize(selectorFactory);
+
+    Assertions.assertTrue(aggregator instanceof DoubleSumAggregator);
+    aggregator.aggregate();
+    Assertions.assertEquals(1.0d, aggregator.getDouble(), 0.0d);
+    EasyMock.verify(selectorFactory);
+  }
+
+  @Test
+  public void testUsesNullableBufferAggregatorWhenInputNullsAreUnknown()
+  {
+    ColumnSelectorFactory selectorFactory = EasyMock.createMock(ColumnSelectorFactory.class);
+    TestDoubleColumnSelectorImpl selector = new TestDoubleColumnSelectorImpl(new double[]{1.0d});
+    ColumnCapabilitiesImpl capabilities =
+        ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.DOUBLE);
+    EasyMock.expect(selectorFactory.makeColumnValueSelector("metric")).andReturn(selector);
+    EasyMock.expect(selectorFactory.getColumnCapabilities("metric")).andReturn(capabilities).times(3);
+    EasyMock.replay(selectorFactory);
+
+    BufferAggregator aggregator = new DoubleSumAggregatorFactory("sum", "metric").factorizeBuffered(selectorFactory);
+
+    Assertions.assertTrue(aggregator instanceof NullableNumericBufferAggregator);
+    EasyMock.verify(selectorFactory);
+  }
+
+  @Test
+  public void testUsesNullableAggregatorWhenInputNullsAreUnknown()
+  {
+    ColumnSelectorFactory selectorFactory = EasyMock.createMock(ColumnSelectorFactory.class);
+    TestDoubleColumnSelectorImpl selector = new TestDoubleColumnSelectorImpl(new double[]{1.0d});
+    ColumnCapabilitiesImpl capabilities =
+        ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.DOUBLE);
+    EasyMock.expect(selectorFactory.makeColumnValueSelector("metric")).andReturn(selector);
+    EasyMock.expect(selectorFactory.getColumnCapabilities("metric")).andReturn(capabilities).times(3);
+    EasyMock.replay(selectorFactory);
+
+    Aggregator aggregator = new DoubleSumAggregatorFactory("sum", "metric").factorize(selectorFactory);
+
+    Assertions.assertTrue(aggregator instanceof NullableNumericAggregator);
+    EasyMock.verify(selectorFactory);
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/aggregation/DoubleSumAggregatorTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/DoubleSumAggregatorTest.java
@@ -80,7 +80,7 @@ public class DoubleSumAggregatorTest
   }
 
   @Test
-  public void testSkipsNullableBufferAggregatorWhenInputHasNoNulls()
+  public void testUsesNullableBufferAggregatorWhenInputHasNoNulls()
   {
     ColumnSelectorFactory selectorFactory = EasyMock.createMock(ColumnSelectorFactory.class);
     TestDoubleColumnSelectorImpl selector = new TestDoubleColumnSelectorImpl(new double[]{1.0d});
@@ -92,16 +92,17 @@ public class DoubleSumAggregatorTest
 
     BufferAggregator aggregator = new DoubleSumAggregatorFactory("sum", "metric").factorizeBuffered(selectorFactory);
 
-    Assertions.assertTrue(aggregator instanceof DoubleSumBufferAggregator);
-    ByteBuffer buffer = ByteBuffer.allocate(Double.BYTES);
+    Assertions.assertTrue(aggregator instanceof NullableNumericBufferAggregator);
+    ByteBuffer buffer = ByteBuffer.allocate(Double.BYTES + Byte.BYTES);
     aggregator.init(buffer, 0);
+    Assertions.assertNull(aggregator.get(buffer, 0));
     aggregator.aggregate(buffer, 0);
     Assertions.assertEquals(1.0d, aggregator.getDouble(buffer, 0), 0.0d);
     EasyMock.verify(selectorFactory);
   }
 
   @Test
-  public void testSkipsNullableAggregatorWhenInputHasNoNulls()
+  public void testUsesNullableAggregatorWhenInputHasNoNulls()
   {
     ColumnSelectorFactory selectorFactory = EasyMock.createMock(ColumnSelectorFactory.class);
     TestDoubleColumnSelectorImpl selector = new TestDoubleColumnSelectorImpl(new double[]{1.0d});
@@ -113,9 +114,33 @@ public class DoubleSumAggregatorTest
 
     Aggregator aggregator = new DoubleSumAggregatorFactory("sum", "metric").factorize(selectorFactory);
 
-    Assertions.assertTrue(aggregator instanceof DoubleSumAggregator);
+    Assertions.assertTrue(aggregator instanceof NullableNumericAggregator);
+    Assertions.assertNull(aggregator.get());
     aggregator.aggregate();
     Assertions.assertEquals(1.0d, aggregator.getDouble(), 0.0d);
+    EasyMock.verify(selectorFactory);
+  }
+
+  @Test
+  public void testPooledTopNSkipsNullableBufferAggregatorWhenInputHasNoNulls()
+  {
+    ColumnSelectorFactory selectorFactory = EasyMock.createMock(ColumnSelectorFactory.class);
+    TestDoubleColumnSelectorImpl selector = new TestDoubleColumnSelectorImpl(new double[]{1.0d});
+    ColumnCapabilitiesImpl capabilities =
+        ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.DOUBLE).setHasNulls(false);
+    DoubleSumAggregatorFactory factory = new DoubleSumAggregatorFactory("sum", "metric");
+    EasyMock.expect(selectorFactory.makeColumnValueSelector("metric")).andReturn(selector);
+    EasyMock.expect(selectorFactory.getColumnCapabilities("metric")).andReturn(capabilities).times(3);
+    EasyMock.replay(selectorFactory);
+
+    BufferAggregator aggregator = factory.factorizeBufferedForPooledTopN(selectorFactory);
+
+    Assertions.assertTrue(aggregator instanceof DoubleSumBufferAggregator);
+    Assertions.assertEquals(Double.BYTES, factory.getMaxIntermediateSizeWithNullsForPooledTopN(selectorFactory));
+    ByteBuffer buffer = ByteBuffer.allocate(Double.BYTES);
+    aggregator.init(buffer, 0);
+    aggregator.aggregate(buffer, 0);
+    Assertions.assertEquals(1.0d, aggregator.getDouble(buffer, 0), 0.0d);
     EasyMock.verify(selectorFactory);
   }
 
@@ -127,7 +152,7 @@ public class DoubleSumAggregatorTest
     ColumnCapabilitiesImpl capabilities =
         ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.DOUBLE);
     EasyMock.expect(selectorFactory.makeColumnValueSelector("metric")).andReturn(selector);
-    EasyMock.expect(selectorFactory.getColumnCapabilities("metric")).andReturn(capabilities).times(3);
+    EasyMock.expect(selectorFactory.getColumnCapabilities("metric")).andReturn(capabilities).times(2);
     EasyMock.replay(selectorFactory);
 
     BufferAggregator aggregator = new DoubleSumAggregatorFactory("sum", "metric").factorizeBuffered(selectorFactory);
@@ -144,7 +169,7 @@ public class DoubleSumAggregatorTest
     ColumnCapabilitiesImpl capabilities =
         ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.DOUBLE);
     EasyMock.expect(selectorFactory.makeColumnValueSelector("metric")).andReturn(selector);
-    EasyMock.expect(selectorFactory.getColumnCapabilities("metric")).andReturn(capabilities).times(3);
+    EasyMock.expect(selectorFactory.getColumnCapabilities("metric")).andReturn(capabilities).times(2);
     EasyMock.replay(selectorFactory);
 
     Aggregator aggregator = new DoubleSumAggregatorFactory("sum", "metric").factorize(selectorFactory);

--- a/processing/src/test/java/org/apache/druid/query/topn/TopNQueryEngineTest.java
+++ b/processing/src/test/java/org/apache/druid/query/topn/TopNQueryEngineTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.query.topn;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.collections.NonBlockingPool;
 import org.apache.druid.collections.ResourceHolder;
+import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.query.aggregation.AggregatorFactory;
@@ -36,7 +37,6 @@ import org.joda.time.Interval;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.util.List;
 
@@ -44,10 +44,10 @@ public class TopNQueryEngineTest
 {
   private static final String DIMENSION = "dim";
   private static final String METRIC = "metric";
-  private static final Interval INTERVAL = new Interval("2000/2001");
+  private static final Interval INTERVAL = Intervals.of("2000/2001");
 
   @Test
-  public void testUsesReducedPooledTopNSizeForPooledVsHeapSelection() throws Exception
+  public void testUsesReducedPooledTopNSizeForPooledVsHeapSelection()
   {
     final TopNAlgorithm algorithm = selectAlgorithm(
         10,
@@ -58,11 +58,11 @@ public class TopNQueryEngineTest
         Granularities.DAY
     );
 
-    Assertions.assertTrue(algorithm instanceof PooledTopNAlgorithm);
+    Assertions.assertInstanceOf(PooledTopNAlgorithm.class, algorithm);
   }
 
   @Test
-  public void testUsesNullableSizeForUnknownNullabilityInPooledVsHeapSelection() throws Exception
+  public void testUsesNullableSizeForUnknownNullabilityInPooledVsHeapSelection()
   {
     final TopNAlgorithm algorithm = selectAlgorithm(
         10,
@@ -73,11 +73,11 @@ public class TopNQueryEngineTest
         Granularities.DAY
     );
 
-    Assertions.assertTrue(algorithm instanceof HeapBasedTopNAlgorithm);
+    Assertions.assertInstanceOf(HeapBasedTopNAlgorithm.class, algorithm);
   }
 
   @Test
-  public void testReducedPooledTopNSizeAvoidsAggregateMetricFirstThreshold() throws Exception
+  public void testReducedPooledTopNSizeAvoidsAggregateMetricFirstThreshold()
   {
     final TopNAlgorithm algorithm = selectAlgorithm(
         400001,
@@ -92,7 +92,7 @@ public class TopNQueryEngineTest
   }
 
   @Test
-  public void testUnknownNullabilityStillUsesAggregateMetricFirstThreshold() throws Exception
+  public void testUnknownNullabilityStillUsesAggregateMetricFirstThreshold()
   {
     final TopNAlgorithm algorithm = selectAlgorithm(
         400001,
@@ -103,7 +103,7 @@ public class TopNQueryEngineTest
         Granularities.ALL
     );
 
-    Assertions.assertTrue(algorithm instanceof AggregateTopNMetricFirstAlgorithm);
+    Assertions.assertInstanceOf(AggregateTopNMetricFirstAlgorithm.class, algorithm);
   }
 
   private static TopNAlgorithm selectAlgorithm(
@@ -113,7 +113,7 @@ public class TopNQueryEngineTest
       final List<AggregatorFactory> aggregatorFactories,
       final TopNMetricSpec metricSpec,
       final Granularity granularity
-  ) throws Exception
+  )
   {
     final TopNQuery query = new TopNQueryBuilder()
         .dataSource("test")
@@ -127,8 +127,7 @@ public class TopNQueryEngineTest
     final CapturingTopNQueryMetrics queryMetrics = new CapturingTopNQueryMetrics();
     final TopNQueryEngine queryEngine = new TopNQueryEngine(new TestBufferPool(bufferSize));
 
-    getMapFn().invoke(
-        queryEngine,
+    queryEngine.getMapFn(
         query,
         new TopNCursorInspector(
             new TestColumnInspector(metricCapabilities),
@@ -140,18 +139,6 @@ public class TopNQueryEngineTest
     );
 
     return queryMetrics.algorithm;
-  }
-
-  private static Method getMapFn() throws NoSuchMethodException
-  {
-    final Method method = TopNQueryEngine.class.getDeclaredMethod(
-        "getMapFn",
-        TopNQuery.class,
-        TopNCursorInspector.class,
-        TopNQueryMetrics.class
-    );
-    method.setAccessible(true);
-    return method;
   }
 
   private static List<AggregatorFactory> doubleSumAggregators(final int count)
@@ -217,7 +204,7 @@ public class TopNQueryEngineTest
     @Override
     public ResourceHolder<ByteBuffer> take()
     {
-      return new ResourceHolder<ByteBuffer>()
+      return new ResourceHolder<>()
       {
         @Override
         public ByteBuffer get()

--- a/processing/src/test/java/org/apache/druid/query/topn/TopNQueryEngineTest.java
+++ b/processing/src/test/java/org/apache/druid/query/topn/TopNQueryEngineTest.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.topn;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.collections.NonBlockingPool;
+import org.apache.druid.collections.ResourceHolder;
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.java.util.common.granularity.Granularity;
+import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.DoubleSumAggregatorFactory;
+import org.apache.druid.query.dimension.DefaultDimensionSpec;
+import org.apache.druid.query.spec.LegacySegmentSpec;
+import org.apache.druid.segment.ColumnInspector;
+import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
+import org.apache.druid.segment.column.ColumnType;
+import org.joda.time.Interval;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+public class TopNQueryEngineTest
+{
+  private static final String DIMENSION = "dim";
+  private static final String METRIC = "metric";
+  private static final Interval INTERVAL = new Interval("2000/2001");
+
+  @Test
+  public void testUsesReducedPooledTopNSizeForPooledVsHeapSelection() throws Exception
+  {
+    final TopNAlgorithm algorithm = selectAlgorithm(
+        10,
+        80,
+        metricCapabilities(false),
+        ImmutableList.of(new DoubleSumAggregatorFactory("sum", METRIC)),
+        new NumericTopNMetricSpec("sum"),
+        Granularities.DAY
+    );
+
+    Assertions.assertTrue(algorithm instanceof PooledTopNAlgorithm);
+  }
+
+  @Test
+  public void testUsesNullableSizeForUnknownNullabilityInPooledVsHeapSelection() throws Exception
+  {
+    final TopNAlgorithm algorithm = selectAlgorithm(
+        10,
+        80,
+        metricCapabilitiesUnknownNullability(),
+        ImmutableList.of(new DoubleSumAggregatorFactory("sum", METRIC)),
+        new NumericTopNMetricSpec("sum"),
+        Granularities.DAY
+    );
+
+    Assertions.assertTrue(algorithm instanceof HeapBasedTopNAlgorithm);
+  }
+
+  @Test
+  public void testReducedPooledTopNSizeAvoidsAggregateMetricFirstThreshold() throws Exception
+  {
+    final TopNAlgorithm algorithm = selectAlgorithm(
+        400001,
+        96,
+        metricCapabilities(false),
+        doubleSumAggregators(12),
+        new NumericTopNMetricSpec("sum0"),
+        Granularities.ALL
+    );
+
+    Assertions.assertEquals(PooledTopNAlgorithm.class, algorithm.getClass());
+  }
+
+  @Test
+  public void testUnknownNullabilityStillUsesAggregateMetricFirstThreshold() throws Exception
+  {
+    final TopNAlgorithm algorithm = selectAlgorithm(
+        400001,
+        108,
+        metricCapabilitiesUnknownNullability(),
+        doubleSumAggregators(12),
+        new NumericTopNMetricSpec("sum0"),
+        Granularities.ALL
+    );
+
+    Assertions.assertTrue(algorithm instanceof AggregateTopNMetricFirstAlgorithm);
+  }
+
+  private static TopNAlgorithm selectAlgorithm(
+      final int dimensionCardinality,
+      final int bufferSize,
+      final ColumnCapabilities metricCapabilities,
+      final List<AggregatorFactory> aggregatorFactories,
+      final TopNMetricSpec metricSpec,
+      final Granularity granularity
+  ) throws Exception
+  {
+    final TopNQuery query = new TopNQueryBuilder()
+        .dataSource("test")
+        .dimension(new DefaultDimensionSpec(DIMENSION, DIMENSION))
+        .metric(metricSpec)
+        .threshold(10)
+        .intervals(new LegacySegmentSpec(INTERVAL))
+        .granularity(granularity)
+        .aggregators(aggregatorFactories)
+        .build();
+    final CapturingTopNQueryMetrics queryMetrics = new CapturingTopNQueryMetrics();
+    final TopNQueryEngine queryEngine = new TopNQueryEngine(new TestBufferPool(bufferSize));
+
+    getMapFn().invoke(
+        queryEngine,
+        query,
+        new TopNCursorInspector(
+            new TestColumnInspector(metricCapabilities),
+            null,
+            INTERVAL,
+            dimensionCardinality
+        ),
+        queryMetrics
+    );
+
+    return queryMetrics.algorithm;
+  }
+
+  private static Method getMapFn() throws NoSuchMethodException
+  {
+    final Method method = TopNQueryEngine.class.getDeclaredMethod(
+        "getMapFn",
+        TopNQuery.class,
+        TopNCursorInspector.class,
+        TopNQueryMetrics.class
+    );
+    method.setAccessible(true);
+    return method;
+  }
+
+  private static List<AggregatorFactory> doubleSumAggregators(final int count)
+  {
+    final ImmutableList.Builder<AggregatorFactory> aggregators = ImmutableList.builder();
+    for (int i = 0; i < count; i++) {
+      aggregators.add(new DoubleSumAggregatorFactory("sum" + i, METRIC));
+    }
+    return aggregators.build();
+  }
+
+  private static ColumnCapabilities metricCapabilities(final boolean hasNulls)
+  {
+    return ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.DOUBLE).setHasNulls(hasNulls);
+  }
+
+  private static ColumnCapabilities metricCapabilitiesUnknownNullability()
+  {
+    return ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.DOUBLE);
+  }
+
+  private static ColumnCapabilities dimensionCapabilities()
+  {
+    return new ColumnCapabilitiesImpl()
+        .setType(ColumnType.STRING)
+        .setHasMultipleValues(false)
+        .setHasBitmapIndexes(false)
+        .setDictionaryEncoded(true)
+        .setDictionaryValuesUnique(true);
+  }
+
+  private static class TestColumnInspector implements ColumnInspector
+  {
+    private final ColumnCapabilities metricCapabilities;
+
+    private TestColumnInspector(final ColumnCapabilities metricCapabilities)
+    {
+      this.metricCapabilities = metricCapabilities;
+    }
+
+    @Override
+    public ColumnCapabilities getColumnCapabilities(final String column)
+    {
+      if (DIMENSION.equals(column)) {
+        return dimensionCapabilities();
+      }
+      if (METRIC.equals(column)) {
+        return metricCapabilities;
+      }
+      return null;
+    }
+  }
+
+  private static class TestBufferPool implements NonBlockingPool<ByteBuffer>
+  {
+    private final int bufferSize;
+
+    private TestBufferPool(final int bufferSize)
+    {
+      this.bufferSize = bufferSize;
+    }
+
+    @Override
+    public ResourceHolder<ByteBuffer> take()
+    {
+      return new ResourceHolder<ByteBuffer>()
+      {
+        @Override
+        public ByteBuffer get()
+        {
+          return ByteBuffer.allocate(bufferSize);
+        }
+
+        @Override
+        public void close()
+        {
+          // Nothing to release.
+        }
+      };
+    }
+  }
+
+  private static class CapturingTopNQueryMetrics extends DefaultTopNQueryMetrics
+  {
+    private TopNAlgorithm algorithm;
+
+    @Override
+    public void algorithm(final TopNAlgorithm algorithm)
+    {
+      this.algorithm = algorithm;
+    }
+  }
+}


### PR DESCRIPTION
Fixes #19344

Note: #19353 is working on a vectorized version for TopN queries. This patch is for the non-vectorized Pooled TopN query path.

### Description
This patch lets Pooled TopN avoid nullable numeric buffer aggregator wrappers when the direct numeric input column is known to have no nulls. General aggregation paths still keep nullable wrappers, preserving SQL-compatible null results for empty groups and no-value aggregations.

### Changes
- Add direct-input-column hooks for simple long/float/double aggregators.
- Add Pooled TopN-specific nullable numeric factorization and intermediate-size calculation.
- Use the same Pooled TopN-specific intermediate-size calculation in `TopNQueryEngine` algorithm selection and in `PooledTopNAlgorithm` buffer layout.
- Add `DoubleSumAggregatorFactory` coverage for known no-null and unknown-nullability inputs, including the Pooled TopN-specific paths.

### Tests
We tested a TopN query over a 24h data set, and latency improved from about 20s to about 11s, similar to the latency where null handling is disabled like on Druid 27.

Local verification:
- `mvn test -pl processing -Dtest=DoubleSumAggregatorTest -Dcheckstyle.skip -Dpmd.skip=true`
- `mvn test -pl processing -Dtest=PooledTopNAlgorithmTest -Dcheckstyle.skip -Dpmd.skip=true`
- `mvn test -pl sql -am -Dtest=CalciteSelectQueryTest#testSelectCountStar -Dsurefire.failIfNoSpecifiedTests=false -Dcheckstyle.skip -Dpmd.skip=true`
