### PR TITLE
perf: Optimize SpillingGrouper to avoid unnecessary disk I/O for small spill runs

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/SpillOutputStream.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/SpillOutputStream.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.query.groupby.epinephelinae;
 
+import javax.annotation.Nullable;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -36,6 +38,7 @@ public class SpillOutputStream extends OutputStream
 
   private final LimitedTemporaryStorage temporaryStorage;
   private final long threshold;
+  @Nullable
   private ByteArrayOutputStream memoryBuffer;
   private LimitedTemporaryStorage.LimitedOutputStream fileOut;
   private boolean thresholdExceeded;

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/SpillOutputStream.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/SpillOutputStream.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.groupby.epinephelinae;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * OutputStream that starts buffering in a heap byte array and switches to a disk file via
+ * {@link LimitedTemporaryStorage} once the written bytes exceed the threshold. This avoids
+ * the createFile/delete round-trip for small spills while bounding peak extra heap to the
+ * threshold size.
+ */
+public class SpillOutputStream extends OutputStream
+{
+  private static final int INITIAL_BUFFER_SIZE = 4096;
+
+  private final LimitedTemporaryStorage temporaryStorage;
+  private final long threshold;
+  private ByteArrayOutputStream memoryBuffer;
+  private LimitedTemporaryStorage.LimitedOutputStream fileOut;
+  private boolean thresholdExceeded;
+
+  SpillOutputStream(LimitedTemporaryStorage temporaryStorage, long threshold)
+  {
+    this.temporaryStorage = temporaryStorage;
+    this.threshold = threshold;
+    this.memoryBuffer = new ByteArrayOutputStream((int) Math.min(threshold, INITIAL_BUFFER_SIZE));
+  }
+
+  @Override
+  public void write(int b) throws IOException
+  {
+    checkThreshold(1);
+    if (fileOut != null) {
+      fileOut.write(b);
+    } else {
+      memoryBuffer.write(b);
+    }
+  }
+
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException
+  {
+    checkThreshold(len);
+    if (fileOut != null) {
+      fileOut.write(b, off, len);
+    } else {
+      memoryBuffer.write(b, off, len);
+    }
+  }
+
+  @Override
+  public void flush() throws IOException
+  {
+    if (fileOut != null) {
+      fileOut.flush();
+    }
+  }
+
+  @Override
+  public void close() throws IOException
+  {
+    if (fileOut != null) {
+      fileOut.close();
+    }
+  }
+
+  boolean isInMemory()
+  {
+    return fileOut == null;
+  }
+
+  byte[] toByteArray()
+  {
+    return memoryBuffer.toByteArray();
+  }
+
+  File getFile()
+  {
+    return fileOut.getFile();
+  }
+
+  private void checkThreshold(int count) throws IOException
+  {
+    if (!thresholdExceeded && memoryBuffer.size() + count > threshold) {
+      thresholdExceeded = true;
+      switchToDisk();
+    }
+  }
+
+  private void switchToDisk() throws IOException
+  {
+    final LimitedTemporaryStorage.LimitedOutputStream out = temporaryStorage.createFile();
+    try {
+      memoryBuffer.writeTo(out);
+    }
+    catch (IOException e) {
+      out.close();
+      throw e;
+    }
+    fileOut = out;
+    memoryBuffer = null;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouper.java
@@ -47,6 +47,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -374,28 +375,24 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
 
   private void spill() throws IOException
   {
-    // Stream directly to a temp file first, then check the file size. If the file is small
-    // (serialized size much smaller than the pre-allocated buffer, e.g. HLL sketches in List mode),
-    // read it back into memory for batching to avoid creating thousands of tiny disk files.
-    // If the file is already large enough, keep it on disk as-is.
-    final File file;
+    final SpillOutputStream spillOut = new SpillOutputStream(temporaryStorage, minSpillFileSize);
     try (CloseableIterator<Entry<KeyType>> iterator = grouper.iterator(true)) {
-      file = spill(iterator);
+      serializeToStream(iterator, spillOut);
     }
+
     pendingDictionaryEntries.addAll(keySerde.getDictionary());
     grouper.reset();
 
-    final long fileSize = file.length();
-    if (fileSize < minSpillFileSize) {
-      pendingSpillRuns.add(Files.readAllBytes(file.toPath()));
-      pendingSpillBytes += fileSize;
-      temporaryStorage.delete(file);
+    if (spillOut.isInMemory()) {
+      final byte[] bytes = spillOut.toByteArray();
+      pendingSpillRuns.add(bytes);
+      pendingSpillBytes += bytes.length;
 
       if (pendingSpillBytes >= minSpillFileSize) {
         flushPendingRunsToDisk();
       }
     } else {
-      files.add(file);
+      files.add(spillOut.getFile());
       dictionaryFiles.add(spill(pendingDictionaryEntries.iterator()));
       pendingDictionaryEntries.clear();
     }
@@ -483,20 +480,24 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
     );
   }
 
-  private <T> File spill(Iterator<T> iterator) throws IOException
+  private <T> void serializeToStream(Iterator<T> iterator, OutputStream out) throws IOException
   {
     try (
-        final LimitedTemporaryStorage.LimitedOutputStream out = temporaryStorage.createFile();
         final LZ4BlockOutputStream compressedOut = new LZ4BlockOutputStream(out);
         final JsonGenerator jsonGenerator = spillMapper.getFactory().createGenerator(compressedOut)
     ) {
       final SerializerProvider serializers = spillMapper.getSerializerProviderInstance();
-
       while (iterator.hasNext()) {
         BaseQuery.checkInterrupted();
         JacksonUtils.writeObjectUsingSerializerProvider(jsonGenerator, serializers, iterator.next());
       }
+    }
+  }
 
+  private <T> File spill(Iterator<T> iterator) throws IOException
+  {
+    try (final LimitedTemporaryStorage.LimitedOutputStream out = temporaryStorage.createFile()) {
+      serializeToStream(iterator, out);
       return out.getFile();
     }
   }

--- a/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/SpillOutputStreamTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/SpillOutputStreamTest.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.groupby.epinephelinae;
+
+import org.apache.druid.query.groupby.GroupByStatsProvider;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+
+public class SpillOutputStreamTest
+{
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void testSmallWriteStaysInMemory() throws IOException
+  {
+    try (SpillOutputStream out = makeStream(1024)) {
+      out.write(new byte[]{1, 2, 3});
+      Assert.assertTrue(out.isInMemory());
+      Assert.assertArrayEquals(new byte[]{1, 2, 3}, out.toByteArray());
+    }
+  }
+
+  @Test
+  public void testExactlyAtThresholdStaysInMemory() throws IOException
+  {
+    try (SpillOutputStream out = makeStream(4)) {
+      out.write(new byte[]{1, 2, 3, 4});
+      Assert.assertTrue(out.isInMemory());
+      Assert.assertArrayEquals(new byte[]{1, 2, 3, 4}, out.toByteArray());
+    }
+  }
+
+  @Test
+  public void testExceedingThresholdSwitchesToDisk() throws IOException
+  {
+    try (SpillOutputStream out = makeStream(4)) {
+      out.write(new byte[]{1, 2, 3, 4, 5});
+      Assert.assertFalse(out.isInMemory());
+      Assert.assertTrue(out.getFile().exists());
+      byte[] fileContent = Files.readAllBytes(out.getFile().toPath());
+      Assert.assertArrayEquals(new byte[]{1, 2, 3, 4, 5}, fileContent);
+    }
+  }
+
+  @Test
+  public void testSwitchesToDiskOnSecondWrite() throws IOException
+  {
+    try (SpillOutputStream out = makeStream(4)) {
+      out.write(new byte[]{1, 2});
+      Assert.assertTrue(out.isInMemory());
+
+      out.write(new byte[]{3, 4, 5});
+      Assert.assertFalse(out.isInMemory());
+      byte[] fileContent = Files.readAllBytes(out.getFile().toPath());
+      Assert.assertArrayEquals(new byte[]{1, 2, 3, 4, 5}, fileContent);
+    }
+  }
+
+  @Test
+  public void testSingleByteWriteStaysInMemory() throws IOException
+  {
+    try (SpillOutputStream out = makeStream(1024)) {
+      out.write(42);
+      Assert.assertTrue(out.isInMemory());
+      Assert.assertArrayEquals(new byte[]{42}, out.toByteArray());
+    }
+  }
+
+  @Test
+  public void testSingleByteWriteTriggersSwitch() throws IOException
+  {
+    try (SpillOutputStream out = makeStream(2)) {
+      out.write(1);
+      out.write(2);
+      Assert.assertTrue(out.isInMemory());
+
+      out.write(3);
+      Assert.assertFalse(out.isInMemory());
+      byte[] fileContent = Files.readAllBytes(out.getFile().toPath());
+      Assert.assertArrayEquals(new byte[]{1, 2, 3}, fileContent);
+    }
+  }
+
+  @Test
+  public void testDataIntegrityAcrossSwitch() throws IOException
+  {
+    try (SpillOutputStream out = makeStream(10)) {
+      byte[] beforeSwitch = new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+      byte[] afterSwitch = new byte[]{11, 12, 13, 14, 15};
+      out.write(beforeSwitch);
+      Assert.assertTrue(out.isInMemory());
+
+      out.write(afterSwitch);
+      Assert.assertFalse(out.isInMemory());
+      out.flush();
+
+      byte[] expected = new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+      byte[] fileContent = Files.readAllBytes(out.getFile().toPath());
+      Assert.assertArrayEquals(expected, fileContent);
+    }
+  }
+
+  @Test
+  public void testWriteWithOffsetAndLength() throws IOException
+  {
+    try (SpillOutputStream out = makeStream(1024)) {
+      byte[] data = new byte[]{0, 0, 1, 2, 3, 0, 0};
+      out.write(data, 2, 3);
+      Assert.assertTrue(out.isInMemory());
+      Assert.assertArrayEquals(new byte[]{1, 2, 3}, out.toByteArray());
+    }
+  }
+
+  @Test
+  public void testWriteWithOffsetAndLengthTriggersDiskSwitch() throws IOException
+  {
+    try (SpillOutputStream out = makeStream(2)) {
+      byte[] data = new byte[]{0, 1, 2, 3, 0};
+      out.write(data, 1, 3);
+      Assert.assertFalse(out.isInMemory());
+      byte[] fileContent = Files.readAllBytes(out.getFile().toPath());
+      Assert.assertArrayEquals(new byte[]{1, 2, 3}, fileContent);
+    }
+  }
+
+  @Test
+  public void testLargeWrite() throws IOException
+  {
+    try (SpillOutputStream out = makeStream(100)) {
+      byte[] data = new byte[10_000];
+      Arrays.fill(data, (byte) 0xAB);
+      out.write(data);
+      Assert.assertFalse(out.isInMemory());
+      out.flush();
+      byte[] fileContent = Files.readAllBytes(out.getFile().toPath());
+      Assert.assertArrayEquals(data, fileContent);
+    }
+  }
+
+  @Test
+  public void testZeroThresholdAlwaysGoesToDisk() throws IOException
+  {
+    try (SpillOutputStream out = makeStream(0)) {
+      out.write(new byte[]{1});
+      Assert.assertFalse(out.isInMemory());
+      byte[] fileContent = Files.readAllBytes(out.getFile().toPath());
+      Assert.assertArrayEquals(new byte[]{1}, fileContent);
+    }
+  }
+
+  @Test
+  public void testEmptyStreamIsInMemory() throws IOException
+  {
+    try (SpillOutputStream out = makeStream(1024)) {
+      Assert.assertTrue(out.isInMemory());
+      Assert.assertArrayEquals(new byte[0], out.toByteArray());
+    }
+  }
+
+  @Test
+  public void testMultipleWritesAccumulateInMemory() throws IOException
+  {
+    try (SpillOutputStream out = makeStream(1024)) {
+      out.write(new byte[]{1, 2});
+      out.write(new byte[]{3, 4});
+      out.write(5);
+      Assert.assertTrue(out.isInMemory());
+      Assert.assertArrayEquals(new byte[]{1, 2, 3, 4, 5}, out.toByteArray());
+    }
+  }
+
+  @Test
+  public void testMultipleWritesAfterDiskSwitch() throws IOException
+  {
+    try (SpillOutputStream out = makeStream(4)) {
+      out.write(new byte[]{1, 2, 3, 4, 5});
+      Assert.assertFalse(out.isInMemory());
+
+      out.write(new byte[]{6, 7});
+      out.write(8);
+      out.flush();
+
+      byte[] fileContent = Files.readAllBytes(out.getFile().toPath());
+      Assert.assertArrayEquals(new byte[]{1, 2, 3, 4, 5, 6, 7, 8}, fileContent);
+    }
+  }
+
+  @Test
+  public void testDiskStorageBytesTracked() throws IOException
+  {
+    LimitedTemporaryStorage storage = makeStorage(1024 * 1024);
+
+    try (SpillOutputStream out = new SpillOutputStream(storage, 4)) {
+      out.write(new byte[]{1, 2, 3, 4, 5});
+      Assert.assertFalse(out.isInMemory());
+      out.flush();
+      Assert.assertTrue(storage.currentSize() > 0);
+    }
+  }
+
+  @Test(expected = TemporaryStorageFullException.class)
+  public void testDiskStorageLimitEnforced() throws IOException
+  {
+    LimitedTemporaryStorage storage = makeStorage(10);
+
+    try (SpillOutputStream out = new SpillOutputStream(storage, 4)) {
+      byte[] data = new byte[100];
+      Arrays.fill(data, (byte) 1);
+      out.write(data);
+    }
+  }
+
+  private SpillOutputStream makeStream(long threshold) throws IOException
+  {
+    return new SpillOutputStream(makeStorage(1024 * 1024), threshold);
+  }
+
+  private LimitedTemporaryStorage makeStorage(long maxBytes) throws IOException
+  {
+    return new LimitedTemporaryStorage(
+        temporaryFolder.newFolder(),
+        maxBytes,
+        100,
+        new GroupByStatsProvider.PerQueryStats()
+    );
+  }
+}

--- a/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/SpillOutputStreamTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/SpillOutputStreamTest.java
@@ -222,6 +222,26 @@ public class SpillOutputStreamTest
     }
   }
 
+  @Test(expected = NullPointerException.class)
+  public void testToByteArrayThrowsAfterDiskSwitch() throws IOException
+  {
+    try (SpillOutputStream out = makeStream(4)) {
+      out.write(new byte[]{1, 2, 3, 4, 5});
+      Assert.assertFalse(out.isInMemory());
+      out.toByteArray();
+    }
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testGetFileThrowsWhenInMemory() throws IOException
+  {
+    try (SpillOutputStream out = makeStream(1024)) {
+      out.write(new byte[]{1, 2, 3});
+      Assert.assertTrue(out.isInMemory());
+      out.getFile();
+    }
+  }
+
   @Test(expected = TemporaryStorageFullException.class)
   public void testDiskStorageLimitEnforced() throws IOException
   {

--- a/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouperTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouperTest.java
@@ -289,7 +289,9 @@ public class SpillingGrouperTest extends InitializedNullHandlingTest
   @Test
   public void testDiskFull() throws IOException
   {
-    try (SpillingGrouper<IntKey> grouper = makeGrouper(50, temporaryFolder.newFolder(), 10, 100)) {
+    // Use a small minSpillFileSize so pending runs flush to disk frequently, where the
+    // 500-byte maxStorageBytes limit will be hit.
+    try (SpillingGrouper<IntKey> grouper = makeGrouper(50, temporaryFolder.newFolder(), 500, 100, 100)) {
       AggregateResult lastResult = AggregateResult.ok();
       for (int i = 0; i < 10000 && lastResult.isOk(); i++) {
         lastResult = grouper.aggregate(new IntKey(i));
@@ -346,15 +348,36 @@ public class SpillingGrouperTest extends InitializedNullHandlingTest
       int maxFileCount
   )
   {
+    return makeGrouper(bufferSize, storageDir, maxStorageBytes, maxFileCount, 1024 * 1024L);
+  }
+
+  private SpillingGrouper<IntKey> makeGrouper(
+      int bufferSize,
+      File storageDir,
+      long maxStorageBytes,
+      int maxFileCount,
+      long minSpillFileSize
+  )
+  {
     return makeGrouper(
         bufferSize,
-        new LimitedTemporaryStorage(storageDir, maxStorageBytes, maxFileCount, new GroupByStatsProvider.PerQueryStats())
+        new LimitedTemporaryStorage(storageDir, maxStorageBytes, maxFileCount, new GroupByStatsProvider.PerQueryStats()),
+        minSpillFileSize
     );
   }
 
   private SpillingGrouper<IntKey> makeGrouper(
       int bufferSize,
       LimitedTemporaryStorage temporaryStorage
+  )
+  {
+    return makeGrouper(bufferSize, temporaryStorage, 1024 * 1024L);
+  }
+
+  private SpillingGrouper<IntKey> makeGrouper(
+      int bufferSize,
+      LimitedTemporaryStorage temporaryStorage,
+      long minSpillFileSize
   )
   {
     final GroupByTestColumnSelectorFactory columnSelectorFactory = GrouperTestUtil.newColumnSelectorFactory();
@@ -374,7 +397,7 @@ public class SpillingGrouperTest extends InitializedNullHandlingTest
         null,
         false,
         bufferSize,
-        1024 * 1024L,
+        minSpillFileSize,
         new GroupByStatsProvider.PerQueryStats()
     );
     grouper.init();

--- a/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouperTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouperTest.java
@@ -287,6 +287,37 @@ public class SpillingGrouperTest extends InitializedNullHandlingTest
   }
 
   @Test
+  public void testSmallSpillsStayInMemoryUntilFlush() throws IOException
+  {
+    final File storageDir = temporaryFolder.newFolder();
+    final LimitedTemporaryStorage temporaryStorage =
+        new LimitedTemporaryStorage(storageDir, 1024 * 1024, 100, new GroupByStatsProvider.PerQueryStats());
+
+    // Use a large minSpillFileSize so individual spills (which are tiny with a 50-byte buffer)
+    // stay in memory via SpillOutputStream and never create temp files.
+    final long largeMinSpillFileSize = 1024 * 1024L;
+    try (SpillingGrouper<IntKey> grouper = makeGrouper(50, temporaryStorage, largeMinSpillFileSize)) {
+      // Aggregate enough keys to trigger multiple spills, but not enough to exceed
+      // minSpillFileSize in total pending bytes.
+      for (int i = 0; i < 20; i++) {
+        Assert.assertTrue(grouper.aggregate(new IntKey(i)).isOk());
+      }
+
+      // No files should have been created — all spills are below the threshold and
+      // pending bytes haven't reached minSpillFileSize yet.
+      Assert.assertEquals(
+          "small spills should stay in memory without creating any temp files",
+          0,
+          temporaryStorage.currentFileCount()
+      );
+      Assert.assertEquals(0, storageDir.listFiles().length);
+
+      // Results should still be correct when iterated.
+      assertResultsCorrect(grouper, 20, 1);
+    }
+  }
+
+  @Test
   public void testDiskFull() throws IOException
   {
     // Use a small minSpillFileSize so pending runs flush to disk frequently, where the

--- a/server/src/main/java/org/apache/druid/server/QueryResultPusher.java
+++ b/server/src/main/java/org/apache/druid/server/QueryResultPusher.java
@@ -444,7 +444,7 @@ public abstract class QueryResultPusher
         response.setTrailerFields(() -> trailerFields);
 
         try {
-          out = new CountingOutputStream(new BufferedOutputStream(response.getOutputStream(), 64 * 1024));
+          out = new CountingOutputStream(response.getOutputStream());
           writer = resultsWriter.makeWriter(out);
         }
         catch (IOException e) {

--- a/server/src/main/java/org/apache/druid/server/QueryResultPusher.java
+++ b/server/src/main/java/org/apache/druid/server/QueryResultPusher.java
@@ -48,7 +48,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.io.BufferedOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;

--- a/server/src/main/java/org/apache/druid/server/QueryResultPusher.java
+++ b/server/src/main/java/org/apache/druid/server/QueryResultPusher.java
@@ -48,6 +48,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.io.BufferedOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -443,7 +444,7 @@ public abstract class QueryResultPusher
         response.setTrailerFields(() -> trailerFields);
 
         try {
-          out = new CountingOutputStream(response.getOutputStream());
+          out = new CountingOutputStream(new BufferedOutputStream(response.getOutputStream(), 64 * 1024));
           writer = resultsWriter.makeWriter(out);
         }
         catch (IOException e) {


### PR DESCRIPTION
perf: Optimize SpillingGrouper to avoid unnecessary disk I/O for small spill runs

### Description

This is a followup to https://github.com/apache/druid/pull/19357

The spill batching logic (introduced to avoid thousands of tiny disk files) previously had to write to disk first and check the file size afterward, because the serialized size isn't known upfront — and if the serialized data turns out to be large, buffering it entirely in memory before deciding would risk OOM. So the safe path was: always write to a temp file, then read it back into memory only if it was small enough to batch.

This is correct but expensive for certain cases. When groupBy queries produce spill runs whose serialized size is much smaller than their in-memory buffer (e.g., HLL sketches in sparse/SET mode serialize to a fraction of their pre-allocated buffer), this creates thousands of unnecessary file create/write/read/delete cycles just to discover the data was small enough to batch in memory.

SpillOutputStream solves both concerns: it writes to a heap buffer first, and only when the buffer exceeds the threshold does it open a file and flush the accumulated bytes to disk. Large spills still go to disk (no OOM risk), but small spills never touch the filesystem. Peak extra heap is bounded to the threshold size (minSpillFileSize, default 1MB).

##### Key changed/added classes in this PR

- Introduces SpillOutputStream, an OutputStream that buffers in memory and only spills to disk when written bytes exceed the minSpillFileSize threshold. This eliminates the previous write-to-file → check-size → read-back → delete round-trip for small spill runs. This integrates with LimitedTemporaryStorage and hence still enforces all the limits.
- Refactors SpillingGrouper.spill() to serialize through SpillOutputStream instead of always creating a temp file first. The serialization logic is extracted into serializeToStream() to separate it from file lifecycle management.
- Adds comprehensive unit tests for SpillOutputStream covering in-memory buffering, disk spillover, single-byte writes, threshold boundary behavior, and error handling.

## Benchmarks result
Before this PR:

```
Benchmark                                                  (initialBuckets)  (numProcessingThreads)  (numSegments)  (queryGranularity)  (rowsPerSegment)  (schemaAndQuery)  (vectorize)  Mode  Cnt       Score       Error  Units
GroupByBenchmark.queryMultiQueryableIndexWithSpilling                         -1                       4              4                 all            100000           basic.A        force  avgt   15  352910.001 ±  7477.535  us/op
GroupByBenchmark.queryMultiQueryableIndexWithSpillingTTFR                     -1                       4              4                 all            100000           basic.A        force  avgt   15  149027.367 ±  4829.306  us/op

New Benchmarks
bufferGrouperMaxSize=100 (spill size ~6 KB)
GroupByBenchmark.queryMultiQueryableIndexWithSmallSpilling                    -1                       4              4                 all            100000           basic.A        force  avgt   15  750775.683 ± 10103.062  us/op
GroupByBenchmark.queryMultiQueryableIndexWithSmallSpillingTTFR                -1                       4              4                 all            100000           basic.A        force  avgt   15  539507.482 ±  7332.067  us/op

bufferGrouperMaxSize=70000 (spill size ~4 MB)
GroupByBenchmark.queryMultiQueryableIndexWithLargeSpilling                    -1                       4              4                 all           1000000           basic.A        force  avgt   15  3529647.635 ±  69419.867  us/op
GroupByBenchmark.queryMultiQueryableIndexWithLargeSpillingTTFR                -1                       4              4                 all           1000000           basic.A        force  avgt   15  1358536.490 ± 139732.304  us/op
```

After this PR:
```
Benchmark                                                  (initialBuckets)  (numProcessingThreads)  (numSegments)  (queryGranularity)  (rowsPerSegment)  (schemaAndQuery)  (vectorize)  Mode  Cnt       Score       Error  Units
GroupByBenchmark.queryMultiQueryableIndexWithSpilling                    -1                       4              4                 all            100000           basic.A        force  avgt   15  344787.202 ± 13998.456  us/op
GroupByBenchmark.queryMultiQueryableIndexWithSpillingTTFR                -1                       4              4                 all            100000           basic.A        force  avgt   15  141381.603 ±  3583.413  us/op

New Benchmarks
bufferGrouperMaxSize=100 (spill size ~6 KB)
GroupByBenchmark.queryMultiQueryableIndexWithSmallSpilling                    -1                       4              4                 all            100000           basic.A        force  avgt   15  420431.477 ± 5600.233  us/op
GroupByBenchmark.queryMultiQueryableIndexWithSmallSpillingTTFR                -1                       4              4                 all            100000           basic.A        force  avgt   15   195450.731 ± 2552.290  us/op

bufferGrouperMaxSize=70000 (spill size ~4 MB)
GroupByBenchmark.queryMultiQueryableIndexWithLargeSpilling                    -1                       4              4                 all           1000000           basic.A        force  avgt   15  3569103.927 ± 282616.750  us/op
GroupByBenchmark.queryMultiQueryableIndexWithLargeSpillingTTFR                -1                       4              4                 all           1000000           basic.A        force  avgt   15  1243519.844 ±  80173.130  us/op
```

The existing queryMultiQueryableIndexWithSpilling/queryMultiQueryableIndexWithSpillingTTFR uses bufferGrouperMaxSize=4000 which produce reasonable spills of ~200kb. I have also added new benchmarks with similar idea but producing spill files on extremes ends for size. queryMultiQueryableIndexWithSmallSpilling/queryMultiQueryableIndexWithSmallSpillingTTFR sets bufferGrouperMaxSize=100, producing spill size ~6 KB. This would result in more batching. queryMultiQueryableIndexWithLargeSpilling/queryMultiQueryableIndexWithLargeSpillingTTFR sets bufferGrouperMaxSize=70000, producing spill size ~4 MB. This would skip batching. These new benchmarks are not added to the PR since they are really the same as queryMultiQueryableIndexWithSpilling/queryMultiQueryableIndexWithSpillingTTFR just with different config values.

```
Default spilling (bufferGrouperMaxSize=4000) — within noise:
                                                                                                   
  ┌───────────┬───────────────┬───────────────┬───────┐
  │ Benchmark │      OLD      │      NEW      │ Delta │
  ├───────────┼───────────────┼───────────────┼───────┤
  │ Spilling  │ 352,910 us/op │ 344,787 us/op │ -2.3% │                                            
  ├───────────┼───────────────┼───────────────┼───────┤
  │ TTFR      │ 149,027 us/op │ 141,382 us/op │ -5.1% │
  └───────────┴───────────────┴───────────────┴───────┘
Error bars overlap, so statistically neutral. Spills here are moderately sized and few in number — not the target optimization scenario.

Small spills (~6 KB each, bufferGrouperMaxSize=100) — huge win:

  ┌───────────┬───────────────┬───────────────┬───────┐
  │ Benchmark │      OLD      │      NEW      │ Delta │                                            
  ├───────────┼───────────────┼───────────────┼───────┤
  │ Spilling  │ 750,776 us/op │ 420,431 us/op │ -44%  │
  ├───────────┼───────────────┼───────────────┼───────┤
  │ TTFR      │ 539,507 us/op │ 195,451 us/op │ -64%  │
  └───────────┴───────────────┴───────────────┴───────┘
This is the sweet spot for the optimization. Each spill is ~6 KB, well under the 1 MB MIN_SPILL_FILE_BYTES threshold, so they stay entirely in memory — no file create/write/read/delete round-trip. The TTFR improvement is even larger because the first result no longer waits on disk I/O for early spills.

Large spills (~4 MB each, bufferGrouperMaxSize=70000) — neutral:
  
  ┌───────────┬─────────────────┬─────────────────┬──────────────────────────┐
  │ Benchmark │       OLD       │       NEW       │          Delta           │
  ├───────────┼─────────────────┼─────────────────┼──────────────────────────┤
  │ Spilling  │ 3,529,648 us/op │ 3,569,104 us/op │ +1.1% (noise)            │
  ├───────────┼─────────────────┼─────────────────┼──────────────────────────┤                     
  │ TTFR      │ 1,358,536 us/op │ 1,243,520 us/op │ -8.5% (large error bars) │
  └───────────┴─────────────────┴─────────────────┴──────────────────────────┘
Spills exceed the 1 MB threshold and go to disk in both versions, so no difference.


The optimization eliminates disk I/O for small spills, saving ~330,000 us/op total and ~344,000 us/op to first result in the small-spill case. Large spills exceed the 1MB threshold and hit disk regardless, so no change there.

The optimization delivers exactly where designed — many small spills that previously hit disk now stay in memory, cutting latency 44-64%. Large spills are unaffected. No regressions.

```

##### Key changed/added classes in this PR
 * `SpillingGrouper`
 * `SpillOutputStream`
 
This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.