### PR TITLE
minor: reduce flakiness in CI

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/StreamIndexFaultToleranceTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/StreamIndexFaultToleranceTest.java
@@ -53,7 +53,7 @@ public abstract class StreamIndexFaultToleranceTest extends StreamIndexTestBase
   @Override
   protected EmbeddedDruidCluster createCluster()
   {
-    return super.createCluster().useDefaultTimeoutForLatchableEmitter(120);
+    return super.createCluster().useDefaultTimeoutForLatchableEmitter(240);
   }
 
   @BeforeEach

--- a/server/src/test/java/org/apache/druid/server/initialization/JettyCertRenewTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/JettyCertRenewTest.java
@@ -27,6 +27,7 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.multibindings.Multibinder;
 import org.apache.commons.io.IOUtils;
+import org.apache.druid.common.utils.SocketUtil;
 import org.apache.druid.guice.GuiceInjectors;
 import org.apache.druid.guice.Jerseys;
 import org.apache.druid.guice.JsonConfigProvider;
@@ -135,7 +136,11 @@ public class JettyCertRenewTest extends BaseJettyTest
       throw new RuntimeException(e);
     }
 
-    final int ephemeralPort = ThreadLocalRandom.current().nextInt(49152, 65535);
+    // Pick ports that are actually bindable rather than guessing a random one: with reused forks and
+    // many concurrent test shards a blind random port frequently collides (BindException). Verify the
+    // plaintext and TLS ports independently since both are enabled below.
+    final int ephemeralPort = SocketUtil.findOpenPortFrom(ThreadLocalRandom.current().nextInt(49152, 60000));
+    final int tlsEphemeralPort = SocketUtil.findOpenPortFrom(ephemeralPort + 1);
 
     latchedRequestState = new LatchedRequestStateHolder();
     injector = Initialization.makeInjectorWithModules(
@@ -149,7 +154,7 @@ public class JettyCertRenewTest extends BaseJettyTest
                 JsonConfigProvider.bindInstance(
                     binder,
                     Key.get(DruidNode.class, Self.class),
-                    new DruidNode("test", "localhost", false, ephemeralPort, ephemeralPort + 1, true, true)
+                    new DruidNode("test", "localhost", false, ephemeralPort, tlsEphemeralPort, true, true)
                 );
                 binder.bind(TLSServerConfig.class).toInstance(tlsConfig);
                 binder.bind(JettyServerInitializer.class).to(JettyServerInit.class).in(LazySingleton.class);


### PR DESCRIPTION
<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

We have a few flaky tests in our own CI environment that fail (I've also seen failures in OSS). 


1. I've observed that under a heavily-subscribed machine the `KafkaIndexFaultToleranceTest.test_supervisorRecovers_afterChangeInTopicPartitions` test can sometimes timeout under the current 120s limit. Increasing this to allow up to 240s has removed these failures for us.

2. Adjust the TLS tests to select ports that are not actually in-use. This should prevent any races that might occur from running tests at a higher concurrency in the future. 

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Reduce CI flakiness in KafkaIndexFaultToleranceTest and JettyCertRenewTest

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.