### PR TITLE
minor: bump Log4j dep to 2.26 and make JsonTemplateLayout available to operators in their custom  log4j configs

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -2040,13 +2040,14 @@ name: Apache Log4j
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.25.4
+version: 2.26.0
 libraries:
   - org.apache.logging.log4j: log4j-1.2-api
   - org.apache.logging.log4j: log4j-api
   - org.apache.logging.log4j: log4j-core
   - org.apache.logging.log4j: log4j-jul
   - org.apache.logging.log4j: log4j-slf4j-impl
+  - org.apache.logging.log4j: log4j-layout-template-json
 notices:
   - log4j-1.2-api: |
       Apache Log4j 1.x Compatibility API
@@ -2068,6 +2069,9 @@ notices:
       Copyright 1999-2015 Apache Software Foundation
   - log4j-slf4j-impl: |
       Apache Log4j SLF4J Binding
+      Copyright 1999-2015 Apache Software Foundation
+  - log4j-layout-template-json: |
+      Apache Log4j Layout Template JSON
       Copyright 1999-2015 Apache Software Foundation
 
 ---

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -2071,8 +2071,8 @@ notices:
       Apache Log4j SLF4J Binding
       Copyright 1999-2015 Apache Software Foundation
   - log4j-layout-template-json: |
-      Apache Log4j Layout Template JSON
-      Copyright 1999-2015 Apache Software Foundation
+      Apache Log4j JSON Template Layout
+      Copyright 1999-2026 The Apache Software Foundation
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <jersey.version>1.19.4</jersey.version>
         <jackson.version>2.21.3</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
-        <log4j.version>2.25.4</log4j.version>
+        <log4j.version>2.26.0</log4j.version>
         <mysql.version>8.2.0</mysql.version>
         <mariadb.version>2.7.3</mariadb.version>
         <netty3.version>3.10.6.Final</netty3.version>
@@ -930,6 +930,11 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-1.2-api</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-layout-template-json</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
             <dependency>

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -161,6 +161,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-layout-template-json</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>runtime</scope>
     </dependency>


### PR DESCRIPTION
### Description

Using json formatted logs is not the default format shipped with Apache Druid stock log4j files, but many operators choose to customize their logging format. It is likely pretty common for them to use JSON formatted logs. As it stands, operators who do not add `log4j-layout-template-json` to their own druid bundle would be stuck with [JsonLayout](https://logging.apache.org/log4j/2.x/manual/layouts.html#JSONLayout) which is deprecated in favor of [JsonTemplateLayout](https://logging.apache.org/log4j/2.x/manual/json-template-layout.html). In addition to being the supported way to use JSON formatted logs, this layout provides superior performance to the legacy Layout. Also, `JsonLayout` is completely removed in log4j 3.x so we will need the new dependency eventually either way.

One of the main reasons I found myself down a rabbit hole in log4j was in doing some chaos testing of my configs for a virtual storage enabled data server. I was purposely stress testing with different configs and one such test put artificial load on the s3 connection pool by way oversubscribing segment read requests compared to the s3 client thread pool size. This led to a cascade of s3 related exceptions which end up logged with extended traces by RetryUtils. Sadly, the data server ended up deadlocked because all of the carrier threads for the virtual storage load virtual threads had pinned virtual threads due to native calls in their stacks that I traced back to log4j exception logging. While I don't know that what I was doing was a very realistic scenario for day to day Druid operations, I do think that it raised a real potential problem for both perf and operations in a cluster using JSON formatted logs.

#### Release note

Bump log4j dependency to 2.26.0. Add `log4j-layout-template-json` as a dependency to allow operators to switch from deprecated `JsonFormat` to `JsonTemplateFormat` if they are using Json formatted logs. Any operator wishing to migrate should refer to [JsonTemplateLayout](https://logging.apache.org/log4j/2.x/manual/json-template-layout.html). The jar ships with default Layouts that are defined in log4j docs, and you can also ship custom layouts if the defaults do not meet your needs.

<hr>

##### Key changed/added classes in this PR
 * `pom.xml`
 * `processing/pom.xml`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.