### PR TITLE
fix: empty loads for asymmetric cluster-group partial-load matchers

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/loading/PartialClusterGroupLoadSpec.java
+++ b/processing/src/main/java/org/apache/druid/segment/loading/PartialClusterGroupLoadSpec.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
-import org.apache.druid.utils.CollectionUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -72,10 +71,9 @@ public class PartialClusterGroupLoadSpec extends PartialLoadSpec
   )
   {
     super(delegate, fingerprint, jsonMapper);
-    Preconditions.checkArgument(
-        !CollectionUtils.isNullOrEmpty(clusterGroupIndices),
-        "clusterGroupIndices must not be null or empty"
-    );
+    // An empty index list is used when a cluster-group matcher applies to a (clustered) segment but no configured
+    // pattern matches its cluster groups. The historical-side partial loader honors this by loading nothing.
+    Preconditions.checkNotNull(clusterGroupIndices, "clusterGroupIndices");
     this.clusterGroupIndices = List.copyOf(clusterGroupIndices);
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/loading/PartialClusterGroupLoadSpec.java
+++ b/processing/src/main/java/org/apache/druid/segment/loading/PartialClusterGroupLoadSpec.java
@@ -33,7 +33,7 @@ import java.util.Objects;
 /**
  * A {@link PartialLoadSpec} that requests partial loading of a clustered segment's cluster groups. The base class
  * carries the common {@code fingerprint} and {@code delegate} wire fields; this subtype adds the resolved
- * {@code clusterGroupIndices} (positions into {@link org.apache.druid.timeline.ClusterGroupTuples#getTuples()}) that
+ * {@code clusterGroupIndices} (positions into {@link org.apache.druid.timeline.ClusterGroupTuples#tuples()}) that
  * the historical should range-read into the local segment.
  */
 @JsonTypeName(PartialClusterGroupLoadSpec.TYPE)

--- a/processing/src/test/java/org/apache/druid/segment/loading/PartialClusterGroupLoadSpecTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/loading/PartialClusterGroupLoadSpecTest.java
@@ -146,15 +146,11 @@ class PartialClusterGroupLoadSpecTest
   }
 
   @Test
-  void testRejectsNullOrEmptyClusterGroupIndices()
+  void testRejectsNullClusterGroupIndices()
   {
     Assertions.assertThrows(
-        IllegalArgumentException.class,
+        NullPointerException.class,
         () -> new PartialClusterGroupLoadSpec(DELEGATE, null, "v1:x", jsonMapper)
-    );
-    Assertions.assertThrows(
-        IllegalArgumentException.class,
-        () -> new PartialClusterGroupLoadSpec(DELEGATE, List.of(), "v1:x", jsonMapper)
     );
   }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/RunRules.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/RunRules.java
@@ -26,17 +26,23 @@ import org.apache.druid.java.util.common.Stopwatch;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.server.coordinator.DruidCluster;
 import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
+import org.apache.druid.server.coordinator.loading.PartialLoadProfile;
 import org.apache.druid.server.coordinator.loading.StrategicSegmentAssigner;
 import org.apache.druid.server.coordinator.rules.BroadcastDistributionRule;
+import org.apache.druid.server.coordinator.rules.PartialLoadMatcher;
 import org.apache.druid.server.coordinator.rules.Rule;
+import org.apache.druid.server.coordinator.rules.SegmentActionHandler;
 import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
 import org.apache.druid.server.coordinator.stats.Dimension;
 import org.apache.druid.server.coordinator.stats.RowKey;
 import org.apache.druid.server.coordinator.stats.Stats;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
+import org.joda.time.Interval;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -83,9 +89,22 @@ public class RunRules implements CoordinatorDuty
     final Set<DataSegment> overshadowed = params.getDataSourcesSnapshot().getOvershadowedSegments();
 
     final StrategicSegmentAssigner segmentAssigner = params.getSegmentAssigner();
+    // Wrap the assigner with a per-shard-group buffering handler. Partial-load matchers that resolve asymmetrically
+    // across siblings dispatch their "no positive content for this segment" decision as an empty-fingerprint
+    // partial-load. The buffer holds those decisions until we finish iterating the shard group; if any sibling
+    // produced a positive match we flush them (preserving broker-side shard-group completeness), otherwise we discard
+    // them (avoiding wasted empty loads on groups with no positive content for the matcher anywhere).
+    final EmptyDeferringHandler segmentHandler = new EmptyDeferringHandler(segmentAssigner);
 
     final DateTime now = DateTimes.nowUtc();
     final Object2IntOpenHashMap<String> datasourceToSegmentsWithNoRule = new Object2IntOpenHashMap<>();
+
+    // Streaming shard-group boundary state. SegmentHolder.NEWEST_SEGMENT_FIRST groups segments contiguously by
+    // (dataSource, interval, version), so on any change in that triple we flush the buffer for the previous group.
+    String currentDs = null;
+    Interval currentInterval = null;
+    String currentVersion = null;
+
     for (DataSegment segment : usedSegments) {
       // Do not apply rules on overshadowed segments as they will be
       // marked unused and eventually unloaded from all historicals
@@ -93,12 +112,22 @@ public class RunRules implements CoordinatorDuty
         continue;
       }
 
+      // Detect a shard-group boundary and flush deferred empty loads for the previous group.
+      if (!segment.getDataSource().equals(currentDs)
+          || !segment.getInterval().equals(currentInterval)
+          || !segment.getVersion().equals(currentVersion)) {
+        segmentHandler.flushAndReset();
+        currentDs = segment.getDataSource();
+        currentInterval = segment.getInterval();
+        currentVersion = segment.getVersion();
+      }
+
       // Find and apply matching rule
       List<Rule> rules = ruleHandler.getRulesWithDefault(segment.getDataSource());
       boolean foundMatchingRule = false;
       for (Rule rule : rules) {
         if (rule.appliesTo(segment, now)) {
-          rule.run(segment, segmentAssigner);
+          rule.run(segment, segmentHandler);
           foundMatchingRule = true;
           break;
         }
@@ -108,6 +137,9 @@ public class RunRules implements CoordinatorDuty
         datasourceToSegmentsWithNoRule.addTo(segment.getDataSource(), 1);
       }
     }
+
+    // Tail flush for the last shard group.
+    segmentHandler.flushAndReset();
 
     processSegmentDeletes(segmentAssigner, params.getCoordinatorStats());
     alertForSegmentsWithNoRules(datasourceToSegmentsWithNoRule);
@@ -179,5 +211,81 @@ public class RunRules implements CoordinatorDuty
     return ruleHandler.getRulesWithDefault(datasource)
                       .stream()
                       .anyMatch(rule -> rule instanceof BroadcastDistributionRule);
+  }
+
+  /**
+   * Per-shard-group buffering decorator for {@link SegmentActionHandler}. Intercepts partial-load dispatches with
+   * the {@link PartialLoadMatcher#EMPTY_LOAD_FINGERPRINT} sentinel and holds them until {@link #flushAndReset} is
+   * called by the surrounding shard-group iteration. Positive partial-loads (non-empty fingerprint) pass through
+   * immediately and mark the current group as having a positive match.
+   *
+   * <p>At flush time, buffered empties are dispatched only if a positive match was seen in the same group. This
+   * preserves broker-side shard-group completeness for asymmetric matchers while avoiding empty loads when no segment
+   * in the group has positive content for the matcher.
+   *
+   * <p>All other handler methods (full load, broadcast, delete) pass through to the delegate unchanged.
+   */
+  static final class EmptyDeferringHandler implements SegmentActionHandler
+  {
+    private final SegmentActionHandler delegate;
+    private final List<DeferredEmpty> pendingEmpties = new ArrayList<>();
+    private boolean anyPositiveInGroup = false;
+
+    EmptyDeferringHandler(SegmentActionHandler delegate)
+    {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void replicateSegment(DataSegment segment, Map<String, Integer> tierToReplicaCount)
+    {
+      delegate.replicateSegment(segment, tierToReplicaCount);
+    }
+
+    @Override
+    public void replicateSegmentPartially(
+        DataSegment segment,
+        PartialLoadProfile profile,
+        Map<String, Integer> tierToReplicaCount
+    )
+    {
+      if (PartialLoadMatcher.EMPTY_LOAD_FINGERPRINT.equals(profile.fingerprint())) {
+        pendingEmpties.add(new DeferredEmpty(segment, profile, tierToReplicaCount));
+      } else {
+        anyPositiveInGroup = true;
+        delegate.replicateSegmentPartially(segment, profile, tierToReplicaCount);
+      }
+    }
+
+    @Override
+    public void broadcastSegment(DataSegment segment)
+    {
+      delegate.broadcastSegment(segment);
+    }
+
+    @Override
+    public void deleteSegment(DataSegment segment)
+    {
+      delegate.deleteSegment(segment);
+    }
+
+    void flushAndReset()
+    {
+      if (anyPositiveInGroup) {
+        for (DeferredEmpty d : pendingEmpties) {
+          delegate.replicateSegmentPartially(d.segment, d.profile, d.tierToReplicaCount);
+        }
+      }
+      pendingEmpties.clear();
+      anyPositiveInGroup = false;
+    }
+
+    private record DeferredEmpty(
+        DataSegment segment,
+        PartialLoadProfile profile,
+        Map<String, Integer> tierToReplicaCount
+    )
+    {
+    }
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/ClusterGroupPartialLoadMatcher.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/ClusterGroupPartialLoadMatcher.java
@@ -24,6 +24,7 @@ import com.google.common.hash.Hashing;
 import com.google.common.io.BaseEncoding;
 import org.apache.druid.segment.loading.PartialClusterGroupLoadSpec;
 import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.partition.ShardSpec;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -51,6 +52,24 @@ public abstract class ClusterGroupPartialLoadMatcher implements PartialLoadMatch
    */
   protected abstract List<Integer> resolveClusterGroupIndices(DataSegment segment);
 
+  /**
+   * Returns the load spec for the resolved cluster-group indices, or null when this matcher has nothing to
+   * contribute for the given segment.
+   *
+   * <p>Null is returned when:
+   * <ul>
+   *   <li>the segment is not clustered, or</li>
+   *   <li>no configured pattern matches the segment's tuples <em>and</em> the segment is not a core partition
+   *       (i.e. {@code partitionNum >= numCorePartitions}). The empty load is only useful to keep the broker's
+   *       shard-group completeness check happy, and that check applies only to the core partition group; appended
+   *       segments are queried individually and don't need an empty stub when no positive content matches.</li>
+   * </ul>
+   *
+   * <p>When the segment is a core partition of a clustered shard group and no pattern matches, returns the
+   * "empty" load (same {@code partialClusterGroup} type with an empty index list and {@link #EMPTY_LOAD_FINGERPRINT}).
+   * The historical-side loader honors it by performing no load, leaving the segment uniformly placed in the timeline
+   * alongside its positively-matched siblings so the broker treats the group as complete.
+   */
   @Override
   @Nullable
   public MatchResult match(DataSegment segment, Map<String, Object> baseLoadSpec)
@@ -59,10 +78,13 @@ public abstract class ClusterGroupPartialLoadMatcher implements PartialLoadMatch
       return null;
     }
     final List<Integer> resolved = resolveClusterGroupIndices(segment);
-    if (resolved.isEmpty()) {
+    final ShardSpec shardSpec = segment.getShardSpec();
+    if (resolved.isEmpty() && shardSpec.getPartitionNum() >= shardSpec.getNumCorePartitions()) {
+      // No patterns match and this segment isn't part of a core partition group, so no need for an empty load. Fall
+      // through to the cannot-match handling.
       return null;
     }
-    final String fingerprint = computeFingerprint(resolved);
+    final String fingerprint = resolved.isEmpty() ? EMPTY_LOAD_FINGERPRINT : computeFingerprint(resolved);
     return new MatchResult(PartialClusterGroupLoadSpec.wireForm(baseLoadSpec, resolved, fingerprint), fingerprint);
   }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/ClusterGroupPartialLoadMatcher.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/ClusterGroupPartialLoadMatcher.java
@@ -47,9 +47,13 @@ public abstract class ClusterGroupPartialLoadMatcher implements PartialLoadMatch
 
   /**
    * Returns the sorted, deduped list of indices into {@code segment.getClusterGroups().getTuples()} selected by this
-   * matcher. Returns an empty list when nothing matches (the segment is not clustered, or no configured pattern /
-   * tuple intersects what the segment has).
+   * matcher. Returns {@code null} when this matcher is incompatible with the segment's clustering scheme (e.g. none
+   * of the configured patterns' columns or virtual columns resolve against the segment's clustering signature),
+   * meaning the matcher cannot meaningfully reason about this segment's content. Returns an empty list when the
+   * matcher applies (its patterns are resolvable) but no configured pattern matches any tuple; the matcher can
+   * reason about the segment but found no positive content.
    */
+  @Nullable
   protected abstract List<Integer> resolveClusterGroupIndices(DataSegment segment);
 
   /**
@@ -58,17 +62,20 @@ public abstract class ClusterGroupPartialLoadMatcher implements PartialLoadMatch
    *
    * <p>Null is returned when:
    * <ul>
-   *   <li>the segment is not clustered, or</li>
+   *   <li>the segment is not clustered,</li>
+   *   <li>the matcher's patterns are incompatible with the segment's clustering scheme (see
+   *       {@link #resolveClusterGroupIndices}), or</li>
    *   <li>no configured pattern matches the segment's tuples <em>and</em> the segment is not a core partition
    *       (i.e. {@code partitionNum >= numCorePartitions}). The empty load is only useful to keep the broker's
    *       shard-group completeness check happy, and that check applies only to the core partition group; appended
    *       segments are queried individually and don't need an empty stub when no positive content matches.</li>
    * </ul>
    *
-   * <p>When the segment is a core partition of a clustered shard group and no pattern matches, returns the
-   * "empty" load (same {@code partialClusterGroup} type with an empty index list and {@link #EMPTY_LOAD_FINGERPRINT}).
-   * The historical-side loader honors it by performing no load, leaving the segment uniformly placed in the timeline
-   * alongside its positively-matched siblings so the broker treats the group as complete.
+   * <p>When the segment is a core partition of a clustered shard group, the matcher is compatible, and no pattern
+   * matches any tuple, returns the "empty" load (same {@code partialClusterGroup} type with an empty index list
+   * and {@link #EMPTY_LOAD_FINGERPRINT}). The historical-side loader honors it by performing no load, leaving the
+   * segment uniformly placed in the timeline alongside its positively-matched siblings so the broker treats the
+   * group as complete.
    */
   @Override
   @Nullable
@@ -78,6 +85,11 @@ public abstract class ClusterGroupPartialLoadMatcher implements PartialLoadMatch
       return null;
     }
     final List<Integer> resolved = resolveClusterGroupIndices(segment);
+    if (resolved == null) {
+      // Matcher is incompatible with this segment's clustering scheme. Treat as opaque so the rule's cannot-match
+      // handling takes over rather than dispatching a stub empty load.
+      return null;
+    }
     final ShardSpec shardSpec = segment.getShardSpec();
     if (resolved.isEmpty() && shardSpec.getPartitionNum() >= shardSpec.getNumCorePartitions()) {
       // No patterns match and this segment isn't part of a core partition group, so no need for an empty load. Fall

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PartialLoadMatcher.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PartialLoadMatcher.java
@@ -43,6 +43,20 @@ import java.util.Map;
 public interface PartialLoadMatcher
 {
   /**
+   * Universal fingerprint sentinel for an "empty match" — a matcher decision to partial-load a segment with no
+   * scheme-specific content. Used by matchers that handle asymmetric resolution across siblings of a shard group:
+   * when the matcher applies to a segment but resolves to no positive content (e.g., a cluster-group matcher on a
+   * clustered segment whose tuples don't intersect any configured pattern), it returns a {@link MatchResult} with
+   * this fingerprint so the coordinator's {@code RunRules} duty can defer the empty-load dispatch and only flush it
+   * when at least one sibling in the same shard group produced a positive match.
+   *
+   * <p>All matchers share this fingerprint for empty loads — different matchers' empty wire forms are equivalent
+   * from a "what's on the historical" perspective (no scheme-specific extras downloaded), and at most one rule
+   * applies per segment per coordinator run, so cross-matcher reconciliation isn't a concern.
+   */
+  String EMPTY_LOAD_FINGERPRINT = "v1:partial-empty";
+
+  /**
    * Returns the {@link MatchResult} this matcher produces for the given segment, or null if the matcher does not apply
    * to the segment. When null, {@link PartialLoadRule} consults {@link CannotMatchBehavior} to decide whether the rule
    * falls through or full-loads.
@@ -58,5 +72,14 @@ public interface PartialLoadMatcher
    */
   record MatchResult(Map<String, Object> wrappedLoadSpec, String fingerprint)
   {
+    /**
+     * Whether this is an "empty match" — the matcher applies to the segment but resolves to no positive content.
+     * Recognized via {@link #EMPTY_LOAD_FINGERPRINT}. Empty loads are dispatched only when at least one sibling in
+     * the same shard group produced a positive match; otherwise they're discarded by {@code RunRules}.
+     */
+    public boolean isEmpty()
+    {
+      return EMPTY_LOAD_FINGERPRINT.equals(fingerprint);
+    }
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/WildcardClusterGroupPartialLoadMatcher.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/WildcardClusterGroupPartialLoadMatcher.java
@@ -126,12 +126,10 @@ public class WildcardClusterGroupPartialLoadMatcher extends ClusterGroupPartialL
   }
 
   @Override
+  @Nullable
   protected List<Integer> resolveClusterGroupIndices(DataSegment segment)
   {
     final ClusterGroupTuples clusterGroups = segment.getClusterGroups();
-    if (clusterGroups == null) {
-      return Collections.emptyList();
-    }
     final RowSignature clusteringColumns = clusterGroups.clusteringColumns();
     final VirtualColumns segmentVcs = clusterGroups.virtualColumns();
     final List<List<Object>> tuples = clusterGroups.tuples();
@@ -141,6 +139,21 @@ public class WildcardClusterGroupPartialLoadMatcher extends ClusterGroupPartialL
     // tuples. A null entry in the resolved list marks the pattern as non-matching for this segment.
     final List<Map<String, String>> resolvedPatterns = resolveAll(compiledPatterns, clusteringColumns, segmentVcs);
     final List<Map<String, String>> resolvedExcludes = resolveAll(compiledExcludePatterns, clusteringColumns, segmentVcs);
+
+    // Compatibility check: at least one pattern must be fully resolvable against this segment's clustering scheme
+    // for the matcher to have any meaningful opinion about the segment. If none of the patterns resolve, the
+    // matcher's columns/VCs don't intersect what the segment clusters on at all, so the matcher is opaque to this
+    // segment and the base class will fall back to the rule's cannot-match handling.
+    boolean anyPatternResolved = false;
+    for (Map<String, String> resolved : resolvedPatterns) {
+      if (resolved != null) {
+        anyPatternResolved = true;
+        break;
+      }
+    }
+    if (!anyPatternResolved) {
+      return null;
+    }
 
     final TreeSet<Integer> matched = new TreeSet<>();
     for (int i = 0; i < tuples.size(); i++) {

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/RunRulesEmptyDeferringHandlerTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/RunRulesEmptyDeferringHandlerTest.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.duty;
+
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.server.coordinator.loading.PartialLoadProfile;
+import org.apache.druid.server.coordinator.rules.PartialLoadMatcher;
+import org.apache.druid.server.coordinator.rules.SegmentActionHandler;
+import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentId;
+import org.apache.druid.timeline.partition.NumberedShardSpec;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class RunRulesEmptyDeferringHandlerTest
+{
+  private static final Map<String, Integer> TIER1_REPLICANTS = Map.of("tier1", 1);
+  private static final String POSITIVE_FINGERPRINT = "v1:positive";
+
+  @Test
+  void positiveLoadPassesThroughImmediately()
+  {
+    final RecordingHandler delegate = new RecordingHandler();
+    final RunRules.EmptyDeferringHandler handler = new RunRules.EmptyDeferringHandler(delegate);
+    final DataSegment seg = segment(0);
+    final PartialLoadProfile positive = profile(POSITIVE_FINGERPRINT);
+
+    handler.replicateSegmentPartially(seg, positive, TIER1_REPLICANTS);
+
+    // Positive load is dispatched immediately, not buffered.
+    Assertions.assertEquals(1, delegate.partialLoads.size());
+    Assertions.assertEquals(seg, delegate.partialLoads.get(0).segment);
+    Assertions.assertSame(positive, delegate.partialLoads.get(0).profile);
+  }
+
+  @Test
+  void emptyLoadIsBufferedUntilFlush()
+  {
+    final RecordingHandler delegate = new RecordingHandler();
+    final RunRules.EmptyDeferringHandler handler = new RunRules.EmptyDeferringHandler(delegate);
+    final DataSegment seg = segment(0);
+    final PartialLoadProfile empty = profile(PartialLoadMatcher.EMPTY_LOAD_FINGERPRINT);
+
+    handler.replicateSegmentPartially(seg, empty, TIER1_REPLICANTS);
+
+    // Empty load is buffered, not dispatched.
+    Assertions.assertTrue(delegate.partialLoads.isEmpty());
+  }
+
+  @Test
+  void flushDispatchesBufferedEmptiesWhenPositiveSeen()
+  {
+    final RecordingHandler delegate = new RecordingHandler();
+    final RunRules.EmptyDeferringHandler handler = new RunRules.EmptyDeferringHandler(delegate);
+    final DataSegment p0 = segment(0);
+    final DataSegment p1 = segment(1);
+    final PartialLoadProfile positive = profile(POSITIVE_FINGERPRINT);
+    final PartialLoadProfile empty = profile(PartialLoadMatcher.EMPTY_LOAD_FINGERPRINT);
+
+    handler.replicateSegmentPartially(p0, positive, TIER1_REPLICANTS);
+    handler.replicateSegmentPartially(p1, empty, TIER1_REPLICANTS);
+    // After the group: p0 dispatched (positive), p1 buffered.
+    Assertions.assertEquals(1, delegate.partialLoads.size());
+
+    handler.flushAndReset();
+    // Now p1 should be dispatched too — the group had a positive match.
+    Assertions.assertEquals(2, delegate.partialLoads.size());
+    Assertions.assertEquals(p1, delegate.partialLoads.get(1).segment);
+  }
+
+  @Test
+  void flushDiscardsBufferedEmptiesWhenNoPositive()
+  {
+    final RecordingHandler delegate = new RecordingHandler();
+    final RunRules.EmptyDeferringHandler handler = new RunRules.EmptyDeferringHandler(delegate);
+    final PartialLoadProfile empty = profile(PartialLoadMatcher.EMPTY_LOAD_FINGERPRINT);
+
+    handler.replicateSegmentPartially(segment(0), empty, TIER1_REPLICANTS);
+    handler.replicateSegmentPartially(segment(1), empty, TIER1_REPLICANTS);
+
+    handler.flushAndReset();
+
+    // No positive in the group — buffered empties are discarded, never dispatched.
+    Assertions.assertTrue(delegate.partialLoads.isEmpty());
+  }
+
+  @Test
+  void flushResetsStateBetweenGroups()
+  {
+    final RecordingHandler delegate = new RecordingHandler();
+    final RunRules.EmptyDeferringHandler handler = new RunRules.EmptyDeferringHandler(delegate);
+    final PartialLoadProfile positive = profile(POSITIVE_FINGERPRINT);
+    final PartialLoadProfile empty = profile(PartialLoadMatcher.EMPTY_LOAD_FINGERPRINT);
+
+    // Group 1: has a positive match → buffered empty gets dispatched on flush.
+    handler.replicateSegmentPartially(segment(0), positive, TIER1_REPLICANTS);
+    handler.replicateSegmentPartially(segment(1), empty, TIER1_REPLICANTS);
+    handler.flushAndReset();
+    Assertions.assertEquals(2, delegate.partialLoads.size());
+
+    // Group 2: only empties → discarded on flush. The previous group's positive must not leak through.
+    handler.replicateSegmentPartially(segment(10), empty, TIER1_REPLICANTS);
+    handler.replicateSegmentPartially(segment(11), empty, TIER1_REPLICANTS);
+    handler.flushAndReset();
+    Assertions.assertEquals(2, delegate.partialLoads.size()); // unchanged
+  }
+
+  @Test
+  void flushOnEmptyBufferIsNoOp()
+  {
+    final RecordingHandler delegate = new RecordingHandler();
+    final RunRules.EmptyDeferringHandler handler = new RunRules.EmptyDeferringHandler(delegate);
+
+    handler.flushAndReset();
+
+    Assertions.assertTrue(delegate.partialLoads.isEmpty());
+  }
+
+  @Test
+  void fullLoadPassesThroughUnchanged()
+  {
+    final RecordingHandler delegate = new RecordingHandler();
+    final RunRules.EmptyDeferringHandler handler = new RunRules.EmptyDeferringHandler(delegate);
+    final DataSegment seg = segment(0);
+
+    handler.replicateSegment(seg, TIER1_REPLICANTS);
+
+    Assertions.assertEquals(1, delegate.fullLoads.size());
+    Assertions.assertEquals(seg, delegate.fullLoads.get(0).segment);
+  }
+
+  @Test
+  void broadcastPassesThroughUnchanged()
+  {
+    final RecordingHandler delegate = new RecordingHandler();
+    final RunRules.EmptyDeferringHandler handler = new RunRules.EmptyDeferringHandler(delegate);
+    final DataSegment seg = segment(0);
+
+    handler.broadcastSegment(seg);
+
+    Assertions.assertEquals(List.of(seg), delegate.broadcasts);
+  }
+
+  @Test
+  void deletePassesThroughUnchanged()
+  {
+    final RecordingHandler delegate = new RecordingHandler();
+    final RunRules.EmptyDeferringHandler handler = new RunRules.EmptyDeferringHandler(delegate);
+    final DataSegment seg = segment(0);
+
+    handler.deleteSegment(seg);
+
+    Assertions.assertEquals(List.of(seg), delegate.deletes);
+  }
+
+  @Test
+  void positiveLoadDispatchedAfterBufferedEmptyStillFlushesEmpty()
+  {
+    // Order shouldn't matter: empties buffered before the positive arrives should still get flushed because the
+    // positive marks the group as having a positive match.
+    final RecordingHandler delegate = new RecordingHandler();
+    final RunRules.EmptyDeferringHandler handler = new RunRules.EmptyDeferringHandler(delegate);
+    final PartialLoadProfile positive = profile(POSITIVE_FINGERPRINT);
+    final PartialLoadProfile empty = profile(PartialLoadMatcher.EMPTY_LOAD_FINGERPRINT);
+
+    handler.replicateSegmentPartially(segment(0), empty, TIER1_REPLICANTS);
+    handler.replicateSegmentPartially(segment(1), positive, TIER1_REPLICANTS);
+    Assertions.assertEquals(1, delegate.partialLoads.size()); // positive only
+
+    handler.flushAndReset();
+    Assertions.assertEquals(2, delegate.partialLoads.size()); // empty now flushed too
+  }
+
+  private static DataSegment segment(int partitionNum)
+  {
+    final NumberedShardSpec shardSpec = new NumberedShardSpec(partitionNum, 2);
+    return DataSegment
+        .builder(SegmentId.of("ds", Intervals.of("2026-01-01/2026-01-02"), "v", shardSpec))
+        .shardSpec(shardSpec)
+        .loadSpec(Map.of("type", "local", "path", "/seg"))
+        .size(0)
+        .build();
+  }
+
+  private static PartialLoadProfile profile(String fingerprint)
+  {
+    return PartialLoadProfile.forRequest(Map.of("type", "test", "fingerprint", fingerprint), fingerprint);
+  }
+
+  private record RecordedPartialLoad(DataSegment segment, PartialLoadProfile profile, Map<String, Integer> replicants)
+  {
+  }
+
+  private record RecordedFullLoad(DataSegment segment, Map<String, Integer> replicants)
+  {
+  }
+
+  private static final class RecordingHandler implements SegmentActionHandler
+  {
+    final List<RecordedPartialLoad> partialLoads = new ArrayList<>();
+    final List<RecordedFullLoad> fullLoads = new ArrayList<>();
+    final List<DataSegment> broadcasts = new ArrayList<>();
+    final List<DataSegment> deletes = new ArrayList<>();
+
+    @Override
+    public void replicateSegment(DataSegment segment, Map<String, Integer> tierToReplicaCount)
+    {
+      fullLoads.add(new RecordedFullLoad(segment, new HashMap<>(tierToReplicaCount)));
+    }
+
+    @Override
+    public void replicateSegmentPartially(
+        DataSegment segment,
+        PartialLoadProfile profile,
+        Map<String, Integer> tierToReplicaCount
+    )
+    {
+      partialLoads.add(new RecordedPartialLoad(segment, profile, new HashMap<>(tierToReplicaCount)));
+    }
+
+    @Override
+    public void broadcastSegment(DataSegment segment)
+    {
+      broadcasts.add(segment);
+    }
+
+    @Override
+    public void deleteSegment(DataSegment segment)
+    {
+      deletes.add(segment);
+    }
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/WildcardClusterGroupPartialLoadMatcherTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/WildcardClusterGroupPartialLoadMatcherTest.java
@@ -280,8 +280,45 @@ class WildcardClusterGroupPartialLoadMatcherTest
         List.of(Map.of("not_a_clustering_column", "anything")),
         null
     );
-    // Segment is clustered, no pattern matches → empty load.
-    final PartialLoadMatcher.MatchResult result = matcher.match(threeGroupSegment(), BASE_LOAD_SPEC);
+    // Pattern references a column the segment doesn't cluster on → matcher is incompatible with this segment's
+    // clustering scheme → null (opaque), rule falls back to cannot-match handling.
+    Assertions.assertNull(matcher.match(threeGroupSegment(), BASE_LOAD_SPEC));
+  }
+
+  @Test
+  void testIncompatibleClusteringReturnsNull()
+  {
+    // None of the matcher's pattern columns exist in the segment's clustering signature → the matcher is opaque to
+    // this segment. The base class returns null (no empty load), letting the rule's cannot-match handling run.
+    final RowSignature regionOnly = RowSignature.builder().add("region", ColumnType.STRING).build();
+    final DataSegment regionClustered = segmentWithGroups(new ClusterGroupTuples(
+        regionOnly,
+        List.of(List.of("us-east-1"))
+    ));
+    final WildcardClusterGroupPartialLoadMatcher matcher = new WildcardClusterGroupPartialLoadMatcher(
+        List.of(Map.of("tenant", "acme")),
+        null
+    );
+    Assertions.assertNull(matcher.match(regionClustered, BASE_LOAD_SPEC));
+  }
+
+  @Test
+  void testCompatibleWhenAnyPatternResolves()
+  {
+    // Multi-pattern matcher where only one pattern's columns exist on the segment. At least one pattern resolves,
+    // so the matcher is compatible and (when no tuple matches) returns the empty load for asymmetric
+    // handling. Patterns that can't be resolved on this segment just don't contribute matches.
+    final RowSignature tenantOnly = RowSignature.builder().add("tenant", ColumnType.STRING).build();
+    final DataSegment tenantClustered = segmentWithGroups(new ClusterGroupTuples(
+        tenantOnly,
+        List.of(List.of("globex"))
+    ));
+    final WildcardClusterGroupPartialLoadMatcher matcher = new WildcardClusterGroupPartialLoadMatcher(
+        // pattern 1 resolves on tenant; pattern 2's "region" doesn't exist on this segment.
+        List.of(Map.of("tenant", "acme"), Map.of("region", "us-east-*")),
+        null
+    );
+    final PartialLoadMatcher.MatchResult result = matcher.match(tenantClustered, BASE_LOAD_SPEC);
     Assertions.assertNotNull(result);
     Assertions.assertEquals(List.of(), result.wrappedLoadSpec().get("clusterGroupIndices"));
   }
@@ -374,10 +411,9 @@ class WildcardClusterGroupPartialLoadMatcherTest
         null,
         operatorVcs
     );
-    // Segment is clustered, pattern non-matching → empty load.
-    final PartialLoadMatcher.MatchResult result = matcher.match(vcClusteredSegment("acme"), BASE_LOAD_SPEC);
-    Assertions.assertNotNull(result);
-    Assertions.assertEquals(List.of(), result.wrappedLoadSpec().get("clusterGroupIndices"));
+    // The operator's VC has no equivalent on the segment → pattern unresolvable → matcher is incompatible with
+    // this segment → null (opaque), rule falls back to cannot-match handling.
+    Assertions.assertNull(matcher.match(vcClusteredSegment("acme"), BASE_LOAD_SPEC));
   }
 
   @Test
@@ -399,10 +435,9 @@ class WildcardClusterGroupPartialLoadMatcherTest
     );
     // Segment that clusters directly on physical "tenant" (no segment VCs). The operator-VC shadowing rule means
     // we don't silently treat the pattern's "tenant" as the clustering column "tenant" — it's interpreted as the
-    // operator-VC, which has no equivalent on the segment → non-matching, so empty load.
-    final PartialLoadMatcher.MatchResult result = matcher.match(threeGroupSegment(), BASE_LOAD_SPEC);
-    Assertions.assertNotNull(result);
-    Assertions.assertEquals(List.of(), result.wrappedLoadSpec().get("clusterGroupIndices"));
+    // operator-VC, which has no equivalent on the segment → unresolvable → matcher is incompatible with this
+    // segment → null (opaque), rule falls back to cannot-match handling.
+    Assertions.assertNull(matcher.match(threeGroupSegment(), BASE_LOAD_SPEC));
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/WildcardClusterGroupPartialLoadMatcherTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/WildcardClusterGroupPartialLoadMatcherTest.java
@@ -81,12 +81,17 @@ class WildcardClusterGroupPartialLoadMatcherTest
 
   private static DataSegment segmentWithGroups(ClusterGroupTuples groups)
   {
+    return segmentWithGroupsAndShardSpec(groups, new NumberedShardSpec(0, 1));
+  }
+
+  private static DataSegment segmentWithGroupsAndShardSpec(ClusterGroupTuples groups, NumberedShardSpec shardSpec)
+  {
     return DataSegment.builder(SegmentId.of(
         "ds",
         Intervals.of("2026-01-01/2026-01-02"),
         "v",
-        new NumberedShardSpec(0, 1)
-    )).loadSpec(BASE_LOAD_SPEC).size(0).clusterGroups(groups).build();
+        shardSpec
+    )).shardSpec(shardSpec).loadSpec(BASE_LOAD_SPEC).size(0).clusterGroups(groups).build();
   }
 
   @Test
@@ -262,7 +267,10 @@ class WildcardClusterGroupPartialLoadMatcherTest
         List.of(Map.of("region", "null")),
         null
     );
-    Assertions.assertNull(matcher.match(segment, BASE_LOAD_SPEC));
+    // Segment is clustered, no pattern matches → empty load.
+    final PartialLoadMatcher.MatchResult result = matcher.match(segment, BASE_LOAD_SPEC);
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals(List.of(), result.wrappedLoadSpec().get("clusterGroupIndices"));
   }
 
   @Test
@@ -272,17 +280,25 @@ class WildcardClusterGroupPartialLoadMatcherTest
         List.of(Map.of("not_a_clustering_column", "anything")),
         null
     );
-    Assertions.assertNull(matcher.match(threeGroupSegment(), BASE_LOAD_SPEC));
+    // Segment is clustered, no pattern matches → empty load.
+    final PartialLoadMatcher.MatchResult result = matcher.match(threeGroupSegment(), BASE_LOAD_SPEC);
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals(List.of(), result.wrappedLoadSpec().get("clusterGroupIndices"));
   }
 
   @Test
-  void testNoMatchReturnsNull()
+  void testNoMatchReturnsEmptyWireForm()
   {
     final WildcardClusterGroupPartialLoadMatcher matcher = new WildcardClusterGroupPartialLoadMatcher(
         List.of(Map.of("tenant", "nobody")),
         null
     );
-    Assertions.assertNull(matcher.match(threeGroupSegment(), BASE_LOAD_SPEC));
+    // Segment is clustered, no pattern matches → empty load (asymmetric handling). The matcher still applies.
+    final PartialLoadMatcher.MatchResult result = matcher.match(threeGroupSegment(), BASE_LOAD_SPEC);
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals("partialClusterGroup", result.wrappedLoadSpec().get("type"));
+    Assertions.assertEquals(List.of(), result.wrappedLoadSpec().get("clusterGroupIndices"));
+    Assertions.assertEquals(BASE_LOAD_SPEC, result.wrappedLoadSpec().get("delegate"));
   }
 
   @Test
@@ -358,7 +374,10 @@ class WildcardClusterGroupPartialLoadMatcherTest
         null,
         operatorVcs
     );
-    Assertions.assertNull(matcher.match(vcClusteredSegment("acme"), BASE_LOAD_SPEC));
+    // Segment is clustered, pattern non-matching → empty load.
+    final PartialLoadMatcher.MatchResult result = matcher.match(vcClusteredSegment("acme"), BASE_LOAD_SPEC);
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals(List.of(), result.wrappedLoadSpec().get("clusterGroupIndices"));
   }
 
   @Test
@@ -380,8 +399,10 @@ class WildcardClusterGroupPartialLoadMatcherTest
     );
     // Segment that clusters directly on physical "tenant" (no segment VCs). The operator-VC shadowing rule means
     // we don't silently treat the pattern's "tenant" as the clustering column "tenant" — it's interpreted as the
-    // operator-VC, which has no equivalent on the segment → non-matching.
-    Assertions.assertNull(matcher.match(threeGroupSegment(), BASE_LOAD_SPEC));
+    // operator-VC, which has no equivalent on the segment → non-matching, so empty load.
+    final PartialLoadMatcher.MatchResult result = matcher.match(threeGroupSegment(), BASE_LOAD_SPEC);
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals(List.of(), result.wrappedLoadSpec().get("clusterGroupIndices"));
   }
 
   @Test
@@ -425,6 +446,98 @@ class WildcardClusterGroupPartialLoadMatcherTest
     );
     final String json = mapper.writeValueAsString(matcher);
     Assertions.assertFalse(json.contains("virtualColumns"), () -> "did not expect virtualColumns in JSON: " + json);
+  }
+
+  @Test
+  void testNoMatchOnAppendedSegmentReturnsNull()
+  {
+    // Appended segment (partitionNum=2, numCorePartitions=2): not part of the core partition group, so no
+    // empty load. The matcher returns null and the rule's cannot-match handling takes over.
+    final ClusterGroupTuples groups = new ClusterGroupTuples(
+        tenantRegion(),
+        List.of(List.of("acme", "us-east-1"))
+    );
+    final DataSegment appended = segmentWithGroupsAndShardSpec(groups, new NumberedShardSpec(2, 2));
+    final WildcardClusterGroupPartialLoadMatcher matcher = new WildcardClusterGroupPartialLoadMatcher(
+        List.of(Map.of("tenant", "nobody")),
+        null
+    );
+    Assertions.assertNull(matcher.match(appended, BASE_LOAD_SPEC));
+  }
+
+  @Test
+  void testNoMatchOnSegmentWithoutCorePartitionsReturnsNull()
+  {
+    // numCorePartitions == 0: append-only ingestion has no core partition group, so no completeness requirement.
+    // The matcher returns null and the rule's cannot-match handling takes over.
+    final ClusterGroupTuples groups = new ClusterGroupTuples(
+        tenantRegion(),
+        List.of(List.of("acme", "us-east-1"))
+    );
+    final DataSegment noCore = segmentWithGroupsAndShardSpec(groups, new NumberedShardSpec(0, 0));
+    final WildcardClusterGroupPartialLoadMatcher matcher = new WildcardClusterGroupPartialLoadMatcher(
+        List.of(Map.of("tenant", "nobody")),
+        null
+    );
+    Assertions.assertNull(matcher.match(noCore, BASE_LOAD_SPEC));
+  }
+
+  @Test
+  void testPositiveMatchOnAppendedSegmentStillReturnsWireForm()
+  {
+    // Positive match: the segment has the matcher's content. Even though it's an appended partition (no
+    // completeness requirement), the operator still wants the matching content on this tier — dispatch the
+    // partial load.
+    final ClusterGroupTuples groups = new ClusterGroupTuples(
+        tenantRegion(),
+        List.of(List.of("acme", "us-east-1"))
+    );
+    final DataSegment appended = segmentWithGroupsAndShardSpec(groups, new NumberedShardSpec(2, 2));
+    final WildcardClusterGroupPartialLoadMatcher matcher = new WildcardClusterGroupPartialLoadMatcher(
+        List.of(Map.of("tenant", "acme")),
+        null
+    );
+    final PartialLoadMatcher.MatchResult result = matcher.match(appended, BASE_LOAD_SPEC);
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals(List.of(0), result.wrappedLoadSpec().get("clusterGroupIndices"));
+  }
+
+  @Test
+  void testEmptyWireFormFingerprintIsStableAcrossInvocations()
+  {
+    // The empty-load (clustered segment, no patterns match) fingerprints must match across invocations so the
+    // coordinator's reconciliation doesn't churn replicas between runs.
+    final WildcardClusterGroupPartialLoadMatcher matcher = new WildcardClusterGroupPartialLoadMatcher(
+        List.of(Map.of("tenant", "nobody")),
+        null
+    );
+    final PartialLoadMatcher.MatchResult a = matcher.match(threeGroupSegment(), BASE_LOAD_SPEC);
+    final PartialLoadMatcher.MatchResult b = matcher.match(threeGroupSegment(), BASE_LOAD_SPEC);
+    Assertions.assertEquals(a.fingerprint(), b.fingerprint());
+    Assertions.assertTrue(
+        a.fingerprint().startsWith(ClusterGroupPartialLoadMatcher.FINGERPRINT_VERSION + ":")
+    );
+  }
+
+  @Test
+  void testEmptyWireFormFingerprintDiffersFromPositiveMatch()
+  {
+    // A positive match and an empty load must produce different fingerprints; otherwise the coordinator can't
+    // tell a real partial load from the empty stub for the same segment.
+    final WildcardClusterGroupPartialLoadMatcher acme = new WildcardClusterGroupPartialLoadMatcher(
+        List.of(Map.of("tenant", "acme")),
+        null
+    );
+    final WildcardClusterGroupPartialLoadMatcher nobody = new WildcardClusterGroupPartialLoadMatcher(
+        List.of(Map.of("tenant", "nobody")),
+        null
+    );
+    final PartialLoadMatcher.MatchResult real = acme.match(threeGroupSegment(), BASE_LOAD_SPEC);
+    final PartialLoadMatcher.MatchResult empty = nobody.match(threeGroupSegment(), BASE_LOAD_SPEC);
+    Assertions.assertNotNull(real);
+    Assertions.assertNotNull(empty);
+    Assertions.assertEquals(List.of(), empty.wrappedLoadSpec().get("clusterGroupIndices"));
+    Assertions.assertNotEquals(real.fingerprint(), empty.fingerprint());
   }
 
   private static VirtualColumns lowerTenantVcs(String outputName)


### PR DESCRIPTION
### Description
This PR fixes a flaw with `ClusterGroupPartialLoadMatcher.match()` when it asymmetrically matches clustered segments within a core-partition group, resulting in only some of the core-partition segments in the group being loaded and being 'incomplete' in the timeline.

The fix is to allow `PartialLoadMatcher` to perform 'empty' loads, where if the rule matcher is processing a clustered segment but none of the cluster groups match. Coupled with this, `RunRules` guards against totally empty groups by using a new `EmptyDeferringHandler` wrapper `SegmentActionHandler` that buffers these empty requests and 'flushes' them at shard-group borders, only performing empty loads when some part of a core partition group was a non-empty match.