### PR TITLE
feat: introduce stopGracefullyOnNewSpec for `Supervisor`s

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
@@ -281,7 +281,7 @@ public class SupervisorManager implements SupervisorStatsProvider
     Preconditions.checkState(started, "SupervisorManager not started");
     List<ListenableFuture<Void>> stopFutures = new ArrayList<>();
     synchronized (lock) {
-      log.info("Stopping [%d] supervisors", supervisors.keySet().size());
+      log.info("Stopping [%d] supervisors", supervisors.size());
       for (String id : supervisors.keySet()) {
         try {
           stopFutures.add(supervisors.get(id).lhs.stopAsync());

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
@@ -377,7 +377,7 @@ public class SupervisorManager implements SupervisorStatsProvider
    * Resets a supervisor to the latest stream offsets and starts a bounded backfill supervisor to
    * process the skipped range from the previously checkpointed offsets up to the latest offsets.
    *
-   * @param id               supervisor ID
+   * @param id                supervisor ID
    * @param backfillTaskCount number of tasks for the backfill supervisor, or null to inherit from the source spec
    * @return map with {@code "id"} (the original supervisor ID) and {@code "backfillSupervisorId"}
    * @throws IllegalArgumentException if the supervisor is not a {@link SeekableStreamSupervisor},
@@ -424,10 +424,20 @@ public class SupervisorManager implements SupervisorStatsProvider
     String backfillSupervisorId = IdUtils.getRandomIdWithPrefix(id + "_backfill");
 
     try {
-      Map<String, Object> normalizedStartOffsets = jsonMapper.readValue(jsonMapper.writeValueAsString(startOffsets), Map.class);
-      Map<String, Object> normalizedEndOffsets = jsonMapper.readValue(jsonMapper.writeValueAsString(endOffsets), Map.class);
+      Map<String, Object> normalizedStartOffsets = jsonMapper.readValue(
+          jsonMapper.writeValueAsString(startOffsets),
+          Map.class
+      );
+      Map<String, Object> normalizedEndOffsets = jsonMapper.readValue(
+          jsonMapper.writeValueAsString(endOffsets),
+          Map.class
+      );
       BoundedStreamConfig boundedStreamConfig = new BoundedStreamConfig(normalizedStartOffsets, normalizedEndOffsets);
-      SupervisorSpec backfillSpec = streamSpec.createBackfillSpec(backfillSupervisorId, boundedStreamConfig, backfillTaskCount);
+      SupervisorSpec backfillSpec = streamSpec.createBackfillSpec(
+          backfillSupervisorId,
+          boundedStreamConfig,
+          backfillTaskCount
+      );
       createOrUpdateAndStartSupervisor(backfillSpec);
     }
     catch (JsonProcessingException e) {
@@ -615,12 +625,10 @@ public class SupervisorManager implements SupervisorStatsProvider
     }
 
     if (writeTombstone) {
-      metadataSupervisorManager.insert(
-          id,
-          new NoopSupervisorSpec(null, pair.rhs.getDataSources())
-      ); // where NoopSupervisorSpec is a tombstone
+      // NoopSupervisorSpec is a tombstone
+      metadataSupervisorManager.insert(id, new NoopSupervisorSpec(null, pair.rhs.getDataSources()));
     }
-    pair.lhs.stop(true);
+    pair.lhs.stop(writeTombstone || pair.lhs.stopGracefullyOnNewSpec());
     supervisors.remove(id);
 
     SupervisorTaskAutoScaler autoscaler = autoscalers.get(id);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -1286,6 +1286,12 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
   }
 
   @Override
+  public boolean stopGracefullyOnNewSpec()
+  {
+    return true;
+  }
+
+  @Override
   public void stop(boolean stopGracefully)
   {
     synchronized (stateChangeLock) {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
@@ -785,9 +785,10 @@ public class SupervisorManagerTest extends EasyMockSupport
   @Test
   public void testStopGracefullyOnNewSpecFalseUsesNonGracefulStop()
   {
-    SupervisorSpec spec = new TestSupervisorSpec("id1", supervisor1);
-    SupervisorSpec spec2 = new TestSupervisorSpec("id1", supervisor2);
-    Map<String, SupervisorSpec> existingSpecs = ImmutableMap.of(
+    final RecordingSupervisor originalSupervisor = new RecordingSupervisor();
+    final SupervisorSpec spec = new TestSupervisorSpec("id1", originalSupervisor);
+    final SupervisorSpec spec2 = new TestSupervisorSpec("id1", supervisor2);
+    final Map<String, SupervisorSpec> existingSpecs = ImmutableMap.of(
         "id3", new TestSupervisorSpec("id3", supervisor3)
     );
 
@@ -795,24 +796,21 @@ public class SupervisorManagerTest extends EasyMockSupport
     metadataSupervisorManager.insert("id1", spec);
     supervisor3.start();
     EasyMock.expect(supervisor3.createAutoscaler(EasyMock.anyObject())).andReturn(null).anyTimes();
-    supervisor1.start();
-    EasyMock.expect(supervisor1.createAutoscaler(EasyMock.anyObject())).andReturn(null).anyTimes();
     replayAll();
 
     manager.start();
     manager.createOrUpdateAndStartSupervisor(spec);
     verifyAll();
 
-    // spec update: supervisor1 opts out of graceful stop-on-new-spec, so it is stopped with stop(false), leaving its
-    // managed tasks running for the replacement supervisor to reconcile.
+    // spec update: originalSupervisor opts out of graceful stop-on-new-spec, so it is stopped with stop(false),
+    // leaving its managed tasks running for the replacement supervisor to reconcile.
     resetAll();
     supervisor2.start();
     EasyMock.expect(supervisor2.createAutoscaler(EasyMock.anyObject())).andReturn(null).anyTimes();
-    EasyMock.expect(supervisor1.stopGracefullyOnNewSpec()).andReturn(false);
-    supervisor1.stop(false);
     replayAll();
 
     manager.createOrUpdateAndStartSupervisor(spec2);
+    Assert.assertEquals(Boolean.FALSE, originalSupervisor.stopGracefully);
     verifyAll();
 
     // terminate always stops gracefully, regardless of the supervisor's new-spec stop policy, so that the terminate
@@ -831,8 +829,8 @@ public class SupervisorManagerTest extends EasyMockSupport
   {
     // suspend triggers the same stop path as a spec update, so it must also consult
     // stopGracefullyOnNewSpec() and stop with stop(false) when the supervisor opts out.
-    Capture<TestSupervisorSpec> capturedInsert = Capture.newInstance();
-    SupervisorSpec spec = new TestSupervisorSpec("id1", supervisor1, false, supervisor2);
+    final Capture<TestSupervisorSpec> capturedInsert = Capture.newInstance();
+    final SupervisorSpec spec = new TestSupervisorSpec("id1", supervisor1, false, supervisor2);
 
     EasyMock.expect(metadataSupervisorManager.getLatest()).andReturn(ImmutableMap.of());
     metadataSupervisorManager.insert("id1", spec);
@@ -1405,6 +1403,39 @@ public class SupervisorManagerTest extends EasyMockSupport
     public List<String> getDataSources()
     {
       return Collections.singletonList(id);
+    }
+  }
+
+  private static class RecordingSupervisor implements Supervisor
+  {
+    private Boolean stopGracefully;
+
+    @Override
+    public void start()
+    {
+    }
+
+    @Override
+    public void stop(boolean stopGracefully)
+    {
+      this.stopGracefully = stopGracefully;
+    }
+
+    @Override
+    public SupervisorReport getStatus()
+    {
+      return null;
+    }
+
+    @Override
+    public SupervisorStateManager.State getState()
+    {
+      return SupervisorStateManager.BasicState.RUNNING;
+    }
+
+    @Override
+    public void reset(DataSourceMetadata dataSourceMetadata)
+    {
     }
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
@@ -135,6 +135,7 @@ public class SupervisorManagerTest extends EasyMockSupport
     resetAll();
     supervisor2.start();
     EasyMock.expect(supervisor2.createAutoscaler(EasyMock.anyObject())).andReturn(null).anyTimes();
+    EasyMock.expect(supervisor1.stopGracefullyOnNewSpec()).andReturn(true);
     supervisor1.stop(true);
     replayAll();
 
@@ -580,6 +581,7 @@ public class SupervisorManagerTest extends EasyMockSupport
     metadataSupervisorManager.insert(EasyMock.eq("id1"), EasyMock.capture(capturedInsert));
     supervisor1.start();
     EasyMock.expect(supervisor1.createAutoscaler(EasyMock.anyObject())).andReturn(null).anyTimes();
+    EasyMock.expect(supervisor1.stopGracefullyOnNewSpec()).andReturn(true);
     supervisor1.stop(true);
     EasyMock.expect(supervisor2.createAutoscaler(EasyMock.anyObject())).andReturn(null).anyTimes();
     supervisor2.start();
@@ -729,6 +731,7 @@ public class SupervisorManagerTest extends EasyMockSupport
     metadataSupervisorManager.insert(EasyMock.eq("id1"), EasyMock.capture(capturedInsert));
     supervisor2.start();
     EasyMock.expect(supervisor2.createAutoscaler(EasyMock.anyObject())).andReturn(null).anyTimes();
+    EasyMock.expect(supervisor1.stopGracefullyOnNewSpec()).andReturn(true);
     supervisor1.stop(true);
     replayAll();
 
@@ -742,6 +745,7 @@ public class SupervisorManagerTest extends EasyMockSupport
     // in TestSupervisorSpec implementation of createRunningSpec
     resetAll();
     metadataSupervisorManager.insert(EasyMock.eq("id1"), EasyMock.capture(capturedInsert));
+    EasyMock.expect(supervisor2.stopGracefullyOnNewSpec()).andReturn(true);
     supervisor2.stop(true);
     supervisor1.start();
     EasyMock.expect(supervisor1.createAutoscaler(EasyMock.anyObject())).andReturn(null).anyTimes();
@@ -776,6 +780,81 @@ public class SupervisorManagerTest extends EasyMockSupport
     verifyAll();
 
     Assert.assertTrue(manager.getSupervisorIds().isEmpty());
+  }
+
+  @Test
+  public void testStopGracefullyOnNewSpecFalseUsesNonGracefulStop()
+  {
+    SupervisorSpec spec = new TestSupervisorSpec("id1", supervisor1);
+    SupervisorSpec spec2 = new TestSupervisorSpec("id1", supervisor2);
+    Map<String, SupervisorSpec> existingSpecs = ImmutableMap.of(
+        "id3", new TestSupervisorSpec("id3", supervisor3)
+    );
+
+    EasyMock.expect(metadataSupervisorManager.getLatest()).andReturn(existingSpecs);
+    metadataSupervisorManager.insert("id1", spec);
+    supervisor3.start();
+    EasyMock.expect(supervisor3.createAutoscaler(EasyMock.anyObject())).andReturn(null).anyTimes();
+    supervisor1.start();
+    EasyMock.expect(supervisor1.createAutoscaler(EasyMock.anyObject())).andReturn(null).anyTimes();
+    replayAll();
+
+    manager.start();
+    manager.createOrUpdateAndStartSupervisor(spec);
+    verifyAll();
+
+    // spec update: supervisor1 opts out of graceful stop-on-new-spec, so it is stopped with stop(false), leaving its
+    // managed tasks running for the replacement supervisor to reconcile.
+    resetAll();
+    supervisor2.start();
+    EasyMock.expect(supervisor2.createAutoscaler(EasyMock.anyObject())).andReturn(null).anyTimes();
+    EasyMock.expect(supervisor1.stopGracefullyOnNewSpec()).andReturn(false);
+    supervisor1.stop(false);
+    replayAll();
+
+    manager.createOrUpdateAndStartSupervisor(spec2);
+    verifyAll();
+
+    // terminate always stops gracefully, regardless of the supervisor's new-spec stop policy, so that the terminate
+    // contract of stopping associated tasks and publishing segments is honored.
+    resetAll();
+    metadataSupervisorManager.insert(EasyMock.eq("id1"), EasyMock.anyObject(NoopSupervisorSpec.class));
+    supervisor2.stop(true);
+    replayAll();
+
+    Assert.assertTrue(manager.stopAndRemoveSupervisor("id1"));
+    verifyAll();
+  }
+
+  @Test
+  public void testSuspendHonorsStopGracefullyOnNewSpecFalse()
+  {
+    // suspend triggers the same stop path as a spec update, so it must also consult
+    // stopGracefullyOnNewSpec() and stop with stop(false) when the supervisor opts out.
+    Capture<TestSupervisorSpec> capturedInsert = Capture.newInstance();
+    SupervisorSpec spec = new TestSupervisorSpec("id1", supervisor1, false, supervisor2);
+
+    EasyMock.expect(metadataSupervisorManager.getLatest()).andReturn(ImmutableMap.of());
+    metadataSupervisorManager.insert("id1", spec);
+    supervisor1.start();
+    EasyMock.expect(supervisor1.createAutoscaler(EasyMock.anyObject())).andReturn(null).anyTimes();
+    replayAll();
+
+    manager.start();
+    manager.createOrUpdateAndStartSupervisor(spec);
+    verifyAll();
+
+    resetAll();
+    metadataSupervisorManager.insert(EasyMock.eq("id1"), EasyMock.capture(capturedInsert));
+    supervisor2.start();
+    EasyMock.expect(supervisor2.createAutoscaler(EasyMock.anyObject())).andReturn(null).anyTimes();
+    EasyMock.expect(supervisor1.stopGracefullyOnNewSpec()).andReturn(false);
+    supervisor1.stop(false);
+    replayAll();
+
+    manager.suspendOrResumeSupervisor("id1", true);
+    Assert.assertTrue(capturedInsert.getValue().suspended);
+    verifyAll();
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
@@ -248,6 +248,20 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
   }
 
   @Test
+  public void testStopGracefullyOnNewSpecReturnsTrue()
+  {
+    EasyMock.expect(spec.isSuspended()).andReturn(false).anyTimes();
+    replayAll();
+
+    SeekableStreamSupervisor supervisor = new TestSeekableStreamSupervisor();
+
+    // SeekableStreamSupervisor retains the historical graceful stop-and-roll behavior on a spec update.
+    Assert.assertTrue(supervisor.stopGracefullyOnNewSpec());
+
+    verifyAll();
+  }
+
+  @Test
   public void testRunningStreamGetSequenceNumberReturnsNull()
   {
     EasyMock.reset(recordSupplier);

--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/Supervisor.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/Supervisor.java
@@ -48,6 +48,14 @@ public interface Supervisor
   void stop(boolean stopGracefully);
 
   /**
+   * Indicates whether this supervisor should be stopped gracefully when its spec is updated/suspended/resumed
+   */
+  default boolean stopGracefullyOnNewSpec()
+  {
+    return false;
+  }
+
+  /**
    * Starts non-graceful shutdown of the supervisor and returns a future that completes when shutdown is complete.
    */
   default ListenableFuture<Void> stopAsync()
@@ -94,6 +102,7 @@ public interface Supervisor
 
   /**
    * Resets any stored metadata by the supervisor.
+   *
    * @param dataSourceMetadata optional dataSource metadata.
    */
   void reset(@Nullable DataSourceMetadata dataSourceMetadata);

--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/Supervisor.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/Supervisor.java
@@ -102,7 +102,6 @@ public interface Supervisor
 
   /**
    * Resets any stored metadata by the supervisor.
-   *
    * @param dataSourceMetadata optional dataSource metadata.
    */
   void reset(@Nullable DataSourceMetadata dataSourceMetadata);

--- a/server/src/test/java/org/apache/druid/indexing/NoopSupervisorSpecTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/NoopSupervisorSpecTest.java
@@ -51,4 +51,12 @@ public class NoopSupervisorSpecTest
     NoopSupervisorSpec noopSupervisorSpec = new NoopSupervisorSpec(null, Collections.singletonList("datasource1"));
     Assert.assertTrue(noopSupervisorSpec.getInputSourceResources().isEmpty());
   }
+
+  @Test
+  public void testStopGracefullyOnNewSpecDefaultsToFalse()
+  {
+    final Supervisor supervisor = new NoopSupervisorSpec(null, Collections.singletonList("datasource1"))
+        .createSupervisor();
+    Assert.assertFalse(supervisor.stopGracefullyOnNewSpec());
+  }
 }


### PR DESCRIPTION
Generally, any supervisor should not terminate their tasks during spec update, but historically it happened that stream supervisors became bound to that logic. This PR introduces the correct behaviour - it supervisor stops gracefully, but stream supervisors do not via `stopGracefullyOnNewSpec()` mechanism.
It was done to enhance UX for existing and future supervisor kinds, and there are plans to enhance stream supervisors to stop gracefully too in a follow-up PR.

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.