### PR TITLE
fix: Perform best effort cleanup of intermediary data in ParallelIndexSupervisorTask

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -1841,7 +1841,8 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask
           DeepStorageIntermediaryDataManager.retrieveShuffleDataStoragePath(getId())
       );
     }
-    catch (IOException e) {
+    catch (Exception e) {
+      // Best effort cleanup, do not fail the task if cleanup fails
       LOG.warn(e, "Failed recursive deep storage cleanup for intermediary path for task[%s]", getId());
     }
 


### PR DESCRIPTION
Failure to cleanup the intermediary data of the task should not cause the task to fail.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.