### PR TITLE
test: Reduce `KafkaIndexFaultToleranceTest` flakiness by increasing latch timeout

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/StreamIndexFaultToleranceTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/StreamIndexFaultToleranceTest.java
@@ -24,6 +24,7 @@ import org.apache.druid.indexing.overlord.supervisor.SupervisorSpec;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.rpc.RequestBuilder;
+import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
 import org.apache.druid.testing.embedded.StreamIngestResource;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.junit.jupiter.api.AfterEach;
@@ -43,6 +44,17 @@ public abstract class StreamIndexFaultToleranceTest extends StreamIndexTestBase
   private int totalRecords = 0;
 
   private StreamIngestResource<?> streamResource;
+
+  /**
+   * Publishing all ingested rows can exceed the 60s {@link StreamIndexTestBase}
+   * default when the CI runner is busy, so match the longer timeout the Kinesis
+   * sibling already uses.
+   */
+  @Override
+  protected EmbeddedDruidCluster createCluster()
+  {
+    return super.createCluster().useDefaultTimeoutForLatchableEmitter(120);
+  }
 
   @BeforeEach
   public void setupTopicAndSupervisor()

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/kinesis/KinesisFaultToleranceTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/kinesis/KinesisFaultToleranceTest.java
@@ -20,7 +20,6 @@
 package org.apache.druid.testing.embedded.kinesis;
 
 import org.apache.druid.indexing.overlord.supervisor.SupervisorSpec;
-import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
 import org.apache.druid.testing.embedded.StreamIngestResource;
 import org.apache.druid.testing.embedded.indexing.StreamIndexFaultToleranceTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,12 +60,6 @@ public class KinesisFaultToleranceTest extends StreamIndexFaultToleranceTest
   protected SupervisorSpec createSupervisorSpec(String dataSource, String topic)
   {
     return createKinesisSupervisor(kinesis, dataSource, topic);
-  }
-
-  @Override
-  protected EmbeddedDruidCluster createCluster()
-  {
-    return super.createCluster().useDefaultTimeoutForLatchableEmitter(120);
   }
 
   @Test


### PR DESCRIPTION
### Description

`KafkaIndexFaultToleranceTest` intermittently fails in CI with:

```
org.apache.druid.java.util.common.ISE: Timed out waiting for event after [60,000]ms
    at org.apache.druid.server.metrics.LatchableEmitter.waitForEventAggregate
    at org.apache.druid.testing.embedded.indexing.StreamIndexTestBase.waitUntilPublishedRecordsAreIngested
```

This PR increases the `LatchableEmitter` timeout to 120s from 60s identical to what `KinesisFaultToleranceTest` was already doing (but hoisted to the parent so both test classes inherit it now), so hopefully these tests finish.

An alternative to "fail if total elapsed > 120s", an interesting refactor could be to instead "fail if no _new_ matching event for X seconds", something like that.

<hr>

This PR has:

- [x] been self-reviewed.
