### PR TITLE
feat: rework `requireRestart` to `getActionOnUpdateTo` to control restart/task-disruption behavior

### DIFF
--- a/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorTuningConfigTest.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorTuningConfigTest.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.indexer.granularity.UniformGranularitySpec;
+import org.apache.druid.indexing.overlord.supervisor.SupervisorSpecUpdateAction;
 import org.apache.druid.indexing.rabbitstream.RabbitStreamIndexTaskModule;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -59,10 +60,15 @@ public class RabbitStreamSupervisorTuningConfigTest
   {
     final RabbitStreamSupervisorSpec oldSpec = supervisorSpec(tuningConfig(15, 16, 17));
 
-    // requireRestart is invoked on the running (old) spec with the proposed spec as argument.
-    Assert.assertTrue(oldSpec.requireRestart(supervisorSpec(tuningConfig(20, 16, 17))));
-    Assert.assertTrue(oldSpec.requireRestart(supervisorSpec(tuningConfig(15, 20, 17))));
-    Assert.assertTrue(oldSpec.requireRestart(supervisorSpec(tuningConfig(15, 16, 20))));
+    // getActionOnUpdateTo is invoked on the running (old) spec with the proposed spec as argument.
+    Assert.assertTrue(requiresRestart(oldSpec, supervisorSpec(tuningConfig(20, 16, 17))));
+    Assert.assertTrue(requiresRestart(oldSpec, supervisorSpec(tuningConfig(15, 20, 17))));
+    Assert.assertTrue(requiresRestart(oldSpec, supervisorSpec(tuningConfig(15, 16, 20))));
+  }
+
+  private static boolean requiresRestart(RabbitStreamSupervisorSpec oldSpec, RabbitStreamSupervisorSpec newSpec)
+  {
+    return oldSpec.getActionOnUpdateTo(newSpec) != SupervisorSpecUpdateAction.NONE;
   }
 
   @Test

--- a/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorTuningConfigTest.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorTuningConfigTest.java
@@ -61,14 +61,18 @@ public class RabbitStreamSupervisorTuningConfigTest
     final RabbitStreamSupervisorSpec oldSpec = supervisorSpec(tuningConfig(15, 16, 17));
 
     // getActionOnUpdateTo is invoked on the running (old) spec with the proposed spec as argument.
-    Assert.assertTrue(requiresRestart(oldSpec, supervisorSpec(tuningConfig(20, 16, 17))));
-    Assert.assertTrue(requiresRestart(oldSpec, supervisorSpec(tuningConfig(15, 20, 17))));
-    Assert.assertTrue(requiresRestart(oldSpec, supervisorSpec(tuningConfig(15, 16, 20))));
-  }
-
-  private static boolean requiresRestart(RabbitStreamSupervisorSpec oldSpec, RabbitStreamSupervisorSpec newSpec)
-  {
-    return oldSpec.getActionOnUpdateTo(newSpec) != SupervisorSpecUpdateAction.NONE;
+    Assert.assertEquals(
+        SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS,
+        oldSpec.getActionOnUpdateTo(supervisorSpec(tuningConfig(20, 16, 17)))
+    );
+    Assert.assertEquals(
+        SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS,
+        oldSpec.getActionOnUpdateTo(supervisorSpec(tuningConfig(15, 20, 17)))
+    );
+    Assert.assertEquals(
+        SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS,
+        oldSpec.getActionOnUpdateTo(supervisorSpec(tuningConfig(15, 16, 20)))
+    );
   }
 
   @Test

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
@@ -197,7 +197,11 @@ public class SupervisorManager implements SupervisorStatsProvider
       if (!skipRestartIfUnmodified) {
         // Always stop/recreate, persisting whenever the spec actually changed (or is new).
         final boolean specChanged = isSpecChangedAndValidated(spec);
-        final SupervisorSpec existingSpec = possiblyStopAndRemoveSupervisorInternal(spec.getId(), false);
+        final SupervisorSpec existingSpec = possiblyStopAndRemoveSupervisorInternal(
+            spec.getId(),
+            false,
+            spec.shouldRestartCauseTaskDisruption()
+        );
         spec.merge(existingSpec);
         createAndStartSupervisorInternal(spec, specChanged);
         return SupervisorSpecUpdateResult.of(specChanged, true);
@@ -234,7 +238,7 @@ public class SupervisorManager implements SupervisorStatsProvider
       }
 
       // Restart path: stop+recreate, persisting the changed spec.
-      possiblyStopAndRemoveSupervisorInternal(spec.getId(), false);
+      possiblyStopAndRemoveSupervisorInternal(spec.getId(), false, spec.shouldRestartCauseTaskDisruption());
       createAndStartSupervisorInternal(spec, true);
       return SupervisorSpecUpdateResult.of(true, true);
     }
@@ -277,7 +281,7 @@ public class SupervisorManager implements SupervisorStatsProvider
 
     synchronized (lock) {
       Preconditions.checkState(started, "SupervisorManager not started");
-      return possiblyStopAndRemoveSupervisorInternal(id, true) != null;
+      return possiblyStopAndRemoveSupervisorInternal(id, true, true) != null;
     }
   }
 
@@ -650,7 +654,11 @@ public class SupervisorManager implements SupervisorStatsProvider
    * @return reference to existing supervisor, if exists and was stopped, null if there was no supervisor with this id
    */
   @Nullable
-  private SupervisorSpec possiblyStopAndRemoveSupervisorInternal(String id, boolean writeTombstone)
+  private SupervisorSpec possiblyStopAndRemoveSupervisorInternal(
+      String id,
+      boolean writeTombstone,
+      boolean shouldRestartCauseTaskDisruption
+  )
   {
     Pair<Supervisor, SupervisorSpec> pair = supervisors.get(id);
     if (pair == null || pair.rhs == null || pair.lhs == null) {
@@ -663,7 +671,7 @@ public class SupervisorManager implements SupervisorStatsProvider
           new NoopSupervisorSpec(null, pair.rhs.getDataSources())
       ); // where NoopSupervisorSpec is a tombstone
     }
-    pair.lhs.stop(true);
+    pair.lhs.stop(shouldRestartCauseTaskDisruption);
     supervisors.remove(id);
 
     SupervisorTaskAutoScaler autoscaler = autoscalers.get(id);
@@ -692,7 +700,7 @@ public class SupervisorManager implements SupervisorStatsProvider
     }
 
     SupervisorSpec nextState = suspend ? pair.rhs.createSuspendedSpec() : pair.rhs.createRunningSpec();
-    possiblyStopAndRemoveSupervisorInternal(nextState.getId(), false);
+    possiblyStopAndRemoveSupervisorInternal(nextState.getId(), false, nextState.shouldRestartCauseTaskDisruption());
     return createAndStartSupervisorInternal(nextState, true);
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
@@ -178,8 +178,9 @@ public class SupervisorManager implements SupervisorStatsProvider
 
   /**
    * Applies {@code spec} under a single lock. With {@code skipRestartIfUnmodified=true}, an unchanged spec
-   * is a no-op; a changed spec is persisted without restart when {@link SupervisorSpec#getActionOnUpdateTo} is
-   * false. With {@code skipRestartIfUnmodified=false}, the supervisor is always recreated (legacy behavior).
+   * is a no-op; a changed spec is persisted without restart when {@link SupervisorSpec#getActionOnUpdateTo}
+   * returns {@link SupervisorSpecUpdateAction#NONE}. With {@code skipRestartIfUnmodified=false}, the supervisor
+   * is always recreated and its tasks always terminated.
    */
   public SupervisorSpecUpdateResult createOrUpdateAndStartSupervisor(
       final SupervisorSpec spec,
@@ -195,21 +196,12 @@ public class SupervisorManager implements SupervisorStatsProvider
       Preconditions.checkState(started, "SupervisorManager not started");
 
       if (!skipRestartIfUnmodified) {
-        // Always stop/recreate, persisting whenever the spec actually changed (or is new).
+        // Always stop/recreate and terminate tasks, persisting whenever the spec actually changed
         final boolean specChanged = isSpecChangedAndValidated(spec);
-        final Pair<Supervisor, SupervisorSpec> current = supervisors.get(spec.getId());
-        final SupervisorSpec currentSpec = current == null ? null : current.rhs;
-        final boolean shouldTerminateTasks =
-            currentSpec == null
-            || currentSpec.getActionOnUpdateTo(spec) == SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS;
-        final SupervisorSpec existingSpec = possiblyStopAndRemoveSupervisorInternal(
-            spec.getId(),
-            false,
-            shouldTerminateTasks
-        );
+        final SupervisorSpec existingSpec = possiblyStopAndRemoveSupervisorInternal(spec.getId(), false, true);
         spec.merge(existingSpec);
         createAndStartSupervisorInternal(spec, specChanged);
-        return SupervisorSpecUpdateResult.of(specChanged, true);
+        return SupervisorSpecUpdateResult.of(specChanged, SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS);
       }
 
       final Pair<Supervisor, SupervisorSpec> current = supervisors.get(spec.getId());
@@ -219,18 +211,18 @@ public class SupervisorManager implements SupervisorStatsProvider
         // merge() self-initializes taskCount from taskCountStart for a new autoscaling supervisor (no existing spec).
         spec.merge(null);
         createAndStartSupervisorInternal(spec, true);
-        return SupervisorSpecUpdateResult.of(true, true);
+        return SupervisorSpecUpdateResult.of(true, SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS);
       }
 
       final SupervisorSpec currentSpec = current.rhs;
       if (!areSpecBytesChanged(spec, currentSpec)) {
-        return SupervisorSpecUpdateResult.of(false, false);
+        return SupervisorSpecUpdateResult.of(false, SupervisorSpecUpdateAction.NONE);
       }
 
       // merge() may carry forward omitted fields (e.g. taskCount); compare the effective spec.
       spec.merge(currentSpec);
       if (!areSpecBytesChanged(spec, currentSpec)) {
-        return SupervisorSpecUpdateResult.of(false, false);
+        return SupervisorSpecUpdateResult.of(false, SupervisorSpecUpdateAction.NONE);
       }
 
       // The effective (merged) spec is what will be persisted, so validate that transition exactly once.
@@ -240,14 +232,14 @@ public class SupervisorManager implements SupervisorStatsProvider
       if (action == SupervisorSpecUpdateAction.NONE) {
         metadataSupervisorManager.insert(spec.getId(), spec);
         supervisors.put(spec.getId(), Pair.of(current.lhs, spec));
-        return SupervisorSpecUpdateResult.of(true, false);
+        return SupervisorSpecUpdateResult.of(true, SupervisorSpecUpdateAction.NONE);
       }
 
       // Restart path: stop+recreate, persisting the changed spec.
       boolean shouldTaskBeTerminated = action == SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS;
       possiblyStopAndRemoveSupervisorInternal(spec.getId(), false, shouldTaskBeTerminated);
       createAndStartSupervisorInternal(spec, true);
-      return SupervisorSpecUpdateResult.of(true, true);
+      return SupervisorSpecUpdateResult.of(true, action);
     }
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
@@ -178,7 +178,7 @@ public class SupervisorManager implements SupervisorStatsProvider
 
   /**
    * Applies {@code spec} under a single lock. With {@code skipRestartIfUnmodified=true}, an unchanged spec
-   * is a no-op; a changed spec is persisted without restart when {@link SupervisorSpec#requireRestart} is
+   * is a no-op; a changed spec is persisted without restart when {@link SupervisorSpec#getActionOnUpdateTo} is
    * false. With {@code skipRestartIfUnmodified=false}, the supervisor is always recreated (legacy behavior).
    */
   public SupervisorSpecUpdateResult createOrUpdateAndStartSupervisor(
@@ -199,10 +199,13 @@ public class SupervisorManager implements SupervisorStatsProvider
         final boolean specChanged = isSpecChangedAndValidated(spec);
         final Pair<Supervisor, SupervisorSpec> current = supervisors.get(spec.getId());
         final SupervisorSpec currentSpec = current == null ? null : current.rhs;
+        final boolean shouldTerminateTasks =
+            currentSpec == null
+            || currentSpec.getActionOnUpdateTo(spec) == SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS;
         final SupervisorSpec existingSpec = possiblyStopAndRemoveSupervisorInternal(
             spec.getId(),
             false,
-            currentSpec == null || currentSpec.shouldRolloverTasksOnRestart(spec)
+            shouldTerminateTasks
         );
         spec.merge(existingSpec);
         createAndStartSupervisorInternal(spec, specChanged);
@@ -233,14 +236,16 @@ public class SupervisorManager implements SupervisorStatsProvider
       // The effective (merged) spec is what will be persisted, so validate that transition exactly once.
       currentSpec.validateSpecUpdateTo(spec);
 
-      if (!currentSpec.requireRestart(spec)) {
+      SupervisorSpecUpdateAction action = currentSpec.getActionOnUpdateTo(spec);
+      if (action == SupervisorSpecUpdateAction.NONE) {
         metadataSupervisorManager.insert(spec.getId(), spec);
         supervisors.put(spec.getId(), Pair.of(current.lhs, spec));
         return SupervisorSpecUpdateResult.of(true, false);
       }
 
       // Restart path: stop+recreate, persisting the changed spec.
-      possiblyStopAndRemoveSupervisorInternal(spec.getId(), false, currentSpec.shouldRolloverTasksOnRestart(spec));
+      boolean shouldTaskBeTerminated = action == SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS;
+      possiblyStopAndRemoveSupervisorInternal(spec.getId(), false, shouldTaskBeTerminated);
       createAndStartSupervisorInternal(spec, true);
       return SupervisorSpecUpdateResult.of(true, true);
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
@@ -197,10 +197,12 @@ public class SupervisorManager implements SupervisorStatsProvider
       if (!skipRestartIfUnmodified) {
         // Always stop/recreate, persisting whenever the spec actually changed (or is new).
         final boolean specChanged = isSpecChangedAndValidated(spec);
+        final Pair<Supervisor, SupervisorSpec> current = supervisors.get(spec.getId());
+        final SupervisorSpec currentSpec = current == null ? null : current.rhs;
         final SupervisorSpec existingSpec = possiblyStopAndRemoveSupervisorInternal(
             spec.getId(),
             false,
-            spec.shouldRestartCauseTaskDisruption()
+            currentSpec == null || currentSpec.shouldRolloverTasksOnRestart(spec)
         );
         spec.merge(existingSpec);
         createAndStartSupervisorInternal(spec, specChanged);
@@ -238,7 +240,7 @@ public class SupervisorManager implements SupervisorStatsProvider
       }
 
       // Restart path: stop+recreate, persisting the changed spec.
-      possiblyStopAndRemoveSupervisorInternal(spec.getId(), false, spec.shouldRestartCauseTaskDisruption());
+      possiblyStopAndRemoveSupervisorInternal(spec.getId(), false, currentSpec.shouldRolloverTasksOnRestart(spec));
       createAndStartSupervisorInternal(spec, true);
       return SupervisorSpecUpdateResult.of(true, true);
     }
@@ -657,7 +659,7 @@ public class SupervisorManager implements SupervisorStatsProvider
   private SupervisorSpec possiblyStopAndRemoveSupervisorInternal(
       String id,
       boolean writeTombstone,
-      boolean shouldRestartCauseTaskDisruption
+      boolean terminateTasks
   )
   {
     Pair<Supervisor, SupervisorSpec> pair = supervisors.get(id);
@@ -671,7 +673,7 @@ public class SupervisorManager implements SupervisorStatsProvider
           new NoopSupervisorSpec(null, pair.rhs.getDataSources())
       ); // where NoopSupervisorSpec is a tombstone
     }
-    pair.lhs.stop(shouldRestartCauseTaskDisruption);
+    pair.lhs.stop(terminateTasks);
     supervisors.remove(id);
 
     SupervisorTaskAutoScaler autoscaler = autoscalers.get(id);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
@@ -700,7 +700,7 @@ public class SupervisorManager implements SupervisorStatsProvider
     }
 
     SupervisorSpec nextState = suspend ? pair.rhs.createSuspendedSpec() : pair.rhs.createRunningSpec();
-    possiblyStopAndRemoveSupervisorInternal(nextState.getId(), false, nextState.shouldRestartCauseTaskDisruption());
+    possiblyStopAndRemoveSupervisorInternal(nextState.getId(), false, true);
     return createAndStartSupervisorInternal(nextState, true);
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpecUpdateResult.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpecUpdateResult.java
@@ -25,17 +25,17 @@ package org.apache.druid.indexing.overlord.supervisor;
 public final class SupervisorSpecUpdateResult
 {
   private final boolean modified;
-  private final boolean restarted;
+  private final SupervisorSpecUpdateAction action;
 
-  private SupervisorSpecUpdateResult(final boolean modified, final boolean restarted)
+  private SupervisorSpecUpdateResult(final boolean modified, final SupervisorSpecUpdateAction action)
   {
     this.modified = modified;
-    this.restarted = restarted;
+    this.action = action;
   }
 
-  public static SupervisorSpecUpdateResult of(final boolean modified, final boolean restarted)
+  public static SupervisorSpecUpdateResult of(final boolean modified, final SupervisorSpecUpdateAction action)
   {
-    return new SupervisorSpecUpdateResult(modified, restarted);
+    return new SupervisorSpecUpdateResult(modified, action);
   }
 
   public boolean isModified()
@@ -45,6 +45,7 @@ public final class SupervisorSpecUpdateResult
 
   public boolean isRestarted()
   {
-    return restarted;
+    return action != SupervisorSpecUpdateAction.NONE;
   }
+
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorSpec.java
@@ -33,6 +33,7 @@ import org.apache.druid.indexing.overlord.TaskMaster;
 import org.apache.druid.indexing.overlord.TaskStorage;
 import org.apache.druid.indexing.overlord.supervisor.Supervisor;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorSpec;
+import org.apache.druid.indexing.overlord.supervisor.SupervisorSpecUpdateAction;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorStateManagerConfig;
 import org.apache.druid.indexing.overlord.supervisor.autoscaler.SupervisorTaskAutoScaler;
 import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskClientFactory;
@@ -298,10 +299,10 @@ public abstract class SeekableStreamSupervisorSpec implements SupervisorSpec
   }
 
   @Override
-  public boolean requireRestart(SupervisorSpec proposedSpec)
+  public SupervisorSpecUpdateAction getActionOnUpdateTo(SupervisorSpec proposedSpec)
   {
     if (!(proposedSpec instanceof SeekableStreamSupervisorSpec proposed)) {
-      return true;
+      return SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS;
     }
 
     final Builder<?> proposedCopy = proposed.toBuilder();
@@ -313,7 +314,9 @@ public abstract class SeekableStreamSupervisorSpec implements SupervisorSpec
       proposedCopy.taskCount(getIoConfig().getTaskCount());
     }
 
-    return !proposedCopy.build().equals(this);
+    return !proposedCopy.build().equals(this)
+           ? SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS
+           : SupervisorSpecUpdateAction.NONE;
   }
 
   private boolean isAutoScalerEnabled()
@@ -353,7 +356,7 @@ public abstract class SeekableStreamSupervisorSpec implements SupervisorSpec
   );
 
   /**
-   * Returns a copy builder seeded from this spec, used by {@link #requireRestart} for structured comparison.
+   * Returns a copy builder seeded from this spec, used by {@link #getActionOnUpdateTo} for structured comparison.
    * Abstract so that every stream supervisor spec participates in the restart decision.
    */
   public abstract Builder<?> toBuilder();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordCompactionResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordCompactionResourceTest.java
@@ -31,6 +31,7 @@ import org.apache.druid.indexing.compact.CompactionSupervisorSpec;
 import org.apache.druid.indexing.overlord.TaskMaster;
 import org.apache.druid.indexing.overlord.supervisor.CompactionSupervisorManager;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorManager;
+import org.apache.druid.indexing.overlord.supervisor.SupervisorSpecUpdateAction;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorSpecUpdateResult;
 import org.apache.druid.indexing.overlord.supervisor.VersionedSupervisorSpec;
 import org.apache.druid.java.util.common.DateTimes;
@@ -317,7 +318,7 @@ public class OverlordCompactionResourceTest
         new CompactionSupervisorSpec(wikiConfig, false, validator);
 
     EasyMock.expect(supervisorManager.createOrUpdateAndStartSupervisor(supervisorSpec, true))
-            .andReturn(SupervisorSpecUpdateResult.of(true, true)).once();
+            .andReturn(SupervisorSpecUpdateResult.of(true, SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS)).once();
     EasyMock.expect(scheduler.validateCompactionConfig(wikiConfig))
             .andReturn(CompactionConfigValidationResult.success()).once();
     replayAll();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
@@ -1610,14 +1610,15 @@ public class SupervisorManagerTest extends EasyMockSupport
     }
 
     /**
-     * Lets a test model either a no-restart change (default) or a restart-requiring change. Invoked on the
-     * running spec, so this models whether the running supervisor requires a restart. (The default
-     * {@link SupervisorSpec#requireRestart} is conservative and returns true.)
+     * Lets a test model either a no-restart change (default) or a restart-requiring change.
+     * Invoked on therunning spec, so this models whether the running supervisor requires a restart.
+     * The default {@link SupervisorSpec#getActionOnUpdateTo} is conservative and
+     * returns {@link SupervisorSpecUpdateAction#RESTART_SUPERVISOR_AND_TASKS}.
      */
     @Override
-    public boolean requireRestart(SupervisorSpec proposedSpec)
+    public SupervisorSpecUpdateAction getActionOnUpdateTo(SupervisorSpec proposedSpec)
     {
-      return requireRestart;
+      return requireRestart ? SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS : SupervisorSpecUpdateAction.NONE;
     }
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
@@ -165,7 +165,7 @@ public class SupervisorResourceTest extends EasyMockSupport
 
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.of(supervisorManager));
     EasyMock.expect(supervisorManager.createOrUpdateAndStartSupervisor(spec, false))
-            .andReturn(SupervisorSpecUpdateResult.of(true, true));
+            .andReturn(SupervisorSpecUpdateResult.of(true, SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS));
 
     setupMockRequest();
     setupMockRequestForAudit();
@@ -185,7 +185,7 @@ public class SupervisorResourceTest extends EasyMockSupport
 
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.of(supervisorManager));
     EasyMock.expect(supervisorManager.createOrUpdateAndStartSupervisor(spec, false))
-            .andReturn(SupervisorSpecUpdateResult.of(false, true));
+            .andReturn(SupervisorSpecUpdateResult.of(false, SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS));
 
     setupMockRequest();
     setupMockRequestForAudit();
@@ -261,7 +261,7 @@ public class SupervisorResourceTest extends EasyMockSupport
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.of(supervisorManager));
     // Changed but no restart needed: persisted without restarting — and the persist must be audited.
     EasyMock.expect(supervisorManager.createOrUpdateAndStartSupervisor(spec, true))
-            .andReturn(SupervisorSpecUpdateResult.of(true, false));
+            .andReturn(SupervisorSpecUpdateResult.of(true, SupervisorSpecUpdateAction.NONE));
 
     setupMockRequest();
     setupMockRequestForAudit();
@@ -281,7 +281,7 @@ public class SupervisorResourceTest extends EasyMockSupport
 
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.of(supervisorManager));
     EasyMock.expect(supervisorManager.createOrUpdateAndStartSupervisor(spec, true))
-            .andReturn(SupervisorSpecUpdateResult.of(false, false));
+            .andReturn(SupervisorSpecUpdateResult.of(false, SupervisorSpecUpdateAction.NONE));
 
     setupMockRequest();
 
@@ -299,7 +299,7 @@ public class SupervisorResourceTest extends EasyMockSupport
 
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.of(supervisorManager));
     EasyMock.expect(supervisorManager.createOrUpdateAndStartSupervisor(spec, true))
-            .andReturn(SupervisorSpecUpdateResult.of(true, true));
+            .andReturn(SupervisorSpecUpdateResult.of(true, SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS));
 
     setupMockRequest();
     setupMockRequestForAudit();
@@ -332,7 +332,7 @@ public class SupervisorResourceTest extends EasyMockSupport
 
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.of(supervisorManager));
     EasyMock.expect(supervisorManager.createOrUpdateAndStartSupervisor(spec, false))
-            .andReturn(SupervisorSpecUpdateResult.of(true, true));
+            .andReturn(SupervisorSpecUpdateResult.of(true, SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS));
     setupMockRequest();
     setupMockRequestForAudit();
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorSpecTest.java
@@ -29,6 +29,8 @@ import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.indexing.overlord.supervisor.NoopSupervisorSpec;
 import org.apache.druid.indexing.overlord.supervisor.Supervisor;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorManager;
+import org.apache.druid.indexing.overlord.supervisor.SupervisorSpec;
+import org.apache.druid.indexing.overlord.supervisor.SupervisorSpecUpdateAction;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorStateManager;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorStateManagerConfig;
 import org.apache.druid.indexing.overlord.supervisor.autoscaler.SupervisorTaskAutoScaler;
@@ -1430,7 +1432,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         buildSpecWithIoConfig("id", createIOConfig(2, lagBasedAutoScalerConfig(1, 8, null)));
     final SeekableStreamSupervisorSpec oldSpec = seed.toBuilder().build();
     final SeekableStreamSupervisorSpec newSpec = seed.toBuilder().build();
-    Assert.assertFalse(oldSpec.requireRestart(newSpec));
+    Assert.assertFalse(requiresRestart(oldSpec, newSpec));
   }
 
   @Test
@@ -1440,7 +1442,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         buildSpecWithIoConfig("id", createIOConfig(2, lagBasedAutoScalerConfig(1, 8, null)));
     final SeekableStreamSupervisorSpec oldSpec = seed.toBuilder().taskCount(2).build();
     final SeekableStreamSupervisorSpec newSpec = seed.toBuilder().taskCount(5).build();
-    Assert.assertFalse(oldSpec.requireRestart(newSpec));
+    Assert.assertFalse(requiresRestart(oldSpec, newSpec));
   }
 
   @Test
@@ -1449,7 +1451,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
     final TestSeekableStreamSupervisorSpec seed = buildSpecWithIoConfig("id", createIOConfig(2, null));
     final SeekableStreamSupervisorSpec oldSpec = seed.toBuilder().taskCount(2).build();
     final SeekableStreamSupervisorSpec newSpec = seed.toBuilder().taskCount(5).build();
-    Assert.assertTrue(oldSpec.requireRestart(newSpec));
+    Assert.assertTrue(requiresRestart(oldSpec, newSpec));
   }
 
   @Test
@@ -1459,7 +1461,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         buildSpecWithIoConfig("id", createIOConfig(2, lagBasedAutoScalerConfig(1, 8, null)));
     final SeekableStreamSupervisorSpec oldSpec = seed.toBuilder().build();
     final SeekableStreamSupervisorSpec newSpec = seed.toBuilder().context(Map.of("k", "v")).build();
-    Assert.assertTrue(oldSpec.requireRestart(newSpec));
+    Assert.assertTrue(requiresRestart(oldSpec, newSpec));
   }
 
   @Test
@@ -1469,7 +1471,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         buildSpecWithIoConfig("id", createIOConfig(2, lagBasedAutoScalerConfig(1, 8, null)));
     final SeekableStreamSupervisorSpec oldSpec = seed.toBuilder().suspended(false).build();
     final SeekableStreamSupervisorSpec newSpec = seed.toBuilder().suspended(true).build();
-    Assert.assertTrue(oldSpec.requireRestart(newSpec));
+    Assert.assertTrue(requiresRestart(oldSpec, newSpec));
   }
 
   @Test
@@ -1479,7 +1481,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         buildSpecWithIoConfig("id", createIOConfig(2, lagBasedAutoScalerConfig(1, 8, null)));
     final SeekableStreamSupervisorSpec oldSpec = seed.toBuilder().build();
     final SeekableStreamSupervisorSpec newSpec = seed.toBuilder().dataSchema(getDataSchema("other-datasource")).build();
-    Assert.assertTrue(oldSpec.requireRestart(newSpec));
+    Assert.assertTrue(requiresRestart(oldSpec, newSpec));
   }
 
   @Test
@@ -1487,7 +1489,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
   {
     final TestSeekableStreamSupervisorSpec seed =
         buildSpecWithIoConfig("id", createIOConfig(2, lagBasedAutoScalerConfig(1, 8, null)));
-    Assert.assertTrue(seed.toBuilder().build().requireRestart(new NoopSupervisorSpec("id", List.of("ds"))));
+    Assert.assertTrue(requiresRestart(seed.toBuilder().build(), new NoopSupervisorSpec("id", List.of("ds"))));
   }
 
   @Test
@@ -1500,7 +1502,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         buildSpecWithIoConfig("id", createIOConfig(2, lagBasedAutoScalerConfig(1, 8, null))).toBuilder().build();
     final SeekableStreamSupervisorSpec newSpec =
         buildSpecWithIoConfig("id", createIOConfig(5, null)).toBuilder().build();
-    Assert.assertTrue(oldSpec.requireRestart(newSpec));
+    Assert.assertTrue(requiresRestart(oldSpec, newSpec));
   }
 
   @Test
@@ -1511,7 +1513,12 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
     final SeekableStreamSupervisorSpec oldSpec = seed.toBuilder().build();
     final SeekableStreamSupervisorSpec newSpec =
         seed.toBuilder().tuningConfig(EasyMock.mock(SeekableStreamSupervisorTuningConfig.class)).build();
-    Assert.assertTrue(oldSpec.requireRestart(newSpec));
+    Assert.assertTrue(requiresRestart(oldSpec, newSpec));
+  }
+
+  private static boolean requiresRestart(SupervisorSpec oldSpec, SupervisorSpec newSpec)
+  {
+    return oldSpec.getActionOnUpdateTo(newSpec) != SupervisorSpecUpdateAction.NONE;
   }
 
   private void assertMergeResult(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorSpecTest.java
@@ -29,7 +29,6 @@ import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.indexing.overlord.supervisor.NoopSupervisorSpec;
 import org.apache.druid.indexing.overlord.supervisor.Supervisor;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorManager;
-import org.apache.druid.indexing.overlord.supervisor.SupervisorSpec;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorSpecUpdateAction;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorStateManager;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorStateManagerConfig;
@@ -1432,7 +1431,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         buildSpecWithIoConfig("id", createIOConfig(2, lagBasedAutoScalerConfig(1, 8, null)));
     final SeekableStreamSupervisorSpec oldSpec = seed.toBuilder().build();
     final SeekableStreamSupervisorSpec newSpec = seed.toBuilder().build();
-    Assert.assertFalse(requiresRestart(oldSpec, newSpec));
+    Assert.assertEquals(SupervisorSpecUpdateAction.NONE, oldSpec.getActionOnUpdateTo(newSpec));
   }
 
   @Test
@@ -1442,7 +1441,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         buildSpecWithIoConfig("id", createIOConfig(2, lagBasedAutoScalerConfig(1, 8, null)));
     final SeekableStreamSupervisorSpec oldSpec = seed.toBuilder().taskCount(2).build();
     final SeekableStreamSupervisorSpec newSpec = seed.toBuilder().taskCount(5).build();
-    Assert.assertFalse(requiresRestart(oldSpec, newSpec));
+    Assert.assertEquals(SupervisorSpecUpdateAction.NONE, oldSpec.getActionOnUpdateTo(newSpec));
   }
 
   @Test
@@ -1451,7 +1450,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
     final TestSeekableStreamSupervisorSpec seed = buildSpecWithIoConfig("id", createIOConfig(2, null));
     final SeekableStreamSupervisorSpec oldSpec = seed.toBuilder().taskCount(2).build();
     final SeekableStreamSupervisorSpec newSpec = seed.toBuilder().taskCount(5).build();
-    Assert.assertTrue(requiresRestart(oldSpec, newSpec));
+    Assert.assertEquals(SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS, oldSpec.getActionOnUpdateTo(newSpec));
   }
 
   @Test
@@ -1461,7 +1460,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         buildSpecWithIoConfig("id", createIOConfig(2, lagBasedAutoScalerConfig(1, 8, null)));
     final SeekableStreamSupervisorSpec oldSpec = seed.toBuilder().build();
     final SeekableStreamSupervisorSpec newSpec = seed.toBuilder().context(Map.of("k", "v")).build();
-    Assert.assertTrue(requiresRestart(oldSpec, newSpec));
+    Assert.assertEquals(SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS, oldSpec.getActionOnUpdateTo(newSpec));
   }
 
   @Test
@@ -1471,7 +1470,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         buildSpecWithIoConfig("id", createIOConfig(2, lagBasedAutoScalerConfig(1, 8, null)));
     final SeekableStreamSupervisorSpec oldSpec = seed.toBuilder().suspended(false).build();
     final SeekableStreamSupervisorSpec newSpec = seed.toBuilder().suspended(true).build();
-    Assert.assertTrue(requiresRestart(oldSpec, newSpec));
+    Assert.assertEquals(SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS, oldSpec.getActionOnUpdateTo(newSpec));
   }
 
   @Test
@@ -1481,7 +1480,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         buildSpecWithIoConfig("id", createIOConfig(2, lagBasedAutoScalerConfig(1, 8, null)));
     final SeekableStreamSupervisorSpec oldSpec = seed.toBuilder().build();
     final SeekableStreamSupervisorSpec newSpec = seed.toBuilder().dataSchema(getDataSchema("other-datasource")).build();
-    Assert.assertTrue(requiresRestart(oldSpec, newSpec));
+    Assert.assertEquals(SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS, oldSpec.getActionOnUpdateTo(newSpec));
   }
 
   @Test
@@ -1489,7 +1488,10 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
   {
     final TestSeekableStreamSupervisorSpec seed =
         buildSpecWithIoConfig("id", createIOConfig(2, lagBasedAutoScalerConfig(1, 8, null)));
-    Assert.assertTrue(requiresRestart(seed.toBuilder().build(), new NoopSupervisorSpec("id", List.of("ds"))));
+    Assert.assertEquals(
+        SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS,
+        seed.toBuilder().build().getActionOnUpdateTo(new NoopSupervisorSpec("id", List.of("ds")))
+    );
   }
 
   @Test
@@ -1502,7 +1504,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         buildSpecWithIoConfig("id", createIOConfig(2, lagBasedAutoScalerConfig(1, 8, null))).toBuilder().build();
     final SeekableStreamSupervisorSpec newSpec =
         buildSpecWithIoConfig("id", createIOConfig(5, null)).toBuilder().build();
-    Assert.assertTrue(requiresRestart(oldSpec, newSpec));
+    Assert.assertEquals(SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS, oldSpec.getActionOnUpdateTo(newSpec));
   }
 
   @Test
@@ -1513,12 +1515,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
     final SeekableStreamSupervisorSpec oldSpec = seed.toBuilder().build();
     final SeekableStreamSupervisorSpec newSpec =
         seed.toBuilder().tuningConfig(EasyMock.mock(SeekableStreamSupervisorTuningConfig.class)).build();
-    Assert.assertTrue(requiresRestart(oldSpec, newSpec));
-  }
-
-  private static boolean requiresRestart(SupervisorSpec oldSpec, SupervisorSpec newSpec)
-  {
-    return oldSpec.getActionOnUpdateTo(newSpec) != SupervisorSpecUpdateAction.NONE;
+    Assert.assertEquals(SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS, oldSpec.getActionOnUpdateTo(newSpec));
   }
 
   private void assertMergeResult(

--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpec.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpec.java
@@ -150,9 +150,11 @@ public interface SupervisorSpec
   }
 
   /**
-   * Returns true if the supervisor restart should cause task disruption, false otherwise
+   * Returns true if replacing this (running) spec with {@code proposedSpec} should roll over (stop and
+   * republish) the currently running tasks, false if the existing tasks should be left running as-is.
+   * Invoked on the running spec; default is conservative (always roll over).
    */
-  default boolean shouldRestartCauseTaskDisruption()
+  default boolean shouldRolloverTasksOnRestart(SupervisorSpec proposedSpec)
   {
     return true;
   }

--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpec.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpec.java
@@ -141,21 +141,11 @@ public interface SupervisorSpec
   }
 
   /**
-   * Returns true if replacing this (running) spec with {@code proposedSpec} requires a supervisor restart.
+   * Returns a required
    * Invoked on the running spec; default is conservative (always restart).
    */
-  default boolean requireRestart(SupervisorSpec proposedSpec)
+  default SupervisorSpecUpdateAction getActionOnUpdateTo(SupervisorSpec proposedSpec)
   {
-    return true;
-  }
-
-  /**
-   * Returns true if replacing this (running) spec with {@code proposedSpec} should roll over (stop and
-   * republish) the currently running tasks, false if the existing tasks should be left running as-is.
-   * Invoked on the running spec; default is conservative (always roll over).
-   */
-  default boolean shouldRolloverTasksOnRestart(SupervisorSpec proposedSpec)
-  {
-    return true;
+    return SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS;
   }
 }

--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpec.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpec.java
@@ -141,8 +141,10 @@ public interface SupervisorSpec
   }
 
   /**
-   * Returns a required
-   * Invoked on the running spec; default is conservative (always restart).
+   * Returns the action to take when this (running) spec is updated to {@code proposedSpec}.
+   * Invoked on the running spec; default is conservative and always restarts the supervisor and its tasks.
+   *
+   * @param proposedSpec the proposed supervisor spec
    */
   default SupervisorSpecUpdateAction getActionOnUpdateTo(SupervisorSpec proposedSpec)
   {

--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpec.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpec.java
@@ -148,4 +148,12 @@ public interface SupervisorSpec
   {
     return true;
   }
+
+  /**
+   * Returns true if the supervisor restart should cause task disruption, false otherwise
+   */
+  default boolean shouldRestartCauseTaskDisruption()
+  {
+    return true;
+  }
 }

--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpecUpdateAction.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpecUpdateAction.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.apache.druid.indexing.overlord.supervisor;
+
+/**
+ * Enum representing the possible actions to take when a supervisor spec is updated.
+ */
+public enum SupervisorSpecUpdateAction
+{
+  NONE,
+  RESTART_SUPERVISOR,
+  RESTART_SUPERVISOR_AND_TASKS
+}


### PR DESCRIPTION
Today, updating a supervisor spec always restarts the supervisor and terminates its running tasks, even when the change is cosmetic. This makes routine spec updates unnecessarily disruptive to in-flight ingestion.

This PR replaces the boolean `SupervisorSpec#requireRestart` with a tri-state `SupervisorSpec#getActionOnUpdateTo(SupervisorSpec proposedSpec`), returning a `SupervisorSpecUpdateAction`:
  - `NONE` - persist the new spec, no restart
  - `RESTART_SUPERVISOR` - restart the supervisor, but leave running tasks alone
  - `RESTART_SUPERVISOR_AND_TASKS` - restart the supervisor and terminate its tasks (previous behavior; still the default)