### PR TITLE
fix: isMounted() should never be blocked by a lock

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/loading/PartialSegmentBundleCacheEntry.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/PartialSegmentBundleCacheEntry.java
@@ -419,8 +419,11 @@ public class PartialSegmentBundleCacheEntry implements CacheEntry
         location = mountLocation;
         holds.addAll(acquired);
         dependencyReferences.addAll(acquiredRefs);
-        mounted = true;
+        // Must be set before `mounted` is published below: `mounted` is volatile and isMounted() reads it without
+        // entryLock, so a lock-free caller must never be able to observe isMounted() == true before the reference
+        // gate exists.
         references.set(new ReferenceCountingCloseableObject<Closeable>(this::doActualUnmount) {});
+        mounted = true;
       }
       finally {
         entryLock.unlock();

--- a/server/src/main/java/org/apache/druid/segment/loading/PartialSegmentBundleCacheEntry.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/PartialSegmentBundleCacheEntry.java
@@ -175,8 +175,10 @@ public class PartialSegmentBundleCacheEntry implements CacheEntry
   // metadata + parents safe from drop-time unmap even if the dependency is statically reserved.
   @GuardedBy("entryLock")
   private final List<Closeable> dependencyReferences = new ArrayList<>();
-  @GuardedBy("entryLock")
-  private boolean mounted;
+  // volatile so isMounted() can read it without blocking behind a concurrent doActualUnmount() holding entryLock
+  // across container eviction. Other reads of this field still go through entryLock since they're paired with other
+  // guarded state (e.g. doMount's mounted + location check).
+  private volatile boolean mounted;
 
   // Reference-counted gate over the actual cleanup work (evict containers, release parent holds, unregister from
   // metadata). Set on successful mount; unmount() closes the wrapper which defers running cleanup until all outstanding
@@ -217,13 +219,7 @@ public class PartialSegmentBundleCacheEntry implements CacheEntry
   @Override
   public boolean isMounted()
   {
-    entryLock.lock();
-    try {
-      return mounted;
-    }
-    finally {
-      entryLock.unlock();
-    }
+    return mounted;
   }
 
   public SegmentId getSegmentId()

--- a/server/src/main/java/org/apache/druid/segment/loading/PartialSegmentMetadataCacheEntry.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/PartialSegmentMetadataCacheEntry.java
@@ -118,9 +118,11 @@ public class PartialSegmentMetadataCacheEntry implements SegmentCacheEntry, Resi
   @GuardedBy("entryLock")
   @Nullable
   private StorageLocation location;
-  @GuardedBy("entryLock")
+  // volatile so isMounted() can read it without blocking behind a concurrent doActualUnmount() holding entryLock
+  // across fileMapper.close() + deleteHeaderFiles() (real file I/O). Other reads of this field still go through
+  // entryLock because they do more than a single null-check (e.g. isFullyDownloaded() also calls a method on it).
   @Nullable
-  private PartialSegmentFileMapperV10 fileMapper;
+  private volatile PartialSegmentFileMapperV10 fileMapper;
   // Cached PartialQueryableIndex for the mounted file mapper. Built lazily on first {@code acquireReference} call
   // so concurrent acquireReference calls share the same memoized column-holder suppliers. first read of a column
   // deserializes once and the ColumnHolder stays cached for subsequent queries against the same entry. Cleared
@@ -666,13 +668,7 @@ public class PartialSegmentMetadataCacheEntry implements SegmentCacheEntry, Resi
   @Override
   public boolean isMounted()
   {
-    entryLock.lock();
-    try {
-      return fileMapper != null;
-    }
-    finally {
-      entryLock.unlock();
-    }
+    return fileMapper != null;
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/segment/loading/PartialSegmentMetadataCacheEntry.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/PartialSegmentMetadataCacheEntry.java
@@ -813,11 +813,13 @@ public class PartialSegmentMetadataCacheEntry implements SegmentCacheEntry, Resi
         entryLock.lock();
         try {
           location = mountLocation;
-          fileMapper = mapper;
           // Install (or re-install, after a previous mount/unmount cycle terminated the prior Phaser) the
           // reference-counted gate over cleanup. Future acquireMetadataReference() / unmount() calls operate on this
-          // instance.
+          // instance. Must be set before fileMapper is published below: fileMapper is volatile and isMounted() reads
+          // it without entryLock, so a lock-free caller must never be able to observe isMounted() == true before the
+          // reference gate exists.
           references.set(new ReferenceCountingCloseableObject<Closeable>(this::doActualUnmount) {});
+          fileMapper = mapper;
         }
         finally {
           entryLock.unlock();
@@ -1168,13 +1170,10 @@ public class PartialSegmentMetadataCacheEntry implements SegmentCacheEntry, Resi
   @Override
   public boolean isFullyDownloaded()
   {
-    entryLock.lock();
-    try {
-      return fileMapper != null && fileMapper.isFullyDownloaded();
-    }
-    finally {
-      entryLock.unlock();
-    }
+    // Lock-free like isMounted(): fileMapper is volatile, and its isFullyDownloaded() shares no mutable state with
+    // close(), so it's safe to call on a mapper that's concurrently unmounting.
+    final PartialSegmentFileMapperV10 mapper = fileMapper;
+    return mapper != null && mapper.isFullyDownloaded();
   }
 
   /**

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
@@ -1878,7 +1878,8 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
     private SegmentLazyLoadFailCallback lazyLoadCallback = SegmentLazyLoadFailCallback.NOOP;
     private StorageLocation location;
     private File storageDir;
-    private ReferenceCountedSegmentProvider referenceProvider;
+    // volatile so isMounted() can read it without blocking behind a concurrent mount()/unmount() holding entryLock.
+    private volatile ReferenceCountedSegmentProvider referenceProvider;
     private final AtomicReference<Runnable> onUnmount = new AtomicReference<>();
     // switched from synchronized to use a ReentrantLock to avoid pinning virtual threads to platform threads until
     // https://openjdk.org/jeps/491, we could consider switching back after java 24+ is the minimum version
@@ -1906,13 +1907,7 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
     @Override
     public boolean isMounted()
     {
-      entryLock.lock();
-      try {
-        return referenceProvider != null;
-      }
-      finally {
-        entryLock.unlock();
-      }
+      return referenceProvider != null;
     }
 
     @Override

--- a/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerConcurrencyTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerConcurrencyTest.java
@@ -19,6 +19,10 @@
 
 package org.apache.druid.segment.loading;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
@@ -59,6 +63,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -92,6 +98,7 @@ class SegmentLocalCacheManagerConcurrencyTest
   {
     jsonMapper = new DefaultObjectMapper();
     jsonMapper.registerSubtypes(new NamedType(LocalLoadSpec.class, "local"));
+    jsonMapper.registerSubtypes(new NamedType(SlowLoadSpec.class, "slow"));
     jsonMapper.setInjectableValues(
         new InjectableValues.Std().addValue(
             LocalDataSegmentPuller.class,
@@ -252,6 +259,45 @@ class SegmentLocalCacheManagerConcurrencyTest
 
     Assertions.assertEquals(8, success);
     Assertions.assertEquals(8 * 1209, rows);
+  }
+
+  @Test
+  public void testAcquireCachedSegmentDoesNotBlockOnConcurrentMount() throws Exception
+  {
+    final File localStorageFolder = new File(tempDir, "local_storage_folder");
+    final Interval interval = Intervals.of("2019-01-01/P1D");
+    final DataSegment segment = makeSlowSegment(localStorageFolder, interval);
+
+    final String key = segment.getId().toString();
+    final CountDownLatch loadStarted = new CountDownLatch(1);
+    final CountDownLatch releaseLoad = new CountDownLatch(1);
+    SlowLoadSpec.STARTED.put(key, loadStarted);
+    SlowLoadSpec.RELEASE.put(key, releaseLoad);
+
+    try {
+      final Future<?> loadFuture = executorService.submit(() -> manager.load(segment));
+      Assertions.assertTrue(loadStarted.await(5, TimeUnit.SECONDS));
+
+      // isMounted() (and hence acquireCachedSegment) must return promptly even while mount() is in flight and
+      // holding entryLock for this same entry; it must not block until the mount finishes.
+      final Future<Optional<Segment>> readFuture =
+          executorService.submit(() -> manager.acquireCachedSegment(segment.getId(), AcquireMode.FULL));
+      final Optional<Segment> whileMounting = readFuture.get(500, TimeUnit.MILLISECONDS);
+      Assertions.assertTrue(whileMounting.isEmpty());
+
+      releaseLoad.countDown();
+      loadFuture.get(5, TimeUnit.SECONDS);
+
+      final Optional<Segment> afterMounting =
+          manager.acquireCachedSegment(segment.getId(), AcquireMode.FULL);
+      Assertions.assertTrue(afterMounting.isPresent());
+      afterMounting.get().close();
+    }
+    finally {
+      SlowLoadSpec.STARTED.remove(key);
+      SlowLoadSpec.RELEASE.remove(key);
+      segmentsToLoad.add(segment);
+    }
   }
 
   @Test
@@ -854,6 +900,36 @@ class SegmentLocalCacheManagerConcurrencyTest
     }
   }
 
+  /**
+   * Builds a segment whose load spec blocks in {@link SlowLoadSpec#loadSegment} until released via
+   * {@link SlowLoadSpec#RELEASE}, keyed by {@link SlowLoadSpec#STARTED}/{@code RELEASE}.get(segment.getId().toString()).
+   */
+  private DataSegment makeSlowSegment(File localStorageFolder, Interval interval) throws IOException
+  {
+    final String segmentPath = Paths.get(
+        localStorageFolder.getCanonicalPath(),
+        dataSource,
+        StringUtils.format("%s_%s", interval.getStart().toString(), interval.getEnd().toString()),
+        segmentVersion,
+        "0"
+    ).toString();
+    final File localSegmentFile = new File(localStorageFolder, segmentPath + "_build");
+    final File indexZip = new File(new File(localStorageFolder, segmentPath), "index.zip");
+    SegmentLocalCacheManagerTest.makeSegmentZip(localSegmentFile, indexZip);
+
+    final DataSegment segment = newSegment(interval, 0, 1000);
+    return segment.withLoadSpec(
+        ImmutableMap.of(
+            "type",
+            "slow",
+            "key",
+            segment.getId().toString(),
+            "path",
+            indexZip.getAbsolutePath()
+        )
+    );
+  }
+
   private DataSegment newSegment(Interval interval, int partitionId, long size)
   {
     return DataSegment.builder()
@@ -887,6 +963,48 @@ class SegmentLocalCacheManagerConcurrencyTest
       this.exceptions = exceptions;
       this.success = success;
       this.rows = rows;
+    }
+  }
+
+  /**
+   * A {@link LoadSpec} that blocks in {@link #loadSegment} until released, so tests can hold {@code entryLock} open
+   * across {@code CompleteSegmentCacheEntry.mount()} for as long as they need. Looked up by a {@code key} property
+   * (rather than passed directly) since {@link LoadSpec} is deserialized from {@link DataSegment#getLoadSpec()}.
+   */
+  @JsonTypeName("slow")
+  public static class SlowLoadSpec implements LoadSpec
+  {
+    static final ConcurrentHashMap<String, CountDownLatch> STARTED = new ConcurrentHashMap<>();
+    static final ConcurrentHashMap<String, CountDownLatch> RELEASE = new ConcurrentHashMap<>();
+
+    private final LocalDataSegmentPuller puller;
+    private final String key;
+    private final String path;
+
+    @JsonCreator
+    public SlowLoadSpec(
+        @JacksonInject LocalDataSegmentPuller puller,
+        @JsonProperty(value = "key", required = true) String key,
+        @JsonProperty(value = "path", required = true) String path
+    )
+    {
+      this.puller = puller;
+      this.key = key;
+      this.path = path;
+    }
+
+    @Override
+    public LoadSpecResult loadSegment(File outDir) throws SegmentLoadingException
+    {
+      STARTED.get(key).countDown();
+      try {
+        RELEASE.get(key).await();
+      }
+      catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
+      }
+      return new LoadSpecResult(puller.getSegmentFiles(new File(path), outDir).size());
     }
   }
 


### PR DESCRIPTION
 
### Description
isMounted() is a cheap, frequent status check, but in several cache entry types it took entryLock — the same lock mount/unmount hold across slow work (deep-storage reads, file close, header deletion, container eviction). A concurrent mount/unmount could stall unrelated isMounted() callers for the full duration of that work.                                                                  
                                                                                                                                     
Made the mounted-flag volatile and dropped the lock from isMounted() in:                                                           
  - SegmentLocalCacheManager.CompleteSegmentCacheEntry (referenceProvider)                                                           
  - PartialSegmentMetadataCacheEntry (fileMapper)                                                                                    
  - PartialSegmentBundleCacheEntry (mounted)          
<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.