### PR TITLE
fix: upgrade Nimbus JOSE JWT to 9.37.4

### DIFF
--- a/extensions-core/druid-pac4j/pom.xml
+++ b/extensions-core/druid-pac4j/pom.xml
@@ -38,7 +38,7 @@
 
     <!-- Following must be updated along with any updates to pac4j version. One can find the compatible version of nimbus libraries in org.pac4j:pac4j-oidc dependencies-->
     <nimbus.lang.tag.version>1.7</nimbus.lang.tag.version>
-    <nimbus.jose.jwt.version>9.37.3</nimbus.jose.jwt.version>
+    <nimbus.jose.jwt.version>9.37.4</nimbus.jose.jwt.version>
     <oauth2.oidc.sdk.version>10.8</oauth2.oidc.sdk.version>
   </properties>
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -919,7 +919,7 @@ name: com.nimbusds nimbus-jose-jwt
 license_category: binary
 module: extensions/druid-pac4j
 license_name: Apache License version 2.0
-version: 9.37.3
+version: 9.37.4
 libraries:
   - com.nimbusds: nimbus-jose-jwt
 


### PR DESCRIPTION
## What changed

Upgrade `com.nimbusds:nimbus-jose-jwt` from `9.37.3` to `9.37.4` in the `druid-pac4j` extension.

## Why

Dependabot alert 438 reports CVE-2025-53864 / GHSA-xwmg-2g98-w7v9. Versions before `9.37.4` can consume excessive resources when parsing deeply nested JSON, allowing a denial-of-service attack.

The vulnerable version is pinned directly in `extensions-core/druid-pac4j/pom.xml`. This change uses the first patched release and stays on the existing `9.37.x` API line, minimizing compatibility risk.

## Impact

JWT parsing and OpenID Connect authentication use the patched Nimbus implementation. No Druid configuration or API changes are required.

## Tests

- `mvn -ntp test -pl extensions-core/druid-pac4j -am -Dtest="org.apache.druid.security.pac4j.JwtAuthenticatorTest" -Dsurefire.failIfNoSpecifiedTests=false -Pskip-static-checks -Dweb.console.skip=true -T1C`
- `mvn -ntp dependency:tree -pl extensions-core/druid-pac4j -Dincludes=com.nimbusds:nimbus-jose-jwt -Pskip-static-checks -Dweb.console.skip=true -DskipTests`
