### PR TITLE
fix: fix prolonged query timeout bug in SetAndVerifyContextQueryRunner

### DIFF
--- a/server/src/main/java/org/apache/druid/server/SetAndVerifyContextQueryRunner.java
+++ b/server/src/main/java/org/apache/druid/server/SetAndVerifyContextQueryRunner.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.server;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.druid.client.DirectDruidClient;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.query.Queries;
@@ -29,6 +28,8 @@ import org.apache.druid.query.QueryPlus;
 import org.apache.druid.query.QueryRunner;
 import org.apache.druid.query.context.ResponseContext;
 import org.apache.druid.server.initialization.ServerConfig;
+
+import java.util.Map;
 
 /**
  * Use this QueryRunner to set and verify Query contexts.
@@ -70,15 +71,25 @@ public class SetAndVerifyContextQueryRunner<T> implements QueryRunner<T>
     );
     // DirectDruidClient.QUERY_FAIL_TIME is used by DirectDruidClient and JsonParserIterator to determine when to
     // fail with a timeout exception
-    final long failTime;
     final QueryContext context = newQuery.context();
+    final long existingFailTime = context.getLong(DirectDruidClient.QUERY_FAIL_TIME, -1L);
+    long computedFailTime;
     if (context.hasTimeout()) {
-      failTime = this.startTimeMillis + context.getTimeout();
+      computedFailTime = this.startTimeMillis + context.getTimeout();
     } else {
-      failTime = this.startTimeMillis + serverConfig.getMaxQueryTimeout();
+      computedFailTime = this.startTimeMillis + serverConfig.getMaxQueryTimeout();
     }
+    // Clamp overflow
+    if (computedFailTime <= 0) {
+      computedFailTime = Long.MAX_VALUE;
+    }
+    // Never extend an existing deadline. This prevents nested native queries and queued historicals
+    // from pushing the effective timeout past the original deadline.
+    final long failTime = (existingFailTime >= 0)
+        ? Math.min(existingFailTime, computedFailTime)
+        : computedFailTime;
     return newQuery.withOverriddenContext(
-        ImmutableMap.of(DirectDruidClient.QUERY_FAIL_TIME, failTime > 0 ? failTime : Long.MAX_VALUE)
+        Map.of(DirectDruidClient.QUERY_FAIL_TIME, failTime)
     );
   }
 }

--- a/server/src/test/java/org/apache/druid/server/SetAndVerifyContextQueryRunnerTest.java
+++ b/server/src/test/java/org/apache/druid/server/SetAndVerifyContextQueryRunnerTest.java
@@ -139,4 +139,94 @@ public class SetAndVerifyContextQueryRunnerTest
         System.currentTimeMillis() < transformed.context().getLong(DirectDruidClient.QUERY_FAIL_TIME)
     );
   }
+
+  @Test
+  public void testExistingQueryFailTimeIsPreservedWhenEarlierThanComputed()
+  {
+    // Simulates the case where a parent runner (e.g. SQL layer) already set QUERY_FAIL_TIME,
+    // and a nested native query runner is created later in execution. The existing deadline
+    // must not be extended.
+    long existingFailTime = System.currentTimeMillis() + 1000L; // 1s from now (earlier than computed)
+    Query<ScanResultValue> query = new Druids.ScanQueryBuilder()
+        .dataSource("foo")
+        .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.ETERNITY)))
+        .context(ImmutableMap.of(
+            QueryContexts.TIMEOUT_KEY, 300_000,
+            DirectDruidClient.QUERY_FAIL_TIME, existingFailTime
+        ))
+        .build();
+
+    ServerConfig defaultConfig = new ServerConfig();
+
+    QueryRunner<ScanResultValue> mockRunner = EasyMock.createMock(QueryRunner.class);
+    SetAndVerifyContextQueryRunner<ScanResultValue> queryRunner = new SetAndVerifyContextQueryRunner<>(defaultConfig, mockRunner);
+
+    Query<ScanResultValue> transformed = queryRunner.withTimeoutAndMaxScatterGatherBytes(query, defaultConfig);
+
+    // The existing fail time (1s from now) is earlier than computed (startTime + 300s),
+    // so it must be preserved — not extended to startTime + 300s.
+    Assert.assertEquals(existingFailTime, (long) transformed.context().getLong(DirectDruidClient.QUERY_FAIL_TIME));
+  }
+
+  @Test
+  public void testExistingQueryFailTimeIsOverriddenWhenLaterThanComputed()
+  {
+    // If the existing QUERY_FAIL_TIME is somehow later than what the current config would compute
+    // (e.g. a very loose parent timeout), the stricter computed value wins.
+    long existingFailTime = System.currentTimeMillis() + 600_000L; // 10 min from now
+    Query<ScanResultValue> query = new Druids.ScanQueryBuilder()
+        .dataSource("foo")
+        .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.ETERNITY)))
+        .context(ImmutableMap.of(
+            QueryContexts.TIMEOUT_KEY, 1,
+            DirectDruidClient.QUERY_FAIL_TIME, existingFailTime
+        ))
+        .build();
+
+    ServerConfig defaultConfig = new ServerConfig();
+
+    QueryRunner<ScanResultValue> mockRunner = EasyMock.createMock(QueryRunner.class);
+    SetAndVerifyContextQueryRunner<ScanResultValue> queryRunner = new SetAndVerifyContextQueryRunner<>(defaultConfig, mockRunner);
+
+    Query<ScanResultValue> transformed = queryRunner.withTimeoutAndMaxScatterGatherBytes(query, defaultConfig);
+
+    // Computed fail time is startTime + 1ms, which is earlier than the existing 10-min deadline.
+    // The computed (stricter) value must win.
+    Assert.assertTrue(
+        transformed.context().getLong(DirectDruidClient.QUERY_FAIL_TIME) < existingFailTime
+    );
+  }
+
+  @Test
+  public void testExistingQueryFailTimeIsPreservedWhenComputedOverflows()
+  {
+    // When timeout is Long.MAX_VALUE, startTimeMillis + timeout overflows to a negative value.
+    // The legitimate (small) existingFailTime must still win — not be erased by the overflow.
+    long existingFailTime = System.currentTimeMillis() + 1000L;
+    Query<ScanResultValue> query = new Druids.ScanQueryBuilder()
+        .dataSource("foo")
+        .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.ETERNITY)))
+        .context(ImmutableMap.of(
+            QueryContexts.TIMEOUT_KEY, Long.MAX_VALUE,
+            DirectDruidClient.QUERY_FAIL_TIME, existingFailTime
+        ))
+        .build();
+
+    // Explicit max so the test does not depend on ServerConfig default values.
+    ServerConfig defaultConfig = new ServerConfig()
+    {
+      @Override
+      public long getMaxQueryTimeout()
+      {
+        return Long.MAX_VALUE;
+      }
+    };
+
+    QueryRunner<ScanResultValue> mockRunner = EasyMock.createMock(QueryRunner.class);
+    SetAndVerifyContextQueryRunner<ScanResultValue> queryRunner = new SetAndVerifyContextQueryRunner<>(defaultConfig, mockRunner);
+
+    Query<ScanResultValue> transformed = queryRunner.withTimeoutAndMaxScatterGatherBytes(query, defaultConfig);
+
+    Assert.assertEquals(existingFailTime, (long) transformed.context().getLong(DirectDruidClient.QUERY_FAIL_TIME));
+  }
 }


### PR DESCRIPTION
### Description

There's a bug in the `SetAndVerifyContextQueryRunner` where it unconditionally overwrites `QUERY_FAIL_TIME` with `startTimeMillis` + timeout, where `startTimeMillis` is when that runner instance was created — not when the original query started.

This can happen when a SQL query generates inner sub-queries first (e.g. CTEs), then outer native queries after those complete. The outer queries re-enter the broker's query pipeline and get a fresh `SetAndVerifyContextQueryRunner` created some ms offset into execution. For example, with timeout=300000ms inherited from context and a 49000ms offset, their deadline becomes now + 300s = original_start + 349s.

This can cause queries to run past their allotted query timeout, hogging resources and breaking operator/user assumptions. 

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Fix prolonged query timeout bug in SetAndVerifyContextQueryRunner that can occur during generated sub-queries.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.