### PR TITLE
minor: Add config and metrics to CostBasedAutoScaler

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScaler.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScaler.java
@@ -65,8 +65,10 @@ public class CostBasedAutoScaler implements SupervisorTaskAutoScaler
 
   public static final String LAG_WEIGHT_METRIC = "task/autoScaler/costBased/lagWeight";
   public static final String IDLE_WEIGHT_METRIC = "task/autoScaler/costBased/idleWeight";
+  public static final String CURRENT_COST_METRIC = "task/autoScaler/costBased/currentCost";
   public static final String CURRENT_LAG_COST_METRIC = "task/autoScaler/costBased/currentLagCost";
   public static final String CURRENT_IDLE_COST_METRIC = "task/autoScaler/costBased/currentIdleCost";
+  public static final String OPTIMAL_COST_METRIC = "task/autoScaler/costBased/optimalCost";
   public static final String OPTIMAL_LAG_COST_METRIC = "task/autoScaler/costBased/optimalLagCost";
   public static final String OPTIMAL_IDLE_COST_METRIC = "task/autoScaler/costBased/optimalIdleCost";
   public static final String OPTIMAL_TASK_COUNT_METRIC = "task/autoScaler/costBased/optimalTaskCount";
@@ -307,6 +309,7 @@ public class CostBasedAutoScaler implements SupervisorTaskAutoScaler
     emitter.emit(getMetricBuilder().setMetric(IDLE_WEIGHT_METRIC, config.getIdleWeight()));
     emitter.emit(getMetricBuilder().setMetric(CURRENT_LAG_COST_METRIC, currentCost.lagCost()));
     emitter.emit(getMetricBuilder().setMetric(CURRENT_IDLE_COST_METRIC, currentCost.idleCost()));
+    emitter.emit(getMetricBuilder().setMetric(CURRENT_COST_METRIC, currentCost.totalCost()));
 
     // Emit avg rate and idle metrics only if they are available
     if (metrics.getAvgProcessingRate() >= 0) {
@@ -326,6 +329,7 @@ public class CostBasedAutoScaler implements SupervisorTaskAutoScaler
       );
       emitter.emit(getMetricBuilder().setMetric(OPTIMAL_LAG_COST_METRIC, optimalCost.lagCost()));
       emitter.emit(getMetricBuilder().setMetric(OPTIMAL_IDLE_COST_METRIC, optimalCost.idleCost()));
+      emitter.emit(getMetricBuilder().setMetric(OPTIMAL_COST_METRIC, optimalCost.totalCost()));
     }
 
     // Scale-up is applied eagerly; scale-down may be deferred by computeTaskCountForScaleAction().

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScaler.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScaler.java
@@ -310,6 +310,7 @@ public class CostBasedAutoScaler implements SupervisorTaskAutoScaler
     emitter.emit(getMetricBuilder().setMetric(CURRENT_LAG_COST_METRIC, currentCost.lagCost()));
     emitter.emit(getMetricBuilder().setMetric(CURRENT_IDLE_COST_METRIC, currentCost.idleCost()));
     emitter.emit(getMetricBuilder().setMetric(CURRENT_COST_METRIC, currentCost.totalCost()));
+    emitter.emit(getMetricBuilder().setMetric(OPTIMAL_COST_METRIC, optimalCost.totalCost()));
 
     // Emit avg rate and idle metrics only if they are available
     if (metrics.getAvgProcessingRate() >= 0) {
@@ -329,7 +330,15 @@ public class CostBasedAutoScaler implements SupervisorTaskAutoScaler
       );
       emitter.emit(getMetricBuilder().setMetric(OPTIMAL_LAG_COST_METRIC, optimalCost.lagCost()));
       emitter.emit(getMetricBuilder().setMetric(OPTIMAL_IDLE_COST_METRIC, optimalCost.idleCost()));
-      emitter.emit(getMetricBuilder().setMetric(OPTIMAL_COST_METRIC, optimalCost.totalCost()));
+
+      final double costDropPercent = (currentCost.totalCost() - optimalCost.totalCost()) / currentCost.totalCost();
+      if (costDropPercent < config.getMinCostDropPercentForScaling()) {
+        log.info(
+            "Skipping scaling since cost drop percent[%.2f] is less than required minCostDropPercentForScaling[%d]",
+            costDropPercent, config.getMinCostDropPercentForScaling()
+        );
+        return currentTaskCount;
+      }
     }
 
     // Scale-up is applied eagerly; scale-down may be deferred by computeTaskCountForScaleAction().

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScaler.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScaler.java
@@ -331,7 +331,8 @@ public class CostBasedAutoScaler implements SupervisorTaskAutoScaler
       emitter.emit(getMetricBuilder().setMetric(OPTIMAL_LAG_COST_METRIC, optimalCost.lagCost()));
       emitter.emit(getMetricBuilder().setMetric(OPTIMAL_IDLE_COST_METRIC, optimalCost.idleCost()));
 
-      final double costDropPercent = (currentCost.totalCost() - optimalCost.totalCost()) / currentCost.totalCost();
+      final double costDropPercent
+          = 100.0 * (currentCost.totalCost() - optimalCost.totalCost()) / currentCost.totalCost();
       if (costDropPercent < config.getMinCostDropPercentForScaling()) {
         log.info(
             "Skipping scaling since cost drop percent[%.2f] is less than required minCostDropPercentForScaling[%d]",

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScalerConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScalerConfig.java
@@ -65,6 +65,7 @@ public class CostBasedAutoScalerConfig implements AutoScalerConfig
   private final Duration minScaleDownDelay;
   private final boolean scaleDownDuringTaskRolloverOnly;
   private final boolean usePollIdleRatio;
+  private final int minCostDropPercentForScaling;
 
   /**
    * Creates a new CostBasedAutoScalerConfig instance.
@@ -85,7 +86,8 @@ public class CostBasedAutoScalerConfig implements AutoScalerConfig
       @Nullable @JsonProperty("minScaleUpDelay") Duration minScaleUpDelay,
       @Nullable @JsonProperty("minScaleDownDelay") Duration minScaleDownDelay,
       @Nullable @JsonProperty("scaleDownDuringTaskRolloverOnly") Boolean scaleDownDuringTaskRolloverOnly,
-      @Nullable @JsonProperty("usePollIdleRatio") Boolean usePollIdleRatio
+      @Nullable @JsonProperty("usePollIdleRatio") Boolean usePollIdleRatio,
+      @Nullable @JsonProperty("minCostDropPercentForScaling") Integer minCostDropPercentForScaling
   )
   {
     this.enableTaskAutoScaler = Configs.valueOrDefault(enableTaskAutoScaler, false);
@@ -103,6 +105,7 @@ public class CostBasedAutoScalerConfig implements AutoScalerConfig
     this.minScaleDownDelay = Configs.valueOrDefault(minScaleDownDelay, DEFAULT_MIN_SCALE_DOWN_DELAY);
     this.scaleDownDuringTaskRolloverOnly = Configs.valueOrDefault(scaleDownDuringTaskRolloverOnly, false);
     this.usePollIdleRatio = Configs.valueOrDefault(usePollIdleRatio, true);
+    this.minCostDropPercentForScaling = Configs.valueOrDefault(minCostDropPercentForScaling, 0);
 
     if (this.enableTaskAutoScaler) {
       Preconditions.checkNotNull(taskCountMax, "taskCountMax is required when enableTaskAutoScaler is true");
@@ -285,6 +288,16 @@ public class CostBasedAutoScalerConfig implements AutoScalerConfig
     return usePollIdleRatio;
   }
 
+  /**
+   * Minimum percentage drop from current cost that is required by the auto-scaler
+   * to choose a new task count.
+   */
+  @JsonProperty
+  public int getMinCostDropPercentForScaling()
+  {
+    return minCostDropPercentForScaling;
+  }
+
   @Override
   public SupervisorTaskAutoScaler createAutoScaler(Supervisor supervisor, SupervisorSpec spec, ServiceEmitter emitter)
   {
@@ -316,6 +329,7 @@ public class CostBasedAutoScalerConfig implements AutoScalerConfig
            && Objects.equals(minScaleDownDelay, that.minScaleDownDelay)
            && scaleDownDuringTaskRolloverOnly == that.scaleDownDuringTaskRolloverOnly
            && usePollIdleRatio == that.usePollIdleRatio
+           && minCostDropPercentForScaling == that.minCostDropPercentForScaling
            && Objects.equals(taskCountStart, that.taskCountStart)
            && Objects.equals(stopTaskCountRatio, that.stopTaskCountRatio);
   }
@@ -338,7 +352,8 @@ public class CostBasedAutoScalerConfig implements AutoScalerConfig
         minScaleUpDelay,
         minScaleDownDelay,
         scaleDownDuringTaskRolloverOnly,
-        usePollIdleRatio
+        usePollIdleRatio,
+        minCostDropPercentForScaling
     );
   }
 
@@ -361,6 +376,7 @@ public class CostBasedAutoScalerConfig implements AutoScalerConfig
            ", minScaleDownDelay=" + minScaleDownDelay +
            ", scaleDownDuringTaskRolloverOnly=" + scaleDownDuringTaskRolloverOnly +
            ", usePollIdleRatio=" + usePollIdleRatio +
+           ", minCostDropPercentForScaling=" + minCostDropPercentForScaling +
            '}';
   }
 
@@ -385,6 +401,7 @@ public class CostBasedAutoScalerConfig implements AutoScalerConfig
     private Duration minScaleDownDelay;
     private Boolean scaleDownDuringTaskRolloverOnly;
     private Boolean usePollIdleRatio;
+    private Integer minCostDropPercentForScaling;
 
     private Builder()
     {
@@ -480,6 +497,12 @@ public class CostBasedAutoScalerConfig implements AutoScalerConfig
       return this;
     }
 
+    public Builder minCostDropPercentForScaling(int minCostDropPercentForScaling)
+    {
+      this.minCostDropPercentForScaling = minCostDropPercentForScaling;
+      return this;
+    }
+
     public CostBasedAutoScalerConfig build()
     {
       return new CostBasedAutoScalerConfig(
@@ -497,7 +520,8 @@ public class CostBasedAutoScalerConfig implements AutoScalerConfig
           minScaleUpDelay,
           minScaleDownDelay,
           scaleDownDuringTaskRolloverOnly,
-          usePollIdleRatio
+          usePollIdleRatio,
+          minCostDropPercentForScaling
       );
     }
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScalerConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScalerConfigTest.java
@@ -54,7 +54,8 @@ public class CostBasedAutoScalerConfigTest
                   + "  \"minScaleUpDelay\": \"PT5M\",\n"
                   + "  \"minScaleDownDelay\": \"PT10M\",\n"
                   + "  \"scaleDownDuringTaskRolloverOnly\": true,\n"
-                  + "  \"usePollIdleRatio\": false\n"
+                  + "  \"usePollIdleRatio\": false,\n"
+                  + "  \"minCostDropPercentForScaling\": 10\n"
                   + "}";
 
     final CostBasedAutoScalerConfig config = mapper.readValue(json, CostBasedAutoScalerConfig.class);
@@ -74,6 +75,7 @@ public class CostBasedAutoScalerConfigTest
     Assert.assertFalse(config.isUsePollIdleRatio());
     Assert.assertFalse(config.isUseTaskCountBoundariesOnScaleUp());
     Assert.assertTrue(config.isUseTaskCountBoundariesOnScaleDown());
+    Assert.assertEquals(10, config.getMinCostDropPercentForScaling());
 
     // Test serialization back to JSON
     final String serialized = mapper.writeValueAsString(config);
@@ -112,6 +114,7 @@ public class CostBasedAutoScalerConfigTest
     Assert.assertTrue(config.isUseTaskCountBoundariesOnScaleDown());
     Assert.assertNull(config.getTaskCountStart());
     Assert.assertNull(config.getStopTaskCountRatio());
+    Assert.assertEquals(0, config.getMinCostDropPercentForScaling());
   }
 
   @Test


### PR DESCRIPTION
### Changes

- Add config to skip scaling if cost drop percentage is less than a threshold.
  - This would help prevent the autoscaler from flapping.
  - This is a temporary fix until we have stabilized the cost function.
- Add metrics for current cost and optimal cost in `CostBasedAutoScaler`.
  - These would help identify the cost difference between the current and optimal cost values when the auto-scaler chooses one task count over another.
  - The autoscaler currently has a lot of metrics. Some of these are expected to go away once the cost function has been stabilized.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.