### PR TITLE
Fix a small typo in bin/start-druid

### DIFF
--- a/examples/bin/start-druid
+++ b/examples/bin/start-druid
@@ -31,5 +31,5 @@ elif [ -x "$(command -v python)" ]
 then
   exec python "$WHEREAMI/start-druid-main.py" "$@"
 else
-  echo "python interepreter not found"
+  echo "python interpreter not found"
 fi


### PR DESCRIPTION
Fixes a typo in the error message "python interpreter not found" when running `bin/start-druid` with no installed python interpreter. The error message previously read "python inter**e**preter not found".

### Description

Only the error message string was changed. I feel like this is not big enough to warrant an addition to the release notes.

This PR has:

- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.