### PR TITLE
fix: Raise `start-druid` middleManager memory to 256m

### DIFF
--- a/examples/bin/start-druid-main.py
+++ b/examples/bin/start-druid-main.py
@@ -74,12 +74,6 @@ SERVICE_MEMORY_RATIO = {
     INDEXER: 32
 }
 
-# The middleManager floor is deliberately set to 256m rather than a smaller value: it not
-# only forks peons but also runs an embedded HTTP server that proxies task reports/logs back
-# to callers (e.g. the web console polling a running query). With a smaller heap (the auto
-# split awards it as little as ~68m at -m 16g) the middleManager OOMs under that proxying
-# load and the task it owns "disappears on the worker". 256m matches the value shipped in the
-# medium/large/xlarge single-server example configs.
 MINIMUM_MEMORY_MB = {
     MIDDLE_MANAGER: 256,
     ROUTER: 256,

--- a/examples/bin/start-druid-main.py
+++ b/examples/bin/start-druid-main.py
@@ -74,8 +74,14 @@ SERVICE_MEMORY_RATIO = {
     INDEXER: 32
 }
 
+# The middleManager floor is deliberately set to 256m rather than a smaller value: it not
+# only forks peons but also runs an embedded HTTP server that proxies task reports/logs back
+# to callers (e.g. the web console polling a running query). With a smaller heap (the auto
+# split awards it as little as ~68m at -m 16g) the middleManager OOMs under that proxying
+# load and the task it owns "disappears on the worker". 256m matches the value shipped in the
+# medium/large/xlarge single-server example configs.
 MINIMUM_MEMORY_MB = {
-    MIDDLE_MANAGER: 64,
+    MIDDLE_MANAGER: 256,
     ROUTER: 256,
     TASKS: 1024,
     BROKER: 900,


### PR DESCRIPTION
This PR addresses a flaky test in the web console's end-to-end test `multi-stage-query.spec.ts`.

_Analysis and implementation done with the help of Claude Code._

### Description

The `bin/start-druid` script allocates memory to services based on assigned weights. The `middleManager`, having the lowest weight, receives a small heap size of about 68 MB when using `-m 16g`. This is inadequate for its role in proxying task reports and logs, which can lead to `OutOfMemoryError` and result in flaky test failures.

#### Change

Increase the `middleManager` allocation in `MINIMUM_MEMORY_MB` from 64 MB to 256 MB.

- 256 MB is consistent with the sizes already in the `medium`, `large`, and `xlarge` single-server example configs,.
- This change impacts only smaller deployments (below ~60 GB total memory), while larger deployments are unaffected.
- Consequently, the minimum memory required for `start-druid` increases from ~4.25 GB to ~4.5 GB.

Validation with `bin/start-druid -m 16g --compute` shows the `middleManager` heap increases to 256 MB, while other services remain stable.

#### Release Note

The `bin/start-druid` now allocates at least 256 MB to the `middleManager`, preventing `OutOfMemoryError`s during task report/log proxying. The overall minimum memory requirement for `start-druid` increases by approximately 240 MB.

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] a release note entry in the PR description.