### PR TITLE
build(deps): Upgrade Kafka to 4.3.0

### DIFF
--- a/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/TestKafkaExtractionCluster.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/TestKafkaExtractionCluster.java
@@ -73,7 +73,7 @@ public class TestKafkaExtractionCluster
   private final Closer closer = Closer.create();
 
   private static final String KAFKA_IMAGE =
-      System.getProperty("druid.testing.kafka.image", "apache/kafka:4.2.0");
+      System.getProperty("druid.testing.kafka.image", "apache/kafka:4.3.0");
 
   private KafkaContainer kafkaServer;
   private Injector injector;

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResource.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResource.java
@@ -57,7 +57,7 @@ public class KafkaResource extends StreamIngestResource<KafkaContainer>
    * defaults to {@code apache/kafka}. Environments that cannot run that
    * image should set the system property to {@code apache/kafka-native}.
    */
-  private static final String KAFKA_IMAGE = System.getProperty("druid.testing.kafka.image", "apache/kafka:4.2.0");
+  private static final String KAFKA_IMAGE = System.getProperty("druid.testing.kafka.image", "apache/kafka:4.3.0");
 
   private EmbeddedDruidCluster cluster;
 

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/test/EmbeddedKafkaBroker.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/test/EmbeddedKafkaBroker.java
@@ -36,7 +36,7 @@ import java.util.concurrent.ThreadLocalRandom;
 public class EmbeddedKafkaBroker implements Closeable
 {
   private static final String KAFKA_IMAGE =
-      System.getProperty("druid.testing.kafka.image", "apache/kafka:4.2.0");
+      System.getProperty("druid.testing.kafka.image", "apache/kafka:4.3.0");
 
   private final KafkaContainer container;
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3453,7 +3453,7 @@ libraries:
 ---
 
 name: Apache Kafka
-version: 4.2.0
+version: 4.3.0
 license_category: binary
 module: extensions/druid-kafka-indexing-service
 license_name: Apache License version 2.0
@@ -3462,7 +3462,7 @@ libraries:
 notices:
   - kafka-clients: |
       Apache Kafka
-      Copyright 2024 The Apache Software Foundation.
+      Copyright 2026 The Apache Software Foundation.
 
       This product includes software developed at
       The Apache Software Foundation (https://www.apache.org/).
@@ -3475,15 +3475,11 @@ notices:
       https://github.com/jlink/jqwik.
 
       The streams-scala (streams/streams-scala) module was donated by Lightbend and the original code was copyrighted by them:
-        Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
-        Copyright (C) 2017-2018 Alexis Seigneurin.
-
-      This project contains the following code copied from Apache Hadoop:
-        clients/src/main/java/org/apache/kafka/common/utils/PureJavaCrc32C.java
-        Some portions of this file Copyright (c) 2004-2006 Intel Corporation and licensed under the BSD license.
+      Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+      Copyright (C) 2017-2018 Alexis Seigneurin.
 
       This project contains the following code copied from Apache Hive:
-        streams/src/main/java/org/apache/kafka/streams/state/internals/Murmur3.java
+      streams/src/main/java/org/apache/kafka/streams/state/internals/Murmur3.java
 
 ---
 
@@ -4457,13 +4453,13 @@ name: Apache Kafka
 license_category: binary
 module: extensions/kafka-extraction-namespace
 license_name: Apache License version 2.0
-version: 4.2.0
+version: 4.3.0
 libraries:
   - org.apache.kafka: kafka-clients
 notices:
   - kafka-clients: |
       Apache Kafka
-      Copyright 2023 The Apache Software Foundation.
+      Copyright 2026 The Apache Software Foundation.
 
       This product includes software developed at
       The Apache Software Foundation (https://www.apache.org/).
@@ -4476,15 +4472,11 @@ notices:
       https://github.com/jlink/jqwik.
 
       The streams-scala (streams/streams-scala) module was donated by Lightbend and the original code was copyrighted by them:
-        Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
-        Copyright (C) 2017-2018 Alexis Seigneurin.
-
-      This project contains the following code copied from Apache Hadoop:
-        clients/src/main/java/org/apache/kafka/common/utils/PureJavaCrc32C.java
-        Some portions of this file Copyright (c) 2004-2006 Intel Corporation and licensed under the BSD license.
+      Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+      Copyright (C) 2017-2018 Alexis Seigneurin.
 
       This project contains the following code copied from Apache Hive:
-        streams/src/main/java/org/apache/kafka/streams/state/internals/Murmur3.java
+      streams/src/main/java/org/apache/kafka/streams/state/internals/Murmur3.java
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <aether.version>0.9.0.M2</aether.version>
         <apache.curator.version>5.8.0</apache.curator.version>
-        <apache.kafka.version>4.2.0</apache.kafka.version>
+        <apache.kafka.version>4.3.0</apache.kafka.version>
         <!-- when updating apache ranger, verify the usage of aws-bundle-sdk vs aws-logs-sdk
         and update as needed in extensions-contrib/druid-ranger-security/pom.xml  -->
         <apache.ranger.version>2.8.0</apache.ranger.version>


### PR DESCRIPTION

### Description
  - apache.kafka.version from 4.2.0 to 4.3.0
  - Kafka test image defaults from apache/kafka:4.2.0 to apache/kafka:4.3.0

#### Release note

Upgrade Kafka to 4.3.0

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.