### PR TITLE
build(deps): Update Jackson to 2.21.4 to address multiple CVEs

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -321,7 +321,7 @@ name: Jackson
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.21.3
+version: 2.22.0
 libraries:
   - com.fasterxml.jackson.core: jackson-core
   - com.fasterxml.jackson.core: jackson-annotations
@@ -374,7 +374,7 @@ name: Jackson
 license_category: binary
 module: extensions-contrib/druid-deltalake-extensions
 license_name: Apache License version 2.0
-version: 2.21.3
+version: 2.22.0
 libraries:
   - com.fasterxml.jackson.core: jackson-databind
 notice: |
@@ -1002,7 +1002,7 @@ name: Jackson
 license_category: binary
 module: extensions-core/kubernetes-overlord-extensions
 license_name: Apache License version 2.0
-version: 2.21.3
+version: 2.22.0
 libraries:
   - com.fasterxml.jackson.dataformat: jackson-dataformat-properties
 notice: |
@@ -3076,7 +3076,7 @@ libraries:
 ---
 
 name: Jackson Dataformat Yaml
-version: 2.21.3
+version: 2.22.0
 license_category: binary
 module: extensions/druid-avro-extensions
 license_name: Apache License version 2.0

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -364,7 +364,7 @@ name: Jackson
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: "2.21"
+version: "2.22"
 libraries:
   - com.fasterxml.jackson.core: jackson-annotations
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -321,7 +321,7 @@ name: Jackson
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.22.0
+version: 2.21.4
 libraries:
   - com.fasterxml.jackson.core: jackson-core
   - com.fasterxml.jackson.core: jackson-annotations
@@ -364,7 +364,7 @@ name: Jackson
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: "2.22"
+version: "2.21"
 libraries:
   - com.fasterxml.jackson.core: jackson-annotations
 
@@ -374,7 +374,7 @@ name: Jackson
 license_category: binary
 module: extensions-contrib/druid-deltalake-extensions
 license_name: Apache License version 2.0
-version: 2.22.0
+version: 2.21.4
 libraries:
   - com.fasterxml.jackson.core: jackson-databind
 notice: |
@@ -1002,7 +1002,7 @@ name: Jackson
 license_category: binary
 module: extensions-core/kubernetes-overlord-extensions
 license_name: Apache License version 2.0
-version: 2.22.0
+version: 2.21.4
 libraries:
   - com.fasterxml.jackson.dataformat: jackson-dataformat-properties
 notice: |
@@ -3076,7 +3076,7 @@ libraries:
 ---
 
 name: Jackson Dataformat Yaml
-version: 2.22.0
+version: 2.21.4
 license_category: binary
 module: extensions/druid-avro-extensions
 license_name: Apache License version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <iceberg.core.version>1.10.0</iceberg.core.version>
         <jetty.version>12.1.8</jetty.version>
         <jersey.version>1.19.4</jersey.version>
-        <jackson.version>2.21.3</jackson.version>
+        <jackson.version>2.22.0</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
         <log4j.version>2.25.4</log4j.version>
         <mysql.version>8.2.0</mysql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <iceberg.core.version>1.10.0</iceberg.core.version>
         <jetty.version>12.1.8</jetty.version>
         <jersey.version>1.19.4</jersey.version>
-        <jackson.version>2.22.0</jackson.version>
+        <jackson.version>2.21.4</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
         <log4j.version>2.25.4</log4j.version>
         <mysql.version>8.2.0</mysql.version>


### PR DESCRIPTION
## Summary

Updates Jackson from version 2.21.3 to 2.21.4 to address 4 high severity security vulnerabilities in jackson-core, jackson-databind, and jackson-annotations.

## Release note

Upgraded com.fasterxml.jackson dependencies from version 2.21.3 to 2.21.4 to address security vulnerabilities.

---

### Key changed/added classes in this PR

* Top Level pom.xml
* licenses.yaml

---

## Reason for upgrade

Jackson is a core JSON processing library used extensively throughout Druid for serialization and deserialization of configuration, query requests, ingestion specs, segment metadata, and internal communication between nodes. The upgrade from 2.21.3 to 2.21.4 addresses 4 high severity security vulnerabilities that pose significant risks to data integrity, service availability, and security posture.

Since Druid processes sensitive data and exposes REST APIs for queries, ingestion, and cluster coordination, these vulnerabilities could allow attackers to manipulate serialized data, cause denial of service, or potentially execute unauthorized operations. Upgrading to version 2.21.4 patches all identified vulnerabilities and is essential for maintaining a secure production environment.

## CVEs Addressed

**High Severity:**

* [CVE-2026-54513](https://nvd.nist.gov/vuln/detail/CVE-2026-54513): Deserialization vulnerability in jackson-databind allowing unauthorized data manipulation through polymorphic type handling bypass
* [CVE-2026-54512](https://nvd.nist.gov/vuln/detail/CVE-2026-54512): Denial of service through unbounded resource consumption in jackson-databind during deeply nested JSON parsing
* [CVE-2026-54514](https://nvd.nist.gov/vuln/detail/CVE-2026-54514): Information disclosure via jackson-databind through improper exception handling exposing internal application state
* [CVE-2026-54516](https://nvd.nist.gov/vuln/detail/CVE-2026-54516): Arbitrary code execution risk in jackson-core through maliciously crafted JSON leading to unsafe object instantiation

## Changes

This PR includes changes to two files to complete the Jackson security upgrade and satisfy Druid's license compliance requirements:

**1. pom.xml (1 line changed)**

* Updated `jackson.version` property from `2.21.3` to `2.21.4`

**2. licenses.yaml (5 sections updated, 10 lines changed)**

* Updated Jackson version: `"2.21"` → `"2.21"` (unchanged, as shortened version remains on 2.21.x line) in `java-core` module
* Updated Jackson core version: `2.21.3` → `2.21.4` in `java-core` module
* Updated Jackson version: `2.21.3` → `2.21.4` in `extensions-contrib/druid-deltalake-extensions` module
* Updated Jackson version: `2.21.3` → `2.21.4` in `extensions-core/kubernetes-overlord-extensions` module
* Updated Jackson Dataformat Yaml version: `2.21.3` → `2.21.4` in `extensions/druid-avro-extensions` module

## Tests

* Verified the dependency resolves correctly with all transitive dependencies
* Build completes successfully with the updated version
* Existing integration tests pass with the upgraded Jackson version
* License validation passes for all modules