### PR TITLE
minor: scale AWSClientConfig default maxConnections with available processors

### DIFF
--- a/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSClientConfig.java
+++ b/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSClientConfig.java
@@ -19,7 +19,9 @@
 
 package org.apache.druid.common.aws;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.utils.RuntimeInfo;
 
 import javax.annotation.Nullable;
 
@@ -31,7 +33,17 @@ public class AWSClientConfig
 
   private static final int DEFAULT_CONNECTION_TIMEOUT_MILLIS = 10_000;
   private static final int DEFAULT_SOCKET_TIMEOUT_MILLIS = 50_000;
-  private static final int DEFAULT_MAX_CONNECTIONS = 50;
+  /** AWS SDK v2's own default. */
+  private static final int DEFAULT_MAX_CONNECTIONS_FLOOR = 50;
+
+  /**
+   * Used by {@link #getMaxConnections} to scale the default connection pool with host size so hosts large enough to
+   * do a lot of concurrent deep-storage I/O (e.g. virtual-storage historicals fanning out on-demand loads to S3)
+   * aren't bottlenecked at the SDK's connection pool. The field initializer covers direct construction (no Jackson);
+   * Jackson overwrites with the injected {@link RuntimeInfo} during deserialization.
+   */
+  @JacksonInject
+  private final RuntimeInfo runtimeInfo = new RuntimeInfo();
 
   @JsonProperty
   private String protocol = "https"; // The default of aws-java-sdk
@@ -60,8 +72,13 @@ public class AWSClientConfig
   @JsonProperty
   private int socketTimeout = DEFAULT_SOCKET_TIMEOUT_MILLIS;
 
+  /**
+   * Null means use the dynamic default in {@link #getMaxConnections} ({@code max(50, 4 × availableProcessors)});
+   * any explicit value set in JSON wins.
+   */
   @JsonProperty
-  private int maxConnections = DEFAULT_MAX_CONNECTIONS;
+  @Nullable
+  private Integer maxConnections = null;
 
   public String getProtocol()
   {
@@ -123,7 +140,10 @@ public class AWSClientConfig
 
   public int getMaxConnections()
   {
-    return maxConnections;
+    if (maxConnections != null) {
+      return maxConnections;
+    }
+    return Math.max(DEFAULT_MAX_CONNECTIONS_FLOOR, 4 * runtimeInfo.getAvailableProcessors());
   }
 
   @Override
@@ -136,7 +156,7 @@ public class AWSClientConfig
            ", crossRegionAccessEnabled=" + isCrossRegionAccessEnabled() +
            ", connectionTimeout=" + connectionTimeout +
            ", socketTimeout=" + socketTimeout +
-           ", maxConnections=" + maxConnections +
+           ", maxConnections=" + getMaxConnections() +
            '}';
   }
 }

--- a/cloud/aws-common/src/test/java/org/apache/druid/common/aws/AWSClientConfigTest.java
+++ b/cloud/aws-common/src/test/java/org/apache/druid/common/aws/AWSClientConfigTest.java
@@ -19,13 +19,24 @@
 
 package org.apache.druid.common.aws;
 
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.utils.RuntimeInfo;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class AWSClientConfigTest
 {
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectMapper MAPPER = new ObjectMapper().setInjectableValues(
+      new InjectableValues.Std().addValue(RuntimeInfo.class, new RuntimeInfo())
+  );
+
+  private static ObjectMapper mapperWithRuntimeInfo(RuntimeInfo runtimeInfo)
+  {
+    return new ObjectMapper().setInjectableValues(
+        new InjectableValues.Std().addValue(RuntimeInfo.class, runtimeInfo)
+    );
+  }
 
   @Test
   public void testDefaultCrossRegionAccessEnabled() throws Exception
@@ -82,5 +93,45 @@ public class AWSClientConfigTest
     );
     Assertions.assertNull(config.isForceGlobalBucketAccessEnabled());
     Assertions.assertTrue(config.isCrossRegionAccessEnabled());
+  }
+
+  @Test
+  public void testDefaultMaxConnectionsKeepsAwsSdkFloorOnSmallHost() throws Exception
+  {
+    AWSClientConfig config = mapperWithRuntimeInfo(new FixedProcessorsRuntimeInfo(8))
+        .readValue("{}", AWSClientConfig.class);
+    Assertions.assertEquals(50, config.getMaxConnections());
+  }
+
+  @Test
+  public void testDefaultMaxConnectionsScalesWithCoresOnLargeHost() throws Exception
+  {
+    AWSClientConfig config = mapperWithRuntimeInfo(new FixedProcessorsRuntimeInfo(32))
+        .readValue("{}", AWSClientConfig.class);
+    Assertions.assertEquals(128, config.getMaxConnections());
+  }
+
+  @Test
+  public void testExplicitMaxConnectionsOverridesDefault() throws Exception
+  {
+    AWSClientConfig config = mapperWithRuntimeInfo(new FixedProcessorsRuntimeInfo(64))
+        .readValue("{\"maxConnections\": 200}", AWSClientConfig.class);
+    Assertions.assertEquals(200, config.getMaxConnections());
+  }
+
+  private static final class FixedProcessorsRuntimeInfo extends RuntimeInfo
+  {
+    private final int availableProcessors;
+
+    private FixedProcessorsRuntimeInfo(int availableProcessors)
+    {
+      this.availableProcessors = availableProcessors;
+    }
+
+    @Override
+    public int getAvailableProcessors()
+    {
+      return availableProcessors;
+    }
   }
 }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3StorageDruidModuleTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3StorageDruidModuleTest.java
@@ -19,11 +19,12 @@
 
 package org.apache.druid.storage.s3;
 
-import com.google.common.collect.ImmutableList;
+import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.apache.druid.common.aws.AWSModule;
-import org.apache.druid.guice.GuiceInjectors;
+import org.apache.druid.guice.DruidSecondaryModule;
 import org.apache.druid.guice.ServerModule;
+import org.apache.druid.guice.StartupInjectorBuilder;
 import org.apache.druid.segment.loading.OmniDataSegmentArchiver;
 import org.apache.druid.segment.loading.OmniDataSegmentKiller;
 import org.apache.druid.segment.loading.OmniDataSegmentMover;
@@ -70,12 +71,12 @@ public class S3StorageDruidModuleTest
 
   private static Injector createInjector()
   {
-    return GuiceInjectors.makeStartupInjectorWithModules(
-        ImmutableList.of(
-            new AWSModule(),
-            new S3StorageDruidModule(),
-            new ServerModule()
-        )
+    final Injector startupInjector = new StartupInjectorBuilder().forServer().build();
+    return Guice.createInjector(
+        startupInjector.getInstance(DruidSecondaryModule.class),
+        new AWSModule(),
+        new S3StorageDruidModule(),
+        new ServerModule()
     );
   }
 }


### PR DESCRIPTION
### Description
This PR updates the default S3 connection pool size to be computed based on the number of available processors to be more friendly to the default load on demand thread pool concurrency limits added in #19396 (so that there are ~ the same number of s3 connections in the pool as there are download threads allowed to run on demand)

changes:
* `AWSClientConfig` now defaults `maxConnections` to scale with available processors `(max(50, 4 * cores))` to be in sync with virtual storage mode historical download thread pool size
* tests with artificial `RuntimeInfo` to cover the config scaling
