### PR TITLE
fix: KafkaBoundedSupervisorTest  flaky test

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/KafkaBoundedSupervisorTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/KafkaBoundedSupervisorTest.java
@@ -87,8 +87,9 @@ public class KafkaBoundedSupervisorTest extends StreamIndexTestBase
 
     cluster.callApi().postSupervisor(supervisor);
 
-    // Wait for records to be ingested
-    waitUntilPublishedRecordsAreIngested(totalRecords);
+    // Bounded supervisor cold start (post supervisor -> schedule task -> consume -> publish) can exceed
+    // the cluster default wait on CI; give it a generous ceiling.
+    waitUntilPublishedRecordsAreIngested(totalRecords, 120_000L);
 
     // Wait for supervisor to transition to COMPLETED state
     waitForSupervisorToComplete(supervisor.getId());

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/StreamIndexTestBase.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/StreamIndexTestBase.java
@@ -49,7 +49,6 @@ import org.apache.druid.testing.embedded.tools.WikipediaStreamEventStreamGenerat
 import org.joda.time.Period;
 import org.junit.jupiter.api.Assertions;
 
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 
@@ -136,7 +135,19 @@ public abstract class StreamIndexTestBase extends EmbeddedClusterTestBase
    */
   protected void waitUntilPublishedRecordsAreIngested(int expectedRowCount)
   {
-    waitUntilPublishedRecordsAreIngested(expectedRowCount, null);
+    indexer.latchableEmitter().waitForEventAggregate(
+        event -> event.hasMetricName("ingest/rows/published")
+                      .hasDimension(DruidMetrics.DATASOURCE, dataSource),
+        agg -> agg.hasSumAtLeast(expectedRowCount)
+    );
+
+    final int totalEventsProcessed = indexer
+        .latchableEmitter()
+        .getMetricValues("ingest/rows/published", Map.of(DruidMetrics.DATASOURCE, dataSource))
+        .stream()
+        .mapToInt(Number::intValue)
+        .sum();
+    Assertions.assertEquals(expectedRowCount, totalEventsProcessed);
   }
 
   /**
@@ -144,22 +155,14 @@ public abstract class StreamIndexTestBase extends EmbeddedClusterTestBase
    * Use for ingestion paths with a heavier task lifecycle (e.g. bounded supervisor cold start) where the
    * cluster default may not allow enough headroom on CI.
    */
-  protected void waitUntilPublishedRecordsAreIngested(int expectedRowCount, @Nullable Long timeoutMillis)
+  protected void waitUntilPublishedRecordsAreIngested(int expectedRowCount, Long timeoutMillis)
   {
-    if (timeoutMillis == null) {
-      indexer.latchableEmitter().waitForEventAggregate(
-          event -> event.hasMetricName("ingest/rows/published")
-                        .hasDimension(DruidMetrics.DATASOURCE, dataSource),
-          agg -> agg.hasSumAtLeast(expectedRowCount)
-      );
-    } else {
-      indexer.latchableEmitter().waitForEventAggregate(
-          event -> event.hasMetricName("ingest/rows/published")
-                        .hasDimension(DruidMetrics.DATASOURCE, dataSource),
-          agg -> agg.hasSumAtLeast(expectedRowCount),
-          timeoutMillis
-      );
-    }
+    indexer.latchableEmitter().waitForEventAggregate(
+        event -> event.hasMetricName("ingest/rows/published")
+                      .hasDimension(DruidMetrics.DATASOURCE, dataSource),
+        agg -> agg.hasSumAtLeast(expectedRowCount),
+        timeoutMillis
+    );
 
     final int totalEventsProcessed = indexer
         .latchableEmitter()

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/StreamIndexTestBase.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/StreamIndexTestBase.java
@@ -49,6 +49,7 @@ import org.apache.druid.testing.embedded.tools.WikipediaStreamEventStreamGenerat
 import org.joda.time.Period;
 import org.junit.jupiter.api.Assertions;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 
@@ -143,7 +144,7 @@ public abstract class StreamIndexTestBase extends EmbeddedClusterTestBase
    * Use for ingestion paths with a heavier task lifecycle (e.g. bounded supervisor cold start) where the
    * cluster default may not allow enough headroom on CI.
    */
-  protected void waitUntilPublishedRecordsAreIngested(int expectedRowCount, Long timeoutMillis)
+  protected void waitUntilPublishedRecordsAreIngested(int expectedRowCount, @Nullable Long timeoutMillis)
   {
     if (timeoutMillis == null) {
       indexer.latchableEmitter().waitForEventAggregate(

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/StreamIndexTestBase.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/StreamIndexTestBase.java
@@ -131,15 +131,34 @@ public abstract class StreamIndexTestBase extends EmbeddedClusterTestBase
 
   /**
    * Waits until the total row count of successfully published segments matches
-   * {@code expectedRowCount}.
+   * {@code expectedRowCount}, using the cluster default emitter timeout.
    */
   protected void waitUntilPublishedRecordsAreIngested(int expectedRowCount)
   {
-    indexer.latchableEmitter().waitForEventAggregate(
-        event -> event.hasMetricName("ingest/rows/published")
-                      .hasDimension(DruidMetrics.DATASOURCE, dataSource),
-        agg -> agg.hasSumAtLeast(expectedRowCount)
-    );
+    waitUntilPublishedRecordsAreIngested(expectedRowCount, null);
+  }
+
+  /**
+   * Same as {@link #waitUntilPublishedRecordsAreIngested(int)} but with an explicit timeout in millis.
+   * Use for ingestion paths with a heavier task lifecycle (e.g. bounded supervisor cold start) where the
+   * cluster default may not allow enough headroom on CI.
+   */
+  protected void waitUntilPublishedRecordsAreIngested(int expectedRowCount, Long timeoutMillis)
+  {
+    if (timeoutMillis == null) {
+      indexer.latchableEmitter().waitForEventAggregate(
+          event -> event.hasMetricName("ingest/rows/published")
+                        .hasDimension(DruidMetrics.DATASOURCE, dataSource),
+          agg -> agg.hasSumAtLeast(expectedRowCount)
+      );
+    } else {
+      indexer.latchableEmitter().waitForEventAggregate(
+          event -> event.hasMetricName("ingest/rows/published")
+                        .hasDimension(DruidMetrics.DATASOURCE, dataSource),
+          agg -> agg.hasSumAtLeast(expectedRowCount),
+          timeoutMillis
+      );
+    }
 
     final int totalEventsProcessed = indexer
         .latchableEmitter()

--- a/server/src/test/java/org/apache/druid/server/metrics/LatchableEmitter.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/LatchableEmitter.java
@@ -203,6 +203,18 @@ public class LatchableEmitter extends StubServiceEmitter
       UnaryOperator<AggregateMatcher> aggregateCondition
   )
   {
+    waitForEventAggregate(condition, aggregateCondition, defaultWaitTimeoutMillis);
+  }
+
+  /**
+   * Same as {@link #waitForEventAggregate(UnaryOperator, UnaryOperator)} but with an explicit timeout.
+   */
+  public void waitForEventAggregate(
+      UnaryOperator<EventMatcher> condition,
+      UnaryOperator<AggregateMatcher> aggregateCondition,
+      long timeoutMillis
+  )
+  {
     final EventMatcher eventMatcher = condition.apply(new EventMatcher());
     final AggregateMatcher aggregateMatcher = aggregateCondition.apply(new AggregateMatcher());
 
@@ -210,7 +222,7 @@ public class LatchableEmitter extends StubServiceEmitter
         event -> event instanceof ServiceMetricEvent
                  && eventMatcher.test((ServiceMetricEvent) event)
                  && aggregateMatcher.test((ServiceMetricEvent) event),
-        defaultWaitTimeoutMillis
+        timeoutMillis
     );
   }
 


### PR DESCRIPTION

Fixes https://github.com/apache/druid/issues/19542 .


### Description
embedded-tests: allow per-call timeout for ingestion wait, bump KafkaBoundedSupervisorTest to 120s

The bounded
supervisor cold-start pipeline (post supervisor -> schedule task ->
assign partitions -> consume from Kafka -> publish -> COMPLETED) can
exceed the cluster default 60s on a cold CI runner.



#### Release note


- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [ ] been tested in a test Druid cluster.