### PR TITLE
docs: added registered trademark symbol to mentions of external software

### DIFF
--- a/docs/configuration/extensions.md
+++ b/docs/configuration/extensions.md
@@ -36,7 +36,7 @@ Core extensions are maintained by Druid committers.
 |Name|Description|Docs|
 |----|-----------|----|
 |druid-avro-extensions|Support for data in Apache Avro data format.|[link](../development/extensions-core/avro.md)|
-|druid-azure-extensions|Microsoft Azure deep storage.|[link](../development/extensions-core/azure.md)|
+|druid-azure-extensions|Microsoft&circledR; Azure deep storage.|[link](../development/extensions-core/azure.md)|
 |druid-basic-security|Support for Basic HTTP authentication and role-based access control.|[link](../development/extensions-core/druid-basic-security.md)|
 |druid-bloom-filter|Support for providing Bloom filters in druid queries.|[link](../development/extensions-core/bloom-filter.md)|
 |druid-catalog|This extension allows users to configure, update, retrieve, and manage metadata stored in Druid's catalog. |[link](../development/extensions-core/catalog.md)|

--- a/docs/configuration/extensions.md
+++ b/docs/configuration/extensions.md
@@ -51,7 +51,7 @@ Core extensions are maintained by Druid committers.
 |druid-lookups-cached-global|A module for [lookups](../querying/lookups.md) providing a jvm-global eager caching for lookups. It provides JDBC and URI implementations for fetching lookup data.|[link](../querying/lookups-cached-global.md)|
 |druid-lookups-cached-single| Per lookup caching module to support the use cases where a lookup need to be isolated from the global pool of lookups |[link](../development/extensions-core/druid-lookups.md)|
 |druid-orc-extensions|Support for data in Apache ORC data format.|[link](../development/extensions-core/orc.md)|
-|druid-parquet-extensions|Support for data in Apache Parquet data format. Requires druid-avro-extensions to be loaded.|[link](../development/extensions-core/parquet.md)|
+|druid-parquet-extensions|Support for data in Apache&circledR; Parquet data format. Requires druid-avro-extensions to be loaded.|[link](../development/extensions-core/parquet.md)|
 |druid-protobuf-extensions| Support for data in Protobuf data format.|[link](../development/extensions-core/protobuf.md)|
 |druid-s3-extensions|Interfacing with data in Amazon S3, and using S3 as deep storage.|[link](../development/extensions-core/s3.md)|
 |druid-ec2-extensions|Interfacing with AWS EC2 for autoscaling middle managers|UNDOCUMENTED|
@@ -104,7 +104,7 @@ All of these community extensions can be downloaded using [pull-deps](../operati
 |prometheus-emitter|Exposes [Druid metrics](../operations/metrics.md) for [Prometheus](https://prometheus.io/)|[link](../development/extensions-contrib/prometheus.md)|
 |druid-spectator-histogram|Support for efficient approximate percentile queries|[link](../development/extensions-contrib/spectator-histogram.md)|
 |druid-rabbit-indexing-service|Support for creating and managing [RabbitMQ](https://www.rabbitmq.com/) indexing tasks|[link](../development/extensions-contrib/rabbit-stream-ingestion.md)|
-|druid-ranger-security|Support for access control through Apache Ranger.|[link](../development/extensions-contrib/druid-ranger-security.md)|
+|druid-ranger-security|Support for access control through Apache&circledR; Ranger.|[link](../development/extensions-contrib/druid-ranger-security.md)|
 
 ## Promoting community extensions to core extensions
 

--- a/docs/configuration/extensions.md
+++ b/docs/configuration/extensions.md
@@ -61,7 +61,7 @@ Core extensions are maintained by Druid committers.
 |postgresql-metadata-storage|PostgreSQL metadata store.|[link](../development/extensions-core/postgresql.md)|
 |simple-client-sslcontext|Simple SSLContext provider module to be used by Druid's internal HttpClient when talking to other Druid processes over HTTPS.|[link](../development/extensions-core/simple-client-sslcontext.md)|
 |druid-pac4j|OpenID Connect authentication for druid processes.|[link](../development/extensions-core/druid-pac4j.md)|
-|druid-kubernetes-extensions|Druid cluster deployment on Kubernetes without Zookeeper.|[link](../development/extensions-core/kubernetes.md)|
+|druid-kubernetes-extensions|Druid cluster deployment on Kubernetes&circledR; without Zookeeper.|[link](../development/extensions-core/kubernetes.md)|
 |druid-kubernetes-overlord-extensions|Support for launching tasks in k8s without Middle Managers|[link](../development/extensions-core/k8s-jobs.md)|
 
 ## Community extensions

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -107,7 +107,7 @@ forking separate JVM processes per-task, the Indexer runs tasks as individual th
 
 The Indexer is designed to be easier to configure and deploy compared to the MiddleManager + Peon system and to better enable resource sharing across tasks, which can help streaming ingestion. The Indexer is currently designated [experimental](../development/experimental.md).
 
-Typically, you would deploy one of the following: MiddleManagers, [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md), or Indexers. You wouldn't deploy more than one of these options.
+Typically, you would deploy one of the following: MiddleManagers, [MiddleManager-less ingestion using Kubernetes&circledR;](../development/extensions-core/k8s-jobs.md), or Indexers. You wouldn't deploy more than one of these options.
 
 ## Colocation of services
 

--- a/docs/design/indexer.md
+++ b/docs/design/indexer.md
@@ -25,7 +25,7 @@ sidebar_label: "Indexer"
   -->
 
 :::info
- The Indexer is an optional and experimental feature. If you're primarily performing batch ingestion, we recommend you use either the MiddleManager and Peon task execution system or [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md). If you're primarily doing streaming ingestion, you may want to try either [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md) or the Indexer service.
+ The Indexer is an optional and experimental feature. If you're primarily performing batch ingestion, we recommend you use either the MiddleManager and Peon task execution system or [MiddleManager-less ingestion using Kubernetes&circledR;](../development/extensions-core/k8s-jobs.md). If you're primarily doing streaming ingestion, you may want to try either [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md) or the Indexer service.
 :::
 
 The Apache&circledR; Druid Indexer service is an alternative to the Middle Manager + Peon task execution system. Instead of forking a separate JVM process per-task, the Indexer runs tasks as separate threads within a single JVM process.

--- a/docs/design/zookeeper.md
+++ b/docs/design/zookeeper.md
@@ -23,7 +23,7 @@ title: "ZooKeeper"
   -->
 
 
-Apache&circledR; Druid uses [Apache ZooKeeper](http://zookeeper.apache.org/) (ZK) for management of current cluster state.
+Apache&circledR; Druid uses [Apache&circledR; ZooKeeper](http://zookeeper.apache.org/) (ZK) for management of current cluster state.
 
 ## Minimum ZooKeeper versions
 

--- a/docs/development/extensions-contrib/consul.md
+++ b/docs/development/extensions-contrib/consul.md
@@ -22,7 +22,7 @@ title: "Consul-based Service Discovery"
   ~ under the License.
   -->
 
-Apache Druid extension to enable using HashiCorp Consul for node discovery. This extension allows Druid clusters to use Consul's service catalog for discovering nodes, as an alternative to ZooKeeper or Kubernetes-based discovery.
+Apache&circledR; Druid extension to enable using HashiCorp Consul for node discovery. This extension allows Druid clusters to use Consul's service catalog for discovering nodes, as an alternative to ZooKeeper or discovery using Kubernetes&circledR;.
 
 ## Quick Start
 

--- a/docs/development/extensions-contrib/druid-ranger-security.md
+++ b/docs/development/extensions-contrib/druid-ranger-security.md
@@ -22,7 +22,7 @@ title: "Apache Ranger Security"
   ~ under the License.
   -->
 
-This Apache Druid extension adds an Authorizer which implements access control for Druid, backed by [Apache Ranger](https://ranger.apache.org/). Please see [Authentication and Authorization](../../operations/auth.md) for more information on the basic facilities this extension provides.
+This Apache Druid extension adds an Authorizer which implements access control for Druid, backed by [Apache&circledR; Ranger](https://ranger.apache.org/). Please see [Authentication and Authorization](../../operations/auth.md) for more information on the basic facilities this extension provides.
 
 Make sure to [include](../../configuration/extensions.md#loading-extensions) `druid-ranger-security` in the extensions load list.
 

--- a/docs/development/extensions-contrib/druid-ranger-security.md
+++ b/docs/development/extensions-contrib/druid-ranger-security.md
@@ -22,7 +22,7 @@ title: "Apache Ranger Security"
   ~ under the License.
   -->
 
-This Apache Druid extension adds an Authorizer which implements access control for Druid, backed by [Apache&circledR; Ranger](https://ranger.apache.org/). Please see [Authentication and Authorization](../../operations/auth.md) for more information on the basic facilities this extension provides.
+This Apache&circledR; Druid extension adds an Authorizer which implements access control for Druid using [Apache&circledR; Ranger](https://ranger.apache.org/). See [Authentication and authorization](../../operations/auth.md) for more information.
 
 Make sure to [include](../../configuration/extensions.md#loading-extensions) `druid-ranger-security` in the extensions load list.
 

--- a/docs/development/extensions-contrib/iceberg.md
+++ b/docs/development/extensions-contrib/iceberg.md
@@ -27,7 +27,7 @@ to Apache Iceberg docs: https://github.com/apache/iceberg/blob/main/docs/mkdocs.
 
 ## Iceberg Ingest extension
 
-Apache&circledR; Iceberg is an open table format for huge analytic datasets. [IcebergInputSource](../../ingestion/input-sources.md#iceberg-input-source) lets you ingest data stored in the Iceberg table format into Apache Druid. To use the iceberg extension, add the `druid-iceberg-extensions` to the list of loaded extensions. See [Loading extensions](../../configuration/extensions.md#loading-extensions) for more information.
+Apache&circledR; Iceberg is an open table format for large analytic datasets. [IcebergInputSource](../../ingestion/input-sources.md#iceberg-input-source) lets you ingest data stored in the Iceberg table format into Apache Druid. To use the Iceberg extension, add the `druid-iceberg-extensions` to the list of loaded extensions. See [Loading extensions](../../configuration/extensions.md#loading-extensions) for more information.
 
 Iceberg manages most of its metadata in metadata files in the object storage. However, it is still dependent on a metastore to manage a certain amount of metadata.
 Iceberg refers to these metastores as catalogs. The Iceberg extension lets you connect to the following Iceberg catalog types:

--- a/docs/development/extensions-contrib/iceberg.md
+++ b/docs/development/extensions-contrib/iceberg.md
@@ -27,7 +27,7 @@ to Apache Iceberg docs: https://github.com/apache/iceberg/blob/main/docs/mkdocs.
 
 ## Iceberg Ingest extension
 
-Apache Iceberg is an open table format for huge analytic datasets. [IcebergInputSource](../../ingestion/input-sources.md#iceberg-input-source) lets you ingest data stored in the Iceberg table format into Apache Druid. To use the iceberg extension, add the `druid-iceberg-extensions` to the list of loaded extensions. See [Loading extensions](../../configuration/extensions.md#loading-extensions) for more information.
+Apache&circledR; Iceberg is an open table format for huge analytic datasets. [IcebergInputSource](../../ingestion/input-sources.md#iceberg-input-source) lets you ingest data stored in the Iceberg table format into Apache Druid. To use the iceberg extension, add the `druid-iceberg-extensions` to the list of loaded extensions. See [Loading extensions](../../configuration/extensions.md#loading-extensions) for more information.
 
 Iceberg manages most of its metadata in metadata files in the object storage. However, it is still dependent on a metastore to manage a certain amount of metadata.
 Iceberg refers to these metastores as catalogs. The Iceberg extension lets you connect to the following Iceberg catalog types:

--- a/docs/development/extensions-contrib/sqlserver.md
+++ b/docs/development/extensions-contrib/sqlserver.md
@@ -32,7 +32,7 @@ To use this Apache Druid extension, [include](../../configuration/extensions.md#
 2. Create a druid database and user
 
   Create the druid user
-  - Microsoft SQL Server Management Studio - Security - Logins - New Login...
+  - Microsoft&circledR; SQL Server Management Studio - Security - Logins - New Login...
   - Create a druid user, enter `diurd` when prompted for the password.
 
   Create a druid database owned by the user we just created

--- a/docs/development/extensions-core/k8s-jobs.md
+++ b/docs/development/extensions-core/k8s-jobs.md
@@ -350,7 +350,7 @@ The logic defining how the pod template is built for your Kubernetes Job depends
 ### Overlord Single Container Pod Adapter/Overlord Multi Container Pod Adapter
 The overlord single container pod adapter takes the podSpec of your `Overlord` pod and creates a kubernetes job from this podSpec.  This is the default pod adapter implementation, to explicitly enable it you can specify the runtime property `druid.indexer.runner.k8s.adapter.type: overlordSingleContainer`
 
-The overlord multi container pod adapter takes the podSpec of your `Overlord` pod and creates a kubernetes job from this podSpec.  It uses kubexit to manage dependency ordering between the main container that runs your druid peon and other sidecars defined in the `Overlord` pod spec. Thus if you have sidecars such as Splunk&circledR; or Istio it will be able to handle them. To enable this pod adapter you can specify the runtime property `druid.indexer.runner.k8s.adapter.type: overlordMultiContainer` 
+The Overlord multi-container pod adapter uses the pod specification of your Overlord pod to create a Kubernetes job. It uses kubexit to manage dependency ordering between the main container that runs your Druid peon and other sidecars defined in the Overlord pod specification. This allows the adapter to handle sidecars such Splunk&circledR; or Istio. To enable this pod adapter, set the runtime property `druid.indexer.runner.k8s.adapter.type: overlordMultiContainer`.
 
 For the sidecar support to work for the multi container pod adapter, your entry point / command in docker must be explicitly defined your spec.
 

--- a/docs/development/extensions-core/k8s-jobs.md
+++ b/docs/development/extensions-core/k8s-jobs.md
@@ -25,7 +25,7 @@ title: "MM-less Druid in K8s"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Apache&circledR; Druid Extension to enable using Kubernetes for launching and managing tasks instead of the Middle Managers.  This extension allows you to launch tasks as kubernetes jobs removing the need for your middle manager.  
+Apache&circledR; Druid Extension to enable using Kubernetes&circledR; for launching and managing tasks instead of the Middle Managers.  This extension allows you to launch tasks as kubernetes jobs removing the need for your middle manager.  
 
 ## How it works
 

--- a/docs/development/extensions-core/k8s-jobs.md
+++ b/docs/development/extensions-core/k8s-jobs.md
@@ -350,7 +350,7 @@ The logic defining how the pod template is built for your Kubernetes Job depends
 ### Overlord Single Container Pod Adapter/Overlord Multi Container Pod Adapter
 The overlord single container pod adapter takes the podSpec of your `Overlord` pod and creates a kubernetes job from this podSpec.  This is the default pod adapter implementation, to explicitly enable it you can specify the runtime property `druid.indexer.runner.k8s.adapter.type: overlordSingleContainer`
 
-The overlord multi container pod adapter takes the podSpec of your `Overlord` pod and creates a kubernetes job from this podSpec.  It uses kubexit to manage dependency ordering between the main container that runs your druid peon and other sidecars defined in the `Overlord` pod spec. Thus if you have sidecars such as Splunk or Istio it will be able to handle them. To enable this pod adapter you can specify the runtime property `druid.indexer.runner.k8s.adapter.type: overlordMultiContainer` 
+The overlord multi container pod adapter takes the podSpec of your `Overlord` pod and creates a kubernetes job from this podSpec.  It uses kubexit to manage dependency ordering between the main container that runs your druid peon and other sidecars defined in the `Overlord` pod spec. Thus if you have sidecars such as Splunk&circledR; or Istio it will be able to handle them. To enable this pod adapter you can specify the runtime property `druid.indexer.runner.k8s.adapter.type: overlordMultiContainer` 
 
 For the sidecar support to work for the multi container pod adapter, your entry point / command in docker must be explicitly defined your spec.
 

--- a/docs/development/extensions-core/kubernetes.md
+++ b/docs/development/extensions-core/kubernetes.md
@@ -24,7 +24,7 @@ title: "Kubernetes"
 
 Consider this an [EXPERIMENTAL](../experimental.md) feature mostly because it has not been tested yet on a wide variety of long running Druid clusters.
 
-Apache&circledR; Druid Extension to enable using Kubernetes API Server for node discovery and leader election. This extension allows Druid cluster deployment on Kubernetes without Zookeeper. It allows running multiple Druid clusters within same Kubernetes Cluster, See `clusterIdentifier` config below.
+Apache&circledR; Druid Extension to enable using Kubernetes&circledR; API Server for node discovery and leader election. This extension allows Druid cluster deployment on Kubernetes without Zookeeper. It allows running multiple Druid clusters within same Kubernetes Cluster, See `clusterIdentifier` config below.
 
 
 ## Configuration

--- a/docs/development/extensions-core/kubernetes.md
+++ b/docs/development/extensions-core/kubernetes.md
@@ -24,7 +24,7 @@ title: "Kubernetes"
 
 Consider this an [EXPERIMENTAL](../experimental.md) feature mostly because it has not been tested yet on a wide variety of long running Druid clusters.
 
-Apache&circledR; Druid Extension to enable using Kubernetes&circledR; API Server for node discovery and leader election. This extension allows Druid cluster deployment on Kubernetes without Zookeeper. It allows running multiple Druid clusters within same Kubernetes Cluster, See `clusterIdentifier` config below.
+Apache&circledR; Druid extension to enable using the Kubernetes&circledR; API Server for node discovery and leader election. This extension allows you to deploy a Druid cluster on Kubernetes without Zookeeper and run multiple Druid clusters within the same Kubernetes cluster. For more information, see the `clusterIdentifier` configuration below.
 
 
 ## Configuration

--- a/docs/development/extensions-core/parquet.md
+++ b/docs/development/extensions-core/parquet.md
@@ -24,4 +24,4 @@ title: "Apache Parquet Extension"
 
 
 This Apache&circledR; Druid module extends [Druid native batch](../../ingestion/native-batch.md) to ingest data directly from offline
-Apache Parquet files.
+Apache&circledR; Parquet files.

--- a/docs/ingestion/hadoop.md
+++ b/docs/ingestion/hadoop.md
@@ -23,11 +23,11 @@ sidebar_label: "Hadoop-based"
   ~ under the License.
   -->
 
-Support for Apache Hadoop-based ingestion was removed from Apache&circledR; Druid 37.0.0. Please use
+Support for ingestion using Apache&circledR; Hadoop was removed from Apache&circledR; Druid 37.0.0. Please use
 [SQL-based ingestion](../multi-stage-query/index.md) or [native batch](../ingestion/native-batch.md) instead.
 
 The associated `materialized-view-selection` and `materialized-view-maintenance` contrib extensions were also removed
 as part of this since they only supported Hadoop based ingestion.
 
 Note that Druid still supports using [`druid-hdfs-storage`](../development/extensions-core/hdfs.md) as deep storage and other Hadoop ecosystem extensions and
-functionality that was not specific to Hadoop-based ingestion.
+functionality that was not specific to ingestion using Hadoop.

--- a/docs/multi-stage-query/reference.md
+++ b/docs/multi-stage-query/reference.md
@@ -528,7 +528,7 @@ SQL-based ingestion supports using durable storage to store intermediate files t
 
 ### Durable storage configurations
 
-Durable storage is supported on Amazon S3 storage, Microsoft's Azure Blob Storage and Google Cloud Storage. 
+Durable storage is supported on Amazon S3 storage, Microsoft&circledR; Azure Blob Storage and Google Cloud Storage. 
 There are common configurations that control the behavior regardless of which storage service you use. Apart from these common configurations, there are a few properties specific to S3 and to Azure.
 
 Common properties to configure the behavior of durable storage

--- a/docs/operations/high-availability.md
+++ b/docs/operations/high-availability.md
@@ -23,7 +23,7 @@ title: "High availability"
   -->
 
 
-Apache ZooKeeper, metadata store, the coordinator, the overlord, and brokers are recommended to set up a high availability environment.
+Apache&circledR; ZooKeeper, metadata store, the coordinator, the overlord, and brokers are recommended to set up a high availability environment.
 
 - For highly-available ZooKeeper, you will need a cluster of 3 or 5 ZooKeeper nodes.
 We recommend either installing ZooKeeper on its own hardware, or running 3 or 5 Master servers (where overlords or coordinators are running)

--- a/docs/operations/kubernetes.md
+++ b/docs/operations/kubernetes.md
@@ -29,6 +29,6 @@ Apache&circledR; Druid distribution is also available as [Docker](https://www.do
 $ docker pull apache/druid
 ```
 
-[druid-operator](https://github.com/datainfrahq/druid-operator) can be used to manage a Druid cluster on [Kubernetes](https://kubernetes.io/) .
+[druid-operator](https://github.com/datainfrahq/druid-operator) can be used to manage a Druid cluster on [Kubernetes&circledR;](https://kubernetes.io/) .
 
 Druid clusters deployed on Kubernetes can function without Zookeeper using [druid–kubernetes-extensions](../development/extensions-core/kubernetes.md) .

--- a/docs/release-info/upgrade-notes.md
+++ b/docs/release-info/upgrade-notes.md
@@ -34,7 +34,7 @@ For the full release notes for a specific version, see the [releases page](https
 
 Support for Hadoop-based ingestion has been removed. The feature was deprecated in Druid 32.
 
-Use one of Druid's other supported ingestion methods, such as SQL-based ingestion or MiddleManager-less ingestion using Kubernetes.
+Use one of Druid's other supported ingestion methods, such as SQL-based ingestion or MiddleManager-less ingestion using Kubernetes&circledR;.
 
 [#19109](https://github.com/apache/druid/pull/19109)
 

--- a/docs/tutorials/tutorial-kafka.md
+++ b/docs/tutorials/tutorial-kafka.md
@@ -46,7 +46,7 @@ Before you follow the steps in this tutorial, download Druid as described in the
 2. If you're already running Kafka on the machine you're using for this tutorial, delete or rename the `kafka-logs` directory in `/tmp`.
    
 :::info
- Druid and Kafka both rely on [Apache ZooKeeper](https://zookeeper.apache.org/) to coordinate and manage services. Because Druid is already running, Kafka attaches to the Druid ZooKeeper instance when it starts up.<br />
+ Druid and Kafka both rely on [Apache&circledR; ZooKeeper](https://zookeeper.apache.org/) to coordinate and manage services. Because Druid is already running, Kafka attaches to the Druid ZooKeeper instance when it starts up.<br />
 
  In a production environment where you're running Druid and Kafka on different machines, [start the Kafka ZooKeeper](https://kafka.apache.org/quickstart) before you start the Kafka broker.
 :::


### PR DESCRIPTION
Changes: Added registered trademark symbol to various external software names found throughout docs
- Apache® Hadoop
- Apache® Parquet
- Apache® Ranger
- Apache® ZooKeeper
- Apache® Iceberg
- Kubernetes®
- Microsoft®
- Splunk®

This PR has:

- [x] been self-reviewed.