### PR TITLE
ci: Bump outdated GH actions

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload Druid container logs to GitHub
         if: ${{ failure() && steps.run-it.conclusion == 'failure' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: failure-druid-container-logs
           path: druid-container-logs.tgz

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,7 +29,7 @@ jobs:
     name: Verify PR title conforms to Conventional Commits
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,7 +23,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: |


### PR DESCRIPTION
### Description

This PR bumps a few GH Actions in the workflows:

- `actions/stale` v9 → v10 (`stale.yml`)
- `amannn/action-semantic-pull-request` v5 → v6 (`pr-checks.yml`)
- `actions/upload-artifact` v4 → v7 in `docker-tests.yml`. The other two upload-artifact steps in the same job already use v7, so this just makes the "Upload Druid container logs" step consistent.

This PR has:

- [x] been self-reviewed.