### PR TITLE
fix: exclude vulnerable SnakeYAML from Cassandra storage

### DIFF
--- a/extensions-contrib/cassandra-storage/pom.xml
+++ b/extensions-contrib/cassandra-storage/pom.xml
@@ -114,6 +114,8 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <!-- Cassandra uses SnakeYAML only for unused server configuration; exclude the vulnerable,
+                     binary-incompatible transitive dependency rather than upgrading it. -->
                 <exclusion>
                     <groupId>org.yaml</groupId>
                     <artifactId>snakeyaml</artifactId>

--- a/extensions-contrib/cassandra-storage/pom.xml
+++ b/extensions-contrib/cassandra-storage/pom.xml
@@ -33,21 +33,6 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <dependencyManagement>
-        <dependencies>
-            <!-- snakeyaml explicitly pinned to version 1.33 as it is
-            a transitive dependency of:
-            com.netflix.astyanax:astyanax:jar -> g.apache.cassandra:cassandra-all:jar
-            please remove this pin after the update of astyanax, see comment below
-             -->
-            <dependency>
-                <groupId>org.yaml</groupId>
-                <artifactId>snakeyaml</artifactId>
-                <version>1.33</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.druid</groupId>
@@ -128,6 +113,10 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>com.github.stephenc.high-scale-lib</groupId>


### PR DESCRIPTION
## What changed

- remove the Cassandra storage module's local dependency-management pin for `org.yaml:snakeyaml:1.33`
- exclude SnakeYAML from the transitive `astyanax -> cassandra-all` dependency chain

## Why

Dependabot alert #297 reports a constructor-deserialization vulnerability in SnakeYAML 1.33. The Cassandra storage extension was overriding Druid's root dependency management to keep this vulnerable version in its runtime graph.

Cassandra 1.0.8 uses old SnakeYAML APIs that were removed in SnakeYAML 2.x, including `org.yaml.snakeyaml.Loader` and `Constructor(Class)`. Replacing 1.33 with the root-managed 2.5 would therefore leave binary-incompatible server-configuration classes on the classpath.

The Druid extension uses Astyanax's Cassandra client/thrift APIs and does not use Cassandra's YAML server-configuration loader. Excluding this unused transitive dependency removes the vulnerable artifact without introducing a knowingly incompatible replacement.

## Impact

The Cassandra storage extension no longer packages SnakeYAML through Astyanax/Cassandra. Other modules and root dependency management are unchanged.

## Verification

- `mvn -ntp dependency:tree -pl extensions-contrib/cassandra-storage -Dincludes=org.yaml:snakeyaml -Pskip-static-checks -Dweb.console.skip=true -T1C`
  - succeeds with no SnakeYAML artifact in the module dependency tree
- `mvn -ntp test -pl extensions-contrib/cassandra-storage -Pskip-static-checks -Dweb.console.skip=true -T1C`
  - succeeds and compiles all six module source files
- `git diff --check`

## Caveat

This module has no test sources, and validation does not connect to a live Cassandra cluster. The change is intentionally limited to an unused Cassandra server-side YAML dependency.
