### PR TITLE
fix: web console services card missing broker count without SQL

### DIFF
--- a/web-console/src/views/home-view/services-card/services-card.tsx
+++ b/web-console/src/views/home-view/services-card/services-card.tsx
@@ -67,6 +67,7 @@ export const ServicesCard = React.memo(function ServicesCard(props: ServicesCard
           : [];
 
         return {
+          broker: services.filter((s: any) => s.type === 'broker').length,
           historical: services.filter((s: any) => s.type === 'historical').length,
           middle_manager: middleManager.length,
           peon: services.filter((s: any) => s.type === 'indexer-executor').length,


### PR DESCRIPTION
### Description

The home dashboard's Services card has two code paths. The SQL path queries `sys.servers` (discovery-backed, so every
 node role is reported), while the coordinator-only fallback only counted `historical`, `middle_manager`, and `peon`.
 `/druid/coordinator/v1/servers?simple` does return brokers as well (brokers are tracked by
`InventoryView`/`ServerType.BROKER`), but they were dropped before being passed to the card, so non-SQL deployments
showed no broker count even when brokers were present.

This change adds the broker count to the fallback so its output matches the SQL path.

The other roles missing from the fallback (`coordinator`, `overlord`, `router`, `indexer`, `middle_manager` vs
`indexer-executor` distinction) cannot be derived from `/druid/coordinator/v1/servers?simple` and would require
additional endpoints; they are intentionally left out of this change.

#### Release note

The home view's Services card now correctly shows the broker count on clusters where the web console is talking to
the coordinator without SQL access.

##### Key changed/added classes in this PR
- `web-console/src/views/home-view/services-card/services-card.tsx`

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors. *(N/A — UI count fix, no user-facing docs)*
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. *(N/A — TypeScript)*
- [x] added or updated version, license, or notice information in
[licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml) *(N/A — no dependency change)*
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar
reader. *(N/A — one-line change)*
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code
coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met. *(no new test —
existing snapshot test covers the SQL path; the fallback path is a one-line filter mirroring an existing line)*
- [x] added integration tests. *(N/A)*
- [x] been tested in a test Druid cluster. *(local `npm run typecheck` / `npm run jest` / `npm run eslint` / `npm run
 prettify-check` all pass)*