### PR TITLE
feat: Make segmentLoadAheadCount able to be configured at worker task level in addition to context

### DIFF
--- a/docs/querying/dart.md
+++ b/docs/querying/dart.md
@@ -73,6 +73,7 @@ For Historicals, you can set the following configs:
 |---|---|---|
 | `druid.msq.dart.worker.concurrentQueries` | Maximum number of query workers that can run concurrently on a Historical. We recommend leaving this config at the default value. If need to change this value, set it to a value equal to or larger than `druid.msq.dart.controller.concurrentQueries` on your Brokers. If you don't, queries can get stuck waiting for each other. Don't set it to a value higher than the number of merge buffers. | Equal to the number of merge buffers |
 | `druid.msq.dart.worker.heapFraction` | Maximum amount of heap available for use across all Dart queries as a decimal. | 0.35 (35% of heap) |
+| `druid.msq.dart.worker.segmentLoadAheadCount` | Number of segments a worker will prefetch ahead of processing them. This lets tiers with different hardware tune prefetch independently. When set, it acts as a floor: the effective value is the larger of this and any value supplied in the query context (`segmentLoadAheadCount`), so a query can request more but not less. Non-positive values are treated as unset. | Unset (uses twice the number of processing threads) |
 
 
 ## Run a Dart query

--- a/docs/querying/dart.md
+++ b/docs/querying/dart.md
@@ -73,7 +73,7 @@ For Historicals, you can set the following configs:
 |---|---|---|
 | `druid.msq.dart.worker.concurrentQueries` | Maximum number of query workers that can run concurrently on a Historical. We recommend leaving this config at the default value. If need to change this value, set it to a value equal to or larger than `druid.msq.dart.controller.concurrentQueries` on your Brokers. If you don't, queries can get stuck waiting for each other. Don't set it to a value higher than the number of merge buffers. | Equal to the number of merge buffers |
 | `druid.msq.dart.worker.heapFraction` | Maximum amount of heap available for use across all Dart queries as a decimal. | 0.35 (35% of heap) |
-| `druid.msq.dart.worker.segmentLoadAheadCount` | Number of segments a worker will prefetch ahead of processing them. This lets tiers with different hardware tune prefetch independently. When set, it acts as a floor: the effective value is the larger of this and any value supplied in the query context (`segmentLoadAheadCount`), so a query can request more but not less. Non-positive values are treated as unset. | Unset (uses twice the number of processing threads) |
+| `druid.msq.dart.worker.segmentLoadAheadCount` | Number of segments a worker will prefetch ahead of processing them. This lets tiers with different hardware tune prefetch independently. It acts as a worker-local default: a value supplied in the query context (`segmentLoadAheadCount`) always takes precedence when it is set. Non-positive values are treated as unset. | Unset (uses twice the number of processing threads) |
 
 
 ## Run a Dart query

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/dart/guice/DartWorkerConfig.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/dart/guice/DartWorkerConfig.java
@@ -48,10 +48,9 @@ public class DartWorkerConfig
    * Worker-local value for the segment load-ahead count used to size segment prefetch in {@link ReadableInputQueue}.
    * <p>
    * Defaults to null (unset), which leaves the value to query context (client or controller-default supplied) and the
-   * built-in {@code 2 * threadCount} fallback. When set to a positive value, it acts as a worker-local floor: the
-   * effective count becomes the larger of this value and any value present in the query context, so a query can still
-   * request more, but never less than this floor. Non-positive values are treated as unset.
-   *
+   * built-in {@code 2 * threadCount} fallback. When set to a positive value, it acts as a worker-local default used
+   * only when the query context does not supply a value.
+   * <p>
    * This is per-worker-process configuration, set independently on each worker. It lets workers with different
    * hardware (for example, separate tiers with more or less memory and storage bandwidth) tune their own prefetch
    * depth, rather than relying solely on a single cluster-wide query-context default.

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/dart/guice/DartWorkerConfig.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/dart/guice/DartWorkerConfig.java
@@ -21,6 +21,9 @@ package org.apache.druid.msq.dart.guice;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.msq.exec.MemoryIntrospector;
+import org.apache.druid.msq.querykit.ReadableInputQueue;
+
+import javax.annotation.Nullable;
 
 /**
  * Runtime configuration for workers (which run on Historicals).
@@ -41,6 +44,22 @@ public class DartWorkerConfig
   @JsonProperty("heapFraction")
   private double heapFraction = DEFAULT_HEAP_FRACTION;
 
+  /**
+   * Worker-local value for the segment load-ahead count used to size segment prefetch in {@link ReadableInputQueue}.
+   * <p>
+   * Defaults to null (unset), which leaves the value to query context (client or controller-default supplied) and the
+   * built-in {@code 2 * threadCount} fallback. When set to a positive value, it acts as a worker-local floor: the
+   * effective count becomes the larger of this value and any value present in the query context, so a query can still
+   * request more, but never less than this floor. Non-positive values are treated as unset.
+   *
+   * This is per-worker-process configuration, set independently on each worker. It lets workers with different
+   * hardware (for example, separate tiers with more or less memory and storage bandwidth) tune their own prefetch
+   * depth, rather than relying solely on a single cluster-wide query-context default.
+   */
+  @JsonProperty("segmentLoadAheadCount")
+  @Nullable
+  private Integer segmentLoadAheadCount = null;
+
   public int getConcurrentQueries()
   {
     return concurrentQueries;
@@ -49,5 +68,11 @@ public class DartWorkerConfig
   public double getHeapFraction()
   {
     return heapFraction;
+  }
+
+  @Nullable
+  public Integer getSegmentLoadAheadCount()
+  {
+    return segmentLoadAheadCount;
   }
 }

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/dart/worker/DartWorkerContext.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/dart/worker/DartWorkerContext.java
@@ -30,6 +30,7 @@ import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.messages.server.Outbox;
 import org.apache.druid.msq.dart.controller.messages.ControllerMessage;
 import org.apache.druid.msq.dart.controller.messages.PostCounters;
+import org.apache.druid.msq.dart.guice.DartWorkerConfig;
 import org.apache.druid.msq.exec.ControllerClient;
 import org.apache.druid.msq.exec.DataServerQueryHandlerFactory;
 import org.apache.druid.msq.exec.FrameContext;
@@ -57,6 +58,7 @@ import org.apache.druid.server.SegmentManager;
 import org.apache.druid.utils.CloseableUtils;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.List;
 
@@ -91,6 +93,13 @@ public class DartWorkerContext implements WorkerContext
   private final QueryContext queryContext;
   private final ServiceEmitter emitter;
   private final int threadCount;
+
+  /**
+   * Worker-local segment load-ahead count from {@link DartWorkerConfig#getSegmentLoadAheadCount()}, or null if unset.
+   * Applied as a floor in {@link #segmentLoadAheadCount(WorkOrder)}.
+   */
+  @Nullable
+  private final Integer segmentLoadAheadCountConfig;
 
   /**
    * Lazy initialized upon call to {@link #frameContext(WorkOrder)}.
@@ -148,6 +157,9 @@ public class DartWorkerContext implements WorkerContext
     final int baseThreadCount = processingConfig.getNumThreads();
     final Integer maxThreads = MultiStageQueryContext.getMaxThreads(queryContext);
     this.threadCount = (maxThreads != null && maxThreads > 0) ? Math.min(baseThreadCount, maxThreads) : baseThreadCount;
+
+    // Worker-local segment load-ahead config, read once from this worker's DartWorkerConfig.
+    this.segmentLoadAheadCountConfig = injector.getInstance(DartWorkerConfig.class).getSegmentLoadAheadCount();
   }
 
   @Override
@@ -275,6 +287,29 @@ public class DartWorkerContext implements WorkerContext
   public int threadCount()
   {
     return threadCount;
+  }
+
+  @Override
+  public int segmentLoadAheadCount(final WorkOrder workOrder)
+  {
+    final Integer fromContext = MultiStageQueryContext.getSegmentLoadAheadCount(workOrder.getWorkerContext());
+    return resolveSegmentLoadAheadCount(fromContext, segmentLoadAheadCountConfig, threadCount);
+  }
+
+  /**
+   * Determine which of the three potential sources of segment load ahead count to use
+   */
+  static int resolveSegmentLoadAheadCount(
+      @Nullable final Integer fromContext,
+      @Nullable final Integer workerConfig,
+      final int threadCount
+  )
+  {
+    final boolean hasWorkerConfig = workerConfig != null && workerConfig > 0;
+    if (!hasWorkerConfig) {
+      return fromContext != null ? fromContext : threadCount * 2;
+    }
+    return fromContext != null ? Math.max(fromContext, workerConfig) : workerConfig;
   }
 
   @Override

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/dart/worker/DartWorkerContext.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/dart/worker/DartWorkerContext.java
@@ -96,7 +96,7 @@ public class DartWorkerContext implements WorkerContext
 
   /**
    * Worker-local segment load-ahead count from {@link DartWorkerConfig#getSegmentLoadAheadCount()}, or null if unset.
-   * Applied as a floor in {@link #segmentLoadAheadCount(WorkOrder)}.
+   * Used as the default in {@link #segmentLoadAheadCount(WorkOrder)} when the query context does not supply a value.
    */
   @Nullable
   private final Integer segmentLoadAheadCountConfig;
@@ -118,6 +118,7 @@ public class DartWorkerContext implements WorkerContext
       final Injector injector,
       final DartWorkerClient workerClient,
       final DruidProcessingConfig processingConfig,
+      final DartWorkerConfig workerConfig,
       final SegmentWrangler segmentWrangler,
       final SegmentManager segmentManager,
       final VirtualStorageManager virtualStorageManager,
@@ -158,8 +159,8 @@ public class DartWorkerContext implements WorkerContext
     final Integer maxThreads = MultiStageQueryContext.getMaxThreads(queryContext);
     this.threadCount = (maxThreads != null && maxThreads > 0) ? Math.min(baseThreadCount, maxThreads) : baseThreadCount;
 
-    // Worker-local segment load-ahead config, read once from this worker's DartWorkerConfig.
-    this.segmentLoadAheadCountConfig = injector.getInstance(DartWorkerConfig.class).getSegmentLoadAheadCount();
+    // Worker-local segment load-ahead config from this worker's DartWorkerConfig.
+    this.segmentLoadAheadCountConfig = workerConfig.getSegmentLoadAheadCount();
   }
 
   @Override
@@ -297,7 +298,10 @@ public class DartWorkerContext implements WorkerContext
   }
 
   /**
-   * Determine which of the three potential sources of segment load ahead count to use
+   * Determine which of the three potential sources of segment load ahead count to use.
+   * <p>
+   * Precedence is: a value supplied in the query context wins when set; otherwise the worker-local config is used
+   * when set to a positive value; lastly we fall back to {@code 2 * threadCount}.
    */
   static int resolveSegmentLoadAheadCount(
       @Nullable final Integer fromContext,
@@ -305,11 +309,11 @@ public class DartWorkerContext implements WorkerContext
       final int threadCount
   )
   {
-    final boolean hasWorkerConfig = workerConfig != null && workerConfig > 0;
-    if (!hasWorkerConfig) {
-      return fromContext != null ? fromContext : threadCount * 2;
+    if (fromContext != null) {
+      return fromContext;
     }
-    return fromContext != null ? Math.max(fromContext, workerConfig) : workerConfig;
+    final boolean hasWorkerConfig = workerConfig != null && workerConfig > 0;
+    return hasWorkerConfig ? workerConfig : threadCount * 2;
   }
 
   @Override

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/dart/worker/DartWorkerContextFactoryImpl.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/dart/worker/DartWorkerContextFactoryImpl.java
@@ -31,6 +31,7 @@ import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.messages.server.Outbox;
 import org.apache.druid.msq.dart.Dart;
 import org.apache.druid.msq.dart.controller.messages.ControllerMessage;
+import org.apache.druid.msq.dart.guice.DartWorkerConfig;
 import org.apache.druid.msq.exec.MemoryIntrospector;
 import org.apache.druid.msq.exec.ProcessingBuffersProvider;
 import org.apache.druid.msq.exec.WorkerContext;
@@ -60,6 +61,7 @@ public class DartWorkerContextFactoryImpl implements DartWorkerContextFactory
   private final Injector injector;
   private final ServiceClientFactory serviceClientFactory;
   private final DruidProcessingConfig processingConfig;
+  private final DartWorkerConfig workerConfig;
   private final SegmentWrangler segmentWrangler;
   private final SegmentManager segmentManager;
   private final VirtualStorageManager virtualStorageManager;
@@ -80,6 +82,7 @@ public class DartWorkerContextFactoryImpl implements DartWorkerContextFactory
       Injector injector,
       @EscalatedGlobal ServiceClientFactory serviceClientFactory,
       DruidProcessingConfig processingConfig,
+      DartWorkerConfig workerConfig,
       SegmentWrangler segmentWrangler,
       SegmentManager segmentManager,
       VirtualStorageManager virtualStorageManager,
@@ -99,6 +102,7 @@ public class DartWorkerContextFactoryImpl implements DartWorkerContextFactory
     this.injector = injector;
     this.serviceClientFactory = serviceClientFactory;
     this.processingConfig = processingConfig;
+    this.workerConfig = workerConfig;
     this.segmentWrangler = segmentWrangler;
     this.coordinatorClient = coordinatorClient;
     this.segmentManager = segmentManager;
@@ -128,6 +132,7 @@ public class DartWorkerContextFactoryImpl implements DartWorkerContextFactory
         injector,
         createWorkerClient(queryId),
         processingConfig,
+        workerConfig,
         segmentWrangler,
         segmentManager,
         virtualStorageManager,

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ExecutionContext.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ExecutionContext.java
@@ -92,6 +92,13 @@ public interface ExecutionContext
   int threadCount();
 
   /**
+   * Effective segment load-ahead count for {@link #workOrder()}, resolved by
+   * {@link WorkerContext#segmentLoadAheadCount(WorkOrder)}. Used to size the segment prefetch in
+   * {@link org.apache.druid.msq.querykit.ReadableInputQueue}.
+   */
+  int segmentLoadAheadCount();
+
+  /**
    * Cancellation ID that must be provided to {@link FrameProcessorExecutor} when running work.
    */
   String cancellationId();

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ExecutionContextImpl.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ExecutionContextImpl.java
@@ -50,6 +50,7 @@ public class ExecutionContextImpl implements ExecutionContext
   private final FrameContext frameContext;
   private final CounterTracker counters;
   private final int maxOutstandingProcessors;
+  private final int segmentLoadAheadCount;
   private final String cancellationId;
   private final RunWorkOrderListener listener;
   private final Set<String> intermediateOutputChannelFactoryNames = Sets.newConcurrentHashSet();
@@ -65,6 +66,7 @@ public class ExecutionContextImpl implements ExecutionContext
       final FrameContext frameContext,
       final CounterTracker counters,
       final int maxOutstandingProcessors,
+      final int segmentLoadAheadCount,
       final String cancellationId,
       final RunWorkOrderListener listener
   )
@@ -79,6 +81,7 @@ public class ExecutionContextImpl implements ExecutionContext
     this.frameContext = frameContext;
     this.counters = counters;
     this.maxOutstandingProcessors = maxOutstandingProcessors;
+    this.segmentLoadAheadCount = segmentLoadAheadCount;
     this.cancellationId = cancellationId;
     this.listener = listener;
   }
@@ -145,6 +148,12 @@ public class ExecutionContextImpl implements ExecutionContext
   public int threadCount()
   {
     return maxOutstandingProcessors;
+  }
+
+  @Override
+  public int segmentLoadAheadCount()
+  {
+    return segmentLoadAheadCount;
   }
 
   @Override

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/RunWorkOrder.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/RunWorkOrder.java
@@ -392,6 +392,7 @@ public class RunWorkOrder
         frameContext,
         counterTracker,
         workerContext.threadCount(),
+        workerContext.segmentLoadAheadCount(workOrder),
         cancellationId,
         listener
     );

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerContext.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerContext.java
@@ -110,6 +110,20 @@ public interface WorkerContext extends Closeable
   int threadCount();
 
   /**
+   * Effective number of segments to load ahead of when they are needed while processing the given {@code workOrder},
+   * used to size the segment prefetch in {@link org.apache.druid.msq.querykit.ReadableInputQueue}.
+   *
+   * The default honors {@link MultiStageQueryContext#CTX_SEGMENT_LOAD_AHEAD_COUNT} from the work order's context
+   * (set by the controller from client and broker-default context), and otherwise falls back to
+   * {@code 2 * threadCount()}. Implementations may override to layer in worker-local configuration.
+   */
+  default int segmentLoadAheadCount(WorkOrder workOrder)
+  {
+    final Integer fromContext = MultiStageQueryContext.getSegmentLoadAheadCount(workOrder.getWorkerContext());
+    return fromContext != null ? fromContext : threadCount() * 2;
+  }
+
+  /**
    * Fetch node info about self.
    */
   DruidNode selfNode();

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/BaseLeafStageProcessor.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/BaseLeafStageProcessor.java
@@ -51,7 +51,6 @@ import org.apache.druid.msq.input.external.ExternalInputSlice;
 import org.apache.druid.msq.input.stage.StageInputSlice;
 import org.apache.druid.msq.input.table.SegmentsInputSlice;
 import org.apache.druid.msq.kernel.StageDefinition;
-import org.apache.druid.msq.util.MultiStageQueryContext;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.filter.SegmentPruner;
 import org.apache.druid.query.planning.ExecutionVertex;
@@ -294,12 +293,10 @@ public abstract class BaseLeafStageProcessor extends BasicStageProcessor
     }
 
     final List<PhysicalInputSlice> filteredSlices = filterBaseInput(physicalInputSlices);
-    final Integer segmentLoadAheadCount =
-        MultiStageQueryContext.getSegmentLoadAheadCount(context.workOrder().getWorkerContext());
     return new ReadableInputQueue(
         new StandardPartitionReader(context),
         filteredSlices,
-        segmentLoadAheadCount != null ? segmentLoadAheadCount : context.threadCount() * 2
+        context.segmentLoadAheadCount()
     );
   }
 

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
@@ -280,9 +280,8 @@ public class MultiStageQueryContext
   /**
    * Number of segments to load ahead of them being needed. Used when setting up {@link ReadableInputQueue}.
    * <p>
-   * A worker may be configured with a local minimum for this value. When it is,
-   * the effective count is the larger of this context value and the worker's configured minimum, so a context value
-   * below that minimum has no effect.
+   * A worker may be configured with a local default for this value. When this context value is set, it always wins;
+   * the worker-local default applies only when this context value is absent.
    */
   public static final String CTX_SEGMENT_LOAD_AHEAD_COUNT = "segmentLoadAheadCount";
 

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
@@ -278,7 +278,11 @@ public class MultiStageQueryContext
   public static final String CTX_MAX_THREADS = "maxThreads";
 
   /**
-   * Maximum number of segments to load ahead of them being needed. Used when setting up {@link ReadableInputQueue}.
+   * Number of segments to load ahead of them being needed. Used when setting up {@link ReadableInputQueue}.
+   * <p>
+   * A worker may be configured with a local minimum for this value. When it is,
+   * the effective count is the larger of this context value and the worker's configured minimum, so a context value
+   * below that minimum has no effect.
    */
   public static final String CTX_SEGMENT_LOAD_AHEAD_COUNT = "segmentLoadAheadCount";
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/dart/worker/DartWorkerContextSegmentLoadAheadTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/dart/worker/DartWorkerContextSegmentLoadAheadTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.dart.worker;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DartWorkerContextSegmentLoadAheadTest
+{
+  private static final int THREAD_COUNT = 8;
+
+  @Test
+  public void test_noWorkerConfig_noContext_fallsBackToTwiceThreadCount()
+  {
+    assertEquals(16, DartWorkerContext.resolveSegmentLoadAheadCount(null, null, THREAD_COUNT));
+  }
+
+  @Test
+  public void test_noWorkerConfig_withContext_usesContext()
+  {
+    assertEquals(40, DartWorkerContext.resolveSegmentLoadAheadCount(40, null, THREAD_COUNT));
+  }
+
+  @Test
+  public void test_workerConfig_noContext_usesWorkerConfig()
+  {
+    assertEquals(128, DartWorkerContext.resolveSegmentLoadAheadCount(null, 128, THREAD_COUNT));
+  }
+
+  @Test
+  public void test_workerConfig_contextLower_usesWorkerConfigAsFloor()
+  {
+    assertEquals(128, DartWorkerContext.resolveSegmentLoadAheadCount(64, 128, THREAD_COUNT));
+  }
+
+  @Test
+  public void test_workerConfig_contextHigher_honorsLargerContext()
+  {
+    assertEquals(256, DartWorkerContext.resolveSegmentLoadAheadCount(256, 128, THREAD_COUNT));
+  }
+
+  @Test
+  public void test_workerConfig_contextEqual_returnsThatValue()
+  {
+    assertEquals(128, DartWorkerContext.resolveSegmentLoadAheadCount(128, 128, THREAD_COUNT));
+  }
+
+  @Test
+  public void test_nonPositiveWorkerConfig_treatedAsUnset_withContext()
+  {
+    assertEquals(40, DartWorkerContext.resolveSegmentLoadAheadCount(40, 0, THREAD_COUNT));
+    assertEquals(40, DartWorkerContext.resolveSegmentLoadAheadCount(40, -5, THREAD_COUNT));
+  }
+
+  @Test
+  public void test_nonPositiveWorkerConfig_treatedAsUnset_noContext()
+  {
+    assertEquals(16, DartWorkerContext.resolveSegmentLoadAheadCount(null, 0, THREAD_COUNT));
+    assertEquals(16, DartWorkerContext.resolveSegmentLoadAheadCount(null, -5, THREAD_COUNT));
+  }
+}

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/dart/worker/DartWorkerContextSegmentLoadAheadTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/dart/worker/DartWorkerContextSegmentLoadAheadTest.java
@@ -46,13 +46,13 @@ public class DartWorkerContextSegmentLoadAheadTest
   }
 
   @Test
-  public void test_workerConfig_contextLower_usesWorkerConfigAsFloor()
+  public void test_workerConfig_contextLower_contextWins()
   {
-    assertEquals(128, DartWorkerContext.resolveSegmentLoadAheadCount(64, 128, THREAD_COUNT));
+    assertEquals(64, DartWorkerContext.resolveSegmentLoadAheadCount(64, 128, THREAD_COUNT));
   }
 
   @Test
-  public void test_workerConfig_contextHigher_honorsLargerContext()
+  public void test_workerConfig_contextHigher_contextWins()
   {
     assertEquals(256, DartWorkerContext.resolveSegmentLoadAheadCount(256, 128, THREAD_COUNT));
   }


### PR DESCRIPTION
### Description

Allow configuring `segmentLoadAheadCount` for dart workers via local runtime property. This unlocks flexibility in situations where you do not want to rely on a controller provided context value to control this property. It can be powerful in situations where you deploy multiple tiers of historicals on disperate hardware, and would like to customize the value to maximize a given hardware spec's capabilities. unset by default, which maintains behavior that already exists - the controller provided context provides the value OR a default `2 * threads` is used.


#### Release note

Add dart worker runtime property `druid.msq.dart.worker.segmentLoadAheadCount` to allow worker local configuration of `segmentLoadAheadCount`. If configured to be `> 0` for a worker, this becomes the default `segmentLoadAheadCount` value for the worker.  If a query controller also sends `segmentLoadAheadCount` in the context for a query, the context value wins for that query.. If not set, the worker will either use the controller provided context value or the default `2 * threads` if nothing is set in context.


<hr>

##### Key changed/added classes in this PR
 * `DartWorkerConfig`
 * `DartWorkerContext`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.