### PR TITLE
docs: fix off-by-one line anchor in docker tutorial DRUID_LOG4J link

### DIFF
--- a/docs/tutorials/docker.md
+++ b/docs/tutorials/docker.md
@@ -81,7 +81,7 @@ Production configuration:
 
 Logging configuration:
 
-* `DRUID_LOG4J` -- set the entire [`log4j.xml` configuration file](https://logging.apache.org/log4j/2.x/manual/configuration.html#XML)  verbatim. ([Example](https://github.com/apache/druid/blob/{{DRUIDVERSION}}/distribution/docker/environment#L52))
+* `DRUID_LOG4J` -- set the entire [`log4j.xml` configuration file](https://logging.apache.org/log4j/2.x/manual/configuration.html#XML)  verbatim. ([Example](https://github.com/apache/druid/blob/{{DRUIDVERSION}}/distribution/docker/environment#L51))
 * `DRUID_LOG_LEVEL` -- override the default [Log4j log level](https://en.wikipedia.org/wiki/Log4j#Log4j_log_levels)
 * `DRUID_SERVICE_LOG4J` -- set the entire [`log4j.xml` configuration file](https://logging.apache.org/log4j/2.x/manual/configuration.html#XML)  verbatim specific to a service.
 * `DRUID_SERVICE_LOG_LEVEL` -- override the default [Log4j log level](https://en.wikipedia.org/wiki/Log4j#Log4j_log_levels) in the service specific log4j.


### PR DESCRIPTION
### Description

The Docker tutorial's `DRUID_LOG4J` bullet links to an example line in
`distribution/docker/environment`:

```md
* `DRUID_LOG4J` -- set the entire [`log4j.xml` configuration file](https://logging.apache.org/log4j/2.x/manual/configuration.html#XML)  verbatim. ([Example](https://github.com/apache/druid/blob/{{DRUIDVERSION}}/distribution/docker/environment#L52))
```

The anchor is off by one. The `environment` file ends at line **51**,
which is where the `DRUID_LOG4J=` row lives — there is no line 52.
Readers who follow the link land at the bottom of the file with nothing
highlighted.

You can see the behavior on `master`:

- Current (broken): https://github.com/apache/druid/blob/master/distribution/docker/environment#L52 — no line highlighted, scrolled past end of file
- After this PR: https://github.com/apache/druid/blob/master/distribution/docker/environment#L51 — `DRUID_LOG4J=<?xml ...` row highlighted

Verified against `master` and the `druid-37.0.0` tag.

This is a one-character follow-up to #19485, which fixed the sibling
`#L125 → #L129` anchor on the same page.

#### Release note

The Docker tutorial's `DRUID_LOG4J` example link now lands on the
correct line of the `environment` file.

##### Key changed/added classes in this PR
- `docs/tutorials/docker.md`

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors. *(this PR is itself a documentation fix)*
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. *(N/A — docs only)*
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml) *(N/A — no dependency change)*
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader. *(N/A — single-line docs change)*
- [x] added unit tests or modified existing tests to cover new code paths. *(N/A — docs only)*
- [x] added integration tests. *(N/A)*
- [x] been tested in a test Druid cluster. *(N/A — verified by inspecting the linked file at `master` and `druid-37.0.0`)*
