### PR TITLE
fix: bugfix in MSQ code path for extern ingest

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedMSQParquetIngestionTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedMSQParquetIngestionTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.testing.embedded.msq;
+
+import com.sun.net.httpserver.HttpServer;
+import org.apache.druid.data.input.parquet.ParquetExtensionsModule;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.query.http.SqlTaskStatus;
+import org.apache.druid.testing.embedded.EmbeddedBroker;
+import org.apache.druid.testing.embedded.EmbeddedCoordinator;
+import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
+import org.apache.druid.testing.embedded.EmbeddedHistorical;
+import org.apache.druid.testing.embedded.EmbeddedIndexer;
+import org.apache.druid.testing.embedded.EmbeddedOverlord;
+import org.apache.druid.testing.embedded.indexing.Resources;
+import org.apache.druid.testing.embedded.junit5.EmbeddedClusterTestBase;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Ingests a Parquet file served over HTTP through an MSQ task, confirming end to end success.
+ *
+ * <p>Reading from a remote source such as HTTP or S3 exercises this fetch-to-disk path; a {@code local} input source
+ * does not, because its file is already on disk and is read in place.
+ */
+public class EmbeddedMSQParquetIngestionTest extends EmbeddedClusterTestBase
+{
+  private static final String PARQUET_RESOURCE = "data/parquet/wikipedia_index_data1.parquet";
+  private static final String PARQUET_PATH = "/wikipedia_index_data1.parquet";
+
+  private final EmbeddedOverlord overlord = new EmbeddedOverlord();
+  private final EmbeddedCoordinator coordinator = new EmbeddedCoordinator();
+  private final EmbeddedIndexer indexer = new EmbeddedIndexer()
+      .setServerMemory(300_000_000L)
+      .addProperty("druid.worker.capacity", "2");
+  private final EmbeddedBroker broker = new EmbeddedBroker().setServerMemory(200_000_000);
+
+  private EmbeddedMSQApis msqApis;
+  private HttpServer parquetServer;
+  private String parquetUri;
+
+  @Override
+  protected EmbeddedDruidCluster createCluster()
+  {
+    return EmbeddedDruidCluster
+        .withEmbeddedDerbyAndZookeeper()
+        .useLatchableEmitter()
+        .addExtension(ParquetExtensionsModule.class)
+        .addServer(overlord)
+        .addServer(coordinator)
+        .addServer(indexer)
+        .addServer(broker)
+        .addServer(new EmbeddedHistorical());
+  }
+
+  @BeforeAll
+  public void initTestClient() throws IOException
+  {
+    msqApis = new EmbeddedMSQApis(cluster, overlord);
+
+    final Path parquet = Resources.getFileForResource(PARQUET_RESOURCE).toPath();
+    final byte[] parquetBytes = Files.readAllBytes(parquet);
+
+    final int port;
+    try (ServerSocket socket = new ServerSocket(0)) {
+      port = socket.getLocalPort();
+    }
+    parquetServer = HttpServer.create(new InetSocketAddress("localhost", port), 0);
+    parquetServer.createContext(
+        PARQUET_PATH,
+        httpExchange -> {
+          httpExchange.sendResponseHeaders(200, parquetBytes.length);
+          try (OutputStream os = httpExchange.getResponseBody()) {
+            os.write(parquetBytes);
+          }
+        }
+    );
+    parquetServer.start();
+    parquetUri = StringUtils.format(
+        "http://%s:%d%s",
+        parquetServer.getAddress().getHostName(),
+        parquetServer.getAddress().getPort(),
+        PARQUET_PATH
+    );
+  }
+
+  @AfterAll
+  public void tearDownServer()
+  {
+    if (parquetServer != null) {
+      parquetServer.stop(0);
+    }
+  }
+
+  @Test
+  public void testReplaceFromExternalParquet()
+  {
+    final String sql = StringUtils.format(
+        "REPLACE INTO %s OVERWRITE ALL\n"
+        + "SELECT\n"
+        + "  TIME_PARSE(\"timestamp\") AS __time,\n"
+        + "  \"page\",\n"
+        + "  \"added\",\n"
+        + "  \"delta\",\n"
+        + "  \"deleted\",\n"
+        + "  \"namespace\"\n"
+        + "FROM TABLE(\n"
+        + "  EXTERN(\n"
+        + "    '{\"type\":\"http\",\"uris\":[\"%s\"]}',\n"
+        + "    '{\"type\":\"parquet\"}'\n"
+        + "  )\n"
+        + ") EXTEND (\n"
+        + "  \"timestamp\" VARCHAR,\n"
+        + "  \"page\" VARCHAR,\n"
+        + "  \"added\" BIGINT,\n"
+        + "  \"delta\" BIGINT,\n"
+        + "  \"deleted\" BIGINT,\n"
+        + "  \"namespace\" VARCHAR\n"
+        + ")\n"
+        + "PARTITIONED BY DAY",
+        dataSource,
+        parquetUri
+    );
+
+    final SqlTaskStatus taskStatus = msqApis.submitTaskSql(sql);
+    cluster.callApi().waitForTaskToSucceed(taskStatus.getTaskId(), overlord.latchableEmitter());
+    cluster.callApi().waitForAllSegmentsToBeAvailable(dataSource, coordinator, broker);
+
+    cluster.callApi().verifySqlQuery(
+        "SELECT __time, page, added, delta, deleted, namespace FROM %s ORDER BY __time",
+        dataSource,
+        "2013-08-31T01:02:33.000Z,Gypsy Danger,57,-143,200,article\n"
+        + "2013-08-31T03:32:45.000Z,Striker Eureka,459,330,129,wikipedia\n"
+        + "2013-08-31T07:11:21.000Z,Cherno Alpha,123,111,12,article"
+    );
+  }
+}

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalInputSliceReader.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalInputSliceReader.java
@@ -148,7 +148,7 @@ public class ExternalInputSliceReader implements InputSliceReader
         ColumnsFilter.all()
     );
 
-    // Some extern sources will need to download the source files to the specified tempoaryDirectory.
+    // Some extern sources will need to download the source files to the specified temporaryDirectory.
     // The fetch runs lazily when the cursor is created, and the directory must exist to avoid task failure.
     try {
       FileUtils.mkdirp(temporaryDirectory);

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalInputSliceReader.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalInputSliceReader.java
@@ -157,7 +157,6 @@ public class ExternalInputSliceReader implements InputSliceReader
       throw new RuntimeException(e);
     }
 
-
     final String description = StringUtils.format("external[%s]", inputSource.toString());
     final SegmentDescriptor descriptor = new SegmentDescriptor(Intervals.ETERNITY, "0", 0);
     final List<InputFilePointer> filePointers = inputSource.asFilePointers();

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalInputSliceReader.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalInputSliceReader.java
@@ -32,6 +32,7 @@ import org.apache.druid.data.input.impl.InlineInputSource;
 import org.apache.druid.data.input.impl.LocalInputSource;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
@@ -59,6 +60,7 @@ import org.apache.druid.segment.loading.external.VirtualStorageManager;
 import org.apache.druid.utils.CloseableUtils;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -145,6 +147,16 @@ public class ExternalInputSliceReader implements InputSliceReader
         ),
         ColumnsFilter.all()
     );
+
+    // Some extern sources will need to download the source files to the specified tempoaryDirectory.
+    // The fetch runs lazily when the cursor is created, and the directory must exist to avoid task failure.
+    try {
+      FileUtils.mkdirp(temporaryDirectory);
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
 
     final String description = StringUtils.format("external[%s]", inputSource.toString());
     final SegmentDescriptor descriptor = new SegmentDescriptor(Intervals.ETERNITY, "0", 0);


### PR DESCRIPTION
### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixes a bug in MSQ ingestion from external sources

https://github.com/apache/druid/pull/18873 introduced a regression when it removed a temporary directory create that some MSQ shapes relied on. If this temporary directory isn't eagerly created, workers may try to write data into it and fail. The attached embedded test reproduces the issue without the app code changes, and no longer fails with the changes.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `ExternalInputSliceReader`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.