### PR TITLE
feat: Replace Task.supportsQueries() with finer-grained config.

### DIFF
--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/RabbitStreamIndexTask.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/RabbitStreamIndexTask.java
@@ -145,10 +145,4 @@ public class RabbitStreamIndexTask extends SeekableStreamIndexTask<String, Long,
   {
     return TYPE;
   }
-
-  @Override
-  public boolean supportsQueries()
-  {
-    return true;
-  }
 }

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTask.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTask.java
@@ -163,10 +163,4 @@ public class KafkaIndexTask extends SeekableStreamIndexTask<KafkaTopicPartition,
   {
     return INPUT_SOURCE_RESOURCES;
   }
-
-  @Override
-  public boolean supportsQueries()
-  {
-    return true;
-  }
 }

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -373,7 +373,6 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
             Duration.standardHours(2).getStandardMinutes()
         )
     );
-    Assert.assertTrue(task.supportsQueries());
 
     final ListenableFuture<TaskStatus> future = runTask(task);
 
@@ -1296,7 +1295,6 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
             Duration.standardHours(2).getStandardMinutes()
         )
     );
-    Assert.assertTrue(task.supportsQueries());
 
     final ListenableFuture<TaskStatus> future = runTask(task);
 
@@ -1369,7 +1367,6 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
             Duration.standardHours(2).getStandardMinutes()
         )
     );
-    Assert.assertTrue(task.supportsQueries());
 
     final ListenableFuture<TaskStatus> future = runTask(task);
 
@@ -3095,7 +3092,6 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         )
     );
 
-    Assert.assertTrue(task.supportsQueries());
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
@@ -3168,7 +3164,6 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         )
     );
 
-    Assert.assertTrue(task.supportsQueries());
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
@@ -3243,7 +3238,6 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         )
     );
 
-    Assert.assertTrue(task.supportsQueries());
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit. Should fail and trip up with the first two bad messages in the stream

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisIndexTask.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisIndexTask.java
@@ -179,12 +179,6 @@ public class KinesisIndexTask extends SeekableStreamIndexTask<String, String, Ki
     return INPUT_SOURCE_RESOURCES;
   }
 
-  @Override
-  public boolean supportsQueries()
-  {
-    return true;
-  }
-
   @VisibleForTesting
   AWSCredentialsConfig getAwsCredentialsConfig()
   {

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskSerdeTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskSerdeTest.java
@@ -138,6 +138,7 @@ public class KinesisIndexTaskSerdeTest
     Assert.assertEquals(ACCESS_KEY, awsCredentialsConfig.getAccessKey().getPassword());
     Assert.assertEquals(SECRET_KEY, awsCredentialsConfig.getSecretKey().getPassword());
     Assert.assertEquals(FILE_SESSION_CREDENTIALS, awsCredentialsConfig.getFileSessionCredentials());
+    Assert.assertNotNull(target.getPeonProcessingModuleConfig());
     Assert.assertEquals(
         Collections.singleton(
             new ResourceAction(new Resource(

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
@@ -320,7 +320,6 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ImmutableMap.of(SHARD_ID1, "2"),
         ImmutableMap.of(SHARD_ID1, "4")
     );
-    Assert.assertTrue(task.supportsQueries());
 
     final ListenableFuture<TaskStatus> future = runTask(task);
 

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/K8sTaskAdapter.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/K8sTaskAdapter.java
@@ -448,7 +448,7 @@ public abstract class K8sTaskAdapter implements TaskAdapter
     // If the task type is queryable, we need to load broadcast segments on the peon, used for
     // join queries. This is replaced by --loadBroadcastDatasourceMode option, but is preserved here
     // for backwards compatibility and can be removed in a future release.
-    if (task.supportsQueries()) {
+    if (task.getBroadcastDatasourceLoadingSpec().getMode().needsBroadcastSegments()) {
       command.add("--loadBroadcastSegments");
       command.add("true");
     }

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
@@ -234,7 +234,7 @@ public class PodTemplateTaskAdapter implements TaskAdapter
             .build(),
         new EnvVarBuilder()
             .withName(DruidK8sConstants.LOAD_BROADCAST_SEGMENTS_ENV)
-            .withValue(Boolean.toString(task.supportsQueries()))
+            .withValue(Boolean.toString(task.getBroadcastDatasourceLoadingSpec().getMode().needsBroadcastSegments()))
             .build()
     );
     if (!shouldUseDeepStorageForTaskPayload(task)) {

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapterTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapterTest.java
@@ -422,7 +422,6 @@ public class PodTemplateTaskAdapterTest
     );
 
     Task task = EasyMock.mock(Task.class);
-    EasyMock.expect(task.supportsQueries()).andReturn(true);
     EasyMock.expect(task.getType()).andReturn("queryable").anyTimes();
     EasyMock.expect(task.getId()).andReturn("id").anyTimes();
     EasyMock.expect(task.getGroupId()).andReturn("groupid").anyTimes();
@@ -456,7 +455,6 @@ public class PodTemplateTaskAdapterTest
     );
 
     Task task = EasyMock.mock(Task.class);
-    EasyMock.expect(task.supportsQueries()).andReturn(true);
     EasyMock.expect(task.getType()).andReturn("queryable").anyTimes();
     EasyMock.expect(task.getId()).andReturn("id").anyTimes();
     EasyMock.expect(task.getGroupId()).andReturn("groupid").anyTimes();

--- a/extensions-core/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobLongIds.yaml
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobLongIds.yaml
@@ -49,7 +49,7 @@ spec:
             - name: "TASK_ID"
               value: "api-issued_kill_wikipedia3_omjobnbc_1000-01-01T00:00:00.000Z_2023-05-14T00:00:00.000Z_2023-05-15T17:03:01.220Z"
             - name: "LOAD_BROADCAST_DATASOURCE_MODE"
-              value: "ALL"
+              value: "NONE"
             - name: "LOAD_BROADCAST_SEGMENTS"
               value: "false"
             - name: "TASK_JSON"

--- a/extensions-core/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobNoTaskJson.yaml
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobNoTaskJson.yaml
@@ -48,7 +48,7 @@ spec:
             - name: "TASK_ID"
               value: "id"
             - name: "LOAD_BROADCAST_DATASOURCE_MODE"
-              value: "ALL"
+              value: "NONE"
             - name: "LOAD_BROADCAST_SEGMENTS"
               value: "false"
           image: one

--- a/extensions-core/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobTlsEnabledBase.yaml
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobTlsEnabledBase.yaml
@@ -49,7 +49,7 @@ spec:
             - name: "TASK_ID"
               value: "id"
             - name: "LOAD_BROADCAST_DATASOURCE_MODE"
-              value: "ALL"
+              value: "NONE"
             - name: "LOAD_BROADCAST_SEGMENTS"
               value: "false"
             - name: "TASK_JSON"

--- a/indexing-service/src/main/java/org/apache/druid/guice/PeonProcessingModule.java
+++ b/indexing-service/src/main/java/org/apache/druid/guice/PeonProcessingModule.java
@@ -84,7 +84,7 @@ public class PeonProcessingModule implements Module
       Lifecycle lifecycle
   )
   {
-    if (task.getPeonProcessingModuleConfig().processingThreads) {
+    if (task.getPeonProcessingModuleConfig().hasProcessingThreads()) {
       return DruidProcessingModule.createProcessingExecutorPool(config, executorServiceMonitor, lifecycle);
     } else {
       if (config.isNumThreadsConfigured()) {
@@ -108,7 +108,7 @@ public class PeonProcessingModule implements Module
       RuntimeInfo runtimeInfo
   )
   {
-    if (task.getPeonProcessingModuleConfig().processingBuffers) {
+    if (task.getPeonProcessingModuleConfig().hasProcessingBuffers()) {
       return DruidProcessingModule.createIntermediateResultsPool(config, runtimeInfo);
     } else {
       return DummyNonBlockingPool.instance();
@@ -120,7 +120,7 @@ public class PeonProcessingModule implements Module
   @Merging
   public BlockingPool<ByteBuffer> getMergeBufferPool(Task task, DruidProcessingConfig config, RuntimeInfo runtimeInfo)
   {
-    if (task.getPeonProcessingModuleConfig().mergeBuffers) {
+    if (task.getPeonProcessingModuleConfig().hasMergeBuffers()) {
       return DruidProcessingModule.createMergeBufferPool(config, runtimeInfo);
     } else {
       if (config.isNumMergeBuffersConfigured()) {
@@ -171,6 +171,21 @@ public class PeonProcessingModule implements Module
     {
       this.mergeBuffers = true;
       return this;
+    }
+
+    public boolean hasProcessingBuffers()
+    {
+      return processingBuffers;
+    }
+
+    public boolean hasProcessingThreads()
+    {
+      return processingThreads;
+    }
+
+    public boolean hasMergeBuffers()
+    {
+      return mergeBuffers;
     }
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/guice/PeonProcessingModule.java
+++ b/indexing-service/src/main/java/org/apache/druid/guice/PeonProcessingModule.java
@@ -84,12 +84,12 @@ public class PeonProcessingModule implements Module
       Lifecycle lifecycle
   )
   {
-    if (task.supportsQueries()) {
+    if (task.getPeonProcessingModuleConfig().processingThreads) {
       return DruidProcessingModule.createProcessingExecutorPool(config, executorServiceMonitor, lifecycle);
     } else {
       if (config.isNumThreadsConfigured()) {
         log.warn(
-            "Ignoring the configured numThreads[%d] because task[%s] of type[%s] does not support queries",
+            "Ignoring the configured numThreads[%d] because task[%s] of type[%s] does not need processing threads",
             config.getNumThreads(),
             task.getId(),
             task.getType()
@@ -108,7 +108,7 @@ public class PeonProcessingModule implements Module
       RuntimeInfo runtimeInfo
   )
   {
-    if (task.supportsQueries()) {
+    if (task.getPeonProcessingModuleConfig().processingBuffers) {
       return DruidProcessingModule.createIntermediateResultsPool(config, runtimeInfo);
     } else {
       return DummyNonBlockingPool.instance();
@@ -120,13 +120,13 @@ public class PeonProcessingModule implements Module
   @Merging
   public BlockingPool<ByteBuffer> getMergeBufferPool(Task task, DruidProcessingConfig config, RuntimeInfo runtimeInfo)
   {
-    if (task.supportsQueries()) {
+    if (task.getPeonProcessingModuleConfig().mergeBuffers) {
       return DruidProcessingModule.createMergeBufferPool(config, runtimeInfo);
     } else {
       if (config.isNumMergeBuffersConfigured()) {
         log.warn(
-            "Ignoring the configured numMergeBuffers[%d] because task[%s] of type[%s] does not support queries",
-            config.getNumThreads(),
+            "Ignoring the configured numMergeBuffers[%d] because task[%s] of type[%s] does not need merge buffers",
+            config.getNumMergeBuffers(),
             task.getId(),
             task.getType()
         );
@@ -144,5 +144,33 @@ public class PeonProcessingModule implements Module
   )
   {
     return new GroupByResourcesReservationPool(mergeBufferPool, groupByQueryConfig);
+  }
+
+  /**
+   * Returned by {@link Task#getPeonProcessingModuleConfig()} to declare which resources the task actually needs.
+   */
+  public static class Config
+  {
+    private boolean processingBuffers;
+    private boolean processingThreads;
+    private boolean mergeBuffers;
+
+    public Config withProcessingBuffers()
+    {
+      this.processingBuffers = true;
+      return this;
+    }
+
+    public Config withProcessingThreads()
+    {
+      this.processingThreads = true;
+      return this;
+    }
+
+    public Config withMergeBuffers()
+    {
+      this.mergeBuffers = true;
+      return this;
+    }
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
@@ -302,12 +302,6 @@ public abstract class AbstractTask implements Task
   }
 
   @Override
-  public boolean supportsQueries()
-  {
-    return false;
-  }
-
-  @Override
   public String getClasspathPrefix()
   {
     return null;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/NoopTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/NoopTask.java
@@ -30,6 +30,8 @@ import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.server.coordination.BroadcastDatasourceLoadingSpec;
+import org.apache.druid.server.lookup.cache.LookupLoadingSpec;
 import org.apache.druid.server.security.ResourceAction;
 
 import javax.annotation.Nonnull;
@@ -145,5 +147,17 @@ public class NoopTask extends AbstractTask implements PendingSegmentAllocatingTa
     final Map<String, Object> context = new HashMap<>();
     context.put(Tasks.PRIORITY_KEY, priority);
     return new NoopTask(null, null, null, 0, 0, context);
+  }
+
+  @Override
+  public LookupLoadingSpec getLookupLoadingSpec()
+  {
+    return LookupLoadingSpec.NONE;
+  }
+
+  @Override
+  public BroadcastDatasourceLoadingSpec getBroadcastDatasourceLoadingSpec()
+  {
+    return BroadcastDatasourceLoadingSpec.NONE;
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.druid.guice.PeonProcessingModule;
 import org.apache.druid.indexer.TaskIdStatus;
 import org.apache.druid.indexer.TaskIdentifier;
 import org.apache.druid.indexer.TaskInfo;
@@ -176,16 +177,13 @@ public interface Task
   <T> QueryRunner<T> getQueryRunner(Query<T> query);
 
   /**
-   * True if this task type embeds a query stack, and therefore should preload resources (like broadcast tables)
-   * that may be needed by queries. Tasks supporting queries are also allocated processing buffers, processing threads
-   * and merge buffers. Those which do not should not assume that these resources are present and must explicitly allocate
-   * any direct buffers or processing pools if required.
-   *
-   * If true, {@link #getQueryRunner(Query)} does not necessarily return nonnull query runners. For example,
-   * MSQWorkerTask returns true from this method (because it embeds a query stack for running multi-stage queries)
-   * even though it is not directly queryable via HTTP.
+   * Declares which resources provided by {@link PeonProcessingModule} this task actually needs. The default
+   * implementation has all the optional items disabled.
    */
-  boolean supportsQueries();
+  default PeonProcessingModule.Config getPeonProcessingModuleConfig()
+  {
+    return new PeonProcessingModule.Config();
+  }
 
   /**
    * Returns an extra classpath that should be prepended to the default classpath when running this task. If no

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
@@ -389,7 +389,7 @@ public class ForkingTaskRunner
                         // If the task type is queryable, we need to load broadcast segments on the peon, used for
                         // join queries. This is replaced by --loadBroadcastDatasourceMode option, but is preserved here
                         // for backwards compatibility and can be removed in a future release.
-                        if (task.supportsQueries()) {
+                        if (task.getBroadcastDatasourceLoadingSpec().getMode().needsBroadcastSegments()) {
                           command.add("--loadBroadcastSegments");
                           command.add("true");
                         }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTask.java
@@ -26,6 +26,7 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import org.apache.druid.common.config.Configs;
 import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.guice.PeonProcessingModule;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.appenderator.ActionBasedPublishedSegmentRetriever;
 import org.apache.druid.indexing.appenderator.ActionBasedSegmentAllocator;
@@ -334,5 +335,14 @@ public abstract class SeekableStreamIndexTask<PartitionIdType, SequenceOffsetTyp
   public SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOffsetType, ?> getRunner()
   {
     return runnerSupplier.get();
+  }
+
+  @Override
+  public PeonProcessingModule.Config getPeonProcessingModuleConfig()
+  {
+    return new PeonProcessingModule.Config()
+        .withProcessingBuffers()
+        .withProcessingThreads()
+        .withMergeBuffers();
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/guice/PeonProcessingModuleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/guice/PeonProcessingModuleTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.guice;
+
+import org.apache.druid.collections.BlockingPool;
+import org.apache.druid.collections.DummyBlockingPool;
+import org.apache.druid.collections.DummyNonBlockingPool;
+import org.apache.druid.collections.NonBlockingPool;
+import org.apache.druid.indexing.common.task.NoopTask;
+import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.java.util.common.lifecycle.Lifecycle;
+import org.apache.druid.query.DruidProcessingConfig;
+import org.apache.druid.query.ExecutorServiceMonitor;
+import org.apache.druid.query.NoopQueryProcessingPool;
+import org.apache.druid.query.QueryProcessingPool;
+import org.apache.druid.utils.RuntimeInfo;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.nio.ByteBuffer;
+
+public class PeonProcessingModuleTest
+{
+  private final PeonProcessingModule module = new PeonProcessingModule();
+
+  @Test
+  public void testConfigBuilder()
+  {
+    final PeonProcessingModule.Config config = new PeonProcessingModule.Config()
+        .withProcessingBuffers()
+        .withProcessingThreads()
+        .withMergeBuffers();
+    Assert.assertTrue(config.hasProcessingBuffers());
+    Assert.assertTrue(config.hasProcessingThreads());
+    Assert.assertTrue(config.hasMergeBuffers());
+  }
+
+  @Test
+  public void testGetProcessingExecutorPool_whenNotNeeded()
+  {
+    final Task task = NoopTask.create();
+    final DruidProcessingConfig config = Mockito.mock(DruidProcessingConfig.class);
+    Mockito.when(config.isNumThreadsConfigured()).thenReturn(false);
+
+    final QueryProcessingPool pool = module.getProcessingExecutorPool(
+        task,
+        config,
+        new ExecutorServiceMonitor(),
+        new Lifecycle()
+    );
+    Assert.assertSame(NoopQueryProcessingPool.instance(), pool);
+  }
+
+  @Test
+  public void testGetProcessingExecutorPool_whenNotNeeded_andThreadsConfigured()
+  {
+    final Task task = NoopTask.create();
+    final DruidProcessingConfig config = Mockito.mock(DruidProcessingConfig.class);
+    Mockito.when(config.isNumThreadsConfigured()).thenReturn(true);
+    Mockito.when(config.getNumThreads()).thenReturn(2);
+
+    final QueryProcessingPool pool = module.getProcessingExecutorPool(
+        task,
+        config,
+        new ExecutorServiceMonitor(),
+        new Lifecycle()
+    );
+    Assert.assertSame(NoopQueryProcessingPool.instance(), pool);
+  }
+
+  @Test
+  public void testGetIntermediateResultsPool_whenNotNeeded()
+  {
+    final Task task = NoopTask.create();
+    final DruidProcessingConfig config = Mockito.mock(DruidProcessingConfig.class);
+    final RuntimeInfo runtimeInfo = Mockito.mock(RuntimeInfo.class);
+
+    final NonBlockingPool<ByteBuffer> pool = module.getIntermediateResultsPool(task, config, runtimeInfo);
+    Assert.assertSame(DummyNonBlockingPool.instance(), pool);
+  }
+
+  @Test
+  public void testGetMergeBufferPool_whenNotNeeded()
+  {
+    final Task task = NoopTask.create();
+    final DruidProcessingConfig config = Mockito.mock(DruidProcessingConfig.class);
+    Mockito.when(config.isNumMergeBuffersConfigured()).thenReturn(false);
+    final RuntimeInfo runtimeInfo = Mockito.mock(RuntimeInfo.class);
+
+    final BlockingPool<ByteBuffer> pool = module.getMergeBufferPool(task, config, runtimeInfo);
+    Assert.assertSame(DummyBlockingPool.instance(), pool);
+  }
+
+  @Test
+  public void testGetMergeBufferPool_whenNotNeeded_andMergeBuffersConfigured()
+  {
+    // Covers the inner "if (config.isNumMergeBuffersConfigured())" warning path.
+    final Task task = NoopTask.create();
+    final DruidProcessingConfig config = Mockito.mock(DruidProcessingConfig.class);
+    Mockito.when(config.isNumMergeBuffersConfigured()).thenReturn(true);
+    Mockito.when(config.getNumMergeBuffers()).thenReturn(2);
+    final RuntimeInfo runtimeInfo = Mockito.mock(RuntimeInfo.class);
+
+    final BlockingPool<ByteBuffer> pool = module.getMergeBufferPool(task, config, runtimeInfo);
+    Assert.assertSame(DummyBlockingPool.instance(), pool);
+  }
+}

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskTest.java
@@ -276,8 +276,6 @@ public class IndexTaskTest extends IngestionTestBase
         null
     );
 
-    Assert.assertFalse(indexTask.supportsQueries());
-
     final DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     final List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
@@ -321,8 +319,6 @@ public class IndexTaskTest extends IngestionTestBase
         ImmutableMap.of(Tasks.STORE_EMPTY_COLUMNS_KEY, false)
     );
 
-    Assert.assertFalse(indexTask.supportsQueries());
-
     final DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     final List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
     Assert.assertEquals(1, segments.size());
@@ -360,8 +356,6 @@ public class IndexTaskTest extends IngestionTestBase
         ),
         null
     );
-
-    Assert.assertFalse(indexTask.supportsQueries());
 
     final DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     final List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskTest.java
@@ -79,12 +79,6 @@ public class TaskTest
     }
 
     @Override
-    public boolean supportsQueries()
-    {
-      return false;
-    }
-
-    @Override
     public String getClasspathPrefix()
     {
       return null;

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQWorkerTask.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQWorkerTask.java
@@ -31,6 +31,7 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Injector;
 import org.apache.druid.common.guava.FutureUtils;
+import org.apache.druid.guice.PeonProcessingModule;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
@@ -180,11 +181,12 @@ public class MSQWorkerTask extends AbstractTask
   }
 
   @Override
-  public boolean supportsQueries()
+  public PeonProcessingModule.Config getPeonProcessingModuleConfig()
   {
-    // Even though we don't have a QueryResource, we do embed a query stack, and so we need preloaded resources
-    // such as broadcast tables.
-    return true;
+    // No merge buffers needed.
+    return new PeonProcessingModule.Config()
+        .withProcessingBuffers()
+        .withProcessingThreads();
   }
 
   @Override

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQWorkerTaskTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQWorkerTaskTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.msq.indexing;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.error.DruidException;
+import org.apache.druid.guice.PeonProcessingModule;
 import org.apache.druid.server.lookup.cache.LookupLoadingSpec;
 import org.junit.Assert;
 import org.junit.Test;
@@ -112,6 +113,15 @@ public class MSQWorkerTaskTest
   {
     MSQWorkerTask msqWorkerTask = new MSQWorkerTask(controllerTaskId, dataSource, workerNumber, context, retryCount);
     Assert.assertTrue(msqWorkerTask.getInputSourceResources().isEmpty());
+  }
+
+  @Test
+  public void testGetPeonProcessingModuleConfig()
+  {
+    final PeonProcessingModule.Config config = msqWorkerTask.getPeonProcessingModuleConfig();
+    Assert.assertTrue(config.hasProcessingThreads());
+    Assert.assertTrue(config.hasProcessingBuffers());
+    Assert.assertFalse(config.hasMergeBuffers());
   }
 
   @Test

--- a/server/src/main/java/org/apache/druid/server/coordination/BroadcastDatasourceLoadingSpec.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/BroadcastDatasourceLoadingSpec.java
@@ -51,7 +51,19 @@ public class BroadcastDatasourceLoadingSpec
 
   public enum Mode
   {
-    ALL, NONE, ONLY_REQUIRED
+    ALL(true), NONE(false), ONLY_REQUIRED(true);
+
+    private final boolean needsBroadcastSegments;
+
+    Mode(boolean needsBroadcastSegments)
+    {
+      this.needsBroadcastSegments = needsBroadcastSegments;
+    }
+
+    public boolean needsBroadcastSegments()
+    {
+      return needsBroadcastSegments;
+    }
   }
 
   private final Mode mode;

--- a/server/src/test/java/org/apache/druid/server/coordination/BroadcastDatasourceLoadingSpecTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/BroadcastDatasourceLoadingSpecTest.java
@@ -44,6 +44,14 @@ public class BroadcastDatasourceLoadingSpecTest
   }
 
   @Test
+  public void testModeNeedsBroadcastSegments()
+  {
+    Assert.assertTrue(BroadcastDatasourceLoadingSpec.Mode.ALL.needsBroadcastSegments());
+    Assert.assertFalse(BroadcastDatasourceLoadingSpec.Mode.NONE.needsBroadcastSegments());
+    Assert.assertTrue(BroadcastDatasourceLoadingSpec.Mode.ONLY_REQUIRED.needsBroadcastSegments());
+  }
+
+  @Test
   public void testLoadingNoLookups()
   {
     final BroadcastDatasourceLoadingSpec spec = BroadcastDatasourceLoadingSpec.NONE;


### PR DESCRIPTION
Tasks can now declare exactly which resources they need. MSQWorkerTask takes advantage of this to declare that it does not need merge buffers, which saves some memory.