### PR TITLE
fix: retry on transient AWS credential resolution failures

### DIFF
--- a/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSClientUtil.java
+++ b/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSClientUtil.java
@@ -62,6 +62,12 @@ public class AWSClientUtil
       "Throttling"
   );
 
+  private static final String UNABLE_TO_LOAD_CREDENTIALS_FROM_PROVIDER_CHAIN =
+      "Unable to load credentials from any of the providers in the chain";
+  private static final String FAILED_TO_LOAD_CREDENTIALS_FROM_IMDS = "Failed to load credentials from IMDS";
+  private static final String CANNOT_REFRESH_AWS_CREDENTIALS = "cannot refresh AWS credentials";
+  private static final String CANNOT_FETCH_CREDENTIALS_FROM_CONTAINER = "Cannot fetch credentials from container";
+
   /**
    * Checks whether an exception can be retried or not for AWS SDK v2.
    */
@@ -101,11 +107,15 @@ public class AWSClientUtil
 
     // Check for SdkClientException specific messages
     if (exception instanceof SdkClientException) {
-      String message = exception.getMessage();
+      final String message = exception.getMessage();
       if (message != null) {
         if (message.contains("Unable to execute HTTP request") ||
             message.contains("Data read has a different length than the expected") ||
-            message.contains("Unable to find a region")) {
+            message.contains("Unable to find a region") ||
+            message.contains(UNABLE_TO_LOAD_CREDENTIALS_FROM_PROVIDER_CHAIN) ||
+            message.contains(FAILED_TO_LOAD_CREDENTIALS_FROM_IMDS) ||
+            message.contains(CANNOT_REFRESH_AWS_CREDENTIALS) ||
+            message.contains(CANNOT_FETCH_CREDENTIALS_FROM_CONTAINER)) {
           return true;
         }
       }

--- a/cloud/aws-common/src/test/java/org/apache/druid/common/aws/AWSClientUtilTest.java
+++ b/cloud/aws-common/src/test/java/org/apache/druid/common/aws/AWSClientUtilTest.java
@@ -90,6 +90,33 @@ public class AWSClientUtilTest
   }
 
   @Test
+  public void testRecoverableException_CredentialsProviderChain()
+  {
+    final SdkClientException ex = SdkClientException.builder()
+        .message("Unable to load credentials from any of the providers in the chain AwsCredentialsProviderChain")
+        .build();
+    Assert.assertTrue(AWSClientUtil.isClientExceptionRecoverable(ex));
+  }
+
+  @Test
+  public void testRecoverableException_FileSessionCredentialsRefresh()
+  {
+    final SdkClientException ex = SdkClientException.builder()
+        .message("LazyFileSessionCredentialsProvider(): cannot refresh AWS credentials")
+        .build();
+    Assert.assertTrue(AWSClientUtil.isClientExceptionRecoverable(ex));
+  }
+
+  @Test
+  public void testRecoverableException_InstanceProfileCredentials()
+  {
+    final SdkClientException ex = SdkClientException.builder()
+        .message("InstanceProfileCredentialsProvider(): Failed to load credentials from IMDS.")
+        .build();
+    Assert.assertTrue(AWSClientUtil.isClientExceptionRecoverable(ex));
+  }
+
+  @Test
   public void testRecoverableException_ClockSkewedError()
   {
     AwsServiceException ex = AwsServiceException.builder()

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3UtilsTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3UtilsTest.java
@@ -36,6 +36,7 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -144,6 +145,31 @@ public class S3UtilsTest
                     + "Must provide an explicit region in the builder or setup environment to supply a region."
                 )
                 .build();
+          }
+        },
+        maxRetries
+    );
+    Assert.assertEquals(maxRetries, count.get());
+  }
+
+  @Test
+  public void testRetryWithAsyncCredentialProviderChainException() throws Exception
+  {
+    final int maxRetries = 3;
+    final AtomicInteger count = new AtomicInteger();
+    S3Utils.retryS3Operation(
+        () -> {
+          if (count.incrementAndGet() >= maxRetries) {
+            return "hey";
+          } else {
+            throw new CompletionException(
+                SdkClientException.builder()
+                                  .message(
+                                      "Unable to load credentials from any of the providers in the chain "
+                                      + "AwsCredentialsProviderChain"
+                                  )
+                                  .build()
+            );
           }
         },
         maxRetries


### PR DESCRIPTION
### Description


S3 segment pushes that use the AWS SDK v2 transfer manager can resolve credentials on the async upload path. If a file-session credential refresh, container credential lookup, or IMDS lookup is temporarily unavailable, the SDK reports an SdkClientException such as 'Unable to load credentials from any of the providers in the chain'.

Druid's S3 push path already wraps uploads in retryS3Operation, but these credential-provider failures were not classified as recoverable after the SDK v2 migration. That made an intermittent credential miss fail the task immediately instead of using the existing retry budget.


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Retry on transient AWS credential resolution failures

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.