### PR TITLE
fix: Flaky test runIndexTask_andKillData

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/IngestionSmokeTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/IngestionSmokeTest.java
@@ -189,6 +189,9 @@ public class IngestionSmokeTest extends EmbeddedClusterTestBase
                       .hasService("druid/broker")
     );
 
+    waitForNextCoordinatorCacheSync();
+    waitForNextBrokerCacheSync();
+
     cluster.callApi().verifySqlQuery("SELECT * FROM sys.segments WHERE datasource='%s'", dataSource, "");
 
     // Kill all unused segments
@@ -427,6 +430,14 @@ public class IngestionSmokeTest extends EmbeddedClusterTestBase
     eventCollector.latchableEmitter().waitForNextEvent(
         event -> event.hasMetricName("segment/metadataCache/sync/time")
                       .hasService("druid/coordinator")
+    );
+  }
+
+  protected void waitForNextBrokerCacheSync()
+  {
+    eventCollector.latchableEmitter().waitForNextEvent(
+        event -> event.hasMetricName("segment/metadataCache/sync/time")
+                      .hasService("druid/broker")
     );
   }
 


### PR DESCRIPTION
### Description

This PR fixes a flaky assertion in `KubernetesClusterDockerTest#test_runIndexTask_andKillData`.

#### Failing Assertion

The failing assertion was caused by the test waiting on `segment/schemaCache/dataSource/removed` before querying `sys.segments`. That metric only proves that the broker schema cache removed the datasource; it does not prove that the broker `MetadataSegmentView`, which backs `sys.segments`, has polled the coordinator after the segments were marked unused.

This PR keeps the production behavior unchanged and updates the test to wait on the cache that actually serves `sys.segments`. The added wait covers the coordinator metadata cache sync and the broker metadata segment view sync before asserting that `sys.segments` is empty.

The `segment/schemaCache/dataSource/removed` metric is still valid for its own cache. The issue was the test using it as a proxy for a different cache’s freshness.

#### Changes
* Add an explicit wait after broker schema-cache datasource removal.
* Wait for the coordinator metadata cache to sync after the unused-segment update.
* Wait for the broker metadata segment view to sync before asserting that `sys.segments` is empty.

This keeps the test aligned with the async cache behavior instead of assuming that schema-cache removal also implies `sys.segments` metadata has refreshed.

<hr>

##### Key changed/added classes in this PR
 * `IngestionSmokeTest`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.