### PR TITLE
fix: return actionable errors for invalid native queries

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/BadJsonQueryException.java
+++ b/processing/src/main/java/org/apache/druid/query/BadJsonQueryException.java
@@ -61,10 +61,18 @@ public class BadJsonQueryException extends BadQueryException
 
   private static String getErrorMessage(ValueInstantiationException e)
   {
-    final Throwable cause = e.getCause();
-    if (cause == null || Strings.isNullOrEmpty(cause.getMessage())) {
+    Throwable cause = e.getCause();
+    String errorMessage = null;
+    while (cause != null) {
+      if (!Strings.isNullOrEmpty(cause.getMessage())) {
+        errorMessage = cause.getMessage();
+      }
+      cause = cause.getCause();
+    }
+
+    if (errorMessage == null) {
       return "Invalid native query: the request contains invalid or missing fields";
     }
-    return "Invalid native query: " + cause.getMessage();
+    return "Invalid native query: " + errorMessage;
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/BadJsonQueryException.java
+++ b/processing/src/main/java/org/apache/druid/query/BadJsonQueryException.java
@@ -22,6 +22,8 @@ package org.apache.druid.query;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
+import com.google.common.base.Strings;
 
 public class BadJsonQueryException extends BadQueryException
 {
@@ -30,6 +32,11 @@ public class BadJsonQueryException extends BadQueryException
   public BadJsonQueryException(JsonParseException e)
   {
     this(e, JSON_PARSE_ERROR_CODE, e.getMessage(), ERROR_CLASS);
+  }
+
+  public BadJsonQueryException(ValueInstantiationException e)
+  {
+    this(e, JSON_PARSE_ERROR_CODE, getErrorMessage(e), e.getClass().getName());
   }
 
   @JsonCreator
@@ -50,5 +57,14 @@ public class BadJsonQueryException extends BadQueryException
   )
   {
     super(cause, errorCode, errorMessage, errorClass, null);
+  }
+
+  private static String getErrorMessage(ValueInstantiationException e)
+  {
+    final Throwable cause = e.getCause();
+    if (cause == null || Strings.isNullOrEmpty(cause.getMessage())) {
+      return "Invalid native query: the request contains invalid or missing fields";
+    }
+    return "Invalid native query: " + cause.getMessage();
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/BadJsonQueryExceptionTest.java
+++ b/processing/src/test/java/org/apache/druid/query/BadJsonQueryExceptionTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query;
+
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class BadJsonQueryExceptionTest
+{
+  @Test
+  public void testUsesDeepestCauseMessage()
+  {
+    final BadJsonQueryException exception = new BadJsonQueryException(
+        valueInstantiationException(
+            new RuntimeException("intermediate wrapper", new IllegalArgumentException("actionable validation message"))
+        )
+    );
+
+    Assertions.assertEquals("Invalid native query: actionable validation message", exception.getMessage());
+  }
+
+  @Test
+  public void testIgnoresEmptyCauseMessage()
+  {
+    final BadJsonQueryException exception = new BadJsonQueryException(
+        valueInstantiationException(
+            new RuntimeException("actionable validation message", new IllegalArgumentException(""))
+        )
+    );
+
+    Assertions.assertEquals("Invalid native query: actionable validation message", exception.getMessage());
+  }
+
+  @Test
+  public void testUsesFallbackWithoutCause()
+  {
+    final BadJsonQueryException exception = new BadJsonQueryException(valueInstantiationException(null));
+
+    Assertions.assertEquals(
+        "Invalid native query: the request contains invalid or missing fields",
+        exception.getMessage()
+    );
+  }
+
+  private static ValueInstantiationException valueInstantiationException(Throwable cause)
+  {
+    return ValueInstantiationException.from(
+        null,
+        "Jackson wrapper",
+        TypeFactory.defaultInstance().constructType(Query.class),
+        cause
+    );
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/QueryResource.java
+++ b/server/src/main/java/org/apache/druid/server/QueryResource.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.fasterxml.jackson.jaxrs.smile.SmileMediaTypes;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterables;
@@ -259,6 +260,9 @@ public class QueryResource implements QueryCountStatsProvider
     final Query<?> baseQuery;
     try {
       baseQuery = ioReaderWriter.getRequestMapper().readValue(in, Query.class);
+    }
+    catch (ValueInstantiationException e) {
+      throw new BadJsonQueryException(e);
     }
     catch (JsonParseException e) {
       throw new BadJsonQueryException(e);

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -1062,6 +1062,20 @@ public class QueryResourceTest
   }
 
   @Test
+  public void testBadJsonQueryExceptionUsesDeepestCauseMessage()
+  {
+    final ValueInstantiationException valueInstantiationException = ValueInstantiationException.from(
+        null,
+        "Jackson wrapper",
+        jsonMapper.constructType(Query.class),
+        new RuntimeException("intermediate wrapper", new IllegalArgumentException("actionable validation message"))
+    );
+
+    final BadJsonQueryException e = new BadJsonQueryException(valueInstantiationException);
+    Assert.assertEquals("Invalid native query: actionable validation message", e.getMessage());
+  }
+
+  @Test
   public void testResourceLimitExceeded() throws IOException
   {
     Response response = queryResource.doPost(

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.server;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.fasterxml.jackson.jaxrs.smile.SmileMediaTypes;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
@@ -1041,6 +1042,23 @@ public class QueryResourceTest
     QueryException e = jsonMapper.readValue((byte[]) response.getEntity(), QueryException.class);
     Assert.assertEquals(QueryException.JSON_PARSE_ERROR_CODE, e.getErrorCode());
     Assert.assertEquals(BadJsonQueryException.ERROR_CLASS, e.getErrorClass());
+  }
+
+  @Test
+  public void testIncompleteQuery() throws IOException
+  {
+    final Response response = queryResource.doPost(
+        new ByteArrayInputStream("{\"queryType\":\"scan\"}".getBytes(StandardCharsets.UTF_8)),
+        null /*pretty*/,
+        testServletRequest
+    );
+
+    Assert.assertNotNull(response);
+    Assert.assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    final QueryException e = jsonMapper.readValue((byte[]) response.getEntity(), QueryException.class);
+    Assert.assertEquals(QueryException.JSON_PARSE_ERROR_CODE, e.getErrorCode());
+    Assert.assertEquals(ValueInstantiationException.class.getName(), e.getErrorClass());
+    Assert.assertEquals("Invalid native query: dataSource can't be null", e.getMessage());
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -1062,20 +1062,6 @@ public class QueryResourceTest
   }
 
   @Test
-  public void testBadJsonQueryExceptionUsesDeepestCauseMessage()
-  {
-    final ValueInstantiationException valueInstantiationException = ValueInstantiationException.from(
-        null,
-        "Jackson wrapper",
-        jsonMapper.constructType(Query.class),
-        new RuntimeException("intermediate wrapper", new IllegalArgumentException("actionable validation message"))
-    );
-
-    final BadJsonQueryException e = new BadJsonQueryException(valueInstantiationException);
-    Assert.assertEquals("Invalid native query: actionable validation message", e.getMessage());
-  }
-
-  @Test
   public void testResourceLimitExceeded() throws IOException
   {
     Response response = queryResource.doPost(


### PR DESCRIPTION
### Description

Native query deserialization currently handles malformed JSON as a client error, but query constructor validation failures escape as opaque HTTP 500 responses.

This is particularly problematic for AI agents that generate native queries. The existing response does not explain what is wrong, so the agent cannot reliably correct and retry its query.

This PR converts Jackson `ValueInstantiationException` failures into HTTP 400 responses and exposes the underlying validation message. For example:

```json
{
  "error": "Json parse failed",
  "errorMessage": "Invalid native query: dataSource can't be null",
  "errorClass": "com.fasterxml.jackson.databind.exc.ValueInstantiationException",
  "host": null
}
```

The HTTP 400 status identifies the request as invalid rather than a transient server failure, while the actionable `errorMessage` helps users, programmatic clients, and AI agents identify and repair the generated native query.

If no underlying validation message is available, the response uses:

```text
Invalid native query: the request contains invalid or missing fields
```

Exceptions occurring after query deserialization are unaffected.

#### Release note

Fixed: Invalid native queries that fail during object construction now return HTTP 400 with an actionable validation message. This helps users and automated clients, including AI agents, identify and correct invalid generated queries.

<hr>

##### Key changed classes in this PR

- `BadJsonQueryException`
- `QueryResource`
- `QueryResourceTest`

<hr>

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [x] added unit tests covering the new error-handling path.

### Testing

The local environment does not have JDK 25, so the focused tests were run on the rebased source using JDK 24 with the Java release property overridden to 24:

```bash
JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-24.jdk/Contents/Home \
mvn test -pl server -am \
  -Djava.version=24 \
  -Dmaven.compiler.release=24 \
  -Dtest="org.apache.druid.server.QueryResourceTest#testBadQuery+testIncompleteQuery+testBadJsonQueryExceptionUsesDeepestCauseMessage" \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -Pskip-static-checks \
  -Dweb.console.skip=true \
  -T1C
```

Result: 3 tests run, 0 failures, 0 errors. GitHub CI remains authoritative for the JDK 25 build.
