### PR TITLE
perf: Double default loadahead for MSQ.

### DIFF
--- a/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/BaseLeafStageProcessor.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/BaseLeafStageProcessor.java
@@ -292,7 +292,7 @@ public abstract class BaseLeafStageProcessor extends BasicStageProcessor
     return new ReadableInputQueue(
         new StandardPartitionReader(context),
         filteredSlices,
-        segmentLoadAheadCount != null ? segmentLoadAheadCount : context.threadCount()
+        segmentLoadAheadCount != null ? segmentLoadAheadCount : context.threadCount() * 2
     );
   }
 


### PR DESCRIPTION
Setting loadahead to double the number of processing threads provides a better likelihood of keeping the processing threads busy. It also matches the default number of VSF on-demand loading threads.