### PR TITLE
feat: Web console support for resetToLatestAndBackfill

### DIFF
--- a/web-console/src/components/fancy-numeric-input/fancy-numeric-input.tsx
+++ b/web-console/src/components/fancy-numeric-input/fancy-numeric-input.tsx
@@ -220,14 +220,20 @@ export const FancyNumericInput = React.memo(function FancyNumericInput(
           disabled={effectiveDisabled || isIncrementDisabled}
           icon={IconNames.CHEVRON_UP}
           intent={intent}
-          onMouseDown={e => increment(getIncrementSize(e.shiftKey, e.altKey))}
+          onMouseDown={e => {
+            e.preventDefault();
+            increment(getIncrementSize(e.shiftKey, e.altKey));
+          }}
         />
         <Button
           aria-label="decrement"
           disabled={effectiveDisabled || isDecrementDisabled}
           icon={IconNames.CHEVRON_DOWN}
           intent={intent}
-          onMouseDown={e => increment(-getIncrementSize(e.shiftKey, e.altKey))}
+          onMouseDown={e => {
+            e.preventDefault();
+            increment(-getIncrementSize(e.shiftKey, e.altKey));
+          }}
         />
       </ButtonGroup>
     </ControlGroup>

--- a/web-console/src/dialogs/index.ts
+++ b/web-console/src/dialogs/index.ts
@@ -37,6 +37,7 @@ export * from './snitch-dialog/snitch-dialog';
 export * from './spec-dialog/spec-dialog';
 export * from './string-input-dialog/string-input-dialog';
 export * from './supervisor-reset-offsets-dialog/supervisor-reset-offsets-dialog';
+export * from './supervisor-reset-to-latest-dialog/supervisor-reset-to-latest-dialog';
 export * from './supervisor-table-action-dialog/supervisor-table-action-dialog';
 export * from './table-action-dialog/table-action-dialog';
 export * from './task-group-handoff-dialog/task-group-handoff-dialog';

--- a/web-console/src/dialogs/supervisor-reset-to-latest-dialog/supervisor-reset-to-latest-dialog.tsx
+++ b/web-console/src/dialogs/supervisor-reset-to-latest-dialog/supervisor-reset-to-latest-dialog.tsx
@@ -75,7 +75,7 @@ export function SupervisorResetToLatestDialog(props: SupervisorResetToLatestDial
           onValueChange={v => setBackfillTaskCount(v)}
           onValueEmpty={() => setBackfillTaskCount(undefined)}
           min={1}
-          placeholder="Use supervisor spec default"
+          placeholder="Use supervisor's taskCount by default"
           fill
         />
       </FormGroup>

--- a/web-console/src/dialogs/supervisor-reset-to-latest-dialog/supervisor-reset-to-latest-dialog.tsx
+++ b/web-console/src/dialogs/supervisor-reset-to-latest-dialog/supervisor-reset-to-latest-dialog.tsx
@@ -36,7 +36,9 @@ export function SupervisorResetToLatestDialog(props: SupervisorResetToLatestDial
   return (
     <AsyncActionDialog
       action={async () => {
-        const url = `/druid/indexer/v1/supervisor/${Api.encodePath(supervisorId)}/resetToLatestAndBackfill${
+        const url = `/druid/indexer/v1/supervisor/${Api.encodePath(
+          supervisorId,
+        )}/resetToLatestAndBackfill${
           backfillTaskCount !== undefined ? `?backfillTaskCount=${backfillTaskCount}` : ''
         }`;
         const resp = await Api.instance.post(url, {});

--- a/web-console/src/dialogs/supervisor-reset-to-latest-dialog/supervisor-reset-to-latest-dialog.tsx
+++ b/web-console/src/dialogs/supervisor-reset-to-latest-dialog/supervisor-reset-to-latest-dialog.tsx
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FormGroup, Intent, Tag } from '@blueprintjs/core';
+import { useState } from 'react';
+
+import { FancyNumericInput } from '../../components/fancy-numeric-input/fancy-numeric-input';
+import { Api } from '../../singletons';
+import { AsyncActionDialog } from '../async-action-dialog/async-action-dialog';
+
+export interface SupervisorResetToLatestDialogProps {
+  supervisorId: string;
+  onClose(): void;
+  onSuccess(): void;
+}
+
+export function SupervisorResetToLatestDialog(props: SupervisorResetToLatestDialogProps) {
+  const { supervisorId, onClose, onSuccess } = props;
+  const [backfillTaskCount, setBackfillTaskCount] = useState<number | undefined>();
+
+  return (
+    <AsyncActionDialog
+      action={async () => {
+        const url = `/druid/indexer/v1/supervisor/${Api.encodePath(supervisorId)}/resetToLatestAndBackfill${
+          backfillTaskCount !== undefined ? `?backfillTaskCount=${backfillTaskCount}` : ''
+        }`;
+        const resp = await Api.instance.post(url, {});
+        return resp.data;
+      }}
+      confirmButtonText="Reset to latest and backfill"
+      successText="Supervisor has been reset to latest and backfill initiated"
+      failText="Could not reset supervisor to latest and backfill"
+      intent={Intent.DANGER}
+      onClose={onClose}
+      onSuccess={onSuccess}
+      warningChecks={[
+        <>
+          I understand that resetting <Tag minimal>{supervisorId}</Tag> may result in duplicate data
+          due to in-flight tasks at the time of reset.
+        </>,
+        'I understand that this operation cannot be undone.',
+      ]}
+    >
+      <p>
+        Are you sure you want to reset supervisor <Tag minimal>{supervisorId}</Tag> to the latest
+        offsets and initiate a backfill?
+      </p>
+      <p>
+        The supervisor will resume from the latest offsets while a backfill supervisor processes the
+        skipped range. Duplicate data may occur due to in-flight tasks at the time of reset.
+      </p>
+      <FormGroup
+        label="Backfill task count"
+        helperText="Number of tasks to use for the backfill. Defaults to the task count in the supervisor spec."
+      >
+        <FancyNumericInput
+          value={backfillTaskCount}
+          onValueChange={v => setBackfillTaskCount(v)}
+          onValueEmpty={() => setBackfillTaskCount(undefined)}
+          min={1}
+          placeholder="Use supervisor spec default"
+          fill
+        />
+      </FormGroup>
+    </AsyncActionDialog>
+  );
+}

--- a/web-console/src/views/supervisors-view/supervisors-view.tsx
+++ b/web-console/src/views/supervisors-view/supervisors-view.tsx
@@ -43,6 +43,7 @@ import {
   AsyncActionDialog,
   SpecDialog,
   SupervisorResetOffsetsDialog,
+  SupervisorResetToLatestDialog,
   SupervisorTableActionDialog,
   TaskGroupHandoffDialog,
 } from '../../dialogs';
@@ -195,6 +196,7 @@ export interface SupervisorsViewState {
   handoffSupervisorId?: string;
   resetOffsetsSupervisorInfo?: { id: string; type: string };
   resetSupervisorId?: string;
+  resetToLatestSupervisorId?: string;
   terminateSupervisorId?: string;
 
   showResumeAllSupervisors: boolean;
@@ -580,6 +582,12 @@ export class SupervisorsView extends React.PureComponent<
         onAction: () => this.setState({ resetSupervisorId: supervisor_id }),
       },
       {
+        icon: IconNames.FAST_FORWARD,
+        title: 'Reset to latest and backfill',
+        intent: Intent.DANGER,
+        onAction: () => this.setState({ resetToLatestSupervisorId: supervisor_id }),
+      },
+      {
         icon: IconNames.CROSS,
         title: 'Terminate',
         intent: Intent.DANGER,
@@ -723,6 +731,23 @@ export class SupervisorsView extends React.PureComponent<
           missing offsets.
         </p>
       </AsyncActionDialog>
+    );
+  }
+
+  renderResetToLatestSupervisorAction() {
+    const { resetToLatestSupervisorId } = this.state;
+    if (!resetToLatestSupervisorId) return;
+
+    return (
+      <SupervisorResetToLatestDialog
+        supervisorId={resetToLatestSupervisorId}
+        onClose={() => {
+          this.setState({ resetToLatestSupervisorId: undefined });
+        }}
+        onSuccess={() => {
+          this.supervisorQueryManager.rerunLastQuery();
+        }}
+      />
     );
   }
 
@@ -1332,6 +1357,7 @@ export class SupervisorsView extends React.PureComponent<
         {this.renderTaskGroupHandoffAction()}
         {this.renderResetOffsetsSupervisorAction()}
         {this.renderResetSupervisorAction()}
+        {this.renderResetToLatestSupervisorAction()}
         {this.renderTerminateSupervisorAction()}
         {supervisorSpecDialogOpen && (
           <SpecDialog


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

Adds web-console support for the resetToLatestAndBackfill endpoint that was added in https://github.com/apache/druid/pull/19477

<img width="207" height="307" alt="Screenshot 2026-05-30 at 2 37 47 PM" src="https://github.com/user-attachments/assets/6d153643-9113-408e-89dd-8053f9ebcfc1" />
<img width="401" height="393" alt="Screenshot 2026-06-01 at 11 54 37 AM" src="https://github.com/user-attachments/assets/4e2ab652-6ea3-4a58-a276-39653bb0ec57" />



<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
Adds web-console support for the resetToLatestAndBackfill endpoint 
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `web-console/src/dialogs/supervisor-reset-to-latest-dialog/supervisor-reset-to-latest-dialog.tsx`
 * `web-console/src/views/supervisors-view/supervisors-view.tsx`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.