### PR TITLE
perf: Use Set instead of List for druid.request.logging.mutedQueryTypes

### DIFF
--- a/server/src/main/java/org/apache/druid/server/log/FilteredRequestLoggerProvider.java
+++ b/server/src/main/java/org/apache/druid/server/log/FilteredRequestLoggerProvider.java
@@ -21,7 +21,6 @@ package org.apache.druid.server.log;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.google.common.collect.ImmutableList;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.common.logger.Logger;
@@ -30,7 +29,7 @@ import org.apache.druid.server.RequestLogLine;
 
 import javax.validation.constraints.NotNull;
 import java.io.IOException;
-import java.util.List;
+import java.util.Set;
 
 /**
  */
@@ -50,7 +49,7 @@ public class FilteredRequestLoggerProvider implements RequestLoggerProvider
   private long sqlQueryTimeThresholdMs = 0;
 
   @JsonProperty
-  private List<String> mutedQueryTypes = ImmutableList.of();
+  private Set<String> mutedQueryTypes = Set.of();
 
   @Override
   public RequestLogger get()
@@ -70,13 +69,13 @@ public class FilteredRequestLoggerProvider implements RequestLoggerProvider
     private final RequestLogger logger;
     private final long queryTimeThresholdMs;
     private final long sqlQueryTimeThresholdMs;
-    private final List<String> mutedQueryTypes;
+    private final Set<String> mutedQueryTypes;
 
     public FilteredRequestLogger(
         RequestLogger logger,
         long queryTimeThresholdMs,
         long sqlQueryTimeThresholdMs,
-        List<String> mutedQueryTypes
+        Set<String> mutedQueryTypes
     )
     {
       this.logger = logger;

--- a/server/src/test/java/org/apache/druid/server/log/FilteredRequestLoggerTest.java
+++ b/server/src/test/java/org/apache/druid/server/log/FilteredRequestLoggerTest.java
@@ -21,7 +21,6 @@ package org.apache.druid.server.log;
 
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.ProvisionException;
 import org.apache.druid.guice.JsonConfigurator;
@@ -39,9 +38,9 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import javax.validation.Validation;
-
 import java.io.IOException;
 import java.util.Properties;
+import java.util.Set;
 
 public class FilteredRequestLoggerTest
 {
@@ -87,7 +86,7 @@ public class FilteredRequestLoggerTest
         delegate,
         1000,
         2000,
-        ImmutableList.of()
+        Set.of()
     );
     RequestLogLine nativeRequestLogLine = EasyMock.createMock(RequestLogLine.class);
     EasyMock.expect(nativeRequestLogLine.getQueryStats())
@@ -130,7 +129,7 @@ public class FilteredRequestLoggerTest
         delegate,
         1000,
         2000,
-        ImmutableList.of()
+        Set.of()
     );
 
     RequestLogLine nativeRequestLogLine = RequestLogLine.forNative(
@@ -166,7 +165,7 @@ public class FilteredRequestLoggerTest
         delegate,
         1000,
         2000,
-        ImmutableList.of(Query.SEGMENT_METADATA)
+        Set.of(Query.SEGMENT_METADATA)
     );
 
     RequestLogLine nativeRequestLogLine = RequestLogLine.forNative(


### PR DESCRIPTION
Update `druid.request.logging.mutedQueryTypes` to use a `Set` instead of a `List`.
Set lookups are faster than list-based lookups, which can matter at high QPS when filtered logging with multiple muted types is enabled on servers.

This PR has:

- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.