### PR TITLE
feat: post-pass shard-group reconciliation for asymmetric partial-load matchers

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/loading/PartialClusterGroupLoadSpec.java
+++ b/processing/src/main/java/org/apache/druid/segment/loading/PartialClusterGroupLoadSpec.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
-import org.apache.druid.utils.CollectionUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -72,10 +71,11 @@ public class PartialClusterGroupLoadSpec extends PartialLoadSpec
   )
   {
     super(delegate, fingerprint, jsonMapper);
-    Preconditions.checkArgument(
-        !CollectionUtils.isNullOrEmpty(clusterGroupIndices),
-        "clusterGroupIndices must not be null or empty"
-    );
+    // An empty index list is the wire form of the matcher's "empty match", used when a cluster-group matcher matches
+    // some siblings of a shard group but not this one. The historical-side partial loader honors this by performing
+    // no cluster-group-specific data download, keeping the shard group uniformly populated for broker-side
+    // completeness.
+    Preconditions.checkNotNull(clusterGroupIndices, "clusterGroupIndices");
     this.clusterGroupIndices = List.copyOf(clusterGroupIndices);
   }
 

--- a/processing/src/main/java/org/apache/druid/timeline/TimelineLookup.java
+++ b/processing/src/main/java/org/apache/druid/timeline/TimelineLookup.java
@@ -20,6 +20,7 @@
 package org.apache.druid.timeline;
 
 import org.apache.druid.timeline.partition.PartitionChunk;
+import org.apache.druid.timeline.partition.PartitionHolder;
 import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
@@ -56,4 +57,15 @@ public interface TimelineLookup<VersionType, ObjectType extends Overshadowable<O
    */
   @Nullable
   PartitionChunk<ObjectType> findChunk(Interval interval, VersionType version, int partitionNum);
+
+  /**
+   * Finds the visible chunks in the shard group for the given time interval and version. Unlike
+   * {@link #lookup(Interval)} this does not filter by partition-holder completeness, so transient mid-publish
+   * groups are returned as-is. Returns {@code null} if no entry exists for the given (interval, version).
+   *
+   * <p>The returned {@link PartitionHolder} is a defensive copy made under the timeline's read lock, so callers
+   * can iterate it without holding the lock.
+   */
+  @Nullable
+  PartitionHolder<ObjectType> findChunks(Interval interval, VersionType version);
 }

--- a/processing/src/main/java/org/apache/druid/timeline/VersionedIntervalTimeline.java
+++ b/processing/src/main/java/org/apache/druid/timeline/VersionedIntervalTimeline.java
@@ -305,6 +305,30 @@ public class VersionedIntervalTimeline<VersionType, ObjectType extends Overshado
     }
   }
 
+  @Override
+  @Nullable
+  public PartitionHolder<ObjectType> findChunks(Interval interval, VersionType version)
+  {
+    lock.readLock().lock();
+    try {
+      for (Entry<Interval, TreeMap<VersionType, TimelineEntry>> entry : allTimelineEntries.entrySet()) {
+        if (entry.getKey().equals(interval) || entry.getKey().contains(interval)) {
+          TimelineEntry foundEntry = entry.getValue().get(version);
+          if (foundEntry != null) {
+            // Return a defensive copy made under the lock so callers can iterate the holder outside the lock
+            // without racing with concurrent timeline mutations. Matches the lookup() pattern.
+            return PartitionHolder.copyWithOnlyVisibleChunks(foundEntry.getPartitionHolder());
+          }
+        }
+      }
+
+      return null;
+    }
+    finally {
+      lock.readLock().unlock();
+    }
+  }
+
   /**
    * Does a lookup for the objects representing the given time interval.  Will *only* return
    * PartitionHolders that are {@linkplain PartitionHolder#isComplete() complete}.

--- a/processing/src/test/java/org/apache/druid/segment/loading/PartialClusterGroupLoadSpecTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/loading/PartialClusterGroupLoadSpecTest.java
@@ -146,15 +146,11 @@ class PartialClusterGroupLoadSpecTest
   }
 
   @Test
-  void testRejectsNullOrEmptyClusterGroupIndices()
+  void testRejectsNullClusterGroupIndices()
   {
     Assertions.assertThrows(
-        IllegalArgumentException.class,
+        NullPointerException.class,
         () -> new PartialClusterGroupLoadSpec(DELEGATE, null, "v1:x", jsonMapper)
-    );
-    Assertions.assertThrows(
-        IllegalArgumentException.class,
-        () -> new PartialClusterGroupLoadSpec(DELEGATE, List.of(), "v1:x", jsonMapper)
     );
   }
 

--- a/processing/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineTest.java
+++ b/processing/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineTest.java
@@ -80,6 +80,85 @@ public class VersionedIntervalTimelineTest extends VersionedIntervalTimelineTest
     );
   }
 
+  @Test
+  public void testFindChunksReturnsHolderForMatchingIntervalAndVersion()
+  {
+    add("2011-01-01/2011-01-10", "1", makeNumbered("1", 0, 7));
+    add("2011-01-01/2011-01-10", "1", makeNumbered("1", 1, 8));
+    add("2011-01-01/2011-01-10", "1", makeNumbered("1", 2, 9));
+
+    PartitionHolder<OvershadowableInteger> holder =
+        timeline.findChunks(Intervals.of("2011-01-01/2011-01-10"), "1");
+
+    Assert.assertNotNull(holder);
+    Assert.assertEquals(
+        ImmutableList.of(
+            new OvershadowableInteger("1", 0, 7),
+            new OvershadowableInteger("1", 1, 8),
+            new OvershadowableInteger("1", 2, 9)
+        ),
+        ImmutableList.copyOf(holder.payloads())
+    );
+  }
+
+  @Test
+  public void testFindChunksReturnsNullForUnknownVersion()
+  {
+    add("2011-01-01/2011-01-10", "1", 1);
+
+    Assert.assertNull(timeline.findChunks(Intervals.of("2011-01-01/2011-01-10"), "no-such-version"));
+  }
+
+  @Test
+  public void testFindChunksReturnsNullForUnknownInterval()
+  {
+    add("2011-01-01/2011-01-10", "1", 1);
+
+    Assert.assertNull(timeline.findChunks(Intervals.of("2050-01-01/2050-01-10"), "1"));
+  }
+
+  @Test
+  public void testFindChunksMatchesContainedQueryInterval()
+  {
+    // findChunks mirrors findChunk's matching semantics: a query interval fully contained inside a timeline key
+    // interval still resolves to that key's entry.
+    add("2011-01-01/2011-01-10", "1", makeNumbered("1", 0, 1));
+    add("2011-01-01/2011-01-10", "1", makeNumbered("1", 1, 2));
+
+    PartitionHolder<OvershadowableInteger> holder =
+        timeline.findChunks(Intervals.of("2011-01-02T02/2011-01-04"), "1");
+
+    Assert.assertNotNull(holder);
+    Assert.assertEquals(
+        ImmutableList.of(
+            new OvershadowableInteger("1", 0, 1),
+            new OvershadowableInteger("1", 1, 2)
+        ),
+        ImmutableList.copyOf(holder.payloads())
+    );
+  }
+
+  @Test
+  public void testFindChunksSelectsByVersionWhenMultipleCoexist()
+  {
+    add("2011-01-01/2011-01-10", "1", makeSingle("1", 0, 1));
+    add("2011-01-01/2011-01-10", "2", makeSingle("2", 0, 2));
+
+    PartitionHolder<OvershadowableInteger> v1 = timeline.findChunks(Intervals.of("2011-01-01/2011-01-10"), "1");
+    PartitionHolder<OvershadowableInteger> v2 = timeline.findChunks(Intervals.of("2011-01-01/2011-01-10"), "2");
+
+    Assert.assertNotNull(v1);
+    Assert.assertNotNull(v2);
+    Assert.assertEquals(
+        ImmutableList.of(new OvershadowableInteger("1", 0, 1)),
+        ImmutableList.copyOf(v1.payloads())
+    );
+    Assert.assertEquals(
+        ImmutableList.of(new OvershadowableInteger("2", 0, 2)),
+        ImmutableList.copyOf(v2.payloads())
+    );
+  }
+
   //   1|----|
   //      1|----|
   @Test(expected = UnsupportedOperationException.class)

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/RunRules.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/RunRules.java
@@ -20,23 +20,38 @@
 package org.apache.druid.server.coordinator.duty;
 
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import org.apache.druid.client.DataSourcesSnapshot;
 import org.apache.druid.client.ImmutableDruidDataSource;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Stopwatch;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.server.coordinator.DruidCluster;
 import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
+import org.apache.druid.server.coordinator.loading.PartialLoadProfile;
 import org.apache.druid.server.coordinator.loading.StrategicSegmentAssigner;
 import org.apache.druid.server.coordinator.rules.BroadcastDistributionRule;
+import org.apache.druid.server.coordinator.rules.PartialLoadMatcher;
 import org.apache.druid.server.coordinator.rules.Rule;
+import org.apache.druid.server.coordinator.rules.RuleRunResult;
+import org.apache.druid.server.coordinator.rules.SegmentActionHandler;
+import org.apache.druid.server.coordinator.rules.ShardGroupFollowup;
 import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
 import org.apache.druid.server.coordinator.stats.Dimension;
 import org.apache.druid.server.coordinator.stats.RowKey;
 import org.apache.druid.server.coordinator.stats.Stats;
 import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentId;
+import org.apache.druid.timeline.SegmentTimeline;
+import org.apache.druid.timeline.partition.PartitionHolder;
 import org.joda.time.DateTime;
+import org.joda.time.Interval;
 
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -86,6 +101,17 @@ public class RunRules implements CoordinatorDuty
 
     final DateTime now = DateTimes.nowUtc();
     final Object2IntOpenHashMap<String> datasourceToSegmentsWithNoRule = new Object2IntOpenHashMap<>();
+    final DataSourcesSnapshot snapshot = params.getDataSourcesSnapshot();
+
+    // Streaming shard-group followup state. The iteration order (SegmentHolder.NEWEST_SEGMENT_FIRST) groups segments
+    // contiguously by (dataSource, interval, version), so we can flush the previous group's followups the moment any
+    // of those three fields changes. This bounds the buffer to ≤ one shard group's worth of followups instead of the
+    // entire run's.
+    String currentDs = null;
+    Interval currentInterval = null;
+    String currentVersion = null;
+    final List<ShardGroupFollowup> pendingShardGroupFollowups = new ArrayList<>();
+
     for (DataSegment segment : usedSegments) {
       // Do not apply rules on overshadowed segments as they will be
       // marked unused and eventually unloaded from all historicals
@@ -93,12 +119,33 @@ public class RunRules implements CoordinatorDuty
         continue;
       }
 
+      // Detect a shard-group boundary and flush followups for the previous group.
+      if (!segment.getDataSource().equals(currentDs)
+          || !segment.getInterval().equals(currentInterval)
+          || !segment.getVersion().equals(currentVersion)) {
+        flushShardGroupFollowups(
+            pendingShardGroupFollowups,
+            currentDs,
+            currentInterval,
+            currentVersion,
+            snapshot,
+            segmentAssigner
+        );
+        pendingShardGroupFollowups.clear();
+        currentDs = segment.getDataSource();
+        currentInterval = segment.getInterval();
+        currentVersion = segment.getVersion();
+      }
+
       // Find and apply matching rule
       List<Rule> rules = ruleHandler.getRulesWithDefault(segment.getDataSource());
       boolean foundMatchingRule = false;
       for (Rule rule : rules) {
         if (rule.appliesTo(segment, now)) {
-          rule.run(segment, segmentAssigner);
+          final RuleRunResult result = rule.run(segment, segmentAssigner);
+          if (result instanceof ShardGroupFollowup followup) {
+            pendingShardGroupFollowups.add(followup);
+          }
           foundMatchingRule = true;
           break;
         }
@@ -108,6 +155,16 @@ public class RunRules implements CoordinatorDuty
         datasourceToSegmentsWithNoRule.addTo(segment.getDataSource(), 1);
       }
     }
+
+    // Tail flush for the last shard group.
+    flushShardGroupFollowups(
+        pendingShardGroupFollowups,
+        currentDs,
+        currentInterval,
+        currentVersion,
+        snapshot,
+        segmentAssigner
+    );
 
     processSegmentDeletes(segmentAssigner, params.getCoordinatorStats());
     alertForSegmentsWithNoRules(datasourceToSegmentsWithNoRule);
@@ -179,5 +236,80 @@ public class RunRules implements CoordinatorDuty
     return ruleHandler.getRulesWithDefault(datasource)
                       .stream()
                       .anyMatch(rule -> rule instanceof BroadcastDistributionRule);
+  }
+
+  /**
+   * Flush {@link ShardGroupFollowup}s for a single {@code (dataSource, interval, version)} shard group: dispatch
+   * {@link PartialLoadMatcher#emptyMatch} loads to siblings that did not get a positive match from the same
+   * matcher. Keeps the broker's {@code PartitionHolder.isComplete()} happy when a matcher resolves asymmetrically
+   * across siblings.
+   *
+   * <p>Followups within the group are grouped by matcher reference identity. Matchers are stable for the lifetime
+   * of the run, and one segment matches at most one rule, so the key disambiguates correctly without requiring
+   * matchers to define equals/hashCode.
+   */
+  static void flushShardGroupFollowups(
+      List<ShardGroupFollowup> pendingFollowups,
+      @Nullable String dataSource,
+      @Nullable Interval interval,
+      @Nullable String version,
+      DataSourcesSnapshot snapshot,
+      SegmentActionHandler segmentAssigner
+  )
+  {
+    if (pendingFollowups.isEmpty()) {
+      return;
+    }
+
+    final SegmentTimeline timeline = snapshot.getUsedSegmentsTimelinesPerDataSource().get(dataSource);
+    if (timeline == null) {
+      return;
+    }
+    final PartitionHolder<DataSegment> holder = timeline.findChunks(interval, version);
+    if (holder == null) {
+      return;
+    }
+
+    // Group by matcher reference identity (matchers don't define equals).
+    final IdentityHashMap<PartialLoadMatcher, MatcherFollowup> byMatcher = new IdentityHashMap<>();
+    for (ShardGroupFollowup followup : pendingFollowups) {
+      byMatcher.computeIfAbsent(followup.matcher(), k -> new MatcherFollowup(followup.tieredReplicants()))
+          .matchedSegmentIds.add(followup.matchedSegment().getId());
+    }
+
+    for (Map.Entry<PartialLoadMatcher, MatcherFollowup> entry : byMatcher.entrySet()) {
+      final PartialLoadMatcher matcher = entry.getKey();
+      final MatcherFollowup mf = entry.getValue();
+      for (DataSegment sibling : holder.payloads()) {
+        // Only the core partition group has an atomic-replace completeness requirement on the broker. Appended
+        // siblings (partitionNum >= numCorePartitions) are queried individually and don't need empty-loads.
+        if (sibling.getShardSpec().getPartitionNum() >= sibling.getShardSpec().getNumCorePartitions()) {
+          continue;
+        }
+        if (mf.matchedSegmentIds.contains(sibling.getId())) {
+          continue;
+        }
+        final PartialLoadMatcher.MatchResult emptyResult = matcher.emptyMatch(sibling, sibling.getLoadSpec());
+        if (emptyResult == null) {
+          continue;
+        }
+        segmentAssigner.replicateSegmentPartially(
+            sibling,
+            PartialLoadProfile.forRequest(emptyResult.wrappedLoadSpec(), emptyResult.fingerprint()),
+            mf.tieredReplicants
+        );
+      }
+    }
+  }
+
+  private static final class MatcherFollowup
+  {
+    private final Map<String, Integer> tieredReplicants;
+    private final Set<SegmentId> matchedSegmentIds = new HashSet<>();
+
+    MatcherFollowup(Map<String, Integer> tieredReplicants)
+    {
+      this.tieredReplicants = tieredReplicants;
+    }
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/BroadcastDistributionRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/BroadcastDistributionRule.java
@@ -25,9 +25,10 @@ public abstract class BroadcastDistributionRule implements Rule
 {
 
   @Override
-  public void run(DataSegment segment, SegmentActionHandler handler)
+  public RuleRunResult run(DataSegment segment, SegmentActionHandler handler)
   {
     handler.broadcastSegment(segment);
+    return RuleRunResult.OK;
   }
 
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/ClusterGroupPartialLoadMatcher.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/ClusterGroupPartialLoadMatcher.java
@@ -24,8 +24,10 @@ import com.google.common.hash.Hashing;
 import com.google.common.io.BaseEncoding;
 import org.apache.druid.segment.loading.PartialClusterGroupLoadSpec;
 import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.partition.PartitionHolder;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -64,6 +66,24 @@ public abstract class ClusterGroupPartialLoadMatcher implements PartialLoadMatch
     }
     final String fingerprint = computeFingerprint(resolved);
     return new MatchResult(PartialClusterGroupLoadSpec.wireForm(baseLoadSpec, resolved, fingerprint), fingerprint);
+  }
+
+  /**
+   * Opts cluster-group matchers into the sibling-aware "empty load" fallback. Cluster-group resolution can legitimately
+   * diverge across partitions of a shard group (range-partitioned segments may contain different cluster tuples), so
+   * when a matcher matches some siblings but not this one the rule layer needs an empty form to keep the group
+   * uniformly placed and let the broker's {@link PartitionHolder} treat the group as complete.
+   * <p>
+   * The wire form is the same {@code partialClusterGroup} shape with an empty index list and the deterministic
+   * fingerprint of the empty list, so the same empty-load on the same segment produces the same fingerprint across
+   * coordinator runs and reconciliation doesn't churn replicas.
+   */
+  @Override
+  public MatchResult emptyMatch(DataSegment segment, Map<String, Object> baseLoadSpec)
+  {
+    final List<Integer> emptyIndices = Collections.emptyList();
+    final String fingerprint = computeFingerprint(emptyIndices);
+    return new MatchResult(PartialClusterGroupLoadSpec.wireForm(baseLoadSpec, emptyIndices, fingerprint), fingerprint);
   }
 
   static String computeFingerprint(List<Integer> sortedDedupedIndices)

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/LoadRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/LoadRule.java
@@ -64,9 +64,10 @@ public abstract class LoadRule implements Rule
   }
 
   @Override
-  public void run(DataSegment segment, SegmentActionHandler handler)
+  public RuleRunResult run(DataSegment segment, SegmentActionHandler handler)
   {
     handler.replicateSegment(segment, getTieredReplicants());
+    return RuleRunResult.OK;
   }
 
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PartialLoadMatcher.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PartialLoadMatcher.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.druid.segment.loading.LoadSpec;
 import org.apache.druid.server.coordination.SegmentChangeRequestLoad;
+import org.apache.druid.server.coordinator.duty.RunRules;
 import org.apache.druid.timeline.DataSegment;
 
 import javax.annotation.Nullable;
@@ -49,6 +50,37 @@ public interface PartialLoadMatcher
    */
   @Nullable
   MatchResult match(DataSegment segment, Map<String, Object> baseLoadSpec);
+
+  /**
+   * Returns the "empty" {@link MatchResult} this matcher produces for the given segment when {@link #match} would
+   * return {@code null}, or {@code null} if this matcher has no meaningful empty form.
+   *
+   * <p>An empty match is the matcher's way of saying "I do not match this segment's content, but I am willing to
+   * partial-load it with a zero-content load spec so the broker's shard-group completeness check still treats the
+   * group as queryable." The {@link RunRules} duty applies this in a post-pass: when at least one sibling in the
+   * same shard group (same dataSource, interval, version) had a positive match from this matcher, {@code RunRules}
+   * dispatches {@code emptyMatch} loads for the unmatched siblings. The post-pass only fires when there's a real
+   * positive match somewhere in the group.
+   *
+   * <p>Matchers that produce uniform per-segment decisions across a shard group don't need this and can leave the
+   * default null. Matchers that resolve per-segment within a shard group must implement this to opt into the post-pass.
+   *
+   * <p>The returned wire form should:
+   * <ul>
+   *   <li>use the same {@code type} and structural shape as {@link #match}'s output, so the historical's
+   *       {@code PartialLoadSpec} subtype can deserialize it without special-casing.</li>
+   *   <li>carry a stable, deterministic fingerprint so the coordinator's reconciler doesn't churn replicas across
+   *       runs when the same matcher produces the same empty result on the same segment.</li>
+   *   <li>describe a load that's actually empty on the historical side (e.g. an empty list of projections or
+   *       cluster-group indices). The historical-side {@code PartialLoadSpec} subtype must accept this form and
+   *       perform no scheme-specific data download.</li>
+   * </ul>
+   */
+  @Nullable
+  default MatchResult emptyMatch(DataSegment segment, Map<String, Object> baseLoadSpec)
+  {
+    return null;
+  }
 
   /**
    * Output of {@link #match(DataSegment, Map)} when the matcher applies. Carries the wrapped load-spec map (ready to

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PartialLoadRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PartialLoadRule.java
@@ -88,23 +88,29 @@ public abstract class PartialLoadRule extends LoadRule
   }
 
   @Override
-  public void run(DataSegment segment, SegmentActionHandler handler)
+  public RuleRunResult run(DataSegment segment, SegmentActionHandler handler)
   {
     final PartialLoadMatcher.MatchResult result = matcher.match(segment, segment.getLoadSpec());
     if (result != null) {
-      // Matcher resolved: route through the partial-load handler. The wrappedLoadSpec map carries scheme-specific
-      // data that the historical-side wrapper deserializes.
       handler.replicateSegmentPartially(
           segment,
           PartialLoadProfile.forRequest(result.wrappedLoadSpec(), result.fingerprint()),
           getTieredReplicants()
       );
-    } else {
-      // Matcher does not apply, but the rule still applies because onCannotMatch == FULL_LOAD (FALL_THROUGH would
-      // have caused appliesTo to return false, so run wouldn't be invoked). Route through the regular full-load
-      // handler.
-      handler.replicateSegment(segment, getTieredReplicants());
+      // Flag the shard group for a post-pass: if the matcher resolves asymmetrically across siblings, RunRules will
+      // dispatch emptyMatch loads to the unmatched ones so the broker's PartitionHolder.isComplete() check still
+      // treats the group as queryable. Matchers without an emptyMatch (the default) make the post-pass a no-op.
+      // Only the core partition group has an atomic-replace completeness requirement on the broker, segments with
+      // no core partitions (e.g. append-only streaming) don't need sibling reconciliation.
+      if (segment.getShardSpec().getNumCorePartitions() > 0) {
+        return new ShardGroupFollowup(segment, matcher, getTieredReplicants());
+      }
+      return RuleRunResult.OK;
     }
+    // Matcher does not apply, but the rule still applies because onCannotMatch == FULL_LOAD (FALL_THROUGH would
+    // have caused appliesTo to return false, so run wouldn't be invoked).
+    handler.replicateSegment(segment, getTieredReplicants());
+    return RuleRunResult.OK;
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
@@ -69,5 +69,5 @@ public interface Rule
     return true;
   }
 
-  void run(DataSegment segment, SegmentActionHandler segmentHandler);
+  RuleRunResult run(DataSegment segment, SegmentActionHandler segmentHandler);
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/RuleRunResult.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/RuleRunResult.java
@@ -19,18 +19,20 @@
 
 package org.apache.druid.server.coordinator.rules;
 
-import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.server.coordinator.duty.RunRules;
 
 /**
- * DropRules indicate when segments should be completely removed from the cluster.
+ * Result of a {@link Rule#run} invocation. Rules return {@link #OK} when there is nothing for the {@link RunRules}
+ * duty to do beyond the actions the rule has already queued on the {@link SegmentActionHandler}. Rules that need
+ * follow-up coordination across siblings in a shard group return a typed implementation (today only
+ * {@link ShardGroupFollowup}); the {@link RunRules} duty dispatches on the concrete type and applies it at an
+ * appropriate point during iteration.
+ * <p>
+ * To add a new kind of post-processing, implement this interface and add a dispatch branch in {@link RunRules}.
  */
-public abstract class DropRule implements Rule
+public interface RuleRunResult
 {
-  @Override
-  public RuleRunResult run(DataSegment segment, SegmentActionHandler handler)
+  RuleRunResult OK = new RuleRunResult()
   {
-    handler.deleteSegment(segment);
-    return RuleRunResult.OK;
-  }
-
+  };
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/ShardGroupFollowup.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/ShardGroupFollowup.java
@@ -21,16 +21,22 @@ package org.apache.druid.server.coordinator.rules;
 
 import org.apache.druid.timeline.DataSegment;
 
-/**
- * DropRules indicate when segments should be completely removed from the cluster.
- */
-public abstract class DropRule implements Rule
-{
-  @Override
-  public RuleRunResult run(DataSegment segment, SegmentActionHandler handler)
-  {
-    handler.deleteSegment(segment);
-    return RuleRunResult.OK;
-  }
+import java.util.Map;
 
+/**
+ * Signal returned by {@link Rule#run} that the entire shard group containing {@link #matchedSegment} should be
+ * inspected for uniform partial-load placement. The {@code RunRules} duty collects these and, after all rules have
+ * run, dispatches {@link PartialLoadMatcher#emptyMatch} loads to siblings that did not get a positive match from
+ * the same {@link #matcher}.
+ *
+ * <p>Used to handle asymmetric matchers (e.g. {@link ClusterGroupPartialLoadMatcher} over range-partitioned segments)
+ * where different partitions of a shard group resolve to different load specs and the broker would otherwise drop
+ * the group as incomplete via {@code PartitionHolder.isComplete()}.
+ */
+public record ShardGroupFollowup(
+    DataSegment matchedSegment,
+    PartialLoadMatcher matcher,
+    Map<String, Integer> tieredReplicants
+) implements RuleRunResult
+{
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/RunRulesShardGroupFollowupTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/RunRulesShardGroupFollowupTest.java
@@ -1,0 +1,334 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.duty;
+
+import org.apache.druid.client.DataSourcesSnapshot;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.server.coordinator.loading.PartialLoadProfile;
+import org.apache.druid.server.coordinator.rules.PartialLoadMatcher;
+import org.apache.druid.server.coordinator.rules.SegmentActionHandler;
+import org.apache.druid.server.coordinator.rules.ShardGroupFollowup;
+import org.apache.druid.server.coordinator.rules.WildcardClusterGroupPartialLoadMatcher;
+import org.apache.druid.timeline.ClusterGroupTuples;
+import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentId;
+import org.apache.druid.timeline.partition.NumberedShardSpec;
+import org.joda.time.Interval;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+class RunRulesShardGroupFollowupTest
+{
+  private static final String DATASOURCE = "wiki";
+  private static final Interval INTERVAL = Intervals.of("2024-01-01/2024-01-02");
+  private static final String VERSION = "v1";
+  private static final Map<String, Integer> TIER1_REPLICANTS = Map.of("tier1", 1);
+
+  @Test
+  void emptyFollowupsIsNoOp()
+  {
+    final RecordingHandler handler = new RecordingHandler();
+    RunRules.flushShardGroupFollowups(
+        List.of(),
+        null,
+        null,
+        null,
+        DataSourcesSnapshot.fromUsedSegments(List.of()),
+        handler
+    );
+    Assertions.assertTrue(handler.partialLoads.isEmpty());
+  }
+
+  @Test
+  void asymmetricMatcherDispatchesEmptyLoadToUnmatchedSibling()
+  {
+    // 2-partition shard group: partition-0 contains cluster-A, partition-1 contains cluster-B.
+    // The rule's matcher targets cluster-A, so partition-0 was matched in the per-segment pass and partition-1 was
+    // not. The flush must dispatch an emptyMatch load to partition-1 so the shard group is uniformly placed.
+    final DataSegment p0 = clusteredSegment(0, "cluster-A");
+    final DataSegment p1 = clusteredSegment(1, "cluster-B");
+    final PartialLoadMatcher matcher = clusterMatcher("cluster-A");
+
+    final DataSourcesSnapshot snapshot = DataSourcesSnapshot.fromUsedSegments(List.of(p0, p1));
+    final RecordingHandler handler = new RecordingHandler();
+    final List<ShardGroupFollowup> followups = List.of(new ShardGroupFollowup(p0, matcher, TIER1_REPLICANTS));
+
+    RunRules.flushShardGroupFollowups(followups, DATASOURCE, INTERVAL, VERSION, snapshot, handler);
+
+    Assertions.assertEquals(1, handler.partialLoads.size());
+    final RecordedPartialLoad emptyLoad = handler.partialLoads.get(0);
+    Assertions.assertEquals(p1, emptyLoad.segment);
+    Assertions.assertEquals(List.of(), emptyLoad.profile.wrappedLoadSpec().get("clusterGroupIndices"));
+    Assertions.assertEquals(TIER1_REPLICANTS, emptyLoad.tieredReplicants);
+  }
+
+  @Test
+  void matchedSiblingIsNotEmptyLoadedAgain()
+  {
+    // Two segments both positively matched in the per-segment pass. The flush should not re-load either of them —
+    // both are already covered by their original positive loads.
+    final DataSegment p0 = clusteredSegment(0, "cluster-A");
+    final DataSegment p1 = clusteredSegment(1, "cluster-A");
+    final PartialLoadMatcher matcher = clusterMatcher("cluster-A");
+
+    final DataSourcesSnapshot snapshot = DataSourcesSnapshot.fromUsedSegments(List.of(p0, p1));
+    final RecordingHandler handler = new RecordingHandler();
+    final List<ShardGroupFollowup> followups = List.of(
+        new ShardGroupFollowup(p0, matcher, TIER1_REPLICANTS),
+        new ShardGroupFollowup(p1, matcher, TIER1_REPLICANTS)
+    );
+
+    RunRules.flushShardGroupFollowups(followups, DATASOURCE, INTERVAL, VERSION, snapshot, handler);
+
+    Assertions.assertTrue(handler.partialLoads.isEmpty());
+  }
+
+  @Test
+  void matcherWithoutEmptyMatchSkipsFlush()
+  {
+    // A matcher that returns null from emptyMatch (the default) opts out of the post-pass. Even though there are
+    // unmatched siblings in the group, no empty-loads are dispatched — symmetric matchers don't need this.
+    final DataSegment p0 = clusteredSegment(0, "cluster-A");
+    final DataSegment p1 = clusteredSegment(1, "cluster-B");
+    final PartialLoadMatcher noEmptyMatcher = new PartialLoadMatcher()
+    {
+      @Override
+      public MatchResult match(DataSegment segment, Map<String, Object> baseLoadSpec)
+      {
+        return null;
+      }
+    };
+
+    final DataSourcesSnapshot snapshot = DataSourcesSnapshot.fromUsedSegments(List.of(p0, p1));
+    final RecordingHandler handler = new RecordingHandler();
+    final List<ShardGroupFollowup> followups =
+        List.of(new ShardGroupFollowup(p0, noEmptyMatcher, TIER1_REPLICANTS));
+
+    RunRules.flushShardGroupFollowups(followups, DATASOURCE, INTERVAL, VERSION, snapshot, handler);
+
+    Assertions.assertTrue(handler.partialLoads.isEmpty());
+  }
+
+  @Test
+  void flushOnlyTouchesSiblingsInTheSpecifiedVersion()
+  {
+    // Two versions of the same interval, each a distinct shard group. Flushing for v1 must not look at v2's
+    // partition, even though both are in the snapshot.
+    final DataSegment v1p0 = clusteredSegmentWithVersion(0, "cluster-A", "v1");
+    final DataSegment v2p0 = clusteredSegmentWithVersion(0, "cluster-A", "v2");
+    final PartialLoadMatcher matcher = clusterMatcher("cluster-A");
+
+    final DataSourcesSnapshot snapshot = DataSourcesSnapshot.fromUsedSegments(List.of(v1p0, v2p0));
+    final RecordingHandler handler = new RecordingHandler();
+    final List<ShardGroupFollowup> followups = List.of(new ShardGroupFollowup(v1p0, matcher, TIER1_REPLICANTS));
+
+    RunRules.flushShardGroupFollowups(followups, DATASOURCE, INTERVAL, "v1", snapshot, handler);
+
+    // v1p0 was matched; v2p0 belongs to a different shard group and must not be touched.
+    Assertions.assertTrue(handler.partialLoads.isEmpty());
+  }
+
+  @Test
+  void multipleFollowupsInSameGroupAreDeduped()
+  {
+    // 3-partition shard group: matcher targets cluster-A and matched partition-0 and partition-1. Two followups
+    // in the same group. The flush dispatches exactly one empty-load (for partition-2), not two — the holder is
+    // walked once per matcher, not once per followup.
+    final DataSegment p0 = clusteredSegment(0, "cluster-A");
+    final DataSegment p1 = clusteredSegment(1, "cluster-A");
+    final DataSegment p2 = clusteredSegment(2, "cluster-B");
+    final PartialLoadMatcher matcher = clusterMatcher("cluster-A");
+
+    final DataSourcesSnapshot snapshot = DataSourcesSnapshot.fromUsedSegments(List.of(p0, p1, p2));
+    final RecordingHandler handler = new RecordingHandler();
+    final List<ShardGroupFollowup> followups = List.of(
+        new ShardGroupFollowup(p0, matcher, TIER1_REPLICANTS),
+        new ShardGroupFollowup(p1, matcher, TIER1_REPLICANTS)
+    );
+
+    RunRules.flushShardGroupFollowups(followups, DATASOURCE, INTERVAL, VERSION, snapshot, handler);
+
+    Assertions.assertEquals(1, handler.partialLoads.size());
+    Assertions.assertEquals(p2, handler.partialLoads.get(0).segment);
+  }
+
+  @Test
+  void differentMatchersInSameGroupAreProcessedIndependently()
+  {
+    // Same shard group, two distinct matcher instances. The flush groups by matcher reference identity and
+    // dispatches each matcher's empty-loads to its own unmatched siblings.
+    final DataSegment p0 = clusteredSegment(0, "cluster-A");
+    final DataSegment p1 = clusteredSegment(1, "cluster-B");
+    final PartialLoadMatcher matcherA = clusterMatcher("cluster-A");
+    final PartialLoadMatcher matcherB = clusterMatcher("cluster-B");
+
+    final DataSourcesSnapshot snapshot = DataSourcesSnapshot.fromUsedSegments(List.of(p0, p1));
+    final RecordingHandler handler = new RecordingHandler();
+    final List<ShardGroupFollowup> followups = List.of(
+        new ShardGroupFollowup(p0, matcherA, TIER1_REPLICANTS),
+        new ShardGroupFollowup(p1, matcherB, TIER1_REPLICANTS)
+    );
+
+    RunRules.flushShardGroupFollowups(followups, DATASOURCE, INTERVAL, VERSION, snapshot, handler);
+
+    // matcherA matched p0, didn't match p1 → empty-load on p1.
+    // matcherB matched p1, didn't match p0 → empty-load on p0.
+    Assertions.assertEquals(2, handler.partialLoads.size());
+    final Set<DataSegment> emptyLoaded = new HashSet<>();
+    handler.partialLoads.forEach(load -> emptyLoaded.add(load.segment));
+    Assertions.assertEquals(Set.of(p0, p1), emptyLoaded);
+  }
+
+  @Test
+  void appendedSiblingIsNotEmptyLoaded()
+  {
+    // 2-core-partition shard group plus one appended sibling (partitionNum=2 with numCorePartitions=2). The
+    // matcher matches core p0 but not core p1 and not the appended segment. The flush must empty-load core p1
+    // (completeness-required) but skip the appended sibling — appended segments are queried individually by the
+    // broker and don't participate in the core-group completeness check.
+    final DataSegment corePartition0 = numberedSegment(0, 2, "cluster-A");
+    final DataSegment corePartition1 = numberedSegment(1, 2, "cluster-B");
+    final DataSegment appendedPartition = numberedSegment(2, 2, "cluster-C");
+    final PartialLoadMatcher matcher = clusterMatcher("cluster-A");
+
+    final DataSourcesSnapshot snapshot =
+        DataSourcesSnapshot.fromUsedSegments(List.of(corePartition0, corePartition1, appendedPartition));
+    final RecordingHandler handler = new RecordingHandler();
+    final List<ShardGroupFollowup> followups =
+        List.of(new ShardGroupFollowup(corePartition0, matcher, TIER1_REPLICANTS));
+
+    RunRules.flushShardGroupFollowups(followups, DATASOURCE, INTERVAL, VERSION, snapshot, handler);
+
+    Assertions.assertEquals(1, handler.partialLoads.size());
+    Assertions.assertEquals(corePartition1, handler.partialLoads.get(0).segment);
+  }
+
+  @Test
+  void datasourceMissingFromSnapshotIsSkipped()
+  {
+    // A followup whose datasource isn't in the snapshot (segment was dropped between collecting followups and
+    // flushing) should be silently skipped, not throw.
+    final DataSegment p0 = clusteredSegment(0, "cluster-A");
+    final PartialLoadMatcher matcher = clusterMatcher("cluster-A");
+
+    final DataSourcesSnapshot snapshot = DataSourcesSnapshot.fromUsedSegments(List.of());
+    final RecordingHandler handler = new RecordingHandler();
+    final List<ShardGroupFollowup> followups = List.of(new ShardGroupFollowup(p0, matcher, TIER1_REPLICANTS));
+
+    RunRules.flushShardGroupFollowups(followups, DATASOURCE, INTERVAL, VERSION, snapshot, handler);
+
+    Assertions.assertTrue(handler.partialLoads.isEmpty());
+  }
+
+  private static DataSegment clusteredSegment(int partitionNum, String cluster)
+  {
+    return clusteredSegmentWithVersion(partitionNum, cluster, VERSION);
+  }
+
+  private static DataSegment clusteredSegmentWithVersion(int partitionNum, String cluster, String version)
+  {
+    return numberedSegmentWithVersion(partitionNum, 3, cluster, version);
+  }
+
+  private static DataSegment numberedSegment(int partitionNum, int numCorePartitions, String cluster)
+  {
+    return numberedSegmentWithVersion(partitionNum, numCorePartitions, cluster, VERSION);
+  }
+
+  /**
+   * Builds a clustered shard-group sibling with explicit core-partition count.
+   * {@link DataSegment#builder(SegmentId)} does not propagate the shardSpec from the SegmentId, so we set it
+   * explicitly so partitions get distinct segment IDs.
+   */
+  private static DataSegment numberedSegmentWithVersion(
+      int partitionNum,
+      int numCorePartitions,
+      String cluster,
+      String version
+  )
+  {
+    final NumberedShardSpec shardSpec = new NumberedShardSpec(partitionNum, numCorePartitions);
+    return DataSegment
+        .builder(SegmentId.of(DATASOURCE, INTERVAL, version, shardSpec))
+        .shardSpec(shardSpec)
+        .loadSpec(Map.of("type", "local", "path", "/var/druid/segments/foo"))
+        .clusterGroups(new ClusterGroupTuples(
+            RowSignature.builder().add("name", ColumnType.STRING).build(),
+            List.of(List.of(cluster))
+        ))
+        .size(0)
+        .build();
+  }
+
+  private static PartialLoadMatcher clusterMatcher(String name)
+  {
+    return new WildcardClusterGroupPartialLoadMatcher(List.of(Map.of("name", name)), null);
+  }
+
+  private record RecordedPartialLoad(
+      DataSegment segment,
+      PartialLoadProfile profile,
+      Map<String, Integer> tieredReplicants
+  )
+  {
+  }
+
+  private static final class RecordingHandler implements SegmentActionHandler
+  {
+    final List<RecordedPartialLoad> partialLoads = new ArrayList<>();
+
+    @Override
+    public void replicateSegment(DataSegment segment, Map<String, Integer> tierToReplicaCount)
+    {
+      throw new AssertionError("Flush must only call replicateSegmentPartially, not replicateSegment");
+    }
+
+    @Override
+    public void replicateSegmentPartially(
+        DataSegment segment,
+        PartialLoadProfile profile,
+        Map<String, Integer> tierToReplicaCount
+    )
+    {
+      partialLoads.add(new RecordedPartialLoad(segment, profile, new HashMap<>(tierToReplicaCount)));
+    }
+
+    @Override
+    public void broadcastSegment(DataSegment segment)
+    {
+      throw new AssertionError("Flush must not call broadcastSegment");
+    }
+
+    @Override
+    public void deleteSegment(DataSegment segment)
+    {
+      throw new AssertionError("Flush must not call deleteSegment");
+    }
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/PartialLoadRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/PartialLoadRuleTest.java
@@ -318,6 +318,48 @@ public class PartialLoadRuleTest
   }
 
   @Test
+  void testRunWithMatchReturnsShardGroupFollowupWhenCorePartitionsExist()
+  {
+    // Segment in a 2-core-partition group with a positive match. run() must return a ShardGroupFollowup so
+    // RunRules can post-pass for sibling reconciliation.
+    PeriodPartialLoadRule rule = new PeriodPartialLoadRule(
+        new Period("P30D"),
+        false,
+        tier(2),
+        null,
+        exact("a"),
+        null
+    );
+    DataSegment segment = segmentWithProjectionsAndCorePartitions(IN_WINDOW, List.of("a", "b"), 2);
+    RecordingHandler handler = new RecordingHandler();
+    RuleRunResult result = rule.run(segment, handler);
+    Assertions.assertEquals(1, handler.replicatePartialCalls);
+    Assertions.assertInstanceOf(ShardGroupFollowup.class, result);
+  }
+
+  @Test
+  void testRunWithMatchSkipsFollowupWhenNoCorePartitions()
+  {
+    // numCorePartitions=0: the shard group has no atomic-replace completeness requirement on the broker, so the
+    // sibling-aware post-pass would be wasted. run() still dispatches the positive load but returns OK, not a
+    // ShardGroupFollowup.
+    PeriodPartialLoadRule rule = new PeriodPartialLoadRule(
+        new Period("P30D"),
+        false,
+        tier(2),
+        null,
+        exact("a"),
+        null
+    );
+    DataSegment segment = segmentWithProjectionsAndCorePartitions(IN_WINDOW, List.of("a", "b"), 0);
+    RecordingHandler handler = new RecordingHandler();
+    RuleRunResult result = rule.run(segment, handler);
+    Assertions.assertEquals(1, handler.replicatePartialCalls);
+    Assertions.assertEquals(0, handler.replicateCalls);
+    Assertions.assertSame(RuleRunResult.OK, result);
+  }
+
+  @Test
   void testRunWithFullLoadFallbackRoutesToReplicateSegment()
   {
     // Matcher does not apply but the rule's onCannotMatch is FULL_LOAD, so run() falls back to the regular full-load
@@ -373,6 +415,27 @@ public class PartialLoadRuleTest
   {
     return DataSegment
         .builder(SegmentId.of("test", interval, DateTimes.nowUtc().toString(), new NumberedShardSpec(0, 0)))
+        .loadSpec(Map.of("type", "local", "path", "/var/druid/segments/foo"))
+        .projections(projections)
+        .size(0)
+        .build();
+  }
+
+  /**
+   * Like {@link #segmentWithProjections} but with an explicit core-partition count so callers can exercise the
+   * core-partition guard in {@link PartialLoadRule#run}. Sets the shardSpec on the builder (the SegmentId's
+   * shardSpec doesn't propagate by default).
+   */
+  private static DataSegment segmentWithProjectionsAndCorePartitions(
+      Interval interval,
+      List<String> projections,
+      int numCorePartitions
+  )
+  {
+    final NumberedShardSpec shardSpec = new NumberedShardSpec(0, numCorePartitions);
+    return DataSegment
+        .builder(SegmentId.of("test", interval, DateTimes.nowUtc().toString(), shardSpec))
+        .shardSpec(shardSpec)
         .loadSpec(Map.of("type", "local", "path", "/var/druid/segments/foo"))
         .projections(projections)
         .size(0)

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/WildcardClusterGroupPartialLoadMatcherTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/WildcardClusterGroupPartialLoadMatcherTest.java
@@ -427,6 +427,56 @@ class WildcardClusterGroupPartialLoadMatcherTest
     Assertions.assertFalse(json.contains("virtualColumns"), () -> "did not expect virtualColumns in JSON: " + json);
   }
 
+  @Test
+  void testEmptyMatchProducesPartialClusterGroupWireFormWithNoIndices()
+  {
+    // The sibling-aware "empty match" fallback used by PartialLoadRule when this matcher resolves to nothing on a
+    // segment but at least one sibling matches positively. The wire form is still partialClusterGroup, but the
+    // clusterGroupIndices list is empty.
+    final WildcardClusterGroupPartialLoadMatcher matcher = new WildcardClusterGroupPartialLoadMatcher(
+        List.of(Map.of("tenant", "nonexistent")),
+        null
+    );
+    final PartialLoadMatcher.MatchResult result = matcher.emptyMatch(threeGroupSegment(), BASE_LOAD_SPEC);
+
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals("partialClusterGroup", result.wrappedLoadSpec().get("type"));
+    Assertions.assertEquals(List.of(), result.wrappedLoadSpec().get("clusterGroupIndices"));
+    // base load-spec carried under the "delegate" key, unchanged.
+    Assertions.assertEquals(BASE_LOAD_SPEC, result.wrappedLoadSpec().get("delegate"));
+    Assertions.assertNotNull(result.fingerprint());
+  }
+
+  @Test
+  void testEmptyMatchFingerprintIsStableAcrossInvocations()
+  {
+    // Same matcher, same segment, two invocations: fingerprints must match so coordinator reconciliation doesn't churn
+    // replicas between runs.
+    final WildcardClusterGroupPartialLoadMatcher matcher = new WildcardClusterGroupPartialLoadMatcher(
+        List.of(Map.of("tenant", "acme")),
+        null
+    );
+    final PartialLoadMatcher.MatchResult a = matcher.emptyMatch(threeGroupSegment(), BASE_LOAD_SPEC);
+    final PartialLoadMatcher.MatchResult b = matcher.emptyMatch(threeGroupSegment(), BASE_LOAD_SPEC);
+    Assertions.assertEquals(a.fingerprint(), b.fingerprint());
+    Assertions.assertTrue(a.fingerprint().startsWith(ClusterGroupPartialLoadMatcher.FINGERPRINT_VERSION + ":"));
+  }
+
+  @Test
+  void testEmptyMatchFingerprintDiffersFromNonEmptyMatch()
+  {
+    // A positive match and an empty match must produce different fingerprints; otherwise the coordinator can't tell
+    // a real partial load from the empty stub for the same segment.
+    final WildcardClusterGroupPartialLoadMatcher matcher = new WildcardClusterGroupPartialLoadMatcher(
+        List.of(Map.of("tenant", "acme")),
+        null
+    );
+    final PartialLoadMatcher.MatchResult real = matcher.match(threeGroupSegment(), BASE_LOAD_SPEC);
+    final PartialLoadMatcher.MatchResult empty = matcher.emptyMatch(threeGroupSegment(), BASE_LOAD_SPEC);
+    Assertions.assertNotNull(real);
+    Assertions.assertNotEquals(real.fingerprint(), empty.fingerprint());
+  }
+
   private static VirtualColumns lowerTenantVcs(String outputName)
   {
     return VirtualColumns.create(new ExpressionVirtualColumn(


### PR DESCRIPTION
### Description
This PR adds a post-processing step to `RunRules` so that partial-load matchers that resolve differently across segments of a shard group (e.g. `ClusterGroupPartialLoadMatcher` over range-partitioned segments) don't leave the broker with an incomplete `PartitionHolder`. `Rule.run` now returns a new `RuleRunResult` object that `RunRules` can use to 'do stuff', though most implementations today do `RuleRunResult.OK`. For these asymmetric partial matchers, there is a `ShardGroupFollowup` implementation of `RuleRunResult` that `RunRules` can use to check the siblings of a shard group to perform an 'empty' partial load to ensure that the group is fully available. I am unsure if there is enough of a pattern to make `RunRules` more generically handle `RuleRunResult`, i was planning to wait and see if any other use cases pop up before trying to make this handling more generic.

Doing an empty load like this seemed cheaper than trying to figure out how to allow the timeline to sometimes allow incomplete groups to appear as complete, since the empty partial load should be cheap for the target historicals.

changes:
* adds `PartialLoadMatcher.emptyMatch` (default null) as an opt-in way to do a zero-content "load" for matchers that can resolve asymmetrically.
* `Rule.run` returns a `RuleRunResult` (`OK` constant for most rules). `PartialLoadRule` returns a `ShardGroupFollowup` on a positive match, but only when numCorePartitions > 0.
* `RunRules` streams followups in a buffer keyed by (dataSource, interval, version), flushing at iteration boundaries (NEWEST_SEGMENT_FIRST groups segments contiguously by that triple). Flush dispatches emptyMatch loads to unmatched core siblings; siblings not part of the core partition group are skipped.
* adds `TimelineLookup.findChunks` which returns a defensive copy via `PartitionHolder.copyWithOnlyVisibleChunks` so iteration is safe outside the timeline lock.
* `PartialClusterGroupLoadSpec` allows an empty `clusterGroupIndices` list as the wire form of an empty match.