### PR TITLE
perf: add SIMD acceleration for doubleMean aggregator

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/DoubleMeanVectorAggregatorBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/DoubleMeanVectorAggregatorBenchmark.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark;
+
+import org.apache.druid.query.aggregation.VectorAggregator;
+import org.apache.druid.query.aggregation.mean.DoubleMeanHolder;
+import org.apache.druid.query.aggregation.mean.DoubleMeanVectorAggregator;
+import org.apache.druid.query.aggregation.simd.SimdDoubleMeanVectorAggregator;
+import org.apache.druid.segment.vector.VectorValueSelector;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Fork(value = 1, jvmArgsAppend = "--add-modules=jdk.incubator.vector")
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class DoubleMeanVectorAggregatorBenchmark
+{
+  @Param({"128", "512", "1024", "4096"})
+  private int vectorSize;
+
+  @Param({"none", "sparse", "alternating"})
+  private String nullPattern;
+
+  private ByteBuffer scalarBuffer;
+  private ByteBuffer simdBuffer;
+  private VectorAggregator scalarAggregator;
+  private VectorAggregator simdAggregator;
+
+  @Setup(Level.Trial)
+  public void setup()
+  {
+    final double[] values = new double[vectorSize];
+    final Random random = new Random(0xC0FFEEL);
+    for (int i = 0; i < vectorSize; i++) {
+      values[i] = (random.nextDouble() - 0.5) * 1000.0;
+    }
+
+    final boolean[] nulls = makeNullVector();
+    final VectorValueSelector selector = new FakeVectorValueSelector(vectorSize, values, nulls);
+    scalarAggregator = new DoubleMeanVectorAggregator(selector);
+    simdAggregator = new SimdDoubleMeanVectorAggregator(selector);
+    scalarBuffer = ByteBuffer.allocate(DoubleMeanHolder.MAX_INTERMEDIATE_SIZE);
+    simdBuffer = ByteBuffer.allocate(DoubleMeanHolder.MAX_INTERMEDIATE_SIZE);
+  }
+
+  @Setup(Level.Invocation)
+  public void setupInvocation()
+  {
+    scalarAggregator.init(scalarBuffer, 0);
+    simdAggregator.init(simdBuffer, 0);
+  }
+
+  @Benchmark
+  public void scalarDoubleMean(final Blackhole blackhole)
+  {
+    scalarAggregator.aggregate(scalarBuffer, 0, 0, vectorSize);
+    blackhole.consume(scalarBuffer.getDouble(0));
+    blackhole.consume(scalarBuffer.getLong(Double.BYTES));
+  }
+
+  @Benchmark
+  public void simdDoubleMean(final Blackhole blackhole)
+  {
+    simdAggregator.aggregate(simdBuffer, 0, 0, vectorSize);
+    blackhole.consume(simdBuffer.getDouble(0));
+    blackhole.consume(simdBuffer.getLong(Double.BYTES));
+  }
+
+  @Nullable
+  private boolean[] makeNullVector()
+  {
+    return switch (nullPattern) {
+      case "none" -> null;
+      case "sparse" -> {
+        final boolean[] nulls = new boolean[vectorSize];
+        for (int i = 0; i < vectorSize; i++) {
+          nulls[i] = i % 17 == 0;
+        }
+        yield nulls;
+      }
+      case "alternating" -> {
+        final boolean[] nulls = new boolean[vectorSize];
+        for (int i = 0; i < vectorSize; i++) {
+          nulls[i] = (i & 1) == 0;
+        }
+        yield nulls;
+      }
+      default -> throw new IllegalStateException("Unsupported null pattern[" + nullPattern + "]");
+    };
+  }
+
+  private static final class FakeVectorValueSelector implements VectorValueSelector
+  {
+    private final int size;
+    private final double[] doubles;
+    @Nullable
+    private final boolean[] nulls;
+
+    FakeVectorValueSelector(final int size, final double[] doubles, @Nullable final boolean[] nulls)
+    {
+      this.size = size;
+      this.doubles = doubles;
+      this.nulls = nulls;
+    }
+
+    @Override
+    public long[] getLongVector()
+    {
+      return null;
+    }
+
+    @Override
+    public float[] getFloatVector()
+    {
+      return null;
+    }
+
+    @Override
+    public double[] getDoubleVector()
+    {
+      return doubles;
+    }
+
+    @Nullable
+    @Override
+    public boolean[] getNullVector()
+    {
+      return nulls;
+    }
+
+    @Override
+    public int getMaxVectorSize()
+    {
+      return size;
+    }
+
+    @Override
+    public int getCurrentVectorSize()
+    {
+      return size;
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregatorFactory.java
@@ -25,17 +25,20 @@ import com.google.common.base.Preconditions;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.collect.Utils;
+import org.apache.druid.math.expr.ExpressionProcessing;
 import org.apache.druid.query.aggregation.Aggregator;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.AggregatorUtil;
 import org.apache.druid.query.aggregation.BufferAggregator;
 import org.apache.druid.query.aggregation.VectorAggregator;
+import org.apache.druid.query.aggregation.simd.SimdDoubleMeanVectorAggregator;
 import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.segment.ColumnInspector;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
+import org.apache.druid.segment.vector.VectorValueSelector;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -122,7 +125,11 @@ public class DoubleMeanAggregatorFactory extends AggregatorFactory
   @Override
   public VectorAggregator factorizeVector(final VectorColumnSelectorFactory selectorFactory)
   {
-    return new DoubleMeanVectorAggregator(selectorFactory.makeValueSelector(fieldName));
+    final VectorValueSelector selector = selectorFactory.makeValueSelector(fieldName);
+    if (ExpressionProcessing.useVectorApi()) {
+      return new SimdDoubleMeanVectorAggregator(selector);
+    }
+    return new DoubleMeanVectorAggregator(selector);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanHolder.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanHolder.java
@@ -107,6 +107,12 @@ public class DoubleMeanHolder
     writeCount(buf, position, getCount(buf, position) + 1);
   }
 
+  public static void update(final ByteBuffer buf, final int position, final double sum, final long count)
+  {
+    writeSum(buf, position, getSum(buf, position) + sum);
+    writeCount(buf, position, getCount(buf, position) + count);
+  }
+
   public static void update(ByteBuffer buf, int position, DoubleMeanHolder other)
   {
     writeSum(buf, position, getSum(buf, position) + other.sum);

--- a/processing/src/main/java/org/apache/druid/query/aggregation/simd/SimdDoubleMeanVectorAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/simd/SimdDoubleMeanVectorAggregator.java
@@ -23,7 +23,6 @@ import jdk.incubator.vector.DoubleVector;
 import jdk.incubator.vector.VectorMask;
 import jdk.incubator.vector.VectorOperators;
 import jdk.incubator.vector.VectorSpecies;
-import org.apache.druid.query.aggregation.NullAwareVectorAggregator;
 import org.apache.druid.query.aggregation.mean.DoubleMeanHolder;
 import org.apache.druid.query.aggregation.mean.DoubleMeanVectorAggregator;
 import org.apache.druid.segment.vector.VectorValueSelector;
@@ -34,8 +33,13 @@ import java.nio.ByteBuffer;
  * SIMD specialization of {@link DoubleMeanVectorAggregator}'s ungrouped contiguous-range aggregation. The hot loop
  * reduces input values into one local sum and count, then updates the mean holder once. The grouped scatter-gather
  * variant is inherited from the parent scalar class.
+ *
+ * Null handling is done internally: {@code DoubleMeanAggregatorFactory} is not a {@code NullableNumericAggregatorFactory},
+ * so this aggregator is never wrapped by {@code NullableNumericVectorAggregator} and does not implement
+ * {@code NullAwareVectorAggregator}. The contiguous-range {@link #aggregate(ByteBuffer, int, int, int)} entry point
+ * inspects the selector's null vector itself and dispatches to a masked or unmasked SIMD loop.
  */
-public final class SimdDoubleMeanVectorAggregator extends DoubleMeanVectorAggregator implements NullAwareVectorAggregator
+public final class SimdDoubleMeanVectorAggregator extends DoubleMeanVectorAggregator
 {
   private static final VectorSpecies<Double> SPECIES = DoubleVector.SPECIES_PREFERRED;
 
@@ -54,12 +58,11 @@ public final class SimdDoubleMeanVectorAggregator extends DoubleMeanVectorAggreg
     if (nullVector == null) {
       aggregateNoNulls(buf, position, startRow, endRow);
     } else {
-      aggregate(buf, position, startRow, endRow, nullVector);
+      aggregateNulls(buf, position, startRow, endRow, nullVector);
     }
   }
 
-  @Override
-  public boolean aggregate(
+  private void aggregateNulls(
       final ByteBuffer buf,
       final int position,
       final int startRow,
@@ -88,9 +91,7 @@ public final class SimdDoubleMeanVectorAggregator extends DoubleMeanVectorAggreg
     }
     if (count > 0) {
       DoubleMeanHolder.update(buf, position, sum, count);
-      return true;
     }
-    return false;
   }
 
   private void aggregateNoNulls(final ByteBuffer buf, final int position, final int startRow, final int endRow)

--- a/processing/src/main/java/org/apache/druid/query/aggregation/simd/SimdDoubleMeanVectorAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/simd/SimdDoubleMeanVectorAggregator.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.aggregation.simd;
+
+import jdk.incubator.vector.DoubleVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
+import org.apache.druid.query.aggregation.NullAwareVectorAggregator;
+import org.apache.druid.query.aggregation.mean.DoubleMeanHolder;
+import org.apache.druid.query.aggregation.mean.DoubleMeanVectorAggregator;
+import org.apache.druid.segment.vector.VectorValueSelector;
+
+import java.nio.ByteBuffer;
+
+/**
+ * SIMD specialization of {@link DoubleMeanVectorAggregator}'s ungrouped contiguous-range aggregation. The hot loop
+ * reduces input values into one local sum and count, then updates the mean holder once. The grouped scatter-gather
+ * variant is inherited from the parent scalar class.
+ */
+public final class SimdDoubleMeanVectorAggregator extends DoubleMeanVectorAggregator implements NullAwareVectorAggregator
+{
+  private static final VectorSpecies<Double> SPECIES = DoubleVector.SPECIES_PREFERRED;
+
+  private final VectorValueSelector selector;
+
+  public SimdDoubleMeanVectorAggregator(final VectorValueSelector selector)
+  {
+    super(selector);
+    this.selector = selector;
+  }
+
+  @Override
+  public void aggregate(final ByteBuffer buf, final int position, final int startRow, final int endRow)
+  {
+    final boolean[] nullVector = selector.getNullVector();
+    if (nullVector == null) {
+      aggregateNoNulls(buf, position, startRow, endRow);
+    } else {
+      aggregate(buf, position, startRow, endRow, nullVector);
+    }
+  }
+
+  @Override
+  public boolean aggregate(
+      final ByteBuffer buf,
+      final int position,
+      final int startRow,
+      final int endRow,
+      final boolean[] nullVector
+  )
+  {
+    final double[] vector = selector.getDoubleVector();
+
+    final int laneCount = SPECIES.length();
+    final int upperBound = startRow + SPECIES.loopBound(endRow - startRow);
+    int i = startRow;
+    DoubleVector vacc = DoubleVector.zero(SPECIES);
+    long count = 0;
+    for (; i < upperBound; i += laneCount) {
+      final VectorMask<Double> notNull = VectorMask.fromArray(SPECIES, nullVector, i).not();
+      vacc = vacc.add(DoubleVector.fromArray(SPECIES, vector, i), notNull);
+      count += notNull.trueCount();
+    }
+    double sum = vacc.reduceLanes(VectorOperators.ADD);
+    for (; i < endRow; i++) {
+      if (!nullVector[i]) {
+        sum += vector[i];
+        count++;
+      }
+    }
+    if (count > 0) {
+      DoubleMeanHolder.update(buf, position, sum, count);
+      return true;
+    }
+    return false;
+  }
+
+  private void aggregateNoNulls(final ByteBuffer buf, final int position, final int startRow, final int endRow)
+  {
+    final double[] vector = selector.getDoubleVector();
+
+    final int laneCount = SPECIES.length();
+    final int upperBound = startRow + SPECIES.loopBound(endRow - startRow);
+    int i = startRow;
+    DoubleVector vacc = DoubleVector.zero(SPECIES);
+    for (; i < upperBound; i += laneCount) {
+      vacc = vacc.add(DoubleVector.fromArray(SPECIES, vector, i));
+    }
+    double sum = vacc.reduceLanes(VectorOperators.ADD);
+    for (; i < endRow; i++) {
+      sum += vector[i];
+    }
+    DoubleMeanHolder.update(buf, position, sum, endRow - startRow);
+  }
+}

--- a/processing/src/test/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregationTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregationTest.java
@@ -23,12 +23,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.druid.data.input.Row;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.guava.Sequence;
+import org.apache.druid.math.expr.ExpressionProcessing;
 import org.apache.druid.query.Druids;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryContexts;
@@ -49,6 +49,7 @@ import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.TestIndex;
 import org.apache.druid.timeline.SegmentId;
 import org.easymock.EasyMock;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -61,9 +62,13 @@ import java.util.List;
 @RunWith(JUnitParamsRunner.class)
 public class DoubleMeanAggregationTest
 {
-  public Object[] doVectorize()
+  public Object[] doVectorizeAndUseVectorApi()
   {
-    return Lists.newArrayList(true, false).toArray();
+    return new Object[]{
+        new Object[]{false, false},
+        new Object[]{true, false},
+        new Object[]{true, true}
+    };
   }
 
   @Rule
@@ -100,10 +105,19 @@ public class DoubleMeanAggregationTest
     );
   }
 
-  @Test
-  @Parameters(method = "doVectorize")
-  public void testBufferAggretatorUsingGroupByQuery(boolean doVectorize) throws Exception
+  @After
+  public void resetExpressionProcessing()
   {
+    ExpressionProcessing.initializeForTests();
+  }
+
+  @Test
+  @Parameters(method = "doVectorizeAndUseVectorApi")
+  public void testBufferAggretatorUsingGroupByQuery(final boolean doVectorize, final boolean useVectorApi)
+      throws Exception
+  {
+    initializeExpressionProcessing(useVectorApi);
+
     GroupByQuery query = new GroupByQuery.Builder()
         .setDataSource("test")
         .setGranularity(Granularities.ALL)
@@ -129,9 +143,15 @@ public class DoubleMeanAggregationTest
   }
 
   @Test
-  @Parameters(method = "doVectorize")
-  public void testVectorAggretatorUsingGroupByQueryOnDoubleColumn(boolean doVectorize) throws Exception
+  @Parameters(method = "doVectorizeAndUseVectorApi")
+  public void testVectorAggretatorUsingGroupByQueryOnDoubleColumn(
+      final boolean doVectorize,
+      final boolean useVectorApi
+  )
+      throws Exception
   {
+    initializeExpressionProcessing(useVectorApi);
+
     GroupByQuery query = new GroupByQuery.Builder()
         .setDataSource("test")
         .setGranularity(Granularities.ALL)
@@ -153,9 +173,14 @@ public class DoubleMeanAggregationTest
   }
 
   @Test
-  @Parameters(method = "doVectorize")
-  public void testVectorAggretatorUsingGroupByQueryOnDoubleColumnOnBiggerSegments(boolean doVectorize) throws Exception
+  @Parameters(method = "doVectorizeAndUseVectorApi")
+  public void testVectorAggretatorUsingGroupByQueryOnDoubleColumnOnBiggerSegments(
+      final boolean doVectorize,
+      final boolean useVectorApi
+  ) throws Exception
   {
+    initializeExpressionProcessing(useVectorApi);
+
     GroupByQuery query = new GroupByQuery.Builder()
         .setDataSource("blah")
         .setGranularity(Granularities.ALL)
@@ -176,9 +201,12 @@ public class DoubleMeanAggregationTest
   }
 
   @Test
-  @Parameters(method = "doVectorize")
-  public void testAggretatorUsingTimeseriesQuery(boolean doVectorize) throws Exception
+  @Parameters(method = "doVectorizeAndUseVectorApi")
+  public void testAggretatorUsingTimeseriesQuery(final boolean doVectorize, final boolean useVectorApi)
+      throws Exception
   {
+    initializeExpressionProcessing(useVectorApi);
+
     TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
                                   .dataSource("test")
                                   .granularity(Granularities.ALL)
@@ -237,5 +265,14 @@ public class DoubleMeanAggregationTest
 
     DoubleMeanHolder meanHolder = (DoubleMeanHolder) aggregator.get();
     Assert.assertEquals(2.0, meanHolder.mean(), 0.0);
+  }
+
+  private static void initializeExpressionProcessing(final boolean useVectorApi)
+  {
+    if (useVectorApi) {
+      ExpressionProcessing.initializeForVectorApiTests();
+    } else {
+      ExpressionProcessing.initializeForTests();
+    }
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/aggregation/simd/SimdDoubleMeanVectorAggregatorTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/simd/SimdDoubleMeanVectorAggregatorTest.java
@@ -22,19 +22,31 @@ package org.apache.druid.query.aggregation.simd;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.aggregation.mean.DoubleMeanHolder;
 import org.apache.druid.query.aggregation.mean.DoubleMeanVectorAggregator;
-import org.apache.druid.segment.vector.VectorValueSelector;
+import org.apache.druid.query.aggregation.simd.SimdAggregatorTestHelpers.FakeVectorValueSelector;
+import org.apache.druid.query.aggregation.simd.SimdAggregatorTestHelpers.NullPattern;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
 import org.junit.Test;
 
-import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
-import java.util.Random;
-import java.util.function.IntPredicate;
 
+import static org.apache.druid.query.aggregation.simd.SimdAggregatorTestHelpers.VECTOR_SIZES;
+import static org.apache.druid.query.aggregation.simd.SimdAggregatorTestHelpers.padNulls;
+import static org.apache.druid.query.aggregation.simd.SimdAggregatorTestHelpers.randomDoubles;
+
+/**
+ * Equivalence test for the SIMD doubleMean vector aggregator. For each (vector size, null pattern) tuple it drives
+ * both the SIMD aggregator and the scalar parent over the same input and asserts the resulting mean holders match.
+ * The SIMD aggregator handles nulls internally (it is not a {@code NullAwareVectorAggregator}), so the contiguous
+ * {@code aggregate} entry point covers both the masked and unmasked loops.
+ *
+ * Each scenario is exercised twice: once with {@code (position=0, startRow=0)} and once with
+ * {@code (position=1, startRow=1)} where the rows before {@code startRow} hold a large "poison" value that would
+ * visibly skew the mean if the aggregator incorrectly read past {@code startRow}, and the buffer slot starts at byte
+ * offset 1 so any indexing off the position parameter shows up.
+ */
 public class SimdDoubleMeanVectorAggregatorTest extends InitializedNullHandlingTest
 {
-  private static final int[] VECTOR_SIZES = {1, 8, 17, 64, 1023};
   private static final double POISON_DOUBLE = 1e15;
   private static final double DELTA = 1e-9;
 
@@ -61,12 +73,12 @@ public class SimdDoubleMeanVectorAggregatorTest extends InitializedNullHandlingT
     for (int i = 0; i < startRow; i++) {
       values[i] = POISON_DOUBLE;
     }
-    System.arraycopy(randomDoubles(size), 0, values, startRow, size);
+    System.arraycopy(randomDoubles(size, 0), 0, values, startRow, size);
 
     final boolean[] realNulls = pattern.toMask(size);
     final boolean[] nulls = realNulls == null ? null : padNulls(realNulls, startRow);
 
-    final FakeVectorValueSelector selector = new FakeVectorValueSelector(arrLen, values, nulls);
+    final FakeVectorValueSelector selector = new FakeVectorValueSelector(arrLen, null, values, null, nulls);
     final int endRow = startRow + size;
     final String msg = StringUtils.format(
         "size[%s] nulls[%s] pos[%s] start[%s]",
@@ -86,14 +98,6 @@ public class SimdDoubleMeanVectorAggregatorTest extends InitializedNullHandlingT
     scalar.aggregate(scalarBuf, position, startRow, endRow);
     simd.aggregate(simdBuf, position, startRow, endRow);
     assertMeanHolderEquals(msg, scalarBuf, simdBuf, position);
-
-    if (nulls != null) {
-      final ByteBuffer directBuf = ByteBuffer.allocate(position + DoubleMeanHolder.MAX_INTERMEDIATE_SIZE);
-      simd.init(directBuf, position);
-      final boolean reported = simd.aggregate(directBuf, position, startRow, endRow, nulls);
-      Assert.assertEquals(msg + " (anyNonNull)", anyNonNull(nulls, startRow, endRow), reported);
-      assertMeanHolderEquals(msg + " (direct null-aware)", scalarBuf, directBuf, position);
-    }
   }
 
   private static void assertMeanHolderEquals(
@@ -128,114 +132,5 @@ public class SimdDoubleMeanVectorAggregatorTest extends InitializedNullHandlingT
   private static long count(final DoubleMeanHolder holder)
   {
     return ByteBuffer.wrap(holder.toBytes()).getLong(Double.BYTES);
-  }
-
-  private static boolean anyNonNull(final boolean[] nulls, final int startRow, final int endRow)
-  {
-    for (int i = startRow; i < endRow; i++) {
-      if (!nulls[i]) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private static boolean[] padNulls(final boolean[] realNulls, final int startRow)
-  {
-    final boolean[] padded = new boolean[startRow + realNulls.length];
-    System.arraycopy(realNulls, 0, padded, startRow, realNulls.length);
-    return padded;
-  }
-
-  private static double[] randomDoubles(final int size)
-  {
-    final Random r = new Random(0xC0FFEEL);
-    final double[] out = new double[size];
-    for (int i = 0; i < size; i++) {
-      out[i] = (r.nextDouble() - 0.5) * 1000.0;
-    }
-    return out;
-  }
-
-  private enum NullPattern
-  {
-    NONE(i -> false),
-    ALL(i -> true),
-    ALTERNATING(i -> (i & 1) == 0),
-    SPARSE(i -> i % 7 == 0),
-    FIRST_THREE(i -> i < 3),
-    CHUNK_BOUNDARY(i -> i == 7 || i == 8);
-
-    private final IntPredicate predicate;
-
-    NullPattern(final IntPredicate predicate)
-    {
-      this.predicate = predicate;
-    }
-
-    @Nullable
-    boolean[] toMask(final int size)
-    {
-      if (this == NONE) {
-        return null;
-      }
-      final boolean[] mask = new boolean[size];
-      for (int i = 0; i < size; i++) {
-        mask[i] = predicate.test(i);
-      }
-      return mask;
-    }
-  }
-
-  private static final class FakeVectorValueSelector implements VectorValueSelector
-  {
-    private final int size;
-    private final double[] doubles;
-    @Nullable
-    private final boolean[] nulls;
-
-    FakeVectorValueSelector(final int size, final double[] doubles, @Nullable final boolean[] nulls)
-    {
-      this.size = size;
-      this.doubles = doubles;
-      this.nulls = nulls;
-    }
-
-    @Override
-    public long[] getLongVector()
-    {
-      return null;
-    }
-
-    @Override
-    public float[] getFloatVector()
-    {
-      return null;
-    }
-
-    @Override
-    public double[] getDoubleVector()
-    {
-      return doubles;
-    }
-
-    @Nullable
-    @Override
-    public boolean[] getNullVector()
-    {
-      return nulls;
-    }
-
-    @Override
-    public int getMaxVectorSize()
-    {
-      return size;
-    }
-
-    @Override
-    public int getCurrentVectorSize()
-    {
-      return size;
-    }
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/aggregation/simd/SimdDoubleMeanVectorAggregatorTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/simd/SimdDoubleMeanVectorAggregatorTest.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.aggregation.simd;
+
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.query.aggregation.mean.DoubleMeanHolder;
+import org.apache.druid.query.aggregation.mean.DoubleMeanVectorAggregator;
+import org.apache.druid.segment.vector.VectorValueSelector;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+import java.util.Random;
+import java.util.function.IntPredicate;
+
+public class SimdDoubleMeanVectorAggregatorTest extends InitializedNullHandlingTest
+{
+  private static final int[] VECTOR_SIZES = {1, 8, 17, 64, 1023};
+  private static final double POISON_DOUBLE = 1e15;
+  private static final double DELTA = 1e-9;
+
+  @Test
+  public void testDoubleMean()
+  {
+    for (int size : VECTOR_SIZES) {
+      for (NullPattern pattern : NullPattern.values()) {
+        runDoubleMean(size, pattern, 0, 0);
+        runDoubleMean(size, pattern, 1, 1);
+      }
+    }
+  }
+
+  private static void runDoubleMean(
+      final int size,
+      final NullPattern pattern,
+      final int position,
+      final int startRow
+  )
+  {
+    final int arrLen = startRow + size;
+    final double[] values = new double[arrLen];
+    for (int i = 0; i < startRow; i++) {
+      values[i] = POISON_DOUBLE;
+    }
+    System.arraycopy(randomDoubles(size), 0, values, startRow, size);
+
+    final boolean[] realNulls = pattern.toMask(size);
+    final boolean[] nulls = realNulls == null ? null : padNulls(realNulls, startRow);
+
+    final FakeVectorValueSelector selector = new FakeVectorValueSelector(arrLen, values, nulls);
+    final int endRow = startRow + size;
+    final String msg = StringUtils.format(
+        "size[%s] nulls[%s] pos[%s] start[%s]",
+        size,
+        pattern,
+        position,
+        startRow
+    );
+
+    final DoubleMeanVectorAggregator scalar = new DoubleMeanVectorAggregator(selector);
+    final SimdDoubleMeanVectorAggregator simd = new SimdDoubleMeanVectorAggregator(selector);
+    final ByteBuffer scalarBuf = ByteBuffer.allocate(position + DoubleMeanHolder.MAX_INTERMEDIATE_SIZE);
+    final ByteBuffer simdBuf = ByteBuffer.allocate(position + DoubleMeanHolder.MAX_INTERMEDIATE_SIZE);
+    scalar.init(scalarBuf, position);
+    simd.init(simdBuf, position);
+
+    scalar.aggregate(scalarBuf, position, startRow, endRow);
+    simd.aggregate(simdBuf, position, startRow, endRow);
+    assertMeanHolderEquals(msg, scalarBuf, simdBuf, position);
+
+    if (nulls != null) {
+      final ByteBuffer directBuf = ByteBuffer.allocate(position + DoubleMeanHolder.MAX_INTERMEDIATE_SIZE);
+      simd.init(directBuf, position);
+      final boolean reported = simd.aggregate(directBuf, position, startRow, endRow, nulls);
+      Assert.assertEquals(msg + " (anyNonNull)", anyNonNull(nulls, startRow, endRow), reported);
+      assertMeanHolderEquals(msg + " (direct null-aware)", scalarBuf, directBuf, position);
+    }
+  }
+
+  private static void assertMeanHolderEquals(
+      final String msg,
+      final ByteBuffer expectedBuf,
+      final ByteBuffer actualBuf,
+      final int position
+  )
+  {
+    final DoubleMeanHolder expected = DoubleMeanHolder.get(expectedBuf, position);
+    final DoubleMeanHolder actual = DoubleMeanHolder.get(actualBuf, position);
+    Assert.assertEquals(msg + " (count)", count(expected), count(actual));
+    Assert.assertEquals(
+        msg + " (sum)",
+        sum(expected),
+        sum(actual),
+        Math.max(Math.abs(sum(expected)) * 1e-12, DELTA)
+    );
+    Assert.assertEquals(
+        msg + " (mean)",
+        expected.mean(),
+        actual.mean(),
+        Math.max(Math.abs(expected.mean()) * 1e-12, DELTA)
+    );
+  }
+
+  private static double sum(final DoubleMeanHolder holder)
+  {
+    return ByteBuffer.wrap(holder.toBytes()).getDouble(0);
+  }
+
+  private static long count(final DoubleMeanHolder holder)
+  {
+    return ByteBuffer.wrap(holder.toBytes()).getLong(Double.BYTES);
+  }
+
+  private static boolean anyNonNull(final boolean[] nulls, final int startRow, final int endRow)
+  {
+    for (int i = startRow; i < endRow; i++) {
+      if (!nulls[i]) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean[] padNulls(final boolean[] realNulls, final int startRow)
+  {
+    final boolean[] padded = new boolean[startRow + realNulls.length];
+    System.arraycopy(realNulls, 0, padded, startRow, realNulls.length);
+    return padded;
+  }
+
+  private static double[] randomDoubles(final int size)
+  {
+    final Random r = new Random(0xC0FFEEL);
+    final double[] out = new double[size];
+    for (int i = 0; i < size; i++) {
+      out[i] = (r.nextDouble() - 0.5) * 1000.0;
+    }
+    return out;
+  }
+
+  private enum NullPattern
+  {
+    NONE(i -> false),
+    ALL(i -> true),
+    ALTERNATING(i -> (i & 1) == 0),
+    SPARSE(i -> i % 7 == 0),
+    FIRST_THREE(i -> i < 3),
+    CHUNK_BOUNDARY(i -> i == 7 || i == 8);
+
+    private final IntPredicate predicate;
+
+    NullPattern(final IntPredicate predicate)
+    {
+      this.predicate = predicate;
+    }
+
+    @Nullable
+    boolean[] toMask(final int size)
+    {
+      if (this == NONE) {
+        return null;
+      }
+      final boolean[] mask = new boolean[size];
+      for (int i = 0; i < size; i++) {
+        mask[i] = predicate.test(i);
+      }
+      return mask;
+    }
+  }
+
+  private static final class FakeVectorValueSelector implements VectorValueSelector
+  {
+    private final int size;
+    private final double[] doubles;
+    @Nullable
+    private final boolean[] nulls;
+
+    FakeVectorValueSelector(final int size, final double[] doubles, @Nullable final boolean[] nulls)
+    {
+      this.size = size;
+      this.doubles = doubles;
+      this.nulls = nulls;
+    }
+
+    @Override
+    public long[] getLongVector()
+    {
+      return null;
+    }
+
+    @Override
+    public float[] getFloatVector()
+    {
+      return null;
+    }
+
+    @Override
+    public double[] getDoubleVector()
+    {
+      return doubles;
+    }
+
+    @Nullable
+    @Override
+    public boolean[] getNullVector()
+    {
+      return nulls;
+    }
+
+    @Override
+    public int getMaxVectorSize()
+    {
+      return size;
+    }
+
+    @Override
+    public int getCurrentVectorSize()
+    {
+      return size;
+    }
+  }
+}


### PR DESCRIPTION
<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

We have a few use-cases of `doubleMean` internally. This along with min/max should finalize basic coverage of all common aggregators.

#### Benchmarks
| Null pattern | Vector size | Scalar ns/op | SIMD ns/op | Speedup |
|---|---:|---:|---:|---:|
| none | 128 | 577.647 | 42.667 | 13.54x |
| none | 512 | 2252.809 | 198.616 | 11.34x |
| none | 1024 | 4728.788 | 389.558 | 12.14x |
| none | 4096 | 18346.941 | 1503.129 | 12.21x |
| sparse | 128 | 498.490 | 91.306 | 5.46x |
| sparse | 512 | 1991.397 | 374.181 | 5.32x |
| sparse | 1024 | 4158.765 | 729.459 | 5.70x |
| sparse | 4096 | 18250.915 | 2818.945 | 6.47x |
| alternating | 128 | 257.435 | 91.506 | 2.81x |
| alternating | 512 | 1105.482 | 378.452 | 2.92x |
| alternating | 1024 | 2284.373 | 716.764 | 3.19x |
| alternating | 4096 | 8967.622 | 3033.222 | 2.96x |


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Add SIMD acceleration for doubleMean aggregator

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.