### PR TITLE
feat: better validation for catalog types, more permissive parsing for native type strings

### DIFF
--- a/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/CatalogException.java
+++ b/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/CatalogException.java
@@ -20,6 +20,8 @@
 package org.apache.druid.catalog;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.error.DruidException;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 
 import javax.ws.rs.core.Response;
@@ -84,6 +86,19 @@ public class CatalogException extends Exception
         msg,
         args
     );
+  }
+
+  /**
+   * Converts a table validation failure into a bad request: {@link IAE} (the traditional catalog validation
+   * exception) and invalid-input {@link DruidException}s become bad requests; a {@link DruidException} of any other
+   * category is a genuine server error, and is rethrown rather than being misreported as a problem with the request.
+   */
+  public static CatalogException validationError(RuntimeException e)
+  {
+    if (e instanceof DruidException && ((DruidException) e).getCategory() != DruidException.Category.INVALID_INPUT) {
+      throw e;
+    }
+    return badRequest(e.getMessage());
   }
 
   public Response toResponse()

--- a/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/http/CatalogResource.java
+++ b/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/http/CatalogResource.java
@@ -31,6 +31,7 @@ import org.apache.druid.catalog.model.TableMetadata;
 import org.apache.druid.catalog.model.TableSpec;
 import org.apache.druid.catalog.storage.CatalogStorage;
 import org.apache.druid.common.utils.IdUtils;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.StringUtils;
@@ -140,8 +141,8 @@ public class CatalogResource
       try {
         catalog.validate(table);
       }
-      catch (IAE e) {
-        throw CatalogException.badRequest(e.getMessage());
+      catch (IAE | DruidException e) {
+        throw CatalogException.validationError(e);
       }
 
       long newVersion;
@@ -270,6 +271,10 @@ public class CatalogResource
     }
     catch (CatalogException e) {
       return e.toResponse();
+    }
+    catch (IAE | DruidException e) {
+      // Edits merge and re-validate the table spec, so validation failures surface here.
+      return CatalogException.validationError(e).toResponse();
     }
   }
 
@@ -524,8 +529,8 @@ public class CatalogResource
     try {
       spec.validate();
     }
-    catch (IAE e) {
-      throw CatalogException.badRequest(e.getMessage());
+    catch (IAE | DruidException e) {
+      throw CatalogException.validationError(e);
     }
 
     if (!schema.accepts(spec.type())) {

--- a/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/http/TableEditor.java
+++ b/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/http/TableEditor.java
@@ -36,6 +36,7 @@ import org.apache.druid.catalog.model.TableMetadata;
 import org.apache.druid.catalog.model.TableSpec;
 import org.apache.druid.catalog.model.table.DatasourceDefn;
 import org.apache.druid.catalog.storage.CatalogStorage;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.utils.CollectionUtils;
 
@@ -312,8 +313,8 @@ public class TableEditor
     try {
       defn.validateColumns(revised);
     }
-    catch (IAE e) {
-      throw CatalogException.badRequest(e.getMessage());
+    catch (IAE | DruidException e) {
+      throw CatalogException.validationError(e);
     }
     return existingSpec.withColumns(revised);
   }

--- a/extensions-core/druid-catalog/src/test/java/org/apache/druid/server/http/catalog/CatalogResourceTest.java
+++ b/extensions-core/druid-catalog/src/test/java/org/apache/druid/server/http/catalog/CatalogResourceTest.java
@@ -146,6 +146,14 @@ public class CatalogResourceTest
     resp = resource.postTable(TableId.DRUID_SCHEMA, tableName, dsSpec, 0, false, postBy(CatalogTests.WRITER_USER));
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), resp.getStatus());
 
+    // Invalid column type: table-level validation failures (which raise DruidException rather than IAE) must also
+    // surface as a bad request, not an internal error.
+    TableSpec badTypeSpec = TableBuilder.datasource("badType", "P1D")
+        .column("foo", "FOO")
+        .buildSpec();
+    resp = resource.postTable(TableId.DRUID_SCHEMA, "badType", badTypeSpec, 0, false, postBy(CatalogTests.SUPER_USER));
+    assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), resp.getStatus());
+
     // Inline input source
     TableSpec inputSpec = TableBuilder.external("inline")
         .inputSource(toMap(new InlineInputSource("a,b,1\nc,d,2\n")))

--- a/processing/src/main/java/org/apache/druid/segment/column/Types.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/Types.java
@@ -39,7 +39,8 @@ public class Types
     if (typeString == null) {
       return null;
     }
-    switch (StringUtils.toUpperCase(typeString)) {
+    final String upperTypeString = StringUtils.toUpperCase(typeString);
+    switch (upperTypeString) {
       case "STRING":
         return typeFactory.ofString();
       case "LONG":
@@ -57,14 +58,16 @@ public class Types
       case "COMPLEX":
         return typeFactory.ofComplex(null);
       default:
-        // we do not convert to uppercase here, because complex type name must be preserved in original casing
-        // array could be converted, but are not for no particular reason other than less spooky magic
-        if (typeString.startsWith(ARRAY_PREFIX)) {
+        // Prefix matching is case-insensitive, consistent with the scalar handling above, but the type parameter is
+        // taken from the original string: complex type names are case-sensitive registry keys which must be preserved
+        // in their original casing (array element types recurse through this method, so any casing works for them).
+        // A parameterized type without the closing bracket is malformed, not a truncated parameter name.
+        if (upperTypeString.startsWith(ARRAY_PREFIX) && upperTypeString.endsWith(">")) {
           T elementType = fromString(typeFactory, typeString.substring(ARRAY_PREFIX.length(), typeString.length() - 1));
           Preconditions.checkNotNull(elementType, "Array element type must not be null");
           return typeFactory.ofArray(elementType);
         }
-        if (typeString.startsWith(COMPLEX_PREFIX)) {
+        if (upperTypeString.startsWith(COMPLEX_PREFIX) && upperTypeString.endsWith(">")) {
           return typeFactory.ofComplex(typeString.substring(COMPLEX_PREFIX.length(), typeString.length() - 1));
         }
     }

--- a/processing/src/main/java/org/apache/druid/segment/column/Types.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/Types.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.segment.column;
 
-import com.google.common.base.Preconditions;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 
@@ -60,12 +59,12 @@ public class Types
       default:
         // Prefix matching is case-insensitive, consistent with the scalar handling above, but the type parameter is
         // taken from the original string: complex type names are case-sensitive registry keys which must be preserved
-        // in their original casing (array element types recurse through this method, so any casing works for them).
-        // A parameterized type without the closing bracket is malformed, not a truncated parameter name.
+        // in their original casing.
         if (upperTypeString.startsWith(ARRAY_PREFIX) && upperTypeString.endsWith(">")) {
           T elementType = fromString(typeFactory, typeString.substring(ARRAY_PREFIX.length(), typeString.length() - 1));
-          Preconditions.checkNotNull(elementType, "Array element type must not be null");
-          return typeFactory.ofArray(elementType);
+          if (elementType != null) {
+            return typeFactory.ofArray(elementType);
+          }
         }
         if (upperTypeString.startsWith(COMPLEX_PREFIX) && upperTypeString.endsWith(">")) {
           return typeFactory.ofComplex(typeString.substring(COMPLEX_PREFIX.length(), typeString.length() - 1));

--- a/processing/src/test/java/org/apache/druid/math/expr/ExpressionTypeTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/ExpressionTypeTest.java
@@ -67,12 +67,15 @@ public class ExpressionTypeTest
     Assertions.assertEquals(ExpressionType.STRING_ARRAY, MAPPER.readValue("\"string_array\"", ExpressionType.class));
     Assertions.assertEquals(ExpressionType.LONG_ARRAY, MAPPER.readValue("\"long_array\"", ExpressionType.class));
     Assertions.assertEquals(ExpressionType.DOUBLE_ARRAY, MAPPER.readValue("\"double_array\"", ExpressionType.class));
-    // ARRAY<*> and COMPLEX<*> patterns must match exactly ...
-    Assertions.assertNotEquals(ExpressionType.STRING_ARRAY, MAPPER.readValue("\"array<string>\"", ExpressionType.class));
-    Assertions.assertNotEquals(ExpressionType.LONG_ARRAY, MAPPER.readValue("\"array<LONG>\"", ExpressionType.class));
-    Assertions.assertNotEquals(SOME_COMPLEX, MAPPER.readValue("\"COMPLEX<FOO>\"", ExpressionType.class));
-    // this works though because array recursively calls on element type...
+    // the ARRAY<*> and COMPLEX<*> prefixes match case-insensitively, like the scalar type names ...
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, MAPPER.readValue("\"array<string>\"", ExpressionType.class));
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, MAPPER.readValue("\"array<LONG>\"", ExpressionType.class));
     Assertions.assertEquals(ExpressionType.DOUBLE_ARRAY, MAPPER.readValue("\"ARRAY<double>\"", ExpressionType.class));
+    Assertions.assertEquals(SOME_COMPLEX, MAPPER.readValue("\"complex<foo>\"", ExpressionType.class));
+    // ... but the complex type name inside the brackets is a case-sensitive registry key, preserved as written
+    Assertions.assertNotEquals(SOME_COMPLEX, MAPPER.readValue("\"COMPLEX<FOO>\"", ExpressionType.class));
+    // a parameterized type missing its closing bracket is malformed, not a truncated type parameter
+    Assertions.assertNull(MAPPER.readValue("\"COMPLEX<foo\"", ExpressionType.class));
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/math/expr/ExpressionTypeTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/ExpressionTypeTest.java
@@ -76,6 +76,9 @@ public class ExpressionTypeTest
     Assertions.assertNotEquals(SOME_COMPLEX, MAPPER.readValue("\"COMPLEX<FOO>\"", ExpressionType.class));
     // a parameterized type missing its closing bracket is malformed, not a truncated type parameter
     Assertions.assertNull(MAPPER.readValue("\"COMPLEX<foo\"", ExpressionType.class));
+    // an unrecognized array element type makes the whole array type unrecognized, rather than an error
+    Assertions.assertNull(MAPPER.readValue("\"ARRAY<FOO>\"", ExpressionType.class));
+    Assertions.assertNull(MAPPER.readValue("\"ARRAY<ARRAY<FOO>>\"", ExpressionType.class));
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/segment/column/ColumnTypeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/column/ColumnTypeTest.java
@@ -69,12 +69,15 @@ public class ColumnTypeTest
     Assertions.assertEquals(ColumnType.STRING_ARRAY, MAPPER.readValue("\"string_array\"", ColumnType.class));
     Assertions.assertEquals(ColumnType.LONG_ARRAY, MAPPER.readValue("\"long_array\"", ColumnType.class));
     Assertions.assertEquals(ColumnType.DOUBLE_ARRAY, MAPPER.readValue("\"double_array\"", ColumnType.class));
-    // ARRAY<*> and COMPLEX<*> patterns must match exactly ...
-    Assertions.assertNotEquals(ColumnType.STRING_ARRAY, MAPPER.readValue("\"array<string>\"", ColumnType.class));
-    Assertions.assertNotEquals(ColumnType.LONG_ARRAY, MAPPER.readValue("\"array<LONG>\"", ColumnType.class));
-    Assertions.assertNotEquals(SOME_COMPLEX, MAPPER.readValue("\"COMPLEX<FOO>\"", ColumnType.class));
-    // this works though because array recursively calls on element type...
+    // the ARRAY<*> and COMPLEX<*> prefixes match case-insensitively, like the scalar type names ...
+    Assertions.assertEquals(ColumnType.STRING_ARRAY, MAPPER.readValue("\"array<string>\"", ColumnType.class));
+    Assertions.assertEquals(ColumnType.LONG_ARRAY, MAPPER.readValue("\"array<LONG>\"", ColumnType.class));
     Assertions.assertEquals(ColumnType.DOUBLE_ARRAY, MAPPER.readValue("\"ARRAY<double>\"", ColumnType.class));
+    Assertions.assertEquals(SOME_COMPLEX, MAPPER.readValue("\"complex<foo>\"", ColumnType.class));
+    // ... but the complex type name inside the brackets is a case-sensitive registry key, preserved as written
+    Assertions.assertNotEquals(SOME_COMPLEX, MAPPER.readValue("\"COMPLEX<FOO>\"", ColumnType.class));
+    // a parameterized type missing its closing bracket is malformed, not a truncated type parameter
+    Assertions.assertNull(MAPPER.readValue("\"COMPLEX<foo\"", ColumnType.class));
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/segment/column/ColumnTypeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/column/ColumnTypeTest.java
@@ -78,6 +78,9 @@ public class ColumnTypeTest
     Assertions.assertNotEquals(SOME_COMPLEX, MAPPER.readValue("\"COMPLEX<FOO>\"", ColumnType.class));
     // a parameterized type missing its closing bracket is malformed, not a truncated type parameter
     Assertions.assertNull(MAPPER.readValue("\"COMPLEX<foo\"", ColumnType.class));
+    // an unrecognized array element type makes the whole array type unrecognized, rather than an error
+    Assertions.assertNull(MAPPER.readValue("\"ARRAY<FOO>\"", ColumnType.class));
+    Assertions.assertNull(MAPPER.readValue("\"ARRAY<ARRAY<FOO>>\"", ColumnType.class));
   }
 
   @Test

--- a/server/src/main/java/org/apache/druid/catalog/model/ClusteredValueGroupsBaseTableMetadata.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/ClusteredValueGroupsBaseTableMetadata.java
@@ -129,6 +129,20 @@ public class ClusteredValueGroupsBaseTableMetadata implements DatasourceBaseTabl
   {
     ColumnType druidType = Columns.druidType(column);
     if (druidType == null) {
+      // A column declared without a type defaults to STRING (mirroring Columns.convertSignature), but a declared
+      // type that does not parse must be rejected rather than silently defaulted: the declared type is the physical
+      // segment schema here.
+      if (column.dataType() != null) {
+        throw InvalidInput.exception(
+            "column [%s] has an unrecognized type [%s]; declare a SQL type (such as [%s]) or a Druid type string"
+            + " (such as [%s] or [%s])",
+            column.name(),
+            column.dataType(),
+            Columns.SQL_BIGINT,
+            ColumnType.LONG_ARRAY.asTypeString(),
+            ColumnType.NESTED_DATA.asTypeString()
+        );
+      }
       druidType = ColumnType.STRING;
     }
     if (druidType.isPrimitive() || druidType.isPrimitiveArray()) {

--- a/server/src/main/java/org/apache/druid/catalog/model/TableDefn.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/TableDefn.java
@@ -22,7 +22,9 @@ package org.apache.druid.catalog.model;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import org.apache.druid.catalog.model.ModelProperties.PropertyDefn;
+import org.apache.druid.error.InvalidInput;
 import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.segment.column.ColumnType;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -106,9 +108,27 @@ public class TableDefn extends ObjectDefn
   /**
    * Table-specific validation of a column spec. Override for table definitions
    * that need table-specific validation rules.
+   * <p>
+   * A column declared without a type is legal (the type is resolved from the physical schema, the ingestion query, or
+   * the input format), but a declared type must parse to a Druid type, otherwise we would silently substitute STRING
+   * for the unrecognized declaration. This runs at catalog write time only: reads never validate, so tables stored
+   * before this rule keep resolving (though editing them surfaces the invalid type). {@link Columns#druidType} maps
+   * {@code __time} to LONG regardless of the declared type, which {@link ColumnSpec#validate} already restricts to
+   * LONG or untyped.
    */
   protected void validateColumn(ColumnSpec colSpec)
   {
+    if (colSpec.dataType() != null && Columns.druidType(colSpec) == null) {
+      throw InvalidInput.exception(
+          "Column [%s] has an unrecognized type [%s]; declare a SQL type (such as [%s]) or a Druid type string"
+          + " (such as [%s] or [%s])",
+          colSpec.name(),
+          colSpec.dataType(),
+          Columns.SQL_BIGINT,
+          ColumnType.LONG_ARRAY.asTypeString(),
+          ColumnType.NESTED_DATA.asTypeString()
+      );
+    }
   }
 
   /**

--- a/server/src/main/java/org/apache/druid/catalog/model/table/DatasourceDefn.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/table/DatasourceDefn.java
@@ -34,6 +34,7 @@ import org.apache.druid.catalog.model.TableSpec;
 import org.apache.druid.error.InvalidInput;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.segment.column.ColumnType;
 
 import java.util.Arrays;
 import java.util.List;
@@ -130,8 +131,21 @@ public class DatasourceDefn extends TableDefn
   protected void validateColumn(ColumnSpec spec)
   {
     super.validateColumn(spec);
-    if (Columns.isTimeColumn(spec.name()) && spec.dataType() != null) {
-      // Validate type in next PR
+    // A column declared without a type is legal (the type is resolved from the physical schema or the ingestion
+    // query), but a declared type must parse to a Druid type. This runs at catalog write time only: reads never
+    // validate, so tables stored before this rule keep resolving (though editing them surfaces the invalid type).
+    // Columns.druidType maps __time to LONG regardless of the declared type, which ColumnSpec.validate already
+    // restricts to LONG or untyped.
+    if (spec.dataType() != null && Columns.druidType(spec) == null) {
+      throw InvalidInput.exception(
+          "Column [%s] has an unrecognized type [%s]; declare a SQL type (such as [%s]) or a Druid type string"
+          + " (such as [%s] or [%s])",
+          spec.name(),
+          spec.dataType(),
+          Columns.SQL_BIGINT,
+          ColumnType.LONG_ARRAY.asTypeString(),
+          ColumnType.NESTED_DATA.asTypeString()
+      );
     }
   }
 

--- a/server/src/main/java/org/apache/druid/catalog/model/table/DatasourceDefn.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/table/DatasourceDefn.java
@@ -21,7 +21,6 @@ package org.apache.druid.catalog.model.table;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.druid.catalog.model.ColumnSpec;
 import org.apache.druid.catalog.model.Columns;
 import org.apache.druid.catalog.model.DatasourceBaseTableMetadata;
 import org.apache.druid.catalog.model.DatasourceProjectionMetadata;
@@ -34,7 +33,6 @@ import org.apache.druid.catalog.model.TableSpec;
 import org.apache.druid.error.InvalidInput;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
-import org.apache.druid.segment.column.ColumnType;
 
 import java.util.Arrays;
 import java.util.List;
@@ -124,28 +122,6 @@ public class DatasourceDefn extends TableDefn
       // Cross-validate the layout against the declared columns by deriving the physical spec, so that catalog writes
       // fail fast instead of surfacing layout problems at ingest time.
       baseTable.createSpec(table.spec().columns());
-    }
-  }
-
-  @Override
-  protected void validateColumn(ColumnSpec spec)
-  {
-    super.validateColumn(spec);
-    // A column declared without a type is legal (the type is resolved from the physical schema or the ingestion
-    // query), but a declared type must parse to a Druid type. This runs at catalog write time only: reads never
-    // validate, so tables stored before this rule keep resolving (though editing them surfaces the invalid type).
-    // Columns.druidType maps __time to LONG regardless of the declared type, which ColumnSpec.validate already
-    // restricts to LONG or untyped.
-    if (spec.dataType() != null && Columns.druidType(spec) == null) {
-      throw InvalidInput.exception(
-          "Column [%s] has an unrecognized type [%s]; declare a SQL type (such as [%s]) or a Druid type string"
-          + " (such as [%s] or [%s])",
-          spec.name(),
-          spec.dataType(),
-          Columns.SQL_BIGINT,
-          ColumnType.LONG_ARRAY.asTypeString(),
-          ColumnType.NESTED_DATA.asTypeString()
-      );
     }
   }
 

--- a/server/src/main/java/org/apache/druid/catalog/model/table/ExternalTableDefn.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/table/ExternalTableDefn.java
@@ -21,7 +21,6 @@ package org.apache.druid.catalog.model.table;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.druid.catalog.model.ColumnSpec;
 import org.apache.druid.catalog.model.ModelProperties.ObjectPropertyDefn;
 import org.apache.druid.catalog.model.ModelProperties.PropertyDefn;
 import org.apache.druid.catalog.model.ResolvedTable;
@@ -282,12 +281,6 @@ public class ExternalTableDefn extends TableDefn
   public TableFunction tableFn(ResolvedTable table)
   {
     return new ResolvedExternalTable(table).resolve(registry).tableFn();
-  }
-
-  @Override
-  protected void validateColumn(ColumnSpec colSpec)
-  {
-    // Validate type in next PR
   }
 
   /**

--- a/server/src/test/java/org/apache/druid/catalog/model/ClusteredValueGroupsBaseTableMetadataTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/ClusteredValueGroupsBaseTableMetadataTest.java
@@ -472,6 +472,7 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
     // parameterized type such as a missing closing bracket parses to null.)
     final DatasourceBaseTableMetadata metadata = new ClusteredValueGroupsBaseTableMetadata(
         Collections.singletonList("tenant"),
+        null,
         null
     );
     for (String badType : new String[]{"COMPLEX<json", "ARRAY<LONG", "ARRAY<FOO>", "FOO"}) {

--- a/server/src/test/java/org/apache/druid/catalog/model/ClusteredValueGroupsBaseTableMetadataTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/ClusteredValueGroupsBaseTableMetadataTest.java
@@ -254,7 +254,7 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
         Collections.singletonList("tenant"),
         null
     );
-    for (String badType : new String[]{"COMPLEX<json", "ARRAY<LONG", "FOO"}) {
+    for (String badType : new String[]{"COMPLEX<json", "ARRAY<LONG", "ARRAY<FOO>", "FOO"}) {
       final List<ColumnSpec> columns = Arrays.asList(
           new ColumnSpec("tenant", Columns.SQL_VARCHAR, null),
           new ColumnSpec(Columns.TIME_COLUMN, null, null),

--- a/server/src/test/java/org/apache/druid/catalog/model/ClusteredValueGroupsBaseTableMetadataTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/ClusteredValueGroupsBaseTableMetadataTest.java
@@ -202,7 +202,10 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
         new ColumnSpec("tags", Columns.SQL_VARCHAR_ARRAY, null),
         new ColumnSpec("vals", Columns.SQL_BIGINT_ARRAY, null),
         new ColumnSpec("ratios", Columns.SQL_FLOAT_ARRAY, null),
-        new ColumnSpec("attrs", ColumnType.NESTED_DATA.asTypeString(), null)
+        new ColumnSpec("attrs", ColumnType.NESTED_DATA.asTypeString(), null),
+        // type prefixes match case-insensitively; these must not silently fall back to STRING
+        new ColumnSpec("attrs2", "complex<json>", null),
+        new ColumnSpec("vals2", "array<long>", null)
     );
     // Declared types are retained in the ingestion schema rather than left to inference: arrays cast an auto column
     // to the declared type (an all-null batch has no values to infer from; FLOAT ARRAY is stored as DOUBLE ARRAY by
@@ -215,7 +218,9 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
                                                        new AutoTypeColumnSchema("tags", ColumnType.STRING_ARRAY, null),
                                                        new AutoTypeColumnSchema("vals", ColumnType.LONG_ARRAY, null),
                                                        new AutoTypeColumnSchema("ratios", ColumnType.DOUBLE_ARRAY, null),
-                                                       new NestedDataColumnSchema("attrs", NestedDataColumnSchema.DEFAULT_FORMAT_VERSION)
+                                                       new NestedDataColumnSchema("attrs", NestedDataColumnSchema.DEFAULT_FORMAT_VERSION),
+                                                       new NestedDataColumnSchema("attrs2", NestedDataColumnSchema.DEFAULT_FORMAT_VERSION),
+                                                       new AutoTypeColumnSchema("vals2", ColumnType.LONG_ARRAY, null)
                                                    )
                                                    .clusteringColumns("tenant")
                                                    .build(),

--- a/server/src/test/java/org/apache/druid/catalog/model/ClusteredValueGroupsBaseTableMetadataTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/ClusteredValueGroupsBaseTableMetadataTest.java
@@ -245,6 +245,30 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
   }
 
   @Test
+  public void testCreateSpecUnparseableTypeFails()
+  {
+    // A column declared WITHOUT a type defaults to STRING, but a declared type that does not parse must be rejected
+    // rather than silently defaulted: the declared type is the physical segment schema here. (A malformed
+    // parameterized type such as a missing closing bracket parses to null.)
+    final DatasourceBaseTableMetadata metadata = new ClusteredValueGroupsBaseTableMetadata(
+        Collections.singletonList("tenant"),
+        null
+    );
+    for (String badType : new String[]{"COMPLEX<json", "ARRAY<LONG", "FOO"}) {
+      final List<ColumnSpec> columns = Arrays.asList(
+          new ColumnSpec("tenant", Columns.SQL_VARCHAR, null),
+          new ColumnSpec(Columns.TIME_COLUMN, null, null),
+          new ColumnSpec("busted", badType, null)
+      );
+      final DruidException e = Assert.assertThrows(DruidException.class, () -> metadata.createSpec(columns));
+      Assert.assertTrue(
+          "expected unrecognized-type error for [" + badType + "] but got: " + e.getMessage(),
+          e.getMessage().contains("column [busted] has an unrecognized type [" + badType + "]")
+      );
+    }
+  }
+
+  @Test
   public void testCreateSpecClusteringColumnsNotLeadingPrefixFails()
   {
     // 'region' is declared, but not as part of the leading prefix of the column list; the declared order is the

--- a/server/src/test/java/org/apache/druid/catalog/model/table/DatasourceTableTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/DatasourceTableTest.java
@@ -465,6 +465,14 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
       assertTrue(e.getMessage().contains("Column [foo] has an unrecognized type [COMPLEX<json]"));
     }
     {
+      // An unrecognized array element type is an invalid input, not an internal error.
+      TableSpec spec = builder.copy()
+          .column("foo", "ARRAY<FOO>")
+          .buildSpec();
+      DruidException e = assertThrows(DruidException.class, () -> registry.resolve(spec).validate());
+      assertTrue(e.getMessage().contains("Column [foo] has an unrecognized type [ARRAY<FOO>]"));
+    }
+    {
       // Parse-level validation only: any well-formed complex type is accepted at the logical layer, whether or not
       // its serde is registered on this server.
       TableSpec spec = builder.copy()

--- a/server/src/test/java/org/apache/druid/catalog/model/table/DatasourceTableTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/DatasourceTableTest.java
@@ -43,6 +43,7 @@ import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
+import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -66,7 +67,7 @@ import static org.junit.Assert.assertTrue;
  * Test of validation and serialization of the catalog table definitions.
  */
 @Category(CatalogTest.class)
-public class DatasourceTableTest
+public class DatasourceTableTest extends InitializedNullHandlingTest
 {
   private static final Logger LOG = new Logger(DatasourceTableTest.class);
 
@@ -445,6 +446,31 @@ public class DatasourceTableTest
           .column("foo", Columns.LONG)
           .buildSpec();
       expectValidationFails(spec);
+    }
+
+    // A declared type must parse to a Druid type; no type at all remains legal (covered above).
+    {
+      TableSpec spec = builder.copy()
+          .column("foo", "FOO")
+          .buildSpec();
+      DruidException e = assertThrows(DruidException.class, () -> registry.resolve(spec).validate());
+      assertTrue(e.getMessage().contains("Column [foo] has an unrecognized type [FOO]"));
+    }
+    {
+      // A parameterized type missing its closing bracket is malformed, and must not silently pass as undeclared.
+      TableSpec spec = builder.copy()
+          .column("foo", "COMPLEX<json")
+          .buildSpec();
+      DruidException e = assertThrows(DruidException.class, () -> registry.resolve(spec).validate());
+      assertTrue(e.getMessage().contains("Column [foo] has an unrecognized type [COMPLEX<json]"));
+    }
+    {
+      // Parse-level validation only: any well-formed complex type is accepted at the logical layer, whether or not
+      // its serde is registered on this server.
+      TableSpec spec = builder.copy()
+          .column("foo", "COMPLEX<thetaSketch>")
+          .buildSpec();
+      expectValidationSucceeds(spec);
     }
   }
 

--- a/server/src/test/java/org/apache/druid/catalog/model/table/ExternalTableTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/ExternalTableTest.java
@@ -30,6 +30,7 @@ import org.apache.druid.data.input.impl.HttpInputSourceConfig;
 import org.apache.druid.data.input.impl.InlineInputSource;
 import org.apache.druid.data.input.impl.JsonInputFormat;
 import org.apache.druid.data.input.impl.LocalInputSource;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.metadata.DefaultPasswordProvider;
@@ -43,6 +44,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class ExternalTableTest extends BaseExternTableTest
 {
@@ -130,6 +132,28 @@ public class ExternalTableTest extends BaseExternTableTest
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     resolved.validate();
+  }
+
+  @Test
+  public void testValidateUnrecognizedColumnType()
+  {
+    // A declared column type must parse to a Druid type: an unrecognized type would otherwise silently become
+    // STRING when the columns are converted to the input row signature.
+    CsvInputFormat format = new CsvInputFormat(
+        Collections.singletonList("a"), ";", false, false, 0, null);
+    for (String badType : new String[]{"FOO", "COMPLEX<json"}) {
+      TableMetadata table = TableBuilder.external("foo")
+          .inputSource(toMap(new InlineInputSource("a\n")))
+          .inputFormat(formatToMap(format))
+          .column("a", badType)
+          .build();
+      ResolvedTable resolved = registry.resolve(table.spec());
+      DruidException e = assertThrows(DruidException.class, () -> resolved.validate());
+      assertTrue(
+          "expected unrecognized-type error for [" + badType + "] but got: " + e.getMessage(),
+          e.getMessage().contains("Column [a] has an unrecognized type [" + badType + "]")
+      );
+    }
   }
 
   /**

--- a/sql/src/main/java/org/apache/druid/sql/calcite/external/Externals.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/external/Externals.java
@@ -273,8 +273,14 @@ public class Externals
       throw unsupportedType(name, dataType);
     }
     String simpleName = typeNameIdentifier.getSimple();
-    if (StringUtils.toLowerCase(simpleName).startsWith(("complex<"))) {
-      return simpleName;
+    if (StringUtils.toLowerCase(simpleName).startsWith("complex<")) {
+      // Parse and validate rather than passing the raw string downstream, where a malformed type string would
+      // silently resolve to a different type; return the canonical form.
+      final ColumnType complexType = ColumnType.fromString(simpleName);
+      if (complexType == null) {
+        throw unsupportedType(name, dataType);
+      }
+      return complexType.asTypeString();
     }
     SqlTypeName type = SqlTypeName.get(simpleName);
     if (type == null) {

--- a/sql/src/test/java/org/apache/druid/sql/calcite/IngestTableFunctionTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/IngestTableFunctionTest.java
@@ -34,6 +34,7 @@ import org.apache.druid.data.input.impl.HttpInputSourceConfig;
 import org.apache.druid.data.input.impl.JsonInputFormat;
 import org.apache.druid.data.input.impl.LocalInputSource;
 import org.apache.druid.data.input.impl.systemfield.SystemFields;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
@@ -455,6 +456,78 @@ public class IngestTableFunctionTest extends CalciteIngestionDmlTest
                 .context(CalciteIngestionDmlTest.PARTITIONED_BY_ALL_TIME_QUERY_CONTEXT)
                 .build()
          )
+        .verify();
+  }
+
+  /**
+   * The COMPLEX type prefix in an EXTEND clause matches case-insensitively (like all other type names) and is
+   * normalized to the canonical form; the complex type name inside the brackets keeps its casing.
+   */
+  @Test
+  public void testHttpJsonLowercaseComplexTypePrefix()
+  {
+    final ExternalDataSource httpDataSource = new ExternalDataSource(
+        new HttpInputSource(
+            Collections.singletonList(toURI("http://foo.com/bar.json")),
+            "bob",
+            new DefaultPasswordProvider("secret"),
+            SystemFields.none(),
+            null,
+            new HttpInputSourceConfig(null, null)
+        ),
+        new JsonInputFormat(null, null, null, null, null),
+        RowSignature.builder()
+                    .add("x", ColumnType.STRING)
+                    .add("z", ColumnType.NESTED_DATA)
+                    .build()
+        );
+    testIngestionQuery()
+        .sql("INSERT INTO dst SELECT *\n" +
+             "FROM TABLE(http(userName => 'bob',\n" +
+            "                 password => 'secret',\n" +
+             "                uris => ARRAY['http://foo.com/bar.json'],\n" +
+             "                format => 'json'))\n" +
+             "     EXTEND (x VARCHAR, z TYPE('complex<json>'))\n" +
+             "PARTITIONED BY ALL TIME")
+        .authentication(CalciteTests.SUPER_USER_AUTH_RESULT)
+        .expectTarget("dst", httpDataSource.getSignature())
+        .expectResources(dataSourceWrite("dst"), Externals.EXTERNAL_RESOURCE_ACTION)
+        .expectQuery(
+            newScanQueryBuilder()
+                .dataSource(httpDataSource)
+                .intervals(querySegmentSpec(Filtration.eternity()))
+                .columns("x", "z")
+                .columnTypes(ColumnType.STRING, ColumnType.ofComplex("json"))
+                .context(CalciteIngestionDmlTest.PARTITIONED_BY_ALL_TIME_QUERY_CONTEXT)
+                .build()
+         )
+        .verify();
+  }
+
+  /**
+   * A malformed complex type in an EXTEND clause (missing the closing bracket) is rejected rather than silently
+   * resolving to a different type.
+   */
+  @Test
+  public void testHttpJsonMalformedComplexTypeRejected()
+  {
+    testIngestionQuery()
+        .sql("INSERT INTO dst SELECT *\n" +
+             "FROM TABLE(http(userName => 'bob',\n" +
+            "                 password => 'secret',\n" +
+             "                uris => ARRAY['http://foo.com/bar.json'],\n" +
+             "                format => 'json'))\n" +
+             "     EXTEND (x VARCHAR, z TYPE('complex<json'))\n" +
+             "PARTITIONED BY ALL TIME")
+        .authentication(CalciteTests.SUPER_USER_AUTH_RESULT)
+        .expectValidationError(
+            CoreMatchers.allOf(
+                CoreMatchers.instanceOf(DruidException.class),
+                ThrowableMessageMatcher.hasMessage(
+                    CoreMatchers.containsString("Column [z] has an unsupported type")
+                )
+            )
+        )
         .verify();
   }
 


### PR DESCRIPTION
### Description
This PR improves catalog type validation to reject invalid complex types instead of silently being ignored. It also updates druid native type validation to perform case insensitive handling of `ARRAY` and `COMPLEX` type prefixes, to be more consistent with how primitive types are handled (case insensitive), and fixes bug with handling of malformed type strings without a closing `>`. Prior to this something like `long` was allowed, but `complex<json>` or `array<long>` was not allowed (while `ARRAY<long>` was since array parsing recurses after removing the prefix). Array and complex prefix handling is now case insensitive, but complex type name handling itself must still be exact, as the underlying complex type registry is still case sensitive.