### PR TITLE
build: Add lock to dependency cache for Dockerfile

### DIFF
--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 COPY . /src
 WORKDIR /src
-RUN --mount=type=cache,target=/root/.m2 if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
+RUN --mount=type=cache,target=/root/.m2,sharing=locked if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
       mvn -B -ff -q \
       install \
       -Pdist,bundle-contrib-exts \
@@ -43,7 +43,7 @@ RUN --mount=type=cache,target=/root/.m2 if [ "$BUILD_FROM_SOURCE" = "true" ]; th
       -Dmaven.javadoc.skip=true -T1C \
       ; fi
 
-RUN --mount=type=cache,target=/root/.m2 VERSION=$(mvn -B -q org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate \
+RUN --mount=type=cache,target=/root/.m2,sharing=locked VERSION=$(mvn -B -q org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate \
       -Dexpression=project.version -DforceStdout=true \
     ) \
  && tar -zxf ./distribution/target/apache-druid-${VERSION}-bin.tar.gz -C /opt \


### PR DESCRIPTION

This PR updates the Docker image build to use locked BuildKit cache mounts for the Maven local repository.

The Dockerfile already uses `RUN --mount=type=cache,target=/root/.m2` to reuse Maven dependencies across image builds. By default, BuildKit cache mounts are shared, which allows multiple concurrent builds to write to the same Maven cache at the same time. Maven’s local repository is not a good fit for concurrent writers, so parallel Docker builds can corrupt or partially write cached artifacts.

This PR changes both Maven cache mounts to use `sharing=locked`, causing concurrent builds that use the same `/root/.m2` cache to wait for the active writer to finish before reusing the cache.

<hr>

##### Key changed/added classes in this PR
 * `distribution/docker/Dockerfile`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.