### PR TITLE
feat: clustered segments + MSQ compaction

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
@@ -660,6 +660,8 @@ public abstract class AbstractBatchIndexTask extends AbstractTask
           transformSpec,
           tuningConfig.getIndexSpec(),
           granularitySpec,
+          null,
+          ingestionSpec.getDataSchema().getBaseTable(),
           ingestionSpec.getDataSchema().getProjections()
       );
     } else {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -39,6 +39,7 @@ import org.apache.druid.collections.ResourceHolder;
 import org.apache.druid.common.guava.FutureUtils;
 import org.apache.druid.data.input.SplitHintSpec;
 import org.apache.druid.data.input.impl.AggregateProjectionSpec;
+import org.apache.druid.data.input.impl.BaseTableProjectionSpec;
 import org.apache.druid.data.input.impl.DimensionSchema;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
@@ -49,6 +50,7 @@ import org.apache.druid.indexer.Checks;
 import org.apache.druid.indexer.Property;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexer.granularity.GranularitySpec;
+import org.apache.druid.indexer.granularity.SegmentGranularitySpec;
 import org.apache.druid.indexer.granularity.UniformGranularitySpec;
 import org.apache.druid.indexer.partitions.DimensionRangePartitionsSpec;
 import org.apache.druid.indexer.partitions.PartitionsSpec;
@@ -169,6 +171,8 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
   @Nullable
   private final List<AggregateProjectionSpec> projections;
   @Nullable
+  private final BaseTableProjectionSpec baseTable;
+  @Nullable
   private final CompactionTuningConfig tuningConfig;
   @Nullable
   private final CompactionRunner compactionRunner;
@@ -191,6 +195,7 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
       @JsonProperty("metricsSpec") @Nullable final AggregatorFactory[] metricsSpec,
       @JsonProperty("segmentGranularity") @Deprecated @Nullable final Granularity segmentGranularity,
       @JsonProperty("granularitySpec") @Nullable final ClientCompactionTaskGranularitySpec granularitySpec,
+      @JsonProperty("baseTable") @Nullable final BaseTableProjectionSpec baseTable,
       @JsonProperty("projections") @Nullable List<AggregateProjectionSpec> projections,
       @JsonProperty("tuningConfig") @Nullable final TuningConfig tuningConfig,
       @JsonProperty("context") @Nullable final Map<String, Object> context,
@@ -263,6 +268,7 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
       this.granularitySpec = granularitySpec;
     }
     this.projections = projections;
+    this.baseTable = baseTable;
     this.tuningConfig = tuningConfig != null ? getTuningConfig(tuningConfig) : null;
     this.segmentProvider = new SegmentProvider(dataSource, this.ioConfig.getInputSpec());
     // Note: The default compactionRunnerType used here should match the default runner used in CompactSegments#run
@@ -429,6 +435,13 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
     return projections;
   }
 
+  @Nullable
+  @JsonProperty
+  public BaseTableProjectionSpec getBaseTable()
+  {
+    return baseTable;
+  }
+
   @JsonProperty
   public CompactionRunner getCompactionRunner()
   {
@@ -551,6 +564,7 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
         metricsSpec,
         granularitySpec,
         projections,
+        baseTable,
         getMetricBuilder(),
         this.identifyMultiValuedDimensions()
     );
@@ -586,6 +600,7 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
       @Nullable final AggregatorFactory[] metricsSpec,
       @Nullable final ClientCompactionTaskGranularitySpec granularitySpec,
       @Nullable final List<AggregateProjectionSpec> projections,
+      @Nullable final BaseTableProjectionSpec baseTable,
       final ServiceMetricEvent.Builder metricBuilder,
       boolean needMultiValuedColumns
   ) throws IOException
@@ -681,6 +696,7 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
             ? new ClientCompactionTaskGranularitySpec(segmentGranularityToUse, null, null)
             : granularitySpec.withSegmentGranularity(segmentGranularityToUse),
             projections,
+            baseTable,
             needMultiValuedColumns
         );
         final QuerySegmentSpec querySegmentSpec;
@@ -729,6 +745,7 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
           metricsSpec,
           granularitySpec,
           projections,
+          baseTable,
           needMultiValuedColumns
       );
       final QuerySegmentSpec querySegmentSpec;
@@ -777,9 +794,30 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
       @Nullable AggregatorFactory[] metricsSpec,
       @Nonnull ClientCompactionTaskGranularitySpec granularitySpec,
       @Nullable List<AggregateProjectionSpec> projections,
+      @Nullable BaseTableProjectionSpec baseTable,
       boolean needMultiValuedColumns
   )
   {
+    if (baseTable != null) {
+      // BaseTable mode: the spec owns dimensions/metrics and (via its query-granularity virtual column) query
+      // granularity; segment granularity + intervals are the compaction config's. Attach the config's query
+      // granularity up front (a no-op if absent/NONE); the generator's incremental index applies it at build time.
+      // Existing-segment analysis (dims/metrics/rollup inference) is bypassed — the spec is authoritative.
+      final BaseTableProjectionSpec baseTableSpec =
+          baseTable.withQueryGranularity(granularitySpec.getQueryGranularity());
+      return CombinedDataSchema.forBaseTable(
+          dataSource,
+          new TimestampSpec(ColumnHolder.TIME_COLUMN_NAME, "millis", null),
+          new SegmentGranularitySpec(
+              Preconditions.checkNotNull(granularitySpec.getSegmentGranularity(), "segmentGranularity"),
+              Collections.singletonList(totalInterval)
+          ),
+          transformSpec == null ? null : new TransformSpec(transformSpec.getFilter(), null),
+          projections,
+          baseTableSpec
+      );
+    }
+
     // Check index metadata & decide which values to propagate (i.e. carry over) for rollup & queryGranularity
     final ExistingSegmentAnalyzer existingSegmentAnalyzer = new ExistingSegmentAnalyzer(
         segments,
@@ -1389,6 +1427,8 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
     private CompactionRunner compactionRunner;
     @Nullable
     private List<AggregateProjectionSpec> projections;
+    @Nullable
+    private BaseTableProjectionSpec baseTable;
 
     public Builder(
         String dataSource,
@@ -1492,6 +1532,12 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
       return this;
     }
 
+    public Builder baseTable(@Nullable BaseTableProjectionSpec baseTable)
+    {
+      this.baseTable = baseTable;
+      return this;
+    }
+
     public CompactionTask build()
     {
       return new CompactionTask(
@@ -1507,6 +1553,7 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
           metricsSpec,
           segmentGranularity,
           granularitySpec,
+          baseTable,
           projections,
           tuningConfig,
           context,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/NativeCompactionRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/NativeCompactionRunner.java
@@ -95,6 +95,12 @@ public class NativeCompactionRunner implements CompactionRunner
       Map<QuerySegmentSpec, DataSchema> inputSchemas
   )
   {
+    if (compactionTask.getBaseTable() != null) {
+      return CompactionConfigValidationResult.failure(
+          "Compaction engine[native] does not support 'baseTable'; use the MSQ compaction engine."
+      );
+    }
+
     // Virtual columns in filter rules are not supported by native compaction
     if (compactionTask.getTransformSpec() != null
         && compactionTask.getTransformSpec().getVirtualColumns() != null

--- a/indexing-service/src/main/java/org/apache/druid/indexing/compact/CascadingReindexingTemplate.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/compact/CascadingReindexingTemplate.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.druid.client.indexing.ClientCompactionRunnerInfo;
 import org.apache.druid.data.input.impl.AggregateProjectionSpec;
+import org.apache.druid.data.input.impl.BaseTableProjectionSpec;
 import org.apache.druid.error.InvalidInput;
 import org.apache.druid.indexer.CompactionEngine;
 import org.apache.druid.indexer.partitions.PartitionsSpec;
@@ -888,6 +889,13 @@ public class CascadingReindexingTemplate implements CompactionJobTemplate, DataS
   public List<AggregateProjectionSpec> getProjections()
   {
     return List.of();
+  }
+
+  @Nullable
+  @Override
+  public BaseTableProjectionSpec getBaseTable()
+  {
+    return null;
   }
 
   @Nullable

--- a/indexing-service/src/main/java/org/apache/druid/indexing/compact/ReindexingConfigBuilder.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/compact/ReindexingConfigBuilder.java
@@ -275,6 +275,10 @@ class ReindexingConfigBuilder
       builder.withProjections(dataSchemaRule.getProjections());
     }
 
+    if (dataSchemaRule.getBaseTable() != null) {
+      builder.withBaseTable(dataSchemaRule.getBaseTable());
+    }
+
     if (dataSchemaRule.getQueryGranularity() != null || dataSchemaRule.getRollup() != null) {
       builder.withQueryGranularityAndRollup(
           dataSchemaRule.getQueryGranularity(),

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientCompactionTaskQuerySerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientCompactionTaskQuerySerdeTest.java
@@ -35,7 +35,10 @@ import org.apache.druid.client.indexing.ClientCompactionTaskQuery;
 import org.apache.druid.client.indexing.ClientCompactionTaskQueryTuningConfig;
 import org.apache.druid.client.indexing.ClientTaskQuery;
 import org.apache.druid.data.input.SegmentsSplitHintSpec;
+import org.apache.druid.data.input.impl.ClusteredValueGroupsBaseTableProjectionSpec;
 import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.LongDimensionSchema;
+import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.guice.GuiceAnnotationIntrospector;
 import org.apache.druid.guice.GuiceInjectableValues;
 import org.apache.druid.guice.GuiceInjectors;
@@ -153,6 +156,42 @@ public class ClientCompactionTaskQuerySerdeTest
 
     expected.getContext().put(LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.NONE.toString());
     Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testClientCompactionTaskQueryBaseTableSerde() throws IOException
+  {
+    final ClusteredValueGroupsBaseTableProjectionSpec baseTable =
+        ClusteredValueGroupsBaseTableProjectionSpec.builder()
+                                                   .columns(
+                                                       new StringDimensionSchema("tenant"),
+                                                       new LongDimensionSchema("__time")
+                                                   )
+                                                   .clusteringColumns("tenant")
+                                                   .build();
+    final ClientCompactionTaskQuery query = new ClientCompactionTaskQuery(
+        "id",
+        "datasource",
+        new ClientCompactionIOConfig(
+            new ClientCompactionIntervalSpec(Intervals.of("2019/2020"), "testSha256OfSortedSegmentIds"),
+            true
+        ),
+        null,
+        null,
+        null,
+        null,
+        null,
+        baseTable,
+        null,
+        ImmutableMap.of(),
+        new ClientCompactionRunnerInfo(CompactionEngine.MSQ)
+    );
+
+    final byte[] json = MAPPER.writeValueAsBytes(query);
+    final ClientCompactionTaskQuery actual = (ClientCompactionTaskQuery) MAPPER.readValue(json, ClientTaskQuery.class);
+
+    Assert.assertEquals(baseTable, actual.getBaseTable());
+    Assert.assertEquals(query, actual);
   }
 
   private static ObjectMapper setupInjectablesInObjectMapper(ObjectMapper objectMapper)
@@ -329,6 +368,7 @@ public class ClientCompactionTaskQuerySerdeTest
         new ClientCompactionTaskDimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("ts", "dim"))),
         METRICS_SPEC,
         transformSpec,
+        null,
         null,
         context,
         new ClientCompactionRunnerInfo(CompactionEngine.NATIVE)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskParallelRunTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskParallelRunTest.java
@@ -210,6 +210,8 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
               true,
               ImmutableList.of(segment.getInterval())
           ),
+          null,
+          null,
           null
       );
       Assert.assertEquals("Compaction state for " + segment.getId(), expectedState, segment.getLastCompactionState());
@@ -258,6 +260,8 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
               true,
               ImmutableList.of(segment.getInterval())
           ),
+          null,
+          null,
           null
       );
       Assert.assertEquals("Compaction state for " + segment.getId(), expectedState, segment.getLastCompactionState());
@@ -321,6 +325,8 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
               true,
               ImmutableList.of(segment.getInterval())
           ),
+          null,
+          null,
           null
       );
       Assert.assertEquals("Compaction state for " + segment.getId(), expectedState, segment.getLastCompactionState());
@@ -374,6 +380,8 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
               true,
               ImmutableList.of(Intervals.of("2014-01-01T00:00:00Z/2014-01-01T03:00:00Z"))
           ),
+          null,
+          null,
           null
       );
       Assert.assertEquals("Compaction state for " + segment.getId(), expectedState, segment.getLastCompactionState());
@@ -425,6 +433,8 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
               true,
               ImmutableList.of(segment.getInterval())
           ),
+          null,
+          null,
           null
       );
       Assert.assertEquals("Compaction state for " + segment.getId(), expectedState, segment.getLastCompactionState());
@@ -473,6 +483,8 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
               true,
               ImmutableList.of(segment.getInterval())
           ),
+          null,
+          null,
           null
       );
       Assert.assertEquals("Compaction state for " + segment.getId(), expectedState, segment.getLastCompactionState());
@@ -524,6 +536,8 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
               true,
               ImmutableList.of(segment.getInterval())
           ),
+          null,
+          null,
           null
       );
       Assert.assertEquals("Compaction state for " + segment.getId(), expectedState, segment.getLastCompactionState());
@@ -605,6 +619,8 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
               true,
               ImmutableList.of(segment.getInterval())
           ),
+          null,
+          null,
           null
       );
       Assert.assertEquals("Compaction state for " + segment.getId(), expectedState, segment.getLastCompactionState());
@@ -660,6 +676,8 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
               true,
               ImmutableList.of(segment.getInterval())
           ),
+          null,
+          null,
           null
       );
       Assert.assertEquals("Compaction state for " + segment.getId(), expectedState, segment.getLastCompactionState());
@@ -936,6 +954,8 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
               true,
               ImmutableList.of(segment.getInterval())
           ),
+          null,
+          null,
           ImmutableList.of(PROJECTION_SPEC)
       );
       Assert.assertEquals("Compaction state for " + segment.getId(), expectedState, segment.getLastCompactionState());
@@ -995,6 +1015,8 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
               true,
               ImmutableList.of(segment.getInterval())
           ),
+          null,
+          null,
           ImmutableList.of(PROJECTION_SPEC, addProjection)
       );
       Assert.assertEquals("Compaction state for " + segment.getId(), expectedState, segment.getLastCompactionState());

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunBase.java
@@ -674,6 +674,8 @@ public abstract class CompactionTaskRunBase
         null,
         expected.getIndexSpec(),
         expected.getGranularitySpec().withIntervals(List.of()),
+        null,
+        null,
         expected.getProjections()
     ), new CompactionState(
         actual.getPartitionsSpec(),
@@ -682,6 +684,8 @@ public abstract class CompactionTaskRunBase
         null,
         actual.getIndexSpec(),
         actual.getGranularitySpec().withIntervals(List.of()),
+        null,
+        null,
         actual.getProjections()
     ));
   }
@@ -1892,6 +1896,8 @@ public abstract class CompactionTaskRunBase
             true,
             intervals
         ),
+        null,
+        null,
         null
     );
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
@@ -803,6 +803,7 @@ public class CompactionTaskTest
         null,
         null,
         null,
+        null,
         METRIC_BUILDER,
         false
     );
@@ -861,6 +862,7 @@ public class CompactionTaskTest
         toolbox,
         LockGranularity.TIME_CHUNK,
         new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null)),
+        null,
         null,
         null,
         null,
@@ -930,6 +932,7 @@ public class CompactionTaskTest
         null,
         null,
         null,
+        null,
         METRIC_BUILDER,
         false
     );
@@ -990,6 +993,7 @@ public class CompactionTaskTest
         toolbox,
         LockGranularity.TIME_CHUNK,
         new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null)),
+        null,
         null,
         null,
         null,
@@ -1067,6 +1071,7 @@ public class CompactionTaskTest
         null,
         null,
         null,
+        null,
         METRIC_BUILDER,
         false
     );
@@ -1119,6 +1124,7 @@ public class CompactionTaskTest
         customMetricsSpec,
         null,
         null,
+        null,
         METRIC_BUILDER,
         false
     );
@@ -1159,6 +1165,7 @@ public class CompactionTaskTest
         toolbox,
         LockGranularity.TIME_CHUNK,
         new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null)),
+        null,
         null,
         null,
         null,
@@ -1216,6 +1223,7 @@ public class CompactionTaskTest
         null,
         null,
         null,
+        null,
         METRIC_BUILDER,
         false
     );
@@ -1242,6 +1250,7 @@ public class CompactionTaskTest
         toolbox,
         LockGranularity.TIME_CHUNK,
         new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null)),
+        null,
         null,
         null,
         null,
@@ -1290,6 +1299,7 @@ public class CompactionTaskTest
         null,
         new ClientCompactionTaskGranularitySpec(new PeriodGranularity(Period.months(3), null, null), null, null),
         null,
+        null,
         METRIC_BUILDER,
         false
     );
@@ -1335,6 +1345,7 @@ public class CompactionTaskTest
         null,
         null,
         new ClientCompactionTaskGranularitySpec(null, new PeriodGranularity(Period.months(3), null, null), null),
+        null,
         null,
         METRIC_BUILDER,
         false
@@ -1383,6 +1394,7 @@ public class CompactionTaskTest
             null
         ),
         null,
+        null,
         METRIC_BUILDER,
         false
     );
@@ -1427,6 +1439,7 @@ public class CompactionTaskTest
         toolbox,
         LockGranularity.TIME_CHUNK,
         new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null)),
+        null,
         null,
         null,
         null,
@@ -1479,6 +1492,7 @@ public class CompactionTaskTest
         null,
         new ClientCompactionTaskGranularitySpec(null, null, null),
         null,
+        null,
         METRIC_BUILDER,
         false
     );
@@ -1526,6 +1540,7 @@ public class CompactionTaskTest
         null,
         new ClientCompactionTaskGranularitySpec(null, null, true),
         null,
+        null,
         METRIC_BUILDER,
         false
     );
@@ -1557,6 +1572,7 @@ public class CompactionTaskTest
         null,
         null,
         new ClientCompactionTaskGranularitySpec(null, null, null),
+        null,
         null,
         METRIC_BUILDER,
         false
@@ -1591,6 +1607,7 @@ public class CompactionTaskTest
         null,
         null,
         new ClientCompactionTaskGranularitySpec(null, null, null),
+        null,
         null,
         METRIC_BUILDER,
         true

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskBuilder.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskBuilder.java
@@ -449,6 +449,7 @@ public abstract class TaskBuilder<
           segmentGranularity,
           granularitySpec,
           null,
+          null,
           tuningConfig.build(),
           null,
           null,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/compact/CascadingReindexingTemplateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/compact/CascadingReindexingTemplateTest.java
@@ -727,7 +727,7 @@ public class CascadingReindexingTemplateTest extends InitializedNullHandlingTest
 
     ReindexingRuleProvider provider = InlineReindexingRuleProvider.builder()
         .dataSchemaRules(List.of(
-            new ReindexingDataSchemaRule("metrics-8d", null, Period.days(8), null, new AggregatorFactory[0], null, null, null),
+            new ReindexingDataSchemaRule("metrics-8d", null, Period.days(8), null, new AggregatorFactory[0], null, null, null, null),
             createReindexingDataSchemaRule("metrics-8d", Period.days(8)),
             createReindexingDataSchemaRule("metrics-14d", Period.days(14)),
             createReindexingDataSchemaRule("metrics-45d", Period.days(45))
@@ -824,9 +824,9 @@ public class CascadingReindexingTemplateTest extends InitializedNullHandlingTest
     ReindexingRuleProvider provider = InlineReindexingRuleProvider.builder()
         .partitioningRules(List.of(monthRule, dayRule))
         .dataSchemaRules(List.of(
-            new ReindexingDataSchemaRule("metrics-7d", null, Period.days(7), null, new AggregatorFactory[0], null, null, null),
-            new ReindexingDataSchemaRule("metrics-14d", null, Period.days(14), null, new AggregatorFactory[0], null, null, null),
-            new ReindexingDataSchemaRule("metrics-21d", null, Period.days(21), null, new AggregatorFactory[0], null, null, null)
+            new ReindexingDataSchemaRule("metrics-7d", null, Period.days(7), null, new AggregatorFactory[0], null, null, null, null),
+            new ReindexingDataSchemaRule("metrics-14d", null, Period.days(14), null, new AggregatorFactory[0], null, null, null, null),
+            new ReindexingDataSchemaRule("metrics-21d", null, Period.days(21), null, new AggregatorFactory[0], null, null, null, null)
         ))
         .build();
 
@@ -932,9 +932,9 @@ public class CascadingReindexingTemplateTest extends InitializedNullHandlingTest
             .builder()
             .partitioningRules(List.of(yearRule, monthRule, dayRule))
             .dataSchemaRules(List.of(
-                new ReindexingDataSchemaRule("metrics-1d", null, Period.days(1), null, new AggregatorFactory[0], null, null, null),
-                new ReindexingDataSchemaRule("metrics-14d", null, Period.days(14), null, new AggregatorFactory[0], null, null, null),
-                new ReindexingDataSchemaRule("metrics-45d", null, Period.days(45), null, new AggregatorFactory[0], null, null, null)
+                new ReindexingDataSchemaRule("metrics-1d", null, Period.days(1), null, new AggregatorFactory[0], null, null, null, null),
+                new ReindexingDataSchemaRule("metrics-14d", null, Period.days(14), null, new AggregatorFactory[0], null, null, null, null),
+                new ReindexingDataSchemaRule("metrics-45d", null, Period.days(45), null, new AggregatorFactory[0], null, null, null, null)
             ))
             .build();
 
@@ -1072,7 +1072,7 @@ public class CascadingReindexingTemplateTest extends InitializedNullHandlingTest
     ReindexingRuleProvider provider = InlineReindexingRuleProvider.builder()
         .partitioningRules(List.of(monthRule))
         .dataSchemaRules(List.of(
-            new ReindexingDataSchemaRule("metrics-1m", null, Period.months(1), null, new AggregatorFactory[0], null, null, null)
+            new ReindexingDataSchemaRule("metrics-1m", null, Period.months(1), null, new AggregatorFactory[0], null, null, null, null)
         ))
         .build();
 
@@ -1140,7 +1140,7 @@ public class CascadingReindexingTemplateTest extends InitializedNullHandlingTest
     ReindexingRuleProvider provider = InlineReindexingRuleProvider.builder()
         .partitioningRules(List.of(dayRule))
         .dataSchemaRules(List.of(
-            new ReindexingDataSchemaRule("metrics-12h", null, Period.hours(12), null, new AggregatorFactory[0], null, null, null)
+            new ReindexingDataSchemaRule("metrics-12h", null, Period.hours(12), null, new AggregatorFactory[0], null, null, null, null)
         ))
         .build();
 
@@ -1211,8 +1211,8 @@ public class CascadingReindexingTemplateTest extends InitializedNullHandlingTest
     ReindexingRuleProvider provider = InlineReindexingRuleProvider.builder()
         .partitioningRules(List.of(dayRule))
         .dataSchemaRules(List.of(
-            new ReindexingDataSchemaRule("metrics-33d-6h", null, Period.hours(33 * 24 + 6), null, new AggregatorFactory[0], null, null, null),
-            new ReindexingDataSchemaRule("metrics-33d-18h", null, Period.hours(33 * 24 + 18), null, new AggregatorFactory[0], null, null, null)
+            new ReindexingDataSchemaRule("metrics-33d-6h", null, Period.hours(33 * 24 + 6), null, new AggregatorFactory[0], null, null, null, null),
+            new ReindexingDataSchemaRule("metrics-33d-18h", null, Period.hours(33 * 24 + 18), null, new AggregatorFactory[0], null, null, null, null)
         ))
         .build();
 
@@ -1507,7 +1507,7 @@ public class CascadingReindexingTemplateTest extends InitializedNullHandlingTest
                 new ReindexingPartitioningRule("day-rule", null, Period.days(90), Granularities.DAY, new DynamicPartitionsSpec(5000000, null), null)
             ))
             .dataSchemaRules(List.of(
-                new ReindexingDataSchemaRule("metrics-7d", null, Period.days(7), null, new AggregatorFactory[0], null, null, null)
+                new ReindexingDataSchemaRule("metrics-7d", null, Period.days(7), null, new AggregatorFactory[0], null, null, null, null)
             ))
             .build();
 
@@ -2013,6 +2013,7 @@ public class CascadingReindexingTemplateTest extends InitializedNullHandlingTest
         period,
         null,
         new AggregatorFactory[0],
+        null,
         null,
         null,
         null

--- a/indexing-service/src/test/java/org/apache/druid/indexing/compact/ReindexingConfigBuilderTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/compact/ReindexingConfigBuilderTest.java
@@ -21,6 +21,10 @@ package org.apache.druid.indexing.compact;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.impl.AggregateProjectionSpec;
+import org.apache.druid.data.input.impl.BaseTableProjectionSpec;
+import org.apache.druid.data.input.impl.ClusteredValueGroupsBaseTableProjectionSpec;
+import org.apache.druid.data.input.impl.LongDimensionSchema;
+import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
 import org.apache.druid.java.util.common.DateTimes;
@@ -76,6 +80,7 @@ public class ReindexingConfigBuilderTest
                     new AggregatorFactory[]{new CountAggregatorFactory("count")},
                     Granularities.HOUR,
                     true,
+                    null,
                     ImmutableList.of()
                 )
             )
@@ -137,6 +142,64 @@ public class ReindexingConfigBuilderTest
     // Verify config matches
     InlineSchemaDataSourceCompactionConfig configFromDetails = builderForDetails.build();
     Assertions.assertEquals(config.getGranularitySpec(), configFromDetails.getGranularitySpec());
+  }
+
+  @Test
+  public void test_applyTo_dataSchemaRuleWithBaseTable_appliesBaseTable()
+  {
+    final BaseTableProjectionSpec baseTable = ClusteredValueGroupsBaseTableProjectionSpec
+        .builder()
+        .columns(new StringDimensionSchema("tenant"), new LongDimensionSchema("__time"))
+        .clusteringColumns("tenant")
+        .build();
+
+    ReindexingRuleProvider provider = InlineReindexingRuleProvider.builder()
+        .dataSchemaRules(
+            ImmutableList.of(
+                new ReindexingDataSchemaRule(
+                    "schema-baseTable-30d",
+                    null,
+                    Period.days(30),
+                    null,
+                    null,
+                    null,
+                    null,
+                    baseTable,
+                    null
+                )
+            )
+        ).build();
+
+    InlineSchemaDataSourceCompactionConfig.Builder builder =
+        InlineSchemaDataSourceCompactionConfig.builder()
+                                              .forDataSource("test_datasource");
+
+    ImmutableList<IntervalPartitioningInfo> syntheticTimeline = ImmutableList.of(
+        new IntervalPartitioningInfo(
+            TEST_INTERVAL,
+            ReindexingPartitioningRule.syntheticRule(
+                Granularities.DAY,
+                new DynamicPartitionsSpec(5000000, null),
+                null
+            ),
+            true
+        )
+    );
+
+    ReindexingConfigBuilder configBuilder = new ReindexingConfigBuilder(
+        provider,
+        TEST_INTERVAL,
+        REFERENCE_TIME,
+        syntheticTimeline,
+        null
+    );
+
+    int count = configBuilder.applyTo(builder);
+
+    Assertions.assertEquals(1, count);
+
+    InlineSchemaDataSourceCompactionConfig config = builder.build();
+    Assertions.assertEquals(baseTable, config.getBaseTable());
   }
 
   @Test
@@ -634,6 +697,7 @@ public class ReindexingConfigBuilderTest
         new AggregatorFactory[]{new CountAggregatorFactory("count")},
         Granularities.HOUR,
         true,
+        null,
         ImmutableList.of(
             new AggregateProjectionSpec("proj1", null, null, null,
                                         new AggregatorFactory[]{new CountAggregatorFactory("count1")}),
@@ -650,6 +714,7 @@ public class ReindexingConfigBuilderTest
         new AggregatorFactory[]{new CountAggregatorFactory("count")},
         Granularities.HOUR,
         true,
+        null,
         ImmutableList.of(
             new AggregateProjectionSpec("proj3", null, null, null,
                                         new AggregatorFactory[]{new CountAggregatorFactory("count3")})

--- a/indexing-service/src/test/java/org/apache/druid/indexing/compact/ReindexingDeletionRuleOptimizerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/compact/ReindexingDeletionRuleOptimizerTest.java
@@ -389,6 +389,8 @@ public class ReindexingDeletionRuleOptimizerTest
         transformSpec,
         IndexSpec.getDefault(),
         null,
+        null,
+        null,
         null
     );
   }
@@ -405,6 +407,8 @@ public class ReindexingDeletionRuleOptimizerTest
         transformSpec,
         IndexSpec.getDefault(),
         null,
+        null,
+        null,
         null
     );
   }
@@ -417,6 +421,8 @@ public class ReindexingDeletionRuleOptimizerTest
         null,
         null,
         IndexSpec.getDefault(),
+        null,
+        null,
         null,
         null
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/duty/KillUnreferencedIndexingStateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/duty/KillUnreferencedIndexingStateTest.java
@@ -371,9 +371,14 @@ public class KillUnreferencedIndexingStateTest
   {
     return new CompactionState(
         new DynamicPartitionsSpec(100, null),
-        null, null, null,
+        null,
+        null,
+        null,
         IndexSpec.getDefault(),
-        null, null
+        null,
+        null,
+        null,
+        null
     );
   }
 }

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -58,6 +58,7 @@ import org.apache.druid.frame.write.InvalidFieldException;
 import org.apache.druid.frame.write.InvalidNullByteException;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.granularity.GranularitySpec;
+import org.apache.druid.indexer.granularity.SegmentGranularitySpec;
 import org.apache.druid.indexer.granularity.UniformGranularitySpec;
 import org.apache.druid.indexer.partitions.DimensionRangePartitionsSpec;
 import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
@@ -1876,13 +1877,26 @@ public class ControllerImpl implements Controller
 
     Granularity segmentGranularity = destination.getSegmentGranularity();
 
-    GranularitySpec granularitySpec = new UniformGranularitySpec(
-        segmentGranularity,
-        querySpec.getContext().getGranularity(DruidSqlInsert.SQL_INSERT_QUERY_GRANULARITY, jsonMapper),
-        dataSchema.getGranularitySpec().isRollup(),
-        // Not using dataSchema.getGranularitySpec().inputIntervals() as that always has ETERNITY
-        destination.getReplaceTimeChunks()
-    );
+    // For baseTable (clustered) mode, segment granularity + intervals live in a SegmentGranularitySpec and query
+    // granularity lives in the baseTable spec's virtual column (already recorded via dataSchema.getBaseTable()), so the
+    // legacy UniformGranularitySpec is left null. For the legacy (non-baseTable) path, the GranularitySpec carries
+    // everything as before and the SegmentGranularitySpec is left null.
+    final GranularitySpec granularitySpec;
+    final SegmentGranularitySpec segmentGranularitySpec;
+    if (dataSchema.getBaseTable() != null) {
+      // Not using dataSchema.getGranularitySpec().inputIntervals() as that always has ETERNITY
+      segmentGranularitySpec = new SegmentGranularitySpec(segmentGranularity, destination.getReplaceTimeChunks());
+      granularitySpec = null;
+    } else {
+      granularitySpec = new UniformGranularitySpec(
+          segmentGranularity,
+          querySpec.getContext().getGranularity(DruidSqlInsert.SQL_INSERT_QUERY_GRANULARITY, jsonMapper),
+          dataSchema.getGranularitySpec().isRollup(),
+          // Not using dataSchema.getGranularitySpec().inputIntervals() as that always has ETERNITY
+          destination.getReplaceTimeChunks()
+      );
+      segmentGranularitySpec = null;
+    }
 
     DimensionsSpec dimensionsSpec = dataSchema.getDimensionsSpec();
 
@@ -1916,6 +1930,8 @@ public class ControllerImpl implements Controller
         transformSpec,
         indexSpec,
         granularitySpec,
+        segmentGranularitySpec,
+        dataSchema.getBaseTable(),
         dataSchema.getProjections()
     );
   }

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQCompactionRunner.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQCompactionRunner.java
@@ -324,6 +324,19 @@ public class MSQCompactionRunner implements CompactionRunner
                                                    .getInputSpec()
                                                    .findInterval(compactionTask.getDataSource());
 
+    if (dataSchema.getBaseTable() != null) {
+      return new DataSourceMSQDestination(
+          dataSchema.getDataSource(),
+          dataSchema.getGranularitySpec().getSegmentGranularity(),
+          null,
+          ImmutableList.of(replaceInterval),
+          null,
+          dataSchema.getBaseTable(),
+          dataSchema.getProjections(),
+          null
+      );
+    }
+
     return new DataSourceMSQDestination(
         dataSchema.getDataSource(),
         dataSchema.getGranularitySpec().getSegmentGranularity(),

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/destination/DataSourceMSQDestination.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/destination/DataSourceMSQDestination.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import org.apache.druid.data.input.impl.AggregateProjectionSpec;
+import org.apache.druid.data.input.impl.BaseTableProjectionSpec;
 import org.apache.druid.data.input.impl.DimensionSchema;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.Intervals;
@@ -61,6 +62,15 @@ public class DataSourceMSQDestination implements MSQDestination
   @Nullable
   private final List<AggregateProjectionSpec> projections;
 
+  /**
+   * When set, generated segments are clustered base tables built from this spec (clustering columns + non-clustering
+   * dimensions + metrics), instead of the legacy {@link #dimensionSchemas}/aggregators shape. Query granularity is
+   * still carried separately (as a virtual column on the spec, derived from the query); see
+   * {@code SegmentGenerationUtils.makeDataSchemaForIngestion}.
+   */
+  @Nullable
+  private final BaseTableProjectionSpec baseTable;
+
   @JsonCreator
   public DataSourceMSQDestination(
       @JsonProperty("dataSource") String dataSource,
@@ -68,6 +78,7 @@ public class DataSourceMSQDestination implements MSQDestination
       @JsonProperty("segmentSortOrder") @Nullable List<String> segmentSortOrder,
       @JsonProperty("replaceTimeChunks") @Nullable List<Interval> replaceTimeChunks,
       @JsonProperty("dimensionSchemas") @Nullable Map<String, DimensionSchema> dimensionSchemas,
+      @JsonProperty("baseTable") @Nullable BaseTableProjectionSpec baseTable,
       @JsonProperty("projections") @Nullable List<AggregateProjectionSpec> projections,
       @JsonProperty("terminalStageSpec") @Nullable TerminalStageSpec terminalStageSpec
   )
@@ -79,9 +90,35 @@ public class DataSourceMSQDestination implements MSQDestination
     this.dimensionSchemas = dimensionSchemas;
     this.projections = projections;
     this.terminalStageSpec = terminalStageSpec != null ? terminalStageSpec : SegmentGenerationStageSpec.instance();
+    this.baseTable = baseTable;
 
     validateReplaceTimeChunksGranularityAligned(segmentGranularity, replaceTimeChunks);
     DataSchema.validateProjections(projections, segmentGranularity);
+  }
+
+  /**
+   * Backwards-compatible overload for callers that don't (yet) supply a {@code baseTable} spec.
+   */
+  public DataSourceMSQDestination(
+      String dataSource,
+      Granularity segmentGranularity,
+      @Nullable List<String> segmentSortOrder,
+      @Nullable List<Interval> replaceTimeChunks,
+      @Nullable Map<String, DimensionSchema> dimensionSchemas,
+      @Nullable List<AggregateProjectionSpec> projections,
+      @Nullable TerminalStageSpec terminalStageSpec
+  )
+  {
+    this(
+        dataSource,
+        segmentGranularity,
+        segmentSortOrder,
+        replaceTimeChunks,
+        dimensionSchemas,
+        null,
+        projections,
+        terminalStageSpec
+    );
   }
 
   @JsonProperty
@@ -147,6 +184,14 @@ public class DataSourceMSQDestination implements MSQDestination
     return projections;
   }
 
+  @Nullable
+  @JsonProperty
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public BaseTableProjectionSpec getBaseTable()
+  {
+    return baseTable;
+  }
+
   /**
    * Whether this object is in replace-existing-time-chunks mode.
    */
@@ -183,13 +228,14 @@ public class DataSourceMSQDestination implements MSQDestination
            && Objects.equals(replaceTimeChunks, that.replaceTimeChunks)
            && Objects.equals(dimensionSchemas, that.dimensionSchemas)
            && Objects.equals(projections, that.projections)
-           && Objects.equals(terminalStageSpec, that.terminalStageSpec);
+           && Objects.equals(terminalStageSpec, that.terminalStageSpec)
+           && Objects.equals(baseTable, that.baseTable);
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(dataSource, segmentGranularity, segmentSortOrder, replaceTimeChunks, dimensionSchemas, projections, terminalStageSpec);
+    return Objects.hash(dataSource, segmentGranularity, segmentSortOrder, replaceTimeChunks, dimensionSchemas, projections, terminalStageSpec, baseTable);
   }
 
   @Override
@@ -201,6 +247,7 @@ public class DataSourceMSQDestination implements MSQDestination
            ", segmentSortOrder=" + segmentSortOrder +
            ", replaceTimeChunks=" + replaceTimeChunks +
            ", dimensionSchemas=" + dimensionSchemas +
+           ", baseTable=" + baseTable +
            ", projections=" + projections +
            ", terminalStageSpec=" + terminalStageSpec +
            '}';

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/destination/SegmentGenerationUtils.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/destination/SegmentGenerationUtils.java
@@ -22,6 +22,7 @@ package org.apache.druid.msq.indexing.destination;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import it.unimi.dsi.fastutil.ints.IntList;
+import org.apache.druid.data.input.impl.BaseTableProjectionSpec;
 import org.apache.druid.data.input.impl.DimensionSchema;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.LongDimensionSchema;
@@ -85,20 +86,6 @@ public final class SegmentGenerationUtils
   {
     final DataSourceMSQDestination destination = (DataSourceMSQDestination) querySpec.getDestination();
     final boolean isRollupQuery = isRollupQuery(query);
-    final boolean forceSegmentSortByTime =
-        MultiStageQueryContext.isForceSegmentSortByTime(querySpec.getContext());
-
-    final NonnullPair<DimensionsSpec, List<AggregatorFactory>> dimensionsAndAggregators =
-        makeDimensionsAndAggregatorsForIngestion(
-            querySignature,
-            queryClusterBy,
-            destination.getSegmentSortOrder(),
-            forceSegmentSortByTime,
-            columnMappings,
-            isRollupQuery,
-            query,
-            destination.getDimensionSchemas()
-        );
 
     final TransformSpec transformSpec;
     if (query.getFilter() != null) {
@@ -112,6 +99,34 @@ public final class SegmentGenerationUtils
     } else {
       transformSpec = null;
     }
+
+    // base-table mode, the destination supplies the base-table shape
+    if (destination.getBaseTable() != null) {
+      final Granularity queryGranularity =
+          query.context().getGranularity(DruidSqlInsert.SQL_INSERT_QUERY_GRANULARITY, jsonMapper);
+      final BaseTableProjectionSpec baseTable =
+          destination.getBaseTable().withQueryGranularity(queryGranularity);
+      return DataSchema.builder()
+                       .withDataSource(destination.getDataSource())
+                       .withTimestamp(new TimestampSpec(ColumnHolder.TIME_COLUMN_NAME, "millis", null))
+                       .withTransform(transformSpec)
+                       .withBaseTable(baseTable)
+                       .build();
+    }
+
+    final boolean forceSegmentSortByTime =
+        MultiStageQueryContext.isForceSegmentSortByTime(querySpec.getContext());
+    final NonnullPair<DimensionsSpec, List<AggregatorFactory>> dimensionsAndAggregators =
+        makeDimensionsAndAggregatorsForIngestion(
+            querySignature,
+            queryClusterBy,
+            destination.getSegmentSortOrder(),
+            forceSegmentSortByTime,
+            columnMappings,
+            isRollupQuery,
+            query,
+            destination.getDimensionSchemas()
+        );
     return DataSchema.builder()
                      .withDataSource(destination.getDataSource())
                      .withTimestamp(new TimestampSpec(ColumnHolder.TIME_COLUMN_NAME, "millis", null))

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/destination/SegmentGenerationUtils.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/destination/SegmentGenerationUtils.java
@@ -111,6 +111,7 @@ public final class SegmentGenerationUtils
                        .withTimestamp(new TimestampSpec(ColumnHolder.TIME_COLUMN_NAME, "millis", null))
                        .withTransform(transformSpec)
                        .withBaseTable(baseTable)
+                       .withProjections(destination.getProjections())
                        .build();
     }
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQCompactionTaskRunTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQCompactionTaskRunTest.java
@@ -780,6 +780,8 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
             true,
             intervals
         ),
+        null,
+        null,
         null
     );
   }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQReplaceTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQReplaceTest.java
@@ -2922,6 +2922,8 @@ public class MSQReplaceTest extends MSQTestBase
         transformSpec,
         indexSpec,
         granularitySpec,
+        null,
+        null,
         null
     );
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQCompactionRunnerTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQCompactionRunnerTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import org.apache.druid.client.indexing.ClientCompactionTaskGranularitySpec;
 import org.apache.druid.data.input.impl.AggregateProjectionSpec;
+import org.apache.druid.data.input.impl.ClusteredValueGroupsBaseTableProjectionSpec;
 import org.apache.druid.data.input.impl.DimensionSchema;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.LongDimensionSchema;
@@ -36,6 +37,7 @@ import org.apache.druid.guice.StartupInjectorBuilder;
 import org.apache.druid.guice.security.EscalatorModule;
 import org.apache.druid.guice.security.PolicyModule;
 import org.apache.druid.indexer.TaskStatus;
+import org.apache.druid.indexer.granularity.SegmentGranularitySpec;
 import org.apache.druid.indexer.granularity.UniformGranularitySpec;
 import org.apache.druid.indexer.partitions.DimensionRangePartitionsSpec;
 import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
@@ -650,6 +652,69 @@ public class MSQCompactionRunnerTest
     Assert.assertEquals(
         PARTITION_DIMENSIONS.stream().map(OrderBy::ascending).collect(Collectors.toList()),
         scanQuery.getOrderBys()
+    );
+  }
+
+  @Test
+  public void testClusteredBaseTableWithoutMetricsProducesScanSpec() throws JsonProcessingException
+  {
+    final StringDimensionSchema tenant = new StringDimensionSchema("tenant");
+    final StringDimensionSchema region = new StringDimensionSchema("region");
+    final ClusteredValueGroupsBaseTableProjectionSpec baseTable =
+        ClusteredValueGroupsBaseTableProjectionSpec.builder()
+                                                   .columns(tenant, region, new LongDimensionSchema(ColumnHolder.TIME_COLUMN_NAME))
+                                                   .clusteringColumns("tenant")
+                                                   .build();
+
+    CompactionTask compactionTask = createCompactionTask(
+        new DynamicPartitionsSpec(TARGET_ROWS_PER_SEGMENT, null),
+        null,
+        Collections.emptyMap(),
+        new ClientCompactionTaskGranularitySpec(SEGMENT_GRANULARITY.getDefaultGranularity(), null, null),
+        null
+    );
+
+    // The input schema is built the same way CompactionTask.createDataSchema hands it to the runner in baseTable mode.
+    DataSchema dataSchema = CombinedDataSchema.forBaseTable(
+        DATA_SOURCE,
+        new TimestampSpec(TIMESTAMP_COLUMN, "millis", null),
+        new SegmentGranularitySpec(
+            SEGMENT_GRANULARITY.getDefaultGranularity(),
+            Collections.singletonList(COMPACTION_INTERVAL)
+        ),
+        null,
+        null,
+        baseTable
+    );
+
+    List<MSQControllerTask> msqControllerTasks = MSQ_COMPACTION_RUNNER.createMsqControllerTasks(
+        compactionTask,
+        Map.of(new MultipleIntervalSegmentSpec(List.of(COMPACTION_INTERVAL)), dataSchema)
+    );
+
+    MSQControllerTask msqControllerTask = Iterables.getOnlyElement(msqControllerTasks);
+    LegacyMSQSpec actualMSQSpec = msqControllerTask.getQuerySpec();
+
+    // Clustered base tables are never rollup, so the query is always a Scan, never a GroupBy.
+    Assert.assertTrue(actualMSQSpec.getQuery() instanceof ScanQuery);
+    ScanQuery scanQuery = (ScanQuery) actualMSQSpec.getQuery();
+
+    // Columns follow the spec's declared order: clustering prefix, remaining columns, then the explicit __time marker.
+    Assert.assertEquals(
+        ImmutableList.of(tenant.getName(), region.getName(), ColumnHolder.TIME_COLUMN_NAME),
+        scanQuery.getColumns()
+    );
+
+    // Destination is base-table-mode: it carries the spec and no legacy dimensionSchemas.
+    Assert.assertTrue(actualMSQSpec.getDestination() instanceof DataSourceMSQDestination);
+    DataSourceMSQDestination destination = (DataSourceMSQDestination) actualMSQSpec.getDestination();
+    Assert.assertEquals(baseTable, destination.getBaseTable());
+    Assert.assertNull(destination.getDimensionSchemas());
+
+    // Column mappings carry the same columns in declared order.
+    Assert.assertEquals(
+        ImmutableList.of(tenant.getName(), region.getName(), ColumnHolder.TIME_COLUMN_NAME),
+        actualMSQSpec.getColumnMappings().getOutputColumnNames()
     );
   }
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/destination/DataSourceMSQDestinationTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/destination/DataSourceMSQDestinationTest.java
@@ -21,10 +21,14 @@ package org.apache.druid.msq.indexing.destination;
 
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.data.input.impl.AggregateProjectionSpec;
+import org.apache.druid.data.input.impl.BaseTableProjectionSpec;
+import org.apache.druid.data.input.impl.ClusteredValueGroupsBaseTableProjectionSpec;
 import org.apache.druid.data.input.impl.DimensionSchema;
+import org.apache.druid.data.input.impl.LongDimensionSchema;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -90,8 +94,46 @@ public class DataSourceMSQDestinationTest
                                                  .build()
                       )
                   )
+                  .withPrefabValues(
+                      BaseTableProjectionSpec.class,
+                      ClusteredValueGroupsBaseTableProjectionSpec.builder()
+                                                                 .columns(new StringDimensionSchema("tenant"), new LongDimensionSchema("__time"))
+                                                                 .clusteringColumns("tenant")
+                                                                 .build(),
+                      ClusteredValueGroupsBaseTableProjectionSpec.builder()
+                                                                 .columns(new StringDimensionSchema("region"), new LongDimensionSchema("__time"))
+                                                                 .clusteringColumns("region")
+                                                                 .build()
+                  )
                   .usingGetClass()
                   .verify();
+  }
+
+  @Test
+  public void testSerdeWithBaseTable() throws JsonProcessingException
+  {
+    final ObjectMapper mapper = new DefaultObjectMapper();
+    final DataSourceMSQDestination destination = new DataSourceMSQDestination(
+        "foo",
+        Granularities.DAY,
+        null,
+        null,
+        null,
+        ClusteredValueGroupsBaseTableProjectionSpec.builder()
+                                                   .columns(
+                                                       new StringDimensionSchema("tenant"),
+                                                       new StringDimensionSchema("region"),
+                                                       new LongDimensionSchema("__time")
+                                                   )
+                                                   .clusteringColumns("tenant")
+                                                   .build(),
+        null,
+        null
+    );
+    final DataSourceMSQDestination roundTrip =
+        mapper.readValue(mapper.writeValueAsString(destination), DataSourceMSQDestination.class);
+    Assert.assertEquals(destination, roundTrip);
+    Assert.assertNotNull(roundTrip.getBaseTable());
   }
 
   @Test

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/table/DataSegmentWithLocationTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/table/DataSegmentWithLocationTest.java
@@ -89,6 +89,8 @@ public class DataSegmentWithLocationTest
         ),
         MAPPER.convertValue(Map.of(), IndexSpec.class),
         MAPPER.convertValue(Map.of(), GranularitySpec.class),
+        null,
+        null,
         null
     );
     final DataSegment segment = DataSegment.builder(segmentId)

--- a/processing/src/main/java/org/apache/druid/data/input/impl/AdaptedBaseTableProjectionSpec.java
+++ b/processing/src/main/java/org/apache/druid/data/input/impl/AdaptedBaseTableProjectionSpec.java
@@ -19,7 +19,9 @@
 
 package org.apache.druid.data.input.impl;
 
+import org.apache.druid.error.DruidException;
 import org.apache.druid.indexer.granularity.GranularitySpec;
+import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.query.OrderBy;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.segment.VirtualColumns;
@@ -90,6 +92,20 @@ public final class AdaptedBaseTableProjectionSpec implements BaseTableProjection
   public List<OrderBy> getOrdering()
   {
     return ordering;
+  }
+
+  @Override
+  public Granularity getQueryGranularity()
+  {
+    return granularitySpec.getQueryGranularity();
+  }
+
+  @Override
+  public BaseTableProjectionSpec withQueryGranularity(@Nullable Granularity queryGranularity)
+  {
+    throw DruidException.defensive(
+        "Cannot apply query granularity to a legacy DataSchema adapter"
+    );
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/data/input/impl/BaseTableProjectionSpec.java
+++ b/processing/src/main/java/org/apache/druid/data/input/impl/BaseTableProjectionSpec.java
@@ -21,8 +21,11 @@ package org.apache.druid.data.input.impl;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.query.OrderBy;
 import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.projections.BaseTableProjectionSchema;
 
@@ -59,4 +62,41 @@ public interface BaseTableProjectionSpec
   AggregatorFactory[] getMetrics();
 
   List<OrderBy> getOrdering();
+
+  /**
+   * Returns the query granularity this spec represents. By default this is read from the
+   * {@link Granularities#GRANULARITY_VIRTUAL_COLUMN_NAME} virtual column in {@link #getVirtualColumns()} (absent or
+   * undecodable means {@link Granularities#NONE}); implementations that carry query granularity elsewhere override this.
+   */
+  default Granularity getQueryGranularity()
+  {
+    final VirtualColumn granularityVirtualColumn =
+        getVirtualColumns().getVirtualColumn(Granularities.GRANULARITY_VIRTUAL_COLUMN_NAME);
+    if (granularityVirtualColumn == null) {
+      return Granularities.NONE;
+    }
+    final Granularity granularity = Granularities.fromVirtualColumn(granularityVirtualColumn);
+    return granularity == null ? Granularities.NONE : granularity;
+  }
+
+  /**
+   * Returns a copy of this spec with the given query granularity applied (implementation-defined representation). Used
+   * by the ingestion and compaction config paths to attach the query-derived granularity to the operator-supplied spec.
+   */
+  BaseTableProjectionSpec withQueryGranularity(@Nullable Granularity queryGranularity);
+
+  /**
+   * Returns true if this spec is equivalent to {@code other} for the purpose of deciding whether a segment is already
+   * compacted. Segment granularity, query granularity, and rollup are each compared by their own compaction check
+   * (query granularity in particular lives in {@link #getVirtualColumns()} as a granularity-carrier virtual column), so
+   * an implementation must ignore those and compare all other state it carries, returning false for a different
+   * implementation type.
+   * <p>
+   * The default compares the whole spec via {@link #equals}; an implementation that carries state compared separately
+   * (such as the query-granularity carrier) overrides this to exclude it.
+   */
+  default boolean hasEqualCompactionState(BaseTableProjectionSpec other)
+  {
+    return equals(other);
+  }
 }

--- a/processing/src/main/java/org/apache/druid/data/input/impl/ClusteredValueGroupsBaseTableProjectionSpec.java
+++ b/processing/src/main/java/org/apache/druid/data/input/impl/ClusteredValueGroupsBaseTableProjectionSpec.java
@@ -175,7 +175,10 @@ public final class ClusteredValueGroupsBaseTableProjectionSpec implements BaseTa
   /**
    * Returns a copy of this spec with a new {@code queryGranularity}, expressed as a
    * {@link Granularities#GRANULARITY_VIRTUAL_COLUMN_NAME} virtual column added to {@link #getVirtualColumns()}. A
-   * {@code null}, {@code NONE}, or {@code ALL} granularity is a no-op, so this returns {@code this} unchanged.
+   * {@code null} or {@code NONE} granularity is a no-op (no flooring), so this returns {@code this} unchanged.
+   * <p>
+   * {@code ALL} is rejected: it would floor {@code __time} to a single constant (the interval start) for the whole
+   * segment, which clustered base tables do not yet support.
    * <p>
    * Idempotent: if the spec already declares a query-granularity virtual column, that one is authoritative and this is
    * a no-op. (The compaction path attaches the virtual column up front; the MSQ generation path then calls this again
@@ -184,9 +187,13 @@ public final class ClusteredValueGroupsBaseTableProjectionSpec implements BaseTa
   @Override
   public ClusteredValueGroupsBaseTableProjectionSpec withQueryGranularity(@Nullable Granularity queryGranularity)
   {
+    if (Granularities.ALL.equals(queryGranularity)) {
+      throw InvalidInput.exception(
+          "Query granularity[ALL] is not supported for clusteredValueGroups base tables"
+      );
+    }
     if (queryGranularity == null
         || Granularities.NONE.equals(queryGranularity)
-        || Granularities.ALL.equals(queryGranularity)
         || virtualColumns.getVirtualColumn(Granularities.GRANULARITY_VIRTUAL_COLUMN_NAME) != null) {
       return this;
     }

--- a/processing/src/main/java/org/apache/druid/data/input/impl/ClusteredValueGroupsBaseTableProjectionSpec.java
+++ b/processing/src/main/java/org/apache/druid/data/input/impl/ClusteredValueGroupsBaseTableProjectionSpec.java
@@ -28,8 +28,10 @@ import com.google.common.collect.Sets;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.error.InvalidInput;
 import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.query.OrderBy;
 import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.projections.Projections;
@@ -168,6 +170,73 @@ public final class ClusteredValueGroupsBaseTableProjectionSpec implements BaseTa
   public DimensionsSpec getDimensionsSpec()
   {
     return dimensionsSpec;
+  }
+
+  /**
+   * Returns a copy of this spec with a new {@code queryGranularity}, expressed as a
+   * {@link Granularities#GRANULARITY_VIRTUAL_COLUMN_NAME} virtual column added to {@link #getVirtualColumns()}. A
+   * {@code null}, {@code NONE}, or {@code ALL} granularity is a no-op, so this returns {@code this} unchanged.
+   * <p>
+   * Idempotent: if the spec already declares a query-granularity virtual column, that one is authoritative and this is
+   * a no-op. (The compaction path attaches the virtual column up front; the MSQ generation path then calls this again
+   * with the query-derived granularity, which must not double-add.)
+   */
+  @Override
+  public ClusteredValueGroupsBaseTableProjectionSpec withQueryGranularity(@Nullable Granularity queryGranularity)
+  {
+    if (queryGranularity == null
+        || Granularities.NONE.equals(queryGranularity)
+        || Granularities.ALL.equals(queryGranularity)
+        || virtualColumns.getVirtualColumn(Granularities.GRANULARITY_VIRTUAL_COLUMN_NAME) != null) {
+      return this;
+    }
+    final VirtualColumn granularityVirtualColumn =
+        Granularities.toVirtualColumn(queryGranularity, Granularities.GRANULARITY_VIRTUAL_COLUMN_NAME);
+    final List<VirtualColumn> merged = new ArrayList<>(Arrays.asList(virtualColumns.getVirtualColumns()));
+    merged.add(granularityVirtualColumn);
+    return builder()
+        .virtualColumns(VirtualColumns.create(merged))
+        .clusteringColumns(clusteringColumns)
+        .columns(columns)
+        .build();
+  }
+
+  /**
+   * Compares clustered-spec state for compaction up-to-date checks: query granularity is compared separately (via its
+   * carrier virtual column), so it is stripped from both sides; everything else (columns, clustering columns, any other
+   * virtual columns) must match. A spec of a different type is never equivalent.
+   */
+  @Override
+  public boolean hasEqualCompactionState(BaseTableProjectionSpec other)
+  {
+    if (!(other instanceof ClusteredValueGroupsBaseTableProjectionSpec)) {
+      return false;
+    }
+    return withoutQueryGranularity()
+        .equals(((ClusteredValueGroupsBaseTableProjectionSpec) other).withoutQueryGranularity());
+  }
+
+  /**
+   * Returns a copy of this spec with the {@link Granularities#GRANULARITY_VIRTUAL_COLUMN_NAME} virtual column removed,
+   * the inverse of {@link #withQueryGranularity(Granularity)}. If no such virtual column is present this returns
+   * {@code this} unchanged. Used to compare schema independently of query granularity in {@link #hasEqualCompactionState}.
+   */
+  private ClusteredValueGroupsBaseTableProjectionSpec withoutQueryGranularity()
+  {
+    if (virtualColumns.getVirtualColumn(Granularities.GRANULARITY_VIRTUAL_COLUMN_NAME) == null) {
+      return this;
+    }
+    final List<VirtualColumn> remaining = new ArrayList<>();
+    for (VirtualColumn vc : virtualColumns.getVirtualColumns()) {
+      if (!Granularities.GRANULARITY_VIRTUAL_COLUMN_NAME.equals(vc.getOutputName())) {
+        remaining.add(vc);
+      }
+    }
+    return builder()
+        .virtualColumns(VirtualColumns.create(remaining))
+        .clusteringColumns(clusteringColumns)
+        .columns(columns)
+        .build();
   }
 
   private static void validate(List<DimensionSchema> columns, List<String> clusteringColumns)

--- a/processing/src/main/java/org/apache/druid/timeline/CompactionState.java
+++ b/processing/src/main/java/org/apache/druid/timeline/CompactionState.java
@@ -23,8 +23,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.data.input.impl.AggregateProjectionSpec;
+import org.apache.druid.data.input.impl.BaseTableProjectionSpec;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.indexer.granularity.GranularitySpec;
+import org.apache.druid.indexer.granularity.SegmentGranularitySpec;
 import org.apache.druid.indexer.partitions.PartitionsSpec;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.segment.IndexSpec;
@@ -58,6 +60,10 @@ public class CompactionState
   private final List<AggregatorFactory> metricsSpec;
   @Nullable
   private final List<AggregateProjectionSpec> projections;
+  @Nullable
+  private final SegmentGranularitySpec segmentGranularitySpec;
+  @Nullable
+  private final BaseTableProjectionSpec baseTable;
 
   @JsonCreator
   public CompactionState(
@@ -67,6 +73,8 @@ public class CompactionState
       @JsonProperty("transformSpec") CompactionTransformSpec transformSpec,
       @JsonProperty("indexSpec") IndexSpec indexSpec,
       @JsonProperty("granularitySpec") GranularitySpec granularitySpec,
+      @JsonProperty("segmentGranularitySpec") @Nullable SegmentGranularitySpec segmentGranularitySpec,
+      @JsonProperty("baseTable") @Nullable BaseTableProjectionSpec baseTable,
       @JsonProperty("projections") @Nullable List<AggregateProjectionSpec> projections
   )
   {
@@ -77,6 +85,8 @@ public class CompactionState
     this.indexSpec = indexSpec;
     this.granularitySpec = granularitySpec;
     this.projections = projections;
+    this.segmentGranularitySpec = segmentGranularitySpec;
+    this.baseTable = baseTable;
   }
 
   @JsonProperty
@@ -123,6 +133,22 @@ public class CompactionState
     return projections;
   }
 
+  @JsonProperty
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @Nullable
+  public SegmentGranularitySpec getSegmentGranularitySpec()
+  {
+    return segmentGranularitySpec;
+  }
+
+  @JsonProperty
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @Nullable
+  public BaseTableProjectionSpec getBaseTable()
+  {
+    return baseTable;
+  }
+
   @Override
   public boolean equals(Object o)
   {
@@ -139,7 +165,9 @@ public class CompactionState
            Objects.equals(indexSpec, that.indexSpec) &&
            Objects.equals(granularitySpec, that.granularitySpec) &&
            Objects.equals(metricsSpec, that.metricsSpec) &&
-           Objects.equals(projections, that.projections);
+           Objects.equals(projections, that.projections) &&
+           Objects.equals(segmentGranularitySpec, that.segmentGranularitySpec) &&
+           Objects.equals(baseTable, that.baseTable);
   }
 
   @Override
@@ -152,7 +180,9 @@ public class CompactionState
         indexSpec,
         granularitySpec,
         metricsSpec,
-        projections
+        projections,
+        segmentGranularitySpec,
+        baseTable
     );
   }
 
@@ -166,6 +196,8 @@ public class CompactionState
            ", indexSpec=" + indexSpec +
            ", granularitySpec=" + granularitySpec +
            ", metricsSpec=" + metricsSpec +
+           ", segmentGranularitySpec=" + segmentGranularitySpec +
+           ", baseTable=" + baseTable +
            ", projections=" + projections +
            '}';
   }
@@ -177,6 +209,8 @@ public class CompactionState
       CompactionTransformSpec transformSpec,
       IndexSpec indexSpec,
       GranularitySpec granularitySpec,
+      @Nullable SegmentGranularitySpec segmentGranularitySpec,
+      @Nullable BaseTableProjectionSpec baseTable,
       @Nullable List<AggregateProjectionSpec> projections
   )
   {
@@ -198,6 +232,8 @@ public class CompactionState
         transformSpec,
         effectiveIndexSpec,
         granularitySpec,
+        segmentGranularitySpec,
+        baseTable,
         projections
     );
 
@@ -223,6 +259,10 @@ public class CompactionState
     private List<AggregatorFactory> metricsSpec;
     @Nullable
     private List<AggregateProjectionSpec> projections;
+    @Nullable
+    private SegmentGranularitySpec segmentGranularitySpec;
+    @Nullable
+    private BaseTableProjectionSpec baseTable;
 
     Builder()
     {
@@ -237,6 +277,8 @@ public class CompactionState
       this.granularitySpec = compactionState.granularitySpec;
       this.metricsSpec = compactionState.metricsSpec;
       this.projections = compactionState.projections;
+      this.segmentGranularitySpec = compactionState.segmentGranularitySpec;
+      this.baseTable = compactionState.baseTable;
     }
 
     public Builder partitionsSpec(PartitionsSpec partitionsSpec)
@@ -281,6 +323,18 @@ public class CompactionState
       return this;
     }
 
+    public Builder segmentGranularitySpec(@Nullable SegmentGranularitySpec segmentGranularitySpec)
+    {
+      this.segmentGranularitySpec = segmentGranularitySpec;
+      return this;
+    }
+
+    public Builder baseTable(@Nullable BaseTableProjectionSpec baseTable)
+    {
+      this.baseTable = baseTable;
+      return this;
+    }
+
     public CompactionState build()
     {
       return new CompactionState(
@@ -290,6 +344,8 @@ public class CompactionState
           transformSpec,
           indexSpec,
           granularitySpec,
+          segmentGranularitySpec,
+          baseTable,
           projections
       );
     }

--- a/processing/src/main/java/org/apache/druid/timeline/CompactionState.java
+++ b/processing/src/main/java/org/apache/druid/timeline/CompactionState.java
@@ -244,6 +244,11 @@ public class CompactionState
   }
 
 
+  public static Builder builder()
+  {
+    return new Builder();
+  }
+
   public Builder toBuilder()
   {
     return new Builder(this);

--- a/processing/src/test/java/org/apache/druid/data/input/impl/ClusteredValueGroupsBaseTableProjectionSpecTest.java
+++ b/processing/src/test/java/org/apache/druid/data/input/impl/ClusteredValueGroupsBaseTableProjectionSpecTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.data.input.impl;
 
+import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.testing.InitializedNullHandlingTest;
@@ -52,14 +53,25 @@ class ClusteredValueGroupsBaseTableProjectionSpecTest extends InitializedNullHan
   }
 
   @Test
-  void testWithQueryGranularityNoneNullAndAllAreNoOps()
+  void testWithQueryGranularityNullAndNoneAreNoOps()
   {
-    // Absent __virtualGranularity virtual column already means NONE, and ALL means "not grouping on time", so these
-    // add nothing and return the same spec.
+    // Absent __virtualGranularity virtual column already means NONE, so null/NONE add nothing and return the same spec.
     final ClusteredValueGroupsBaseTableProjectionSpec spec = tenantSpec();
     Assertions.assertSame(spec, spec.withQueryGranularity(null));
     Assertions.assertSame(spec, spec.withQueryGranularity(Granularities.NONE));
-    Assertions.assertSame(spec, spec.withQueryGranularity(Granularities.ALL));
+  }
+
+  @Test
+  void testWithQueryGranularityAllIsRejected()
+  {
+    // ALL would floor __time to a single constant (the interval start) for the whole segment, which clustered base
+    // tables do not yet support, so it is rejected rather than silently ignored.
+    final ClusteredValueGroupsBaseTableProjectionSpec spec = tenantSpec();
+    final DruidException e = Assertions.assertThrows(
+        DruidException.class,
+        () -> spec.withQueryGranularity(Granularities.ALL)
+    );
+    Assertions.assertTrue(e.getMessage().contains("ALL"));
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/data/input/impl/ClusteredValueGroupsBaseTableProjectionSpecTest.java
+++ b/processing/src/test/java/org/apache/druid/data/input/impl/ClusteredValueGroupsBaseTableProjectionSpecTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.impl;
+
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.segment.VirtualColumn;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ClusteredValueGroupsBaseTableProjectionSpecTest extends InitializedNullHandlingTest
+{
+  private static ClusteredValueGroupsBaseTableProjectionSpec tenantSpec()
+  {
+    return ClusteredValueGroupsBaseTableProjectionSpec.builder()
+        .columns(new StringDimensionSchema("tenant"), new StringDimensionSchema("region"), new LongDimensionSchema("__time"))
+        .clusteringColumns("tenant")
+        .build();
+  }
+
+  @Test
+  void testWithQueryGranularityAddsVirtualGranularityColumn()
+  {
+    final ClusteredValueGroupsBaseTableProjectionSpec spec = tenantSpec().withQueryGranularity(Granularities.HOUR);
+
+    final VirtualColumn vc = spec.getVirtualColumns().getVirtualColumn(Granularities.GRANULARITY_VIRTUAL_COLUMN_NAME);
+    Assertions.assertNotNull(vc);
+    Assertions.assertEquals(Granularities.HOUR, Granularities.fromVirtualColumn(vc));
+
+    // The rest of the spec is unchanged.
+    Assertions.assertEquals(tenantSpec().getClusteringColumns(), spec.getClusteringColumns());
+    Assertions.assertEquals(tenantSpec().getColumns(), spec.getColumns());
+    Assertions.assertEquals(tenantSpec().getOrdering(), spec.getOrdering());
+    Assertions.assertArrayEquals(tenantSpec().getMetrics(), spec.getMetrics());
+  }
+
+  @Test
+  void testWithQueryGranularityNoneNullAndAllAreNoOps()
+  {
+    // Absent __virtualGranularity virtual column already means NONE, and ALL means "not grouping on time", so these
+    // add nothing and return the same spec.
+    final ClusteredValueGroupsBaseTableProjectionSpec spec = tenantSpec();
+    Assertions.assertSame(spec, spec.withQueryGranularity(null));
+    Assertions.assertSame(spec, spec.withQueryGranularity(Granularities.NONE));
+    Assertions.assertSame(spec, spec.withQueryGranularity(Granularities.ALL));
+  }
+
+  @Test
+  void testGetQueryGranularityRoundTrips()
+  {
+    Assertions.assertEquals(
+        Granularities.HOUR,
+        tenantSpec().withQueryGranularity(Granularities.HOUR).getQueryGranularity()
+    );
+  }
+
+  @Test
+  void testGetQueryGranularityIsNoneWhenNoVirtualColumn()
+  {
+    Assertions.assertEquals(Granularities.NONE, tenantSpec().getQueryGranularity());
+  }
+
+  @Test
+  void testHasEqualCompactionStateIgnoresQueryGranularity()
+  {
+    // Two specs that differ only in their query granularity are equivalent for compaction (query granularity is
+    // compared by its own check), regardless of which granularity each carries.
+    Assertions.assertTrue(tenantSpec().withQueryGranularity(Granularities.HOUR).hasEqualCompactionState(tenantSpec()));
+    Assertions.assertTrue(tenantSpec().hasEqualCompactionState(tenantSpec().withQueryGranularity(Granularities.HOUR)));
+    Assertions.assertTrue(
+        tenantSpec().withQueryGranularity(Granularities.HOUR)
+                    .hasEqualCompactionState(tenantSpec().withQueryGranularity(Granularities.DAY))
+    );
+  }
+
+  @Test
+  void testHasEqualCompactionStateComparesSchema()
+  {
+    final ClusteredValueGroupsBaseTableProjectionSpec differentClustering =
+        ClusteredValueGroupsBaseTableProjectionSpec.builder()
+            .columns(new StringDimensionSchema("tenant"), new StringDimensionSchema("region"), new LongDimensionSchema("__time"))
+            .clusteringColumns("tenant", "region")
+            .build();
+
+    Assertions.assertFalse(tenantSpec().hasEqualCompactionState(differentClustering));
+    Assertions.assertTrue(tenantSpec().hasEqualCompactionState(tenantSpec()));
+  }
+
+  @Test
+  void testWithQueryGranularityIsIdempotentWhenAlreadyPresent()
+  {
+    // Once a query-granularity virtual column is present it is authoritative; a second call is a no-op and does not
+    // double-add or change it (the compaction path attaches it up front, then MSQ generation calls this again).
+    final ClusteredValueGroupsBaseTableProjectionSpec withGranularity =
+        tenantSpec().withQueryGranularity(Granularities.HOUR);
+    final ClusteredValueGroupsBaseTableProjectionSpec reapplied = withGranularity.withQueryGranularity(Granularities.DAY);
+
+    Assertions.assertSame(withGranularity, reapplied);
+    Assertions.assertEquals(
+        Granularities.HOUR,
+        Granularities.fromVirtualColumn(
+            reapplied.getVirtualColumns().getVirtualColumn(Granularities.GRANULARITY_VIRTUAL_COLUMN_NAME)
+        )
+    );
+  }
+}

--- a/processing/src/test/java/org/apache/druid/timeline/CompactionStateTest.java
+++ b/processing/src/test/java/org/apache/druid/timeline/CompactionStateTest.java
@@ -19,14 +19,21 @@
 
 package org.apache.druid.timeline;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.data.input.impl.AggregateProjectionSpec;
+import org.apache.druid.data.input.impl.ClusteredValueGroupsBaseTableProjectionSpec;
 import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.LongDimensionSchema;
+import org.apache.druid.data.input.impl.StringDimensionSchema;
+import org.apache.druid.indexer.granularity.SegmentGranularitySpec;
 import org.apache.druid.indexer.granularity.UniformGranularitySpec;
 import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
+import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.segment.IndexSpec;
+import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.transform.CompactionTransformSpec;
 import org.junit.jupiter.api.Assertions;
@@ -106,6 +113,44 @@ public class CompactionStateTest
   }
 
   @Test
+  public void testBuilderWithBaseTable()
+  {
+    DynamicPartitionsSpec partitionsSpec = new DynamicPartitionsSpec(null, null);
+    DimensionsSpec dimensionsSpec = DimensionsSpec.builder().build();
+    List<AggregatorFactory> metricsSpec = List.of(new CountAggregatorFactory("count"));
+    CompactionTransformSpec transformSpec = new CompactionTransformSpec(null, null);
+    IndexSpec indexSpec = IndexSpec.getDefault();
+    UniformGranularitySpec granularitySpec = new UniformGranularitySpec(
+        Granularities.DAY,
+        Granularities.NONE,
+        Collections.emptyList()
+    );
+    ClusteredValueGroupsBaseTableProjectionSpec baseTable =
+        ClusteredValueGroupsBaseTableProjectionSpec.builder()
+                                                   .columns(
+                                                       new StringDimensionSchema("tenant"),
+                                                       new LongDimensionSchema("__time")
+                                                   )
+                                                   .clusteringColumns("tenant")
+                                                   .build();
+
+    CompactionState state = new CompactionState.Builder()
+        .partitionsSpec(partitionsSpec)
+        .dimensionsSpec(dimensionsSpec)
+        .metricsSpec(metricsSpec)
+        .transformSpec(transformSpec)
+        .indexSpec(indexSpec)
+        .granularitySpec(granularitySpec)
+        .baseTable(baseTable)
+        .build();
+
+    Assertions.assertEquals(baseTable, state.getBaseTable());
+
+    // round-trips through the builder
+    Assertions.assertEquals(baseTable, state.toBuilder().build().getBaseTable());
+  }
+
+  @Test
   public void testToBuilder()
   {
     DynamicPartitionsSpec partitionsSpec = new DynamicPartitionsSpec(null, null);
@@ -135,6 +180,8 @@ public class CompactionStateTest
         transformSpec,
         indexSpec,
         granularitySpec,
+        null,
+        null,
         projections
     );
 
@@ -171,6 +218,8 @@ public class CompactionStateTest
         transformSpec,
         indexSpec,
         granularitySpec,
+        null,
+        null,
         null
     );
 
@@ -212,6 +261,8 @@ public class CompactionStateTest
         transformSpec,
         indexSpec,
         granularitySpec,
+        null,
+        null,
         null
     );
 
@@ -224,5 +275,101 @@ public class CompactionStateTest
     Assertions.assertEquals(partitionsSpec1, originalState.getPartitionsSpec());
     // Modified state should have the new partitionsSpec
     Assertions.assertEquals(partitionsSpec2, modifiedState.getPartitionsSpec());
+  }
+
+  @Test
+  public void testSerdeWithBaseTable() throws Exception
+  {
+    final ObjectMapper mapper = new DefaultObjectMapper();
+    ClusteredValueGroupsBaseTableProjectionSpec baseTable =
+        ClusteredValueGroupsBaseTableProjectionSpec.builder()
+                                                   .columns(
+                                                       new StringDimensionSchema("tenant"),
+                                                       new LongDimensionSchema("__time")
+                                                   )
+                                                   .clusteringColumns("tenant")
+                                                   .build();
+
+    CompactionState state = new CompactionState(
+        new DynamicPartitionsSpec(null, null),
+        DimensionsSpec.builder().build(),
+        List.of(new CountAggregatorFactory("count")),
+        new CompactionTransformSpec(null, null),
+        IndexSpec.getDefault(),
+        new UniformGranularitySpec(Granularities.DAY, Granularities.NONE, Collections.emptyList()),
+        null,
+        baseTable,
+        null
+    );
+
+    CompactionState roundTrip = mapper.readValue(mapper.writeValueAsString(state), CompactionState.class);
+    Assertions.assertEquals(state, roundTrip);
+    Assertions.assertEquals(baseTable, roundTrip.getBaseTable());
+  }
+
+  @Test
+  public void testSerdeWithSegmentGranularitySpec() throws Exception
+  {
+    // The baseTable carries a query-granularity expression virtual column, whose deserialization needs an injected
+    // ExprMacroTable, so use the TestHelper mapper instead of the plain DefaultObjectMapper.
+    final ObjectMapper mapper = TestHelper.makeJsonMapper();
+    ClusteredValueGroupsBaseTableProjectionSpec baseTable =
+        ClusteredValueGroupsBaseTableProjectionSpec.builder()
+                                                   .columns(
+                                                       new StringDimensionSchema("tenant"),
+                                                       new LongDimensionSchema("__time")
+                                                   )
+                                                   .clusteringColumns("tenant")
+                                                   .build()
+                                                   .withQueryGranularity(Granularities.HOUR);
+
+    SegmentGranularitySpec segmentGranularitySpec = new SegmentGranularitySpec(Granularities.DAY, null);
+
+    CompactionState state = new CompactionState(
+        new DynamicPartitionsSpec(null, null),
+        DimensionsSpec.builder().build(),
+        List.of(new CountAggregatorFactory("count")),
+        new CompactionTransformSpec(null, null),
+        IndexSpec.getDefault(),
+        null,
+        segmentGranularitySpec,
+        baseTable,
+        null
+    );
+
+    final String json = mapper.writeValueAsString(state);
+    CompactionState roundTrip = mapper.readValue(json, CompactionState.class);
+    Assertions.assertEquals(state, roundTrip);
+    Assertions.assertEquals(segmentGranularitySpec, roundTrip.getSegmentGranularitySpec());
+    Assertions.assertEquals(baseTable, roundTrip.getBaseTable());
+    Assertions.assertTrue(json.contains("segmentGranularitySpec"));
+  }
+
+  /**
+   * Legacy (non-baseTable) CompactionState must serialize WITHOUT a "segmentGranularitySpec" key (the field is
+   * {@code @JsonInclude(NON_NULL)}), so legacy fingerprints are byte-for-byte unchanged.
+   */
+  @Test
+  public void testSerdeLegacyOmitsSegmentGranularitySpec() throws Exception
+  {
+    final ObjectMapper mapper = new DefaultObjectMapper();
+    CompactionState state = new CompactionState(
+        new DynamicPartitionsSpec(null, null),
+        DimensionsSpec.builder().build(),
+        List.of(new CountAggregatorFactory("count")),
+        new CompactionTransformSpec(null, null),
+        IndexSpec.getDefault(),
+        new UniformGranularitySpec(Granularities.DAY, Granularities.NONE, Collections.emptyList()),
+        null,
+        null,
+        null
+    );
+
+    final String json = mapper.writeValueAsString(state);
+    Assertions.assertFalse(json.contains("segmentGranularitySpec"));
+
+    CompactionState roundTrip = mapper.readValue(json, CompactionState.class);
+    Assertions.assertEquals(state, roundTrip);
+    Assertions.assertNull(roundTrip.getSegmentGranularitySpec());
   }
 }

--- a/processing/src/test/java/org/apache/druid/timeline/CompactionStateTest.java
+++ b/processing/src/test/java/org/apache/druid/timeline/CompactionStateTest.java
@@ -290,17 +290,15 @@ public class CompactionStateTest
                                                    .clusteringColumns("tenant")
                                                    .build();
 
-    CompactionState state = new CompactionState(
-        new DynamicPartitionsSpec(null, null),
-        DimensionsSpec.builder().build(),
-        List.of(new CountAggregatorFactory("count")),
-        new CompactionTransformSpec(null, null),
-        IndexSpec.getDefault(),
-        new UniformGranularitySpec(Granularities.DAY, Granularities.NONE, Collections.emptyList()),
-        null,
-        baseTable,
-        null
-    );
+    CompactionState state = CompactionState.builder()
+        .partitionsSpec(new DynamicPartitionsSpec(null, null))
+        .dimensionsSpec(DimensionsSpec.builder().build())
+        .metricsSpec(List.of(new CountAggregatorFactory("count")))
+        .transformSpec(new CompactionTransformSpec(null, null))
+        .indexSpec(IndexSpec.getDefault())
+        .granularitySpec(new UniformGranularitySpec(Granularities.DAY, Granularities.NONE, Collections.emptyList()))
+        .baseTable(baseTable)
+        .build();
 
     CompactionState roundTrip = mapper.readValue(mapper.writeValueAsString(state), CompactionState.class);
     Assertions.assertEquals(state, roundTrip);
@@ -325,17 +323,15 @@ public class CompactionStateTest
 
     SegmentGranularitySpec segmentGranularitySpec = new SegmentGranularitySpec(Granularities.DAY, null);
 
-    CompactionState state = new CompactionState(
-        new DynamicPartitionsSpec(null, null),
-        DimensionsSpec.builder().build(),
-        List.of(new CountAggregatorFactory("count")),
-        new CompactionTransformSpec(null, null),
-        IndexSpec.getDefault(),
-        null,
-        segmentGranularitySpec,
-        baseTable,
-        null
-    );
+    CompactionState state = CompactionState.builder()
+        .partitionsSpec(new DynamicPartitionsSpec(null, null))
+        .dimensionsSpec(DimensionsSpec.builder().build())
+        .metricsSpec(List.of(new CountAggregatorFactory("count")))
+        .transformSpec(new CompactionTransformSpec(null, null))
+        .indexSpec(IndexSpec.getDefault())
+        .segmentGranularitySpec(segmentGranularitySpec)
+        .baseTable(baseTable)
+        .build();
 
     final String json = mapper.writeValueAsString(state);
     CompactionState roundTrip = mapper.readValue(json, CompactionState.class);

--- a/processing/src/test/java/org/apache/druid/timeline/DataSegmentTest.java
+++ b/processing/src/test/java/org/apache/druid/timeline/DataSegmentTest.java
@@ -101,6 +101,8 @@ public class DataSegmentTest
         ),
         MAPPER.convertValue(ImmutableMap.of(), IndexSpec.class),
         MAPPER.convertValue(ImmutableMap.of(), GranularitySpec.class),
+        null,
+        null,
         null
     );
     final DataSegment segment = DataSegment.builder(segmentId)
@@ -176,6 +178,8 @@ public class DataSegmentTest
                                          ),
                                          MAPPER.convertValue(ImmutableMap.of(), IndexSpec.class),
                                          MAPPER.convertValue(ImmutableMap.of(), GranularitySpec.class),
+                                         null,
+                                         null,
                                          null
                                      ))
                                      .binaryVersion(TEST_VERSION)
@@ -227,6 +231,8 @@ public class DataSegmentTest
                                          null,
                                          MAPPER.convertValue(ImmutableMap.of(), IndexSpec.class),
                                          MAPPER.convertValue(ImmutableMap.of(), GranularitySpec.class),
+                                         null,
+                                         null,
                                          null
                                      ))
                                      .binaryVersion(TEST_VERSION)
@@ -386,6 +392,8 @@ public class DataSegmentTest
         ),
         MAPPER.convertValue(Map.of("test", "map"), IndexSpec.class),
         MAPPER.convertValue(Map.of("test2", "map2"), GranularitySpec.class),
+        null,
+        null,
         null
     );
     final DataSegment segment1 = DataSegment.builder(SegmentId.of(
@@ -433,6 +441,8 @@ public class DataSegmentTest
         transformSpec,
         indexSpec,
         granularitySpec,
+        null,
+        null,
         null
     );
 
@@ -444,6 +454,8 @@ public class DataSegmentTest
             transformSpec,
             indexSpec,
             granularitySpec,
+            null,
+            null,
             null
         );
 

--- a/server/src/main/java/org/apache/druid/client/indexing/ClientCompactionRunnerInfo.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/ClientCompactionRunnerInfo.java
@@ -124,9 +124,17 @@ public class ClientCompactionRunnerInfo
   {
     List<CompactionConfigValidationResult> validationResults = new ArrayList<>();
     if (newConfig.getTuningConfig() != null) {
+      // In baseTable mode the dimensions live on the baseTable spec, not the legacy top-level dimensionsSpec, so
+      // validate range-partition columns against it.
+      final List<DimensionSchema> dimensionSchemas;
+      if (newConfig.getBaseTable() != null) {
+        dimensionSchemas = newConfig.getBaseTable().getDimensionsSpec().getDimensions();
+      } else {
+        dimensionSchemas = newConfig.getDimensionsSpec() == null ? null : newConfig.getDimensionsSpec().getDimensions();
+      }
       validationResults.add(validatePartitionsSpecForMSQ(
           newConfig.getTuningConfig().getPartitionsSpec(),
-          newConfig.getDimensionsSpec() == null ? null : newConfig.getDimensionsSpec().getDimensions(),
+          dimensionSchemas,
           newConfig.getTransformSpec() == null ? VirtualColumns.EMPTY : newConfig.getTransformSpec().getVirtualColumns()
       ));
     }

--- a/server/src/main/java/org/apache/druid/client/indexing/ClientCompactionRunnerInfo.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/ClientCompactionRunnerInfo.java
@@ -99,6 +99,11 @@ public class ClientCompactionRunnerInfo
   {
     CompactionEngine compactionEngine = newConfig.getEngine() == null ? defaultCompactionEngine : newConfig.getEngine();
     if (compactionEngine == CompactionEngine.NATIVE) {
+      if (newConfig.getBaseTable() != null) {
+        return CompactionConfigValidationResult.failure(
+            "Compaction engine[native] does not support 'baseTable'; use the MSQ compaction engine."
+        );
+      }
       return CompactionConfigValidationResult.success();
     } else {
       return compactionConfigSupportedByMSQEngine(newConfig);

--- a/server/src/main/java/org/apache/druid/client/indexing/ClientCompactionTaskQuery.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/ClientCompactionTaskQuery.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import org.apache.druid.data.input.impl.AggregateProjectionSpec;
+import org.apache.druid.data.input.impl.BaseTableProjectionSpec;
 import org.apache.druid.indexer.CompactionEngine;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.segment.transform.CompactionTransformSpec;
@@ -52,6 +53,8 @@ public class ClientCompactionTaskQuery implements ClientTaskQuery
   private final CompactionTransformSpec transformSpec;
   @Nullable
   private final List<AggregateProjectionSpec> projections;
+  @Nullable
+  private final BaseTableProjectionSpec baseTable;
   private final Map<String, Object> context;
   private final ClientCompactionRunnerInfo compactionRunner;
 
@@ -65,6 +68,7 @@ public class ClientCompactionTaskQuery implements ClientTaskQuery
       @JsonProperty("dimensionsSpec") ClientCompactionTaskDimensionsSpec dimensionsSpec,
       @JsonProperty("metricsSpec") AggregatorFactory[] metrics,
       @JsonProperty("transformSpec") CompactionTransformSpec transformSpec,
+      @JsonProperty("baseTable") @Nullable BaseTableProjectionSpec baseTable,
       @JsonProperty("projections") @Nullable List<AggregateProjectionSpec> projections,
       @JsonProperty("context") Map<String, Object> context,
       @JsonProperty("compactionRunner") @Nullable ClientCompactionRunnerInfo compactionRunner
@@ -79,6 +83,7 @@ public class ClientCompactionTaskQuery implements ClientTaskQuery
     this.metricsSpec = metrics;
     this.transformSpec = transformSpec;
     this.projections = projections;
+    this.baseTable = baseTable;
     this.context = context;
     this.compactionRunner = compactionRunner;
   }
@@ -155,6 +160,14 @@ public class ClientCompactionTaskQuery implements ClientTaskQuery
     return projections;
   }
 
+  @JsonProperty("baseTable")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @Nullable
+  public BaseTableProjectionSpec getBaseTable()
+  {
+    return baseTable;
+  }
+
   @JsonProperty("compactionRunner")
   @Nullable
   public ClientCompactionRunnerInfo getCompactionRunner()
@@ -189,6 +202,7 @@ public class ClientCompactionTaskQuery implements ClientTaskQuery
            Arrays.equals(metricsSpec, that.metricsSpec) &&
            Objects.equals(transformSpec, that.transformSpec) &&
            Objects.equals(projections, that.projections) &&
+           Objects.equals(baseTable, that.baseTable) &&
            Objects.equals(context, that.context) &&
            Objects.equals(compactionRunner, that.compactionRunner);
   }
@@ -205,6 +219,7 @@ public class ClientCompactionTaskQuery implements ClientTaskQuery
         dimensionsSpec,
         transformSpec,
         projections,
+        baseTable,
         context,
         compactionRunner
     );
@@ -225,6 +240,7 @@ public class ClientCompactionTaskQuery implements ClientTaskQuery
            ", metricsSpec=" + Arrays.toString(metricsSpec) +
            ", transformSpec=" + transformSpec +
            ", catalogConfig=" + projections +
+           ", baseTable=" + baseTable +
            ", context=" + context +
            ", compactionRunner=" + compactionRunner +
            '}';

--- a/server/src/main/java/org/apache/druid/segment/indexing/CombinedDataSchema.java
+++ b/server/src/main/java/org/apache/druid/segment/indexing/CombinedDataSchema.java
@@ -20,9 +20,11 @@
 package org.apache.druid.segment.indexing;
 
 import org.apache.druid.data.input.impl.AggregateProjectionSpec;
+import org.apache.druid.data.input.impl.BaseTableProjectionSpec;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.indexer.granularity.GranularitySpec;
+import org.apache.druid.indexer.granularity.SegmentGranularitySpec;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.segment.transform.TransformSpec;
 
@@ -35,6 +37,21 @@ import java.util.Set;
  */
 public class CombinedDataSchema extends DataSchema
 {
+  /**
+   * Builds a base-table-mode schema for compaction. The legacy dimensions/metrics/granularity fields are left empty.
+   */
+  public static CombinedDataSchema forBaseTable(
+      String dataSource,
+      @Nullable TimestampSpec timestampSpec,
+      @Nullable SegmentGranularitySpec segmentGranularitySpec,
+      @Nullable TransformSpec transformSpec,
+      @Nullable List<AggregateProjectionSpec> projections,
+      BaseTableProjectionSpec baseTable
+  )
+  {
+    return new CombinedDataSchema(dataSource, timestampSpec, segmentGranularitySpec, transformSpec, projections, baseTable);
+  }
+
   private final Set<String> multiValuedDimensions;
 
   public CombinedDataSchema(
@@ -61,6 +78,19 @@ public class CombinedDataSchema extends DataSchema
         null
     );
     this.multiValuedDimensions = multiValuedDimensions;
+  }
+
+  private CombinedDataSchema(
+      String dataSource,
+      @Nullable TimestampSpec timestampSpec,
+      @Nullable SegmentGranularitySpec segmentGranularitySpec,
+      @Nullable TransformSpec transformSpec,
+      @Nullable List<AggregateProjectionSpec> projections,
+      BaseTableProjectionSpec baseTable
+  )
+  {
+    super(dataSource, timestampSpec, null, null, null, segmentGranularitySpec, transformSpec, projections, baseTable, null);
+    this.multiValuedDimensions = null;
   }
 
   @Nullable

--- a/server/src/main/java/org/apache/druid/server/compaction/CompactionStatus.java
+++ b/server/src/main/java/org/apache/druid/server/compaction/CompactionStatus.java
@@ -22,6 +22,7 @@ package org.apache.druid.server.compaction;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.druid.client.indexing.ClientCompactionTaskQueryTuningConfig;
 import org.apache.druid.common.config.Configs;
+import org.apache.druid.data.input.impl.BaseTableProjectionSpec;
 import org.apache.druid.data.input.impl.DimensionSchema;
 import org.apache.druid.indexer.partitions.DimensionRangePartitionsSpec;
 import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
@@ -88,7 +89,8 @@ public class CompactionStatus
       Evaluator::dimensionsSpecIsUpToDate,
       Evaluator::metricsSpecIsUpToDate,
       Evaluator::transformSpecIsUpToDate,
-      Evaluator::projectionsAreUpToDate
+      Evaluator::projectionsAreUpToDate,
+      Evaluator::baseTableIsUpToDate
   );
 
   private final State state;
@@ -569,6 +571,11 @@ public class CompactionStatus
       return evaluateForAllCompactionStates(this::projectionsAreUpToDate);
     }
 
+    private CompactionStatus baseTableIsUpToDate()
+    {
+      return evaluateForAllCompactionStates(this::baseTableIsUpToDate);
+    }
+
     private CompactionStatus segmentGranularityIsUpToDate()
     {
       return evaluateForAllCompactionStates(this::segmentGranularityIsUpToDate);
@@ -638,6 +645,18 @@ public class CompactionStatus
       );
     }
 
+    private CompactionStatus baseTableIsUpToDate(CompactionState lastCompactionState)
+    {
+      // The baseTable spec compares its own state; segment/query granularity and rollup are covered by their own
+      // checks, so the spec excludes them. A null configured baseTable means "don't care".
+      final BaseTableProjectionSpec configured = compactionConfig.getBaseTable();
+      final BaseTableProjectionSpec current = lastCompactionState.getBaseTable();
+      if (configured == null || (current != null && configured.hasEqualCompactionState(current))) {
+        return COMPLETE;
+      }
+      return configChanged("baseTable", configured, current, String::valueOf);
+    }
+
     private CompactionStatus inputBytesAreWithinLimit()
     {
       final long inputSegmentSize = compactionConfig.getInputSegmentSizeBytes();
@@ -659,9 +678,18 @@ public class CompactionStatus
       }
 
       final Granularity configuredSegmentGranularity = configuredGranularitySpec.getSegmentGranularity();
-      final UserCompactionTaskGranularityConfig existingGranularitySpec = getGranularitySpec(lastCompactionState);
-      final Granularity existingSegmentGranularity
-          = existingGranularitySpec == null ? null : existingGranularitySpec.getSegmentGranularity();
+      final Granularity existingSegmentGranularity;
+      if (lastCompactionState.getBaseTable() != null) {
+        // baseTable mode: segment granularity is recorded in the SegmentGranularitySpec, not the (null) GranularitySpec.
+        existingSegmentGranularity = lastCompactionState.getSegmentGranularitySpec() == null
+                                     ? null
+                                     : lastCompactionState.getSegmentGranularitySpec().getSegmentGranularity();
+      } else {
+        final UserCompactionTaskGranularityConfig existingGranularitySpec = getGranularitySpec(lastCompactionState);
+        existingSegmentGranularity = existingGranularitySpec == null
+                                     ? null
+                                     : existingGranularitySpec.getSegmentGranularity();
+      }
 
       if (configuredSegmentGranularity.equals(existingSegmentGranularity)) {
         return COMPLETE;
@@ -692,6 +720,9 @@ public class CompactionStatus
 
     private CompactionStatus rollupIsUpToDate(CompactionState lastCompactionState)
     {
+      if (lastCompactionState.getBaseTable() != null) {
+        return COMPLETE;
+      }
       if (configuredGranularitySpec == null) {
         return COMPLETE;
       } else {
@@ -710,16 +741,23 @@ public class CompactionStatus
     {
       if (configuredGranularitySpec == null) {
         return COMPLETE;
+      }
+      final Granularity existingQueryGranularity;
+      if (lastCompactionState.getBaseTable() != null) {
+        // baseTable mode: query granularity is owned by the baseTable spec's virtual column, not the (null)
+        // GranularitySpec.
+        existingQueryGranularity = lastCompactionState.getBaseTable().getQueryGranularity();
       } else {
         final UserCompactionTaskGranularityConfig existingGranularitySpec
             = getGranularitySpec(lastCompactionState);
-        return CompactionStatus.completeIfNullOrEqual(
-            "queryGranularity",
-            configuredGranularitySpec.getQueryGranularity(),
-            existingGranularitySpec == null ? null : existingGranularitySpec.getQueryGranularity(),
-            CompactionStatus::asString
-        );
+        existingQueryGranularity = existingGranularitySpec == null ? null : existingGranularitySpec.getQueryGranularity();
       }
+      return CompactionStatus.completeIfNullOrEqual(
+          "queryGranularity",
+          configuredGranularitySpec.getQueryGranularity(),
+          existingQueryGranularity,
+          CompactionStatus::asString
+      );
     }
 
     /**

--- a/server/src/main/java/org/apache/druid/server/compaction/ReindexingDataSchemaRule.java
+++ b/server/src/main/java/org/apache/druid/server/compaction/ReindexingDataSchemaRule.java
@@ -21,6 +21,7 @@ package org.apache.druid.server.compaction;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.data.input.impl.AggregateProjectionSpec;
+import org.apache.druid.data.input.impl.BaseTableProjectionSpec;
 import org.apache.druid.error.InvalidInput;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.query.aggregation.AggregatorFactory;
@@ -56,6 +57,7 @@ public class ReindexingDataSchemaRule extends AbstractReindexingRule
   private final Granularity queryGranularity;
   private final Boolean rollup;
   private final List<AggregateProjectionSpec> projections;
+  private final BaseTableProjectionSpec baseTable;
 
   public ReindexingDataSchemaRule(
       @JsonProperty("id") @Nonnull String id,
@@ -65,19 +67,21 @@ public class ReindexingDataSchemaRule extends AbstractReindexingRule
       @JsonProperty("metricsSpec") @Nullable AggregatorFactory[] metricsSpec,
       @JsonProperty("queryGranularity") @Nullable Granularity queryGranularity,
       @JsonProperty("rollup") @Nullable Boolean rollup,
+      @JsonProperty("baseTable") @Nullable BaseTableProjectionSpec baseTable,
       @JsonProperty("projections") @Nullable List<AggregateProjectionSpec> projections
   )
   {
     super(id, description, olderThan);
     InvalidInput.conditionalException(
-        (dimensionsSpec != null || metricsSpec != null || queryGranularity != null || rollup != null || projections != null),
-        "At least oe of 'dimensionsSpec', 'metricsSpec', 'queryGranularity', 'rollup' or 'projections' must be non-null"
+        (dimensionsSpec != null || metricsSpec != null || queryGranularity != null || rollup != null || projections != null || baseTable != null),
+        "At least one of 'dimensionsSpec', 'metricsSpec', 'queryGranularity', 'rollup', 'projections' or 'baseTable' must be non-null"
     );
     this.dimensionsSpec = dimensionsSpec;
     this.metricsSpec = metricsSpec;
     this.queryGranularity = queryGranularity;
     this.rollup = rollup;
     this.projections = projections;
+    this.baseTable = baseTable;
   }
 
   @JsonProperty
@@ -90,6 +94,13 @@ public class ReindexingDataSchemaRule extends AbstractReindexingRule
   public List<AggregateProjectionSpec> getProjections()
   {
     return projections;
+  }
+
+  @JsonProperty
+  @Nullable
+  public BaseTableProjectionSpec getBaseTable()
+  {
+    return baseTable;
   }
 
   @JsonProperty
@@ -127,7 +138,8 @@ public class ReindexingDataSchemaRule extends AbstractReindexingRule
            && Objects.deepEquals(metricsSpec, that.metricsSpec)
            && Objects.equals(queryGranularity, that.queryGranularity)
            && Objects.equals(rollup, that.rollup)
-           && Objects.equals(projections, that.projections);
+           && Objects.equals(projections, that.projections)
+           && Objects.equals(baseTable, that.baseTable);
   }
 
   @Override
@@ -140,7 +152,8 @@ public class ReindexingDataSchemaRule extends AbstractReindexingRule
         dimensionsSpec,
         queryGranularity,
         rollup,
-        projections
+        projections,
+        baseTable
     );
     result = 31 * result + Arrays.hashCode(metricsSpec);
     return result;
@@ -157,6 +170,7 @@ public class ReindexingDataSchemaRule extends AbstractReindexingRule
            + ", metricsSpec=" + Arrays.toString(metricsSpec)
            + ", queryGranularity=" + queryGranularity
            + ", rollup=" + rollup
+           + ", baseTable=" + baseTable
            + ", projections=" + projections
            + '}';
   }

--- a/server/src/main/java/org/apache/druid/server/coordinator/CatalogDataSourceCompactionConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/CatalogDataSourceCompactionConfig.java
@@ -32,6 +32,7 @@ import org.apache.druid.catalog.model.TableId;
 import org.apache.druid.catalog.model.table.DatasourceDefn;
 import org.apache.druid.client.indexing.ClientCompactionRunnerInfo;
 import org.apache.druid.data.input.impl.AggregateProjectionSpec;
+import org.apache.druid.data.input.impl.BaseTableProjectionSpec;
 import org.apache.druid.indexer.CompactionEngine;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.query.aggregation.AggregatorFactory;
@@ -188,6 +189,14 @@ public class CatalogDataSourceCompactionConfig implements DataSourceCompactionCo
       return null;
     }
     return projections.stream().map(DatasourceProjectionMetadata::getSpec).collect(Collectors.toList());
+  }
+
+  @JsonIgnore
+  @Nullable
+  @Override
+  public BaseTableProjectionSpec getBaseTable()
+  {
+    return null;
   }
 
   @JsonIgnore

--- a/server/src/main/java/org/apache/druid/server/coordinator/DataSourceCompactionConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DataSourceCompactionConfig.java
@@ -23,9 +23,11 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.druid.client.indexing.ClientCompactionTaskQueryTuningConfig;
 import org.apache.druid.data.input.impl.AggregateProjectionSpec;
+import org.apache.druid.data.input.impl.BaseTableProjectionSpec;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.indexer.CompactionEngine;
 import org.apache.druid.indexer.granularity.GranularitySpec;
+import org.apache.druid.indexer.granularity.SegmentGranularitySpec;
 import org.apache.druid.indexer.granularity.UniformGranularitySpec;
 import org.apache.druid.indexer.partitions.PartitionsSpec;
 import org.apache.druid.java.util.common.granularity.Granularity;
@@ -97,6 +99,9 @@ public interface DataSourceCompactionConfig
   List<AggregateProjectionSpec> getProjections();
 
   @Nullable
+  BaseTableProjectionSpec getBaseTable();
+
+  @Nullable
   CompactionTransformSpec getTransformSpec();
 
   @Nullable
@@ -140,8 +145,25 @@ public interface DataSourceCompactionConfig
 
     CompactionTransformSpec transformSpec = getTransformSpec();
 
+    List<AggregateProjectionSpec> projections = getProjections();
+
     GranularitySpec granularitySpec = null;
-    if (getGranularitySpec() != null) {
+    SegmentGranularitySpec segmentGranularitySpec = null;
+    BaseTableProjectionSpec baseTable = getBaseTable();
+    if (baseTable != null) {
+      // baseTable (clustered) mode: segment granularity goes in a SegmentGranularitySpec and query granularity lives in
+      // the baseTable spec's virtual column. The effective baseTable carries the configured query granularity so the
+      // expected state matches the recorded effective spec.
+      // (intervals=null here mirrors the existing legacy behavior; the fingerprint-vs-recorded intervals discrepancy is
+      // a known separate bug.)
+      segmentGranularitySpec = new SegmentGranularitySpec(
+          getGranularitySpec() == null ? null : getGranularitySpec().getSegmentGranularity(),
+          null  // intervals
+      );
+      baseTable = baseTable.withQueryGranularity(
+          getGranularitySpec() == null ? null : getGranularitySpec().getQueryGranularity()
+      );
+    } else if (getGranularitySpec() != null) {
       UserCompactionTaskGranularityConfig userGranularityConfig = getGranularitySpec();
       granularitySpec = new UniformGranularitySpec(
           userGranularityConfig.getSegmentGranularity(),
@@ -151,8 +173,6 @@ public interface DataSourceCompactionConfig
       );
     }
 
-    List<AggregateProjectionSpec> projections = getProjections();
-
     return new CompactionState(
         partitionsSpec,
         dimensionsSpec,
@@ -160,6 +180,8 @@ public interface DataSourceCompactionConfig
         transformSpec,
         indexSpec,
         granularitySpec,
+        segmentGranularitySpec,
+        baseTable,
         projections
     );
   }

--- a/server/src/main/java/org/apache/druid/server/coordinator/DataSourceCompactionConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DataSourceCompactionConfig.java
@@ -154,8 +154,8 @@ public interface DataSourceCompactionConfig
       // baseTable (clustered) mode: segment granularity goes in a SegmentGranularitySpec and query granularity lives in
       // the baseTable spec's virtual column. The effective baseTable carries the configured query granularity so the
       // expected state matches the recorded effective spec.
-      // (intervals=null here mirrors the existing legacy behavior; the fingerprint-vs-recorded intervals discrepancy is
-      // a known separate bug.)
+      // intervals=null is consistent the legacy path: input intervals are not a compaction-config property, are
+      // excluded from the fingerprint, and are not compared by the per-field checks.
       segmentGranularitySpec = new SegmentGranularitySpec(
           getGranularitySpec() == null ? null : getGranularitySpec().getSegmentGranularity(),
           null  // intervals

--- a/server/src/main/java/org/apache/druid/server/coordinator/InlineSchemaDataSourceCompactionConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/InlineSchemaDataSourceCompactionConfig.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import org.apache.druid.client.indexing.ClientCompactionRunnerInfo;
 import org.apache.druid.data.input.impl.AggregateProjectionSpec;
+import org.apache.druid.data.input.impl.BaseTableProjectionSpec;
 import org.apache.druid.indexer.CompactionEngine;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.query.aggregation.AggregatorFactory;
@@ -68,6 +69,8 @@ public class InlineSchemaDataSourceCompactionConfig implements DataSourceCompact
   @Nullable
   private final List<AggregateProjectionSpec> projections;
   @Nullable
+  private final BaseTableProjectionSpec baseTable;
+  @Nullable
   private final UserCompactionTaskIOConfig ioConfig;
   @Nullable
   private final Map<String, Object> taskContext;
@@ -86,6 +89,7 @@ public class InlineSchemaDataSourceCompactionConfig implements DataSourceCompact
       @JsonProperty("dimensionsSpec") @Nullable UserCompactionTaskDimensionsConfig dimensionsSpec,
       @JsonProperty("metricsSpec") @Nullable AggregatorFactory[] metricsSpec,
       @JsonProperty("transformSpec") @Nullable CompactionTransformSpec transformSpec,
+      @JsonProperty("baseTable") @Nullable BaseTableProjectionSpec baseTable,
       @JsonProperty("projections") @Nullable List<AggregateProjectionSpec> projections,
       @JsonProperty("ioConfig") @Nullable UserCompactionTaskIOConfig ioConfig,
       @JsonProperty("engine") @Nullable CompactionEngine engine,
@@ -108,6 +112,7 @@ public class InlineSchemaDataSourceCompactionConfig implements DataSourceCompact
     this.dimensionsSpec = dimensionsSpec;
     this.transformSpec = transformSpec;
     this.projections = projections;
+    this.baseTable = baseTable;
     this.taskContext = taskContext;
     this.engine = engine;
   }
@@ -208,6 +213,14 @@ public class InlineSchemaDataSourceCompactionConfig implements DataSourceCompact
   @JsonProperty
   @Nullable
   @Override
+  public BaseTableProjectionSpec getBaseTable()
+  {
+    return baseTable;
+  }
+
+  @JsonProperty
+  @Nullable
+  @Override
   public Map<String, Object> getTaskContext()
   {
     return taskContext;
@@ -256,6 +269,7 @@ public class InlineSchemaDataSourceCompactionConfig implements DataSourceCompact
            Arrays.equals(metricsSpec, that.metricsSpec) &&
            Objects.equals(transformSpec, that.transformSpec) &&
            Objects.equals(projections, that.projections) &&
+           Objects.equals(baseTable, that.baseTable) &&
            Objects.equals(ioConfig, that.ioConfig) &&
            this.engine == that.engine &&
            Objects.equals(taskContext, that.taskContext);
@@ -275,6 +289,7 @@ public class InlineSchemaDataSourceCompactionConfig implements DataSourceCompact
         dimensionsSpec,
         transformSpec,
         projections,
+        baseTable,
         ioConfig,
         taskContext,
         engine
@@ -301,6 +316,7 @@ public class InlineSchemaDataSourceCompactionConfig implements DataSourceCompact
         .withMetricsSpec(this.metricsSpec)
         .withTransformSpec(this.transformSpec)
         .withProjections(this.projections)
+        .withBaseTable(this.baseTable)
         .withIoConfig(this.ioConfig)
         .withEngine(this.engine)
         .withTaskContext(this.taskContext);
@@ -319,6 +335,7 @@ public class InlineSchemaDataSourceCompactionConfig implements DataSourceCompact
     private AggregatorFactory[] metricsSpec;
     private CompactionTransformSpec transformSpec;
     private List<AggregateProjectionSpec> projections;
+    private BaseTableProjectionSpec baseTable;
     private UserCompactionTaskIOConfig ioConfig;
     private CompactionEngine engine;
     private Map<String, Object> taskContext;
@@ -336,6 +353,7 @@ public class InlineSchemaDataSourceCompactionConfig implements DataSourceCompact
           dimensionsSpec,
           metricsSpec,
           transformSpec,
+          baseTable,
           projections,
           ioConfig,
           engine,
@@ -443,6 +461,12 @@ public class InlineSchemaDataSourceCompactionConfig implements DataSourceCompact
     public Builder withProjections(List<AggregateProjectionSpec> projections)
     {
       this.projections = projections;
+      return this;
+    }
+
+    public Builder withBaseTable(BaseTableProjectionSpec baseTable)
+    {
+      this.baseTable = baseTable;
       return this;
     }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
@@ -36,6 +36,7 @@ import org.apache.druid.client.indexing.ClientMinorCompactionInputSpec;
 import org.apache.druid.common.guava.FutureUtils;
 import org.apache.druid.common.utils.IdUtils;
 import org.apache.druid.data.input.impl.AggregateProjectionSpec;
+import org.apache.druid.data.input.impl.BaseTableProjectionSpec;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.indexer.CompactionEngine;
 import org.apache.druid.java.util.common.granularity.Granularity;
@@ -401,6 +402,7 @@ public class CompactSegments implements CoordinatorCustomDuty
         dimensionsSpec,
         config.getMetricsSpec(),
         config.getTransformSpec(),
+        config.getBaseTable(),
         config.getProjections(),
         dropExisting,
         autoCompactionContext,
@@ -457,6 +459,7 @@ public class CompactSegments implements CoordinatorCustomDuty
       @Nullable ClientCompactionTaskDimensionsSpec dimensionsSpec,
       @Nullable AggregatorFactory[] metricsSpec,
       @Nullable CompactionTransformSpec transformSpec,
+      @Nullable BaseTableProjectionSpec baseTable,
       @Nullable List<AggregateProjectionSpec> projectionSpecs,
       @Nullable Boolean dropExisting,
       Map<String, Object> context,
@@ -509,6 +512,7 @@ public class CompactSegments implements CoordinatorCustomDuty
         dimensionsSpec,
         metricsSpec,
         transformSpec,
+        baseTable,
         projectionSpecs,
         context,
         compactionRunner

--- a/server/src/test/java/org/apache/druid/client/indexing/ClientCompactionRunnerInfoTest.java
+++ b/server/src/test/java/org/apache/druid/client/indexing/ClientCompactionRunnerInfoTest.java
@@ -293,6 +293,55 @@ public class ClientCompactionRunnerInfoTest
     );
   }
 
+  @Test
+  public void testMSQEngineWithBaseTableStringRangePartitionDimensionIsValid()
+  {
+    final ClusteredValueGroupsBaseTableProjectionSpec baseTable =
+        ClusteredValueGroupsBaseTableProjectionSpec.builder()
+                                                   .columns(
+                                                       new StringDimensionSchema("tenant"),
+                                                       new LongDimensionSchema("__time")
+                                                   )
+                                                   .clusteringColumns("tenant")
+                                                   .build();
+    final DataSourceCompactionConfig compactionConfig = createBaseTableCompactionConfig(
+        CompactionEngine.MSQ,
+        new DimensionRangePartitionsSpec(100, null, ImmutableList.of("tenant"), false),
+        baseTable
+    );
+    Assert.assertTrue(
+        ClientCompactionRunnerInfo.validateCompactionConfig(compactionConfig, CompactionEngine.NATIVE).isValid()
+    );
+  }
+
+  @Test
+  public void testMSQEngineWithBaseTableLongRangePartitionDimensionIsInvalid()
+  {
+    // baseTable configs carry their columns on the baseTable spec (no legacy dimensionsSpec); the range-partition
+    // column-type check must still run at config time against those columns, not be silently skipped.
+    final ClusteredValueGroupsBaseTableProjectionSpec baseTable =
+        ClusteredValueGroupsBaseTableProjectionSpec.builder()
+                                                   .columns(
+                                                       new StringDimensionSchema("tenant"),
+                                                       new LongDimensionSchema("region_id"),
+                                                       new LongDimensionSchema("__time")
+                                                   )
+                                                   .clusteringColumns("tenant")
+                                                   .build();
+    final DataSourceCompactionConfig compactionConfig = createBaseTableCompactionConfig(
+        CompactionEngine.MSQ,
+        new DimensionRangePartitionsSpec(100, null, ImmutableList.of("region_id"), false),
+        baseTable
+    );
+    final CompactionConfigValidationResult validationResult =
+        ClientCompactionRunnerInfo.validateCompactionConfig(compactionConfig, CompactionEngine.NATIVE);
+    Assert.assertFalse(validationResult.isValid());
+    Assert.assertEquals(
+        "MSQ: Non-string partition dimension[region_id] of type[LONG] not supported with 'range' partition spec",
+        validationResult.getReason()
+    );
+  }
+
   private static DataSourceCompactionConfig createBaseTableCompactionConfig(CompactionEngine engine)
   {
     final ClusteredValueGroupsBaseTableProjectionSpec baseTable =
@@ -303,11 +352,20 @@ public class ClientCompactionRunnerInfoTest
                                                    )
                                                    .clusteringColumns("tenant")
                                                    .build();
+    return createBaseTableCompactionConfig(engine, new DynamicPartitionsSpec(100, null), baseTable);
+  }
+
+  private static DataSourceCompactionConfig createBaseTableCompactionConfig(
+      CompactionEngine engine,
+      PartitionsSpec partitionsSpec,
+      ClusteredValueGroupsBaseTableProjectionSpec baseTable
+  )
+  {
     return InlineSchemaDataSourceCompactionConfig.builder()
                                                  .forDataSource("dataSource")
                                                  .withInputSegmentSizeBytes(500L)
                                                  .withSkipOffsetFromLatest(new Period(3600))
-                                                 .withTuningConfig(createTuningConfig(new DynamicPartitionsSpec(100, null)))
+                                                 .withTuningConfig(createTuningConfig(partitionsSpec))
                                                  .withBaseTable(baseTable)
                                                  .withEngine(engine)
                                                  .build();

--- a/server/src/test/java/org/apache/druid/client/indexing/ClientCompactionRunnerInfoTest.java
+++ b/server/src/test/java/org/apache/druid/client/indexing/ClientCompactionRunnerInfoTest.java
@@ -21,8 +21,10 @@ package org.apache.druid.client.indexing;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.SegmentsSplitHintSpec;
+import org.apache.druid.data.input.impl.ClusteredValueGroupsBaseTableProjectionSpec;
 import org.apache.druid.data.input.impl.DimensionSchema;
 import org.apache.druid.data.input.impl.LongDimensionSchema;
+import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.indexer.CompactionEngine;
 import org.apache.druid.indexer.partitions.DimensionRangePartitionsSpec;
 import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
@@ -265,6 +267,50 @@ public class ClientCompactionRunnerInfoTest
         "MSQ: 'granularitySpec.rollup' must be true if and only if 'metricsSpec' is specified",
         validationResult.getReason()
     );
+  }
+
+  @Test
+  public void testMSQEngineWithBaseTableIsValid()
+  {
+    DataSourceCompactionConfig compactionConfig = createBaseTableCompactionConfig(CompactionEngine.MSQ);
+    Assert.assertTrue(
+        ClientCompactionRunnerInfo.validateCompactionConfig(compactionConfig, CompactionEngine.NATIVE).isValid()
+    );
+  }
+
+  @Test
+  public void testNativeEngineWithBaseTableIsInvalid()
+  {
+    DataSourceCompactionConfig compactionConfig = createBaseTableCompactionConfig(CompactionEngine.NATIVE);
+    CompactionConfigValidationResult validationResult = ClientCompactionRunnerInfo.validateCompactionConfig(
+        compactionConfig,
+        CompactionEngine.MSQ
+    );
+    Assert.assertFalse(validationResult.isValid());
+    Assert.assertEquals(
+        "Compaction engine[native] does not support 'baseTable'; use the MSQ compaction engine.",
+        validationResult.getReason()
+    );
+  }
+
+  private static DataSourceCompactionConfig createBaseTableCompactionConfig(CompactionEngine engine)
+  {
+    final ClusteredValueGroupsBaseTableProjectionSpec baseTable =
+        ClusteredValueGroupsBaseTableProjectionSpec.builder()
+                                                   .columns(
+                                                       new StringDimensionSchema("tenant"),
+                                                       new LongDimensionSchema("__time")
+                                                   )
+                                                   .clusteringColumns("tenant")
+                                                   .build();
+    return InlineSchemaDataSourceCompactionConfig.builder()
+                                                 .forDataSource("dataSource")
+                                                 .withInputSegmentSizeBytes(500L)
+                                                 .withSkipOffsetFromLatest(new Period(3600))
+                                                 .withTuningConfig(createTuningConfig(new DynamicPartitionsSpec(100, null)))
+                                                 .withBaseTable(baseTable)
+                                                 .withEngine(engine)
+                                                 .build();
   }
 
   private static DataSourceCompactionConfig createMSQCompactionConfig(

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
@@ -4565,9 +4565,14 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   {
     return new CompactionState(
         new DynamicPartitionsSpec(100, null),
-        null, null, null,
+        null,
+        null,
+        null,
         IndexSpec.getDefault(),
-        null, null
+        null,
+        null,
+        null,
+        null
     );
   }
 

--- a/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataQueryTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataQueryTest.java
@@ -448,6 +448,8 @@ public class SqlSegmentsMetadataQueryTest
         null,
         IndexSpec.getDefault(),
         null,
+        null,
+        null,
         null
     );
     CompactionState state3 = createTestIndexingState();
@@ -653,6 +655,8 @@ public class SqlSegmentsMetadataQueryTest
         null,
         null,
         IndexSpec.getDefault(),
+        null,
+        null,
         null,
         null
     );

--- a/server/src/test/java/org/apache/druid/segment/metadata/IndexingStateCacheTest.java
+++ b/server/src/test/java/org/apache/druid/segment/metadata/IndexingStateCacheTest.java
@@ -251,6 +251,8 @@ public class IndexingStateCacheTest
         null,
         IndexSpec.getDefault(),
         null,
+        null,
+        null,
         null
     );
     String fingerprint = "same_fp";
@@ -294,6 +296,8 @@ public class IndexingStateCacheTest
         null,
         null,
         IndexSpec.getDefault(),
+        null,
+        null,
         null,
         null
     );

--- a/server/src/test/java/org/apache/druid/segment/metadata/SqlIndexingStateStorageTest.java
+++ b/server/src/test/java/org/apache/druid/segment/metadata/SqlIndexingStateStorageTest.java
@@ -488,6 +488,8 @@ public class SqlIndexingStateStorageTest
         null,
         IndexSpec.getDefault(),
         null,
+        null,
+        null,
         null
     );
 
@@ -497,6 +499,8 @@ public class SqlIndexingStateStorageTest
         metrics2,
         null,
         IndexSpec.getDefault(),
+        null,
+        null,
         null,
         null
     );
@@ -529,6 +533,8 @@ public class SqlIndexingStateStorageTest
         null,
         IndexSpec.getDefault(),
         null,
+        null,
+        null,
         null
     );
 
@@ -538,6 +544,8 @@ public class SqlIndexingStateStorageTest
         Collections.singletonList(new CountAggregatorFactory("count")),
         null,
         IndexSpec.getDefault(),
+        null,
+        null,
         null,
         null
     );
@@ -562,6 +570,8 @@ public class SqlIndexingStateStorageTest
         null,
         IndexSpec.getDefault(),
         null,
+        null,
+        null,
         null
     );
 
@@ -571,6 +581,8 @@ public class SqlIndexingStateStorageTest
         Collections.singletonList(new CountAggregatorFactory("count")),
         null,
         IndexSpec.getDefault(),
+        null,
+        null,
         null,
         null
     );
@@ -594,6 +606,8 @@ public class SqlIndexingStateStorageTest
         null,
         IndexSpec.getDefault(),
         null,
+        null,
+        null,
         null
     );
   }
@@ -606,6 +620,8 @@ public class SqlIndexingStateStorageTest
         null,
         null,
         IndexSpec.getDefault(),
+        null,
+        null,
         null,
         null
     );

--- a/server/src/test/java/org/apache/druid/server/compaction/CompactionSlotManagerTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/CompactionSlotManagerTest.java
@@ -75,6 +75,7 @@ public class CompactionSlotManagerTest
         null,
         null,
         null,
+        null,
         context,
         new ClientCompactionRunnerInfo(CompactionEngine.MSQ)
     );

--- a/server/src/test/java/org/apache/druid/server/compaction/CompactionStatusTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/CompactionStatusTest.java
@@ -21,10 +21,12 @@ package org.apache.druid.server.compaction;
 
 import org.apache.druid.client.indexing.ClientCompactionTaskQueryTuningConfig;
 import org.apache.druid.data.input.impl.AggregateProjectionSpec;
+import org.apache.druid.data.input.impl.ClusteredValueGroupsBaseTableProjectionSpec;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.LongDimensionSchema;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.indexer.granularity.GranularitySpec;
+import org.apache.druid.indexer.granularity.SegmentGranularitySpec;
 import org.apache.druid.indexer.granularity.UniformGranularitySpec;
 import org.apache.druid.indexer.partitions.DimensionRangePartitionsSpec;
 import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
@@ -239,7 +241,7 @@ public class CompactionStatusTest
   {
     final PartitionsSpec requiredPartitionsSpec = new DynamicPartitionsSpec(5_000_000, null);
     verifyCompactionStatusIsPendingBecause(
-        new CompactionState(null, null, null, null, null, null, null),
+        new CompactionState(null, null, null, null, null, null, null, null, null),
         InlineSchemaDataSourceCompactionConfig
             .builder()
             .withTuningConfig(createTuningConfig(requiredPartitionsSpec, null))
@@ -256,7 +258,7 @@ public class CompactionStatusTest
     final PartitionsSpec currentPartitionsSpec = new DynamicPartitionsSpec(100, null);
 
     final CompactionState lastCompactionState
-        = new CompactionState(currentPartitionsSpec, null, null, null, null, null, null);
+        = new CompactionState(currentPartitionsSpec, null, null, null, null, null, null, null, null);
     final DataSourceCompactionConfig compactionConfig = InlineSchemaDataSourceCompactionConfig
         .builder()
         .withTuningConfig(createTuningConfig(requiredPartitionsSpec, null))
@@ -284,6 +286,8 @@ public class CompactionStatusTest
         null,
         null,
         currentIndexSpec,
+        null,
+        null,
         null,
         null
     );
@@ -326,6 +330,8 @@ public class CompactionStatusTest
         null,
         currentIndexSpec,
         currentGranularitySpec,
+        null,
+        null,
         null
     );
     final DataSourceCompactionConfig compactionConfig = InlineSchemaDataSourceCompactionConfig
@@ -357,6 +363,8 @@ public class CompactionStatusTest
         null,
         currentIndexSpec,
         currentGranularitySpec,
+        null,
+        null,
         null
     );
     final DataSourceCompactionConfig compactionConfig = InlineSchemaDataSourceCompactionConfig
@@ -406,6 +414,8 @@ public class CompactionStatusTest
         null,
         currentIndexSpec,
         currentGranularitySpec,
+        null,
+        null,
         List.of(projection1)
     );
     final DataSourceCompactionConfig compactionConfig = InlineSchemaDataSourceCompactionConfig
@@ -414,6 +424,51 @@ public class CompactionStatusTest
         .withTuningConfig(createTuningConfig(currentPartitionsSpec, currentIndexSpec))
         .withGranularitySpec(new UserCompactionTaskGranularityConfig(Granularities.HOUR, null, null))
         .withProjections(List.of(projection1))
+        .build();
+
+    final DataSegment segment = DataSegment.builder(WIKI_SEGMENT).lastCompactionState(lastCompactionState).build();
+    final CompactionStatus status = CompactionStatus.compute(
+        List.of(segment),
+        compactionConfig,
+        fingerprintMapper
+    );
+    Assert.assertTrue(status.isComplete());
+  }
+
+  @Test
+  public void testStatusWhenBaseTableMatchesWithQueryGranularity()
+  {
+    // The published segment records the EFFECTIVE baseTable (query-granularity virtual column baked in by
+    // CompactionTask.createDataSchema), while the config carries the query granularity via its granularitySpec plus a
+    // raw baseTable spec. The status check must apply the same withQueryGranularity before comparing, otherwise this
+    // would be perpetually "pending" (re-compacting every cycle).
+    final PartitionsSpec currentPartitionsSpec = new DynamicPartitionsSpec(100, null);
+    final IndexSpec currentIndexSpec
+        = IndexSpec.builder().withDimensionCompression(CompressionStrategy.ZSTD).build();
+    final ClusteredValueGroupsBaseTableProjectionSpec baseTable =
+        ClusteredValueGroupsBaseTableProjectionSpec.builder()
+                                                   .columns(new StringDimensionSchema("tenant"), new LongDimensionSchema("__time"))
+                                                   .clusteringColumns("tenant")
+                                                   .build();
+    // The published segment records baseTable mode: segment granularity in a SegmentGranularitySpec (null
+    // GranularitySpec) and query granularity in the effective baseTable's virtual column.
+    final CompactionState lastCompactionState = new CompactionState(
+        currentPartitionsSpec,
+        null,
+        null,
+        null,
+        currentIndexSpec,
+        null,
+        new SegmentGranularitySpec(Granularities.HOUR, null),
+        baseTable.withQueryGranularity(Granularities.HOUR),
+        null
+    );
+    final DataSourceCompactionConfig compactionConfig = InlineSchemaDataSourceCompactionConfig
+        .builder()
+        .forDataSource(TestDataSource.WIKI)
+        .withTuningConfig(createTuningConfig(currentPartitionsSpec, currentIndexSpec))
+        .withGranularitySpec(new UserCompactionTaskGranularityConfig(Granularities.HOUR, Granularities.HOUR, null))
+        .withBaseTable(baseTable)
         .build();
 
     final DataSegment segment = DataSegment.builder(WIKI_SEGMENT).lastCompactionState(lastCompactionState).build();
@@ -461,6 +516,8 @@ public class CompactionStatusTest
         null,
         currentIndexSpec,
         currentGranularitySpec,
+        null,
+        null,
         List.of(projection1)
     );
     final DataSourceCompactionConfig compactionConfig = InlineSchemaDataSourceCompactionConfig
@@ -497,6 +554,8 @@ public class CompactionStatusTest
         transformSpec,
         IndexSpec.getDefault(),
         null,
+        null,
+        null,
         null
     );
     DataSourceCompactionConfig compactionConfig = InlineSchemaDataSourceCompactionConfig
@@ -529,6 +588,8 @@ public class CompactionStatusTest
         null,
         new CompactionTransformSpec(filter, VirtualColumns.create(oldVc)),
         IndexSpec.getDefault(),
+        null,
+        null,
         null,
         null
     );
@@ -600,6 +661,8 @@ public class CompactionStatusTest
         null,
         IndexSpec.getDefault().getEffectiveSpec(),
         currentGranularitySpec,
+        null,
+        null,
         Collections.emptyList()
     );
     final DataSourceCompactionConfig compactionConfig = InlineSchemaDataSourceCompactionConfig
@@ -654,6 +717,8 @@ public class CompactionStatusTest
         null,
         IndexSpec.getDefault(),
         currentGranularitySpec,
+        null,
+        null,
         Collections.emptyList()
     );
     final DataSourceCompactionConfig compactionConfig = InlineSchemaDataSourceCompactionConfig
@@ -986,6 +1051,8 @@ public class CompactionStatusTest
         null,
         IndexSpec.getDefault(),
         new UniformGranularitySpec(segmentGranularity, null, null, null),
+        null,
+        null,
         null
     );
   }

--- a/server/src/test/java/org/apache/druid/server/compaction/CompactionStatusTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/CompactionStatusTest.java
@@ -452,17 +452,12 @@ public class CompactionStatusTest
                                                    .build();
     // The published segment records baseTable mode: segment granularity in a SegmentGranularitySpec (null
     // GranularitySpec) and query granularity in the effective baseTable's virtual column.
-    final CompactionState lastCompactionState = new CompactionState(
-        currentPartitionsSpec,
-        null,
-        null,
-        null,
-        currentIndexSpec,
-        null,
-        new SegmentGranularitySpec(Granularities.HOUR, null),
-        baseTable.withQueryGranularity(Granularities.HOUR),
-        null
-    );
+    final CompactionState lastCompactionState = CompactionState.builder()
+        .partitionsSpec(currentPartitionsSpec)
+        .indexSpec(currentIndexSpec)
+        .segmentGranularitySpec(new SegmentGranularitySpec(Granularities.HOUR, null))
+        .baseTable(baseTable.withQueryGranularity(Granularities.HOUR))
+        .build();
     final DataSourceCompactionConfig compactionConfig = InlineSchemaDataSourceCompactionConfig
         .builder()
         .forDataSource(TestDataSource.WIKI)

--- a/server/src/test/java/org/apache/druid/server/compaction/ComposingReindexingRuleProviderTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/ComposingReindexingRuleProviderTest.java
@@ -454,6 +454,7 @@ public class ComposingReindexingRuleProviderTest
         new AggregatorFactory[]{new CountAggregatorFactory("count")},
         Granularities.DAY,
         true,
+        null,
         ImmutableList.of(
             new AggregateProjectionSpec(
                 "test_projection",

--- a/server/src/test/java/org/apache/druid/server/compaction/InlineReindexingRuleProviderTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/InlineReindexingRuleProviderTest.java
@@ -292,6 +292,7 @@ public class InlineReindexingRuleProviderTest
         new AggregatorFactory[]{new CountAggregatorFactory("count")},
         Granularities.DAY,
         true,
+        null,
         ImmutableList.of(new AggregateProjectionSpec(
             "test_projection",
             null,

--- a/server/src/test/java/org/apache/druid/server/compaction/NewestSegmentFirstPolicyTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/NewestSegmentFirstPolicyTest.java
@@ -747,11 +747,11 @@ public class NewestSegmentFirstPolicyTest
     final SegmentTimeline timeline = createTimeline(
         createSegments()
             .startingAt("2017-10-01")
-            .withCompactionState(new CompactionState(partitionsSpec, null, null, null, indexSpec, null, null))
+            .withCompactionState(new CompactionState(partitionsSpec, null, null, null, indexSpec, null, null, null, null))
             .withNumPartitions(4),
         createSegments()
             .startingAt("2017-10-02")
-            .withCompactionState(new CompactionState(partitionsSpec, null, null, null, indexSpec, null, null))
+            .withCompactionState(new CompactionState(partitionsSpec, null, null, null, indexSpec, null, null, null, null))
             .withNumPartitions(4)
     );
 
@@ -780,6 +780,8 @@ public class NewestSegmentFirstPolicyTest
         null,
         indexSpec,
         mapper.convertValue(ImmutableMap.of("segmentGranularity", "day"), GranularitySpec.class),
+        null,
+        null,
         null
     );
     final SegmentTimeline timeline = createTimeline(
@@ -814,6 +816,8 @@ public class NewestSegmentFirstPolicyTest
         null,
         null,
         indexSpec,
+        null,
+        null,
         null,
         null
     );
@@ -863,6 +867,8 @@ public class NewestSegmentFirstPolicyTest
         null,
         indexSpec,
         mapper.convertValue(ImmutableMap.of("segmentGranularity", "day"), GranularitySpec.class),
+        null,
+        null,
         null
     );
     final SegmentTimeline timeline = createTimeline(
@@ -909,7 +915,7 @@ public class NewestSegmentFirstPolicyTest
             .forIntervals(1, Granularities.DAY)
             .startingAt("2017-10-02")
             .withNumPartitions(4)
-            .withCompactionState(new CompactionState(partitionsSpec, null, null, null, indexSpec, null, null))
+            .withCompactionState(new CompactionState(partitionsSpec, null, null, null, indexSpec, null, null, null, null))
     );
 
     // Duration of new segmentGranularity is the same as before (P1D),
@@ -959,7 +965,7 @@ public class NewestSegmentFirstPolicyTest
             .forIntervals(1, Granularities.DAY)
             .startingAt("2017-10-02")
             .withNumPartitions(4)
-            .withCompactionState(new CompactionState(partitionsSpec, null, null, null, indexSpec, null, null))
+            .withCompactionState(new CompactionState(partitionsSpec, null, null, null, indexSpec, null, null, null, null))
     );
 
     // Duration of new segmentGranularity is the same as before (P1D), but we changed the origin in the autocompaction spec
@@ -1018,6 +1024,8 @@ public class NewestSegmentFirstPolicyTest
                 null,
                 indexSpec,
                 new UniformGranularitySpec(null, null, false, null),
+                null,
+                null,
                 null
             )),
         createSegments()
@@ -1031,6 +1039,8 @@ public class NewestSegmentFirstPolicyTest
                 null,
                 indexSpec,
                 new UniformGranularitySpec(null, null, true, null),
+                null,
+                null,
                 null
             )),
         createSegments()
@@ -1044,6 +1054,8 @@ public class NewestSegmentFirstPolicyTest
                 null,
                 indexSpec,
                 new UniformGranularitySpec(null, null, false, null),
+                null,
+                null,
                 null
             ))
     );
@@ -1110,6 +1122,8 @@ public class NewestSegmentFirstPolicyTest
                     ImmutableMap.of("queryGranularity", "day"),
                     GranularitySpec.class
                 ),
+                null,
+                null,
                 null
             )),
         createSegments()
@@ -1126,6 +1140,8 @@ public class NewestSegmentFirstPolicyTest
                     ImmutableMap.of("queryGranularity", "minute"),
                     GranularitySpec.class
                 ),
+                null,
+                null,
                 null
             )),
         createSegments()
@@ -1139,6 +1155,8 @@ public class NewestSegmentFirstPolicyTest
                 null,
                 indexSpec,
                 mapper.convertValue(ImmutableMap.of(), GranularitySpec.class),
+                null,
+                null,
                 null
             ))
     );
@@ -1206,6 +1224,8 @@ public class NewestSegmentFirstPolicyTest
                     null,
                     indexSpec,
                     null,
+                    null,
+                    null,
                     null
                 )
             ),
@@ -1220,6 +1240,8 @@ public class NewestSegmentFirstPolicyTest
                     null,
                     indexSpec,
                     null,
+                    null,
+                    null,
                     null
                 )
             ),
@@ -1233,12 +1255,14 @@ public class NewestSegmentFirstPolicyTest
                 null,
                 indexSpec,
                 null,
+                null,
+                null,
                 null
             )),
         createSegments()
             .startingAt("2017-10-04")
             .withNumPartitions(4)
-            .withCompactionState(new CompactionState(partitionsSpec, null, null, null, indexSpec, null, null))
+            .withCompactionState(new CompactionState(partitionsSpec, null, null, null, indexSpec, null, null, null, null))
     );
 
     // Auto compaction config sets Dimensions=["foo"]
@@ -1329,6 +1353,8 @@ public class NewestSegmentFirstPolicyTest
                     null,
                     indexSpec,
                     null,
+                    null,
+                    null,
                     null
                 )
             ),
@@ -1347,6 +1373,8 @@ public class NewestSegmentFirstPolicyTest
                     null,
                     null,
                     indexSpec,
+                    null,
+                    null,
                     null,
                     null
                 )
@@ -1432,6 +1460,8 @@ public class NewestSegmentFirstPolicyTest
                     new CompactionTransformSpec(new SelectorDimFilter("dim1", "foo", null), null),
                     indexSpec,
                     null,
+                    null,
+                    null,
                     null
                 )
             ),
@@ -1445,6 +1475,8 @@ public class NewestSegmentFirstPolicyTest
                     null,
                     new CompactionTransformSpec(new SelectorDimFilter("dim1", "bar", null), null),
                     indexSpec,
+                    null,
+                    null,
                     null,
                     null
                 )
@@ -1460,13 +1492,15 @@ public class NewestSegmentFirstPolicyTest
                     new CompactionTransformSpec(null, null),
                     indexSpec,
                     null,
+                    null,
+                    null,
                     null
                 )
             ),
         createSegments()
             .startingAt("2017-10-04")
             .withNumPartitions(4)
-            .withCompactionState(new CompactionState(partitionsSpec, null, null, null, indexSpec, null, null))
+            .withCompactionState(new CompactionState(partitionsSpec, null, null, null, indexSpec, null, null, null, null))
     );
 
     // Auto compaction config sets filter=SelectorDimFilter("dim1", "bar", null)
@@ -1554,6 +1588,8 @@ public class NewestSegmentFirstPolicyTest
                     null,
                     indexSpec,
                     null,
+                    null,
+                    null,
                     null
                 )
             ),
@@ -1571,6 +1607,8 @@ public class NewestSegmentFirstPolicyTest
                     null,
                     indexSpec,
                     null,
+                    null,
+                    null,
                     null
                 )
             ),
@@ -1585,13 +1623,15 @@ public class NewestSegmentFirstPolicyTest
                     null,
                     indexSpec,
                     null,
+                    null,
+                    null,
                     null
                 )
             ),
         createSegments()
             .startingAt("2017-10-04")
             .withNumPartitions(4)
-            .withCompactionState(new CompactionState(partitionsSpec, null, null, null, indexSpec, null, null))
+            .withCompactionState(new CompactionState(partitionsSpec, null, null, null, indexSpec, null, null, null, null))
     );
 
     // Auto compaction config sets metricsSpec={CountAggregatorFactory("cnt"), LongSumAggregatorFactory("val", "val")}
@@ -1695,7 +1735,7 @@ public class NewestSegmentFirstPolicyTest
             .forIntervals(1, Granularities.DAY)
             .startingAt("2017-10-02")
             .withNumPartitions(4)
-            .withCompactionState(new CompactionState(partitionsSpec, null, null, null, newIndexSpec, null, null))
+            .withCompactionState(new CompactionState(partitionsSpec, null, null, null, newIndexSpec, null, null, null, null))
     );
 
     // Duration of new segmentGranularity is the same as before (P1D)
@@ -1740,7 +1780,7 @@ public class NewestSegmentFirstPolicyTest
             .startingAt("2017-10-01")
             .withNumPartitions(4)
             .withCompactionState(
-                new CompactionState(partitionsSpec, null, null, null, IndexSpec.getDefault(), null, null)
+                new CompactionState(partitionsSpec, null, null, null, IndexSpec.getDefault(), null, null, null, null)
             )
     );
 

--- a/server/src/test/java/org/apache/druid/server/compaction/ReindexingDataSchemaRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/ReindexingDataSchemaRuleTest.java
@@ -19,15 +19,23 @@
 
 package org.apache.druid.server.compaction;
 
+import com.fasterxml.jackson.databind.InjectableValues;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.data.input.impl.BaseTableProjectionSpec;
+import org.apache.druid.data.input.impl.ClusteredValueGroupsBaseTableProjectionSpec;
 import org.apache.druid.data.input.impl.LongDimensionSchema;
+import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.error.DruidException;
+import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.granularity.Granularity;
+import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
+import org.apache.druid.query.expression.TestExprMacroTable;
 import org.apache.druid.server.coordinator.UserCompactionTaskDimensionsConfig;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -50,6 +58,11 @@ public class ReindexingDataSchemaRuleTest
   };
   private final Granularity queryGranularity = Granularities.MINUTE;
   private final Boolean rollup = true;
+  private final BaseTableProjectionSpec baseTable = ClusteredValueGroupsBaseTableProjectionSpec
+      .builder()
+      .columns(new StringDimensionSchema("tenant"), new LongDimensionSchema("__time"))
+      .clusteringColumns("tenant")
+      .build();
 
   private final ReindexingDataSchemaRule rule = new ReindexingDataSchemaRule(
       "test-schema-rule",
@@ -59,6 +72,7 @@ public class ReindexingDataSchemaRuleTest
       metricsSpec,
       queryGranularity,
       rollup,
+      baseTable,
       Collections.emptyList()
   );
 
@@ -156,6 +170,13 @@ public class ReindexingDataSchemaRuleTest
   }
 
   @Test
+  public void test_getBaseTable_returnsConfiguredValue()
+  {
+    Assertions.assertNotNull(rule.getBaseTable());
+    Assertions.assertEquals(baseTable, rule.getBaseTable());
+  }
+
+  @Test
   public void test_getId_returnsConfiguredId()
   {
     Assertions.assertEquals("test-schema-rule", rule.getId());
@@ -186,6 +207,7 @@ public class ReindexingDataSchemaRuleTest
             metricsSpec,
             queryGranularity,
             rollup,
+            null,
             Collections.emptyList()
         )
     );
@@ -204,6 +226,7 @@ public class ReindexingDataSchemaRuleTest
             metricsSpec,
             queryGranularity,
             rollup,
+            null,
             Collections.emptyList()
         )
     );
@@ -222,6 +245,7 @@ public class ReindexingDataSchemaRuleTest
         metricsSpec,
         queryGranularity,
         rollup,
+        null,
         Collections.emptyList()
     );
     Assertions.assertEquals(zeroPeriod, rule.getOlderThan());
@@ -241,6 +265,7 @@ public class ReindexingDataSchemaRuleTest
             metricsSpec,
             queryGranularity,
             rollup,
+            null,
             Collections.emptyList()
         )
     );
@@ -258,6 +283,7 @@ public class ReindexingDataSchemaRuleTest
         metricsSpec,
         queryGranularity,
         rollup,
+        null,
         Collections.emptyList()
     );
     Assertions.assertNull(rule.getDimensionsSpec());
@@ -275,6 +301,7 @@ public class ReindexingDataSchemaRuleTest
         null,
         queryGranularity,
         rollup,
+        null,
         Collections.emptyList()
     );
     Assertions.assertNull(rule.getMetricsSpec());
@@ -292,6 +319,7 @@ public class ReindexingDataSchemaRuleTest
         metricsSpec,
         null,
         rollup,
+        null,
         Collections.emptyList()
     );
     Assertions.assertNull(rule.getQueryGranularity());
@@ -308,6 +336,7 @@ public class ReindexingDataSchemaRuleTest
         dimensionsSpec,
         metricsSpec,
         queryGranularity,
+        null,
         null,
         Collections.emptyList()
     );
@@ -326,9 +355,46 @@ public class ReindexingDataSchemaRuleTest
         metricsSpec,
         queryGranularity,
         rollup,
+        null,
         null
     );
     Assertions.assertNull(rule.getProjections());
+  }
+
+  @Test
+  public void test_constructor_nullBaseTable_succeeds()
+  {
+    // Null baseTable is allowed
+    ReindexingDataSchemaRule rule = new ReindexingDataSchemaRule(
+        "test-id",
+        "description",
+        PERIOD_14_DAYS,
+        dimensionsSpec,
+        metricsSpec,
+        queryGranularity,
+        rollup,
+        null,
+        Collections.emptyList()
+    );
+    Assertions.assertNull(rule.getBaseTable());
+  }
+
+  @Test
+  public void test_constructor_baseTableOnly_succeeds()
+  {
+    // A baseTable alone satisfies the at-least-one-non-null requirement
+    ReindexingDataSchemaRule rule = new ReindexingDataSchemaRule(
+        "test-id",
+        "description",
+        PERIOD_14_DAYS,
+        null,
+        null,
+        null,
+        null,
+        baseTable,
+        null
+    );
+    Assertions.assertEquals(baseTable, rule.getBaseTable());
   }
 
   @Test
@@ -344,6 +410,7 @@ public class ReindexingDataSchemaRuleTest
         emptyMetrics,
         queryGranularity,
         rollup,
+        null,
         Collections.emptyList()
     );
     Assertions.assertNotNull(rule.getMetricsSpec());
@@ -363,8 +430,23 @@ public class ReindexingDataSchemaRuleTest
             null,
             null,
             null,
+            null,
             null
         )
     );
+  }
+
+  @Test
+  public void test_serde_roundTripWithBaseTable() throws Exception
+  {
+    final ObjectMapper mapper = new DefaultObjectMapper();
+    mapper.setInjectableValues(
+        new InjectableValues.Std().addValue(ExprMacroTable.class, TestExprMacroTable.INSTANCE)
+    );
+    final String json = mapper.writeValueAsString(rule);
+    final ReindexingDataSchemaRule fromJson = mapper.readValue(json, ReindexingDataSchemaRule.class);
+
+    Assertions.assertEquals(baseTable, fromJson.getBaseTable());
+    Assertions.assertEquals(rule, fromJson);
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordination/LoadableDataSegmentTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/LoadableDataSegmentTest.java
@@ -86,6 +86,8 @@ public class LoadableDataSegmentTest
         ),
         MAPPER.convertValue(Map.of(), IndexSpec.class),
         MAPPER.convertValue(Map.of(), GranularitySpec.class),
+        null,
+        null,
         null
     );
     final DataSegment segment = DataSegment.builder(segmentId)

--- a/server/src/test/java/org/apache/druid/server/coordinator/InlineSchemaDataSourceCompactionConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/InlineSchemaDataSourceCompactionConfigTest.java
@@ -24,7 +24,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.data.input.SegmentsSplitHintSpec;
+import org.apache.druid.data.input.impl.ClusteredValueGroupsBaseTableProjectionSpec;
 import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.LongDimensionSchema;
+import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.indexer.CompactionEngine;
 import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
 import org.apache.druid.jackson.DefaultObjectMapper;
@@ -500,5 +503,34 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
     Assert.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
     Assert.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
     Assert.assertEquals(config.getMetricsSpec(), fromJson.getMetricsSpec());
+  }
+
+  @Test
+  public void testSerdeBaseTable() throws IOException
+  {
+    final ClusteredValueGroupsBaseTableProjectionSpec baseTable =
+        ClusteredValueGroupsBaseTableProjectionSpec.builder()
+                                                   .columns(
+                                                       new StringDimensionSchema("tenant"),
+                                                       new LongDimensionSchema("__time")
+                                                   )
+                                                   .clusteringColumns("tenant")
+                                                   .build();
+    final InlineSchemaDataSourceCompactionConfig config = InlineSchemaDataSourceCompactionConfig
+        .builder()
+        .forDataSource("dataSource")
+        .withInputSegmentSizeBytes(500L)
+        .withSkipOffsetFromLatest(new Period(3600))
+        .withEngine(CompactionEngine.MSQ)
+        .withBaseTable(baseTable)
+        .withTaskContext(ImmutableMap.of("key", "val"))
+        .build();
+    final String json = OBJECT_MAPPER.writeValueAsString(config);
+    final InlineSchemaDataSourceCompactionConfig fromJson = OBJECT_MAPPER.readValue(json, InlineSchemaDataSourceCompactionConfig.class);
+
+    Assert.assertEquals(config.getDataSource(), fromJson.getDataSource());
+    Assert.assertEquals(config.getBaseTable(), fromJson.getBaseTable());
+    Assert.assertEquals(baseTable, fromJson.getBaseTable());
+    Assert.assertEquals(config, fromJson);
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
@@ -46,7 +46,9 @@ import org.apache.druid.client.indexing.ClientTaskQuery;
 import org.apache.druid.client.indexing.IndexingTotalWorkerCapacityInfo;
 import org.apache.druid.client.indexing.TaskPayloadResponse;
 import org.apache.druid.data.input.impl.AggregateProjectionSpec;
+import org.apache.druid.data.input.impl.ClusteredValueGroupsBaseTableProjectionSpec;
 import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.LongDimensionSchema;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.indexer.CompactionEngine;
 import org.apache.druid.indexer.RunnerTaskState;
@@ -459,6 +461,8 @@ public class CompactSegmentsTest
                   null,
                   JSON_MAPPER.convertValue(ImmutableMap.of(), IndexSpec.class),
                   JSON_MAPPER.convertValue(ImmutableMap.of(), GranularitySpec.class),
+                  null,
+                  null,
                   null
               )
           );
@@ -470,6 +474,8 @@ public class CompactSegmentsTest
                   null,
                   JSON_MAPPER.convertValue(ImmutableMap.of(), IndexSpec.class),
                   JSON_MAPPER.convertValue(ImmutableMap.of(), GranularitySpec.class),
+                  null,
+                  null,
                   null
               )
           );
@@ -484,6 +490,8 @@ public class CompactSegmentsTest
                   null,
                   JSON_MAPPER.convertValue(ImmutableMap.of(), IndexSpec.class),
                   JSON_MAPPER.convertValue(ImmutableMap.of(), GranularitySpec.class),
+                  null,
+                  null,
                   null
               )
           );
@@ -985,6 +993,43 @@ public class CompactSegmentsTest
   }
 
   @Test
+  public void testCompactWithBaseTable()
+  {
+    final OverlordClient mockClient = Mockito.mock(OverlordClient.class);
+    final ArgumentCaptor<Object> payloadCaptor = setUpMockClient(mockClient);
+    final CompactSegments compactSegments = new CompactSegments(statusTracker, mockClient);
+    final List<DataSourceCompactionConfig> compactionConfigs = new ArrayList<>();
+    final String dataSource = DATA_SOURCE_PREFIX + 0;
+    final ClusteredValueGroupsBaseTableProjectionSpec baseTable =
+        ClusteredValueGroupsBaseTableProjectionSpec.builder()
+                                                   .columns(
+                                                       new StringDimensionSchema("bar"),
+                                                       new LongDimensionSchema("__time")
+                                                   )
+                                                   .clusteringColumns("bar")
+                                                   .build();
+
+    compactionConfigs.add(
+        InlineSchemaDataSourceCompactionConfig.builder()
+                                              .forDataSource(dataSource)
+                                              .withTaskPriority(0)
+                                              .withInputSegmentSizeBytes(500L)
+                                              .withSkipOffsetFromLatest(new Period("PT0H")) // smaller than segment interval
+                                              .withTuningConfig(getTuningConfig(3))
+                                              .withBaseTable(baseTable)
+                                              // baseTable requires the MSQ compaction engine
+                                              .withEngine(CompactionEngine.MSQ)
+                                              .build()
+    );
+    doCompactSegments(compactSegments, compactionConfigs);
+    ClientCompactionTaskQuery taskPayload = (ClientCompactionTaskQuery) payloadCaptor.getValue();
+    Assert.assertEquals(
+        baseTable,
+        taskPayload.getBaseTable()
+    );
+  }
+
+  @Test
   public void testCompactWithCatalogProjections()
   {
     final String dataSource = DATA_SOURCE_PREFIX + 0;
@@ -1112,6 +1157,7 @@ public class CompactSegmentsTest
             ),
             null,
             new ClientCompactionTaskGranularitySpec(Granularities.DAY, null, null),
+            null,
             null,
             null,
             null,
@@ -1979,6 +2025,8 @@ public class CompactSegmentsTest
                     IndexSpec.class
                 ),
                 jsonMapper.convertValue(ImmutableMap.of(), GranularitySpec.class),
+                null,
+                null,
                 null
             ),
             1,

--- a/server/src/test/java/org/apache/druid/server/http/DataSegmentPlusTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/DataSegmentPlusTest.java
@@ -114,6 +114,8 @@ public class DataSegmentPlusTest
                        ),
                        MAPPER.convertValue(ImmutableMap.of(), IndexSpec.class),
                        MAPPER.convertValue(ImmutableMap.of(), GranularitySpec.class),
+                       null,
+                       null,
                        null
                    ))
                    .indexingStateFingerprint(indexingStateFingerprint)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
@@ -309,6 +309,8 @@ public class SystemSchemaTest extends CalciteTestBase
       null,
       MAPPER.convertValue(Collections.singletonMap("test", "map"), IndexSpec.class),
       MAPPER.convertValue(Collections.singletonMap("test2", "map2"), GranularitySpec.class),
+      null,
+      null,
       null
   );
 


### PR DESCRIPTION
### Description
Follow-up to #19579, this PR adds MSQ compaction support for clustered segments when using 'inline' or reindexing template based compaction.

changes:
* `CompactionTask` now can specify `baseTable` spec to create clustered segments
* `DataSourceMSQDestination` can now specify a `baseTable` so MSQ can generate clustered segments (or any other future baseTable spec)
* adds `baseTable` to 'inline' and reindexing template compaction configs to feed to compaction task for auto-compaction
* adds `baseTable`, `segmentGranularitySpec` to `CompactionState`, `CompactionStatus` is `baseTable` aware for checks
* guards to prevent `baseTable` from working with 'native' compaction and direct towards MSQ compaction