### PR TITLE
docs: use {{DRUIDVERSION}} template in docker tutorial port link

### DIFF
--- a/docs/tutorials/docker.md
+++ b/docs/tutorials/docker.md
@@ -100,7 +100,7 @@ is translated into the following option in the Java launch command for the Druid
 
 `-Ddruid.metadata.storage.type=postgresql`
 
-Note that Druid uses port 8888 for the console. This port is also used by Jupyter and other tools. To avoid conflicts, you can change the port in the [`ports`](https://github.com/apache/druid/blob/0.21.1/distribution/docker/docker-compose.yml#L125) section of the `docker-compose.yml` file. For example, to expose the console on port 9999 of the host:
+Note that Druid uses port 8888 for the console. This port is also used by Jupyter and other tools. To avoid conflicts, you can change the port in the [`ports`](https://github.com/apache/druid/blob/{{DRUIDVERSION}}/distribution/docker/docker-compose.yml#L129) section of the `docker-compose.yml` file. For example, to expose the console on port 9999 of the host:
 
 ```yaml
     container_name: router


### PR DESCRIPTION
### Description

The Docker tutorial (`docs/tutorials/docker.md`) tells the reader how to change the console port and links to the `ports` section of `docker-compose.yml` for reference. The link is hardcoded to the **0.21.1** release of that file:

> ...you can change the port in the [`ports`](https://github.com/apache/druid/blob/0.21.1/distribution/docker/docker-compose.yml#L125) section of the `docker-compose.yml` file.

You can see the broken behavior on the published docs today: https://druid.apache.org/docs/latest/tutorials/docker — clicking the `ports` link in that paragraph lands on the 0.21.1 version of the file, which is four years out of date and no longer reflects the current cluster layout.

The other three GitHub links in the same page (lines 51, 84, and 134) use the `{{DRUIDVERSION}}` template variable, which the docs build replaces with the current Druid release tag (see `website/README.md`). This one link appears to have just been missed when the rest of the page was templated.

This change:

- Replaces `0.21.1` with `{{DRUIDVERSION}}` so the link follows the same pattern as the rest of the file.
- Updates the line anchor from `#L125` to `#L129`, which is the router service's `ports:` row in `distribution/docker/docker-compose.yml` at the current release (verified against both `master` and the `druid-37.0.0` tag).

#### Release note

The Docker tutorial's `ports` link now points to the current release of `docker-compose.yml` instead of `0.21.1`.

##### Key changed/added classes in this PR
- `docs/tutorials/docker.md`

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors. *(this PR is itself a documentation fix)*
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. *(N/A — docs only)*
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml) *(N/A — no dependency change)*
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader. *(N/A — single-line docs change)*
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met. *(N/A — docs only)*
- [x] added integration tests. *(N/A)*
- [x] been tested in a test Druid cluster. *(N/A — verified by inspecting the rendered link target on the published docs and confirming the `{{DRUIDVERSION}}` template usage on adjacent lines)*
