### PR TITLE
ci: use npm ci for website checks

### DIFF
--- a/.github/scripts/web-checks.sh
+++ b/.github/scripts/web-checks.sh
@@ -23,7 +23,7 @@ mvn -B com.github.eirslett:frontend-maven-plugin:install-node-and-npm@install-no
 PATH+=:web-console/target/node/
 
 # docs
-(cd website && npm install)
+(cd website && npm ci)
 cd website
 npm run build
 npm run link-lint


### PR DESCRIPTION
## What changed

Use `npm ci` instead of `npm install` when installing website dependencies in the web checks workflow.

## Why

The repository commits `website/package-lock.json`, and Dependabot security updates can intentionally modify only that lockfile when updating a transitive dependency. `npm install` may reconcile or rewrite dependency resolution during CI, which means a passing build does not prove that the committed manifest and lockfile are consistent or that the exact locked dependency graph was tested.

`npm ci` fails when `package.json` and `package-lock.json` disagree, installs the exact committed dependency graph, and does not rewrite the lockfile. This makes website dependency checks reproducible while leaving the local development workflow unchanged; developers can continue to use `npm install` when adding or updating dependencies.

## Validation

- `bash -n .github/scripts/web-checks.sh`
- `cd website && npm ci`
- `npm run build`
- `npm run link-lint`
- `npm run spellcheck`
