### PR TITLE
docs: remove outdated experimental

### DIFF
--- a/docs/api-reference/sql-ingestion-api.md
+++ b/docs/api-reference/sql-ingestion-api.md
@@ -297,7 +297,7 @@ Keep the following in mind when using the task API to view reports:
 
 - The task report for an entire job is associated with the `query_controller` task. The `query_worker` tasks don't have their own reports; their information is incorporated into the controller report.
 - The task report API may report `404 Not Found` temporarily while the task is in the process of starting up.
-- As an experimental feature, the MSQ task engine supports running SELECT queries. SELECT query results are written into
+- The MSQ task engine supports running SELECT queries. SELECT query results are written into
 the `multiStageQuery.payload.results.results` task report key as an array of arrays. The behavior and result format of plain
 SELECT queries (without INSERT or REPLACE) is subject to change.
 - `multiStageQuery.payload.results.resultsTruncated` denotes whether the results of the report have been truncated to prevent the reports from blowing up.

--- a/docs/api-reference/sql-ingestion-api.md
+++ b/docs/api-reference/sql-ingestion-api.md
@@ -48,7 +48,7 @@ The `/druid/v2/sql/task` endpoint accepts the following:
 - [SQL requests in the JSON-over-HTTP form](sql-api.md#request-body) using the
 `query`, `context`, and `parameters` fields. The endpoint ignores the `resultFormat`, `header`, `typesHeader`, and `sqlTypesHeader` fields.
 - [INSERT](../multi-stage-query/reference.md#insert) and [REPLACE](../multi-stage-query/reference.md#replace) statements.
-- SELECT queries (experimental feature). SELECT query results are collected from workers by the controller, and written into the [task report](#get-the-report-for-a-query-task) as an array of arrays. The behavior and result format of plain SELECT queries (without INSERT or REPLACE) is subject to change.
+- SELECT queries as batch tasks. SELECT query results are collected from workers by the controller and written into the [task report](#get-the-report-for-a-query-task) as an array of arrays.
 
 ### URL
 

--- a/docs/multi-stage-query/concepts.md
+++ b/docs/multi-stage-query/concepts.md
@@ -28,7 +28,7 @@ sidebar_label: "Key concepts"
 ## Multi-stage query task engine
 
 The MSQ task engine executes SQL statements as batch tasks in the indexing service, which execute on [Middle Managers](../design/architecture.md#druid-services).
-[INSERT](reference.md#insert) and [REPLACE](reference.md#replace) tasks publish [segments](../design/storage.md) just like [all other forms of batch ingestion](../ingestion/index.md#batch). Each query occupies at least two task slots while running: one controller task, and at least one worker task. As an experimental feature, the MSQ task engine also supports running SELECT queries as batch tasks. The behavior and result format of plain SELECT (without INSERT or REPLACE) is subject to change.
+[INSERT](reference.md#insert) and [REPLACE](reference.md#replace) tasks publish [segments](../design/storage.md) just like [all other forms of batch ingestion](../ingestion/index.md#batch). Each query occupies at least two task slots while running: one controller task, and at least one worker task. The MSQ task engine also supports running SELECT queries as batch tasks. The behavior and result format of plain SELECT (without INSERT or REPLACE) is subject to change.
 
 You can execute SQL statements using the MSQ task engine through the **Query** view in the [web
 console](../operations/web-console.md) or through the [`/druid/v2/sql/task` API](../api-reference/sql-ingestion-api.md).

--- a/docs/multi-stage-query/index.md
+++ b/docs/multi-stage-query/index.md
@@ -27,8 +27,7 @@ description: Introduces multi-stage query architecture and its task engine
 This page describes SQL-based batch ingestion using the [multi-stage query (MSQ) task engine](../multi-stage-query/index.md). Refer to the [ingestion methods](../ingestion/index.md#batch) table to determine which ingestion method is right for you.
 
 Apache&circledR; Druid supports SQL-based ingestion using MSQ task engine that allows running SQL
-[INSERT](concepts.md#load-data-with-insert) and [REPLACE](concepts.md#overwrite-data-with-replace) statements as batch tasks. As an experimental feature,
-the task engine also supports running `SELECT` queries as batch tasks.
+[INSERT](concepts.md#load-data-with-insert) and [REPLACE](concepts.md#overwrite-data-with-replace) statements as batch tasks. The task engine also supports running `SELECT` queries as batch tasks.
 
 Nearly all `SELECT` capabilities are available in the multi-stage query (MSQ) task engine, with certain exceptions listed on the [Known
 issues](./known-issues.md#select-statement) page. This allows great flexibility to apply transformations, filters, JOINs,


### PR DESCRIPTION
We missed some of the `experimental` when MSQ went GA. Will also backport to 38.0.0