### PR TITLE
test: Try to fix row-count race in flaky `EmbeddedKafkaSupervisorTest`

### DIFF
--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/EmbeddedKafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/EmbeddedKafkaSupervisorTest.java
@@ -125,8 +125,19 @@ public class EmbeddedKafkaSupervisorTest extends EmbeddedClusterTestBase
     Assertions.assertEquals(1, taskStatuses.size());
     Assertions.assertEquals(TaskState.RUNNING, taskStatuses.get(0).getStatusCode());
 
+    // Wait until all produced records have been ingested before verifying the row count,
+    // otherwise the query below can race ingestion and observe fewer than the expected rows
+    indexer.latchableEmitter().waitForEventAggregate(
+        event -> event.hasMetricName("ingest/events/processed")
+                      .hasDimension(DruidMetrics.DATASOURCE, dataSource),
+        agg -> agg.hasSumAtLeast(expectedSegments)
+    );
+
     // Verify the count of rows ingested into the datasource so far
-    Assertions.assertEquals("10", cluster.runSql("SELECT COUNT(*) FROM %s", dataSource));
+    Assertions.assertEquals(
+        String.valueOf(expectedSegments),
+        cluster.runSql("SELECT COUNT(*) FROM %s", dataSource)
+    );
 
     // Suspend the supervisor and verify the state
     cluster.callApi().postSupervisor(kafkaSupervisorSpec.createSuspendedSpec());


### PR DESCRIPTION
`EmbeddedKafkaSupervisorTest.test_runKafkaSupervisor` is flaky in CI:

```
EmbeddedKafkaSupervisorTest.test_runKafkaSupervisor:129 expected: <10> but was: <8>
```

(observed values 7–9 across retries)

The test produces 10 records, waits only for the broker to discover the datasource (the first matching metric event), then immediately asserts `SELECT COUNT(*) == 10`. Under a loaded CI runner the query races ingestion and observes fewer than 10 rows.

This adds a wait on `ingest/events/processed` reaching the expected count before the row-count assertion identical to what `test_runSupervisor_withEmptyDimension` in this file already uses. 

<hr>

This PR has:

- [x] been self-reviewed.
