### PR TITLE
feat: allow clustered segments to create projection grouped by a vc derived clustered column

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/incremental/OnHeapClusteredBaseTable.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/OnHeapClusteredBaseTable.java
@@ -30,6 +30,7 @@ import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.segment.DimensionDictionary;
 import org.apache.druid.segment.DimensionHandlerUtils;
+import org.apache.druid.segment.EncodedKeyComponent;
 import org.apache.druid.segment.SortedDimensionDictionary;
 import org.apache.druid.segment.StringDimensionDictionary;
 import org.apache.druid.segment.VirtualColumn;
@@ -52,6 +53,7 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
 
 /**
  * Segment-wide root of the clustered base-table machinery for {@link OnheapIncrementalIndex}: holds the per-type
@@ -147,22 +149,33 @@ public final class OnHeapClusteredBaseTable
   }
 
   /**
-   * Resolve the clustering tuple for {@code row}, locate (or create) the matching {@link OnHeapClusterGroup}, and
-   * dispatch the row to it. {@code key} carries the bucketed timestamp from the parent's {@code toIncrementalIndexRow}
-   * pre-processing, its dim slots are ignored here since in clustered mode the non-clustering data lives only on the
-   * per-group facts holders. Returns true when the row created a new fact entry in its group (vs. rolling up into an
-   * existing one).
+   * Derive this row's clustering values eagerly, and (when there are projections) materialize the derived clustering
+   * columns ones into {@code key.dims} so if a projection groups on it, it reads the derived value rather than
+   * a null if it was not eagerly derived. The returned array is handed back to {@link #addToFacts} so the
+   * derivation happens exactly once.
    */
-  boolean addToFacts(
+  Object[] prepareClusteringValues(
       IncrementalIndexRow key,
-      InputRow row,
-      List<String> parseExceptionMessages,
-      AtomicLong totalSizeInBytes
+      Function<String, IncrementalIndex.DimensionDesc> getBaseDimension,
+      boolean materializeForProjections,
+      List<String> parseExceptionMessages
   )
   {
-    final long clusteringDictSizeBefore = clusteringDictionariesSizeInBytes();
+    final Object[] clusteringValues = computeClusteringValues(parseExceptionMessages);
+    if (materializeForProjections) {
+      materializeDerivedClusteringDims(key, clusteringValues, getBaseDimension);
+    }
+    return clusteringValues;
+  }
+
+  /**
+   * Resolve each clustering column's value for the current row (through the virtual-column selector, coerced to the
+   * column's clustering type), without interning or routing. Reads through {@link #virtualSelectorFactory}, which is
+   * backed by the parent's {@code inputRowHolder} (already set to the current row by {@code IncrementalIndex#add}).
+   */
+  private Object[] computeClusteringValues(List<String> parseExceptionMessages)
+  {
     final Object[] clusteringValues = new Object[clusteringColumns.size()];
-    final List<Integer> clusteringValueIds = new ArrayList<>(clusteringColumns.size());
     for (int i = 0; i < clusteringColumns.size(); i++) {
       final String name = clusteringColumns.getColumnName(i);
       final ColumnType type = clusteringColumns.getColumnType(i)
@@ -181,7 +194,69 @@ public final class OnHeapClusteredBaseTable
         coerced = null;
       }
       clusteringValues[i] = coerced;
-      clusteringValueIds.add(internClusteringValue(type, coerced));
+    }
+    return clusteringValues;
+  }
+
+  /**
+   * Write the <em>derived</em> clustering values (those produced by a virtual column, e.g. a value extracted from a
+   * nested column) into the parent row's {@code key.dims}, encoded through the parent's own dimension indexer. Raw
+   * clustering columns are already populated by {@code toIncrementalIndexRow} and are left untouched.
+   * <p>
+   * A derived clustering column is absent from the raw input row and is not computed by the parent, so its
+   * {@code key.dims} slot is null. A projection grouping on that column binds to the base-table dimension (a base
+   * column shadows a same-named projection virtual column) and would otherwise read that null. Populating it here lets
+   * the projection read the same value the clustering path produced. Base-segment output is unaffected: the base facts
+   * holder is empty in clustered mode, so these parent-dimension entries never reach a base segment; only the
+   * projection (which shares the parent's indexer for this column) reads them.
+   */
+  private void materializeDerivedClusteringDims(
+      IncrementalIndexRow key,
+      Object[] clusteringValues,
+      Function<String, IncrementalIndex.DimensionDesc> getBaseDimension
+  )
+  {
+    for (int i = 0; i < clusteringColumns.size(); i++) {
+      final String name = clusteringColumns.getColumnName(i);
+      if (!virtualColumns.exists(name)) {
+        // raw clustering column: already materialized into key.dims by toIncrementalIndexRow
+        continue;
+      }
+      final IncrementalIndex.DimensionDesc desc = getBaseDimension.apply(name);
+      if (desc == null || desc.getIndex() >= key.dims.length) {
+        continue;
+      }
+      final EncodedKeyComponent<?> encoded =
+          desc.getIndexer().processRowValsToUnsortedEncodedKeyComponent(clusteringValues[i], false);
+      key.dims[desc.getIndex()] = encoded.getComponent();
+    }
+  }
+
+  /**
+   * Intern the {@code clusteringValues} (from {@link #computeClusteringValues}) into the per-type clustering
+   * dictionaries, locate (or create) the matching {@link OnHeapClusterGroup}, and dispatch the row to it. {@code key}
+   * carries the bucketed timestamp from the parent's {@code toIncrementalIndexRow} pre-processing, its dim slots are
+   * ignored here since in clustered mode the non-clustering data lives only on the per-group facts holders. Returns
+   * true when the row created a new fact entry in its group (vs. rolling up into an existing one).
+   */
+  boolean addToFacts(
+      IncrementalIndexRow key,
+      InputRow row,
+      Object[] clusteringValues,
+      List<String> parseExceptionMessages,
+      AtomicLong totalSizeInBytes
+  )
+  {
+    final long clusteringDictSizeBefore = clusteringDictionariesSizeInBytes();
+    final List<Integer> clusteringValueIds = new ArrayList<>(clusteringColumns.size());
+    for (int i = 0; i < clusteringColumns.size(); i++) {
+      final String name = clusteringColumns.getColumnName(i);
+      final ColumnType type = clusteringColumns.getColumnType(i)
+                                               .orElseThrow(() -> DruidException.defensive(
+                                                   "clustering column [%s] has no type",
+                                                   name
+                                               ));
+      clusteringValueIds.add(internClusteringValue(type, clusteringValues[i]));
     }
     totalSizeInBytes.addAndGet(clusteringDictionariesSizeInBytes() - clusteringDictSizeBefore);
 

--- a/processing/src/main/java/org/apache/druid/segment/incremental/OnHeapClusteredBaseTable.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/OnHeapClusteredBaseTable.java
@@ -81,6 +81,19 @@ public final class OnHeapClusteredBaseTable
   private final ColumnSelectorFactory virtualSelectorFactory;
   private final IncrementalIndex.InputRowHolder inputRowHolder;
 
+  // Per-clustering-column name/type, resolved once so the per-row ingestion path does not re-read the RowSignature
+  // Optional + defensive lambda for every column of every row.
+  private final String[] clusteringColumnNames;
+  private final ColumnType[] clusteringColumnTypes;
+  // Indices into the clustering tuple of the derived clustering columns — those produced by a virtual column, so absent
+  // from the raw row. Only these get their value written back into the parent's key.dims (see
+  // materializeDerivedClusteringDims); raw clustering columns are already populated there by toIncrementalIndexRow.
+  private final int[] derivedClusteringColumnIndices;
+  // Parent DimensionDesc for each derivedClusteringColumnIndices entry, memoized on first non-null resolve (the base
+  // dimension may not be registered on the parent when the first rows arrive). The value is idempotent, so the racy
+  // publication across concurrent adds is benign.
+  private final IncrementalIndex.DimensionDesc[] materializedDimensionDescs;
+
   // template state for instantiating new OnHeapClusterGroups
   private final List<DimensionSchema> nonClusteringDimensions;
   private final boolean rollup;
@@ -142,28 +155,52 @@ public final class OnHeapClusteredBaseTable
     }
     this.clusteringColumns = sigBuilder.build();
 
+    final int numClusteringColumns = clusteringColumns.size();
+    this.clusteringColumnNames = new String[numClusteringColumns];
+    this.clusteringColumnTypes = new ColumnType[numClusteringColumns];
+    for (int i = 0; i < numClusteringColumns; i++) {
+      final String name = clusteringColumns.getColumnName(i);
+      clusteringColumnNames[i] = name;
+      clusteringColumnTypes[i] = clusteringColumns.getColumnType(i)
+                                                  .orElseThrow(() -> DruidException.defensive(
+                                                      "clustering column [%s] has no type",
+                                                      name
+                                                  ));
+    }
+
     this.virtualColumns = mergeVirtualColumns(segmentVirtualColumns, spec.getVirtualColumns());
     this.virtualSelectorFactory = new OnheapIncrementalIndex.CachingColumnSelectorFactory(
         IncrementalIndex.makeColumnSelectorFactory(this.virtualColumns, inputRowHolder, null)
     );
+
+    final List<Integer> derived = new ArrayList<>();
+    for (int i = 0; i < numClusteringColumns; i++) {
+      if (this.virtualColumns.exists(clusteringColumnNames[i])) {
+        derived.add(i);
+      }
+    }
+    this.derivedClusteringColumnIndices = derived.stream().mapToInt(Integer::intValue).toArray();
+    this.materializedDimensionDescs =
+        new IncrementalIndex.DimensionDesc[derivedClusteringColumnIndices.length];
   }
 
   /**
-   * Derive this row's clustering values eagerly, and (when there are projections) materialize the derived clustering
-   * columns ones into {@code key.dims} so if a projection groups on it, it reads the derived value rather than
-   * a null if it was not eagerly derived. The returned array is handed back to {@link #addToFacts} so the
-   * derivation happens exactly once.
+   * Resolve this row's clustering values once, up front, and — when {@code materializeForProjections} is set —
+   * materialize the derived clustering values into {@code key.dims} so a projection grouping on such a column reads
+   * that value rather than null (see {@link #materializeDerivedClusteringDims} for why). The returned array is handed
+   * back to {@link #addToFacts} so the clustering derivation happens exactly once per row.
    */
   Object[] prepareClusteringValues(
       IncrementalIndexRow key,
       Function<String, IncrementalIndex.DimensionDesc> getBaseDimension,
       boolean materializeForProjections,
-      List<String> parseExceptionMessages
+      List<String> parseExceptionMessages,
+      AtomicLong totalSizeInBytes
   )
   {
     final Object[] clusteringValues = computeClusteringValues(parseExceptionMessages);
     if (materializeForProjections) {
-      materializeDerivedClusteringDims(key, clusteringValues, getBaseDimension);
+      materializeDerivedClusteringDims(key, clusteringValues, getBaseDimension, totalSizeInBytes);
     }
     return clusteringValues;
   }
@@ -175,19 +212,14 @@ public final class OnHeapClusteredBaseTable
    */
   private Object[] computeClusteringValues(List<String> parseExceptionMessages)
   {
-    final Object[] clusteringValues = new Object[clusteringColumns.size()];
-    for (int i = 0; i < clusteringColumns.size(); i++) {
-      final String name = clusteringColumns.getColumnName(i);
-      final ColumnType type = clusteringColumns.getColumnType(i)
-                                               .orElseThrow(() -> DruidException.defensive(
-                                                   "clustering column [%s] has no type",
-                                                   name
-                                               ));
+    final Object[] clusteringValues = new Object[clusteringColumnNames.length];
+    for (int i = 0; i < clusteringColumnNames.length; i++) {
+      final String name = clusteringColumnNames[i];
       final ColumnValueSelector<?> selector = virtualSelectorFactory.makeColumnValueSelector(name);
       final Object raw = selector.getObject();
       Object coerced;
       try {
-        coerced = DimensionHandlerUtils.convertObjectToType(raw, type, true, name);
+        coerced = DimensionHandlerUtils.convertObjectToType(raw, clusteringColumnTypes[i], true, name);
       }
       catch (ParseException pe) {
         parseExceptionMessages.add(pe.getMessage());
@@ -206,29 +238,38 @@ public final class OnHeapClusteredBaseTable
    * A derived clustering column is absent from the raw input row and is not computed by the parent, so its
    * {@code key.dims} slot is null. A projection grouping on that column binds to the base-table dimension (a base
    * column shadows a same-named projection virtual column) and would otherwise read that null. Populating it here lets
-   * the projection read the same value the clustering path produced. Base-segment output is unaffected: the base facts
-   * holder is empty in clustered mode, so these parent-dimension entries never reach a base segment; only the
-   * projection (which shares the parent's indexer for this column) reads them.
+   * the projection read the same value the clustering path produced.
+   * <p>
+   * This mutates the parent dimension's indexer: it interns the value into that dimension's dictionary, and the per-row
+   * encoding cost is folded into {@code totalSizeInBytes} — the same accounting the projection path does for its own
+   * grouping columns. In clustered mode the base facts holder holds no rows, so no base-segment row references these
+   * entries; only the projection, which shares the parent's indexer for this column, reads the id written here.
    */
   private void materializeDerivedClusteringDims(
       IncrementalIndexRow key,
       Object[] clusteringValues,
-      Function<String, IncrementalIndex.DimensionDesc> getBaseDimension
+      Function<String, IncrementalIndex.DimensionDesc> getBaseDimension,
+      AtomicLong totalSizeInBytes
   )
   {
-    for (int i = 0; i < clusteringColumns.size(); i++) {
-      final String name = clusteringColumns.getColumnName(i);
-      if (!virtualColumns.exists(name)) {
-        // raw clustering column: already materialized into key.dims by toIncrementalIndexRow
-        continue;
+    for (int d = 0; d < derivedClusteringColumnIndices.length; d++) {
+      final int i = derivedClusteringColumnIndices[d];
+      IncrementalIndex.DimensionDesc desc = materializedDimensionDescs[d];
+      if (desc == null) {
+        desc = getBaseDimension.apply(clusteringColumnNames[i]);
+        if (desc == null) {
+          // base dimension not registered on the parent yet; retry on a later row
+          continue;
+        }
+        materializedDimensionDescs[d] = desc;
       }
-      final IncrementalIndex.DimensionDesc desc = getBaseDimension.apply(name);
-      if (desc == null || desc.getIndex() >= key.dims.length) {
+      if (desc.getIndex() >= key.dims.length) {
         continue;
       }
       final EncodedKeyComponent<?> encoded =
           desc.getIndexer().processRowValsToUnsortedEncodedKeyComponent(clusteringValues[i], false);
       key.dims[desc.getIndex()] = encoded.getComponent();
+      totalSizeInBytes.addAndGet(encoded.getEffectiveSizeBytes());
     }
   }
 
@@ -248,15 +289,9 @@ public final class OnHeapClusteredBaseTable
   )
   {
     final long clusteringDictSizeBefore = clusteringDictionariesSizeInBytes();
-    final List<Integer> clusteringValueIds = new ArrayList<>(clusteringColumns.size());
-    for (int i = 0; i < clusteringColumns.size(); i++) {
-      final String name = clusteringColumns.getColumnName(i);
-      final ColumnType type = clusteringColumns.getColumnType(i)
-                                               .orElseThrow(() -> DruidException.defensive(
-                                                   "clustering column [%s] has no type",
-                                                   name
-                                               ));
-      clusteringValueIds.add(internClusteringValue(type, clusteringValues[i]));
+    final List<Integer> clusteringValueIds = new ArrayList<>(clusteringColumnNames.length);
+    for (int i = 0; i < clusteringColumnNames.length; i++) {
+      clusteringValueIds.add(internClusteringValue(clusteringColumnTypes[i], clusteringValues[i]));
     }
     totalSizeInBytes.addAndGet(clusteringDictionariesSizeInBytes() - clusteringDictSizeBefore);
 
@@ -440,7 +475,7 @@ public final class OnHeapClusteredBaseTable
       final List<Integer> oldIds = group.getClusteringValueIds();
       final List<Integer> newIds = new ArrayList<>(oldIds.size());
       for (int i = 0; i < oldIds.size(); i++) {
-        final ColumnType type = clusteringColumns.getColumnType(i).orElseThrow();
+        final ColumnType type = clusteringColumnTypes[i];
         final int[] remap = remapForType(type, stringRemap, longRemap, doubleRemap, floatRemap);
         newIds.add(remap[oldIds.get(i)]);
       }

--- a/processing/src/main/java/org/apache/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -282,15 +282,19 @@ public class OnheapIncrementalIndex extends IncrementalIndex
     final List<String> parseExceptionMessages = new ArrayList<>();
     final AtomicLong totalSizeInBytes = getBytesInMemory();
 
-    // In clustered mode, derive the clustering values once, up front, and materialize any derived (virtual-column)
-    // columns into key.dims before projections run. A derived clustering column is absent from the raw row and not
-    // computed by the parent, so its key.dims slot is null; a projection grouping on it binds to that base-table
-    // dimension and would read null. Materializing it here lets such projections read the same value the clustering
-    // path produces, and the computed values are reused by the clustered addToFacts below so the derivation happens
-    // exactly once.
+    // In clustered mode, derive the clustering values once, up front, and (when projections exist) materialize any
+    // derived clustering columns into key.dims before projections run so a projection grouping on one reads the derived
+    // value rather than null (see OnHeapClusteredBaseTable#materializeDerivedClusteringDims). The computed values are
+    // reused by the clustered addToFacts below so the clustering derivation happens exactly once.
     final Object[] clusteringValues = clusteredBaseTable == null
         ? null
-        : clusteredBaseTable.prepareClusteringValues(key, this::getDimension, !projections.isEmpty(), parseExceptionMessages);
+        : clusteredBaseTable.prepareClusteringValues(
+            key,
+            this::getDimension,
+            !projections.isEmpty(),
+            parseExceptionMessages,
+            totalSizeInBytes
+        );
 
     // add to projections first so if one is chosen by queries the data will always be ahead of the base table since
     // rows are not added atomically to all facts holders at once

--- a/processing/src/main/java/org/apache/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -282,6 +282,16 @@ public class OnheapIncrementalIndex extends IncrementalIndex
     final List<String> parseExceptionMessages = new ArrayList<>();
     final AtomicLong totalSizeInBytes = getBytesInMemory();
 
+    // In clustered mode, derive the clustering values once, up front, and materialize any derived (virtual-column)
+    // columns into key.dims before projections run. A derived clustering column is absent from the raw row and not
+    // computed by the parent, so its key.dims slot is null; a projection grouping on it binds to that base-table
+    // dimension and would read null. Materializing it here lets such projections read the same value the clustering
+    // path produces, and the computed values are reused by the clustered addToFacts below so the derivation happens
+    // exactly once.
+    final Object[] clusteringValues = clusteredBaseTable == null
+        ? null
+        : clusteredBaseTable.prepareClusteringValues(key, this::getDimension, !projections.isEmpty(), parseExceptionMessages);
+
     // add to projections first so if one is chosen by queries the data will always be ahead of the base table since
     // rows are not added atomically to all facts holders at once
     for (OnHeapAggregateProjection projection : projections.values()) {
@@ -296,6 +306,7 @@ public class OnheapIncrementalIndex extends IncrementalIndex
       final boolean isNewEntry = clusteredBaseTable.addToFacts(
           key,
           inputRowHolder.getRow(),
+          clusteringValues,
           parseExceptionMessages,
           totalSizeInBytes
       );

--- a/processing/src/test/java/org/apache/druid/segment/incremental/ClusteredProjectionTestUtils.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/ClusteredProjectionTestUtils.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.incremental;
+
+import org.apache.druid.segment.DimensionIndexer;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Shared test helpers for aggregate projections over a clustered base table.
+ */
+public final class ClusteredProjectionTestUtils
+{
+  private ClusteredProjectionTestUtils()
+  {
+  }
+
+  /**
+   * Decodes the distinct grouping-column tuples stored in a projection's facts holder back to their actual values.
+   * The raw indexer type mirrors IncrementalIndex's own call sites: a wildcard-typed encoded key component (here a
+   * String dictionary-id array) can only be passed back to its indexer through the erased signature.
+   */
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public static Set<List<Object>> projectionGroupingTuples(OnheapIncrementalIndex index, String projectionName)
+  {
+    final IncrementalIndexRowSelector projection = index.getProjection(projectionName);
+    final List<IncrementalIndex.DimensionDesc> dimensions = projection.getDimensions();
+    final Set<List<Object>> tuples = new HashSet<>();
+    for (IncrementalIndexRow row : projection.getFacts().keySet()) {
+      final List<Object> tuple = new ArrayList<>(dimensions.size());
+      for (int i = 0; i < dimensions.size(); i++) {
+        final DimensionIndexer indexer = dimensions.get(i).getIndexer();
+        tuple.add(indexer.convertUnsortedEncodedKeyComponentToActualList(row.getDims()[i]));
+      }
+      tuples.add(tuple);
+    }
+    return tuples;
+  }
+}

--- a/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexClusteredProjectionDerivedColumnTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexClusteredProjectionDerivedColumnTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.incremental;
+
+import org.apache.druid.data.input.MapBasedInputRow;
+import org.apache.druid.data.input.impl.AggregateProjectionSpec;
+import org.apache.druid.data.input.impl.ClusteredValueGroupsBaseTableProjectionSpec;
+import org.apache.druid.data.input.impl.LongDimensionSchema;
+import org.apache.druid.data.input.impl.StringDimensionSchema;
+import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
+import org.apache.druid.segment.AutoTypeColumnSchema;
+import org.apache.druid.segment.DimensionIndexer;
+import org.apache.druid.segment.VirtualColumns;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.virtual.NestedFieldVirtualColumn;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Covers an aggregate projection that groups on a <em>derived</em> clustering column of a clustered base table — one
+ * produced by a virtual column rather than present on the raw input row (here {@code region} extracted from a
+ * {@code COMPLEX<json>} {@code extra_attrs} column).
+ * <p>
+ * A derived clustering column is absent from the raw row, and in clustered mode the parent incremental index does not
+ * compute it (the clustered base table resolves it into its per-group clustering dictionaries), so the parent's
+ * {@code key.dims} slot for it stays null. A projection grouping on it binds to the base-table dimension of the same
+ * name (a base column shadows a same-named projection virtual column) and therefore reads null, storing a null value
+ * for every row and collapsing all groups. This asserts the projection instead sees the same derived value the
+ * clustering path produced.
+ */
+class IncrementalIndexClusteredProjectionDerivedColumnTest extends InitializedNullHandlingTest
+{
+  private static final long T0 = DateTimes.of("2026-01-01T00:00:00").getMillis();
+  private static final TimestampSpec TIMESTAMP_SPEC = new TimestampSpec("ts", "millis", null);
+
+  private static MapBasedInputRow row(long ts, String tenant, String region, long x)
+  {
+    final Map<String, Object> event = new LinkedHashMap<>();
+    event.put("ts", ts);
+    event.put("tenant", tenant);
+    // `region` is not present as a top-level field; it is derived from the nested extra_attrs column.
+    event.put("extra_attrs", Map.of("region", region));
+    event.put("x", x);
+    return new MapBasedInputRow(ts, List.of("tenant", "x"), event);
+  }
+
+  private static OnheapIncrementalIndex clusteredWithDerivedColumnProjection()
+  {
+    // Clustered by tenant + a `region` derived from the nested extra_attrs column, and carrying a projection that
+    // groups on that derived `region`.
+    final ClusteredValueGroupsBaseTableProjectionSpec spec = ClusteredValueGroupsBaseTableProjectionSpec.builder()
+        .virtualColumns(VirtualColumns.create(
+            new NestedFieldVirtualColumn("extra_attrs", "$.region", "region", ColumnType.STRING)
+        ))
+        .columns(
+            new StringDimensionSchema("tenant"),
+            new StringDimensionSchema("region"),   // clustering column derived from extra_attrs
+            AutoTypeColumnSchema.of("extra_attrs"),
+            new LongDimensionSchema("x"),
+            new LongDimensionSchema("__time")
+        )
+        .clusteringColumns("tenant", "region")
+        .build();
+
+    final AggregateProjectionSpec projectionSpec =
+        AggregateProjectionSpec.builder("proj")
+                               .groupingColumns(
+                                   new StringDimensionSchema("tenant"),
+                                   new StringDimensionSchema("region")
+                               )
+                               .aggregators(new LongSumAggregatorFactory("sum_x", "x"))
+                               .build();
+
+    final IncrementalIndexSchema schema = IncrementalIndexSchema.builder()
+        .withMinTimestamp(T0)
+        .withTimestampSpec(TIMESTAMP_SPEC)
+        .withQueryGranularity(Granularities.NONE)
+        .withDimensionsSpec(spec.getDimensionsSpec())
+        .withRollup(false)
+        .withClusterSpec(spec)
+        .withProjections(List.of(projectionSpec))
+        .build();
+
+    final OnheapIncrementalIndex index = (OnheapIncrementalIndex) new OnheapIncrementalIndex.Builder()
+        .setIndexSchema(schema)
+        .setMaxRowCount(10_000)
+        .build();
+    index.add(row(T0, "acme", "us-east-1", 10));
+    index.add(row(T0 + 1, "acme", "us-west-2", 5));
+    index.add(row(T0 + 2, "globex", "eu-west-1", 7));
+    return index;
+  }
+
+  /**
+   * Decodes the distinct grouping-column tuples stored in a projection's facts holder back to their actual values.
+   */
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private static Set<List<Object>> projectionGroupingTuples(OnheapIncrementalIndex index, String projectionName)
+  {
+    final IncrementalIndexRowSelector projection = index.getProjection(projectionName);
+    final List<IncrementalIndex.DimensionDesc> dimensions = projection.getDimensions();
+    final Set<List<Object>> tuples = new HashSet<>();
+    for (IncrementalIndexRow row : projection.getFacts().keySet()) {
+      final List<Object> tuple = new ArrayList<>(dimensions.size());
+      for (int i = 0; i < dimensions.size(); i++) {
+        final DimensionIndexer indexer = dimensions.get(i).getIndexer();
+        tuple.add(indexer.convertUnsortedEncodedKeyComponentToActualList(row.getDims()[i]));
+      }
+      tuples.add(tuple);
+    }
+    return tuples;
+  }
+
+  @Test
+  void testProjectionGroupsOnDerivedClusteringColumn()
+  {
+    try (OnheapIncrementalIndex index = clusteredWithDerivedColumnProjection()) {
+      // The projection's `region` grouping column is derived from extra_attrs; it must carry the derived value the
+      // clustering path produces, not null, so the three distinct (tenant, region) groups form.
+      Assertions.assertEquals(
+          Set.of(
+              List.of("acme", "us-east-1"),
+              List.of("acme", "us-west-2"),
+              List.of("globex", "eu-west-1")
+          ),
+          projectionGroupingTuples(index, "proj")
+      );
+    }
+  }
+}

--- a/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexClusteredProjectionDerivedColumnTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexClusteredProjectionDerivedColumnTest.java
@@ -29,7 +29,6 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.segment.AutoTypeColumnSchema;
-import org.apache.druid.segment.DimensionIndexer;
 import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.virtual.NestedFieldVirtualColumn;
@@ -37,24 +36,16 @@ import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 /**
- * Covers an aggregate projection that groups on a <em>derived</em> clustering column of a clustered base table — one
- * produced by a virtual column rather than present on the raw input row (here {@code region} extracted from a
- * {@code COMPLEX<json>} {@code extra_attrs} column).
- * <p>
- * A derived clustering column is absent from the raw row, and in clustered mode the parent incremental index does not
- * compute it (the clustered base table resolves it into its per-group clustering dictionaries), so the parent's
- * {@code key.dims} slot for it stays null. A projection grouping on it binds to the base-table dimension of the same
- * name (a base column shadows a same-named projection virtual column) and therefore reads null, storing a null value
- * for every row and collapsing all groups. This asserts the projection instead sees the same derived value the
- * clustering path produced.
+ * A clustered base table whose {@code region} clustering column is <em>derived</em> from a nested {@code extra_attrs}
+ * column (absent from the raw row), carrying an aggregate projection that groups on that same {@code region}. Asserts
+ * the projection groups on the derived value the clustering path produced, rather than a null that would collapse the
+ * distinct (tenant, region) groups into one.
  */
 class IncrementalIndexClusteredProjectionDerivedColumnTest extends InitializedNullHandlingTest
 {
@@ -119,26 +110,6 @@ class IncrementalIndexClusteredProjectionDerivedColumnTest extends InitializedNu
     return index;
   }
 
-  /**
-   * Decodes the distinct grouping-column tuples stored in a projection's facts holder back to their actual values.
-   */
-  @SuppressWarnings({"rawtypes", "unchecked"})
-  private static Set<List<Object>> projectionGroupingTuples(OnheapIncrementalIndex index, String projectionName)
-  {
-    final IncrementalIndexRowSelector projection = index.getProjection(projectionName);
-    final List<IncrementalIndex.DimensionDesc> dimensions = projection.getDimensions();
-    final Set<List<Object>> tuples = new HashSet<>();
-    for (IncrementalIndexRow row : projection.getFacts().keySet()) {
-      final List<Object> tuple = new ArrayList<>(dimensions.size());
-      for (int i = 0; i < dimensions.size(); i++) {
-        final DimensionIndexer indexer = dimensions.get(i).getIndexer();
-        tuple.add(indexer.convertUnsortedEncodedKeyComponentToActualList(row.getDims()[i]));
-      }
-      tuples.add(tuple);
-    }
-    return tuples;
-  }
-
   @Test
   void testProjectionGroupsOnDerivedClusteringColumn()
   {
@@ -151,7 +122,7 @@ class IncrementalIndexClusteredProjectionDerivedColumnTest extends InitializedNu
               List.of("acme", "us-west-2"),
               List.of("globex", "eu-west-1")
           ),
-          projectionGroupingTuples(index, "proj")
+          ClusteredProjectionTestUtils.projectionGroupingTuples(index, "proj")
       );
     }
   }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Eagerly derive clustered columns during indexing and if the spec has projections materialize the clustered columns for each row so if a projection being built groups on a VC derived clustering column, the grouping value is available to the indexer. Before this change, if you tried to do ingestion with a vc derived clustering column that was then used for a grouping column in a projection, the projection would register null for all rows for that grouping column because it wasn't available at build time.

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

N/A. part of larger Druid 39 release note on clustered segment improvements


<hr>

##### Key changed/added classes in this PR
 * `OnHeapClusteredBaseTable`
 * `OnHeapIncrementalIndex`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.