### PR TITLE
fix: web console services card omits most service types without SQL

### DIFF
--- a/web-console/src/views/home-view/services-card/services-card.tsx
+++ b/web-console/src/views/home-view/services-card/services-card.tsx
@@ -22,6 +22,7 @@ import { PluralPairIfNeeded } from '../../../components';
 import { getConsoleViewIcon } from '../../../druid-models';
 import type { Capabilities } from '../../../helpers';
 import { useQueryManager } from '../../../hooks';
+import { Api } from '../../../singletons';
 import { getApiArray, lookupBy, queryDruidSql } from '../../../utils';
 import { HomeViewCard } from '../home-view-card/home-view-card';
 
@@ -60,16 +61,25 @@ export const ServicesCard = React.memo(function ServicesCard(props: ServicesCard
           x => x.count,
         );
       } else if (capabilities.hasCoordinatorAccess()) {
-        const services = await getApiArray('/druid/coordinator/v1/servers?simple', signal);
-
-        const middleManager = capabilities.hasOverlordAccess()
-          ? await getApiArray('/druid/indexer/v1/workers', signal)
-          : [];
+        // /druid/coordinator/v1/cluster is discovery-backed and reports every node role
+        // (the same source sys.servers uses), so the fallback matches the SQL branch.
+        // /druid/coordinator/v1/servers?simple is segment-inventory-backed and only sees
+        // historical, indexer-executor (peon), and any broker that holds broadcast segments,
+        // so it is only used here to surface the peon count, which the cluster endpoint
+        // does not return.
+        const clusterResp = await Api.instance.get('/druid/coordinator/v1/cluster', { signal });
+        const cluster: Record<string, unknown[]> = clusterResp.data || {};
+        const segmentServers = await getApiArray('/druid/coordinator/v1/servers?simple', signal);
 
         return {
-          historical: services.filter((s: any) => s.type === 'historical').length,
-          middle_manager: middleManager.length,
-          peon: services.filter((s: any) => s.type === 'indexer-executor').length,
+          coordinator: (cluster.coordinator || []).length,
+          overlord: (cluster.overlord || []).length,
+          router: (cluster.router || []).length,
+          broker: (cluster.broker || []).length,
+          historical: (cluster.historical || []).length,
+          middle_manager: (cluster.middleManager || []).length,
+          indexer: (cluster.indexer || []).length,
+          peon: segmentServers.filter((s: any) => s.type === 'indexer-executor').length,
         };
       } else {
         throw new Error(`must have SQL or coordinator access`);


### PR DESCRIPTION
### Description

The home dashboard's Services card has two code paths. The SQL path counts every node role via `sys.servers`, while the coordinator-only fallback was calling `/druid/coordinator/v1/servers?simple` — an inventory-backed endpoint that only reports segment-loading servers (historical, peon, and brokers that hold broadcast segments). As a result, on clusters where the console talks to the coordinator without SQL, **overlord, coordinator, router, broker, and indexer counts were silently dropped from the card**, making the cluster look smaller than it actually is.

This change switches the fallback to `/druid/coordinator/v1/cluster`, which is backed by `DruidNodeDiscoveryProvider` — the same discovery source `sys.servers` exposes — so it reports every node role. The `/servers?simple` call is kept just to surface the peon count, which the cluster endpoint does not return.

As a side effect, the `/druid/indexer/v1/workers` call (and the `hasOverlordAccess()` requirement that gated it) is no longer needed: `middle_manager` now comes from the cluster endpoint.

#### Verified on a Druid 30.0.0 cluster (SQL branch disabled in the console)

The cluster has 1 overlord, 1 coordinator, 1 router, 1 broker, 2 historicals, 2 middle managers, and 1 peon.

| Before | After |
| :---: | :---: |
| coordinator fallback drops overlord/coordinator/router/broker | fallback now matches the SQL branch output |
| <img width="246" height="165" alt="before" src="https://github.com/user-attachments/assets/8c072c3d-34ec-4e74-9d18-250b95c64f54" /> | <img width="244" height="164" alt="after" src="https://github.com/user-attachments/assets/0a8494e1-5e46-44d1-b1c7-e657c491b7b8" /> |

#### Release note

The home view's Services card now correctly reports overlord, coordinator, router, broker, and indexer counts on clusters where the web console talks to the coordinator without SQL access.

##### Key changed/added classes in this PR
- `web-console/src/views/home-view/services-card/services-card.tsx`

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors. *(N/A — UI count fix, no user-facing docs)*
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. *(N/A — TypeScript)*
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml) *(N/A — no dependency change)*
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met. *(existing snapshot test still passes; fallback code path is gated on capabilities and exercised manually)*
- [x] added integration tests. *(N/A)*
- [x] been tested in a test Druid cluster. *(verified locally against a Druid 30.0.0 cluster with the SQL branch disabled in the console; see screenshots)*
