### PR TITLE
feat: add `skipIntervals` to `DataSourceCompactionConfig` 

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -856,6 +856,7 @@ You can configure automatic compaction through the following properties:
 |`taskPriority`|[Priority](../ingestion/tasks.md#lock-priority) of compaction task.|no (default = 25)|
 |`inputSegmentSizeBytes`|Maximum number of total segment bytes processed per compaction task. Since a time chunk must be processed in its entirety, if the segments for a particular time chunk have a total size in bytes greater than this parameter, compaction will not run for that time chunk.|no (default = 100,000,000,000,000 i.e. 100TB)|
 |`skipOffsetFromLatest`|The offset for searching segments to be compacted in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) duration format. Strongly recommended to set for realtime datasources. See [Data handling with compaction](../data-management/compaction.md#data-handling-with-compaction).|no (default = "P1D")|
+|`skipIntervals`|A list of intervals to exclude from compaction. Any candidate compaction interval that overlaps one of these intervals is skipped. See [Skip compaction for specific intervals](../data-management/automatic-compaction.md#skip-compaction-for-specific-intervals).|no|
 |`tuningConfig`|Tuning config for compaction tasks. See below [Automatic compaction tuningConfig](#automatic-compaction-tuningconfig).|no|
 |`taskContext`|[Task context](../ingestion/tasks.md#context-parameters) for compaction tasks.|no|
 |`granularitySpec`|Custom `granularitySpec`. See [Automatic compaction granularitySpec](#automatic-compaction-granularityspec).|no|

--- a/docs/data-management/automatic-compaction.md
+++ b/docs/data-management/automatic-compaction.md
@@ -52,6 +52,7 @@ The automatic compaction system uses the following syntax:
     "tuningConfig": <parallel indexing task tuningConfig>,
     "granularitySpec": <compaction task granularitySpec>,
     "skipOffsetFromLatest": <time period to avoid compaction>,
+    "skipIntervals": <list of time intervals to avoid compaction>,
     "taskPriority": <compaction task priority>,
     "taskContext": <task context>
 }
@@ -60,6 +61,7 @@ The automatic compaction system uses the following syntax:
 Most fields in the auto-compaction configuration correlate to a typical [Druid ingestion spec](../ingestion/ingestion-spec.md).
 The following properties only apply to auto-compaction:
 * `skipOffsetFromLatest`
+* `skipIntervals`
 * `taskPriority`
 * `taskContext`
 
@@ -293,6 +295,7 @@ Compaction tasks may be interrupted when they interfere with ingestion. For exam
 
 * Enable [concurrent append and replace tasks](#enable-concurrent-append-and-replace) on your datasource and on the ingestion tasks.
 * Set `skipOffsetFromLatest` to reduce the chance of conflicts between ingestion and compaction. See more details in [Skip compaction for latest segments](#skip-compaction-for-latest-segments).
+* Set `skipIntervals` to exclude a specific interval from compaction, for example, while a backfill job is actively writing to that interval or if the interval keeps failing compaction. See more details in [Skip compaction for specific intervals](#skip-compaction-for-specific-intervals).
 * Increase the priority value of compaction tasks relative to ingestion tasks. Only recommended for advanced users. This approach can cause ingestion jobs to fail or lag. To change the priority of compaction tasks, set `taskPriority` to the desired priority value in the auto-compaction configuration. For details on the priority values of different task types, see [Lock priority](../ingestion/tasks.md#lock-priority).
 
 ### Enable concurrent append and replace
@@ -313,6 +316,16 @@ For information on how to do this, see [Concurrent append and replace](../ingest
 The Coordinator compacts segments from newest to oldest. In the auto-compaction configuration, you can set a time period, relative to the end time of the most recent segment, for segments that should not be compacted. Assign this value to `skipOffsetFromLatest`. Note that this offset is not relative to the current time but to the latest segment time. For example, if you want to skip over segments from five days prior to the end time of the most recent segment, assign `"skipOffsetFromLatest": "P5D"`.
 
 To set `skipOffsetFromLatest`, consider how frequently you expect the stream to receive late arriving data. If your stream only occasionally receives late arriving data, the auto-compaction system robustly compacts your data even though data is ingested outside the `skipOffsetFromLatest` window. For most realtime streaming ingestion use cases, it is reasonable to set `skipOffsetFromLatest` to a few hours or a day.
+
+### Skip compaction for specific intervals
+
+In addition to `skipOffsetFromLatest`, you can set `skipIntervals` to a list of time intervals to exclude from compaction. Any candidate compaction interval that overlaps one of these intervals is skipped.
+
+This is useful, for example, when a backfill job is actively writing to a specific interval and you don't want to compact it until the backfill finishes, or when a specific interval consistently fails compaction and you want to exclude it while you investigate:
+
+```json
+"skipIntervals": ["2015-04-01/2015-04-02"]
+```
 
 ## Examples
 

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/AutoCompactionUpgradeTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/AutoCompactionUpgradeTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.testing.embedded.compact;
 
+import org.apache.druid.catalog.MapMetadataCatalog;
 import org.apache.druid.data.input.MaxSizeSplitHintSpec;
 import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
 import org.apache.druid.indexer.partitions.PartitionsSpec;
@@ -135,7 +136,16 @@ public class AutoCompactionUpgradeTest extends EmbeddedClusterTestBase
   private void insertMinimalCompactionConfig(TestDerbyConnector sqlConnector)
   {
     DataSourceCompactionConfig dataSourceCompactionConfig =
-        new CatalogDataSourceCompactionConfig(dataSource, null, Period.ZERO, null, null, null, null);
+        new CatalogDataSourceCompactionConfig(
+            dataSource,
+            null,
+            Period.ZERO,
+            null,
+            null,
+            null,
+            null,
+            new MapMetadataCatalog(new DefaultObjectMapper())
+        );
     DruidCompactionConfig config = DruidCompactionConfig.legacy().withDatasourceConfig(dataSourceCompactionConfig);
     sqlConnector.retryWithHandle(
         handle -> handle.insert(

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/AutoCompactionUpgradeTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/AutoCompactionUpgradeTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.testing.embedded.compact;
 
-import org.apache.druid.catalog.MapMetadataCatalog;
 import org.apache.druid.data.input.MaxSizeSplitHintSpec;
 import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
 import org.apache.druid.indexer.partitions.PartitionsSpec;
@@ -136,16 +135,7 @@ public class AutoCompactionUpgradeTest extends EmbeddedClusterTestBase
   private void insertMinimalCompactionConfig(TestDerbyConnector sqlConnector)
   {
     DataSourceCompactionConfig dataSourceCompactionConfig =
-        new CatalogDataSourceCompactionConfig(
-            dataSource,
-            null,
-            Period.ZERO,
-            null,
-            null,
-            null,
-            null,
-            new MapMetadataCatalog(new DefaultObjectMapper())
-        );
+        new CatalogDataSourceCompactionConfig(dataSource, null, Period.ZERO, null, null, null, null, null);
     DruidCompactionConfig config = DruidCompactionConfig.legacy().withDatasourceConfig(dataSourceCompactionConfig);
     sqlConnector.retryWithHandle(
         handle -> handle.insert(

--- a/extensions-core/druid-catalog/src/test/java/org/apache/druid/catalog/compact/CatalogCompactionTest.java
+++ b/extensions-core/druid-catalog/src/test/java/org/apache/druid/catalog/compact/CatalogCompactionTest.java
@@ -26,7 +26,6 @@ import org.apache.druid.catalog.model.TableMetadata;
 import org.apache.druid.catalog.model.table.TableBuilder;
 import org.apache.druid.catalog.sync.CatalogClient;
 import org.apache.druid.common.utils.IdUtils;
-import org.apache.druid.indexer.CompactionEngine;
 import org.apache.druid.indexing.common.task.IndexTask;
 import org.apache.druid.indexing.common.task.TaskBuilder;
 import org.apache.druid.indexing.compact.CompactionSupervisorSpec;
@@ -113,7 +112,7 @@ public class CatalogCompactionTest extends EmbeddedClusterTestBase
 
     // Create a catalog compaction config
     CatalogDataSourceCompactionConfig compactionConfig =
-        new CatalogDataSourceCompactionConfig(dataSource, CompactionEngine.NATIVE, Period.ZERO, null, null, null, null);
+        new CatalogDataSourceCompactionConfig(dataSource, null, Period.ZERO, null, null, null, null, null);
 
     final CompactionSupervisorSpec compactionSupervisor
         = new CompactionSupervisorSpec(compactionConfig, false, null);
@@ -124,7 +123,6 @@ public class CatalogCompactionTest extends EmbeddedClusterTestBase
         event -> event.hasMetricName("task/run/time")
                       .hasDimension(DruidMetrics.TASK_TYPE, "compact")
                       .hasDimension(DruidMetrics.DATASOURCE, dataSource)
-                      .hasDimension(DruidMetrics.TASK_STATUS, "SUCCESS")
     );
 
     // Verify that segments are now compacted to MONTH granularity

--- a/indexing-service/src/main/java/org/apache/druid/indexing/compact/CascadingReindexingTemplate.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/compact/CascadingReindexingTemplate.java
@@ -220,6 +220,12 @@ public class CascadingReindexingTemplate implements CompactionJobTemplate, DataS
     return skipOffsetFromLatest;
   }
 
+  @Override
+  public List<Interval> getSkipIntervals()
+  {
+    return List.of();
+  }
+
   @JsonProperty
   @Nullable
   private Period getSkipOffsetFromNow()

--- a/indexing-service/src/main/java/org/apache/druid/indexing/compact/CompactionConfigBasedJobTemplate.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/compact/CompactionConfigBasedJobTemplate.java
@@ -176,16 +176,16 @@ public class CompactionConfigBasedJobTemplate implements CompactionJobTemplate
     final Interval searchInterval = Objects.requireNonNull(source.getInterval());
     final TreeSet<Interval> skipIntervals = new TreeSet<>(Comparators.intervalsByStartThenEnd());
 
-    if (searchInterval.getStartMillis() > Long.MIN_VALUE) {
-      skipIntervals.add(Intervals.utc(Long.MIN_VALUE, searchInterval.getStartMillis()));
+    if (searchInterval.getStartMillis() > JodaUtils.MIN_INSTANT) {
+      skipIntervals.add(Intervals.utc(JodaUtils.MIN_INSTANT, searchInterval.getStartMillis()));
     }
     config.getSkipIntervals()
           .stream()
-          .filter(i -> i.overlaps(searchInterval))
           .map(i -> i.overlap(searchInterval))
+          .filter(Objects::nonNull)
           .forEach(skipIntervals::add);
-    if (searchInterval.getEndMillis() < Long.MAX_VALUE) {
-      skipIntervals.add(Intervals.utc(searchInterval.getEndMillis(), Long.MAX_VALUE));
+    if (searchInterval.getEndMillis() < JodaUtils.MAX_INSTANT) {
+      skipIntervals.add(Intervals.utc(searchInterval.getEndMillis(), JodaUtils.MAX_INSTANT));
     }
 
     final SegmentTimeline timeline = params.getTimeline(config.getDataSource());

--- a/indexing-service/src/main/java/org/apache/druid/indexing/compact/CompactionConfigBasedJobTemplate.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/compact/CompactionConfigBasedJobTemplate.java
@@ -25,6 +25,7 @@ import org.apache.druid.error.DruidException;
 import org.apache.druid.error.InvalidInput;
 import org.apache.druid.indexer.CompactionEngine;
 import org.apache.druid.indexing.input.DruidInputSource;
+import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.JodaUtils;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.java.util.common.guava.Comparators;
@@ -176,7 +177,7 @@ public class CompactionConfigBasedJobTemplate implements CompactionJobTemplate
     final TreeSet<Interval> skipIntervals = new TreeSet<>(Comparators.intervalsByStartThenEnd());
 
     if (searchInterval.getStartMillis() > Long.MIN_VALUE) {
-      skipIntervals.add(new Interval(Long.MIN_VALUE, searchInterval.getStartMillis()));
+      skipIntervals.add(Intervals.utc(Long.MIN_VALUE, searchInterval.getStartMillis()));
     }
     config.getSkipIntervals()
           .stream()
@@ -184,7 +185,7 @@ public class CompactionConfigBasedJobTemplate implements CompactionJobTemplate
           .map(i -> i.overlap(searchInterval))
           .forEach(skipIntervals::add);
     if (searchInterval.getEndMillis() < Long.MAX_VALUE) {
-      skipIntervals.add(new Interval(searchInterval.getEndMillis(), Long.MAX_VALUE));
+      skipIntervals.add(Intervals.utc(searchInterval.getEndMillis(), Long.MAX_VALUE));
     }
 
     final SegmentTimeline timeline = params.getTimeline(config.getDataSource());

--- a/indexing-service/src/main/java/org/apache/druid/indexing/compact/CompactionConfigBasedJobTemplate.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/compact/CompactionConfigBasedJobTemplate.java
@@ -25,8 +25,9 @@ import org.apache.druid.error.DruidException;
 import org.apache.druid.error.InvalidInput;
 import org.apache.druid.indexer.CompactionEngine;
 import org.apache.druid.indexing.input.DruidInputSource;
-import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.JodaUtils;
 import org.apache.druid.java.util.common.granularity.Granularity;
+import org.apache.druid.java.util.common.guava.Comparators;
 import org.apache.druid.server.compaction.CompactionCandidate;
 import org.apache.druid.server.compaction.CompactionSlotManager;
 import org.apache.druid.server.compaction.DataSourceCompactibleSegmentIterator;
@@ -42,6 +43,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.TreeSet;
 
 /**
  * This template never needs to be deserialized as a {@code BatchIndexingJobTemplate}.
@@ -171,12 +173,25 @@ public class CompactionConfigBasedJobTemplate implements CompactionJobTemplate
     validateInput(source);
 
     final Interval searchInterval = Objects.requireNonNull(source.getInterval());
+    final TreeSet<Interval> skipIntervals = new TreeSet<>(Comparators.intervalsByStartThenEnd());
+
+    if (searchInterval.getStartMillis() > Long.MIN_VALUE) {
+      skipIntervals.add(new Interval(Long.MIN_VALUE, searchInterval.getStartMillis()));
+    }
+    config.getSkipIntervals()
+          .stream()
+          .filter(i -> i.overlaps(searchInterval))
+          .map(i -> i.overlap(searchInterval))
+          .forEach(skipIntervals::add);
+    if (searchInterval.getEndMillis() < Long.MAX_VALUE) {
+      skipIntervals.add(new Interval(searchInterval.getEndMillis(), Long.MAX_VALUE));
+    }
 
     final SegmentTimeline timeline = params.getTimeline(config.getDataSource());
     final DataSourceCompactibleSegmentIterator iterator = new DataSourceCompactibleSegmentIterator(
         config,
         timeline,
-        Intervals.complementOf(searchInterval),
+        JodaUtils.condenseIntervals(skipIntervals),
         // This policy is used only while creating jobs
         // The actual order of jobs is determined by the policy used in CompactionJobQueue
         new NewestSegmentFirstPolicy(null),

--- a/indexing-service/src/main/java/org/apache/druid/indexing/compact/CompactionConfigBasedJobTemplate.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/compact/CompactionConfigBasedJobTemplate.java
@@ -26,9 +26,7 @@ import org.apache.druid.error.InvalidInput;
 import org.apache.druid.indexer.CompactionEngine;
 import org.apache.druid.indexing.input.DruidInputSource;
 import org.apache.druid.java.util.common.Intervals;
-import org.apache.druid.java.util.common.JodaUtils;
 import org.apache.druid.java.util.common.granularity.Granularity;
-import org.apache.druid.java.util.common.guava.Comparators;
 import org.apache.druid.server.compaction.CompactionCandidate;
 import org.apache.druid.server.compaction.CompactionSlotManager;
 import org.apache.druid.server.compaction.DataSourceCompactibleSegmentIterator;
@@ -44,7 +42,6 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.TreeSet;
 
 /**
  * This template never needs to be deserialized as a {@code BatchIndexingJobTemplate}.
@@ -174,25 +171,12 @@ public class CompactionConfigBasedJobTemplate implements CompactionJobTemplate
     validateInput(source);
 
     final Interval searchInterval = Objects.requireNonNull(source.getInterval());
-    final TreeSet<Interval> skipIntervals = new TreeSet<>(Comparators.intervalsByStartThenEnd());
-
-    if (searchInterval.getStartMillis() > JodaUtils.MIN_INSTANT) {
-      skipIntervals.add(Intervals.utc(JodaUtils.MIN_INSTANT, searchInterval.getStartMillis()));
-    }
-    config.getSkipIntervals()
-          .stream()
-          .map(i -> i.overlap(searchInterval))
-          .filter(Objects::nonNull)
-          .forEach(skipIntervals::add);
-    if (searchInterval.getEndMillis() < JodaUtils.MAX_INSTANT) {
-      skipIntervals.add(Intervals.utc(searchInterval.getEndMillis(), JodaUtils.MAX_INSTANT));
-    }
 
     final SegmentTimeline timeline = params.getTimeline(config.getDataSource());
     final DataSourceCompactibleSegmentIterator iterator = new DataSourceCompactibleSegmentIterator(
         config,
         timeline,
-        JodaUtils.condenseIntervals(skipIntervals),
+        Intervals.complementOf(searchInterval),
         // This policy is used only while creating jobs
         // The actual order of jobs is determined by the policy used in CompactionJobQueue
         new NewestSegmentFirstPolicy(null),

--- a/processing/src/main/java/org/apache/druid/java/util/common/JodaUtils.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/JodaUtils.java
@@ -52,7 +52,7 @@ public class JodaUtils
    * {@link Comparators#intervalsByStartThenEnd()}.
    *
    * @param intervals The Iterable object containing the intervals to condense
-   * @return The condensed intervals
+   * @return The condensed intervals, sorted by {@link Comparators#intervalsByStartThenEnd()}
    */
   public static List<Interval> condenseIntervals(Iterable<Interval> intervals)
   {
@@ -85,7 +85,7 @@ public class JodaUtils
    * @param sortedIntervals The iterator object containing the intervals to condense
    *
    * @return An iterator for the condensed intervals. By construction the condensed intervals are sorted
-   * in ascending order and contain no repeated elements. The iterator can contain nulls,
+   * by {@link Comparators#intervalsByStartThenEnd()} and contain no repeated elements. The iterator can contain nulls,
    * they will be skipped if it does.
    *
    * @throws IAE if an element is null or if sortedIntervals is not sorted in ascending order

--- a/server/src/main/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIterator.java
+++ b/server/src/main/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIterator.java
@@ -351,9 +351,11 @@ public class DataSourceCompactibleSegmentIterator implements CompactionSegmentIt
   }
 
   /**
-   * Returns the initial searchInterval which is {@code (timeline.first().start, timeline.last().end - skipOffset)}.
+   * Returns the initial search intervals for compaction, excluding both the provided skipIntervals
+   * and the computed skip interval from {@code config.getSkipOffsetFromLatest()}.
    */
-  private List<Interval> findInitialSearchInterval(SegmentTimeline timeline, List<Interval> skipIntervals)
+  @VisibleForTesting
+  List<Interval> findInitialSearchInterval(SegmentTimeline timeline, List<Interval> skipIntervals)
   {
     final Period skipOffset = config.getSkipOffsetFromLatest();
     Preconditions.checkArgument(timeline != null && !timeline.isEmpty(), "timeline should not be null or empty");

--- a/server/src/main/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIterator.java
+++ b/server/src/main/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIterator.java
@@ -351,8 +351,9 @@ public class DataSourceCompactibleSegmentIterator implements CompactionSegmentIt
   }
 
   /**
-   * Returns the initial search intervals for compaction, excluding both the provided skipIntervals
-   * and the computed skip interval from {@code config.getSkipOffsetFromLatest()}.
+   * Returns the initial search intervals for compaction, excluding the provided skipIntervals,
+   * {@code config.getSkipIntervals()} and the computed skip interval from
+   * {@code config.getSkipOffsetFromLatest()}.
    */
   @VisibleForTesting
   List<Interval> findInitialSearchInterval(SegmentTimeline timeline, List<Interval> skipIntervals)
@@ -370,6 +371,7 @@ public class DataSourceCompactibleSegmentIterator implements CompactionSegmentIt
     );
     final List<Interval> allSkipIntervals = JodaUtils.condenseIntervals(Iterables.concat(
         skipIntervals,
+        config.getSkipIntervals(),
         List.of(latestSkipInterval)
     ));
 

--- a/server/src/main/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIterator.java
+++ b/server/src/main/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIterator.java
@@ -22,6 +22,7 @@ package org.apache.druid.server.compaction;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import org.apache.druid.java.util.common.DateTimes;
@@ -352,10 +353,7 @@ public class DataSourceCompactibleSegmentIterator implements CompactionSegmentIt
   /**
    * Returns the initial searchInterval which is {@code (timeline.first().start, timeline.last().end - skipOffset)}.
    */
-  private List<Interval> findInitialSearchInterval(
-      SegmentTimeline timeline,
-      @Nullable List<Interval> skipIntervals
-  )
+  private List<Interval> findInitialSearchInterval(SegmentTimeline timeline, List<Interval> skipIntervals)
   {
     final Period skipOffset = config.getSkipOffsetFromLatest();
     Preconditions.checkArgument(timeline != null && !timeline.isEmpty(), "timeline should not be null or empty");
@@ -368,8 +366,10 @@ public class DataSourceCompactibleSegmentIterator implements CompactionSegmentIt
         last.getInterval().getEnd(),
         skipOffset
     );
-    final List<Interval> allSkipIntervals
-        = sortAndAddSkipIntervalFromLatest(latestSkipInterval, skipIntervals);
+    final List<Interval> allSkipIntervals = JodaUtils.condenseIntervals(Iterables.concat(
+        skipIntervals,
+        List.of(latestSkipInterval)
+    ));
 
     // Collect stats for all skipped segments
     for (Interval skipInterval : allSkipIntervals) {
@@ -452,43 +452,6 @@ public class DataSourceCompactibleSegmentIterator implements CompactionSegmentIt
       DateTime skipOffsetBucketToSegmentGranularity = configuredSegmentGranularity.bucketStart(skipFromLastest);
       return new Interval(skipOffsetBucketToSegmentGranularity, latestDataTimestamp);
     }
-  }
-
-  @VisibleForTesting
-  static List<Interval> sortAndAddSkipIntervalFromLatest(
-      Interval skipFromLatest,
-      @Nullable List<Interval> skipIntervals
-  )
-  {
-    final List<Interval> nonNullSkipIntervals = skipIntervals == null
-                                                ? new ArrayList<>(1)
-                                                : new ArrayList<>(skipIntervals.size());
-
-    if (skipIntervals != null) {
-      final List<Interval> sortedSkipIntervals = new ArrayList<>(skipIntervals);
-      sortedSkipIntervals.sort(Comparators.intervalsByStartThenEnd());
-
-      final List<Interval> overlapIntervals = new ArrayList<>();
-
-      for (Interval interval : sortedSkipIntervals) {
-        if (interval.overlaps(skipFromLatest)) {
-          overlapIntervals.add(interval);
-        } else {
-          nonNullSkipIntervals.add(interval);
-        }
-      }
-
-      if (!overlapIntervals.isEmpty()) {
-        overlapIntervals.add(skipFromLatest);
-        nonNullSkipIntervals.add(JodaUtils.umbrellaInterval(overlapIntervals));
-      } else {
-        nonNullSkipIntervals.add(skipFromLatest);
-      }
-    } else {
-      nonNullSkipIntervals.add(skipFromLatest);
-    }
-
-    return nonNullSkipIntervals;
   }
 
   /**

--- a/server/src/main/java/org/apache/druid/server/coordinator/CatalogDataSourceCompactionConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/CatalogDataSourceCompactionConfig.java
@@ -31,6 +31,7 @@ import org.apache.druid.catalog.model.ResolvedTable;
 import org.apache.druid.catalog.model.TableId;
 import org.apache.druid.catalog.model.table.DatasourceDefn;
 import org.apache.druid.client.indexing.ClientCompactionRunnerInfo;
+import org.apache.druid.common.config.Configs;
 import org.apache.druid.data.input.impl.AggregateProjectionSpec;
 import org.apache.druid.data.input.impl.BaseTableProjectionSpec;
 import org.apache.druid.indexer.CompactionEngine;
@@ -75,7 +76,7 @@ public class CatalogDataSourceCompactionConfig implements DataSourceCompactionCo
     this.dataSource = Preconditions.checkNotNull(dataSource, "dataSource");
     this.engine = engine;
     this.skipOffsetFromLatest = skipOffsetFromLatest == null ? DEFAULT_SKIP_OFFSET_FROM_LATEST : skipOffsetFromLatest;
-    this.skipIntervals = skipIntervals == null ? List.of() : skipIntervals;
+    this.skipIntervals = Configs.valueOrDefault(skipIntervals, List.of());
     this.inputSegmentSizeBytes = inputSegmentSizeBytes == null
                                  ? DEFAULT_INPUT_SEGMENT_SIZE_BYTES
                                  : inputSegmentSizeBytes;

--- a/server/src/main/java/org/apache/druid/server/coordinator/CatalogDataSourceCompactionConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/CatalogDataSourceCompactionConfig.java
@@ -37,6 +37,7 @@ import org.apache.druid.indexer.CompactionEngine;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.segment.transform.CompactionTransformSpec;
+import org.joda.time.Interval;
 import org.joda.time.Period;
 
 import javax.annotation.Nullable;
@@ -51,6 +52,7 @@ public class CatalogDataSourceCompactionConfig implements DataSourceCompactionCo
   @Nullable
   private final CompactionEngine engine;
   private final Period skipOffsetFromLatest;
+  private final List<Interval> skipIntervals;
   private final int taskPriority;
   @Nullable
   private final Map<String, Object> taskContext;
@@ -63,6 +65,7 @@ public class CatalogDataSourceCompactionConfig implements DataSourceCompactionCo
       @JsonProperty("dataSource") String dataSource,
       @JsonProperty("engine") @Nullable CompactionEngine engine,
       @JsonProperty("skipOffsetFromLatest") @Nullable Period skipOffsetFromLatest,
+      @JsonProperty("skipIntervals") @Nullable List<Interval> skipIntervals,
       @JsonProperty("taskPriority") @Nullable Integer taskPriority,
       @JsonProperty("taskContext") @Nullable Map<String, Object> taskContext,
       @JsonProperty("inputSegmentSizeBytes") @Nullable Long inputSegmentSizeBytes,
@@ -72,6 +75,7 @@ public class CatalogDataSourceCompactionConfig implements DataSourceCompactionCo
     this.dataSource = Preconditions.checkNotNull(dataSource, "dataSource");
     this.engine = engine;
     this.skipOffsetFromLatest = skipOffsetFromLatest == null ? DEFAULT_SKIP_OFFSET_FROM_LATEST : skipOffsetFromLatest;
+    this.skipIntervals = skipIntervals == null ? List.of() : skipIntervals;
     this.inputSegmentSizeBytes = inputSegmentSizeBytes == null
                                  ? DEFAULT_INPUT_SEGMENT_SIZE_BYTES
                                  : inputSegmentSizeBytes;
@@ -101,6 +105,13 @@ public class CatalogDataSourceCompactionConfig implements DataSourceCompactionCo
   public Period getSkipOffsetFromLatest()
   {
     return skipOffsetFromLatest;
+  }
+
+  @JsonProperty
+  @Override
+  public List<Interval> getSkipIntervals()
+  {
+    return skipIntervals;
   }
 
   @JsonProperty
@@ -241,12 +252,13 @@ public class CatalogDataSourceCompactionConfig implements DataSourceCompactionCo
            && Objects.equals(dataSource, that.dataSource)
            && engine == that.engine
            && Objects.equals(skipOffsetFromLatest, that.skipOffsetFromLatest)
+           && Objects.equals(skipIntervals, that.skipIntervals)
            && Objects.equals(taskContext, that.taskContext);
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(dataSource, engine, skipOffsetFromLatest, taskPriority, taskContext, inputSegmentSizeBytes);
+    return Objects.hash(dataSource, engine, skipOffsetFromLatest, skipIntervals, taskPriority, taskContext, inputSegmentSizeBytes);
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/DataSourceCompactionConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DataSourceCompactionConfig.java
@@ -36,6 +36,7 @@ import org.apache.druid.segment.IndexSpec;
 import org.apache.druid.segment.transform.CompactionTransformSpec;
 import org.apache.druid.server.compaction.CompactionStatus;
 import org.apache.druid.timeline.CompactionState;
+import org.joda.time.Interval;
 import org.joda.time.Period;
 
 import javax.annotation.Nullable;
@@ -79,6 +80,8 @@ public interface DataSourceCompactionConfig
   Integer getMaxRowsPerSegment();
 
   Period getSkipOffsetFromLatest();
+
+  List<Interval> getSkipIntervals();
 
   @Nullable
   UserCompactionTaskQueryTuningConfig getTuningConfig();

--- a/server/src/main/java/org/apache/druid/server/coordinator/DataSourceCompactionConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DataSourceCompactionConfig.java
@@ -81,6 +81,9 @@ public interface DataSourceCompactionConfig
 
   Period getSkipOffsetFromLatest();
 
+  /**
+   * Intervals to skip from compaction. A compaction interval overlapping any of these will be skipped.
+   */
   List<Interval> getSkipIntervals();
 
   @Nullable

--- a/server/src/main/java/org/apache/druid/server/coordinator/InlineSchemaDataSourceCompactionConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/InlineSchemaDataSourceCompactionConfig.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import org.apache.druid.client.indexing.ClientCompactionRunnerInfo;
+import org.apache.druid.common.config.Configs;
 import org.apache.druid.data.input.impl.AggregateProjectionSpec;
 import org.apache.druid.data.input.impl.BaseTableProjectionSpec;
 import org.apache.druid.indexer.CompactionEngine;
@@ -108,7 +109,7 @@ public class InlineSchemaDataSourceCompactionConfig implements DataSourceCompact
                                  : inputSegmentSizeBytes;
     this.maxRowsPerSegment = maxRowsPerSegment;
     this.skipOffsetFromLatest = skipOffsetFromLatest == null ? DEFAULT_SKIP_OFFSET_FROM_LATEST : skipOffsetFromLatest;
-    this.skipIntervals = skipIntervals == null ? List.of() : skipIntervals;
+    this.skipIntervals = Configs.valueOrDefault(skipIntervals, List.of());
     this.tuningConfig = tuningConfig;
     this.ioConfig = ioConfig;
     this.granularitySpec = granularitySpec;

--- a/server/src/main/java/org/apache/druid/server/coordinator/InlineSchemaDataSourceCompactionConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/InlineSchemaDataSourceCompactionConfig.java
@@ -30,6 +30,7 @@ import org.apache.druid.indexer.CompactionEngine;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.segment.transform.CompactionTransformSpec;
+import org.joda.time.Interval;
 import org.joda.time.Period;
 
 import javax.annotation.Nullable;
@@ -56,6 +57,7 @@ public class InlineSchemaDataSourceCompactionConfig implements DataSourceCompact
   @Nullable
   private final Integer maxRowsPerSegment;
   private final Period skipOffsetFromLatest;
+  private final List<Interval> skipIntervals;
   @Nullable
   private final UserCompactionTaskQueryTuningConfig tuningConfig;
   @Nullable
@@ -84,6 +86,7 @@ public class InlineSchemaDataSourceCompactionConfig implements DataSourceCompact
       @JsonProperty("inputSegmentSizeBytes") @Nullable Long inputSegmentSizeBytes,
       @JsonProperty("maxRowsPerSegment") @Deprecated @Nullable Integer maxRowsPerSegment,
       @JsonProperty("skipOffsetFromLatest") @Nullable Period skipOffsetFromLatest,
+      @JsonProperty("skipIntervals") @Nullable List<Interval> skipIntervals,
       @JsonProperty("tuningConfig") @Nullable UserCompactionTaskQueryTuningConfig tuningConfig,
       @JsonProperty("granularitySpec") @Nullable UserCompactionTaskGranularityConfig granularitySpec,
       @JsonProperty("dimensionsSpec") @Nullable UserCompactionTaskDimensionsConfig dimensionsSpec,
@@ -105,6 +108,7 @@ public class InlineSchemaDataSourceCompactionConfig implements DataSourceCompact
                                  : inputSegmentSizeBytes;
     this.maxRowsPerSegment = maxRowsPerSegment;
     this.skipOffsetFromLatest = skipOffsetFromLatest == null ? DEFAULT_SKIP_OFFSET_FROM_LATEST : skipOffsetFromLatest;
+    this.skipIntervals = skipIntervals == null ? List.of() : skipIntervals;
     this.tuningConfig = tuningConfig;
     this.ioConfig = ioConfig;
     this.granularitySpec = granularitySpec;
@@ -152,6 +156,13 @@ public class InlineSchemaDataSourceCompactionConfig implements DataSourceCompact
   public Period getSkipOffsetFromLatest()
   {
     return skipOffsetFromLatest;
+  }
+
+  @JsonProperty
+  @Override
+  public List<Interval> getSkipIntervals()
+  {
+    return skipIntervals;
   }
 
   @JsonProperty
@@ -263,6 +274,7 @@ public class InlineSchemaDataSourceCompactionConfig implements DataSourceCompact
            Objects.equals(dataSource, that.dataSource) &&
            Objects.equals(maxRowsPerSegment, that.maxRowsPerSegment) &&
            Objects.equals(skipOffsetFromLatest, that.skipOffsetFromLatest) &&
+           Objects.equals(skipIntervals, that.skipIntervals) &&
            Objects.equals(tuningConfig, that.tuningConfig) &&
            Objects.equals(granularitySpec, that.granularitySpec) &&
            Objects.equals(dimensionsSpec, that.dimensionsSpec) &&
@@ -284,6 +296,7 @@ public class InlineSchemaDataSourceCompactionConfig implements DataSourceCompact
         inputSegmentSizeBytes,
         maxRowsPerSegment,
         skipOffsetFromLatest,
+        skipIntervals,
         tuningConfig,
         granularitySpec,
         dimensionsSpec,
@@ -310,6 +323,7 @@ public class InlineSchemaDataSourceCompactionConfig implements DataSourceCompact
         .withInputSegmentSizeBytes(this.inputSegmentSizeBytes)
         .withMaxRowsPerSegment(this.maxRowsPerSegment)
         .withSkipOffsetFromLatest(this.skipOffsetFromLatest)
+        .withSkipIntervals(this.skipIntervals)
         .withTuningConfig(this.tuningConfig)
         .withGranularitySpec(this.granularitySpec)
         .withDimensionsSpec(this.dimensionsSpec)
@@ -329,6 +343,7 @@ public class InlineSchemaDataSourceCompactionConfig implements DataSourceCompact
     private Long inputSegmentSizeBytes;
     private Integer maxRowsPerSegment;
     private Period skipOffsetFromLatest;
+    private List<Interval> skipIntervals;
     private UserCompactionTaskQueryTuningConfig tuningConfig;
     private UserCompactionTaskGranularityConfig granularitySpec;
     private UserCompactionTaskDimensionsConfig dimensionsSpec;
@@ -348,6 +363,7 @@ public class InlineSchemaDataSourceCompactionConfig implements DataSourceCompact
           inputSegmentSizeBytes,
           maxRowsPerSegment,
           skipOffsetFromLatest,
+          skipIntervals,
           tuningConfig,
           granularitySpec,
           dimensionsSpec,
@@ -389,6 +405,12 @@ public class InlineSchemaDataSourceCompactionConfig implements DataSourceCompact
     public Builder withSkipOffsetFromLatest(Period skipOffsetFromLatest)
     {
       this.skipOffsetFromLatest = skipOffsetFromLatest;
+      return this;
+    }
+
+    public Builder withSkipIntervals(List<Interval> skipIntervals)
+    {
+      this.skipIntervals = skipIntervals;
       return this;
     }
 

--- a/server/src/test/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIteratorTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIteratorTest.java
@@ -19,17 +19,35 @@
 
 package org.apache.druid.server.compaction;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.segment.metadata.DefaultIndexingStateFingerprintMapper;
+import org.apache.druid.segment.metadata.IndexingStateFingerprintMapper;
+import org.apache.druid.segment.metadata.NoopIndexingStateCache;
+import org.apache.druid.server.coordinator.CreateDataSegments;
+import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
+import org.apache.druid.server.coordinator.InlineSchemaDataSourceCompactionConfig;
+import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.joda.time.Interval;
+import org.joda.time.Period;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Iterator;
 import java.util.List;
 
 public class DataSourceCompactibleSegmentIteratorTest
 {
+  private static final ObjectMapper MAPPER = new DefaultObjectMapper();
+  private static final CompactionCandidateSearchPolicy POLICY = new NewestSegmentFirstPolicy(null);
+  private static final IndexingStateFingerprintMapper FINGERPRINT_MAPPER =
+      new DefaultIndexingStateFingerprintMapper(new NoopIndexingStateCache(), MAPPER);
+
   @Test
   public void testFilterSkipIntervals()
   {
@@ -54,22 +72,86 @@ public class DataSourceCompactibleSegmentIteratorTest
   }
 
   @Test
-  public void testAddSkipIntervalFromLatestAndSort()
+  public void testFindInitialSearchInterval()
   {
-    final List<Interval> expectedIntervals = ImmutableList.of(
-        Intervals.of("2018-12-24/2018-12-25"),
-        Intervals.of("2018-12-29/2019-01-01")
+    final Iterator<DataSegment> segments = CreateDataSegments.ofDatasource("test_datasource")
+                                                             .forIntervals(12, Granularities.HOUR)
+                                                             .startingAt("2018-01-01")
+                                                             .withNumPartitions(1)
+                                                             .eachOfSizeInMb(100)
+                                                             .iterator();
+    final SegmentTimeline timeline = SegmentTimeline.forSegments(segments);
+    final DataSourceCompactionConfig config =
+        InlineSchemaDataSourceCompactionConfig.builder()
+                                              .forDataSource("test_datasource")
+                                              .withSkipOffsetFromLatest(new Period("PT4H"))
+                                              .build();
+    final DataSourceCompactibleSegmentIterator iterator = new DataSourceCompactibleSegmentIterator(
+        config,
+        timeline,
+        List.of(),
+        POLICY,
+        FINGERPRINT_MAPPER
     );
-    /*final List<Interval> fullSkipIntervals = DataSourceCompactibleSegmentIterator.sortAndAddSkipIntervalFromLatest(
-        DateTimes.of("2019-01-01"),
-        new Period(72, 0, 0, 0),
-        null,
-        ImmutableList.of(
-            Intervals.of("2018-12-30/2018-12-31"),
-            Intervals.of("2018-12-24/2018-12-25")
-        )
-    );*/
 
-    //Assert.assertEquals(expectedIntervals, fullSkipIntervals);
+    final List<Interval> searchIntervals = iterator.findInitialSearchInterval(timeline, config.getSkipIntervals());
+
+    // Expected: Total interval is 2018-01-01T00:00:00/2018-01-01T12:00:00
+    // Skip interval: 2018-01-01T08:00:00/2018-01-01T12:00:00 (computed from 4h offset)
+    // Search interval should be: [2018-01-01T00:00:00/2018-01-01T10:00:00]
+    Assert.assertEquals(1, searchIntervals.size());
+    Assert.assertEquals(Intervals.of("2018-01-01T00:00:00/2018-01-01T08:00:00"), searchIntervals.get(0));
+  }
+
+  @Test
+  public void testFindInitialSearchIntervalWithMultipleSkipIntervals()
+  {
+    final Iterator<DataSegment> segments = CreateDataSegments.ofDatasource("test_datasource")
+                                                             .forIntervals(24, Granularities.HOUR)
+                                                             .startingAt("2018-01-01")
+                                                             .withNumPartitions(1)
+                                                             .eachOfSizeInMb(100)
+                                                             .iterator();
+    final SegmentTimeline timeline = SegmentTimeline.forSegments(segments);
+    final DataSourceCompactionConfig config =
+        InlineSchemaDataSourceCompactionConfig.builder()
+                                              .forDataSource("test_datasource")
+                                              .withSkipOffsetFromLatest(new Period("PT4H"))
+                                              .withSkipIntervals(List.of(
+                                                  Intervals.of("2018-01-01T06:00:00/2018-01-01T08:00:00"),
+                                                  Intervals.of("2018-01-01T12:00:00/2018-01-01T14:00:00"),
+                                                  Intervals.of("2018-01-01T18:30:00/2018-01-01T21:00:00")
+                                              ))
+                                              .build();
+    final DataSourceCompactibleSegmentIterator iterator = new DataSourceCompactibleSegmentIterator(
+        config,
+        timeline,
+        List.of(),
+        POLICY,
+        FINGERPRINT_MAPPER
+    );
+
+    final List<Interval> searchIntervals = iterator.findInitialSearchInterval(timeline, config.getSkipIntervals());
+
+    // Expected: Total interval is 2018-01-01T00:00:00/2018-01-02T00:00:00
+    // Skip intervals: 2018-01-01T06:00:00/2018-01-01T08:00:00 (explicit)
+    //                 2018-01-01T12:00:00/2018-01-01T14:00:00 (explicit)
+    //                 2018-01-01T18:30:00/2018-01-01T21:00:00 (explicit)
+    //                 2018-01-01T20:00:00/2018-01-02T00:00:00 (computed from 4h offset)
+    // After condensing: 2018-01-01T06:00:00/2018-01-01T08:00:00
+    //                   2018-01-01T12:00:00/2018-01-01T14:00:00
+    //                   2018-01-01T18:30:00/2018-01-02T00:00:00 (merged from overlapping intervals)
+    // Filtered intervals: 2018-01-01T00:00:00/2018-01-01T06:00:00
+    //                     2018-01-01T08:00:00/2018-01-01T12:00:00
+    //                     2018-01-01T14:00:00/2018-01-01T18:30:00
+    // Actual segments are hourly (aligned to hour boundaries), so the segment 18:00-19:00 overlaps with skip interval starting at 18:30 and is excluded.
+    // Search intervals based on actual segment boundaries:
+    //   [2018-01-01T00:00:00/2018-01-01T06:00:00,
+    //    2018-01-01T08:00:00/2018-01-01T12:00:00,
+    //    2018-01-01T14:00:00/2018-01-01T18:00:00]
+    Assert.assertEquals(3, searchIntervals.size());
+    Assert.assertEquals(Intervals.of("2018-01-01T00:00:00/2018-01-01T06:00:00"), searchIntervals.get(0));
+    Assert.assertEquals(Intervals.of("2018-01-01T08:00:00/2018-01-01T12:00:00"), searchIntervals.get(1));
+    Assert.assertEquals(Intervals.of("2018-01-01T14:00:00/2018-01-01T18:00:00"), searchIntervals.get(2));
   }
 }

--- a/server/src/test/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIteratorTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIteratorTest.java
@@ -98,7 +98,7 @@ public class DataSourceCompactibleSegmentIteratorTest
 
     // Expected: Total interval is 2018-01-01T00:00:00/2018-01-01T12:00:00
     // Skip interval: 2018-01-01T08:00:00/2018-01-01T12:00:00 (computed from 4h offset)
-    // Search interval should be: [2018-01-01T00:00:00/2018-01-01T10:00:00]
+    // Search interval should be: [2018-01-01T00:00:00/2018-01-01T08:00:00]
     Assert.assertEquals(1, searchIntervals.size());
     Assert.assertEquals(Intervals.of("2018-01-01T00:00:00/2018-01-01T08:00:00"), searchIntervals.get(0));
   }

--- a/server/src/test/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIteratorTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIteratorTest.java
@@ -133,25 +133,16 @@ public class DataSourceCompactibleSegmentIteratorTest
 
     final List<Interval> searchIntervals = iterator.findInitialSearchInterval(timeline, List.of());
 
-    // Expected: Total interval is 2018-01-01T00:00:00/2018-01-02T00:00:00
-    // Skip intervals: 2018-01-01T06:00:00/2018-01-01T08:00:00 (explicit)
-    //                 2018-01-01T12:00:00/2018-01-01T14:00:00 (explicit)
-    //                 2018-01-01T18:30:00/2018-01-01T21:00:00 (explicit)
-    //                 2018-01-01T20:00:00/2018-01-02T00:00:00 (computed from 4h offset)
-    // After condensing: 2018-01-01T06:00:00/2018-01-01T08:00:00
-    //                   2018-01-01T12:00:00/2018-01-01T14:00:00
-    //                   2018-01-01T18:30:00/2018-01-02T00:00:00 (merged from overlapping intervals)
-    // Filtered intervals: 2018-01-01T00:00:00/2018-01-01T06:00:00
-    //                     2018-01-01T08:00:00/2018-01-01T12:00:00
-    //                     2018-01-01T14:00:00/2018-01-01T18:30:00
-    // Actual segments are hourly (aligned to hour boundaries), so the segment 18:00-19:00 overlaps with skip interval starting at 18:30 and is excluded.
-    // Search intervals based on actual segment boundaries:
-    //   [2018-01-01T00:00:00/2018-01-01T06:00:00,
-    //    2018-01-01T08:00:00/2018-01-01T12:00:00,
-    //    2018-01-01T14:00:00/2018-01-01T18:00:00]
-    Assert.assertEquals(3, searchIntervals.size());
-    Assert.assertEquals(Intervals.of("2018-01-01T00:00:00/2018-01-01T06:00:00"), searchIntervals.get(0));
-    Assert.assertEquals(Intervals.of("2018-01-01T08:00:00/2018-01-01T12:00:00"), searchIntervals.get(1));
-    Assert.assertEquals(Intervals.of("2018-01-01T14:00:00/2018-01-01T18:00:00"), searchIntervals.get(2));
+    // The three configured skip intervals and the 4h-offset skip interval (18:30-21:00 and
+    // 20:00-00:00 merge) leave three search windows. The last window is clipped to 18:00
+    // since segments are hourly and the 18:00-19:00 segment overlaps the 18:30 skip start.
+    Assert.assertEquals(
+        List.of(
+            Intervals.of("2018-01-01T00:00:00/PT6H"),
+            Intervals.of("2018-01-01T08:00:00/PT4H"),
+            Intervals.of("2018-01-01T14:00:00/PT4H")
+        ),
+        searchIntervals
+    );
   }
 }

--- a/server/src/test/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIteratorTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIteratorTest.java
@@ -94,7 +94,7 @@ public class DataSourceCompactibleSegmentIteratorTest
         FINGERPRINT_MAPPER
     );
 
-    final List<Interval> searchIntervals = iterator.findInitialSearchInterval(timeline, config.getSkipIntervals());
+    final List<Interval> searchIntervals = iterator.findInitialSearchInterval(timeline, List.of());
 
     // Expected: Total interval is 2018-01-01T00:00:00/2018-01-01T12:00:00
     // Skip interval: 2018-01-01T08:00:00/2018-01-01T12:00:00 (computed from 4h offset)
@@ -131,7 +131,7 @@ public class DataSourceCompactibleSegmentIteratorTest
         FINGERPRINT_MAPPER
     );
 
-    final List<Interval> searchIntervals = iterator.findInitialSearchInterval(timeline, config.getSkipIntervals());
+    final List<Interval> searchIntervals = iterator.findInitialSearchInterval(timeline, List.of());
 
     // Expected: Total interval is 2018-01-01T00:00:00/2018-01-02T00:00:00
     // Skip intervals: 2018-01-01T06:00:00/2018-01-01T08:00:00 (explicit)

--- a/server/src/test/java/org/apache/druid/server/compaction/NewestSegmentFirstPolicyTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/NewestSegmentFirstPolicyTest.java
@@ -535,6 +535,43 @@ public class NewestSegmentFirstPolicyTest
   }
 
   @Test
+  public void testWithConfiguredSkipIntervals()
+  {
+    // Uses createIterator(), which mirrors the Coordinator duty path
+    // (PriorityBasedCompactionSegmentIterator with no externally supplied skip intervals), to
+    // verify that config.getSkipIntervals() is honored even when nothing else carries skip
+    // information into the iterator.
+    final SegmentTimeline timeline = createTimeline(
+        createSegments().forIntervals(4, Granularities.DAY)
+                        .startingAt("2017-12-01")
+                        .withNumPartitions(1)
+    );
+
+    final CompactionSegmentIterator iterator = createIterator(
+        configBuilder()
+            .withSkipIntervals(List.of(Intervals.of("2017-12-02/2017-12-03")))
+            .build(),
+        timeline
+    );
+
+    final List<DataSegment> expectedSegmentsToCompact = new ArrayList<>(
+        timeline.findNonOvershadowedObjectsInInterval(Intervals.of("2017-12-01/2017-12-02"), Partitions.ONLY_COMPLETE)
+    );
+    expectedSegmentsToCompact.addAll(
+        timeline.findNonOvershadowedObjectsInInterval(Intervals.of("2017-12-03/2017-12-05"), Partitions.ONLY_COMPLETE)
+    );
+
+    Assert.assertTrue(iterator.hasNext());
+    final Set<DataSegment> observedSegmentsToCompact = Streams.sequentialStreamFrom(iterator)
+                                                              .flatMap(s -> s.getSegments().stream())
+                                                              .collect(Collectors.toSet());
+    Assert.assertEquals(
+        ImmutableSet.copyOf(expectedSegmentsToCompact),
+        observedSegmentsToCompact
+    );
+  }
+
+  @Test
   public void testHoleInSearchInterval()
   {
     final Period segmentPeriod = Period.hours(1);

--- a/server/src/test/java/org/apache/druid/server/compaction/NewestSegmentFirstPolicyTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/NewestSegmentFirstPolicyTest.java
@@ -535,12 +535,8 @@ public class NewestSegmentFirstPolicyTest
   }
 
   @Test
-  public void testWithConfiguredSkipIntervals()
+  public void testConfiguredSkipIntervalsAreHonoredWithNoExternalSkipIntervals()
   {
-    // Uses createIterator(), which mirrors the Coordinator duty path
-    // (PriorityBasedCompactionSegmentIterator with no externally supplied skip intervals), to
-    // verify that config.getSkipIntervals() is honored even when nothing else carries skip
-    // information into the iterator.
     final SegmentTimeline timeline = createTimeline(
         createSegments().forIntervals(4, Granularities.DAY)
                         .startingAt("2017-12-01")

--- a/server/src/test/java/org/apache/druid/server/coordinator/CatalogDataSourceCompactionConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/CatalogDataSourceCompactionConfigTest.java
@@ -152,7 +152,7 @@ public class CatalogDataSourceCompactionConfigTest
   }
 
   @Test
-  public void testSerdeWithSkip() throws JsonProcessingException
+  public void testSerdeWithSkipIntervals() throws JsonProcessingException
   {
     final Period skipOffsetFromLatest = new Period("PT1H");
     final List<Interval> skipIntervals = List.of(

--- a/server/src/test/java/org/apache/druid/server/coordinator/CatalogDataSourceCompactionConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/CatalogDataSourceCompactionConfigTest.java
@@ -34,14 +34,19 @@ import org.apache.druid.catalog.model.table.TableBuilder;
 import org.apache.druid.data.input.impl.AggregateProjectionSpec;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.query.expression.TestExprMacroTable;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ColumnType;
+import org.joda.time.Interval;
+import org.joda.time.Period;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 public class CatalogDataSourceCompactionConfigTest
 {
@@ -116,6 +121,7 @@ public class CatalogDataSourceCompactionConfigTest
         null,
         null,
         null,
+        null,
         METADATA_CATALOG
     );
 
@@ -135,6 +141,7 @@ public class CatalogDataSourceCompactionConfigTest
         null,
         null,
         null,
+        null,
         METADATA_CATALOG
     );
 
@@ -142,6 +149,37 @@ public class CatalogDataSourceCompactionConfigTest
         config,
         MAPPER.readValue(MAPPER.writeValueAsString(config), DataSourceCompactionConfig.class)
     );
+  }
+
+  @Test
+  public void testSerdeWithSkip() throws JsonProcessingException
+  {
+    final Period skipOffsetFromLatest = new Period("PT1H");
+    final List<Interval> skipIntervals = List.of(
+        Intervals.of("2024-01-01/2024-01-02"),
+        Intervals.of("2024-02-15/2024-02-16")
+    );
+
+    final CatalogDataSourceCompactionConfig config = new CatalogDataSourceCompactionConfig(
+        "foo",
+        null,
+        skipOffsetFromLatest,
+        skipIntervals,
+        null,
+        null,
+        null,
+        METADATA_CATALOG
+    );
+
+    final CatalogDataSourceCompactionConfig deserialized =
+        (CatalogDataSourceCompactionConfig) MAPPER.readValue(
+            MAPPER.writeValueAsString(config),
+            DataSourceCompactionConfig.class
+        );
+
+    Assertions.assertEquals(config, deserialized);
+    Assertions.assertEquals(skipOffsetFromLatest, deserialized.getSkipOffsetFromLatest());
+    Assertions.assertEquals(skipIntervals, deserialized.getSkipIntervals());
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/server/coordinator/InlineSchemaDataSourceCompactionConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/InlineSchemaDataSourceCompactionConfigTest.java
@@ -32,6 +32,7 @@ import org.apache.druid.indexer.CompactionEngine;
 import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.HumanReadableBytes;
+import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.aggregation.AggregatorFactory;
@@ -54,6 +55,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.List;
 
 public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullHandlingTest
 {
@@ -74,6 +76,7 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
         .builder()
         .forDataSource("dataSource")
         .withSkipOffsetFromLatest(new Period(3600))
+        .withSkipIntervals(List.of(Intervals.of("2024-02-15/2024-02-16")))
         .withTaskContext(ImmutableMap.of("key", "val"))
         .build();
     final String json = OBJECT_MAPPER.writeValueAsString(config);
@@ -84,6 +87,7 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
     Assert.assertEquals(100_000_000_000_000L, fromJson.getInputSegmentSizeBytes());
     Assert.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
     Assert.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
+    Assert.assertEquals(config.getSkipIntervals(), fromJson.getSkipIntervals());
     Assert.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
     Assert.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
     Assert.assertEquals(config.getGranularitySpec(), fromJson.getGranularitySpec());
@@ -99,6 +103,7 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
         .withInputSegmentSizeBytes(500L)
         .withMaxRowsPerSegment(30)
         .withSkipOffsetFromLatest(new Period(3600))
+        .withSkipIntervals(List.of(Intervals.of("2024-01-01/2024-01-02")))
         .withEngine(CompactionEngine.MSQ)
         .withTaskContext(ImmutableMap.of("key", "val"))
         .build();
@@ -123,6 +128,7 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
         .forDataSource("dataSource")
         .withInputSegmentSizeBytes(500L)
         .withSkipOffsetFromLatest(new Period(3600))
+        .withSkipIntervals(List.of(Intervals.of("2024-03-01/2024-03-02")))
         .withEngine(CompactionEngine.NATIVE)
         .withTaskContext(ImmutableMap.of("key", "val"))
         .build();
@@ -148,6 +154,7 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
         .withInputSegmentSizeBytes(500L)
         .withMaxRowsPerSegment(10000)
         .withSkipOffsetFromLatest(new Period(3600))
+        .withSkipIntervals(List.of(Intervals.of("2024-04-01/2024-04-02")))
         .withTaskContext(ImmutableMap.of("key", "val"))
         .build();
     final String json = OBJECT_MAPPER.writeValueAsString(config);
@@ -248,6 +255,7 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
         .forDataSource("dataSource")
         .withInputSegmentSizeBytes(500L)
         .withSkipOffsetFromLatest(new Period(3600))
+        .withSkipIntervals(List.of(Intervals.of("2024-01-15/2024-01-16")))
         .withGranularitySpec(new UserCompactionTaskGranularityConfig(Granularities.HOUR, null, null))
         .withTaskContext(ImmutableMap.of("key", "val"))
         .build();
@@ -272,6 +280,7 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
         .forDataSource("dataSource")
         .withInputSegmentSizeBytes(500L)
         .withSkipOffsetFromLatest(new Period(3600))
+        .withSkipIntervals(List.of(Intervals.of("2024-01-15/2024-01-16")))
         .withGranularitySpec(new UserCompactionTaskGranularityConfig(null, Granularities.YEAR, null))
         .withTaskContext(ImmutableMap.of("key", "val"))
         .build();
@@ -299,6 +308,7 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
         .forDataSource("dataSource")
         .withInputSegmentSizeBytes(500L)
         .withSkipOffsetFromLatest(new Period(3600))
+        .withSkipIntervals(List.of(Intervals.of("2024-01-15/2024-01-16")))
         .withTaskContext(ImmutableMap.of("key", "val"))
         .build();
     final String json = OBJECT_MAPPER.writeValueAsString(config);
@@ -322,6 +332,7 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
         .forDataSource("dataSource")
         .withInputSegmentSizeBytes(500L)
         .withSkipOffsetFromLatest(new Period(3600))
+        .withSkipIntervals(List.of(Intervals.of("2024-01-15/2024-01-16")))
         .withGranularitySpec(new UserCompactionTaskGranularityConfig(null, null, null))
         .withTaskContext(ImmutableMap.of("key", "val"))
         .build();
@@ -346,6 +357,7 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
         .forDataSource("dataSource")
         .withInputSegmentSizeBytes(500L)
         .withSkipOffsetFromLatest(new Period(3600))
+        .withSkipIntervals(List.of(Intervals.of("2024-01-15/2024-01-16")))
         .withGranularitySpec(new UserCompactionTaskGranularityConfig(null, null, true))
         .withTaskContext(ImmutableMap.of("key", "val"))
         .build();
@@ -373,6 +385,7 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
         .forDataSource("dataSource")
         .withInputSegmentSizeBytes(500L)
         .withSkipOffsetFromLatest(new Period(3600))
+        .withSkipIntervals(List.of(Intervals.of("2024-01-15/2024-01-16")))
         .withGranularitySpec(new UserCompactionTaskGranularityConfig(Granularities.HOUR, null, null))
         .withIoConfig(new UserCompactionTaskIOConfig(true))
         .withTaskContext(ImmutableMap.of("key", "val"))
@@ -399,6 +412,7 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
         .forDataSource("dataSource")
         .withInputSegmentSizeBytes(500L)
         .withSkipOffsetFromLatest(new Period(3600))
+        .withSkipIntervals(List.of(Intervals.of("2024-01-15/2024-01-16")))
         .withGranularitySpec(new UserCompactionTaskGranularityConfig(Granularities.HOUR, null, null))
         .withIoConfig(new UserCompactionTaskIOConfig(null))
         .withTaskContext(ImmutableMap.of("key", "val"))
@@ -425,6 +439,7 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
         .forDataSource("dataSource")
         .withInputSegmentSizeBytes(500L)
         .withSkipOffsetFromLatest(new Period(3600))
+        .withSkipIntervals(List.of(Intervals.of("2024-01-15/2024-01-16")))
         .withDimensionsSpec(
             new UserCompactionTaskDimensionsConfig(
                 DimensionsSpec.getDefaultSchemas(ImmutableList.of("foo"))
@@ -453,6 +468,7 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
         .forDataSource("dataSource")
         .withInputSegmentSizeBytes(500L)
         .withSkipOffsetFromLatest(new Period(3600))
+        .withSkipIntervals(List.of(Intervals.of("2024-01-15/2024-01-16")))
         .withTransformSpec(
             new CompactionTransformSpec(
                 new SelectorDimFilter("dim1", "foo", null),
@@ -489,6 +505,7 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
         .forDataSource("dataSource")
         .withInputSegmentSizeBytes(500L)
         .withSkipOffsetFromLatest(new Period(3600))
+        .withSkipIntervals(List.of(Intervals.of("2024-01-15/2024-01-16")))
         .withMetricsSpec(new AggregatorFactory[]{new CountAggregatorFactory("cnt")})
         .withTaskContext(ImmutableMap.of("key", "val"))
         .build();

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
@@ -1053,6 +1053,7 @@ public class CompactSegmentsTest
             dataSource,
             engine,
             new Period("PT0H"),
+            null,
             0,
             null,
             500L,


### PR DESCRIPTION
### Description
Adds a skipIntervals field to compaction configs, allowing users to specify explicit time intervals to exclude from compaction in addition to the existing skipOffsetFromLatest period.

### Changes
- DataSourceCompactionConfig interface: Added getSkipIntervals() method returning List
- Javadoc: Updated JodaUtils.condenseIntervals() and condensedIntervalsIterator() to document that results are sorted by intervalsByStartThenEnd()
- DataSourceCompactibleSegmentIterator: findInitialSearchInterval() now reads config.getSkipIntervals() directly (matching how it already reads config.getSkipOffsetFromLatest()), so configured skip intervals are honored on both the supervisor and legacy Coordinator-duty compaction paths. Simplified CompactionConfigBasedJobTemplate to use Intervals.complementOf() for bounding the search interval.

### Release note                                                                                                                                                     
Auto-compaction now supports a `skipIntervals` setting on datasource compaction config, allowing specific intervals to be excluded from compaction in addition to the existing `skipOffsetFromLatest` behavior. This is useful, for example, to exclude an interval that a backfill job is actively writing to, or one that consistently fails compaction.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

