### PR TITLE
fix: Improve reserved keyword SQL parse errors

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlParser.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlParser.java
@@ -28,6 +28,7 @@ import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlSetOption;
 import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.dialect.CalciteSqlDialect;
+import org.apache.calcite.sql.parser.SqlAbstractParserImpl;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.parser.SqlParserPos;
@@ -47,6 +48,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -73,13 +75,13 @@ public class DruidSqlParser
 
   public static StatementAndSetContext parse(final String sql, final boolean allowSetStatements)
   {
+    final SqlParser parser = SqlParser.create(new SourceStringReader(sql), PARSER_CONFIG);
     try {
-      SqlParser parser = SqlParser.create(new SourceStringReader(sql), PARSER_CONFIG);
       SqlNode sqlNode = parser.parseStmtList();
       return processStatementList(sqlNode, allowSetStatements);
     }
     catch (SqlParseException e) {
-      throw translateParseException(e);
+      throw translateParseException(e, parser.getMetadata());
     }
   }
 
@@ -176,7 +178,10 @@ public class DruidSqlParser
   /**
    * Constructs a user-friendly {@link DruidException} from a Calcite {@link SqlParseException}.
    */
-  private static DruidException translateParseException(SqlParseException e)
+  private static DruidException translateParseException(
+      SqlParseException e,
+      SqlAbstractParserImpl.Metadata parserMetadata
+  )
   {
     final Throwable cause = e.getCause();
     if (cause instanceof DruidException) {
@@ -198,6 +203,24 @@ public class DruidSqlParser
                              .withContext("sourceType", "sql");
       } else {
         final String theUnexpectedToken = getUnexpectedTokenString(parseException);
+
+        if (parserMetadata.isReservedWord(theUnexpectedToken.toUpperCase(Locale.ROOT))) {
+          return InvalidSqlInput
+              .exception(
+                  e,
+                  "Token [%s] (line [%s], column [%s]) is a reserved keyword. "
+                  + "To use it as an identifier, quote it as [\"%s\"]",
+                  theUnexpectedToken,
+                  failurePosition.getLineNum(),
+                  failurePosition.getColumnNum(),
+                  theUnexpectedToken
+              )
+              .withContext("line", failurePosition.getLineNum())
+              .withContext("column", failurePosition.getColumnNum())
+              .withContext("endLine", failurePosition.getEndLineNum())
+              .withContext("endColumn", failurePosition.getEndColumnNum())
+              .withContext("token", theUnexpectedToken);
+        }
 
         final String[] tokenDictionary = e.getTokenImages();
         final int[][] expectedTokenSequences = e.getExpectedTokenSequences();

--- a/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlParser.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlParser.java
@@ -203,8 +203,12 @@ public class DruidSqlParser
                              .withContext("sourceType", "sql");
       } else {
         final String theUnexpectedToken = getUnexpectedTokenString(parseException);
+        final String[] tokenDictionary = e.getTokenImages();
+        final int[][] expectedTokenSequences = e.getExpectedTokenSequences();
 
-        if (parserMetadata.isReservedWord(theUnexpectedToken.toUpperCase(Locale.ROOT))) {
+        if (parserMetadata != null
+            && isIdentifierExpected(tokenDictionary, expectedTokenSequences)
+            && parserMetadata.isReservedWord(theUnexpectedToken.toUpperCase(Locale.ROOT))) {
           return InvalidSqlInput
               .exception(
                   e,
@@ -222,8 +226,6 @@ public class DruidSqlParser
               .withContext("token", theUnexpectedToken);
         }
 
-        final String[] tokenDictionary = e.getTokenImages();
-        final int[][] expectedTokenSequences = e.getExpectedTokenSequences();
         final ArrayList<String> expectedTokens = new ArrayList<>(expectedTokenSequences.length);
         for (int[] expectedTokenSequence : expectedTokenSequences) {
           String[] strings = new String[expectedTokenSequence.length];
@@ -253,6 +255,23 @@ public class DruidSqlParser
     }
 
     return InvalidSqlInput.exception(e.getMessage());
+  }
+
+  private static boolean isIdentifierExpected(String[] tokenDictionary, int[][] expectedTokenSequences)
+  {
+    for (int[] expectedTokenSequence : expectedTokenSequences) {
+      if (expectedTokenSequence.length > 0) {
+        final String token = tokenDictionary[expectedTokenSequence[0]];
+        if ("<IDENTIFIER>".equals(token)
+            || "<QUOTED_IDENTIFIER>".equals(token)
+            || "<BACK_QUOTED_IDENTIFIER>".equals(token)
+            || "<BRACKET_QUOTED_IDENTIFIER>".equals(token)
+            || "<UNICODE_QUOTED_IDENTIFIER>".equals(token)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   /**

--- a/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlParser.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlParser.java
@@ -81,7 +81,7 @@ public class DruidSqlParser
       return processStatementList(sqlNode, allowSetStatements);
     }
     catch (SqlParseException e) {
-      throw translateParseException(e, parser.getMetadata());
+      throw translateParseException(e, parser.getMetadata(), sql);
     }
   }
 
@@ -180,7 +180,8 @@ public class DruidSqlParser
    */
   private static DruidException translateParseException(
       SqlParseException e,
-      SqlAbstractParserImpl.Metadata parserMetadata
+      SqlAbstractParserImpl.Metadata parserMetadata,
+      String sql
   )
   {
     final Throwable cause = e.getCause();
@@ -209,7 +210,7 @@ public class DruidSqlParser
 
         if (parserMetadata != null
             && isIdentifierExpected(tokenDictionary, expectedTokenSequences)
-            && !isFunctionCall(parseException)
+            && !isFunctionCall(sql, failurePosition, parseException.currentToken.next.image)
             && parserMetadata.isReservedWord(firstUnexpectedToken.toUpperCase(Locale.ROOT))) {
           return InvalidSqlInput
               .exception(
@@ -276,10 +277,21 @@ public class DruidSqlParser
     return false;
   }
 
-  private static boolean isFunctionCall(ParseException parseException)
+  private static boolean isFunctionCall(String sql, SqlParserPos failurePosition, String token)
   {
-    final Token nextToken = parseException.currentToken.next;
-    return nextToken.next != null && "(".equals(nextToken.next.image);
+    int tokenEndOffset = 0;
+    for (int line = 1; line < failurePosition.getLineNum(); line++) {
+      tokenEndOffset = sql.indexOf('\n', tokenEndOffset) + 1;
+      if (tokenEndOffset == 0) {
+        return false;
+      }
+    }
+
+    tokenEndOffset += failurePosition.getColumnNum() - 1 + token.length();
+    while (tokenEndOffset < sql.length() && Character.isWhitespace(sql.charAt(tokenEndOffset))) {
+      tokenEndOffset++;
+    }
+    return tokenEndOffset < sql.length() && sql.charAt(tokenEndOffset) == '(';
   }
 
   /**

--- a/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlParser.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlParser.java
@@ -32,6 +32,7 @@ import org.apache.calcite.sql.parser.SqlAbstractParserImpl;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.parser.SqlParserUtil;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.NlsString;
 import org.apache.calcite.util.SourceStringReader;
@@ -210,6 +211,7 @@ public class DruidSqlParser
 
         if (parserMetadata != null
             && isIdentifierExpected(tokenDictionary, expectedTokenSequences)
+            && !isKeywordExpected(firstUnexpectedToken, tokenDictionary, expectedTokenSequences)
             && !isFunctionCall(sql, failurePosition, parseException.currentToken.next.image)
             && parserMetadata.isReservedWord(firstUnexpectedToken.toUpperCase(Locale.ROOT))) {
           return InvalidSqlInput
@@ -272,6 +274,23 @@ public class DruidSqlParser
             || "<UNICODE_QUOTED_IDENTIFIER>".equals(token)) {
           return true;
         }
+      }
+    }
+    return false;
+  }
+
+  private static boolean isKeywordExpected(
+      String unexpectedToken,
+      String[] tokenDictionary,
+      int[][] expectedTokenSequences
+  )
+  {
+    for (int[] expectedTokenSequence : expectedTokenSequences) {
+      if (expectedTokenSequence.length > 0
+          && unexpectedToken.equalsIgnoreCase(
+              SqlParserUtil.getTokenVal(tokenDictionary[expectedTokenSequence[0]])
+          )) {
+        return true;
       }
     }
     return false;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlParser.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlParser.java
@@ -203,27 +203,29 @@ public class DruidSqlParser
                              .withContext("sourceType", "sql");
       } else {
         final String theUnexpectedToken = getUnexpectedTokenString(parseException);
+        final String firstUnexpectedToken = getUnexpectedTokenString(parseException, 1);
         final String[] tokenDictionary = e.getTokenImages();
         final int[][] expectedTokenSequences = e.getExpectedTokenSequences();
 
         if (parserMetadata != null
             && isIdentifierExpected(tokenDictionary, expectedTokenSequences)
-            && parserMetadata.isReservedWord(theUnexpectedToken.toUpperCase(Locale.ROOT))) {
+            && !isFunctionCall(parseException)
+            && parserMetadata.isReservedWord(firstUnexpectedToken.toUpperCase(Locale.ROOT))) {
           return InvalidSqlInput
               .exception(
                   e,
                   "Token [%s] (line [%s], column [%s]) is a reserved keyword. "
                   + "To use it as an identifier, quote it as [\"%s\"]",
-                  theUnexpectedToken,
+                  firstUnexpectedToken,
                   failurePosition.getLineNum(),
                   failurePosition.getColumnNum(),
-                  theUnexpectedToken
+                  firstUnexpectedToken
               )
               .withContext("line", failurePosition.getLineNum())
               .withContext("column", failurePosition.getColumnNum())
               .withContext("endLine", failurePosition.getEndLineNum())
               .withContext("endColumn", failurePosition.getEndColumnNum())
-              .withContext("token", theUnexpectedToken);
+              .withContext("token", firstUnexpectedToken);
         }
 
         final ArrayList<String> expectedTokens = new ArrayList<>(expectedTokenSequences.length);
@@ -274,6 +276,12 @@ public class DruidSqlParser
     return false;
   }
 
+  private static boolean isFunctionCall(ParseException parseException)
+  {
+    final Token nextToken = parseException.currentToken.next;
+    return nextToken.next != null && "(".equals(nextToken.next.image);
+  }
+
   /**
    * Grabs the unexpected token string.  This code is borrowed with minimal adjustments from
    * {@link ParseException#getMessage()}.  It is possible that if that code changes, we need to also
@@ -291,6 +299,12 @@ public class DruidSqlParser
         maxSize = ints.length;
       }
     }
+
+    return getUnexpectedTokenString(parseException, maxSize);
+  }
+
+  private static String getUnexpectedTokenString(ParseException parseException, int maxSize)
+  {
 
     StringBuilder bob = new StringBuilder();
     Token tok = parseException.currentToken.next;

--- a/sql/src/test/java/org/apache/druid/sql/calcite/parser/DruidSqlParserTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/parser/DruidSqlParserTest.java
@@ -155,4 +155,16 @@ public class DruidSqlParserTest
         exception.getMessage()
     );
   }
+
+  @Test
+  public void testParse_reservedKeywordOutsideIdentifierContext()
+  {
+    final DruidException exception = Assert.assertThrows(
+        DruidException.class,
+        () -> DruidSqlParser.parse("SELECT * FROM foo GROUP ORDER BY x", false)
+    );
+
+    Assert.assertTrue(exception.getMessage().contains("Received an unexpected token [ORDER]"));
+    Assert.assertFalse(exception.getMessage().contains("is a reserved keyword"));
+  }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/parser/DruidSqlParserTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/parser/DruidSqlParserTest.java
@@ -140,4 +140,19 @@ public class DruidSqlParserTest
     );
     Assert.assertTrue(exception.getMessage().contains("Unsupported type for SET"));
   }
+
+  @Test
+  public void testParse_reservedKeywordIdentifier()
+  {
+    final DruidException exception = Assert.assertThrows(
+        DruidException.class,
+        () -> DruidSqlParser.parse("SELECT start FROM sys.\"segments\" LIMIT 1", false)
+    );
+
+    Assert.assertEquals(
+        "Token [start] (line [1], column [8]) is a reserved keyword. "
+        + "To use it as an identifier, quote it as [\"start\"]",
+        exception.getMessage()
+    );
+  }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/parser/DruidSqlParserTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/parser/DruidSqlParserTest.java
@@ -164,7 +164,20 @@ public class DruidSqlParserTest
         () -> DruidSqlParser.parse("SELECT * FROM foo GROUP ORDER BY x", false)
     );
 
-    Assert.assertTrue(exception.getMessage().contains("Received an unexpected token [ORDER]"));
+    Assert.assertTrue(exception.getMessage().contains("Received an unexpected token"));
+    Assert.assertFalse(exception.getMessage().contains("is a reserved keyword"));
+  }
+
+  @Test
+  public void testParse_reservedKeywordFunctionCall()
+  {
+    // UNNEST is a reserved keyword, but it appears in a function-call context, not as an identifier.
+    final DruidException exception = Assert.assertThrows(
+        DruidException.class,
+        () -> DruidSqlParser.parse("SELECT strlen(unnest(a_int))", false)
+    );
+
+    Assert.assertTrue(exception.getMessage().contains("Received an unexpected token"));
     Assert.assertFalse(exception.getMessage().contains("is a reserved keyword"));
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/parser/DruidSqlParserTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/parser/DruidSqlParserTest.java
@@ -164,7 +164,6 @@ public class DruidSqlParserTest
         () -> DruidSqlParser.parse("SELECT * FROM foo GROUP ORDER BY x", false)
     );
 
-    Assert.assertTrue(exception.getMessage().contains("Received an unexpected token"));
     Assert.assertFalse(exception.getMessage().contains("is a reserved keyword"));
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/parser/DruidSqlParserTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/parser/DruidSqlParserTest.java
@@ -168,6 +168,17 @@ public class DruidSqlParserTest
   }
 
   @Test
+  public void testParse_expectedReservedKeyword()
+  {
+    final DruidException exception = Assert.assertThrows(
+        DruidException.class,
+        () -> DruidSqlParser.parse("SELECT a FROM", false)
+    );
+
+    Assert.assertFalse(exception.getMessage().contains("is a reserved keyword"));
+  }
+
+  @Test
   public void testParse_reservedKeywordFunctionCall()
   {
     // UNNEST is a reserved keyword, but it appears in a function-call context, not as an identifier.


### PR DESCRIPTION
## Summary

### Before

Received an unexpected token [start] (line [1], column [8]), acceptable options: ["UNION", "INTERSECT", "EXCEPT", "MINUS", "ORDER", "LIMIT", "OFFSET", "FETCH", "STREAM", "DISTINCT", "ALL", "*", "+", "-", "NOT", "EXISTS", <UNSIGNED_INTEGER_LITERAL>, <DECIMAL_NUMERIC_LITERAL>, <APPROX_NUMERIC_LITERAL>, <BINARY_STRING_LITERAL>, <PREFIXED_STRING_LITERAL>, <QUOTED_STRING>, <UNICODE_STRING_LITERAL>, "TRUE", "FALSE", "UNKNOWN", "NULL", <LBRACE_D>, <LBRACE_T>, <LBRACE_TS>, "DATE", "TIME", "TIMESTAMP", "INTERVAL", "?", "CAST", "EXTRACT", "POSITION", "CONVERT", "TRANSLATE", "OVERLAY", "FLOOR", "CEIL", "CEILING", "SUBSTRING", "TRIM", "CLASSIFIER", "MATCH_NUMBER", "RUNNING", "PREV", "NEXT", "JSON_EXISTS", "JSON_VALUE", "JSON_QUERY", "JSON_OBJECT", "JSON_OBJECTAGG", "JSON_ARRAY", "JSON_ARRAYAGG", <LBRACE_FN>, "MULTISET", "ARRAY", "PERIOD", "SPECIFIC", <IDENTIFIER>, <QUOTED_IDENTIFIER>, <BACK_QUOTED_IDENTIFIER>, <BRACKET_QUOTED_IDENTIFIER>, <UNICODE_QUOTED_IDENTIFIER>, "ABS", "AVG", "CARDINALITY", "CHAR_LENGTH", "CHARACTER_LENGTH", "COALESCE", "COLLECT", "COVAR_POP", "COVAR_SAMP", "CUME_DIST", "COUNT", "CURRENT_DATE", "CURRENT_TIME", "CURRENT_TIMESTAMP", "DENSE_RANK", "ELEMENT", "EXP", "FIRST_VALUE", "FUSION", "GROUPING", "HOUR", "LAG", "LEAD", "LEFT", "LAST_VALUE", "LN", "LOCALTIME", "LOCALTIMESTAMP", "LOWER", "MAX", "MIN", "MINUTE", "MOD", "MONTH", "NTH_VALUE", "NTILE", "NULLIF", "OCTET_LENGTH", "PERCENT_RANK", "POWER", "RANK", "REGR_COUNT", "REGR_SXX", "REGR_SYY", "RIGHT", "ROW_NUMBER", "SECOND", "SQRT", "STDDEV_POP", "STDDEV_SAMP", "SUM", "UPPER", "TRUNCATE", "USER", "VAR_POP", "VAR_SAMP", "YEAR", "CURRENT_CATALOG", "CURRENT_DEFAULT_TRANSFORM_GROUP", "CURRENT_PATH", "CURRENT_ROLE", "CURRENT_SCHEMA", "CURRENT_USER", "SESSION_USER", "SYSTEM_USER", "NEW", "CASE", "CURRENT", "CURSOR", "ROW", "("]

### After

```
Token [start] (line [1], column [8]) is a reserved keyword. To use it as an identifier, quote it as ["start"]
```

- Detect reserved Calcite tokens in Druid SQL parse errors.
- Add coverage for SELECT start FROM sys."segments" LIMIT 1.
- Give AI-generated SQL an explicit corrective action: quote the reported identifier and retry the query.

## Root cause

Calcite rejects reserved tokens during parsing, before Druid can resolve them as columns or datasources. Its generic error listed a large set of parser alternatives without explaining the identifier-quoting remedy.

## User impact

Users with a column or datasource whose name is a reserved keyword receive a concise, actionable error that includes the quoted identifier form.

## Validation

- mvn -pl sql checkstyle:check
- Focused DruidSqlParserTest not run locally: this branch requires Java 25 and the available compiler is Java 21.
