### PR TITLE
fix: Address issue where Broker upgrade before Overlord causes NPE

### DIFF
--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorStatus.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorStatus.java
@@ -57,7 +57,7 @@ public class SupervisorStatus
   )
   {
     this.id = Preconditions.checkNotNull(builder.id, "id");
-    this.dataSource = builder.dataSource;
+    this.dataSource = builder.dataSource != null ? builder.dataSource : this.id;
     this.state = builder.state;
     this.detailedState = builder.detailedState;
     this.healthy = builder.healthy;

--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorStatus.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorStatus.java
@@ -57,6 +57,7 @@ public class SupervisorStatus
   )
   {
     this.id = Preconditions.checkNotNull(builder.id, "id");
+    // Fallback to id for rolling upgrade purposes. See https://github.com/apache/druid/pull/19425
     this.dataSource = builder.dataSource != null ? builder.dataSource : this.id;
     this.state = builder.state;
     this.detailedState = builder.detailedState;

--- a/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorStatusTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorStatusTest.java
@@ -47,6 +47,25 @@ public class SupervisorStatusTest
   }
 
   @Test
+  public void testGetDataSourceFallsBackToIdWhenNull() throws IOException
+  {
+    // Simulate an old Overlord response that does not include the "dataSource" field
+    String json = "{"
+                  + "\"id\":\"wikipedia\","
+                  + "\"state\":\"RUNNING\","
+                  + "\"detailedState\":\"RUNNING\","
+                  + "\"healthy\":true,"
+                  + "\"type\":\"kafka\","
+                  + "\"source\":\"wikipedia\","
+                  + "\"suspended\":false"
+                  + "}";
+    final ObjectMapper mapper = new ObjectMapper();
+    final SupervisorStatus deserialized = mapper.readValue(json, SupervisorStatus.class);
+    Assert.assertEquals("wikipedia", deserialized.getId());
+    Assert.assertEquals("wikipedia", deserialized.getDataSource());
+  }
+
+  @Test
   public void testJsonAttr() throws IOException
   {
     String json = "{"


### PR DESCRIPTION
### Description

This PR fixes a rolling-upgrade compatibility issue when Brokers are upgraded before Overlords. In my case, I faced the following issue when upgrading from v27 -> v37.

Newer Brokers expect `SupervisorStatus` responses to include the `dataSource` field. Older Overlords do not include that field, so a newer Broker can deserialize an old Overlord response with a null datasource and later hit a `NullPointerException`.

This PR preserves compatibility by falling back to the supervisor `id` when `dataSource` is absent. This matches the old response shape where the supervisor id is the datasource identifier for this status object.

A regression test was added for deserializing an old Overlord response without `dataSource`.

#### Release note

Fixes a rolling-upgrade issue where upgrading Brokers before Overlords could cause a `NullPointerException` while reading supervisor status responses from older Overlords.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.