### PR TITLE
fix: remove vulnerable legacy LZ4 dependency

### DIFF
--- a/extensions-contrib/rabbit-stream-indexing-service/pom.xml
+++ b/extensions-contrib/rabbit-stream-indexing-service/pom.xml
@@ -122,6 +122,12 @@
       <groupId>com.rabbitmq</groupId>
       <artifactId>stream-client</artifactId>
       <version>0.15.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.lz4</groupId>
+          <artifactId>lz4-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>jakarta.validation</groupId>

--- a/extensions-core/avro-extensions/pom.xml
+++ b/extensions-core/avro-extensions/pom.xml
@@ -154,6 +154,10 @@
           <groupId>jakarta.ws.rs</groupId>
           <artifactId>jakarta.ws.rs-api</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.lz4</groupId>
+          <artifactId>lz4-java</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/extensions-core/protobuf-extensions/pom.xml
+++ b/extensions-core/protobuf-extensions/pom.xml
@@ -93,6 +93,10 @@
           <artifactId>jakarta.ws.rs-api</artifactId>
           <groupId>jakarta.ws.rs</groupId>
         </exclusion>
+        <exclusion>
+          <artifactId>lz4-java</artifactId>
+          <groupId>org.lz4</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -2684,16 +2684,6 @@ name: LZ4 Java
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 1.8.1
-libraries:
-  - org.lz4: lz4-java
-
----
-
-name: LZ4 Java
-license_category: binary
-module: java-core
-license_name: Apache License version 2.0
 version: 1.11.1
 libraries:
   - at.yawk.lz4: lz4-java

--- a/pom.xml
+++ b/pom.xml
@@ -986,17 +986,6 @@
                 <artifactId>commons-dbcp2</artifactId>
                 <version>2.11.0</version>
             </dependency>
-            <!-- this is relocated to at.yawk.lz4, but license checker script (the one that uses licenses.yaml)
-             complains about stuff (our dependencies) using org.lz4 package, so put this here even though our own
-              packaging doesn't use it directly anymore
-             -->
-            <dependency>
-                <groupId>org.lz4</groupId>
-                <artifactId>lz4-java</artifactId>
-                <version>1.8.1</version>
-            </dependency>
-            <!-- dependency:analyze complains if we don't declare this like this in our own packaging, since this is
-             what org.lz4 is relocated as -->
             <dependency>
                 <groupId>at.yawk.lz4</groupId>
                 <artifactId>lz4-java</artifactId>


### PR DESCRIPTION
## Summary

- remove the vulnerable legacy `org.lz4:lz4-java` 1.8.1 dependency management entry
- exclude remaining legacy `org.lz4` transitives from the Confluent Avro/Protobuf and Rabbit stream-client dependency paths
- retain the maintained relocated `at.yawk.lz4:lz4-java` dependency
- remove the obsolete `org.lz4` license inventory entry

## Why

Dependabot alerts #472 and #741 report vulnerabilities in `org.lz4:lz4-java` 1.8.1. There is no patched release under those coordinates. Druid already uses the maintained relocated artifact, but several third-party paths could still introduce the legacy coordinates.

## Impact

The reactor dependency graph no longer contains `org.lz4:lz4-java`. LZ4 functionality continues through `at.yawk.lz4:lz4-java` 1.11.1.

## Validation

- complete reactor dependency tree filtered for `org.lz4:lz4-java` is clean
- focused dependency trees resolve only `at.yawk.lz4:lz4-java` 1.11.1
- Avro extension tests: 45 passed
- Protobuf extension tests: 40 passed
- Rabbit stream indexing tests: 38 passed
- generated Avro and Protobuf license reports pass
- `git diff --check` passes

The full Apache release workflow was not completed because its nested report requires installed snapshot modules and the default Python environment lacks PyYAML.
