### PR TITLE
refactor: split out RowCountInspector, PhysicalSegmentColumnInspector from PhysicalSegmentInspector

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/SqlBaseBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/SqlBaseBenchmark.java
@@ -65,12 +65,13 @@ import org.apache.druid.query.policy.NoopPolicyEnforcer;
 import org.apache.druid.segment.AutoTypeColumnSchema;
 import org.apache.druid.segment.IncrementalIndexSegment;
 import org.apache.druid.segment.IndexSpec;
+import org.apache.druid.segment.Metadata;
 import org.apache.druid.segment.PhysicalSegmentColumnInspector;
-import org.apache.druid.segment.PhysicalSegmentInspector;
 import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.QueryableIndexCursorFactory;
 import org.apache.druid.segment.QueryableIndexPhysicalSegmentInspector;
 import org.apache.druid.segment.QueryableIndexSegment;
+import org.apache.druid.segment.RowCountInspector;
 import org.apache.druid.segment.column.StringEncodingStrategy;
 import org.apache.druid.segment.data.CompressionStrategy;
 import org.apache.druid.segment.data.FrontCodedIndexed;
@@ -522,8 +523,10 @@ public class SqlBaseBenchmark
             public <T> T as(@Nonnull Class<T> clazz)
             {
               // computed sql schema uses segment metadata, which relies on physical inspector, use the underlying index
-              if (clazz.equals(PhysicalSegmentInspector.class) || clazz.equals(PhysicalSegmentColumnInspector.class)) {
+              if (clazz.equals(RowCountInspector.class) || clazz.equals(PhysicalSegmentColumnInspector.class)) {
                 return (T) new QueryableIndexPhysicalSegmentInspector(index);
+              } else if (clazz.equals(Metadata.class)) {
+                return (T) index.getMetadata();
               }
               return super.as(clazz);
             }
@@ -549,8 +552,10 @@ public class SqlBaseBenchmark
             public <T> T as(@Nonnull Class<T> clazz)
             {
               // computed sql schema uses segment metadata, which relies on physical inspector, use the underlying index
-              if (clazz.equals(PhysicalSegmentInspector.class) || clazz.equals(PhysicalSegmentColumnInspector.class)) {
+              if (clazz.equals(RowCountInspector.class) || clazz.equals(PhysicalSegmentColumnInspector.class)) {
                 return (T) new QueryableIndexPhysicalSegmentInspector(index);
+              } else if (clazz.equals(Metadata.class)) {
+                return (T) index.getMetadata();
               }
               return super.as(clazz);
             }

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/SqlBaseBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/SqlBaseBenchmark.java
@@ -65,6 +65,7 @@ import org.apache.druid.query.policy.NoopPolicyEnforcer;
 import org.apache.druid.segment.AutoTypeColumnSchema;
 import org.apache.druid.segment.IncrementalIndexSegment;
 import org.apache.druid.segment.IndexSpec;
+import org.apache.druid.segment.PhysicalSegmentColumnInspector;
 import org.apache.druid.segment.PhysicalSegmentInspector;
 import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.QueryableIndexCursorFactory;
@@ -521,7 +522,7 @@ public class SqlBaseBenchmark
             public <T> T as(@Nonnull Class<T> clazz)
             {
               // computed sql schema uses segment metadata, which relies on physical inspector, use the underlying index
-              if (clazz.equals(PhysicalSegmentInspector.class)) {
+              if (clazz.equals(PhysicalSegmentInspector.class) || clazz.equals(PhysicalSegmentColumnInspector.class)) {
                 return (T) new QueryableIndexPhysicalSegmentInspector(index);
               }
               return super.as(clazz);
@@ -548,7 +549,7 @@ public class SqlBaseBenchmark
             public <T> T as(@Nonnull Class<T> clazz)
             {
               // computed sql schema uses segment metadata, which relies on physical inspector, use the underlying index
-              if (clazz.equals(PhysicalSegmentInspector.class)) {
+              if (clazz.equals(PhysicalSegmentInspector.class) || clazz.equals(PhysicalSegmentColumnInspector.class)) {
                 return (T) new QueryableIndexPhysicalSegmentInspector(index);
               }
               return super.as(clazz);

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/input/LoadableSegmentUtils.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/input/LoadableSegmentUtils.java
@@ -22,7 +22,7 @@ package org.apache.druid.msq.input;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.druid.common.guava.FutureUtils;
 import org.apache.druid.msq.counters.ChannelCounters;
-import org.apache.druid.segment.PhysicalSegmentInspector;
+import org.apache.druid.segment.RowCountInspector;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.loading.AcquireSegmentAction;
 import org.apache.druid.segment.loading.AcquireSegmentResult;
@@ -73,11 +73,11 @@ public class LoadableSegmentUtils
   }
 
   /**
-   * Gets the number of rows for a segment, using a {@link PhysicalSegmentInspector}. Returns 0 when unknown.
+   * Gets the number of rows for a segment, using a {@link RowCountInspector}. Returns 0 when unknown.
    */
   public static int getSegmentRowCount(final Segment segment)
   {
-    final PhysicalSegmentInspector inspector = segment.as(PhysicalSegmentInspector.class);
+    final RowCountInspector inspector = segment.as(RowCountInspector.class);
     return inspector != null ? inspector.getNumRows() : 0;
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/RegularLoadableSegmentTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/RegularLoadableSegmentTest.java
@@ -44,7 +44,7 @@ import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.expression.TestExprMacroTable;
 import org.apache.druid.segment.IndexIO;
 import org.apache.druid.segment.IndexSpec;
-import org.apache.druid.segment.PhysicalSegmentInspector;
+import org.apache.druid.segment.RowCountInspector;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.TestIndex;
@@ -249,7 +249,7 @@ class RegularLoadableSegmentTest extends InitializedNullHandlingTest
                 try (final AcquireSegmentAction ignored = pair.lhs;
                      final Segment acquiredSegment = acquiredSegmentOptional.get()) {
                   Assertions.assertEquals(segment.getId(), acquiredSegment.getId());
-                  PhysicalSegmentInspector gadget = acquiredSegment.as(PhysicalSegmentInspector.class);
+                  RowCountInspector gadget = acquiredSegment.as(RowCountInspector.class);
                   Assertions.assertNotNull(gadget);
                   Assertions.assertEquals(1209, gadget.getNumRows());
                   return true;
@@ -320,7 +320,7 @@ class RegularLoadableSegmentTest extends InitializedNullHandlingTest
                 try (final AcquireSegmentAction ignored = pair.lhs;
                      final Segment acquiredSegment = acquiredSegmentOptional.get()) {
                   Assertions.assertEquals(segment.getId(), acquiredSegment.getId());
-                  PhysicalSegmentInspector gadget = acquiredSegment.as(PhysicalSegmentInspector.class);
+                  RowCountInspector gadget = acquiredSegment.as(RowCountInspector.class);
                   Assertions.assertNotNull(gadget);
                   Assertions.assertEquals(1209, gadget.getNumRows());
                   return true;
@@ -377,7 +377,7 @@ class RegularLoadableSegmentTest extends InitializedNullHandlingTest
 
     try (final Segment acquiredSegment = cachedSegment.get()) {
       Assertions.assertEquals(segment.getId(), acquiredSegment.getId());
-      final PhysicalSegmentInspector gadget = acquiredSegment.as(PhysicalSegmentInspector.class);
+      final RowCountInspector gadget = acquiredSegment.as(RowCountInspector.class);
       Assertions.assertNotNull(gadget);
       Assertions.assertEquals(1209, gadget.getNumRows());
     }
@@ -440,7 +440,7 @@ class RegularLoadableSegmentTest extends InitializedNullHandlingTest
     try (final AcquireSegmentAction ignored = acquireAction;
          final Segment acquiredSegment = acquiredSegmentOptional.get()) {
       Assertions.assertEquals(segment.getId(), acquiredSegment.getId());
-      final PhysicalSegmentInspector gadget = acquiredSegment.as(PhysicalSegmentInspector.class);
+      final RowCountInspector gadget = acquiredSegment.as(RowCountInspector.class);
       Assertions.assertNotNull(gadget);
       Assertions.assertEquals(1209, gadget.getNumRows());
     }
@@ -479,7 +479,7 @@ class RegularLoadableSegmentTest extends InitializedNullHandlingTest
     try (final AcquireSegmentAction ignored = acquireAction;
          final Segment acquiredSegment = acquiredSegmentOptional.get()) {
       Assertions.assertEquals(segment.getId(), acquiredSegment.getId());
-      final PhysicalSegmentInspector gadget = acquiredSegment.as(PhysicalSegmentInspector.class);
+      final RowCountInspector gadget = acquiredSegment.as(RowCountInspector.class);
       Assertions.assertNotNull(gadget);
       Assertions.assertEquals(1209, gadget.getNumRows());
     }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
@@ -145,6 +145,7 @@ import org.apache.druid.segment.AggregateProjectionMetadata;
 import org.apache.druid.segment.CursorFactory;
 import org.apache.druid.segment.IndexBuilder;
 import org.apache.druid.segment.IndexIO;
+import org.apache.druid.segment.PhysicalSegmentColumnInspector;
 import org.apache.druid.segment.PhysicalSegmentInspector;
 import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.QueryableIndexCursorFactory;
@@ -791,7 +792,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
         {
           if (CursorFactory.class.equals(clazz)) {
             return (T) new QueryableIndexCursorFactory(index);
-          } else if (PhysicalSegmentInspector.class.equals(clazz)) {
+          } else if (PhysicalSegmentInspector.class.equals(clazz) || PhysicalSegmentColumnInspector.class.equals(clazz)) {
             return (T) new QueryableIndexPhysicalSegmentInspector(index);
           } else if (QueryableIndex.class.equals(clazz)) {
             return (T) index;

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
@@ -145,11 +145,12 @@ import org.apache.druid.segment.AggregateProjectionMetadata;
 import org.apache.druid.segment.CursorFactory;
 import org.apache.druid.segment.IndexBuilder;
 import org.apache.druid.segment.IndexIO;
+import org.apache.druid.segment.Metadata;
 import org.apache.druid.segment.PhysicalSegmentColumnInspector;
-import org.apache.druid.segment.PhysicalSegmentInspector;
 import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.QueryableIndexCursorFactory;
 import org.apache.druid.segment.QueryableIndexPhysicalSegmentInspector;
+import org.apache.druid.segment.RowCountInspector;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.column.ColumnConfig;
 import org.apache.druid.segment.column.ColumnHolder;
@@ -792,10 +793,12 @@ public class MSQTestBase extends BaseCalciteQueryTest
         {
           if (CursorFactory.class.equals(clazz)) {
             return (T) new QueryableIndexCursorFactory(index);
-          } else if (PhysicalSegmentInspector.class.equals(clazz) || PhysicalSegmentColumnInspector.class.equals(clazz)) {
+          } else if (RowCountInspector.class.equals(clazz) || PhysicalSegmentColumnInspector.class.equals(clazz)) {
             return (T) new QueryableIndexPhysicalSegmentInspector(index);
           } else if (QueryableIndex.class.equals(clazz)) {
             return (T) index;
+          } else if (Metadata.class.equals(clazz)) {
+            return (T) index.getMetadata();
           }
           return null;
         }

--- a/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
@@ -31,6 +31,7 @@ import org.apache.druid.segment.CursorBuildSpec;
 import org.apache.druid.segment.CursorFactory;
 import org.apache.druid.segment.CursorHolder;
 import org.apache.druid.segment.DimensionSelector;
+import org.apache.druid.segment.PhysicalSegmentColumnInspector;
 import org.apache.druid.segment.PhysicalSegmentInspector;
 import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.Segment;
@@ -90,8 +91,9 @@ public class SegmentAnalyzer
   {
     Preconditions.checkNotNull(segment, "segment");
     final PhysicalSegmentInspector segmentInspector = segment.as(PhysicalSegmentInspector.class);
+    final PhysicalSegmentColumnInspector columnInspector = segment.as(PhysicalSegmentColumnInspector.class);
 
-    // index is null for incremental-index-based segments, but segmentInspector should always be available
+    // index is null for incremental-index-based segments, but the inspectors should always be available
     final QueryableIndex index = segment.as(QueryableIndex.class);
     final CursorFactory cursorFactory = Objects.requireNonNull(segment.as(CursorFactory.class));
 
@@ -104,8 +106,8 @@ public class SegmentAnalyzer
     for (String columnName : rowSignature.getColumnNames()) {
       final ColumnCapabilities capabilities;
 
-      if (segmentInspector != null) {
-        capabilities = segmentInspector.getColumnCapabilities(columnName);
+      if (columnInspector != null) {
+        capabilities = columnInspector.getColumnCapabilities(columnName);
       } else {
         capabilities = null;
       }
@@ -135,7 +137,7 @@ public class SegmentAnalyzer
             if (index != null) {
               analysis = analyzeStringColumn(capabilities, index.getColumnHolder(columnName));
             } else {
-              analysis = analyzeStringColumn(capabilities, segmentInspector, cursorFactory, columnName);
+              analysis = analyzeStringColumn(capabilities, columnInspector, cursorFactory, columnName);
             }
             break;
           case ARRAY:
@@ -260,7 +262,7 @@ public class SegmentAnalyzer
 
   private ColumnAnalysis analyzeStringColumn(
       final ColumnCapabilities capabilities,
-      @Nullable final PhysicalSegmentInspector analysisInspector,
+      @Nullable final PhysicalSegmentColumnInspector analysisInspector,
       final CursorFactory cursorFactory,
       final String columnName
   )

--- a/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
@@ -32,8 +32,8 @@ import org.apache.druid.segment.CursorFactory;
 import org.apache.druid.segment.CursorHolder;
 import org.apache.druid.segment.DimensionSelector;
 import org.apache.druid.segment.PhysicalSegmentColumnInspector;
-import org.apache.druid.segment.PhysicalSegmentInspector;
 import org.apache.druid.segment.QueryableIndex;
+import org.apache.druid.segment.RowCountInspector;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.column.BaseColumn;
 import org.apache.druid.segment.column.BaseColumnHolder;
@@ -83,21 +83,21 @@ public class SegmentAnalyzer
 
   public long numRows(Segment segment)
   {
-    return Preconditions.checkNotNull(segment.as(PhysicalSegmentInspector.class), "PhysicalSegmentInspector")
+    return Preconditions.checkNotNull(segment.as(RowCountInspector.class), "RowCountInspector")
                         .getNumRows();
   }
 
   public Map<String, ColumnAnalysis> analyze(Segment segment)
   {
     Preconditions.checkNotNull(segment, "segment");
-    final PhysicalSegmentInspector segmentInspector = segment.as(PhysicalSegmentInspector.class);
+    final RowCountInspector rowCountInspector = segment.as(RowCountInspector.class);
     final PhysicalSegmentColumnInspector columnInspector = segment.as(PhysicalSegmentColumnInspector.class);
 
     // index is null for incremental-index-based segments, but the inspectors should always be available
     final QueryableIndex index = segment.as(QueryableIndex.class);
     final CursorFactory cursorFactory = Objects.requireNonNull(segment.as(CursorFactory.class));
 
-    final int numRows = segmentInspector != null ? segmentInspector.getNumRows() : 0;
+    final int numRows = rowCountInspector != null ? rowCountInspector.getNumRows() : 0;
 
     // Use LinkedHashMap to preserve column order.
     final Map<String, ColumnAnalysis> columns = new LinkedHashMap<>();

--- a/processing/src/main/java/org/apache/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
@@ -39,7 +39,6 @@ import org.apache.druid.query.metadata.metadata.SegmentAnalysis;
 import org.apache.druid.query.metadata.metadata.SegmentMetadataQuery;
 import org.apache.druid.segment.AggregateProjectionMetadata;
 import org.apache.druid.segment.Metadata;
-import org.apache.druid.segment.PhysicalSegmentInspector;
 import org.apache.druid.segment.Segment;
 import org.joda.time.Interval;
 
@@ -204,10 +203,6 @@ public class SegmentMetadataQueryRunnerFactory implements QueryRunnerFactory<Seg
   @Nullable
   private Metadata getMetadata(Segment segment)
   {
-    PhysicalSegmentInspector inspector = segment.as(PhysicalSegmentInspector.class);
-    if (inspector != null) {
-      return inspector.getMetadata();
-    }
-    return null;
+    return segment.as(Metadata.class);
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/search/SearchStrategy.java
+++ b/processing/src/main/java/org/apache/druid/query/search/SearchStrategy.java
@@ -28,7 +28,6 @@ import org.apache.druid.query.dimension.DimensionSpec;
 import org.apache.druid.query.filter.Filter;
 import org.apache.druid.segment.CursorFactory;
 import org.apache.druid.segment.Metadata;
-import org.apache.druid.segment.PhysicalSegmentInspector;
 import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.column.ColumnHolder;
@@ -70,8 +69,7 @@ public abstract class SearchStrategy
         }
       } else {
         // fallback to RowSignature and Metadata if QueryableIndex not available
-        final PhysicalSegmentInspector segmentInspector = segment.as(PhysicalSegmentInspector.class);
-        final Metadata metadata = segmentInspector != null ? segmentInspector.getMetadata() : null;
+        final Metadata metadata = segment.as(Metadata.class);
         final Set<String> ignore = new HashSet<>();
         ignore.add(ColumnHolder.TIME_COLUMN_NAME);
         if (metadata != null && metadata.getAggregators() != null) {

--- a/processing/src/main/java/org/apache/druid/segment/IncrementalIndexSegment.java
+++ b/processing/src/main/java/org/apache/druid/segment/IncrementalIndexSegment.java
@@ -64,7 +64,7 @@ public class IncrementalIndexSegment implements Segment
       return (T) new IncrementalIndexMaxIngestedEventTimeInspector(index);
     } else if (Metadata.class.equals(clazz)) {
       return (T) index.getMetadata();
-    } else if (PhysicalSegmentInspector.class.equals(clazz)) {
+    } else if (PhysicalSegmentInspector.class.equals(clazz) || PhysicalSegmentColumnInspector.class.equals(clazz)) {
       return (T) new IncrementalIndexPhysicalSegmentInspector(index);
     } else if (TopNOptimizationInspector.class.equals(clazz)) {
       return (T) new SimpleTopNOptimizationInspector(true);

--- a/processing/src/main/java/org/apache/druid/segment/IncrementalIndexSegment.java
+++ b/processing/src/main/java/org/apache/druid/segment/IncrementalIndexSegment.java
@@ -52,6 +52,7 @@ public class IncrementalIndexSegment implements Segment
     return index.getInterval();
   }
 
+  @SuppressWarnings("deprecation")
   @Nullable
   @Override
   public <T> T as(final Class<T> clazz)
@@ -64,7 +65,9 @@ public class IncrementalIndexSegment implements Segment
       return (T) new IncrementalIndexMaxIngestedEventTimeInspector(index);
     } else if (Metadata.class.equals(clazz)) {
       return (T) index.getMetadata();
-    } else if (PhysicalSegmentInspector.class.equals(clazz) || PhysicalSegmentColumnInspector.class.equals(clazz)) {
+    } else if (RowCountInspector.class.equals(clazz)
+               || PhysicalSegmentColumnInspector.class.equals(clazz)
+               || PhysicalSegmentInspector.class.equals(clazz)) {
       return (T) new IncrementalIndexPhysicalSegmentInspector(index);
     } else if (TopNOptimizationInspector.class.equals(clazz)) {
       return (T) new SimpleTopNOptimizationInspector(true);

--- a/processing/src/main/java/org/apache/druid/segment/PhysicalSegmentColumnInspector.java
+++ b/processing/src/main/java/org/apache/druid/segment/PhysicalSegmentColumnInspector.java
@@ -38,7 +38,7 @@ public interface PhysicalSegmentColumnInspector extends ColumnInspector
   Comparable getMinValue(String column);
 
   /**
-   * Returns the minimum value of the provided column, if known through an index, dictionary, or cache. Returns null
+   * Returns the maximum value of the provided column, if known through an index, dictionary, or cache. Returns null
    * if not known. Does not scan the column to find the maximum value.
    */
   @Nullable

--- a/processing/src/main/java/org/apache/druid/segment/PhysicalSegmentColumnInspector.java
+++ b/processing/src/main/java/org/apache/druid/segment/PhysicalSegmentColumnInspector.java
@@ -24,9 +24,6 @@ import javax.annotation.Nullable;
 /**
  * Interface for methods describing the columns of physical segments such as {@link QueryableIndexSegment} and
  * {@link IncrementalIndexSegment} that is not typically used at query time (outside of metadata queries).
- * <p>
- * For general metadata information about a segment that is not column specific, use {@link PhysicalSegmentInspector}
- * instead.
  */
 public interface PhysicalSegmentColumnInspector extends ColumnInspector
 {

--- a/processing/src/main/java/org/apache/druid/segment/PhysicalSegmentColumnInspector.java
+++ b/processing/src/main/java/org/apache/druid/segment/PhysicalSegmentColumnInspector.java
@@ -22,21 +22,31 @@ package org.apache.druid.segment;
 import javax.annotation.Nullable;
 
 /**
- * Interface for methods describing physical segments such as {@link QueryableIndexSegment} and
+ * Interface for methods describing the columns of physical segments such as {@link QueryableIndexSegment} and
  * {@link IncrementalIndexSegment} that is not typically used at query time (outside of metadata queries).
  * <p>
- * For metadata information about specific columns, use {@link PhysicalSegmentColumnInspector}.
+ * For general metadata information about a segment that is not column specific, use {@link PhysicalSegmentInspector}
+ * instead.
  */
-public interface PhysicalSegmentInspector
+public interface PhysicalSegmentColumnInspector extends ColumnInspector
 {
   /**
-   * Returns {@link Metadata} which contains details about how the segment was created
+   * Returns the minimum value of the provided column, if known through an index, dictionary, or cache. Returns null
+   * if not known. Does not scan the column to find the minimum value.
    */
   @Nullable
-  Metadata getMetadata();
+  Comparable getMinValue(String column);
 
   /**
-   * Returns the number of rows in the segment
+   * Returns the minimum value of the provided column, if known through an index, dictionary, or cache. Returns null
+   * if not known. Does not scan the column to find the maximum value.
    */
-  int getNumRows();
+  @Nullable
+  Comparable getMaxValue(String column);
+
+  /**
+   * Returns the number of distinct values in a column, if known, or
+   * {@link DimensionDictionarySelector#CARDINALITY_UNKNOWN} if not.
+   */
+  int getDimensionCardinality(String column);
 }

--- a/processing/src/main/java/org/apache/druid/segment/PhysicalSegmentInspector.java
+++ b/processing/src/main/java/org/apache/druid/segment/PhysicalSegmentInspector.java
@@ -24,19 +24,21 @@ import javax.annotation.Nullable;
 /**
  * Interface for methods describing physical segments such as {@link QueryableIndexSegment} and
  * {@link IncrementalIndexSegment} that is not typically used at query time (outside of metadata queries).
- * <p>
- * For metadata information about specific columns, use {@link PhysicalSegmentColumnInspector}.
+ *
+ * @deprecated this interface has been split into smaller, single-purpose interfaces. Use {@link RowCountInspector} for
+ * the number of rows in a segment, {@link PhysicalSegmentColumnInspector} for column details, and {@link Segment#as}
+ * to get {@link Metadata} instead. It is retained, implemented only by {@link QueryableIndexSegment} and
+ * {@link IncrementalIndexSegment}, so that existing callers reaching it through {@link Segment#as} continue to work.
  */
-public interface PhysicalSegmentInspector
+@Deprecated
+public interface PhysicalSegmentInspector extends RowCountInspector, PhysicalSegmentColumnInspector
 {
   /**
    * Returns {@link Metadata} which contains details about how the segment was created
+   *
+   * @deprecated use {@link Segment#as} to get {@link Metadata} instead
    */
+  @Deprecated
   @Nullable
   Metadata getMetadata();
-
-  /**
-   * Returns the number of rows in the segment
-   */
-  int getNumRows();
 }

--- a/processing/src/main/java/org/apache/druid/segment/QueryableIndexPhysicalSegmentInspector.java
+++ b/processing/src/main/java/org/apache/druid/segment/QueryableIndexPhysicalSegmentInspector.java
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-public class QueryableIndexPhysicalSegmentInspector implements PhysicalSegmentInspector
+public class QueryableIndexPhysicalSegmentInspector implements PhysicalSegmentInspector, PhysicalSegmentColumnInspector
 {
   private final QueryableIndex index;
 

--- a/processing/src/main/java/org/apache/druid/segment/QueryableIndexPhysicalSegmentInspector.java
+++ b/processing/src/main/java/org/apache/druid/segment/QueryableIndexPhysicalSegmentInspector.java
@@ -30,7 +30,8 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-public class QueryableIndexPhysicalSegmentInspector implements PhysicalSegmentInspector, PhysicalSegmentColumnInspector
+@SuppressWarnings("deprecation")
+public class QueryableIndexPhysicalSegmentInspector implements PhysicalSegmentInspector
 {
   private final QueryableIndex index;
 

--- a/processing/src/main/java/org/apache/druid/segment/QueryableIndexSegment.java
+++ b/processing/src/main/java/org/apache/druid/segment/QueryableIndexSegment.java
@@ -91,7 +91,7 @@ public class QueryableIndexSegment implements Segment
       return (T) timeBoundaryInspector;
     } else if (Metadata.class.equals(clazz)) {
       return (T) index.getMetadata();
-    } else if (PhysicalSegmentInspector.class.equals(clazz)) {
+    } else if (PhysicalSegmentInspector.class.equals(clazz) || PhysicalSegmentColumnInspector.class.equals(clazz)) {
       return (T) new QueryableIndexPhysicalSegmentInspector(index);
     } else if (TopNOptimizationInspector.class.equals(clazz)) {
       return (T) new SimpleTopNOptimizationInspector(true);

--- a/processing/src/main/java/org/apache/druid/segment/QueryableIndexSegment.java
+++ b/processing/src/main/java/org/apache/druid/segment/QueryableIndexSegment.java
@@ -70,7 +70,7 @@ public class QueryableIndexSegment implements Segment
     index.close();
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "deprecation"})
   @Nullable
   @Override
   public <T> T as(@Nonnull Class<T> clazz)
@@ -91,7 +91,9 @@ public class QueryableIndexSegment implements Segment
       return (T) timeBoundaryInspector;
     } else if (Metadata.class.equals(clazz)) {
       return (T) index.getMetadata();
-    } else if (PhysicalSegmentInspector.class.equals(clazz) || PhysicalSegmentColumnInspector.class.equals(clazz)) {
+    } else if (RowCountInspector.class.equals(clazz)
+               || PhysicalSegmentColumnInspector.class.equals(clazz)
+               || PhysicalSegmentInspector.class.equals(clazz)) {
       return (T) new QueryableIndexPhysicalSegmentInspector(index);
     } else if (TopNOptimizationInspector.class.equals(clazz)) {
       return (T) new SimpleTopNOptimizationInspector(true);

--- a/processing/src/main/java/org/apache/druid/segment/RowCountInspector.java
+++ b/processing/src/main/java/org/apache/druid/segment/RowCountInspector.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment;
+
+/**
+ * Inspector for the number of rows of physical segments.
+ */
+public interface RowCountInspector
+{
+  /**
+   * Returns the number of rows in the segment
+   */
+  int getNumRows();
+}

--- a/processing/src/main/java/org/apache/druid/segment/Segment.java
+++ b/processing/src/main/java/org/apache/druid/segment/Segment.java
@@ -68,6 +68,7 @@ public interface Segment extends Closeable
    *   <li> {@link IndexedTable}, table object, if this is a joinable indexed table.
    *   <li> {@link TimeBoundaryInspector}, inspector for min/max timestamps, if supported by this segment.
    *   <li> {@link PhysicalSegmentInspector}, inspector for physical segment details, if supported by this segment.
+   *   <li> {@link PhysicalSegmentColumnInspector}, inspector for physical segment column details, if supported by this segment.
    *   <li> {@link MaxIngestedEventTimeInspector}, inspector for {@link DataSourceMetadataResultValue#getMaxIngestedEventTime()}
    *   <li> {@link TopNOptimizationInspector}, inspector containing information for topN specific optimizations
    *   <li> {@link CloseableShapeshifter}, stepping stone to {@link org.apache.druid.query.rowsandcols.RowsAndColumns}.

--- a/processing/src/main/java/org/apache/druid/segment/Segment.java
+++ b/processing/src/main/java/org/apache/druid/segment/Segment.java
@@ -64,15 +64,17 @@ public interface Segment extends Closeable
    * @return instance of clazz, or null if the interface is not supported by this segment, one of the following:
    * <ul>
    *   <li> {@link CursorFactory}, to make cursors to run queries. Never null.</li>
-   *   <li> {@link QueryableIndex}, index object, if this is a memory-mapped regular segment.
-   *   <li> {@link IndexedTable}, table object, if this is a joinable indexed table.
-   *   <li> {@link TimeBoundaryInspector}, inspector for min/max timestamps, if supported by this segment.
-   *   <li> {@link PhysicalSegmentInspector}, inspector for physical segment details, if supported by this segment.
-   *   <li> {@link PhysicalSegmentColumnInspector}, inspector for physical segment column details, if supported by this segment.
-   *   <li> {@link MaxIngestedEventTimeInspector}, inspector for {@link DataSourceMetadataResultValue#getMaxIngestedEventTime()}
-   *   <li> {@link TopNOptimizationInspector}, inspector containing information for topN specific optimizations
-   *   <li> {@link CloseableShapeshifter}, stepping stone to {@link org.apache.druid.query.rowsandcols.RowsAndColumns}.
-   *   <li> {@link BypassRestrictedSegment}, a policy-aware segment, converted from a policy-enforced segment.
+   *   <li> {@link QueryableIndex}, index object, if this is a memory-mapped regular segment.</li>
+   *   <li> {@link IndexedTable}, table object, if this is a joinable indexed table.</li>
+   *   <li> {@link TimeBoundaryInspector}, inspector for min/max timestamps.</li>
+   *   <li> {@link PhysicalSegmentInspector}, deprecated, superseded by {@link RowCountInspector}, {@link PhysicalSegmentColumnInspector}, and {@link Metadata}.</li>
+   *   <li> {@link RowCountInspector}, inspector for number of rows.</li>
+   *   <li> {@link Metadata}, segment metadata.</li>
+   *   <li> {@link PhysicalSegmentColumnInspector}, inspector for physical segment column details.</li>
+   *   <li> {@link MaxIngestedEventTimeInspector}, inspector for {@link DataSourceMetadataResultValue#getMaxIngestedEventTime()}.</li>
+   *   <li> {@link TopNOptimizationInspector}, inspector containing information for topN specific optimizations.</li>
+   *   <li> {@link CloseableShapeshifter}, stepping stone to {@link org.apache.druid.query.rowsandcols.RowsAndColumns}.</li>
+   *   <li> {@link BypassRestrictedSegment}, a policy-aware segment, converted from a policy-enforced segment.</li>
    * </ul>
    */
   @SuppressWarnings({"unused", "unchecked"})

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexPhysicalSegmentInspector.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexPhysicalSegmentInspector.java
@@ -22,6 +22,7 @@ package org.apache.druid.segment.incremental;
 import org.apache.druid.segment.DimensionDictionarySelector;
 import org.apache.druid.segment.DimensionIndexer;
 import org.apache.druid.segment.Metadata;
+import org.apache.druid.segment.PhysicalSegmentColumnInspector;
 import org.apache.druid.segment.PhysicalSegmentInspector;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
@@ -29,7 +30,8 @@ import org.apache.druid.segment.column.ColumnHolder;
 
 import javax.annotation.Nullable;
 
-public class IncrementalIndexPhysicalSegmentInspector implements PhysicalSegmentInspector
+public class IncrementalIndexPhysicalSegmentInspector
+    implements PhysicalSegmentInspector, PhysicalSegmentColumnInspector
 {
   static final ColumnCapabilities.CoercionLogic SNAPSHOT_COERCE_LOGIC =
       new ColumnCapabilities.CoercionLogic()

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexPhysicalSegmentInspector.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexPhysicalSegmentInspector.java
@@ -22,7 +22,6 @@ package org.apache.druid.segment.incremental;
 import org.apache.druid.segment.DimensionDictionarySelector;
 import org.apache.druid.segment.DimensionIndexer;
 import org.apache.druid.segment.Metadata;
-import org.apache.druid.segment.PhysicalSegmentColumnInspector;
 import org.apache.druid.segment.PhysicalSegmentInspector;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
@@ -30,8 +29,8 @@ import org.apache.druid.segment.column.ColumnHolder;
 
 import javax.annotation.Nullable;
 
-public class IncrementalIndexPhysicalSegmentInspector
-    implements PhysicalSegmentInspector, PhysicalSegmentColumnInspector
+@SuppressWarnings("deprecation")
+public class IncrementalIndexPhysicalSegmentInspector implements PhysicalSegmentInspector
 {
   static final ColumnCapabilities.CoercionLogic SNAPSHOT_COERCE_LOGIC =
       new ColumnCapabilities.CoercionLogic()

--- a/processing/src/test/java/org/apache/druid/segment/IndexMergerTestBase.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexMergerTestBase.java
@@ -1694,7 +1694,7 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
     );
     Assert.assertEquals(
         ImmutableSet.of("A", "C"),
-        Arrays.stream(segment.as(PhysicalSegmentInspector.class).getMetadata().getAggregators()).map(AggregatorFactory::getName).collect(Collectors.toSet())
+        Arrays.stream(segment.as(Metadata.class).getAggregators()).map(AggregatorFactory::getName).collect(Collectors.toSet())
     );
   }
 
@@ -1770,7 +1770,7 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
     );
     Assert.assertEquals(
         ImmutableSet.of("A", "C"),
-        Arrays.stream(segment.as(PhysicalSegmentInspector.class).getMetadata().getAggregators()).map(AggregatorFactory::getName).collect(Collectors.toSet())
+        Arrays.stream(segment.as(Metadata.class).getAggregators()).map(AggregatorFactory::getName).collect(Collectors.toSet())
     );
 
   }
@@ -1842,7 +1842,7 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
     );
     Assert.assertEquals(
         ImmutableSet.of("A", "B", "C"),
-        Arrays.stream(segment.as(PhysicalSegmentInspector.class).getMetadata().getAggregators()).map(AggregatorFactory::getName).collect(Collectors.toSet())
+        Arrays.stream(segment.as(Metadata.class).getAggregators()).map(AggregatorFactory::getName).collect(Collectors.toSet())
     );
   }
 
@@ -1890,7 +1890,7 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
     );
     Assert.assertEquals(
         ImmutableSet.of("A", "B", "C"),
-        Arrays.stream(segment.as(PhysicalSegmentInspector.class).getMetadata().getAggregators()).map(AggregatorFactory::getName).collect(Collectors.toSet())
+        Arrays.stream(segment.as(Metadata.class).getAggregators()).map(AggregatorFactory::getName).collect(Collectors.toSet())
     );
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/PhysicalSegmentInspectorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/PhysicalSegmentInspectorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment;
+
+import org.apache.druid.segment.incremental.IncrementalIndex;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.apache.druid.timeline.SegmentId;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("deprecation")
+public class PhysicalSegmentInspectorTest extends InitializedNullHandlingTest
+{
+  @Test
+  public void testQueryableIndexSegmentProvidesDeprecatedInspector()
+  {
+    final QueryableIndex index = TestIndex.getMMappedTestIndex();
+    // not closed on purpose: the index is a shared static fixture
+    final QueryableIndexSegment segment = new QueryableIndexSegment(index, SegmentId.dummy("test"));
+
+    final PhysicalSegmentInspector inspector = segment.as(PhysicalSegmentInspector.class);
+    Assertions.assertNotNull(inspector);
+    Assertions.assertEquals(index.getNumRows(), inspector.getNumRows());
+    Assertions.assertEquals(index.getMetadata(), inspector.getMetadata());
+
+    // the deprecated inspector is the union of the interfaces that supersede it
+    Assertions.assertNotNull(segment.as(RowCountInspector.class));
+    Assertions.assertNotNull(segment.as(PhysicalSegmentColumnInspector.class));
+  }
+
+  @Test
+  public void testIncrementalIndexSegmentProvidesDeprecatedInspector()
+  {
+    final IncrementalIndex index = TestIndex.getIncrementalTestIndex();
+    // not closed on purpose: the index is a shared static fixture
+    final IncrementalIndexSegment segment = new IncrementalIndexSegment(index, SegmentId.dummy("test"));
+
+    final PhysicalSegmentInspector inspector = segment.as(PhysicalSegmentInspector.class);
+    Assertions.assertNotNull(inspector);
+    Assertions.assertEquals(index.numRows(), inspector.getNumRows());
+    Assertions.assertEquals(index.getMetadata(), inspector.getMetadata());
+
+    Assertions.assertNotNull(segment.as(RowCountInspector.class));
+    Assertions.assertNotNull(segment.as(PhysicalSegmentColumnInspector.class));
+  }
+}

--- a/processing/src/test/java/org/apache/druid/segment/TestSegmentUtils.java
+++ b/processing/src/test/java/org/apache/druid/segment/TestSegmentUtils.java
@@ -184,8 +184,10 @@ public class TestSegmentUtils
         return (T) INDEX;
       } else if (clazz.equals(CursorFactory.class)) {
         return (T) new QueryableIndexCursorFactory(INDEX);
-      } else if (clazz.equals(PhysicalSegmentInspector.class) || clazz.equals(PhysicalSegmentColumnInspector.class)) {
+      } else if (clazz.equals(RowCountInspector.class) || clazz.equals(PhysicalSegmentColumnInspector.class)) {
         return (T) new QueryableIndexPhysicalSegmentInspector(INDEX);
+      } else if (clazz.equals(Metadata.class)) {
+        return (T) INDEX.getMetadata();
       }
       return null;
     }

--- a/processing/src/test/java/org/apache/druid/segment/TestSegmentUtils.java
+++ b/processing/src/test/java/org/apache/druid/segment/TestSegmentUtils.java
@@ -184,7 +184,7 @@ public class TestSegmentUtils
         return (T) INDEX;
       } else if (clazz.equals(CursorFactory.class)) {
         return (T) new QueryableIndexCursorFactory(INDEX);
-      } else if (clazz.equals(PhysicalSegmentInspector.class)) {
+      } else if (clazz.equals(PhysicalSegmentInspector.class) || clazz.equals(PhysicalSegmentColumnInspector.class)) {
         return (T) new QueryableIndexPhysicalSegmentInspector(INDEX);
       }
       return null;

--- a/processing/src/test/java/org/apache/druid/segment/join/table/BroadcastSegmentIndexedTableTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/table/BroadcastSegmentIndexedTableTest.java
@@ -41,10 +41,10 @@ import org.apache.druid.segment.IndexIO;
 import org.apache.druid.segment.IndexMerger;
 import org.apache.druid.segment.IndexMergerV9;
 import org.apache.druid.segment.IndexSpec;
-import org.apache.druid.segment.PhysicalSegmentInspector;
 import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.QueryableIndexCursorFactory;
 import org.apache.druid.segment.QueryableIndexSegment;
+import org.apache.druid.segment.RowCountInspector;
 import org.apache.druid.segment.SegmentLazyLoadFailCallback;
 import org.apache.druid.segment.SimpleAscendingOffset;
 import org.apache.druid.segment.TestIndex;
@@ -296,7 +296,7 @@ public class BroadcastSegmentIndexedTableTest extends InitializedNullHandlingTes
     checkColumnSelectorFactory(columnName);
     try (final Closer closer = Closer.create()) {
       final int columnIndex = columnNames.indexOf(columnName);
-      final int numRows = backingSegment.as(PhysicalSegmentInspector.class).getNumRows();
+      final int numRows = backingSegment.as(RowCountInspector.class).getNumRows();
       final IndexedTable.Reader reader = broadcastTable.columnReader(columnIndex);
       closer.register(reader);
       final SimpleAscendingOffset offset = new SimpleAscendingOffset(numRows);
@@ -326,7 +326,7 @@ public class BroadcastSegmentIndexedTableTest extends InitializedNullHandlingTes
   private void checkColumnSelectorFactory(String columnName)
   {
     try (final Closer closer = Closer.create()) {
-      final int numRows = backingSegment.as(PhysicalSegmentInspector.class).getNumRows();
+      final int numRows = backingSegment.as(RowCountInspector.class).getNumRows();
 
       final SimpleAscendingOffset offset = new SimpleAscendingOffset(numRows);
       final BaseColumn theColumn = backingSegment.as(QueryableIndex.class)

--- a/server/src/main/java/org/apache/druid/segment/loading/VirtualPlaceholderSegment.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/VirtualPlaceholderSegment.java
@@ -22,11 +22,10 @@ package org.apache.druid.segment.loading;
 import org.apache.druid.data.input.Row;
 import org.apache.druid.java.util.common.guava.Sequences;
 import org.apache.druid.segment.DimensionDictionarySelector;
-import org.apache.druid.segment.Metadata;
 import org.apache.druid.segment.PhysicalSegmentColumnInspector;
-import org.apache.druid.segment.PhysicalSegmentInspector;
 import org.apache.druid.segment.RowAdapters;
 import org.apache.druid.segment.RowBasedSegment;
+import org.apache.druid.segment.RowCountInspector;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ColumnHolder;
@@ -75,13 +74,13 @@ public class VirtualPlaceholderSegment extends RowBasedSegment<Row>
   @Override
   public <T> T as(@Nonnull Class<T> clazz)
   {
-    if (PhysicalSegmentInspector.class.equals(clazz) || PhysicalSegmentColumnInspector.class.equals(clazz)) {
+    if (RowCountInspector.class.equals(clazz) || PhysicalSegmentColumnInspector.class.equals(clazz)) {
       return (T) EmptyPhysicalInspector.INSTANCE;
     }
     return super.as(clazz);
   }
 
-  private static class EmptyPhysicalInspector implements PhysicalSegmentInspector, PhysicalSegmentColumnInspector
+  private static class EmptyPhysicalInspector implements RowCountInspector, PhysicalSegmentColumnInspector
   {
     private static final EmptyPhysicalInspector INSTANCE = new EmptyPhysicalInspector();
 
@@ -92,13 +91,6 @@ public class VirtualPlaceholderSegment extends RowBasedSegment<Row>
       if (ColumnHolder.TIME_COLUMN_NAME.equals(column)) {
         return ColumnCapabilitiesImpl.createDefault().setType(ColumnType.LONG);
       }
-      return null;
-    }
-
-    @Nullable
-    @Override
-    public Metadata getMetadata()
-    {
       return null;
     }
 

--- a/server/src/main/java/org/apache/druid/segment/loading/VirtualPlaceholderSegment.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/VirtualPlaceholderSegment.java
@@ -23,6 +23,7 @@ import org.apache.druid.data.input.Row;
 import org.apache.druid.java.util.common.guava.Sequences;
 import org.apache.druid.segment.DimensionDictionarySelector;
 import org.apache.druid.segment.Metadata;
+import org.apache.druid.segment.PhysicalSegmentColumnInspector;
 import org.apache.druid.segment.PhysicalSegmentInspector;
 import org.apache.druid.segment.RowAdapters;
 import org.apache.druid.segment.RowBasedSegment;
@@ -74,13 +75,13 @@ public class VirtualPlaceholderSegment extends RowBasedSegment<Row>
   @Override
   public <T> T as(@Nonnull Class<T> clazz)
   {
-    if (PhysicalSegmentInspector.class.equals(clazz)) {
+    if (PhysicalSegmentInspector.class.equals(clazz) || PhysicalSegmentColumnInspector.class.equals(clazz)) {
       return (T) EmptyPhysicalInspector.INSTANCE;
     }
     return super.as(clazz);
   }
 
-  private static class EmptyPhysicalInspector implements PhysicalSegmentInspector
+  private static class EmptyPhysicalInspector implements PhysicalSegmentInspector, PhysicalSegmentColumnInspector
   {
     private static final EmptyPhysicalInspector INSTANCE = new EmptyPhysicalInspector();
 

--- a/server/src/main/java/org/apache/druid/segment/realtime/FireHydrant.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/FireHydrant.java
@@ -23,7 +23,6 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.segment.IncrementalIndexSegment;
 import org.apache.druid.segment.Metadata;
-import org.apache.druid.segment.PhysicalSegmentInspector;
 import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.ReferenceCountedSegmentProvider;
 import org.apache.druid.segment.Segment;
@@ -93,8 +92,7 @@ public class FireHydrant
   {
     final Segment segment = segmentReferenceProvider.get().getBaseSegment();
     if (segment != null) {
-      final PhysicalSegmentInspector segmentInspector = segment.as(PhysicalSegmentInspector.class);
-      final Metadata metadata = segmentInspector == null ? null : segmentInspector.getMetadata();
+      final Metadata metadata = segment.as(Metadata.class);
       return metadata != null && metadata.getAggregators() != null ? metadata.getAggregators().length : 0;
     }
     return 0;

--- a/server/src/main/java/org/apache/druid/server/SegmentManager.java
+++ b/server/src/main/java/org/apache/druid/server/SegmentManager.java
@@ -31,7 +31,7 @@ import org.apache.druid.query.DataSegmentAndDescriptor;
 import org.apache.druid.query.LeafSegmentsBundle;
 import org.apache.druid.query.SegmentDescriptor;
 import org.apache.druid.query.TableDataSource;
-import org.apache.druid.segment.PhysicalSegmentInspector;
+import org.apache.druid.segment.RowCountInspector;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.SegmentLazyLoadFailCallback;
 import org.apache.druid.segment.SegmentMapFunction;
@@ -357,7 +357,7 @@ public class SegmentManager
                     segment.getId()
                 );
               }
-              final PhysicalSegmentInspector countInspector = segment.as(PhysicalSegmentInspector.class);
+              final RowCountInspector countInspector = segment.as(RowCountInspector.class);
               if (countInspector != null) {
                 numOfRows = countInspector.getNumRows();
               }
@@ -405,7 +405,7 @@ public class SegmentManager
                 final Optional<Segment> oldSegment = cacheManager.acquireCachedSegment(oldSegmentRef.getId());
                 long numberOfRows = oldSegment.map(segment -> {
                   closer.register(segment);
-                  final PhysicalSegmentInspector countInspector = segment.as(PhysicalSegmentInspector.class);
+                  final RowCountInspector countInspector = segment.as(RowCountInspector.class);
                   if (countInspector != null) {
                     return countInspector.getNumRows();
                   }

--- a/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerConcurrencyTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerConcurrencyTest.java
@@ -34,7 +34,7 @@ import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.segment.IndexIO;
-import org.apache.druid.segment.PhysicalSegmentInspector;
+import org.apache.druid.segment.RowCountInspector;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.TestIndex;
@@ -950,7 +950,7 @@ class SegmentLocalCacheManagerConcurrencyTest
         }
         final Optional<Segment> segment = result.getReferenceProvider().acquireReference().map(closer::register);
         if (segment.isPresent()) {
-          PhysicalSegmentInspector gadget = segment.get().as(PhysicalSegmentInspector.class);
+          RowCountInspector gadget = segment.get().as(RowCountInspector.class);
           if (delayMin >= 0 && delayMax > 0) {
             Thread.sleep(ThreadLocalRandom.current().nextInt(delayMin, delayMax));
           }
@@ -997,7 +997,7 @@ class SegmentLocalCacheManagerConcurrencyTest
         }
         final Optional<Segment> segmentReference = segmentManager.acquireCachedSegment(segment.getId()).map(closer::register);
         if (segmentReference.isPresent()) {
-          PhysicalSegmentInspector gadget = segmentReference.get().as(PhysicalSegmentInspector.class);
+          RowCountInspector gadget = segmentReference.get().as(RowCountInspector.class);
           if (maxDelayAfter > 0) {
             Thread.sleep(ThreadLocalRandom.current().nextInt(maxDelayAfter));
           }

--- a/server/src/test/java/org/apache/druid/segment/metadata/CoordinatorSegmentMetadataCacheTest.java
+++ b/server/src/test/java/org/apache/druid/segment/metadata/CoordinatorSegmentMetadataCacheTest.java
@@ -58,10 +58,10 @@ import org.apache.druid.query.metadata.metadata.SegmentMetadataQuery;
 import org.apache.druid.query.policy.NoRestrictionPolicy;
 import org.apache.druid.query.spec.MultipleSpecificSegmentSpec;
 import org.apache.druid.segment.IndexBuilder;
-import org.apache.druid.segment.PhysicalSegmentInspector;
 import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.QueryableIndexCursorFactory;
 import org.apache.druid.segment.QueryableIndexSegment;
+import org.apache.druid.segment.RowCountInspector;
 import org.apache.druid.segment.SchemaPayload;
 import org.apache.druid.segment.SchemaPayloadPlus;
 import org.apache.druid.segment.SegmentMetadata;
@@ -1758,7 +1758,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     CoordinatorSegmentMetadataCache schema = buildSchemaMarkAndTableLatch(config);
 
     QueryableIndexSegment queryableIndexSegment = new QueryableIndexSegment(index2, SegmentId.dummy("test"));
-    PhysicalSegmentInspector rowCountInspector = queryableIndexSegment.as(PhysicalSegmentInspector.class);
+    RowCountInspector rowCountInspector = queryableIndexSegment.as(RowCountInspector.class);
     QueryableIndexCursorFactory cursorFactory = new QueryableIndexCursorFactory(index2);
 
     ImmutableMap.Builder<SegmentId, SegmentMetadata> segmentStatsMap = new ImmutableMap.Builder<>();

--- a/server/src/test/java/org/apache/druid/server/coordination/SegmentManagerThreadSafetyTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/SegmentManagerThreadSafetyTest.java
@@ -31,7 +31,7 @@ import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.emitter.EmittingLogger;
-import org.apache.druid.segment.PhysicalSegmentInspector;
+import org.apache.druid.segment.RowCountInspector;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.SegmentLazyLoadFailCallback;
 import org.apache.druid.segment.TestIndex;
@@ -247,7 +247,7 @@ public class SegmentManagerThreadSafetyTest
     {
       return new Segment()
       {
-        PhysicalSegmentInspector rowCountInspector = Mockito.mock(PhysicalSegmentInspector.class);
+        RowCountInspector rowCountInspector = Mockito.mock(RowCountInspector.class);
 
         @Override
         public SegmentId getId()
@@ -264,7 +264,7 @@ public class SegmentManagerThreadSafetyTest
         @Override
         public <T> T as(Class<T> clazz)
         {
-          if (PhysicalSegmentInspector.class.equals(clazz)) {
+          if (RowCountInspector.class.equals(clazz)) {
             Mockito.when(rowCountInspector.getNumRows()).thenReturn(1);
             return (T) rowCountInspector;
           }


### PR DESCRIPTION
### Description
Small change to split out a new  `RowCountInspector` and `PhysicalSegmentColumnInspector` from `PhysicalSegmentInspector`, the latter of which takes all of the column specific methods (and the `ColumnInspector` part). These changes should simplify some things for the partial load functionality I have been working on, since the methods I have moved to `PhysicalSegmentColumnInspector` currently at least need the actual column present to correctly implement, however the remaining methods in `PhysicalSegmentInspector` can be answered purely with metadata. `PhysicalSegmentColumnInspector` is only used by `SegmentAnalyzer` for segment metadata queries for column analysis, row count is driven through `RowCountInspector`, and `Metadata` retrieval is now done directly from `Segment.as`. The existing interface is marked deprecated, and still wired up for QueryableIndex/IncrementalIndex, but is no longer used internally other than a test.