### PR TITLE
fix: invalid ISO 8601 start_time placeholder in services view fallback

### DIFF
--- a/web-console/src/views/services-view/services-view.tsx
+++ b/web-console/src/views/services-view/services-view.tsx
@@ -485,7 +485,7 @@ ORDER BY
                 max_size: s.maxSize,
                 storage_size: s.maxSize,
                 effective_size: s.maxSize,
-                start_time: '1970:01:01T00:00:00Z',
+                start_time: '1970-01-01T00:00:00Z',
                 is_leader: 0,
                 version: '',
                 build_revision: '',


### PR DESCRIPTION
### Description

The non-SQL fallback path in `ServicesView` builds rows from
`/druid/coordinator/v1/servers?simple`, which does not return a
`start_time`, so the column is set to a hardcoded epoch placeholder:

```ts
start_time: '1970:01:01T00:00:00Z',
```

The date portion uses `:` separators instead of `-`, which makes the
literal an invalid ISO 8601 string:

```js
> new Date('1970:01:01T00:00:00Z')
Invalid Date
> new Date('1970-01-01T00:00:00Z')
1970-01-01T00:00:00.000Z
```

The `Start time` column's cell renderer hands this value to `formatDate`
(`web-console/src/utils/date.ts`), which calls `dayjs(value).toISOString()`.
On an invalid input that throws, the surrounding `try/catch` falls
through and returns the original string as-is. So on clusters where the
console talks to the coordinator without SQL access, every row's
`Start time` cell renders as the literal text `1970:01:01T00:00:00Z`
rather than a parsed date.

Replacing the separators with dashes makes the placeholder a valid ISO
8601 epoch timestamp and matches every other ISO 8601 string literal in
the web console (e.g. `dialogs/doctor-dialog/doctor-checks.tsx`'s
`missingValue: '2010-01-01T00:00:00Z'`, all timestamps in
`utils/sampler.mock.ts`).

This is a one-character follow-up in the same area touched by #19481.

#### Release note

The web console's Services view now renders a valid epoch timestamp for
the `Start time` column on clusters where the console talks to the
coordinator without SQL access, instead of the literal placeholder
string `1970:01:01T00:00:00Z`.

##### Key changed/added classes in this PR
- `web-console/src/views/services-view/services-view.tsx`

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors. *(N/A — internal placeholder fix, no user-facing docs)*
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. *(N/A — TypeScript)*
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml) *(N/A — no dependency change)*
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader. *(N/A — single-line literal fix)*
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met. *(existing snapshot test uses its own mock — `start_time: 0` — and is unaffected)*
- [x] added integration tests. *(N/A)*
- [x] been tested in a test Druid cluster. *(N/A — verified by inspection: `new Date('1970:01:01T00:00:00Z')` returns `Invalid Date` while `'1970-01-01T00:00:00Z'` parses correctly; every other ISO 8601 literal in the codebase uses the dash form)*
