### PR TITLE
build(deps): Properly document Javassist MPL 1.1 triple-licensing

### DIFF
--- a/distribution/bin/check-licenses.py
+++ b/distribution/bin/check-licenses.py
@@ -299,6 +299,9 @@ def build_compatible_license_names():
     compatible_licenses['Mozilla Public License Version 2.0'] = 'Mozilla Public License Version 2.0'
     compatible_licenses['Mozilla Public License, Version 2.0'] = 'Mozilla Public License Version 2.0'
 
+    compatible_licenses['MPL 1.1'] = 'MPL 1.1'
+    compatible_licenses['Mozilla Public License 1.1'] = 'MPL 1.1'
+
     compatible_licenses['Creative Commons Attribution 2.5'] = 'Creative Commons Attribution 2.5'
 
     compatible_licenses['Creative Commons CC0'] = 'Creative Commons CC0'

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -7132,7 +7132,15 @@ libraries:
 name: Javassist
 license_category: binary
 module: extensions-core/druid-kerberos
-license_name: Apache License version 2.0
+license_name: MPL 1.1
 version: 3.30.2-GA
 libraries:
   - org.javassist: javassist
+notice: |
+  Javassist is triple-licensed under MPL 1.1, LGPL 2.1, and Apache License 2.0.
+  Apache Druid uses Javassist under the Apache License 2.0 terms.
+
+  From the Javassist license page (https://www.javassist.org/):
+  "Javassist is distributed under the Mozilla Public License 1.1 (MPL),
+  the GNU Lesser General Public License 2.1 (LGPL), and the Apache License 2.0 (AL).
+  You can choose one of them."


### PR DESCRIPTION
  ### Description

  Properly document Javassist's triple-licensing (MPL 1.1, LGPL 2.1, Apache License 2.0) in the license metadata. Apache Druid uses Javassist
  under the Apache License 2.0 terms, which is permitted by the triple-licensing.

  This fixes the "Unsupported license: MPL 1.1" error in the license checker by:
  1. Adding MPL 1.1 as a recognized license in `check-licenses.py`
  2. Updating the Javassist entry in `licenses.yaml` to declare MPL 1.1 as its primary license (as reported by Maven POM)
  3. Adding a notice explaining the triple-licensing and that Druid uses Apache 2.0 terms

  Addresses review feedback from FrankChen021 to properly canonicalize MPL 1.1 to its own license name rather than hiding it by mapping to
  Apache 2.0.

  ### Release note

  Not applicable - license metadata only, no functional changes.

  ### This PR has:

  - [x] been self-reviewed.
  - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the
   PR doesn't have any relation to concurrency.)
  - [ ] added documentation for new or modified features or behaviors.
  - [ ] a release note entry in the PR description.
  - [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
  - [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
  - [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
  - [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code 
  coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
  - [ ] added integration tests.
  - [ ] been tested in a test Druid cluster.

  ### Key changed/added classes in this PR

  - `distribution/bin/check-licenses.py` - Added MPL 1.1 license recognition
  - `licenses.yaml` - Updated Javassist license metadata with triple-licensing notice

  Use this description in the PR form! All checkboxes are appropriately marked based on what this PR actually does (license metadata only).
