### PR TITLE
feat: coordinator-side reconciliation for partial-load rules

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/loading/PartialLoadSpec.java
+++ b/processing/src/main/java/org/apache/druid/segment/loading/PartialLoadSpec.java
@@ -61,6 +61,35 @@ public abstract class PartialLoadSpec implements LoadSpec
    */
   public static final String TYPE_PREFIX = "partial";
 
+  /**
+   * Returns {@code true} if {@code loadSpec} matches the shape of the {@link PartialLoadSpec} subtype.
+   * Convention-based detection (no subtype allowlist): the {@code type} field must be a {@link String} starting with
+   * {@link #TYPE_PREFIX}, the {@code fingerprint} field must be a {@link String}, and the {@code delegate} field
+   * must be a {@link Map}. These properties are enforced by this base class's {@code @JsonProperty} getters, so any
+   * subtype satisfies them automatically.
+   */
+  public static boolean detectPartialLoadSpec(@Nullable Map<String, Object> loadSpec)
+  {
+    return loadSpec != null
+           && loadSpec.get("type") instanceof String typeString
+           && typeString.startsWith(TYPE_PREFIX)
+           && loadSpec.get("fingerprint") instanceof String
+           && loadSpec.get("delegate") instanceof Map;
+  }
+
+  /**
+   * Returns {@code true} if {@code loadSpec}'s {@code type} field claims partial-load semantics (starts with
+   * {@link #TYPE_PREFIX}), regardless of whether the remaining wire form is well-formed. Useful when callers want
+   * to distinguish "not a partial-load wrapper" from "claims to be partial but the {@code fingerprint} or
+   * {@code delegate} fields are missing or malformed" — the latter typically indicates a bug worth logging.
+   */
+  public static boolean hasPartialTypePrefix(@Nullable Map<String, Object> loadSpec)
+  {
+    return loadSpec != null
+           && loadSpec.get("type") instanceof String typeString
+           && typeString.startsWith(TYPE_PREFIX);
+  }
+
   private final Map<String, Object> delegate;
   private final String fingerprint;
   private final Supplier<LoadSpec> materializedDelegateSupplier;

--- a/processing/src/main/java/org/apache/druid/segment/loading/PartialLoadSpec.java
+++ b/processing/src/main/java/org/apache/druid/segment/loading/PartialLoadSpec.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.loading;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Base for {@link LoadSpec} wrappers that carry partial-load metadata (a fingerprint identifying the request the
+ * coordinator made plus a raw {@code delegate} inner load spec describing where the segment data lives) alongside
+ * scheme-specific data in concrete subtypes (projection names, row ranges, etc.). The {@code delegate} is held as a
+ * raw {@link Map} so the concrete backend type (e.g. {@code s3}, {@code local}, {@code hdfs}) is only materialized
+ * when needed via {@link #materializedDelegate()}; this avoids pulling backend-specific dependencies onto every node
+ * that touches the wire form.
+ * <p>
+ * The default {@link #loadSegment(File)} and {@link #openRangeReader()} delegate verbatim to the materialized inner
+ * load spec — i.e., a full load. Subtypes override these only when they actually implement scheme-specific partial
+ * loading; until then, historicals fall back to a full download and the announcement-side path stamps the
+ * wrapper's fingerprint plus the full segment size on the load announcement so the coordinator counts the replica
+ * as a satisfying full-fallback rather than re-queueing the load.
+ * <p>
+ * Wire-format conventions required of all subtypes (enforced by code that inspects raw {@code Map}-form load specs):
+ * <ul>
+ *   <li>The Jackson {@code @JsonTypeName} starts with {@link #TYPE_PREFIX} ({@code "partial"}).</li>
+ *   <li>The wire form includes {@code fingerprint} ({@link String}) and {@code delegate} ({@link Map}) at the top
+ *       level. These are provided by {@link #getFingerprint()} and {@link #getDelegate()} on this base class, so
+ *       subtypes inherit the contract automatically.</li>
+ * </ul>
+ * Together these let callers identify any partial-load wrapper from its raw map form without enumerating concrete
+ * subtypes.
+ */
+public abstract class PartialLoadSpec implements LoadSpec
+{
+  /**
+   * All partial-load LoadSpec wire types use this Jackson type-name prefix. See class doc for the convention.
+   */
+  public static final String TYPE_PREFIX = "partial";
+
+  private final Map<String, Object> delegate;
+  private final String fingerprint;
+  private final Supplier<LoadSpec> materializedDelegateSupplier;
+
+  protected PartialLoadSpec(Map<String, Object> delegate, String fingerprint, ObjectMapper jsonMapper)
+  {
+    this.delegate = Preconditions.checkNotNull(delegate, "delegate");
+    this.fingerprint = Preconditions.checkNotNull(fingerprint, "fingerprint");
+    Preconditions.checkNotNull(jsonMapper, "jsonMapper");
+    this.materializedDelegateSupplier = Suppliers.memoize(() -> jsonMapper.convertValue(delegate, LoadSpec.class));
+  }
+
+  @JsonProperty
+  public final Map<String, Object> getDelegate()
+  {
+    return delegate;
+  }
+
+  @JsonProperty
+  public final String getFingerprint()
+  {
+    return fingerprint;
+  }
+
+  /**
+   * Returns the materialized inner {@link LoadSpec}. Lazy + memoized so the backend-specific deserialization runs
+   * once per wrapper instance. Used by the default {@link #loadSegment(File)} / {@link #openRangeReader()}
+   * implementations and available to subtypes that want to compose full-fallback into their scheme-specific paths.
+   */
+  protected LoadSpec materializedDelegate()
+  {
+    return materializedDelegateSupplier.get();
+  }
+
+  @Override
+  public LoadSpecResult loadSegment(File destDir) throws SegmentLoadingException
+  {
+    return materializedDelegate().loadSegment(destDir);
+  }
+
+  @Override
+  @Nullable
+  public SegmentRangeReader openRangeReader() throws IOException
+  {
+    return materializedDelegate().openRangeReader();
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/loading/PartialProjectionLoadSpec.java
+++ b/processing/src/main/java/org/apache/druid/segment/loading/PartialProjectionLoadSpec.java
@@ -25,36 +25,28 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import org.apache.druid.utils.CollectionUtils;
 
-import javax.annotation.Nullable;
-import java.io.File;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 /**
- * A {@link LoadSpec} wrapper that carries partial-projection metadata from the coordinator to a historical alongside
- * the original backend-specific load spec. The wrapped {@code delegate} is held as a raw {@link Map} so that the
- * concrete backend type (e.g. {@code s3}, {@code local}, {@code hdfs}) is materialized only when needed; this avoids
- * pulling backend-specific dependencies onto every node that touches the wire form.
+ * A {@link PartialLoadSpec} that requests partial loading of a segment's projections. The base class carries the
+ * common {@code fingerprint} and {@code delegate} wire fields; this subtype adds the resolved projection names that
+ * the historical should range-read into the local segment.
  * <p>
- * Both {@link #loadSegment(File)} and {@link #openRangeReader()} delegate verbatim to the inner load spec. The
- * historical-side partial-load path inspects this wrapper at mount time to learn which projections to range-read and
- * the fingerprint identifying the request the coordinator made.
+ * The historical-side partial-load path inspects this wrapper at mount time. Until that path exists, the base
+ * class's default {@link #loadSegment} performs a full download via the inner delegate, and the announcement layer
+ * stamps the fingerprint + full size on the response so the coordinator's reconciler counts the replica as a
+ * satisfying full-fallback rather than re-queuing the load.
  */
 @JsonTypeName(PartialProjectionLoadSpec.TYPE)
-public class PartialProjectionLoadSpec implements LoadSpec
+public class PartialProjectionLoadSpec extends PartialLoadSpec
 {
   public static final String TYPE = "partialProjection";
 
-  private final Map<String, Object> delegate;
   private final List<String> projections;
-  private final String fingerprint;
-  private final Supplier<LoadSpec> materializedDelegateSupplier;
 
   @JsonCreator
   public PartialProjectionLoadSpec(
@@ -64,46 +56,18 @@ public class PartialProjectionLoadSpec implements LoadSpec
       @JacksonInject ObjectMapper jsonMapper
   )
   {
-    Preconditions.checkNotNull(jsonMapper, "jsonMapper");
-    this.delegate = Preconditions.checkNotNull(delegate, "delegate");
+    super(delegate, fingerprint, jsonMapper);
     Preconditions.checkArgument(
         !CollectionUtils.isNullOrEmpty(projections),
         "projections must not be null or empty"
     );
     this.projections = List.copyOf(projections);
-    this.fingerprint = Preconditions.checkNotNull(fingerprint, "fingerprint");
-    this.materializedDelegateSupplier = Suppliers.memoize(() -> jsonMapper.convertValue(delegate, LoadSpec.class));
-  }
-
-  @JsonProperty
-  public Map<String, Object> getDelegate()
-  {
-    return delegate;
   }
 
   @JsonProperty
   public List<String> getProjections()
   {
     return projections;
-  }
-
-  @JsonProperty
-  public String getFingerprint()
-  {
-    return fingerprint;
-  }
-
-  @Override
-  public LoadSpecResult loadSegment(File destDir) throws SegmentLoadingException
-  {
-    return materializedDelegateSupplier.get().loadSegment(destDir);
-  }
-
-  @Override
-  @Nullable
-  public SegmentRangeReader openRangeReader() throws IOException
-  {
-    return materializedDelegateSupplier.get().openRangeReader();
   }
 
   @Override
@@ -116,24 +80,24 @@ public class PartialProjectionLoadSpec implements LoadSpec
       return false;
     }
     PartialProjectionLoadSpec that = (PartialProjectionLoadSpec) o;
-    return Objects.equals(delegate, that.delegate)
+    return Objects.equals(getDelegate(), that.getDelegate())
         && Objects.equals(projections, that.projections)
-        && Objects.equals(fingerprint, that.fingerprint);
+        && Objects.equals(getFingerprint(), that.getFingerprint());
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(delegate, projections, fingerprint);
+    return Objects.hash(getDelegate(), projections, getFingerprint());
   }
 
   @Override
   public String toString()
   {
     return "PartialProjectionLoadSpec{" +
-           "delegate=" + delegate +
+           "delegate=" + getDelegate() +
            ", projections=" + projections +
-           ", fingerprint=" + fingerprint +
+           ", fingerprint=" + getFingerprint() +
            '}';
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/loading/PartialProjectionLoadSpec.java
+++ b/processing/src/main/java/org/apache/druid/segment/loading/PartialProjectionLoadSpec.java
@@ -46,6 +46,25 @@ public class PartialProjectionLoadSpec extends PartialLoadSpec
 {
   public static final String TYPE = "partialProjection";
 
+  /**
+   * Builds the raw wire-form {@link Map} representation of a {@link PartialProjectionLoadSpec} request. Used by the
+   * coordinator-side matcher (which doesn't instantiate the typed class because doing so would require plumbing an
+   * {@link ObjectMapper} through every matcher just to satisfy the constructor's lazy-delegate supplier).
+   */
+  public static Map<String, Object> wireForm(
+      Map<String, Object> delegate,
+      List<String> projections,
+      String fingerprint
+  )
+  {
+    return Map.of(
+        "type", TYPE,
+        "delegate", delegate,
+        "projections", projections,
+        "fingerprint", fingerprint
+    );
+  }
+
   private final List<String> projections;
 
   @JsonCreator

--- a/server/src/main/java/org/apache/druid/client/DataSegmentAndLoadProfile.java
+++ b/server/src/main/java/org/apache/druid/client/DataSegmentAndLoadProfile.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.client;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.druid.server.coordination.SegmentChangeRequestLoad;
+import org.apache.druid.server.coordinator.loading.PartialLoadProfile;
+import org.apache.druid.timeline.DataSegment;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+/**
+ * A {@link DataSegment} carrying optional partial-load metadata describing how it was loaded onto a particular server.
+ * Extends {@code DataSegment} so the inventory ({@link DruidDataSource} / {@link ImmutableDruidDataSource}) can store
+ * either a bare {@code DataSegment} (full-load, the common case) or a {@code DataSegmentAndLoadProfile} (partial-load)
+ * in a single map slot. Full-load segments pay zero per-segment wrapper overhead, only segments with a non-null
+ * profile allocate the subclass.
+ * <p>
+ * Inherits all {@code DataSegment} JSON serialization, equality, hashCode, and ordering. The added profile field is
+ * marked to be ignored by JSON serialization since the profile travels via {@link SegmentChangeRequestLoad} wire
+ * fields, not as a segment property.
+ */
+public class DataSegmentAndLoadProfile extends DataSegment
+{
+  @JsonIgnore
+  private final PartialLoadProfile profile;
+
+  public DataSegmentAndLoadProfile(DataSegment delegate, PartialLoadProfile profile)
+  {
+    super(
+        delegate.getDataSource(),
+        delegate.getInterval(),
+        delegate.getVersion(),
+        delegate.getLoadSpec(),
+        delegate.getDimensions(),
+        delegate.getMetrics(),
+        delegate.getProjections(),
+        delegate.getShardSpec(),
+        delegate.getLastCompactionState(),
+        delegate.getBinaryVersion(),
+        delegate.getSize(),
+        delegate.getTotalRows(),
+        delegate.getIndexingStateFingerprint(),
+        PruneSpecsHolder.DEFAULT
+    );
+    this.profile = Objects.requireNonNull(profile, "profile");
+  }
+
+  /**
+   * The {@link PartialLoadProfile} for this segment on the host server. Never null, bare {@link DataSegment}
+   * instances are used to represent the no-profile case.
+   */
+  public PartialLoadProfile profile()
+  {
+    return profile;
+  }
+
+  /**
+   * The realized on-disk footprint of this segment on the server: {@link PartialLoadProfile#loadedBytes()} when the
+   * profile carries it, else {@link DataSegment#getSize()}.
+   */
+  public long effectiveSize()
+  {
+    final Long loadedBytes = profile.loadedBytes();
+    return loadedBytes != null ? loadedBytes : getSize();
+  }
+
+  /**
+   * Returns the partial-load profile attached to {@code segment} if it is a {@link DataSegmentAndLoadProfile}, else
+   * {@code null}. Convenience for the common pattern of reading the profile out of the inventory's
+   * {@code Map<SegmentId, DataSegment>} value type.
+   */
+  @Nullable
+  public static PartialLoadProfile profileOf(DataSegment segment)
+  {
+    return segment instanceof DataSegmentAndLoadProfile p ? p.profile() : null;
+  }
+
+  /**
+   * Returns the on-disk footprint of {@code segment}: the partial-load profile's {@code loadedBytes} when present,
+   * else the segment's full {@link DataSegment#getSize() size}.
+   */
+  public static long effectiveSizeOf(DataSegment segment)
+  {
+    return segment instanceof DataSegmentAndLoadProfile p ? p.effectiveSize() : segment.getSize();
+  }
+}

--- a/server/src/main/java/org/apache/druid/client/DruidDataSource.java
+++ b/server/src/main/java/org/apache/druid/client/DruidDataSource.java
@@ -21,6 +21,7 @@ package org.apache.druid.client;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import org.apache.druid.server.coordinator.loading.PartialLoadProfile;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 
@@ -30,13 +31,12 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.function.Predicate;
 
 /**
- * A mutable collection of metadata of segments ({@link DataSegment} objects), belonging to a particular data source.
- *
- * Concurrency: could be updated concurrently via {@link #addSegment}, {@link #removeSegment}, and {@link
- * #removeSegmentsIf}, and accessed concurrently (e. g. via {@link #getSegments}) as well.
+ * A mutable collection of metadata of {@link DataSegment}, belonging to a particular data source.
+ * By default segments are stored as bare {@code DataSegment} when fully loading; segments that carry a
+ * {@link PartialLoadProfile} are stored as {@link DataSegmentAndLoadProfile} (a {@code DataSegment} subclass) instead,
+ * so partial-load metadata travels alongside the segment.
  *
  * @see ImmutableDruidDataSource - an immutable counterpart of this class
  */
@@ -45,7 +45,8 @@ public class DruidDataSource
   private final String name;
   private final Map<String, String> properties;
   /**
-   * This map needs to be concurrent to support concurrent iteration and updates.
+   * Concurrent to support concurrent iteration and updates. Values are bare {@link DataSegment} for full-load slots
+   * and {@link DataSegmentAndLoadProfile} for partial-load slots.
    */
   private final ConcurrentMap<SegmentId, DataSegment> idToSegmentMap = new ConcurrentHashMap<>();
 
@@ -73,22 +74,29 @@ public class DruidDataSource
     return idToSegmentMap.get(segmentId);
   }
 
+  /**
+   * Returns the partial-load profile for the given segment, or {@code null} if the segment was loaded as a regular
+   * full-load (no partial-load metadata announced) or is not present in this data source.
+   */
+  @Nullable
+  public PartialLoadProfile getPartialLoadProfile(SegmentId segmentId)
+  {
+    return DataSegmentAndLoadProfile.profileOf(idToSegmentMap.get(segmentId));
+  }
+
   public Collection<DataSegment> getSegments()
   {
     return Collections.unmodifiableCollection(idToSegmentMap.values());
   }
 
-  /**
-   * Removes segments for which the given filter returns true.
-   */
-  public void removeSegmentsIf(Predicate<DataSegment> filter)
-  {
-    idToSegmentMap.values().removeIf(filter);
-  }
-
   public DruidDataSource addSegment(DataSegment dataSegment)
   {
-    idToSegmentMap.put(dataSegment.getId(), dataSegment);
+    return addSegment(dataSegment, null);
+  }
+
+  public DruidDataSource addSegment(DataSegment dataSegment, @Nullable PartialLoadProfile profile)
+  {
+    idToSegmentMap.put(dataSegment.getId(), wrapIfNeeded(dataSegment, profile));
     return this;
   }
 
@@ -98,14 +106,22 @@ public class DruidDataSource
    */
   public boolean addSegmentIfAbsent(DataSegment dataSegment)
   {
-    return idToSegmentMap.putIfAbsent(dataSegment.getId(), dataSegment) == null;
+    return addSegmentIfAbsent(dataSegment, null);
+  }
+
+  public boolean addSegmentIfAbsent(DataSegment dataSegment, @Nullable PartialLoadProfile profile)
+  {
+    return idToSegmentMap.putIfAbsent(dataSegment.getId(), wrapIfNeeded(dataSegment, profile)) == null;
   }
 
   /**
-   * Returns the removed segment, or null if there was no segment with the given {@link SegmentId} in this
-   * DruidDataSource.
+   * Returns the removed segment, or {@code null} if there was no segment with the given {@link SegmentId} in this
+   * DruidDataSource. The returned value may be a {@link DataSegmentAndLoadProfile} when the removed entry carried a
+   * partial-load profile; callers that need the profile or its {@code loadedBytes} should use
+   * {@link DataSegmentAndLoadProfile#profileOf} / {@link DataSegmentAndLoadProfile#effectiveSizeOf}.
    */
-  public @Nullable DataSegment removeSegment(SegmentId segmentId)
+  @Nullable
+  public DataSegment removeSegment(SegmentId segmentId)
   {
     return idToSegmentMap.remove(segmentId);
   }
@@ -118,6 +134,11 @@ public class DruidDataSource
   public ImmutableDruidDataSource toImmutableDruidDataSource()
   {
     return new ImmutableDruidDataSource(name, properties, idToSegmentMap);
+  }
+
+  private static DataSegment wrapIfNeeded(DataSegment dataSegment, @Nullable PartialLoadProfile profile)
+  {
+    return profile == null ? dataSegment : new DataSegmentAndLoadProfile(dataSegment, profile);
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/client/DruidServer.java
+++ b/server/src/main/java/org/apache/druid/client/DruidServer.java
@@ -264,12 +264,41 @@ public class DruidServer implements Comparable<DruidServer>
     return dataSource == null ? null : dataSource.getPartialLoadProfile(segmentId);
   }
 
-  public DruidServer addDataSegments(DruidServer server)
+  /**
+   * Updates the {@link PartialLoadProfile} attached to an already-present segment, used by the inventory layer when a
+   * historical re-announces a segment whose load spec has changed (e.g. an additive partial-load reload swapping the
+   * wrapper / fingerprint). The segment stays in the inventory at the same {@link SegmentId}; only the per-server
+   * profile and the {@link #currSize} accounting (which uses {@link DataSegmentAndLoadProfile#effectiveSizeOf}) are
+   * adjusted. {@link #totalSegments} is unchanged. No-op if the segment isn't currently present on this server.
+   *
+   * @return {@code true} if the entry was updated; {@code false} if the segment wasn't present on this server.
+   */
+  public boolean updateDataSegmentProfile(DataSegment segment, @Nullable PartialLoadProfile profile)
   {
-    // Preserve any partial-load profile attached to the source segment so currSize accounting and downstream
-    // reconciliation still see the correct loadedBytes / fingerprint.
-    server.iterateAllSegments().forEach(s -> addDataSegment(s, DataSegmentAndLoadProfile.profileOf(s)));
-    return this;
+    final boolean[] updated = {false};
+    dataSources.compute(
+        segment.getDataSource(),
+        (dataSourceName, dataSource) -> {
+          if (dataSource == null) {
+            return null;
+          }
+          final DataSegment existing = dataSource.getSegment(segment.getId());
+          if (existing == null) {
+            return dataSource;
+          }
+          final long oldEffectiveSize = DataSegmentAndLoadProfile.effectiveSizeOf(existing);
+          final long newEffectiveSize = (profile != null && profile.loadedBytes() != null)
+                                        ? profile.loadedBytes()
+                                        : segment.getSize();
+          // addSegment unconditionally overwrites (vs addSegmentIfAbsent in addDataSegment); we already know the
+          // entry exists, so this swaps the value for the same key.
+          dataSource.addSegment(segment, profile);
+          currSize.addAndGet(newEffectiveSize - oldEffectiveSize);
+          updated[0] = true;
+          return dataSource;
+        }
+    );
+    return updated[0];
   }
 
   @Nullable

--- a/server/src/main/java/org/apache/druid/client/DruidServer.java
+++ b/server/src/main/java/org/apache/druid/client/DruidServer.java
@@ -27,6 +27,7 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.coordination.DruidServerMetadata;
 import org.apache.druid.server.coordination.ServerType;
+import org.apache.druid.server.coordinator.loading.PartialLoadProfile;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 
@@ -214,6 +215,21 @@ public class DruidServer implements Comparable<DruidServer>
 
   public DruidServer addDataSegment(DataSegment segment)
   {
+    return addDataSegment(segment, null);
+  }
+
+  /**
+   * Adds a segment along with optional partial-load metadata. When {@code profile} is non-null and carries a
+   * {@code loadedBytes} value, the server's {@link #currSize} accounting uses that figure instead of
+   * {@link DataSegment#getSize()} so balancing decisions reflect the actual on-disk footprint of partial replicas.
+   * The profile is stored alongside the segment in the {@link DruidDataSource} for the coordinator's
+   * replica-reconciliation logic to consult.
+   */
+  public DruidServer addDataSegment(DataSegment segment, @Nullable PartialLoadProfile profile)
+  {
+    final long sizeToAdd = (profile != null && profile.loadedBytes() != null)
+                           ? profile.loadedBytes()
+                           : segment.getSize();
     // ConcurrentHashMap.compute() ensures that all actions for specific dataSource are linearizable.
     dataSources.compute(
         segment.getDataSource(),
@@ -221,8 +237,8 @@ public class DruidServer implements Comparable<DruidServer>
           if (dataSource == null) {
             dataSource = new DruidDataSource(dataSourceName, ImmutableMap.of("client", "side"));
           }
-          if (dataSource.addSegmentIfAbsent(segment)) {
-            currSize.addAndGet(segment.getSize());
+          if (dataSource.addSegmentIfAbsent(segment, profile)) {
+            currSize.addAndGet(sizeToAdd);
             totalSegments.incrementAndGet();
           } else {
             log.warn(
@@ -237,9 +253,22 @@ public class DruidServer implements Comparable<DruidServer>
     return this;
   }
 
+  /**
+   * Returns the partial-load profile for the given segment, or {@code null} if the segment was loaded as a regular
+   * full-load (no partial-load metadata announced).
+   */
+  @Nullable
+  public PartialLoadProfile getPartialLoadProfile(SegmentId segmentId)
+  {
+    final DruidDataSource dataSource = dataSources.get(segmentId.getDataSource());
+    return dataSource == null ? null : dataSource.getPartialLoadProfile(segmentId);
+  }
+
   public DruidServer addDataSegments(DruidServer server)
   {
-    server.iterateAllSegments().forEach(this::addDataSegment);
+    // Preserve any partial-load profile attached to the source segment so currSize accounting and downstream
+    // reconciliation still see the correct loadedBytes / fingerprint.
+    server.iterateAllSegments().forEach(s -> addDataSegment(s, DataSegmentAndLoadProfile.profileOf(s)));
     return this;
   }
 
@@ -261,10 +290,12 @@ public class DruidServer implements Comparable<DruidServer>
             // Returning null from the lambda here makes the ConcurrentHashMap to not record any entry.
             return null;
           }
-          DataSegment segment = dataSource.removeSegment(segmentId);
-          if (segment != null) {
-            segmentRemoved[0] = segment;
-            currSize.addAndGet(-segment.getSize());
+          DataSegment removed = dataSource.removeSegment(segmentId);
+          if (removed != null) {
+            segmentRemoved[0] = removed;
+            // Use effectiveSizeOf (loadedBytes when the value is a DataSegmentAndLoadProfile, else segment size)
+            // so the books balance against what we added.
+            currSize.addAndGet(-DataSegmentAndLoadProfile.effectiveSizeOf(removed));
             totalSegments.decrementAndGet();
           } else {
             log.warn("Asked to remove data segment that doesn't exist!? server[%s], segment[%s]", getName(), segmentId);

--- a/server/src/main/java/org/apache/druid/client/HttpServerInventoryView.java
+++ b/server/src/main/java/org/apache/druid/client/HttpServerInventoryView.java
@@ -698,12 +698,7 @@ public class HttpServerInventoryView implements ServerInventoryView, FilteredSer
       }
       final DataSegment segment = loadRequest.getSegment();
       final Map<String, Object> loadSpec = segment.getLoadSpec();
-      if (loadedBytes < segment.getSize()
-          && loadSpec != null
-          && loadSpec.get("type") instanceof String
-          && ((String) loadSpec.get("type")).startsWith(PartialLoadSpec.TYPE_PREFIX)
-          && loadSpec.get("fingerprint") instanceof String
-          && loadSpec.get("delegate") instanceof Map) {
+      if (loadedBytes < segment.getSize() && PartialLoadSpec.detectPartialLoadSpec(loadSpec)) {
         return PartialLoadProfile.forLoaded(loadSpec, fingerprint, loadedBytes);
       }
       return PartialLoadProfile.forFullFallback(fingerprint, loadedBytes);

--- a/server/src/main/java/org/apache/druid/client/HttpServerInventoryView.java
+++ b/server/src/main/java/org/apache/druid/client/HttpServerInventoryView.java
@@ -48,6 +48,7 @@ import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.java.util.http.client.HttpClient;
+import org.apache.druid.segment.loading.PartialLoadSpec;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.coordination.ChangeRequestHttpSyncer;
 import org.apache.druid.server.coordination.ChangeRequestsSnapshot;
@@ -593,13 +594,12 @@ public class HttpServerInventoryView implements ServerInventoryView, FilteredSer
           druidServer.iterateAllSegments().forEach(segment -> toRemove.put(segment.getId(), segment));
 
           for (DataSegmentChangeRequest request : changes) {
-            if (request instanceof SegmentChangeRequestLoad) {
-              SegmentChangeRequestLoad loadRequest = (SegmentChangeRequestLoad) request;
+            if (request instanceof SegmentChangeRequestLoad loadRequest) {
               DataSegment segment = loadRequest.getSegment();
               toRemove.remove(segment.getId());
               addSegment(segment, partialLoadProfileFor(loadRequest), true);
-            } else if (request instanceof SegmentSchemasChangeRequest) {
-              runSegmentCallbacks(input -> input.segmentSchemasAnnounced(((SegmentSchemasChangeRequest) request).getSegmentSchemas()));
+            } else if (request instanceof SegmentSchemasChangeRequest changeRequest) {
+              runSegmentCallbacks(input -> input.segmentSchemasAnnounced((changeRequest).getSegmentSchemas()));
             } else {
               log.error(
                   "Server[%s] gave a non-load dataSegmentChangeRequest[%s]., Ignored.",
@@ -666,7 +666,20 @@ public class HttpServerInventoryView implements ServerInventoryView, FilteredSer
 
     /**
      * Builds a {@link PartialLoadProfile} from a load announcement when the historical populated the partial-load
-     * fields ({@code fingerprint} + {@code loadedBytes}). Returns null for full-load announcements.
+     * wire fields ({@code fingerprint} + {@code loadedBytes}). Returns {@code null} for plain full-load
+     * announcements.
+     * <p>
+     * Picks between {@link PartialLoadProfile#forLoaded forLoaded} and
+     * {@link PartialLoadProfile#forFullFallback forFullFallback} based on what the historical actually realized:
+     * <ul>
+     *   <li>If {@code loadedBytes} is strictly less than the segment's full size <em>and</em> the announced segment
+     *       carries a {@link PartialLoadSpec} wrapper on its load spec, the historical honored the partial request —
+     *       preserve the wrapped load spec on the profile so per-replica observability (e.g.
+     *       {@link PartialLoadProfile#isFullFallback}) reports correctly.</li>
+     *   <li>Otherwise the historical either fell back to full or doesn't yet implement scheme-specific partial
+     *       loading; build a full-fallback profile (the wire fingerprint still satisfies the rule, so the
+     *       coordinator's reconciler counts it as matching without reload thrash).</li>
+     * </ul>
      */
     @Nullable
     private static PartialLoadProfile partialLoadProfileFor(SegmentChangeRequestLoad loadRequest)
@@ -676,9 +689,16 @@ public class HttpServerInventoryView implements ServerInventoryView, FilteredSer
       if (fingerprint == null || loadedBytes == null) {
         return null;
       }
-      // The wrapped LoadSpec is on the segment itself when a partial load was requested by the coordinator; we don't
-      // duplicate it on the inventory profile; the announcement uses the full-fallback factory which carries the
-      // fingerprint and the realized loadedBytes only.
+      final DataSegment segment = loadRequest.getSegment();
+      final Map<String, Object> loadSpec = segment.getLoadSpec();
+      if (loadedBytes < segment.getSize()
+          && loadSpec != null
+          && loadSpec.get("type") instanceof String
+          && ((String) loadSpec.get("type")).startsWith(PartialLoadSpec.TYPE_PREFIX)
+          && loadSpec.get("fingerprint") instanceof String
+          && loadSpec.get("delegate") instanceof Map) {
+        return PartialLoadProfile.forLoaded(loadSpec, fingerprint, loadedBytes);
+      }
       return PartialLoadProfile.forFullFallback(fingerprint, loadedBytes);
     }
 

--- a/server/src/main/java/org/apache/druid/client/HttpServerInventoryView.java
+++ b/server/src/main/java/org/apache/druid/client/HttpServerInventoryView.java
@@ -71,6 +71,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -653,6 +654,12 @@ public class HttpServerInventoryView implements ServerInventoryView, FilteredSer
                 }
               }
           );
+        } else if (!Objects.equals(druidServer.getPartialLoadProfile(segment.getId()), profile)) {
+          // Already present, but the per-server partial-load profile changed (e.g. the historical re-announced after
+          // an additive reload swapped the wrapper / fingerprint). Update the inventory state in place; the segment
+          // is still on this server, only the profile metadata changed, so don't fire segmentAdded/segmentRemoved
+          // callbacks
+          druidServer.updateDataSegmentProfile(segment, profile);
         } else if (!fullSync) {
           // duplicates can happen when doing a full sync from a 'reset', so only warn for dupes on delta changes
           log.warn(

--- a/server/src/main/java/org/apache/druid/client/HttpServerInventoryView.java
+++ b/server/src/main/java/org/apache/druid/client/HttpServerInventoryView.java
@@ -57,9 +57,12 @@ import org.apache.druid.server.coordination.SegmentChangeRequestDrop;
 import org.apache.druid.server.coordination.SegmentChangeRequestLoad;
 import org.apache.druid.server.coordination.SegmentSchemasChangeRequest;
 import org.apache.druid.server.coordination.ServerType;
+import org.apache.druid.server.coordinator.loading.PartialLoadProfile;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.joda.time.Duration;
+
+import javax.annotation.Nullable;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -591,9 +594,10 @@ public class HttpServerInventoryView implements ServerInventoryView, FilteredSer
 
           for (DataSegmentChangeRequest request : changes) {
             if (request instanceof SegmentChangeRequestLoad) {
-              DataSegment segment = ((SegmentChangeRequestLoad) request).getSegment();
+              SegmentChangeRequestLoad loadRequest = (SegmentChangeRequestLoad) request;
+              DataSegment segment = loadRequest.getSegment();
               toRemove.remove(segment.getId());
-              addSegment(segment, true);
+              addSegment(segment, partialLoadProfileFor(loadRequest), true);
             } else if (request instanceof SegmentSchemasChangeRequest) {
               runSegmentCallbacks(input -> input.segmentSchemasAnnounced(((SegmentSchemasChangeRequest) request).getSegmentSchemas()));
             } else {
@@ -615,7 +619,8 @@ public class HttpServerInventoryView implements ServerInventoryView, FilteredSer
         {
           for (DataSegmentChangeRequest request : changes) {
             if (request instanceof SegmentChangeRequestLoad) {
-              addSegment(((SegmentChangeRequestLoad) request).getSegment(), false);
+              SegmentChangeRequestLoad loadRequest = (SegmentChangeRequestLoad) request;
+              addSegment(loadRequest.getSegment(), partialLoadProfileFor(loadRequest), false);
             } else if (request instanceof SegmentChangeRequestDrop) {
               removeSegment(((SegmentChangeRequestDrop) request).getSegment(), false);
             } else if (request instanceof SegmentSchemasChangeRequest) {
@@ -632,12 +637,12 @@ public class HttpServerInventoryView implements ServerInventoryView, FilteredSer
       };
     }
 
-    private void addSegment(DataSegment segment, boolean fullSync)
+    private void addSegment(DataSegment segment, @Nullable PartialLoadProfile profile, boolean fullSync)
     {
       if (finalPredicate.apply(Pair.of(druidServer.getMetadata(), segment))) {
         if (druidServer.getSegment(segment.getId()) == null) {
           DataSegment theSegment = DataSegmentInterner.intern(segment);
-          druidServer.addDataSegment(theSegment);
+          druidServer.addDataSegment(theSegment, profile);
           runSegmentCallbacks(
               new Function<>()
               {
@@ -657,6 +662,24 @@ public class HttpServerInventoryView implements ServerInventoryView, FilteredSer
           );
         }
       }
+    }
+
+    /**
+     * Builds a {@link PartialLoadProfile} from a load announcement when the historical populated the partial-load
+     * fields ({@code fingerprint} + {@code loadedBytes}). Returns null for full-load announcements.
+     */
+    @Nullable
+    private static PartialLoadProfile partialLoadProfileFor(SegmentChangeRequestLoad loadRequest)
+    {
+      final String fingerprint = loadRequest.getFingerprint();
+      final Long loadedBytes = loadRequest.getLoadedBytes();
+      if (fingerprint == null || loadedBytes == null) {
+        return null;
+      }
+      // The wrapped LoadSpec is on the segment itself when a partial load was requested by the coordinator; we don't
+      // duplicate it on the inventory profile; the announcement uses the full-fallback factory which carries the
+      // fingerprint and the realized loadedBytes only.
+      return PartialLoadProfile.forFullFallback(fingerprint, loadedBytes);
     }
 
     private void removeSegment(final DataSegment segment, boolean fullSync)

--- a/server/src/main/java/org/apache/druid/client/ImmutableDruidDataSource.java
+++ b/server/src/main/java/org/apache/druid/client/ImmutableDruidDataSource.java
@@ -26,15 +26,20 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
+import org.apache.druid.server.coordinator.loading.PartialLoadProfile;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 /**
  * An immutable collection of metadata of segments ({@link DataSegment} objects), belonging to a particular data
- * source.
+ * source. Like {@link DruidDataSource}, partial-load segments are stored as {@link DataSegmentAndLoadProfile} (a
+ * {@link DataSegment} subclass); full-load segments are stored as bare {@code DataSegment} so the common case pays no
+ * per-segment wrapper overhead.
  *
  * @see DruidDataSource - a mutable counterpart of this class
  */
@@ -49,12 +54,18 @@ public class ImmutableDruidDataSource
    * Concurrency: idToSegments argument might be a {@link java.util.concurrent.ConcurrentMap} that is being updated
    * concurrently while this constructor is executed.
    */
-  public ImmutableDruidDataSource(String name, Map<String, String> properties, Map<SegmentId, DataSegment> idToSegments)
+  public ImmutableDruidDataSource(
+      String name,
+      Map<String, String> properties,
+      Map<SegmentId, DataSegment> idToSegments
+  )
   {
     this.name = Preconditions.checkNotNull(name);
     this.properties = ImmutableMap.copyOf(properties);
     this.idToSegments = ImmutableSortedMap.copyOf(idToSegments);
-    this.totalSizeOfSegments = idToSegments.values().stream().mapToLong(DataSegment::getSize).sum();
+    this.totalSizeOfSegments = this.idToSegments.values().stream()
+                                                .mapToLong(DataSegmentAndLoadProfile::effectiveSizeOf)
+                                                .sum();
   }
 
   @JsonCreator
@@ -70,6 +81,7 @@ public class ImmutableDruidDataSource
     final ImmutableSortedMap.Builder<SegmentId, DataSegment> idToSegmentsBuilder = ImmutableSortedMap.naturalOrder();
     long totalSizeOfSegments = 0;
     for (DataSegment segment : segments) {
+      // JSON deserialization carries no partial-load profile state; segments are stored bare.
       idToSegmentsBuilder.put(segment.getId(), segment);
       totalSizeOfSegments += segment.getSize();
     }
@@ -92,17 +104,31 @@ public class ImmutableDruidDataSource
   @JsonProperty
   public Collection<DataSegment> getSegments()
   {
-    return idToSegments.values();
+    return Collections.unmodifiableCollection(idToSegments.values());
   }
 
   @JsonIgnore
+  @Nullable
   public DataSegment getSegment(SegmentId segmentId)
   {
     return idToSegments.get(segmentId);
   }
 
   /**
-   * Returns the sum of the {@link DataSegment#getSize() sizes} of all segments in this ImmutableDruidDataSource.
+   * Returns the partial-load profile for the given segment, or {@code null} if the segment was loaded as a regular
+   * full-load (no partial-load metadata announced) or is not present in this data source.
+   */
+  @JsonIgnore
+  @Nullable
+  public PartialLoadProfile getPartialLoadProfile(SegmentId segmentId)
+  {
+    return DataSegmentAndLoadProfile.profileOf(idToSegments.get(segmentId));
+  }
+
+  /**
+   * Returns the sum of {@link DataSegmentAndLoadProfile#effectiveSizeOf effective sizes} of all segments in this
+   * ImmutableDruidDataSource, i.e. {@code loadedBytes} for partial replicas and {@link DataSegment#getSize()} for
+   * full-load replicas.
    */
   @JsonIgnore
   public long getTotalSizeOfSegments()

--- a/server/src/main/java/org/apache/druid/client/ImmutableDruidServer.java
+++ b/server/src/main/java/org/apache/druid/client/ImmutableDruidServer.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.server.coordination.DruidServerMetadata;
 import org.apache.druid.server.coordination.ServerType;
+import org.apache.druid.server.coordinator.loading.PartialLoadProfile;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.utils.CollectionUtils;
@@ -120,6 +121,17 @@ public class ImmutableDruidServer
       return null;
     }
     return dataSource.getSegment(segmentId);
+  }
+
+  /**
+   * Returns the partial-load profile for the given segment on this server, or {@code null} if the segment is loaded as
+   * a regular full-load (no partial-load metadata announced) or is not present on this server.
+   */
+  @Nullable
+  public PartialLoadProfile getPartialLoadProfile(SegmentId segmentId)
+  {
+    final ImmutableDruidDataSource dataSource = dataSources.get(segmentId.getDataSource());
+    return dataSource == null ? null : dataSource.getPartialLoadProfile(segmentId);
   }
 
   public Iterable<ImmutableDruidDataSource> getDataSources()

--- a/server/src/main/java/org/apache/druid/server/coordination/BatchDataSegmentAnnouncer.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/BatchDataSegmentAnnouncer.java
@@ -27,11 +27,12 @@ import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.segment.realtime.appenderator.SegmentSchemas;
 import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentId;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -39,7 +40,13 @@ public class BatchDataSegmentAnnouncer implements DataSegmentAnnouncer
 {
   private static final Logger log = new Logger(BatchDataSegmentAnnouncer.class);
 
-  private final Set<DataSegment> announcedSegments = ConcurrentHashMap.newKeySet();
+  /**
+   * Tracks the most recently announced {@link DataSegment} per {@link SegmentId} so that a re-announcement with a
+   * changed load spec (e.g. an additive partial-load reload that swaps the wrapper / fingerprint) emits a fresh
+   * {@link SegmentChangeRequestLoad} rather than being silently skipped. A no-op re-announcement (same id, same
+   * load spec) is still skipped to keep the delta sync quiet for ordinary heartbeat-style flows.
+   */
+  private final ConcurrentMap<SegmentId, DataSegment> announcedSegments = new ConcurrentHashMap<>();
 
   private final ChangeRequestHistory<DataSegmentChangeRequest> changes = new ChangeRequestHistory<>();
 
@@ -54,17 +61,21 @@ public class BatchDataSegmentAnnouncer implements DataSegmentAnnouncer
   @Override
   public void announceSegment(DataSegment segment)
   {
-    if (!announcedSegments.add(segment)) {
+    final DataSegment prev = announcedSegments.put(segment.getId(), segment);
+    if (prev != null && Objects.equals(prev.getLoadSpec(), segment.getLoadSpec())) {
       log.info("Skipping announcement of segment [%s]. Announcement exists already.", segment.getId());
       return;
     }
+    // First announcement for this id, or the load spec changed (additive reload swapped the wrapper). Emit a fresh
+    // load change request; the coordinator's inventory will recognize "already present, profile changed" and update
+    // its per-server profile in place without disturbing broker routing.
     changes.addChangeRequest(SegmentChangeRequestLoad.forAnnouncement(segment));
   }
 
   @Override
   public void unannounceSegment(DataSegment segment)
   {
-    if (!announcedSegments.remove(segment)) {
+    if (announcedSegments.remove(segment.getId()) == null) {
       log.warn("No announcement to remove for segment[%s]", segment.getId());
       return;
     }
@@ -76,10 +87,11 @@ public class BatchDataSegmentAnnouncer implements DataSegmentAnnouncer
   {
     List<DataSegmentChangeRequest> changesBatch = new ArrayList<>();
     for (DataSegment segment : segments) {
-      if (announcedSegments.add(segment)) {
-        changesBatch.add(SegmentChangeRequestLoad.forAnnouncement(segment));
-      } else {
+      final DataSegment prev = announcedSegments.put(segment.getId(), segment);
+      if (prev != null && Objects.equals(prev.getLoadSpec(), segment.getLoadSpec())) {
         log.info("Skipping announcement of segment [%s]. Announcement exists already.", segment.getId());
+      } else {
+        changesBatch.add(SegmentChangeRequestLoad.forAnnouncement(segment));
       }
     }
     if (!changesBatch.isEmpty()) {
@@ -127,7 +139,7 @@ public class BatchDataSegmentAnnouncer implements DataSegmentAnnouncer
   {
     if (counter.getCounter() < 0) {
       Iterable<DataSegmentChangeRequest> segments = Iterables.transform(
-          announcedSegments,
+          announcedSegments.values(),
           SegmentChangeRequestLoad::forAnnouncement
       );
 

--- a/server/src/main/java/org/apache/druid/server/coordination/BatchDataSegmentAnnouncer.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/BatchDataSegmentAnnouncer.java
@@ -58,7 +58,7 @@ public class BatchDataSegmentAnnouncer implements DataSegmentAnnouncer
       log.info("Skipping announcement of segment [%s]. Announcement exists already.", segment.getId());
       return;
     }
-    changes.addChangeRequest(new SegmentChangeRequestLoad(segment));
+    changes.addChangeRequest(SegmentChangeRequestLoad.forAnnouncement(segment));
   }
 
   @Override
@@ -77,7 +77,7 @@ public class BatchDataSegmentAnnouncer implements DataSegmentAnnouncer
     List<DataSegmentChangeRequest> changesBatch = new ArrayList<>();
     for (DataSegment segment : segments) {
       if (announcedSegments.add(segment)) {
-        changesBatch.add(new SegmentChangeRequestLoad(segment));
+        changesBatch.add(SegmentChangeRequestLoad.forAnnouncement(segment));
       } else {
         log.info("Skipping announcement of segment [%s]. Announcement exists already.", segment.getId());
       }
@@ -128,7 +128,7 @@ public class BatchDataSegmentAnnouncer implements DataSegmentAnnouncer
     if (counter.getCounter() < 0) {
       Iterable<DataSegmentChangeRequest> segments = Iterables.transform(
           announcedSegments,
-          SegmentChangeRequestLoad::new
+          SegmentChangeRequestLoad::forAnnouncement
       );
 
       Iterable<DataSegmentChangeRequest> sinkSchema = Iterables.transform(

--- a/server/src/main/java/org/apache/druid/server/coordination/SegmentChangeRequestLoad.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/SegmentChangeRequestLoad.java
@@ -24,9 +24,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.segment.loading.PartialProjectionLoadSpec;
 import org.apache.druid.timeline.DataSegment;
 
 import javax.annotation.Nullable;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -38,6 +40,29 @@ import java.util.Objects;
  */
 public class SegmentChangeRequestLoad implements DataSegmentChangeRequest
 {
+  /**
+   * Builds a load announcement for a segment loaded on a historical. When the segment was loaded via a
+   * {@link PartialProjectionLoadSpec} wrapper (the coordinator stamped a partial-load request onto the outbound
+   * segment), the announcement carries the wrapper's fingerprint and {@link DataSegment#getSize()} as
+   * {@code loadedBytes}; a "full-fallback" advertisement that satisfies the coordinator's partial-load rule even
+   * though the historical did a regular full load via the inner delegate. Without this, the coordinator's reconciler
+   * would treat the replica as stale and re-queue the load indefinitely.
+   * <p>
+   * For segments loaded without a partial-load wrapper (the common case), this returns a bare load request with no
+   * fingerprint or loadedBytes, equivalent to {@link #SegmentChangeRequestLoad(DataSegment)}.
+   */
+  public static SegmentChangeRequestLoad forAnnouncement(DataSegment segment)
+  {
+    final Map<String, Object> loadSpec = segment.getLoadSpec();
+    if (loadSpec != null && PartialProjectionLoadSpec.TYPE.equals(loadSpec.get("type"))) {
+      final Object fingerprint = loadSpec.get("fingerprint");
+      if (fingerprint instanceof String) {
+        return new SegmentChangeRequestLoad(segment, (String) fingerprint, segment.getSize());
+      }
+    }
+    return new SegmentChangeRequestLoad(segment);
+  }
+
   private final DataSegment segment;
   @Nullable private final String fingerprint;
   @Nullable private final Long loadedBytes;

--- a/server/src/main/java/org/apache/druid/server/coordination/SegmentChangeRequestLoad.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/SegmentChangeRequestLoad.java
@@ -24,7 +24,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import org.apache.druid.java.util.common.StringUtils;
-import org.apache.druid.segment.loading.PartialProjectionLoadSpec;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.segment.loading.PartialLoadSpec;
 import org.apache.druid.timeline.DataSegment;
 
 import javax.annotation.Nullable;
@@ -40,13 +41,19 @@ import java.util.Objects;
  */
 public class SegmentChangeRequestLoad implements DataSegmentChangeRequest
 {
+  private static final Logger log = new Logger(SegmentChangeRequestLoad.class);
+
   /**
-   * Builds a load announcement for a segment loaded on a historical. When the segment was loaded via a
-   * {@link PartialProjectionLoadSpec} wrapper (the coordinator stamped a partial-load request onto the outbound
-   * segment), the announcement carries the wrapper's fingerprint and {@link DataSegment#getSize()} as
-   * {@code loadedBytes}; a "full-fallback" advertisement that satisfies the coordinator's partial-load rule even
-   * though the historical did a regular full load via the inner delegate. Without this, the coordinator's reconciler
-   * would treat the replica as stale and re-queue the load indefinitely.
+   * Builds a load announcement for a segment loaded on a historical. Any {@link PartialLoadSpec} subtype (identified
+   * by the wire-form conventions documented on that class: a {@code type} starting with
+   * {@link PartialLoadSpec#TYPE_PREFIX}, plus top-level {@code fingerprint} and {@code delegate} fields) produces a
+   * "full-fallback" announcement: the wrapper's fingerprint and {@link DataSegment#getSize()} ride along as
+   * {@code loadedBytes}, satisfying the coordinator's partial-load rule even when the historical did a regular full
+   * load via the inner delegate. Without this, the coordinator's reconciler would treat the replica as stale and
+   * re-queue the load indefinitely.
+   * <p>
+   * Detection is convention-based (no subtype allowlist) so future {@link PartialLoadSpec} subtypes work
+   * automatically without touching this code.
    * <p>
    * For segments loaded without a partial-load wrapper (the common case), this returns a bare load request with no
    * fingerprint or loadedBytes, equivalent to {@link #SegmentChangeRequestLoad(DataSegment)}.
@@ -54,12 +61,29 @@ public class SegmentChangeRequestLoad implements DataSegmentChangeRequest
   public static SegmentChangeRequestLoad forAnnouncement(DataSegment segment)
   {
     final Map<String, Object> loadSpec = segment.getLoadSpec();
-    if (loadSpec != null && PartialProjectionLoadSpec.TYPE.equals(loadSpec.get("type"))) {
-      final Object fingerprint = loadSpec.get("fingerprint");
-      if (fingerprint instanceof String) {
-        return new SegmentChangeRequestLoad(segment, (String) fingerprint, segment.getSize());
-      }
+    if (loadSpec == null) {
+      return new SegmentChangeRequestLoad(segment);
     }
+    final Object type = loadSpec.get("type");
+    if (!(type instanceof String stringType) || !stringType.startsWith(PartialLoadSpec.TYPE_PREFIX)) {
+      return new SegmentChangeRequestLoad(segment);
+    }
+    final Object fingerprint = loadSpec.get("fingerprint");
+    final Object delegate = loadSpec.get("delegate");
+    if (fingerprint instanceof String stringFingerprint && delegate instanceof Map) {
+      return new SegmentChangeRequestLoad(segment, stringFingerprint, segment.getSize());
+    }
+    // Type name says partial-load but the wire form is malformed, the PartialLoadSpec subtype's @JsonProperty
+    // contract guarantees both fields, so this is a bug. Log and fall through to a plain announcement to keep the
+    // queue moving.
+    log.warn(
+        "Partial-load wrapper for segment[%s] type[%s] is malformed (fingerprint[%s], delegate[%s]); "
+        + "announcing as a regular load.",
+        segment.getId(),
+        type,
+        fingerprint,
+        delegate
+    );
     return new SegmentChangeRequestLoad(segment);
   }
 

--- a/server/src/main/java/org/apache/druid/server/coordination/SegmentChangeRequestLoad.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/SegmentChangeRequestLoad.java
@@ -61,29 +61,22 @@ public class SegmentChangeRequestLoad implements DataSegmentChangeRequest
   public static SegmentChangeRequestLoad forAnnouncement(DataSegment segment)
   {
     final Map<String, Object> loadSpec = segment.getLoadSpec();
-    if (loadSpec == null) {
-      return new SegmentChangeRequestLoad(segment);
+    if (PartialLoadSpec.detectPartialLoadSpec(loadSpec)) {
+      return new SegmentChangeRequestLoad(segment, (String) loadSpec.get("fingerprint"), segment.getSize());
     }
-    final Object type = loadSpec.get("type");
-    if (!(type instanceof String stringType) || !stringType.startsWith(PartialLoadSpec.TYPE_PREFIX)) {
-      return new SegmentChangeRequestLoad(segment);
+    if (PartialLoadSpec.hasPartialTypePrefix(loadSpec)) {
+      // Type name claims partial-load but the wire form is malformed, the PartialLoadSpec subtype's @JsonProperty
+      // contract guarantees both fields, so this is a bug. Log and fall through to a plain announcement to keep the
+      // queue moving.
+      log.warn(
+          "Partial-load wrapper for segment[%s] type[%s] is malformed (fingerprint[%s], delegate[%s]); "
+          + "announcing as a regular load.",
+          segment.getId(),
+          loadSpec.get("type"),
+          loadSpec.get("fingerprint"),
+          loadSpec.get("delegate")
+      );
     }
-    final Object fingerprint = loadSpec.get("fingerprint");
-    final Object delegate = loadSpec.get("delegate");
-    if (fingerprint instanceof String stringFingerprint && delegate instanceof Map) {
-      return new SegmentChangeRequestLoad(segment, stringFingerprint, segment.getSize());
-    }
-    // Type name says partial-load but the wire form is malformed, the PartialLoadSpec subtype's @JsonProperty
-    // contract guarantees both fields, so this is a bug. Log and fall through to a plain announcement to keep the
-    // queue moving.
-    log.warn(
-        "Partial-load wrapper for segment[%s] type[%s] is malformed (fingerprint[%s], delegate[%s]); "
-        + "announcing as a regular load.",
-        segment.getId(),
-        type,
-        fingerprint,
-        delegate
-    );
     return new SegmentChangeRequestLoad(segment);
   }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/ServerHolder.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/ServerHolder.java
@@ -23,11 +23,13 @@ import org.apache.druid.client.ImmutableDruidServer;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.server.coordinator.loading.LoadQueuePeon;
+import org.apache.druid.server.coordinator.loading.PartialLoadProfile;
 import org.apache.druid.server.coordinator.loading.SegmentAction;
 import org.apache.druid.server.coordinator.loading.SegmentHolder;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -75,6 +77,14 @@ public class ServerHolder implements Comparable<ServerHolder>
    * Do not remove entries on load/drop success or failure during the run.
    */
   private final Map<DataSegment, SegmentAction> queuedSegments = new HashMap<>();
+
+  /**
+   * Tracks the {@link PartialLoadProfile} for in-flight load operations on this server. Populated from the peon's
+   * existing queue at construction time and updated by {@link #startOperation(SegmentAction, DataSegment,
+   * PartialLoadProfile)} when a fresh partial load is queued during the run. Cleared when the corresponding queued
+   * operation is canceled. Read by the partial-load reconciler to classify in-flight replicas as matching or stale.
+   */
+  private final Map<DataSegment, PartialLoadProfile> inFlightProfiles = new HashMap<>();
 
   private final SegmentCountsPerInterval projectedSegmentCounts = new SegmentCountsPerInterval();
 
@@ -158,6 +168,9 @@ public class ServerHolder implements Comparable<ServerHolder>
 
       final SegmentAction action = holder.getAction();
       addToQueuedSegments(holder.getSegment(), simplify(action));
+      if (holder.getProfile() != null) {
+        inFlightProfiles.put(holder.getSegment(), holder.getProfile());
+      }
 
       if (action == SegmentAction.MOVE_TO) {
         movingSegmentCount.incrementAndGet();
@@ -388,6 +401,16 @@ public class ServerHolder implements Comparable<ServerHolder>
 
   public boolean startOperation(SegmentAction action, DataSegment segment)
   {
+    return startOperation(action, segment, null);
+  }
+
+  /**
+   * Like {@link #startOperation(SegmentAction, DataSegment)}, but additionally records the {@link PartialLoadProfile}
+   * for the queued load so the reconciler can read it back via {@link #getInFlightProfile(DataSegment)} during the
+   * same coordinator run.
+   */
+  public boolean startOperation(SegmentAction action, DataSegment segment, @Nullable PartialLoadProfile profile)
+  {
     if (queuedSegments.containsKey(segment)) {
       return false;
     }
@@ -397,6 +420,9 @@ public class ServerHolder implements Comparable<ServerHolder>
     }
 
     addToQueuedSegments(segment, simplify(action));
+    if (profile != null) {
+      inFlightProfiles.put(segment, profile);
+    }
     return true;
   }
 
@@ -412,10 +438,22 @@ public class ServerHolder implements Comparable<ServerHolder>
     // MOVE_FROM operations are not sent to the peon, so they can be considered cancelled
     if (queuedAction == SegmentAction.MOVE_FROM || peon.cancelOperation(segment)) {
       removeFromQueuedSegments(segment, queuedAction);
+      inFlightProfiles.remove(segment);
       return true;
     } else {
       return false;
     }
+  }
+
+  /**
+   * Returns the {@link PartialLoadProfile} for an in-flight load of {@code segment} on this server, or {@code null}
+   * if there's no in-flight load or the in-flight load is a regular full-load (no profile). Used by the partial-load
+   * reconciler to classify in-flight replicas as matching or stale relative to the current rule's fingerprint.
+   */
+  @Nullable
+  public PartialLoadProfile getInFlightProfile(DataSegment segment)
+  {
+    return inFlightProfiles.get(segment);
   }
 
   private boolean hasSegmentLoaded(SegmentId segmentId)

--- a/server/src/main/java/org/apache/druid/server/coordinator/ServerHolder.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/ServerHolder.java
@@ -399,15 +399,27 @@ public class ServerHolder implements Comparable<ServerHolder>
     return queuedSegments.size();
   }
 
+  /**
+   * Convenience that delegates to {@link #startOperation(SegmentAction, DataSegment, PartialLoadProfile)} with no
+   * partial-load profile, for the regular full-load / drop / move paths that don't carry one.
+   */
   public boolean startOperation(SegmentAction action, DataSegment segment)
   {
     return startOperation(action, segment, null);
   }
 
   /**
-   * Like {@link #startOperation(SegmentAction, DataSegment)}, but additionally records the {@link PartialLoadProfile}
-   * for the queued load so the reconciler can read it back via {@link #getInFlightProfile(DataSegment)} during the
-   * same coordinator run.
+   * Records the start of {@code action} on {@code segment} on this server for the current coordinator run.
+   * <p>
+   * If the segment already has a queued action, returns {@code false} and does nothing (the caller is expected to
+   * treat this as a no-op / collision). Otherwise: marks the segment as queued, increments the per-run assignment
+   * counter for load actions (so {@link #isLoadQueueFull()} converges), and updates projected segment counts and
+   * size accounting via {@link #addToQueuedSegments}.
+   * <p>
+   * When {@code profile} is non-null, the {@link PartialLoadProfile} is stashed so the partial-load reconciler can
+   * read the in-flight fingerprint back during the same coordinator run via {@link #getInFlightProfile(DataSegment)}.
+   * The profile is cleared on {@link #cancelOperation}; it stays put on success/failure of the queued action so the
+   * inventory's eventual announcement (with realized fingerprint and loadedBytes) is what overwrites it.
    */
   public boolean startOperation(SegmentAction action, DataSegment segment, @Nullable PartialLoadProfile profile)
   {

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/HttpLoadQueuePeon.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/HttpLoadQueuePeon.java
@@ -54,6 +54,7 @@ import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.joda.time.Duration;
 
+import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.MediaType;
 import java.io.InputStream;
@@ -473,6 +474,17 @@ public class HttpLoadQueuePeon implements LoadQueuePeon
   @Override
   public void loadSegment(DataSegment segment, SegmentAction action, LoadPeonCallback callback)
   {
+    loadSegment(segment, action, null, callback);
+  }
+
+  @Override
+  public void loadSegment(
+      DataSegment segment,
+      SegmentAction action,
+      @Nullable PartialLoadProfile profile,
+      LoadPeonCallback callback
+  )
+  {
     if (!action.isLoad()) {
       log.warn("Invalid load action[%s] for segment[%s] on server[%s].", action, segment.getId(), serverId);
       return;
@@ -493,7 +505,7 @@ public class HttpLoadQueuePeon implements LoadQueuePeon
       SegmentHolder holder = segmentsToLoad.get(segment);
       if (holder == null) {
         queuedSize.addAndGet(segment.getSize());
-        holder = new SegmentHolder(segment, action, config.getLoadTimeout(), callback);
+        holder = new SegmentHolder(segment, action, profile, config.getLoadTimeout(), callback);
         segmentsToLoad.put(segment, holder);
         queuedSegments.add(holder);
         processingExecutor.execute(this::doSegmentManagement);

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/LoadQueuePeon.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/LoadQueuePeon.java
@@ -22,6 +22,7 @@ package org.apache.druid.server.coordinator.loading;
 import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
 import org.apache.druid.timeline.DataSegment;
 
+import javax.annotation.Nullable;
 import java.util.Set;
 
 /**
@@ -48,6 +49,29 @@ public interface LoadQueuePeon
   Set<DataSegment> getSegmentsMarkedToDrop();
 
   void loadSegment(DataSegment segment, SegmentAction action, LoadPeonCallback callback);
+
+  /**
+   * Like {@link #loadSegment(DataSegment, SegmentAction, LoadPeonCallback)} but for a partial-load request. The
+   * {@code profile} carries the wrapped load-spec map and fingerprint that ride out to the historical via the
+   * outbound {@link org.apache.druid.server.coordination.SegmentChangeRequestLoad}.
+   * <p>
+   * Default implementation throws {@link UnsupportedOperationException} when {@code profile} is non-null so that
+   * minimal mock peons used in tests don't have to implement it; production peons must override.
+   */
+  default void loadSegment(
+      DataSegment segment,
+      SegmentAction action,
+      @Nullable PartialLoadProfile profile,
+      LoadPeonCallback callback
+  )
+  {
+    if (profile != null) {
+      throw new UnsupportedOperationException(
+          "Partial load profile is not supported by this LoadQueuePeon implementation"
+      );
+    }
+    loadSegment(segment, action, callback);
+  }
 
   void dropSegment(DataSegment segment, LoadPeonCallback callback);
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/PartialLoadProfile.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/PartialLoadProfile.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.server.coordinator.loading;
 
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
 import org.apache.druid.error.InvalidInput;
 
 import javax.annotation.Nullable;
@@ -46,7 +48,7 @@ import java.util.Objects;
  *       requested the load, so no reload-thrash occurs.</li>
  * </ul>
  * The fingerprint is derived from the resolved scheme-specific data (e.g., for projections, the sorted/deduped name
- * list — see {@code ProjectionPartialLoadMatcher}) so that two rule configurations that resolve to the same set on a
+ * list, see {@code ProjectionPartialLoadMatcher}) so that two rule configurations that resolve to the same set on a
  * segment produce the same fingerprint and don't churn replicas across coordinator runs.
  */
 public record PartialLoadProfile(
@@ -55,6 +57,13 @@ public record PartialLoadProfile(
     @Nullable Long loadedBytes
 )
 {
+  /**
+   * Weak interner so the same partial-load profile is shared by reference. Most of the per-profile heap is in the
+   * {@code wrappedLoadSpec} map and its contents; collapsing those across replicas is the main win at scale
+   * (large partial-load tiers with multiple replicas per segment). All factory methods route through {@link #intern}.
+   */
+  private static final Interner<PartialLoadProfile> INTERNER = Interners.newWeakInterner();
+
   public PartialLoadProfile
   {
     Objects.requireNonNull(fingerprint, "fingerprint");
@@ -73,7 +82,7 @@ public record PartialLoadProfile(
     if (wrappedLoadSpec == null || wrappedLoadSpec.isEmpty()) {
       throw InvalidInput.exception("wrappedLoadSpec must not be null or empty for an outbound load request");
     }
-    return new PartialLoadProfile(wrappedLoadSpec, fingerprint, null);
+    return intern(new PartialLoadProfile(wrappedLoadSpec, fingerprint, null));
   }
 
   /**
@@ -84,7 +93,7 @@ public record PartialLoadProfile(
     if (wrappedLoadSpec == null || wrappedLoadSpec.isEmpty()) {
       throw InvalidInput.exception("wrappedLoadSpec must not be null or empty for a loaded announcement");
     }
-    return new PartialLoadProfile(wrappedLoadSpec, fingerprint, loadedBytes);
+    return intern(new PartialLoadProfile(wrappedLoadSpec, fingerprint, loadedBytes));
   }
 
   /**
@@ -94,7 +103,12 @@ public record PartialLoadProfile(
    */
   public static PartialLoadProfile forFullFallback(String fingerprint, long fullBytes)
   {
-    return new PartialLoadProfile(null, fingerprint, fullBytes);
+    return intern(new PartialLoadProfile(null, fingerprint, fullBytes));
+  }
+
+  private static PartialLoadProfile intern(PartialLoadProfile profile)
+  {
+    return INTERNER.intern(profile);
   }
 
   /**

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/PartialSegmentStatusInTier.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/PartialSegmentStatusInTier.java
@@ -29,15 +29,25 @@ import java.util.Objects;
 
 /**
  * Classifies the servers in a tier by their relationship to a {@link PartialLoadProfile} request for a specific
- * segment. Used by the partial-load reconciler in {@link StrategicSegmentAssigner} to decide what to load, drop, or
- * cancel under the load-then-drop swap pattern.
+ * segment. This is a passive snapshot the partial-load reconciler reads back during a coordinator run, see
+ * {@link StrategicSegmentAssigner#updateReplicasInTierPartial} for the algorithm that consumes these buckets and
+ * decides what to load, drop, or cancel. Partial load variant of {@link SegmentStatusInTier}.
  * <p>
- * Per the additive-historical model: matching means the announced fingerprint equals the requested fingerprint. A
- * full-fallback profile (where the historical was asked to partial-load but couldn't, announcing
- * {@code wrappedLoadSpec=null} with the requested fingerprint) is also treated as matching, the rule was
- * satisfied even though the historical fell back to full.
+ * A partial-load rule resolves, per segment, to a {@link PartialLoadProfile} carrying a {@code wrappedLoadSpec}
+ * (scheme-specific request payload) and a {@code fingerprint} that uniquely identifies the request. The coordinator
+ * stamps the wrapped load spec onto the outbound segment; the historical loads (partially, or via full-fallback
+ * when it can't honor the scheme) and announces back with the wrapper's fingerprint plus realized {@code loadedBytes}.
+ * On the next coordinator run this class reads the announced profile per replica and decides "matching" (announced
+ * fingerprint equals the requested fingerprint; rule is satisfied for that replica) vs "stale" (any other state,
+ * including a non-profile regular full-load replica).
  * <p>
- * Replicas without any profile (regular full-load) are always classified as stale relative to a partial-load rule.
+ * As a last resort, when a stale replica has nowhere better to be replaced, this classifies the same server as a
+ * target for an "additive-historical" in-place replace: a partial-load request arriving at a server that's already
+ * (stale-)loaded fills in the missing parts in place rather than re-downloading from scratch. That's what makes
+ * {@link #getEligibleForAdditiveReload()} a safe fallback destination when the tier has no spare capacity. This
+ * option is the least preferred because the contract of an additive reload is to load only what is now needed and
+ * missing; it does not drop anything that is no longer needed, so the server can end up holding a larger amount of
+ * data than the current rule strictly requires.
  */
 public class PartialSegmentStatusInTier
 {
@@ -98,8 +108,9 @@ public class PartialSegmentStatusInTier
   }
 
   /**
-   * Servers that don't have the segment and can take a fresh load (preferred destinations for new replicas; empty
-   * slots, no in-place mutation needed).
+   * Servers that don't have the segment and can take a fresh load. See the algorithm doc on
+   * {@code StrategicSegmentAssigner.updateReplicasInTierPartial} for how this bucket is consumed relative to the
+   * other buckets.
    */
   public List<ServerHolder> getEligibleForFreshLoad()
   {
@@ -107,16 +118,28 @@ public class PartialSegmentStatusInTier
   }
 
   /**
-   * Stale-loaded servers that can take an additive reload request (same as {@link #getStaleLoaded()} once filtered for
-   * decommissioning / queue-full / pending-action, kept separate so the reconciler can prefer fresh-load destinations
-   * before falling back to in-place additive reload). The historical's additive load semantics make this the
-   * mitigation for the "no spare server" stuck state.
+   * Stale-loaded servers that can take an additive reload request; kept as a subset of {@link #getStaleLoaded()}
+   * filtered for decommissioning / load-queue-full, so the algorithm can target them as a fallback destination when
+   * no fresh-load slots are available. See {@code StrategicSegmentAssigner.updateReplicasInTierPartial}.
    */
   public List<ServerHolder> getEligibleForAdditiveReload()
   {
     return eligibleForAdditiveReload;
   }
 
+  /**
+   * Mechanical classification of one server against the request fingerprint. Branches are mutually exclusive in
+   * order: <b>loaded</b> ({@link ServerHolder#isServingSegment}: matching / stale, with stale optionally also added
+   * to {@link #eligibleForAdditiveReload}), <b>in-flight LOAD/REPLICATE</b> (matching / stale based on the peon's
+   * queued profile), <b>empty-and-loadable</b> ({@link #eligibleForFreshLoad}).
+   * <p>
+   * Servers with a queued {@link SegmentAction#DROP}, {@link SegmentAction#MOVE_TO}, or
+   * {@link SegmentAction#MOVE_FROM} fall through all branches by design, they're already accounted for in
+   * {@link SegmentReplicaCount} totals and {@link StrategicSegmentAssigner}'s cross-tier drop budget.
+   * The {@code isLoaded} branch is in particular gated by {@link ServerHolder#isServingSegment}, which requires
+   * <em>no</em> action queued, so stale-loaded servers added to {@link #eligibleForAdditiveReload} are guaranteed
+   * to be action-free at snapshot time.
+   */
   private void classify(ServerHolder server, DataSegment segment, String requestedFingerprint)
   {
     final SegmentAction action = server.getActionOnSegment(segment);
@@ -142,17 +165,19 @@ public class PartialSegmentStatusInTier
     } else if (action == null && server.canLoadSegment(segment)) {
       eligibleForFreshLoad.add(server);
     }
-    // Other actions (DROP, MOVE_TO, MOVE_FROM) are intentionally not classified here, they're handled by the
-    // existing replica-counting paths.
   }
 
   /**
-   * A stale-loaded server is reload-eligible iff it's not decommissioning, has no other action queued for the segment,
-   * and hasn't already exceeded its load-queue assignment budget for this run. Disk space is not checked here; the
-   * additive reload's marginal cost is at most {@code segment.size − alreadyLoadedSize}, and a strict disk check
-   * against the full segment size would over-conservatively block reloads on near-full servers that already host the
-   * stale replica. If the historical is too full to add the missing parts, the load will fail at the historical and
-   * report as failed; the reconciler retries next run.
+   * Filters a stale-loaded server for additive-reload eligibility: not decommissioning, and not over its per-run
+   * load-queue budget. The "no other action queued" requirement that you'd otherwise expect to find here is
+   * already satisfied implicitly, this is only called from the {@code isLoaded} branch of {@link #classify}, which
+   * requires {@link ServerHolder#isServingSegment} = true (loaded AND no queued action). Same-run dedup against
+   * subsequent re-queueing on the same server is enforced at {@link ServerHolder#startOperation}, not here.
+   * <p>
+   * Disk space is not checked: the additive reload's marginal cost is at most
+   * {@code segment.size − alreadyLoadedSize}, and a strict full-size disk check would over-conservatively block
+   * reloads on near-full servers that already host the stale replica. If the historical is too full to add the
+   * missing parts, the load fails at the historical and reports as failed; the reconciler retries next run.
    */
   private static boolean canReloadAdditively(ServerHolder server)
   {

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/PartialSegmentStatusInTier.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/PartialSegmentStatusInTier.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.loading;
+
+import org.apache.druid.server.coordinator.ServerHolder;
+import org.apache.druid.timeline.DataSegment;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.Objects;
+
+/**
+ * Classifies the servers in a tier by their relationship to a {@link PartialLoadProfile} request for a specific
+ * segment. Used by the partial-load reconciler in {@link StrategicSegmentAssigner} to decide what to load, drop, or
+ * cancel under the load-then-drop swap pattern.
+ * <p>
+ * Per the additive-historical model: matching means the announced fingerprint equals the requested fingerprint. A
+ * full-fallback profile (where the historical was asked to partial-load but couldn't, announcing
+ * {@code wrappedLoadSpec=null} with the requested fingerprint) is also treated as matching, the rule was
+ * satisfied even though the historical fell back to full.
+ * <p>
+ * Replicas without any profile (regular full-load) are always classified as stale relative to a partial-load rule.
+ */
+public class PartialSegmentStatusInTier
+{
+  private final List<ServerHolder> matchingLoaded = new ArrayList<>();
+  private final List<ServerHolder> staleLoaded = new ArrayList<>();
+  private final List<ServerHolder> matchingInFlight = new ArrayList<>();
+  private final List<ServerHolder> staleInFlight = new ArrayList<>();
+  private final List<ServerHolder> eligibleForFreshLoad = new ArrayList<>();
+  private final List<ServerHolder> eligibleForAdditiveReload = new ArrayList<>();
+
+  public PartialSegmentStatusInTier(
+      DataSegment segment,
+      String requestedFingerprint,
+      NavigableSet<ServerHolder> historicals
+  )
+  {
+    for (ServerHolder server : historicals) {
+      classify(server, segment, requestedFingerprint);
+    }
+  }
+
+  /**
+   * Servers that have the segment loaded with a profile whose fingerprint matches the request (including full-fallback
+   * announcements with the matching fingerprint). Count toward the tier's required matching replica count.
+   */
+  public List<ServerHolder> getMatchingLoaded()
+  {
+    return matchingLoaded;
+  }
+
+  /**
+   * Servers that have the segment loaded but with a non-matching profile (different fingerprint, or no profile at all,
+   * i.e. a regular full-load replica seen against a partial rule). Eligible for additive reload (the historical
+   * fills in the missing parts in place) and for being dropped once enough matching replicas exist.
+   */
+  public List<ServerHolder> getStaleLoaded()
+  {
+    return staleLoaded;
+  }
+
+  /**
+   * Servers with an in-flight load whose profile fingerprint matches the request. Counts toward projected matching
+   * replicas, the load is on its way to satisfying the rule.
+   */
+  public List<ServerHolder> getMatchingInFlight()
+  {
+    return matchingInFlight;
+  }
+
+  /**
+   * Servers with an in-flight load whose profile fingerprint differs from the request (e.g., the rule changed
+   * mid-flight, or an in-flight regular full-load against a partial rule). Cancel-and-replace targets when there is a
+   * matching deficit.
+   */
+  public List<ServerHolder> getStaleInFlight()
+  {
+    return staleInFlight;
+  }
+
+  /**
+   * Servers that don't have the segment and can take a fresh load (preferred destinations for new replicas; empty
+   * slots, no in-place mutation needed).
+   */
+  public List<ServerHolder> getEligibleForFreshLoad()
+  {
+    return eligibleForFreshLoad;
+  }
+
+  /**
+   * Stale-loaded servers that can take an additive reload request (same as {@link #getStaleLoaded()} once filtered for
+   * decommissioning / queue-full / pending-action, kept separate so the reconciler can prefer fresh-load destinations
+   * before falling back to in-place additive reload). The historical's additive load semantics make this the
+   * mitigation for the "no spare server" stuck state.
+   */
+  public List<ServerHolder> getEligibleForAdditiveReload()
+  {
+    return eligibleForAdditiveReload;
+  }
+
+  private void classify(ServerHolder server, DataSegment segment, String requestedFingerprint)
+  {
+    final SegmentAction action = server.getActionOnSegment(segment);
+    final boolean isLoaded = server.isServingSegment(segment);
+
+    if (isLoaded) {
+      final PartialLoadProfile loaded = server.getServer().getPartialLoadProfile(segment.getId());
+      if (loaded != null && Objects.equals(loaded.fingerprint(), requestedFingerprint)) {
+        matchingLoaded.add(server);
+      } else {
+        staleLoaded.add(server);
+        if (canReloadAdditively(server)) {
+          eligibleForAdditiveReload.add(server);
+        }
+      }
+    } else if (action == SegmentAction.LOAD || action == SegmentAction.REPLICATE) {
+      final PartialLoadProfile inFlight = server.getInFlightProfile(segment);
+      if (inFlight != null && Objects.equals(inFlight.fingerprint(), requestedFingerprint)) {
+        matchingInFlight.add(server);
+      } else {
+        staleInFlight.add(server);
+      }
+    } else if (action == null && server.canLoadSegment(segment)) {
+      eligibleForFreshLoad.add(server);
+    }
+    // Other actions (DROP, MOVE_TO, MOVE_FROM) are intentionally not classified here, they're handled by the
+    // existing replica-counting paths.
+  }
+
+  /**
+   * A stale-loaded server is reload-eligible iff it's not decommissioning, has no other action queued for the segment,
+   * and hasn't already exceeded its load-queue assignment budget for this run. Disk space is not checked here; the
+   * additive reload's marginal cost is at most {@code segment.size − alreadyLoadedSize}, and a strict disk check
+   * against the full segment size would over-conservatively block reloads on near-full servers that already host the
+   * stale replica. If the historical is too full to add the missing parts, the load will fail at the historical and
+   * report as failed; the reconciler retries next run.
+   */
+  private static boolean canReloadAdditively(ServerHolder server)
+  {
+    return !server.isDecommissioning() && !server.isLoadQueueFull();
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentHolder.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentHolder.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
 import org.apache.druid.java.util.common.Stopwatch;
 import org.apache.druid.java.util.common.guava.Comparators;
+import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.server.coordination.DataSegmentChangeRequest;
 import org.apache.druid.server.coordination.SegmentChangeRequestDrop;
 import org.apache.druid.server.coordination.SegmentChangeRequestLoad;
@@ -43,6 +44,8 @@ import java.util.Objects;
  */
 public class SegmentHolder implements Comparable<SegmentHolder>
 {
+  private static final Logger log = new Logger(SegmentHolder.class);
+
   /**
    * Orders newest segments first (i.e. segments with most recent intervals).
    * <p>
@@ -121,6 +124,17 @@ public class SegmentHolder implements Comparable<SegmentHolder>
       // wrapper; identity (segment field) stays original so dedup in the load queue is unaffected.
       this.changeRequest = new SegmentChangeRequestLoad(segment.withLoadSpec(profile.wrappedLoadSpec()));
     } else {
+      if (profile != null) {
+        // Outbound profiles (forRequest / forLoaded) must always carry a non-null wrappedLoadSpec; only the inbound
+        // forFullFallback announcement uses the null sentinel, and those never reach this constructor. Log if it
+        // happens so the bug surfaces — we still proceed with a plain load request to avoid stalling the queue.
+        log.warn(
+            "Profile with null wrappedLoadSpec on outbound load for segment[%s], action[%s]; "
+            + "queuing as a regular load.",
+            segment.getId(),
+            action
+        );
+      }
       this.changeRequest = new SegmentChangeRequestLoad(segment);
     }
     if (callback != null) {

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentHolder.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentHolder.java
@@ -76,6 +76,8 @@ public class SegmentHolder implements Comparable<SegmentHolder>
   private final DataSegment segment;
   private final DataSegmentChangeRequest changeRequest;
   private final SegmentAction action;
+  @Nullable
+  private final PartialLoadProfile profile;
 
   private final Duration requestTimeout;
 
@@ -91,15 +93,51 @@ public class SegmentHolder implements Comparable<SegmentHolder>
       @Nullable LoadPeonCallback callback
   )
   {
+    this(segment, action, null, requestTimeout, callback);
+  }
+
+  /**
+   * Creates a holder for a load (or move) request that may carry a partial-load profile. When {@code profile} is
+   * non-null and the action is a load, the outbound {@link SegmentChangeRequestLoad}'s segment has its load spec
+   * replaced with {@link PartialLoadProfile#wrappedLoadSpec()} so the historical sees the partial-load wrapper. The
+   * holder's own {@link #segment} field stays the original so identity / equals / hashCode / callback resolution
+   * remain unchanged from the regular full-load path.
+   */
+  public SegmentHolder(
+      DataSegment segment,
+      SegmentAction action,
+      @Nullable PartialLoadProfile profile,
+      Duration requestTimeout,
+      @Nullable LoadPeonCallback callback
+  )
+  {
     this.segment = segment;
     this.action = action;
-    this.changeRequest = (action == SegmentAction.DROP)
-                         ? new SegmentChangeRequestDrop(segment)
-                         : new SegmentChangeRequestLoad(segment);
+    this.profile = profile;
+    if (action == SegmentAction.DROP) {
+      this.changeRequest = new SegmentChangeRequestDrop(segment);
+    } else if (profile != null && profile.wrappedLoadSpec() != null) {
+      // Stamp the wrapped load-spec map onto the outbound segment so the historical receives the partial-load
+      // wrapper; identity (segment field) stays original so dedup in the load queue is unaffected.
+      this.changeRequest = new SegmentChangeRequestLoad(segment.withLoadSpec(profile.wrappedLoadSpec()));
+    } else {
+      this.changeRequest = new SegmentChangeRequestLoad(segment);
+    }
     if (callback != null) {
       callbacks.add(callback);
     }
     this.requestTimeout = requestTimeout;
+  }
+
+  /**
+   * Returns the {@link PartialLoadProfile} that this holder was created with, or {@code null} for regular full-load
+   * (or drop) requests. The fingerprint inside the profile is what an in-flight reconciler reads to decide whether
+   * an in-flight load satisfies the current rule.
+   */
+  @Nullable
+  public PartialLoadProfile getProfile()
+  {
+    return profile;
   }
 
   public DataSegment getSegment()

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentLoadQueueManager.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentLoadQueueManager.java
@@ -25,6 +25,8 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.server.coordinator.ServerHolder;
 import org.apache.druid.timeline.DataSegment;
 
+import javax.annotation.Nullable;
+
 /**
  * Manager for addition/removal of segments to server load queues and the
  * corresponding success/failure callbacks.
@@ -51,12 +53,30 @@ public class SegmentLoadQueueManager
    */
   public boolean loadSegment(DataSegment segment, ServerHolder server, SegmentAction action)
   {
+    return loadSegment(segment, server, action, null);
+  }
+
+  /**
+   * Queues load of the segment on the given server, optionally carrying a partial-load profile that wraps the
+   * outbound load spec for the historical.
+   */
+  public boolean loadSegment(
+      DataSegment segment,
+      ServerHolder server,
+      SegmentAction action,
+      @Nullable PartialLoadProfile profile
+  )
+  {
     try {
-      if (!server.startOperation(action, segment)) {
+      if (!server.startOperation(action, segment, profile)) {
         return false;
       }
 
-      server.getPeon().loadSegment(segment, action, null);
+      if (profile == null) {
+        server.getPeon().loadSegment(segment, action, null);
+      } else {
+        server.getPeon().loadSegment(segment, action, profile, null);
+      }
       return true;
     }
     catch (Exception e) {

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/StrategicSegmentAssigner.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/StrategicSegmentAssigner.java
@@ -34,6 +34,7 @@ import org.apache.druid.server.coordinator.stats.Stats;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -185,9 +186,9 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
         int loadedCountOnTier = replicaCountMap.get(segment.getId(), tier)
                                                .loadedNotDropping();
         if (loadedCountOnTier >= 1) {
-          return replicateSegment(segment, serverB);
+          return replicateSegment(segment, serverB, null);
         } else {
-          return loadSegment(segment, serverB);
+          return loadSegment(segment, serverB, null);
         }
       }
 
@@ -274,6 +275,273 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
   }
 
   /**
+   * Fingerprint-aware partial-load reconciler. Mirrors {@link #replicateSegment} for replica-count and surplus
+   * accounting, but per-tier the load/drop decisions are made by classifying replicas as matching or stale relative
+   * to the requested {@link PartialLoadProfile#fingerprint()} and applying the load-then-drop swap pattern: stale
+   * replicas keep serving until matching replicas have actually loaded.
+   */
+  @Override
+  public void replicateSegmentPartially(
+      DataSegment segment,
+      PartialLoadProfile profile,
+      Map<String, Integer> tierToReplicaCount
+  )
+  {
+    final Map<String, Integer> effectiveTierToReplicaCount = expandWithAliases(tierToReplicaCount);
+    final Set<String> allTiersInCluster = Sets.newHashSet(cluster.getTierNames());
+
+    if (effectiveTierToReplicaCount.isEmpty()) {
+      replicaCountMap.computeIfAbsent(segment.getId(), DruidServer.DEFAULT_TIER);
+    } else {
+      effectiveTierToReplicaCount.forEach((tier, requiredReplicas) -> {
+        reportTierCapacityStats(segment, requiredReplicas, tier);
+
+        SegmentReplicaCount replicaCount = replicaCountMap.computeIfAbsent(segment.getId(), tier);
+        replicaCount.setRequired(requiredReplicas, tierToHistoricalCount.getOrDefault(tier, 0));
+
+        if (!allTiersInCluster.contains(tier)) {
+          datasourceToInvalidLoadTiers.computeIfAbsent(segment.getDataSource(), ds -> new HashSet<>())
+                                      .add(tier);
+        }
+      });
+    }
+
+    final SegmentReplicaCount replicaCountInCluster = replicaCountMap.getTotal(segment.getId());
+    if (replicaCountInCluster.required() <= 0) {
+      segmentsWithZeroRequiredReplicas
+          .computeIfAbsent(segment.getDataSource(), ds -> new HashSet<>())
+          .add(segment);
+    }
+
+    final int replicaSurplus = replicaCountInCluster.loadedNotDropping()
+                               - replicaCountInCluster.requiredAndLoadable();
+
+    int dropsQueued = 0;
+    for (String tier : allTiersInCluster) {
+      dropsQueued += updateReplicasInTierPartial(
+          segment,
+          profile,
+          tier,
+          effectiveTierToReplicaCount.getOrDefault(tier, 0),
+          replicaSurplus - dropsQueued
+      );
+    }
+  }
+
+  /**
+   * Per-tier reconciliation under the partial-load model. The flow is:
+   * <ol>
+   *   <li>Compute matching count: matching-loaded + matching-in-flight − pending-move-drop.</li>
+   *   <li>If matching count is short of {@code requiredReplicas}, cancel stale-fingerprint in-flight loads to free
+   *       slots, then queue fresh partial-load requests on eligible servers (preferring empty servers, falling back
+   *       to additive reload on stale-loaded servers; the historical fills in missing parts in place).</li>
+   *   <li>If matching count exceeds requirement, drop the excess like the full-load surplus path.</li>
+   *   <li>Drop stale-loaded replicas only when the count of actually-loaded matching replicas already meets the
+   *       requirement; this preserves availability across the swap (stale replicas keep serving until matching
+   *       replicas have completed loading and announced).</li>
+   * </ol>
+   * Returns the total number of drop operations queued on this tier (matching surplus + stale), used to budget
+   * cross-tier drop pressure.
+   */
+  private int updateReplicasInTierPartial(
+      DataSegment segment,
+      PartialLoadProfile profile,
+      String tier,
+      int requiredReplicas,
+      int maxReplicasToDrop
+  )
+  {
+    final SegmentReplicaCount replicaCountOnTier = replicaCountMap.get(segment.getId(), tier);
+    final int movingReplicas = replicaCountOnTier.moving();
+    final int moveCompletedPendingDrop = Math.max(0, replicaCountOnTier.moveCompletedPendingDrop());
+
+    final PartialSegmentStatusInTier status = new PartialSegmentStatusInTier(
+        segment,
+        profile.fingerprint(),
+        cluster.getManagedHistoricalsByTier(tier)
+    );
+
+    final int matchingProjected = status.getMatchingLoaded().size()
+                                  + status.getMatchingInFlight().size()
+                                  - moveCompletedPendingDrop;
+    final boolean shouldCancelMoves = requiredReplicas == 0 && movingReplicas > 0;
+
+    // If everything's already in shape and no stale work, fast-exit.
+    if (matchingProjected == requiredReplicas
+        && !shouldCancelMoves
+        && status.getStaleInFlight().isEmpty()
+        && (status.getStaleLoaded().isEmpty() || status.getMatchingLoaded().size() < requiredReplicas)) {
+      return 0;
+    }
+
+    if (shouldCancelMoves) {
+      // Convert to SegmentStatusInTier for the existing cancelOperations move-cancel helper.
+      final SegmentStatusInTier vanillaStatus =
+          new SegmentStatusInTier(segment, cluster.getManagedHistoricalsByTier(tier));
+      cancelOperations(SegmentAction.MOVE_TO, movingReplicas, segment, vanillaStatus);
+      cancelOperations(SegmentAction.MOVE_FROM, movingReplicas, segment, vanillaStatus);
+    }
+
+    // Cancel stale in-flight: when there's a matching deficit we want their slots back; when requirement is 0 we
+    // want them gone unconditionally so we don't realize a stale fingerprint nobody asked for. Canceled servers
+    // become eligible for a fresh matching load later in this same run.
+    final int matchingDeficit = requiredReplicas - matchingProjected;
+    final List<ServerHolder> cancelledStaleServers = new ArrayList<>();
+    if (matchingDeficit > 0 || requiredReplicas == 0) {
+      final int toCancel = requiredReplicas == 0 ? status.getStaleInFlight().size() : matchingDeficit;
+      cancelLoadsOnServers(segment, status.getStaleInFlight(), toCancel, cancelledStaleServers);
+      if (!cancelledStaleServers.isEmpty()) {
+        incrementStat(Stats.Segments.PARTIAL_STALE_CANCELLED, segment, tier, cancelledStaleServers.size());
+      }
+    }
+
+    // Queue fresh matching loads to fill the deficit.
+    if (matchingDeficit > 0) {
+      final int numLoadedReplicas = status.getMatchingLoaded().size() + status.getStaleLoaded().size();
+      final int queued = loadPartialReplicas(
+          matchingDeficit, numLoadedReplicas, segment, tier, status, cancelledStaleServers, profile
+      );
+      if (queued > 0) {
+        incrementStat(Stats.Segments.PARTIAL_ASSIGNED, segment, tier, queued);
+      }
+    }
+
+    int dropsQueuedOnTier = 0;
+    int dropBudget = maxReplicasToDrop;
+
+    // Surplus matching: drop excess matching replicas. Same shape as the full-load surplus path.
+    if (matchingProjected > requiredReplicas) {
+      final int surplus = matchingProjected - requiredReplicas;
+      final List<ServerHolder> cancelledMatching = new ArrayList<>();
+      cancelLoadsOnServers(segment, status.getMatchingInFlight(), surplus, cancelledMatching);
+      final int numToDrop = Math.min(surplus - cancelledMatching.size(), dropBudget);
+      if (numToDrop > 0) {
+        final int dropped = dropFromList(numToDrop, segment, status.getMatchingLoaded());
+        incrementStat(Stats.Segments.DROPPED, segment, tier, dropped);
+        dropsQueuedOnTier += dropped;
+        dropBudget -= dropped;
+      }
+    }
+
+    // Stale drops: only safe once matching-loaded already satisfies the requirement (i.e., truly-serving matching
+    // replicas already cover the rule before we touch any stale). This is the "load then drop" half of the swap.
+    if (status.getMatchingLoaded().size() >= requiredReplicas
+        && !status.getStaleLoaded().isEmpty()
+        && dropBudget > 0) {
+      final int numToDrop = Math.min(status.getStaleLoaded().size(), dropBudget);
+      final int dropped = dropFromList(numToDrop, segment, status.getStaleLoaded());
+      if (dropped > 0) {
+        incrementStat(Stats.Segments.PARTIAL_STALE_DROPPED, segment, tier, dropped);
+        dropsQueuedOnTier += dropped;
+      }
+    }
+
+    return dropsQueuedOnTier;
+  }
+
+  /**
+   * Queues fresh partial-load requests on up to {@code numToLoad} eligible servers. Preference order: empty
+   * (fresh-load) servers first; then servers whose stale-fingerprint in-flight loads were just canceled (their slot
+   * is now free); then stale-loaded servers (additive reload; the historical fills missing parts in place). The last
+   * fallback is what mitigates the "tier saturated with stale" stuck state.
+   */
+  private int loadPartialReplicas(
+      int numToLoad,
+      int numLoadedReplicas,
+      DataSegment segment,
+      String tier,
+      PartialSegmentStatusInTier status,
+      List<ServerHolder> cancelledStaleServers,
+      PartialLoadProfile profile
+  )
+  {
+    final boolean isAlreadyLoadedOnTier = numLoadedReplicas >= 1;
+
+    if (isAlreadyLoadedOnTier && replicationThrottler.isReplicationThrottledForTier(tier)) {
+      return 0;
+    }
+
+    final List<ServerHolder> destinations = new ArrayList<>(
+        status.getEligibleForFreshLoad().size()
+        + cancelledStaleServers.size()
+        + status.getEligibleForAdditiveReload().size()
+    );
+    destinations.addAll(status.getEligibleForFreshLoad());
+    destinations.addAll(cancelledStaleServers);
+    destinations.addAll(status.getEligibleForAdditiveReload());
+
+    if (destinations.isEmpty()) {
+      incrementSkipStat(Stats.Segments.ASSIGN_SKIPPED, "No eligible server", segment, tier);
+      return 0;
+    }
+
+    int numLoadsQueued = 0;
+    for (ServerHolder server : destinations) {
+      if (numLoadsQueued >= numToLoad) {
+        break;
+      }
+      final boolean queuedSuccessfully = isAlreadyLoadedOnTier
+                                         ? replicateSegment(segment, server, profile)
+                                         : loadSegment(segment, server, profile);
+      if (queuedSuccessfully) {
+        ++numLoadsQueued;
+      }
+    }
+    return numLoadsQueued;
+  }
+
+  /**
+   * Cancels up to {@code numToCancel} in-flight load operations across the given list of servers. Successfully
+   * canceled servers are appended to {@code cancelledOut} so the caller can re-target them as fresh-load
+   * destinations within the same run. Used both to release slots taken by stale-fingerprint in-flight loads and to
+   * reduce a matching surplus.
+   */
+  private void cancelLoadsOnServers(
+      DataSegment segment,
+      List<ServerHolder> servers,
+      int numToCancel,
+      List<ServerHolder> cancelledOut
+  )
+  {
+    if (numToCancel <= 0) {
+      return;
+    }
+    for (ServerHolder server : servers) {
+      if (cancelledOut.size() >= numToCancel) {
+        break;
+      }
+      // Try LOAD then REPLICATE; the queued action depends on whether this was a primary or a replica.
+      if (server.cancelOperation(SegmentAction.LOAD, segment)
+          || server.cancelOperation(SegmentAction.REPLICATE, segment)) {
+        cancelledOut.add(server);
+      }
+    }
+  }
+
+  /**
+   * Drops the segment from up to {@code numToDrop} servers in the given list, preferring decommissioning servers
+   * first (they're trying to shed load anyway). Returns the number of drop operations queued.
+   */
+  private int dropFromList(int numToDrop, DataSegment segment, List<ServerHolder> candidates)
+  {
+    if (numToDrop <= 0 || candidates.isEmpty()) {
+      return 0;
+    }
+    final List<ServerHolder> ordered = new ArrayList<>(candidates);
+    ordered.sort((a, b) -> Boolean.compare(b.isDecommissioning(), a.isDecommissioning()));
+    int dropped = 0;
+    for (ServerHolder server : ordered) {
+      if (dropped >= numToDrop) {
+        break;
+      }
+      if (loadQueueManager.dropSegment(segment, server)) {
+        ++dropped;
+      }
+    }
+    return dropped;
+  }
+
+  /**
    * Queues load or drop operations on this tier based on the required
    * number of replicas and the current state.
    * <p>
@@ -324,7 +592,7 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
       int numReplicasToLoad = replicaDeficit - cancelledDrops;
       if (numReplicasToLoad > 0) {
         int numLoadedReplicas = replicaCountOnTier.loadedNotDropping() + cancelledDrops;
-        int numLoadsQueued = loadReplicas(numReplicasToLoad, numLoadedReplicas, segment, tier, segmentStatus);
+        int numLoadsQueued = loadReplicas(numReplicasToLoad, numLoadedReplicas, segment, tier, segmentStatus, null);
         incrementStat(Stats.Segments.ASSIGNED, segment, tier, numLoadsQueued);
       }
     }
@@ -411,7 +679,7 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
     } else if (server.isDroppingSegment(segment)) {
       return server.cancelOperation(SegmentAction.DROP, segment);
     } else if (server.canLoadSegment(segment)) {
-      return loadSegment(segment, server);
+      return loadSegment(segment, server, null);
     }
 
     final String skipReason;
@@ -534,7 +802,8 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
       int numLoadedReplicas,
       DataSegment segment,
       String tier,
-      SegmentStatusInTier segmentStatus
+      SegmentStatusInTier segmentStatus,
+      @Nullable PartialLoadProfile profile
   )
   {
     final boolean isAlreadyLoadedOnTier = numLoadedReplicas >= 1;
@@ -563,17 +832,17 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
     int numLoadsQueued = 0;
     while (numLoadsQueued < numToLoad && serverIterator.hasNext()) {
       ServerHolder server = serverIterator.next();
-      boolean queuedSuccessfully = isAlreadyLoadedOnTier ? replicateSegment(segment, server)
-                                                         : loadSegment(segment, server);
+      boolean queuedSuccessfully = isAlreadyLoadedOnTier ? replicateSegment(segment, server, profile)
+                                                         : loadSegment(segment, server, profile);
       numLoadsQueued += queuedSuccessfully ? 1 : 0;
     }
 
     return numLoadsQueued;
   }
 
-  private boolean loadSegment(DataSegment segment, ServerHolder server)
+  private boolean loadSegment(DataSegment segment, ServerHolder server, @Nullable PartialLoadProfile profile)
   {
-    final boolean assigned = loadQueueManager.loadSegment(segment, server, SegmentAction.LOAD);
+    final boolean assigned = loadQueueManager.loadSegment(segment, server, SegmentAction.LOAD, profile);
 
     if (!assigned) {
       incrementSkipStat(Stats.Segments.ASSIGN_SKIPPED, "Encountered error", segment, server);
@@ -582,7 +851,7 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
     return assigned;
   }
 
-  private boolean replicateSegment(DataSegment segment, ServerHolder server)
+  private boolean replicateSegment(DataSegment segment, ServerHolder server, @Nullable PartialLoadProfile profile)
   {
     final String tier = server.getServer().getTier();
     if (replicationThrottler.isReplicationThrottledForTier(tier)) {
@@ -590,7 +859,7 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
       return false;
     }
 
-    final boolean assigned = loadQueueManager.loadSegment(segment, server, SegmentAction.REPLICATE);
+    final boolean assigned = loadQueueManager.loadSegment(segment, server, SegmentAction.REPLICATE, profile);
     if (!assigned) {
       incrementSkipStat(Stats.Segments.ASSIGN_SKIPPED, "Encountered error", segment, server);
     } else {

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/StrategicSegmentAssigner.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/StrategicSegmentAssigner.java
@@ -329,19 +329,46 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
   }
 
   /**
-   * Per-tier reconciliation under the partial-load model. The flow is:
+   * Per-tier reconciliation under the partial-load model; partial load equivalent of
+   * {@link #updateReplicasInTier(DataSegment, String, int, int)}
+   *
+   * <h3>Algorithm</h3>
    * <ol>
-   *   <li>Compute matching count: matching-loaded + matching-in-flight − pending-move-drop.</li>
-   *   <li>If matching count is short of {@code requiredReplicas}, cancel stale-fingerprint in-flight loads to free
-   *       slots, then queue fresh partial-load requests on eligible servers (preferring empty servers, falling back
-   *       to additive reload on stale-loaded servers; the historical fills in missing parts in place).</li>
-   *   <li>If matching count exceeds requirement, drop the excess like the full-load surplus path.</li>
-   *   <li>Drop stale-loaded replicas only when the count of actually-loaded matching replicas already meets the
-   *       requirement; this preserves availability across the swap (stale replicas keep serving until matching
-   *       replicas have completed loading and announced).</li>
+   *   <li><b>Classify.</b> Build {@link PartialSegmentStatusInTier} for this tier; every server falls into at most
+   *       one of: matching-loaded, stale-loaded (optionally also eligible-for-additive-reload),
+   *       matching-in-flight, stale-in-flight, eligible-for-fresh-load, or unclassified (drop/move pending; see
+   *       {@link PartialSegmentStatusInTier#classify} for why). Matching means the announced fingerprint equals
+   *       this request's fingerprint; stale is anything else, including a non-profile regular full-load replica.</li>
+   *   <li><b>Compute matching count:</b> matching-loaded + matching-in-flight − pending-move-drop.</li>
+   *   <li><b>If matching count is short of {@code requiredReplicas}</b> (deficit):
+   *     <ol type="a">
+   *       <li>Cancel stale-in-flight loads to free their slots. Canceled servers become same-run fresh-load
+   *           destinations.</li>
+   *       <li>Queue fresh partial-load requests up to the deficit. Destination preference order, applied in
+   *           {@link #loadPartialReplicas}:
+   *           <ol>
+   *             <li>Empty servers (clean slate, no in-place mutation needed).</li>
+   *             <li>Servers whose stale-in-flight load we just canceled in (a), their slot is now free.</li>
+   *             <li>Stale-loaded servers eligible for additive reload (the historical fills in the missing parts in
+   *                 place). This is the fallback path that mitigates the "no spare server" stuck state.
+   *                 Same-run dedup is enforced by {@link ServerHolder#startOperation}, which rejects a second
+   *                 queue attempt on a server whose segment is already queued.</li>
+   *           </ol>
+   *       </li>
+   *     </ol>
+   *   </li>
+   *   <li><b>If matching count exceeds requirement</b> (surplus): drop the excess like the full-load surplus
+   *       path.</li>
+   *   <li><b>Drop stale-loaded replicas</b> only when the count of <em>actually-loaded</em> matching replicas
+   *       already meets the requirement. This preserves availability across the swap: stale replicas keep serving
+   *       until matching replicas have completed loading and announced, then get dropped. The
+   *       {@code maxReplicasToDrop} budget caps how many drops we queue per coordinator run to avoid drop
+   *       storms.</li>
    * </ol>
-   * Returns the total number of drop operations queued on this tier (matching surplus + stale), used to budget
-   * cross-tier drop pressure.
+   *
+   * <h3>Returns</h3>
+   * Total number of drop operations queued on this tier (matching surplus + stale), used to budget cross-tier drop
+   * pressure across subsequent tier reconciliations in the same run.
    */
   private int updateReplicasInTierPartial(
       DataSegment segment,
@@ -386,12 +413,12 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
     // want them gone unconditionally so we don't realize a stale fingerprint nobody asked for. Canceled servers
     // become eligible for a fresh matching load later in this same run.
     final int matchingDeficit = requiredReplicas - matchingProjected;
-    final List<ServerHolder> cancelledStaleServers = new ArrayList<>();
+    final List<ServerHolder> canceledStaleServers = new ArrayList<>();
     if (matchingDeficit > 0 || requiredReplicas == 0) {
       final int toCancel = requiredReplicas == 0 ? status.getStaleInFlight().size() : matchingDeficit;
-      cancelLoadsOnServers(segment, status.getStaleInFlight(), toCancel, cancelledStaleServers);
-      if (!cancelledStaleServers.isEmpty()) {
-        incrementStat(Stats.Segments.PARTIAL_STALE_CANCELLED, segment, tier, cancelledStaleServers.size());
+      cancelLoadsOnServers(segment, status.getStaleInFlight(), toCancel, canceledStaleServers);
+      if (!canceledStaleServers.isEmpty()) {
+        incrementStat(Stats.Segments.PARTIAL_STALE_CANCELLED, segment, tier, canceledStaleServers.size());
       }
     }
 
@@ -399,7 +426,13 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
     if (matchingDeficit > 0) {
       final int numLoadedReplicas = status.getMatchingLoaded().size() + status.getStaleLoaded().size();
       final int queued = loadPartialReplicas(
-          matchingDeficit, numLoadedReplicas, segment, tier, status, cancelledStaleServers, profile
+          matchingDeficit,
+          numLoadedReplicas,
+          segment,
+          tier,
+          status,
+          canceledStaleServers,
+          profile
       );
       if (queued > 0) {
         incrementStat(Stats.Segments.PARTIAL_ASSIGNED, segment, tier, queued);
@@ -410,11 +443,16 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
     int dropBudget = maxReplicasToDrop;
 
     // Surplus matching: drop excess matching replicas. Same shape as the full-load surplus path.
+    // Note: cancellations of matching in-flight loads here are intentionally not emitted as a separate stat. Unlike
+    // the stale-in-flight cancellations above (a distinct "rule churn" event), these are a surplus-absorption
+    // mechanism: each canceled in-flight load just reduces how many physical drops we'd otherwise need to queue
+    // (see `surplus - canceledMatching.size()` below). The full-load path in `updateReplicasInTier` follows the same
+    // convention: canceled surplus loads aren't statted, only the resulting drops are.
     if (matchingProjected > requiredReplicas) {
       final int surplus = matchingProjected - requiredReplicas;
-      final List<ServerHolder> cancelledMatching = new ArrayList<>();
-      cancelLoadsOnServers(segment, status.getMatchingInFlight(), surplus, cancelledMatching);
-      final int numToDrop = Math.min(surplus - cancelledMatching.size(), dropBudget);
+      final List<ServerHolder> canceledMatching = new ArrayList<>();
+      cancelLoadsOnServers(segment, status.getMatchingInFlight(), surplus, canceledMatching);
+      final int numToDrop = Math.min(surplus - canceledMatching.size(), dropBudget);
       if (numToDrop > 0) {
         final int dropped = dropFromList(numToDrop, segment, status.getMatchingLoaded());
         incrementStat(Stats.Segments.DROPPED, segment, tier, dropped);
@@ -451,7 +489,7 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
       DataSegment segment,
       String tier,
       PartialSegmentStatusInTier status,
-      List<ServerHolder> cancelledStaleServers,
+      List<ServerHolder> canceledStaleServers,
       PartialLoadProfile profile
   )
   {
@@ -463,11 +501,11 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
 
     final List<ServerHolder> destinations = new ArrayList<>(
         status.getEligibleForFreshLoad().size()
-        + cancelledStaleServers.size()
+        + canceledStaleServers.size()
         + status.getEligibleForAdditiveReload().size()
     );
     destinations.addAll(status.getEligibleForFreshLoad());
-    destinations.addAll(cancelledStaleServers);
+    destinations.addAll(canceledStaleServers);
     destinations.addAll(status.getEligibleForAdditiveReload());
 
     if (destinations.isEmpty()) {
@@ -492,7 +530,7 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
 
   /**
    * Cancels up to {@code numToCancel} in-flight load operations across the given list of servers. Successfully
-   * canceled servers are appended to {@code cancelledOut} so the caller can re-target them as fresh-load
+   * canceled servers are appended to {@code canceledOut} so the caller can re-target them as fresh-load
    * destinations within the same run. Used both to release slots taken by stale-fingerprint in-flight loads and to
    * reduce a matching surplus.
    */
@@ -500,20 +538,20 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
       DataSegment segment,
       List<ServerHolder> servers,
       int numToCancel,
-      List<ServerHolder> cancelledOut
+      List<ServerHolder> canceledOut
   )
   {
     if (numToCancel <= 0) {
       return;
     }
     for (ServerHolder server : servers) {
-      if (cancelledOut.size() >= numToCancel) {
+      if (canceledOut.size() >= numToCancel) {
         break;
       }
       // Try LOAD then REPLICATE; the queued action depends on whether this was a primary or a replica.
       if (server.cancelOperation(SegmentAction.LOAD, segment)
           || server.cancelOperation(SegmentAction.REPLICATE, segment)) {
-        cancelledOut.add(server);
+        canceledOut.add(server);
       }
     }
   }
@@ -585,13 +623,13 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
     // Cancel drops and queue loads if the projected count is below the requirement
     if (projectedReplicas < requiredReplicas) {
       int replicaDeficit = requiredReplicas - projectedReplicas;
-      int cancelledDrops =
+      int canceledDrops =
           cancelOperations(SegmentAction.DROP, replicaDeficit, segment, segmentStatus);
 
-      // Cancelled drops can be counted as loaded replicas, thus reducing deficit
-      int numReplicasToLoad = replicaDeficit - cancelledDrops;
+      // Canceled drops can be counted as loaded replicas, thus reducing deficit
+      int numReplicasToLoad = replicaDeficit - canceledDrops;
       if (numReplicasToLoad > 0) {
-        int numLoadedReplicas = replicaCountOnTier.loadedNotDropping() + cancelledDrops;
+        int numLoadedReplicas = replicaCountOnTier.loadedNotDropping() + canceledDrops;
         int numLoadsQueued = loadReplicas(numReplicasToLoad, numLoadedReplicas, segment, tier, segmentStatus, null);
         incrementStat(Stats.Segments.ASSIGNED, segment, tier, numLoadsQueued);
       }
@@ -600,10 +638,10 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
     // Cancel loads and queue drops if the projected count exceeds the requirement
     if (projectedReplicas > requiredReplicas) {
       int replicaSurplus = projectedReplicas - requiredReplicas;
-      int cancelledLoads =
+      int canceledLoads =
           cancelOperations(SegmentAction.LOAD, replicaSurplus, segment, segmentStatus);
 
-      int numReplicasToDrop = Math.min(replicaSurplus - cancelledLoads, maxReplicasToDrop);
+      int numReplicasToDrop = Math.min(replicaSurplus - canceledLoads, maxReplicasToDrop);
       if (numReplicasToDrop > 0) {
         int dropsQueuedOnTier = dropReplicas(numReplicasToDrop, segment, tier, segmentStatus);
         incrementStat(Stats.Segments.DROPPED, segment, tier, dropsQueuedOnTier);
@@ -900,11 +938,11 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
       return 0;
     }
 
-    int numCancelled = 0;
-    for (int i = 0; i < servers.size() && numCancelled < maxNumToCancel; ++i) {
-      numCancelled += servers.get(i).cancelOperation(action, segment) ? 1 : 0;
+    int numCanceled = 0;
+    for (int i = 0; i < servers.size() && numCanceled < maxNumToCancel; ++i) {
+      numCanceled += servers.get(i).cancelOperation(action, segment) ? 1 : 0;
     }
-    return numCancelled;
+    return numCanceled;
   }
 
   private void incrementSkipStat(CoordinatorStat stat, String reason, DataSegment segment, String tier)

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/ProjectionPartialLoadMatcher.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/ProjectionPartialLoadMatcher.java
@@ -22,6 +22,7 @@ package org.apache.druid.server.coordinator.rules;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import com.google.common.io.BaseEncoding;
+import org.apache.druid.segment.loading.PartialProjectionLoadSpec;
 import org.apache.druid.timeline.DataSegment;
 
 import javax.annotation.Nullable;
@@ -33,7 +34,7 @@ import java.util.Map;
  * Base for {@link PartialLoadMatcher} implementations that decide which of a segment's V10 projections to load.
  * Subclasses supply the resolution policy via {@link #resolveProjectionNames(DataSegment)}; this base handles
  * fingerprint computation and wraps the result into the {@code partialProjection} load-spec wire form consumed
- * by the historical-side {@code PartialProjectionLoadSpec}.
+ * by the historical-side {@link PartialProjectionLoadSpec}.
  * <p>
  * The fingerprint is a hash of what projections are partially loaded on a segment by this rule; the data node will
  * include this value in the segment announcement so that it can be used as a lightweight value to compare against
@@ -41,7 +42,6 @@ import java.util.Map;
  */
 public abstract class ProjectionPartialLoadMatcher implements PartialLoadMatcher
 {
-  static final String LOAD_SPEC_TYPE = "partialProjection";
   static final String FINGERPRINT_VERSION = "v1";
 
   /**
@@ -60,13 +60,7 @@ public abstract class ProjectionPartialLoadMatcher implements PartialLoadMatcher
       return null;
     }
     final String fingerprint = computeFingerprint(resolved);
-    final Map<String, Object> wrapped = Map.of(
-        "type", LOAD_SPEC_TYPE,
-        "delegate", baseLoadSpec,
-        "projections", resolved,
-        "fingerprint", fingerprint
-    );
-    return new MatchResult(wrapped, fingerprint);
+    return new MatchResult(PartialProjectionLoadSpec.wireForm(baseLoadSpec, resolved, fingerprint), fingerprint);
   }
 
   static String computeFingerprint(List<String> sortedDedupedNames)

--- a/server/src/main/java/org/apache/druid/server/coordinator/stats/Stats.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/stats/Stats.java
@@ -71,6 +71,14 @@ public class Stats
         = CoordinatorStat.toDebugAndEmit("cloneLoad", "segment/clone/assigned/count");
     public static final CoordinatorStat DROPPED_FROM_CLONE
         = CoordinatorStat.toDebugAndEmit("cloneDrop", "segment/clone/dropped/count");
+
+    // Partial-load reconciliation in a run
+    public static final CoordinatorStat PARTIAL_ASSIGNED
+        = CoordinatorStat.toDebugAndEmit("partialAssigned", "segment/partial/assigned/count");
+    public static final CoordinatorStat PARTIAL_STALE_DROPPED
+        = CoordinatorStat.toDebugAndEmit("partialStaleDropped", "segment/partial/staleDropped/count");
+    public static final CoordinatorStat PARTIAL_STALE_CANCELLED
+        = CoordinatorStat.toDebugAndEmit("partialStaleCancelled", "segment/partial/staleCancelled/count");
   }
 
   public static class SegmentQueue

--- a/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
@@ -755,7 +755,7 @@ public class DataSourcesResource
       }
     }
 
-    return new ImmutableDruidDataSource(dataSourceName, Collections.emptyMap(), segmentMap);
+    return new ImmutableDruidDataSource(dataSourceName, Collections.emptyMap(), segmentMap.values());
   }
 
   @Nullable

--- a/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
@@ -755,6 +755,13 @@ public class DataSourcesResource
       }
     }
 
+    // Use the Collection<DataSegment> @JsonCreator overload here rather than passing segmentMap directly. The two
+    // ImmutableDruidDataSource constructors differ in how they compute totalSizeOfSegments: the Map-based in-process
+    // constructor sums effectiveSizeOf (per-server realized loadedBytes when a segment is wrapped with a partial-load
+    // profile), whereas the Collection-based @JsonCreator overload sums DataSegment.getSize() (the segment's logical
+    // full size). For this synthesized cross-server view, where Map.put dedup picks an arbitrary "winning" server's
+    // instance per segmentId, reporting per-server realized sizes from arbitrary winners would mis-report the total.
+    // Logical-size accumulation is the operator-meaningful "how big is this datasource" semantic.
     return new ImmutableDruidDataSource(dataSourceName, Collections.emptyMap(), segmentMap.values());
   }
 

--- a/server/src/main/java/org/apache/druid/server/http/SegmentListerResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/SegmentListerResource.java
@@ -298,12 +298,8 @@ public class SegmentListerResource
     }
 
     SegmentLoaderConfig config = loadDropRequestHandler.getSegmentLoaderConfig();
-    // supportsPartialLoad is hard-coded false until the historical-side load handler actually honors the
-    // partial-load LoadSpec wrapper and announces the realized fingerprint and loadedBytes back. Until then, the
-    // wire format and coordinator routing exist but the historical performs a regular full load on any request, so
-    // advertising the capability would lie to the coordinator and cause it to thrash partial-load assignments.
     SegmentLoadingCapabilities capabilitiesResponse =
-        new SegmentLoadingCapabilities(config.getNumLoadingThreads(), config.getNumBootstrapThreads(), false);
+        new SegmentLoadingCapabilities(config.getNumLoadingThreads(), config.getNumBootstrapThreads());
 
     return Response.status(Response.Status.OK).entity(capabilitiesResponse).build();
   }

--- a/server/src/main/java/org/apache/druid/server/http/SegmentLoadingCapabilities.java
+++ b/server/src/main/java/org/apache/druid/server/http/SegmentLoadingCapabilities.java
@@ -30,27 +30,15 @@ public class SegmentLoadingCapabilities
 {
   private final int numLoadingThreads;
   private final int numTurboLoadingThreads;
-  private final boolean supportsPartialLoad;
 
   @JsonCreator
   public SegmentLoadingCapabilities(
       @JsonProperty("numLoadingThreads") int numLoadingThreads,
-      @JsonProperty("numTurboLoadingThreads") int numTurboLoadingThreads,
-      @JsonProperty("supportsPartialLoad") boolean supportsPartialLoad
+      @JsonProperty("numTurboLoadingThreads") int numTurboLoadingThreads
   )
   {
     this.numLoadingThreads = numLoadingThreads;
     this.numTurboLoadingThreads = numTurboLoadingThreads;
-    this.supportsPartialLoad = supportsPartialLoad;
-  }
-
-  /**
-   * Convenience for callers that don't care about the partial-load capability (older code paths and tests).
-   * Defaults the capability to {@code false}.
-   */
-  public SegmentLoadingCapabilities(int numLoadingThreads, int numTurboLoadingThreads)
-  {
-    this(numLoadingThreads, numTurboLoadingThreads, false);
   }
 
   @JsonProperty
@@ -65,25 +53,12 @@ public class SegmentLoadingCapabilities
     return numTurboLoadingThreads;
   }
 
-  /**
-   * Whether the server understands the partial-load {@code LoadSpec} wrapper wire formats this Druid version ships
-   * with (e.g., {@code PartialProjectionLoadSpec}). Older historicals deserialize an unknown wrapper type and fail;
-   * the coordinator consults this flag and degrades partial-load requests to full-loads when it is {@code false}.
-   * Treated as a single capability across all built-in partial-load schemes since they are all core-loaded.
-   */
-  @JsonProperty
-  public boolean isSupportsPartialLoad()
-  {
-    return supportsPartialLoad;
-  }
-
   @Override
   public String toString()
   {
     return "SegmentLoadingCapabilities{" +
            "numLoadingThreads=" + numLoadingThreads +
            ", numTurboLoadingThreads=" + numTurboLoadingThreads +
-           ", supportsPartialLoad=" + supportsPartialLoad +
            '}';
   }
 }

--- a/server/src/test/java/org/apache/druid/client/DruidServerPartialLoadTest.java
+++ b/server/src/test/java/org/apache/druid/client/DruidServerPartialLoadTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.client;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.server.coordination.ServerType;
+import org.apache.druid.server.coordinator.loading.PartialLoadProfile;
+import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.partition.NoneShardSpec;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link DruidServer}'s partial-load profile bookkeeping: profile-aware {@code currSize} accounting,
+ * profile retrieval, and balanced add/remove of profile state.
+ */
+public class DruidServerPartialLoadTest
+{
+  private static final String FINGERPRINT = "v1:0123456789abcdef";
+
+  private static DruidServer newServer()
+  {
+    return new DruidServer(
+        "test",
+        "localhost:8083",
+        null,
+        100_000_000L,
+        100_000_000L,
+        ServerType.HISTORICAL,
+        "_default_tier",
+        0
+    );
+  }
+
+  private static DataSegment buildSegment(String dataSource, String version, long size)
+  {
+    return new DataSegment(
+        dataSource,
+        Intervals.of("2024-01-01/2024-02-01"),
+        version,
+        ImmutableMap.of("type", "local", "path", "/var/druid/segments/foo"),
+        null,
+        null,
+        NoneShardSpec.instance(),
+        9,
+        size
+    );
+  }
+
+  @Test
+  void testAddSegmentWithoutProfileUsesSegmentSizeForCurrSize()
+  {
+    DruidServer server = newServer();
+    DataSegment segment = buildSegment("ds", "v1", 1000L);
+    server.addDataSegment(segment);
+    Assertions.assertEquals(1000L, server.getCurrSize());
+    Assertions.assertNull(server.getPartialLoadProfile(segment.getId()));
+  }
+
+  @Test
+  void testAddSegmentWithProfileUsesLoadedBytesForCurrSize()
+  {
+    DruidServer server = newServer();
+    DataSegment segment = buildSegment("ds", "v1", 1000L);
+    PartialLoadProfile profile = PartialLoadProfile.forLoaded(
+        ImmutableMap.of("type", "partialProjection", "fingerprint", FINGERPRINT),
+        FINGERPRINT,
+        300L
+    );
+    server.addDataSegment(segment, profile);
+    Assertions.assertEquals(300L, server.getCurrSize());
+    Assertions.assertEquals(profile, server.getPartialLoadProfile(segment.getId()));
+  }
+
+  @Test
+  void testRemoveSegmentSubtractsProfileLoadedBytes()
+  {
+    DruidServer server = newServer();
+    DataSegment segment = buildSegment("ds", "v1", 1000L);
+    PartialLoadProfile profile = PartialLoadProfile.forLoaded(
+        ImmutableMap.of("type", "partialProjection", "fingerprint", FINGERPRINT),
+        FINGERPRINT,
+        300L
+    );
+    server.addDataSegment(segment, profile);
+    server.removeDataSegment(segment.getId());
+    Assertions.assertEquals(0L, server.getCurrSize());
+    Assertions.assertNull(server.getPartialLoadProfile(segment.getId()));
+  }
+
+  @Test
+  void testFullFallbackProfileUsesFullSegmentSize()
+  {
+    // Historical was asked to partial-load but fell back to full download; profile.loadedBytes equals
+    // segment.getSize, so currSize accounting reflects the full footprint.
+    DruidServer server = newServer();
+    DataSegment segment = buildSegment("ds", "v1", 1000L);
+    PartialLoadProfile profile = PartialLoadProfile.forFullFallback(FINGERPRINT, segment.getSize());
+    server.addDataSegment(segment, profile);
+    Assertions.assertEquals(1000L, server.getCurrSize());
+    Assertions.assertEquals(profile, server.getPartialLoadProfile(segment.getId()));
+    Assertions.assertTrue(profile.isFullFallback());
+  }
+
+  @Test
+  void testMixedFullAndPartialReplicasAccount()
+  {
+    // Two segments on the same server: one full-loaded, one partial. currSize sums correctly.
+    DruidServer server = newServer();
+    DataSegment fullSegment = buildSegment("ds", "v1", 1000L);
+    DataSegment partialSegment = buildSegment("ds", "v2", 5000L);
+    PartialLoadProfile profile = PartialLoadProfile.forLoaded(
+        ImmutableMap.of("type", "partialProjection", "fingerprint", FINGERPRINT),
+        FINGERPRINT,
+        500L
+    );
+    server.addDataSegment(fullSegment);
+    server.addDataSegment(partialSegment, profile);
+    Assertions.assertEquals(1500L, server.getCurrSize());
+    Assertions.assertNull(server.getPartialLoadProfile(fullSegment.getId()));
+    Assertions.assertEquals(profile, server.getPartialLoadProfile(partialSegment.getId()));
+  }
+}

--- a/server/src/test/java/org/apache/druid/client/DruidServerPartialLoadTest.java
+++ b/server/src/test/java/org/apache/druid/client/DruidServerPartialLoadTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.client;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.server.coordinator.loading.PartialLoadProfile;
@@ -28,6 +27,8 @@ import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
 
 /**
  * Tests {@link DruidServer}'s partial-load profile bookkeeping: profile-aware {@code currSize} accounting,
@@ -56,7 +57,7 @@ public class DruidServerPartialLoadTest
     return DataSegment
         .builder(SegmentId.of(dataSource, Intervals.of("2024-01-01/2024-02-01"), version, NoneShardSpec.instance()))
         .shardSpec(NoneShardSpec.instance())
-        .loadSpec(ImmutableMap.of("type", "local", "path", "/var/druid/segments/foo"))
+        .loadSpec(Map.of("type", "local", "path", "/var/druid/segments/foo"))
         .binaryVersion(9)
         .size(size)
         .build();
@@ -78,7 +79,7 @@ public class DruidServerPartialLoadTest
     DruidServer server = newServer();
     DataSegment segment = buildSegment("ds", "v1", 1000L);
     PartialLoadProfile profile = PartialLoadProfile.forLoaded(
-        ImmutableMap.of("type", "partialProjection", "fingerprint", FINGERPRINT),
+        Map.of("type", "partialProjection", "fingerprint", FINGERPRINT),
         FINGERPRINT,
         300L
     );
@@ -93,7 +94,7 @@ public class DruidServerPartialLoadTest
     DruidServer server = newServer();
     DataSegment segment = buildSegment("ds", "v1", 1000L);
     PartialLoadProfile profile = PartialLoadProfile.forLoaded(
-        ImmutableMap.of("type", "partialProjection", "fingerprint", FINGERPRINT),
+        Map.of("type", "partialProjection", "fingerprint", FINGERPRINT),
         FINGERPRINT,
         300L
     );
@@ -123,19 +124,19 @@ public class DruidServerPartialLoadTest
     // Simulates the historical re-announcing a segment after an additive reload swapped the wrapper / fingerprint.
     // Inventory state updates in place (no add/remove); currSize tracks the difference between the old and new
     // effective sizes.
-    final String FINGERPRINT_OLD = "v1:111111aaaa";
+    final String staleFingerprint = "v1:111111aaaa";
     DruidServer server = newServer();
     DataSegment segment = buildSegment("ds", "v1", 1000L);
     PartialLoadProfile oldProfile = PartialLoadProfile.forLoaded(
-        ImmutableMap.of("type", "partialProjection", "fingerprint", FINGERPRINT_OLD),
-        FINGERPRINT_OLD,
+        Map.of("type", "partialProjection", "fingerprint", staleFingerprint),
+        staleFingerprint,
         200L
     );
     server.addDataSegment(segment, oldProfile);
     Assertions.assertEquals(200L, server.getCurrSize());
 
     PartialLoadProfile newProfile = PartialLoadProfile.forLoaded(
-        ImmutableMap.of("type", "partialProjection", "fingerprint", FINGERPRINT),
+        Map.of("type", "partialProjection", "fingerprint", FINGERPRINT),
         FINGERPRINT,
         700L
     );
@@ -150,7 +151,7 @@ public class DruidServerPartialLoadTest
     DruidServer server = newServer();
     DataSegment segment = buildSegment("ds", "v1", 1000L);
     PartialLoadProfile profile = PartialLoadProfile.forLoaded(
-        ImmutableMap.of("type", "partialProjection", "fingerprint", FINGERPRINT),
+        Map.of("type", "partialProjection", "fingerprint", FINGERPRINT),
         FINGERPRINT,
         500L
     );
@@ -167,7 +168,7 @@ public class DruidServerPartialLoadTest
     DataSegment fullSegment = buildSegment("ds", "v1", 1000L);
     DataSegment partialSegment = buildSegment("ds", "v2", 5000L);
     PartialLoadProfile profile = PartialLoadProfile.forLoaded(
-        ImmutableMap.of("type", "partialProjection", "fingerprint", FINGERPRINT),
+        Map.of("type", "partialProjection", "fingerprint", FINGERPRINT),
         FINGERPRINT,
         500L
     );

--- a/server/src/test/java/org/apache/druid/client/DruidServerPartialLoadTest.java
+++ b/server/src/test/java/org/apache/druid/client/DruidServerPartialLoadTest.java
@@ -118,6 +118,48 @@ public class DruidServerPartialLoadTest
   }
 
   @Test
+  void testUpdateDataSegmentProfileSwapsFingerprintAndAdjustsCurrSize()
+  {
+    // Simulates the historical re-announcing a segment after an additive reload swapped the wrapper / fingerprint.
+    // Inventory state updates in place (no add/remove); currSize tracks the difference between the old and new
+    // effective sizes.
+    final String FINGERPRINT_OLD = "v1:111111aaaa";
+    DruidServer server = newServer();
+    DataSegment segment = buildSegment("ds", "v1", 1000L);
+    PartialLoadProfile oldProfile = PartialLoadProfile.forLoaded(
+        ImmutableMap.of("type", "partialProjection", "fingerprint", FINGERPRINT_OLD),
+        FINGERPRINT_OLD,
+        200L
+    );
+    server.addDataSegment(segment, oldProfile);
+    Assertions.assertEquals(200L, server.getCurrSize());
+
+    PartialLoadProfile newProfile = PartialLoadProfile.forLoaded(
+        ImmutableMap.of("type", "partialProjection", "fingerprint", FINGERPRINT),
+        FINGERPRINT,
+        700L
+    );
+    Assertions.assertTrue(server.updateDataSegmentProfile(segment, newProfile));
+    Assertions.assertEquals(700L, server.getCurrSize());
+    Assertions.assertEquals(newProfile, server.getPartialLoadProfile(segment.getId()));
+  }
+
+  @Test
+  void testUpdateDataSegmentProfileNoopWhenSegmentAbsent()
+  {
+    DruidServer server = newServer();
+    DataSegment segment = buildSegment("ds", "v1", 1000L);
+    PartialLoadProfile profile = PartialLoadProfile.forLoaded(
+        ImmutableMap.of("type", "partialProjection", "fingerprint", FINGERPRINT),
+        FINGERPRINT,
+        500L
+    );
+    Assertions.assertFalse(server.updateDataSegmentProfile(segment, profile));
+    Assertions.assertEquals(0L, server.getCurrSize());
+    Assertions.assertNull(server.getPartialLoadProfile(segment.getId()));
+  }
+
+  @Test
   void testMixedFullAndPartialReplicasAccount()
   {
     // Two segments on the same server: one full-loaded, one partial. currSize sums correctly.

--- a/server/src/test/java/org/apache/druid/client/DruidServerPartialLoadTest.java
+++ b/server/src/test/java/org/apache/druid/client/DruidServerPartialLoadTest.java
@@ -24,6 +24,7 @@ import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.server.coordinator.loading.PartialLoadProfile;
 import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -52,17 +53,13 @@ public class DruidServerPartialLoadTest
 
   private static DataSegment buildSegment(String dataSource, String version, long size)
   {
-    return new DataSegment(
-        dataSource,
-        Intervals.of("2024-01-01/2024-02-01"),
-        version,
-        ImmutableMap.of("type", "local", "path", "/var/druid/segments/foo"),
-        null,
-        null,
-        NoneShardSpec.instance(),
-        9,
-        size
-    );
+    return DataSegment
+        .builder(SegmentId.of(dataSource, Intervals.of("2024-01-01/2024-02-01"), version, NoneShardSpec.instance()))
+        .shardSpec(NoneShardSpec.instance())
+        .loadSpec(ImmutableMap.of("type", "local", "path", "/var/druid/segments/foo"))
+        .binaryVersion(9)
+        .size(size)
+        .build();
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/server/coordination/SegmentChangeRequestLoadTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/SegmentChangeRequestLoadTest.java
@@ -180,6 +180,86 @@ public class SegmentChangeRequestLoadTest
   }
 
   @Test
+  public void testForAnnouncementUnknownPartialTypeStillRecognizedByConvention()
+  {
+    // Any partial-load wire form (type starts with "partial", plus fingerprint + delegate at top level) gets the
+    // full-fallback treatment — the announcement layer doesn't need to know about specific subtypes. This is what
+    // makes future PartialLoadSpec subtypes work without touching this code.
+    Map<String, Object> wrapped = Map.of(
+        "type", "partialFutureScheme",
+        "delegate", Map.of("type", "local", "path", "/var/druid/segments/foo"),
+        "fingerprint", "v1:1111111111111111"
+    );
+    DataSegment segment = new DataSegment(
+        "ds",
+        Intervals.of("2024-01-01/2024-02-01"),
+        "v1",
+        wrapped,
+        List.of("d"),
+        List.of("m"),
+        NoneShardSpec.instance(),
+        IndexIO.CURRENT_VERSION_ID,
+        7777
+    );
+    SegmentChangeRequestLoad announcement = SegmentChangeRequestLoad.forAnnouncement(segment);
+    Assert.assertEquals("v1:1111111111111111", announcement.getFingerprint());
+    Assert.assertEquals(Long.valueOf(7777L), announcement.getLoadedBytes());
+  }
+
+  @Test
+  public void testForAnnouncementNonPartialTypeIgnoredEvenWithFingerprint()
+  {
+    // The type-prefix gate keeps non-partial LoadSpecs that happen to use a "fingerprint" key from being
+    // mis-classified as partial-load wrappers.
+    Map<String, Object> looksSuspicious = Map.of(
+        "type", "local",
+        "path", "/var/druid/segments/foo",
+        "fingerprint", "v1:notreallypartial",
+        "delegate", Map.of("ignored", "yes")
+    );
+    DataSegment segment = new DataSegment(
+        "ds",
+        Intervals.of("2024-01-01/2024-02-01"),
+        "v1",
+        looksSuspicious,
+        List.of("d"),
+        List.of("m"),
+        NoneShardSpec.instance(),
+        IndexIO.CURRENT_VERSION_ID,
+        100
+    );
+    SegmentChangeRequestLoad announcement = SegmentChangeRequestLoad.forAnnouncement(segment);
+    Assert.assertNull(announcement.getFingerprint());
+    Assert.assertNull(announcement.getLoadedBytes());
+  }
+
+  @Test
+  public void testForAnnouncementMalformedPartialTypeFallsThroughToPlainLoad()
+  {
+    // A partial-typed loadSpec missing the fingerprint contract should not stall the queue: announce as a plain
+    // load (the log.warn at the call site surfaces the bug).
+    Map<String, Object> malformed = Map.of(
+        "type", "partialProjection",
+        "delegate", Map.of("type", "local", "path", "/var/druid/segments/foo")
+        // no fingerprint
+    );
+    DataSegment segment = new DataSegment(
+        "ds",
+        Intervals.of("2024-01-01/2024-02-01"),
+        "v1",
+        malformed,
+        List.of("d"),
+        List.of("m"),
+        NoneShardSpec.instance(),
+        IndexIO.CURRENT_VERSION_ID,
+        100
+    );
+    SegmentChangeRequestLoad announcement = SegmentChangeRequestLoad.forAnnouncement(segment);
+    Assert.assertNull(announcement.getFingerprint());
+    Assert.assertNull(announcement.getLoadedBytes());
+  }
+
+  @Test
   public void testOldPayloadDeserializesWithoutPartialFields() throws Exception
   {
     // An old-version payload with no partial-load fields should deserialize cleanly; the partial fields are null.

--- a/server/src/test/java/org/apache/druid/server/coordination/SegmentChangeRequestLoadTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/SegmentChangeRequestLoadTest.java
@@ -26,6 +26,7 @@ import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.jackson.JacksonUtils;
 import org.apache.druid.segment.IndexIO;
 import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.joda.time.Interval;
 import org.junit.Assert;
@@ -39,6 +40,13 @@ import java.util.Map;
  */
 public class SegmentChangeRequestLoadTest
 {
+  private static DataSegment.Builder segmentBuilder(String dataSource, Interval interval, String version)
+  {
+    return DataSegment.builder(SegmentId.of(dataSource, interval, version, NoneShardSpec.instance()))
+                      .shardSpec(NoneShardSpec.instance())
+                      .binaryVersion(IndexIO.CURRENT_VERSION_ID);
+  }
+
   @Test
   public void testV1Serialization() throws Exception
   {
@@ -47,17 +55,12 @@ public class SegmentChangeRequestLoadTest
     final Interval interval = Intervals.of("2011-10-01/2011-10-02");
     final ImmutableMap<String, Object> loadSpec = ImmutableMap.of("something", "or_other");
 
-    DataSegment segment = new DataSegment(
-        "something",
-        interval,
-        "1",
-        loadSpec,
-        Arrays.asList("dim1", "dim2"),
-        Arrays.asList("met1", "met2"),
-        NoneShardSpec.instance(),
-        IndexIO.CURRENT_VERSION_ID,
-        1
-    );
+    DataSegment segment = segmentBuilder("something", interval, "1")
+        .loadSpec(loadSpec)
+        .dimensions(Arrays.asList("dim1", "dim2"))
+        .metrics(Arrays.asList("met1", "met2"))
+        .size(1)
+        .build();
 
     final SegmentChangeRequestLoad segmentDrop = new SegmentChangeRequestLoad(segment);
 
@@ -83,17 +86,12 @@ public class SegmentChangeRequestLoadTest
   {
     // Coordinator-issued load requests leave the partial-load fields null; the wire payload should not include them.
     ObjectMapper mapper = new DefaultObjectMapper();
-    DataSegment segment = new DataSegment(
-        "ds",
-        Intervals.of("2024-01-01/2024-02-01"),
-        "v1",
-        Map.of("type", "local"),
-        List.of("d"),
-        List.of("m"),
-        NoneShardSpec.instance(),
-        IndexIO.CURRENT_VERSION_ID,
-        1
-    );
+    DataSegment segment = segmentBuilder("ds", Intervals.of("2024-01-01/2024-02-01"), "v1")
+        .loadSpec(Map.of("type", "local"))
+        .dimensions(List.of("d"))
+        .metrics(List.of("m"))
+        .size(1)
+        .build();
     SegmentChangeRequestLoad load = new SegmentChangeRequestLoad(segment);
     Map<String, Object> objectMap = mapper.readValue(
         mapper.writeValueAsString(load),
@@ -108,17 +106,12 @@ public class SegmentChangeRequestLoadTest
   {
     // Historical announcement with partial-load metadata: round-trip preserves both fields.
     ObjectMapper mapper = new DefaultObjectMapper();
-    DataSegment segment = new DataSegment(
-        "ds",
-        Intervals.of("2024-01-01/2024-02-01"),
-        "v1",
-        Map.of("type", "local"),
-        List.of("d"),
-        List.of("m"),
-        NoneShardSpec.instance(),
-        IndexIO.CURRENT_VERSION_ID,
-        1
-    );
+    DataSegment segment = segmentBuilder("ds", Intervals.of("2024-01-01/2024-02-01"), "v1")
+        .loadSpec(Map.of("type", "local"))
+        .dimensions(List.of("d"))
+        .metrics(List.of("m"))
+        .size(1)
+        .build();
     SegmentChangeRequestLoad load = new SegmentChangeRequestLoad(
         segment,
         "v1:abcdef0123456789",
@@ -135,17 +128,12 @@ public class SegmentChangeRequestLoadTest
   public void testForAnnouncementBareSegment()
   {
     // A segment loaded without a partial-load wrapper produces a plain announcement with no partial fields.
-    DataSegment segment = new DataSegment(
-        "ds",
-        Intervals.of("2024-01-01/2024-02-01"),
-        "v1",
-        Map.of("type", "local"),
-        List.of("d"),
-        List.of("m"),
-        NoneShardSpec.instance(),
-        IndexIO.CURRENT_VERSION_ID,
-        100
-    );
+    DataSegment segment = segmentBuilder("ds", Intervals.of("2024-01-01/2024-02-01"), "v1")
+        .loadSpec(Map.of("type", "local"))
+        .dimensions(List.of("d"))
+        .metrics(List.of("m"))
+        .size(100)
+        .build();
     SegmentChangeRequestLoad announcement = SegmentChangeRequestLoad.forAnnouncement(segment);
     Assert.assertNull(announcement.getFingerprint());
     Assert.assertNull(announcement.getLoadedBytes());
@@ -163,17 +151,12 @@ public class SegmentChangeRequestLoadTest
         "projections", List.of("revenue"),
         "fingerprint", "v1:abcdef0123456789"
     );
-    DataSegment segment = new DataSegment(
-        "ds",
-        Intervals.of("2024-01-01/2024-02-01"),
-        "v1",
-        wrapped,
-        List.of("d"),
-        List.of("m"),
-        NoneShardSpec.instance(),
-        IndexIO.CURRENT_VERSION_ID,
-        12345
-    );
+    DataSegment segment = segmentBuilder("ds", Intervals.of("2024-01-01/2024-02-01"), "v1")
+        .loadSpec(wrapped)
+        .dimensions(List.of("d"))
+        .metrics(List.of("m"))
+        .size(12345)
+        .build();
     SegmentChangeRequestLoad announcement = SegmentChangeRequestLoad.forAnnouncement(segment);
     Assert.assertEquals("v1:abcdef0123456789", announcement.getFingerprint());
     Assert.assertEquals(Long.valueOf(12345L), announcement.getLoadedBytes());
@@ -190,17 +173,12 @@ public class SegmentChangeRequestLoadTest
         "delegate", Map.of("type", "local", "path", "/var/druid/segments/foo"),
         "fingerprint", "v1:1111111111111111"
     );
-    DataSegment segment = new DataSegment(
-        "ds",
-        Intervals.of("2024-01-01/2024-02-01"),
-        "v1",
-        wrapped,
-        List.of("d"),
-        List.of("m"),
-        NoneShardSpec.instance(),
-        IndexIO.CURRENT_VERSION_ID,
-        7777
-    );
+    DataSegment segment = segmentBuilder("ds", Intervals.of("2024-01-01/2024-02-01"), "v1")
+        .loadSpec(wrapped)
+        .dimensions(List.of("d"))
+        .metrics(List.of("m"))
+        .size(7777)
+        .build();
     SegmentChangeRequestLoad announcement = SegmentChangeRequestLoad.forAnnouncement(segment);
     Assert.assertEquals("v1:1111111111111111", announcement.getFingerprint());
     Assert.assertEquals(Long.valueOf(7777L), announcement.getLoadedBytes());
@@ -217,17 +195,12 @@ public class SegmentChangeRequestLoadTest
         "fingerprint", "v1:notreallypartial",
         "delegate", Map.of("ignored", "yes")
     );
-    DataSegment segment = new DataSegment(
-        "ds",
-        Intervals.of("2024-01-01/2024-02-01"),
-        "v1",
-        looksSuspicious,
-        List.of("d"),
-        List.of("m"),
-        NoneShardSpec.instance(),
-        IndexIO.CURRENT_VERSION_ID,
-        100
-    );
+    DataSegment segment = segmentBuilder("ds", Intervals.of("2024-01-01/2024-02-01"), "v1")
+        .loadSpec(looksSuspicious)
+        .dimensions(List.of("d"))
+        .metrics(List.of("m"))
+        .size(100)
+        .build();
     SegmentChangeRequestLoad announcement = SegmentChangeRequestLoad.forAnnouncement(segment);
     Assert.assertNull(announcement.getFingerprint());
     Assert.assertNull(announcement.getLoadedBytes());
@@ -243,17 +216,12 @@ public class SegmentChangeRequestLoadTest
         "delegate", Map.of("type", "local", "path", "/var/druid/segments/foo")
         // no fingerprint
     );
-    DataSegment segment = new DataSegment(
-        "ds",
-        Intervals.of("2024-01-01/2024-02-01"),
-        "v1",
-        malformed,
-        List.of("d"),
-        List.of("m"),
-        NoneShardSpec.instance(),
-        IndexIO.CURRENT_VERSION_ID,
-        100
-    );
+    DataSegment segment = segmentBuilder("ds", Intervals.of("2024-01-01/2024-02-01"), "v1")
+        .loadSpec(malformed)
+        .dimensions(List.of("d"))
+        .metrics(List.of("m"))
+        .size(100)
+        .build();
     SegmentChangeRequestLoad announcement = SegmentChangeRequestLoad.forAnnouncement(segment);
     Assert.assertNull(announcement.getFingerprint());
     Assert.assertNull(announcement.getLoadedBytes());
@@ -264,17 +232,12 @@ public class SegmentChangeRequestLoadTest
   {
     // An old-version payload with no partial-load fields should deserialize cleanly; the partial fields are null.
     ObjectMapper mapper = new DefaultObjectMapper();
-    DataSegment segment = new DataSegment(
-        "ds",
-        Intervals.of("2024-01-01/2024-02-01"),
-        "v1",
-        Map.of("type", "local"),
-        List.of("d"),
-        List.of("m"),
-        NoneShardSpec.instance(),
-        IndexIO.CURRENT_VERSION_ID,
-        1
-    );
+    DataSegment segment = segmentBuilder("ds", Intervals.of("2024-01-01/2024-02-01"), "v1")
+        .loadSpec(Map.of("type", "local"))
+        .dimensions(List.of("d"))
+        .metrics(List.of("m"))
+        .size(1)
+        .build();
     String oldJson = mapper.writeValueAsString(new SegmentChangeRequestLoad(segment));
     SegmentChangeRequestLoad reread = mapper.readValue(oldJson, SegmentChangeRequestLoad.class);
     Assert.assertNull(reread.getFingerprint());

--- a/server/src/test/java/org/apache/druid/server/coordination/SegmentChangeRequestLoadTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/SegmentChangeRequestLoadTest.java
@@ -132,6 +132,54 @@ public class SegmentChangeRequestLoadTest
   }
 
   @Test
+  public void testForAnnouncementBareSegment()
+  {
+    // A segment loaded without a partial-load wrapper produces a plain announcement with no partial fields.
+    DataSegment segment = new DataSegment(
+        "ds",
+        Intervals.of("2024-01-01/2024-02-01"),
+        "v1",
+        Map.of("type", "local"),
+        List.of("d"),
+        List.of("m"),
+        NoneShardSpec.instance(),
+        IndexIO.CURRENT_VERSION_ID,
+        100
+    );
+    SegmentChangeRequestLoad announcement = SegmentChangeRequestLoad.forAnnouncement(segment);
+    Assert.assertNull(announcement.getFingerprint());
+    Assert.assertNull(announcement.getLoadedBytes());
+  }
+
+  @Test
+  public void testForAnnouncementPartialProjectionWrapperProducesFullFallback()
+  {
+    // When the segment's loadSpec is a partialProjection wrapper, the announcement stamps the wrapper's fingerprint
+    // and the segment's full size as loadedBytes — coordinator reads this as a full-fallback profile and counts the
+    // replica as matching, avoiding reload thrash on historicals that don't (yet) do real partial loading.
+    Map<String, Object> wrapped = Map.of(
+        "type", "partialProjection",
+        "delegate", Map.of("type", "local", "path", "/var/druid/segments/foo"),
+        "projections", List.of("revenue"),
+        "fingerprint", "v1:abcdef0123456789"
+    );
+    DataSegment segment = new DataSegment(
+        "ds",
+        Intervals.of("2024-01-01/2024-02-01"),
+        "v1",
+        wrapped,
+        List.of("d"),
+        List.of("m"),
+        NoneShardSpec.instance(),
+        IndexIO.CURRENT_VERSION_ID,
+        12345
+    );
+    SegmentChangeRequestLoad announcement = SegmentChangeRequestLoad.forAnnouncement(segment);
+    Assert.assertEquals("v1:abcdef0123456789", announcement.getFingerprint());
+    Assert.assertEquals(Long.valueOf(12345L), announcement.getLoadedBytes());
+  }
+
+  @Test
   public void testOldPayloadDeserializesWithoutPartialFields() throws Exception
   {
     // An old-version payload with no partial-load fields should deserialize cleanly; the partial fields are null.

--- a/server/src/test/java/org/apache/druid/server/coordinator/loading/PartialLoadProfileTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/loading/PartialLoadProfileTest.java
@@ -135,4 +135,31 @@ public class PartialLoadProfileTest
                   .usingGetClass()
                   .verify();
   }
+
+  @Test
+  public void testInterningSharesReferenceForEquivalentProfiles()
+  {
+    // Two semantically-identical forLoaded calls (same wrappedLoadSpec contents, same fingerprint, same loadedBytes)
+    // should resolve to the same instance via the static interner. This is the win that lets multiple replicas of the
+    // same partial load share the heavy wrappedLoadSpec map by reference.
+    Map<String, Object> a = new HashMap<>(WRAPPED);
+    Map<String, Object> b = new HashMap<>(WRAPPED);
+    PartialLoadProfile pa = PartialLoadProfile.forLoaded(a, FINGERPRINT, 12345L);
+    PartialLoadProfile pb = PartialLoadProfile.forLoaded(b, FINGERPRINT, 12345L);
+    Assertions.assertSame(pa, pb);
+
+    // Different loadedBytes ⇒ different profile, no sharing.
+    PartialLoadProfile pc = PartialLoadProfile.forLoaded(WRAPPED, FINGERPRINT, 99999L);
+    Assertions.assertNotSame(pa, pc);
+
+    // Different fingerprint ⇒ different profile, no sharing.
+    PartialLoadProfile pd = PartialLoadProfile.forLoaded(WRAPPED, "v1:differentfingerprint", 12345L);
+    Assertions.assertNotSame(pa, pd);
+
+    // Full-fallback variants intern independently of forLoaded variants.
+    PartialLoadProfile fb1 = PartialLoadProfile.forFullFallback(FINGERPRINT, 12345L);
+    PartialLoadProfile fb2 = PartialLoadProfile.forFullFallback(FINGERPRINT, 12345L);
+    Assertions.assertSame(fb1, fb2);
+    Assertions.assertNotSame(pa, fb1);
+  }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/loading/StrategicSegmentAssignerPartialTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/loading/StrategicSegmentAssignerPartialTest.java
@@ -1,0 +1,485 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.loading;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import org.apache.druid.client.DruidServer;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.segment.TestDataSource;
+import org.apache.druid.server.coordination.ServerType;
+import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
+import org.apache.druid.server.coordinator.DruidCluster;
+import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
+import org.apache.druid.server.coordinator.ServerHolder;
+import org.apache.druid.server.coordinator.balancer.BalancerStrategy;
+import org.apache.druid.server.coordinator.balancer.CostBalancerStrategy;
+import org.apache.druid.server.coordinator.rules.CannotMatchBehavior;
+import org.apache.druid.server.coordinator.rules.ExactProjectionPartialLoadMatcher;
+import org.apache.druid.server.coordinator.rules.ForeverPartialLoadRule;
+import org.apache.druid.server.coordinator.rules.PartialLoadRule;
+import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
+import org.apache.druid.server.coordinator.stats.Stats;
+import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentId;
+import org.apache.druid.timeline.partition.NumberedShardSpec;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Verifies that {@link StrategicSegmentAssigner#replicateSegmentPartially} threads the {@link PartialLoadProfile}
+ * through the load queue and reconciles fingerprint state correctly: matching replicas count toward the requirement,
+ * stale-fingerprint replicas (and full-load replicas under a partial rule) are treated as "loaded but not satisfying"
+ * and follow the load-then-drop swap so the cluster never goes unavailable during reconciliation.
+ */
+public class StrategicSegmentAssignerPartialTest
+{
+  private static final String TIER1 = "tier1";
+  private static final String TIER2 = "tier2";
+
+  private static final String FP_REVENUE = "v1:deadbeefcafebabe";
+  private static final String FP_USERS = "v1:0123456789abcdef";
+
+  private ListeningExecutorService exec;
+  private BalancerStrategy balancerStrategy;
+  private SegmentLoadQueueManager loadQueueManager;
+
+  private final AtomicInteger serverId = new AtomicInteger();
+
+  @Before
+  public void setUp()
+  {
+    exec = MoreExecutors.listeningDecorator(Execs.multiThreaded(1, "StrategicSegmentAssignerPartialTest-%d"));
+    balancerStrategy = new CostBalancerStrategy(exec);
+    loadQueueManager = new SegmentLoadQueueManager(null, null);
+  }
+
+  @After
+  public void tearDown()
+  {
+    exec.shutdown();
+  }
+
+  @Test
+  public void testReplicateSegmentPartiallyAssignsAndThreadsProfileToPeon()
+  {
+    final ServerHolder server = createServer(TIER1);
+    final DruidCluster cluster = DruidCluster.builder().addTier(TIER1, server).build();
+
+    final DataSegment segment = createSegment();
+    final PartialLoadProfile profile = profileForRevenue();
+
+    final DruidCoordinatorRuntimeParams params = makeRuntimeParams(cluster, segment);
+    params.getSegmentAssigner().replicateSegmentPartially(segment, profile, ImmutableMap.of(TIER1, 1));
+
+    Assert.assertEquals(
+        1L,
+        params.getCoordinatorStats().getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER1, segment.getDataSource())
+    );
+    Assert.assertTrue(server.getLoadingSegments().contains(segment));
+    Assert.assertEquals(profile, ((TestLoadQueuePeon) server.getPeon()).getProfileFor(segment));
+  }
+
+  @Test
+  public void testReplicateSegmentPartiallyAssignsAcrossTiers()
+  {
+    final ServerHolder s1 = createServer(TIER1);
+    final ServerHolder s2 = createServer(TIER2);
+    final DruidCluster cluster = DruidCluster.builder().addTier(TIER1, s1).addTier(TIER2, s2).build();
+
+    final DataSegment segment = createSegment();
+    final PartialLoadProfile profile = profileForRevenue();
+
+    final DruidCoordinatorRuntimeParams params = makeRuntimeParams(cluster, segment);
+    params.getSegmentAssigner()
+          .replicateSegmentPartially(segment, profile, ImmutableMap.of(TIER1, 1, TIER2, 1));
+
+    final CoordinatorRunStats stats = params.getCoordinatorStats();
+    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER1, segment.getDataSource()));
+    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER2, segment.getDataSource()));
+    Assert.assertEquals(profile, ((TestLoadQueuePeon) s1.getPeon()).getProfileFor(segment));
+    Assert.assertEquals(profile, ((TestLoadQueuePeon) s2.getPeon()).getProfileFor(segment));
+  }
+
+  @Test
+  public void testNoActionWhenMatchingReplicaAlreadyLoaded()
+  {
+    // s1 has the segment loaded with the matching fingerprint; required = 1. Reconciler should do nothing; no
+    // load queued on s2, no drop on s1.
+    final DataSegment segment = createSegment();
+    final ServerHolder s1 = createServerWithLoaded(TIER1, segment, profileForRevenue());
+    final ServerHolder s2 = createServer(TIER1);
+    final DruidCluster cluster = DruidCluster.builder().addTier(TIER1, s1, s2).build();
+
+    final DruidCoordinatorRuntimeParams params = makeRuntimeParams(cluster, segment);
+    params.getSegmentAssigner()
+          .replicateSegmentPartially(segment, profileForRevenue(), ImmutableMap.of(TIER1, 1));
+
+    final CoordinatorRunStats stats = params.getCoordinatorStats();
+    Assert.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_ASSIGNED));
+    Assert.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_STALE_DROPPED));
+    Assert.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
+    Assert.assertTrue(s2.getLoadingSegments().isEmpty());
+    Assert.assertTrue(s1.getPeon().getSegmentsToDrop().isEmpty());
+  }
+
+  @Test
+  public void testFullFallbackProfileCountsAsMatching()
+  {
+    // s1 announced with a full-fallback profile (historical was asked to partial-load but fell back to full). The
+    // fingerprint matches the rule, so the rule is satisfied; no further action.
+    final DataSegment segment = createSegment();
+    final PartialLoadProfile fullFallback = PartialLoadProfile.forFullFallback(FP_REVENUE, 1024L);
+    final ServerHolder s1 = createServerWithLoaded(TIER1, segment, fullFallback);
+    final ServerHolder s2 = createServer(TIER1);
+    final DruidCluster cluster = DruidCluster.builder().addTier(TIER1, s1, s2).build();
+
+    final DruidCoordinatorRuntimeParams params = makeRuntimeParams(cluster, segment);
+    params.getSegmentAssigner()
+          .replicateSegmentPartially(segment, profileForRevenue(), ImmutableMap.of(TIER1, 1));
+
+    Assert.assertFalse(params.getCoordinatorStats().hasStat(Stats.Segments.PARTIAL_ASSIGNED));
+    Assert.assertTrue(s2.getLoadingSegments().isEmpty());
+  }
+
+  @Test
+  public void testFullLoadReplicaTreatedAsStaleAgainstPartialRule()
+  {
+    // s1 holds the segment as a regular full-load (no profile). Under a partial rule it counts as stale: queue a
+    // fresh load to satisfy the partial rule, but don't drop s1 yet; stale stays serving until the matching load
+    // completes. Note: s1 is also reload-eligible (additive), but because s2 is empty, s2 is preferred.
+    final DataSegment segment = createSegment();
+    final ServerHolder s1 = createServerWithLoaded(TIER1, segment, null);
+    final ServerHolder s2 = createServer(TIER1);
+    final DruidCluster cluster = DruidCluster.builder().addTier(TIER1, s1, s2).build();
+
+    final DruidCoordinatorRuntimeParams params = makeRuntimeParams(cluster, segment);
+    params.getSegmentAssigner()
+          .replicateSegmentPartially(segment, profileForRevenue(), ImmutableMap.of(TIER1, 1));
+
+    final CoordinatorRunStats stats = params.getCoordinatorStats();
+    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER1, segment.getDataSource()));
+    Assert.assertFalse(
+        "Stale must not be dropped before matching has actually loaded",
+        stats.hasStat(Stats.Segments.PARTIAL_STALE_DROPPED)
+    );
+    Assert.assertTrue(s2.getLoadingSegments().contains(segment));
+    Assert.assertEquals(profileForRevenue(), ((TestLoadQueuePeon) s2.getPeon()).getProfileFor(segment));
+    Assert.assertTrue(s1.getPeon().getSegmentsToDrop().isEmpty());
+  }
+
+  @Test
+  public void testStaleDroppedAfterMatchingLoadedSatisfiesRequirement()
+  {
+    // s1 has matching fingerprint already loaded (sufficient to satisfy required=1). s2 holds the segment as
+    // full-load (stale). Reconciler should drop s2 in this run because s1's matching count already covers the
+    // requirement.
+    final DataSegment segment = createSegment();
+    final ServerHolder s1 = createServerWithLoaded(TIER1, segment, profileForRevenue());
+    final ServerHolder s2 = createServerWithLoaded(TIER1, segment, null);
+    final DruidCluster cluster = DruidCluster.builder().addTier(TIER1, s1, s2).build();
+
+    final DruidCoordinatorRuntimeParams params = makeRuntimeParams(cluster, segment);
+    params.getSegmentAssigner()
+          .replicateSegmentPartially(segment, profileForRevenue(), ImmutableMap.of(TIER1, 1));
+
+    final CoordinatorRunStats stats = params.getCoordinatorStats();
+    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.PARTIAL_STALE_DROPPED, TIER1, segment.getDataSource()));
+    Assert.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_ASSIGNED));
+    Assert.assertTrue(s2.getPeon().getSegmentsToDrop().contains(segment));
+    Assert.assertTrue(s1.getPeon().getSegmentsToDrop().isEmpty());
+  }
+
+  @Test
+  public void testStuckStateAdditiveReloadOnStaleServers()
+  {
+    // Both servers hold the segment with mismatched fingerprints (and there are no spare servers). Reconciler
+    // queues additive-reload requests on both stale servers; the historical's additive-load semantics fill in the
+    // missing parts in place. matching count is still 0 in the same run, so stale isn't dropped; but next run, after
+    // the loads land, the servers reclassify as matching.
+    final DataSegment segment = createSegment();
+    final PartialLoadProfile usersProfile = PartialLoadProfile.forLoaded(
+        Map.of("type", "partialProjection", "projections", List.of("users"), "fingerprint", FP_USERS),
+        FP_USERS,
+        512L
+    );
+    final ServerHolder s1 = createServerWithLoaded(TIER1, segment, usersProfile);
+    final ServerHolder s2 = createServerWithLoaded(TIER1, segment, usersProfile);
+    final DruidCluster cluster = DruidCluster.builder().addTier(TIER1, s1, s2).build();
+
+    final DruidCoordinatorRuntimeParams params = makeRuntimeParams(cluster, segment);
+    params.getSegmentAssigner()
+          .replicateSegmentPartially(segment, profileForRevenue(), ImmutableMap.of(TIER1, 2));
+
+    final CoordinatorRunStats stats = params.getCoordinatorStats();
+    Assert.assertEquals(2L, stats.getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER1, segment.getDataSource()));
+    Assert.assertEquals(profileForRevenue(), ((TestLoadQueuePeon) s1.getPeon()).getProfileFor(segment));
+    Assert.assertEquals(profileForRevenue(), ((TestLoadQueuePeon) s2.getPeon()).getProfileFor(segment));
+    // Stale must NOT be dropped; matching hasn't loaded yet.
+    Assert.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_STALE_DROPPED));
+  }
+
+  @Test
+  public void testDropsExcessMatchingReplicas()
+  {
+    // 2 matching replicas, required = 1. Reconciler drops the excess matching using the regular DROPPED stat (this
+    // is the surplus path, not the stale path).
+    final DataSegment segment = createSegment();
+    final ServerHolder s1 = createServerWithLoaded(TIER1, segment, profileForRevenue());
+    final ServerHolder s2 = createServerWithLoaded(TIER1, segment, profileForRevenue());
+    final DruidCluster cluster = DruidCluster.builder().addTier(TIER1, s1, s2).build();
+
+    final DruidCoordinatorRuntimeParams params = makeRuntimeParams(cluster, segment);
+    params.getSegmentAssigner()
+          .replicateSegmentPartially(segment, profileForRevenue(), ImmutableMap.of(TIER1, 1));
+
+    final CoordinatorRunStats stats = params.getCoordinatorStats();
+    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.DROPPED, TIER1, segment.getDataSource()));
+    Assert.assertEquals(
+        1,
+        s1.getPeon().getSegmentsToDrop().size() + s2.getPeon().getSegmentsToDrop().size()
+    );
+  }
+
+  @Test
+  public void testReplicateSegmentPartiallySkipsDecommissioningServer()
+  {
+    // Decommissioning server must not be picked as a load destination, just like the regular full-load path.
+    final ServerHolder decommServer = createDecommissioningServer(TIER1);
+    final ServerHolder activeServer = createServer(TIER1);
+    final DruidCluster cluster = DruidCluster.builder().addTier(TIER1, decommServer, activeServer).build();
+
+    final DataSegment segment = createSegment();
+    final PartialLoadProfile profile = profileForRevenue();
+
+    final DruidCoordinatorRuntimeParams params = makeRuntimeParams(cluster, segment);
+    params.getSegmentAssigner().replicateSegmentPartially(segment, profile, ImmutableMap.of(TIER1, 1));
+
+    Assert.assertEquals(
+        1L,
+        params.getCoordinatorStats().getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER1, segment.getDataSource())
+    );
+    Assert.assertTrue(decommServer.getLoadingSegments().isEmpty());
+    Assert.assertTrue(activeServer.getLoadingSegments().contains(segment));
+    Assert.assertEquals(profile, ((TestLoadQueuePeon) activeServer.getPeon()).getProfileFor(segment));
+    Assert.assertNull(((TestLoadQueuePeon) decommServer.getPeon()).getProfileFor(segment));
+  }
+
+  @Test
+  public void testStaleInFlightCancelledAndReplaced()
+  {
+    // s1 has a stale-fingerprint load already in-flight (from a previous coordinator run with a different rule).
+    // The current rule wants the revenue fingerprint. Reconciler cancels the stale in-flight on s1 and queues a
+    // matching load (additive; same server, same slot).
+    final DataSegment segment = createSegment();
+    final PartialLoadProfile staleInFlightProfile = PartialLoadProfile.forRequest(
+        Map.of(
+            "type", "partialProjection",
+            "projections", List.of("users"),
+            "fingerprint", FP_USERS
+        ),
+        FP_USERS
+    );
+    final TestLoadQueuePeon peon = new TestLoadQueuePeon();
+    // Pre-seed the peon with an in-flight stale load; simulates a previous coordinator run that queued the load
+    // before the rule changed.
+    peon.addInFlightHolder(new SegmentHolder(
+        segment,
+        SegmentAction.LOAD,
+        staleInFlightProfile,
+        org.joda.time.Duration.standardSeconds(10),
+        null
+    ));
+    final DruidServer druidServer = createDruidServer(TIER1);
+    final ServerHolder s1 = new ServerHolder(druidServer.toImmutableDruidServer(), peon);
+    final DruidCluster cluster = DruidCluster.builder().addTier(TIER1, s1).build();
+
+    final DruidCoordinatorRuntimeParams params = makeRuntimeParams(cluster, segment);
+    params.getSegmentAssigner()
+          .replicateSegmentPartially(segment, profileForRevenue(), ImmutableMap.of(TIER1, 1));
+
+    final CoordinatorRunStats stats = params.getCoordinatorStats();
+    Assert.assertEquals(
+        1L,
+        stats.getSegmentStat(Stats.Segments.PARTIAL_STALE_CANCELLED, TIER1, segment.getDataSource())
+    );
+    Assert.assertEquals(
+        1L,
+        stats.getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER1, segment.getDataSource())
+    );
+    Assert.assertEquals(profileForRevenue(), peon.getProfileFor(segment));
+  }
+
+  @Test
+  public void testForeverPartialLoadRuleEndToEndThreadsProfile()
+  {
+    // Run the full rule.run() → assigner.replicateSegmentPartially() → peon path with a real matcher that resolves
+    // to a wrapped projection load spec on a segment carrying the matching projection.
+    final ServerHolder server = createServer(TIER1);
+    final DruidCluster cluster = DruidCluster.builder().addTier(TIER1, server).build();
+
+    final DataSegment segment = segmentWithProjections(List.of("revenue", "users"));
+    final PartialLoadRule rule = new ForeverPartialLoadRule(
+        ImmutableMap.of(TIER1, 1),
+        null,
+        new ExactProjectionPartialLoadMatcher(List.of("revenue")),
+        null
+    );
+
+    final DruidCoordinatorRuntimeParams params = makeRuntimeParams(cluster, segment);
+    rule.run(segment, params.getSegmentAssigner());
+
+    Assert.assertEquals(
+        1L,
+        params.getCoordinatorStats().getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER1, segment.getDataSource())
+    );
+    final PartialLoadProfile profile = ((TestLoadQueuePeon) server.getPeon()).getProfileFor(segment);
+    Assert.assertNotNull("Matcher matched, profile should be threaded", profile);
+    Assert.assertEquals("partialProjection", profile.wrappedLoadSpec().get("type"));
+    Assert.assertEquals(List.of("revenue"), profile.wrappedLoadSpec().get("projections"));
+    Assert.assertTrue(profile.fingerprint().startsWith("v1:"));
+    Assert.assertNull("Outbound request profile should not carry loadedBytes", profile.loadedBytes());
+  }
+
+  @Test
+  public void testForeverPartialLoadRuleEndToEndFullLoadFallback()
+  {
+    // Matcher does not apply (segment has no overlap); FULL_LOAD onCannotMatch (default) → run() routes through
+    // replicateSegment instead, so the peon must not see a profile and the stat is the regular ASSIGNED.
+    final ServerHolder server = createServer(TIER1);
+    final DruidCluster cluster = DruidCluster.builder().addTier(TIER1, server).build();
+
+    final DataSegment segment = segmentWithProjections(List.of("users"));
+    final PartialLoadRule rule = new ForeverPartialLoadRule(
+        ImmutableMap.of(TIER1, 1),
+        null,
+        new ExactProjectionPartialLoadMatcher(List.of("nonexistent")),
+        CannotMatchBehavior.FULL_LOAD
+    );
+
+    final DruidCoordinatorRuntimeParams params = makeRuntimeParams(cluster, segment);
+    rule.run(segment, params.getSegmentAssigner());
+
+    Assert.assertEquals(
+        1L,
+        params.getCoordinatorStats().getSegmentStat(Stats.Segments.ASSIGNED, TIER1, segment.getDataSource())
+    );
+    Assert.assertTrue(server.getLoadingSegments().contains(segment));
+    Assert.assertNull(
+        "Full-load fallback must not thread a profile to the peon",
+        ((TestLoadQueuePeon) server.getPeon()).getProfileFor(segment)
+    );
+  }
+
+  private DruidCoordinatorRuntimeParams makeRuntimeParams(DruidCluster cluster, DataSegment... segments)
+  {
+    return DruidCoordinatorRuntimeParams
+        .builder()
+        .withDruidCluster(cluster)
+        .withBalancerStrategy(balancerStrategy)
+        .withUsedSegments(segments)
+        .withDynamicConfigs(
+            CoordinatorDynamicConfig.builder()
+                                    .withSmartSegmentLoading(false)
+                                    .withUseRoundRobinSegmentAssignment(false)
+                                    .build()
+        )
+        .withSegmentAssignerUsing(loadQueueManager)
+        .build();
+  }
+
+  private DruidServer createDruidServer(String tier)
+  {
+    final String serverName = "hist_" + tier + "_" + serverId.incrementAndGet();
+    return new DruidServer(serverName, serverName, null, 10L << 30, null, ServerType.HISTORICAL, tier, 0);
+  }
+
+  private ServerHolder createServer(String tier, DataSegment... segments)
+  {
+    final DruidServer server = createDruidServer(tier);
+    for (DataSegment segment : segments) {
+      server.addDataSegment(segment);
+    }
+    return new ServerHolder(server.toImmutableDruidServer(), new TestLoadQueuePeon());
+  }
+
+  /**
+   * Creates a server that already serves the given segment. If {@code profile} is non-null, the segment is announced
+   * with that partial-load profile attached (matching/stale/full-fallback depending on the test's needs); if
+   * {@code profile} is null, the segment is loaded as a regular full-load.
+   */
+  private ServerHolder createServerWithLoaded(String tier, DataSegment segment, @Nullable PartialLoadProfile profile)
+  {
+    final DruidServer server = createDruidServer(tier);
+    server.addDataSegment(segment, profile);
+    return new ServerHolder(server.toImmutableDruidServer(), new TestLoadQueuePeon());
+  }
+
+  private ServerHolder createDecommissioningServer(String tier)
+  {
+    return new ServerHolder(createDruidServer(tier).toImmutableDruidServer(), new TestLoadQueuePeon(), true);
+  }
+
+  private static DataSegment createSegment()
+  {
+    return DataSegment
+        .builder(SegmentId.of(TestDataSource.WIKI, Intervals.of("2024/2025"), DateTimes.nowUtc().toString(), null))
+        .loadSpec(Map.of("type", "local", "path", "/var/druid/segments/foo"))
+        .dimensions(Collections.emptyList())
+        .metrics(Collections.emptyList())
+        .size(0)
+        .build();
+  }
+
+  private static DataSegment segmentWithProjections(List<String> projections)
+  {
+    return DataSegment
+        .builder(SegmentId.of(TestDataSource.WIKI, Intervals.of("2024/2025"), DateTimes.nowUtc().toString(),
+                              new NumberedShardSpec(0, 0)))
+        .loadSpec(Map.of("type", "local", "path", "/var/druid/segments/foo"))
+        .projections(projections)
+        .size(0)
+        .build();
+  }
+
+  private static PartialLoadProfile profileForRevenue()
+  {
+    return PartialLoadProfile.forRequest(
+        Map.of(
+            "type", "partialProjection",
+            "delegate", Map.of("type", "local", "path", "/var/druid/segments/foo"),
+            "projections", List.of("revenue"),
+            "fingerprint", FP_REVENUE
+        ),
+        FP_REVENUE
+    );
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/coordinator/loading/TestLoadQueuePeon.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/loading/TestLoadQueuePeon.java
@@ -24,7 +24,10 @@ import org.apache.druid.timeline.DataSegment;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 
 /**
@@ -35,13 +38,53 @@ public class TestLoadQueuePeon implements LoadQueuePeon
 {
   private final ConcurrentSkipListSet<DataSegment> segmentsToLoad = new ConcurrentSkipListSet<>();
   private final ConcurrentSkipListSet<DataSegment> segmentsToDrop = new ConcurrentSkipListSet<>();
+  private final ConcurrentHashMap<DataSegment, PartialLoadProfile> segmentToProfile = new ConcurrentHashMap<>();
+  private final ConcurrentSkipListSet<SegmentHolder> queuedHolders = new ConcurrentSkipListSet<>();
 
   private final CoordinatorRunStats stats = new CoordinatorRunStats();
+
+  /**
+   * Adds a {@link SegmentHolder} to the in-flight queue as if a previous coordinator run had queued the load. Tests
+   * use this to simulate pre-existing in-flight loads (e.g., stale-fingerprint loads from a prior run) so the
+   * reconciler can observe and act on them.
+   */
+  public void addInFlightHolder(SegmentHolder holder)
+  {
+    queuedHolders.add(holder);
+    segmentsToLoad.add(holder.getSegment());
+    if (holder.getProfile() != null) {
+      segmentToProfile.put(holder.getSegment(), holder.getProfile());
+    }
+  }
 
   @Override
   public void loadSegment(DataSegment segment, SegmentAction action, @Nullable LoadPeonCallback callback)
   {
     segmentsToLoad.add(segment);
+  }
+
+  @Override
+  public void loadSegment(
+      DataSegment segment,
+      SegmentAction action,
+      @Nullable PartialLoadProfile profile,
+      @Nullable LoadPeonCallback callback
+  )
+  {
+    segmentsToLoad.add(segment);
+    if (profile != null) {
+      segmentToProfile.put(segment, profile);
+    }
+  }
+
+  /**
+   * Returns the {@link PartialLoadProfile} that was passed alongside the load request for the given segment, or
+   * {@code null} if the segment was loaded as a regular full-load (no profile threaded).
+   */
+  @Nullable
+  public PartialLoadProfile getProfileFor(DataSegment segment)
+  {
+    return segmentToProfile.get(segment);
   }
 
   @Override
@@ -71,7 +114,11 @@ public class TestLoadQueuePeon implements LoadQueuePeon
   @Override
   public boolean cancelOperation(DataSegment segment)
   {
-    return false;
+    final boolean removedFromLoad = segmentsToLoad.remove(segment);
+    final boolean removedFromDrop = segmentsToDrop.remove(segment);
+    queuedHolders.removeIf(h -> h.getSegment().equals(segment));
+    segmentToProfile.remove(segment);
+    return removedFromLoad || removedFromDrop;
   }
 
   @Override
@@ -95,7 +142,7 @@ public class TestLoadQueuePeon implements LoadQueuePeon
   @Override
   public Set<SegmentHolder> getSegmentsInQueue()
   {
-    return Collections.emptySet();
+    return queuedHolders;
   }
 
   @Override

--- a/server/src/test/java/org/apache/druid/server/coordinator/loading/TestLoadQueuePeon.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/loading/TestLoadQueuePeon.java
@@ -24,8 +24,6 @@ import org.apache.druid.timeline.DataSegment;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;

--- a/server/src/test/java/org/apache/druid/server/http/SegmentLoadingCapabilitiesTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/SegmentLoadingCapabilitiesTest.java
@@ -50,31 +50,4 @@ public class SegmentLoadingCapabilitiesTest
     Assert.assertEquals(5, reread.getNumTurboLoadingThreads());
   }
 
-  @Test
-  public void testTwoArgConstructorDefaultsPartialLoadToFalse()
-  {
-    SegmentLoadingCapabilities capabilities = new SegmentLoadingCapabilities(1, 4);
-    Assert.assertFalse(capabilities.isSupportsPartialLoad());
-  }
-
-  @Test
-  public void testSerdeWithPartialLoadTrue() throws Exception
-  {
-    SegmentLoadingCapabilities capabilities = new SegmentLoadingCapabilities(1, 4, true);
-    SegmentLoadingCapabilities reread = jsonMapper.readValue(
-        jsonMapper.writeValueAsString(capabilities),
-        SegmentLoadingCapabilities.class
-    );
-    Assert.assertTrue(reread.isSupportsPartialLoad());
-  }
-
-  @Test
-  public void testOldPayloadDeserializesWithPartialLoadFalse() throws JsonProcessingException
-  {
-    // An older historical that doesn't include the new field should deserialize cleanly with the field defaulting to
-    // false. The coordinator then conservatively avoids sending wrapped LoadSpecs to that historical.
-    String json = "{\"numLoadingThreads\":3,\"numTurboLoadingThreads\":5}";
-    SegmentLoadingCapabilities reread = jsonMapper.readValue(json, SegmentLoadingCapabilities.class);
-    Assert.assertFalse(reread.isSupportsPartialLoad());
-  }
 }


### PR DESCRIPTION
### Description
Follow-up to #19409, this PR enhances the coordintor side stuff so that partial replication is wired up and managed, taking the partial load size and rule fingerprints into consideration when doing assignment and balancing. A lot of the new code is similar to existing functionality of `StrategicSegmentAssigner`, but separate to minimize the chance of impacting existing code paths.

changes:
* adds selective inventory wrapping with `DataSegmentAndLoadProfile` which extends `DataSegment`; full-load slots in `DruidDataSource` / `ImmutableDruidDataSource` stay bare, only partial-loaded slots allocate a wrapper
* `PartialLoadProfile` records routed through a weak interner so identical profiles across replicas share by reference (the `wrappedLoadSpec` map is the bulk of per-replica heap).
* `SegmentChangeRequestLoad.forAnnouncement(segment)` detects a `partialProjection` wrapper on the segment's load spec and stamps the wrapper's fingerprint plus full segment size as `loadedBytes`; the coordinator reads this as a full-fallback profile, so partial-load rules work end-to-end (modulo no real partial loading yet) without thrashing
* `BatchDataSegmentAnnouncer` calls new method `forAnnouncement` on all three announcement paths to create the proper announcement depending on partial load profile
* fingerprint-aware partial reconciler in `StrategicSegmentAssigner`; classifies replicas (matching/stale, loaded/in-flight) via new `PartialSegmentStatusInTier`, applies the load-then-drop swap (stale stays serving until matching has actually loaded), cancels stale in-flight loads and re-targets the freed slots, allows additive reload on stale-loaded servers to mitigate the no-spare-server stuck state
* `ImmutableDruidServer.getPartialLoadProfile`, `DruidServer.addDataSegment(segment, profile)` with `loadedBytes`-aware `currSize` accounting, `HttpServerInventoryView` threads announcement-side profile through
* in-flight profile tracking on `ServerHolder.startOperation(action, segment, profile)` and `SegmentHolder.getProfile()` so the reconciler can read in-flight fingerprints.
* new coordinator stats - `PARTIAL_ASSIGNED`, `PARTIAL_STALE_DROPPED`, `PARTIAL_STALE_CANCELLED`
* removed `SegmentLoadingCapabilities.supportsPartialLoad` (now unused; per-replica `isFullFallback` is the better signal); coordinator always issues partial-load requests, historical handles via full-fallback until real partial loading lands
* tests: `StrategicSegmentAssignerPartialTest` (reconciler scenarios), `DruidServerPartialLoadTest` (size accounting), `PartialLoadProfileTest` (interning), `SegmentChangeRequestLoadTest` (forAnnouncement), updates across affected fixtures