### PR TITLE
refactor: Cleanup create table and alter table methods in SQLMetadataConnector

### DIFF
--- a/extensions-contrib/sqlserver-metadata-storage/src/test/java/org/apache/druid/metadata/storage/sqlserver/CustomStatementRewriterTest.java
+++ b/extensions-contrib/sqlserver-metadata-storage/src/test/java/org/apache/druid/metadata/storage/sqlserver/CustomStatementRewriterTest.java
@@ -91,7 +91,7 @@ public class CustomStatementRewriterTest
 
   /**
    *
-   * @see org.apache.druid.metadata.SQLMetadataConnector#createTable(String, Iterable)
+   * @see org.apache.druid.metadata.SQLMetadataConnector#createTableIfNotExists(String, Iterable)
    *
    */
   @Test

--- a/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/storage/sql/SQLCatalogManager.java
+++ b/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/storage/sql/SQLCatalogManager.java
@@ -117,7 +117,7 @@ public class SQLCatalogManager implements CatalogManager
     if (!metastoreManager.config().isCreateTables()) {
       return;
     }
-    connector.createTable(
+    connector.createTableIfNotExists(
         tableName,
         ImmutableList.of(
             StringUtils.format(

--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
@@ -370,7 +370,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
       columns.add("num_rows BIGINT");
     }
 
-    StringBuilder createStatementBuilder = new StringBuilder("CREATE TABLE %1$s (");
+    final StringBuilder createStatementBuilder = new StringBuilder("CREATE TABLE %1$s (");
 
     for (String column : columns) {
       createStatementBuilder.append(column);
@@ -399,6 +399,15 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
             "start"
         )
     );
+
+    // Index to cover the query to find the segments that were upgraded from a
+    // given segment ID in 'retrieveUpgradedToSegmentIds' task action
+    createIndex(
+        tableName,
+        "IDX_%S_DATASOURCE_UPGRADED_FROM_SEGMENT_ID",
+        List.of("dataSource", "upgraded_from_segment_id")
+    );
+
     // Covering index for the used-segment ID scan performed on every metadata
     // cache sync (SELECT id, dataSource, used_status_last_updated WHERE used=true).
     // Includes id explicitly so the scan is index-only on all backends (not only
@@ -619,6 +628,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
   /**
    * Adds new columns (used_status_last_updated) to the "segments" table.
    * Conditionally, add schema_fingerprint, num_rows columns.
+   * This method is a no-op for a freshly created segment table in a new Druid cluster.
    */
   protected void alterSegmentTable()
   {

--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
@@ -239,7 +239,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
   /**
    * Creates the given table and indexes if the table doesn't already exist.
    */
-  public void createTable(final String tableName, final Iterable<String> sql)
+  public void createTableIfNotExists(final String tableName, final Iterable<String> sql)
   {
     try {
       retryWithHandle(handle -> {
@@ -291,7 +291,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
 
   public void createPendingSegmentsTable(final String tableName)
   {
-    createTable(
+    createTableIfNotExists(
         tableName,
         ImmutableList.of(
             StringUtils.format(
@@ -305,6 +305,8 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
                 + "  sequence_prev_id VARCHAR(255) NOT NULL,\n"
                 + "  sequence_name_prev_id_sha1 VARCHAR(255) NOT NULL,\n"
                 + "  payload %2$s NOT NULL,\n"
+                + "  upgraded_from_segment_id VARCHAR(255),\n"
+                + "  task_allocator_id VARCHAR(255),\n"
                 + "  PRIMARY KEY (id),\n"
                 + "  UNIQUE (sequence_name_prev_id_sha1)\n"
                 + ")",
@@ -312,17 +314,21 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
             )
         )
     );
-    createIndex(
+    createIndexIfNotExists(
         tableName,
         "IDX_%S_DATASOURCE_END",
         List.of("dataSource", quoteColumn("end"))
     );
-    createIndex(
+    createIndexIfNotExists(
         tableName,
         "IDX_%S_DATASOURCE_SEQUENCE",
         List.of("dataSource", "sequence_name")
     );
-    alterPendingSegmentsTable(tableName);
+    createIndexIfNotExists(
+        tableName,
+        "IDX_%S_DATASOURCE_TASK_ALLOCATOR_ID",
+        List.of("dataSource", "task_allocator_id")
+    );
   }
 
   /**
@@ -332,7 +338,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
    */
   public void createDataSourceTable(final String tableName)
   {
-    createTable(
+    createTableIfNotExists(
         tableName,
         ImmutableList.of(
             StringUtils.format(
@@ -379,7 +385,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
 
     createStatementBuilder.append("PRIMARY KEY (id)\n)");
 
-    createTable(
+    createTableIfNotExists(
         tableName,
         ImmutableList.of(
             StringUtils.format(
@@ -389,7 +395,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
         )
     );
 
-    createIndex(
+    createIndexIfNotExists(
         tableName,
         "IDX_%S_DATASOURCE_USED_END_START",
         List.of(
@@ -402,7 +408,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
 
     // Index to cover the query to find the segments that were upgraded from a
     // given segment ID in 'retrieveUpgradedToSegmentIds' task action
-    createIndex(
+    createIndexIfNotExists(
         tableName,
         "IDX_%S_DATASOURCE_UPGRADED_FROM_SEGMENT_ID",
         List.of("dataSource", "upgraded_from_segment_id")
@@ -414,7 +420,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
     // engines like InnoDB that append the primary key to secondary indexes).
     // Its leading 'used' column also serves plain 'WHERE used = ?' lookups, so a
     // separate IDX_%S_USED index is not created.
-    createIndex(
+    createIndexIfNotExists(
         tableName,
         "IDX_%S_USED_USLU_DATASOURCE",
         List.of("used", "used_status_last_updated", "dataSource", "id")
@@ -423,7 +429,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
 
   private void createUpgradeSegmentsTable(final String tableName)
   {
-    createTable(
+    createTableIfNotExists(
         tableName,
         ImmutableList.of(
             StringUtils.format(
@@ -438,7 +444,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
             )
         )
     );
-    createIndex(
+    createIndexIfNotExists(
         tableName,
         "IDX_%S_TASK",
         List.of("task_id")
@@ -447,7 +453,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
 
   public void createRulesTable(final String tableName)
   {
-    createTable(
+    createTableIfNotExists(
         tableName,
         ImmutableList.of(
             StringUtils.format(
@@ -462,7 +468,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
             )
         )
     );
-    createIndex(
+    createIndexIfNotExists(
         tableName,
         "IDX_%S_DATASOURCE",
         List.of("dataSource")
@@ -471,7 +477,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
 
   public void createConfigTable(final String tableName)
   {
-    createTable(
+    createTableIfNotExists(
         tableName,
         ImmutableList.of(
             StringUtils.format(
@@ -488,13 +494,13 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
 
   public void prepareTaskEntryTable(final String tableName)
   {
-    createEntryTable(tableName);
-    alterEntryTableAddTypeAndGroupId(tableName);
+    createTaskTable(tableName);
+    alterTaskTableAddTypeAndGroupId(tableName);
   }
 
-  public void createEntryTable(final String tableName)
+  public void createTaskTable(final String tableName)
   {
-    createTable(
+    createTableIfNotExists(
         tableName,
         ImmutableList.of(
             StringUtils.format(
@@ -505,25 +511,27 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
                 + "  payload %2$s NOT NULL,\n"
                 + "  status_payload %2$s NOT NULL,\n"
                 + "  active BOOLEAN NOT NULL DEFAULT FALSE,\n"
+                + "  type VARCHAR(255),\n"
+                + "  group_id VARCHAR(255),\n"
                 + "  PRIMARY KEY (id)\n"
                 + ")",
                 tableName, getPayloadType(), getCollation()
             )
         )
     );
-    createIndex(
+    createIndexIfNotExists(
         tableName,
         "IDX_%S_ACTIVE_CREATED_DATE",
         List.of("active", "created_date")
     );
-    createIndex(
+    createIndexIfNotExists(
         tableName,
         "IDX_%S_DATASOURCE_ACTIVE",
         List.of("datasource", "active")
     );
   }
 
-  private void alterEntryTableAddTypeAndGroupId(final String tableName)
+  private void alterTaskTableAddTypeAndGroupId(final String tableName)
   {
     List<String> statements = new ArrayList<>();
     if (tableHasColumn(tableName, "type")) {
@@ -571,7 +579,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
       alterTable(tableName, statements);
     }
 
-    createIndex(
+    createIndexIfNotExists(
         tableName,
         "IDX_%S_DATASOURCE_TASK_ALLOCATOR_ID",
         List.of("dataSource", "task_allocator_id")
@@ -580,7 +588,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
 
   public void createLockTable(final String tableName)
   {
-    createTable(
+    createTableIfNotExists(
         tableName,
         ImmutableList.of(
             StringUtils.format(
@@ -594,7 +602,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
             )
         )
     );
-    createIndex(
+    createIndexIfNotExists(
         tableName,
         "IDX_%S_TASK_ID",
         List.of("task_id")
@@ -603,7 +611,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
 
   public void createSupervisorsTable(final String tableName)
   {
-    createTable(
+    createTableIfNotExists(
         tableName,
         ImmutableList.of(
             StringUtils.format(
@@ -618,7 +626,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
             )
         )
     );
-    createIndex(
+    createIndexIfNotExists(
         tableName,
         "IDX_%S_SPEC_ID",
         List.of("spec_id")
@@ -674,14 +682,14 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
 
     alterTable(tableName, alterCommands);
 
-    createIndex(
+    createIndexIfNotExists(
         tableName,
         "IDX_%S_DATASOURCE_UPGRADED_FROM_SEGMENT_ID",
         List.of("dataSource", "upgraded_from_segment_id")
     );
     // Migration for existing tables: covering index backing the used-segment ID
     // scan on every cache sync (see createSegmentTable).
-    createIndex(
+    createIndexIfNotExists(
         tableName,
         "IDX_%S_USED_USLU_DATASOURCE",
         List.of("used", "used_status_last_updated", "dataSource", "id")
@@ -827,7 +835,9 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
   public void createPendingSegmentsTable()
   {
     if (config.get().isCreateTables()) {
-      createPendingSegmentsTable(tablesConfigSupplier.get().getPendingSegmentsTable());
+      final String tableName = tablesConfigSupplier.get().getPendingSegmentsTable();
+      createPendingSegmentsTable(tableName);
+      alterPendingSegmentsTable(tableName);
     }
   }
 
@@ -1021,7 +1031,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
 
   private void createAuditTable(final String tableName)
   {
-    createTable(
+    createTableIfNotExists(
         tableName,
         ImmutableList.of(
             StringUtils.format(
@@ -1039,17 +1049,17 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
             )
         )
     );
-    createIndex(
+    createIndexIfNotExists(
         tableName,
         "IDX_%s_KEY_TIME",
         List.of("audit_key", "created_date")
     );
-    createIndex(
+    createIndexIfNotExists(
         tableName,
         "IDX_%s_TYPE_TIME",
         List.of("type", "created_date")
     );
-    createIndex(
+    createIndexIfNotExists(
         tableName,
         "IDX_%s_AUDIT_TIME",
         List.of("created_date")
@@ -1094,7 +1104,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
 
   public void createSegmentSchemasTable(final String tableName)
   {
-    createTable(
+    createTableIfNotExists(
         tableName,
         ImmutableList.of(
             StringUtils.format(
@@ -1114,12 +1124,12 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
             )
         )
     );
-    createIndex(
+    createIndexIfNotExists(
         tableName,
         "IDX_%s_FINGERPRINT",
         List.of("fingerprint")
     );
-    createIndex(
+    createIndexIfNotExists(
         tableName,
         "IDX_%s_USED",
         List.of("used", "used_status_last_updated")
@@ -1142,7 +1152,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
    */
   public void createIndexingStatesTable(final String tableName)
   {
-    createTable(
+    createTableIfNotExists(
         tableName,
         ImmutableList.of(
             StringUtils.format(
@@ -1161,7 +1171,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
         )
     );
 
-    createIndex(
+    createIndexIfNotExists(
         tableName,
         "IDX_%s_USED",
         List.of("used", "used_status_last_updated")
@@ -1229,14 +1239,14 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
   }
 
   /**
-   * Create index on the table {@code tableName} with retry if not already exist, to be called after {@link #createTable}.
+   * Create index on the table {@code tableName} with retry if not already exist, to be called after {@link #createTableIfNotExists}.
    * Format of index name is either specified via {@code fullIndexNameFormat} or {@link #generateShortIndexName}.
    *
    * @param tableName           Name of the table to create index on
    * @param fullIndexNameFormat Template to create index ID. If specified, the only placeholder should be for the tableName. Otherwise, uses the format: {@code IDX_{table name}_{columns}}.
    * @param indexCols           List of un-escaped column names to be indexed on (case-sensitive).
    */
-  public void createIndex(
+  public void createIndexIfNotExists(
       final String tableName,
       @Nullable final String fullIndexNameFormat,
       final List<String> indexCols
@@ -1284,12 +1294,12 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
 
   /**
    * Drops an index on {@code tableName} if it exists, under either the full or
-   * short naming convention (see {@link #createIndex}). No-op if absent, so it is
+   * short naming convention (see {@link #createIndexIfNotExists}). No-op if absent, so it is
    * safe to call on every startup.
    *
    * @param tableName           Name of the table the index is on
-   * @param fullIndexNameFormat Same format string that was passed to {@link #createIndex}
-   * @param indexCols           Same columns that were passed to {@link #createIndex}
+   * @param fullIndexNameFormat Same format string that was passed to {@link #createIndexIfNotExists}
+   * @param indexCols           Same columns that were passed to {@link #createIndexIfNotExists}
    */
   public void dropIndex(
       final String tableName,

--- a/server/src/test/java/org/apache/druid/metadata/SQLMetadataConnectorSchemaPersistenceTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SQLMetadataConnectorSchemaPersistenceTest.java
@@ -47,7 +47,7 @@ public class SQLMetadataConnectorSchemaPersistenceTest
   }
 
   @Test
-  public void testCreateTables()
+  public void testCreateTablesIfNotExists()
   {
     final List<String> tables = new ArrayList<>();
     tables.add(tablesConfig.getConfigTable());

--- a/server/src/test/java/org/apache/druid/metadata/SQLMetadataConnectorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SQLMetadataConnectorTest.java
@@ -66,7 +66,7 @@ public class SQLMetadataConnectorTest
   }
 
   @Test
-  public void testCreateTables()
+  public void testCreateTablesIfNotExists()
   {
     final List<String> tables = new ArrayList<>();
     tables.add(tablesConfig.getConfigTable());
@@ -134,11 +134,11 @@ public class SQLMetadataConnectorTest
   }
 
   @Test
-  public void testCreateIndexOnNoTable()
+  public void testCreateIndexIfNotExistsOnNoTable()
   {
     String tableName = "noTable";
     try {
-      connector.createIndex(
+      connector.createIndexIfNotExists(
           tableName,
           "some_string",
           Lists.newArrayList("a", "b")

--- a/server/src/test/java/org/apache/druid/metadata/input/SqlTestUtils.java
+++ b/server/src/test/java/org/apache/druid/metadata/input/SqlTestUtils.java
@@ -139,7 +139,7 @@ public class SqlTestUtils
 
   public List<InputRow> createTableWithRows(final String tableName, int numEntries)
   {
-    derbyConnector.createTable(
+    derbyConnector.createTableIfNotExists(
         tableName,
         ImmutableList.of(
             StringUtils.format(


### PR DESCRIPTION
Changes:
- Cleanup methods in `SQLMetadataConnector` so that the entire table definition is contained in the corresponding `createXyzTable()` methods
- `alterXyzTable()` methods become no-op on new clusters where the corresponding table has been freshly created

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.