### PR TITLE
minor: Updated query to matches the index for retriving unused intervals. 

### DIFF
--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
@@ -1069,14 +1069,14 @@ public class SqlSegmentsMetadataQuery
    * guarantee on the order of intervals in the list or on whether the limited
    * list contains the earliest or latest intervals present in the datasource.
    *
-   * @return List of unused segment intervals containing upto {@code limit} entries.
+   * @return List of unused segment intervals containing upto {@code limit} interval entries.
    */
   public List<Interval> retrieveUnusedSegmentIntervals(String dataSource, int limit)
   {
     final String sql = StringUtils.format(
         "SELECT start, %2$send%2$s FROM %1$s"
         + " WHERE dataSource = :dataSource AND used = false"
-        + " GROUP BY start, %2$send%2$s"
+        + " GROUP BY %2$send%2$s, start"
         + "  %3$s",
         dbTables.getSegmentsTable(), connector.getQuoteString(), connector.limitClause(limit)
     );


### PR DESCRIPTION
We create an index like this :
      
https://github.com/implydata/druid/blob/528e8079cdc92a1c98bc46ea8e0af30032018b3a/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java#L397-L406
 
 Updating query to match the index above. 
 
 
 Real world results on mysql 8.0.0:
 
### Before
```
mysql> explain SELECT start, end FROM druid_segments WHERE dataSource = 'xxxx' AND used = false GROUP BY start , end limit 100 \G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: druid_segments
   partitions: NULL
         type: ref
possible_keys: idx_druid_segments_used,idx_druid_segments_datasource_used_end_start,idx_druid_segments_datasource_upgraded_from_segment_id
          key: idx_druid_segments_used
      key_len: 1
          ref: const
         rows: xxxx
     filtered: 50.00
        Extra: Using where; Using temporary
1 row in set, 1 warning (0.01 sec)     
````
As you can see the index used was `idx_druid_segments_used`

### After

 
 ```
 mysql> explain SELECT start, end FROM druid_segments WHERE dataSource = 'xxxx' AND used = false GROUP BY end , start limit 100 \G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: druid_segments
   partitions: NULL
         type: range
possible_keys: idx_druid_segments_used,idx_druid_segments_datasource_used_end_start,idx_druid_segments_datasource_upgraded_from_segment_id
          key: idx_druid_segments_datasource_used_end_start
      key_len: xxx
          ref: NULL
         rows: xxx
     filtered: 100.00
        Extra: Using where; Using index
1 row in set, 1 warning (0.00 sec)
```
As you can see the index used is `idx_druid_segments_datasource_used_end_start`

Will send in another PR to adjust the limit to the intervals as well. 
