### PR TITLE
fix: release record supplier lock on validation failure

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -5409,11 +5409,11 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     StreamPartition<PartitionIdType> streamPartition = StreamPartition.of(ioConfig.getStream(), partition);
     OrderedSequenceNumber<SequenceOffsetType> sequenceNumber = makeSequenceNumber(offsetFromMetadata);
     recordSupplierLock.lock();
-    if (!recordSupplier.getAssignment().contains(streamPartition)) {
-      // this shouldn't happen, but in case it does...
-      throw new IllegalStateException("Record supplier does not match current known partitions");
-    }
     try {
+      if (!recordSupplier.getAssignment().contains(streamPartition)) {
+        // this shouldn't happen, but in case it does...
+        throw new IllegalStateException("Record supplier does not match current known partitions");
+      }
       return recordSupplier.isOffsetAvailable(streamPartition, sequenceNumber);
     }
     finally {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
@@ -112,6 +112,8 @@ import org.junit.Test;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -245,6 +247,32 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
     Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
+    verifyAll();
+  }
+
+  @Test
+  public void testCheckOffsetAvailabilityReleasesLockWhenAssignmentDoesNotMatch() throws Exception
+  {
+    EasyMock.expect(spec.isSuspended()).andReturn(false);
+    EasyMock.reset(recordSupplier);
+    EasyMock.expect(recordSupplier.getAssignment()).andReturn(ImmutableSet.of());
+    replayAll();
+
+    final TestSeekableStreamSupervisor supervisor = new TestSeekableStreamSupervisor();
+    supervisor.recordSupplier = recordSupplier;
+    final Method checkOffsetAvailability = SeekableStreamSupervisor.class.getDeclaredMethod(
+        "checkOffsetAvailability",
+        Object.class,
+        Object.class
+    );
+    checkOffsetAvailability.setAccessible(true);
+
+    final InvocationTargetException exception = Assert.assertThrows(
+        InvocationTargetException.class,
+        () -> checkOffsetAvailability.invoke(supervisor, SHARD_ID, "1")
+    );
+    Assert.assertEquals(IllegalStateException.class, exception.getCause().getClass());
+    Assert.assertFalse(supervisor.getRecordSupplierLock().isLocked());
     verifyAll();
   }
 


### PR DESCRIPTION
## Root cause

`checkOffsetAvailability` acquired `recordSupplierLock`, then validated the record supplier assignment before entering the `try`/`finally` that releases the lock. If the assignment did not contain the expected stream partition, the validation threw `IllegalStateException` and permanently retained the reentrant lock on that thread.

## Fix

Move the assignment validation into the existing `try` block so every path after successful lock acquisition reaches the `finally` and unlocks.

Add a focused regression test that exercises the assignment-mismatch exception and verifies that `recordSupplierLock` is no longer locked afterward.

## Impact

This prevents a malformed or unexpectedly changed record-supplier assignment from leaking the supervisor's supplier lock and potentially blocking later record-supplier operations. Successful offset-availability checks and lock scope are unchanged.

## Validation

- `mvn -ntp -Pskip-static-checks -pl indexing-service -Dtest=SeekableStreamSupervisorStateTest test`
  - 60 tests run; 0 failures; 0 errors; 0 skipped
- `mvn -ntp -pl indexing-service -DskipTests checkstyle:check`
  - 0 Checkstyle violations
- `git diff --check`
