### PR TITLE
fix: UI cache toggle should disable all cache layers

### DIFF
--- a/web-console/src/druid-models/query-context/query-context.tsx
+++ b/web-console/src/druid-models/query-context/query-context.tsx
@@ -25,6 +25,10 @@ export type SqlJoinAlgorithm = 'broadcast' | 'sortMerge';
 export interface QueryContext {
   useCache?: boolean;
   populateCache?: boolean;
+  useResultLevelCache?: boolean;
+  populateResultLevelCache?: boolean;
+  useForwardedResultLevelCache?: boolean;
+  populateForwardedResultLevelCache?: boolean;
   useApproximateCountDistinct?: boolean;
   useApproximateTopN?: boolean;
   sqlTimeZone?: string;

--- a/web-console/src/views/workbench-view/run-panel/run-panel.tsx
+++ b/web-console/src/views/workbench-view/run-panel/run-panel.tsx
@@ -565,6 +565,10 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
                         ...queryContext,
                         useCache,
                         populateCache: useCache,
+                        useResultLevelCache: useCache,
+                        populateResultLevelCache: useCache,
+                        useForwardedResultLevelCache: useCache,
+                        populateForwardedResultLevelCache: useCache,
                       })
                     }
                     optionsText={ENABLED_DISABLED_OPTIONS_TEXT}


### PR DESCRIPTION
## Summary
- The web console "Use cache" toggle in the run panel only set `useCache`/`populateCache` in the query context, leaving result-level and forwarded result-level cache settings unaffected.
- Extends the toggle handler to also set `useResultLevelCache`, `populateResultLevelCache`, `useForwardedResultLevelCache`, and `populateForwardedResultLevelCache`, so disabling cache from the UI actually disables all cache layers.
- Adds the new keys to the `QueryContext` type definition.

## Test plan
- [x] `tsc --noEmit` passes for web-console
- [ ] Manually verify in the console: toggling "Use cache" off/on in the run panel's settings menu and confirming the resulting query context includes all six cache-related keys set to the same boolean value