### PR TITLE
feat: ensure statusCode is included in router logs

### DIFF
--- a/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 import com.fasterxml.jackson.jaxrs.smile.SmileMediaTypes;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import org.apache.calcite.avatica.remote.ProtobufTranslation;
@@ -387,7 +386,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
     final String errorMessage = exceptionToReport.getMessage() == null
                                 ? "no error message" : exceptionToReport.getMessage();
 
-    AuthenticationResult authenticationResult = AuthorizationUtils.authenticationResultFromRequest(request);
+    final AuthenticationResult authenticationResult = AuthorizationUtils.authenticationResultFromRequest(request);
 
     if (isNativeQuery) {
       requestLogger.logNativeQuery(
@@ -395,7 +394,18 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
               null,
               DateTimes.nowUtc(),
               request.getRemoteAddr(),
-              new QueryStats(ImmutableMap.of("success", false, "exception", errorMessage, "identity", authenticationResult.getIdentity()))
+              new QueryStats(
+                  Map.of(
+                      "success",
+                      false,
+                      DruidMetrics.STATUS_CODE,
+                      httpStatusCode,
+                      "exception",
+                      errorMessage,
+                      "identity",
+                      authenticationResult.getIdentity()
+                  )
+              )
           )
       );
     } else {
@@ -405,7 +415,18 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
               null,
               DateTimes.nowUtc(),
               request.getRemoteAddr(),
-              new QueryStats(ImmutableMap.of("success", false, "exception", errorMessage, "identity", authenticationResult.getIdentity()))
+              new QueryStats(
+                  Map.of(
+                      "success",
+                      false,
+                      DruidMetrics.STATUS_CODE,
+                      httpStatusCode,
+                      "exception",
+                      errorMessage,
+                      "identity",
+                      authenticationResult.getIdentity()
+                  )
+              )
           )
       );
     }
@@ -770,7 +791,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
         failedQueryCount.incrementAndGet();
       }
 
-      AuthenticationResult authenticationResult = AuthorizationUtils.authenticationResultFromRequest(req);
+      final AuthenticationResult authenticationResult = AuthorizationUtils.authenticationResultFromRequest(req);
 
       // As router is simply a proxy, we don't make an effort to construct the error code from the exception ourselves.
       // We rely on broker to set this for us if the error occurs downstream.
@@ -789,11 +810,13 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
                     DateTimes.nowUtc(),
                     req.getRemoteAddr(),
                     new QueryStats(
-                        ImmutableMap.of(
+                        Map.of(
                             "query/time",
                             TimeUnit.NANOSECONDS.toMillis(requestTimeNs),
                             "success",
                             success,
+                            DruidMetrics.STATUS_CODE,
+                            statusCode,
                             "identity",
                             authenticationResult.getIdentity()
                         )
@@ -816,11 +839,13 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
                 DateTimes.nowUtc(),
                 req.getRemoteAddr(),
                 new QueryStats(
-                    ImmutableMap.of(
+                    Map.of(
                         "query/time",
                         TimeUnit.NANOSECONDS.toMillis(requestTimeNs),
                         "success",
                         success,
+                        DruidMetrics.STATUS_CODE,
+                        statusCode,
                         "identity",
                         authenticationResult.getIdentity()
                     )
@@ -863,7 +888,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       // We rely on broker to set this for us if the error occurs downstream. 
       // Otherwise, if there's a router/client error, we log this as an unknown error.
       final int statusCode = determineStatusCode(false, response.getStatus());
-      AuthenticationResult authenticationResult = AuthorizationUtils.authenticationResultFromRequest(req);
+      final AuthenticationResult authenticationResult = AuthorizationUtils.authenticationResultFromRequest(req);
       emitQueryTime(requestTimeNs, false, sqlQueryId, queryId, statusCode, authenticationResult);
 
       //noinspection VariableNotUsedInsideIf
@@ -878,9 +903,11 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
                     DateTimes.nowUtc(),
                     req.getRemoteAddr(),
                     new QueryStats(
-                        ImmutableMap.of(
+                        Map.of(
                             "success",
                             false,
+                            DruidMetrics.STATUS_CODE,
+                            statusCode,
                             "exception",
                             errorMessage == null ? "no message" : errorMessage,
                             "identity",
@@ -910,9 +937,11 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
                 DateTimes.nowUtc(),
                 req.getRemoteAddr(),
                 new QueryStats(
-                    ImmutableMap.of(
+                    Map.of(
                         "success",
                         false,
+                        DruidMetrics.STATUS_CODE,
+                        statusCode,
                         "exception",
                         errorMessage == null ? "no message" : errorMessage,
                         "identity",

--- a/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -394,18 +394,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
               null,
               DateTimes.nowUtc(),
               request.getRemoteAddr(),
-              new QueryStats(
-                  Map.of(
-                      "success",
-                      false,
-                      DruidMetrics.STATUS_CODE,
-                      httpStatusCode,
-                      "exception",
-                      errorMessage,
-                      "identity",
-                      authenticationResult.getIdentity()
-                  )
-              )
+              buildRequestLogQueryStats(false, httpStatusCode, authenticationResult.getIdentity(), null, errorMessage)
           )
       );
     } else {
@@ -415,18 +404,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
               null,
               DateTimes.nowUtc(),
               request.getRemoteAddr(),
-              new QueryStats(
-                  Map.of(
-                      "success",
-                      false,
-                      DruidMetrics.STATUS_CODE,
-                      httpStatusCode,
-                      "exception",
-                      errorMessage,
-                      "identity",
-                      authenticationResult.getIdentity()
-                  )
-              )
+              buildRequestLogQueryStats(false, httpStatusCode, authenticationResult.getIdentity(), null, errorMessage)
           )
       );
     }
@@ -437,6 +415,38 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
     objectMapper.writeValue(
         response.getOutputStream(),
         serverConfig.getErrorResponseTransformStrategy().transformIfNeeded(exceptionToReport)
+    );
+  }
+
+  /**
+   * Builds the {@link QueryStats} recorded in router request logs. Success paths pass {@code queryTimeMs};
+   * failure paths pass {@code exceptionMessage}. Exactly one of the two is non-null at every call site.
+   */
+  private static QueryStats buildRequestLogQueryStats(
+      boolean success,
+      int statusCode,
+      String identity,
+      @Nullable Long queryTimeMs,
+      @Nullable String exceptionMessage
+  )
+  {
+    if (exceptionMessage != null) {
+      return new QueryStats(
+          Map.of(
+              "success", success,
+              DruidMetrics.STATUS_CODE, statusCode,
+              "exception", exceptionMessage,
+              "identity", identity
+          )
+      );
+    }
+    return new QueryStats(
+        Map.of(
+            "query/time", queryTimeMs,
+            "success", success,
+            DruidMetrics.STATUS_CODE, statusCode,
+            "identity", identity
+        )
     );
   }
 
@@ -809,17 +819,12 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
                     sqlQuery.getContext(),
                     DateTimes.nowUtc(),
                     req.getRemoteAddr(),
-                    new QueryStats(
-                        Map.of(
-                            "query/time",
-                            TimeUnit.NANOSECONDS.toMillis(requestTimeNs),
-                            "success",
-                            success,
-                            DruidMetrics.STATUS_CODE,
-                            statusCode,
-                            "identity",
-                            authenticationResult.getIdentity()
-                        )
+                    buildRequestLogQueryStats(
+                        success,
+                        statusCode,
+                        authenticationResult.getIdentity(),
+                        TimeUnit.NANOSECONDS.toMillis(requestTimeNs),
+                        null
                     )
                 )
             );
@@ -838,17 +843,12 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
                 query,
                 DateTimes.nowUtc(),
                 req.getRemoteAddr(),
-                new QueryStats(
-                    Map.of(
-                        "query/time",
-                        TimeUnit.NANOSECONDS.toMillis(requestTimeNs),
-                        "success",
-                        success,
-                        DruidMetrics.STATUS_CODE,
-                        statusCode,
-                        "identity",
-                        authenticationResult.getIdentity()
-                    )
+                buildRequestLogQueryStats(
+                    success,
+                    statusCode,
+                    authenticationResult.getIdentity(),
+                    TimeUnit.NANOSECONDS.toMillis(requestTimeNs),
+                    null
                 )
             )
         );
@@ -902,17 +902,12 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
                     sqlQuery.getContext(),
                     DateTimes.nowUtc(),
                     req.getRemoteAddr(),
-                    new QueryStats(
-                        Map.of(
-                            "success",
-                            false,
-                            DruidMetrics.STATUS_CODE,
-                            statusCode,
-                            "exception",
-                            errorMessage == null ? "no message" : errorMessage,
-                            "identity",
-                            authenticationResult.getIdentity()
-                        )
+                    buildRequestLogQueryStats(
+                        false,
+                        statusCode,
+                        authenticationResult.getIdentity(),
+                        null,
+                        errorMessage == null ? "no message" : errorMessage
                     )
                 )
             );
@@ -936,17 +931,12 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
                 query,
                 DateTimes.nowUtc(),
                 req.getRemoteAddr(),
-                new QueryStats(
-                    Map.of(
-                        "success",
-                        false,
-                        DruidMetrics.STATUS_CODE,
-                        statusCode,
-                        "exception",
-                        errorMessage == null ? "no message" : errorMessage,
-                        "identity",
-                        authenticationResult.getIdentity()
-                    )
+                buildRequestLogQueryStats(
+                    false,
+                    statusCode,
+                    authenticationResult.getIdentity(),
+                    null,
+                    errorMessage == null ? "no message" : errorMessage
                 )
             )
         );

--- a/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
+++ b/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
@@ -73,6 +73,7 @@ import org.apache.druid.server.initialization.ServerConfig;
 import org.apache.druid.server.initialization.jetty.JettyServerInitUtils;
 import org.apache.druid.server.initialization.jetty.JettyServerInitializer;
 import org.apache.druid.server.log.NoopRequestLogger;
+import org.apache.druid.server.log.RequestLogger;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.apache.druid.server.router.QueryHostFinder;
 import org.apache.druid.server.router.RendezvousHashAvaticaConnectionBalancer;
@@ -506,7 +507,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
   }
 
   @Test
-  public void testMetricsEmittedWithErrorStatusCodeButNoResultException()
+  public void testMetricsEmittedWithErrorStatusCodeButNoResultException() throws IOException
   {
     final TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
                                         .dataSource("foo")
@@ -539,6 +540,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
     };
 
     final StubServiceEmitter stubServiceEmitter = StubServiceEmitter.createStarted();
+    final RequestLogger requestLogger = Mockito.mock(RequestLogger.class);
     final AsyncQueryForwardingServlet servlet = new AsyncQueryForwardingServlet(
         new MapQueryToolChestWarehouse(ImmutableMap.of()),
         TestHelper.makeJsonMapper(),
@@ -547,7 +549,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
         null,
         null,
         stubServiceEmitter,
-        NoopRequestLogger.instance(),
+        requestLogger,
         makeRouterTestOverrideEmittingFactory(),
         new AuthenticatorMapper(ImmutableMap.of()),
         new Properties(),
@@ -566,6 +568,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
         504,
         stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE)
     );
+    assertNativeQueryStatusCodeMatchesMetric(requestLogger, getEmittedStatusCode(stubServiceEmitter));
     Assert.assertEquals("false", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("success"));
     Assert.assertEquals("testUser", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("identity"));
   }
@@ -643,7 +646,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
   }
 
   @Test
-  public void testOnFailureWithExceptionAndUnassignedStatusCode()
+  public void testOnFailureWithExceptionAndUnassignedStatusCode() throws IOException
   {
     final TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
                                         .dataSource("foo")
@@ -665,6 +668,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
     Mockito.when(responseMock.getHeaders()).thenReturn(HttpFields.build());
 
     final StubServiceEmitter stubServiceEmitter = StubServiceEmitter.createStarted();
+    final RequestLogger requestLogger = Mockito.mock(RequestLogger.class);
     final AsyncQueryForwardingServlet servlet = new AsyncQueryForwardingServlet(
         new MapQueryToolChestWarehouse(ImmutableMap.of()),
         TestHelper.makeJsonMapper(),
@@ -673,7 +677,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
         null,
         null,
         stubServiceEmitter,
-        NoopRequestLogger.instance(),
+        requestLogger,
         makeRouterTestOverrideEmittingFactory(),
         new AuthenticatorMapper(ImmutableMap.of()),
         new Properties(),
@@ -693,6 +697,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
         500, // Should default to 500 when status is 0
         stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE)
     );
+    assertNativeQueryStatusCodeMatchesMetric(requestLogger, getEmittedStatusCode(stubServiceEmitter));
     Assert.assertEquals("false", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("success"));
     Assert.assertEquals("testUser", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("identity"));
   }
@@ -913,6 +918,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
     };
     final Result result = new Result(proxyRequestMock, response);
     final StubServiceEmitter stubServiceEmitter = StubServiceEmitter.createStarted();
+    final RequestLogger requestLogger = Mockito.mock(RequestLogger.class);
     final AsyncQueryForwardingServlet servlet = new AsyncQueryForwardingServlet(
         new MapQueryToolChestWarehouse(ImmutableMap.of()),
         jsonMapper,
@@ -921,7 +927,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
         null,
         null,
         stubServiceEmitter,
-        NoopRequestLogger.instance(),
+        requestLogger,
         new DefaultGenericQueryMetricsFactory(),
         new AuthenticatorMapper(ImmutableMap.of()),
         properties,
@@ -967,10 +973,51 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
           stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE)
       );
     }
+    if (!isJDBCSql) {
+      assertStatusCodeMatchesMetric(requestLogger, isNativeSql, getEmittedStatusCode(stubServiceEmitter));
+    }
 
     // This test is mostly about verifying that the servlet calls the right methods the right number of times.
     EasyMock.verify(hostFinder, requestMock);
     Assert.assertEquals(1, didService.get());
+  }
+
+  private static int getEmittedStatusCode(StubServiceEmitter stubServiceEmitter)
+  {
+    return (int) stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE);
+  }
+
+  private static void assertStatusCodeMatchesMetric(
+      RequestLogger requestLogger,
+      boolean isSqlQuery,
+      int metricStatusCode
+  ) throws IOException
+  {
+    if (isSqlQuery) {
+      final ArgumentCaptor<RequestLogLine> requestLogLineCaptor = ArgumentCaptor.forClass(RequestLogLine.class);
+      Mockito.verify(requestLogger).logSqlQuery(requestLogLineCaptor.capture());
+      assertStatusCode(requestLogLineCaptor.getValue(), metricStatusCode);
+    } else {
+      assertNativeQueryStatusCodeMatchesMetric(requestLogger, metricStatusCode);
+    }
+  }
+
+  private static void assertNativeQueryStatusCodeMatchesMetric(
+      RequestLogger requestLogger,
+      int metricStatusCode
+  ) throws IOException
+  {
+    final ArgumentCaptor<RequestLogLine> requestLogLineCaptor = ArgumentCaptor.forClass(RequestLogLine.class);
+    Mockito.verify(requestLogger).logNativeQuery(requestLogLineCaptor.capture());
+    assertStatusCode(requestLogLineCaptor.getValue(), metricStatusCode);
+  }
+
+  private static void assertStatusCode(RequestLogLine requestLogLine, int metricStatusCode)
+  {
+    Assert.assertEquals(
+        metricStatusCode,
+        requestLogLine.getQueryStats().getStats().get(DruidMetrics.STATUS_CODE)
+    );
   }
 
   private static Server makeTestDeleteServer(int port, final CountDownLatch latch)


### PR DESCRIPTION
We rely on query logs for observability, operations. Currently the only source of query status code on the router is in the metric emitted by the router. We should make sure it's emitted as part of the query log as well.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Ensures that the statusCode dimension is included in router logs for better historical analysis.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.