### PR TITLE
ci: pre-pull Testcontainers images in worker before unit tests (#19464)

### DIFF
--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -86,6 +86,21 @@ jobs:
           echo "HASH=$(echo -n "${{ inputs.key }}" | sha256sum | cut -c-8)" >> $GITHUB_ENV
           ./.github/scripts/collect_jvm_diagnostics &
 
+      - name: Pre-pull Testcontainers images for unit tests
+        if: ${{ contains(inputs.script, 'run_unit-tests') }}
+        run: |
+          set -eu
+          for image in apache/kafka:4.2.0 postgres:16-alpine minio/minio:latest; do
+            for attempt in 1 2 3; do
+              if docker pull --quiet "$image"; then
+                break
+              fi
+              echo "::warning ::docker pull $image failed (attempt $attempt); retrying in 10s"
+              sleep 10
+            done
+          done
+        timeout-minutes: 5
+
       - name: 'Execute: ${{ inputs.script }}'
         run: ${{ inputs.script }}
         timeout-minutes: 60

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -90,7 +90,18 @@ jobs:
         if: ${{ contains(inputs.script, 'run_unit-tests') }}
         run: |
           set -eu
-          for image in apache/kafka:4.2.0 postgres:16-alpine minio/minio:latest; do
+          images=(
+            apache/kafka:4.2.0
+            postgres:16-alpine
+            minio/minio:latest
+            hashicorp/consul:1.18
+            tabulario/iceberg-rest:1.6.0
+            localstack/localstack:4.13.1
+            mcr.microsoft.com/azure-storage/azurite:3.35.0
+            osixia/openldap:1.5.0
+            rancher/k3s:v1.35.0-k3s1
+          )
+          for image in "${images[@]}"; do
             for attempt in 1 2 3; do
               if docker pull --quiet "$image"; then
                 break
@@ -99,7 +110,7 @@ jobs:
               sleep 10
             done
           done
-        timeout-minutes: 5
+        timeout-minutes: 10
 
       - name: 'Execute: ${{ inputs.script }}'
         run: ${{ inputs.script }}


### PR DESCRIPTION


Fixes https://github.com/apache/druid/issues/19464.



### Description
Once the image is in the runner's local Docker daemon cache, KafkaContainer start in KafkaResource becomes a pure container-spinup (~5-15 s) instead of pull+spinup (~30-90 s + Docker Hub variance). The 60 s LatchableEmitter wall now has 4-12× more headroom.

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.