### PR TITLE
perf: Optimize HLL sketch merge by avoiding unnecessary HLL_8 to HLL_4 conversion

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/DataSketchesHllBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/DataSketchesHllBenchmark.java
@@ -20,8 +20,10 @@
 package org.apache.druid.benchmark;
 
 import org.apache.datasketches.hll.HllSketch;
+import org.apache.datasketches.hll.Union;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.BufferAggregator;
+import org.apache.druid.query.aggregation.datasketches.hll.HllSketchHolder;
 import org.apache.druid.query.aggregation.datasketches.hll.HllSketchMergeAggregatorFactory;
 import org.apache.druid.query.dimension.DimensionSpec;
 import org.apache.druid.segment.ColumnSelectorFactory;
@@ -121,5 +123,34 @@ public class DataSketchesHllBenchmark
   {
     aggregator.init(buf, 0);
     return aggregatorFactory.deserialize(((HllSketch) aggregator.get(buf, 0)).toCompactByteArray());
+  }
+
+  @Benchmark
+  public HllSketchHolder mergeUnionHolders()
+  {
+    final int lgK = 12;
+    final int numValue = (1 << lgK) * 8;
+
+    HllSketch s1 = new HllSketch(lgK);
+    HllSketch s2 = new HllSketch(lgK);
+    for (int i = 0; i < numValue; i++) {
+      s1.update(i);
+      s2.update(numValue + i);
+    }
+    byte[] mergeSketchBytes1 = s1.toCompactByteArray();
+    byte[] mergeSketchBytes2 = s2.toCompactByteArray();
+
+    HllSketchHolder mergeHolder1;
+    HllSketchHolder mergeHolder2;
+
+    Union u1 = new Union(lgK);
+    u1.update(HllSketch.heapify(mergeSketchBytes1));
+    mergeHolder1 = HllSketchHolder.of(u1);
+
+    Union u2 = new Union(lgK);
+    u2.update(HllSketch.heapify(mergeSketchBytes2));
+    mergeHolder2 = HllSketchHolder.of(u2);
+
+    return mergeHolder1.merge(mergeHolder2);
   }
 }

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/DataSketchesHllBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/DataSketchesHllBenchmark.java
@@ -68,11 +68,27 @@ public class DataSketchesHllBenchmark
 
   private final ByteBuffer buf = ByteBuffer.allocateDirect(aggregatorFactory.getMaxIntermediateSize());
 
+  private static final int MERGE_LG_K = 12;
+  private static final int MERGE_NUM_VALUES = (1 << MERGE_LG_K) * 8;
+
   private BufferAggregator aggregator;
+
+  private byte[] mergeSketchBytes1;
+  private byte[] mergeSketchBytes2;
+  private HllSketchHolder mergeHolder1;
+  private HllSketchHolder mergeHolder2;
 
   @Setup(Level.Trial)
   public void setUp()
   {
+    HllSketch s1 = new HllSketch(MERGE_LG_K);
+    HllSketch s2 = new HllSketch(MERGE_LG_K);
+    for (int i = 0; i < MERGE_NUM_VALUES; i++) {
+      s1.update(i);
+      s2.update(MERGE_NUM_VALUES + i);
+    }
+    mergeSketchBytes1 = s1.toCompactByteArray();
+    mergeSketchBytes2 = s2.toCompactByteArray();
     aggregator = aggregatorFactory.factorizeBuffered(
         new ColumnSelectorFactory()
         {
@@ -125,32 +141,21 @@ public class DataSketchesHllBenchmark
     return aggregatorFactory.deserialize(((HllSketch) aggregator.get(buf, 0)).toCompactByteArray());
   }
 
-  @Benchmark
-  public HllSketchHolder mergeUnionHolders()
+  @Setup(Level.Invocation)
+  public void setUpMerge()
   {
-    final int lgK = 12;
-    final int numValue = (1 << lgK) * 8;
-
-    HllSketch s1 = new HllSketch(lgK);
-    HllSketch s2 = new HllSketch(lgK);
-    for (int i = 0; i < numValue; i++) {
-      s1.update(i);
-      s2.update(numValue + i);
-    }
-    byte[] mergeSketchBytes1 = s1.toCompactByteArray();
-    byte[] mergeSketchBytes2 = s2.toCompactByteArray();
-
-    HllSketchHolder mergeHolder1;
-    HllSketchHolder mergeHolder2;
-
-    Union u1 = new Union(lgK);
+    Union u1 = new Union(MERGE_LG_K);
     u1.update(HllSketch.heapify(mergeSketchBytes1));
     mergeHolder1 = HllSketchHolder.of(u1);
 
-    Union u2 = new Union(lgK);
+    Union u2 = new Union(MERGE_LG_K);
     u2.update(HllSketch.heapify(mergeSketchBytes2));
     mergeHolder2 = HllSketchHolder.of(u2);
+  }
 
+  @Benchmark
+  public HllSketchHolder mergeUnionHolders()
+  {
     return mergeHolder1.merge(mergeHolder2);
   }
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchHolder.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchHolder.java
@@ -158,7 +158,16 @@ public class HllSketchHolder
         return other;
       }
     } else {
-      add(other.getSketch());
+      if (other.union != null && other.sketch == null) {
+        // Both holders have unions. Materialize the other union's result as HLL_8
+        // (the union's native internal type) to avoid the expensive HLL_8 to HLL_4
+        // conversion that getResult() would trigger by default. The receiving union
+        // accepts any HLL type, so HLL_8 is fine and copies as a cheap byte[] clone.
+        union.update(other.union.getResult(TgtHllType.HLL_8));
+        sketch = null;
+      } else {
+        add(other.getSketch());
+      }
       return this;
     }
   }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchHolderTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchHolderTest.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.aggregation.datasketches.hll;
+
+import org.apache.datasketches.hll.HllSketch;
+import org.apache.datasketches.hll.TgtHllType;
+import org.apache.datasketches.hll.Union;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HllSketchHolderTest
+{
+  private static final int LG_K = 12;
+  private static final int NUM_VALUES = 1000;
+
+  @Test
+  public void testMergeSketchWithSketch()
+  {
+    HllSketchHolder holder1 = makeSketchHolder(0, NUM_VALUES);
+    HllSketchHolder holder2 = makeSketchHolder(NUM_VALUES, NUM_VALUES * 2);
+
+    HllSketchHolder result = holder1.merge(holder2);
+
+    Assert.assertSame(holder1, result);
+    assertEstimateWithinBounds(NUM_VALUES * 2, result);
+  }
+
+  @Test
+  public void testMergeSketchWithUnion()
+  {
+    HllSketchHolder holder1 = makeSketchHolder(0, NUM_VALUES);
+    HllSketchHolder holder2 = makeUnionHolder(NUM_VALUES, NUM_VALUES * 2);
+
+    HllSketchHolder result = holder1.merge(holder2);
+
+    Assert.assertSame(holder2, result);
+    assertEstimateWithinBounds(NUM_VALUES * 2, result);
+  }
+
+  @Test
+  public void testMergeUnionWithSketch()
+  {
+    HllSketchHolder holder1 = makeUnionHolder(0, NUM_VALUES);
+    HllSketchHolder holder2 = makeSketchHolder(NUM_VALUES, NUM_VALUES * 2);
+
+    HllSketchHolder result = holder1.merge(holder2);
+
+    Assert.assertSame(holder1, result);
+    assertEstimateWithinBounds(NUM_VALUES * 2, result);
+  }
+
+  @Test
+  public void testMergeUnionWithUnion()
+  {
+    HllSketchHolder holder1 = makeUnionHolder(0, NUM_VALUES);
+    HllSketchHolder holder2 = makeUnionHolder(NUM_VALUES, NUM_VALUES * 2);
+
+    HllSketchHolder result = holder1.merge(holder2);
+
+    Assert.assertSame(holder1, result);
+    assertEstimateWithinBounds(NUM_VALUES * 2, result);
+  }
+
+  @Test
+  public void testMergeUnionWithUnionMatchesNaiveMerge()
+  {
+    HllSketchHolder holder1 = makeUnionHolder(0, NUM_VALUES);
+    HllSketchHolder holder2 = makeUnionHolder(NUM_VALUES, NUM_VALUES * 2);
+
+    HllSketchHolder naiveHolder1 = makeUnionHolder(0, NUM_VALUES);
+    HllSketchHolder naiveHolder2 = makeUnionHolder(NUM_VALUES, NUM_VALUES * 2);
+    naiveHolder1.add(naiveHolder2.getSketch());
+
+    HllSketchHolder optimizedResult = holder1.merge(holder2);
+
+    Assert.assertEquals(naiveHolder1.getEstimate(), optimizedResult.getEstimate(), 0.0);
+  }
+
+  @Test
+  public void testMergeUnionWithUnionPreservesTargetType()
+  {
+    HllSketchHolder holder1 = makeUnionHolder(0, NUM_VALUES);
+    HllSketchHolder holder2 = makeUnionHolder(NUM_VALUES, NUM_VALUES * 2);
+
+    HllSketchHolder result = holder1.merge(holder2);
+
+    Assert.assertEquals(TgtHllType.HLL_4, result.getSketch().getTgtHllType());
+  }
+
+  @Test
+  public void testMergeWithOverlappingValues()
+  {
+    HllSketchHolder holder1 = makeUnionHolder(0, NUM_VALUES);
+    HllSketchHolder holder2 = makeUnionHolder(NUM_VALUES / 2, NUM_VALUES + NUM_VALUES / 2);
+
+    HllSketchHolder result = holder1.merge(holder2);
+
+    double estimate = result.getEstimate();
+    double expected = NUM_VALUES + NUM_VALUES / 2;
+    Assert.assertTrue(
+        "Estimate " + estimate + " not within 10% of " + expected,
+        Math.abs(estimate - expected) / expected < 0.10
+    );
+  }
+
+  private static HllSketchHolder makeSketchHolder(int startValue, int endValue)
+  {
+    HllSketch sketch = new HllSketch(LG_K);
+    for (int i = startValue; i < endValue; i++) {
+      sketch.update(i);
+    }
+    return HllSketchHolder.of(sketch);
+  }
+
+  private static HllSketchHolder makeUnionHolder(int startValue, int endValue)
+  {
+    HllSketch sketch = new HllSketch(LG_K);
+    for (int i = startValue; i < endValue; i++) {
+      sketch.update(i);
+    }
+    Union union = new Union(LG_K);
+    union.update(sketch);
+    return HllSketchHolder.of(union);
+  }
+
+  private static void assertEstimateWithinBounds(double expected, HllSketchHolder holder)
+  {
+    double estimate = holder.getEstimate();
+    Assert.assertTrue(
+        "Estimate " + estimate + " not within 10% of " + expected,
+        Math.abs(estimate - expected) / expected < 0.10
+    );
+  }
+}

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchHolderTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchHolderTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 public class HllSketchHolderTest
 {
   private static final int LG_K = 12;
-  private static final int NUM_VALUES = 1000;
+  private static final int NUM_VALUES = 100;
 
   @Test
   public void testMergeSketchWithSketch()
@@ -39,7 +39,7 @@ public class HllSketchHolderTest
     HllSketchHolder result = holder1.merge(holder2);
 
     Assert.assertSame(holder1, result);
-    assertEstimateWithinBounds(NUM_VALUES * 2, result);
+    Assert.assertEquals(NUM_VALUES * 2, result.getEstimate(), 0.01);
   }
 
   @Test
@@ -51,7 +51,7 @@ public class HllSketchHolderTest
     HllSketchHolder result = holder1.merge(holder2);
 
     Assert.assertSame(holder2, result);
-    assertEstimateWithinBounds(NUM_VALUES * 2, result);
+    Assert.assertEquals(NUM_VALUES * 2, result.getEstimate(), 0.01);
   }
 
   @Test
@@ -63,7 +63,7 @@ public class HllSketchHolderTest
     HllSketchHolder result = holder1.merge(holder2);
 
     Assert.assertSame(holder1, result);
-    assertEstimateWithinBounds(NUM_VALUES * 2, result);
+    Assert.assertEquals(NUM_VALUES * 2, result.getEstimate(), 0.01);
   }
 
   @Test
@@ -75,7 +75,7 @@ public class HllSketchHolderTest
     HllSketchHolder result = holder1.merge(holder2);
 
     Assert.assertSame(holder1, result);
-    assertEstimateWithinBounds(NUM_VALUES * 2, result);
+    Assert.assertEquals(NUM_VALUES * 2, result.getEstimate(), 0.01);
   }
 
   @Test
@@ -113,11 +113,8 @@ public class HllSketchHolderTest
     HllSketchHolder result = holder1.merge(holder2);
 
     double estimate = result.getEstimate();
-    double expected = NUM_VALUES + NUM_VALUES / 2;
-    Assert.assertTrue(
-        "Estimate " + estimate + " not within 10% of " + expected,
-        Math.abs(estimate - expected) / expected < 0.10
-    );
+    double expected = NUM_VALUES + (double) NUM_VALUES / 2;
+    Assert.assertEquals(expected, estimate, expected * 0.01);
   }
 
   private static HllSketchHolder makeSketchHolder(int startValue, int endValue)
@@ -138,14 +135,5 @@ public class HllSketchHolderTest
     Union union = new Union(LG_K);
     union.update(sketch);
     return HllSketchHolder.of(union);
-  }
-
-  private static void assertEstimateWithinBounds(double expected, HllSketchHolder holder)
-  {
-    double estimate = holder.getEstimate();
-    Assert.assertTrue(
-        "Estimate " + estimate + " not within 10% of " + expected,
-        Math.abs(estimate - expected) / expected < 0.10
-    );
   }
 }


### PR DESCRIPTION
perf: Optimize HLL sketch merge by avoiding unnecessary HLL_8 to HLL_4 conversion

### Description

This is a further improvement built on top of https://github.com/apache/druid/pull/13737

  - When two Union-backed HllSketchHolder instances are merged on the broker (e.g. during ParallelMergeCombiningSequence), the old code called other.getSketch() which invokes Union.getResult() — defaulting to HLL_4 output type. Since the Union internally stores data as HLL_8, this triggers an expensive convertToHll4 operation with an O(K) curMinAndNum scan. The receiving union then immediately converts the HLL_4 sketch back to HLL_8 internally.
  - This change detects the union-to-union merge case and calls Union.getResult(TgtHllType.HLL_8) instead, which returns an HLL_8 sketch via a cheap byte[].clone(). The receiving union accepts any HLL type, so correctness is preserved.
  - Adds a mergeUnionHolders benchmark to DataSketchesHllBenchmark covering this merge path.

### Testing Results

#### Flame Graph Results 

Flame Graph Analysis: Before vs After this PR
The below flame graphs are taken of the same query. The query is a group by on high cardinality dimension with APPROX_COUNT_DISTINCT_DS_HLL

Before (avg of 2 runs, ~11 min total):
  - convertToHll4: ~1,541 samples (7.5% of HLL work)
  - curMinAndNum: ~1,553 samples (8.1% of HLL work)
  - Total HLL samples: ~20,261
  - Total flame graph samples: ~5.1M

After (avg of 2 runs, ~700s total):
  - convertToHll4: 0 samples — completely eliminated
  - curMinAndNum: 0 samples — completely eliminated
  - copyAs (the cheap HLL_8 same-type copy): ~191 samples (1.3% of HLL work)
  - Total HLL samples: ~15,135
  - Total flame graph samples: ~2.8M
  
The expensive HLL_8 → HLL_4 conversion and the O(K) curMinAndNum scan are gone. The replacement copyAs(HLL_8) path is just a byte[].clone() at ~191 samples — roughly 16x cheaper than the old path (~3,094 combined samples eliminated, replaced by ~191).

The overall HLL footprint dropped by ~25% (20,261 → 15,135 samples), and total wall time dropped from ~11 min to ~700s.

#### Benchmark Results 

```
Before:
Benchmark                                    Mode  Cnt      Score     Error  Units
DataSketchesHllBenchmark.mergeUnionHolders  thrpt   15  56119.650 ± 605.940  ops/s

After:
Benchmark                                    Mode  Cnt       Score       Error  Units
DataSketchesHllBenchmark.mergeUnionHolders  thrpt   15  844025.643 ± 19959.812  ops/s
```

15x throughput improvement — from 56K to 844K ops/s.

##### Key changed/added classes in this PR
 * `extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchHolder.java`

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.