### PR TITLE
fix: Limit number of unused segment rows scanned

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/duty/UnusedSegmentsKiller.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/duty/UnusedSegmentsKiller.java
@@ -249,7 +249,7 @@ public class UnusedSegmentsKiller implements OverlordDuty
 
       final Map<String, Integer> dataSourceToIntervalCounts = new HashMap<>();
       for (String dataSource : dataSources) {
-        storageCoordinator.retrieveUnusedSegmentIntervals(dataSource, MAX_INTERVALS_TO_KILL_IN_DATASOURCE).forEach(
+        storageCoordinator.retrieveSomeUnusedSegmentIntervals(dataSource, MAX_INTERVALS_TO_KILL_IN_DATASOURCE).forEach(
             interval -> {
               dataSourceToIntervalCounts.merge(dataSource, 1, Integer::sum);
               killQueue.offer(new KillCandidate(dataSource, interval));

--- a/indexing-service/src/test/java/org/apache/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
@@ -70,7 +70,7 @@ public class TestIndexerMetadataStorageCoordinator implements IndexerMetadataSto
   }
 
   @Override
-  public List<Interval> retrieveUnusedSegmentIntervals(String dataSource, int limit)
+  public List<Interval> retrieveSomeUnusedSegmentIntervals(String dataSource, int limit)
   {
     return List.of();
   }

--- a/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
@@ -600,12 +600,22 @@ public interface IndexerMetadataStorageCoordinator
 
   /**
    * Retrieves intervals of the specified datasource that contain any unused segments.
-   * There is no guarantee on the order of intervals in the list or on whether
-   * the limited list contains the earliest or latest intervals of the datasource.
+   * <p>
+   * This method ensures that if there is any unused segment for the datasource,
+   * the returned list is not empty. However, it does NOT guarantee that:
+   * <ul>
+   * <li>the intervals in the result would be ordered</li>
+   * <li>the result would contain the earliest or latest intervals for this datasource</li>
+   * <li>it would scan all unused segments for this datasource. So, the result
+   * may contain less than {@code limit} entries even when there are more distinct
+   * unused segment intervals in the metadata store for this datasource.</li>
+   * </ul>
    *
-   * @return Unsorted list of unused segment intervals containing upto {@code limit} entries.
+   * @return List of distinct unused segment intervals for the specified datasource
+   * containing at least 1 entry if there is any unused segment for the datasource,
+   * upto a maximum of {@code limit} entries.
    */
-  List<Interval> retrieveUnusedSegmentIntervals(String dataSource, int limit);
+  List<Interval> retrieveSomeUnusedSegmentIntervals(String dataSource, int limit);
 
   /**
    * Returns the number of segment entries in the database whose state was changed as the result of this call (that is,

--- a/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -167,7 +167,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
   public List<Interval> retrieveUnusedSegmentIntervals(String dataSource, int limit)
   {
     return inReadOnlyTransaction(
-        sql -> sql.retrieveUnusedSegmentIntervals(dataSource, limit)
+        sql -> sql.retrieveSomeUnusedSegmentIntervals(dataSource, limit)
     );
   }
 

--- a/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -164,7 +164,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
   }
 
   @Override
-  public List<Interval> retrieveUnusedSegmentIntervals(String dataSource, int limit)
+  public List<Interval> retrieveSomeUnusedSegmentIntervals(String dataSource, int limit)
   {
     return inReadOnlyTransaction(
         sql -> sql.retrieveSomeUnusedSegmentIntervals(dataSource, limit)

--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
@@ -1081,16 +1081,20 @@ public class SqlSegmentsMetadataQuery
   public List<Interval> retrieveUnusedSegmentIntervals(String dataSource, int limit)
   {
     final String sql = StringUtils.format(
+        // Text blocks are not supported in the current checkstyle version
+        //CHECKSTYLE.OFF: Regexp
         """
-            SELECT start, %2$send%2$s FROM
-            (
-              SELECT start, %2$send%2$s FROM %1$s
+            SELECT start, %2$send%2$s
+            FROM (
+              SELECT start, %2$send%2$s
+              FROM %1$s
               WHERE dataSource = :dataSource AND used = false
               %3$s
             ) AS unused
             GROUP BY %2$send%2$s, start
             %4$s
             """,
+        //CHECKSTYLE.ON: Regexp
         dbTables.getSegmentsTable(),
         connector.getQuoteString(),
         connector.limitClause(1_000_000), // limit unused segment rows scanned to 1M

--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
@@ -1065,20 +1065,36 @@ public class SqlSegmentsMetadataQuery
   }
 
   /**
-   * Gets unused segment intervals for the specified datasource. There is no
-   * guarantee on the order of intervals in the list or on whether the limited
-   * list contains the earliest or latest intervals present in the datasource.
+   * Gets unused segment intervals for the specified datasource.
+   * <p>
+   * Note: This method does NOT guarantee that:
+   * <ul>
+   * <li>the intervals in the result would be ordered</li>
+   * <li>the result would contain the earliest or latest intervals for this datasource</li>
+   * <li>it would scan all unused segments for this datasource. So, the result
+   * may contain less than {@code limit} entries even when there are more distinct
+   * unused segment intervals in the metadata store for this datasource.</li>
+   * </ul>
    *
    * @return List of unused segment intervals containing upto {@code limit} interval entries.
    */
   public List<Interval> retrieveUnusedSegmentIntervals(String dataSource, int limit)
   {
     final String sql = StringUtils.format(
-        "SELECT start, %2$send%2$s FROM %1$s"
-        + " WHERE dataSource = :dataSource AND used = false"
-        + " GROUP BY %2$send%2$s, start"
-        + "  %3$s",
-        dbTables.getSegmentsTable(), connector.getQuoteString(), connector.limitClause(limit)
+        """
+            SELECT start, %2$send%2$s FROM
+            (
+              SELECT start, %2$send%2$s FROM %1$s
+              WHERE dataSource = :dataSource AND used = false
+              %3$s
+            ) AS unused
+            GROUP BY %2$send%2$s, start
+            %4$s
+            """,
+        dbTables.getSegmentsTable(),
+        connector.getQuoteString(),
+        connector.limitClause(1_000_000), // limit unused segment rows scanned to 1M
+        connector.limitClause(limit)
     );
 
     final List<Interval> intervals = connector.inReadOnlyTransaction(

--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
@@ -1065,9 +1065,10 @@ public class SqlSegmentsMetadataQuery
   }
 
   /**
-   * Gets unused segment intervals for the specified datasource.
+   * Gets some unused segment intervals for the specified datasource.
    * <p>
-   * Note: This method does NOT guarantee that:
+   * This method ensures that if there are any unused segments for the datasource,
+   * the returned list is not empty. However, it does NOT guarantee that:
    * <ul>
    * <li>the intervals in the result would be ordered</li>
    * <li>the result would contain the earliest or latest intervals for this datasource</li>
@@ -1076,12 +1077,14 @@ public class SqlSegmentsMetadataQuery
    * unused segment intervals in the metadata store for this datasource.</li>
    * </ul>
    *
-   * @return List of unused segment intervals containing upto {@code limit} interval entries.
+   * @return List of distinct unused segment intervals for the specified datasource
+   * containing at least 1 entry if there is any unused segment for the datasource,
+   * upto a maximum of {@code limit} entries.
    */
-  public List<Interval> retrieveUnusedSegmentIntervals(String dataSource, int limit)
+  public List<Interval> retrieveSomeUnusedSegmentIntervals(String dataSource, int limit)
   {
     final String sql = StringUtils.format(
-        // Text blocks are not supported in the current checkstyle version
+        // Disable checkstyle to avoid argumentLineBreaking rule from getting triggered
         //CHECKSTYLE.OFF: Regexp
         """
             SELECT start, %2$send%2$s

--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
@@ -1065,9 +1065,9 @@ public class SqlSegmentsMetadataQuery
   }
 
   /**
-   * Gets some unused segment intervals for the specified datasource.
+   * Retrieves intervals containing unused segments for the specified datasource.
    * <p>
-   * This method ensures that if there are any unused segments for the datasource,
+   * This method ensures that if there is any unused segment for the datasource,
    * the returned list is not empty. However, it does NOT guarantee that:
    * <ul>
    * <li>the intervals in the result would be ordered</li>

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
@@ -2252,29 +2252,29 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   }
 
   @Test
-  public void testRetrieveUnusedSegmentIntervals()
+  public void testRetrieveSomeUnusedSegmentIntervals()
   {
     final String dataSource = defaultSegment.getDataSource();
     coordinator.commitSegments(Set.of(defaultSegment, defaultSegment3), null);
 
-    Assert.assertTrue(coordinator.retrieveUnusedSegmentIntervals(dataSource, 100).isEmpty());
+    Assert.assertTrue(coordinator.retrieveSomeUnusedSegmentIntervals(dataSource, 100).isEmpty());
 
     markAllSegmentsUnused(Set.of(defaultSegment), DateTimes.nowUtc().minusHours(1));
     Assert.assertEquals(
         List.of(defaultSegment.getInterval()),
-        coordinator.retrieveUnusedSegmentIntervals(dataSource, 100)
+        coordinator.retrieveSomeUnusedSegmentIntervals(dataSource, 100)
     );
 
     markAllSegmentsUnused(Set.of(defaultSegment3), DateTimes.nowUtc().minusHours(1));
     Assert.assertEquals(
         Set.of(defaultSegment.getInterval(), defaultSegment3.getInterval()),
-        Set.copyOf(coordinator.retrieveUnusedSegmentIntervals(dataSource, 100))
+        Set.copyOf(coordinator.retrieveSomeUnusedSegmentIntervals(dataSource, 100))
     );
 
     // Verify retrieve with limit 1 returns only 1 interval
     Assert.assertEquals(
         1,
-        coordinator.retrieveUnusedSegmentIntervals(dataSource, 1).size()
+        coordinator.retrieveSomeUnusedSegmentIntervals(dataSource, 1).size()
     );
   }
 


### PR DESCRIPTION
Related to #19685 

### Description

In large clusters with a large number of unused segments for a single datasource, the `UnusedSegmentsKiller` may error out while fetching the list of unused segment intervals.

### Fix

- Limit the number of unused segment rows scanned in a single cycle of the `UnusedSegmentsKiller` to 1M

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.