### PR TITLE
feat: separate worker disabled state from worker version

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ImmutableWorkerInfo.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ImmutableWorkerInfo.java
@@ -211,7 +211,7 @@ public class ImmutableWorkerInfo
 
   public boolean isValidVersion(String minVersion)
   {
-    return worker.getVersion().compareTo(minVersion) >= 0;
+    return !worker.isDisabled() && worker.getVersion().compareTo(minVersion) >= 0;
   }
 
   public boolean canRunTask(Task task, double parallelIndexTaskSlotRatio)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ZkWorker.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ZkWorker.java
@@ -205,7 +205,8 @@ public class ZkWorker implements Closeable
   @UsedInGeneratedCode // See JavaScriptWorkerSelectStrategyTest
   public boolean isValidVersion(String minVersion)
   {
-    return worker.get().getVersion().compareTo(minVersion) >= 0;
+    final Worker w = worker.get();
+    return !w.isDisabled() && w.getVersion().compareTo(minVersion) >= 0;
   }
 
   public void setWorker(Worker newWorker)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/WorkerHolder.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/WorkerHolder.java
@@ -65,8 +65,11 @@ public class WorkerHolder
   public static final TypeReference<ChangeRequestsSnapshot<WorkerHistoryItem>> WORKER_SYNC_RESP_TYPE_REF = new TypeReference<>() {};
 
 
-  private final Worker worker;
-  private Worker disabledWorker;
+  /**
+   * Pre-built views with isDisabled() set to false/true respectively. {@link #getWorker()} selects between them based on {@link #disabled}.
+   */
+  private final Worker enabledWorker;
+  private final Worker disabledWorker;
 
   protected final AtomicBoolean disabled;
   private final AtomicBoolean syncedAtleastOnce = new AtomicBoolean(false);
@@ -100,15 +103,16 @@ public class WorkerHolder
     this.httpClient = httpClient;
     this.config = config;
     this.listener = listener;
-    this.worker = worker;
-    //worker holder is created disabled and gets enabled after first sync success.
+    this.enabledWorker = workerWithDisabledState(worker, false);
+    this.disabledWorker = workerWithDisabledState(worker, true);
+    // WorkerHolder starts disabled and gets enabled after first successful sync.
     this.disabled = new AtomicBoolean(true);
 
     this.syncer = new ChangeRequestHttpSyncer<>(
         smileMapper,
         httpClient,
         workersSyncExec,
-        TaskRunnerUtils.makeWorkerURL(worker, "/"),
+        TaskRunnerUtils.makeWorkerURL(enabledWorker, "/"),
         "/druid-internal/v1/worker",
         WORKER_SYNC_RESP_TYPE_REF,
         config.getSyncRequestTimeout().toStandardDuration().getMillis(),
@@ -125,7 +129,7 @@ public class WorkerHolder
 
   public Worker getWorker()
   {
-    return worker;
+    return disabled.get() ? disabledWorker : enabledWorker;
   }
 
   public DateTime getBlacklistedUntil()
@@ -145,23 +149,8 @@ public class WorkerHolder
 
   public ImmutableWorkerInfo toImmutable()
   {
-    Worker w = worker;
-    if (disabled.get()) {
-      if (disabledWorker == null) {
-        disabledWorker = new Worker(
-            worker.getScheme(),
-            worker.getHost(),
-            worker.getIp(),
-            worker.getCapacity(),
-            "",
-            worker.getCategory()
-        );
-      }
-      w = disabledWorker;
-    }
-
     return ImmutableWorkerInfo.fromWorkerAnnouncements(
-        w,
+        getWorker(),
         tasksSnapshotRef.get(),
         lastCompletedTaskTime.get(),
         blacklistedUntil.get()
@@ -189,12 +178,12 @@ public class WorkerHolder
       log.info(
           "Received task[%s] assignment on worker[%s] when worker is disabled.",
           task.getId(),
-          worker.getHost()
+          enabledWorker.getHost()
       );
       return false;
     }
 
-    URL url = TaskRunnerUtils.makeWorkerURL(worker, "/druid-internal/v1/worker/assignTask");
+    URL url = TaskRunnerUtils.makeWorkerURL(enabledWorker, "/druid-internal/v1/worker/assignTask");
     int numTries = config.getAssignRequestMaxRetries();
 
     try {
@@ -215,7 +204,7 @@ public class WorkerHolder
                 throw new RE(
                     "Failed to assign task[%s] to worker[%s]. Response Code[%s] and Message[%s]. Retrying...",
                     task.getId(),
-                    worker.getHost(),
+                    enabledWorker.getHost(),
                     response.getStatus().getCode(),
                     response.getContent()
                 );
@@ -226,7 +215,7 @@ public class WorkerHolder
                   ex,
                   "Request to assign task[%s] to worker[%s] failed. Retrying...",
                   task.getId(),
-                  worker.getHost()
+                  enabledWorker.getHost()
               );
             }
           },
@@ -235,14 +224,14 @@ public class WorkerHolder
       );
     }
     catch (Exception ex) {
-      log.info("Not sure whether task[%s] was successfully assigned to worker[%s].", task.getId(), worker.getHost());
+      log.info("Not sure whether task[%s] was successfully assigned to worker[%s].", task.getId(), enabledWorker.getHost());
       return true;
     }
   }
 
   public void shutdownTask(String taskId)
   {
-    final URL url = TaskRunnerUtils.makeWorkerURL(worker, "/druid/worker/v1/task/%s/shutdown", taskId);
+    final URL url = TaskRunnerUtils.makeWorkerURL(enabledWorker, "/druid/worker/v1/task/%s/shutdown", taskId);
 
     try {
       RetryUtils.retry(
@@ -257,17 +246,17 @@ public class WorkerHolder
               if (response.getStatus().getCode() == 200) {
                 log.info(
                     "Sent shutdown message to worker: %s, status %s, response: %s",
-                    worker.getHost(),
+                    enabledWorker.getHost(),
                     response.getStatus(),
                     response.getContent()
                 );
                 return null;
               } else {
-                throw new RE("Attempt to shutdown task[%s] on worker[%s] failed.", taskId, worker.getHost());
+                throw new RE("Attempt to shutdown task[%s] on worker[%s] failed.", taskId, enabledWorker.getHost());
               }
             }
             catch (ExecutionException e) {
-              throw new RE(e, "Error in handling post to [%s] for task [%s]", worker.getHost(), taskId);
+              throw new RE(e, "Error in handling post to [%s] for task [%s]", enabledWorker.getHost(), taskId);
             }
           },
           e -> !(e instanceof InterruptedException),
@@ -279,7 +268,7 @@ public class WorkerHolder
         Thread.currentThread().interrupt();
       }
 
-      log.error("Failed to shutdown task[%s] on worker[%s] failed.", taskId, worker.getHost());
+      log.error("Failed to shutdown task[%s] on worker[%s] failed.", taskId, enabledWorker.getHost());
     }
   }
 
@@ -296,7 +285,7 @@ public class WorkerHolder
   public void waitForInitialization() throws InterruptedException
   {
     if (!syncer.awaitInitialization()) {
-      throw new RE("Failed to sync with worker[%s].", worker.getHost());
+      throw new RE("Failed to sync with worker[%s].", enabledWorker.getHost());
     }
   }
 
@@ -347,7 +336,7 @@ public class WorkerHolder
             log.makeAlert(
                 "Got unknown sync update[%s] from worker[%s]. Ignored.",
                 change.getClass().getName(),
-                worker.getHost()
+                enabledWorker.getHost()
             ).emit();
           }
         }
@@ -359,7 +348,7 @@ public class WorkerHolder
                 "task[%s] in state[%s] suddenly disappeared on worker[%s]. failing it.",
                 announcement.getTaskId(),
                 announcement.getStatus(),
-                worker.getHost()
+                enabledWorker.getHost()
             );
             delta.add(
                 TaskAnnouncement.create(
@@ -402,7 +391,7 @@ public class WorkerHolder
                   "task[%s] in state[%s] suddenly disappeared on worker[%s]. failing it.",
                   announcement.getTaskId(),
                   announcement.getStatus(),
-                  worker.getHost()
+                  enabledWorker.getHost()
               );
               delta.add(
                   TaskAnnouncement.create(
@@ -425,7 +414,7 @@ public class WorkerHolder
             log.makeAlert(
                 "Got unknown sync update[%s] from worker[%s]. Ignored.",
                 change.getClass().getName(),
-                worker.getHost()
+                enabledWorker.getHost()
             ).emit();
           }
         }
@@ -444,7 +433,7 @@ public class WorkerHolder
                 ex,
                 "Unknown exception while updating task[%s] state from worker[%s].",
                 announcement.getTaskId(),
-                worker.getHost()
+                enabledWorker.getHost()
             );
           }
         }
@@ -452,11 +441,19 @@ public class WorkerHolder
         syncedAtleastOnce.set(true);
         if (isWorkerDisabled != disabled.get()) {
           disabled.set(isWorkerDisabled);
-          log.info("Worker[%s] disabled set to [%s].", worker.getHost(), isWorkerDisabled);
+          log.info("Worker[%s] disabled set to [%s].", enabledWorker.getHost(), isWorkerDisabled);
           listener.stateChanged(!isWorkerDisabled, WorkerHolder.this);
         }
       }
     };
+  }
+
+  private static Worker workerWithDisabledState(Worker w, boolean disabled)
+  {
+    if (w.isDisabled() == disabled) {
+      return w;
+    }
+    return new Worker(w.getScheme(), w.getHost(), w.getIp(), w.getCapacity(), w.getVersion(), w.getCategory(), disabled);
   }
 
   public interface Listener

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/Worker.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/Worker.java
@@ -21,7 +21,10 @@ package org.apache.druid.indexing.worker;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.common.config.Configs;
 import org.apache.druid.guice.annotations.PublicApi;
+
+import javax.annotation.Nullable;
 
 /**
  * A container for worker metadata.
@@ -35,6 +38,7 @@ public class Worker
   private final int capacity;
   private final String version;
   private final String category;
+  private final boolean disabled;
 
   @JsonCreator
   public Worker(
@@ -43,7 +47,8 @@ public class Worker
       @JsonProperty("ip") String ip,
       @JsonProperty("capacity") int capacity,
       @JsonProperty("version") String version,
-      @JsonProperty("category") String category
+      @JsonProperty("category") String category,
+      @JsonProperty("disabled") @Nullable Boolean disabled
   )
   {
     this.scheme = scheme == null ? "http" : scheme; // needed for backwards compatibility with older workers (pre-#4270)
@@ -52,6 +57,19 @@ public class Worker
     this.capacity = capacity;
     this.version = version;
     this.category = category;
+    this.disabled = Configs.valueOrDefault(disabled, false);
+  }
+
+  public Worker(
+      String scheme,
+      String host,
+      String ip,
+      int capacity,
+      String version,
+      String category
+  )
+  {
+    this(scheme, host, ip, capacity, version, category, false);
   }
 
   @JsonProperty
@@ -90,6 +108,12 @@ public class Worker
     return category;
   }
 
+  @JsonProperty
+  public boolean isDisabled()
+  {
+    return disabled;
+  }
+
   @Override
   public boolean equals(Object o)
   {
@@ -103,6 +127,9 @@ public class Worker
     Worker worker = (Worker) o;
 
     if (capacity != worker.capacity) {
+      return false;
+    }
+    if (disabled != worker.disabled) {
       return false;
     }
     if (!scheme.equals(worker.scheme)) {
@@ -129,6 +156,7 @@ public class Worker
     result = 31 * result + capacity;
     result = 31 * result + version.hashCode();
     result = 31 * result + category.hashCode();
+    result = 31 * result + (disabled ? 1 : 0);
     return result;
   }
 
@@ -142,6 +170,7 @@ public class Worker
            ", capacity=" + capacity +
            ", version='" + version + '\'' +
            ", category='" + category + '\'' +
+           ", disabled=" + disabled +
            '}';
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/http/WorkerResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/http/WorkerResource.java
@@ -100,13 +100,16 @@ public class WorkerResource
   {
     try {
       if (curatorCoordinator != null) {
+        // Dual-write disabled signal: legacy version="" for old overlords + disabled=true for new overlords.
+        // TODO: Safe to drop DISABLED_VERSION once backward compatibility with overlords is no longer required.
         final Worker disabledWorker = new Worker(
             enabledWorker.getScheme(),
             enabledWorker.getHost(),
             enabledWorker.getIp(),
             enabledWorker.getCapacity(),
             DISABLED_VERSION,
-            enabledWorker.getCategory()
+            enabledWorker.getCategory(),
+            true
         );
         curatorCoordinator.updateWorkerAnnouncement(disabledWorker);
       }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTest.java
@@ -560,7 +560,7 @@ public class RemoteTaskRunnerTest
     Assert.assertEquals(TaskState.SUCCESS, result.get().getStatusCode());
 
     // Confirm RTR thinks the worker is disabled.
-    Assert.assertEquals("", Iterables.getOnlyElement(remoteTaskRunner.getWorkers()).getWorker().getVersion());
+    Assert.assertTrue(Iterables.getOnlyElement(remoteTaskRunner.getWorkers()).getWorker().isDisabled());
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTestUtils.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTestUtils.java
@@ -186,8 +186,9 @@ public class RemoteTaskRunnerTestUtils
             worker.getHost(),
             worker.getIp(),
             worker.getCapacity(),
-            "",
-            worker.getCategory()
+            worker.getVersion(),
+            worker.getCategory(),
+            true
         ))
     );
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/hrtr/WorkerHolderTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/hrtr/WorkerHolderTest.java
@@ -90,7 +90,7 @@ public class WorkerHolderTest
 
     ChangeRequestHttpSyncer.Listener<WorkerHistoryItem> syncListener = workerHolder.createSyncListener();
 
-    Assert.assertTrue(workerHolder.disabled.get());
+    Assert.assertFalse(workerHolder.isEnabled());
     Assert.assertFalse(workerHolder.isInitialized());
 
     syncListener.fullSync(
@@ -114,7 +114,7 @@ public class WorkerHolderTest
         )
     );
 
-    Assert.assertFalse(workerHolder.disabled.get());
+    Assert.assertTrue(workerHolder.isEnabled());
 
     Assert.assertEquals(4, updates.size());
 
@@ -153,7 +153,7 @@ public class WorkerHolderTest
         )
     );
 
-    Assert.assertFalse(workerHolder.disabled.get());
+    Assert.assertTrue(workerHolder.isEnabled());
     Assert.assertEquals(2, updates.size());
 
     Assert.assertEquals(task2.getId(), updates.get(0).getTaskId());
@@ -191,7 +191,7 @@ public class WorkerHolderTest
         )
     );
 
-    Assert.assertTrue(workerHolder.disabled.get());
+    Assert.assertFalse(workerHolder.isEnabled());
 
     Assert.assertEquals(3, updates.size());
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/setup/EqualDistributionWorkerSelectStrategyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/setup/EqualDistributionWorkerSelectStrategyTest.java
@@ -125,7 +125,6 @@ public class EqualDistributionWorkerSelectStrategyTest
   @Test
   public void testOneDisableWorkerDifferentUsedCapacity()
   {
-    String disabledVersion = "";
     final EqualDistributionWorkerSelectStrategy strategy = new EqualDistributionWorkerSelectStrategy(null, null);
 
     ImmutableWorkerInfo worker = strategy.findWorkerForTask(
@@ -133,7 +132,7 @@ public class EqualDistributionWorkerSelectStrategyTest
         ImmutableMap.of(
             "lhost",
             new ImmutableWorkerInfo(
-                new Worker("http", "disableHost", "disableHost", 10, disabledVersion, WorkerConfig.DEFAULT_CATEGORY), 2,
+                new Worker("http", "disableHost", "disableHost", 10, "v1", WorkerConfig.DEFAULT_CATEGORY, true), 2,
                 new HashSet<>(),
                 new HashSet<>(),
                 DateTimes.nowUtc()
@@ -154,7 +153,6 @@ public class EqualDistributionWorkerSelectStrategyTest
   @Test
   public void testOneDisableWorkerSameUsedCapacity()
   {
-    String disabledVersion = "";
     final EqualDistributionWorkerSelectStrategy strategy = new EqualDistributionWorkerSelectStrategy(null, null);
 
     ImmutableWorkerInfo worker = strategy.findWorkerForTask(
@@ -162,7 +160,7 @@ public class EqualDistributionWorkerSelectStrategyTest
         ImmutableMap.of(
             "lhost",
             new ImmutableWorkerInfo(
-                new Worker("http", "disableHost", "disableHost", 10, disabledVersion, WorkerConfig.DEFAULT_CATEGORY), 5,
+                new Worker("http", "disableHost", "disableHost", 10, "v1", WorkerConfig.DEFAULT_CATEGORY, true), 5,
                 new HashSet<>(),
                 new HashSet<>(),
                 DateTimes.nowUtc()

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/http/WorkerResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/http/WorkerResourceTest.java
@@ -124,12 +124,14 @@ public class WorkerResourceTest
   {
     Worker theWorker = JSON_MAPPER.readValue(cf.getData().forPath(ANNOUNCEMENT_PATH), Worker.class);
     Assert.assertEquals("v1", theWorker.getVersion());
+    Assert.assertFalse(theWorker.isDisabled());
 
     Response res = workerResource.doDisable();
     Assert.assertEquals(Response.Status.OK.getStatusCode(), res.getStatus());
 
     theWorker = JSON_MAPPER.readValue(cf.getData().forPath(ANNOUNCEMENT_PATH), Worker.class);
     Assert.assertTrue(theWorker.getVersion().isEmpty());
+    Assert.assertTrue(theWorker.isDisabled());
   }
 
   @Test
@@ -140,11 +142,13 @@ public class WorkerResourceTest
     Assert.assertEquals(Response.Status.OK.getStatusCode(), res.getStatus());
     Worker theWorker = JSON_MAPPER.readValue(cf.getData().forPath(ANNOUNCEMENT_PATH), Worker.class);
     Assert.assertTrue(theWorker.getVersion().isEmpty());
+    Assert.assertTrue(theWorker.isDisabled());
 
     // Enable the worker
     res = workerResource.doEnable();
     Assert.assertEquals(Response.Status.OK.getStatusCode(), res.getStatus());
     theWorker = JSON_MAPPER.readValue(cf.getData().forPath(ANNOUNCEMENT_PATH), Worker.class);
     Assert.assertEquals("v1", theWorker.getVersion());
+    Assert.assertFalse(theWorker.isDisabled());
   }
 }

--- a/web-console/src/views/services-view/services-view.tsx
+++ b/web-console/src/views/services-view/services-view.tsx
@@ -261,7 +261,7 @@ function DetailCell({ original, workerInfoLookup }: DetailCellProps) {
       const workerInfo = workerInfoLookup[service];
       if (!workerInfo) return null;
 
-      if (workerInfo.worker.version === '') return <>Disabled</>;
+      if (workerInfo.worker.disabled || workerInfo.worker.version === '') return <>Disabled</>;
 
       const details: string[] = [];
       if (workerInfo.lastCompletedTaskTime) {
@@ -397,6 +397,7 @@ interface WorkerInfo {
     readonly scheme: string;
     readonly version: string;
     readonly category: string;
+    readonly disabled?: boolean;
   };
 }
 
@@ -1077,10 +1078,9 @@ ORDER BY
   ): BasicAction[] {
     const actions: BasicAction[] = [];
 
-    // Add worker-specific actions (enable/disable) if this is a worker
     if (workerInfo) {
       const { worker } = workerInfo;
-      const disabled = worker.version === '';
+      const disabled = worker.disabled || worker.version === '';
 
       if (disabled) {
         actions.push({


### PR DESCRIPTION
<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Currently, to disable a worker (MM/Indexer), you need to set the version as `""`. This is not ideal, as it's difficult to see a) what version a disabled worker is and b) write any logic to perform scaling around multi-version worker deployments (for example during a rolling upgrade).

This ensures the disabled state is tracked separately from the worker version. The change is backwards compatible (to not break existing deployments) and can then be migrated to simply relying on the `disabled` flag in a subsequent release.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Track the worker enabled state separately from the worker version.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.