### PR TITLE
feat: emit lane and priority in query metrics

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -47,13 +47,13 @@ Most metric values reset each emission period, as specified in `druid.monitoring
 
 |Metric|Description|Dimensions|Normal value|
 |------|-----------|----------|------------|
-|`query/time`|Milliseconds taken to complete a query.|Native Query: `dataSource`, `type`, `interval`, `hasFilters`, `duration`, `context`, `remoteAddress`, `id`, `statusCode`.|< 1s|
+|`query/time`|Milliseconds taken to complete a query.|Native Query: `dataSource`, `type`, `interval`, `hasFilters`, `duration`, `context`, `remoteAddress`, `id`, `statusCode`, `priority`, `lane` (only for queries assigned to a lane).|< 1s|
 
 ### Broker
 
 |Metric|Description|Dimensions|Normal value|
 |------|-----------|----------|------------|
-|`query/time`|Milliseconds taken to complete a query.|<p>Common: `dataSource`, `type`, `interval`, `hasFilters`, `duration`, `context`, `remoteAddress`, `id`, `statusCode`.</p><p>Aggregation Queries: `numMetrics`, `numComplexMetrics`.</p><p>GroupBy: `numDimensions`.</p><p> TopN: `threshold`, `dimension`.</p>|< 1s|
+|`query/time`|Milliseconds taken to complete a query.|<p>Common: `dataSource`, `type`, `interval`, `hasFilters`, `duration`, `context`, `remoteAddress`, `id`, `statusCode`, `priority`, `lane` (only for queries assigned to a lane).</p><p>Aggregation Queries: `numMetrics`, `numComplexMetrics`.</p><p>GroupBy: `numDimensions`.</p><p> TopN: `threshold`, `dimension`.</p>|< 1s|
 |`query/bytes`|The total number of bytes returned to the requesting client in the query response from the broker. Other services report the total bytes for their portion of the query. |<p>Common: `dataSource`, `type`, `interval`, `hasFilters`, `duration`, `context`, `remoteAddress`, `id`.</p><p> Aggregation Queries: `numMetrics`, `numComplexMetrics`.</p><p> GroupBy: `numDimensions`.</p><p> TopN: `threshold`, `dimension`.</p>| |
 |`query/node/time`|Milliseconds taken to query individual historical/realtime processes.|`id`, `status`, `server`|< 1s|
 |`query/resultCache/hit`|Whether the query hit the result cache (1) or not (0). Emission of the metric indicates the result-level cache was polled.|<p>Common: `dataSource`, `type`, `interval`, `hasFilters`, `duration`, `context`, `remoteAddress`, `id`.</p>|Varies|
@@ -106,7 +106,7 @@ Most metric values reset each emission period, as specified in `druid.monitoring
 
 |Metric|Description|Dimensions|Normal value|
 |------|-----------|----------|------------|
-|`query/time`|Milliseconds taken to complete a query.|<p>Common: `dataSource`, `type`, `interval`, `hasFilters`, `duration`, `context`, `remoteAddress`, `id`, `statusCode`.</p><p> Aggregation Queries: `numMetrics`, `numComplexMetrics`.</p><p> GroupBy: `numDimensions`.</p><p> TopN: `threshold`, `dimension`.</p>|< 1s|
+|`query/time`|Milliseconds taken to complete a query.|<p>Common: `dataSource`, `type`, `interval`, `hasFilters`, `duration`, `context`, `remoteAddress`, `id`, `statusCode`, `priority`, `lane` (only for queries assigned to a lane).</p><p> Aggregation Queries: `numMetrics`, `numComplexMetrics`.</p><p> GroupBy: `numDimensions`.</p><p> TopN: `threshold`, `dimension`.</p>|< 1s|
 |`query/segments/count`|This metric is not enabled by default. Number of segments this Historical scans for a query.|<p>Common: `dataSource`, `type`, `interval`, `hasFilters`, `duration`, `context`, `remoteAddress`, `id`.</p><p> Aggregation Queries: `numMetrics`, `numComplexMetrics`.</p><p> GroupBy: `numDimensions`.</p><p> TopN: `threshold`, `dimension`.</p>|Varies|
 |`query/segment/time`|Milliseconds taken to query individual segment. Includes time to page in the segment from disk.|`id`, `status`, `segment`, `vectorized`.|several hundred milliseconds|
 |`query/wait/time`|Milliseconds spent waiting for a segment to be scanned.|`id`, `segment`|< several hundred milliseconds|
@@ -141,7 +141,7 @@ to represent the task ID are deprecated and will be removed in a future release.
 
 |Metric|Description|Dimensions|Normal value|
 |------|-----------|----------|------------|
-|`query/time`|Milliseconds taken to complete a query.|<p>Common: `dataSource`, `type`, `interval`, `hasFilters`, `duration`, `context`, `remoteAddress`, `id`, `statusCode`.</p><p> Aggregation Queries: `numMetrics`, `numComplexMetrics`.</p><p> GroupBy: `numDimensions`.</p><p> TopN: `threshold`, `dimension`.</p>|< 1s|
+|`query/time`|Milliseconds taken to complete a query.|<p>Common: `dataSource`, `type`, `interval`, `hasFilters`, `duration`, `context`, `remoteAddress`, `id`, `statusCode`, `priority`, `lane` (only for queries assigned to a lane).</p><p> Aggregation Queries: `numMetrics`, `numComplexMetrics`.</p><p> GroupBy: `numDimensions`.</p><p> TopN: `threshold`, `dimension`.</p>|< 1s|
 |`query/segments/count`|This metric is not enabled by default. Number of segments this Peon scans for a query.|<p>Common: `dataSource`, `type`, `interval`, `hasFilters`, `duration`, `context`, `remoteAddress`, `id`.</p><p> Aggregation Queries: `numMetrics`, `numComplexMetrics`.</p><p> GroupBy: `numDimensions`. </p><p>TopN: `threshold`, `dimension`.</p>|Varies|
 |`query/wait/time`|Milliseconds spent waiting for a segment to be scanned.|`id`, `segment`|several hundred milliseconds|
 |`segment/scan/pending`|Number of segments in queue waiting to be scanned.||Close to 0|

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/QueryLaningHiLoTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/QueryLaningHiLoTest.java
@@ -25,20 +25,25 @@ import org.apache.druid.query.http.ClientSqlQuery;
 import org.apache.druid.sql.http.ResultFormat;
 import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-public class QueryLaningTest extends QueryTestBase
+/**
+ * Covers the case the {@code manual} strategy in {@link QueryLaningTest} cannot: the {@code hilo} strategy derives the
+ * lane from the priority, so a negative-priority query is assigned to the {@code low} lane even though its context
+ * never carried a lane. The lane therefore only reaches {@code query/time} if the scheduler's assignment is reported
+ * back to the query lifecycle, which captured the query before the scheduler ran.
+ */
+public class QueryLaningHiLoTest extends QueryTestBase
 {
-  private static final String LANE_1 = "lane1";
+  private static final String LOW_LANE = "low";
 
   @Override
   protected EmbeddedDruidCluster createCluster()
   {
-    broker.addProperty("druid.query.scheduler.laning.strategy", "manual")
-          .addProperty("druid.query.scheduler.laning.lanes." + LANE_1, "1");
+    broker.addProperty("druid.query.scheduler.laning.strategy", "hilo")
+          .addProperty("druid.query.scheduler.laning.maxLowPercent", "50");
 
     return super.createCluster().useDefaultTimeoutForLatchableEmitter(100);
   }
@@ -50,44 +55,27 @@ public class QueryLaningTest extends QueryTestBase
   }
 
   @Test
-  public void test_queryUsesLaneInQueryContext_inManualStrategy()
+  public void test_queryTimeReportsStrategyAssignedLane_inHiLoStrategy()
   {
     final String testDatasource = ingestBasicData();
     final String result = cluster.callApi().onAnyBroker(
-        b -> b.submitSqlQuery(createQuery("SELECT SUM(\"value\") FROM %s", testDatasource, LANE_1))
+        b -> b.submitSqlQuery(createNegativePriorityQuery("SELECT SUM(\"value\") FROM %s", testDatasource))
     ).trim();
     Assertions.assertEquals("3003.0", result);
 
     broker.latchableEmitter().waitForEvent(
-        event -> event.hasMetricName("query/priority").hasDimension("lane", LANE_1)
+        event -> event.hasMetricName("query/priority").hasDimension("lane", LOW_LANE)
     );
 
-    // The manual strategy echoes back the context lane, so this only covers the context-derived dimension. See
-    // QueryLaningHiLoTest for the case where the strategy assigns a lane the context never carried.
+    // The lane was never in the query context; only the laning strategy knows it.
     broker.latchableEmitter().waitForEvent(
-        event -> event.hasMetricName("query/time").hasDimension("lane", LANE_1)
+        event -> event.hasMetricName("query/time")
+                      .hasDimension("lane", LOW_LANE)
+                      .hasDimension("priority", -1)
     );
   }
 
-  @Test
-  @Disabled("sleep() function does not seem to keep the lane occupied")
-  public void test_queryFails_ifLaneIsFull()
-  {
-    final String testDatasource = ingestBasicData();
-
-    // Fire a slow query which keeps the lane occupied
-    executeQueryAsync(
-        routerEndpoint,
-        createQuery("SELECT sleep(10), SUM(\"value\") FROM %s", testDatasource, LANE_1)
-    );
-
-    // Fire another query and ensure that we get a capacity exceeded exception
-    cluster.callApi().onAnyBroker(
-        b -> b.submitSqlQuery(createQuery("SELECT SUM(\"value\") FROM %s", testDatasource, LANE_1))
-    );
-  }
-
-  private ClientSqlQuery createQuery(String sql, String dataSource, String lane)
+  private ClientSqlQuery createNegativePriorityQuery(String sql, String dataSource)
   {
     return new ClientSqlQuery(
         StringUtils.format(sql, dataSource),
@@ -95,7 +83,7 @@ public class QueryLaningTest extends QueryTestBase
         false,
         false,
         false,
-        Map.of(QueryContexts.LANE_KEY, lane),
+        Map.of(QueryContexts.PRIORITY_KEY, -1),
         null
     );
   }

--- a/extensions-contrib/grpc-query/src/main/java/org/apache/druid/grpc/server/QueryDriver.java
+++ b/extensions-contrib/grpc-query/src/main/java/org/apache/druid/grpc/server/QueryDriver.java
@@ -44,6 +44,7 @@ import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryConfigProvider;
 import org.apache.druid.query.QueryInterruptedException;
 import org.apache.druid.query.QueryToolChest;
+import org.apache.druid.query.context.ResponseContext;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
@@ -175,6 +176,9 @@ public class QueryDriver
     }
 
     final org.apache.druid.server.QueryResponse queryResponse;
+    // Read in the finally block to report the scheduler-assigned lane and priority; stays null if execute() is never
+    // reached.
+    ResponseContext responseContext = null;
     final String currThreadName = Thread.currentThread().getName();
     Throwable caught = null;
     try {
@@ -184,6 +188,7 @@ public class QueryDriver
         throw new ForbiddenException(Access.DEFAULT_ERROR_MESSAGE);
       }
       queryResponse = queryLifecycle.execute();
+      responseContext = queryResponse.getResponseContext();
 
       QueryToolChest queryToolChest = queryLifecycle.getToolChest();
 
@@ -213,7 +218,7 @@ public class QueryDriver
                           .build();
     }
     finally {
-      queryLifecycle.emitLogsAndMetrics(caught, null, -1);
+      queryLifecycle.emitLogsAndMetrics(caught, null, -1, responseContext);
       Thread.currentThread().setName(currThreadName);
     }
   }

--- a/extensions-contrib/prometheus-emitter/src/main/resources/defaultMetrics.json
+++ b/extensions-contrib/prometheus-emitter/src/main/resources/defaultMetrics.json
@@ -1,5 +1,5 @@
 {
-  "query/time" : { "dimensions" : ["dataSource", "type"], "type" : "timer", "conversionFactor": 1000.0, "help":  "Seconds taken to complete a query."},
+  "query/time" : { "dimensions" : ["dataSource", "type", "lane", "priority"], "type" : "timer", "conversionFactor": 1000.0, "help":  "Seconds taken to complete a query."},
   "query/bytes" : { "dimensions" : ["dataSource", "type"], "type" : "count", "help":  "Number of bytes returned in query response."},
   "query/node/time" : { "dimensions" : ["server"], "type" : "timer", "conversionFactor": 1000.0, "help": "Seconds taken to query individual historical/realtime processes."},
   "query/node/bytes" : { "dimensions" : ["server"], "type" : "count", "help": "Number of bytes returned from querying individual historical/realtime processes."},

--- a/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/MetricsTest.java
+++ b/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/MetricsTest.java
@@ -41,7 +41,9 @@ public class MetricsTest
     Assert.assertEquals("dataSource", dimensions[0]);
     Assert.assertEquals("druid_service", dimensions[1]);
     Assert.assertEquals("host_name", dimensions[2]);
-    Assert.assertEquals("type", dimensions[3]);
+    Assert.assertEquals("lane", dimensions[3]);
+    Assert.assertEquals("priority", dimensions[4]);
+    Assert.assertEquals("type", dimensions[5]);
     Assert.assertEquals(1000.0, dimensionsAndCollector.getConversionFactor(), 0.0);
     double[] defaultHistogramBuckets = {0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0, 30.0, 60.0, 120.0, 300.0};
     Assert.assertArrayEquals(defaultHistogramBuckets, dimensionsAndCollector.getHistogramBuckets(), 0.0);
@@ -70,7 +72,9 @@ public class MetricsTest
     Assert.assertEquals("druid_service", dimensions[1]);
     Assert.assertEquals("extra_label", dimensions[2]);
     Assert.assertEquals("host_name", dimensions[3]);
-    Assert.assertEquals("type", dimensions[4]);
+    Assert.assertEquals("lane", dimensions[4]);
+    Assert.assertEquals("priority", dimensions[5]);
+    Assert.assertEquals("type", dimensions[6]);
     Assert.assertEquals(1000.0, dimensionsAndCollector.getConversionFactor(), 0.0);
     double[] defaultHistogramBuckets = {0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0, 30.0, 60.0, 120.0, 300.0};
     Assert.assertArrayEquals(defaultHistogramBuckets, dimensionsAndCollector.getHistogramBuckets(), 0.0);

--- a/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
@@ -1,5 +1,5 @@
 {
-  "query/time" : { "dimensions" : ["dataSource", "type"], "type" : "timer"},
+  "query/time" : { "dimensions" : ["dataSource", "type", "lane", "priority"], "type" : "timer"},
   "query/bytes" : { "dimensions" : ["dataSource", "type"], "type" : "count"},
   "query/node/time" : { "dimensions" : ["server"], "type" : "timer"},
   "query/node/ttfb" : { "dimensions" : ["server"], "type" : "timer"},

--- a/processing/src/main/java/org/apache/druid/query/DefaultQueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/DefaultQueryMetrics.java
@@ -28,6 +28,7 @@ import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.joda.time.Interval;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -110,6 +111,8 @@ public class DefaultQueryMetrics<QueryType extends Query<?>> implements QueryMet
     subQueryId(query);
     sqlQueryId(query);
     context(query);
+    lane(query);
+    priority(query);
   }
 
   @Override
@@ -180,6 +183,34 @@ public class DefaultQueryMetrics<QueryType extends Query<?>> implements QueryMet
   public void context(QueryType query)
   {
     setDimension("context", query.getContext() == null ? ImmutableMap.of() : query.getContext());
+  }
+
+  @Override
+  public void lane(QueryType query)
+  {
+    lane(query.context().getLane());
+  }
+
+  @Override
+  public void lane(@Nullable String lane)
+  {
+    // An unlaned query is not in any lane -- the scheduler gives it no lane bulkhead, only the 'total' one -- so emit
+    // no dimension at all rather than inventing a lane name for it.
+    if (lane != null) {
+      setDimension(DruidMetrics.LANE, lane);
+    }
+  }
+
+  @Override
+  public void priority(QueryType query)
+  {
+    priority(query.context().getPriority());
+  }
+
+  @Override
+  public void priority(int priority)
+  {
+    setDimension(DruidMetrics.PRIORITY, priority);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/DruidMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/DruidMetrics.java
@@ -42,6 +42,8 @@ public class DruidMetrics
   public static final String ENGINE = "engine";
   public static final String DURATION = "duration";
   public static final String SUCCESS = "success";
+  public static final String LANE = "lane";
+  public static final String PRIORITY = "priority";
 
   // Task dimensions
   public static final String TASK_ID = "taskId";

--- a/processing/src/main/java/org/apache/druid/query/QueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryMetrics.java
@@ -27,6 +27,7 @@ import org.apache.druid.query.filter.Filter;
 import org.apache.druid.query.filter.FilterBundle;
 import org.apache.druid.query.search.SearchQueryMetricsFactory;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -232,6 +233,57 @@ public interface QueryMetrics<QueryType extends Query<?>>
    */
   @PublicApi
   void context(QueryType query);
+
+  /**
+   * Sets the query lane as dimension, read from the query context. Emits no dimension when the query is not laned,
+   * since an unlaned query is genuinely in no lane.
+   *
+   * <p>On a Broker the lane may instead be assigned by the laning strategy after this is called; see
+   * {@link #lane(String)}.
+   *
+   * <p>Defaults to emitting nothing, so that implementations outside this repository keep compiling.
+   */
+  @PublicApi
+  default void lane(@SuppressWarnings("UnusedParameters") QueryType query)
+  {
+    // Emit nothing by default.
+  }
+
+  /**
+   * Sets the given lane as dimension, overriding any value derived from the query context. Used on the Broker to
+   * report the lane that the laning strategy actually assigned. A null lane emits no dimension.
+   *
+   * <p>Defaults to emitting nothing, so that implementations outside this repository keep compiling.
+   */
+  @PublicApi
+  default void lane(@SuppressWarnings("UnusedParameters") @Nullable String lane)
+  {
+    // Emit nothing by default.
+  }
+
+  /**
+   * Sets the query priority as dimension, read from the query context. Reports
+   * {@link QueryContexts#DEFAULT_PRIORITY} when the query has no explicit priority.
+   *
+   * <p>Defaults to emitting nothing, so that implementations outside this repository keep compiling.
+   */
+  @PublicApi
+  default void priority(@SuppressWarnings("UnusedParameters") QueryType query)
+  {
+    // Emit nothing by default.
+  }
+
+  /**
+   * Sets the given priority as dimension, overriding any value derived from the query context. Used on the Broker to
+   * report the priority that the prioritization strategy actually assigned.
+   *
+   * <p>Defaults to emitting nothing, so that implementations outside this repository keep compiling.
+   */
+  @PublicApi
+  default void priority(@SuppressWarnings("UnusedParameters") int priority)
+  {
+    // Emit nothing by default.
+  }
 
   void server(String host);
 

--- a/processing/src/main/java/org/apache/druid/query/context/ResponseContext.java
+++ b/processing/src/main/java/org/apache/druid/query/context/ResponseContext.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.druid.guice.annotations.ExtensionPoint;
 import org.apache.druid.guice.annotations.PublicApi;
@@ -38,6 +39,7 @@ import org.apache.druid.query.SegmentDescriptor;
 import org.apache.druid.utils.CollectionUtils;
 import org.joda.time.Interval;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -462,6 +464,27 @@ public abstract class ResponseContext
     );
 
     /**
+     * Lane assigned to the query by the laning strategy on the Broker. The assignment happens after the query
+     * lifecycle has captured the query, so it is passed back through the response context purely so that the query
+     * metrics can report the lane that was actually used. Broker-local; never sent to the client or to data servers,
+     * and never expected back from a data server.
+     */
+    public static final Key ASSIGNED_LANE = new StringKey(
+        "assignedLane",
+        false, false
+    );
+
+    /**
+     * Priority assigned to the query by the prioritization strategy on the Broker. See {@link #ASSIGNED_LANE}. Held
+     * as a long because that is the narrowest numeric key type available here, but the value is always an
+     * {@code int}.
+     */
+    public static final Key ASSIGNED_PRIORITY = new LongKey(
+        "assignedPriority",
+        false
+    );
+
+    /**
      * One and only global list of keys. This is a semi-constant: it is mutable
      * at start-up time, but then is not thread-safe, and must remain unchanged
      * for the duration of the server run.
@@ -488,7 +511,9 @@ public abstract class ResponseContext
               TIMEOUT_AT,
               NUM_SCANNED_ROWS,
               CPU_CONSUMED_NANOS,
-              TRUNCATED
+              TRUNCATED,
+              ASSIGNED_LANE,
+              ASSIGNED_PRIORITY
           }
       );
     }
@@ -631,6 +656,20 @@ public abstract class ResponseContext
     putValue(Keys.ETAG, eTag);
   }
 
+  /**
+   * @throws NullPointerException if {@code lane} is null. There is no way to unset a key, so callers that may not have
+   *                              a lane must simply not call this.
+   */
+  public void putAssignedLane(@Nonnull String lane)
+  {
+    putValue(Keys.ASSIGNED_LANE, Preconditions.checkNotNull(lane, "lane"));
+  }
+
+  public void putAssignedPriority(int priority)
+  {
+    putValue(Keys.ASSIGNED_PRIORITY, (long) priority);
+  }
+
   public void putTimeoutTime(long time)
   {
     putValue(Keys.TIMEOUT_AT, time);
@@ -676,6 +715,18 @@ public abstract class ResponseContext
   public String getEntityTag()
   {
     return (String) get(Keys.ETAG);
+  }
+
+  @Nullable
+  public String getAssignedLane()
+  {
+    return (String) get(Keys.ASSIGNED_LANE);
+  }
+
+  @Nullable
+  public Long getAssignedPriority()
+  {
+    return (Long) get(Keys.ASSIGNED_PRIORITY);
   }
 
   public AtomicLong getTotalBytes()

--- a/processing/src/main/java/org/apache/druid/query/search/DefaultSearchQueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/search/DefaultSearchQueryMetrics.java
@@ -122,6 +122,30 @@ public class DefaultSearchQueryMetrics implements SearchQueryMetrics
   }
 
   @Override
+  public void lane(SearchQuery query)
+  {
+    throw new ISE("Unsupported method in default query metrics implementation.");
+  }
+
+  @Override
+  public void lane(String lane)
+  {
+    delegateQueryMetrics.lane(lane);
+  }
+
+  @Override
+  public void priority(SearchQuery query)
+  {
+    throw new ISE("Unsupported method in default query metrics implementation.");
+  }
+
+  @Override
+  public void priority(int priority)
+  {
+    delegateQueryMetrics.priority(priority);
+  }
+
+  @Override
   public void server(String host)
   {
     delegateQueryMetrics.server(host);

--- a/processing/src/test/java/org/apache/druid/query/DefaultQueryMetricsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/DefaultQueryMetricsTest.java
@@ -72,7 +72,7 @@ public class DefaultQueryMetricsTest extends InitializedNullHandlingTest
     queryMetrics.queryId("dummy");
     queryMetrics.reportQueryTime(0).emit(serviceEmitter);
     Map<String, Object> actualEvent = serviceEmitter.getEvents().get(0).toMap();
-    Assertions.assertEquals(13, actualEvent.size());
+    Assertions.assertEquals(14, actualEvent.size());
     Assertions.assertTrue(actualEvent.containsKey("feed"));
     Assertions.assertTrue(actualEvent.containsKey("timestamp"));
     Assertions.assertEquals("localhost", actualEvent.get("host"));
@@ -89,6 +89,8 @@ public class DefaultQueryMetricsTest extends InitializedNullHandlingTest
     Assertions.assertEquals("query/time", actualEvent.get("metric"));
     Assertions.assertEquals(0L, actualEvent.get("value"));
     Assertions.assertEquals(ImmutableMap.of("testKey", "testValue"), actualEvent.get("context"));
+    Assertions.assertFalse(actualEvent.containsKey(DruidMetrics.LANE));
+    Assertions.assertEquals(QueryContexts.DEFAULT_PRIORITY, actualEvent.get(DruidMetrics.PRIORITY));
   }
 
   @Test
@@ -139,6 +141,94 @@ public class DefaultQueryMetricsTest extends InitializedNullHandlingTest
     // and the total number of emitted metrics remains unchanged
     queryMetrics.reportQueriedSegmentCount(25).emit(serviceEmitter);
     Assertions.assertEquals(10, serviceEmitter.getNumEmittedEvents());
+  }
+
+  @Test
+  public void testLaneAndPriorityReadFromQueryContext()
+  {
+    final StubServiceEmitter serviceEmitter = StubServiceEmitter.createStarted();
+    final DefaultQueryMetrics<Query<?>> queryMetrics = new DefaultQueryMetrics<>();
+
+    queryMetrics.query(
+        makeQueryWithContext(ImmutableMap.of(QueryContexts.LANE_KEY, "low", QueryContexts.PRIORITY_KEY, -5))
+    );
+    queryMetrics.reportQueryTime(0).emit(serviceEmitter);
+
+    final Map<String, Object> actualEvent = serviceEmitter.getEvents().get(0).toMap();
+    Assertions.assertEquals("low", actualEvent.get(DruidMetrics.LANE));
+    Assertions.assertEquals(-5, actualEvent.get(DruidMetrics.PRIORITY));
+  }
+
+  /**
+   * An unlaned query is in no lane at all -- the scheduler gives it no lane bulkhead -- so no lane dimension is
+   * emitted rather than a fabricated one. Priority always has a value, so it is always emitted.
+   */
+  @Test
+  public void testUnlanedQueryOmitsLaneAndReportsDefaultPriority()
+  {
+    final StubServiceEmitter serviceEmitter = StubServiceEmitter.createStarted();
+    final DefaultQueryMetrics<Query<?>> queryMetrics = new DefaultQueryMetrics<>();
+
+    queryMetrics.query(makeQueryWithContext(ImmutableMap.of()));
+    queryMetrics.reportQueryTime(0).emit(serviceEmitter);
+
+    final Map<String, Object> actualEvent = serviceEmitter.getEvents().get(0).toMap();
+    Assertions.assertFalse(actualEvent.containsKey(DruidMetrics.LANE));
+    Assertions.assertEquals(QueryContexts.DEFAULT_PRIORITY, actualEvent.get(DruidMetrics.PRIORITY));
+  }
+
+  /**
+   * The direct setters are what the Broker uses to report the lane/priority the scheduler actually assigned, which can
+   * differ from whatever the caller put in the context.
+   */
+  @Test
+  public void testDirectLaneAndPriorityOverrideQueryContext()
+  {
+    final StubServiceEmitter serviceEmitter = StubServiceEmitter.createStarted();
+    final DefaultQueryMetrics<Query<?>> queryMetrics = new DefaultQueryMetrics<>();
+
+    queryMetrics.query(
+        makeQueryWithContext(ImmutableMap.of(QueryContexts.LANE_KEY, "low", QueryContexts.PRIORITY_KEY, -5))
+    );
+    queryMetrics.lane("high");
+    queryMetrics.priority(10);
+    queryMetrics.reportQueryTime(0).emit(serviceEmitter);
+
+    final Map<String, Object> actualEvent = serviceEmitter.getEvents().get(0).toMap();
+    Assertions.assertEquals("high", actualEvent.get(DruidMetrics.LANE));
+    Assertions.assertEquals(10, actualEvent.get(DruidMetrics.PRIORITY));
+  }
+
+  /**
+   * Dimensions live on a shared builder, so lane/priority ride along on every metric emitted by the same instance.
+   */
+  @Test
+  public void testLaneAndPriorityPresentOnOtherQueryMetrics()
+  {
+    final StubServiceEmitter serviceEmitter = StubServiceEmitter.createStarted();
+    final DefaultQueryMetrics<Query<?>> queryMetrics = new DefaultQueryMetrics<>();
+
+    queryMetrics.query(makeQueryWithContext(ImmutableMap.of(QueryContexts.LANE_KEY, "low")));
+    queryMetrics.reportQueryBytes(42).emit(serviceEmitter);
+
+    final Map<String, Object> actualEvent = serviceEmitter.getEvents().get(0).toMap();
+    Assertions.assertEquals("query/bytes", actualEvent.get("metric"));
+    Assertions.assertEquals("low", actualEvent.get(DruidMetrics.LANE));
+    Assertions.assertEquals(QueryContexts.DEFAULT_PRIORITY, actualEvent.get(DruidMetrics.PRIORITY));
+  }
+
+  private static TopNQuery makeQueryWithContext(Map<String, Object> context)
+  {
+    return new TopNQueryBuilder()
+        .dataSource("xx")
+        .granularity(Granularities.ALL)
+        .dimension(new DefaultDimensionSpec("tags", "tags"))
+        .metric("count")
+        .intervals(QueryRunnerTestHelper.FULL_ON_INTERVAL_SPEC)
+        .aggregators(new CountAggregatorFactory("count"))
+        .threshold(5)
+        .context(context)
+        .build();
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/query/context/ResponseContextTest.java
+++ b/processing/src/test/java/org/apache/druid/query/context/ResponseContextTest.java
@@ -88,6 +88,36 @@ public class ResponseContextTest
     Assert.assertEquals("new-dummy-etag", ctx.getEntityTag());
   }
 
+  @Test
+  public void assignedLaneAndPriorityTest()
+  {
+    final ResponseContext ctx = ResponseContext.createEmpty();
+    Assert.assertNull(ctx.getAssignedLane());
+    Assert.assertNull(ctx.getAssignedPriority());
+
+    ctx.putAssignedLane("low");
+    ctx.putAssignedPriority(-5);
+    Assert.assertEquals("low", ctx.getAssignedLane());
+    Assert.assertEquals(Long.valueOf(-5), ctx.getAssignedPriority());
+
+    // Latest assignment wins
+    ctx.putAssignedLane("high");
+    ctx.putAssignedPriority(10);
+    Assert.assertEquals("high", ctx.getAssignedLane());
+    Assert.assertEquals(Long.valueOf(10), ctx.getAssignedPriority());
+  }
+
+  /**
+   * These keys are Broker-local: they exist only to carry the scheduler's assignment back to the query lifecycle, and
+   * must never be serialized into the response header sent to callers.
+   */
+  @Test
+  public void assignedLaneAndPriorityAreNotInHeaderTest()
+  {
+    Assert.assertFalse(Keys.ASSIGNED_LANE.includeInHeader());
+    Assert.assertFalse(Keys.ASSIGNED_PRIORITY.includeInHeader());
+  }
+
   private static final Interval INTERVAL_01 = Intervals.of("2019-01-01/P1D");
   private static final Interval INTERVAL_12 = Intervals.of("2019-01-02/P1D");
   private static final Interval INTERVAL_23 = Intervals.of("2019-01-03/P1D");

--- a/processing/src/test/java/org/apache/druid/query/groupby/DefaultGroupByQueryMetricsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/DefaultGroupByQueryMetricsTest.java
@@ -75,7 +75,7 @@ public class DefaultGroupByQueryMetricsTest extends InitializedNullHandlingTest
 
     queryMetrics.reportQueryTime(0).emit(serviceEmitter);
     Map<String, Object> actualEvent = serviceEmitter.getEvents().get(0).toMap();
-    Assertions.assertEquals(16, actualEvent.size());
+    Assertions.assertEquals(17, actualEvent.size());
     Assertions.assertTrue(actualEvent.containsKey("feed"));
     Assertions.assertTrue(actualEvent.containsKey("timestamp"));
     Assertions.assertEquals("localhost", actualEvent.get("host"));

--- a/processing/src/test/java/org/apache/druid/query/search/DefaultSearchQueryMetricsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/search/DefaultSearchQueryMetricsTest.java
@@ -67,7 +67,7 @@ public class DefaultSearchQueryMetricsTest extends InitializedNullHandlingTest
 
     queryMetrics.reportQueryTime(0).emit(serviceEmitter);
     Map<String, Object> actualEvent = serviceEmitter.getEvents().get(0).toMap();
-    Assertions.assertEquals(13, actualEvent.size());
+    Assertions.assertEquals(14, actualEvent.size());
     Assertions.assertTrue(actualEvent.containsKey("feed"));
     Assertions.assertTrue(actualEvent.containsKey("timestamp"));
     Assertions.assertEquals("localhost", actualEvent.get("host"));
@@ -88,6 +88,35 @@ public class DefaultSearchQueryMetricsTest extends InitializedNullHandlingTest
     Assertions.assertEquals(0L, actualEvent.get("value"));
 
     Assertions.assertThrows(ISE.class, () -> queryMetrics.sqlQueryId("dummy"));
+  }
+
+  /**
+   * The query-derived variants are unsupported here (the delegate already applied them), but the direct setters must
+   * delegate, since the Broker uses them to report the lane/priority the scheduler assigned.
+   */
+  @Test
+  public void testLaneAndPriorityDelegation()
+  {
+    final StubServiceEmitter serviceEmitter = StubServiceEmitter.createStarted();
+    SearchQuery query = Druids
+        .newSearchQueryBuilder()
+        .dataSource(QueryRunnerTestHelper.DATA_SOURCE)
+        .granularity(QueryRunnerTestHelper.DAY_GRAN)
+        .intervals(QueryRunnerTestHelper.FULL_ON_INTERVAL_SPEC)
+        .build();
+
+    SearchQueryMetrics queryMetrics = DefaultSearchQueryMetricsFactory.instance().makeMetrics(query);
+
+    Assertions.assertThrows(ISE.class, () -> queryMetrics.lane(query));
+    Assertions.assertThrows(ISE.class, () -> queryMetrics.priority(query));
+
+    queryMetrics.lane("high");
+    queryMetrics.priority(10);
+    queryMetrics.reportQueryTime(0).emit(serviceEmitter);
+
+    Map<String, Object> actualEvent = serviceEmitter.getEvents().get(0).toMap();
+    Assertions.assertEquals("high", actualEvent.get(DruidMetrics.LANE));
+    Assertions.assertEquals(10, actualEvent.get(DruidMetrics.PRIORITY));
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/query/timeseries/DefaultTimeseriesQueryMetricsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/timeseries/DefaultTimeseriesQueryMetricsTest.java
@@ -60,7 +60,7 @@ public class DefaultTimeseriesQueryMetricsTest extends InitializedNullHandlingTe
 
     queryMetrics.reportQueryTime(0).emit(serviceEmitter);
     Map<String, Object> actualEvent = serviceEmitter.getEvents().get(0).toMap();
-    Assertions.assertEquals(16, actualEvent.size());
+    Assertions.assertEquals(17, actualEvent.size());
     Assertions.assertTrue(actualEvent.containsKey("feed"));
     Assertions.assertTrue(actualEvent.containsKey("timestamp"));
     Assertions.assertEquals("localhost", actualEvent.get("host"));

--- a/processing/src/test/java/org/apache/druid/query/topn/DefaultTopNQueryMetricsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/topn/DefaultTopNQueryMetricsTest.java
@@ -70,7 +70,7 @@ public class DefaultTopNQueryMetricsTest extends InitializedNullHandlingTest
 
     queryMetrics.reportQueryTime(0).emit(serviceEmitter);
     Map<String, Object> actualEvent = serviceEmitter.getEvents().get(0).toMap();
-    Assertions.assertEquals(17, actualEvent.size());
+    Assertions.assertEquals(18, actualEvent.size());
     Assertions.assertTrue(actualEvent.containsKey("feed"));
     Assertions.assertTrue(actualEvent.containsKey("timestamp"));
     Assertions.assertEquals("localhost", actualEvent.get("host"));

--- a/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
+++ b/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
@@ -365,6 +365,7 @@ public class CachingClusteredClient implements QuerySegmentWalker
           pruneSegmentsWithCachedResults(queryCacheKey, segmentServers);
 
       query = scheduler.prioritizeAndLaneQuery(queryPlus, segmentServers);
+      reportLaningAssignmentToQueryLifecycle(query);
       queryPlus = queryPlus.withQuery(query);
       queryPlus = queryPlus.withQueryMetrics(toolChest);
       queryPlus.getQueryMetrics().reportQueriedSegmentCount(segmentServers.size()).emit(emitter);
@@ -381,6 +382,37 @@ public class CachingClusteredClient implements QuerySegmentWalker
       });
 
       return new ClusterQueryResult<>(scheduler.run(query, mergedResultSequence), segmentsByServer.size());
+    }
+
+    /**
+     * Reports the lane and priority the scheduler just assigned back to {@code QueryLifecycle}, which captured the
+     * query before the scheduler ran and would otherwise emit only whatever the caller happened to set in the context.
+     * <p>
+     * A single request can reach here more than once -- a union datasource fans out into one cluster query per table,
+     * and an inline subquery runs its inner query here before the outer query is merged locally. Those can be assigned
+     * different lanes, and there is only one pair of dimensions to report. The first assignment wins, so that the
+     * reported lane and priority always describe the same cluster query rather than being spliced together from
+     * several: writing on every call would let a later unlaned subquery leave an earlier subquery's lane in place while
+     * overwriting its priority. First also happens to be the most useful one, since for an inline subquery the inner
+     * cluster query is the one that actually consumed lane capacity.
+     * <p>
+     * Synchronized on the response context because those fan-outs are not guaranteed to be sequential, and a bare
+     * check-then-write would let two of them interleave into the mismatched pair this method exists to avoid. Costs one
+     * uncontended lock per cluster query.
+     */
+    private void reportLaningAssignmentToQueryLifecycle(Query<T> assignedQuery)
+    {
+      synchronized (responseContext) {
+        if (responseContext.getAssignedPriority() != null) {
+          return;
+        }
+        final String assignedLane = assignedQuery.context().getLane();
+        if (assignedLane != null) {
+          responseContext.putAssignedLane(assignedLane);
+        }
+        // Written last so that it is a valid "already reported" marker for the check above.
+        responseContext.putAssignedPriority(assignedQuery.context().getPriority());
+      }
     }
 
     private Sequence<T> merge(List<Sequence<T>> sequencesByInterval)

--- a/server/src/main/java/org/apache/druid/server/QueryLifecycle.java
+++ b/server/src/main/java/org/apache/druid/server/QueryLifecycle.java
@@ -195,7 +195,7 @@ public class QueryLifecycle
               @Override
               public void after(final boolean isDone, final Throwable thrown)
               {
-                emitLogsAndMetrics(thrown, null, -1);
+                emitLogsAndMetrics(thrown, null, -1, queryResponse.getResponseContext());
               }
             }
         ),
@@ -446,11 +446,31 @@ public class QueryLifecycle
    * @param remoteAddress remote address, for logging; or null if unknown
    * @param bytesWritten  number of bytes written; will become a query/bytes metric if >= 0
    */
-  @SuppressWarnings("unchecked")
   public void emitLogsAndMetrics(
       @Nullable final Throwable e,
       @Nullable final String remoteAddress,
       final long bytesWritten
+  )
+  {
+    emitLogsAndMetrics(e, remoteAddress, bytesWritten, null);
+  }
+
+  /**
+   * Emits logs and metrics for this query, reporting the lane and priority that the scheduler assigned.
+   *
+   * @param e               exception that occurred while processing this query
+   * @param remoteAddress   remote address, for logging; or null if unknown
+   * @param bytesWritten    number of bytes written; will become a query/bytes metric if >= 0
+   * @param responseContext response context of the executed query, as returned by {@link #execute()}; or null if the
+   *                        query never got far enough to have one, in which case the lane and priority dimensions fall
+   *                        back to whatever the query context carried
+   */
+  @SuppressWarnings("unchecked")
+  public void emitLogsAndMetrics(
+      @Nullable final Throwable e,
+      @Nullable final String remoteAddress,
+      final long bytesWritten,
+      @Nullable final ResponseContext responseContext
   )
   {
     if (baseQuery == null) {
@@ -476,6 +496,22 @@ public class QueryLifecycle
           StringUtils.nullToEmptyNonDruidDataString(remoteAddress)
       );
       queryMetrics.success(success);
+
+      // The scheduler assigns lane/priority after this lifecycle captured the query, so prefer what it reported.
+      if (responseContext != null) {
+        final String assignedLane = responseContext.getAssignedLane();
+        if (assignedLane != null) {
+          queryMetrics.lane(assignedLane);
+        }
+        final Long assignedPriority = responseContext.getAssignedPriority();
+        // Priority is an int everywhere it is set, so an out of range value can only mean the key was populated by
+        // something other than this Broker's scheduler. Keep the context-derived dimension rather than truncating.
+        if (assignedPriority != null
+            && assignedPriority >= Integer.MIN_VALUE
+            && assignedPriority <= Integer.MAX_VALUE) {
+          queryMetrics.priority(assignedPriority.intValue());
+        }
+      }
 
       final int statusCode = DruidMetrics.computeStatusCode(e);
       queryMetrics.statusCode(statusCode);

--- a/server/src/main/java/org/apache/druid/server/QueryResourceQueryResultPusherFactory.java
+++ b/server/src/main/java/org/apache/druid/server/QueryResourceQueryResultPusherFactory.java
@@ -27,6 +27,7 @@ import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.query.context.ResponseContext;
 
+import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -129,12 +130,21 @@ public class QueryResourceQueryResultPusherFactory
           final String prevEtag = getPreviousEtag(req);
 
           if (prevEtag != null && prevEtag.equals(responseContext.getEntityTag())) {
-            queryLifecycle.emitLogsAndMetrics(null, req.getRemoteAddr(), -1);
+            queryLifecycle.emitLogsAndMetrics(null, req.getRemoteAddr(), -1, responseContext);
             counter.incrementSuccess();
             return Response.status(Response.Status.NOT_MODIFIED);
           }
 
           return null;
+        }
+
+        /**
+         * Null when {@link #start()} failed before the query was executed.
+         */
+        @Nullable
+        private ResponseContext getResponseContextOrNull()
+        {
+          return queryResponse == null ? null : queryResponse.getResponseContext();
         }
 
         @Override
@@ -152,13 +162,13 @@ public class QueryResourceQueryResultPusherFactory
         @Override
         public void recordSuccess(long numBytes)
         {
-          queryLifecycle.emitLogsAndMetrics(null, req.getRemoteAddr(), numBytes);
+          queryLifecycle.emitLogsAndMetrics(null, req.getRemoteAddr(), numBytes, getResponseContextOrNull());
         }
 
         @Override
         public void recordFailure(Exception e, long bytesWritten)
         {
-          queryLifecycle.emitLogsAndMetrics(e, req.getRemoteAddr(), bytesWritten);
+          queryLifecycle.emitLogsAndMetrics(e, req.getRemoteAddr(), bytesWritten, getResponseContextOrNull());
         }
 
         @Override

--- a/server/src/main/java/org/apache/druid/server/QueryScheduler.java
+++ b/server/src/main/java/org/apache/druid/server/QueryScheduler.java
@@ -38,6 +38,7 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.core.NoopEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryCapacityExceededException;
 import org.apache.druid.query.QueryPlus;
@@ -176,7 +177,7 @@ public class QueryScheduler implements QueryWatcher
         priority.orElse(0)
     );
     final ServiceMetricEvent.Builder builderUsr = ServiceMetricEvent.builder().setFeed("metrics")
-                                                                    .setDimension("lane", lane.orElse(DEFAULT))
+                                                                    .setDimension(DruidMetrics.LANE, lane.orElse(DEFAULT))
                                                                     .setDimension("dataSource", query.getDataSource().getTableNames())
                                                                     .setDimension("type", query.getType());
     emitter.emit(builderUsr.setMetric("query/priority", priority.orElse(Integer.valueOf(0))));

--- a/server/src/test/java/org/apache/druid/client/CachingClusteredClientTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingClusteredClientTest.java
@@ -3053,6 +3053,118 @@ public class CachingClusteredClientTest
     Assert.assertEquals("RsQmZHYstvXNeGf86z3pgpk+Wsg=", responseContext.getEntityTag());
   }
 
+  /**
+   * The lane and priority the scheduler assigns must be reported back through the response context, since the query
+   * lifecycle captured the query before the scheduler ran and cannot see the assignment otherwise.
+   */
+  @Test
+  public void testAssignedLaneAndPriorityReportedInResponseContext()
+  {
+    prepareTimeBoundaryTimeline();
+
+    final TimeBoundaryQuery query = Druids
+        .newTimeBoundaryQueryBuilder()
+        .dataSource(DATA_SOURCE)
+        .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2016-01-01/2016-01-02"))))
+        .context(ImmutableMap.of(QueryContexts.LANE_KEY, "low", QueryContexts.PRIORITY_KEY, -5))
+        .randomQueryId()
+        .build();
+
+    final ResponseContext responseContext = initializeResponseContext();
+    getDefaultQueryRunner().run(QueryPlus.wrap(query), responseContext);
+
+    Assert.assertEquals("low", responseContext.getAssignedLane());
+    Assert.assertEquals(Long.valueOf(-5), responseContext.getAssignedPriority());
+  }
+
+  /**
+   * An unlaned query has no lane to report, so nothing is written; the metric then omits the lane dimension rather
+   * than inventing one. Priority always has a value.
+   */
+  @Test
+  public void testUnlanedQueryReportsNoLaneInResponseContext()
+  {
+    prepareTimeBoundaryTimeline();
+
+    final TimeBoundaryQuery query = Druids
+        .newTimeBoundaryQueryBuilder()
+        .dataSource(DATA_SOURCE)
+        .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2016-01-01/2016-01-02"))))
+        .randomQueryId()
+        .build();
+
+    final ResponseContext responseContext = initializeResponseContext();
+    getDefaultQueryRunner().run(QueryPlus.wrap(query), responseContext);
+
+    Assert.assertNull(responseContext.getAssignedLane());
+    Assert.assertEquals(
+        Long.valueOf(QueryContexts.DEFAULT_PRIORITY),
+        responseContext.getAssignedPriority()
+    );
+  }
+
+  /**
+   * A union datasource or an inline subquery drives more than one cluster query through the same response context, and
+   * those can be assigned different lanes. The first assignment must win, so that the single pair of reported
+   * dimensions always describes one cluster query instead of being spliced together from several -- writing on every
+   * call would let the second query below overwrite the priority while leaving the first query's lane behind.
+   */
+  @Test
+  public void testFirstAssignedLaneAndPriorityWinsAcrossClusterQueries()
+  {
+    prepareTimeBoundaryTimeline();
+
+    final ResponseContext responseContext = initializeResponseContext();
+
+    getDefaultQueryRunner().run(
+        QueryPlus.wrap(
+            Druids.newTimeBoundaryQueryBuilder()
+                  .dataSource(DATA_SOURCE)
+                  .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2016-01-01/2016-01-02"))))
+                  .context(ImmutableMap.of(QueryContexts.LANE_KEY, "low", QueryContexts.PRIORITY_KEY, -5))
+                  .randomQueryId()
+                  .build()
+        ),
+        responseContext
+    );
+    // A second, unlaned cluster query with a different priority must not disturb the first assignment.
+    getDefaultQueryRunner().run(
+        QueryPlus.wrap(
+            Druids.newTimeBoundaryQueryBuilder()
+                  .dataSource(DATA_SOURCE)
+                  .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2016-01-01/2016-01-02"))))
+                  .context(ImmutableMap.of(QueryContexts.PRIORITY_KEY, 10))
+                  .randomQueryId()
+                  .build()
+        ),
+        responseContext
+    );
+
+    Assert.assertEquals("low", responseContext.getAssignedLane());
+    Assert.assertEquals(Long.valueOf(-5), responseContext.getAssignedPriority());
+  }
+
+  private void prepareTimeBoundaryTimeline()
+  {
+    final Interval interval = Intervals.of("2016-01-01/2016-01-02");
+    final DataSegment dataSegment =
+        DataSegment.builder(SegmentId.of("dataSource", interval, "ver", NoneShardSpec.instance()))
+                   .loadSpec(ImmutableMap.of("type", "hdfs", "path", "/tmp"))
+                   .dimensions(ImmutableList.of("product"))
+                   .metrics(ImmutableList.of("visited_sum"))
+                   .shardSpec(NoneShardSpec.instance())
+                   .binaryVersion(9)
+                   .size(12334)
+                   .build();
+    final ServerSelector selector = new ServerSelector(
+        dataSegment,
+        new HighestPriorityTierSelectorStrategy(new RandomServerSelectorStrategy()),
+        HistoricalFilter.IDENTITY_FILTER
+    );
+    selector.addServerAndUpdateSegment(new QueryableDruidServer(servers[0], null), dataSegment);
+    timeline.add(interval, "ver", new SingleElementPartitionChunk<>(selector));
+  }
+
   @Test
   public void testEtagforDifferentQueryInterval()
   {

--- a/server/src/test/java/org/apache/druid/server/QueryLifecycleTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryLifecycleTest.java
@@ -49,6 +49,7 @@ import org.apache.druid.query.QueryToolChest;
 import org.apache.druid.query.RestrictedDataSource;
 import org.apache.druid.query.TableDataSource;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
+import org.apache.druid.query.context.ResponseContext;
 import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.query.filter.NullFilter;
 import org.apache.druid.query.metadata.metadata.SegmentMetadataQuery;
@@ -932,6 +933,72 @@ public class QueryLifecycleTest
             .andReturn(null).anyTimes();
     EasyMock.replay(request);
     return request;
+  }
+
+  /**
+   * The laning strategy assigns lane/priority inside {@link org.apache.druid.client.CachingClusteredClient}, after this
+   * lifecycle already captured the query, and reports them back through the response context. Verify the metrics use
+   * that assignment rather than whatever the caller happened to put in the context.
+   */
+  @Test
+  public void testRunSimple_reportsSchedulerAssignedLaneAndPriority()
+  {
+    EasyMock.expect(queryConfig.getContext()).andReturn(ImmutableMap.of()).anyTimes();
+    EasyMock.expect(authenticationResult.getIdentity()).andReturn(IDENTITY).anyTimes();
+    EasyMock.expect(conglomerate.getToolChest(EasyMock.anyObject())).andReturn(toolChest).once();
+    EasyMock.expect(toolChest.makeMetrics(EasyMock.anyObject())).andReturn(metrics).anyTimes();
+    EasyMock.expect(texasRanger.getQueryRunnerForIntervals(EasyMock.anyObject(), EasyMock.anyObject()))
+            .andReturn(runner)
+            .once();
+    // Stand in for the scheduler: record an assignment that differs from the query context.
+    EasyMock.expect(runner.run(EasyMock.anyObject(), EasyMock.anyObject())).andAnswer(() -> {
+      final ResponseContext responseContext = (ResponseContext) EasyMock.getCurrentArguments()[1];
+      responseContext.putAssignedLane("low");
+      responseContext.putAssignedPriority(-5);
+      return Sequences.empty();
+    }).once();
+
+    metrics.lane("low");
+    EasyMock.expectLastCall().once();
+    metrics.priority(-5);
+    EasyMock.expectLastCall().once();
+
+    replayAll();
+
+    QueryLifecycle lifecycle = createLifecycle();
+    lifecycle.runSimple(query, authenticationResult, AuthorizationResult.ALLOW_NO_RESTRICTION)
+             .getResults()
+             .toList();
+  }
+
+  /**
+   * When the query never reaches the scheduler there is nothing to override with, so the metrics keep the values
+   * {@code DefaultQueryMetrics.query()} already derived from the query context.
+   */
+  @Test
+  public void testRunSimple_noSchedulerAssignmentLeavesLaneAndPriorityAlone()
+  {
+    EasyMock.expect(queryConfig.getContext()).andReturn(ImmutableMap.of()).anyTimes();
+    EasyMock.expect(authenticationResult.getIdentity()).andReturn(IDENTITY).anyTimes();
+    EasyMock.expect(conglomerate.getToolChest(EasyMock.anyObject())).andReturn(toolChest).once();
+    EasyMock.expect(toolChest.makeMetrics(EasyMock.anyObject())).andReturn(metrics).anyTimes();
+    EasyMock.expect(texasRanger.getQueryRunnerForIntervals(EasyMock.anyObject(), EasyMock.anyObject()))
+            .andReturn(runner)
+            .once();
+    EasyMock.expect(runner.run(EasyMock.anyObject(), EasyMock.anyObject())).andReturn(Sequences.empty()).once();
+
+    // No lane(String)/priority(int) override is expected on a strict-count basis.
+    metrics.lane(EasyMock.anyString());
+    EasyMock.expectLastCall().andThrow(new AssertionError("lane must not be overridden")).anyTimes();
+    metrics.priority(EasyMock.anyInt());
+    EasyMock.expectLastCall().andThrow(new AssertionError("priority must not be overridden")).anyTimes();
+
+    replayAll();
+
+    QueryLifecycle lifecycle = createLifecycle();
+    lifecycle.runSimple(query, authenticationResult, AuthorizationResult.ALLOW_NO_RESTRICTION)
+             .getResults()
+             .toList();
   }
 
   private void replayAll()

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -40,6 +40,7 @@ import org.apache.druid.guice.annotations.Smile;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.guava.Accumulator;
 import org.apache.druid.java.util.common.guava.BaseSequence;
@@ -60,6 +61,7 @@ import org.apache.druid.query.DefaultQueryRunnerFactoryConglomerate;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryCapacityExceededException;
+import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.QueryException;
 import org.apache.druid.query.QueryInterruptedException;
 import org.apache.druid.query.QueryRunner;
@@ -70,6 +72,7 @@ import org.apache.druid.query.ResourceLimitExceededException;
 import org.apache.druid.query.Result;
 import org.apache.druid.query.SegmentDescriptor;
 import org.apache.druid.query.TruncatedResponseContextException;
+import org.apache.druid.query.context.ResponseContext;
 import org.apache.druid.query.filter.NullFilter;
 import org.apache.druid.query.policy.NoopPolicyEnforcer;
 import org.apache.druid.query.policy.RowFilterPolicy;
@@ -98,6 +101,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.joda.time.Interval;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -259,6 +263,32 @@ public class QueryResourceTest
     testRequestLogger = new TestRequestLogger();
     emitter = StubServiceEmitter.createStarted();
     queryResource = createQueryResource(ResponseContextConfig.newConfig(true));
+  }
+
+  /**
+   * Every {@code query/time} emission must carry a priority dimension, whatever the outcome of the query was — success,
+   * timeout, capacity rejection, or a failure raised anywhere in the lifecycle. Lane is only emitted when the query is
+   * actually laned, but when present it must be a String. Runs after each test so that no outcome covered by this class
+   * can silently drop or corrupt them.
+   */
+  @After
+  public void verifyLaneAndPriorityDimensions()
+  {
+    for (ServiceMetricEvent event : emitter.getMetricEvents("query/time")) {
+      final Map<String, Object> map = event.toMap();
+      MatcherAssert.assertThat(
+          StringUtils.format("priority dimension on event %s", map),
+          map.get(DruidMetrics.PRIORITY),
+          CoreMatchers.instanceOf(Integer.class)
+      );
+      if (map.containsKey(DruidMetrics.LANE)) {
+        MatcherAssert.assertThat(
+            StringUtils.format("lane dimension on event %s", map),
+            map.get(DruidMetrics.LANE),
+            CoreMatchers.instanceOf(String.class)
+        );
+      }
+    }
   }
 
   private QueryResource createQueryResource(ResponseContextConfig responseContextConfig)
@@ -427,6 +457,9 @@ public class QueryResourceTest
     Assert.assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
     emitter.verifyEmitted("query/time", 1);
     Assert.assertEquals(500, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assert.assertFalse(emitter.getMetricEvents("query/time").get(0).toMap().containsKey(DruidMetrics.LANE));
+    // server-side DefaultQueryConfig supplies priority=678 here
+    Assert.assertEquals(678, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.PRIORITY));
 
     final ErrorResponse entity = (ErrorResponse) response.getEntity();
     MatcherAssert.assertThat(
@@ -538,6 +571,8 @@ public class QueryResourceTest
 
     emitter.verifyEmitted("query/time", 1);
     Assert.assertEquals(504, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assert.assertFalse(emitter.getMetricEvents("query/time").get(0).toMap().containsKey(DruidMetrics.LANE));
+    Assert.assertEquals(QueryContexts.DEFAULT_PRIORITY, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.PRIORITY));
   }
 
   @Test
@@ -621,6 +656,8 @@ public class QueryResourceTest
     );
     emitter.verifyEmitted("query/time", 1);
     Assert.assertEquals(400, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assert.assertFalse(emitter.getMetricEvents("query/time").get(0).toMap().containsKey(DruidMetrics.LANE));
+    Assert.assertEquals(QueryContexts.DEFAULT_PRIORITY, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.PRIORITY));
   }
 
   @Test
@@ -726,6 +763,8 @@ public class QueryResourceTest
 
     emitter.verifyEmitted("query/time", 1);
     Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assert.assertFalse(emitter.getMetricEvents("query/time").get(0).toMap().containsKey(DruidMetrics.LANE));
+    Assert.assertEquals(QueryContexts.DEFAULT_PRIORITY, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.PRIORITY));
   }
 
 
@@ -782,9 +821,14 @@ public class QueryResourceTest
             )
             {
               @Override
-              public void emitLogsAndMetrics(@Nullable Throwable e, @Nullable String remoteAddress, long bytesWritten)
+              public void emitLogsAndMetrics(
+                  @Nullable Throwable e,
+                  @Nullable String remoteAddress,
+                  long bytesWritten,
+                  @Nullable ResponseContext responseContext
+              )
               {
-                super.emitLogsAndMetrics(e, remoteAddress, bytesWritten);
+                super.emitLogsAndMetrics(e, remoteAddress, bytesWritten, responseContext);
                 Assert.assertTrue(Throwables.getStackTraceAsString(e).contains(embeddedExceptionMessage));
               }
             };
@@ -820,6 +864,9 @@ public class QueryResourceTest
     );
     emitter.verifyEmitted("query/time", 1);
     Assert.assertEquals(500, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assert.assertFalse(emitter.getMetricEvents("query/time").get(0).toMap().containsKey(DruidMetrics.LANE));
+    // server-side DefaultQueryConfig supplies priority=678 here
+    Assert.assertEquals(678, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.PRIORITY));
   }
 
   @Test
@@ -883,6 +930,9 @@ public class QueryResourceTest
     );
     emitter.verifyEmitted("query/time", 1);
     Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assert.assertFalse(emitter.getMetricEvents("query/time").get(0).toMap().containsKey(DruidMetrics.LANE));
+    // query context priority=-1 wins over the server default here
+    Assert.assertEquals(-1, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.PRIORITY));
   }
 
   @Test
@@ -909,6 +959,8 @@ public class QueryResourceTest
     );
     emitter.verifyEmitted("query/time", 1);
     Assert.assertEquals(500, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assert.assertFalse(emitter.getMetricEvents("query/time").get(0).toMap().containsKey(DruidMetrics.LANE));
+    Assert.assertEquals(QueryContexts.DEFAULT_PRIORITY, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.PRIORITY));
   }
 
   @Test
@@ -927,6 +979,8 @@ public class QueryResourceTest
     emitter.verifyEmitted("query/time", 1);
     Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
     Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assert.assertFalse(emitter.getMetricEvents("query/time").get(0).toMap().containsKey(DruidMetrics.LANE));
+    Assert.assertEquals(QueryContexts.DEFAULT_PRIORITY, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.PRIORITY));
   }
 
   @Test
@@ -943,6 +997,8 @@ public class QueryResourceTest
     emitter.verifyEmitted("query/time", 1);
     Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
     Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assert.assertFalse(emitter.getMetricEvents("query/time").get(0).toMap().containsKey(DruidMetrics.LANE));
+    Assert.assertEquals(QueryContexts.DEFAULT_PRIORITY, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.PRIORITY));
   }
 
   @Test
@@ -960,6 +1016,8 @@ public class QueryResourceTest
     emitter.verifyEmitted("query/time", 1);
     Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
     Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assert.assertFalse(emitter.getMetricEvents("query/time").get(0).toMap().containsKey(DruidMetrics.LANE));
+    Assert.assertEquals(QueryContexts.DEFAULT_PRIORITY, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.PRIORITY));
   }
 
   @Test
@@ -979,6 +1037,8 @@ public class QueryResourceTest
     emitter.verifyEmitted("query/time", 1);
     Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
     Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assert.assertFalse(emitter.getMetricEvents("query/time").get(0).toMap().containsKey(DruidMetrics.LANE));
+    Assert.assertEquals(QueryContexts.DEFAULT_PRIORITY, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.PRIORITY));
   }
 
   @Test
@@ -1003,6 +1063,8 @@ public class QueryResourceTest
     emitter.verifyEmitted("query/time", 1);
     Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
     Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assert.assertFalse(emitter.getMetricEvents("query/time").get(0).toMap().containsKey(DruidMetrics.LANE));
+    Assert.assertEquals(QueryContexts.DEFAULT_PRIORITY, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.PRIORITY));
   }
 
   @Test
@@ -1026,6 +1088,8 @@ public class QueryResourceTest
     emitter.verifyEmitted("query/time", 1);
     Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
     Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assert.assertFalse(emitter.getMetricEvents("query/time").get(0).toMap().containsKey(DruidMetrics.LANE));
+    Assert.assertEquals(QueryContexts.DEFAULT_PRIORITY, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.PRIORITY));
   }
 
   @Test
@@ -1239,6 +1303,8 @@ public class QueryResourceTest
 
     emitter.verifyEmitted("query/time", 1);
     Assert.assertEquals(504, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assert.assertFalse(emitter.getMetricEvents("query/time").get(0).toMap().containsKey(DruidMetrics.LANE));
+    Assert.assertEquals(QueryContexts.DEFAULT_PRIORITY, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.PRIORITY));
   }
 
   @Test(timeout = 60_000L)


### PR DESCRIPTION
<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Currently, identifying a query's assigned lane/priority via metrics is very difficult without logs. This adds `lane` and `priority` dimensions to all relevant query metrics (`lane` is added conditionally, `priority` is added always). This helps to quickly map a given query ID to a lane/priority, while also allowing metric queries to identify relationship between query latency, shape, etc. and lane/priority for better tuning.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Emit `lane` and `priority` dimensions in query timing metrics


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.