### PR TITLE
fix:  Fix unhealthy supervisor when a priority-assigned task dies before discovery

### DIFF
--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -1727,24 +1727,12 @@ public class KafkaSupervisorTest extends EasyMockSupport
   }
 
   /**
-   * Regression test for a bug where {@code taskIdToServerPriority} could retain a stale entry for a task that
-   * was submitted in run 1 but died before the next supervisor run, causing
-   * {@link SeekableStreamSupervisor#computeUnassignedServerPriorities} to see a fully-assigned priority set and
-   * throw {@link org.apache.druid.error.DruidException} on run 2 even though {@code group.tasks} was short by a
-   * replica.
-   *
-   * <p>The repro is identical to the production stack trace:
-   * <pre>
-   *   Found unassignedServerPriorities[[]] of size[0] &lt; total replicas[1] for taskGroupId[0].
-   *   Task server priorities[[1, 0]] have already been assigned to tasks[[&lt;surviving_task&gt;]].
-   * </pre>
-   *
-   * <p>Without the fix (single-writer of {@code taskIdToServerPriority} via {@code discoverTasks}),
-   * run 2's {@code createNewTasks} throws. With the fix, it silently submits a replacement task with the
-   * missing priority.
+   * Regression test: {@link SeekableStreamSupervisor.TaskGroup#tasks} and {@link SeekableStreamSupervisor.TaskGroup#taskIdToServerPriority}
+   * must not go out of sync when a newly-submitted task dies before the next supervisor run observes it. Otherwise, the orphan priority entry
+   * makes {@link SeekableStreamSupervisor#computeUnassignedServerPriorities} throw on the replacement attempt.
    */
   @Test
-  public void testTaskFailingBeforeDiscoveryDoesNotBlockReplacement() throws Exception
+  public void testReplacementSubmittedWhenPriorityTaskDiesBeforeDiscovery() throws Exception
   {
     // replicas=2, taskCount=1, priorities {0:1, 1:1} — matches the observed prod config.
     supervisor = getTestableSupervisor(null, 2, 1, true, true, "PT1H", null, null, false, kafkaHost, null, Map.of(0, 1, 1, 1));

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -1726,6 +1726,96 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Assert.assertEquals(Integer.valueOf(1), retriedTask.getServerPriority());
   }
 
+  /**
+   * Regression test for a bug where {@code taskIdToServerPriority} could retain a stale entry for a task that
+   * was submitted in run 1 but died before the next supervisor run, causing
+   * {@link SeekableStreamSupervisor#computeUnassignedServerPriorities} to see a fully-assigned priority set and
+   * throw {@link org.apache.druid.error.DruidException} on run 2 even though {@code group.tasks} was short by a
+   * replica.
+   *
+   * <p>The repro is identical to the production stack trace:
+   * <pre>
+   *   Found unassignedServerPriorities[[]] of size[0] &lt; total replicas[1] for taskGroupId[0].
+   *   Task server priorities[[1, 0]] have already been assigned to tasks[[&lt;surviving_task&gt;]].
+   * </pre>
+   *
+   * <p>Without the fix (single-writer of {@code taskIdToServerPriority} via {@code discoverTasks}),
+   * run 2's {@code createNewTasks} throws. With the fix, it silently submits a replacement task with the
+   * missing priority.
+   */
+  @Test
+  public void testTaskFailingBeforeDiscoveryDoesNotBlockReplacement() throws Exception
+  {
+    // replicas=2, taskCount=1, priorities {0:1, 1:1} — matches the observed prod config.
+    supervisor = getTestableSupervisor(null, 2, 1, true, true, "PT1H", null, null, false, kafkaHost, null, Map.of(0, 1, 1, 1));
+    addSomeEvents(1);
+
+    Capture<Task> captured = Capture.newInstance(CaptureType.ALL);
+    EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
+    EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.of(taskRunner)).anyTimes();
+    EasyMock.expect(taskRunner.getRunningTasks()).andReturn(Collections.emptyList()).anyTimes();
+    EasyMock.expect(taskQueue.getActiveTasksForDatasource(DATASOURCE)).andReturn(Map.of()).anyTimes();
+    EasyMock.expect(taskClient.getStatusAsync(EasyMock.anyString()))
+            .andReturn(Futures.immediateFuture(Status.NOT_STARTED))
+            .anyTimes();
+    EasyMock.expect(taskClient.getStartTimeAsync(EasyMock.anyString()))
+            .andReturn(Futures.immediateFuture(DateTimes.nowUtc()))
+            .anyTimes();
+    EasyMock.expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE)).andReturn(
+        new KafkaDataSourceMetadata(null)
+    ).anyTimes();
+    // Run 1 submits the initial 2 replicas. (Run 2's 1 replacement is programmed after the reset below.)
+    EasyMock.expect(taskQueue.add(EasyMock.capture(captured))).andReturn(true).times(2);
+
+    // discoverTasks() on run 2 calls verifyAndMergeCheckpoints -> taskClient.getCheckpointsAsync on the survivor.
+    EasyMock.expect(taskClient.getCheckpointsAsync(EasyMock.anyString(), EasyMock.anyBoolean()))
+            .andReturn(Futures.immediateFuture(new TreeMap<>()))
+            .anyTimes();
+
+    taskRunner.registerListener(EasyMock.anyObject(TaskRunnerListener.class), EasyMock.anyObject(Executor.class));
+    replayAll();
+
+    supervisor.start();
+    supervisor.runInternal();
+    verifyAll();
+
+    final List<Task> run1Tasks = captured.getValues();
+    Assert.assertEquals(2, run1Tasks.size());
+    final KafkaIndexTask orphan = (KafkaIndexTask) run1Tasks.get(0);
+    final KafkaIndexTask survivor = (KafkaIndexTask) run1Tasks.get(1);
+    // Sanity check: the two replicas must hold the two configured priorities.
+    Assert.assertEquals(
+        Set.of(0, 1),
+        Set.of(orphan.getServerPriority(), survivor.getServerPriority())
+    );
+
+    // Run 2: the first replica died before discoverTasks() could observe it, so activeTaskMap contains only
+    // the survivor. Prior to the fix, createTasksForGroup had already written the orphan's priority into
+    // taskIdToServerPriority during run 1, so run 2's computeUnassignedServerPriorities would see both
+    // priorities as "assigned" and throw.
+    EasyMock.reset(taskStorage);
+    EasyMock.reset(taskQueue);
+    EasyMock.expect(taskQueue.getActiveTasksForDatasource(DATASOURCE))
+            .andReturn(toMap(List.of(survivor)))
+            .anyTimes();
+    EasyMock.expect(taskStorage.getStatus(survivor.getId()))
+            .andReturn(Optional.of(TaskStatus.running(survivor.getId())))
+            .anyTimes();
+    EasyMock.expect(taskStorage.getTask(survivor.getId())).andReturn(Optional.of(survivor)).anyTimes();
+    final Capture<Task> replacementCapture = Capture.newInstance();
+    EasyMock.expect(taskQueue.add(EasyMock.capture(replacementCapture))).andReturn(true);
+    EasyMock.replay(taskStorage);
+    EasyMock.replay(taskQueue);
+
+    // Must not throw.
+    supervisor.runInternal();
+    verifyAll();
+
+    // The replacement task should take the orphan's priority, not duplicate the survivor's or block.
+    final KafkaIndexTask replacement = (KafkaIndexTask) replacementCapture.getValue();
+    Assert.assertEquals(orphan.getServerPriority(), replacement.getServerPriority());
+  }
+
   @Test
   public void testRequeueAdoptedTaskWhenFailed() throws Exception
   {

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -1734,7 +1734,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
   @Test
   public void testReplacementSubmittedWhenPriorityTaskDiesBeforeDiscovery() throws Exception
   {
-    // replicas=2, taskCount=1, priorities {0:1, 1:1} — matches the observed prod config.
+    // replicas=2, taskCount=1, priorities {0:1, 1:1}
     supervisor = getTestableSupervisor(null, 2, 1, true, true, "PT1H", null, null, false, kafkaHost, null, Map.of(0, 1, 1, 1));
     addSomeEvents(1);
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -4417,14 +4417,6 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     );
 
     for (SeekableStreamIndexTask indexTask : taskList) {
-      final String taskId = indexTask.getId();
-      final Integer serverPriority = indexTask.getServerPriority();
-
-      if (serverPriority != null) {
-        log.info("Adding serverPriority[%d] for task[%s] and groupId[%s]", serverPriority, taskId, groupId);
-        group.taskIdToServerPriority.put(taskId, serverPriority);
-      }
-
       Optional<TaskQueue> taskQueue = taskMaster.getTaskQueue();
       if (taskQueue.isPresent()) {
         try {
@@ -4462,18 +4454,6 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
       }
     }
     allRequiredPriorities.sort(Collections.reverseOrder());
-
-    // Drop any stale taskIdToServerPriority entries for tasks no longer in the group. Entries can linger if a
-    // task was created (priority recorded) but failed before being observed by discoverTasks(), since the usual
-    // removeTask() cleanup only runs for tasks that make it into group.tasks.
-    final Set<String> orphanedTaskIds = Sets.difference(group.taskIdToServerPriority.keySet(), group.taskIds());
-    if (!orphanedTaskIds.isEmpty()) {
-      log.warn(
-          "Dropping orphaned taskIdToServerPriority entries[%s] in taskGroupId[%d]; these tasks are not in group.tasks[%s].",
-          orphanedTaskIds, group.groupId, group.taskIds()
-      );
-      group.taskIdToServerPriority.keySet().removeAll(orphanedTaskIds);
-    }
 
     // Remove already assigned priorities
     final List<Integer> assignedPriorities = new ArrayList<>(group.taskIdToServerPriority.values());

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -4463,6 +4463,18 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     }
     allRequiredPriorities.sort(Collections.reverseOrder());
 
+    // Drop any stale taskIdToServerPriority entries for tasks no longer in the group. Entries can linger if a
+    // task was created (priority recorded) but failed before being observed by discoverTasks(), since the usual
+    // removeTask() cleanup only runs for tasks that make it into group.tasks.
+    final Set<String> orphanedTaskIds = Sets.difference(group.taskIdToServerPriority.keySet(), group.taskIds());
+    if (!orphanedTaskIds.isEmpty()) {
+      log.warn(
+          "Dropping orphaned taskIdToServerPriority entries[%s] in taskGroupId[%d]; these tasks are not in group.tasks[%s].",
+          orphanedTaskIds, group.groupId, group.taskIds()
+      );
+      group.taskIdToServerPriority.keySet().removeAll(orphanedTaskIds);
+    }
+
     // Remove already assigned priorities
     final List<Integer> assignedPriorities = new ArrayList<>(group.taskIdToServerPriority.values());
     final List<Integer> unassignedServerPriorities = new ArrayList<>(allRequiredPriorities);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
@@ -2886,6 +2886,50 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     verifyAll();
   }
 
+  @Test
+  public void testComputeUnassignedServerPriorities_ignoresOrphanedPriorityEntries()
+  {
+    // Reproduces the orphan scenario: a previously-created task with an assigned server priority was never
+    // observed by discoverTasks() (e.g. it failed before the next supervisor run), so its entry lives on in
+    // taskIdToServerPriority even though the task is absent from group.tasks. The computation must derive
+    // assigned priorities from the live task set, not from stale entries.
+    final SeekableStreamSupervisorIOConfig ioConfig = createSupervisorIOConfig(2, Map.of(0, 1, 1, 1));
+
+    Assert.assertEquals(2, (int) ioConfig.getReplicas());
+
+    EasyMock.reset(spec);
+    EasyMock.expect(spec.getId()).andReturn(SUPERVISOR_ID).anyTimes();
+    EasyMock.expect(spec.getSupervisorStateManagerConfig()).andReturn(supervisorConfig).anyTimes();
+    EasyMock.expect(spec.getDataSchema()).andReturn(getDataSchema()).anyTimes();
+    EasyMock.expect(spec.getIoConfig()).andReturn(ioConfig).anyTimes();
+    EasyMock.expect(spec.getTuningConfig()).andReturn(getTuningConfig()).anyTimes();
+    EasyMock.expect(spec.getEmitter()).andReturn(emitter).anyTimes();
+    EasyMock.expect(spec.getContextValue(DruidMetrics.TAGS)).andReturn(METRIC_TAGS).anyTimes();
+    EasyMock.expect(spec.isSuspended()).andReturn(false).anyTimes();
+
+    replayAll();
+
+    TestSeekableStreamSupervisor supervisor = new TestSeekableStreamSupervisor();
+
+    // Only "task_survivor" is actually in the task group; "task_failed_orphan" died before being discovered,
+    // but its priority(1) entry was never cleaned up.
+    final SeekableStreamSupervisor<String, String, ByteEntity>.TaskGroup taskGroup =
+        supervisor.addTaskGroupToActivelyReadingTaskGroup(
+            0,
+            ImmutableMap.of("0", "0"),
+            null,
+            null,
+            Set.of("task_survivor"),
+            Set.of(),
+            Map.of("task_failed_orphan", 1, "task_survivor", 0)
+        );
+
+    // With the orphan priority(1) ignored, the only unassigned priority is 1 — enough for the 1 new replica.
+    Assert.assertEquals(List.of(1), supervisor.computeUnassignedServerPriorities(taskGroup, 1));
+
+    verifyAll();
+  }
+
   private static DataSchema getDataSchema()
   {
     List<DimensionSchema> dimensions = new ArrayList<>();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
@@ -2886,50 +2886,6 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     verifyAll();
   }
 
-  @Test
-  public void testComputeUnassignedServerPriorities_ignoresOrphanedPriorityEntries()
-  {
-    // Reproduces the orphan scenario: a previously-created task with an assigned server priority was never
-    // observed by discoverTasks() (e.g. it failed before the next supervisor run), so its entry lives on in
-    // taskIdToServerPriority even though the task is absent from group.tasks. The computation must derive
-    // assigned priorities from the live task set, not from stale entries.
-    final SeekableStreamSupervisorIOConfig ioConfig = createSupervisorIOConfig(2, Map.of(0, 1, 1, 1));
-
-    Assert.assertEquals(2, (int) ioConfig.getReplicas());
-
-    EasyMock.reset(spec);
-    EasyMock.expect(spec.getId()).andReturn(SUPERVISOR_ID).anyTimes();
-    EasyMock.expect(spec.getSupervisorStateManagerConfig()).andReturn(supervisorConfig).anyTimes();
-    EasyMock.expect(spec.getDataSchema()).andReturn(getDataSchema()).anyTimes();
-    EasyMock.expect(spec.getIoConfig()).andReturn(ioConfig).anyTimes();
-    EasyMock.expect(spec.getTuningConfig()).andReturn(getTuningConfig()).anyTimes();
-    EasyMock.expect(spec.getEmitter()).andReturn(emitter).anyTimes();
-    EasyMock.expect(spec.getContextValue(DruidMetrics.TAGS)).andReturn(METRIC_TAGS).anyTimes();
-    EasyMock.expect(spec.isSuspended()).andReturn(false).anyTimes();
-
-    replayAll();
-
-    TestSeekableStreamSupervisor supervisor = new TestSeekableStreamSupervisor();
-
-    // Only "task_survivor" is actually in the task group; "task_failed_orphan" died before being discovered,
-    // but its priority(1) entry was never cleaned up.
-    final SeekableStreamSupervisor<String, String, ByteEntity>.TaskGroup taskGroup =
-        supervisor.addTaskGroupToActivelyReadingTaskGroup(
-            0,
-            ImmutableMap.of("0", "0"),
-            null,
-            null,
-            Set.of("task_survivor"),
-            Set.of(),
-            Map.of("task_failed_orphan", 1, "task_survivor", 0)
-        );
-
-    // With the orphan priority(1) ignored, the only unassigned priority is 1 — enough for the 1 new replica.
-    Assert.assertEquals(List.of(1), supervisor.computeUnassignedServerPriorities(taskGroup, 1));
-
-    verifyAll();
-  }
-
   private static DataSchema getDataSchema()
   {
     List<DimensionSchema> dimensions = new ArrayList<>();
@@ -3638,6 +3594,127 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     Assert.assertEquals(Integer.valueOf(10), taskIdToServerPriority.get("task3"));
 
     verifyAll();
+  }
+
+  /**
+   * Regression test for a bug where {@code taskIdToServerPriority} could retain a stale entry for a task that
+   * was submitted in run 1 but died before the next supervisor run, causing
+   * {@link SeekableStreamSupervisor#computeUnassignedServerPriorities} to see a fully-assigned priority set and
+   * throw {@link DruidException} on run 2 even though {@code group.tasks} was short by a replica.
+   *
+   * <p>Without the fix (single-writer of {@code taskIdToServerPriority} via {@code discoverTasks}), run 2's
+   * {@code createNewTasks} throws. With the fix, it silently submits a replacement task with the missing
+   * priority.
+   */
+  @Test
+  public void testTaskFailingBeforeDiscoveryDoesNotBlockReplacement()
+  {
+    // replicas=2, taskCount=1, priorities {0:1, 1:1} — matches the observed prod config.
+    final SeekableStreamSupervisorIOConfig ioConfig = createSupervisorIOConfig(1, Map.of(0, 1, 1, 1));
+
+    Assert.assertEquals(2, (int) ioConfig.getReplicas());
+
+    EasyMock.reset(spec);
+    EasyMock.expect(spec.getId()).andReturn(SUPERVISOR_ID).anyTimes();
+    EasyMock.expect(spec.getSupervisorStateManagerConfig()).andReturn(supervisorConfig).anyTimes();
+    EasyMock.expect(spec.getDataSchema()).andReturn(getDataSchema()).anyTimes();
+    EasyMock.expect(spec.getIoConfig()).andReturn(ioConfig).anyTimes();
+    EasyMock.expect(spec.getTuningConfig()).andReturn(getTuningConfig()).anyTimes();
+    EasyMock.expect(spec.getEmitter()).andReturn(emitter).anyTimes();
+    EasyMock.expect(spec.getContextValue(DruidMetrics.TAGS)).andReturn(METRIC_TAGS).anyTimes();
+    EasyMock.expect(spec.isSuspended()).andReturn(false).anyTimes();
+
+    EasyMock.expect(recordSupplier.getPartitionIds(STREAM)).andReturn(ImmutableSet.of(SHARD_ID)).anyTimes();
+
+    // Run 1 starts with no active tasks in the overlord. After runInternal() we reset & replay the mock
+    // below to simulate run 2, where one replica is missing from activeTaskMap.
+    EasyMock.expect(taskQueue.getActiveTasksForDatasource(DATASOURCE))
+            .andReturn(Map.of())
+            .anyTimes();
+
+    EasyMock.expect(indexTaskClient.getCheckpointsAsync(EasyMock.anyString(), EasyMock.anyBoolean()))
+            .andReturn(Futures.immediateFuture(new TreeMap<>()))
+            .anyTimes();
+    EasyMock.expect(indexTaskClient.getStatusAsync(EasyMock.anyString()))
+            .andReturn(Futures.immediateFuture(SeekableStreamIndexTaskRunner.Status.READING))
+            .anyTimes();
+    EasyMock.expect(indexTaskClient.getStartTimeAsync(EasyMock.anyString()))
+            .andReturn(Futures.immediateFuture(DateTimes.nowUtc()))
+            .anyTimes();
+    EasyMock.expect(indexTaskClient.getCurrentOffsetsAsync(EasyMock.anyString(), EasyMock.anyBoolean()))
+            .andReturn(Futures.immediateFuture(ImmutableMap.of(SHARD_ID, "5")))
+            .anyTimes();
+    EasyMock.expect(taskRunner.getRunningTasks()).andReturn(ImmutableList.of()).anyTimes();
+
+    final Capture<Task> submittedTasks = Capture.newInstance(CaptureType.ALL);
+    EasyMock.expect(taskQueue.add(EasyMock.capture(submittedTasks))).andReturn(true).anyTimes();
+
+    replayAll();
+
+    // Custom supervisor that honors serverPrioritiesToAssign when creating tasks so run 1 produces
+    // two replicas carrying real priorities (matching prod behavior).
+    final TestSeekableStreamSupervisor supervisor = new TestSeekableStreamSupervisor()
+    {
+      @Override
+      protected List<SeekableStreamIndexTask<String, String, ByteEntity>> createIndexTasks(
+          int replicas,
+          String baseSequenceName,
+          ObjectMapper sortingMapper,
+          TreeMap<Integer, Map<String, String>> sequenceOffsets,
+          SeekableStreamIndexTaskIOConfig taskIoConfig,
+          SeekableStreamIndexTaskTuningConfig taskTuningConfig,
+          RowIngestionMetersFactory rowIngestionMetersFactory,
+          @Nullable List<Integer> serverPrioritiesToAssign
+      )
+      {
+        final List<SeekableStreamIndexTask<String, String, ByteEntity>> tasks = new ArrayList<>();
+        for (int i = 0; i < replicas; i++) {
+          final Integer priority = serverPrioritiesToAssign == null ? null : serverPrioritiesToAssign.get(i);
+          tasks.add(createTestTask(
+              baseSequenceName + "_replica_" + i + "_p" + priority,
+              "0",
+              priority,
+              taskIoConfig,
+              recordSupplier
+          ));
+        }
+        return tasks;
+      }
+    };
+
+    supervisor.start();
+    supervisor.runInternal();
+
+    // Run 1 should have submitted 2 replicas.
+    final List<Task> run1Tasks = submittedTasks.getValues();
+    Assert.assertEquals(2, run1Tasks.size());
+    final TestSeekableStreamIndexTask orphan = (TestSeekableStreamIndexTask) run1Tasks.get(0);
+    final TestSeekableStreamIndexTask survivor = (TestSeekableStreamIndexTask) run1Tasks.get(1);
+    Assert.assertEquals(
+        Set.of(0, 1),
+        Set.of(orphan.getServerPriority(), survivor.getServerPriority())
+    );
+
+    // Run 2: only the survivor is still active. The orphan died before discoverTasks() could observe it,
+    // so with the old eager-write bug it would linger in taskIdToServerPriority and block replacement.
+    EasyMock.reset(taskQueue, taskStorage);
+    EasyMock.expect(taskQueue.getActiveTasksForDatasource(DATASOURCE))
+            .andReturn(Map.of(survivor.getId(), survivor))
+            .anyTimes();
+    EasyMock.expect(taskStorage.getStatus(survivor.getId()))
+            .andReturn(Optional.of(TaskStatus.running(survivor.getId())))
+            .anyTimes();
+    EasyMock.expect(taskStorage.getTask(survivor.getId())).andReturn(Optional.of(survivor)).anyTimes();
+    final Capture<Task> replacementCapture = Capture.newInstance();
+    EasyMock.expect(taskQueue.add(EasyMock.capture(replacementCapture))).andReturn(true).once();
+    EasyMock.replay(taskQueue, taskStorage);
+
+    // Must not throw.
+    supervisor.runInternal();
+
+    // Replacement task should carry the orphan's missing priority, not duplicate the survivor's.
+    final TestSeekableStreamIndexTask replacement = (TestSeekableStreamIndexTask) replacementCapture.getValue();
+    Assert.assertEquals(orphan.getServerPriority(), replacement.getServerPriority());
   }
 
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
@@ -3604,7 +3604,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
   @Test
   public void testReplacementSubmittedWhenPriorityTaskDiesBeforeDiscovery()
   {
-    // replicas=2, taskCount=1, priorities {0:1, 1:1} — matches the observed prod config.
+    // replicas=2, taskCount=1, priorities {0:1, 1:1}
     final SeekableStreamSupervisorIOConfig ioConfig = createSupervisorIOConfig(1, Map.of(0, 1, 1, 1));
 
     Assert.assertEquals(2, (int) ioConfig.getReplicas());
@@ -3647,7 +3647,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     replayAll();
 
     // Custom supervisor that honors serverPrioritiesToAssign when creating tasks so run 1 produces
-    // two replicas carrying real priorities (matching prod behavior).
+    // two replicas carrying priorities
     final TestSeekableStreamSupervisor supervisor = new TestSeekableStreamSupervisor()
     {
       @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
@@ -3597,17 +3597,12 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
   }
 
   /**
-   * Regression test for a bug where {@code taskIdToServerPriority} could retain a stale entry for a task that
-   * was submitted in run 1 but died before the next supervisor run, causing
-   * {@link SeekableStreamSupervisor#computeUnassignedServerPriorities} to see a fully-assigned priority set and
-   * throw {@link DruidException} on run 2 even though {@code group.tasks} was short by a replica.
-   *
-   * <p>Without the fix (single-writer of {@code taskIdToServerPriority} via {@code discoverTasks}), run 2's
-   * {@code createNewTasks} throws. With the fix, it silently submits a replacement task with the missing
-   * priority.
+   * Regression test: {@link SeekableStreamSupervisor.TaskGroup#tasks} and {@link SeekableStreamSupervisor.TaskGroup#taskIdToServerPriority}
+   * must not go out of sync when a newly-submitted task dies before the next supervisor run observes it. Otherwise, the orphan priority entry
+   * makes {@link SeekableStreamSupervisor#computeUnassignedServerPriorities} throw on the replacement attempt.
    */
   @Test
-  public void testTaskFailingBeforeDiscoveryDoesNotBlockReplacement()
+  public void testReplacementSubmittedWhenPriorityTaskDiesBeforeDiscovery()
   {
     // replicas=2, taskCount=1, priorities {0:1, 1:1} — matches the observed prod config.
     final SeekableStreamSupervisorIOConfig ioConfig = createSupervisorIOConfig(1, Map.of(0, 1, 1, 1));


### PR DESCRIPTION
### Description

  With https://github.com/apache/druid/pull/19040, when `ioConfig.serverPriorityToReplicas` is set, a supervisor can get stuck throwing
  `DruidException` from `computeUnassignedServerPriorities`, preventing any new
  task replicas with destined replicas from being created until the old tasks rollover. The 
exception is as follows:
  ```
Found unassignedServerPriorities[[]] of size[0] < total replicas[1] for taskGroupId[0].
  Task server priorities[[1, 0]] have already been assigned to tasks[[foo]].
```

The supervisor can remain in this unhealthy state unable to create additional task replicas until tasks eventually rollover. This can happen when a task spuriously fails after it's created but before it's discovered in the `runInternal()` loop.

  ### Root cause
  `createTasksForGroup` was an *additional* writer of `group.taskIdToServerPriority`,
  recording the priority at task-submission time — before the task was ever observed
  in `group.tasks`. The group's other invariant (`tasks` and `taskIdToServerPriority`
  stay in sync) is enforced by `discoverTasks` (additions) and `TaskGroup.removeTask`
  (removals), both of which operate on `group.tasks`.

  If a task died after submission but before the next supervisor run picked it up from
  the overlord, it never entered `group.tasks`, so `removeTask` never fired — the
  priority entry was orphaned and made the next `computeUnassignedServerPriorities`
  call throw.

 ### Fix

  This patch removes the additional writer, leaving `discoverTasks` and `removeTask`
  as the sole mutators. `group.taskIdToServerPriority` should now stay in sync with `group.tasks`.
  The added unit tests fail on master without the fix.

This PR has:

- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
