### PR TITLE
[Backport] fix: ensure supervisor worker threadpool is reapable (#19738)

### DIFF
--- a/processing/src/main/java/org/apache/druid/java/util/common/concurrent/ScheduledExecutors.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/concurrent/ScheduledExecutors.java
@@ -225,9 +225,14 @@ public class ScheduledExecutors
   }
 
   /**
-   * Creates a new {@link ScheduledExecutorService} with a minimum number of threads along with a
-   * keep-alive time for idle non-core threads.
+   * Creates a new {@link ScheduledThreadPoolExecutor} sized to {@code corePoolSize} whose idle threads
+   * are reclaimed after {@code keepAliveTimeInMillis}.
    * <p>
+   * A {@link ScheduledThreadPoolExecutor} never grows beyond its core pool size (its work queue is
+   * unbounded), so {@code corePoolSize} is really a ceiling. Without {@code allowCoreThreadTimeOut(true)}
+   * the keep-alive would never apply to those core threads and they would live for the lifetime of the
+   * pool even while idle. Enabling core-thread timeout lets the pool shrink back toward zero when idle,
+   * so {@code corePoolSize} behaves as a peak-concurrency ceiling rather than a permanent allocation.
    */
   public static ScheduledThreadPoolExecutor fixedWithKeepAliveTime(
       int corePoolSize,
@@ -240,6 +245,7 @@ public class ScheduledExecutors
         Execs.makeThreadFactory(nameFormat)
     );
     scheduledExecutor.setKeepAliveTime(keepAliveTimeInMillis, TimeUnit.MILLISECONDS);
+    scheduledExecutor.allowCoreThreadTimeOut(true);
     return scheduledExecutor;
   }
 }

--- a/processing/src/test/java/org/apache/druid/java/util/common/concurrent/ScheduledExecutorsTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/concurrent/ScheduledExecutorsTest.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -332,5 +333,32 @@ public class ScheduledExecutorsTest
 
     Assertions.assertTrue(completed, "Should continue executing after exception");
     Assertions.assertEquals(3, executionCount.get(), "Should have exactly 3 executions");
+  }
+
+  @Test
+  public void testFixedWithKeepAliveTimeReclaimsIdleThreads() throws Exception
+  {
+    final ScheduledThreadPoolExecutor exec = ScheduledExecutors.fixedWithKeepAliveTime(8, "testKeepAlive-%d", 100);
+    try {
+      // Core threads must be eligible for timeout, otherwise a large corePoolSize would pin that many
+      // threads for the lifetime of the pool even when idle.
+      Assertions.assertTrue(exec.allowsCoreThreadTimeOut(), "Core threads should be allowed to time out");
+
+      final CountDownLatch latch = new CountDownLatch(4);
+      for (int i = 0; i < 4; i++) {
+        exec.submit(latch::countDown);
+      }
+      Assertions.assertTrue(latch.await(5, TimeUnit.SECONDS), "Submitted tasks should run");
+
+      // Once idle past the keep-alive, all workers should be reclaimed and the pool shrink back to zero.
+      final long deadline = System.currentTimeMillis() + 5000;
+      while (exec.getPoolSize() > 0 && System.currentTimeMillis() < deadline) {
+        Thread.sleep(50);
+      }
+      Assertions.assertEquals(0, exec.getPoolSize(), "Idle core threads should be reclaimed");
+    }
+    finally {
+      exec.shutdownNow();
+    }
   }
 }


### PR DESCRIPTION
Backports https://github.com/apache/druid/commit/dbe1d23ee03a8ee96cbe2b2b100912a680445b66 for v38.0.0

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.