### PR TITLE
fix: Centralise iceberg.core.version in root pom and align embedded-tests on 1.10.0

### DIFF
--- a/embedded-tests/pom.xml
+++ b/embedded-tests/pom.xml
@@ -29,8 +29,6 @@
 
   <properties>
     <surefire.rerunFailingTestsCount>0</surefire.rerunFailingTestsCount>
-    <!-- Must match iceberg.core.version in extensions-contrib/druid-iceberg-extensions/pom.xml -->
-    <iceberg.version>1.7.2</iceberg.version>
   </properties>
 
   <parent>
@@ -418,13 +416,13 @@
     <dependency>
       <groupId>org.apache.iceberg</groupId>
       <artifactId>iceberg-api</artifactId>
-      <version>${iceberg.version}</version>
+      <version>${iceberg.core.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.iceberg</groupId>
       <artifactId>iceberg-core</artifactId>
-      <version>${iceberg.version}</version>
+      <version>${iceberg.core.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -436,7 +434,7 @@
     <dependency>
       <groupId>org.apache.iceberg</groupId>
       <artifactId>iceberg-parquet</artifactId>
-      <version>${iceberg.version}</version>
+      <version>${iceberg.core.version}</version>
       <scope>test</scope>
       <exclusions>
         <!-- Let parquet version be driven by druid-parquet-extensions (${parquet.version}) -->

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/iceberg/IcebergRestCatalogIngestionTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/iceberg/IcebergRestCatalogIngestionTest.java
@@ -109,7 +109,7 @@ public class IcebergRestCatalogIngestionTest extends EmbeddedClusterTestBase
     final DataWriter<GenericRecord> writer;
     try (DataWriter<GenericRecord> w = Parquet.writeData(file)
                                               .schema(ICEBERG_SCHEMA)
-                                              .createWriterFunc(GenericParquetWriter::buildWriter)
+                                              .createWriterFunc(GenericParquetWriter::create)
                                               .overwrite()
                                               .withSpec(table.spec())
                                               .build()) {

--- a/extensions-contrib/druid-iceberg-extensions/pom.xml
+++ b/extensions-contrib/druid-iceberg-extensions/pom.xml
@@ -35,7 +35,6 @@
   <modelVersion>4.0.0</modelVersion>
 
   <properties>
-    <iceberg.core.version>1.10.0</iceberg.core.version>
     <hive.version>3.1.3</hive.version>
   </properties>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
         <guava.version>32.1.3-jre</guava.version>
         <guice.version>6.0.0</guice.version>
         <hamcrest.version>2.2</hamcrest.version>
+        <iceberg.core.version>1.10.0</iceberg.core.version>
         <jetty.version>12.1.8</jetty.version>
         <jersey.version>1.19.4</jersey.version>
         <jackson.version>2.20.2</jackson.version>


### PR DESCRIPTION
Fixes https://github.com/apache/druid/issues/19469


### Description

Centralise iceberg.core.version in root pom and align embedded-tests on 1.10.0
GenericParquetWriter.buildWriter() was removed in Iceberg 1.10.0 in favour of create().

#### Release note

Centralise iceberg.core.version in root pom and align embedded-tests on 1.10.0

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.