### PR TITLE
build(deps): Bump jackson to `2.21.3`

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -321,7 +321,7 @@ name: Jackson
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.20.2
+version: 2.21.3
 libraries:
   - com.fasterxml.jackson.core: jackson-core
   - com.fasterxml.jackson.core: jackson-annotations
@@ -364,7 +364,7 @@ name: Jackson
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: "2.20"
+version: "2.21"
 libraries:
   - com.fasterxml.jackson.core: jackson-annotations
 
@@ -374,7 +374,7 @@ name: Jackson
 license_category: binary
 module: extensions-contrib/druid-deltalake-extensions
 license_name: Apache License version 2.0
-version: 2.20.2
+version: 2.21.3
 libraries:
   - com.fasterxml.jackson.core: jackson-databind
 notice: |
@@ -1002,7 +1002,7 @@ name: Jackson
 license_category: binary
 module: extensions-core/kubernetes-overlord-extensions
 license_name: Apache License version 2.0
-version: 2.20.2
+version: 2.21.3
 libraries:
   - com.fasterxml.jackson.dataformat: jackson-dataformat-properties
 notice: |
@@ -1104,6 +1104,16 @@ license_name: Apache License version 2.0
 version: 1.17.2
 libraries:
   - com.squareup.okio: okio
+
+---
+
+name: org.jspecify jspecify
+license_category: binary
+module: extensions-core/kubernetes-extensions
+license_name: Apache License version 2.0
+version: 1.0.0
+libraries:
+  - org.jspecify: jspecify
 
 ---
 
@@ -3069,7 +3079,7 @@ libraries:
 ---
 
 name: Jackson Dataformat Yaml
-version: 2.20.2
+version: 2.21.3
 license_category: binary
 module: extensions/druid-avro-extensions
 license_name: Apache License version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <iceberg.core.version>1.10.0</iceberg.core.version>
         <jetty.version>12.1.8</jetty.version>
         <jersey.version>1.19.4</jersey.version>
-        <jackson.version>2.20.2</jackson.version>
+        <jackson.version>2.21.3</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
         <log4j.version>2.25.4</log4j.version>
         <mysql.version>8.2.0</mysql.version>

--- a/processing/src/main/java/org/apache/druid/guice/GuiceAnnotationIntrospector.java
+++ b/processing/src/main/java/org/apache/druid/guice/GuiceAnnotationIntrospector.java
@@ -44,19 +44,25 @@ public class GuiceAnnotationIntrospector extends NopAnnotationIntrospector
   @Override
   public JacksonInject.Value findInjectableValue(AnnotatedMember m)
   {
-    Object id = findGuiceInjectId(m);
+    // Preserve useInput / optional from the annotation. The simpler Value.forId(id) drops
+    // them and relies on AnnotationIntrospectorPair's fallback. See FasterXML/jackson-databind#1381.
+    final JacksonInject annotation = m.getAnnotation(JacksonInject.class);
+    if (annotation == null) {
+      return null;
+    }
+    final Object id = findGuiceInjectId(m);
     if (id == null) {
       return null;
     }
-    return JacksonInject.Value.forId(id);
+    return JacksonInject.Value.from(annotation).withId(id);
   }
 
+  /**
+   * Resolves the Guice {@link Key} for an annotated member. Callers must verify that {@code m}
+   * carries a {@link JacksonInject} annotation before invoking; this method does not re-check.
+   */
   private Object findGuiceInjectId(AnnotatedMember m)
   {
-    if (m.getAnnotation(JacksonInject.class) == null) {
-      return null;
-    }
-
     Type genericType = null;
 
     Annotation guiceAnnotation = null;

--- a/server/src/main/java/org/apache/druid/server/DruidNode.java
+++ b/server/src/main/java/org/apache/druid/server/DruidNode.java
@@ -22,6 +22,7 @@ package org.apache.druid.server;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.OptBoolean;
 import com.google.common.base.Preconditions;
 import com.google.common.net.HostAndPort;
 import com.google.inject.name.Named;
@@ -130,12 +131,12 @@ public class DruidNode
    */
   @JsonCreator
   public DruidNode(
-      @JacksonInject @Named("serviceName") @JsonProperty("service") String serviceName,
+      @JacksonInject(useInput = OptBoolean.TRUE) @Named("serviceName") @JsonProperty("service") String serviceName,
       @JsonProperty("host") String host,
       @JsonProperty("bindOnHost") boolean bindOnHost,
       @JsonProperty("plaintextPort") Integer plaintextPort,
-      @JacksonInject @Named("servicePort") @JsonProperty("port") Integer port,
-      @JacksonInject @Named("tlsServicePort") @JsonProperty("tlsPort") Integer tlsPort,
+      @JacksonInject(useInput = OptBoolean.TRUE) @Named("servicePort") @JsonProperty("port") Integer port,
+      @JacksonInject(useInput = OptBoolean.TRUE) @Named("tlsServicePort") @JsonProperty("tlsPort") Integer tlsPort,
       @JsonProperty("enablePlaintextPort") Boolean enablePlaintextPort,
       @JsonProperty("enableTlsPort") boolean enableTlsPort,
       @JsonProperty("labels") @Nullable Map<String, String> labels


### PR DESCRIPTION
### Description

This PR bumps `jackson` (`2.20.2` to `2.21.3`) and adds a missing license entry for `org.jspecify:jspecify` in `extensions-core/kubernetes-extensions`.

#### Bumped Jackson to 2.21.3

Jackson 2.21 changed the default resolution behaviour when `@JacksonInject` and `@JsonProperty` annotate the same parameter: the injected value now wins over the JSON value, where 2.20 treated the inject as a fallback used only when JSON did not supply one. This affects `DruidNode`'s `serviceName`, `port`, and `tlsPort` parameters, which carry both annotations with the expectation that JSON config values win when present; everywhere else the annotations are on distinct parameters and are unaffected. See _Most Wanted Feature: Injection-only `@JacksonInject`_ in the [release blog post](https://cowtowncoder.medium.com/jackson-2-21-released-ce0b6582ae67).

#### Restored JSON-input precedence on `DruidNode`

Added the explicit `useInput = OptBoolean.TRUE` to the three `@JacksonInject` annotations on `DruidNode`'s constructor parameters so that JSON wins over inject.

#### Release note

Dependency Bumps:
* jackson: 2.20.2 → 2.21.3

If external code has both `@JacksonInject` and `@JsonProperty` on the same parameter and relies on the JSON value winning when supplied, add the explicit `useInput = OptBoolean.TRUE` to the annotation (or stay on Jackson 2.20.x). All such sites in Druid itself have been updated.

<hr>

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.