### PR TITLE
fix: Fix for flaky embedded test QueryVirtualStorageTest

### DIFF
--- a/processing/src/test/java/org/apache/druid/java/util/metrics/StubServiceEmitter.java
+++ b/processing/src/test/java/org/apache/druid/java/util/metrics/StubServiceEmitter.java
@@ -152,8 +152,10 @@ public class StubServiceEmitter extends ServiceEmitter implements MetricsVerifie
   {
     final Queue<ServiceMetricEvent> metricEventQueue = metricEvents.get(metricName);
     long total = 0;
-    for (ServiceMetricEvent event : metricEventQueue) {
-      total += event.getValue().longValue();
+    if (metricEventQueue != null) {
+      for (ServiceMetricEvent event : metricEventQueue) {
+        total += event.getValue().longValue();
+      }
     }
     return total;
   }


### PR DESCRIPTION
Adds a null check to ensure that the test does not fail due to a race.

```
QueryVirtualStorageTest.class:197 | Cannot invoke "java.util.Queue.iterator()" because "metricEventQueue" is null 0.005s
```
<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.