### PR TITLE
fix: Stop kill task if segment IDs that share load spec of killable segment could not be determined

### DIFF
--- a/docs/data-management/delete.md
+++ b/docs/data-management/delete.md
@@ -112,9 +112,13 @@ Some of the parameters used in the task payload are further explained below:
 | `limit`     | null (no limit) | Maximum number of segments for the kill task to delete.|
 | `maxUsedStatusLastUpdatedTime` | null (no cutoff) | Maximum timestamp used as a cutoff to include unused segments. The kill task only considers segments which lie in the specified `interval` and were marked as unused no later than this time. The default behavior is to kill all unused segments in the `interval` regardless of when they where marked as unused.|
 
-
-**WARNING:** The `kill` task permanently removes all information about the affected segments from the metadata store and
+:::warning
+- The `kill` task permanently removes all information about the affected segments from the metadata store and
 deep storage. This operation cannot be undone.
+- When using [concurrent locks](../ingestion/concurrent-append-replace.md) to run a `kill` task, ensure to keep a large
+enough buffer period before killing segments after they have been marked as unused. Otherwise, there may be a potential
+data loss if a concurrent append job upgrades one of the segments that are being killed.
+:::
 
 ### Auto-kill data using Coordinator duties
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTask.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.client.indexing.ClientKillUnusedSegmentsTaskQuery;
@@ -259,58 +260,50 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
         );
       }
 
-      // Kill segments. Order is important here:
-      // Retrieve the segment upgrade infos for the batch _before_ the segments are nuked
-      // We then want the nuke action to clean up the metadata records _before_ the segments are removed from storage.
-      // This helps maintain that we will always have a storage segment if the metadata segment is present.
-      // Determine the subset of segments to be killed from deep storage based on loadspecs.
-      // If the segment nuke throws an exception, then the segment cleanup is abandoned.
+      // Kill segments - order of steps 1, 2, 3, 4 must remain the same
 
-      // Determine upgraded segment ids before nuking
-      final Map<String, String> upgradedFromSegmentIds = new HashMap<>();
-      try {
-        upgradedFromSegmentIds.putAll(
-            fetchParentIdsForSegments(toolbox, unusedSegmentsPlus)
-        );
-      }
-      catch (Exception e) {
-        // Do not proceed with killing these segments as we cannot be sure if their
-        // load spec is shared by any other segment or not. If load spec is shared,
-        // segment files cannot be deleted from deep store. If load spec is not
-        // shared, segments cannot be deleted from metadata store as that would
-        // leave deep store files orphaned, and they would never be cleaned up.
-        LOG.error(
-            e,
-            "Could not retrieve parent segment ids using task action[retrieveUpgradedFromSegmentIds]."
-            + " Stopping kill task to avoid data loss in case the segment files"
-            + " are shared by other segments."
-        );
+      // 1. Determine parent segment ids of killable unused segments
+      final Optional<Map<String, String>> upgradedFromSegmentIds
+          = fetchParentIdsForSegments(toolbox, unusedSegmentsPlus);
+      if (!upgradedFromSegmentIds.isPresent()) {
+        // Do not proceed further as we do not know for sure if load specs are shared or not
         break;
       }
 
-      // Nuke Segments
-      taskActionClient.submit(new SegmentNukeAction(unusedSegments));
-      emitMetric(toolbox.getEmitter(), TaskMetrics.SEGMENTS_DELETED_FROM_METADATA_STORE, unusedSegments.size());
+      // 2. Identify killable segments whose load specs are not shared with any other segment
+      final List<DataSegment> segmentsToKillFromDeepStore = getKillableSegments(
+          unusedSegments,
+          upgradedFromSegmentIds.get(),
+          usedSegmentLoadSpecs,
+          taskActionClient
+      );
+      if (segmentsToKillFromDeepStore.isEmpty()) {
+        // Do not proceed further as we do not know for sure if load specs are shared or not
+        break;
+      }
 
-      // Determine segments to be killed
-      final List<DataSegment> segmentsToBeKilled
-          = getKillableSegments(unusedSegments, upgradedFromSegmentIds, usedSegmentLoadSpecs, taskActionClient);
-
+      // 2a. Track segments that cannot be removed from deep store yet
       final Set<DataSegment> segmentsNotKilled = new HashSet<>(unusedSegments);
-      segmentsToBeKilled.forEach(segmentsNotKilled::remove);
-
+      segmentsToKillFromDeepStore.forEach(segmentsNotKilled::remove);
       if (!segmentsNotKilled.isEmpty()) {
         LOG.warn(
-            "Skipping kill of [%d] segments from deep storage as their load specs are used by other segments.",
-            segmentsNotKilled.size()
+            "Skipping kill of [%d] segments of datasource[%s] from deep storage"
+            + " as their load specs are used by other segments.",
+            segmentsNotKilled.size(), getDataSource()
         );
       }
 
-      toolbox.getDataSegmentKiller().kill(segmentsToBeKilled);
-      emitMetric(toolbox.getEmitter(), TaskMetrics.SEGMENTS_DELETED_FROM_DEEPSTORE, segmentsToBeKilled.size());
+      // 3. Nuke all eligible unused segments, but only if we know for sure if their
+      // load specs are shared by other segments or not
+      taskActionClient.submit(new SegmentNukeAction(unusedSegments));
+      emitMetric(toolbox.getEmitter(), TaskMetrics.SEGMENTS_DELETED_FROM_METADATA_STORE, unusedSegments.size());
+
+      // 4. Delete deep store files only for segments which do not share load specs with other segments
+      toolbox.getDataSegmentKiller().kill(segmentsToKillFromDeepStore);
+      emitMetric(toolbox.getEmitter(), TaskMetrics.SEGMENTS_DELETED_FROM_DEEPSTORE, segmentsToKillFromDeepStore.size());
 
       numBatchesProcessed++;
-      numSegmentsKilled += segmentsToBeKilled.size();
+      numSegmentsKilled += segmentsToKillFromDeepStore.size();
 
       logInfo("Processed [%d] batches for kill task[%s].", numBatchesProcessed, getId());
 
@@ -371,22 +364,42 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
    * Fetches the parent IDs (if any) for the given unused segments.
    *
    * @param unusedSegments Unused segments whose parent IDs need to be fetched
-   * @return Map from segment ID to the segment ID from which it was upgraded.
-   * If an input segment was not upgraded from any other segment, it does not
-   * have an entry in the map.
+   * @return Optional containing Map from segment ID to the segment ID from which
+   * it was upgraded. If an input segment was not upgraded from any other segment,
+   * it does not have an entry in the map. Empty optional if an error occurred.
    */
-  protected Map<String, String> fetchParentIdsForSegments(
+  protected Optional<Map<String, String>> fetchParentIdsForSegments(
       TaskToolbox toolbox,
       List<DataSegmentPlus> unusedSegments
-  ) throws IOException
+  )
   {
-    final Set<String> segmentIds = unusedSegments.stream().map(
-        s -> s.getDataSegment().getId().toString()
-    ).collect(Collectors.toSet());
+    try {
+      final Set<String> segmentIds = unusedSegments.stream().map(
+          s -> s.getDataSegment().getId().toString()
+      ).collect(Collectors.toSet());
 
-    return toolbox.getTaskActionClient().submit(
-        new RetrieveUpgradedFromSegmentIdsAction(getDataSource(), segmentIds)
-    ).getUpgradedFromSegmentIds();
+      final Map<String, String> segmentIdToParentId = toolbox.getTaskActionClient().submit(
+          new RetrieveUpgradedFromSegmentIdsAction(getDataSource(), segmentIds)
+      ).getUpgradedFromSegmentIds();
+
+      return segmentIdToParentId == null
+             ? Optional.of(Map.of())
+             : Optional.of(segmentIdToParentId);
+    }
+    catch (Exception e) {
+      // Do not proceed with killing these segments as we cannot be sure if their
+      // load spec is shared by any other segment or not. If load spec is shared,
+      // segment files cannot be deleted from deep store. If load spec is not
+      // shared, segments cannot be deleted from metadata store as that would
+      // leave deep store files orphaned, and they would never be cleaned up.
+      LOG.error(
+          e,
+          "Could not retrieve parent segment ids using task action[retrieveUpgradedFromSegmentIds]."
+          + " Stopping kill task to avoid data loss in case the segment files"
+          + " are shared by other segments."
+      );
+      return Optional.absent();
+    }
   }
 
   /**
@@ -427,7 +440,6 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
       TaskActionClient taskActionClient
   )
   {
-
     // Determine parentId for each unused segment
     final Map<String, Set<DataSegment>> parentIdToUnusedSegments = new HashMap<>();
     for (DataSegment segment : unusedSegments) {
@@ -457,11 +469,16 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
       }
     }
     catch (Exception e) {
-      LOG.warn(
+      // Do not proceed with the kill of any segment as we cannot be sure if their
+      // load specs are shared by any other segment
+      LOG.error(
           e,
-          "Could not retrieve referenced ids using task action[retrieveUpgradedToSegmentIds]."
-          + " Overlord may be on an older version."
+          "Could not perform task action[retrieveUpgradedToSegmentIds] to retrieve"
+          + " segment IDs which share load specs with segments being killed."
+          + " Stopping kill task to avoid data loss in case the segment files"
+          + " are shared by other segments."
       );
+      return List.of();
     }
 
     // Filter using the used segment load specs as segment upgrades predate the above task action
@@ -483,7 +500,7 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
   {
     boolean isPresent = usedSegmentLoadSpecs.contains(segment.getLoadSpec());
     if (isPresent) {
-      LOG.info("Skipping kill of segment[%s] as its load spec is also used by other segments.", segment);
+      LOG.info("Skipping kill of segment[%s] as its load spec is shared by other 'used' segments.", segment);
     }
     return isPresent;
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTask.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.client.indexing.ClientKillUnusedSegmentsTaskQuery;
@@ -53,7 +52,6 @@ import org.apache.druid.server.http.DataSegmentPlus;
 import org.apache.druid.server.lookup.cache.LookupLoadingSpec;
 import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.timeline.DataSegment;
-import org.apache.druid.utils.CollectionUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
@@ -263,24 +261,16 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
       // Kill segments - order of steps 1, 2, 3, 4 must remain the same
 
       // 1. Determine parent segment ids of killable unused segments
-      final Optional<Map<String, String>> upgradedFromSegmentIds
+      final Map<String, String> upgradedFromSegmentIds
           = fetchParentIdsForSegments(toolbox, unusedSegmentsPlus);
-      if (!upgradedFromSegmentIds.isPresent()) {
-        // Do not proceed further as we do not know for sure if load specs are shared or not
-        break;
-      }
 
       // 2. Identify killable segments whose load specs are not shared with any other segment
       final List<DataSegment> segmentsToKillFromDeepStore = getKillableSegments(
           unusedSegments,
-          upgradedFromSegmentIds.get(),
+          upgradedFromSegmentIds,
           usedSegmentLoadSpecs,
           taskActionClient
       );
-      if (segmentsToKillFromDeepStore.isEmpty()) {
-        // Do not proceed further as we do not know for sure if load specs are shared or not
-        break;
-      }
 
       // 2a. Track segments that cannot be removed from deep store yet
       final Set<DataSegment> segmentsNotKilled = new HashSet<>(unusedSegments);
@@ -288,13 +278,16 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
       if (!segmentsNotKilled.isEmpty()) {
         LOG.warn(
             "Skipping kill of [%d] segments of datasource[%s] from deep storage"
-            + " as their load specs are used by other segments.",
+            + " as their load specs are shared by other segments.",
             segmentsNotKilled.size(), getDataSource()
         );
       }
+      if (segmentsToKillFromDeepStore.isEmpty()) {
+        // Do not proceed further as we will always keep getting the same batch of segments
+        break;
+      }
 
-      // 3. Nuke all eligible unused segments, but only if we know for sure if their
-      // load specs are shared by other segments or not
+      // 3. Nuke all eligible unused segments
       taskActionClient.submit(new SegmentNukeAction(unusedSegments));
       emitMetric(toolbox.getEmitter(), TaskMetrics.SEGMENTS_DELETED_FROM_METADATA_STORE, unusedSegments.size());
 
@@ -364,11 +357,11 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
    * Fetches the parent IDs (if any) for the given unused segments.
    *
    * @param unusedSegments Unused segments whose parent IDs need to be fetched
-   * @return Optional containing Map from segment ID to the segment ID from which
+   * @return Map from segment ID to the segment ID from which
    * it was upgraded. If an input segment was not upgraded from any other segment,
-   * it does not have an entry in the map. Empty optional if an error occurred.
+   * it does not have an entry in the map.
    */
-  protected Optional<Map<String, String>> fetchParentIdsForSegments(
+  protected Map<String, String> fetchParentIdsForSegments(
       TaskToolbox toolbox,
       List<DataSegmentPlus> unusedSegments
   )
@@ -378,13 +371,9 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
           s -> s.getDataSegment().getId().toString()
       ).collect(Collectors.toSet());
 
-      final Map<String, String> segmentIdToParentId = toolbox.getTaskActionClient().submit(
+      return toolbox.getTaskActionClient().submit(
           new RetrieveUpgradedFromSegmentIdsAction(getDataSource(), segmentIds)
       ).getUpgradedFromSegmentIds();
-
-      return segmentIdToParentId == null
-             ? Optional.of(Map.of())
-             : Optional.of(segmentIdToParentId);
     }
     catch (Exception e) {
       // Do not proceed with killing these segments as we cannot be sure if their
@@ -392,13 +381,12 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
       // segment files cannot be deleted from deep store. If load spec is not
       // shared, segments cannot be deleted from metadata store as that would
       // leave deep store files orphaned, and they would never be cleaned up.
-      LOG.error(
+      throw new ISE(
           e,
           "Could not retrieve parent segment ids using task action[retrieveUpgradedFromSegmentIds]."
           + " Stopping kill task to avoid data loss in case the segment files"
           + " are shared by other segments."
       );
-      return Optional.absent();
     }
   }
 
@@ -440,7 +428,12 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
       TaskActionClient taskActionClient
   )
   {
-    // Determine parentId for each unused segment
+    // Unused segment IDs being killed
+    final Set<String> segmentIdsBeingKilled = unusedSegments.stream()
+                                                            .map(s -> s.getId().toString())
+                                                            .collect(Collectors.toSet());
+
+    // Determine parentId (or self, if no parent) for each unused segment
     final Map<String, Set<DataSegment>> parentIdToUnusedSegments = new HashMap<>();
     for (DataSegment segment : unusedSegments) {
       final String segmentId = segment.getId().toString();
@@ -457,10 +450,11 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
       );
       if (response != null && response.getUpgradedToSegmentIds() != null) {
         response.getUpgradedToSegmentIds().forEach((parent, children) -> {
-          if (!CollectionUtils.isNullOrEmpty(children)) {
-            // Do not kill segment if its parent or any of its siblings still exist in metadata store
+          if (!segmentIdsBeingKilled.containsAll(children)) {
+            // Do not kill segment if its load spec is shared by another segment
+            // which is not being killed.
             LOG.info(
-                "Skipping kill of segments[%s] as its load spec is also used by segment IDs[%s].",
+                "Skipping kill of segments[%s] as its load spec is shared by segment IDs[%s].",
                 parentIdToUnusedSegments.get(parent), children
             );
             parentIdToUnusedSegments.remove(parent);
@@ -471,14 +465,13 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
     catch (Exception e) {
       // Do not proceed with the kill of any segment as we cannot be sure if their
       // load specs are shared by any other segment
-      LOG.error(
+      throw new ISE(
           e,
           "Could not perform task action[retrieveUpgradedToSegmentIds] to retrieve"
           + " segment IDs which share load specs with segments being killed."
           + " Stopping kill task to avoid data loss in case the segment files"
           + " are shared by other segments."
       );
-      return List.of();
     }
 
     // Filter using the used segment load specs as segment upgrades predate the above task action

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTask.java
@@ -69,7 +69,6 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 /**
- * <p/>
  * The client representation of this task is {@link ClientKillUnusedSegmentsTaskQuery}.
  * JSON serialization fields of this class must correspond to those of {@link
  * ClientKillUnusedSegmentsTaskQuery}, except for {@link #id} and {@link #context} fields.
@@ -86,6 +85,10 @@ import java.util.stream.Collectors;
  * <li> Filter the set of unreferenced segments using load specs from the set of used segments. </li>
  * <li> Kill the filtered set of segments from deep storage. </li>
  * </ol>
+ * Note: When {@link Tasks#USE_CONCURRENT_LOCKS} is true, keep a large buffer
+ * period before killing segments after they have been marked as unused.
+ * Otherwise, there may be a potential data loss if a concurrent APPEND job
+ * upgrades one of the segments that are being killed.
  */
 public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
 {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTask.java
@@ -52,7 +52,6 @@ import org.apache.druid.server.http.DataSegmentPlus;
 import org.apache.druid.server.lookup.cache.LookupLoadingSpec;
 import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.timeline.DataSegment;
-import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.utils.CollectionUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -239,7 +238,7 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
 
       unusedSegmentsPlus = fetchNextBatchOfUnusedSegments(toolbox, nextBatchSize);
       if (unusedSegmentsPlus.isEmpty()) {
-        // No segments eligible for kill
+        // No more segments eligible for kill, do not proceed further
         break;
       }
 
@@ -276,12 +275,15 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
       }
       catch (Exception e) {
         // Do not proceed with killing these segments as we cannot be sure if their
-        // load spec is used by any other segment or not
+        // load spec is shared by any other segment or not. If load spec is shared,
+        // segment files cannot be deleted from deep store. If load spec is not
+        // shared, segments cannot be deleted from metadata store as that would
+        // leave deep store files orphaned, and they would never be cleaned up.
         LOG.error(
             e,
             "Could not retrieve parent segment ids using task action[retrieveUpgradedFromSegmentIds]."
-            + " Stopping kill task to avoid deletion of segment files that may be"
-            + " needed for other segments."
+            + " Stopping kill task to avoid data loss in case the segment files"
+            + " are shared by other segments."
         );
         break;
       }
@@ -378,11 +380,10 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
       List<DataSegmentPlus> unusedSegments
   ) throws IOException
   {
-    final Set<String> segmentIds = unusedSegments.stream()
-                                                 .map(DataSegmentPlus::getDataSegment)
-                                                 .map(DataSegment::getId)
-                                                 .map(SegmentId::toString)
-                                                 .collect(Collectors.toSet());
+    final Set<String> segmentIds = unusedSegments.stream().map(
+        s -> s.getDataSegment().getId().toString()
+    ).collect(Collectors.toSet());
+
     return toolbox.getTaskActionClient().submit(
         new RetrieveUpgradedFromSegmentIdsAction(getDataSource(), segmentIds)
     ).getUpgradedFromSegmentIds();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTask.java
@@ -48,6 +48,7 @@ import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.server.coordination.BroadcastDatasourceLoadingSpec;
+import org.apache.druid.server.http.DataSegmentPlus;
 import org.apache.druid.server.lookup.cache.LookupLoadingSpec;
 import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.timeline.DataSegment;
@@ -211,7 +212,7 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
     // List unused segments
     int nextBatchSize = computeNextBatchSize(numSegmentsKilled);
     @Nullable Integer numTotalBatches = getNumTotalBatches();
-    List<DataSegment> unusedSegments;
+    List<DataSegmentPlus> unusedSegmentsPlus;
     logInfo(
         "Starting kill for datasource[%s] in interval[%s] and versions[%s] with batchSize[%d], up to limit[%d]"
         + " segments before maxUsedStatusLastUpdatedTime[%s] will be deleted%s",
@@ -236,11 +237,19 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
         break;
       }
 
-      unusedSegments = fetchNextBatchOfUnusedSegments(toolbox, nextBatchSize);
+      unusedSegmentsPlus = fetchNextBatchOfUnusedSegments(toolbox, nextBatchSize);
+      if (unusedSegmentsPlus.isEmpty()) {
+        // No segments eligible for kill
+        break;
+      }
 
       // Fetch locks each time as a revokal could have occurred in between batches
       final NavigableMap<DateTime, List<TaskLock>> taskLockMap
               = getNonRevokedTaskLockMap(toolbox.getTaskActionClient());
+
+      final Set<DataSegment> unusedSegments = unusedSegmentsPlus.stream()
+                                                                 .map(DataSegmentPlus::getDataSegment)
+                                                                 .collect(Collectors.toSet());
 
       if (!TaskLocks.isLockCoversSegments(taskLockMap, unusedSegments)) {
         throw new ISE(
@@ -259,28 +268,26 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
       // If the segment nuke throws an exception, then the segment cleanup is abandoned.
 
       // Determine upgraded segment ids before nuking
-      final Set<String> segmentIds = unusedSegments.stream()
-                                                   .map(DataSegment::getId)
-                                                   .map(SegmentId::toString)
-                                                   .collect(Collectors.toSet());
       final Map<String, String> upgradedFromSegmentIds = new HashMap<>();
       try {
         upgradedFromSegmentIds.putAll(
-            taskActionClient.submit(
-                new RetrieveUpgradedFromSegmentIdsAction(getDataSource(), segmentIds)
-            ).getUpgradedFromSegmentIds()
+            fetchParentIdsForSegments(toolbox, unusedSegmentsPlus)
         );
       }
       catch (Exception e) {
-        LOG.warn(
+        // Do not proceed with killing these segments as we cannot be sure if their
+        // load spec is used by any other segment or not
+        LOG.error(
             e,
             "Could not retrieve parent segment ids using task action[retrieveUpgradedFromSegmentIds]."
-            + " Overlord may be on an older version."
+            + " Stopping kill task to avoid deletion of segment files that may be"
+            + " needed for other segments."
         );
+        break;
       }
 
       // Nuke Segments
-      taskActionClient.submit(new SegmentNukeAction(new HashSet<>(unusedSegments)));
+      taskActionClient.submit(new SegmentNukeAction(unusedSegments));
       emitMetric(toolbox.getEmitter(), TaskMetrics.SEGMENTS_DELETED_FROM_METADATA_STORE, unusedSegments.size());
 
       // Determine segments to be killed
@@ -306,7 +313,7 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
       logInfo("Processed [%d] batches for kill task[%s].", numBatchesProcessed, getId());
 
       nextBatchSize = computeNextBatchSize(numSegmentsKilled);
-    } while (!unusedSegments.isEmpty() && (null == numTotalBatches || numBatchesProcessed < numTotalBatches));
+    } while (!unusedSegmentsPlus.isEmpty() && (null == numTotalBatches || numBatchesProcessed < numTotalBatches));
 
     final String taskId = getId();
     logInfo(
@@ -342,7 +349,7 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
   /**
    * Fetches the next batch of unused segments that are eligible for kill.
    */
-  protected List<DataSegment> fetchNextBatchOfUnusedSegments(TaskToolbox toolbox, int nextBatchSize) throws IOException
+  protected List<DataSegmentPlus> fetchNextBatchOfUnusedSegments(TaskToolbox toolbox, int nextBatchSize) throws IOException
   {
     return toolbox.getTaskActionClient().submit(
         new RetrieveUnusedSegmentsAction(
@@ -352,7 +359,33 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
             nextBatchSize,
             maxUsedStatusLastUpdatedTime
         )
-    );
+    )
+                  .stream()
+                  .map(segment -> new DataSegmentPlus(segment, null, null, null, null, null, null, null))
+                  .collect(Collectors.toList());
+  }
+
+  /**
+   * Fetches the parent IDs (if any) for the given unused segments.
+   *
+   * @param unusedSegments Unused segments whose parent IDs need to be fetched
+   * @return Map from segment ID to the segment ID from which it was upgraded.
+   * If an input segment was not upgraded from any other segment, it does not
+   * have an entry in the map.
+   */
+  protected Map<String, String> fetchParentIdsForSegments(
+      TaskToolbox toolbox,
+      List<DataSegmentPlus> unusedSegments
+  ) throws IOException
+  {
+    final Set<String> segmentIds = unusedSegments.stream()
+                                                 .map(DataSegmentPlus::getDataSegment)
+                                                 .map(DataSegment::getId)
+                                                 .map(SegmentId::toString)
+                                                 .collect(Collectors.toSet());
+    return toolbox.getTaskActionClient().submit(
+        new RetrieveUpgradedFromSegmentIdsAction(getDataSource(), segmentIds)
+    ).getUpgradedFromSegmentIds();
   }
 
   /**
@@ -387,7 +420,7 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
    * @return list of segments to kill from deep storage
    */
   private List<DataSegment> getKillableSegments(
-      List<DataSegment> unusedSegments,
+      Set<DataSegment> unusedSegments,
       Map<String, String> upgradedFromSegmentIds,
       Set<Map<String, Object>> usedSegmentLoadSpecs,
       TaskActionClient taskActionClient

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTask.java
@@ -282,10 +282,6 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
             segmentsNotKilled.size(), getDataSource()
         );
       }
-      if (segmentsToKillFromDeepStore.isEmpty()) {
-        // Do not proceed further as we will always keep getting the same batch of segments
-        break;
-      }
 
       // 3. Nuke all eligible unused segments
       taskActionClient.submit(new SegmentNukeAction(unusedSegments));

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTask.java
@@ -52,6 +52,7 @@ import org.apache.druid.server.http.DataSegmentPlus;
 import org.apache.druid.server.lookup.cache.LookupLoadingSpec;
 import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.utils.CollectionUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
@@ -66,6 +67,7 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -249,8 +251,13 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
               = getNonRevokedTaskLockMap(toolbox.getTaskActionClient());
 
       final Set<DataSegment> unusedSegments = unusedSegmentsPlus.stream()
-                                                                 .map(DataSegmentPlus::getDataSegment)
-                                                                 .collect(Collectors.toSet());
+                                                                .map(DataSegmentPlus::getDataSegment)
+                                                                .collect(Collectors.toSet());
+      final Map<String, DataSegmentPlus> unusedIdToSegmentPlus = CollectionUtils.toMap(
+          unusedSegmentsPlus,
+          segment -> segment.getDataSegment().getId().toString(),
+          Function.identity()
+      );
 
       if (!TaskLocks.isLockCoversSegments(taskLockMap, unusedSegments)) {
         throw new ISE(
@@ -265,11 +272,11 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
 
       // 1. Determine parent segment ids of killable unused segments
       final Map<String, String> upgradedFromSegmentIds
-          = fetchParentIdsForSegments(toolbox, unusedSegmentsPlus);
+          = fetchParentIdsForSegments(toolbox, unusedIdToSegmentPlus);
 
       // 2. Identify killable segments whose load specs are not shared with any other segment
       final List<DataSegment> segmentsToKillFromDeepStore = getKillableSegments(
-          unusedSegments,
+          unusedIdToSegmentPlus,
           upgradedFromSegmentIds,
           usedSegmentLoadSpecs,
           taskActionClient
@@ -288,7 +295,7 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
 
       // 3. Nuke all eligible unused segments
       taskActionClient.submit(new SegmentNukeAction(unusedSegments));
-      emitMetric(toolbox.getEmitter(), TaskMetrics.SEGMENTS_DELETED_FROM_METADATA_STORE, unusedSegments.size());
+      emitMetric(toolbox.getEmitter(), TaskMetrics.SEGMENTS_DELETED_FROM_METADATA_STORE, unusedIdToSegmentPlus.size());
 
       // 4. Delete deep store files only for segments which do not share load specs with other segments
       toolbox.getDataSegmentKiller().kill(segmentsToKillFromDeepStore);
@@ -355,23 +362,20 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
   /**
    * Fetches the parent IDs (if any) for the given unused segments.
    *
-   * @param unusedSegments Unused segments whose parent IDs need to be fetched
+   * @param unusedIdToSegmentPlus Map containing unused segments whose parent IDs
+   *                              need to be fetched
    * @return Map from segment ID to the segment ID from which
    * it was upgraded. If an input segment was not upgraded from any other segment,
    * it does not have an entry in the map.
    */
   protected Map<String, String> fetchParentIdsForSegments(
       TaskToolbox toolbox,
-      List<DataSegmentPlus> unusedSegments
+      Map<String, DataSegmentPlus> unusedIdToSegmentPlus
   )
   {
     try {
-      final Set<String> segmentIds = unusedSegments.stream().map(
-          s -> s.getDataSegment().getId().toString()
-      ).collect(Collectors.toSet());
-
       return toolbox.getTaskActionClient().submit(
-          new RetrieveUpgradedFromSegmentIdsAction(getDataSource(), segmentIds)
+          new RetrieveUpgradedFromSegmentIdsAction(getDataSource(), unusedIdToSegmentPlus.keySet())
       ).getUpgradedFromSegmentIds();
     }
     catch (Exception e) {
@@ -421,25 +425,20 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
    * @return list of segments to kill from deep storage
    */
   private List<DataSegment> getKillableSegments(
-      Set<DataSegment> unusedSegments,
+      Map<String, DataSegmentPlus> unusedSegments,
       Map<String, String> upgradedFromSegmentIds,
       Set<Map<String, Object>> usedSegmentLoadSpecs,
       TaskActionClient taskActionClient
   )
   {
-    // Unused segment IDs being killed
-    final Set<String> segmentIdsBeingKilled = unusedSegments.stream()
-                                                            .map(s -> s.getId().toString())
-                                                            .collect(Collectors.toSet());
-
     // Determine parentId (or self, if no parent) for each unused segment
     final Map<String, Set<DataSegment>> parentIdToUnusedSegments = new HashMap<>();
-    for (DataSegment segment : unusedSegments) {
-      final String segmentId = segment.getId().toString();
+    for (Map.Entry<String, DataSegmentPlus> entry : unusedSegments.entrySet()) {
+      final String segmentId = entry.getKey();
       parentIdToUnusedSegments.computeIfAbsent(
           upgradedFromSegmentIds.getOrDefault(segmentId, segmentId),
           k -> new HashSet<>()
-      ).add(segment);
+      ).add(entry.getValue().getDataSegment());
     }
 
     // Check if the parent or any of its children exist in metadata store
@@ -449,7 +448,7 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
       );
       if (response != null && response.getUpgradedToSegmentIds() != null) {
         response.getUpgradedToSegmentIds().forEach((parent, children) -> {
-          if (!segmentIdsBeingKilled.containsAll(children)) {
+          if (!unusedSegments.keySet().containsAll(children)) {
             // Do not kill segment if its load spec is shared by another segment
             // which is not being killed.
             LOG.info(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/duty/UnusedSegmentsKiller.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/duty/UnusedSegmentsKiller.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.indexing.overlord.duty;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.Ordering;
 import com.google.inject.Inject;
 import org.apache.druid.client.indexing.IndexingService;
@@ -468,7 +467,7 @@ public class UnusedSegmentsKiller implements OverlordDuty
     }
 
     @Override
-    protected Optional<Map<String, String>> fetchParentIdsForSegments(TaskToolbox toolbox, List<DataSegmentPlus> unusedSegments)
+    protected Map<String, String> fetchParentIdsForSegments(TaskToolbox toolbox, List<DataSegmentPlus> unusedSegments)
     {
       // No need to make another DB call, the parent IDs have already been fetched
       // in fetchNextBatchOfUnusedSegments
@@ -482,7 +481,7 @@ public class UnusedSegmentsKiller implements OverlordDuty
         }
       }
 
-      return Optional.of(unusedSegmentIdToParentId);
+      return unusedSegmentIdToParentId;
     }
 
     @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/duty/UnusedSegmentsKiller.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/duty/UnusedSegmentsKiller.java
@@ -45,7 +45,7 @@ import org.apache.druid.metadata.SegmentsMetadataManagerConfig;
 import org.apache.druid.metadata.UnusedSegmentKillerConfig;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.segment.loading.DataSegmentKiller;
-import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.server.http.DataSegmentPlus;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
@@ -455,7 +455,7 @@ public class UnusedSegmentsKiller implements OverlordDuty
     }
 
     @Override
-    protected List<DataSegment> fetchNextBatchOfUnusedSegments(TaskToolbox toolbox, int nextBatchSize)
+    protected List<DataSegmentPlus> fetchNextBatchOfUnusedSegments(TaskToolbox toolbox, int nextBatchSize)
     {
       // Kill only 1000 segments in the batch so that locks are not held for very long
       return storageCoordinator.retrieveUnusedSegmentsWithExactInterval(
@@ -464,6 +464,24 @@ public class UnusedSegmentsKiller implements OverlordDuty
           getMaxUsedStatusLastUpdatedTime(),
           MAX_SEGMENTS_TO_KILL_IN_INTERVAL
       );
+    }
+
+    @Override
+    protected Map<String, String> fetchParentIdsForSegments(TaskToolbox toolbox, List<DataSegmentPlus> unusedSegments)
+    {
+      // No need to make another DB call, the parent IDs have already been fetched
+      // in fetchNextBatchOfUnusedSegments
+      final Map<String, String> unusedSegmentIdToParentId = new HashMap<>();
+      for (DataSegmentPlus segment : unusedSegments) {
+        if (segment.getUpgradedFromSegmentId() != null) {
+          unusedSegmentIdToParentId.put(
+              segment.getDataSegment().getId().toString(),
+              segment.getUpgradedFromSegmentId()
+          );
+        }
+      }
+
+      return unusedSegmentIdToParentId;
     }
 
     @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/duty/UnusedSegmentsKiller.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/duty/UnusedSegmentsKiller.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.indexing.overlord.duty;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.Ordering;
 import com.google.inject.Inject;
 import org.apache.druid.client.indexing.IndexingService;
@@ -467,7 +468,7 @@ public class UnusedSegmentsKiller implements OverlordDuty
     }
 
     @Override
-    protected Map<String, String> fetchParentIdsForSegments(TaskToolbox toolbox, List<DataSegmentPlus> unusedSegments)
+    protected Optional<Map<String, String>> fetchParentIdsForSegments(TaskToolbox toolbox, List<DataSegmentPlus> unusedSegments)
     {
       // No need to make another DB call, the parent IDs have already been fetched
       // in fetchNextBatchOfUnusedSegments
@@ -481,7 +482,7 @@ public class UnusedSegmentsKiller implements OverlordDuty
         }
       }
 
-      return unusedSegmentIdToParentId;
+      return Optional.of(unusedSegmentIdToParentId);
     }
 
     @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/duty/UnusedSegmentsKiller.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/duty/UnusedSegmentsKiller.java
@@ -467,12 +467,15 @@ public class UnusedSegmentsKiller implements OverlordDuty
     }
 
     @Override
-    protected Map<String, String> fetchParentIdsForSegments(TaskToolbox toolbox, List<DataSegmentPlus> unusedSegments)
+    protected Map<String, String> fetchParentIdsForSegments(
+        TaskToolbox toolbox,
+        Map<String, DataSegmentPlus> unusedIdToSegmentPlus
+    )
     {
       // No need to make another DB call, the parent IDs have already been fetched
       // in fetchNextBatchOfUnusedSegments
       final Map<String, String> unusedSegmentIdToParentId = new HashMap<>();
-      for (DataSegmentPlus segment : unusedSegments) {
+      for (DataSegmentPlus segment : unusedIdToSegmentPlus.values()) {
         if (segment.getUpgradedFromSegmentId() != null) {
           unusedSegmentIdToParentId.put(
               segment.getDataSegment().getId().toString(),

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/TaskActionTestKit.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/TaskActionTestKit.java
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Suppliers;
 import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.config.TaskStorageConfig;
+import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.GlobalTaskLockbox;
 import org.apache.druid.indexing.overlord.HeapMemoryTaskStorage;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
@@ -53,7 +54,10 @@ import org.apache.druid.server.coordinator.simulate.WrappingScheduledExecutorSer
 import org.joda.time.Period;
 import org.junit.rules.ExternalResource;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 public class TaskActionTestKit extends ExternalResource
 {
@@ -73,6 +77,7 @@ public class TaskActionTestKit extends ExternalResource
   private boolean useCentralizedDatasourceSchema = false;
   private boolean batchSegmentAllocation = true;
   private boolean skipSegmentPayloadFetchForAllocation = new TaskLockConfig().isBatchAllocationReduceMetadataIO();
+  private Map<Class<? extends TaskAction<?>>, Supplier<?>> taskActionDelegate;
   private AtomicBoolean configFinalized = new AtomicBoolean();
 
   public TaskActionTestKit setUseSegmentMetadataCache(boolean useSegmentMetadataCache)
@@ -156,6 +161,36 @@ public class TaskActionTestKit extends ExternalResource
     metadataCachePollExec.finishNextPendingTasks(4);
   }
 
+  /**
+   * Creates a {@link LocalTaskActionClient}. The response for a specific task
+   * action type may be overridden by calling {@link #registerDelegateForTaskAction}.
+   */
+  public TaskActionClient createTaskActionClient(Task task)
+  {
+    return new LocalTaskActionClient(task, getTaskActionToolbox())
+    {
+      @Override
+      @SuppressWarnings("unchecked")
+      public <V> V submit(TaskAction<V> taskAction)
+      {
+        final Supplier<?> delegate = taskActionDelegate.get(taskAction.getClass());
+        if (delegate == null) {
+          return super.submit(taskAction);
+        } else {
+          return (V) delegate.get();
+        }
+      }
+    };
+  }
+
+  /**
+   * Registers an override action to be performed for task actions of the given type.
+   */
+  public <V> void registerDelegateForTaskAction(Class<? extends TaskAction<V>> actionType, Supplier<V> function)
+  {
+    taskActionDelegate.put(actionType, function);
+  }
+
   @Override
   public void before()
   {
@@ -234,6 +269,7 @@ public class TaskActionTestKit extends ExternalResource
         supervisorManager,
         objectMapper
     );
+    taskActionDelegate = new HashMap<>();
     testDerbyConnector.createDataSourceTable();
     testDerbyConnector.createUpgradeSegmentsTable();
     testDerbyConnector.createPendingSegmentsTable();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IngestionTestBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IngestionTestBase.java
@@ -376,7 +376,7 @@ public abstract class IngestionTestBase extends InitializedNullHandlingTest
     private final SegmentSchemaMapping segmentSchemaMapping
         = new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION);
 
-    private TestLocalTaskActionClient(Task task)
+    public TestLocalTaskActionClient(Task task)
     {
       super(task, taskStorage, getTaskActionToolbox());
     }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTaskTest.java
@@ -24,11 +24,15 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.error.DruidExceptionMatcher;
+import org.apache.druid.error.ExceptionMatcher;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.report.KillTaskReport;
 import org.apache.druid.indexer.report.TaskReport;
 import org.apache.druid.indexing.common.SegmentLock;
 import org.apache.druid.indexing.common.TaskLockType;
+import org.apache.druid.indexing.common.actions.RetrieveUpgradedFromSegmentIdsAction;
+import org.apache.druid.indexing.common.actions.RetrieveUpgradedToSegmentIdsAction;
+import org.apache.druid.indexing.common.actions.TaskAction;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.actions.TimeChunkLockTryAcquireAction;
 import org.apache.druid.indexing.overlord.Segments;
@@ -54,10 +58,12 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 @RunWith(Parameterized.class)
@@ -66,6 +72,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
   private static final String DATA_SOURCE = "wiki";
 
   private TestTaskRunner taskRunner;
+  private Map<Class<? extends TaskAction<?>>, Supplier<Object>> taskActionDelegate;
 
   private DataSegment segment1;
   private DataSegment segment2;
@@ -87,12 +94,32 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
   public void setup()
   {
     taskRunner = new TestTaskRunner();
+    taskActionDelegate = new HashMap<>();
 
     final String version = DateTimes.nowUtc().toString();
     segment1 = newSegment(Intervals.of("2019-01-01/2019-02-01"), version).withLoadSpec(ImmutableMap.of("k", 1));
     segment2 = newSegment(Intervals.of("2019-02-01/2019-03-01"), version).withLoadSpec(ImmutableMap.of("k", 2));
     segment3 = newSegment(Intervals.of("2019-03-01/2019-04-01"), version).withLoadSpec(ImmutableMap.of("k", 3));
     segment4 = newSegment(Intervals.of("2019-04-01/2019-05-01"), version).withLoadSpec(ImmutableMap.of("k", 4));
+  }
+
+  @Override
+  public TestLocalTaskActionClient createActionClient(Task task)
+  {
+    return new TestLocalTaskActionClient(task)
+    {
+      @Override
+      @SuppressWarnings("unchecked")
+      public <V> V submit(TaskAction<V> taskAction)
+      {
+        final Supplier<Object> delegate = taskActionDelegate.get(taskAction.getClass());
+        if (delegate == null) {
+          return super.submit(taskAction);
+        } else {
+          return (V) delegate.get();
+        }
+      }
+    };
   }
 
   @Test
@@ -350,6 +377,95 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         getReportedStats()
     );
     Assert.assertEquals(ImmutableSet.of(segment1, segment2, segment3), getDataSegmentKiller().getKilledSegments());
+  }
+
+  @Test
+  public void testTaskFails_andNoSegmentIsDeleted_ifErrorWhileFetchingParentIds()
+  {
+    // Insert some segments and mark them as unused
+    insertUsedSegments(Set.of(segment1, segment2, segment3), Map.of());
+    getMetadataStorageCoordinator().markSegmentAsUnused(segment1.getId());
+    getMetadataStorageCoordinator().markSegmentAsUnused(segment2.getId());
+    getMetadataStorageCoordinator().markSegmentAsUnused(segment3.getId());
+
+    // Make the retrieveUpgradedFromSegmentIds task action fail
+    taskActionDelegate.put(
+        RetrieveUpgradedFromSegmentIdsAction.class,
+        () -> {
+          throw new ISE("Failed to fetch parent IDs");
+        }
+    );
+
+    // Verify that task run fails
+    final KillUnusedSegmentsTask task = new KillUnusedSegmentsTaskBuilder()
+        .dataSource(DATA_SOURCE)
+        .interval(Intervals.ETERNITY)
+        .build();
+
+    MatcherAssert.assertThat(
+        Assert.assertThrows(Exception.class, () -> taskRunner.run(task).get()),
+        ExceptionMatcher.of(Exception.class).expectMessageContains(
+            "Could not retrieve parent segment ids using task action[retrieveUpgradedFromSegmentIds]."
+            + " Stopping kill task to avoid data loss in case the segment files are shared by other segments."
+        )
+    );
+
+    // Verify that all unused segments are still present in both metadata store and deep store
+    final List<DataSegment> observedUnusedSegments =
+        getMetadataStorageCoordinator().retrieveUnusedSegmentsForInterval(
+            DATA_SOURCE,
+            Intervals.ETERNITY,
+            null,
+            null,
+            null
+        );
+    Assert.assertEquals(List.of(segment1, segment2, segment3), observedUnusedSegments);
+    Assert.assertEquals(Set.of(), getDataSegmentKiller().getKilledSegments());
+  }
+
+  @Test
+  public void testTaskFails_andNoSegmentIsDeleted_ifErrorWhileFetchingChildrenIds()
+  {
+    // Insert some segments and mark them as unused
+    insertUsedSegments(Set.of(segment1, segment2, segment3), Map.of());
+    getMetadataStorageCoordinator().markSegmentAsUnused(segment1.getId());
+    getMetadataStorageCoordinator().markSegmentAsUnused(segment2.getId());
+    getMetadataStorageCoordinator().markSegmentAsUnused(segment3.getId());
+
+    // Make the retrieveUpgradedFromSegmentIds task action fail
+    taskActionDelegate.put(
+        RetrieveUpgradedToSegmentIdsAction.class,
+        () -> {
+          throw new ISE("Failed to fetch children IDs");
+        }
+    );
+
+    // Verify that task run fails
+    final KillUnusedSegmentsTask task = new KillUnusedSegmentsTaskBuilder()
+        .dataSource(DATA_SOURCE)
+        .interval(Intervals.ETERNITY)
+        .build();
+
+    MatcherAssert.assertThat(
+        Assert.assertThrows(Exception.class, () -> taskRunner.run(task).get()),
+        ExceptionMatcher.of(Exception.class).expectMessageContains(
+            "Could not perform task action[retrieveUpgradedToSegmentIds] to retrieve"
+            + " segment IDs which share load specs with segments being killed."
+            + " Stopping kill task to avoid data loss in case the segment files are shared by other segments."
+        )
+    );
+
+    // Verify that all unused segments are still present in both metadata store and deep store
+    final List<DataSegment> observedUnusedSegments =
+        getMetadataStorageCoordinator().retrieveUnusedSegmentsForInterval(
+            DATA_SOURCE,
+            Intervals.ETERNITY,
+            null,
+            null,
+            null
+        );
+    Assert.assertEquals(List.of(segment1, segment2, segment3), observedUnusedSegments);
+    Assert.assertEquals(Set.of(), getDataSegmentKiller().getKilledSegments());
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTaskTest.java
@@ -139,7 +139,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
     ).containsExactlyInAnyOrder(segment1, segment4);
 
     Assert.assertEquals(
-        new KillTaskReport.Stats(1, 2),
+        new KillTaskReport.Stats(1, 1),
         getReportedStats()
     );
     Assert.assertEquals(ImmutableSet.of(segment3), getDataSegmentKiller().getKilledSegments());
@@ -178,7 +178,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
     Assert.assertEquals(Collections.emptyList(), observedUnusedSegments);
 
     Assert.assertEquals(
-        new KillTaskReport.Stats(2, 2),
+        new KillTaskReport.Stats(2, 1),
         getReportedStats()
     );
     Assert.assertEquals(ImmutableSet.of(segment1, segment2), getDataSegmentKiller().getKilledSegments());
@@ -217,7 +217,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
     Assert.assertEquals(Collections.singletonList(segment2), observedUnusedSegments);
 
     Assert.assertEquals(
-        new KillTaskReport.Stats(0, 2),
+        new KillTaskReport.Stats(0, 1),
         getReportedStats()
     );
     Assert.assertEquals(Collections.emptySet(), getDataSegmentKiller().getKilledSegments());
@@ -262,7 +262,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
     ).containsExactlyInAnyOrder(segment1);
 
     Assert.assertEquals(
-        new KillTaskReport.Stats(0, 2),
+        new KillTaskReport.Stats(0, 1),
         getReportedStats()
     );
     Assert.assertEquals(Collections.emptySet(), getDataSegmentKiller().getKilledSegments());
@@ -307,7 +307,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
     ).containsExactlyInAnyOrder(segment3);
 
     Assert.assertEquals(
-        new KillTaskReport.Stats(0, 2),
+        new KillTaskReport.Stats(0, 1),
         getReportedStats()
     );
     Assert.assertEquals(Collections.emptySet(), getDataSegmentKiller().getKilledSegments());
@@ -346,7 +346,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
     Assert.assertEquals(ImmutableList.of(), observedUnusedSegments);
 
     Assert.assertEquals(
-        new KillTaskReport.Stats(3, 2),
+        new KillTaskReport.Stats(3, 1),
         getReportedStats()
     );
     Assert.assertEquals(ImmutableSet.of(segment1, segment2, segment3), getDataSegmentKiller().getKilledSegments());
@@ -386,7 +386,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
 
     Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
     Assert.assertEquals(
-        new KillTaskReport.Stats(4, 3),
+        new KillTaskReport.Stats(4, 2),
         getReportedStats()
     );
 
@@ -435,7 +435,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
 
     Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
     Assert.assertEquals(
-        new KillTaskReport.Stats(0, 1),
+        new KillTaskReport.Stats(0, 0),
         getReportedStats()
     );
 
@@ -535,7 +535,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
 
     Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
     Assert.assertEquals(
-        new KillTaskReport.Stats(0, 1),
+        new KillTaskReport.Stats(0, 0),
         getReportedStats()
     );
 
@@ -741,7 +741,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
 
     Assert.assertEquals(ImmutableList.of(), observedUnusedSegments);
     Assert.assertEquals(
-        new KillTaskReport.Stats(3, 4),
+        new KillTaskReport.Stats(3, 3),
         getReportedStats()
     );
   }
@@ -827,7 +827,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
 
     Assert.assertEquals(ImmutableList.of(segment3), observedUnusedSegments);
     Assert.assertEquals(
-        new KillTaskReport.Stats(2, 3),
+        new KillTaskReport.Stats(2, 2),
         getReportedStats()
     );
 
@@ -851,7 +851,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
 
     Assert.assertEquals(ImmutableList.of(), observedUnusedSegments2);
     Assert.assertEquals(
-        new KillTaskReport.Stats(1, 2),
+        new KillTaskReport.Stats(1, 1),
         getReportedStats()
     );
   }
@@ -927,7 +927,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
 
     Assert.assertEquals(ImmutableList.of(segment2, segment3), observedUnusedSegments1);
     Assert.assertEquals(
-        new KillTaskReport.Stats(2, 3),
+        new KillTaskReport.Stats(2, 2),
         getReportedStats()
     );
 
@@ -951,7 +951,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
 
     Assert.assertEquals(ImmutableList.of(), observedUnusedSegments2);
     Assert.assertEquals(
-        new KillTaskReport.Stats(2, 3),
+        new KillTaskReport.Stats(2, 2),
         getReportedStats()
     );
   }
@@ -1010,7 +1010,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
 
     Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task1).get().getStatusCode());
     Assert.assertEquals(
-        new KillTaskReport.Stats(2, 3),
+        new KillTaskReport.Stats(2, 2),
         getReportedStats()
     );
 
@@ -1035,7 +1035,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
 
     Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task2).get().getStatusCode());
     Assert.assertEquals(
-        new KillTaskReport.Stats(1, 2),
+        new KillTaskReport.Stats(1, 1),
         getReportedStats()
     );
 
@@ -1084,7 +1084,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
 
     Assert.assertEquals(Collections.emptyList(), observedUnusedSegments);
     Assert.assertEquals(
-        new KillTaskReport.Stats(4, 3),
+        new KillTaskReport.Stats(4, 2),
         getReportedStats()
     );
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
@@ -846,7 +846,7 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
     Assert.assertEquals("merged statusCode", TaskState.SUCCESS, status.getStatusCode());
     Assert.assertEquals("num segments published", 3, mdc.getPublished().size());
     Assert.assertEquals("num segments nuked", 3, mdc.getNuked().size());
-    Assert.assertEquals("delete segment batch call count", 2, mdc.getDeleteSegmentsCount());
+    Assert.assertEquals("delete segment batch call count", 1, mdc.getDeleteSegmentsCount());
     Assert.assertTrue(
         "expected unused segments get killed",
         expectedUnusedSegments.containsAll(mdc.getNuked()) && mdc.getNuked().containsAll(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/duty/UnusedSegmentsKillerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/duty/UnusedSegmentsKillerTest.java
@@ -20,7 +20,7 @@
 package org.apache.druid.indexing.overlord.duty;
 
 import org.apache.druid.indexing.common.TaskLockType;
-import org.apache.druid.indexing.common.actions.LocalTaskActionClient;
+import org.apache.druid.indexing.common.actions.RetrieveUpgradedToSegmentIdsAction;
 import org.apache.druid.indexing.common.actions.TaskActionTestKit;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.Task;
@@ -29,6 +29,7 @@ import org.apache.druid.indexing.overlord.GlobalTaskLockbox;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
 import org.apache.druid.indexing.overlord.TimeChunkLockRequest;
 import org.apache.druid.indexing.test.TestDataSegmentKiller;
+import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.guava.Comparators;
@@ -53,6 +54,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -94,7 +96,7 @@ public class UnusedSegmentsKillerTest
             SegmentMetadataCache.UsageMode.ALWAYS,
             killerConfig
         ),
-        task -> new LocalTaskActionClient(task, taskActionTestKit.getTaskActionToolbox()),
+        taskActionTestKit::createTaskActionClient,
         storageCoordinator,
         leaderSelector,
         (corePoolSize, nameFormat) -> new WrappingScheduledExecutorService(nameFormat, killExecutor, true),
@@ -365,6 +367,32 @@ public class UnusedSegmentsKillerTest
     finishQueuedKillJobs();
     emitter.verifySum(TaskMetrics.SEGMENTS_DELETED_FROM_METADATA_STORE, 10L);
     emitter.verifySum(TaskMetrics.SEGMENTS_DELETED_FROM_DEEPSTORE, 8L);
+  }
+
+  @Test
+  public void test_run_isNoop_ifRetrieveUpgradedToSegmentIdsFails()
+  {
+    storageCoordinator.commitSegments(Set.copyOf(WIKI_SEGMENTS_1X10D), null);
+    storageCoordinator.markAllSegmentsAsUnused(TestDataSource.WIKI);
+
+    // Make the retrieveUpgradedFromSegmentIds task action fail
+    taskActionTestKit.registerDelegateForTaskAction(
+        RetrieveUpgradedToSegmentIdsAction.class,
+        () -> {
+          throw new ISE("Failed to fetch children IDs");
+        }
+    );
+
+    leaderSelector.becomeLeader();
+    killer.run();
+
+    // Verify that no unused segment is deleted from metadata store or deep store
+    finishQueuedKillJobs();
+    emitter.verifyNotEmitted(TaskMetrics.SEGMENTS_DELETED_FROM_METADATA_STORE);
+    emitter.verifyNotEmitted(TaskMetrics.SEGMENTS_DELETED_FROM_DEEPSTORE);
+
+    // Verify that the task is marked as failed
+    emitter.verifyEmitted("task/run/time", Map.of("taskStatus", "FAILED"), 10);
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
@@ -76,7 +76,7 @@ public class TestIndexerMetadataStorageCoordinator implements IndexerMetadataSto
   }
 
   @Override
-  public List<DataSegment> retrieveUnusedSegmentsWithExactInterval(
+  public List<DataSegmentPlus> retrieveUnusedSegmentsWithExactInterval(
       String dataSource,
       Interval interval,
       DateTime maxUpdatedTime,

--- a/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
@@ -161,10 +161,11 @@ public interface IndexerMetadataStorageCoordinator
    * @param maxUpdatedTime Returned segments must have a {@code used_status_last_updated}
    *                       which is either null or earlier than this value.
    * @param limit          Maximum number of segments to return.
-   *
    * @return Unsorted list of unused segments that match the given parameters.
+   * The entries in the lost are required to have the {@link DataSegmentPlus#getDataSegment()}
+   * and {@link DataSegmentPlus#getUpgradedFromSegmentId()} fields populated.
    */
-  List<DataSegment> retrieveUnusedSegmentsWithExactInterval(
+  List<DataSegmentPlus> retrieveUnusedSegmentsWithExactInterval(
       String dataSource,
       Interval interval,
       DateTime maxUpdatedTime,

--- a/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
@@ -162,7 +162,7 @@ public interface IndexerMetadataStorageCoordinator
    *                       which is either null or earlier than this value.
    * @param limit          Maximum number of segments to return.
    * @return Unsorted list of unused segments that match the given parameters.
-   * The entries in the lost are required to have the {@link DataSegmentPlus#getDataSegment()}
+   * The entries in the list are required to have the {@link DataSegmentPlus#getDataSegment()}
    * and {@link DataSegmentPlus#getUpgradedFromSegmentId()} fields populated.
    */
   List<DataSegmentPlus> retrieveUnusedSegmentsWithExactInterval(

--- a/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -259,7 +259,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
   }
 
   @Override
-  public List<DataSegment> retrieveUnusedSegmentsWithExactInterval(
+  public List<DataSegmentPlus> retrieveUnusedSegmentsWithExactInterval(
       String dataSource,
       Interval interval,
       DateTime maxUpdatedTime,

--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
@@ -1124,7 +1124,7 @@ public class SqlSegmentsMetadataQuery
    *                       which is either null or earlier than this value.
    * @param limit          Maximum number of segments to return
    */
-  public List<DataSegment> retrieveUnusedSegmentsWithExactInterval(
+  public List<DataSegmentPlus> retrieveUnusedSegmentsWithExactInterval(
       String dataSource,
       Interval interval,
       DateTime maxUpdatedTime,
@@ -1132,7 +1132,7 @@ public class SqlSegmentsMetadataQuery
   )
   {
     final String sql = StringUtils.format(
-        "SELECT id, payload FROM %1$s"
+        "SELECT id, payload, upgraded_from_segment_id FROM %1$s"
         + " WHERE dataSource = :dataSource AND used = false"
         + " AND %2$send%2$s = :end AND start = :start"
         + " AND (used_status_last_updated IS NULL OR used_status_last_updated <= :maxUpdatedTime)"
@@ -1140,7 +1140,7 @@ public class SqlSegmentsMetadataQuery
         dbTables.getSegmentsTable(), connector.getQuoteString(), connector.limitClause(limit)
     );
 
-    final List<DataSegment> segments = connector.inReadOnlyTransaction(
+    final List<DataSegmentPlus> segments = connector.inReadOnlyTransaction(
         (handle, status) ->
             handle.createQuery(sql)
                   .setFetchSize(connector.getStreamingFetchSize())
@@ -1148,7 +1148,7 @@ public class SqlSegmentsMetadataQuery
                   .bind("start", interval.getStart().toString())
                   .bind("end", interval.getEnd().toString())
                   .bind("maxUpdatedTime", maxUpdatedTime.toString())
-                  .map((index, r, ctx) -> mapToSegment(r))
+                  .map((index, r, ctx) -> mapToSegmentPlusUpgradedId(r))
                   .list()
     );
 
@@ -1878,13 +1878,27 @@ public class SqlSegmentsMetadataQuery
     }).iterator();
   }
 
+  /**
+   * Maps the given result set to a {@link DataSegmentPlus} with the segment
+   * payload and the {@code upgradedFromSegmentId} populated (if non-null).
+   */
   @Nullable
-  private DataSegment mapToSegment(ResultSet resultSet)
+  private DataSegmentPlus mapToSegmentPlusUpgradedId(ResultSet resultSet)
   {
     String segmentId = "";
     try {
       segmentId = resultSet.getString("id");
-      return JacksonUtils.readValue(jsonMapper, resultSet.getBytes("payload"), DataSegment.class);
+      final String upgradedFromSegmentId = resultSet.getString("upgraded_from_segment_id");
+      return new DataSegmentPlus(
+          JacksonUtils.readValue(jsonMapper, resultSet.getBytes("payload"), DataSegment.class),
+          null,
+          null,
+          null,
+          null,
+          null,
+          upgradedFromSegmentId,
+          null
+      );
     }
     catch (Throwable t) {
       log.error(t, "Could not read segment with ID[%s]", segmentId);

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
@@ -2217,7 +2217,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
     // Verify that query for exact interval returns the segments
     Assert.assertEquals(
-        List.of(defaultSegment3),
+        List.of(toSegmentPlusUpgradedId(defaultSegment3, null)),
         coordinator.retrieveUnusedSegmentsWithExactInterval(
             dataSource,
             defaultSegment3.getInterval(),
@@ -2228,7 +2228,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
     Assert.assertEquals(defaultSegment.getInterval(), defaultSegment2.getInterval());
     Assert.assertEquals(
-        Set.of(defaultSegment, defaultSegment2),
+        Set.of(toSegmentPlusUpgradedId(defaultSegment, null), toSegmentPlusUpgradedId(defaultSegment2, null)),
         Set.copyOf(
             coordinator.retrieveUnusedSegmentsWithExactInterval(
                 dataSource,
@@ -4844,5 +4844,10 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         Set.of(expectedSegments),
         coordinator.retrieveUsedSegmentsForIntervals(dataSource, List.of(interval), Segments.ONLY_VISIBLE)
     );
+  }
+
+  private DataSegmentPlus toSegmentPlusUpgradedId(DataSegment segment, String upgradedFromSegmentId)
+  {
+    return new DataSegmentPlus(segment, null, null, null, null, null, upgradedFromSegmentId, null);
   }
 }


### PR DESCRIPTION
### Bug

When concurrent append and replace is enabled and `kill` tasks (or embedded kill tasks on Overlord) are used, there may be potential data loss if the task action `retrieveUpgradedFromSegmentIds` or `retrieveUpgradedToSegmentIds` fired by the `kill` task fails. This is because the failure of these task actions is currently ignored and we may end up removing segment files from deep store even if the same load specs are shared by other segments.

### Changes

- Stop `kill` task (and embedded kill tasks) if parent IDs of the killable unused segments could not be determined. There are 2 cases possible:
  - Segment does not share load spec: Do not remove segment from metadata store, otherwise deep store files would become orphaned and will never be removed.
  - Segment shares load spec with other segments: Do not remove segment files from deep store as the same files are needed by other segments.
- Stop `kill` task (and embedded kill tasks) if sibling segment IDs or children segment IDs could not be determined. Same cases as above. 
- Improve performance of embedded kill tasks by avoiding extra DB call to fetch parent IDs
  - pre-fetch the parent IDs in the previous call which identifies the killable unused segments in the first place.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.