### PR TITLE
fix: retry S3 segment reads on transient SSLException (TLS "Tag mismatch")

### DIFF
--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
@@ -48,6 +48,7 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
 import javax.annotation.Nullable;
+import javax.net.ssl.SSLException;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -77,6 +78,10 @@ public class S3Utils
     {
       if (e == null) {
         return false;
+      } else if (e instanceof SSLException) {
+        // Transient TLS read failure (e.g. AEADBadTagException "Tag mismatch!"). Retry here, ahead of
+        // the IOException branch, which would recurse into the non-IOException crypto cause and not retry.
+        return true;
       } else if (e instanceof IOException) {
         if (e.getCause() != null) {
           // Recurse with the underlying cause to see if it's retriable.

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3UtilsTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3UtilsTest.java
@@ -34,6 +34,8 @@ import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.S3Error;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
+import javax.crypto.AEADBadTagException;
+import javax.net.ssl.SSLException;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CompletionException;
@@ -53,6 +55,24 @@ public class S3UtilsTest
             () -> {
               count.incrementAndGet();
               throw new IOException("hmm");
+            },
+            maxRetries
+        ));
+    Assert.assertEquals(maxRetries, count.get());
+  }
+
+  @Test
+  public void testRetryWithSslExceptionWrappingAeadBadTag()
+  {
+    // Transient TLS "Tag mismatch!" should be retried, not treated as terminal. See issue #19616.
+    final int maxRetries = 3;
+    final AtomicInteger count = new AtomicInteger();
+    Assert.assertThrows(
+        SSLException.class,
+        () -> S3Utils.retryS3Operation(
+            () -> {
+              count.incrementAndGet();
+              throw new SSLException("Tag mismatch!", new AEADBadTagException("Tag mismatch!"));
             },
             maxRetries
         ));


### PR DESCRIPTION
### Description

`S3Utils.S3RETRY` classifies a transient TLS/transport read failure as non-retriable when the `SSLException` wraps a non-`IOException` cause.

A segment pull from S3 (`S3DataSegmentPuller.getSegmentFiles` -> `CompressionUtils.unzip`, retried via `RetryUtils.retry(..., S3Utils.S3RETRY, ...)`) can fail mid-stream with `javax.net.ssl.SSLException: Tag mismatch!` caused by `javax.crypto.AEADBadTagException` — a corrupted TLS record failing AES-GCM authentication during the HTTPS GET. This is a transient transport error; a fresh `getObject` (which `S3DataSegmentPuller` already opens per retry via its `ByteSource`) would almost certainly succeed.

`SSLException` is an `IOException`, but it has a cause, so `S3RETRY` recurses into the cause (`AEADBadTagException`, a `GeneralSecurityException`), which matches none of the retriable branches and returns `false`. The segment load is therefore not retried. Under MSQ this surfaces as a non-retriable `UnknownError` and aborts the entire multi-stage query — a single transient corrupted TLS record on one worker can fail a large multi-worker SELECT.

This change classifies `SSLException` as retriable, ahead of the generic `IOException` branch. It mirrors the targeted-signature approach of #11941 (which added retry for the `SdkClientException` "Data read has a different length than the expected" dropped-connection case).

Fixes #19616.

### Release note
Retry S3 reads that fail with a transient `SSLException` (e.g. a TLS "Tag mismatch") instead of treating them as terminal.

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added unit tests covering the new behavior (`S3UtilsTest#testRetryWithSslExceptionWrappingAeadBadTag`).
