### PR TITLE
docs: update 37 release notes for java17 removal

### DIFF
--- a/docs/release-info/release-notes.md
+++ b/docs/release-info/release-notes.md
@@ -514,6 +514,12 @@ Added support for `lz4` compression. As part of this change, the following metri
 
 ### Upgrade notes
 
+#### Java 17
+
+The Druid 38.0.0, the next planned release, requires either Java 21 or 25 (recommended). Support for Java 17 will be dropped.
+
+[#19304](https://github.com/apache/druid/pull/19304)
+
 #### Hadoop-based ingestion
 
 Support for Hadoop-based ingestion has been removed. The feature was deprecated in Druid 34.

--- a/docs/release-info/release-notes.md
+++ b/docs/release-info/release-notes.md
@@ -65,6 +65,12 @@ Use one of Druid's other supported ingestion methods, such as SQL-based ingestio
 
 [#19109](https://github.com/apache/druid/pull/19109)
 
+### Java 17
+
+Druid 38.0.0, the next planned release, requires either Java 21 or 25 (recommended). Support for Java 17 will be dropped.
+
+[#19304](https://github.com/apache/druid/pull/19304)
+
 ### Query blocklist
 
 You can now use the Broker API (`/druid/coordinator/v1/config/broker`) to create a query blocklist to dynamically block queries by datasource, query type, or query context. The blocklist takes effect without a restarting Druid. Block rules use `AND` logic, which means all criteria must match.
@@ -516,7 +522,7 @@ Added support for `lz4` compression. As part of this change, the following metri
 
 #### Java 17
 
-The Druid 38.0.0, the next planned release, requires either Java 21 or 25 (recommended). Support for Java 17 will be dropped.
+Druid 38.0.0, the next planned release, requires either Java 21 or 25 (recommended). Support for Java 17 will be dropped.
 
 [#19304](https://github.com/apache/druid/pull/19304)
 

--- a/docs/release-info/release-notes.md
+++ b/docs/release-info/release-notes.md
@@ -67,7 +67,7 @@ Use one of Druid's other supported ingestion methods, such as SQL-based ingestio
 
 ### Java 17
 
-Druid 38.0.0, the next planned release, requires either Java 21 or 25 (recommended). Support for Java 17 will be dropped.
+Druid 38.0.0, the next planned release, requires either Java 21 or 25 (recommended). Support for Java 17 will be removed.
 
 [#19304](https://github.com/apache/druid/pull/19304)
 

--- a/docs/release-info/release-notes.md
+++ b/docs/release-info/release-notes.md
@@ -522,7 +522,7 @@ Added support for `lz4` compression. As part of this change, the following metri
 
 #### Java 17
 
-Druid 38.0.0, the next planned release, requires either Java 21 or 25 (recommended). Support for Java 17 will be dropped.
+Druid 38.0.0, the next planned release, requires either Java 21 or 25 (recommended). Support for Java 17 will be removed.
 
 [#19304](https://github.com/apache/druid/pull/19304)
 

--- a/docs/release-info/upgrade-notes.md
+++ b/docs/release-info/upgrade-notes.md
@@ -32,6 +32,12 @@ For the full release notes for a specific version, see the [releases page](https
 
 ### Upgrade notes
 
+#### Java 17
+
+The Druid 38.0.0, the next planned release, requires either Java 21 or 25 (recommended). Support for Java 17 will be dropped.
+
+[#19304](https://github.com/apache/druid/pull/19304)
+
 #### Hadoop-based ingestion
 
 Support for Hadoop-based ingestion has been removed. The feature was deprecated in Druid 34.

--- a/docs/release-info/upgrade-notes.md
+++ b/docs/release-info/upgrade-notes.md
@@ -34,7 +34,7 @@ For the full release notes for a specific version, see the [releases page](https
 
 #### Java 17
 
-The Druid 38.0.0, the next planned release, requires either Java 21 or 25 (recommended). Support for Java 17 will be dropped.
+Druid 38.0.0, the next planned release, requires either Java 21 or 25 (recommended). Support for Java 17 will be dropped.
 
 [#19304](https://github.com/apache/druid/pull/19304)
 


### PR DESCRIPTION
Adds Java 17 removal info to the release notes

https://github.com/apache/druid/pull/19304
https://lists.apache.org/thread/ovk7y4hkvn6fpk71trnbvmno22l6n1bx

This PR has:

- [x] been self-reviewed.
