### PR TITLE
feat: use java virtual threads for virtual storage load on demand thread pool by default

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderConfig.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderConfig.java
@@ -75,7 +75,16 @@ public class SegmentLoaderConfig
   private boolean virtualStorage = false;
 
   @JsonProperty("virtualStorageLoadThreads")
-  private int virtualStorageLoadThreads = 2 * runtimeInfo.getAvailableProcessors();
+  private int virtualStorageLoadThreads = Math.max(32, 4 * runtimeInfo.getAvailableProcessors());
+
+  /**
+   * When true (the default), the on-demand load executor uses one virtual thread per task with a {@link
+   * java.util.concurrent.Semaphore} sized by {@link #virtualStorageLoadThreads} for backpressure. When false, falls back
+   * to a fixed platform-thread pool of that size. The escape hatch exists in case virtual threads behave poorly with a
+   * particular deep storage SDK or workload.
+   */
+  @JsonProperty("virtualStorageUseVirtualThreads")
+  private boolean virtualStorageUseVirtualThreads = true;
 
   /**
    * When enabled, weakly-held cache entries are evicted immediately upon release of all holds, rather than
@@ -162,6 +171,11 @@ public class SegmentLoaderConfig
     return virtualStorageLoadThreads;
   }
 
+  public boolean isVirtualStorageUseVirtualThreads()
+  {
+    return virtualStorageUseVirtualThreads;
+  }
+
   public boolean isVirtualStorageEphemeral()
   {
     return virtualStorageIsEphemeral;
@@ -218,6 +232,7 @@ public class SegmentLoaderConfig
            ", statusQueueMaxSize=" + statusQueueMaxSize +
            ", virtualStorage=" + virtualStorage +
            ", virtualStorageLoadThreads=" + virtualStorageLoadThreads +
+           ", virtualStorageUseVirtualThreads=" + virtualStorageUseVirtualThreads +
            ", virtualStorageIsEphemeral=" + virtualStorageIsEphemeral +
            ", combinedMaxSize=" + combinedMaxSize +
            '}';

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
@@ -1025,6 +1025,8 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
     private File storageDir;
     private ReferenceCountedSegmentProvider referenceProvider;
     private final AtomicReference<Runnable> onUnmount = new AtomicReference<>();
+    // switched from synchronized to use a ReentrantLock to avoid pinning virtual threads to platform threads until
+    // https://openjdk.org/jeps/491, we could consider switching back after java 24+ is the minimum version
     private final ReentrantLock entryLock = new ReentrantLock();
 
     private SegmentCacheEntry(final DataSegment dataSegment)

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
@@ -151,6 +151,14 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
       if (config.getNumThreadsToLoadSegmentsIntoPageCacheOnBootstrap() > 0) {
         throw DruidException.defensive("Invalid configuration: virtualStorage is incompatible with numThreadsToLoadSegmentsIntoPageCacheOnBootstrap");
       }
+      if (config.getVirtualStorageLoadThreads() <= 0) {
+        throw DruidException.forPersona(DruidException.Persona.OPERATOR)
+                            .ofCategory(DruidException.Category.INVALID_INPUT)
+                            .build(
+                                "virtualStorageLoadThreads must be greater than 0, got [%d]",
+                                config.getVirtualStorageLoadThreads()
+                            );
+      }
       if (config.isVirtualStorageEphemeral()) {
         for (StorageLocation location : locations) {
           location.setAreWeakEntriesEphemeral(true);

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
@@ -64,9 +64,11 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
 /**
@@ -116,6 +118,12 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
   private final IndexIO indexIO;
 
   private final ListeningExecutorService virtualStorageLoadOnDemandExec;
+  /**
+   * Bounds the number of in-flight on-demand loads when running with virtual threads. Null when virtual storage is
+   * disabled or when the legacy fixed-pool path is selected (the pool size is the implicit limit there).
+   */
+  @Nullable
+  private final Semaphore virtualStorageLoadOnDemandPermits;
   private ExecutorService loadOnBootstrapExec = null;
   private ExecutorService loadOnDownloadExec = null;
 
@@ -137,10 +145,6 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
     log.info("Using storage location strategy[%s].", this.strategy.getClass().getSimpleName());
 
     if (config.isVirtualStorage()) {
-      log.info(
-          "Using virtual storage mode - on demand load threads: [%d].",
-          config.getVirtualStorageLoadThreads()
-      );
       if (config.getNumThreadsToLoadSegmentsIntoPageCacheOnDownload() > 0) {
         throw DruidException.defensive("Invalid configuration: virtualStorage is incompatible with numThreadsToLoadSegmentsIntoPageCacheOnDownload");
       }
@@ -152,14 +156,32 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
           location.setAreWeakEntriesEphemeral(true);
         }
       }
-      virtualStorageLoadOnDemandExec =
-          MoreExecutors.listeningDecorator(
-              // probably replace this with virtual threads once minimum version is java 21
-              Executors.newFixedThreadPool(
-                  config.getVirtualStorageLoadThreads(),
-                  Execs.makeThreadFactory("VirtualStorageOnDemandLoadingThread-%s")
-              )
-          );
+      if (config.isVirtualStorageUseVirtualThreads()) {
+        log.info(
+            "Using virtual storage mode with virtual threads - max concurrent on demand loads: [%d].",
+            config.getVirtualStorageLoadThreads()
+        );
+        virtualStorageLoadOnDemandPermits = new Semaphore(config.getVirtualStorageLoadThreads());
+        virtualStorageLoadOnDemandExec = MoreExecutors.listeningDecorator(
+            Executors.newThreadPerTaskExecutor(
+                Thread.ofVirtual()
+                      .name("VirtualStorageOnDemandLoadingThread-", 0)
+                      .factory()
+            )
+        );
+      } else {
+        log.info(
+            "Using virtual storage mode with fixed platform thread pool - on demand load threads: [%d].",
+            config.getVirtualStorageLoadThreads()
+        );
+        virtualStorageLoadOnDemandPermits = null;
+        virtualStorageLoadOnDemandExec = MoreExecutors.listeningDecorator(
+            Executors.newFixedThreadPool(
+                config.getVirtualStorageLoadThreads(),
+                Execs.makeThreadFactory("VirtualStorageOnDemandLoadingThread-%s")
+            )
+        );
+      }
     } else {
       log.info(
           "Number of threads to load segments into page cache - on bootstrap: [%d], on download: [%d].",
@@ -181,6 +203,7 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
         );
       }
       virtualStorageLoadOnDemandExec = null;
+      virtualStorageLoadOnDemandPermits = null;
     }
   }
 
@@ -786,15 +809,27 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
           final long startTime = System.nanoTime();
           return virtualStorageLoadOnDemandExec.submit(
               () -> {
-                final long execStartTime = System.nanoTime();
-                final long waitTime = execStartTime - startTime;
-                entry.mount(location);
-                return new AcquireSegmentResult(
-                    entry.referenceProvider,
-                    entry.dataSegment.getSize(),
-                    waitTime,
-                    System.nanoTime() - execStartTime
-                );
+                // Acquire a permit inside the task so that waiting parks the (virtual) thread instead of blocking the
+                // submitter. In fixed-pool mode permits is null and the pool size itself bounds concurrency.
+                if (virtualStorageLoadOnDemandPermits != null) {
+                  virtualStorageLoadOnDemandPermits.acquireUninterruptibly();
+                }
+                try {
+                  final long execStartTime = System.nanoTime();
+                  final long waitTime = execStartTime - startTime;
+                  entry.mount(location);
+                  return new AcquireSegmentResult(
+                      entry.referenceProvider,
+                      entry.dataSegment.getSize(),
+                      waitTime,
+                      System.nanoTime() - execStartTime
+                  );
+                }
+                finally {
+                  if (virtualStorageLoadOnDemandPermits != null) {
+                    virtualStorageLoadOnDemandPermits.release();
+                  }
+                }
               }
           );
         }
@@ -982,6 +1017,7 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
     private File storageDir;
     private ReferenceCountedSegmentProvider referenceProvider;
     private final AtomicReference<Runnable> onUnmount = new AtomicReference<>();
+    private final ReentrantLock entryLock = new ReentrantLock();
 
     private SegmentCacheEntry(final DataSegment dataSegment)
     {
@@ -1003,9 +1039,15 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
     }
 
     @Override
-    public synchronized boolean isMounted()
+    public boolean isMounted()
     {
-      return referenceProvider != null;
+      entryLock.lock();
+      try {
+        return referenceProvider != null;
+      }
+      finally {
+        entryLock.unlock();
+      }
     }
 
     @Override
@@ -1024,7 +1066,8 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
       }
 
       try {
-        synchronized (this) {
+        entryLock.lock();
+        try {
           if (location != null) {
             log.debug(
                 "already mounted [%s] in location[%s], but asked to load in [%s], unmounting old location",
@@ -1070,7 +1113,9 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
           lazyLoadCallback = SegmentLazyLoadFailCallback.NOOP;
           referenceProvider = ReferenceCountedSegmentProvider.of(segment);
         }
-
+        finally {
+          entryLock.unlock();
+        }
 
         // since we do not hold a lock on the location while mounting, make sure that we actually are reserved and
         // should have mounted, otherwise unmount so we don't leave any orphaned files
@@ -1114,16 +1159,21 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
     @Override
     public void unmount()
     {
-      final Lock lock;
-      synchronized (this) {
+      final Lock locationLock;
+      entryLock.lock();
+      try {
         if (location == null) {
           return;
         }
-        lock = location.getLock().readLock();
+        locationLock = location.getLock().readLock();
       }
-      lock.lock();
+      finally {
+        entryLock.unlock();
+      }
+      locationLock.lock();
       try {
-        synchronized (this) {
+        entryLock.lock();
+        try {
           if (referenceProvider != null) {
             ReferenceCountedSegmentProvider provider = referenceProvider;
             referenceProvider = null;
@@ -1145,32 +1195,53 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
             onUnmountRunnable.run();
           }
         }
+        finally {
+          entryLock.unlock();
+        }
       }
       finally {
-        lock.unlock();
+        locationLock.unlock();
       }
     }
 
-    public synchronized Optional<Segment> acquireReference()
+    public Optional<Segment> acquireReference()
     {
-      if (referenceProvider == null) {
-        return Optional.empty();
+      entryLock.lock();
+      try {
+        if (referenceProvider == null) {
+          return Optional.empty();
+        }
+        return referenceProvider.acquireReference();
       }
-      return referenceProvider.acquireReference();
+      finally {
+        entryLock.unlock();
+      }
     }
 
-    public synchronized boolean setDeleteInfoFileOnUnmount()
+    public boolean setDeleteInfoFileOnUnmount()
     {
-      if (location == null) {
-        return false;
+      entryLock.lock();
+      try {
+        if (location == null) {
+          return false;
+        }
+        onUnmount.set(() -> deleteSegmentInfoFile(dataSegment));
+        return true;
       }
-      onUnmount.set(() -> deleteSegmentInfoFile(dataSegment));
-      return true;
+      finally {
+        entryLock.unlock();
+      }
     }
 
-    public synchronized void clearOnUnmount()
+    public void clearOnUnmount()
     {
-      onUnmount.set(null);
+      entryLock.lock();
+      try {
+        onUnmount.set(null);
+      }
+      finally {
+        entryLock.unlock();
+      }
     }
 
     public void loadIntoPageCache()
@@ -1178,7 +1249,8 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
       if (!isMounted()) {
         return;
       }
-      synchronized (this) {
+      entryLock.lock();
+      try {
         final File[] children = storageDir.listFiles();
         if (children != null) {
           for (File child : children) {
@@ -1192,6 +1264,9 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
           }
         }
       }
+      finally {
+        entryLock.unlock();
+      }
     }
 
     public boolean checkExists(final File location)
@@ -1204,7 +1279,7 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
       return new File(location, relativePathString);
     }
 
-    @GuardedBy("this")
+    @GuardedBy("entryLock")
     private void loadInLocationWithStartMarker(final DataSegment segment, final File storageDir)
         throws SegmentLoadingException
     {
@@ -1228,7 +1303,7 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
       }
     }
 
-    @GuardedBy("this")
+    @GuardedBy("entryLock")
     private void loadInLocation(final DataSegment segment, final File storageDir)
         throws SegmentLoadingException
     {
@@ -1246,7 +1321,7 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
       }
     }
 
-    @GuardedBy("this")
+    @GuardedBy("entryLock")
     private SegmentizerFactory getSegmentFactory(final File segmentFiles) throws SegmentLoadingException
     {
       final File factoryJson = new File(segmentFiles, "factory.json");

--- a/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerTest.java
@@ -947,6 +947,50 @@ public class SegmentLocalCacheManagerTest extends InitializedNullHandlingTest
   }
 
   @Test
+  public void testVirtualStorageRejectsNonPositiveLoadThreads()
+  {
+    final StorageLocationConfig locationConfig = new StorageLocationConfig(localSegmentCacheDir, 10000L, null);
+    final SegmentLoaderConfig loaderConfig = new SegmentLoaderConfig()
+    {
+      @Override
+      public List<StorageLocationConfig> getLocations()
+      {
+        return ImmutableList.of(locationConfig);
+      }
+
+      @Override
+      public boolean isVirtualStorage()
+      {
+        return true;
+      }
+
+      @Override
+      public int getVirtualStorageLoadThreads()
+      {
+        return 0;
+      }
+    };
+    final List<StorageLocation> storageLocations = loaderConfig.toStorageLocations();
+    MatcherAssert.assertThat(
+        Assert.assertThrows(
+            DruidException.class,
+            () -> new SegmentLocalCacheManager(
+                storageLocations,
+                loaderConfig,
+                new LeastBytesUsedStorageLocationSelectorStrategy(storageLocations),
+                TestHelper.getTestIndexIO(jsonMapper, ColumnConfig.DEFAULT),
+                jsonMapper
+            )
+        ),
+        new DruidExceptionMatcher(
+            DruidException.Persona.OPERATOR,
+            DruidException.Category.INVALID_INPUT,
+            "general"
+        ).expectMessageIs("virtualStorageLoadThreads must be greater than 0, got [0]")
+    );
+  }
+
+  @Test
   public void testGetBootstrapSegmentVirtualStorage() throws Exception
   {
     final StorageLocationConfig locationConfig = new StorageLocationConfig(localSegmentCacheDir, 10000L, null);


### PR DESCRIPTION
### Description
This PR switches the `SegmentLocalCacheManager` on-demand load executor (used in virtual-storage mode) from a fixed platform-thread pool to one virtual thread per task with a `Semaphore` for backpressure, and converts `SegmentCacheEntry` from  synchronized to ReentrantLock so virtual threads park rather than pinning their carrier during the long-running mount path.

The on-demand load work is overwhelmingly socket wait against deep storage with a small CPU portion at the end (factorize/mmap setup). Virtual threads let us fan out hundreds of in-flight loads cheaply, with the semaphore providing a similar kind of backpressure the pool size used to give implicitly. This becomes  especially relevant once partial loading lands and the pool starts handling many smaller per-internal-segment-file range read calls instead of one big mount per segment.

The `ReentrantLock` conversion in `SegmentCacheEntry` is what makes the virtual threads switch actually pay off on Java 21. Without it, the entire `mount()` body runs inside `synchronized (this)`, pinning the carrier thread and effectively       
  capping concurrent mounts at the carrier-pool size regardless of how many virtual threads are spawned. `ReentrantLock` parks the virtual thread properly. Once Druid's minimum is Java 24+, [JEP 491](https://openjdk.org/jeps/491) makes this conversion redundant, but it's a mechanical minimum-risk change in the meantime.  

changes:
* switch default `SegmentLocalCacheManager.virtualStorageLoadOnDemandExec` to virtual threads with a `Semaphore` for backpressure
* added `SegmentLoaderConfig.virtualStorageUseVirtualThreads` (`druid.segmentCache.virtualStorageUseVirtualThreads`) config that defaults to true, but allows opt-out via setting to false
* raise default `SegmentLoaderConfig.virtualStorageLoadThreads` default to Math.max(32, 4 * cores), sized as ~4x lookahead per processing thread
* convert `SegmentCacheEntry` from `synchronized` to `ReentrantLock` so virtual threads park instead of pinning the carrier during mount
