### PR TITLE
fix: ensure query timeout is respected at router

### DIFF
--- a/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -44,6 +44,7 @@ import org.apache.druid.query.BaseQuery;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.query.GenericQueryMetricsFactory;
 import org.apache.druid.query.Query;
+import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.QueryInterruptedException;
 import org.apache.druid.query.QueryMetrics;
 import org.apache.druid.query.QueryToolChestWarehouse;
@@ -435,9 +436,6 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       Request proxyRequest
   )
   {
-    proxyRequest.timeout(httpClientConfig.getReadTimeout().getMillis(), TimeUnit.MILLISECONDS);
-    proxyRequest.idleTimeout(httpClientConfig.getReadTimeout().getMillis(), TimeUnit.MILLISECONDS);
-
     byte[] avaticaQuery = (byte[]) clientRequest.getAttribute(AVATICA_QUERY_ATTRIBUTE);
     if (avaticaQuery != null) {
       proxyRequest.body(new BytesRequestContent(avaticaQuery));
@@ -450,6 +448,10 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
     } else if (sqlQuery != null) {
       setProxyRequestContent(proxyRequest, clientRequest, sqlQuery);
     }
+
+    final long proxyTimeoutMillis = resolveProxyTimeoutMillis(query, sqlQuery);
+    proxyRequest.timeout(proxyTimeoutMillis, TimeUnit.MILLISECONDS);
+    proxyRequest.idleTimeout(proxyTimeoutMillis, TimeUnit.MILLISECONDS);
 
     // Since we can't see the request object on the remote side, we can't check whether the remote side actually
     // performed an authorization check here, so always set this to true for the proxy servlet.
@@ -478,6 +480,48 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
         proxyResponse,
         proxyRequest
     );
+  }
+
+  /**
+   * Resolves the proxy request timeout as min(query timeout, druid.router.http.readTimeout).
+   * Falls back to readTimeout when no per-query timeout is set or the value is unusable
+   * (Avatica requests, missing/invalid context value, or {@link QueryContexts#NO_TIMEOUT}).
+   */
+  @VisibleForTesting
+  long resolveProxyTimeoutMillis(@Nullable Query<?> query, @Nullable SqlQuery sqlQuery)
+  {
+    final long readTimeoutMillis = httpClientConfig.getReadTimeout().getMillis();
+    final Long queryTimeoutMillis;
+    if (query != null) {
+      long t = query.context().getTimeout(QueryContexts.NO_TIMEOUT);
+      queryTimeoutMillis = t > 0 ? t : null;
+    } else if (sqlQuery != null) {
+      queryTimeoutMillis = extractSqlTimeoutMillis(sqlQuery);
+    } else {
+      queryTimeoutMillis = null;
+    }
+    return queryTimeoutMillis == null ? readTimeoutMillis : Math.min(queryTimeoutMillis, readTimeoutMillis);
+  }
+
+  @Nullable
+  private static Long extractSqlTimeoutMillis(SqlQuery sqlQuery)
+  {
+    Object raw = sqlQuery.getContext().get(QueryContexts.TIMEOUT_KEY);
+    if (raw == null) {
+      return null;
+    }
+    try {
+      final long t;
+      if (raw instanceof Number) {
+        t = ((Number) raw).longValue();
+      } else {
+        t = Long.parseLong(raw.toString());
+      }
+      return t > 0 ? t : null;
+    }
+    catch (NumberFormatException ignored) {
+      return null;
+    }
   }
 
   private void setProxyRequestContent(Request proxyRequest, HttpServletRequest clientRequest, Object content)

--- a/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
+++ b/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
@@ -1206,6 +1206,118 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
     return mapper.readValue(json, JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT);
   }
 
+  @Test
+  public void testResolveProxyTimeoutMillis()
+  {
+    final long readTimeoutMillis = 900_000L;
+    final DruidHttpClientConfig httpClientConfig = Mockito.mock(DruidHttpClientConfig.class);
+    Mockito.when(httpClientConfig.getReadTimeout()).thenReturn(org.joda.time.Duration.millis(readTimeoutMillis));
+
+    final AsyncQueryForwardingServlet servlet = new AsyncQueryForwardingServlet(
+        new MapQueryToolChestWarehouse(ImmutableMap.of()),
+        TestHelper.makeJsonMapper(),
+        TestHelper.makeSmileMapper(),
+        null,
+        null,
+        httpClientConfig,
+        NoopServiceEmitter.instance(),
+        NoopRequestLogger.instance(),
+        new DefaultGenericQueryMetricsFactory(),
+        new AuthenticatorMapper(ImmutableMap.of()),
+        new Properties(),
+        new ServerConfig()
+    );
+
+    // No query, no sqlQuery -> readTimeout
+    Assert.assertEquals(readTimeoutMillis, servlet.resolveProxyTimeoutMillis(null, null));
+
+    // Native query with shorter timeout -> query timeout wins
+    final TimeseriesQuery shortQuery = Druids.newTimeseriesQueryBuilder()
+                                             .dataSource("test")
+                                             .intervals("2000/3000")
+                                             .granularity(Granularities.ALL)
+                                             .context(ImmutableMap.of("timeout", 30_000))
+                                             .build();
+    Assert.assertEquals(30_000L, servlet.resolveProxyTimeoutMillis(shortQuery, null));
+
+    // Native query with longer timeout -> readTimeout wins
+    final TimeseriesQuery longQuery = Druids.newTimeseriesQueryBuilder()
+                                            .dataSource("test")
+                                            .intervals("2000/3000")
+                                            .granularity(Granularities.ALL)
+                                            .context(ImmutableMap.of("timeout", 1_800_000))
+                                            .build();
+    Assert.assertEquals(readTimeoutMillis, servlet.resolveProxyTimeoutMillis(longQuery, null));
+
+    // Native query with no timeout context -> readTimeout
+    final TimeseriesQuery noTimeoutQuery = Druids.newTimeseriesQueryBuilder()
+                                                 .dataSource("test")
+                                                 .intervals("2000/3000")
+                                                 .granularity(Granularities.ALL)
+                                                 .build();
+    Assert.assertEquals(readTimeoutMillis, servlet.resolveProxyTimeoutMillis(noTimeoutQuery, null));
+
+    // SQL query with shorter timeout (Number) -> query timeout wins
+    final SqlQuery shortSql = new SqlQuery(
+        "SELECT 1",
+        ResultFormat.OBJECT,
+        false,
+        false,
+        false,
+        ImmutableMap.of("timeout", 45_000),
+        null
+    );
+    Assert.assertEquals(45_000L, servlet.resolveProxyTimeoutMillis(null, shortSql));
+
+    // SQL query with timeout as String -> parsed
+    final SqlQuery stringSql = new SqlQuery(
+        "SELECT 1",
+        ResultFormat.OBJECT,
+        false,
+        false,
+        false,
+        ImmutableMap.of("timeout", "60000"),
+        null
+    );
+    Assert.assertEquals(60_000L, servlet.resolveProxyTimeoutMillis(null, stringSql));
+
+    // SQL query with longer timeout -> readTimeout wins
+    final SqlQuery longSql = new SqlQuery(
+        "SELECT 1",
+        ResultFormat.OBJECT,
+        false,
+        false,
+        false,
+        ImmutableMap.of("timeout", 1_800_000),
+        null
+    );
+    Assert.assertEquals(readTimeoutMillis, servlet.resolveProxyTimeoutMillis(null, longSql));
+
+    // SQL query with invalid timeout -> readTimeout
+    final SqlQuery invalidSql = new SqlQuery(
+        "SELECT 1",
+        ResultFormat.OBJECT,
+        false,
+        false,
+        false,
+        ImmutableMap.of("timeout", "not-a-number"),
+        null
+    );
+    Assert.assertEquals(readTimeoutMillis, servlet.resolveProxyTimeoutMillis(null, invalidSql));
+
+    // SQL query with no context -> readTimeout
+    final SqlQuery noCtxSql = new SqlQuery(
+        "SELECT 1",
+        ResultFormat.OBJECT,
+        false,
+        false,
+        false,
+        ImmutableMap.of(),
+        null
+    );
+    Assert.assertEquals(readTimeoutMillis, servlet.resolveProxyTimeoutMillis(null, noCtxSql));
+  }
+
   private static class TestServer implements org.apache.druid.client.selector.Server
   {
 


### PR DESCRIPTION
<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

We have seen queries fail to reach upstream brokers for a variety of reasons (lack of available broker connections, DNS issues, etc.). In these cases, the router does not fall-back to a sensible timeout (defaulting to the 15mins connection timeout). Since the router is part of Druid, we should be treating the maximum timeout as the min(query timeout, configured router<-->broker connection timeout) to avoid pathological cases where users expect a result in ≤ {query timeout} but end up receiving it 15mins later (or whatever `druid.router.http.readTimeout` is set to).

Other databases separate timeouts into connection vs read timeouts, the former being a timeout on the time taken for the client to establish a connection to the server whereas the latter is a bound on the time taken to perform the actual query. This ensures Druid properly sets read timeout to be the minimum of `druid.router.http.readTimeout` and user-specified/cluster-configured default query timeout.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.