### PR TITLE
feat: Metrics tracking storage load begin and end.

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/CompactionSupervisorTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/CompactionSupervisorTest.java
@@ -100,6 +100,7 @@ import org.apache.druid.testing.embedded.tools.WikipediaStreamEventStreamGenerat
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.DimensionRangeShardSpec;
 import org.hamcrest.Matcher;
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -522,14 +523,21 @@ public class CompactionSupervisorTest extends EmbeddedClusterTestBase
     // Verify the correct rows were filtered
     verifyNoRowsWithNestedValue("extraInfo", "fieldA", "valueA");
 
-    List<ServiceMetricEvent> events = emitter.getMetricEvents(StorageMonitor.VSF_LOAD_COUNT);
-    long count = 0;
-    for (ServiceMetricEvent event : events) {
-      count += event.getValue().longValue();
+    List<ServiceMetricEvent> loadBeginEvents = emitter.getMetricEvents(StorageMonitor.VSF_LOAD_BEGIN_COUNT);
+    List<ServiceMetricEvent> loadEvents = emitter.getMetricEvents(StorageMonitor.VSF_LOAD_COUNT);
+    long loadBeginCount = 0, loadCount = 0;
+    for (ServiceMetricEvent event : loadBeginEvents) {
+      loadBeginCount += event.getValue().longValue();
       Assertions.assertNotNull(event.getUserDims().get("taskId"));
       Assertions.assertNotNull(event.getUserDims().get("groupId"));
     }
-    Assertions.assertTrue(count > 0);
+    for (ServiceMetricEvent event : loadEvents) {
+      loadCount += event.getValue().longValue();
+      Assertions.assertNotNull(event.getUserDims().get("taskId"));
+      Assertions.assertNotNull(event.getUserDims().get("groupId"));
+    }
+    MatcherAssert.assertThat(loadBeginCount, Matchers.greaterThan(0L));
+    MatcherAssert.assertThat(loadCount, Matchers.greaterThan(0L));
   }
 
   @Test

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/QueryVirtualStorageTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/QueryVirtualStorageTest.java
@@ -181,15 +181,15 @@ class QueryVirtualStorageTest extends EmbeddedClusterTestBase
     LatchableEmitter coordinatorEmitter = coordinator.latchableEmitter();
 
     // clear out the pipe to get zerod out storage monitor metrics
-    ServiceMetricEvent monitorEvent = emitter.waitForNextEvent(event -> event.hasMetricName(StorageMonitor.VSF_LOAD_COUNT));
+    ServiceMetricEvent monitorEvent = emitter.waitForNextEvent(event -> event.hasMetricName(StorageMonitor.VSF_LOAD_BEGIN_COUNT));
     while (monitorEvent != null && monitorEvent.getValue().longValue() > 0) {
-      monitorEvent = emitter.waitForNextEvent(event -> event.hasMetricName(StorageMonitor.VSF_LOAD_COUNT));
+      monitorEvent = emitter.waitForNextEvent(event -> event.hasMetricName(StorageMonitor.VSF_LOAD_BEGIN_COUNT));
     }
     // then flush (which clears out the internal events stores in test emitter) so we can do clean sums across them
     emitter.flush();
 
-    emitter.waitForNextEvent(event -> event.hasMetricName(StorageMonitor.VSF_LOAD_COUNT));
-    long beforeLoads = emitter.getMetricEventLongSum(StorageMonitor.VSF_LOAD_COUNT);
+    emitter.waitForNextEvent(event -> event.hasMetricName(StorageMonitor.VSF_LOAD_BEGIN_COUNT));
+    long beforeLoads = emitter.getMetricEventLongSum(StorageMonitor.VSF_LOAD_BEGIN_COUNT);
     // confirm flushed
     Assertions.assertEquals(0, beforeLoads);
 
@@ -203,8 +203,8 @@ class QueryVirtualStorageTest extends EmbeddedClusterTestBase
     Assertions.assertEquals(expectedResults[3], Long.parseLong(cluster.runSql(queries[3], dataSource)));
     assertQueryMetrics(4, expectedLoads[3]);
 
-    emitter.waitForNextEvent(event -> event.hasMetricName(StorageMonitor.VSF_LOAD_COUNT));
-    long firstLoads = emitter.getMetricEventLongSum(StorageMonitor.VSF_LOAD_COUNT);
+    emitter.waitForNextEvent(event -> event.hasMetricName(StorageMonitor.VSF_LOAD_BEGIN_COUNT));
+    long firstLoads = emitter.getMetricEventLongSum(StorageMonitor.VSF_LOAD_BEGIN_COUNT);
     Assertions.assertTrue(firstLoads >= 24, "expected " + 24 + " but only got " + firstLoads);
 
     long expectedTotalHits = 0;
@@ -225,9 +225,11 @@ class QueryVirtualStorageTest extends EmbeddedClusterTestBase
       emitter.waitForNextEvent(event -> event.hasMetricName(StorageMonitor.VSF_HIT_BYTES));
       Assertions.assertTrue(emitter.getMetricEventLongSum(StorageMonitor.VSF_HIT_BYTES) >= 0);
     }
-    emitter.waitForNextEvent(event -> event.hasMetricName(StorageMonitor.VSF_LOAD_COUNT));
-    long loads = emitter.getMetricEventLongSum(StorageMonitor.VSF_LOAD_COUNT);
+    emitter.waitForNextEvent(event -> event.hasMetricName(StorageMonitor.VSF_LOAD_BEGIN_COUNT));
+    long loads = emitter.getMetricEventLongSum(StorageMonitor.VSF_LOAD_BEGIN_COUNT);
     Assertions.assertTrue(loads >= expectedTotalLoad, "expected " + expectedTotalLoad + " but only got " + loads);
+    Assertions.assertTrue(emitter.getMetricEventLongSum(StorageMonitor.VSF_LOAD_BEGIN_BYTES) > 0);
+    Assertions.assertTrue(emitter.getMetricEventLongSum(StorageMonitor.VSF_LOAD_COUNT) > 0);
     Assertions.assertTrue(emitter.getMetricEventLongSum(StorageMonitor.VSF_LOAD_BYTES) > 0);
     emitter.waitForNextEvent(event -> event.hasMetricName(StorageMonitor.VSF_EVICT_COUNT));
     Assertions.assertTrue(emitter.getMetricEventLongSum(StorageMonitor.VSF_EVICT_COUNT) >= 0);

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
@@ -1128,14 +1128,21 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
         }
 
         // since we do not hold a lock on the location while mounting, make sure that we actually are reserved and
-        // should have mounted, otherwise unmount so we don't leave any orphaned files
-        if (!mountLocation.isReserved(this.id) && !mountLocation.isWeakReserved(this.id)) {
+        // should have mounted, otherwise unmount so we don't leave any orphaned files. These checks acquire the
+        // location lock, so they must run with entryLock released to avoid deadlocking.
+        final boolean isWeak = mountLocation.isWeakReserved(this.id);
+        final boolean isStatic = !isWeak && mountLocation.isReserved(this.id);
+        if (!isWeak && !isStatic) {
           log.debug(
               "aborting mount in location[%s] since entry[%s] is no longer reserved",
               mountLocation.getPath(),
               this.id
           );
           unmount();
+        } else if (isWeak) {
+          mountLocation.trackWeakLoad(dataSegment.getSize());
+        } else {
+          mountLocation.trackStaticLoad(dataSegment.getSize());
         }
 
         if (config.isVirtualStorageEphemeral()) {

--- a/server/src/main/java/org/apache/druid/segment/loading/StorageLocation.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/StorageLocation.java
@@ -275,7 +275,7 @@ public class StorageLocation
       unmountReclaimed(reclaimResult);
       if (reclaimResult.isSuccess()) {
         staticCacheEntries.put(entry.getId(), entry);
-        trackLoad(entry);
+        trackStaticLoadBegin(entry);
       }
       return reclaimResult.isSuccess();
     }
@@ -323,7 +323,7 @@ public class StorageLocation
         final WeakCacheEntry newEntry = new WeakCacheEntry(entry);
         linkNewWeakEntry(newEntry);
         weakCacheEntries.put(entry.getId(), newEntry);
-        weakStats.getAndUpdate(s -> s.load(entry.getSize()));
+        weakStats.getAndUpdate(s -> s.loadBegin(entry.getSize()));
       }
       return reclaimResult.isSuccess();
     }
@@ -407,7 +407,7 @@ public class StorageLocation
         linkNewWeakEntry(newWeakEntry);
         weakCacheEntries.put(newEntry.getId(), newWeakEntry);
         trackWeakHold(newWeakEntry);
-        weakStats.getAndUpdate(s -> s.load(newEntry.getSize()));
+        weakStats.getAndUpdate(s -> s.loadBegin(newEntry.getSize()));
         hold = new ReservationHold<>(
             (T) newEntry,
             createWeakEntryReleaseRunnable(newWeakEntry, true)
@@ -506,7 +506,7 @@ public class StorageLocation
       hand = newWeakEntry;
     }
     head = newWeakEntry;
-    trackWeakLoad(newWeakEntry);
+    trackWeakLoadBegin(newWeakEntry);
   }
 
   /**
@@ -643,11 +643,16 @@ public class StorageLocation
     }
   }
 
-  private void trackLoad(CacheEntry entry)
+  private void trackStaticLoadBegin(CacheEntry entry)
   {
     currSizeBytes.getAndAdd(entry.getSize());
     currStaticSizeBytes.getAndAdd(entry.getSize());
-    staticStats.getAndUpdate(s -> s.load(entry.getSize()));
+    staticStats.getAndUpdate(s -> s.loadBegin(entry.getSize()));
+  }
+
+  public void trackStaticLoad(long size)
+  {
+    staticStats.getAndUpdate(s -> s.load(size));
   }
 
   private void trackDrop(CacheEntry entry)
@@ -657,7 +662,7 @@ public class StorageLocation
     staticStats.getAndUpdate(s -> s.drop(entry.getSize()));
   }
 
-  private void trackWeakLoad(WeakCacheEntry entry)
+  private void trackWeakLoadBegin(WeakCacheEntry entry)
   {
     currSizeBytes.getAndAdd(entry.cacheEntry.getSize());
     currWeakSizeBytes.getAndAdd(entry.cacheEntry.getSize());
@@ -667,6 +672,11 @@ public class StorageLocation
   {
     currSizeBytes.getAndAdd(-entry.cacheEntry.getSize());
     currWeakSizeBytes.getAndAdd(-entry.cacheEntry.getSize());
+  }
+
+  public void trackWeakLoad(long size)
+  {
+    weakStats.getAndUpdate(s -> s.load(size));
   }
 
   private void trackWeakHold(WeakCacheEntry entry)
@@ -1008,6 +1018,8 @@ public class StorageLocation
   public static final class StaticStats implements StorageLocationStats
   {
     private final AtomicLong sizeUsed;
+    private final AtomicLong loadBeginCount = new AtomicLong(0);
+    private final AtomicLong loadBeginBytes = new AtomicLong(0);
     private final AtomicLong loadCount = new AtomicLong(0);
     private final AtomicLong loadBytes = new AtomicLong(0);
     private final AtomicLong dropCount = new AtomicLong(0);
@@ -1016,6 +1028,13 @@ public class StorageLocation
     public StaticStats(AtomicLong sizeUsed)
     {
       this.sizeUsed = sizeUsed;
+    }
+
+    public StaticStats loadBegin(long size)
+    {
+      loadBeginCount.getAndIncrement();
+      loadBeginBytes.getAndAdd(size);
+      return this;
     }
 
     public StaticStats load(long size)
@@ -1036,6 +1055,18 @@ public class StorageLocation
     public long getUsedBytes()
     {
       return sizeUsed.get();
+    }
+
+    @Override
+    public long getLoadBeginCount()
+    {
+      return loadBeginCount.get();
+    }
+
+    @Override
+    public long getLoadBeginBytes()
+    {
+      return loadBeginBytes.get();
     }
 
     @Override
@@ -1068,6 +1099,8 @@ public class StorageLocation
     private final AtomicLong sizeUsed;
     private final AtomicLong holdCount;
     private final AtomicLong holdBytes;
+    private final AtomicLong loadBeginCount = new AtomicLong(0);
+    private final AtomicLong loadBeginBytes = new AtomicLong(0);
     private final AtomicLong loadCount = new AtomicLong(0);
     private final AtomicLong loadBytes = new AtomicLong(0);
     private final AtomicLong rejectionCount = new AtomicLong(0);
@@ -1088,6 +1121,13 @@ public class StorageLocation
     {
       hitCount.getAndIncrement();
       hitBytes.getAndAdd(size);
+      return this;
+    }
+
+    public WeakStats loadBegin(long size)
+    {
+      loadBeginCount.getAndIncrement();
+      loadBeginBytes.getAndAdd(size);
       return this;
     }
 
@@ -1145,6 +1185,18 @@ public class StorageLocation
     public long getHitBytes()
     {
       return hitBytes.get();
+    }
+
+    @Override
+    public long getLoadBeginCount()
+    {
+      return loadBeginCount.get();
+    }
+
+    @Override
+    public long getLoadBeginBytes()
+    {
+      return loadBeginBytes.get();
     }
 
     @Override

--- a/server/src/main/java/org/apache/druid/segment/loading/StorageLocationStats.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/StorageLocationStats.java
@@ -27,12 +27,25 @@ public interface StorageLocationStats
   long getUsedBytes();
 
   /**
-   * Number of load operations during the measurement period
+   * Number of load operations that were started (space reserved) during the measurement period. This is incremented
+   * when the load begins, regardless of whether it ultimately completes.
+   */
+  long getLoadBeginCount();
+
+  /**
+   * Number of bytes for which a load was started (space reserved) during the measurement period. This is incremented
+   * when the load begins, regardless of whether it ultimately completes.
+   */
+  long getLoadBeginBytes();
+
+  /**
+   * Number of load operations that finished (segment downloaded, deserialized, and made queryable) during the
+   * measurement period. This may be lower than {@link #getLoadBeginCount()} when mounts fail or are aborted.
    */
   long getLoadCount();
 
   /**
-   * Number of bytes loaded during the measurement period
+   * Number of bytes for load operations that finished during the measurement period.
    */
   long getLoadBytes();
 

--- a/server/src/main/java/org/apache/druid/segment/loading/VirtualStorageLocationStats.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/VirtualStorageLocationStats.java
@@ -50,12 +50,25 @@ public interface VirtualStorageLocationStats
   long getHitBytes();
 
   /**
-   * Number of operations for which an entry was missing and was loaded into the cache during the measurement period
+   * Number of operations for which an entry was missing and a load was started (space reserved) during the measurement
+   * period. This is incremented when the load begins, regardless of whether it ultimately completes.
+   */
+  long getLoadBeginCount();
+
+  /**
+   * Number of bytes for entries missing from the cache for which a load was started (space reserved) during the
+   * measurement period. This is incremented when the load begins, regardless of whether it ultimately completes.
+   */
+  long getLoadBeginBytes();
+
+  /**
+   * Number of cache entries that finished loading (segment downloaded, deserialized, and made queryable) during the
+   * measurement period. This may be lower than {@link #getLoadBeginCount()} when mounts fail or are aborted.
    */
   long getLoadCount();
 
   /**
-   * Number of bytes loaded for entries missing from the cache during the measurement period
+   * Number of bytes for cache entries that finished loading during the measurement period.
    */
   long getLoadBytes();
 

--- a/server/src/main/java/org/apache/druid/server/metrics/StorageMonitor.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/StorageMonitor.java
@@ -45,20 +45,109 @@ import java.util.Map;
 public class StorageMonitor extends AbstractMonitor
 {
   public static final String LOCATION_DIMENSION = "location";
+
+  /**
+   * Total number of bytes reserved by strongly-held objects in the storage location. Includes reservations that are not
+   * yet loaded.
+   */
   public static final String USED_BYTES = "storage/used/bytes";
+
+  /**
+   * Number of strongly-held objects whose load was started during the measurement period. Incremented when space is
+   * reserved, before the object has been downloaded.
+   */
+  public static final String LOAD_BEGIN_COUNT = "storage/load/begin/count";
+
+  /**
+   * Total bytes of strongly-held objects whose load was started during the measurement period.
+   */
+  public static final String LOAD_BEGIN_BYTES = "storage/load/begin/bytes";
+
+  /**
+   * Number of strongly-held objects whose load completed during the measurement period. Incremented after the object
+   * has been downloaded and is usable.
+   */
   public static final String LOAD_COUNT = "storage/load/count";
+
+  /**
+   * Total bytes of strongly-held objects whose load completed during the measurement period.
+   */
   public static final String LOAD_BYTES = "storage/load/bytes";
+
+  /**
+   * Number of strongly-held objects dropped from the storage location during the measurement period.
+   */
   public static final String DROP_COUNT = "storage/drop/count";
+
+  /**
+   * Total bytes of strongly-held objects dropped from the storage location during the measurement period.
+   */
   public static final String DROP_BYTES = "storage/drop/bytes";
+
+  /**
+   * Total number of bytes reserved by weakly-held objects in virtual storage. Includes reservations that are not yet
+   * loaded.
+   */
   public static final String VSF_USED_BYTES = "storage/virtual/used/bytes";
+
+  /**
+   * Number of active holds on weakly-held objects, indicating objects currently in use.
+   */
   public static final String VSF_HOLD_COUNT = "storage/virtual/hold/count";
+
+  /**
+   * Total bytes from active holds on weakly-held objects.
+   */
   public static final String VSF_HOLD_BYTES = "storage/virtual/hold/bytes";
+
+  /**
+   * Number of acquire operations during the measurement period that found an existing weakly-held entry already in
+   * virtual storage.
+   */
   public static final String VSF_HIT_COUNT = "storage/virtual/hit/count";
+
+  /**
+   * Total bytes from acquire operations during the measurement period that found an existing weakly-held entry already
+   * in virtual storage.
+   */
   public static final String VSF_HIT_BYTES = "storage/virtual/hit/bytes";
+
+  /**
+   * Number of weakly-held objects whose load was started during the measurement period. Incremented when space is
+   * reserved, before the object has been downloaded.
+   */
+  public static final String VSF_LOAD_BEGIN_COUNT = "storage/virtual/load/begin/count";
+
+  /**
+   * Total bytes of weakly-held objects whose load was started during the measurement period.
+   */
+  public static final String VSF_LOAD_BEGIN_BYTES = "storage/virtual/load/begin/bytes";
+
+  /**
+   * Number of weakly-held objects whose load completed during the measurement period. Incremented after the object has
+   * been downloaded and is usable.
+   */
   public static final String VSF_LOAD_COUNT = "storage/virtual/load/count";
+
+  /**
+   * Total bytes of weakly-held objects whose load completed during the measurement period.
+   */
   public static final String VSF_LOAD_BYTES = "storage/virtual/load/bytes";
+
+  /**
+   * Number of weakly-held objects evicted from virtual storage during the measurement period.
+   */
   public static final String VSF_EVICT_COUNT = "storage/virtual/evict/count";
+
+  /**
+   * Total bytes of weakly-held objects evicted from virtual storage during the measurement period.
+   */
   public static final String VSF_EVICT_BYTES = "storage/virtual/evict/bytes";
+
+  /**
+   * Number of acquire operations during the measurement period that could not load a weakly-held object due to
+   * insufficient space in virtual storage.
+   */
   public static final String VSF_REJECT_COUNT = "storage/virtual/reject/count";
 
   private final SegmentCacheManager cacheManager;
@@ -84,6 +173,8 @@ public class StorageMonitor extends AbstractMonitor
         final ServiceMetricEvent.Builder builder = builderSupplier.get()
                                                                   .setDimension(LOCATION_DIMENSION, location.getKey());
         emitter.emit(builder.setMetric(USED_BYTES, staticStats.getUsedBytes()));
+        emitter.emit(builder.setMetric(LOAD_BEGIN_COUNT, staticStats.getLoadBeginCount()));
+        emitter.emit(builder.setMetric(LOAD_BEGIN_BYTES, staticStats.getLoadBeginBytes()));
         emitter.emit(builder.setMetric(LOAD_COUNT, staticStats.getLoadCount()));
         emitter.emit(builder.setMetric(LOAD_BYTES, staticStats.getLoadBytes()));
         emitter.emit(builder.setMetric(DROP_COUNT, staticStats.getDropCount()));
@@ -99,6 +190,8 @@ public class StorageMonitor extends AbstractMonitor
         emitter.emit(builder.setMetric(VSF_HOLD_BYTES, weakStats.getHoldBytes()));
         emitter.emit(builder.setMetric(VSF_HIT_COUNT, weakStats.getHitCount()));
         emitter.emit(builder.setMetric(VSF_HIT_BYTES, weakStats.getHitBytes()));
+        emitter.emit(builder.setMetric(VSF_LOAD_BEGIN_COUNT, weakStats.getLoadBeginCount()));
+        emitter.emit(builder.setMetric(VSF_LOAD_BEGIN_BYTES, weakStats.getLoadBeginBytes()));
         emitter.emit(builder.setMetric(VSF_LOAD_COUNT, weakStats.getLoadCount()));
         emitter.emit(builder.setMetric(VSF_LOAD_BYTES, weakStats.getLoadBytes()));
         emitter.emit(builder.setMetric(VSF_EVICT_COUNT, weakStats.getEvictionCount()));

--- a/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerConcurrencyTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerConcurrencyTest.java
@@ -604,16 +604,16 @@ class SegmentLocalCacheManagerConcurrencyTest
         totalFailures += result.exceptions.size();
         Assertions.assertEquals(
             totalSuccess,
-            location.getWeakStats().getLoadCount() +
+            location.getWeakStats().getLoadBeginCount() +
             location.getWeakStats().getHitCount() +
-            location2.getWeakStats().getLoadCount() +
+            location2.getWeakStats().getLoadBeginCount() +
             location2.getWeakStats().getHitCount(),
             StringUtils.format(
                 "iteration[%s] - loc1: loads[%s] hits[%s] loc2: loads[%s] hits[%s]",
                 i,
-                location.getWeakStats().getLoadCount(),
+                location.getWeakStats().getLoadBeginCount(),
                 location.getWeakStats().getHitCount(),
-                location2.getWeakStats().getLoadCount(),
+                location2.getWeakStats().getLoadBeginCount(),
                 location2.getWeakStats().getHitCount()
             )
         );
@@ -631,9 +631,9 @@ class SegmentLocalCacheManagerConcurrencyTest
     Assertions.assertEquals(iterations, totalSuccess + totalFailures);
     Assertions.assertEquals(
         totalSuccess,
-        location.getWeakStats().getLoadCount()
+        location.getWeakStats().getLoadBeginCount()
         + location.getWeakStats().getHitCount()
-        + location2.getWeakStats().getLoadCount()
+        + location2.getWeakStats().getLoadBeginCount()
         + location2.getWeakStats().getHitCount()
     );
     Assertions.assertTrue(totalFailures <= location.getWeakStats().getRejectCount() + location2.getWeakStats()
@@ -805,14 +805,14 @@ class SegmentLocalCacheManagerConcurrencyTest
     // 5 because __drop path
     Assertions.assertTrue(5 >= location.getPath().listFiles().length);
     Assertions.assertTrue(5 >= location2.getPath().listFiles().length);
-    Assertions.assertTrue(location.getWeakStats().getLoadCount() >= 4);
-    Assertions.assertTrue(location2.getWeakStats().getLoadCount() >= 4);
+    Assertions.assertTrue(location.getWeakStats().getLoadBeginCount() >= 4);
+    Assertions.assertTrue(location2.getWeakStats().getLoadBeginCount() >= 4);
     Assertions.assertEquals(location.getWeakStats().getEvictionCount(), location.getWeakStats().getUnmountCount());
     Assertions.assertEquals(location2.getWeakStats().getEvictionCount(), location2.getWeakStats().getUnmountCount());
-    Assertions.assertEquals(location.getWeakStats().getLoadCount() - 4, location.getWeakStats().getEvictionCount());
-    Assertions.assertEquals(location2.getWeakStats().getLoadCount() - 4, location2.getWeakStats().getEvictionCount());
-    Assertions.assertEquals(location.getWeakStats().getLoadCount() - 4, location.getWeakStats().getUnmountCount());
-    Assertions.assertEquals(location2.getWeakStats().getLoadCount() - 4, location2.getWeakStats().getUnmountCount());
+    Assertions.assertEquals(location.getWeakStats().getLoadBeginCount() - 4, location.getWeakStats().getEvictionCount());
+    Assertions.assertEquals(location2.getWeakStats().getLoadBeginCount() - 4, location2.getWeakStats().getEvictionCount());
+    Assertions.assertEquals(location.getWeakStats().getLoadBeginCount() - 4, location.getWeakStats().getUnmountCount());
+    Assertions.assertEquals(location2.getWeakStats().getLoadBeginCount() - 4, location2.getWeakStats().getUnmountCount());
   }
 
   private void makeSegmentsToLoad(


### PR DESCRIPTION
Prior to this patch, the `storage/load/bytes` and `storage/virtual/load/bytes` metrics were measured from the time the space is reserved, which can obscure timings of the actual load. This patch makes two changes:

1) Modify `storage/load/bytes` and `storage/virtual/load/bytes` to measure once the load is complete, rather than when it starts.

2) Introduce `storage/load/begin/bytes` and `storage/virtual/load/begin/bytes` to match what the `storage/load/bytes` and `storage/virtual/load/bytes` were previously defined as.

The same changes are made to the corresponding `count` metrics.