### PR TITLE
fix: upgrade RoaringBitmap to 1.6.14

### DIFF
--- a/extensions-contrib/druid-exact-count-bitmap/src/test/java/org/apache/druid/query/aggregation/exact/count/bitmap64/Bitmap64ExactCountMergeAggregatorTest.java
+++ b/extensions-contrib/druid-exact-count-bitmap/src/test/java/org/apache/druid/query/aggregation/exact/count/bitmap64/Bitmap64ExactCountMergeAggregatorTest.java
@@ -95,6 +95,29 @@ public class Bitmap64ExactCountMergeAggregatorTest
 
     EasyMock.verify(mockSelector);
   }
+
+  @Test
+  public void testAggregateCountersAcrossSignedHighBoundary()
+  {
+    RoaringBitmap64Counter negativeHighCounter = new RoaringBitmap64Counter();
+    negativeHighCounter.add(-1L);
+
+    RoaringBitmap64Counter nonNegativeHighCounter = new RoaringBitmap64Counter();
+    nonNegativeHighCounter.add(0L);
+    nonNegativeHighCounter.add(1L);
+
+    EasyMock.expect(mockSelector.getObject()).andReturn(negativeHighCounter).once();
+    EasyMock.expect(mockSelector.getObject()).andReturn(nonNegativeHighCounter).once();
+    EasyMock.replay(mockSelector);
+
+    aggregator.aggregate();
+    aggregator.aggregate();
+
+    Bitmap64 resultCounter = (Bitmap64) aggregator.get();
+    Assertions.assertEquals(3, resultCounter.getCardinality());
+
+    EasyMock.verify(mockSelector);
+  }
   
   @Test
   public void testAggregateMultipleCountersIncludingNull()

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -2693,7 +2693,7 @@ name: RoaringBitmap
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 1.6.13
+version: 1.6.14
 libraries:
   - org.roaringbitmap: RoaringBitmap
   - org.roaringbitmap: shims

--- a/pom.xml
+++ b/pom.xml
@@ -1117,7 +1117,7 @@
             <dependency>
                 <groupId>org.roaringbitmap</groupId>
                 <artifactId>RoaringBitmap</artifactId>
-                <version>1.6.13</version>
+                <version>1.6.14</version>
             </dependency>
             <dependency>
                 <groupId>org.yaml</groupId>


### PR DESCRIPTION
### Description

Upgrade RoaringBitmap from 1.6.13 to 1.6.14.

RoaringBitmap 1.6.13 invalidates its `Roaring64NavigableMap` cumulative-cardinality cache using signed `Math.min` even when high keys are ordered as unsigned values. Merging a bitmap containing a negative `long` value with one containing non-negative values can therefore leave the cache in an inconsistent state and fail while reading cardinality.

RoaringBitmap fixed this in [issue #828](https://github.com/RoaringBitmap/RoaringBitmap/issues/828) and [PR #829](https://github.com/RoaringBitmap/RoaringBitmap/pull/829), released in 1.6.14. This PR also adds a regression test through Druid's `Bitmap64ExactCountMergeAggregator` path.

Before the dependency upgrade, the regression test fails with:

```
java.lang.AssertionError: 1 is bigger than 0
  at org.roaringbitmap.longlong.Roaring64NavigableMap.ensureOne(...)
  at org.roaringbitmap.longlong.Roaring64NavigableMap.getLongCardinality(...)
```

With 1.6.14, the regression and all 78 `Bitmap64ExactCount*Test` tests pass.

#### Release note

Upgrades RoaringBitmap to 1.6.14 to prevent bitmap64 exact-count queries from failing when merged bitmaps span negative and non-negative `long` values.

<hr>

##### Key changed/added classes in this PR
 * `Bitmap64ExactCountMergeAggregatorTest`

<hr>

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [x] added or updated version, license, or notice information in `licenses.yaml`.
- [x] added unit tests to cover the affected merge path.
