### PR TITLE
fix: emit query/node/{bytes/time} metrics on query failure to data nodes

### DIFF
--- a/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
+++ b/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
@@ -181,6 +181,7 @@ public class DirectDruidClient<T> implements QueryRunner<T>
         private final AtomicLong channelSuspendedTime = new AtomicLong(0);
         private final BlockingQueue<InputStreamHolder> queue = new LinkedBlockingQueue<>();
         private final AtomicBoolean done = new AtomicBoolean(false);
+        private final AtomicBoolean nodeMetricsEmitted = new AtomicBoolean(false);
         private final AtomicReference<String> fail = new AtomicReference<>();
         private final AtomicReference<TrafficCop> trafficCopRef = new AtomicReference<>();
 
@@ -359,15 +360,7 @@ public class DirectDruidClient<T> implements QueryRunner<T>
               // Floating math; division by zero will yield Inf, not exception
               totalByteCount.get() / (0.001 * nodeTimeMs)
           );
-          QueryMetrics<? super Query<T>> responseMetrics = acquireResponseMetrics();
-          responseMetrics.reportNodeTime(nodeTimeNs);
-          responseMetrics.reportNodeBytes(totalByteCount.get());
-
-          if (usingBackpressure) {
-            responseMetrics.reportBackPressureTime(channelSuspendedTime.get());
-          }
-
-          responseMetrics.emit(emitter);
+          emitNodeMetrics(nodeTimeNs);
           synchronized (done) {
             try {
               // An empty byte array is put at the end to give the SequenceInputStream.close() as something to close out
@@ -400,6 +393,7 @@ public class DirectDruidClient<T> implements QueryRunner<T>
 
         private void setupResponseReadFailure(String msg, Throwable th)
         {
+          emitNodeMetrics(System.nanoTime() - requestStartTimeNs);
           fail.set(msg);
           queue.clear();
           queue.offer(
@@ -420,6 +414,21 @@ public class DirectDruidClient<T> implements QueryRunner<T>
                   0
               )
           );
+        }
+
+        // Emit exactly once, regardless of whether we reach this via done() or setupResponseReadFailure().
+        private void emitNodeMetrics(long nodeTimeNs)
+        {
+          if (!nodeMetricsEmitted.compareAndSet(false, true)) {
+            return;
+          }
+          QueryMetrics<? super Query<T>> responseMetrics = acquireResponseMetrics();
+          responseMetrics.reportNodeTime(nodeTimeNs);
+          responseMetrics.reportNodeBytes(totalByteCount.get());
+          if (usingBackpressure) {
+            responseMetrics.reportBackPressureTime(channelSuspendedTime.get());
+          }
+          responseMetrics.emit(emitter);
         }
 
         // Returns remaining timeout or throws exception if timeout already elapsed.

--- a/server/src/test/java/org/apache/druid/client/DirectDruidClientTest.java
+++ b/server/src/test/java/org/apache/druid/client/DirectDruidClientTest.java
@@ -29,8 +29,10 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.guava.Sequence;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.http.client.HttpClient;
 import org.apache.druid.java.util.http.client.Request;
+import org.apache.druid.java.util.metrics.StubServiceEmitter;
 import org.apache.druid.query.Druids;
 import org.apache.druid.query.NestedDataTestUtils;
 import org.apache.druid.query.QueryContexts;
@@ -323,6 +325,60 @@ public class DirectDruidClientTest
   }
 
   @Test
+  public void testNodeMetricsEmittedOnSuccess()
+  {
+    StubServiceEmitter stubEmitter = StubServiceEmitter.createStarted();
+    DirectDruidClient client = makeDirectDruidClient(initHttpClientWithSuccessfulQuery(), stubEmitter);
+
+    client.run(getQueryPlus(), responseContext).toList();
+
+    Assert.assertEquals(1, stubEmitter.getMetricEventCount("query/node/time"));
+    Assert.assertEquals(1, stubEmitter.getMetricEventCount("query/node/bytes"));
+  }
+
+  @Test
+  public void testNodeMetricsEmittedOnError()
+  {
+    // Only setupResponseReadFailure fires (checkQueryTimeout during handleResponse) — done() is never called.
+    StubServiceEmitter stubEmitter = StubServiceEmitter.createStarted();
+    final TestHttpClient testHttpClient = new TestHttpClient(objectMapper, 110);
+    DirectDruidClient client = makeDirectDruidClient(initHttpClientFromExistingClient(testHttpClient, false), stubEmitter);
+
+    final QueryPlus queryPlus = getQueryPlus(Map.of(
+        DirectDruidClient.QUERY_FAIL_TIME, System.currentTimeMillis() + 50
+    ));
+
+    Assert.assertThrows(QueryTimeoutException.class, () -> client.run(queryPlus, responseContext));
+
+    Assert.assertEquals(1, stubEmitter.getMetricEventCount("query/node/time"));
+    Assert.assertEquals(1, stubEmitter.getMetricEventCount("query/node/bytes"));
+  }
+
+  @Test
+  public void testNodeMetricsEmittedExactlyOnceWhenDoneAndTimeoutBothFire() throws InterruptedException
+  {
+    // done() fires synchronously during run(), then results.toList() calls checkQueryTimeout() after the
+    // timeout has already expired, triggering setupResponseReadFailure(). The compareAndSet guard must
+    // prevent the second emitNodeMetrics() call from emitting.
+    StubServiceEmitter stubEmitter = StubServiceEmitter.createStarted();
+    DirectDruidClient client = makeDirectDruidClient(initHttpClientWithSuccessfulQuery(), stubEmitter);
+
+    // Timeout far enough in the future that handleResponse + done() complete during run(), but we sleep
+    // past it before consuming the sequence so that checkQueryTimeout() fires during toList().
+    final QueryPlus queryPlus = getQueryPlus(Map.of(
+        DirectDruidClient.QUERY_FAIL_TIME, System.currentTimeMillis() + 500
+    ));
+
+    Sequence results = client.run(queryPlus, responseContext);
+    Thread.sleep(600);
+
+    Assert.assertThrows(QueryTimeoutException.class, results::toList);
+
+    Assert.assertEquals(1, stubEmitter.getMetricEventCount("query/node/time"));
+    Assert.assertEquals(1, stubEmitter.getMetricEventCount("query/node/bytes"));
+  }
+
+  @Test
   public void testResourceLimitExceededException()
   {
     final DirectDruidClient client = makeDirectDruidClient(initHttpClientWithSuccessfulQuery());
@@ -347,6 +403,11 @@ public class DirectDruidClientTest
 
   private DirectDruidClient makeDirectDruidClient(HttpClient httpClient)
   {
+    return makeDirectDruidClient(httpClient, new NoopServiceEmitter());
+  }
+
+  private DirectDruidClient makeDirectDruidClient(HttpClient httpClient, ServiceEmitter emitter)
+  {
     return new DirectDruidClient(
         conglomerateRule.getConglomerate(),
         QueryRunnerTestHelper.NOOP_QUERYWATCHER,
@@ -354,7 +415,7 @@ public class DirectDruidClientTest
         httpClient,
         "http",
         hostName,
-        new NoopServiceEmitter(),
+        emitter,
         queryCancellationExecutor
     );
   }


### PR DESCRIPTION
<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Failed requests to data nodes (e.g. timeouts) will not log query/node/bytes, query/node/time, nor any backpressure metrics which are all useful in debugging bottlenecks for queries. Make sure these are emitted irrespective of whether the query was successful or not.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note

Emit query/node/{bytes/time} and backpressure metrics even on query failure to data nodes.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.