### PR TITLE
minor: empty cursor holder time ordering

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/EmptyCursorHolder.java
+++ b/processing/src/main/java/org/apache/druid/segment/EmptyCursorHolder.java
@@ -20,6 +20,7 @@
 package org.apache.druid.segment;
 
 import org.apache.druid.error.DruidException;
+import org.apache.druid.query.Order;
 import org.apache.druid.query.OrderBy;
 import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.dimension.DimensionSpec;
@@ -42,16 +43,46 @@ import java.util.List;
  * A {@link CursorHolder} that yields no rows. Its cursors are always done, but its selector factories hand out harmless
  * nil selectors and {@link #canVectorize()} reports true.
  * <p>
- * Useful wherever a segment can be proven to match no rows without scanning it.
+ * Useful wherever a segment can be proven to match no rows without scanning it. Use {@link #getDefault()} when no
+ * ordering needs to be advertised, or {@link #forTimeOrder(Order)} when the caller must satisfy a requested
+ * {@code __time} ordering.
  */
 public final class EmptyCursorHolder implements CursorHolder
 {
-  public static final EmptyCursorHolder INSTANCE = new EmptyCursorHolder();
+  private static final EmptyCursorHolder INSTANCE = new EmptyCursorHolder(Collections.emptyList());
+  private static final EmptyCursorHolder TIME_ASCENDING = new EmptyCursorHolder(Cursors.ascendingTimeOrder());
+  private static final EmptyCursorHolder TIME_DESCENDING = new EmptyCursorHolder(Cursors.descendingTimeOrder());
 
   private static final ColumnSelectorFactory NIL_SELECTOR_FACTORY = new AllNullColumnSelectorFactory();
 
-  private EmptyCursorHolder()
+  public static EmptyCursorHolder getDefault()
   {
+    return INSTANCE;
+  }
+
+  /**
+   * An empty holder that advertises the given {@code __time} ordering, so a time-ordered query engine that hard-checks
+   * cursor ordering (e.g. scan) accepts the empty result instead of failing. An empty cursor is trivially ordered in
+   * any direction, so it can honestly claim whichever direction the query asked for. {@link Order#NONE} yields the
+   * unordered {@link #getDefault()}.
+   */
+  public static EmptyCursorHolder forTimeOrder(Order timeOrder)
+  {
+    switch (timeOrder) {
+      case ASCENDING:
+        return TIME_ASCENDING;
+      case DESCENDING:
+        return TIME_DESCENDING;
+      default:
+        return INSTANCE;
+    }
+  }
+
+  private final List<OrderBy> ordering;
+
+  private EmptyCursorHolder(List<OrderBy> ordering)
+  {
+    this.ordering = ordering;
   }
 
   @Override
@@ -211,6 +242,6 @@ public final class EmptyCursorHolder implements CursorHolder
   @Override
   public List<OrderBy> getOrdering()
   {
-    return Collections.emptyList();
+    return ordering;
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/EmptyCursorHolder.java
+++ b/processing/src/main/java/org/apache/druid/segment/EmptyCursorHolder.java
@@ -43,39 +43,32 @@ import java.util.List;
  * A {@link CursorHolder} that yields no rows. Its cursors are always done, but its selector factories hand out harmless
  * nil selectors and {@link #canVectorize()} reports true.
  * <p>
- * Useful wherever a segment can be proven to match no rows without scanning it. Use {@link #getDefault()} when no
- * ordering needs to be advertised, or {@link #forTimeOrder(Order)} when the caller must satisfy a requested
- * {@code __time} ordering.
+ * Useful wherever a segment can be proven to match no rows without scanning it. Use {@link #forSpec(CursorBuildSpec)}
+ * to produce an empty cursor matching the preferred ordering of the {@link CursorBuildSpec}.
  */
 public final class EmptyCursorHolder implements CursorHolder
 {
-  private static final EmptyCursorHolder INSTANCE = new EmptyCursorHolder(Collections.emptyList());
+  private static final EmptyCursorHolder NO_ORDER = new EmptyCursorHolder(Collections.emptyList());
   private static final EmptyCursorHolder TIME_ASCENDING = new EmptyCursorHolder(Cursors.ascendingTimeOrder());
   private static final EmptyCursorHolder TIME_DESCENDING = new EmptyCursorHolder(Cursors.descendingTimeOrder());
 
   private static final ColumnSelectorFactory NIL_SELECTOR_FACTORY = new AllNullColumnSelectorFactory();
 
-  public static EmptyCursorHolder getDefault()
-  {
-    return INSTANCE;
-  }
-
   /**
-   * An empty holder that advertises the given {@code __time} ordering, so a time-ordered query engine that hard-checks
-   * cursor ordering (e.g. scan) accepts the empty result instead of failing. An empty cursor is trivially ordered in
-   * any direction, so it can honestly claim whichever direction the query asked for. {@link Order#NONE} yields the
-   * unordered {@link #getDefault()}.
+   * An empty holder that advertises the spec's preferred ordering. A cursor with no rows trivially satisfies any
+   * ordering, so it can honestly claim whatever the query asked for. The two {@code __time} directions reuse cached
+   * singletons (the common case); any other non-empty preferred ordering gets a fresh instance, and an empty preferred
+   * ordering yields the unordered shared instance.
    */
-  public static EmptyCursorHolder forTimeOrder(Order timeOrder)
+  public static EmptyCursorHolder forSpec(CursorBuildSpec spec)
   {
-    switch (timeOrder) {
-      case ASCENDING:
-        return TIME_ASCENDING;
-      case DESCENDING:
-        return TIME_DESCENDING;
-      default:
-        return INSTANCE;
-    }
+    final List<OrderBy> preferredOrdering = spec.getPreferredOrdering();
+    final Order timeOrder = Cursors.getTimeOrdering(preferredOrdering);
+    return switch (timeOrder) {
+      case ASCENDING -> TIME_ASCENDING;
+      case DESCENDING -> TIME_DESCENDING;
+      default -> preferredOrdering.isEmpty() ? NO_ORDER : new EmptyCursorHolder(preferredOrdering);
+    };
   }
 
   private final List<OrderBy> ordering;

--- a/processing/src/main/java/org/apache/druid/segment/PartialQueryableIndexCursorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/PartialQueryableIndexCursorFactory.java
@@ -110,9 +110,7 @@ public class PartialQueryableIndexCursorFactory implements CursorFactory
     if (plan.clusterGroupPlan() != null) {
       if (plan.bundles().isEmpty()) {
         // Filter rules out every cluster group: no bundle to acquire, nothing to download.
-        return AsyncCursorHolder.completed(
-            EmptyCursorHolder.forTimeOrder(Cursors.getTimeOrdering(spec.getPreferredOrdering()))
-        );
+        return AsyncCursorHolder.completed(EmptyCursorHolder.forSpec(spec));
       }
       // reuse the plan's cluster resolution
       return buildAsyncCursorHolder(

--- a/processing/src/main/java/org/apache/druid/segment/PartialQueryableIndexCursorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/PartialQueryableIndexCursorFactory.java
@@ -110,7 +110,9 @@ public class PartialQueryableIndexCursorFactory implements CursorFactory
     if (plan.clusterGroupPlan() != null) {
       if (plan.bundles().isEmpty()) {
         // Filter rules out every cluster group: no bundle to acquire, nothing to download.
-        return AsyncCursorHolder.completed(EmptyCursorHolder.INSTANCE);
+        return AsyncCursorHolder.completed(
+            EmptyCursorHolder.forTimeOrder(Cursors.getTimeOrdering(spec.getPreferredOrdering()))
+        );
       }
       // reuse the plan's cluster resolution
       return buildAsyncCursorHolder(

--- a/processing/src/main/java/org/apache/druid/segment/QueryableIndexCursorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/QueryableIndexCursorFactory.java
@@ -126,7 +126,7 @@ public class QueryableIndexCursorFactory implements ResidentCursorFactory
   public CursorHolder makeClusteredCursorHolder(CursorBuildSpec spec, ClusterGroupQueryPlan plan)
   {
     if (plan.survivingGroups().isEmpty()) {
-      return EmptyCursorHolder.INSTANCE;
+      return EmptyCursorHolder.forTimeOrder(Cursors.getTimeOrdering(spec.getPreferredOrdering()));
     }
 
     if (plan.survivingGroups().size() == 1) {

--- a/processing/src/main/java/org/apache/druid/segment/QueryableIndexCursorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/QueryableIndexCursorFactory.java
@@ -126,7 +126,7 @@ public class QueryableIndexCursorFactory implements ResidentCursorFactory
   public CursorHolder makeClusteredCursorHolder(CursorBuildSpec spec, ClusterGroupQueryPlan plan)
   {
     if (plan.survivingGroups().isEmpty()) {
-      return EmptyCursorHolder.forTimeOrder(Cursors.getTimeOrdering(spec.getPreferredOrdering()));
+      return EmptyCursorHolder.forSpec(spec);
     }
 
     if (plan.survivingGroups().size() == 1) {

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexCursorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexCursorFactory.java
@@ -149,7 +149,7 @@ public class IncrementalIndexCursorFactory implements ResidentCursorFactory
     final List<TableClusterGroupSpec> surviving = plan.survivingGroups();
 
     if (surviving.isEmpty()) {
-      return EmptyCursorHolder.forTimeOrder(Cursors.getTimeOrdering(spec.getPreferredOrdering()));
+      return EmptyCursorHolder.forSpec(spec);
     }
 
     final RowSignature clusteringColumns = summary.getClusteringColumns();

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexCursorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexCursorFactory.java
@@ -149,7 +149,7 @@ public class IncrementalIndexCursorFactory implements ResidentCursorFactory
     final List<TableClusterGroupSpec> surviving = plan.survivingGroups();
 
     if (surviving.isEmpty()) {
-      return EmptyCursorHolder.INSTANCE;
+      return EmptyCursorHolder.forTimeOrder(Cursors.getTimeOrdering(spec.getPreferredOrdering()));
     }
 
     final RowSignature clusteringColumns = summary.getClusteringColumns();

--- a/processing/src/test/java/org/apache/druid/segment/ClusteredSegmentTimeOrderedQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/ClusteredSegmentTimeOrderedQueryTest.java
@@ -38,6 +38,8 @@ import org.apache.druid.query.QueryRunnerTestHelper;
 import org.apache.druid.query.Result;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.query.expression.TestExprMacroTable;
+import org.apache.druid.query.filter.DimFilter;
+import org.apache.druid.query.filter.EqualityFilter;
 import org.apache.druid.query.scan.ScanQuery;
 import org.apache.druid.query.scan.ScanQueryConfig;
 import org.apache.druid.query.scan.ScanQueryEngine;
@@ -65,6 +67,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -245,6 +248,21 @@ class ClusteredSegmentTimeOrderedQueryTest extends InitializedNullHandlingTest
   }
 
   @Test
+  void testTimeOrderedScanPruningAllGroupsReturnsEmpty()
+  {
+    // A filter on the clustering column that matches no group prunes every cluster group, so the clustered cursor
+    // factory returns an empty holder. The scan engine hard-enforces cursor time ordering, so the empty holder must
+    // advertise the requested __time direction (asc or desc) or the scan explodes instead of returning zero rows.
+    // Covers both the historical (QueryableIndexCursorFactory) and realtime (IncrementalIndexCursorFactory) paths.
+    final DimFilter noGroup = new EqualityFilter("tenant", ColumnType.STRING, "nobody", null);
+    final Segment incremental = buildClusteredIncremental(ROWS);
+    for (final Segment segment : List.of(clusteredSegment, incremental)) {
+      Assertions.assertEquals(List.of(), runScanRows(segment, Order.ASCENDING, noGroup));
+      Assertions.assertEquals(List.of(), runScanRows(segment, Order.DESCENDING, noGroup));
+    }
+  }
+
+  @Test
   void testTimeOrderedQueriesOverIncrementalClusteredSegment()
   {
     // The realtime path (IncrementalIndexCursorFactory) must also k-way-merge groups for a __time-ordered query.
@@ -310,13 +328,21 @@ class ClusteredSegmentTimeOrderedQueryTest extends InitializedNullHandlingTest
 
   private static List<List<Object>> runScanRows(Segment segment, Order order)
   {
-    final ScanQuery query = Druids.newScanQueryBuilder()
-                                  .dataSource(DATA_SOURCE)
-                                  .intervals(new MultipleIntervalSegmentSpec(List.of(INTERVAL)))
-                                  .columns(ColumnHolder.TIME_COLUMN_NAME, "tenant", "m")
-                                  .order(order)
-                                  .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
-                                  .build();
+    return runScanRows(segment, order, null);
+  }
+
+  private static List<List<Object>> runScanRows(Segment segment, Order order, @Nullable DimFilter filter)
+  {
+    final Druids.ScanQueryBuilder builder = Druids.newScanQueryBuilder()
+                                                  .dataSource(DATA_SOURCE)
+                                                  .intervals(new MultipleIntervalSegmentSpec(List.of(INTERVAL)))
+                                                  .columns(ColumnHolder.TIME_COLUMN_NAME, "tenant", "m")
+                                                  .order(order)
+                                                  .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST);
+    if (filter != null) {
+      builder.filters(filter);
+    }
+    final ScanQuery query = builder.build();
     final ScanQueryRunnerFactory factory = new ScanQueryRunnerFactory(
         new ScanQueryQueryToolChest(DefaultGenericQueryMetricsFactory.instance()),
         new ScanQueryEngine(),

--- a/processing/src/test/java/org/apache/druid/segment/EmptyCursorHolderTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/EmptyCursorHolderTest.java
@@ -19,41 +19,73 @@
 
 package org.apache.druid.segment;
 
-import org.apache.druid.query.Order;
+import org.apache.druid.query.OrderBy;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 class EmptyCursorHolderTest
 {
+  private static final CursorBuildSpec ASC = CursorBuildSpec.builder()
+                                                            .setPreferredOrdering(Cursors.ascendingTimeOrder())
+                                                            .build();
+  private static final CursorBuildSpec DESC = CursorBuildSpec.builder()
+                                                             .setPreferredOrdering(Cursors.descendingTimeOrder())
+                                                             .build();
+
   @Test
   void testForTimeOrderAscendingAdvertisesAscendingTime()
   {
+    CursorHolder holder = EmptyCursorHolder.forSpec(ASC);
     Assertions.assertEquals(
         Cursors.ascendingTimeOrder(),
-        EmptyCursorHolder.forTimeOrder(Order.ASCENDING).getOrdering()
+        holder.getOrdering()
     );
-    Assertions.assertSame(EmptyCursorHolder.forTimeOrder(Order.ASCENDING), EmptyCursorHolder.forTimeOrder(Order.ASCENDING));
+    Assertions.assertSame(EmptyCursorHolder.forSpec(ASC), holder);
   }
 
   @Test
   void testForTimeOrderDescendingAdvertisesDescendingTime()
   {
+    CursorHolder holder = EmptyCursorHolder.forSpec(DESC);
     Assertions.assertEquals(
         Cursors.descendingTimeOrder(),
-        EmptyCursorHolder.forTimeOrder(Order.DESCENDING).getOrdering()
+        holder.getOrdering()
     );
-    Assertions.assertSame(EmptyCursorHolder.forTimeOrder(Order.DESCENDING), EmptyCursorHolder.forTimeOrder(Order.DESCENDING));
+    Assertions.assertSame(EmptyCursorHolder.forSpec(DESC), holder);
   }
 
   @Test
   void testForTimeOrderNoneReturnsUnorderedInstance()
   {
-    Assertions.assertSame(EmptyCursorHolder.forTimeOrder(Order.NONE), EmptyCursorHolder.forTimeOrder(Order.NONE));
+    CursorHolder holder = EmptyCursorHolder.forSpec(CursorBuildSpec.FULL_SCAN);
+    Assertions.assertEquals(
+        List.of(),
+        holder.getOrdering()
+    );
+    Assertions.assertSame(EmptyCursorHolder.forSpec(CursorBuildSpec.FULL_SCAN), holder);
+  }
+
+  @Test
+  void testForSpecNonTimeOrderingAdvertisedVerbatim()
+  {
+    // preferredOrdering decouples from assumed __time ordering; an empty cursor trivially satisfies any ordering, so
+    // forSpec advertises a non-__time preferred ordering verbatim via a fresh, uncached instance.
+    final List<OrderBy> ordering = List.of(OrderBy.ascending("dim"));
+    final CursorBuildSpec spec = CursorBuildSpec.builder().setPreferredOrdering(ordering).build();
+    final CursorHolder holder = EmptyCursorHolder.forSpec(spec);
+    Assertions.assertEquals(ordering, holder.getOrdering());
+    // Not the unordered singleton, and arbitrary orderings are not cached (a fresh instance each call).
+    Assertions.assertNotSame(holder, EmptyCursorHolder.forSpec(CursorBuildSpec.FULL_SCAN));
+    Assertions.assertNotSame(holder, EmptyCursorHolder.forSpec(spec));
   }
 
   @Test
   void testCursorIsAlwaysDone()
   {
-    Assertions.assertTrue(EmptyCursorHolder.forTimeOrder(Order.ASCENDING).asCursor().isDone());
+    Assertions.assertTrue(EmptyCursorHolder.forSpec(ASC).asCursor().isDone());
+    Assertions.assertTrue(EmptyCursorHolder.forSpec(DESC).asCursor().isDone());
+    Assertions.assertTrue(EmptyCursorHolder.forSpec(CursorBuildSpec.FULL_SCAN).asCursor().isDone());
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/EmptyCursorHolderTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/EmptyCursorHolderTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment;
+
+import org.apache.druid.query.Order;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class EmptyCursorHolderTest
+{
+  @Test
+  void testForTimeOrderAscendingAdvertisesAscendingTime()
+  {
+    Assertions.assertEquals(
+        Cursors.ascendingTimeOrder(),
+        EmptyCursorHolder.forTimeOrder(Order.ASCENDING).getOrdering()
+    );
+    Assertions.assertSame(EmptyCursorHolder.forTimeOrder(Order.ASCENDING), EmptyCursorHolder.forTimeOrder(Order.ASCENDING));
+  }
+
+  @Test
+  void testForTimeOrderDescendingAdvertisesDescendingTime()
+  {
+    Assertions.assertEquals(
+        Cursors.descendingTimeOrder(),
+        EmptyCursorHolder.forTimeOrder(Order.DESCENDING).getOrdering()
+    );
+    Assertions.assertSame(EmptyCursorHolder.forTimeOrder(Order.DESCENDING), EmptyCursorHolder.forTimeOrder(Order.DESCENDING));
+  }
+
+  @Test
+  void testForTimeOrderNoneReturnsUnorderedInstance()
+  {
+    Assertions.assertSame(EmptyCursorHolder.forTimeOrder(Order.NONE), EmptyCursorHolder.forTimeOrder(Order.NONE));
+  }
+
+  @Test
+  void testCursorIsAlwaysDone()
+  {
+    Assertions.assertTrue(EmptyCursorHolder.forTimeOrder(Order.ASCENDING).asCursor().isDone());
+  }
+}


### PR DESCRIPTION
### Description
Missed this after #19726 and #19753, causing a clustered segment with all of the groups filtered out not reporting time ordering. `EmptyCursorHolder` now has `forTimeOrder` to produce an empty cursor with the desired ordering to satisfy the query engines.