### PR TITLE
feat: introduce intermediate valid task counts for big partition counts

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScaler.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScaler.java
@@ -78,6 +78,14 @@ public class CostBasedAutoScaler implements SupervisorTaskAutoScaler
    */
   static final int MAX_IDLENESS_PARTITION_LAG = 10_000;
 
+  /**
+   * Adjacent candidate task counts whose gap exceeds this value are split with intermediate
+   * candidates so the cost model has finer-grained options to evaluate.
+   */
+  static final int MAX_CANDIDATE_GAP = 100;
+
+  static final double[] INTERPOLATION_FRACTIONS = new double[]{0.33, 0.66};
+
   private final String supervisorId;
   private final SeekableStreamSupervisor supervisor;
   private final ServiceEmitter emitter;
@@ -326,7 +334,31 @@ public class CostBasedAutoScaler implements SupervisorTaskAutoScaler
         result.add(taskCount);
       }
     }
-    return result.toIntArray();
+
+    int[] candidates = result.toIntArray();
+    Arrays.sort(candidates);
+
+    // The partition-per-task candidates can be far apart (for example 250 -> 500), leaving the
+    // cost model with no options in between. Wherever two adjacent candidates differ by more than
+    // MAX_CANDIDATE_GAP, split that interval with deterministic intermediate task counts.
+    boolean enriched = false;
+    for (int i = 0; i < candidates.length - 1; i++) {
+      final int lower = candidates[i];
+      final int upper = candidates[i + 1];
+      if (upper - lower > MAX_CANDIDATE_GAP) {
+        for (double fraction : INTERPOLATION_FRACTIONS) {
+          result.add(Math.toIntExact(Math.round(lower + fraction * (upper - lower))));
+        }
+        enriched = true;
+      }
+    }
+    if (enriched) {
+      candidates = result.toIntArray();
+      Arrays.sort(candidates);
+    }
+
+    // Sorted ascending because computeOptimalTaskCount relies on Arrays.binarySearch.
+    return candidates;
   }
 
   /**

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/WeightedCostFunction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/WeightedCostFunction.java
@@ -40,7 +40,7 @@ public class WeightedCostFunction
    * Multiplier for a lag amplification factor; it was carefully chosen
    * during extensive testing as the most balanced multiplier for high-lag recovery.
    */
-  static final double LAG_AMPLIFICATION_MULTIPLIER = 0.4;
+  static final double LAG_AMPLIFICATION_MULTIPLIER = 0.35;
 
   /**
    * Minimum rate of processing for any task in records per second. This is used

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScalerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScalerTest.java
@@ -141,6 +141,49 @@ public class CostBasedAutoScalerTest
   }
 
   @Test
+  public void testComputeValidTaskCountsGapEnrichment()
+  {
+    // All adjacent gaps are <= 100 (33 and 99), so no intermediate candidates are inserted.
+    final int[] noGaps = computeValidTaskCounts(199, 100, 67, 199);
+    Assert.assertArrayEquals(new int[]{67, 100, 199}, noGaps);
+
+    // 250 partitions, base {84, 125, 250}: only the 125 -> 250 gap (125) exceeds 100.
+    // 33%/66% of [125, 250] give 166 and 208.
+    final int[] p250 = computeValidTaskCounts(250, 125, 84, 250);
+    Assert.assertArrayEquals(new int[]{84, 125, 166, 208, 250}, p250);
+
+    // 300 partitions, base {100, 150, 300}: only the 150 -> 300 gap (150) exceeds 100.
+    final int[] p300 = computeValidTaskCounts(300, 150, 100, 300);
+    Assert.assertArrayEquals(new int[]{100, 150, 200, 249, 300}, p300);
+
+    // 500 partitions, base {167, 250, 500}: only the 250 -> 500 gap (250) exceeds 100.
+    final int[] p500 = computeValidTaskCounts(500, 250, 167, 500);
+    Assert.assertArrayEquals(new int[]{167, 250, 333, 415, 500}, p500);
+
+    // Multiple wide gaps are all split. 900 partitions, base
+    // {100, 113, 129, 150, 180, 225, 300, 450, 900}: the 300 -> 450 (150) and 450 -> 900 (450)
+    // gaps each get two intermediate candidates.
+    final int[] multi = computeValidTaskCounts(900, 450, 100, 900);
+    Assert.assertTrue("Split of 300 -> 450 at 33%", contains(multi, 350));
+    Assert.assertTrue("Split of 300 -> 450 at 66%", contains(multi, 399));
+    Assert.assertTrue("Split of 450 -> 900 at 33%", contains(multi, 599));
+    Assert.assertTrue("Split of 450 -> 900 at 66%", contains(multi, 747));
+
+    // A single candidate has no adjacent pair, so nothing is inserted.
+    final int[] single = computeValidTaskCounts(200, 100, 100, 100);
+    Assert.assertArrayEquals(new int[]{100}, single);
+
+    // Every returned array is sorted ascending, as computeOptimalTaskCount relies on binarySearch,
+    // and every candidate stays within the configured bounds.
+    Assert.assertTrue(contains(multi, 100) && contains(multi, 900));
+    for (int[] counts : new int[][]{noGaps, p250, p300, p500, multi, single}) {
+      for (int i = 1; i < counts.length; i++) {
+        Assert.assertTrue("Candidates must be sorted ascending", counts[i - 1] < counts[i]);
+      }
+    }
+  }
+
+  @Test
   public void testComputeOptimalTaskCount()
   {
     // Invalid inputs return -1


### PR DESCRIPTION
**Description**
  
The cost-based autoscaler derives candidate task counts from possible partitions-per-task ratios. For large partition counts these candidates can be very far apart near the top of the assignment range - e.g. for 400 partitions, the candidates scales `200 -> 400`. Because the cost model only evaluates the generated candidates, it has no intermediate option to settle on, forcing coarse, all-or-nothing scaling decisions.
  
This PR adds deterministic intermediate candidates so the cost model has finer-grained options, without changing the cost model itself. 
  
**Introduced intermediate valid task counts for large gaps**
  
`CostBasedAutoScaler.computeValidTaskCounts` now post-processes the generated candidate list: after the base partitions-per-task candidates are produced and sorted, every adjacent pair whose gap exceeds `MAX_CANDIDATE_GAP` (100) is split with intermediate candidates at`INTERPOLATION_FRACTIONS = {0.33, 0.66}`, rounded to the nearest integer.

**Tuned the lag amplification multiplier:** 
`WeightedCostFunction.LAG_AMPLIFICATION_MULTIPLIER` is lowered from 0.4 to 0.35 based on further testing, for a slightly more balanced high-lag recovery response.

**Release note**
  
The cost-based supervisor autoscaler now considers intermediate task counts when the candidate task counts derived from partition assignment are far apart, enabling smoother scaling for streams with large partition counts.
 
  This PR has:

  - [x] been self-reviewed.
  - [x] added unit tests covering the new candidate-generation behaviour (no-gap, single-gap,
  multi-gap, and single-candidate cases) in CostBasedAutoScalerTest.
  - [x] been tested in a test Druid cluster.