### PR TITLE
fix: fix chat handler response parsing

### DIFF
--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
@@ -21,7 +21,6 @@ package org.apache.druid.k8s.overlord;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -53,15 +52,12 @@ import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.java.util.http.client.HttpClient;
-import org.apache.druid.java.util.http.client.Request;
-import org.apache.druid.java.util.http.client.response.InputStreamResponseHandler;
 import org.apache.druid.k8s.overlord.common.K8sTaskId;
 import org.apache.druid.k8s.overlord.common.KubernetesPeonClient;
 import org.apache.druid.k8s.overlord.common.KubernetesResourceNotFoundException;
 import org.apache.druid.k8s.overlord.execution.KubernetesTaskRunnerDynamicConfig;
 import org.apache.druid.k8s.overlord.taskadapter.TaskAdapter;
 import org.apache.druid.tasklogs.TaskLogStreamer;
-import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 
@@ -349,20 +345,7 @@ public class KubernetesTaskRunner implements TaskLogStreamer, TaskRunner
         taskid
     );
 
-    try {
-      return Optional.of(httpClient.go(
-          new Request(HttpMethod.GET, url),
-          new InputStreamResponseHandler()
-      ).get());
-    }
-    catch (InterruptedException e) {
-      throw new RuntimeException(e);
-    }
-    catch (ExecutionException e) {
-      // Unwrap if possible
-      Throwables.propagateIfPossible(e.getCause(), IOException.class);
-      throw new RuntimeException(e);
-    }
+    return TaskRunnerUtils.streamTaskReportsFromTaskLocation(httpClient, url);
   }
 
   @Override

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerTest.java
@@ -38,7 +38,8 @@ import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceEventBuilder;
 import org.apache.druid.java.util.http.client.HttpClient;
 import org.apache.druid.java.util.http.client.Request;
-import org.apache.druid.java.util.http.client.response.InputStreamResponseHandler;
+import org.apache.druid.java.util.http.client.response.InputStreamFullResponseHandler;
+import org.apache.druid.java.util.http.client.response.InputStreamFullResponseHolder;
 import org.apache.druid.k8s.overlord.common.K8sTestUtils;
 import org.apache.druid.k8s.overlord.common.KubernetesPeonClient;
 import org.apache.druid.k8s.overlord.execution.DefaultKubernetesTaskRunnerDynamicConfig;
@@ -50,6 +51,9 @@ import org.easymock.EasyMockSupport;
 import org.easymock.Mock;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.jboss.netty.handler.codec.http.HttpVersion;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -558,7 +562,7 @@ public class KubernetesTaskRunnerTest extends EasyMockSupport
   @Test
   public void test_streamTaskReports_withExistingTask() throws Exception
   {
-    KubernetesWorkItem workItem = new KubernetesWorkItem(task, null, kubernetesPeonLifecycle) {
+    final KubernetesWorkItem workItem = new KubernetesWorkItem(task, null, kubernetesPeonLifecycle) {
       @Override
       public TaskLocation getLocation()
       {
@@ -570,12 +574,12 @@ public class KubernetesTaskRunnerTest extends EasyMockSupport
 
     EasyMock.expect(httpClient.go(
         EasyMock.anyObject(Request.class),
-        EasyMock.anyObject(InputStreamResponseHandler.class))
-    ).andReturn(Futures.immediateFuture(IOUtils.toInputStream("{}", StandardCharsets.UTF_8)));
+        EasyMock.anyObject(InputStreamFullResponseHandler.class))
+    ).andReturn(Futures.immediateFuture(taskReportResponse(HttpResponseStatus.OK, "{}")));
 
     replayAll();
 
-    Optional<InputStream> maybeInputStream = runner.streamTaskReports(task.getId());
+    final Optional<InputStream> maybeInputStream = runner.streamTaskReports(task.getId());
 
     verifyAll();
 
@@ -584,33 +588,9 @@ public class KubernetesTaskRunnerTest extends EasyMockSupport
   }
 
   @Test
-  public void test_streamTaskReports_withoutExistingTask_returnsEmptyOptional() throws Exception
+  public void test_streamTaskReports_whenTaskReportsUnavailable_returnsEmptyOptional() throws Exception
   {
-    Optional<InputStream> maybeInputStream = runner.streamTaskReports(task.getId());
-    Assertions.assertFalse(maybeInputStream.isPresent());
-  }
-
-  @Test
-  public void test_streamTaskReports_withUnknownTaskLocation_returnsEmptyOptional() throws Exception
-  {
-    KubernetesWorkItem workItem = new KubernetesWorkItem(task, null, kubernetesPeonLifecycle) {
-      @Override
-      public TaskLocation getLocation()
-      {
-        return TaskLocation.unknown();
-      }
-    };
-
-    runner.tasks.put(task.getId(), workItem);
-
-    Optional<InputStream> maybeInputStream = runner.streamTaskReports(task.getId());
-    Assertions.assertFalse(maybeInputStream.isPresent());
-  }
-
-  @Test
-  public void test_streamTaskReports_whenInterruptedExceptionThrown_throwsRuntimeException()
-  {
-    KubernetesWorkItem workItem = new KubernetesWorkItem(task, null, kubernetesPeonLifecycle) {
+    final KubernetesWorkItem workItem = new KubernetesWorkItem(task, null, kubernetesPeonLifecycle) {
       @Override
       public TaskLocation getLocation()
       {
@@ -620,7 +600,58 @@ public class KubernetesTaskRunnerTest extends EasyMockSupport
 
     runner.tasks.put(task.getId(), workItem);
 
-    ListenableFuture<InputStream> future = new ListenableFuture<>()
+    EasyMock.expect(httpClient.go(
+        EasyMock.anyObject(Request.class),
+        EasyMock.anyObject(InputStreamFullResponseHandler.class))
+    ).andReturn(Futures.immediateFuture(taskReportResponse(HttpResponseStatus.SERVICE_UNAVAILABLE, "error")));
+
+    replayAll();
+
+    final Optional<InputStream> maybeInputStream = runner.streamTaskReports(task.getId());
+
+    verifyAll();
+
+    Assertions.assertFalse(maybeInputStream.isPresent());
+  }
+
+  @Test
+  public void test_streamTaskReports_withoutExistingTask_returnsEmptyOptional() throws Exception
+  {
+    final Optional<InputStream> maybeInputStream = runner.streamTaskReports(task.getId());
+    Assertions.assertFalse(maybeInputStream.isPresent());
+  }
+
+  @Test
+  public void test_streamTaskReports_withUnknownTaskLocation_returnsEmptyOptional() throws Exception
+  {
+    final KubernetesWorkItem workItem = new KubernetesWorkItem(task, null, kubernetesPeonLifecycle) {
+      @Override
+      public TaskLocation getLocation()
+      {
+        return TaskLocation.unknown();
+      }
+    };
+
+    runner.tasks.put(task.getId(), workItem);
+
+    final Optional<InputStream> maybeInputStream = runner.streamTaskReports(task.getId());
+    Assertions.assertFalse(maybeInputStream.isPresent());
+  }
+
+  @Test
+  public void test_streamTaskReports_whenInterruptedExceptionThrown_throwsRuntimeException()
+  {
+    final KubernetesWorkItem workItem = new KubernetesWorkItem(task, null, kubernetesPeonLifecycle) {
+      @Override
+      public TaskLocation getLocation()
+      {
+        return TaskLocation.create("host", 0, 1, false);
+      }
+    };
+
+    runner.tasks.put(task.getId(), workItem);
+
+    final ListenableFuture<InputStreamFullResponseHolder> future = new ListenableFuture<>()
     {
       @Override
       public void addListener(Runnable runnable, Executor executor)
@@ -646,13 +677,13 @@ public class KubernetesTaskRunnerTest extends EasyMockSupport
       }
 
       @Override
-      public InputStream get() throws InterruptedException
+      public InputStreamFullResponseHolder get() throws InterruptedException
       {
         throw new InterruptedException();
       }
 
       @Override
-      public InputStream get(long timeout, TimeUnit unit) throws InterruptedException
+      public InputStreamFullResponseHolder get(long timeout, TimeUnit unit) throws InterruptedException
       {
         throw new InterruptedException();
       }
@@ -660,12 +691,12 @@ public class KubernetesTaskRunnerTest extends EasyMockSupport
 
     EasyMock.expect(httpClient.go(
         EasyMock.anyObject(Request.class),
-        EasyMock.anyObject(InputStreamResponseHandler.class))
+        EasyMock.anyObject(InputStreamFullResponseHandler.class))
     ).andReturn(future);
 
     replayAll();
 
-    Exception e = Assertions.assertThrows(RuntimeException.class, () -> runner.streamTaskReports(task.getId()));
+    final Exception e = Assertions.assertThrows(RuntimeException.class, () -> runner.streamTaskReports(task.getId()));
     Assertions.assertTrue(e.getCause() instanceof InterruptedException);
 
     verifyAll();
@@ -674,7 +705,7 @@ public class KubernetesTaskRunnerTest extends EasyMockSupport
   @Test
   public void test_streamTaskReports_whenExecutionExceptionThrown_throwsRuntimeException()
   {
-    KubernetesWorkItem workItem = new KubernetesWorkItem(task, null, kubernetesPeonLifecycle) {
+    final KubernetesWorkItem workItem = new KubernetesWorkItem(task, null, kubernetesPeonLifecycle) {
       @Override
       public TaskLocation getLocation()
       {
@@ -686,7 +717,7 @@ public class KubernetesTaskRunnerTest extends EasyMockSupport
 
     EasyMock.expect(httpClient.go(
         EasyMock.anyObject(Request.class),
-        EasyMock.anyObject(InputStreamResponseHandler.class))
+        EasyMock.anyObject(InputStreamFullResponseHandler.class))
     ).andReturn(Futures.immediateFailedFuture(new Exception()));
 
     replayAll();
@@ -857,5 +888,18 @@ public class KubernetesTaskRunnerTest extends EasyMockSupport
     Assertions.assertEquals(1, executor.getCorePoolSize());
     Assertions.assertEquals(1, executor.getMaximumPoolSize());
     Assertions.assertEquals(1, runner.getTotalCapacity());
+  }
+
+  private static InputStreamFullResponseHolder taskReportResponse(
+      final HttpResponseStatus status,
+      final String content
+  )
+  {
+    final InputStreamFullResponseHolder response = new InputStreamFullResponseHolder(
+        new DefaultHttpResponse(HttpVersion.HTTP_1_1, status)
+    );
+    response.addChunk(content.getBytes(StandardCharsets.UTF_8));
+    response.done();
+    return response;
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/RemoteTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/RemoteTaskRunner.java
@@ -701,20 +701,7 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
         taskId
     );
 
-    try {
-      return Optional.of(httpClient.go(
-          new Request(HttpMethod.GET, url),
-          new InputStreamResponseHandler()
-      ).get());
-    }
-    catch (InterruptedException e) {
-      throw new RuntimeException(e);
-    }
-    catch (ExecutionException e) {
-      // Unwrap if possible
-      Throwables.propagateIfPossible(e.getCause(), IOException.class);
-      throw new RuntimeException(e);
-    }
+    return TaskRunnerUtils.streamTaskReportsFromTaskLocation(httpClient, url);
   }
 
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskRunnerUtils.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskRunnerUtils.java
@@ -19,19 +19,30 @@
 
 package org.apache.druid.indexing.overlord;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
 import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.worker.Worker;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.emitter.EmittingLogger;
+import org.apache.druid.java.util.http.client.HttpClient;
+import org.apache.druid.java.util.http.client.Request;
+import org.apache.druid.java.util.http.client.response.InputStreamFullResponseHandler;
+import org.apache.druid.java.util.http.client.response.InputStreamFullResponseHolder;
+import org.jboss.netty.handler.codec.http.HttpMethod;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 
 public class TaskRunnerUtils
@@ -108,6 +119,38 @@ public class TaskRunnerUtils
       return taskLocation.makeURL(path);
     }
     catch (MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static Optional<InputStream> streamTaskReportsFromTaskLocation(
+      final HttpClient httpClient,
+      final URL url
+  ) throws IOException
+  {
+    try {
+      final InputStreamFullResponseHolder response = httpClient.go(
+          new Request(HttpMethod.GET, url),
+          new InputStreamFullResponseHandler()
+      ).get();
+      final HttpResponseStatus responseStatus = response.getResponse().getStatus();
+
+      if (HttpResponseStatus.OK.equals(responseStatus)) {
+        return Optional.of(response.getContent());
+      } else if (HttpResponseStatus.NOT_FOUND.equals(responseStatus)
+                 || HttpResponseStatus.SERVICE_UNAVAILABLE.equals(responseStatus)) {
+        return Optional.absent();
+      } else {
+        throw new IOException(
+            StringUtils.format("Failed to stream task reports from [%s]. Response status [%s].", url, responseStatus)
+        );
+      }
+    }
+    catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+    catch (ExecutionException e) {
+      Throwables.propagateIfPossible(e.getCause(), IOException.class);
       throw new RuntimeException(e);
     }
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunner.java
@@ -1074,20 +1074,7 @@ public class HttpRemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer, 
           taskId
       );
 
-      try {
-        return Optional.of(httpClient.go(
-            new Request(HttpMethod.GET, url),
-            new InputStreamResponseHandler()
-        ).get());
-      }
-      catch (InterruptedException e) {
-        throw new RuntimeException(e);
-      }
-      catch (ExecutionException e) {
-        // Unwrap if possible
-        Throwables.propagateIfPossible(e.getCause(), IOException.class);
-        throw new RuntimeException(e);
-      }
+      return TaskRunnerUtils.streamTaskReportsFromTaskLocation(httpClient, url);
     }
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTest.java
@@ -59,11 +59,15 @@ import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.http.client.HttpClient;
 import org.apache.druid.java.util.http.client.Request;
+import org.apache.druid.java.util.http.client.response.InputStreamFullResponseHolder;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.apache.druid.testing.DeadlockDetectingTimeout;
 import org.apache.zookeeper.Watcher;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
+import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.jboss.netty.handler.codec.http.HttpVersion;
 import org.joda.time.Period;
 import org.junit.After;
 import org.junit.Assert;
@@ -75,7 +79,6 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.mockito.Mockito;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -1167,7 +1170,7 @@ public class RemoteTaskRunnerTest
     doSetup();
     final Capture<Request> capturedRequest = Capture.newInstance();
     final String reportString = "my report!";
-    final ByteArrayInputStream reportResponse = new ByteArrayInputStream(StringUtils.toUtf8(reportString));
+    final InputStreamFullResponseHolder reportResponse = taskReportResponse(HttpResponseStatus.OK, reportString);
     EasyMock.expect(httpClient.go(EasyMock.capture(capturedRequest), EasyMock.anyObject()))
             .andReturn(Futures.immediateFuture(reportResponse));
     EasyMock.replay(httpClient);
@@ -1199,6 +1202,43 @@ public class RemoteTaskRunnerTest
     Assert.assertEquals(Optional.absent(), remoteTaskRunner.streamTaskReports(task.getId()));
 
     // Verify the HTTP request.
+    EasyMock.verify(httpClient);
+    Assert.assertEquals(
+        "http://dummy:9000/druid/worker/v1/chat/task%20id%20with%20spaces/liveReports",
+        capturedRequest.getValue().getUrl().toString()
+    );
+  }
+
+  @Test
+  public void testStreamTaskReportsUnavailableFromWorker() throws Exception
+  {
+    doSetup();
+    final Capture<Request> capturedRequest = Capture.newInstance();
+    final InputStreamFullResponseHolder reportResponse = taskReportResponse(
+        HttpResponseStatus.SERVICE_UNAVAILABLE,
+        "{\"error\":\"Can't find chatHandler for handler[task]\"}"
+    );
+    EasyMock.expect(httpClient.go(EasyMock.capture(capturedRequest), EasyMock.anyObject()))
+            .andReturn(Futures.immediateFuture(reportResponse));
+    EasyMock.replay(httpClient);
+
+    remoteTaskRunner.run(task);
+    Assert.assertTrue(taskAnnounced(task.getId()));
+    mockWorkerRunningTask(task);
+
+    // Wait for the task to have a known location.
+    Assert.assertTrue(
+        TestUtils.conditionValid(
+            () ->
+                !remoteTaskRunner.getRunningTasks().isEmpty()
+                && !Iterables.getOnlyElement(remoteTaskRunner.getRunningTasks())
+                             .getLocation()
+                             .equals(TaskLocation.unknown())
+        )
+    );
+
+    Assert.assertEquals(Optional.absent(), remoteTaskRunner.streamTaskReports(task.getId()));
+
     EasyMock.verify(httpClient);
     Assert.assertEquals(
         "http://dummy:9000/druid/worker/v1/chat/task%20id%20with%20spaces/liveReports",
@@ -1246,5 +1286,18 @@ public class RemoteTaskRunnerTest
             TaskLockType.EXCLUSIVE
         ).getClass()
     );
+  }
+
+  private static InputStreamFullResponseHolder taskReportResponse(
+      final HttpResponseStatus status,
+      final String content
+  )
+  {
+    final InputStreamFullResponseHolder response = new InputStreamFullResponseHolder(
+        new DefaultHttpResponse(HttpVersion.HTTP_1_1, status)
+    );
+    response.addChunk(StringUtils.toUtf8(content));
+    response.done();
+    return response;
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskRunnerUtilsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskRunnerUtilsTest.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URL;
 
 public class TaskRunnerUtilsTest
@@ -78,7 +79,7 @@ public class TaskRunnerUtilsTest
 
     final Optional<InputStream> stream = TaskRunnerUtils.streamTaskReportsFromTaskLocation(
         httpClient,
-        new URL("http://example.com/liveReports")
+        url("http://example.com/liveReports")
     );
 
     Assert.assertTrue(stream.isPresent());
@@ -110,7 +111,7 @@ public class TaskRunnerUtilsTest
         IOException.class,
         () -> TaskRunnerUtils.streamTaskReportsFromTaskLocation(
             httpClient,
-            new URL("http://example.com/liveReports")
+            url("http://example.com/liveReports")
         )
     );
 
@@ -129,9 +130,14 @@ public class TaskRunnerUtilsTest
 
     Assert.assertEquals(
         Optional.absent(),
-        TaskRunnerUtils.streamTaskReportsFromTaskLocation(httpClient, new URL("http://example.com/liveReports"))
+        TaskRunnerUtils.streamTaskReportsFromTaskLocation(httpClient, url("http://example.com/liveReports"))
     );
     EasyMock.verify(httpClient);
+  }
+
+  private static URL url(final String value) throws IOException
+  {
+    return URI.create(value).toURL();
   }
 
   private static InputStreamFullResponseHolder response(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskRunnerUtilsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskRunnerUtilsTest.java
@@ -19,12 +19,26 @@
 
 package org.apache.druid.indexing.overlord;
 
+import com.google.common.base.Optional;
+import com.google.common.io.ByteStreams;
+import com.google.common.util.concurrent.Futures;
 import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexing.worker.Worker;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.http.client.HttpClient;
+import org.apache.druid.java.util.http.client.Request;
+import org.apache.druid.java.util.http.client.response.InputStreamFullResponseHandler;
+import org.apache.druid.java.util.http.client.response.InputStreamFullResponseHolder;
+import org.easymock.EasyMock;
+import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.jboss.netty.handler.codec.http.HttpVersion;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 
 public class TaskRunnerUtilsTest
@@ -51,5 +65,85 @@ public class TaskRunnerUtilsTest
         "foo bar&"
     );
     Assert.assertEquals("https://1.2.3.4:8290/druid/worker/v1/task/foo%20bar%26/log", url.toString());
+  }
+
+  @Test
+  public void testStreamTaskReportsFromTaskLocationOk() throws Exception
+  {
+    final HttpClient httpClient = EasyMock.createMock(HttpClient.class);
+    final String report = "my report";
+    EasyMock.expect(httpClient.go(EasyMock.anyObject(Request.class), EasyMock.anyObject(InputStreamFullResponseHandler.class)))
+            .andReturn(Futures.immediateFuture(response(HttpResponseStatus.OK, report)));
+    EasyMock.replay(httpClient);
+
+    final Optional<InputStream> stream = TaskRunnerUtils.streamTaskReportsFromTaskLocation(
+        httpClient,
+        new URL("http://example.com/liveReports")
+    );
+
+    Assert.assertTrue(stream.isPresent());
+    Assert.assertEquals(report, StringUtils.fromUtf8(ByteStreams.toByteArray(stream.get())));
+    EasyMock.verify(httpClient);
+  }
+
+  @Test
+  public void testStreamTaskReportsFromTaskLocationNotFound() throws Exception
+  {
+    assertStreamTaskReportsFromTaskLocationUnavailable(HttpResponseStatus.NOT_FOUND);
+  }
+
+  @Test
+  public void testStreamTaskReportsFromTaskLocationServiceUnavailable() throws Exception
+  {
+    assertStreamTaskReportsFromTaskLocationUnavailable(HttpResponseStatus.SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  public void testStreamTaskReportsFromTaskLocationUnexpectedStatus() throws Exception
+  {
+    final HttpClient httpClient = EasyMock.createMock(HttpClient.class);
+    EasyMock.expect(httpClient.go(EasyMock.anyObject(Request.class), EasyMock.anyObject(InputStreamFullResponseHandler.class)))
+            .andReturn(Futures.immediateFuture(response(HttpResponseStatus.INTERNAL_SERVER_ERROR, "error")));
+    EasyMock.replay(httpClient);
+
+    final IOException e = Assert.assertThrows(
+        IOException.class,
+        () -> TaskRunnerUtils.streamTaskReportsFromTaskLocation(
+            httpClient,
+            new URL("http://example.com/liveReports")
+        )
+    );
+
+    Assert.assertTrue(e.getMessage().contains("500 Internal Server Error"));
+    EasyMock.verify(httpClient);
+  }
+
+  private static void assertStreamTaskReportsFromTaskLocationUnavailable(
+      final HttpResponseStatus status
+  ) throws Exception
+  {
+    final HttpClient httpClient = EasyMock.createMock(HttpClient.class);
+    EasyMock.expect(httpClient.go(EasyMock.anyObject(Request.class), EasyMock.anyObject(InputStreamFullResponseHandler.class)))
+            .andReturn(Futures.immediateFuture(response(status, "error")));
+    EasyMock.replay(httpClient);
+
+    Assert.assertEquals(
+        Optional.absent(),
+        TaskRunnerUtils.streamTaskReportsFromTaskLocation(httpClient, new URL("http://example.com/liveReports"))
+    );
+    EasyMock.verify(httpClient);
+  }
+
+  private static InputStreamFullResponseHolder response(
+      final HttpResponseStatus status,
+      final String content
+  )
+  {
+    final InputStreamFullResponseHolder response = new InputStreamFullResponseHolder(
+        new DefaultHttpResponse(HttpVersion.HTTP_1_1, status)
+    );
+    response.addChunk(StringUtils.toUtf8(content));
+    response.done();
+    return response;
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunnerTest.java
@@ -26,6 +26,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.io.ByteStreams;
+import com.google.common.util.concurrent.Futures;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.druid.common.guava.DSuppliers;
 import org.apache.druid.concurrent.LifecycleLock;
@@ -37,6 +39,7 @@ import org.apache.druid.discovery.WorkerNodeService;
 import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.TaskStatus;
+import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.TaskRunnerListener;
@@ -58,18 +61,26 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.java.util.http.client.HttpClient;
+import org.apache.druid.java.util.http.client.Request;
+import org.apache.druid.java.util.http.client.response.InputStreamFullResponseHandler;
+import org.apache.druid.java.util.http.client.response.InputStreamFullResponseHolder;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.coordination.ChangeRequestHttpSyncer;
 import org.apache.druid.server.initialization.IndexerZkConfig;
 import org.apache.druid.server.initialization.ZkPathsConfig;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
+import org.easymock.Capture;
 import org.easymock.EasyMock;
+import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.jboss.netty.handler.codec.http.HttpVersion;
 import org.joda.time.Period;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -1185,6 +1196,18 @@ public class HttpRemoteTaskRunnerTest
     Assert.assertFalse(taskRunner.getLazyTaskSlotCount().containsKey(additionalWorkerCategory));
   }
 
+  @Test(timeout = 60_000L)
+  public void testStreamTaskReportsFromWorker() throws Exception
+  {
+    assertStreamTaskReportsFromWorker(HttpResponseStatus.OK, Optional.of("my report!"));
+  }
+
+  @Test(timeout = 60_000L)
+  public void testStreamTaskReportsUnavailableFromWorker() throws Exception
+  {
+    assertStreamTaskReportsFromWorker(HttpResponseStatus.SERVICE_UNAVAILABLE, Optional.absent());
+  }
+
   /*
    * Task goes PENDING -> RUNNING -> SUCCESS and few more useless notifications in between.
    */
@@ -1939,6 +1962,107 @@ public class HttpRemoteTaskRunnerTest
     return workerHolder;
   }
 
+  private static void assertStreamTaskReportsFromWorker(
+      final HttpResponseStatus responseStatus,
+      final Optional<String> expectedReport
+  ) throws Exception
+  {
+    final HttpClient httpClient = EasyMock.createMock(HttpClient.class);
+    final Capture<Request> capturedRequest = Capture.newInstance();
+    EasyMock.expect(httpClient.go(
+        EasyMock.capture(capturedRequest),
+        EasyMock.anyObject(InputStreamFullResponseHandler.class))
+    ).andReturn(Futures.immediateFuture(taskReportResponse(responseStatus, expectedReport.or("error"))));
+    EasyMock.replay(httpClient);
+
+    final TestDruidNodeDiscovery druidNodeDiscovery = new TestDruidNodeDiscovery();
+    final DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY))
+            .andReturn(druidNodeDiscovery)
+            .times(2);
+    EasyMock.replay(druidNodeDiscoveryProvider);
+
+    final Task task = new NoopTask("task id with spaces", null, null, 0, 0, null);
+    final HttpRemoteTaskRunner taskRunner = newHttpTaskRunnerInstance(
+        druidNodeDiscoveryProvider,
+        new NoopProvisioningStrategy<>(),
+        httpClient,
+        ImmutableMap.of(
+            task,
+            ImmutableList.of(
+                TaskAnnouncement.create(
+                    task,
+                    TaskStatus.running(task.getId()),
+                    TaskLocation.unknown()
+                ),
+                TaskAnnouncement.create(
+                    task,
+                    TaskStatus.running(task.getId()),
+                    TaskLocation.create("host", 1234, -1)
+                )
+            )
+        )
+    );
+
+    try {
+      taskRunner.start();
+      druidNodeDiscovery.getListeners().get(0).nodesAdded(
+          ImmutableList.of(
+              new DiscoveryDruidNode(
+                  new DruidNode("service", "host", false, 1234, null, true, false),
+                  NodeRole.MIDDLE_MANAGER,
+                  ImmutableMap.of(
+                      WorkerNodeService.DISCOVERY_SERVICE_KEY,
+                      new WorkerNodeService("ip1", 1, "0", WorkerConfig.DEFAULT_CATEGORY)
+                  )
+              )
+          )
+      );
+      taskRunner.run(task);
+
+      Assert.assertTrue(
+          TestUtils.conditionValid(
+              () ->
+                  !taskRunner.getRunningTasks().isEmpty()
+                  && !Iterables.getOnlyElement(taskRunner.getRunningTasks())
+                               .getLocation()
+                               .equals(TaskLocation.unknown())
+          )
+      );
+
+      final Optional<InputStream> stream = taskRunner.streamTaskReports(task.getId());
+      if (expectedReport.isPresent()) {
+        Assert.assertTrue(stream.isPresent());
+        Assert.assertEquals(expectedReport.get(), StringUtils.fromUtf8(ByteStreams.toByteArray(stream.get())));
+      } else {
+        Assert.assertEquals(Optional.absent(), stream);
+      }
+
+      Assert.assertEquals(
+          "http://host:1234/druid/worker/v1/chat/task%20id%20with%20spaces/liveReports",
+          capturedRequest.getValue().getUrl().toString()
+      );
+    }
+    finally {
+      taskRunner.stop();
+    }
+
+    EasyMock.verify(druidNodeDiscoveryProvider, httpClient);
+  }
+
+  private static InputStreamFullResponseHolder taskReportResponse(
+      final HttpResponseStatus status,
+      final String content
+  )
+  {
+    final InputStreamFullResponseHolder response = new InputStreamFullResponseHolder(
+        new DefaultHttpResponse(HttpVersion.HTTP_1_1, status)
+    );
+    response.addChunk(StringUtils.toUtf8(content));
+    response.done();
+    return response;
+  }
+
   private static WorkerHolder createWorkerHolder(
       ObjectMapper smileMapper,
       HttpClient httpClient,
@@ -2172,6 +2296,20 @@ public class HttpRemoteTaskRunnerTest
       DruidNodeDiscoveryProvider druidNodeDiscoveryProvider,
       ProvisioningStrategy provisioningStrategy)
   {
+    return newHttpTaskRunnerInstance(
+        druidNodeDiscoveryProvider,
+        provisioningStrategy,
+        EasyMock.createNiceMock(HttpClient.class),
+        ImmutableMap.of()
+    );
+  }
+
+  private static HttpRemoteTaskRunner newHttpTaskRunnerInstance(
+      DruidNodeDiscoveryProvider druidNodeDiscoveryProvider,
+      ProvisioningStrategy provisioningStrategy,
+      HttpClient httpClient,
+      Map<Task, List<TaskAnnouncement>> toBeAssignedTasks)
+  {
     return new HttpRemoteTaskRunner(
         TestHelper.makeJsonMapper(),
         new HttpRemoteTaskRunnerConfig()
@@ -2182,7 +2320,7 @@ public class HttpRemoteTaskRunnerTest
             return 3;
           }
         },
-        EasyMock.createNiceMock(HttpClient.class),
+        httpClient,
         DSuppliers.of(new AtomicReference<>(DefaultWorkerBehaviorConfig.defaultConfig())),
         provisioningStrategy,
         druidNodeDiscoveryProvider,
@@ -2212,7 +2350,7 @@ public class HttpRemoteTaskRunnerTest
             worker,
             ImmutableList.of(),
             ImmutableList.of(),
-            ImmutableMap.of(),
+            toBeAssignedTasks,
             new AtomicInteger(),
             ImmutableSet.of()
         );


### PR DESCRIPTION
<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Overlord task report requests can sometimes be too eager during ingestion and ping a task before the http server servicing the chat requests has spun up. This causes 4xx/5xx to be returned, which are not correctly parsed by the chat client. While this doesn't explicitly fail the ingestion, it spams the logs and causes confusion.

This properly propagates the error code/body through to the response, so no parse exceptions occur.

Example:


```
2026-05-21T01:33:43,097 WARN [qtp1790748582-95] org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTask - Encountered exception when getting live subtask report for task: task123
java.util.concurrent.ExecutionException: java.lang.RuntimeException: com.fasterxml.jackson.databind.exc.InvalidTypeIdException: Could not resolve subtype of [simple type, class org.apache.druid.indexer.report.TaskReport]: missing type id property 'type'
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 10] (through reference chain: org.apache.druid.indexer.report.TaskReport$ReportMap["error"])
	at com.google.common.util.concurrent.AbstractFuture.getDoneValue(AbstractFuture.java:592) ~[guava-32.1.3-jre.jar:?]
	at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:571) ~[guava-32.1.3-jre.jar:?]
	at com.google.common.util.concurrent.FluentFuture$TrustedFuture.get(FluentFuture.java:91) ~[guava-32.1.3-jre.jar:?]
	at org.apache.druid.common.guava.FutureUtils.get(FutureUtils.java:52) ~[druid-processing-34.0.0.jar:34.0.0]
	at org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTask.getTaskReport(ParallelIndexSupervisorTask.java:1881) ~[druid-indexing-service-34.0.0.jar:34.0.0]
	at org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTask.getRowStatsAndUnparseableEventsForRunningTasks(ParallelIndexSupervisorTask.java:1711) ~[druid-indexing-service-34.0.0.jar:34.0.0]
	at org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTask.doGetRowStatsAndUnparseableEventsParallelMultiPhase(ParallelIndexSupervisorTask.java:1688) ~[druid-indexing-service-34.0.0.jar:34.0.0]
	at org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTask.doGetRowStatsAndUnparseableEvents(ParallelIndexSupervisorTask.java:1795) ~[druid-indexing-service-34.0.0.jar:34.0.0]
	at org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTask.doGetLiveReports(ParallelIndexSupervisorTask.java:1838) ~[druid-indexing-service-34.0.0.jar:34.0.0]
	at org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTask.getLiveReports(ParallelIndexSupervisorTask.java:1868) ~[druid-indexing-service-34.0.0.jar:34.0.0]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:569) ~[?:?]
	at com.sun.jersey.spi.container.JavaMethodInvokerFactory$1.invoke(JavaMethodInvokerFactory.java:60) ~[jersey-server-1.19.4.jar:1.19.4]
	at com.sun.jersey.server.impl.model.method.dispatch.AbstractResourceMethodDispatchProvider$ResponseOutInvoker._dispatch(AbstractResourceMethodDispatchProvider.java:205) ~[jersey-server-1.19.4.jar:1.19.4]
	at com.sun.jersey.server.impl.model.method.dispatch.ResourceJavaMethodDispatcher.dispatch(ResourceJavaMethodDispatcher.java:75) ~[jersey-server-1.19.4.jar:1.19.4]
	at com.sun.jersey.server.impl.uri.rules.HttpMethodRule.accept(HttpMethodRule.java:302) ~[jersey-server-1.19.4.jar:1.19.4]
	at com.sun.jersey.server.impl.uri.rules.RightHandPathRule.accept(RightHandPathRule.java:147) ~[jersey-server-1.19.4.jar:1.19.4]
	at com.sun.jersey.server.impl.uri.rules.SubLocatorRule.accept(SubLocatorRule.java:137) ~[jersey-server-1.19.4.jar:1.19.4]
	at com.sun.jersey.server.impl.uri.rules.RightHandPathRule.accept(RightHandPathRule.java:147) ~[jersey-server-1.19.4.jar:1.19.4]
	at com.sun.jersey.server.impl.uri.rules.ResourceClassRule.accept(ResourceClassRule.java:108) ~[jersey-server-1.19.4.jar:1.19.4]
	at com.sun.jersey.server.impl.uri.rules.RightHandPathRule.accept(RightHandPathRule.java:147) ~[jersey-server-1.19.4.jar:1.19.4]
	at com.sun.jersey.server.impl.uri.rules.RootResourceClassesRule.accept(RootResourceClassesRule.java:84) ~[jersey-server-1.19.4.jar:1.19.4]
	at com.sun.jersey.server.impl.application.WebApplicationImpl._handleRequest(WebApplicationImpl.java:1542) ~[jersey-server-1.19.4.jar:1.19.4]
	at com.sun.jersey.server.impl.application.WebApplicationImpl._handleRequest(WebApplicationImpl.java:1473) ~[jersey-server-1.19.4.jar:1.19.4]
	at com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:1419) ~[jersey-server-1.19.4.jar:1.19.4]
	at com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:1409) ~[jersey-server-1.19.4.jar:1.19.4]
	at com.sun.jersey.spi.container.servlet.WebComponent.service(WebComponent.java:409) ~[jersey-servlet-1.19.4.jar:1.19.4]
	at com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:558) ~[jersey-servlet-1.19.4.jar:1.19.4]
	at com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:733) ~[jersey-servlet-1.19.4.jar:1.19.4]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790) ~[javax.servlet-api-3.1.0.jar:3.1.0]
	at com.google.inject.servlet.ServletDefinition.doServiceImpl(ServletDefinition.java:290) ~[guice-servlet-5.1.0.jar:?]
	at com.google.inject.servlet.ServletDefinition.doService(ServletDefinition.java:280) ~[guice-servlet-5.1.0.jar:?]
	at com.google.inject.servlet.ServletDefinition.service(ServletDefinition.java:184) ~[guice-servlet-5.1.0.jar:?]
	at com.google.inject.servlet.ManagedServletPipeline.service(ManagedServletPipeline.java:89) ~[guice-servlet-5.1.0.jar:?]
	at com.google.inject.servlet.FilterChainInvocation.doFilter(FilterChainInvocation.java:85) ~[guice-servlet-5.1.0.jar:?]
	at com.google.inject.servlet.ManagedFilterPipeline.dispatch(ManagedFilterPipeline.java:121) ~[guice-servlet-5.1.0.jar:?]
	at com.google.inject.servlet.GuiceFilter.doFilter(GuiceFilter.java:133) ~[guice-servlet-5.1.0.jar:?]
	at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193) ~[jetty-servlet-9.4.57.v20241219.jar:9.4.57.v20241219]
	at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1626) ~[jetty-servlet-9.4.57.v20241219.jar:9.4.57.v20241219]
	at org.apache.druid.server.security.PreResponseAuthorizationCheckFilter.doFilter(PreResponseAuthorizationCheckFilter.java:84) ~[druid-server-34.0.0.jar:34.0.0]
	at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193) ~[jetty-servlet-9.4.57.v20241219.jar:9.4.57.v20241219]
	at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1626) ~[jetty-servlet-9.4.57.v20241219.jar:9.4.57.v20241219]
	at org.apache.druid.server.initialization.jetty.StandardResponseHeaderFilterHolder$StandardResponseHeaderFilter.doFilter(StandardResponseHeaderFilterHolder.java:164) ~[druid-server-34.0.0.jar:34.0.0]
	at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193) ~[jetty-servlet-9.4.57.v20241219.jar:9.4.57.v20241219]
	at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1626) ~[jetty-servlet-9.4.57.v20241219.jar:9.4.57.v20241219]
	at org.apache.druid.server.initialization.jetty.ResponseHeaderFilterHolder$ResponseHeaderFilter.doFilter(ResponseHeaderFilterHolder.java:100) ~[druid-server-34.0.0.jar:34.0.0]
	at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193) ~[jetty-servlet-9.4.57.v20241219.jar:9.4.57.v20241219]
	at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1626) ~[jetty-servlet-...
```

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Overlord task report requests can sometimes be too eager during ingestion and ping a task before the http server servicing the chat requests has spun up. This causes 4xx/5xx to be returned, which are not correctly parsed by the chat client. While this doesn't explicitly fail the ingestion, it spams the logs and causes confusion.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.