### PR TITLE
fix: Retain exception that triggered Dart query cancellation.

### DIFF
--- a/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/sql/DartQueryMaker.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/sql/DartQueryMaker.java
@@ -279,7 +279,7 @@ public class DartQueryMaker implements QueryMaker
       return Sequences.simple(List.<Object[]>of(new Object[]{reportMap}));
     }
     catch (InterruptedException e) {
-      controllerHolder.cancel(CancellationReason.UNKNOWN);
+      controllerHolder.cancel(CancellationReason.UNKNOWN, null);
       Thread.currentThread().interrupt();
       throw new RuntimeException(e);
     }
@@ -321,8 +321,11 @@ public class DartQueryMaker implements QueryMaker
           @Override
           public void after(final boolean isDone, final Throwable thrown)
           {
-            if (!isDone || thrown != null) {
-              controllerHolder.cancel(CancellationReason.UNKNOWN);
+            if (thrown != null || !isDone) {
+              // If an exception is set (thrown != null), retain it. Otherwise, if we're in here, !isDone indicates
+              // the caller went away before reading the entire stream of results. The best we can do in that case
+              // is a generic UNKNOWN cancellation reason.
+              controllerHolder.cancel(CancellationReason.UNKNOWN, thrown);
             }
           }
         }

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/sql/DartSqlEngine.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/sql/DartSqlEngine.java
@@ -379,7 +379,7 @@ public class DartSqlEngine implements SqlEngine
     if (dartQueryId instanceof String) {
       final ControllerHolder holder = controllerRegistry.getController((String) dartQueryId);
       if (holder != null) {
-        holder.cancel(CancellationReason.USER_REQUEST);
+        holder.cancel(CancellationReason.USER_REQUEST, null);
       }
     } else {
       log.warn(

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/Controller.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/Controller.java
@@ -60,7 +60,7 @@ public interface Controller
    * Terminate the controller upon a cancellation request. Causes a concurrently-running {@link #run} method in
    * a separate thread to cancel all outstanding work and exit.
    */
-  void stop(CancellationReason reason);
+  void stop(CancellationReason reason, @Nullable Throwable cause);
 
   // Worker-to-controller messages
 

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerHolder.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerHolder.java
@@ -238,7 +238,7 @@ public class ControllerHolder
   /**
    * Places this holder into {@link State#CANCELED} and stops the controller.
    */
-  public void cancel(final CancellationReason reason)
+  public void cancel(final CancellationReason reason, @Nullable final Throwable cause)
   {
     final State prevState;
     synchronized (this) {
@@ -251,7 +251,7 @@ public class ControllerHolder
     }
 
     if (prevState == State.RUNNING) {
-      controller.stop(reason);
+      controller.stop(reason, cause);
 
       // Interrupt the controller thread as a failsafe, in case the controller is blocked on something.
       synchronized (this) {
@@ -299,12 +299,12 @@ public class ControllerHolder
     if (delayMs <= 0) {
       // Deadline has already passed. Cancel immediately rather than scheduling, so the cancellation
       // takes effect even when using a direct executor for the controller thread.
-      cancel(CancellationReason.QUERY_TIMEOUT);
+      cancel(CancellationReason.QUERY_TIMEOUT, null);
       return null;
     }
 
     return scheduledExec.schedule(
-        () -> cancel(CancellationReason.QUERY_TIMEOUT),
+        () -> cancel(CancellationReason.QUERY_TIMEOUT, null),
         delayMs,
         TimeUnit.MILLISECONDS
     );

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -252,11 +252,19 @@ public class ControllerImpl implements Controller
   private final AtomicReference<MSQErrorReport> workerErrorRef = new AtomicReference<>();
 
   /**
-   * Set by {@link #stop(CancellationReason)}. If non-null, this reason takes priority over any exception
-   * encountered during execution when building the error report. If we didn't do this, interrupts arising
-   * from cancellation could produce errors that are less informative than the actual cancellation reason.
+   * Set by {@link #stop(CancellationReason, Throwable)}. If non-null, this reason takes priority over any
+   * exception encountered during execution when building the error report. If we didn't do this, interrupts
+   * arising from cancellation could produce errors that are less informative than the actual cancellation reason.
    */
   private volatile CancellationReason cancelReason;
+
+  /**
+   * Set by {@link #stop(CancellationReason, Throwable)} when cancellation was triggered by an external error
+   * (such as a failure writing results back to the client). If non-null, this exception is logged and included
+   * in the error report instead of a bare {@link CanceledFault}, so the original error is not lost.
+   */
+  @Nullable
+  private volatile Throwable cancelException;
 
   // For system warning reporting
   private final ConcurrentLinkedQueue<MSQErrorReport> workerWarnings = new ConcurrentLinkedQueue<>();
@@ -375,14 +383,20 @@ public class ControllerImpl implements Controller
   }
 
   @Override
-  public void stop(CancellationReason reason)
+  public void stop(CancellationReason reason, @Nullable Throwable cause)
   {
     final QueryDefinition queryDef = queryDefRef.get();
 
     // stopGracefully() is called when the containing process is terminated, or when the task is canceled.
-    log.info("Query [%s] canceled.", queryDef != null ? queryDef.getQueryId() : "<no id yet>");
+    final String queryIdForLog = queryDef != null ? queryDef.getQueryId() : "<no id yet>";
+    if (cause != null) {
+      log.warn(cause, "Query[%s] canceled, reason[%s].", queryIdForLog, reason);
+    } else {
+      log.info("Query[%s] canceled, reason[%s].", queryIdForLog, reason);
+    }
 
     cancelReason = reason;
+    cancelException = cause;
     stopExternalFetchers();
     kernelManipulationQueue.clear(); // No point processing any possibly-queued commands.
     addToKernelManipulationQueue(
@@ -483,7 +497,14 @@ public class ControllerImpl implements Controller
 
       taskStateForReport = TaskState.FAILED;
 
-      if (cancelReason != null) {
+      if (cancelReason == CancellationReason.UNKNOWN && cancelException != null) {
+        // Cancellation triggered by an external error. Report the original error.
+        if (exceptionEncountered != null) {
+          cancelException.addSuppressed(exceptionEncountered);
+        }
+        errorForReport =
+            MSQErrorReport.fromException(queryId(), selfHost, null, cancelException, querySpec.getColumnMappings());
+      } else if (cancelReason != null) {
         errorForReport = MSQErrorReport.fromFault(queryId(), selfHost, null, new CanceledFault(cancelReason));
       } else {
         errorForReport = MSQTasks.makeErrorReport(queryId(), selfHost, controllerError, workerError);

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQControllerTask.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQControllerTask.java
@@ -317,7 +317,7 @@ public class MSQControllerTask extends AbstractTask implements ClientTaskQuery, 
   {
     final ControllerHolder holder = controllerHolder;
     if (holder != null) {
-      holder.cancel(CancellationReason.TASK_SHUTDOWN);
+      holder.cancel(CancellationReason.TASK_SHUTDOWN, null);
     }
   }
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/ControllerHolderTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/ControllerHolderTest.java
@@ -47,6 +47,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class ControllerHolderTest
 {
@@ -107,7 +108,7 @@ public class ControllerHolderTest
     final ListenableFuture<?> future = holder.runAsync(new NoopQueryListener(), null, controllerThreadPool);
 
     controllerStarted.await();
-    holder.cancel(CancellationReason.USER_REQUEST);
+    holder.cancel(CancellationReason.USER_REQUEST, null);
     controllerFinished.await();
 
     try {
@@ -146,7 +147,7 @@ public class ControllerHolderTest
       }
 
       @Override
-      public void stop(final CancellationReason reason)
+      public void stop(final CancellationReason reason, @Nullable Throwable cause)
       {
         stopCalled.set(true);
       }
@@ -156,10 +157,52 @@ public class ControllerHolderTest
     holder.runAsync(new NoopQueryListener(), null, controllerThreadPool);
 
     controllerStarted.await();
-    holder.cancel(CancellationReason.USER_REQUEST);
+    holder.cancel(CancellationReason.USER_REQUEST, null);
     controllerFinished.await();
 
     Assert.assertTrue("stop() should have been called as failsafe", stopCalled.get());
+  }
+
+  @Test
+  public void testCancelPassesCauseToStop() throws Exception
+  {
+    final CountDownLatch controllerStarted = new CountDownLatch(1);
+    final CountDownLatch controllerFinished = new CountDownLatch(1);
+    final AtomicReference<Throwable> stopCause = new AtomicReference<>();
+    final RuntimeException cause = new RuntimeException("error writing to client");
+    final Controller controller = new TestController("test-query")
+    {
+      @Override
+      public void run(final QueryListener listener)
+      {
+        try {
+          controllerStarted.countDown();
+          Thread.sleep(300_000);
+        }
+        catch (InterruptedException e) {
+          // expected
+        }
+        finally {
+          listener.onQueryComplete(makeSuccessReport());
+          controllerFinished.countDown();
+        }
+      }
+
+      @Override
+      public void stop(final CancellationReason reason, @Nullable final Throwable cause)
+      {
+        stopCause.set(cause);
+      }
+    };
+
+    final ControllerHolder holder = new ControllerHolder(controller, "sql-1", null, null, DateTimes.nowUtc());
+    holder.runAsync(new NoopQueryListener(), null, controllerThreadPool);
+
+    controllerStarted.await();
+    holder.cancel(CancellationReason.UNKNOWN, cause);
+    controllerFinished.await();
+
+    Assert.assertSame("stop() should have received the cause", cause, stopCause.get());
   }
 
   @Test
@@ -198,7 +241,7 @@ public class ControllerHolderTest
     final ControllerHolder holder = new ControllerHolder(controller, "sql-1", null, null, DateTimes.nowUtc());
 
     // Cancel before run
-    holder.cancel(CancellationReason.USER_REQUEST);
+    holder.cancel(CancellationReason.USER_REQUEST, null);
     Assert.assertEquals(ControllerHolder.State.CANCELED, holder.getState());
 
     // Run should complete quickly without running the controller
@@ -238,8 +281,8 @@ public class ControllerHolderTest
     controllerStarted.await();
 
     // Cancel twice — should not throw
-    holder.cancel(CancellationReason.USER_REQUEST);
-    holder.cancel(CancellationReason.USER_REQUEST);
+    holder.cancel(CancellationReason.USER_REQUEST, null);
+    holder.cancel(CancellationReason.USER_REQUEST, null);
     controllerFinished.await();
 
     Assert.assertEquals(ControllerHolder.State.CANCELED, holder.getState());
@@ -264,7 +307,7 @@ public class ControllerHolderTest
     Assert.assertEquals(ControllerHolder.State.SUCCESS, holder.getState());
 
     // Cancel after completion — should be a no-op
-    holder.cancel(CancellationReason.USER_REQUEST);
+    holder.cancel(CancellationReason.USER_REQUEST, null);
     Assert.assertEquals(ControllerHolder.State.SUCCESS, holder.getState());
   }
 
@@ -391,7 +434,7 @@ public class ControllerHolderTest
     }
 
     @Override
-    public void stop(final CancellationReason reason)
+    public void stop(final CancellationReason reason, @Nullable Throwable cause)
     {
     }
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestOverlordServiceClient.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestOverlordServiceClient.java
@@ -258,7 +258,7 @@ public class MSQTestOverlordServiceClient extends NoopOverlordClient
   @Override
   public ListenableFuture<Void> cancelTask(String taskId)
   {
-    getControllerForQueryId(taskId).stop(CancellationReason.TASK_SHUTDOWN);
+    getControllerForQueryId(taskId).stop(CancellationReason.TASK_SHUTDOWN, null);
     return Futures.immediateFuture(null);
   }
 


### PR DESCRIPTION
In some cases, cancellation is triggered by an exception (rather than a non-exceptional reason, like timeout or user request). This patch retains the exception and includes it in the query report.