### PR TITLE
fix: delegate row/vector id inspectors for clustered selector factories

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/projections/ClusteringColumnSelectorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/projections/ClusteringColumnSelectorFactory.java
@@ -85,8 +85,6 @@ public class ClusteringColumnSelectorFactory implements ColumnSelectorFactory
   // Bumped on every setDelegate(...) so per-call selector wrappers can detect group transitions and rebuild their
   // cached inner state
   private long generation;
-  private long rowIdBase;
-  private long lastDelegateRowId = RowIdSupplier.INIT;
   private final RowIdSupplier rowIdSupplier = new DelegatingRowIdSupplier(this);
 
   public ClusteringColumnSelectorFactory(
@@ -113,11 +111,6 @@ public class ClusteringColumnSelectorFactory implements ColumnSelectorFactory
           clusteringColumns.size()
       );
     }
-    // Advance the row-id base past every id issued for the outgoing group so getRowId() stays globally unique across
-    // the concatenation (each per-group delegate restarts its row offset at 0). lastDelegateRowId is that group's
-    // high-water mark; +1 makes the incoming group's first row id strictly greater than the previous group's last.
-    this.rowIdBase += this.lastDelegateRowId + 1;
-    this.lastDelegateRowId = RowIdSupplier.INIT;
     this.delegate = delegate;
     this.clusteringValues = clusteringValues;
     this.generation++;
@@ -189,37 +182,21 @@ public class ClusteringColumnSelectorFactory implements ColumnSelectorFactory
     return delegate.getRowIdSupplier() == null ? null : rowIdSupplier;
   }
 
-  /**
-   * The current row id, remapped to be unique across the whole concatenation (see {@link #rowIdBase}). Records the
-   * delegate's raw row id as this group's running high-water mark for the next transition.
-   */
-  long currentRowId()
-  {
-    final RowIdSupplier supplier = delegate.getRowIdSupplier();
-    if (supplier == null) {
-      // getRowIdSupplier() only hands out this wrapper when the delegate supports row ids; clustered groups are
-      // homogeneous, so a null here would mean a group mid-cursor stopped supporting them.
-      throw DruidException.defensive("delegate row id supplier became null across a cluster-group transition");
-    }
-    final long rowId = supplier.getRowId();
-    lastDelegateRowId = rowId;
-    return rowIdBase + rowId;
-  }
-
   Object currentValue(int idx)
   {
     return clusteringValues[idx];
   }
 
   /**
-   * A {@link RowIdSupplier} that forwards to the factory's <em>current</em> delegate. A single instance is handed out
-   * for the factory's lifetime; because a multi-group {@code ConcatenatingCursor} swaps the delegate on each group
-   * transition via {@link #setDelegate}, a consumer that grabbed the supplier once must observe the active group's
-   * row id. Row ids are remapped to stay unique across group boundaries (see {@link #currentRowId}).
+   * A {@link RowIdSupplier} bound to the factory, {@link #getRowId} follows whichever delegate is current, so a
+   * supplier grabbed once keeps tracking the active group across {@code ConcatenatingCursor} transitions.
    */
   private static final class DelegatingRowIdSupplier implements RowIdSupplier
   {
     private final ClusteringColumnSelectorFactory parent;
+    private long rowId = INIT;
+    private long lastDelegateRowId = INIT;
+    private RowIdSupplier lastDelegate;
 
     private DelegatingRowIdSupplier(ClusteringColumnSelectorFactory parent)
     {
@@ -229,7 +206,22 @@ public class ClusteringColumnSelectorFactory implements ColumnSelectorFactory
     @Override
     public long getRowId()
     {
-      return parent.currentRowId();
+      final RowIdSupplier delegate = parent.getDelegate().getRowIdSupplier();
+      if (delegate == null) {
+        // getRowIdSupplier() only hands out this wrapper when the delegate supports row ids; clustered groups are
+        // homogeneous, so a null here would mean a group mid-cursor stopped supporting them.
+        throw DruidException.defensive("delegate row id supplier became null across a cluster-group transition");
+      }
+      final long id = delegate.getRowId();
+      if (id == INIT) {
+        return INIT;
+      }
+      if (delegate != lastDelegate || id != lastDelegateRowId) {
+        lastDelegate = delegate;
+        lastDelegateRowId = id;
+        rowId++;
+      }
+      return rowId;
     }
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/projections/ClusteringColumnSelectorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/projections/ClusteringColumnSelectorFactory.java
@@ -85,6 +85,9 @@ public class ClusteringColumnSelectorFactory implements ColumnSelectorFactory
   // Bumped on every setDelegate(...) so per-call selector wrappers can detect group transitions and rebuild their
   // cached inner state
   private long generation;
+  private long rowIdBase;
+  private long lastDelegateRowId = RowIdSupplier.INIT;
+  private final RowIdSupplier rowIdSupplier = new DelegatingRowIdSupplier(this);
 
   public ClusteringColumnSelectorFactory(
       ColumnSelectorFactory delegate,
@@ -110,6 +113,11 @@ public class ClusteringColumnSelectorFactory implements ColumnSelectorFactory
           clusteringColumns.size()
       );
     }
+    // Advance the row-id base past every id issued for the outgoing group so getRowId() stays globally unique across
+    // the concatenation (each per-group delegate restarts its row offset at 0). lastDelegateRowId is that group's
+    // high-water mark; +1 makes the incoming group's first row id strictly greater than the previous group's last.
+    this.rowIdBase += this.lastDelegateRowId + 1;
+    this.lastDelegateRowId = RowIdSupplier.INIT;
     this.delegate = delegate;
     this.clusteringValues = clusteringValues;
     this.generation++;
@@ -177,12 +185,52 @@ public class ClusteringColumnSelectorFactory implements ColumnSelectorFactory
   @Override
   public RowIdSupplier getRowIdSupplier()
   {
-    return delegate.getRowIdSupplier();
+    // A delegate may not support row-id caching; mirror that so callers skip caching (null)
+    return delegate.getRowIdSupplier() == null ? null : rowIdSupplier;
+  }
+
+  /**
+   * The current row id, remapped to be unique across the whole concatenation (see {@link #rowIdBase}). Records the
+   * delegate's raw row id as this group's running high-water mark for the next transition.
+   */
+  long currentRowId()
+  {
+    final RowIdSupplier supplier = delegate.getRowIdSupplier();
+    if (supplier == null) {
+      // getRowIdSupplier() only hands out this wrapper when the delegate supports row ids; clustered groups are
+      // homogeneous, so a null here would mean a group mid-cursor stopped supporting them.
+      throw DruidException.defensive("delegate row id supplier became null across a cluster-group transition");
+    }
+    final long rowId = supplier.getRowId();
+    lastDelegateRowId = rowId;
+    return rowIdBase + rowId;
   }
 
   Object currentValue(int idx)
   {
     return clusteringValues[idx];
+  }
+
+  /**
+   * A {@link RowIdSupplier} that forwards to the factory's <em>current</em> delegate. A single instance is handed out
+   * for the factory's lifetime; because a multi-group {@code ConcatenatingCursor} swaps the delegate on each group
+   * transition via {@link #setDelegate}, a consumer that grabbed the supplier once must observe the active group's
+   * row id. Row ids are remapped to stay unique across group boundaries (see {@link #currentRowId}).
+   */
+  private static final class DelegatingRowIdSupplier implements RowIdSupplier
+  {
+    private final ClusteringColumnSelectorFactory parent;
+
+    private DelegatingRowIdSupplier(ClusteringColumnSelectorFactory parent)
+    {
+      this.parent = parent;
+    }
+
+    @Override
+    public long getRowId()
+    {
+      return parent.currentRowId();
+    }
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/segment/projections/ClusteringVectorColumnSelectorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/projections/ClusteringVectorColumnSelectorFactory.java
@@ -58,8 +58,6 @@ public class ClusteringVectorColumnSelectorFactory implements VectorColumnSelect
   // Bumped on every setDelegate(...) so per-call selector wrappers can detect group transitions and rebuild their
   // cached inner state.
   private long generation;
-  private int idBase;
-  private int lastDelegateId = -1;
   private final ReadableVectorInspector readableVectorInspector = new DelegatingReadableVectorInspector(this);
 
   /**
@@ -100,11 +98,6 @@ public class ClusteringVectorColumnSelectorFactory implements VectorColumnSelect
           clusteringColumns.size()
       );
     }
-    // Advance the id base past every id issued for the outgoing group so getId() stays globally unique across the
-    // concatenation (each per-group offset restarts its id sequence at 0). lastDelegateId is that group's high-water
-    // mark; +1 makes the incoming group's first id strictly greater than the last id the previous group handed out.
-    this.idBase += this.lastDelegateId + 1;
-    this.lastDelegateId = -1;
     this.delegate = delegate;
     this.clusteringValues = clusteringValues;
     this.generation++;
@@ -123,31 +116,6 @@ public class ClusteringVectorColumnSelectorFactory implements VectorColumnSelect
   Object currentValue(int idx)
   {
     return clusteringValues[idx];
-  }
-
-  /**
-   * Current-vector size of the group the factory currently delegates to. Read live so that a
-   * {@link DelegatingReadableVectorInspector} handed out once still reports the active group's size after a
-   * {@link #setDelegate} transition.
-   */
-  int currentVectorSize()
-  {
-    return delegate.getReadableVectorInspector().getCurrentVectorSize();
-  }
-
-  /**
-   * The current vector id, remapped to be unique across the whole concatenation. Returns
-   * {@link ReadableVectorInspector#NULL_ID} unchanged when the delegate has no stable id, so callers still know
-   * caching is unsafe. Records the delegate's raw id as this group's running high-water mark for the next transition.
-   */
-  int currentVectorId()
-  {
-    final int id = delegate.getReadableVectorInspector().getId();
-    if (id == ReadableVectorInspector.NULL_ID) {
-      return ReadableVectorInspector.NULL_ID;
-    }
-    lastDelegateId = id;
-    return idBase + id;
   }
 
   @Override
@@ -235,18 +203,16 @@ public class ClusteringVectorColumnSelectorFactory implements VectorColumnSelect
   }
 
   /**
-   * A {@link ReadableVectorInspector} that forwards to the factory's <em>current</em> delegate. A single instance is
-   * handed out for the factory's lifetime; because a multi-group {@code ConcatenatingVectorCursor} swaps the delegate
-   * on each group transition via {@link #setDelegate}, a consumer that grabbed the inspector once must observe the
-   * active group's size and id.
-   * <p>
-   * {@link #getMaxVectorSize} reports the factory's fixed max (stable for the cursor lifetime, matching
-   * {@code ConcatenatingVectorCursor#getMaxVectorSize}); {@link #getCurrentVectorSize} and {@link #getId} track the
-   * current delegate, with ids remapped to stay unique across group boundaries (see {@link #currentVectorId}).
+   * A {@link ReadableVectorInspector} bound to the factory, not to one delegate: {@link #getCurrentVectorSize} and
+   * {@link #getId} follow whichever delegate is current, so an inspector grabbed once keeps tracking the active group
+   * across {@code ConcatenatingVectorCursor} transitions. {@link #getMaxVectorSize} is the factory's fixed max.
    */
   private static final class DelegatingReadableVectorInspector implements ReadableVectorInspector
   {
     private final ClusteringVectorColumnSelectorFactory parent;
+    private int vectorId = NULL_ID;
+    private int lastDelegateId = NULL_ID;
+    private VectorColumnSelectorFactory lastDelegate;
 
     private DelegatingReadableVectorInspector(ClusteringVectorColumnSelectorFactory parent)
     {
@@ -262,13 +228,23 @@ public class ClusteringVectorColumnSelectorFactory implements VectorColumnSelect
     @Override
     public int getCurrentVectorSize()
     {
-      return parent.currentVectorSize();
+      return parent.getDelegate().getReadableVectorInspector().getCurrentVectorSize();
     }
 
     @Override
     public int getId()
     {
-      return parent.currentVectorId();
+      final VectorColumnSelectorFactory delegate = parent.getDelegate();
+      final int id = delegate.getReadableVectorInspector().getId();
+      if (id == NULL_ID) {
+        return NULL_ID;
+      }
+      if (delegate != lastDelegate || id != lastDelegateId) {
+        lastDelegate = delegate;
+        lastDelegateId = id;
+        vectorId++;
+      }
+      return vectorId;
     }
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/projections/ClusteringVectorColumnSelectorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/projections/ClusteringVectorColumnSelectorFactory.java
@@ -58,6 +58,9 @@ public class ClusteringVectorColumnSelectorFactory implements VectorColumnSelect
   // Bumped on every setDelegate(...) so per-call selector wrappers can detect group transitions and rebuild their
   // cached inner state.
   private long generation;
+  private int idBase;
+  private int lastDelegateId = -1;
+  private final ReadableVectorInspector readableVectorInspector = new DelegatingReadableVectorInspector(this);
 
   /**
    * Convenience overload that derives {@code maxVectorSize} from the supplied delegate. Used by single-group
@@ -97,6 +100,11 @@ public class ClusteringVectorColumnSelectorFactory implements VectorColumnSelect
           clusteringColumns.size()
       );
     }
+    // Advance the id base past every id issued for the outgoing group so getId() stays globally unique across the
+    // concatenation (each per-group offset restarts its id sequence at 0). lastDelegateId is that group's high-water
+    // mark; +1 makes the incoming group's first id strictly greater than the last id the previous group handed out.
+    this.idBase += this.lastDelegateId + 1;
+    this.lastDelegateId = -1;
     this.delegate = delegate;
     this.clusteringValues = clusteringValues;
     this.generation++;
@@ -117,10 +125,35 @@ public class ClusteringVectorColumnSelectorFactory implements VectorColumnSelect
     return clusteringValues[idx];
   }
 
+  /**
+   * Current-vector size of the group the factory currently delegates to. Read live so that a
+   * {@link DelegatingReadableVectorInspector} handed out once still reports the active group's size after a
+   * {@link #setDelegate} transition.
+   */
+  int currentVectorSize()
+  {
+    return delegate.getReadableVectorInspector().getCurrentVectorSize();
+  }
+
+  /**
+   * The current vector id, remapped to be unique across the whole concatenation. Returns
+   * {@link ReadableVectorInspector#NULL_ID} unchanged when the delegate has no stable id, so callers still know
+   * caching is unsafe. Records the delegate's raw id as this group's running high-water mark for the next transition.
+   */
+  int currentVectorId()
+  {
+    final int id = delegate.getReadableVectorInspector().getId();
+    if (id == ReadableVectorInspector.NULL_ID) {
+      return ReadableVectorInspector.NULL_ID;
+    }
+    lastDelegateId = id;
+    return idBase + id;
+  }
+
   @Override
   public ReadableVectorInspector getReadableVectorInspector()
   {
-    return delegate.getReadableVectorInspector();
+    return readableVectorInspector;
   }
 
   @Override
@@ -199,6 +232,44 @@ public class ClusteringVectorColumnSelectorFactory implements VectorColumnSelect
       return ColumnCapabilitiesImpl.createSimpleSingleValueStringColumnCapabilities();
     }
     return ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(type);
+  }
+
+  /**
+   * A {@link ReadableVectorInspector} that forwards to the factory's <em>current</em> delegate. A single instance is
+   * handed out for the factory's lifetime; because a multi-group {@code ConcatenatingVectorCursor} swaps the delegate
+   * on each group transition via {@link #setDelegate}, a consumer that grabbed the inspector once must observe the
+   * active group's size and id.
+   * <p>
+   * {@link #getMaxVectorSize} reports the factory's fixed max (stable for the cursor lifetime, matching
+   * {@code ConcatenatingVectorCursor#getMaxVectorSize}); {@link #getCurrentVectorSize} and {@link #getId} track the
+   * current delegate, with ids remapped to stay unique across group boundaries (see {@link #currentVectorId}).
+   */
+  private static final class DelegatingReadableVectorInspector implements ReadableVectorInspector
+  {
+    private final ClusteringVectorColumnSelectorFactory parent;
+
+    private DelegatingReadableVectorInspector(ClusteringVectorColumnSelectorFactory parent)
+    {
+      this.parent = parent;
+    }
+
+    @Override
+    public int getMaxVectorSize()
+    {
+      return parent.getMaxVectorSize();
+    }
+
+    @Override
+    public int getCurrentVectorSize()
+    {
+      return parent.currentVectorSize();
+    }
+
+    @Override
+    public int getId()
+    {
+      return parent.currentVectorId();
+    }
   }
 
   private static final class ClusteringVectorValueSelector implements VectorValueSelector

--- a/processing/src/test/java/org/apache/druid/segment/projections/ClusteringColumnSelectorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/projections/ClusteringColumnSelectorFactoryTest.java
@@ -201,6 +201,84 @@ class ClusteringColumnSelectorFactoryTest
   }
 
   @Test
+  void testRowIdSupplierFollowsCurrentDelegate()
+  {
+    // getRowIdSupplier() must return a supplier that reflects the current delegate, even for a reference grabbed
+    // before a group transition. A multi-group ConcatenatingCursor swaps the delegate on each group, and a consumer
+    // that cached the supplier must observe the active group's row id (not the group current when it first asked).
+    RecordingDelegate first = new RecordingDelegate();
+    first.rowId = 7;
+    ClusteringColumnSelectorFactory f = new ClusteringColumnSelectorFactory(first, SIGNATURE, new Object[]{"acme"});
+
+    RowIdSupplier supplier = f.getRowIdSupplier();
+    Assertions.assertNotNull(supplier);
+    long firstId = supplier.getRowId();
+
+    // Simulate a group transition; the second group's offset restarts its row id at 0.
+    RecordingDelegate second = new RecordingDelegate();
+    second.rowId = 0;
+    f.setDelegate(second, new Object[]{"globex"});
+
+    // The previously-acquired supplier now reads the second delegate, and its remapped id differs despite the reset.
+    Assertions.assertNotEquals(firstId, supplier.getRowId());
+  }
+
+  @Test
+  void testGetRowIdUniqueAcrossSingleRowGroups()
+  {
+    // A group whose offset restarts at 0, followed by another such group, must not report the same row id across the
+    // transition, or a single-slot row-id cache would hand back the previous group's stale row.
+    ClusteringColumnSelectorFactory f = new ClusteringColumnSelectorFactory(
+        new RecordingDelegate(),   // rowId 0
+        SIGNATURE,
+        new Object[]{"a"}
+    );
+    RowIdSupplier supplier = f.getRowIdSupplier();
+    long idA = supplier.getRowId();
+
+    f.setDelegate(new RecordingDelegate(), new Object[]{"b"});   // rowId 0
+    long idB = supplier.getRowId();
+
+    f.setDelegate(new RecordingDelegate(), new Object[]{"c"});   // rowId 0
+    long idC = supplier.getRowId();
+
+    Assertions.assertNotEquals(idA, idB);
+    Assertions.assertNotEquals(idB, idC);
+    Assertions.assertNotEquals(idA, idC);
+  }
+
+  @Test
+  void testGetRowIdAdvancesWithinGroupAndStaysAheadAcrossTransition()
+  {
+    // Within a group, row ids track the delegate offset as it advances. Across a transition, the next group's first
+    // row id must be strictly greater than the last id the previous group handed out.
+    RecordingDelegate d = new RecordingDelegate();
+    ClusteringColumnSelectorFactory f = new ClusteringColumnSelectorFactory(d, SIGNATURE, new Object[]{"a"});
+    RowIdSupplier supplier = f.getRowIdSupplier();
+    d.rowId = 0;
+    long id0 = supplier.getRowId();
+    d.rowId = 5;
+    long id1 = supplier.getRowId();
+    d.rowId = 9;
+    long id2 = supplier.getRowId();
+    Assertions.assertTrue(id0 < id1 && id1 < id2, "row ids must increase as the group advances");
+
+    f.setDelegate(new RecordingDelegate(), new Object[]{"b"});   // rowId 0
+    Assertions.assertTrue(supplier.getRowId() > id2, "new group's first row id must exceed the previous group's last");
+  }
+
+  @Test
+  void testGetRowIdSupplierNullWhenDelegateHasNone()
+  {
+    // A delegate that doesn't support row-id caching (null supplier) must surface as a null supplier on the wrapper,
+    // so callers take the no-caching path rather than caching against a fabricated id.
+    RecordingDelegate d = new RecordingDelegate();
+    d.supportsRowId = false;
+    ClusteringColumnSelectorFactory f = new ClusteringColumnSelectorFactory(d, SIGNATURE, new Object[]{"a"});
+    Assertions.assertNull(f.getRowIdSupplier());
+  }
+
+  @Test
   void testGetColumnCapabilitiesForClusteringColumns()
   {
     ClusteringColumnSelectorFactory f = new ClusteringColumnSelectorFactory(
@@ -389,6 +467,10 @@ class ClusteringColumnSelectorFactoryTest
     String lastDimSelectorName;
     String lastValueSelectorName;
     String lastCapabilitiesColumn;
+    // Row id handed out by this delegate's supplier; per-group offsets restart at 0, so the default mirrors a fresh
+    // group cursor. supportsRowId=false models a delegate with no row-id caching (getRowIdSupplier() == null).
+    long rowId;
+    boolean supportsRowId = true;
 
     @Override
     public DimensionSelector makeDimensionSelector(org.apache.druid.query.dimension.DimensionSpec dimensionSpec)
@@ -416,7 +498,7 @@ class ClusteringColumnSelectorFactoryTest
     @Override
     public RowIdSupplier getRowIdSupplier()
     {
-      return null;
+      return supportsRowId ? () -> rowId : null;
     }
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/projections/ClusteringColumnSelectorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/projections/ClusteringColumnSelectorFactoryTest.java
@@ -268,6 +268,29 @@ class ClusteringColumnSelectorFactoryTest
   }
 
   @Test
+  void testGetRowIdMintsMonotonicIdsRegardlessOfDelegateIdOrder()
+  {
+    // The RowIdSupplier contract does not require monotonic (or meaningful) delegate ids. We mint our own
+    // strictly-increasing ids purely from change detection, so a non-monotonic sequence within a group and an id that
+    // overlaps across a group boundary both still yield clean, collision-free ids.
+    RecordingDelegate d = new RecordingDelegate();
+    ClusteringColumnSelectorFactory f = new ClusteringColumnSelectorFactory(d, SIGNATURE, new Object[]{"a"});
+    RowIdSupplier supplier = f.getRowIdSupplier();
+
+    d.rowId = 100;
+    long a = supplier.getRowId();
+    d.rowId = 5;                       // non-monotonic within the group
+    long b = supplier.getRowId();
+
+    RecordingDelegate second = new RecordingDelegate();
+    second.rowId = 100;                // reuse an id the first group already handed out
+    f.setDelegate(second, new Object[]{"b"});
+    long c = supplier.getRowId();
+
+    Assertions.assertTrue(a < b && b < c, "minted row ids must be strictly increasing regardless of delegate id order");
+  }
+
+  @Test
   void testGetRowIdSupplierNullWhenDelegateHasNone()
   {
     // A delegate that doesn't support row-id caching (null supplier) must surface as a null supplier on the wrapper,
@@ -276,6 +299,35 @@ class ClusteringColumnSelectorFactoryTest
     d.supportsRowId = false;
     ClusteringColumnSelectorFactory f = new ClusteringColumnSelectorFactory(d, SIGNATURE, new Object[]{"a"});
     Assertions.assertNull(f.getRowIdSupplier());
+  }
+
+  @Test
+  void testGetRowIdStableWhenPositionUnchanged()
+  {
+    // The caching contract: reading twice without the cursor moving (same delegate, same raw id) must return the SAME
+    // minted id, so a downstream row-id-keyed cache hits instead of recomputing. Guards against an always-tick regression.
+    RecordingDelegate d = new RecordingDelegate();
+    d.rowId = 3;
+    ClusteringColumnSelectorFactory f = new ClusteringColumnSelectorFactory(d, SIGNATURE, new Object[]{"a"});
+    RowIdSupplier supplier = f.getRowIdSupplier();
+    long first = supplier.getRowId();
+    Assertions.assertEquals(first, supplier.getRowId());
+    Assertions.assertEquals(first, supplier.getRowId());
+  }
+
+  @Test
+  void testGetRowIdReturnsSentinelWhenDelegateUnpositioned()
+  {
+    // When the delegate reports the unpositioned sentinel (INIT), the wrapper must pass it through unchanged and not
+    // advance its minted counter, so a later real row still mints a fresh id starting at 0.
+    RecordingDelegate d = new RecordingDelegate();
+    d.rowId = RowIdSupplier.INIT;
+    ClusteringColumnSelectorFactory f = new ClusteringColumnSelectorFactory(d, SIGNATURE, new Object[]{"a"});
+    RowIdSupplier supplier = f.getRowIdSupplier();
+    Assertions.assertEquals(RowIdSupplier.INIT, supplier.getRowId());
+
+    d.rowId = 0;
+    Assertions.assertEquals(0L, supplier.getRowId());
   }
 
   @Test
@@ -471,6 +523,10 @@ class ClusteringColumnSelectorFactoryTest
     // group cursor. supportsRowId=false models a delegate with no row-id caching (getRowIdSupplier() == null).
     long rowId;
     boolean supportsRowId = true;
+    // A single stable supplier instance (reads the mutable rowId each call), mirroring a real factory that returns
+    // `this` from getRowIdSupplier(). A fresh lambda per call would make the wrapper's delegate-identity check tick on
+    // every read, hiding whether the raw-id-change branch works.
+    private final RowIdSupplier stableRowIdSupplier = () -> rowId;
 
     @Override
     public DimensionSelector makeDimensionSelector(org.apache.druid.query.dimension.DimensionSpec dimensionSpec)
@@ -498,7 +554,7 @@ class ClusteringColumnSelectorFactoryTest
     @Override
     public RowIdSupplier getRowIdSupplier()
     {
-      return supportsRowId ? () -> rowId : null;
+      return supportsRowId ? stableRowIdSupplier : null;
     }
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/projections/ClusteringVectorColumnSelectorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/projections/ClusteringVectorColumnSelectorFactoryTest.java
@@ -291,6 +291,81 @@ class ClusteringVectorColumnSelectorFactoryTest
     );
   }
 
+  @Test
+  void testReadableVectorInspectorFollowsCurrentDelegate()
+  {
+    // getReadableVectorInspector() must return an inspector that reflects the current delegate, even for a reference
+    // grabbed before a group transition. A multi-group ConcatenatingVectorCursor swaps the delegate on each group, and
+    // a consumer that cached the inspector must observe the active group's size (not the group that was current when
+    // it first asked).
+    ClusteringVectorColumnSelectorFactory f = new ClusteringVectorColumnSelectorFactory(
+        new StubDelegate(new NoFilterVectorOffset(8, 0, 5)),   // current vector size 5
+        CLUSTER_SIGNATURE,
+        new Object[]{"acme"}
+    );
+
+    ReadableVectorInspector inspector = f.getReadableVectorInspector();
+    Assertions.assertEquals(8, inspector.getMaxVectorSize());
+    Assertions.assertEquals(5, inspector.getCurrentVectorSize());
+    int firstId = inspector.getId();
+
+    // Simulate a group transition. The second group's offset restarts its id at 0 and has a smaller final vector.
+    f.setDelegate(new StubDelegate(new NoFilterVectorOffset(8, 0, 3)), new Object[]{"globex"});
+
+    // The previously-acquired inspector reference now reports the second group's size ...
+    Assertions.assertEquals(3, inspector.getCurrentVectorSize());
+    // ... and a distinct id, even though the delegate offset restarted at 0.
+    Assertions.assertNotEquals(firstId, inspector.getId());
+  }
+
+  @Test
+  void testGetIdUniqueAcrossSingleVectorGroups()
+  {
+    // A group that fits in one vector reports delegate id 0; the next group's offset also restarts at 0. The remapped
+    // id must differ across the transition so a single-slot id cache doesn't treat the new group's first vector as
+    // unchanged and hand back the previous group's stale vector.
+    ClusteringVectorColumnSelectorFactory f = new ClusteringVectorColumnSelectorFactory(
+        new StubDelegate(new NoFilterVectorOffset(8, 0, 4)),
+        CLUSTER_SIGNATURE,
+        new Object[]{"a"}
+    );
+    ReadableVectorInspector inspector = f.getReadableVectorInspector();
+    int idA = inspector.getId();
+
+    f.setDelegate(new StubDelegate(new NoFilterVectorOffset(8, 0, 4)), new Object[]{"b"});
+    int idB = inspector.getId();
+
+    f.setDelegate(new StubDelegate(new NoFilterVectorOffset(8, 0, 4)), new Object[]{"c"});
+    int idC = inspector.getId();
+
+    Assertions.assertNotEquals(idA, idB);
+    Assertions.assertNotEquals(idB, idC);
+    Assertions.assertNotEquals(idA, idC);
+  }
+
+  @Test
+  void testGetIdAdvancesWithinGroupAndStaysAheadAcrossTransition()
+  {
+    // Within a group, ids track the delegate offset as it advances. Across a transition, the next group's first id
+    // must be strictly greater than the last id the previous group handed out.
+    NoFilterVectorOffset offset = new NoFilterVectorOffset(4, 0, 12); // ids 0, 4, 8 as it advances
+    ClusteringVectorColumnSelectorFactory f = new ClusteringVectorColumnSelectorFactory(
+        new StubDelegate(offset),
+        CLUSTER_SIGNATURE,
+        new Object[]{"a"}
+    );
+    ReadableVectorInspector inspector = f.getReadableVectorInspector();
+    int id0 = inspector.getId();
+    offset.advance();
+    int id1 = inspector.getId();
+    offset.advance();
+    int id2 = inspector.getId();
+    Assertions.assertTrue(id0 < id1 && id1 < id2, "ids must increase as the group advances");
+
+    f.setDelegate(new StubDelegate(new NoFilterVectorOffset(4, 0, 4)), new Object[]{"b"});
+    Assertions.assertTrue(inspector.getId() > id2, "new group's first id must exceed the previous group's last id");
+  }
+
   private static ReadableVectorInspector inspectorFor(int size)
   {
     return new NoFilterVectorOffset(size, 0, size);

--- a/processing/src/test/java/org/apache/druid/segment/projections/ClusteringVectorColumnSelectorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/projections/ClusteringVectorColumnSelectorFactoryTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.segment.projections;
 
 import org.apache.druid.error.DruidException;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
+import org.apache.druid.query.dimension.DimensionSpec;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
@@ -366,9 +367,106 @@ class ClusteringVectorColumnSelectorFactoryTest
     Assertions.assertTrue(inspector.getId() > id2, "new group's first id must exceed the previous group's last id");
   }
 
+  @Test
+  void testGetIdMintsMonotonicIdsRegardlessOfDelegateIdOrder()
+  {
+    // The ReadableVectorInspector contract does not require monotonic (or meaningful) delegate ids. We mint our own
+    // strictly-increasing ids purely from change detection, so a non-monotonic sequence within a group and an id that
+    // overlaps across a group boundary both still yield clean, collision-free ids.
+    SettableVectorInspector first = new SettableVectorInspector(4);
+    ClusteringVectorColumnSelectorFactory f = new ClusteringVectorColumnSelectorFactory(
+        new StubDelegate(first),
+        CLUSTER_SIGNATURE,
+        new Object[]{"a"}
+    );
+    ReadableVectorInspector inspector = f.getReadableVectorInspector();
+
+    first.id = 100;
+    int a = inspector.getId();
+    first.id = 5;                    // non-monotonic within the group
+    int b = inspector.getId();
+
+    SettableVectorInspector second = new SettableVectorInspector(4);
+    second.id = 100;                 // reuse an id the first group already handed out
+    f.setDelegate(new StubDelegate(second), new Object[]{"b"});
+    int c = inspector.getId();
+
+    Assertions.assertTrue(a < b && b < c, "minted ids must be strictly increasing regardless of delegate id order");
+  }
+
+  @Test
+  void testGetIdStableWhenPositionUnchanged()
+  {
+    // The caching contract: reading getId() twice without advancing (same delegate, same raw id) must return the SAME
+    // minted id, so a downstream id-keyed cache hits instead of recomputing. Guards against an always-tick regression.
+    ClusteringVectorColumnSelectorFactory f = new ClusteringVectorColumnSelectorFactory(
+        new StubDelegate(new NoFilterVectorOffset(8, 0, 5)),
+        CLUSTER_SIGNATURE,
+        new Object[]{"a"}
+    );
+    ReadableVectorInspector inspector = f.getReadableVectorInspector();
+    int first = inspector.getId();
+    Assertions.assertEquals(first, inspector.getId());
+    Assertions.assertEquals(first, inspector.getId());
+  }
+
+  @Test
+  void testGetIdReturnsSentinelWhenDelegateUnpositioned()
+  {
+    // When the delegate inspector reports NULL_ID (no stable vector), the wrapper must pass it through unchanged and
+    // not advance its minted counter, so a later real vector still mints a fresh id starting at 0.
+    SettableVectorInspector state = new SettableVectorInspector(4);
+    state.id = ReadableVectorInspector.NULL_ID;
+    ClusteringVectorColumnSelectorFactory f = new ClusteringVectorColumnSelectorFactory(
+        new StubDelegate(state),
+        CLUSTER_SIGNATURE,
+        new Object[]{"a"}
+    );
+    ReadableVectorInspector inspector = f.getReadableVectorInspector();
+    Assertions.assertEquals(ReadableVectorInspector.NULL_ID, inspector.getId());
+
+    state.id = 0;
+    Assertions.assertEquals(0, inspector.getId());
+  }
+
   private static ReadableVectorInspector inspectorFor(int size)
   {
     return new NoFilterVectorOffset(size, 0, size);
+  }
+
+  /**
+   * A {@link ReadableVectorInspector} whose id and current size can be set arbitrarily, to exercise delegate id
+   * sequences that are not monotonic (which the contract permits).
+   */
+  private static final class SettableVectorInspector implements ReadableVectorInspector
+  {
+    private final int maxSize;
+    private int id;
+    private int currentSize;
+
+    private SettableVectorInspector(int maxSize)
+    {
+      this.maxSize = maxSize;
+      this.currentSize = maxSize;
+    }
+
+    @Override
+    public int getId()
+    {
+      return id;
+    }
+
+    @Override
+    public int getMaxVectorSize()
+    {
+      return maxSize;
+    }
+
+    @Override
+    public int getCurrentVectorSize()
+    {
+      return currentSize;
+    }
   }
 
   private static class StubDelegate implements VectorColumnSelectorFactory
@@ -392,7 +490,7 @@ class ClusteringVectorColumnSelectorFactoryTest
 
     @Override
     public SingleValueDimensionVectorSelector makeSingleValueDimensionSelector(
-        org.apache.druid.query.dimension.DimensionSpec dimensionSpec
+        DimensionSpec dimensionSpec
     )
     {
       lastSingleValDimRequest = dimensionSpec.getDimension();
@@ -401,7 +499,7 @@ class ClusteringVectorColumnSelectorFactoryTest
 
     @Override
     public MultiValueDimensionVectorSelector makeMultiValueDimensionSelector(
-        org.apache.druid.query.dimension.DimensionSpec dimensionSpec
+        DimensionSpec dimensionSpec
     )
     {
       throw new UnsupportedOperationException("not used");


### PR DESCRIPTION
### Description
Fixes an oversight with `ClusteringColumnSelectorFactory`/`ClusteringVectorColumnSelectorFactory` with rowid supplier/vector inspector, which were incorrectly being pulled from the current delegate instead of delegating to the current delegate.