### PR TITLE
test: Fix flaky `BasicAuthMSQTest`

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/auth/BasicAuthMSQTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/auth/BasicAuthMSQTest.java
@@ -251,7 +251,7 @@ public class BasicAuthMSQTest extends EmbeddedClusterTestBase
   {
     return RetryUtils.retry(
         () -> submitSqlTaskAsUser(sql),
-        e -> unauthorizedExceptionMatcher().matches(e) || forbiddenMessageMatcher().matches(e),
+        e -> unauthorizedExceptionMatcher().matches(e) || forbiddenExceptionMatcher().matches(e),
         AUTH_PROPAGATION_ATTEMPTS
     );
   }
@@ -270,7 +270,7 @@ public class BasicAuthMSQTest extends EmbeddedClusterTestBase
       Assertions.fail("Expected submit to fail with 403 Forbidden");
     }
     catch (Exception e) {
-      MatcherAssert.assertThat(e, forbiddenMessageMatcher());
+      MatcherAssert.assertThat(e, forbiddenExceptionMatcher());
     }
   }
 
@@ -279,7 +279,7 @@ public class BasicAuthMSQTest extends EmbeddedClusterTestBase
     return ExceptionMatcher.of(Exception.class).expectMessageContains("401 Unauthorized");
   }
 
-  private static ExceptionMatcher forbiddenMessageMatcher()
+  private static ExceptionMatcher forbiddenExceptionMatcher()
   {
     return ExceptionMatcher.of(Exception.class).expectMessageContains("403 Forbidden");
   }

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/auth/BasicAuthMSQTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/auth/BasicAuthMSQTest.java
@@ -245,48 +245,42 @@ public class BasicAuthMSQTest extends EmbeddedClusterTestBase
   }
 
   /**
-   * Submits an MSQ task as {@link #USER_1}, retrying on a transient 401/403 while the Broker's
-   * auth cache catches up with the test setup.
+   * Submits an MSQ task as {@link #USER_1}.
    */
   private SqlTaskStatus submitSqlTaskWhenAuthorized(String sql) throws Exception
   {
     return RetryUtils.retry(
         () -> submitSqlTaskAsUser(sql),
-        BasicAuthMSQTest::isTransientAuthFailure,
+        e -> unauthorizedExceptionMatcher().matches(e) || forbiddenMessageMatcher().matches(e),
         AUTH_PROPAGATION_ATTEMPTS
     );
   }
 
   /**
-   * Asserts that submitting the SQL as an unauthorized user fails with 403 Forbidden. Retries on a
-   * transient 401 (authentication not yet propagated); 403 is the expected result, so it is not.
+   * Asserts that submitting SQL as an unauthorized user fails with 403 Forbidden.
    */
   private void verifySqlSubmitFailsWith403Forbidden(String sql)
   {
     try {
       RetryUtils.retry(
           () -> submitSqlTaskAsUser(sql),
-          e -> failedWithHttpError(e, "401 Unauthorized"),
+          e -> unauthorizedExceptionMatcher().matches(e),
           AUTH_PROPAGATION_ATTEMPTS
       );
       Assertions.fail("Expected submit to fail with 403 Forbidden");
     }
     catch (Exception e) {
-      MatcherAssert.assertThat(e, ExceptionMatcher.of(Exception.class).expectMessageContains("403 Forbidden"));
+      MatcherAssert.assertThat(e, forbiddenMessageMatcher());
     }
   }
 
-  /**
-   * Whether the error is a transient 401 (new user) or 403 (new permission) from the Broker's
-   * auth cache lagging behind the test setup.
-   */
-  private static boolean isTransientAuthFailure(Throwable t)
+  private static ExceptionMatcher unauthorizedExceptionMatcher()
   {
-    return failedWithHttpError(t, "401 Unauthorized") || failedWithHttpError(t, "403 Forbidden");
+    return ExceptionMatcher.of(Exception.class).expectMessageContains("401 Unauthorized");
   }
 
-  private static boolean failedWithHttpError(Throwable t, String httpError)
+  private static ExceptionMatcher forbiddenMessageMatcher()
   {
-    return ExceptionMatcher.of(Exception.class).expectMessageContains(httpError).matches(t);
+    return ExceptionMatcher.of(Exception.class).expectMessageContains("403 Forbidden");
   }
 }

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/auth/BasicAuthMSQTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/auth/BasicAuthMSQTest.java
@@ -177,16 +177,18 @@ public class BasicAuthMSQTest extends EmbeddedClusterTestBase
 
     String exportQuery =
         StringUtils.format(
-            "INSERT INTO extern(%s(exportPath => '%s'))\n"
-            + "AS CSV\n"
-            + "SELECT page, added, delta\n"
-            + "FROM TABLE(\n"
-            + "  EXTERN(\n"
-            + "    '{\"type\":\"local\",\"files\":[\"%s\"]}',\n"
-            + "    '{\"type\":\"json\"}',\n"
-            + "    '[{\"type\":\"string\",\"name\":\"timestamp\"},{\"type\":\"string\",\"name\":\"isRobot\"},{\"type\":\"string\",\"name\":\"diffUrl\"},{\"type\":\"long\",\"name\":\"added\"},{\"type\":\"string\",\"name\":\"countryIsoCode\"},{\"type\":\"string\",\"name\":\"regionName\"},{\"type\":\"string\",\"name\":\"channel\"},{\"type\":\"string\",\"name\":\"flags\"},{\"type\":\"long\",\"name\":\"delta\"},{\"type\":\"string\",\"name\":\"isUnpatrolled\"},{\"type\":\"string\",\"name\":\"isNew\"},{\"type\":\"double\",\"name\":\"deltaBucket\"},{\"type\":\"string\",\"name\":\"isMinor\"},{\"type\":\"string\",\"name\":\"isAnonymous\"},{\"type\":\"long\",\"name\":\"deleted\"},{\"type\":\"string\",\"name\":\"cityName\"},{\"type\":\"long\",\"name\":\"metroCode\"},{\"type\":\"string\",\"name\":\"namespace\"},{\"type\":\"string\",\"name\":\"comment\"},{\"type\":\"string\",\"name\":\"page\"},{\"type\":\"long\",\"name\":\"commentLength\"},{\"type\":\"string\",\"name\":\"countryName\"},{\"type\":\"string\",\"name\":\"user\"},{\"type\":\"string\",\"name\":\"regionIsoCode\"}]'\n"
-            + "  )\n"
-            + ")\n",
+            """
+                INSERT INTO extern(%s(exportPath => '%s'))
+                AS CSV
+                SELECT page, added, delta
+                FROM TABLE(
+                  EXTERN(
+                    '{"type":"local","files":["%s"]}',
+                    '{"type":"json"}',
+                    '[{"type":"string","name":"timestamp"},{"type":"string","name":"isRobot"},{"type":"string","name":"diffUrl"},{"type":"long","name":"added"},{"type":"string","name":"countryIsoCode"},{"type":"string","name":"regionName"},{"type":"string","name":"channel"},{"type":"string","name":"flags"},{"type":"long","name":"delta"},{"type":"string","name":"isUnpatrolled"},{"type":"string","name":"isNew"},{"type":"double","name":"deltaBucket"},{"type":"string","name":"isMinor"},{"type":"string","name":"isAnonymous"},{"type":"long","name":"deleted"},{"type":"string","name":"cityName"},{"type":"long","name":"metroCode"},{"type":"string","name":"namespace"},{"type":"string","name":"comment"},{"type":"string","name":"page"},{"type":"long","name":"commentLength"},{"type":"string","name":"countryName"},{"type":"string","name":"user"},{"type":"string","name":"regionIsoCode"}]'
+                  )
+                )
+                """,
             LocalFileExportStorageProvider.TYPE_NAME,
             cluster.getTestFolder().getOrCreateFolder("msq-export").getAbsolutePath(),
             Resources.DataFile.tinyWiki1Json().getAbsolutePath()
@@ -210,16 +212,18 @@ public class BasicAuthMSQTest extends EmbeddedClusterTestBase
 
     String exportQuery =
         StringUtils.format(
-            "INSERT INTO extern(%s(exportPath => '%s'))\n"
-            + "AS CSV\n"
-            + "SELECT page, added, delta\n"
-            + "FROM TABLE(\n"
-            + "  EXTERN(\n"
-            + "    '{\"type\":\"local\",\"files\":[\"%s\"]}',\n"
-            + "    '{\"type\":\"json\"}',\n"
-            + "    '[{\"type\":\"string\",\"name\":\"timestamp\"},{\"type\":\"string\",\"name\":\"isRobot\"},{\"type\":\"string\",\"name\":\"diffUrl\"},{\"type\":\"long\",\"name\":\"added\"},{\"type\":\"string\",\"name\":\"countryIsoCode\"},{\"type\":\"string\",\"name\":\"regionName\"},{\"type\":\"string\",\"name\":\"channel\"},{\"type\":\"string\",\"name\":\"flags\"},{\"type\":\"long\",\"name\":\"delta\"},{\"type\":\"string\",\"name\":\"isUnpatrolled\"},{\"type\":\"string\",\"name\":\"isNew\"},{\"type\":\"double\",\"name\":\"deltaBucket\"},{\"type\":\"string\",\"name\":\"isMinor\"},{\"type\":\"string\",\"name\":\"isAnonymous\"},{\"type\":\"long\",\"name\":\"deleted\"},{\"type\":\"string\",\"name\":\"cityName\"},{\"type\":\"long\",\"name\":\"metroCode\"},{\"type\":\"string\",\"name\":\"namespace\"},{\"type\":\"string\",\"name\":\"comment\"},{\"type\":\"string\",\"name\":\"page\"},{\"type\":\"long\",\"name\":\"commentLength\"},{\"type\":\"string\",\"name\":\"countryName\"},{\"type\":\"string\",\"name\":\"user\"},{\"type\":\"string\",\"name\":\"regionIsoCode\"}]'\n"
-            + "  )\n"
-            + ")\n",
+            """
+                INSERT INTO extern(%s(exportPath => '%s'))
+                AS CSV
+                SELECT page, added, delta
+                FROM TABLE(
+                  EXTERN(
+                    '{"type":"local","files":["%s"]}',
+                    '{"type":"json"}',
+                    '[{"type":"string","name":"timestamp"},{"type":"string","name":"isRobot"},{"type":"string","name":"diffUrl"},{"type":"long","name":"added"},{"type":"string","name":"countryIsoCode"},{"type":"string","name":"regionName"},{"type":"string","name":"channel"},{"type":"string","name":"flags"},{"type":"long","name":"delta"},{"type":"string","name":"isUnpatrolled"},{"type":"string","name":"isNew"},{"type":"double","name":"deltaBucket"},{"type":"string","name":"isMinor"},{"type":"string","name":"isAnonymous"},{"type":"long","name":"deleted"},{"type":"string","name":"cityName"},{"type":"long","name":"metroCode"},{"type":"string","name":"namespace"},{"type":"string","name":"comment"},{"type":"string","name":"page"},{"type":"long","name":"commentLength"},{"type":"string","name":"countryName"},{"type":"string","name":"user"},{"type":"string","name":"regionIsoCode"}]'
+                  )
+                )
+                """,
             LocalFileExportStorageProvider.TYPE_NAME,
             new File(exportDirectory.get(), dataSource).getAbsolutePath(),
             Resources.DataFile.tinyWiki1Json()
@@ -258,7 +262,7 @@ public class BasicAuthMSQTest extends EmbeddedClusterTestBase
    * Asserts that submitting the SQL as an unauthorized user fails with 403 Forbidden. Retries on a
    * transient 401 (authentication not yet propagated); 403 is the expected result, so it is not.
    */
-  private void verifySqlSubmitFailsWith403Forbidden(String sql) throws Exception
+  private void verifySqlSubmitFailsWith403Forbidden(String sql)
   {
     try {
       RetryUtils.retry(

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/auth/BasicAuthMSQTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/auth/BasicAuthMSQTest.java
@@ -126,7 +126,7 @@ public class BasicAuthMSQTest extends EmbeddedClusterTestBase
   }
 
   @Test
-  public void testIngestionWithoutPermissions() throws Exception
+  public void testIngestionWithoutPermissions()
   {
     List<ResourceAction> permissions = ImmutableList.of();
     securityClient.setPermissionsToRole(ROLE_1, permissions);
@@ -162,7 +162,7 @@ public class BasicAuthMSQTest extends EmbeddedClusterTestBase
   }
 
   @Test
-  public void testExportWithoutPermissions() throws Exception
+  public void testExportWithoutPermissions()
   {
     // No external write permissions for s3
     List<ResourceAction> permissions = ImmutableList.of(

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/auth/BasicAuthMSQTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/auth/BasicAuthMSQTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.testing.embedded.auth;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.error.ExceptionMatcher;
+import org.apache.druid.java.util.common.RetryUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.metadata.DefaultPasswordProvider;
 import org.apache.druid.query.http.ClientSqlQuery;
@@ -57,6 +58,13 @@ public class BasicAuthMSQTest extends EmbeddedClusterTestBase
   public static final String USER_1 = "user1";
   public static final String ROLE_1 = "role1";
   public static final String USER_1_PASSWORD = "password1";
+
+  /**
+   * Attempts allowed for a request while basic-auth changes reach the Broker, which the
+   * Coordinator propagates asynchronously (a push plus a poll every
+   * {@code druid.auth.basic.common.pollingPeriod}).
+   */
+  private static final int AUTH_PROPAGATION_ATTEMPTS = 5;
 
   private SecurityClient securityClient;
   private EmbeddedServiceClient userClient;
@@ -119,7 +127,7 @@ public class BasicAuthMSQTest extends EmbeddedClusterTestBase
   }
 
   @Test
-  public void testIngestionWithoutPermissions()
+  public void testIngestionWithoutPermissions() throws Exception
   {
     List<ResourceAction> permissions = ImmutableList.of();
     securityClient.setPermissionsToRole(ROLE_1, permissions);
@@ -134,7 +142,7 @@ public class BasicAuthMSQTest extends EmbeddedClusterTestBase
   }
 
   @Test
-  public void testIngestionWithPermissions()
+  public void testIngestionWithPermissions() throws Exception
   {
     List<ResourceAction> permissions = ImmutableList.of(
         new ResourceAction(new Resource(".*", "DATASOURCE"), Action.READ),
@@ -150,16 +158,12 @@ public class BasicAuthMSQTest extends EmbeddedClusterTestBase
         Resources.DataFile.tinyWiki1Json()
     );
 
-    final SqlTaskStatus taskStatus = userClient.onAnyBroker(
-        b -> b.submitSqlTask(
-            new ClientSqlQuery(queryLocal, null, false, false, false, Map.of(), List.of())
-        )
-    );
+    final SqlTaskStatus taskStatus = submitSqlTaskWhenAuthorized(queryLocal);
     cluster.callApi().waitForTaskToSucceed(taskStatus.getTaskId(), overlord);
   }
 
   @Test
-  public void testExportWithoutPermissions()
+  public void testExportWithoutPermissions() throws Exception
   {
     // No external write permissions for s3
     List<ResourceAction> permissions = ImmutableList.of(
@@ -192,7 +196,7 @@ public class BasicAuthMSQTest extends EmbeddedClusterTestBase
   }
 
   @Test
-  public void testExportWithPermissions()
+  public void testExportWithPermissions() throws Exception
   {
     // No external write permissions for s3
     List<ResourceAction> permissions = ImmutableList.of(
@@ -221,26 +225,70 @@ public class BasicAuthMSQTest extends EmbeddedClusterTestBase
             Resources.DataFile.tinyWiki1Json()
         );
 
-    final SqlTaskStatus taskStatus = userClient.onAnyBroker(
-        b -> b.submitSqlTask(
-            new ClientSqlQuery(exportQuery, null, false, false, false, Map.of(), List.of())
-        )
-    );
+    final SqlTaskStatus taskStatus = submitSqlTaskWhenAuthorized(exportQuery);
     cluster.callApi().waitForTaskToSucceed(taskStatus.getTaskId(), overlord);
   }
 
-  private void verifySqlSubmitFailsWith403Forbidden(String sql)
+  /**
+   * Submits an MSQ task to an arbitrary Broker as {@link #USER_1}.
+   */
+  private SqlTaskStatus submitSqlTaskAsUser(String sql)
   {
-    MatcherAssert.assertThat(
-        Assertions.assertThrows(
-            Exception.class,
-            () -> userClient.onAnyBroker(
-                b -> b.submitSqlTask(
-                    new ClientSqlQuery(sql, null, false, false, false, Map.of(), List.of())
-                )
-            )
-        ),
-        ExceptionMatcher.of(Exception.class).expectMessageContains("403 Forbidden")
+    return userClient.onAnyBroker(
+        b -> b.submitSqlTask(
+            new ClientSqlQuery(sql, null, false, false, false, Map.of(), List.of())
+        )
     );
+  }
+
+  /**
+   * Submits an MSQ task as {@link #USER_1}, retrying on a transient 401/403 while the Broker's
+   * auth cache catches up with the test setup.
+   */
+  private SqlTaskStatus submitSqlTaskWhenAuthorized(String sql) throws Exception
+  {
+    return RetryUtils.retry(
+        () -> submitSqlTaskAsUser(sql),
+        BasicAuthMSQTest::isTransientAuthFailure,
+        AUTH_PROPAGATION_ATTEMPTS
+    );
+  }
+
+  /**
+   * Asserts that submitting the SQL as an unauthorized user fails with 403 Forbidden. Retries on a
+   * transient 401 (authentication not yet propagated); 403 is the expected result, so it is not.
+   */
+  private void verifySqlSubmitFailsWith403Forbidden(String sql) throws Exception
+  {
+    try {
+      RetryUtils.retry(
+          () -> submitSqlTaskAsUser(sql),
+          e -> messageContains(e, "401 Unauthorized"),
+          AUTH_PROPAGATION_ATTEMPTS
+      );
+      Assertions.fail("Expected submit to fail with 403 Forbidden");
+    }
+    catch (Exception e) {
+      MatcherAssert.assertThat(e, ExceptionMatcher.of(Exception.class).expectMessageContains("403 Forbidden"));
+    }
+  }
+
+  /**
+   * Whether the error is a transient 401 (new user) or 403 (new permission) from the Broker's
+   * auth cache lagging behind the test setup.
+   */
+  private static boolean isTransientAuthFailure(Throwable t)
+  {
+    return messageContains(t, "401 Unauthorized") || messageContains(t, "403 Forbidden");
+  }
+
+  private static boolean messageContains(Throwable t, String text)
+  {
+    for (Throwable cause = t; cause != null; cause = cause.getCause()) {
+      if (cause.getMessage() != null && cause.getMessage().contains(text)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/auth/BasicAuthMSQTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/auth/BasicAuthMSQTest.java
@@ -267,7 +267,7 @@ public class BasicAuthMSQTest extends EmbeddedClusterTestBase
     try {
       RetryUtils.retry(
           () -> submitSqlTaskAsUser(sql),
-          e -> messageContains(e, "401 Unauthorized"),
+          e -> failedWithHttpError(e, "401 Unauthorized"),
           AUTH_PROPAGATION_ATTEMPTS
       );
       Assertions.fail("Expected submit to fail with 403 Forbidden");
@@ -283,16 +283,11 @@ public class BasicAuthMSQTest extends EmbeddedClusterTestBase
    */
   private static boolean isTransientAuthFailure(Throwable t)
   {
-    return messageContains(t, "401 Unauthorized") || messageContains(t, "403 Forbidden");
+    return failedWithHttpError(t, "401 Unauthorized") || failedWithHttpError(t, "403 Forbidden");
   }
 
-  private static boolean messageContains(Throwable t, String text)
+  private static boolean failedWithHttpError(Throwable t, String httpError)
   {
-    for (Throwable cause = t; cause != null; cause = cause.getCause()) {
-      if (cause.getMessage() != null && cause.getMessage().contains(text)) {
-        return true;
-      }
-    }
-    return false;
+    return ExceptionMatcher.of(Exception.class).expectMessageContains(httpError).matches(t);
   }
 }

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/auth/BasicAuthMSQTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/auth/BasicAuthMSQTest.java
@@ -60,9 +60,8 @@ public class BasicAuthMSQTest extends EmbeddedClusterTestBase
   public static final String USER_1_PASSWORD = "password1";
 
   /**
-   * Attempts allowed for a request while basic-auth changes reach the Broker, which the
-   * Coordinator propagates asynchronously (a push plus a poll every
-   * {@code druid.auth.basic.common.pollingPeriod}).
+   * Attempts allowed for a request while basic-auth changes reach the broker, which the
+   * coordinator then propagates asynchronously.
    */
   private static final int AUTH_PROPAGATION_ATTEMPTS = 5;
 


### PR DESCRIPTION
### Description

`BasicAuthMSQTest` is intermittently flaky: a test occasionally fails with `401 Unauthorized` instead of the expected `403 Forbidden`.

The permission updates in the tests are eventually consistent, but propagate to other services (like the broker) asynchronously, so the MSQ task in the test can reach the Broker before its auth cache has caught up.

### Fix

Retry the task submission while it fails with a transient auth errors, so the assertions only run once the Broker's auth cache reflects the test setup. Other failures are not retried, so genuine errors still fail fast. This follows the retry-on-propagation pattern already used by sibling tests (e.g. `TLSTest`).

Verified by compiling, running checkstyle, and running the test; a fault-injection run that forces a transient `401` then `403` confirms the retries fire and all four tests recover.

_Analysis and implementation done with the help of Claude Code._

<hr>

This PR has:

- [x] been self-reviewed.
