### PR TITLE
feat: enhance U-shape idle prediction for scale-down scenarios

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/WeightedCostFunction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/WeightedCostFunction.java
@@ -43,6 +43,12 @@ public class WeightedCostFunction
   static final double LAG_AMPLIFICATION_MULTIPLIER = 0.4;
 
   /**
+   * Exponent (&lt; 1) for sublinear busy redistribution in the idle projection: busy grows as
+   * {@code (currentTaskCount / proposedTaskCount)^EXPONENT}, not linearly. Calibrated as log2(1.25) ~= 0.32.
+   */
+  static final double IDLE_SUBLINEARITY_EXPONENT = 0.32;
+
+  /**
    * Minimum rate of processing for any task in records per second. This is used
    * as a placeholder if avg rate is not available to ensure that cost computations
    * do not return infinitely large lag recovery times.
@@ -109,10 +115,10 @@ public class WeightedCostFunction
       lagRecoveryTime = metrics.getAggregateLag() * amplification / (proposedTaskCount * adjustedProcessingRate);
     }
 
-    // Capacity-based idle prediction. When the proposed count would oversaturate the cluster
-    // (busy work exceeds available capacity), the unmet demand becomes a virtual lag-recovery
-    // time on the same axis as real lag — so the optimizer treats predicted saturation as
-    // predicted lag, not as "perfect utilization".
+    // Capacity-based idle prediction with sublinear busy redistribution. When the proposed count
+    // would oversaturate the cluster (busy work exceeds available capacity), the unmet demand
+    // becomes a virtual lag-recovery time on the same axis as real lag — so the optimizer treats
+    // predicted saturation as predicted lag, not as "perfect utilization".
     final double currentPollIdleRatio = metrics.getPollIdleRatio();
     final int currentTaskCount = metrics.getCurrentTaskCount();
     final double predictedIdleRatio;
@@ -125,8 +131,10 @@ public class WeightedCostFunction
       overrun = 0.0;
     } else {
       final double busyFraction = 1.0 - currentPollIdleRatio;
-      final double taskRatio = (double) proposedTaskCount / currentTaskCount;
-      final double rawIdle = 1.0 - busyFraction / taskRatio;
+      // Sublinear redistribution factor: keeps a healthy consolidation from projecting negative idle,
+      // yet still diverges as proposed -> 0 so extreme consolidation registers as overrun.
+      final double idle = Math.pow((double) currentTaskCount / proposedTaskCount, IDLE_SUBLINEARITY_EXPONENT);
+      final double rawIdle = 1.0 - busyFraction * idle;
       if (rawIdle >= 0) {
         predictedIdleRatio = Math.min(1.0, rawIdle);
         overrun = 0.0;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/WeightedCostFunction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/WeightedCostFunction.java
@@ -43,8 +43,10 @@ public class WeightedCostFunction
   static final double LAG_AMPLIFICATION_MULTIPLIER = 0.4;
 
   /**
-   * Exponent (&lt; 1) for sublinear busy redistribution in the idle projection: busy grows as
-   * {@code (currentTaskCount / proposedTaskCount)^EXPONENT}, not linearly. Calibrated as log2(1.25) ~= 0.32.
+   * Exponent (< 1) for sublinear busy redistribution in the idle projection:
+   * busy grows as {@code (currentTaskCount / proposedTaskCount)^EXPONENT}, not linearly.
+   * The core idea around it - when task count is halved, the idle ratio increases roughly by 1.25.
+   * Calibrated as log2(1.25) ~= 0.32.
    */
   static final double IDLE_SUBLINEARITY_EXPONENT = 0.32;
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScalerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScalerTest.java
@@ -175,6 +175,19 @@ public class CostBasedAutoScalerTest
   }
 
   @Test
+  public void testModerateIdleScalesDownOverProvisioned()
+  {
+    // Over-provisioned: 100 tasks at 40% idle, minimal lag. Sublinear projection reads the
+    // consolidation as near-ideal idle (not a false overload), so it scales down; linear stayed at 100.
+    final int currentTaskCount = 100;
+    final int optimal = autoScaler.computeOptimalTaskCount(createMetrics(0.0, currentTaskCount, 100, 0.4));
+    Assert.assertTrue(
+        "Moderate idle (0.4) with minimal lag should scale an over-provisioned supervisor down",
+        optimal < currentTaskCount
+    );
+  }
+
+  @Test
   public void testComputeOptimalTaskCountLimitsTaskCountJumps()
   {
     final CostBasedAutoScalerConfig boundedScaleUpConfig = CostBasedAutoScalerConfig.builder()

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/WeightedCostFunctionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/WeightedCostFunctionTest.java
@@ -234,8 +234,8 @@ public class WeightedCostFunctionTest
                                                                         .build();
 
     // Extreme scale-down: 10 tasks → 2 tasks with 40% idle
-    // busyFraction = 0.6, taskRatio = 0.2
-    // predictedIdle = 1 - 0.6/0.2 = 1 - 3 = -2 → clamped to 0
+    // busyFraction = 0.6; projectedBusy = 0.6 * (10/2)^0.32 ≈ 1.004
+    // predictedIdle = 1 - 1.004 ≈ -0.004 → still clamped to 0 at this extreme
     CostMetrics metrics = createMetrics(0.0, 10, 100, 0.4);
     double costAt2 = costFunction.computeCost(metrics, 2, idleOnlyConfig).totalCost();
 
@@ -246,11 +246,42 @@ public class WeightedCostFunctionTest
 
     // Extreme scale-up shouldn't exceed 1.0 for idle ratio
     // 10 tasks → 100 tasks with 10% idle
-    // busyFraction = 0.9, taskRatio = 10
-    // predictedIdle = 1 - 0.9/10 = 1 - 0.09 = 0.91 (within bounds)
+    // busyFraction = 0.9; projectedBusy = 0.9 * (10/100)^0.32 ≈ 0.431
+    // predictedIdle = 1 - 0.431 ≈ 0.569 (within bounds)
     CostMetrics lowIdle = createMetrics(0.0, 10, 100, 0.1);
     double costAt100 = costFunction.computeCost(lowIdle, 100, idleOnlyConfig).totalCost();
     Assert.assertTrue("Cost should be finite and positive", Double.isFinite(costAt100) && costAt100 > 0);
+  }
+
+  @Test
+  public void testModerateConsolidationProjectsHealthyIdle()
+  {
+    // The regime the linear model got wrong: a healthy 2x consolidation from 40% idle.
+    // Sublinear gives predictedIdle ≈ 0.25 (near ideal, no overrun), not the linear -0.2 that clamps to 0.
+    CostBasedAutoScalerConfig idleOnlyConfig = CostBasedAutoScalerConfig.builder()
+                                                                        .taskCountMax(100)
+                                                                        .taskCountMin(1)
+                                                                        .enableTaskAutoScaler(true)
+                                                                        .lagWeight(0.0)
+                                                                        .idleWeight(1.0)
+                                                                        .build();
+
+    CostMetrics metrics = createMetrics(0.0, 10, 100, 0.4);
+    double costCurrent = costFunction.computeCost(metrics, 10, idleOnlyConfig).totalCost();
+    double costScaleDown = costFunction.computeCost(metrics, 5, idleOnlyConfig).totalCost();
+
+    Assert.assertTrue(
+        "Healthy 2x consolidation should be cheaper than staying at the current count",
+        costScaleDown < costCurrent
+    );
+
+    // Far below the clamped-to-zero cost the linear model produced: idle is healthy, not clamped.
+    double clampedToZeroCost =
+        5 * (WeightedCostFunction.IDEAL_IDLE_RATIO + WeightedCostFunction.UNDER_PROVISIONING_PENALTY);
+    Assert.assertTrue(
+        "Predicted idle should be healthy, not clamped to zero",
+        costScaleDown < clampedToZeroCost
+    );
   }
 
   @Test


### PR DESCRIPTION
**Description**

The cost-based supervisor autoscaler wouldn't scale down a healthy, over-provisioned supervisor - one above the ideal idle ratio with low lag stayed pinned at its current task count.

**Root cause.** The idle projection was linear:

```rawIdle = 1.0 - busyFraction / taskRatio;   // taskRatio = proposed / current```

This assumes busy time is fully conserved when work moves onto fewer tasks, so a reasonable consolidation projects negative idle `(e.g. 1 − 0.6/0.5 =−0.2)`. That clamps to 0 (the worst point of the U-shaped idle cost) and turns an overrun into phantom virtual lag — pinning the task count even at ~0 real lag. In reality, busy grows sublinearly (an observed 2× consolidation raised busy ~1.25×, not 2×).

**Fix.** Redistribute busy sublinearly:
```
projectedBusy = busyFraction * (currentTaskCount / proposedTaskCount) ^ IDLE_SUBLINEARITY_EXPONENT;  // 0.32
rawIdle = 1.0 - projectedBusy;
```
`IDLE_SUBLINEARITY_EXPONENT = 0.32 (≈ log₂(1.25))` is a tuned constant based on careful testing and theoretical math application.

A healthy consolidation now lands near the ideal idle ratio instead of going negative, so the supervisor scales down; the exponent stays > 0, so extreme over-consolidation still diverges and is broken. 

**Validation (plots under hood)**

<details>
Optimal task count vs. observed poll-idle ratio, across realistic configs (rate = total cluster throughput, split per-task):

<img width="1200" height="750" alt="cost_based_scaledown_medium_7Mpm" src="https://github.com/user-attachments/assets/45a1387a-aa00-40b8-97a9-63796425f618" />

Old version stays pinned at 128 until idle ~0.55, while new version consolidates from ~0.32.

<img width="1200" height="750" alt="cost_based_scaledown_large_30Mpm" src="https://github.com/user-attachments/assets/36732e97-e622-4f1f-8257-6680378ea8d3" />

Safe under load: new version consolidates earlier on the high-idle side, but at low idle both still jump to max — lag-driven scale-up is unaffected.

<img width="1800" height="675" alt="cost_based_v1_vs_v2_large_30Mpm_amp0 35" src="https://github.com/user-attachments/assets/df23085a-de92-4aea-8e3d-b2791d0842ff" />

The existing version is flat (pinned at max by the phantom overrun); new version consolidates and holds more tasks as lag weight rises.

</details>

**Release note**

Fixed an issue where the cost-based supervisor autoscaler would not scale down an over-provisioned supervisor running above its ideal idle ratio with low lag.

  - [x] self-reviewed.
  - [x] added comments explaining the "why".
  - [x] added/updated unit tests.