### PR TITLE
feat: Always allow scaling during task rollover in costBased auto-scaler

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScaler.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScaler.java
@@ -177,11 +177,10 @@ public class CostBasedAutoScaler implements SupervisorTaskAutoScaler
   @Override
   public int computeTaskCountForRollover()
   {
-    if (config.isScaleDownOnTaskRolloverOnly()) {
-      return computeOptimalTaskCount(lastKnownMetrics);
-    } else {
-      return CANNOT_COMPUTE;
-    }
+    // Always allow scaling on task rollover.
+    // If a scaling has happened recently, the caller may not invoke this method
+    // at all or simply reject the task count returned.
+    return computeOptimalTaskCount(lastKnownMetrics);
   }
 
   public int computeTaskCountForScaleAction()


### PR DESCRIPTION
### Description

Sometimes scaling decisions can get rejected if there are some tasks pending completion.
This becomes problematic when there are task failures as the failure to scale up compounds the issue and the lag builds up rapidly.

### Fix

- Always allow scaling during task rollover and not only when `scaleDownDuringTaskRolloverOnly` is `true`.
- Scaling during task rollover is not rejected even if there are tasks pending completion.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.