### PR TITLE
perf: Hoist config check in acquireSegment.

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
@@ -473,16 +473,16 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
       return acquireExisting;
     }
 
+    if (!config.isVirtualStorage()) {
+      return AcquireSegmentAction.missingSegment();
+    }
+
     final ReferenceCountingLock lock = lock(dataSegment);
     synchronized (lock) {
       try {
         final AcquireSegmentAction retryAcquireExisting = acquireExistingSegment(identifier);
         if (retryAcquireExisting != null) {
           return retryAcquireExisting;
-        }
-
-        if (!config.isVirtualStorage()) {
-          return AcquireSegmentAction.missingSegment();
         }
 
         final Iterator<StorageLocation> iterator = strategy.getLocations();


### PR DESCRIPTION
When virtual storage is not enabled, it is not possible for a segment to be acquired unless it is already-existing.