### PR TITLE
fix: Peon metrics emit same value

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/SinkQuerySegmentWalker.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/SinkQuerySegmentWalker.java
@@ -22,7 +22,6 @@ package org.apache.druid.segment.realtime.appenderator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.client.CachingQueryRunner;
 import org.apache.druid.client.cache.Cache;
@@ -90,7 +89,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.ObjLongConsumer;
 import java.util.stream.Collectors;
 
 /**
@@ -106,13 +104,6 @@ public class SinkQuerySegmentWalker implements QuerySegmentWalker
       DefaultQueryMetrics.QUERY_WAIT_TIME,
       DefaultQueryMetrics.QUERY_SEGMENT_AND_CACHE_TIME
   );
-
-  private static final Map<String, ObjLongConsumer<? super QueryMetrics<?>>> METRICS_TO_REPORT =
-      ImmutableMap.of(
-          DefaultQueryMetrics.QUERY_SEGMENT_TIME, QueryMetrics::reportSegmentTime,
-          DefaultQueryMetrics.QUERY_SEGMENT_AND_CACHE_TIME, QueryMetrics::reportSegmentAndCacheTime,
-          DefaultQueryMetrics.QUERY_WAIT_TIME, QueryMetrics::reportWaitTime
-      );
 
   private final String dataSource;
 
@@ -539,17 +530,11 @@ public class SinkQuerySegmentWalker implements QuerySegmentWalker
                 for (Map.Entry<String, SegmentMetrics> segmentAndMetrics : segmentMetricsAccumulator.entrySet()) {
                   queryMetrics.segment(segmentAndMetrics.getKey());
 
-                  for (Map.Entry<String, ObjLongConsumer<? super QueryMetrics<?>>> reportMetric : METRICS_TO_REPORT.entrySet()) {
-                    final String metricName = reportMetric.getKey();
-                    switch (metricName) {
-                      case DefaultQueryMetrics.QUERY_SEGMENT_TIME:
-                        reportMetric.getValue().accept(queryMetrics, segmentAndMetrics.getValue().getSegmentTime());
-                      case DefaultQueryMetrics.QUERY_WAIT_TIME:
-                        reportMetric.getValue().accept(queryMetrics, segmentAndMetrics.getValue().getWaitTime());
-                      case DefaultQueryMetrics.QUERY_SEGMENT_AND_CACHE_TIME:
-                        reportMetric.getValue().accept(queryMetrics, segmentAndMetrics.getValue().getSegmentAndCacheTime());
-                    }
-                  }
+                  final SegmentMetrics segmentMetrics = segmentAndMetrics.getValue();
+
+                  queryMetrics.reportSegmentTime(segmentMetrics.getSegmentTime());
+                  queryMetrics.reportWaitTime(segmentMetrics.getWaitTime());
+                  queryMetrics.reportSegmentAndCacheTime(segmentMetrics.getSegmentAndCacheTime());
 
                   try {
                     queryMetrics.emit(emitter);

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorTest.java
@@ -35,6 +35,7 @@ import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;
 import org.apache.druid.metadata.PendingSegmentRecord;
+import org.apache.druid.query.DefaultQueryMetrics;
 import org.apache.druid.query.Druids;
 import org.apache.druid.query.Order;
 import org.apache.druid.query.QueryPlus;
@@ -2296,14 +2297,14 @@ public class StreamAppenderatorTest extends InitializedNullHandlingTest
   private void verifySinkMetrics(StubServiceEmitter emitter, Set<String> segmentIds)
   {
     int segments = segmentIds.size();
-    emitter.verifyEmitted("query/cpu/time", 1);
-    Assert.assertEquals(segments, emitter.getMetricEvents("query/segment/time").size());
-    Assert.assertEquals(segments, emitter.getMetricEvents("query/segmentAndCache/time").size());
-    Assert.assertEquals(segments, emitter.getMetricEvents("query/wait/time").size());
+    emitter.verifyEmitted(DefaultQueryMetrics.QUERY_CPU_TIME, 1);
+    Assert.assertEquals(segments, emitter.getMetricEvents(DefaultQueryMetrics.QUERY_SEGMENT_TIME).size());
+    Assert.assertEquals(segments, emitter.getMetricEvents(DefaultQueryMetrics.QUERY_SEGMENT_AND_CACHE_TIME).size());
+    Assert.assertEquals(segments, emitter.getMetricEvents(DefaultQueryMetrics.QUERY_WAIT_TIME).size());
     for (String id : segmentIds) {
-      Assert.assertTrue(emitter.getMetricEvents("query/segment/time").stream().anyMatch(value -> value.getUserDims().containsValue(id)));
-      Assert.assertTrue(emitter.getMetricEvents("query/segmentAndCache/time").stream().anyMatch(value -> value.getUserDims().containsValue(id)));
-      Assert.assertTrue(emitter.getMetricEvents("query/wait/time").stream().anyMatch(value -> value.getUserDims().containsValue(id)));
+      Assert.assertTrue(emitter.getMetricEvents(DefaultQueryMetrics.QUERY_SEGMENT_TIME).stream().anyMatch(value -> value.getUserDims().containsValue(id)));
+      Assert.assertTrue(emitter.getMetricEvents(DefaultQueryMetrics.QUERY_SEGMENT_AND_CACHE_TIME).stream().anyMatch(value -> value.getUserDims().containsValue(id)));
+      Assert.assertTrue(emitter.getMetricEvents(DefaultQueryMetrics.QUERY_WAIT_TIME).stream().anyMatch(value -> value.getUserDims().containsValue(id)));
     }
   }
 


### PR DESCRIPTION
### Description

This PR fixes incorrect Peon sink-level query metric emission in SinkQuerySegmentWalker. This bug exists since v32, introduced by #17170 

#### The Bug
Currently, the following Peon metrics will be emitted with misleading values, making the three metrics appear identical:
- query/segment/time
- query/segmentAndCache/time
- query/wait/time

<img width="3330" height="1232" alt="image-20260519165853832" src="https://github.com/user-attachments/assets/a719ee59-6154-4e07-97d2-4f1855e16256" />

#### Cause
The existing code iterated over METRICS_TO_REPORT and used a switch without break statements. Because reportMetric.getValue() is bound to the current metric reporter, fallthrough caused later accumulator values to be reported through the wrong reporter. For example, the query/segment/time reporter could be called with segment time, then wait time, then segment-and-cache time before emit(). Since DefaultQueryMetrics stores metric values by metric name before emission, the last value overwrote earlier ones.


#### Release note
Fix incorrect reporting of `query/segment/time`, `query/wait/time` and `query/segmentAndCache/time` on Peon.

<hr>

##### Key changed/added classes in this PR
 * `SinkQuerySegmentWalker`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.