### PR TITLE
feat: Add endpoint to fetch configured peon pod template names

### DIFF
--- a/docs/development/extensions-core/k8s-jobs.md
+++ b/docs/development/extensions-core/k8s-jobs.md
@@ -344,11 +344,11 @@ Host: http://ROUTER_IP:ROUTER_PORT
 ```
 </details>
 
-#### Get pod templates
+#### Get pod template names
 
-Retrieves the peon pod templates currently configured on the Overlord for the Kubernetes task runner.
-Returns a JSON array of the configured templates, each with its runtime property name and the full
-[Pod Template](https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates) spec.
+Retrieves the names of the peon pod templates currently configured on the Overlord for the Kubernetes
+task runner. Returns a JSON array of the configured template names (the keys of the
+`druid.indexer.runner.k8s.podTemplate.*` runtime properties, such as `base` and per task type names).
 
 This endpoint is only available when the [Custom Template Pod Adapter](#custom-template-pod-adapter) is
 configured (`druid.indexer.runner.k8s.adapter.type: customTemplateAdapter`). For any other adapter it
@@ -365,7 +365,7 @@ returns a `404` response.
 <TabItem value="13" label="200 SUCCESS">
 
 
-*Successfully retrieved pod templates*
+*Successfully retrieved pod template names*
 
 </TabItem>
 
@@ -407,46 +407,8 @@ Host: http://ROUTER_IP:ROUTER_PORT
 
 ```json
 [
-  {
-    "name": "base",
-    "podTemplate": {
-      "apiVersion": "v1",
-      "kind": "PodTemplate",
-      "metadata": {
-        "name": "druid-peon-template"
-      },
-      "template": {
-        "spec": {
-          "containers": [
-            {
-              "name": "main",
-              "image": "apache/druid:latest"
-            }
-          ]
-        }
-      }
-    }
-  },
-  {
-    "name": "index_kafka",
-    "podTemplate": {
-      "apiVersion": "v1",
-      "kind": "PodTemplate",
-      "metadata": {
-        "name": "druid-kafka-peon-template"
-      },
-      "template": {
-        "spec": {
-          "containers": [
-            {
-              "name": "main",
-              "image": "apache/druid:latest"
-            }
-          ]
-        }
-      }
-    }
-  }
+  "base",
+  "index_kafka"
 ]
 ```
 </details>

--- a/docs/development/extensions-core/k8s-jobs.md
+++ b/docs/development/extensions-core/k8s-jobs.md
@@ -344,6 +344,113 @@ Host: http://ROUTER_IP:ROUTER_PORT
 ```
 </details>
 
+#### Get pod templates
+
+Retrieves the peon pod templates currently configured on the Overlord for the Kubernetes task runner.
+Returns a JSON array of the configured templates, each with its runtime property name and the full
+[Pod Template](https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates) spec.
+
+This endpoint is only available when the [Custom Template Pod Adapter](#custom-template-pod-adapter) is
+configured (`druid.indexer.runner.k8s.adapter.type: customTemplateAdapter`). For any other adapter it
+returns a `404` response.
+
+##### URL
+
+`GET` `/druid/indexer/v1/k8s/taskrunner/podTemplates`
+
+##### Responses
+
+<Tabs>
+
+<TabItem value="13" label="200 SUCCESS">
+
+
+*Successfully retrieved pod templates*
+
+</TabItem>
+
+<TabItem value="14" label="404 NOT FOUND">
+
+
+*The configured pod adapter is not the custom template pod adapter*
+
+</TabItem>
+</Tabs>
+
+---
+
+##### Sample request
+
+<Tabs>
+
+<TabItem value="15" label="cURL">
+
+```shell
+curl "http://ROUTER_IP:ROUTER_PORT/druid/indexer/v1/k8s/taskrunner/podTemplates"
+```
+</TabItem>
+
+<TabItem value="16" label="HTTP">
+
+```HTTP
+GET /druid/indexer/v1/k8s/taskrunner/podTemplates HTTP/1.1
+Host: http://ROUTER_IP:ROUTER_PORT
+```
+
+</TabItem>
+</Tabs>
+
+##### Sample response
+
+<details>
+<summary>View the response</summary>
+
+```json
+[
+  {
+    "name": "base",
+    "podTemplate": {
+      "apiVersion": "v1",
+      "kind": "PodTemplate",
+      "metadata": {
+        "name": "druid-peon-template"
+      },
+      "template": {
+        "spec": {
+          "containers": [
+            {
+              "name": "main",
+              "image": "apache/druid:latest"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "name": "index_kafka",
+    "podTemplate": {
+      "apiVersion": "v1",
+      "kind": "PodTemplate",
+      "metadata": {
+        "name": "druid-kafka-peon-template"
+      },
+      "template": {
+        "spec": {
+          "containers": [
+            {
+              "name": "main",
+              "image": "apache/druid:latest"
+            }
+          ]
+        }
+      }
+    }
+  }
+]
+```
+</details>
+
 ## Pod adapters
 The logic defining how the pod template is built for your Kubernetes Job depends on which pod adapter you have specified.
 

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesOverlordModule.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesOverlordModule.java
@@ -64,6 +64,7 @@ import org.apache.druid.k8s.overlord.common.httpclient.vertx.DruidKubernetesVert
 import org.apache.druid.k8s.overlord.common.httpclient.vertx.DruidKubernetesVertxHttpClientFactory;
 import org.apache.druid.k8s.overlord.execution.KubernetesTaskExecutionConfigResource;
 import org.apache.druid.k8s.overlord.execution.KubernetesTaskRunnerDynamicConfig;
+import org.apache.druid.k8s.overlord.execution.KubernetesTaskRunnerPodTemplateResource;
 import org.apache.druid.k8s.overlord.runnerstrategy.RunnerStrategy;
 import org.apache.druid.k8s.overlord.taskadapter.DynamicConfigPodTemplateSelector;
 import org.apache.druid.k8s.overlord.taskadapter.MultiContainerTaskAdapter;
@@ -129,6 +130,7 @@ public class KubernetesOverlordModule implements DruidModule
           .in(LazySingleton.class);
 
     Jerseys.addResource(binder, KubernetesTaskExecutionConfigResource.class);
+    Jerseys.addResource(binder, KubernetesTaskRunnerPodTemplateResource.class);
 
     PolyBind.createChoiceWithDefault(
         binder,

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/KubernetesTaskRunnerPodTemplateResource.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/KubernetesTaskRunnerPodTemplateResource.java
@@ -34,7 +34,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 /**
- * Resource that exposes the pod templates currently configured for running peons in Kubernetes.
+ * Resource that exposes the names of the pod templates currently configured for running peons in
+ * Kubernetes.
  *
  * <p>Pod templates only exist for the pod template adapter ("customTemplateAdapter"). For any other
  * adapter this endpoint returns a 404.</p>
@@ -51,15 +52,15 @@ public class KubernetesTaskRunnerPodTemplateResource
   }
 
   /**
-   * Retrieves the currently configured peon pod templates.
+   * Retrieves the names of the currently configured peon pod templates.
    *
-   * @return a Response with the configured templates (200), or 404 when the configured adapter has
-   *         no pod templates.
+   * @return a Response with the configured template names (200), or 404 when the configured adapter
+   *         has no pod templates.
    */
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @ResourceFilters(ConfigResourceFilter.class)
-  public Response getPodTemplates()
+  public Response getPodTemplateNames()
   {
     if (!(taskAdapter instanceof PodTemplateTaskAdapter)) {
       return ServletResourceUtils.buildErrorResponseFrom(
@@ -71,6 +72,6 @@ public class KubernetesTaskRunnerPodTemplateResource
                         )
       );
     }
-    return Response.ok(((PodTemplateTaskAdapter) taskAdapter).getPodTemplateSelector().getPodTemplates()).build();
+    return Response.ok(((PodTemplateTaskAdapter) taskAdapter).getPodTemplateSelector().getPodTemplateNames()).build();
   }
 }

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/KubernetesTaskRunnerPodTemplateResource.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/KubernetesTaskRunnerPodTemplateResource.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.k8s.overlord.execution;
+
+import com.sun.jersey.spi.container.ResourceFilters;
+import org.apache.druid.error.DruidException;
+import org.apache.druid.k8s.overlord.taskadapter.PodTemplateTaskAdapter;
+import org.apache.druid.k8s.overlord.taskadapter.TaskAdapter;
+import org.apache.druid.server.http.ServletResourceUtils;
+import org.apache.druid.server.http.security.ConfigResourceFilter;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * Resource that exposes the pod templates currently configured for running peons in Kubernetes.
+ *
+ * <p>Pod templates only exist for the pod template adapter ("customTemplateAdapter"). For any other
+ * adapter this endpoint returns a 404.</p>
+ */
+@Path("/druid/indexer/v1/k8s/taskrunner/podTemplates")
+public class KubernetesTaskRunnerPodTemplateResource
+{
+  private final TaskAdapter taskAdapter;
+
+  @Inject
+  public KubernetesTaskRunnerPodTemplateResource(final TaskAdapter taskAdapter)
+  {
+    this.taskAdapter = taskAdapter;
+  }
+
+  /**
+   * Retrieves the currently configured peon pod templates.
+   *
+   * @return a Response with the configured templates (200), or 404 when the configured adapter has
+   *         no pod templates.
+   */
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @ResourceFilters(ConfigResourceFilter.class)
+  public Response getPodTemplates()
+  {
+    if (!(taskAdapter instanceof PodTemplateTaskAdapter)) {
+      return ServletResourceUtils.buildErrorResponseFrom(
+          DruidException.forPersona(DruidException.Persona.OPERATOR)
+                        .ofCategory(DruidException.Category.NOT_FOUND)
+                        .build(
+                            "Pod templates are only available when the k8s task adapter type is [%s]",
+                            PodTemplateTaskAdapter.TYPE
+                        )
+      );
+    }
+    return Response.ok(((PodTemplateTaskAdapter) taskAdapter).getPodTemplateSelector().getPodTemplates()).build();
+  }
+}

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/DynamicConfigPodTemplateSelector.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/DynamicConfigPodTemplateSelector.java
@@ -149,10 +149,10 @@ public class DynamicConfigPodTemplateSelector implements PodTemplateSelector
   }
 
   @Override
-  public List<PodTemplateWithName> getPodTemplates()
+  public List<String> getPodTemplateNames()
   {
-    List<PodTemplateWithName> resolved = new ArrayList<>();
-    podTemplates.forEach((name, supplier) -> resolved.add(new PodTemplateWithName(name, supplier.get())));
-    return Collections.unmodifiableList(resolved);
+    List<String> names = new ArrayList<>(podTemplates.keySet());
+    Collections.sort(names);
+    return names;
   }
 }

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/DynamicConfigPodTemplateSelector.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/DynamicConfigPodTemplateSelector.java
@@ -32,8 +32,11 @@ import org.apache.druid.k8s.overlord.common.DruidK8sConstants;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
@@ -143,5 +146,13 @@ public class DynamicConfigPodTemplateSelector implements PodTemplateSelector
     }
 
     return Optional.of(effectiveConfig.getPodTemplateSelectStrategy().getPodTemplateForTask(task, podTemplates));
+  }
+
+  @Override
+  public List<PodTemplateWithName> getPodTemplates()
+  {
+    List<PodTemplateWithName> resolved = new ArrayList<>();
+    podTemplates.forEach((name, supplier) -> resolved.add(new PodTemplateWithName(name, supplier.get())));
+    return Collections.unmodifiableList(resolved);
   }
 }

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateSelector.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateSelector.java
@@ -22,6 +22,8 @@ package org.apache.druid.k8s.overlord.taskadapter;
 import com.google.common.base.Optional;
 import org.apache.druid.indexing.common.task.Task;
 
+import java.util.List;
+
 /**
  * Interface for selecting a Pod template based on a given task.
  * Implementations of this interface are responsible for determining the appropriate
@@ -37,4 +39,10 @@ public interface PodTemplateSelector
    *         is available for the given task.
    */
   Optional<PodTemplateWithName> getPodTemplateForTask(Task task);
+
+  /**
+   * Returns all currently configured pod templates.
+   * @return the configured templates as a list of name + {@link io.fabric8.kubernetes.api.model.PodTemplate}.
+   */
+  List<PodTemplateWithName> getPodTemplates();
 }

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateSelector.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateSelector.java
@@ -41,8 +41,8 @@ public interface PodTemplateSelector
   Optional<PodTemplateWithName> getPodTemplateForTask(Task task);
 
   /**
-   * Returns all currently configured pod templates.
-   * @return the configured templates as a list of name + {@link io.fabric8.kubernetes.api.model.PodTemplate}.
+   * Returns the names of all currently configured pod templates.
+   * @return the configured template names.
    */
-  List<PodTemplateWithName> getPodTemplates();
+  List<String> getPodTemplateNames();
 }

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
@@ -103,6 +103,11 @@ public class PodTemplateTaskAdapter implements TaskAdapter
     return TYPE;
   }
 
+  public PodTemplateSelector getPodTemplateSelector()
+  {
+    return podTemplateSelector;
+  }
+
   /**
    * Create a {@link Job} from a {@link Task}
    *

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/execution/KubernetesTaskRunnerPodTemplateResourceTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/execution/KubernetesTaskRunnerPodTemplateResourceTest.java
@@ -20,12 +20,8 @@
 package org.apache.druid.k8s.overlord.execution;
 
 import com.google.common.collect.ImmutableList;
-import io.fabric8.kubernetes.api.model.PodTemplate;
-import org.apache.druid.k8s.overlord.common.K8sTestUtils;
 import org.apache.druid.k8s.overlord.taskadapter.PodTemplateSelector;
 import org.apache.druid.k8s.overlord.taskadapter.PodTemplateTaskAdapter;
-import org.apache.druid.k8s.overlord.taskadapter.PodTemplateWithName;
-import org.apache.druid.k8s.overlord.taskadapter.SingleContainerTaskAdapter;
 import org.apache.druid.k8s.overlord.taskadapter.TaskAdapter;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.Assertions;
@@ -37,30 +33,29 @@ import java.util.List;
 public class KubernetesTaskRunnerPodTemplateResourceTest
 {
   @Test
-  public void test_getPodTemplates_returnsConfiguredTemplates()
+  public void test_getPodTemplateNames_returnsConfiguredTemplateNames()
   {
-    PodTemplate template = K8sTestUtils.fileToResource("basePodTemplate.yaml", PodTemplate.class);
-    List<PodTemplateWithName> templates = ImmutableList.of(new PodTemplateWithName("base", template));
+    List<String> names = ImmutableList.of("base", "index_kafka");
 
     PodTemplateSelector selector = EasyMock.createMock(PodTemplateSelector.class);
-    EasyMock.expect(selector.getPodTemplates()).andReturn(templates);
+    EasyMock.expect(selector.getPodTemplateNames()).andReturn(names);
     PodTemplateTaskAdapter adapter = EasyMock.createMock(PodTemplateTaskAdapter.class);
     EasyMock.expect(adapter.getPodTemplateSelector()).andReturn(selector);
     EasyMock.replay(selector, adapter);
 
-    Response result = new KubernetesTaskRunnerPodTemplateResource(adapter).getPodTemplates();
+    Response result = new KubernetesTaskRunnerPodTemplateResource(adapter).getPodTemplateNames();
 
     Assertions.assertEquals(Response.Status.OK.getStatusCode(), result.getStatus());
-    Assertions.assertEquals(templates, result.getEntity());
+    Assertions.assertEquals(names, result.getEntity());
   }
 
   @Test
-  public void test_getPodTemplates_whenAdapterIsNotPodTemplateAdapter_returnsNotFound()
+  public void test_getPodTemplateNames_whenAdapterIsNotPodTemplateAdapter_returnsNotFound()
   {
-    TaskAdapter adapter = EasyMock.createMock(SingleContainerTaskAdapter.class);
+    TaskAdapter adapter = EasyMock.createMock(TaskAdapter.class);
     EasyMock.replay(adapter);
 
-    Response result = new KubernetesTaskRunnerPodTemplateResource(adapter).getPodTemplates();
+    Response result = new KubernetesTaskRunnerPodTemplateResource(adapter).getPodTemplateNames();
 
     Assertions.assertEquals(Response.Status.NOT_FOUND.getStatusCode(), result.getStatus());
   }

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/execution/KubernetesTaskRunnerPodTemplateResourceTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/execution/KubernetesTaskRunnerPodTemplateResourceTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.k8s.overlord.execution;
+
+import com.google.common.collect.ImmutableList;
+import io.fabric8.kubernetes.api.model.PodTemplate;
+import org.apache.druid.k8s.overlord.common.K8sTestUtils;
+import org.apache.druid.k8s.overlord.taskadapter.PodTemplateSelector;
+import org.apache.druid.k8s.overlord.taskadapter.PodTemplateTaskAdapter;
+import org.apache.druid.k8s.overlord.taskadapter.PodTemplateWithName;
+import org.apache.druid.k8s.overlord.taskadapter.SingleContainerTaskAdapter;
+import org.apache.druid.k8s.overlord.taskadapter.TaskAdapter;
+import org.easymock.EasyMock;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+public class KubernetesTaskRunnerPodTemplateResourceTest
+{
+  @Test
+  public void test_getPodTemplates_returnsConfiguredTemplates()
+  {
+    PodTemplate template = K8sTestUtils.fileToResource("basePodTemplate.yaml", PodTemplate.class);
+    List<PodTemplateWithName> templates = ImmutableList.of(new PodTemplateWithName("base", template));
+
+    PodTemplateSelector selector = EasyMock.createMock(PodTemplateSelector.class);
+    EasyMock.expect(selector.getPodTemplates()).andReturn(templates);
+    PodTemplateTaskAdapter adapter = EasyMock.createMock(PodTemplateTaskAdapter.class);
+    EasyMock.expect(adapter.getPodTemplateSelector()).andReturn(selector);
+    EasyMock.replay(selector, adapter);
+
+    Response result = new KubernetesTaskRunnerPodTemplateResource(adapter).getPodTemplates();
+
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), result.getStatus());
+    Assertions.assertEquals(templates, result.getEntity());
+  }
+
+  @Test
+  public void test_getPodTemplates_whenAdapterIsNotPodTemplateAdapter_returnsNotFound()
+  {
+    TaskAdapter adapter = EasyMock.createMock(SingleContainerTaskAdapter.class);
+    EasyMock.replay(adapter);
+
+    Response result = new KubernetesTaskRunnerPodTemplateResource(adapter).getPodTemplates();
+
+    Assertions.assertEquals(Response.Status.NOT_FOUND.getStatusCode(), result.getStatus());
+  }
+}

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/DynamicConfigPodTemplateSelectorTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/DynamicConfigPodTemplateSelectorTest.java
@@ -49,7 +49,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 public class DynamicConfigPodTemplateSelectorTest
 {
@@ -184,6 +186,29 @@ public class DynamicConfigPodTemplateSelectorTest
         1
     );
     Assertions.assertEquals("base", podTemplateWithName.get().getName());
+  }
+
+  @Test
+  public void test_getPodTemplates() throws IOException
+  {
+    Path baseTemplatePath = Files.createFile(tempDir.resolve("base.yaml"));
+    mapper.writeValue(baseTemplatePath.toFile(), podTemplateSpec);
+
+    Path kafkaTemplatePath = Files.createFile(tempDir.resolve("kafka.yaml"));
+    mapper.writeValue(kafkaTemplatePath.toFile(), podTemplateSpec);
+
+    Properties props = new Properties();
+    props.setProperty("druid.indexer.runner.k8s.podTemplate.base", baseTemplatePath.toString());
+    props.setProperty("druid.indexer.runner.k8s.podTemplate.index_kafka", kafkaTemplatePath.toString());
+
+    DynamicConfigPodTemplateSelector selector = new DynamicConfigPodTemplateSelector(props, effectiveConfig);
+
+    List<PodTemplateWithName> templates = selector.getPodTemplates();
+    Assertions.assertEquals(2, templates.size());
+    Assertions.assertEquals(
+        Sets.newSet("base", "index_kafka"),
+        templates.stream().map(PodTemplateWithName::getName).collect(Collectors.toSet())
+    );
   }
 
   @Test

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/DynamicConfigPodTemplateSelectorTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/DynamicConfigPodTemplateSelectorTest.java
@@ -49,9 +49,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
-import java.util.stream.Collectors;
 
 public class DynamicConfigPodTemplateSelectorTest
 {
@@ -189,7 +189,7 @@ public class DynamicConfigPodTemplateSelectorTest
   }
 
   @Test
-  public void test_getPodTemplates() throws IOException
+  public void test_getPodTemplateNames() throws IOException
   {
     Path baseTemplatePath = Files.createFile(tempDir.resolve("base.yaml"));
     mapper.writeValue(baseTemplatePath.toFile(), podTemplateSpec);
@@ -203,12 +203,8 @@ public class DynamicConfigPodTemplateSelectorTest
 
     DynamicConfigPodTemplateSelector selector = new DynamicConfigPodTemplateSelector(props, effectiveConfig);
 
-    List<PodTemplateWithName> templates = selector.getPodTemplates();
-    Assertions.assertEquals(2, templates.size());
-    Assertions.assertEquals(
-        Sets.newSet("base", "index_kafka"),
-        templates.stream().map(PodTemplateWithName::getName).collect(Collectors.toSet())
-    );
+    List<String> names = selector.getPodTemplateNames();
+    Assertions.assertEquals(Sets.newSet("base", "index_kafka"), new HashSet<>(names));
   }
 
   @Test

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/TestPodTemplateSelector.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/TestPodTemplateSelector.java
@@ -23,6 +23,9 @@ import com.google.common.base.Optional;
 import io.fabric8.kubernetes.api.model.PodTemplate;
 import org.apache.druid.indexing.common.task.Task;
 
+import java.util.Collections;
+import java.util.List;
+
 public class TestPodTemplateSelector implements PodTemplateSelector
 {
 
@@ -37,5 +40,11 @@ public class TestPodTemplateSelector implements PodTemplateSelector
   public Optional<PodTemplateWithName> getPodTemplateForTask(Task task)
   {
     return Optional.of(new PodTemplateWithName("base", basePodTemplate));
+  }
+
+  @Override
+  public List<PodTemplateWithName> getPodTemplates()
+  {
+    return Collections.singletonList(new PodTemplateWithName("base", basePodTemplate));
   }
 }

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/TestPodTemplateSelector.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/TestPodTemplateSelector.java
@@ -43,8 +43,8 @@ public class TestPodTemplateSelector implements PodTemplateSelector
   }
 
   @Override
-  public List<PodTemplateWithName> getPodTemplates()
+  public List<String> getPodTemplateNames()
   {
-    return Collections.singletonList(new PodTemplateWithName("base", basePodTemplate));
+    return Collections.singletonList("base");
   }
 }


### PR DESCRIPTION
### Description
Adds a new API to inspect the peon pod templates currently loaded by the Kubernetes task runner's custom template pod adapter. These are configured via `druid.indexer.runner.k8s.podTemplate.*` runtime properties pointing to files on disk. This adds a way to see which templates the Overlord actually has loaded.

#### Added a new API `/druid/indexer/v1/k8s/taskrunner/podTemplates`
Returns a JSON array of the configured template names. 

- Exposes the templates through a new `PodTemplateSelector.getPodTemplateNames()` method that returns `List<String>` (reusing the existing PodTemplateWithName wrapper).
- Guarded by `ConfigResourceFilter` which is the same gate as the sibling `executionconfig` endpoints.
-  Pod templates only exist for the pod template adapter. The endpoint checks `TaskAdapter instanceof PodTemplateTaskAdapter` and for any other adapter it returns a 404. 

#### Release note
You can now retrieve the peon pod template names currently configured on the Overlord via the new GET `/druid/indexer/v1/k8s/taskrunner/podTemplates` endpoint. It returns each configured template's name and full pod spec. The endpoint requires CONFIG read permission and returns 404 when the Overlord is not using the custom template pod adapter.

<hr>

##### Key changed/added classes in this PR
- `KubernetesTaskRunnerPodTemplateResource`
- `PodTemplateSelector#getPodTemplates()`

<hr>

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.